### PR TITLE
[BTRX-421][risk=no] Get Swagger lib from maven

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,7 @@
     <owl.version>5.0.5</owl.version>
     <jackson.version>2.9.5</jackson.version>
     <swagger.ui.version>2.2.8</swagger.ui.version>
+    <swagger.ui.path>META-INF/resources/webjars/swagger-ui/${swagger.ui.version}/</swagger.ui.path>
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -45,6 +46,23 @@
     </testResources>
 
     <plugins>
+      
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>properties-maven-plugin</artifactId>
+        <version>1.0.0</version>
+        <executions>
+          <execution>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>write-project-properties</goal>
+            </goals>
+            <configuration>
+              <outputFile>${project.build.outputDirectory}/mvn.properties</outputFile>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
 
       <plugin>
         <groupId>org.jacoco</groupId>

--- a/src/main/java/org/broadinstitute/consent/http/resources/SwaggerResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/SwaggerResource.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.consent.http.resources;
 
+import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.consent.http.configurations.GoogleOAuth2Config;
 import org.parboiled.common.FileUtils;
 
@@ -10,9 +11,20 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
+import java.io.InputStream;
+import java.util.Properties;
+import java.util.logging.Logger;
 
 @Path("/swagger")
 public class SwaggerResource {
+
+    private static final Logger logger = Logger.getLogger(SwaggerResource.class.getName());
+    // Default swagger ui library if not found in properties
+    private final static String DEFAULT_LIB = "META-INF/resources/webjars/swagger-ui/2.2.8/";
+    final static String MEDIA_TYPE_CSS = new MediaType("text", "css").toString();
+    final static String MEDIA_TYPE_JS = new MediaType("application", "js").toString();
+    final static String MEDIA_TYPE_PNG = new MediaType("image", "png").toString();
+    final static String MEDIA_TYPE_GIF = new MediaType("image", "gif").toString();
 
     private GoogleOAuth2Config config;
 
@@ -20,7 +32,26 @@ public class SwaggerResource {
         this.config = config;
     }
 
-    private final static String swaggerResource = "META-INF/resources/webjars/swagger-ui/2.2.8/";
+    private String swaggerResource = null;
+
+    private String getSwaggerResource() {
+        if (swaggerResource == null) {
+            try (InputStream is = this.getClass().getResourceAsStream("/mvn.properties")) {
+                Properties p = new Properties();
+                p.load(is);
+                if (StringUtils.isNotEmpty(p.getProperty("swagger.ui.path"))) {
+                    swaggerResource = p.getProperty("swagger.ui.path");
+                } else {
+                    logger.warning("swagger.ui.path is not configured correctly");
+                    swaggerResource = DEFAULT_LIB;
+                }
+            } catch (Exception e) {
+                logger.warning(e.getMessage());
+                swaggerResource = DEFAULT_LIB;
+            }
+        }
+        return swaggerResource;
+    }
 
     @Context
     UriInfo uriInfo;
@@ -28,44 +59,55 @@ public class SwaggerResource {
     @GET
     @Path("{path:.*}")
     public Response content(@PathParam("path") String path) {
+        String swaggerResource = getSwaggerResource();
         Response response;
         String mediaType = getMediaTypeFromPath(path);
         if (path.isEmpty() || path.equals("index.html")) {
-            response = Response.ok().entity(getIndex()).type(mediaType).build();
+            response = Response.ok().entity(getIndex(swaggerResource)).type(mediaType).build();
         } else {
             mediaType = getMediaTypeFromPath(path);
             if (path.endsWith("png") || path.endsWith("gif")) {
                 byte[] content = FileUtils.readAllBytesFromResource(swaggerResource + path);
-                response = Response.ok().entity(content).type(mediaType).build();
+                if (content != null) {
+                    response = Response.ok().entity(content).type(mediaType).build();
+                } else {
+                    response = Response.status(Response.Status.NOT_FOUND).build();
+                }
             } else {
                 String content = FileUtils.readAllTextFromResource(swaggerResource + path);
-                response = Response.ok().entity(content).type(mediaType).build();
+                if (StringUtils.isNotEmpty(content)) {
+                    response = Response.ok().entity(content).type(mediaType).build();
+                } else {
+                    response = Response.status(Response.Status.NOT_FOUND).build();
+                }
             }
         }
         return response;
     }
 
     private String getMediaTypeFromPath(String path) {
-        // Default case:
-        String mediaType = MediaType.TEXT_HTML;
-
-        // Handle specific cases for the various swagger ui file content types:
-        if (path.endsWith("css")) {
-            mediaType = "text/css";
-        }
-        if (path.endsWith("js")) {
-            mediaType = "application/js";
-        }
-        if (path.endsWith("png")) {
-            mediaType = "image/png";
-        }
-        if (path.endsWith("gif")) {
-            mediaType = "image/gif";
+        String mediaType;
+        switch (StringUtils.substringAfterLast(path, ".")) {
+            case "css":
+                mediaType = MEDIA_TYPE_CSS;
+                break;
+            case "js":
+                mediaType = MEDIA_TYPE_JS;
+                break;
+            case "png":
+                mediaType = MEDIA_TYPE_PNG;
+                break;
+            case "gif":
+                mediaType = MEDIA_TYPE_GIF;
+                break;
+            default:
+                mediaType = MediaType.TEXT_HTML;
+                break;
         }
         return mediaType;
     }
 
-    private String getIndex() {
+    private String getIndex(String swaggerResource) {
         String content = FileUtils.readAllTextFromResource(swaggerResource + "index.html");
         return content
             .replace("your-client-id", config.getClientId())

--- a/src/test/java/org/broadinstitute/consent/http/resources/SwaggerResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/SwaggerResourceTest.java
@@ -1,0 +1,83 @@
+package org.broadinstitute.consent.http.resources;
+
+import org.apache.commons.lang3.RandomStringUtils;
+import org.broadinstitute.consent.http.configurations.GoogleOAuth2Config;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import static org.broadinstitute.consent.http.resources.SwaggerResource.MEDIA_TYPE_CSS;
+import static org.broadinstitute.consent.http.resources.SwaggerResource.MEDIA_TYPE_GIF;
+import static org.broadinstitute.consent.http.resources.SwaggerResource.MEDIA_TYPE_JS;
+import static org.broadinstitute.consent.http.resources.SwaggerResource.MEDIA_TYPE_PNG;
+
+public class SwaggerResourceTest {
+
+    private SwaggerResource swaggerResource;
+
+    @Before
+    public void setUp() {
+        GoogleOAuth2Config config = new GoogleOAuth2Config();
+        config.setClientId(RandomStringUtils.random(10, true, true));
+        swaggerResource = new SwaggerResource(config);
+    }
+
+    @Test
+    public void testIndex() {
+        Response response = swaggerResource.content("index.html");
+        checkStatusAndHeader(response, MediaType.TEXT_HTML);
+        String content = response.getEntity().toString().trim();
+        Assert.assertTrue(content.startsWith("<!DOCTYPE html>"));
+        Assert.assertTrue(content.endsWith("</html>"));
+    }
+
+    @Test
+    public void testStyle() {
+        Response response = swaggerResource.content("css/style.css");
+        checkStatusAndHeader(response, MEDIA_TYPE_CSS);
+        String content = response.getEntity().toString().trim();
+        Assert.assertTrue(content.startsWith(".swagger-section"));
+    }
+
+    @Test
+    public void testJavascript() {
+        Response response = swaggerResource.content("lib/marked.js");
+        checkStatusAndHeader(response, MEDIA_TYPE_JS);
+        String content = response.getEntity().toString().trim();
+        Assert.assertTrue(content.startsWith("(function()"));
+    }
+
+    @Test
+    public void testPng() {
+        Response response = swaggerResource.content("images/explorer_icons.png");
+        checkStatusAndHeader(response, MEDIA_TYPE_PNG);
+    }
+
+    @Test
+    public void testGif() {
+        Response response = swaggerResource.content("images/expand.gif");
+        checkStatusAndHeader(response, MEDIA_TYPE_GIF);
+    }
+
+    @Test
+    public void testNotFound() {
+        Response response = swaggerResource.content("foo/bar.txt");
+        Assert.assertEquals(response.getStatus(), Response.Status.NOT_FOUND.getStatusCode());
+    }
+
+    @Test
+    public void testImageNotFound() {
+        Response response = swaggerResource.content("foo/bar.png");
+        Assert.assertEquals(response.getStatus(), Response.Status.NOT_FOUND.getStatusCode());
+    }
+
+    private void checkStatusAndHeader(Response response, String header) {
+        Assert.assertEquals(response.getStatus(), Response.Status.OK.getStatusCode());
+        Object headerObject = response.getHeaders().get("Content-type");
+        Assert.assertTrue(headerObject.toString().contains(header));
+    }
+
+}

--- a/src/test/resources/mvn.properties
+++ b/src/test/resources/mvn.properties
@@ -1,3 +1,2 @@
 #Properties
-swagger.ui.version=2.2.8
 swagger.ui.path=META-INF/resources/webjars/swagger-ui/2.2.8/

--- a/src/test/resources/mvn.properties
+++ b/src/test/resources/mvn.properties
@@ -1,0 +1,3 @@
+#Properties
+swagger.ui.version=2.2.8
+swagger.ui.path=META-INF/resources/webjars/swagger-ui/2.2.8/


### PR DESCRIPTION
## Addresses 
Consent side of https://broadinstitute.atlassian.net/browse/BTRX-421
Does not complete this story though. Will require a corresponding PR in ontology.
See also: https://github.com/DataBiosphere/consent-ontology/pull/108

## Changes
* Add some mvn magic to convert pom properties to a properties file
* Keep configurations wrt swagger in pom properties
* Read the properties file for the right swagger library in swagger resource.