### PR TITLE
Extract consent from consent resource

### DIFF
--- a/consent-ws/src/main/java/org/genomebridge/consent/http/db/ConsentDAO.java
+++ b/consent-ws/src/main/java/org/genomebridge/consent/http/db/ConsentDAO.java
@@ -16,7 +16,7 @@
 
 package org.genomebridge.consent.http.db;
 
-import org.genomebridge.consent.http.resources.ConsentResource;
+import org.genomebridge.consent.http.models.Consent;
 import org.skife.jdbi.v2.sqlobject.Bind;
 import org.skife.jdbi.v2.sqlobject.SqlBatch;
 import org.skife.jdbi.v2.sqlobject.SqlQuery;
@@ -26,11 +26,11 @@ import org.skife.jdbi.v2.sqlobject.mixins.Transactional;
 
 import java.util.List;
 
-@RegisterMapper({ ConsentResourceMapper.class })
+@RegisterMapper({ ConsentMapper.class })
 public interface ConsentDAO extends Transactional<ConsentDAO> {
 
     @SqlQuery("select * from consents where consentId = :consentId and active=true")
-    public ConsentResource findConsentById(@Bind("consentId") String consentId);
+    public Consent findConsentById(@Bind("consentId") String consentId);
 
     @SqlQuery("select consentId from consents where consentId = :consentId and active=true")
     public String checkConsentbyId(@Bind("consentId") String consentId);

--- a/consent-ws/src/main/java/org/genomebridge/consent/http/db/ConsentMapper.java
+++ b/consent-ws/src/main/java/org/genomebridge/consent/http/db/ConsentMapper.java
@@ -16,8 +16,8 @@
 
 package org.genomebridge.consent.http.db;
 
+import org.genomebridge.consent.http.models.Consent;
 import org.genomebridge.consent.http.models.UseRestriction;
-import org.genomebridge.consent.http.resources.ConsentResource;
 import org.skife.jdbi.v2.StatementContext;
 import org.skife.jdbi.v2.tweak.ResultSetMapper;
 
@@ -25,17 +25,15 @@ import java.io.IOException;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
-public class ConsentResourceMapper implements ResultSetMapper<ConsentResource> {
-    public ConsentResource map(int index, ResultSet r, StatementContext ctx) throws SQLException {
-        ConsentResource rec = new ConsentResource();
-
+public class ConsentMapper implements ResultSetMapper<Consent> {
+    public Consent map(int index, ResultSet r, StatementContext ctx) throws SQLException {
+        Consent rec = new Consent();
         rec.requiresManualReview = r.getBoolean("requiresManualReview");
         try {
             rec.useRestriction = UseRestriction.parse(r.getString("useRestriction"));
         } catch (IOException e) {
             throw new SQLException(e);
         }
-
         return rec;
     }
 }

--- a/consent-ws/src/main/java/org/genomebridge/consent/http/models/Consent.java
+++ b/consent-ws/src/main/java/org/genomebridge/consent/http/models/Consent.java
@@ -1,0 +1,46 @@
+package org.genomebridge.consent.http.models;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Consent Representation object.
+ *
+ * Created by grushton on 6/3/15.
+ */
+public class Consent {
+
+    @JsonProperty
+    public Boolean requiresManualReview;
+
+    @JsonProperty
+    public UseRestriction useRestriction;
+
+    public Consent() {
+    }
+
+    public Consent(Boolean requiresManualReview, UseRestriction useRestriction) {
+        this.requiresManualReview = requiresManualReview;
+        this.useRestriction = useRestriction;
+    }
+
+    @JsonProperty
+    public Boolean getRequiresManualReview() {
+        return requiresManualReview;
+    }
+
+    @JsonProperty
+    public void setRequiresManualReview(Boolean requiresManualReview) {
+        this.requiresManualReview = requiresManualReview;
+    }
+
+    @JsonProperty
+    public UseRestriction getUseRestriction() {
+        return useRestriction;
+    }
+
+    @JsonProperty
+    public void setUseRestriction(UseRestriction useRestriction) {
+        this.useRestriction = useRestriction;
+    }
+
+}

--- a/consent-ws/src/main/java/org/genomebridge/consent/http/resources/AllConsentsResource.java
+++ b/consent-ws/src/main/java/org/genomebridge/consent/http/resources/AllConsentsResource.java
@@ -15,8 +15,7 @@
  */
 package org.genomebridge.consent.http.resources;
 
-import com.sun.jersey.spi.container.WebApplication;
-import javassist.tools.web.BadHttpRequest;
+import org.genomebridge.consent.http.models.Consent;
 import org.genomebridge.consent.http.service.AbstractConsentAPI;
 import org.genomebridge.consent.http.service.ConsentAPI;
 import org.genomebridge.consent.http.service.DuplicateIdentifierException;
@@ -24,7 +23,6 @@ import org.genomebridge.consent.http.service.DuplicateIdentifierException;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
-import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
@@ -40,7 +38,7 @@ public class AllConsentsResource extends Resource {
 
     @PUT
     @Consumes("application/json")
-    public Response createConsent(@Context UriInfo info, ConsentResource rec) {
+    public Response createConsent(@Context UriInfo info, Consent rec) {
         URI uri = null;
         do {
             String newId = UUID.randomUUID().toString();

--- a/consent-ws/src/main/java/org/genomebridge/consent/http/resources/ConsentResource.java
+++ b/consent-ws/src/main/java/org/genomebridge/consent/http/resources/ConsentResource.java
@@ -16,8 +16,7 @@
 package org.genomebridge.consent.http.resources;
 
 import com.sun.jersey.api.NotFoundException;
-import org.apache.log4j.Logger;
-import org.genomebridge.consent.http.models.UseRestriction;
+import org.genomebridge.consent.http.models.Consent;
 import org.genomebridge.consent.http.service.AbstractConsentAPI;
 import org.genomebridge.consent.http.service.ConsentAPI;
 import org.genomebridge.consent.http.service.UnknownIdentifierException;
@@ -28,19 +27,15 @@ import javax.ws.rs.core.Response;
 @Path("consent/{id}")
 public class ConsentResource extends Resource {
 
-    public Boolean requiresManualReview;
-    public UseRestriction useRestriction;
-
     private ConsentAPI api;
 
     public ConsentResource() { this.api = AbstractConsentAPI.getInstance(); }
 
     @GET
     @Produces("application/json")
-    public ConsentResource describe(@PathParam("id") String id) {
+    public Consent describe(@PathParam("id") String id) {
         try {
-            populateFromApi(id);
-            return this;
+            return populateFromApi(id);
         } catch (UnknownIdentifierException e) {
             throw new NotFoundException(String.format("Could not find consent with id %s", id));
         }
@@ -49,7 +44,7 @@ public class ConsentResource extends Resource {
     @POST
     @Consumes("application/json")
     @Produces("application/json")
-    public Response update(@PathParam("id") String id, ConsentResource updated) {
+    public Response update(@PathParam("id") String id, Consent updated) {
         try {
             api.update(id, updated);
             return Response.ok(updated).build();
@@ -58,13 +53,8 @@ public class ConsentResource extends Resource {
         }
     }
 
-    private void populateFromApi(String id) throws UnknownIdentifierException {
-        ConsentResource rec = api.retrieve(id);
-        this.requiresManualReview = rec.requiresManualReview;
-        this.useRestriction = rec.useRestriction;
+    private Consent populateFromApi(String id) throws UnknownIdentifierException {
+        return api.retrieve(id);
     }
 
-    private void saveToApi(String id) throws UnknownIdentifierException {
-        api.update(id, this);
-    }
 }

--- a/consent-ws/src/main/java/org/genomebridge/consent/http/service/ConsentAPI.java
+++ b/consent-ws/src/main/java/org/genomebridge/consent/http/service/ConsentAPI.java
@@ -15,8 +15,8 @@
  */
 package org.genomebridge.consent.http.service;
 
+import org.genomebridge.consent.http.models.Consent;
 import org.genomebridge.consent.http.models.ConsentAssociation;
-import org.genomebridge.consent.http.resources.ConsentResource;
 
 import javax.ws.rs.core.UriInfo;
 import java.util.List;
@@ -26,9 +26,9 @@ import java.util.List;
  */
 public interface ConsentAPI {
 
-    public void create(String id, ConsentResource rec) throws DuplicateIdentifierException;
-    public ConsentResource retrieve( String id ) throws UnknownIdentifierException;
-    public void update(String id, ConsentResource rec) throws UnknownIdentifierException;
+    public void create(String id, Consent rec) throws DuplicateIdentifierException;
+    public Consent retrieve( String id ) throws UnknownIdentifierException;
+    public void update(String id, Consent rec) throws UnknownIdentifierException;
 
     /**
      * This isn't actually used in the web services at the moment, but i'm including it for

--- a/consent-ws/src/main/java/org/genomebridge/consent/http/service/DatabaseConsentAPI.java
+++ b/consent-ws/src/main/java/org/genomebridge/consent/http/service/DatabaseConsentAPI.java
@@ -18,8 +18,8 @@ package org.genomebridge.consent.http.service;
 import com.sun.jersey.api.NotFoundException;
 import org.apache.log4j.Logger;
 import org.genomebridge.consent.http.db.ConsentDAO;
+import org.genomebridge.consent.http.models.Consent;
 import org.genomebridge.consent.http.models.ConsentAssociation;
-import org.genomebridge.consent.http.resources.ConsentResource;
 
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
@@ -64,17 +64,17 @@ public class DatabaseConsentAPI extends AbstractConsentAPI {
     // Consent Methods
 
     @Override
-    public void create(String id, ConsentResource rec) throws DuplicateIdentifierException {
+    public void create(String id, Consent rec) throws DuplicateIdentifierException {
         consentDAO.insertConsent(id, rec.requiresManualReview, rec.useRestriction.toString());
     }
 
     @Override
-    public ConsentResource retrieve(String id) throws UnknownIdentifierException {
+    public Consent retrieve(String id) throws UnknownIdentifierException {
         return consentDAO.findConsentById(id);
     }
 
     @Override
-    public void update(String id, ConsentResource rec) throws UnknownIdentifierException {
+    public void update(String id, Consent rec) throws UnknownIdentifierException {
         consentDAO.updateConsent(id, rec.requiresManualReview, rec.useRestriction.toString());
     }
 

--- a/consent-ws/src/test/java/org/genomebridge/consent/http/AssociationTest.java
+++ b/consent-ws/src/test/java/org/genomebridge/consent/http/AssociationTest.java
@@ -23,6 +23,7 @@ import com.sun.jersey.api.client.Client;
 import com.sun.jersey.api.client.ClientResponse;
 import io.dropwizard.jackson.Jackson;
 import io.dropwizard.testing.junit.DropwizardAppRule;
+import org.genomebridge.consent.http.models.Consent;
 import org.genomebridge.consent.http.models.ConsentAssociation;
 import org.genomebridge.consent.http.models.Everything;
 import org.genomebridge.consent.http.resources.ConsentResource;
@@ -368,10 +369,7 @@ public class AssociationTest extends ConsentServiceTest {
     private String setupConsent() {
         Client client = new Client();
 
-        ConsentResource rec = new ConsentResource();
-        rec.requiresManualReview = false;
-        rec.useRestriction = new Everything();
-
+        Consent rec = new Consent(false, new Everything());
         ClientResponse response = checkStatus( CREATED, put(client, consentPath(), rec) );
         String createdLocation = checkHeader(response, "Location");
         String consent_id = createdLocation.substring(createdLocation.lastIndexOf("/")+1);

--- a/consent-ws/src/test/java/org/genomebridge/consent/http/ConsentAcceptanceTest.java
+++ b/consent-ws/src/test/java/org/genomebridge/consent/http/ConsentAcceptanceTest.java
@@ -17,10 +17,8 @@ package org.genomebridge.consent.http;
 
 import com.sun.jersey.api.client.Client;
 import com.sun.jersey.api.client.ClientResponse;
-import com.sun.jersey.api.client.filter.LoggingFilter;
 import io.dropwizard.testing.junit.DropwizardAppRule;
 import org.genomebridge.consent.http.models.*;
-import org.genomebridge.consent.http.resources.ConsentResource;
 import org.junit.ClassRule;
 import org.junit.Test;
 
@@ -45,7 +43,7 @@ public class ConsentAcceptanceTest extends ConsentServiceTest {
     public void testCreateConsent() {
         Client client = new Client();
 
-        ConsentResource rec = new ConsentResource();
+        Consent rec = new Consent();
         rec.requiresManualReview = true;
         rec.useRestriction = new Everything();
 
@@ -56,7 +54,7 @@ public class ConsentAcceptanceTest extends ConsentServiceTest {
     public void testUpdateConsent() {
         Client client = new Client();
 
-        ConsentResource rec = new ConsentResource();
+        Consent rec = new Consent();
         rec.requiresManualReview = true;
         rec.useRestriction = new Everything();
 
@@ -64,18 +62,18 @@ public class ConsentAcceptanceTest extends ConsentServiceTest {
 
         String createdLocation = checkHeader(response, "Location");
 
-        ConsentResource created = retrieveConsent(client, createdLocation);
+        Consent created = retrieveConsent(client, createdLocation);
 
         assertThat(created.requiresManualReview).isEqualTo(rec.requiresManualReview);
         assertThat(created.useRestriction).isEqualTo(rec.useRestriction);
 
-        ConsentResource update = new ConsentResource();
+        Consent update = new Consent();
         update.requiresManualReview = false;
         update.useRestriction = new Nothing();
 
         check200(post(client, createdLocation, update));
 
-        ConsentResource updated = retrieveConsent(client, createdLocation);
+        Consent updated = retrieveConsent(client, createdLocation);
 
         assertThat(updated.requiresManualReview).isEqualTo(update.requiresManualReview);
         assertThat(updated.useRestriction).isEqualTo(update.useRestriction);
@@ -85,7 +83,7 @@ public class ConsentAcceptanceTest extends ConsentServiceTest {
     public void testOnlyOrNamedConsent() {
         Client client = new Client();
 
-        ConsentResource rec = new ConsentResource();
+        Consent rec = new Consent();
         rec.requiresManualReview = false;
         rec.useRestriction = new Only(
                 "http://broadinstitute.org/ontology/consent/research_on",
@@ -99,7 +97,7 @@ public class ConsentAcceptanceTest extends ConsentServiceTest {
     public void testAndConsent() {
         Client client = new Client();
 
-        ConsentResource rec = new ConsentResource();
+        Consent rec = new Consent();
         rec.requiresManualReview = false;
         rec.useRestriction = new And(new Named("DOID:1"), new Named("DOID:2"));
 
@@ -110,7 +108,7 @@ public class ConsentAcceptanceTest extends ConsentServiceTest {
     public void testNotConsent() {
         Client client = new Client();
 
-        ConsentResource rec = new ConsentResource();
+        Consent rec = new Consent();
         rec.requiresManualReview = false;
         rec.useRestriction = new Not(new Named("DOID:1"));
 
@@ -121,7 +119,7 @@ public class ConsentAcceptanceTest extends ConsentServiceTest {
     public void testNothingConsent() {
         Client client = new Client();
 
-        ConsentResource rec = new ConsentResource();
+        Consent rec = new Consent();
         rec.requiresManualReview = false;
         rec.useRestriction = new Nothing();
 
@@ -132,7 +130,7 @@ public class ConsentAcceptanceTest extends ConsentServiceTest {
     public void testSomeConsent() {
         Client client = new Client();
 
-        ConsentResource rec = new ConsentResource();
+        Consent rec = new Consent();
         rec.requiresManualReview = false;
         rec.useRestriction = new Some(
                 "http://broadinstitute.org/ontology/consent/research_on",
@@ -143,12 +141,11 @@ public class ConsentAcceptanceTest extends ConsentServiceTest {
     }
 
 
-    private void assertValidConsentResource(Client client, ConsentResource rec) {
+    private void assertValidConsentResource(Client client, Consent rec) {
         ClientResponse response = checkStatus( CREATED, put(client, consentPath(), rec) );
 
         String createdLocation = checkHeader(response, "Location");
-
-        ConsentResource created = retrieveConsent(client, createdLocation);
+        Consent created = retrieveConsent(client, createdLocation);
 
         assertThat(created.requiresManualReview).isEqualTo(rec.requiresManualReview);
         assertThat(created.useRestriction).isEqualTo(rec.useRestriction);

--- a/consent-ws/src/test/java/org/genomebridge/consent/http/ConsentServiceTest.java
+++ b/consent-ws/src/test/java/org/genomebridge/consent/http/ConsentServiceTest.java
@@ -16,8 +16,7 @@
 package org.genomebridge.consent.http;
 
 import com.sun.jersey.api.client.Client;
-import com.sun.jersey.api.client.ClientResponse;
-import org.genomebridge.consent.http.resources.ConsentResource;
+import org.genomebridge.consent.http.models.Consent;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
@@ -35,16 +34,8 @@ public abstract class ConsentServiceTest extends AbstractTest {
         }
     }
 
-    public ConsentResource retrieveConsent(Client client, String url) {
-        return get(client, url).getEntity(ConsentResource.class);
+    public Consent retrieveConsent(Client client, String url) {
+        return get(client, url).getEntity(Consent.class);
     }
 
-    public String createConsent( Client client, ConsentResource toCreate ) {
-        ClientResponse response = put(client, consentPath(), toCreate);
-        return response.getHeaders().getFirst("Location");
-    }
-
-    public void updateConsent( Client client, String url, ConsentResource resource ) {
-        post(client, url, resource);
-    }
 }


### PR DESCRIPTION
The current consent endpoint conflates the concept of a Consent entity and Consent service into a single class. This PR pulls out Consent as a separate model object.
