### PR TITLE
Add a secondary Mongo Client host.

### DIFF
--- a/consent-ws/pom.xml
+++ b/consent-ws/pom.xml
@@ -327,13 +327,13 @@
         <dependency>
             <groupId>org.mongodb</groupId>
             <artifactId>mongo-java-driver</artifactId>
-            <version>3.0.3</version>
+            <version>3.2.2</version>
         </dependency>
         
         <dependency>
             <groupId>com.github.fakemongo</groupId>
             <artifactId>fongo</artifactId>
-            <version>2.0.1</version>
+            <version>2.0.6</version>
             <type>jar</type>
         </dependency>
 

--- a/consent-ws/src/main/config/consent.conf.ctmpl
+++ b/consent-ws/src/main/config/consent.conf.ctmpl
@@ -32,6 +32,8 @@ googleStore:
   type: GCS
 mongo:
   uri: {{.Data.mongodb_uri}}
+  host1: {{.Data.mongodb_host1}}
+  host2: {{.Data.mongodb_host2}}
   dbName: {{.Data.mongodb_name}}
   username: {{.Data.mongodb_user}}
   password: {{.Data.mongodb_password}}

--- a/consent-ws/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
+++ b/consent-ws/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
@@ -3,7 +3,6 @@ package org.broadinstitute.consent.http;
 import com.github.fakemongo.Fongo;
 import org.broadinstitute.consent.http.configurations.ElasticSearchConfiguration;
 import com.mongodb.MongoClient;
-import com.mongodb.MongoClientURI;
 import de.spinscale.dropwizard.jobs.JobsBundle;
 import io.dropwizard.Application;
 import io.dropwizard.assets.AssetsBundle;
@@ -85,7 +84,7 @@ public class ConsentApplication extends Application<ConsentConfiguration> {
             Fongo fongo = new Fongo("TestServer");
             mongoClient =  fongo.getMongo();
         } else {
-            mongoClient = new MongoClient(new MongoClientURI(mongoConfiguration.getUri()));
+            mongoClient = mongoConfiguration.getMongoClient();
         }
 
         final MongoConsentDB mongoInstance = new MongoConsentDB(mongoClient, mongoConfiguration.getDbName());

--- a/consent-ws/src/main/java/org/broadinstitute/consent/http/configurations/MongoConfiguration.java
+++ b/consent-ws/src/main/java/org/broadinstitute/consent/http/configurations/MongoConfiguration.java
@@ -1,6 +1,14 @@
 package org.broadinstitute.consent.http.configurations;
 
+import com.mongodb.MongoClient;
+import com.mongodb.MongoClientURI;
+import com.mongodb.MongoCredential;
+import com.mongodb.ServerAddress;
+
 import javax.validation.constraints.NotNull;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 public class MongoConfiguration {
 
@@ -10,6 +18,10 @@ public class MongoConfiguration {
 
     @NotNull
     public String uri;
+
+    public String host1;
+
+    public String host2;
 
     @NotNull
     public String dbName;
@@ -28,6 +40,7 @@ public class MongoConfiguration {
         return password;
     }
 
+    @SuppressWarnings("unused")
     public void setPassword(String password) {
         this.password = password;
     }
@@ -40,10 +53,29 @@ public class MongoConfiguration {
         this.uri = uri;
     }
 
+    public String getHost1() {
+        return host1;
+    }
+
+    @SuppressWarnings("unused")
+    public void setHost1(String host1) {
+        this.host1 = host1;
+    }
+
+    public String getHost2() {
+        return host2;
+    }
+
+    @SuppressWarnings("unused")
+    public void setHost2(String host2) {
+        this.host2 = host2;
+    }
+
     public String getDbName() {
         return dbName;
     }
 
+    @SuppressWarnings("unused")
     public void setDbName(String dbName) {
         this.dbName = dbName;
     }
@@ -52,12 +84,28 @@ public class MongoConfiguration {
         return testMode;
     }
 
+    @SuppressWarnings("unused")
     public Boolean getTestMode() {
         return testMode;
     }
 
+    @SuppressWarnings("unused")
     public void setTestMode(Boolean testMode) {
         this.testMode = testMode;
     }
+
+    public MongoClient getMongoClient() {
+        if (getHost1() == null || getHost2() == null) {
+            return new MongoClient(new MongoClientURI(getUri()));
+        } else if (getHost1() != null && getHost2() != null) {
+            List<ServerAddress> seeds = new ArrayList<>();
+            seeds.add(new ServerAddress(getHost1()));
+            seeds.add(new ServerAddress(getHost2()));
+            MongoCredential credential = MongoCredential.createCredential(getUsername(), getDbName(), getPassword().toCharArray());
+            return new MongoClient(seeds, Collections.singletonList(credential));
+        }
+        return null;
+    }
+
 
 }

--- a/consent-ws/src/test/resources/consent-config.yml
+++ b/consent-ws/src/test/resources/consent-config.yml
@@ -19,6 +19,8 @@ googleStore:
   type: GCS
 mongo:
   uri: mongodb://localhost:27017
+  host1:
+  host2:
   dbName: consent
   username:
   password:


### PR DESCRIPTION
See https://broadinstitute.atlassian.net/browse/DUOS-29
This story requires configuration changes in both vault and on the deployed google node so that the deployed mongo server names (see below) are mapped to their internal IP addresses. 

To test this locally, it is required that you have in your /etc/hosts mappings entries for the following:
- mongodb-dev-1
- mongodb-dev-2
- mongodb-dev-arbiter-1

Log into the google console and look at each of these hosts. Add the **external** ip (not the internal ip since that is not accessible on the Broad vpn)
Make sure your local config is updated with the correct mongo host1 and host2 configurations as found in vault.

Vault has been updated with changes to the configuration file on both dev and prod.
