### PR TITLE
Upgrade to dropwizard 8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -149,3 +149,4 @@ hs_err_pid*
 
 ### OSX ###
 .DS_STORE
+*.yml

--- a/consent-autocomplete/pom.xml
+++ b/consent-autocomplete/pom.xml
@@ -8,10 +8,6 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <properties>
-        <dropwizard.version>0.8.1</dropwizard.version>
-    </properties>
-
     <artifactId>consent-autocomplete</artifactId>
     <packaging>jar</packaging>
     <name>Consent Management: Autocomplete Services</name>

--- a/consent-ws/pom.xml
+++ b/consent-ws/pom.xml
@@ -1,6 +1,12 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
+    <prerequisites>
+        <maven>3.0.0</maven>
+    </prerequisites>
 
     <artifactId>consent-ws</artifactId>
     <packaging>jar</packaging>
@@ -13,8 +19,8 @@
     </parent>
 
     <properties>
-        <java.version>1.8</java.version>
-        <dropwizard.version>0.7.0</dropwizard.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <driver>org.hsqldb.jdbc.JDBCDriver</driver>
         <url>jdbc:hsqldb:file:${project.build.testOutputDirectory}/testdb;shutdown=true</url>
         <username>sa</username>
@@ -33,7 +39,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.2</version>
+                <version>3.1</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
@@ -115,7 +121,7 @@
                     <dependency>
                         <groupId>org.hsqldb</groupId>
                         <artifactId>hsqldb</artifactId>
-                        <version>2.3.2</version>
+                        <version>2.3.3</version>
                     </dependency>
                 </dependencies>
                 <executions>
@@ -157,6 +163,12 @@
 
         <dependency>
             <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-forms</artifactId>
+            <version>${dropwizard.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-testing</artifactId>
             <version>${dropwizard.version}</version>
         </dependency>
@@ -190,11 +202,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.sun.jersey</groupId>
-            <artifactId>jersey-client</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>com.google.api-client</groupId>
             <artifactId>google-api-client</artifactId>
             <version>1.20.0</version>
@@ -204,12 +211,6 @@
             <groupId>com.google.apis</groupId>
             <artifactId>google-api-services-storage</artifactId>
             <version>v1-rev35-1.20.0</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.sun.jersey.contribs</groupId>
-            <artifactId>jersey-multipart</artifactId>
-            <version>1.18.1</version>
         </dependency>
 
         <dependency>

--- a/consent-ws/src/main/java/org/genomebridge/consent/http/resources/AllAssociationsResource.java
+++ b/consent-ws/src/main/java/org/genomebridge/consent/http/resources/AllAssociationsResource.java
@@ -1,14 +1,10 @@
 package org.genomebridge.consent.http.resources;
 
-import com.sun.jersey.api.NotFoundException;
 import org.apache.log4j.Logger;
 import org.genomebridge.consent.http.service.AbstractConsentAPI;
 import org.genomebridge.consent.http.service.ConsentAPI;
 
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
+import javax.ws.rs.*;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -16,9 +12,6 @@ import javax.ws.rs.core.UriInfo;
 import java.net.URI;
 import java.util.List;
 
-/**
- * Created by egolin on 9/24/14.
- */
 @Path("consent/associations/{associationType}/{id}")
 public class AllAssociationsResource extends Resource {
     private ConsentAPI api;

--- a/consent-ws/src/main/java/org/genomebridge/consent/http/resources/ConsentAssociationResource.java
+++ b/consent-ws/src/main/java/org/genomebridge/consent/http/resources/ConsentAssociationResource.java
@@ -1,6 +1,5 @@
 package org.genomebridge.consent.http.resources;
 
-import com.sun.jersey.api.NotFoundException;
 import org.apache.log4j.Logger;
 import org.genomebridge.consent.http.models.ConsentAssociation;
 import org.genomebridge.consent.http.service.AbstractConsentAPI;
@@ -14,9 +13,6 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 
-/**
- * Created by egolin on 9/15/14.
- */
 @Path("consent/{id}/association")
 public class ConsentAssociationResource extends Resource {
 

--- a/consent-ws/src/main/java/org/genomebridge/consent/http/resources/ConsentElectionResource.java
+++ b/consent-ws/src/main/java/org/genomebridge/consent/http/resources/ConsentElectionResource.java
@@ -1,28 +1,18 @@
 package org.genomebridge.consent.http.resources;
 
-import java.net.URI;
-
-import javax.ws.rs.Consumes;
-import javax.ws.rs.DELETE;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.PUT;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.Status;
-import javax.ws.rs.core.UriInfo;
-
 import org.genomebridge.consent.http.models.Election;
 import org.genomebridge.consent.http.service.AbstractElectionAPI;
 import org.genomebridge.consent.http.service.AbstractVoteAPI;
 import org.genomebridge.consent.http.service.ElectionAPI;
 import org.genomebridge.consent.http.service.VoteAPI;
 
-import com.sun.jersey.api.NotFoundException;
+import javax.ws.rs.*;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import javax.ws.rs.core.UriInfo;
+import java.net.URI;
 
 @Path("consent/{consentId}/election")
 public class ConsentElectionResource extends Resource {

--- a/consent-ws/src/main/java/org/genomebridge/consent/http/resources/ConsentResource.java
+++ b/consent-ws/src/main/java/org/genomebridge/consent/http/resources/ConsentResource.java
@@ -1,6 +1,5 @@
 package org.genomebridge.consent.http.resources;
 
-import com.sun.jersey.api.NotFoundException;
 import org.genomebridge.consent.http.models.Consent;
 import org.genomebridge.consent.http.service.AbstractConsentAPI;
 import org.genomebridge.consent.http.service.ConsentAPI;

--- a/consent-ws/src/main/java/org/genomebridge/consent/http/resources/ConsentVoteResource.java
+++ b/consent-ws/src/main/java/org/genomebridge/consent/http/resources/ConsentVoteResource.java
@@ -1,6 +1,5 @@
 package org.genomebridge.consent.http.resources;
 
-import com.sun.jersey.api.NotFoundException;
 import org.genomebridge.consent.http.models.Vote;
 import org.genomebridge.consent.http.service.AbstractVoteAPI;
 import org.genomebridge.consent.http.service.VoteAPI;

--- a/consent-ws/src/main/java/org/genomebridge/consent/http/resources/ConsentsResource.java
+++ b/consent-ws/src/main/java/org/genomebridge/consent/http/resources/ConsentsResource.java
@@ -1,8 +1,7 @@
 package org.genomebridge.consent.http.resources;
 
 import com.google.common.base.Optional;
-import com.sun.jersey.api.NotFoundException;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
 import org.genomebridge.consent.http.models.Consent;
 import org.genomebridge.consent.http.service.AbstractConsentAPI;

--- a/consent-ws/src/main/java/org/genomebridge/consent/http/resources/DataRequestElectionResource.java
+++ b/consent-ws/src/main/java/org/genomebridge/consent/http/resources/DataRequestElectionResource.java
@@ -1,29 +1,15 @@
 package org.genomebridge.consent.http.resources;
 
-import java.net.URI;
-
-import javax.ws.rs.Consumes;
-import javax.ws.rs.DELETE;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.PUT;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.Status;
-import javax.ws.rs.core.UriBuilder;
-import javax.ws.rs.core.UriInfo;
-
 import org.genomebridge.consent.http.models.Election;
 import org.genomebridge.consent.http.service.AbstractElectionAPI;
 import org.genomebridge.consent.http.service.AbstractVoteAPI;
 import org.genomebridge.consent.http.service.ElectionAPI;
 import org.genomebridge.consent.http.service.VoteAPI;
 
-import com.sun.jersey.api.NotFoundException;
+import javax.ws.rs.*;
+import javax.ws.rs.core.*;
+import javax.ws.rs.core.Response.Status;
+import java.net.URI;
 
 @Path("dataRequest/{requestId}/election")
 public class DataRequestElectionResource extends Resource {

--- a/consent-ws/src/main/java/org/genomebridge/consent/http/resources/DataRequestVoteResource.java
+++ b/consent-ws/src/main/java/org/genomebridge/consent/http/resources/DataRequestVoteResource.java
@@ -1,27 +1,17 @@
 package org.genomebridge.consent.http.resources;
 
-import java.net.URI;
-import java.util.List;
+import org.genomebridge.consent.http.models.Vote;
+import org.genomebridge.consent.http.service.AbstractVoteAPI;
+import org.genomebridge.consent.http.service.VoteAPI;
 
-import javax.ws.rs.Consumes;
-import javax.ws.rs.DELETE;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.PUT;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
+import javax.ws.rs.*;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriInfo;
-
-import org.genomebridge.consent.http.models.Vote;
-import org.genomebridge.consent.http.service.AbstractVoteAPI;
-import org.genomebridge.consent.http.service.VoteAPI;
-
-import com.sun.jersey.api.NotFoundException;
+import java.net.URI;
+import java.util.List;
 
 @Path("dataRequest/{requestId}/vote")
 public class DataRequestVoteResource extends Resource {

--- a/consent-ws/src/main/java/org/genomebridge/consent/http/resources/DataUseLetterResource.java
+++ b/consent-ws/src/main/java/org/genomebridge/consent/http/resources/DataUseLetterResource.java
@@ -1,18 +1,17 @@
 package org.genomebridge.consent.http.resources;
 
 import com.google.api.client.http.HttpResponse;
-import com.sun.jersey.api.NotFoundException;
-import com.sun.jersey.multipart.FormDataBodyPart;
-import com.sun.jersey.multipart.FormDataParam;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
 import org.genomebridge.consent.http.cloudstore.GCSStore;
 import org.genomebridge.consent.http.models.Consent;
 import org.genomebridge.consent.http.service.AbstractConsentAPI;
 import org.genomebridge.consent.http.service.ConsentAPI;
 import org.genomebridge.consent.http.service.UnknownIdentifierException;
+import org.glassfish.jersey.media.multipart.FormDataBodyPart;
+import org.glassfish.jersey.media.multipart.FormDataParam;
 
 import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
@@ -47,7 +46,10 @@ public class DataUseLetterResource extends Resource {
     @POST
     @Consumes(MediaType.MULTIPART_FORM_DATA)
     @Produces(MediaType.APPLICATION_JSON)
-    public Consent createDUL(@FormDataParam("data") InputStream uploadedDUL, @FormDataParam("data") FormDataBodyPart part, @PathParam("id") String consentId) {
+    public Consent createDUL(
+            @FormDataParam("data") InputStream uploadedDUL,
+            @FormDataParam("data") FormDataBodyPart part,
+            @PathParam("id") String consentId) {
         String msg = String.format("POSTing Data Use Letter to consent with id '%s'", consentId);
         logger().debug(msg);
 
@@ -68,7 +70,10 @@ public class DataUseLetterResource extends Resource {
     @PUT
     @Consumes(MediaType.MULTIPART_FORM_DATA)
     @Produces(MediaType.APPLICATION_JSON)
-    public Consent updateDUL(@FormDataParam("data") InputStream uploadedDUL, @FormDataParam("data") FormDataBodyPart part, @PathParam("id") String consentId) {
+    public Consent updateDUL(
+            @FormDataParam("data") InputStream uploadedDUL,
+            @FormDataParam("data") FormDataBodyPart part,
+            @PathParam("id") String consentId) {
         String msg = String.format("PUTing Data Use Letter to consent with id '%s'", consentId);
         logger().debug(msg);
         try {

--- a/consent-ws/src/main/java/org/genomebridge/consent/http/service/DACUserAPI.java
+++ b/consent-ws/src/main/java/org/genomebridge/consent/http/service/DACUserAPI.java
@@ -1,7 +1,8 @@
 package org.genomebridge.consent.http.service;
 
-import com.sun.jersey.api.NotFoundException;
 import org.genomebridge.consent.http.models.DACUser;
+
+import javax.ws.rs.NotFoundException;
 
 public interface DACUserAPI {
 

--- a/consent-ws/src/main/java/org/genomebridge/consent/http/service/DataRequestAPI.java
+++ b/consent-ws/src/main/java/org/genomebridge/consent/http/service/DataRequestAPI.java
@@ -2,7 +2,7 @@ package org.genomebridge.consent.http.service;
 
 import org.genomebridge.consent.http.models.DataRequest;
 
-import com.sun.jersey.api.NotFoundException;
+import javax.ws.rs.NotFoundException;
 
 public interface DataRequestAPI {
 

--- a/consent-ws/src/main/java/org/genomebridge/consent/http/service/DatabaseConsentAPI.java
+++ b/consent-ws/src/main/java/org/genomebridge/consent/http/service/DatabaseConsentAPI.java
@@ -2,8 +2,7 @@ package org.genomebridge.consent.http.service;
 
 import com.google.common.base.Function;
 import com.google.common.collect.Collections2;
-import com.sun.jersey.api.NotFoundException;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
 import org.genomebridge.consent.http.db.ConsentDAO;
 import org.genomebridge.consent.http.db.ConsentMapper;
@@ -14,6 +13,7 @@ import org.genomebridge.consent.http.models.ConsentManage;
 import org.skife.jdbi.v2.DBI;
 import org.skife.jdbi.v2.Handle;
 
+import javax.ws.rs.NotFoundException;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriBuilder;

--- a/consent-ws/src/main/java/org/genomebridge/consent/http/service/DatabaseDACUserAPI.java
+++ b/consent-ws/src/main/java/org/genomebridge/consent/http/service/DatabaseDACUserAPI.java
@@ -1,8 +1,9 @@
 package org.genomebridge.consent.http.service;
 
-import com.sun.jersey.api.NotFoundException;
 import org.genomebridge.consent.http.db.DACUserDAO;
 import org.genomebridge.consent.http.models.DACUser;
+
+import javax.ws.rs.NotFoundException;
 
 /**
  * Implementation class for VoteAPI on top of ElectionDAO database support.

--- a/consent-ws/src/main/java/org/genomebridge/consent/http/service/DatabaseDataRequestAPI.java
+++ b/consent-ws/src/main/java/org/genomebridge/consent/http/service/DatabaseDataRequestAPI.java
@@ -5,7 +5,7 @@ import org.genomebridge.consent.http.db.DataSetDAO;
 import org.genomebridge.consent.http.db.ResearchPurposeDAO;
 import org.genomebridge.consent.http.models.DataRequest;
 
-import com.sun.jersey.api.NotFoundException;
+import javax.ws.rs.NotFoundException;
 
 /**
  * Implementation class for DataRequestAPI on top of DataRequestDAO database

--- a/consent-ws/src/main/java/org/genomebridge/consent/http/service/DatabaseElectionAPI.java
+++ b/consent-ws/src/main/java/org/genomebridge/consent/http/service/DatabaseElectionAPI.java
@@ -1,8 +1,6 @@
 package org.genomebridge.consent.http.service;
 
-import java.util.Date;
-
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.genomebridge.consent.http.db.ConsentDAO;
 import org.genomebridge.consent.http.db.DataRequestDAO;
 import org.genomebridge.consent.http.db.ElectionDAO;
@@ -10,7 +8,8 @@ import org.genomebridge.consent.http.enumeration.ElectionStatus;
 import org.genomebridge.consent.http.enumeration.ElectionType;
 import org.genomebridge.consent.http.models.Election;
 
-import com.sun.jersey.api.NotFoundException;
+import javax.ws.rs.NotFoundException;
+import java.util.Date;
 
 /**
  * Implementation class for ElectionAPI on top of ElectionDAO database support.

--- a/consent-ws/src/main/java/org/genomebridge/consent/http/service/DatabaseElectionCaseAPI.java
+++ b/consent-ws/src/main/java/org/genomebridge/consent/http/service/DatabaseElectionCaseAPI.java
@@ -1,8 +1,5 @@
 package org.genomebridge.consent.http.service;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import org.genomebridge.consent.http.db.ElectionDAO;
 import org.genomebridge.consent.http.db.VoteDAO;
 import org.genomebridge.consent.http.enumeration.ElectionStatus;
@@ -12,7 +9,9 @@ import org.genomebridge.consent.http.models.Election;
 import org.genomebridge.consent.http.models.PendingCase;
 import org.genomebridge.consent.http.models.Vote;
 
-import com.sun.jersey.api.NotFoundException;
+import javax.ws.rs.NotFoundException;
+import java.util.ArrayList;
+import java.util.List;
 
 public class DatabaseElectionCaseAPI extends AbstractPendingCaseAPI {
 

--- a/consent-ws/src/main/java/org/genomebridge/consent/http/service/DatabaseVoteAPI.java
+++ b/consent-ws/src/main/java/org/genomebridge/consent/http/service/DatabaseVoteAPI.java
@@ -1,17 +1,16 @@
 package org.genomebridge.consent.http.service;
 
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.genomebridge.consent.http.db.DACUserDAO;
 import org.genomebridge.consent.http.db.ElectionDAO;
 import org.genomebridge.consent.http.db.VoteDAO;
 import org.genomebridge.consent.http.models.DACUser;
 import org.genomebridge.consent.http.models.Vote;
 
-import com.sun.jersey.api.NotFoundException;
+import javax.ws.rs.NotFoundException;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
 
 /**
  * Implementation class for VoteAPI on top of ElectionDAO database support.

--- a/consent-ws/src/main/java/org/genomebridge/consent/http/service/ElectionAPI.java
+++ b/consent-ws/src/main/java/org/genomebridge/consent/http/service/ElectionAPI.java
@@ -2,7 +2,7 @@ package org.genomebridge.consent.http.service;
 
 import org.genomebridge.consent.http.models.Election;
 
-import com.sun.jersey.api.NotFoundException;
+import javax.ws.rs.NotFoundException;
 
 public interface ElectionAPI {
 

--- a/consent-ws/src/main/java/org/genomebridge/consent/http/service/PendingCaseAPI.java
+++ b/consent-ws/src/main/java/org/genomebridge/consent/http/service/PendingCaseAPI.java
@@ -1,10 +1,9 @@
 package org.genomebridge.consent.http.service;
 
-import java.util.List;
-
 import org.genomebridge.consent.http.models.PendingCase;
 
-import com.sun.jersey.api.NotFoundException;
+import javax.ws.rs.NotFoundException;
+import java.util.List;
 
 public interface PendingCaseAPI {
 

--- a/consent-ws/src/main/java/org/genomebridge/consent/http/service/VoteAPI.java
+++ b/consent-ws/src/main/java/org/genomebridge/consent/http/service/VoteAPI.java
@@ -1,10 +1,9 @@
 package org.genomebridge.consent.http.service;
 
-import java.util.List;
-
 import org.genomebridge.consent.http.models.Vote;
 
-import com.sun.jersey.api.NotFoundException;
+import javax.ws.rs.NotFoundException;
+import java.util.List;
 
 public interface VoteAPI {
 

--- a/consent-ws/src/test/java/org/genomebridge/consent/http/AbstractTest.java
+++ b/consent-ws/src/test/java/org/genomebridge/consent/http/AbstractTest.java
@@ -1,13 +1,14 @@
 package org.genomebridge.consent.http;
 
-import com.sun.jersey.api.client.Client;
-import com.sun.jersey.api.client.ClientResponse;
 import io.dropwizard.testing.junit.DropwizardAppRule;
 
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
 
-import static org.fest.assertions.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * An abstract superclass for Tests that involve the BOSS API, includes helper methods for setting up
@@ -16,10 +17,10 @@ import static org.fest.assertions.api.Assertions.assertThat;
  */
 abstract public class AbstractTest extends ResourcedTest {
 
-    public static final int CREATED = ClientResponse.Status.CREATED.getStatusCode();
-    public static final int OK = ClientResponse.Status.OK.getStatusCode();
-    public static final int NOT_FOUND = ClientResponse.Status.NOT_FOUND.getStatusCode();
-    public static final int BAD_REQUEST = ClientResponse.Status.BAD_REQUEST.getStatusCode();
+    public static final int CREATED = Response.Status.CREATED.getStatusCode();
+    public static final int OK = Response.Status.OK.getStatusCode();
+    public static final int NOT_FOUND = Response.Status.NOT_FOUND.getStatusCode();
+    public static final int BAD_REQUEST = Response.Status.BAD_REQUEST.getStatusCode();
 
     abstract public DropwizardAppRule<ConsentConfiguration> rule();
 
@@ -27,76 +28,70 @@ abstract public class AbstractTest extends ResourcedTest {
      * Some utility methods for interacting with HTTP-services.
      */
 
-    public <T> ClientResponse post(Client client, String path, T value) {
+    public <T> Response post(Client client, String path, T value) {
         return post(client, path, "testuser", value);
     }
 
-    public <T> ClientResponse post(Client client, String path, String user, T value) {
-        return client.resource(path)
-                .type(MediaType.APPLICATION_JSON_TYPE)
+    public <T> Response post(Client client, String path, String user, T value) {
+        return client.target(path)
+                .request(MediaType.APPLICATION_JSON_TYPE)
                 .accept(MediaType.APPLICATION_JSON_TYPE)
                 .header("REMOTE_USER", user)
-                .post(ClientResponse.class, value);
+                .post(Entity.json(value), Response.class);
     }
 
-    public <T> ClientResponse put(Client client, String path, T value) {
+    public <T> Response put(Client client, String path, T value) {
         return put(client, path, "testuser", value);
     }
 
-    public <T> ClientResponse put(Client client, String path, String user, T value) {
-        return client.resource(path)
-                .type(MediaType.APPLICATION_JSON_TYPE)
+    public <T> Response put(Client client, String path, String user, T value) {
+        return client.target(path)
+                .request(MediaType.APPLICATION_JSON_TYPE)
                 .accept(MediaType.APPLICATION_JSON_TYPE)
                 .header("REMOTE_USER", user)
-                .put(ClientResponse.class, value);
+                .put(Entity.json(value), Response.class);
     }
 
-    public ClientResponse delete(Client client, String path) {
+    public Response delete(Client client, String path) {
         return delete(client, path, "testuser");
     }
 
-    public ClientResponse delete(Client client, String path, String user) {
-        return client.resource(path)
-                .header("REMOTE_USER", user)
-                .delete(ClientResponse.class);
-    }
-
-    public ClientResponse get(Client client, String path) {
-        return get(client, path, "testuser");
-    }
-
-    public ClientResponse getFile(Client client, String path) {
-        return getFile(client, path, "testuser");
-    }
-
-    public ClientResponse get(Client client, String path, String user) {
-        return client.resource(path)
+    public Response delete(Client client, String path, String user) {
+        return client.target(path)
+                .request(MediaType.APPLICATION_JSON_TYPE)
                 .accept(MediaType.APPLICATION_JSON_TYPE)
                 .header("REMOTE_USER", user)
-                .get(ClientResponse.class);
+                .delete(Response.class);
     }
 
-    public ClientResponse getFile(Client client, String path, String user) {
-        return client.resource(path)
-                .accept(MediaType.TEXT_PLAIN)
-                .header("REMOTE_USER", user)
-                .get(ClientResponse.class);
+    public Response getJson(Client client, String path) {
+        return getWithMediaType(client, path, MediaType.APPLICATION_JSON_TYPE);
     }
 
+    public Response getTextPlain(Client client, String path) {
+        return getWithMediaType(client, path, MediaType.TEXT_PLAIN_TYPE);
+    }
 
-    public ClientResponse check200(ClientResponse response) {
+    private Response getWithMediaType(Client client, String path, MediaType mediaType) {
+        return client.target(path)
+                .request(mediaType)
+                .header("REMOTE_USER", "testuser")
+                .get(Response.class);
+    }
+
+    public Response check200(Response response) {
         return checkStatus(200, response);
     }
 
-    public ClientResponse checkStatus(int status, ClientResponse response) {
+    public Response checkStatus(int status, Response response) {
         assertThat(response.getStatus()).isEqualTo(status);
         return response;
     }
 
-    public String checkHeader(ClientResponse response, String header) {
-        MultivaluedMap<String, String> map = response.getHeaders();
+    public String checkHeader(Response response, String header) {
+        MultivaluedMap<String, Object> map = response.getHeaders();
         assertThat(map).describedAs(String.format("header \"%s\"", header)).containsKey(header);
-        return map.getFirst(header);
+        return map.getFirst(header).toString();
     }
 
     public String path2Url(String path) {

--- a/consent-ws/src/test/java/org/genomebridge/consent/http/AssociationTest.java
+++ b/consent-ws/src/test/java/org/genomebridge/consent/http/AssociationTest.java
@@ -1,7 +1,8 @@
 package org.genomebridge.consent.http;
 
-import static org.fest.assertions.api.Assertions.assertThat;
-import static org.fest.assertions.api.Assertions.fail;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.type.TypeFactory;
 import io.dropwizard.jackson.Jackson;
 import io.dropwizard.testing.junit.DropwizardAppRule;
 import org.genomebridge.consent.http.models.Consent;
@@ -9,16 +10,14 @@ import org.genomebridge.consent.http.models.ConsentAssociation;
 import org.genomebridge.consent.http.models.grammar.Everything;
 import org.junit.ClassRule;
 import org.junit.Test;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Random;
-import java.util.UUID;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.type.TypeFactory;
-import com.sun.jersey.api.client.Client;
-import com.sun.jersey.api.client.ClientResponse;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.core.Response;
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 
 /**
@@ -47,12 +46,12 @@ public class AssociationTest extends ConsentServiceTest {
     public void testCreateAssociation() {
         final String consentId = setupConsent();
 
-        Client client = new Client();
+        Client client = ClientBuilder.newClient();
 
         List<ConsentAssociation> assoc_list = new ArrayList<>();
         assoc_list.add(buildConsentAssociation("sample", "SM-1234", "SM-5678"));
 
-        ClientResponse response = checkStatus(OK, post(client, associationPath(consentId), assoc_list));
+        Response response = checkStatus(OK, post(client, associationPath(consentId), assoc_list));
         checkAssociations(assoc_list, response);
         String location = checkHeader(response, "Location");
         System.out.println(String.format("*** testCreateAssociation - returned location '%s'", location));
@@ -62,13 +61,13 @@ public class AssociationTest extends ConsentServiceTest {
     public void testCreateComplexAssociation() {
         final String consentId = setupConsent();
 
-        Client client = new Client();
+        Client client = ClientBuilder.newClient();
 
         ArrayList<ConsentAssociation> assoc_list = new ArrayList<>();
         assoc_list.add(buildConsentAssociation("sample", "SM-1234", "SM-5678"));
         assoc_list.add(buildConsentAssociation("sampleSet", "SC-9571"));
 
-        ClientResponse response = checkStatus(OK, post(client, associationPath(consentId), assoc_list));
+        Response response = checkStatus(OK, post(client, associationPath(consentId), assoc_list));
         checkAssociations(assoc_list, response);
         String location = checkHeader(response, "Location");
         System.out.println(String.format("*** testCreateComplexAssociation - returned location '%s'", location));
@@ -78,7 +77,7 @@ public class AssociationTest extends ConsentServiceTest {
     public void testUpdateAssociation() {
         final String consentId = setupConsent();
 
-        Client client = new Client();
+        Client client = ClientBuilder.newClient();
 
         ArrayList<ConsentAssociation> assoc_list1 = new ArrayList<>();
         assoc_list1.add(buildConsentAssociation("sample", "SM-1234"));
@@ -89,7 +88,7 @@ public class AssociationTest extends ConsentServiceTest {
         ArrayList<ConsentAssociation> assoc_list3 = new ArrayList<>();
         assoc_list3.add(buildConsentAssociation("sample", "SM-1234", "SM-5678"));
 
-        ClientResponse response = checkStatus(OK, put(client, associationPath(consentId), assoc_list1));
+        Response response = checkStatus(OK, put(client, associationPath(consentId), assoc_list1));
         checkAssociations(assoc_list1, response);
         String location = checkHeader(response, "Location");
         System.out.println(String.format("*** testUpdateAssociation - returned location '%s'", location));
@@ -117,30 +116,30 @@ public class AssociationTest extends ConsentServiceTest {
     public void testGetAssociation() {
         final String consentId = setupConsent();
 
-        Client client = new Client();
+        Client client = ClientBuilder.newClient();
 
         List<ConsentAssociation> assoc_list = new ArrayList<>();
         assoc_list.add(buildConsentAssociation("sample", "SM-1234", "SM-5678"));
 
-        ClientResponse response = checkStatus(OK, post(client, associationPath(consentId), assoc_list));
+        Response response = checkStatus(OK, post(client, associationPath(consentId), assoc_list));
         checkAssociations(assoc_list, response);
         String location = checkHeader(response, "Location");
         System.out.println(String.format("*** testGetAssociation - returned location '%s'", location));
 
         // test no query parameters
-        response = checkStatus(OK, get(client, associationQueryPath(consentId, null, null)));
+        response = checkStatus(OK, getJson(client, associationQueryPath(consentId, null, null)));
         checkAssociations(assoc_list, response);
         location = checkHeader(response, "Location");
         System.out.println(String.format("*** testGetAssociation - returned location '%s'", location));
 
         // test associationType="sample"
-        response = checkStatus(OK, get(client, associationQueryPath(consentId, "sample", null)));
+        response = checkStatus(OK, getJson(client, associationQueryPath(consentId, "sample", null)));
         checkAssociations(assoc_list, response);
         location = checkHeader(response, "Location");
         System.out.println(String.format("*** testGetAssociation - returned location '%s'", location));
 
         // test associationType="sample"&id="SM-1234"
-        response = checkStatus(OK, get(client, associationQueryPath(consentId, "sample", "SM-1234")));
+        response = checkStatus(OK, getJson(client, associationQueryPath(consentId, "sample", "SM-1234")));
         List<ConsentAssociation> singleSample = new ArrayList<>();
         singleSample.add(buildConsentAssociation("sample", "SM-1234"));
         checkAssociations(singleSample, response);
@@ -148,20 +147,20 @@ public class AssociationTest extends ConsentServiceTest {
         System.out.println(String.format("*** testGetAssociation - returned location '%s'", location));
 
         // test id="SM-1234" (error case)
-        checkStatus(BAD_REQUEST, get(client, associationQueryPath(consentId, null, "SM-1234")));
+        checkStatus(BAD_REQUEST, getJson(client, associationQueryPath(consentId, null, "SM-1234")));
     }
 
     @Test
     public void testDeleteAssociationByTypeAndObject() {
         final String consentId = setupConsent();
 
-        Client client = new Client();
+        Client client = ClientBuilder.newClient();
 
         ArrayList<ConsentAssociation> assoc_list1 = new ArrayList<>();
         assoc_list1.add(buildConsentAssociation("sample", "SM-1234", "SM-5678"));
         assoc_list1.add(buildConsentAssociation("sampleSet", "SC-9571"));
 
-        ClientResponse response = checkStatus(OK, post(client, associationPath(consentId), assoc_list1));
+        Response response = checkStatus(OK, post(client, associationPath(consentId), assoc_list1));
         checkAssociations(assoc_list1, response);
 
         response = checkStatus(OK, delete(client, associationQueryPath(consentId, "sample", "SM-1234")));
@@ -178,13 +177,13 @@ public class AssociationTest extends ConsentServiceTest {
     public void testDeleteAssociationByType() {
         final String consentId = setupConsent();
 
-        Client client = new Client();
+        Client client = ClientBuilder.newClient();
 
         ArrayList<ConsentAssociation> assoc_list1 = new ArrayList<>();
         assoc_list1.add(buildConsentAssociation("sample", "SM-1234", "SM-5678"));
         assoc_list1.add(buildConsentAssociation("sampleSet", "SC-9571"));
 
-        ClientResponse response = checkStatus(OK, post(client, associationPath(consentId), assoc_list1));
+        Response response = checkStatus(OK, post(client, associationPath(consentId), assoc_list1));
         checkAssociations(assoc_list1, response);
 
         response = checkStatus(OK, delete(client, associationQueryPath(consentId, "sample", null)));
@@ -200,13 +199,13 @@ public class AssociationTest extends ConsentServiceTest {
     public void testDeleteAssociationAll() {
         final String consentId = setupConsent();
 
-        Client client = new Client();
+        Client client = ClientBuilder.newClient();
 
         ArrayList<ConsentAssociation> assoc_list1 = new ArrayList<>();
         assoc_list1.add(buildConsentAssociation("sample", "SM-1234", "SM-5678"));
         assoc_list1.add(buildConsentAssociation("sampleSet", "SC-9571"));
 
-        ClientResponse response = checkStatus(OK, post(client, associationPath(consentId), assoc_list1));
+        Response response = checkStatus(OK, post(client, associationPath(consentId), assoc_list1));
         checkAssociations(assoc_list1, response);
 
         response = checkStatus(OK, delete(client, associationQueryPath(consentId, null, null)));
@@ -221,13 +220,13 @@ public class AssociationTest extends ConsentServiceTest {
     public void testDeleteAssociationError() {
         final String consentId = setupConsent();
 
-        Client client = new Client();
+        Client client = ClientBuilder.newClient();
 
         ArrayList<ConsentAssociation> assoc_list1 = new ArrayList<>();
         assoc_list1.add(buildConsentAssociation("sample", "SM-1234", "SM-5678"));
         assoc_list1.add(buildConsentAssociation("sampleSet", "SC-9571"));
 
-        ClientResponse response = checkStatus(OK, post(client, associationPath(consentId), assoc_list1));
+        Response response = checkStatus(OK, post(client, associationPath(consentId), assoc_list1));
         checkAssociations(assoc_list1, response);
 
         checkStatus(BAD_REQUEST, delete(client, associationQueryPath(consentId, null, "SM-1234")));
@@ -244,11 +243,11 @@ public class AssociationTest extends ConsentServiceTest {
         final String s4 = genSampleId();
         System.out.println(String.format("*** testQueryByAssociation, generated ids: '%s', '%s', '%s', '%s'", s1, s2, s3, s4));
 
-        Client client = new Client();
+        Client client = ClientBuilder.newClient();
 
         List<ConsentAssociation> assoc_list = new ArrayList<>();
         assoc_list.add(buildConsentAssociation("sample", s1, s2, s3));
-        ClientResponse response = checkStatus(OK, post(client, associationPath(consentId1), assoc_list));
+        Response response = checkStatus(OK, post(client, associationPath(consentId1), assoc_list));
         checkAssociations(assoc_list, response);
         System.out.println(String.format("*** testQueryConsentByAssociation ***:  created consent 1: '%s'", consentId1));
 
@@ -259,7 +258,7 @@ public class AssociationTest extends ConsentServiceTest {
         System.out.println(String.format("*** testQueryConsentByAssociation ***:  created consent 2: '%s'", consentId2));
 
         String qpath = queryAssociationPath("sample", s2);
-        response = checkStatus(OK, get(client, qpath));
+        response = checkStatus(OK, getJson(client, qpath));
 
         // check that we got back both consents
         ArrayList<String> consent_urls = getConsentUrls(response);
@@ -268,19 +267,19 @@ public class AssociationTest extends ConsentServiceTest {
         System.out.println(String.format("*** testQueryByAssociation(1) - returned location '%s'", location));
 
         // check that we got back just consent1
-        response = checkStatus(OK, get(client, queryAssociationPath("sample", s1)));
+        response = checkStatus(OK, getJson(client, queryAssociationPath("sample", s1)));
         consent_urls = getConsentUrls(response);
         assertThat(consent_urls.size()).isEqualTo(1);
         location = checkHeader(response, "Location");
         System.out.println(String.format("*** testQueryByAssociation(2) - returned location '%s'", location));
 
         // check that we got back no consents
-        response = checkStatus(OK, get(client, queryAssociationPath("sample", "TST-$$$$")));
+        response = checkStatus(OK, getJson(client, queryAssociationPath("sample", "TST-$$$$")));
         consent_urls = getConsentUrls(response);
         assertThat(consent_urls.size()).isEqualTo(0);
 
         // check that we got back no consents
-        response = checkStatus(OK, get(client, queryAssociationPath("sampleSet", s2)));
+        response = checkStatus(OK, getJson(client, queryAssociationPath("sampleSet", s2)));
         consent_urls = getConsentUrls(response);
         assertThat(consent_urls.size()).isEqualTo(0);
     }
@@ -314,8 +313,8 @@ public class AssociationTest extends ConsentServiceTest {
         return query_path;
     }
 
-    private void checkAssociations(List<ConsentAssociation> assoc_list, ClientResponse response) {
-        String result_json = response.getEntity(String.class);
+    private void checkAssociations(List<ConsentAssociation> assoc_list, Response response) {
+        String result_json = response.readEntity(String.class);
         try {
             final ObjectMapper MAPPER = Jackson.newObjectMapper();
             assertThat(result_json).isEqualTo(MAPPER.writeValueAsString(assoc_list));
@@ -324,9 +323,9 @@ public class AssociationTest extends ConsentServiceTest {
         }
     }
 
-    private ArrayList<String> getConsentUrls(ClientResponse response) {
+    private ArrayList<String> getConsentUrls(Response response) {
         ArrayList<String> urls = null;
-        String result_json = response.getEntity(String.class);
+        String result_json = response.readEntity(String.class);
         try {
             final ObjectMapper MAPPER = Jackson.newObjectMapper();
             TypeFactory tf = TypeFactory.defaultInstance();
@@ -352,9 +351,9 @@ public class AssociationTest extends ConsentServiceTest {
     }
 
     private String setupConsent() {
-        Client client = new Client();
+        Client client = ClientBuilder.newClient();
         Consent rec = new Consent(false, new Everything(), UUID.randomUUID().toString());
-        ClientResponse response = checkStatus( CREATED, put(client, consentPath(), rec) );
+        Response response = checkStatus( CREATED, put(client, consentPath(), rec) );
         String createdLocation = checkHeader(response, "Location");
         String consent_id = createdLocation.substring(createdLocation.lastIndexOf("/") + 1);
         System.out.println(String.format("setupConsent created consent with id '%s' at location '%s'", createdLocation, consent_id));

--- a/consent-ws/src/test/java/org/genomebridge/consent/http/ConsentAcceptanceTest.java
+++ b/consent-ws/src/test/java/org/genomebridge/consent/http/ConsentAcceptanceTest.java
@@ -1,15 +1,17 @@
 package org.genomebridge.consent.http;
 
-import static org.fest.assertions.api.Assertions.assertThat;
 import io.dropwizard.testing.junit.DropwizardAppRule;
-import org.genomebridge.consent.http.models.grammar.*;
-import java.util.UUID;
 import org.genomebridge.consent.http.models.Consent;
+import org.genomebridge.consent.http.models.grammar.*;
 import org.junit.ClassRule;
 import org.junit.Test;
 
-import com.sun.jersey.api.client.Client;
-import com.sun.jersey.api.client.ClientResponse;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.core.Response;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ConsentAcceptanceTest extends ConsentServiceTest {
 
@@ -27,16 +29,16 @@ public class ConsentAcceptanceTest extends ConsentServiceTest {
 
     @Test
     public void testCreateConsent() {
-        Client client = new Client();
+        Client client = ClientBuilder.newClient();
         Consent rec = new Consent(true,  new Everything(), null, null, UUID.randomUUID().toString());
         assertValidConsentResource(client, rec);
     }
 
     @Test
     public void testUpdateConsent() {
-        Client client = new Client();
+        Client client = ClientBuilder.newClient();
         Consent rec = new Consent(true,  new Everything(), null, null, UUID.randomUUID().toString());
-        ClientResponse response = checkStatus(CREATED, put(client, consentPath(), rec));
+        Response response = checkStatus(CREATED, put(client, consentPath(), rec));
         String createdLocation = checkHeader(response, "Location");
         Consent created = retrieveConsent(client, createdLocation);
         assertThat(created.requiresManualReview).isEqualTo(rec.requiresManualReview);
@@ -51,7 +53,7 @@ public class ConsentAcceptanceTest extends ConsentServiceTest {
 
     @Test
     public void testOnlyOrNamedConsent() {
-        Client client = new Client();
+        Client client = ClientBuilder.newClient();
         Consent rec = new Consent(false, new Only("http://broadinstitute.org/ontology/consent/research_on", new Or(new Named("DOID:1"), new Named("DOID:2"))),
                                   null, null, UUID.randomUUID().toString());
         assertValidConsentResource(client, rec);
@@ -59,28 +61,28 @@ public class ConsentAcceptanceTest extends ConsentServiceTest {
 
     @Test
     public void testAndConsent() {
-        Client client = new Client();
+        Client client = ClientBuilder.newClient();
         Consent rec = new Consent(false, new And(new Named("DOID:1"), new Named("DOID:2")), null, null, UUID.randomUUID().toString());
         assertValidConsentResource(client, rec);
     }
 
     @Test
     public void testNotConsent() {
-        Client client = new Client();
+        Client client = ClientBuilder.newClient();
         Consent rec = new Consent(false, new Not(new Named("DOID:1")), null, null, UUID.randomUUID().toString());
         assertValidConsentResource(client, rec);
     }
 
     @Test
     public void testNothingConsent() {
-        Client client = new Client();
+        Client client = ClientBuilder.newClient();
         Consent rec = new Consent(false,  new Nothing(), null, null, UUID.randomUUID().toString());
         assertValidConsentResource(client, rec);
     }
 
     @Test
     public void testSomeConsent() {
-        Client client = new Client();
+        Client client = ClientBuilder.newClient();
         Consent rec = new Consent(false,  new Some(
                 "http://broadinstitute.org/ontology/consent/research_on",
                 new Named("DOID:1")), null, null, UUID.randomUUID().toString());
@@ -89,7 +91,7 @@ public class ConsentAcceptanceTest extends ConsentServiceTest {
 
 
     private void assertValidConsentResource(Client client, Consent rec) {
-        ClientResponse response = checkStatus(CREATED, put(client, consentPath(), rec));
+        Response response = checkStatus(CREATED, put(client, consentPath(), rec));
         String createdLocation = checkHeader(response, "Location");
         Consent created = retrieveConsent(client, createdLocation);
 

--- a/consent-ws/src/test/java/org/genomebridge/consent/http/ConsentAssociationTest.java
+++ b/consent-ws/src/test/java/org/genomebridge/consent/http/ConsentAssociationTest.java
@@ -1,15 +1,15 @@
 package org.genomebridge.consent.http;
 
-import java.util.*;
-
-import static io.dropwizard.testing.FixtureHelpers.*;
-import static org.fest.assertions.api.Assertions.assertThat;
-
-import io.dropwizard.jackson.Jackson;
-import org.junit.Test;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
+import io.dropwizard.jackson.Jackson;
 import org.genomebridge.consent.http.models.ConsentAssociation;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+
+import static io.dropwizard.testing.FixtureHelpers.fixture;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Unit Tests for ConsentAssociation object.
@@ -34,7 +34,8 @@ public class ConsentAssociationTest {
     @Test
     public void deserializesFromJSON() throws Exception {
         final ConsentAssociation consent_association = buildConsentAssociation("sample", "SM-1234", "SM-5678");
-        assertThat(MAPPER.readValue(fixture("fixtures/consentassociation.json"), ConsentAssociation.class)).isEqualsToByComparingFields(consent_association);
+        assertThat(MAPPER.readValue(fixture("fixtures/consentassociation.json"), ConsentAssociation.class)).
+                isEqualToComparingFieldByField(consent_association);
     }
 
     @Test

--- a/consent-ws/src/test/java/org/genomebridge/consent/http/ConsentElectionTest.java
+++ b/consent-ws/src/test/java/org/genomebridge/consent/http/ConsentElectionTest.java
@@ -1,29 +1,28 @@
 package org.genomebridge.consent.http;
 
-import static org.fest.assertions.api.Assertions.assertThat;
-
-import java.util.List;
-
 import io.dropwizard.testing.junit.DropwizardAppRule;
-
-import org.genomebridge.consent.http.enumeration.ElectionType;
 import org.genomebridge.consent.http.enumeration.ElectionStatus;
+import org.genomebridge.consent.http.enumeration.ElectionType;
 import org.genomebridge.consent.http.models.Election;
 import org.genomebridge.consent.http.models.Vote;
 import org.junit.ClassRule;
 import org.junit.Test;
 
-import com.sun.jersey.api.client.Client;
-import com.sun.jersey.api.client.ClientResponse;
-import com.sun.jersey.api.client.GenericType;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.core.GenericType;
+import javax.ws.rs.core.Response;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ConsentElectionTest extends ElectionVoteServiceTest {
 
-    public static final int CREATED = ClientResponse.Status.CREATED
+    public static final int CREATED = Response.Status.CREATED
             .getStatusCode();
-    public static final int OK = ClientResponse.Status.OK.getStatusCode();
-    public static final int BADREQUEST = ClientResponse.Status.BAD_REQUEST.getStatusCode();
-    public static final int NOT_FOUND = ClientResponse.Status.NOT_FOUND.getStatusCode();
+    public static final int OK = Response.Status.OK.getStatusCode();
+    public static final int BADREQUEST = Response.Status.BAD_REQUEST.getStatusCode();
+    public static final int NOT_FOUND = Response.Status.NOT_FOUND.getStatusCode();
     private static final String CONSENT_ID = "testId";
     private static final String CONSENT_ID_2 = "testId2";
     private static final String INVALID_CONSENT_ID = "invalidId";
@@ -41,10 +40,10 @@ public class ConsentElectionTest extends ElectionVoteServiceTest {
 
     @Test
     public void testCreateConsentElection() {
-        Client client = new Client();
+        Client client = ClientBuilder.newClient();
         Election election = new Election();
         election.setStatus(ElectionStatus.OPEN.getValue());
-        ClientResponse response = checkStatus(CREATED,
+        Response response = checkStatus(CREATED,
                 post(client, electionConsentPath(CONSENT_ID), election));
         String createdLocation = checkHeader(response, "Location");
         Election created = retrieveElection(client, createdLocation);
@@ -63,7 +62,7 @@ public class ConsentElectionTest extends ElectionVoteServiceTest {
     }
 
     public void testUpdateConsentElection(Election created) {
-        Client client = new Client();
+        Client client = ClientBuilder.newClient();
         created.setFinalVote(true);
         created.setFinalRationale(FINAL_RATIONALE);
         checkStatus(OK, put(client, electionConsentPathById(CONSENT_ID, created.getElectionId()), created));
@@ -79,8 +78,8 @@ public class ConsentElectionTest extends ElectionVoteServiceTest {
     }
 
     public void deleteElection(Integer electionId) {
-        Client client = new Client();
-        List<Vote> votes = get(client, voteConsentPath(CONSENT_ID)).getEntity(new GenericType<List<Vote>>() {
+        Client client = ClientBuilder.newClient();
+        List<Vote> votes = getJson(client, voteConsentPath(CONSENT_ID)).readEntity(new GenericType<List<Vote>>() {
         });
         for (Vote vote : votes) {
             checkStatus(OK,
@@ -93,14 +92,14 @@ public class ConsentElectionTest extends ElectionVoteServiceTest {
 
     @Test
     public void retrieveElectionWithInvalidConsentId() {
-        Client client = new Client();
+        Client client = ClientBuilder.newClient();
         checkStatus(NOT_FOUND,
-                get(client, electionConsentPath(INVALID_CONSENT_ID)));
+                getJson(client, electionConsentPath(INVALID_CONSENT_ID)));
     }
 
     @Test
     public void testCreateConsentElectionWithInvalidConsent() {
-        Client client = new Client();
+        Client client = ClientBuilder.newClient();
         Election election = new Election();
         election.setStatus(ElectionStatus.OPEN.getValue());
         // should return 400 bad request because the consent id does not exist
@@ -110,7 +109,7 @@ public class ConsentElectionTest extends ElectionVoteServiceTest {
 
     @Test
     public void testUpdateConsentElectionWithInvalidConsent() {
-        Client client = new Client();
+        Client client = ClientBuilder.newClient();
         Election election = new Election();
         // should return 400 bad request because the consent id does not exist
         checkStatus(NOT_FOUND,
@@ -119,7 +118,7 @@ public class ConsentElectionTest extends ElectionVoteServiceTest {
 
     @Test
     public void testCreateConsentElectionWithInvalidStatus() {
-        Client client = new Client();
+        Client client = ClientBuilder.newClient();
         Election election = new Election();
         election.setStatus(INVALID_STATUS);
         // should return 400 bad request because status is invalid

--- a/consent-ws/src/test/java/org/genomebridge/consent/http/ConsentManageTest.java
+++ b/consent-ws/src/test/java/org/genomebridge/consent/http/ConsentManageTest.java
@@ -1,7 +1,5 @@
 package org.genomebridge.consent.http;
 
-import com.sun.jersey.api.client.Client;
-import com.sun.jersey.api.client.GenericType;
 import io.dropwizard.testing.junit.DropwizardAppRule;
 import org.genomebridge.consent.http.enumeration.ElectionStatus;
 import org.genomebridge.consent.http.models.ConsentManage;
@@ -11,6 +9,9 @@ import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Test;
 
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.core.GenericType;
 import java.util.List;
 
 public class ConsentManageTest extends ElectionVoteServiceTest {
@@ -30,9 +31,8 @@ public class ConsentManageTest extends ElectionVoteServiceTest {
     @Test
     public void testConsentManage() {
         Integer electionId = createElection(CONSENT_ID);
-        Client client = new Client();
-        List<ConsentManage> consentManage = get(client, consentManagePath()).getEntity(new GenericType<List<ConsentManage>>() {
-        });
+        Client client = ClientBuilder.newClient();
+        List<ConsentManage> consentManage = getJson(client, consentManagePath()).readEntity(new GenericType<List<ConsentManage>>() { });
         Assert.assertTrue(consentManage.size() > 0);
         Assert.assertTrue(consentManage.get(consentManage.size() - 1).getConsentId().equals(CONSENT_ID));
         Assert.assertTrue(consentManage.get(consentManage.size() - 1).getElectionStatus().equals(ElectionStatus.OPEN.getValue()));
@@ -40,25 +40,24 @@ public class ConsentManageTest extends ElectionVoteServiceTest {
         Assert.assertNotNull(consentManage.get(0).getConsentId());
         Assert.assertTrue(consentManage.get(0).getElectionStatus().equals("un-reviewed"));
         Integer electionId_2 = createElection(CONSENT_ID_2);
-        List<ConsentManage> consentManageUpdated = get(client, consentManagePath()).getEntity(new GenericType<List<ConsentManage>>() {
+        List<ConsentManage> consentManageUpdated = getJson(client, consentManagePath()).readEntity(new GenericType<List<ConsentManage>>() {
         });
         Assert.assertTrue(consentManageUpdated.size() > 1);
         Assert.assertTrue(consentManageUpdated.get(consentManage.size() - 2).getElectionStatus()
                 .equals(ElectionStatus.OPEN.getValue()));
         Assert.assertTrue(consentManageUpdated.get(consentManage.size() - 2).getElectionStatus()
                 .equals(ElectionStatus.OPEN.getValue()));
-        List<Vote> votes = get(client, voteConsentPath(CONSENT_ID)).getEntity(new GenericType<List<Vote>>() {
-        });
+        List<Vote> votes = getJson(client, voteConsentPath(CONSENT_ID)).readEntity(new GenericType<List<Vote>>() { });
         deleteVotes(votes, CONSENT_ID);
         delete(client, electionConsentPathById(CONSENT_ID, electionId));
-        List<Vote> votesElection2 = get(client, voteConsentPath(CONSENT_ID_2)).getEntity(new GenericType<List<Vote>>() {
+        List<Vote> votesElection2 = getJson(client, voteConsentPath(CONSENT_ID_2)).readEntity(new GenericType<List<Vote>>() {
         });
         deleteVotes(votesElection2, CONSENT_ID_2);
         delete(client, electionConsentPathById(CONSENT_ID_2, electionId_2));
     }
 
     public void deleteVotes(List<Vote> votes, String consentId) {
-        Client client = new Client();
+        Client client = ClientBuilder.newClient();
         for (Vote vote : votes) {
             checkStatus(
                     OK,
@@ -69,12 +68,11 @@ public class ConsentManageTest extends ElectionVoteServiceTest {
     }
 
     private Integer createElection(String consentId) {
-        Client client = new Client();
+        Client client = ClientBuilder.newClient();
         Election election = new Election();
         election.setStatus(ElectionStatus.OPEN.getValue());
         post(client, electionConsentPath(consentId), election);
-        election = get(client, electionConsentPath(consentId)).getEntity(
-                Election.class);
+        election = getJson(client, electionConsentPath(consentId)).readEntity(Election.class);
         return election.getElectionId();
     }
 

--- a/consent-ws/src/test/java/org/genomebridge/consent/http/ConsentServiceTest.java
+++ b/consent-ws/src/test/java/org/genomebridge/consent/http/ConsentServiceTest.java
@@ -1,8 +1,8 @@
 package org.genomebridge.consent.http;
 
-import com.sun.jersey.api.client.Client;
 import org.genomebridge.consent.http.models.Consent;
 
+import javax.ws.rs.client.Client;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 
@@ -22,7 +22,7 @@ public abstract class ConsentServiceTest extends AbstractTest {
     }
 
     public Consent retrieveConsent(Client client, String url) {
-        return get(client, url).getEntity(Consent.class);
+        return getJson(client, url).readEntity(Consent.class);
     }
 
 }

--- a/consent-ws/src/test/java/org/genomebridge/consent/http/ConsentSummaryTest.java
+++ b/consent-ws/src/test/java/org/genomebridge/consent/http/ConsentSummaryTest.java
@@ -1,22 +1,19 @@
 package org.genomebridge.consent.http;
 
 import io.dropwizard.testing.junit.DropwizardAppRule;
-
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.util.Arrays;
-import java.util.EnumSet;
-import java.util.stream.Collectors;
-
-import org.apache.commons.lang.StringUtils;
 import org.genomebridge.consent.http.enumeration.HeaderSummary;
 import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Test;
 
-import com.sun.jersey.api.client.Client;
-import com.sun.jersey.api.client.ClientResponse;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.core.Response;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.EnumSet;
+import java.util.stream.Collectors;
 
 public class ConsentSummaryTest extends ElectionVoteServiceTest {
 
@@ -33,20 +30,12 @@ public class ConsentSummaryTest extends ElectionVoteServiceTest {
 
     @Test
     public void testConsentSummaryFile() throws IOException {
-        Client client = new Client();
-        ClientResponse response = getFile(client, consentSummaryPath());
-        BufferedReader br = new BufferedReader(new InputStreamReader(
-                response.getEntityInputStream()));
-        String output;
+        Client client = ClientBuilder.newClient();
+        Response response = getTextPlain(client, consentSummaryPath());
+        String output = new BufferedReader(new StringReader(response.readEntity(String.class))).readLine();
         String summary = EnumSet.allOf(HeaderSummary.class).stream().
                 map(HeaderSummary::getValue).collect(Collectors.joining(SEPARATOR));
-        boolean isFirst = true;
-        while ((output = br.readLine()) != null) {
-            if (isFirst) {
-                Assert.assertTrue(summary.equals(output));
-                isFirst = false;
-            }
-        }
+        Assert.assertTrue(summary.equals(output));
     }
 
 }

--- a/consent-ws/src/test/java/org/genomebridge/consent/http/ConsentsServiceTest.java
+++ b/consent-ws/src/test/java/org/genomebridge/consent/http/ConsentsServiceTest.java
@@ -1,21 +1,22 @@
 package org.genomebridge.consent.http;
 
-import com.sun.jersey.api.client.Client;
-import com.sun.jersey.api.client.ClientResponse;
-import com.sun.jersey.api.client.GenericType;
-import com.sun.jersey.api.client.WebResource;
 import io.dropwizard.testing.junit.DropwizardAppRule;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.genomebridge.consent.http.models.Consent;
 import org.genomebridge.consent.http.models.ConsentAssociation;
 import org.genomebridge.consent.http.models.grammar.Everything;
 import org.junit.ClassRule;
 import org.junit.Test;
 
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 import java.util.*;
 
-import static org.fest.assertions.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ConsentsServiceTest extends AbstractTest {
 
@@ -37,42 +38,42 @@ public class ConsentsServiceTest extends AbstractTest {
         Collection<String> ids = populateConsents();
         assertThat(ids.size() == N);
 
-        Client client = new Client();
-        WebResource webResource = client.
-                resource(path2Url("/consents")).
+        Client client = ClientBuilder.newClient();
+        WebTarget webTarget = client.
+                target(path2Url("/consents")).
                 queryParam("ids", StringUtils.join(ids, ","));
-        ClientResponse response = webResource.
-                accept(MediaType.APPLICATION_JSON_TYPE).
+        Response response = webTarget.
+                request(MediaType.APPLICATION_JSON_TYPE).
                 header("REMOTE_USER", "testuser").
-                get(ClientResponse.class);
+                get(Response.class);
         assertThat(response.getStatus() == OK);
 
-        List<Consent> consents = webResource.get(new GenericType<List<Consent>>() {});
+        List<Consent> consents = response.readEntity(new GenericType<List<Consent>>() {});
         assertThat(consents.size() == N);
     }
 
     @Test
     public void testFindNoConsents() {
-        Client client = new Client();
-        WebResource webResource = client.resource(path2Url("/consents"));
-        ClientResponse response = webResource.
-                accept(MediaType.APPLICATION_JSON_TYPE).
+        Client client = ClientBuilder.newClient();
+        WebTarget webTarget = client.target(path2Url("/consents"));
+        Response response = webTarget.
+                request(MediaType.APPLICATION_JSON_TYPE).
                 header("REMOTE_USER", "testuser").
-                get(ClientResponse.class);
+                get(Response.class);
         assertThat(response.getStatus() == NOT_FOUND);
     }
 
     @Test
     public void testFindMissingConsents() {
         Collection<String> ids = Arrays.asList("missing-id1", "missing-id2", UUID.randomUUID().toString());
-        Client client = new Client();
-        WebResource webResource = client.
-                resource(path2Url("/consents")).
+        Client client = ClientBuilder.newClient();
+        WebTarget webTarget = client.
+                target(path2Url("/consents")).
                 queryParam("ids", StringUtils.join(ids, ","));
-        ClientResponse response = webResource.
-                accept(MediaType.APPLICATION_JSON_TYPE).
+        Response response = webTarget.
+                request(MediaType.APPLICATION_JSON_TYPE).
                 header("REMOTE_USER", "testuser").
-                get(ClientResponse.class);
+                get(Response.class);
         assertThat(response.getStatus() == NOT_FOUND);
     }
 
@@ -85,15 +86,15 @@ public class ConsentsServiceTest extends AbstractTest {
         Collection<String> ids = populateConsentAssociations();
         assertThat(ids.size() == N);
 
-        Client client = new Client();
-        WebResource webResource = client.resource(path2Url("/consents/sample"));
-        ClientResponse response = webResource.
-                accept(MediaType.APPLICATION_JSON_TYPE).
+        Client client = ClientBuilder.newClient();
+        WebTarget webTarget = client.target(path2Url("/consents/sample"));
+        Response response = webTarget.
+                request(MediaType.APPLICATION_JSON_TYPE).
                 header("REMOTE_USER", "testuser").
-                get(ClientResponse.class);
+                get(Response.class);
         assertThat(response.getStatus() == OK);
 
-        List<Consent> consents = webResource.get(new GenericType<List<Consent>>() {});
+        List<Consent> consents = response.readEntity(new GenericType<List<Consent>>() {});
         assertThat(consents.size() == N);
     }
 
@@ -102,12 +103,12 @@ public class ConsentsServiceTest extends AbstractTest {
         Collection<String> ids = populateConsentAssociations();
         assertThat(ids.size() == N);
 
-        Client client = new Client();
-        WebResource webResource = client.resource(path2Url("/consents/nothing"));
-        ClientResponse response = webResource.
-                accept(MediaType.APPLICATION_JSON_TYPE).
+        Client client = ClientBuilder.newClient();
+        WebTarget webTarget = client.target(path2Url("/consents/nothing"));
+        Response response = webTarget.
+                request(MediaType.APPLICATION_JSON_TYPE).
                 header("REMOTE_USER", "testuser").
-                get(ClientResponse.class);
+                get(Response.class);
         assertThat(response.getStatus() == NOT_FOUND);
     }
 
@@ -116,18 +117,18 @@ public class ConsentsServiceTest extends AbstractTest {
         Collection<String> ids = populateConsentAssociations();
         assertThat(ids.size() == N);
 
-        Client client = new Client();
-        WebResource webResource = client.resource(path2Url("/consents/"));
-        ClientResponse response = webResource.
-                accept(MediaType.APPLICATION_JSON_TYPE).
+        Client client = ClientBuilder.newClient();
+        WebTarget webTarget = client.target(path2Url("/consents/"));
+        Response response = webTarget.
+                request(MediaType.APPLICATION_JSON_TYPE).
                 header("REMOTE_USER", "testuser").
-                get(ClientResponse.class);
+                get(Response.class);
         assertThat(response.getStatus() == NOT_FOUND);
     }
 
     private Collection<String> populateConsentAssociations() {
         Collection<String> ids = populateConsents();
-        Client client = new Client();
+        Client client = ClientBuilder.newClient();
         for (String id : ids) {
             ConsentAssociation ca = new ConsentAssociation();
             ca.setAssociationType("sample");
@@ -139,7 +140,7 @@ public class ConsentsServiceTest extends AbstractTest {
 
     private Collection<String> populateConsents() {
         Collection<String> ids = new ArrayList<>();
-        Client client = new Client();
+        Client client = ClientBuilder.newClient();
         for (int i = 1; i <= N; i++) {
             ids.add(postConsent(client));
         }
@@ -152,7 +153,7 @@ public class ConsentsServiceTest extends AbstractTest {
         consent.requiresManualReview = true;
         consent.useRestriction = new Everything();
         consent.name = Math.random()+"Name";
-        ClientResponse response = checkStatus(CREATED, put(client, consentPath, consent));
+        Response response = checkStatus(CREATED, put(client, consentPath, consent));
         String createdLocation = checkHeader(response, "Location");
         return createdLocation.substring(createdLocation.lastIndexOf("/") + 1);
     }

--- a/consent-ws/src/test/java/org/genomebridge/consent/http/DACUserServiceTest.java
+++ b/consent-ws/src/test/java/org/genomebridge/consent/http/DACUserServiceTest.java
@@ -1,7 +1,8 @@
 package org.genomebridge.consent.http;
 
-import com.sun.jersey.api.client.Client;
 import org.genomebridge.consent.http.models.DACUser;
+
+import javax.ws.rs.client.Client;
 
 public abstract class DACUserServiceTest extends AbstractTest {
 
@@ -10,7 +11,7 @@ public abstract class DACUserServiceTest extends AbstractTest {
     }
 
     public DACUser retrieveDacUser(Client client, String url) {
-        return get(client, url).getEntity(DACUser.class);
+        return getJson(client, url).readEntity(DACUser.class);
     }
 
     public String dacUserPathByEmail(String email) {

--- a/consent-ws/src/test/java/org/genomebridge/consent/http/DACUserTest.java
+++ b/consent-ws/src/test/java/org/genomebridge/consent/http/DACUserTest.java
@@ -1,24 +1,24 @@
 package org.genomebridge.consent.http;
 
-import static org.fest.assertions.api.Assertions.assertThat;
-
 import io.dropwizard.testing.junit.DropwizardAppRule;
-
 import org.genomebridge.consent.http.models.DACUser;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 
-import com.sun.jersey.api.client.Client;
-import com.sun.jersey.api.client.ClientResponse;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.core.Response;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class DACUserTest extends DACUserServiceTest {
 
-    public static final int CREATED = ClientResponse.Status.CREATED
+    public static final int CREATED = Response.Status.CREATED
             .getStatusCode();
-    public static final int OK = ClientResponse.Status.OK.getStatusCode();
-    public static final int NOT_FOUND = ClientResponse.Status.NOT_FOUND.getStatusCode();
+    public static final int OK = Response.Status.OK.getStatusCode();
+    public static final int NOT_FOUND = Response.Status.NOT_FOUND.getStatusCode();
 
     private static final String INVALID_USER_EMAIL = "invalidemail@broad.com";
     private static final String DAC_USER_EMAIL = "dacmember@broad.com";
@@ -63,41 +63,39 @@ public class DACUserTest extends DACUserServiceTest {
 
     @After
     public void removeTestData() {
-        Client client = new Client();
+        Client client = ClientBuilder.newClient();
         delete(client, dacUserPathByEmail(CHAIR_USER_EMAIL));
         delete(client, dacUserPathByEmail(DAC_USER_EMAIL));
         delete(client, dacUserPathByEmail(CHAIR_2_USER_EMAIL));
     }
 
     public DACUser testCreate(DACUser dacuser) {
-        Client client = new Client();
-        ClientResponse response = checkStatus(CREATED,
-                post(client, dacUserPath(), dacuser));
+        Client client = ClientBuilder.newClient();
+        Response response = checkStatus(CREATED, post(client, dacUserPath(), dacuser));
         String createdLocation = checkHeader(response, "Location");
         return retrieveDacUser(client, createdLocation);
     }
 
     @Test
     public void deleteUser() {
-        Client client = new Client();
-        DACUser user = get(client, dacUserPathByEmail(DACMEMBERMAIL))
-                .getEntity(DACUser.class);
+        Client client = ClientBuilder.newClient();
+        DACUser user = getJson(client, dacUserPathByEmail(DACMEMBERMAIL)).readEntity(DACUser.class);
         checkStatus(OK, delete(client, dacUserPathByEmail(user.getEmail())));
-        checkStatus(NOT_FOUND, get(client, dacUserPathByEmail(user.getEmail())));
+        checkStatus(NOT_FOUND, getJson(client, dacUserPathByEmail(user.getEmail())));
     }
 
     @Test
     public void retrieveDACUserWithInvalidEmail() {
-        Client client = new Client();
-        checkStatus(NOT_FOUND, get(client, dacUserPathByEmail(INVALID_USER_EMAIL)));
+        Client client = ClientBuilder.newClient();
+        checkStatus(NOT_FOUND, getJson(client, dacUserPathByEmail(INVALID_USER_EMAIL)));
     }
 
     @Test
     public void testUpdateDACUser() {
-        Client client = new Client();
+        Client client = ClientBuilder.newClient();
         DACUser user = testCreate(createDacUser("Updated Chair Person", CHAIR_2_USER_EMAIL, CHAIRPERSON));
         checkStatus(OK, put(client, dacUserPath(), user));
-        user = get(client, dacUserPathByEmail(user.getEmail())).getEntity(DACUser.class);
+        user = getJson(client, dacUserPathByEmail(user.getEmail())).readEntity(DACUser.class);
         assertThat(user.getDisplayName()).isEqualTo("Updated Chair Person");
     }
 

--- a/consent-ws/src/test/java/org/genomebridge/consent/http/DataRequestElectionTest.java
+++ b/consent-ws/src/test/java/org/genomebridge/consent/http/DataRequestElectionTest.java
@@ -1,28 +1,27 @@
 package org.genomebridge.consent.http;
 
-import static org.fest.assertions.api.Assertions.assertThat;
-
-import java.util.List;
-
 import io.dropwizard.testing.junit.DropwizardAppRule;
-
-import org.genomebridge.consent.http.enumeration.ElectionType;
 import org.genomebridge.consent.http.enumeration.ElectionStatus;
+import org.genomebridge.consent.http.enumeration.ElectionType;
 import org.genomebridge.consent.http.models.Election;
 import org.genomebridge.consent.http.models.Vote;
 import org.junit.ClassRule;
 import org.junit.Test;
 
-import com.sun.jersey.api.client.Client;
-import com.sun.jersey.api.client.ClientResponse;
-import com.sun.jersey.api.client.GenericType;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.core.GenericType;
+import javax.ws.rs.core.Response;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class DataRequestElectionTest extends ElectionVoteServiceTest {
 
-    public static final int CREATED = ClientResponse.Status.CREATED.getStatusCode();
-    public static final int OK = ClientResponse.Status.OK.getStatusCode();
-    public static final int BADREQUEST = ClientResponse.Status.BAD_REQUEST.getStatusCode();
-    public static final int NOT_FOUND = ClientResponse.Status.NOT_FOUND.getStatusCode();
+    public static final int CREATED = Response.Status.CREATED.getStatusCode();
+    public static final int OK = Response.Status.OK.getStatusCode();
+    public static final int BADREQUEST = Response.Status.BAD_REQUEST.getStatusCode();
+    public static final int NOT_FOUND = Response.Status.NOT_FOUND.getStatusCode();
     private static final String DATA_REQUEST_ID = "1";
     private static final String DATA_REQUEST_ID_2 = "2";
     private static final String INVALID_DATA_REQUEST_ID = "invalidId";
@@ -40,10 +39,10 @@ public class DataRequestElectionTest extends ElectionVoteServiceTest {
 
     @Test
     public void testCreateDataRequestElection() {
-        Client client = new Client();
+        Client client = ClientBuilder.newClient();
         Election election = new Election();
         election.setStatus(ElectionStatus.OPEN.getValue());
-        ClientResponse response = checkStatus(CREATED,
+        Response response = checkStatus(CREATED,
                 post(client, electionDataRequestPath(DATA_REQUEST_ID), election));
         String createdLocation = checkHeader(response, "Location");
         Election created = retrieveElection(client, createdLocation);
@@ -61,7 +60,7 @@ public class DataRequestElectionTest extends ElectionVoteServiceTest {
     }
 
     public void testUpdateDataRequestElection(Election created) {
-        Client client = new Client();
+        Client client = ClientBuilder.newClient();
         created.setFinalVote(true);
         created.setFinalRationale(FINAL_RATIONALE);
         checkStatus(OK, put(client, electionDataRequestPathById(DATA_REQUEST_ID, created.getElectionId()), created));
@@ -76,8 +75,8 @@ public class DataRequestElectionTest extends ElectionVoteServiceTest {
     }
 
     public void deleteElection(Integer electionId) {
-        Client client = new Client();
-        List<Vote> votes = get(client, voteDataRequestPath(DATA_REQUEST_ID)).getEntity(new GenericType<List<Vote>>() {
+        Client client = ClientBuilder.newClient();
+        List<Vote> votes = getJson(client, voteDataRequestPath(DATA_REQUEST_ID)).readEntity(new GenericType<List<Vote>>() {
         });
         for (Vote vote : votes) {
             checkStatus(OK,
@@ -89,14 +88,14 @@ public class DataRequestElectionTest extends ElectionVoteServiceTest {
 
     @Test
     public void retrieveElectionWithInvalidConsentId() {
-        Client client = new Client();
+        Client client = ClientBuilder.newClient();
         checkStatus(NOT_FOUND,
-                get(client, electionDataRequestPath(INVALID_DATA_REQUEST_ID)));
+                getJson(client, electionDataRequestPath(INVALID_DATA_REQUEST_ID)));
     }
 
     @Test
     public void testDataRequestElectionWithInvalidDataRequest() {
-        Client client = new Client();
+        Client client = ClientBuilder.newClient();
         Election election = new Election();
         election.setStatus(ElectionStatus.OPEN.getValue());
         // should return 400 bad request because the data request id does not exist
@@ -106,7 +105,7 @@ public class DataRequestElectionTest extends ElectionVoteServiceTest {
 
     @Test
     public void testUpdateDataRequestElectionWithId() {
-        Client client = new Client();
+        Client client = ClientBuilder.newClient();
         Election election = new Election();
         // should return 400 bad request because the data request id does not exist
         checkStatus(NOT_FOUND,
@@ -115,7 +114,7 @@ public class DataRequestElectionTest extends ElectionVoteServiceTest {
 
     @Test
     public void testCreateDataRequestElectionWithInvalidStatus() {
-        Client client = new Client();
+        Client client = ClientBuilder.newClient();
         Election election = new Election();
         election.setStatus(INVALID_STATUS);
         // should return 400 bad request because status is invalid

--- a/consent-ws/src/test/java/org/genomebridge/consent/http/DataRequestServiceTest.java
+++ b/consent-ws/src/test/java/org/genomebridge/consent/http/DataRequestServiceTest.java
@@ -2,7 +2,7 @@ package org.genomebridge.consent.http;
 
 import org.genomebridge.consent.http.models.DataRequest;
 
-import com.sun.jersey.api.client.Client;
+import javax.ws.rs.client.Client;
 
 public abstract class DataRequestServiceTest extends AbstractTest {
 
@@ -11,7 +11,7 @@ public abstract class DataRequestServiceTest extends AbstractTest {
     }
 
     public DataRequest retrieveDataRequest(Client client, String url) {
-        return get(client, url).getEntity(DataRequest.class);
+        return getJson(client, url).readEntity(DataRequest.class);
     }
 
     public String dataRequestPathById(Integer id) {

--- a/consent-ws/src/test/java/org/genomebridge/consent/http/DataRequestTest.java
+++ b/consent-ws/src/test/java/org/genomebridge/consent/http/DataRequestTest.java
@@ -1,21 +1,21 @@
 package org.genomebridge.consent.http;
 
-import static org.fest.assertions.api.Assertions.assertThat;
-
 import io.dropwizard.testing.junit.DropwizardAppRule;
-
 import org.genomebridge.consent.http.models.DataRequest;
 import org.junit.ClassRule;
 import org.junit.Test;
 
-import com.sun.jersey.api.client.Client;
-import com.sun.jersey.api.client.ClientResponse;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.core.Response;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class DataRequestTest extends DataRequestServiceTest {
 
-    public static final int CREATED = ClientResponse.Status.CREATED.getStatusCode();
-    public static final int OK = ClientResponse.Status.OK.getStatusCode();
-    public static final int NOT_FOUND = ClientResponse.Status.NOT_FOUND.getStatusCode();
+    public static final int CREATED = Response.Status.CREATED.getStatusCode();
+    public static final int OK = Response.Status.OK.getStatusCode();
+    public static final int NOT_FOUND = Response.Status.NOT_FOUND.getStatusCode();
     private static final Integer ID = 1;
     private static final Integer ID_2 = 2;
     private static final String DESCRIPTION = "TestDescription";
@@ -34,13 +34,13 @@ public class DataRequestTest extends DataRequestServiceTest {
 
     @Test
     public void testCreateDataRequest() {
-        Client client = new Client();
+        Client client = ClientBuilder.newClient();
         DataRequest dataRequest = new DataRequest();
         dataRequest.setDataSetId(ID);
         dataRequest.setPurposeId(ID);
         dataRequest.setDescription(DESCRIPTION);
         dataRequest.setResearcher(RESEARCHER);
-        ClientResponse response = checkStatus(CREATED,
+        Response response = checkStatus(CREATED,
                 post(client, dataRequestPath(), dataRequest));
         String createdLocation = checkHeader(response, "Location");
         DataRequest created = retrieveDataRequest(client, createdLocation);
@@ -54,7 +54,7 @@ public class DataRequestTest extends DataRequestServiceTest {
     }
 
     public void testUpdateDataRequest(DataRequest created) {
-        Client client = new Client();
+        Client client = ClientBuilder.newClient();
         created.setDataSetId(ID_2);
         created.setDescription(DESCRIPTION + "DR");
         checkStatus(OK, put(client, dataRequestPathById(created.getRequestId()), created));
@@ -68,21 +68,21 @@ public class DataRequestTest extends DataRequestServiceTest {
     }
 
     public void deleteDataRequest(Integer id) {
-        Client client = new Client();
+        Client client = ClientBuilder.newClient();
         checkStatus(OK,
                 delete(client, dataRequestPathById(id)));
     }
 
     @Test
     public void retrieveDataRequestWithInvalidId() {
-        Client client = new Client();
+        Client client = ClientBuilder.newClient();
         checkStatus(NOT_FOUND,
-                get(client, dataRequestPathById(INVALID_DATA_REQUEST_ID)));
+                getJson(client, dataRequestPathById(INVALID_DATA_REQUEST_ID)));
     }
 
     @Test
     public void testDataRequestWithNullRequieredFields() {
-        Client client = new Client();
+        Client client = ClientBuilder.newClient();
         DataRequest dataRequest = new DataRequest();
         dataRequest.setPurposeId(ID);
         dataRequest.setDescription(DESCRIPTION);
@@ -94,7 +94,7 @@ public class DataRequestTest extends DataRequestServiceTest {
 
     @Test
     public void testUpdateDataRequestWithInvalidId() {
-        Client client = new Client();
+        Client client = ClientBuilder.newClient();
         DataRequest dataRequest = new DataRequest();
         // should return 400 bad request because the data request id does not exist
         checkStatus(NOT_FOUND,

--- a/consent-ws/src/test/java/org/genomebridge/consent/http/ElectionVoteServiceTest.java
+++ b/consent-ws/src/test/java/org/genomebridge/consent/http/ElectionVoteServiceTest.java
@@ -1,12 +1,11 @@
 package org.genomebridge.consent.http;
 
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
-
 import org.genomebridge.consent.http.models.Election;
 import org.genomebridge.consent.http.models.Vote;
 
-import com.sun.jersey.api.client.Client;
+import javax.ws.rs.client.Client;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 
 public abstract class ElectionVoteServiceTest extends AbstractTest {
 
@@ -20,7 +19,7 @@ public abstract class ElectionVoteServiceTest extends AbstractTest {
     }
 
     public Election retrieveElection(Client client, String url) {
-        return get(client, url).getEntity(Election.class);
+        return getJson(client, url).readEntity(Election.class);
     }
 
     public String electionDataRequestPath(String id) {
@@ -61,7 +60,7 @@ public abstract class ElectionVoteServiceTest extends AbstractTest {
     }
 
     public Vote retrieveVote(Client client, String url) {
-        return get(client, url).getEntity(Vote.class);
+        return getJson(client, url).readEntity(Vote.class);
     }
 
     public String voteDataRequestPath(String id) {
@@ -104,8 +103,7 @@ public abstract class ElectionVoteServiceTest extends AbstractTest {
     }
     
     public String consentManagePath() {
-        return path2Url(String.format("consent/manage"));
+        return path2Url("consent/manage");
     }
-
 
 }

--- a/consent-ws/src/test/java/org/genomebridge/consent/http/VoteConsentTest.java
+++ b/consent-ws/src/test/java/org/genomebridge/consent/http/VoteConsentTest.java
@@ -1,11 +1,6 @@
 package org.genomebridge.consent.http;
 
-import static org.fest.assertions.api.Assertions.assertThat;
-
 import io.dropwizard.testing.junit.DropwizardAppRule;
-
-import java.util.List;
-
 import org.genomebridge.consent.http.enumeration.ElectionStatus;
 import org.genomebridge.consent.http.models.Election;
 import org.genomebridge.consent.http.models.PendingCase;
@@ -13,14 +8,18 @@ import org.genomebridge.consent.http.models.Vote;
 import org.junit.ClassRule;
 import org.junit.Test;
 
-import com.sun.jersey.api.client.Client;
-import com.sun.jersey.api.client.ClientResponse;
-import com.sun.jersey.api.client.GenericType;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.core.GenericType;
+import javax.ws.rs.core.Response;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class VoteConsentTest extends ElectionVoteServiceTest {
 
-    public static final int CREATED = ClientResponse.Status.CREATED.getStatusCode();
-    public static final int OK = ClientResponse.Status.OK.getStatusCode();
+    public static final int CREATED = Response.Status.CREATED.getStatusCode();
+    public static final int OK = Response.Status.OK.getStatusCode();
     private static final String CONSENT_ID = "testId";
     private static final Integer DAC_USER_ID = 1;
     private static final String RATIONALE = "Test";
@@ -39,8 +38,8 @@ public class VoteConsentTest extends ElectionVoteServiceTest {
     public void testCreateConsentVote() {
         // should exist an election for specified consent
         Integer electionId = createElection();
-        Client client = new Client();
-        List<Vote> votes = get(client, voteConsentPath(CONSENT_ID)).getEntity(new GenericType<List<Vote>>() {
+        Client client = ClientBuilder.newClient();
+        List<Vote> votes = getJson(client, voteConsentPath(CONSENT_ID)).readEntity(new GenericType<List<Vote>>() {
         });
         Vote vote = new Vote();
         vote.setVote(false);
@@ -61,7 +60,7 @@ public class VoteConsentTest extends ElectionVoteServiceTest {
 
 
     public void deleteVotes(List<Vote> votes) {
-        Client client = new Client();
+        Client client = ClientBuilder.newClient();
         for (Vote vote : votes) {
             checkStatus(OK,
                     delete(client, voteConsentIdPath(CONSENT_ID, vote.getVoteId())));
@@ -70,7 +69,7 @@ public class VoteConsentTest extends ElectionVoteServiceTest {
 
 
     public void updateVote(Vote vote) {
-        Client client = new Client();
+        Client client = ClientBuilder.newClient();
         vote.setVote(true);
         vote.setRationale(null);
         checkStatus(OK,
@@ -82,18 +81,18 @@ public class VoteConsentTest extends ElectionVoteServiceTest {
     }
 
     private Integer createElection() {
-        Client client = new Client();
+        Client client = ClientBuilder.newClient();
         Election election = new Election();
         election.setStatus(ElectionStatus.OPEN.getValue());
         post(client, electionConsentPath(CONSENT_ID), election);
-        election = get(client, electionConsentPath(CONSENT_ID))
-                .getEntity(Election.class);
+        election = getJson(client, electionConsentPath(CONSENT_ID))
+                .readEntity(Election.class);
         return election.getElectionId();
     }
 
     public void testConsentPendingCase(Integer dacUserId) {
-        Client client = new Client();
-        List<PendingCase> pendingCases = get(client, consentPendingCasesPath(dacUserId)).getEntity(new GenericType<List<PendingCase>>() {
+        Client client = ClientBuilder.newClient();
+        List<PendingCase> pendingCases = getJson(client, consentPendingCasesPath(dacUserId)).readEntity(new GenericType<List<PendingCase>>() {
         });
         assertThat(pendingCases).isNotNull();
         assertThat(pendingCases.size()).isEqualTo(1);
@@ -104,8 +103,8 @@ public class VoteConsentTest extends ElectionVoteServiceTest {
 
     @Test
     public void testConsentPendingCaseWithInvalidUser() {
-        Client client = new Client();
-        List<PendingCase> pendingCases = get(client, consentPendingCasesPath(789)).getEntity(new GenericType<List<PendingCase>>() {
+        Client client = ClientBuilder.newClient();
+        List<PendingCase> pendingCases = getJson(client, consentPendingCasesPath(789)).readEntity(new GenericType<List<PendingCase>>() {
         });
         assertThat(pendingCases).isEmpty();
     }

--- a/pom.xml
+++ b/pom.xml
@@ -9,12 +9,12 @@
 
   <properties>
     <java.version>1.8</java.version>
-    <jersey.version>2.5.1</jersey.version>
-    <jackson.version>1.9.9</jackson.version>
+    <jackson.version>2.6.0</jackson.version>
     <lucene.version>4.9.0</lucene.version>
-    <hsqldb.version>2.3.2</hsqldb.version>
+    <hsqldb.version>2.3.3</hsqldb.version>
     <liquibase.version>3.1.1</liquibase.version>
-    <dropwizard.version>0.7.1</dropwizard.version>
+    <dropwizard.version>0.8.1</dropwizard.version>
+    <jersey.version>2.19</jersey.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <jetty.version>9.0.7.v20131107</jetty.version>
@@ -207,7 +207,7 @@
       <dependency>
         <groupId>com.hubspot.dropwizard</groupId>
         <artifactId>dropwizard-guice</artifactId>
-        <version>0.7.0.2</version>
+        <version>0.8.1.0</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
There are quite a few non-trivial changes required to convert this module to DW8.
- https://github.com/dropwizard/dropwizard/wiki/Upgrade-guide-0.7.x-to-0.8.x
- Significant changes to tests due to jersey changes.
- Use dropwizard-forms module to handle file uploads. 
- Optimized imports on all touched classes.
- Minor refactoring of some AbstractTest methods.
- Use `readEntity` instead of `getEntity` throughout.
