### PR TITLE
use ontology URI as ID for ES indexing; this should prevent duplicate entries in the index

### DIFF
--- a/consent-indexer/src/main/java/org/genomebridge/datause/indexer/Indexer.java
+++ b/consent-indexer/src/main/java/org/genomebridge/datause/indexer/Indexer.java
@@ -93,7 +93,9 @@ public class Indexer {
                 }
 
                 bulk.add(client.prepareIndex(configuration.getIndexName(), "ontology_term")
-                        .setSource(term.document()));
+                        .setSource(term.document())
+                        .setId(owlClass.toStringID())
+                );
                 if (count++ > 1000) {
                     bulk.execute().actionGet();
                     bulk = client.prepareBulk();


### PR DESCRIPTION
When indexing ontology terms (for the autocomplete service), use the ontology node's URI as the ID in elasticsearch.

Thus, if we index the same ontology more than once, the indexing process should simply update an existing entry, instead of creating duplicate entries.

Note that this will require the autocomplete index to be cleared and recreated before this is effective - but from there out, hopefully we're good.
