### PR TITLE
Clean up consent creation API and resource call.

### DIFF
--- a/consent-ws/src/main/java/org/genomebridge/consent/http/resources/AllConsentsResource.java
+++ b/consent-ws/src/main/java/org/genomebridge/consent/http/resources/AllConsentsResource.java
@@ -3,7 +3,6 @@ package org.genomebridge.consent.http.resources;
 import org.genomebridge.consent.http.models.Consent;
 import org.genomebridge.consent.http.service.AbstractConsentAPI;
 import org.genomebridge.consent.http.service.ConsentAPI;
-import org.genomebridge.consent.http.service.DuplicateIdentifierException;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.PUT;
@@ -12,7 +11,6 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 import java.net.URI;
-import java.util.UUID;
 
 @Path("consent")
 public class AllConsentsResource extends Resource {
@@ -24,16 +22,12 @@ public class AllConsentsResource extends Resource {
     @PUT
     @Consumes("application/json")
     public Response createConsent(@Context UriInfo info, Consent rec) {
-        URI uri = null;
-        do {
-            String newId = UUID.randomUUID().toString();
-            try {
-                api.create(newId, rec);
-                uri = info.getRequestUriBuilder().path("{id}").build(newId);
-            } catch (DuplicateIdentifierException ignored) {
-                // since user is not passing in id, generate a new ID and try again
-            }
-        } while (uri == null);
-        return Response.created(uri).build();
+        try {
+            Consent consent = api.create(rec);
+            URI uri = info.getRequestUriBuilder().path("{id}").build(consent.consentId);
+            return Response.created(uri).build();
+        } catch (Exception e) {
+            return Response.serverError().build();
+        }
     }
 }

--- a/consent-ws/src/main/java/org/genomebridge/consent/http/service/ConsentAPI.java
+++ b/consent-ws/src/main/java/org/genomebridge/consent/http/service/ConsentAPI.java
@@ -9,7 +9,7 @@ import java.util.List;
 
 public interface ConsentAPI {
 
-    void create(String id, Consent rec) throws DuplicateIdentifierException;
+    Consent create(Consent rec);
     Consent retrieve( String id ) throws UnknownIdentifierException;
     Collection<Consent> findConsentsByAssociationType( String associationType );
     Collection<Consent> retrieve( List<String> ids );

--- a/consent-ws/src/main/java/org/genomebridge/consent/http/service/DatabaseConsentAPI.java
+++ b/consent-ws/src/main/java/org/genomebridge/consent/http/service/DatabaseConsentAPI.java
@@ -54,8 +54,10 @@ public class DatabaseConsentAPI extends AbstractConsentAPI {
     // Consent Methods
 
     @Override
-    public void create(String id, Consent rec) throws DuplicateIdentifierException {
+    public Consent create(Consent rec) {
+        String id = UUID.randomUUID().toString();
         consentDAO.insertConsent(id, rec.requiresManualReview, rec.useRestriction.toString());
+        return consentDAO.findConsentById(id);
     }
 
     @Override


### PR DESCRIPTION
Update the call to the create consent API so that it handles ID creation and returns the full object created.

Relevant for Veronica's Vote API story: https://broadinstitute.atlassian.net/browse/DSDEEPB-488
