### PR TITLE
Move grammar model classes to their own package

### DIFF
--- a/consent-ws/src/main/java/org/genomebridge/consent/http/db/ConsentMapper.java
+++ b/consent-ws/src/main/java/org/genomebridge/consent/http/db/ConsentMapper.java
@@ -1,7 +1,7 @@
 package org.genomebridge.consent.http.db;
 
 import org.genomebridge.consent.http.models.Consent;
-import org.genomebridge.consent.http.models.UseRestriction;
+import org.genomebridge.consent.http.models.grammar.UseRestriction;
 import org.skife.jdbi.v2.StatementContext;
 import org.skife.jdbi.v2.tweak.ResultSetMapper;
 

--- a/consent-ws/src/main/java/org/genomebridge/consent/http/models/Consent.java
+++ b/consent-ws/src/main/java/org/genomebridge/consent/http/models/Consent.java
@@ -1,6 +1,7 @@
 package org.genomebridge.consent.http.models;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.genomebridge.consent.http.models.grammar.UseRestriction;
 
 /**
  * Consent Representation object.

--- a/consent-ws/src/main/java/org/genomebridge/consent/http/models/grammar/And.java
+++ b/consent-ws/src/main/java/org/genomebridge/consent/http/models/grammar/And.java
@@ -1,23 +1,20 @@
-package org.genomebridge.consent.http.models;
+package org.genomebridge.consent.http.models.grammar;
 
 import com.google.common.base.Objects;
 
 import java.util.Arrays;
 
-public class Or extends UseRestriction {
+public class And extends UseRestriction {
 
-    private String type = "or";
+    private String type = "and";
 
     private UseRestriction[] operands;
 
-    public Or() {
+    public And() {
     }
 
-    public Or(UseRestriction... operands) {
+    public And(UseRestriction... operands) {
         this.operands = operands;
-        if (operands.length < 2) {
-            throw new IllegalArgumentException("Disjunction must have at least two operands");
-        }
     }
 
     public String getType() {
@@ -39,8 +36,8 @@ public class Or extends UseRestriction {
 
     @Override
     public boolean equals(Object o) {
-        return o instanceof Or &&
-                Arrays.deepEquals(this.operands, ((Or) o).operands);
+        return o instanceof And &&
+                Arrays.deepEquals(this.operands, ((And) o).operands);
     }
 
     public boolean visitAndContinue(UseRestrictionVisitor visitor) {

--- a/consent-ws/src/main/java/org/genomebridge/consent/http/models/grammar/Everything.java
+++ b/consent-ws/src/main/java/org/genomebridge/consent/http/models/grammar/Everything.java
@@ -1,12 +1,12 @@
-package org.genomebridge.consent.http.models;
+package org.genomebridge.consent.http.models.grammar;
 
 import com.google.common.base.Objects;
 
-public class Nothing extends UseRestriction {
+public class Everything extends UseRestriction {
 
-    private String type = "nothing";
+    private String type = "everything";
 
-    public Nothing() {
+    public Everything() {
     }
 
     public String getType() {
@@ -20,7 +20,7 @@ public class Nothing extends UseRestriction {
 
     @Override
     public boolean equals(Object o) {
-        return o instanceof Nothing;
+        return o instanceof Everything;
     }
 
     public boolean visitAndContinue(UseRestrictionVisitor visitor) {

--- a/consent-ws/src/main/java/org/genomebridge/consent/http/models/grammar/Named.java
+++ b/consent-ws/src/main/java/org/genomebridge/consent/http/models/grammar/Named.java
@@ -1,4 +1,4 @@
-package org.genomebridge.consent.http.models;
+package org.genomebridge.consent.http.models.grammar;
 
 import com.google.common.base.Objects;
 

--- a/consent-ws/src/main/java/org/genomebridge/consent/http/models/grammar/Not.java
+++ b/consent-ws/src/main/java/org/genomebridge/consent/http/models/grammar/Not.java
@@ -1,4 +1,4 @@
-package org.genomebridge.consent.http.models;
+package org.genomebridge.consent.http.models.grammar;
 
 import com.google.common.base.Objects;
 

--- a/consent-ws/src/main/java/org/genomebridge/consent/http/models/grammar/Nothing.java
+++ b/consent-ws/src/main/java/org/genomebridge/consent/http/models/grammar/Nothing.java
@@ -1,12 +1,12 @@
-package org.genomebridge.consent.http.models;
+package org.genomebridge.consent.http.models.grammar;
 
 import com.google.common.base.Objects;
 
-public class Everything extends UseRestriction {
+public class Nothing extends UseRestriction {
 
-    private String type = "everything";
+    private String type = "nothing";
 
-    public Everything() {
+    public Nothing() {
     }
 
     public String getType() {
@@ -20,7 +20,7 @@ public class Everything extends UseRestriction {
 
     @Override
     public boolean equals(Object o) {
-        return o instanceof Everything;
+        return o instanceof Nothing;
     }
 
     public boolean visitAndContinue(UseRestrictionVisitor visitor) {

--- a/consent-ws/src/main/java/org/genomebridge/consent/http/models/grammar/Only.java
+++ b/consent-ws/src/main/java/org/genomebridge/consent/http/models/grammar/Only.java
@@ -1,4 +1,4 @@
-package org.genomebridge.consent.http.models;
+package org.genomebridge.consent.http.models.grammar;
 
 import com.google.common.base.Objects;
 

--- a/consent-ws/src/main/java/org/genomebridge/consent/http/models/grammar/Or.java
+++ b/consent-ws/src/main/java/org/genomebridge/consent/http/models/grammar/Or.java
@@ -1,20 +1,23 @@
-package org.genomebridge.consent.http.models;
+package org.genomebridge.consent.http.models.grammar;
 
 import com.google.common.base.Objects;
 
 import java.util.Arrays;
 
-public class And extends UseRestriction {
+public class Or extends UseRestriction {
 
-    private String type = "and";
+    private String type = "or";
 
     private UseRestriction[] operands;
 
-    public And() {
+    public Or() {
     }
 
-    public And(UseRestriction... operands) {
+    public Or(UseRestriction... operands) {
         this.operands = operands;
+        if (operands.length < 2) {
+            throw new IllegalArgumentException("Disjunction must have at least two operands");
+        }
     }
 
     public String getType() {
@@ -36,8 +39,8 @@ public class And extends UseRestriction {
 
     @Override
     public boolean equals(Object o) {
-        return o instanceof And &&
-                Arrays.deepEquals(this.operands, ((And) o).operands);
+        return o instanceof Or &&
+                Arrays.deepEquals(this.operands, ((Or) o).operands);
     }
 
     public boolean visitAndContinue(UseRestrictionVisitor visitor) {

--- a/consent-ws/src/main/java/org/genomebridge/consent/http/models/grammar/Some.java
+++ b/consent-ws/src/main/java/org/genomebridge/consent/http/models/grammar/Some.java
@@ -1,4 +1,4 @@
-package org.genomebridge.consent.http.models;
+package org.genomebridge.consent.http.models.grammar;
 
 import com.google.common.base.Objects;
 

--- a/consent-ws/src/main/java/org/genomebridge/consent/http/models/grammar/UseRestriction.java
+++ b/consent-ws/src/main/java/org/genomebridge/consent/http/models/grammar/UseRestriction.java
@@ -1,4 +1,4 @@
-package org.genomebridge.consent.http.models;
+package org.genomebridge.consent.http.models.grammar;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;

--- a/consent-ws/src/main/java/org/genomebridge/consent/http/models/grammar/UseRestrictionVisitor.java
+++ b/consent-ws/src/main/java/org/genomebridge/consent/http/models/grammar/UseRestrictionVisitor.java
@@ -1,4 +1,4 @@
-package org.genomebridge.consent.http.models;
+package org.genomebridge.consent.http.models.grammar;
 
 public interface UseRestrictionVisitor {
 

--- a/consent-ws/src/test/java/org/genomebridge/consent/http/AssociationTest.java
+++ b/consent-ws/src/test/java/org/genomebridge/consent/http/AssociationTest.java
@@ -9,7 +9,7 @@ import io.dropwizard.jackson.Jackson;
 import io.dropwizard.testing.junit.DropwizardAppRule;
 import org.genomebridge.consent.http.models.Consent;
 import org.genomebridge.consent.http.models.ConsentAssociation;
-import org.genomebridge.consent.http.models.Everything;
+import org.genomebridge.consent.http.models.grammar.Everything;
 import org.junit.ClassRule;
 import org.junit.Test;
 

--- a/consent-ws/src/test/java/org/genomebridge/consent/http/ConsentAcceptanceTest.java
+++ b/consent-ws/src/test/java/org/genomebridge/consent/http/ConsentAcceptanceTest.java
@@ -4,6 +4,7 @@ import com.sun.jersey.api.client.Client;
 import com.sun.jersey.api.client.ClientResponse;
 import io.dropwizard.testing.junit.DropwizardAppRule;
 import org.genomebridge.consent.http.models.*;
+import org.genomebridge.consent.http.models.grammar.*;
 import org.junit.ClassRule;
 import org.junit.Test;
 

--- a/consent-ws/src/test/java/org/genomebridge/consent/http/ConsentsServiceTest.java
+++ b/consent-ws/src/test/java/org/genomebridge/consent/http/ConsentsServiceTest.java
@@ -8,7 +8,7 @@ import io.dropwizard.testing.junit.DropwizardAppRule;
 import org.apache.commons.lang.StringUtils;
 import org.genomebridge.consent.http.models.Consent;
 import org.genomebridge.consent.http.models.ConsentAssociation;
-import org.genomebridge.consent.http.models.Everything;
+import org.genomebridge.consent.http.models.grammar.Everything;
 import org.junit.ClassRule;
 import org.junit.Test;
 

--- a/consent-ws/src/test/java/org/genomebridge/consent/http/DataUseLetterResourceTest.java
+++ b/consent-ws/src/test/java/org/genomebridge/consent/http/DataUseLetterResourceTest.java
@@ -7,7 +7,7 @@ import com.sun.jersey.multipart.FormDataBodyPart;
 import io.dropwizard.testing.junit.DropwizardAppRule;
 import org.genomebridge.consent.http.cloudstore.GCSStore;
 import org.genomebridge.consent.http.models.Consent;
-import org.genomebridge.consent.http.models.Everything;
+import org.genomebridge.consent.http.models.grammar.Everything;
 import org.genomebridge.consent.http.resources.DataUseLetterResource;
 import org.junit.Before;
 import org.junit.ClassRule;

--- a/consent-ws/src/test/java/org/genomebridge/consent/http/JsonTest.java
+++ b/consent-ws/src/test/java/org/genomebridge/consent/http/JsonTest.java
@@ -1,6 +1,6 @@
 package org.genomebridge.consent.http;
 
-import org.genomebridge.consent.http.models.*;
+import org.genomebridge.consent.http.models.grammar.*;
 import org.junit.Assert;
 import org.junit.Test;
 

--- a/consent-ws/src/test/java/org/genomebridge/consent/http/RestrictionParserTest.java
+++ b/consent-ws/src/test/java/org/genomebridge/consent/http/RestrictionParserTest.java
@@ -1,6 +1,6 @@
 package org.genomebridge.consent.http;
 
-import org.genomebridge.consent.http.models.*;
+import org.genomebridge.consent.http.models.grammar.*;
 import org.junit.Assert;
 import org.junit.Test;
 


### PR DESCRIPTION
… to distinguish them from other application model classes.

This is in relation to https://broadinstitute.atlassian.net/browse/DSDEEPB-928
