### PR TITLE
BTRX - 427 - 434 - Adding pdf values

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/DataSetDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DataSetDAO.java
@@ -159,7 +159,7 @@ public interface DataSetDAO extends Transactional<DataSetDAO> {
     Integer getConsentAssociationByObjectId(@Bind("objectId") String objectId);
 
     @SqlQuery("SELECT ca.consentId FROM consentassociations ca INNER JOIN dataset ds on ds.dataSetId = ca.dataSetId WHERE ds.dataSetId = :dataSetId")
-    String getConsentAssociationByDataSetId(@Bind("dataSetId") Integer dataSetId);
+    String getAssociatedConsentIdByDataSetId(@Bind("dataSetId") Integer dataSetId);
 
     @SqlQuery("SELECT dataSetId FROM dataset WHERE name = :name")
     Integer getDataSetByName(@Bind("name") String name);

--- a/src/main/java/org/broadinstitute/consent/http/db/DataSetDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DataSetDAO.java
@@ -158,6 +158,9 @@ public interface DataSetDAO extends Transactional<DataSetDAO> {
     @SqlQuery("SELECT ca.associationId FROM consentassociations ca INNER JOIN dataset ds on ds.dataSetId = ca.dataSetId WHERE ds.objectId = :objectId")
     Integer getConsentAssociationByObjectId(@Bind("objectId") String objectId);
 
+    @SqlQuery("SELECT ca.consentId FROM consentassociations ca INNER JOIN dataset ds on ds.dataSetId = ca.dataSetId WHERE ds.dataSetId = :dataSetId")
+    String getConsentAssociationByDataSetId(@Bind("dataSetId") Integer dataSetId);
+
     @SqlQuery("SELECT dataSetId FROM dataset WHERE name = :name")
     Integer getDataSetByName(@Bind("name") String name);
 

--- a/src/main/java/org/broadinstitute/consent/http/db/ElectionDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/ElectionDAO.java
@@ -282,4 +282,11 @@ public interface ElectionDAO extends Transactional<ElectionDAO> {
 
     @SqlQuery("select  v.vote from vote v where v.electionId = :electionId and v.type = 'FINAL'")
     Boolean findFinalAccessVote(@Bind("electionId") Integer electionId);
+
+    @SqlQuery("select * from election e inner join (select referenceId, MAX(createDate) maxDate from election e where e.status = 'Closed' group by referenceId) " +
+            "electionView ON electionView.maxDate = e.createDate AND electionView.referenceId = e.referenceId  " +
+            "AND e.referenceId = :referenceId " +
+            "inner join vote v on v.electionId = e.electionId and v.vote = true  and v.type = 'CHAIRPERSON'")
+    @Mapper(DatabaseElectionMapper.class)
+    Election findDULApprovedElectionByReferenceId(@Bind("referenceId") String referenceId);
 }

--- a/src/main/java/org/broadinstitute/consent/http/resources/DataRequestReportsResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataRequestReportsResource.java
@@ -42,9 +42,10 @@ public class DataRequestReportsResource extends Resource {
         DACUserRole role = dacUserAPI.getRoleStatus(dar.getInteger(DarConstants.USER_ID));
         String fileName = "FullDARApplication-" + dar.getString(DarConstants.DAR_CODE);
         try{
+            String sDul = darApi.getStructuredDulForPdf(dar);
             Boolean manualReview = DarUtil.requiresManualReview(dar);
             return Response
-                    .ok(darApi.createDARDocument(dar, researcherProperties, role, manualReview), MediaType.APPLICATION_OCTET_STREAM)
+                    .ok(darApi.createDARDocument(dar, researcherProperties, role, manualReview, sDul), MediaType.APPLICATION_OCTET_STREAM)
                     .header(HttpHeaders.CONTENT_DISPOSITION,"attachment; filename =" + fileName + ".pdf")
                     .header(HttpHeaders.ACCEPT, "application/pdf")
                     .header("Access-Control-Expose-Headers", HttpHeaders.CONTENT_DISPOSITION)

--- a/src/main/java/org/broadinstitute/consent/http/resources/DataRequestReportsResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataRequestReportsResource.java
@@ -42,10 +42,10 @@ public class DataRequestReportsResource extends Resource {
         DACUserRole role = dacUserAPI.getRoleStatus(dar.getInteger(DarConstants.USER_ID));
         String fileName = "FullDARApplication-" + dar.getString(DarConstants.DAR_CODE);
         try{
-            String sDul = darApi.getStructuredDulForPdf(dar);
+            String sDUR = darApi.getStructuredDURForPdf(dar);
             Boolean manualReview = DarUtil.requiresManualReview(dar);
             return Response
-                    .ok(darApi.createDARDocument(dar, researcherProperties, role, manualReview, sDul), MediaType.APPLICATION_OCTET_STREAM)
+                    .ok(darApi.createDARDocument(dar, researcherProperties, role, manualReview, sDUR), MediaType.APPLICATION_OCTET_STREAM)
                     .header(HttpHeaders.CONTENT_DISPOSITION,"attachment; filename =" + fileName + ".pdf")
                     .header(HttpHeaders.ACCEPT, "application/pdf")
                     .header("Access-Control-Expose-Headers", HttpHeaders.CONTENT_DISPOSITION)

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessParser.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessParser.java
@@ -15,7 +15,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 public class DataAccessParser {
-    public PDAcroForm fillDARForm(Document dar, Map<String, String> researcherProperties, DACUserRole role, Boolean manualReview, PDAcroForm acroForm, String sDul) throws IOException {
+    public PDAcroForm fillDARForm(Document dar, Map<String, String> researcherProperties, DACUserRole role, Boolean manualReview, PDAcroForm acroForm, String sDUR) throws IOException {
         for (PDField field : acroForm.getFields()) {
             String fieldName = field.getFullyQualifiedName();
             switch (fieldName) {
@@ -227,13 +227,13 @@ public class DataAccessParser {
                     break;
                 }
                 case DarConstants.DATA_ACCESS_AGREEMENT: {
-                    Boolean existDataAccessAgreement = (dar.getString(DarConstants.DATA_ACCESS_AGREEMENT_URL) != null &&
-                            dar.getString(DarConstants.DATA_ACCESS_AGREEMENT_NAME) != null);
+                    Boolean existDataAccessAgreement = (StringUtils.isNotEmpty(dar.getString(DarConstants.DATA_ACCESS_AGREEMENT_URL)) &&
+                            StringUtils.isNotEmpty(dar.getString(DarConstants.DATA_ACCESS_AGREEMENT_NAME)));
                     field.setValue(getYesOrNoValue(existDataAccessAgreement));
                     break;
                 }
                 case DarConstants.TRANSLATED_RESTRICTION: {
-                    field.setValue(getDefaultValue(sDul.replaceAll("<[^>]*>","\n")));
+                    field.setValue(getDefaultValue(sDUR.replaceAll("<[^>]*>","\n")));
                     break;
                 }
             }

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessParser.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessParser.java
@@ -15,7 +15,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 public class DataAccessParser {
-    public PDAcroForm fillDARForm(Document dar, Map<String, String> researcherProperties, DACUserRole role, Boolean manualReview, PDAcroForm acroForm) throws IOException {
+    public PDAcroForm fillDARForm(Document dar, Map<String, String> researcherProperties, DACUserRole role, Boolean manualReview, PDAcroForm acroForm, String sDul) throws IOException {
         for (PDField field : acroForm.getFields()) {
             String fieldName = field.getFullyQualifiedName();
             switch (fieldName) {
@@ -233,7 +233,7 @@ public class DataAccessParser {
                     break;
                 }
                 case DarConstants.TRANSLATED_RESTRICTION: {
-                    field.setValue(getDefaultValue(dar.getString(DarConstants.TRANSLATED_RESTRICTION)).replaceAll("<[^>]*>","\n"));
+                    field.setValue(getDefaultValue(sDul.replaceAll("<[^>]*>","\n")));
                     break;
                 }
             }

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessParser.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessParser.java
@@ -15,7 +15,6 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 public class DataAccessParser {
-
     public PDAcroForm fillDARForm(Document dar, Map<String, String> researcherProperties, DACUserRole role, Boolean manualReview, PDAcroForm acroForm) throws IOException {
         for (PDField field : acroForm.getFields()) {
             String fieldName = field.getFullyQualifiedName();
@@ -228,8 +227,13 @@ public class DataAccessParser {
                     break;
                 }
                 case DarConstants.DATA_ACCESS_AGREEMENT: {
-                    Boolean existDataAccessAgreement = dar.getString(DarConstants.DATA_ACCESS_AGREEMENT) == null? false: true;
+                    Boolean existDataAccessAgreement = (dar.getString(DarConstants.DATA_ACCESS_AGREEMENT_URL) != null &&
+                            dar.getString(DarConstants.DATA_ACCESS_AGREEMENT_NAME) != null);
                     field.setValue(getYesOrNoValue(existDataAccessAgreement));
+                    break;
+                }
+                case DarConstants.TRANSLATED_RESTRICTION: {
+                    field.setValue(getDefaultValue(dar.getString(DarConstants.TRANSLATED_RESTRICTION)).replaceAll("<[^>]*>","."));
                     break;
                 }
             }

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessParser.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessParser.java
@@ -233,7 +233,7 @@ public class DataAccessParser {
                     break;
                 }
                 case DarConstants.TRANSLATED_RESTRICTION: {
-                    field.setValue(getDefaultValue(dar.getString(DarConstants.TRANSLATED_RESTRICTION)).replaceAll("<[^>]*>","."));
+                    field.setValue(getDefaultValue(dar.getString(DarConstants.TRANSLATED_RESTRICTION)).replaceAll("<[^>]*>","\n"));
                     break;
                 }
             }
@@ -252,7 +252,7 @@ public class DataAccessParser {
 
         return datasetDetailMap.entrySet().stream()
                 .map(name -> name.getKey() + name.getValue())
-                .collect(Collectors.joining(", "));
+                .collect(Collectors.joining("\n"));
     }
 
     private String getYesOrNoValue(Boolean value){

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestAPI.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestAPI.java
@@ -78,9 +78,9 @@ public interface DataAccessRequestAPI {
 
     List<Document> describeDataAccessWithDataSetId(List<String> dataSetIds);
 
-    byte[] createDARDocument(Document dar, Map<String, String> researcherProperties, DACUserRole role, Boolean manualReview, String sDul) throws IOException;
+    byte[] createDARDocument(Document dar, Map<String, String> researcherProperties, DACUserRole role, Boolean manualReview, String sDUR) throws IOException;
 
-    String getStructuredDulForPdf(Document dar) throws UnknownIdentifierException;
+    String getStructuredDURForPdf(Document dar);
 
     File createApprovedDARDocument() throws NotFoundException, IOException;
 

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestAPI.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestAPI.java
@@ -78,7 +78,9 @@ public interface DataAccessRequestAPI {
 
     List<Document> describeDataAccessWithDataSetId(List<String> dataSetIds);
 
-    byte[] createDARDocument(Document dar, Map<String, String> researcherProperties, DACUserRole role, Boolean manualReview) throws IOException;
+    byte[] createDARDocument(Document dar, Map<String, String> researcherProperties, DACUserRole role, Boolean manualReview, String sDul) throws IOException;
+
+    String getStructuredDulForPdf(Document dar) throws UnknownIdentifierException;
 
     File createApprovedDARDocument() throws NotFoundException, IOException;
 

--- a/src/main/java/org/broadinstitute/consent/http/service/DatabaseDataAccessRequestAPI.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatabaseDataAccessRequestAPI.java
@@ -415,18 +415,18 @@ public class DatabaseDataAccessRequestAPI extends AbstractDataAccessRequestAPI {
     }
 
     /**
-     * Description: this method returns the correct structured Data Use Restriction, also handles the old elections.
-     * If there is no Access Election with the corresponding DAR reference Id, it will return Consent election's sDul
-     * associated with its DatasetId.
+     * Description: this method returns the correct structured Data Use Restriction for an election.
+     * If there is no Access Election with the corresponding DAR reference Id, it will return Consent
+     * Election's sDUR associated with its DatasetId.
      *
-     * On the other hand if accessElection is not null, we use its electionId to query our accesselection_consentelection table in mysql
-     * which contains its consent election id related. After we obtained consent election id, we try to get sdul from it.
+     * If there is a valid Access Election, we find the consent associated to it by the electionId
+     * and try to get the sDUR from there.
      *
-     * It might happen that there's no relation in this table (due to a very old election), in that case we bring the consent election
-     * by its reference Id (consentId).
+     * If there is no Access Election relationship to be found, we treat the reference id (a loose
+     * reference to an ID) as a consent id and look up the Consent Election's sDUR.
      *
-     * Finally, if for some reason there's no consent election realted to a given consentId we use sDul in consents table, gotten by
-     * its id.
+     * Finally, if for some reason there's no Election related to a given Consent we use DUR in
+     * consents table, we look for the DUR on the consent itself.
      *
      * @param dar Mongo document correponding to a specific its reference Id
      * @return sDUR Structured Data Use Restriction

--- a/src/main/java/org/broadinstitute/consent/http/service/DatabaseDataSetAPI.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatabaseDataSetAPI.java
@@ -308,7 +308,6 @@ public class DatabaseDataSetAPI extends AbstractDataSetAPI {
         throw new NotFoundException();
     }
 
-
     private List<String> addMissingAssociationsErrors(List<DataSet> dataSets) {
         List<String> errors = new ArrayList<>();
         List<String> objectIdList = dataSets.stream().filter(dataset -> dataset.getObjectId() != null).map(DataSet::getObjectId).collect(Collectors.toList());

--- a/src/main/java/org/broadinstitute/consent/http/util/DarConstants.java
+++ b/src/main/java/org/broadinstitute/consent/http/util/DarConstants.java
@@ -27,7 +27,7 @@ public class DarConstants {
 
     public static final String RESTRICTION = "restriction";
 
-    public static final String TRANSLATED_RESTRICTION = "translated_restriction";
+    public static final String TRANSLATED_RESTRICTION = "translatedUseRestriction";
 
     public static final String PARTIAL_DAR_CODE = "partial_dar_code";
 
@@ -69,7 +69,7 @@ public class DarConstants {
 
     public static final String PI_EMAIL = "piEmail";
 
-    public static final String NON_TECH_RUS = "non_tech_rus";
+    public static final String NON_TECH_RUS = "nonTechRus";
 
     public static final String DISEASES = "diseases";
 
@@ -124,6 +124,10 @@ public class DarConstants {
     public static final String RESEARCHER_GATE = "researcherGate";
 
     public static final String DATA_ACCESS_AGREEMENT = "dataAccessAgreement";
+
+    public static final String DATA_ACCESS_AGREEMENT_URL = "urlDAA";
+
+    public static final String DATA_ACCESS_AGREEMENT_NAME = "nameDAA";
 
     public static final String HEALTH = "health";
 

--- a/src/main/java/org/broadinstitute/consent/http/util/DarConstants.java
+++ b/src/main/java/org/broadinstitute/consent/http/util/DarConstants.java
@@ -69,7 +69,7 @@ public class DarConstants {
 
     public static final String PI_EMAIL = "piEmail";
 
-    public static final String NON_TECH_RUS = "nonTechRus";
+    public static final String NON_TECH_RUS = "non_tech_rus";
 
     public static final String DISEASES = "diseases";
 

--- a/src/test/java/org/broadinstitute/consent/http/service/DataAccessParserTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DataAccessParserTest.java
@@ -104,7 +104,7 @@ public class DataAccessParserTest {
         this.manualReview = false;
         this.role.setStatus("approved");
         this.role.setRationale("granted bonafide");
-        PDAcroForm acroForm = dataAccessParser.fillDARForm(dar, researcherProperties,role, manualReview, PDDocument.load(classLoader.getResourceAsStream(PATH)).getDocumentCatalog().getAcroForm());
+        PDAcroForm acroForm = dataAccessParser.fillDARForm(dar, researcherProperties,role, manualReview, PDDocument.load(classLoader.getResourceAsStream(PATH)).getDocumentCatalog().getAcroForm(), TRANSLATED_USE_RESTRICTION);
         Assert.isTrue(acroForm.getField(ResearcherFields.INSTITUTION.getValue()).getValueAsString().equals(INSTITUTION));
         Assert.isTrue(acroForm.getField(ResearcherFields.DEPARTMENT.getValue()).getValueAsString().equals(DEPARTMENT));
         Assert.isTrue(acroForm.getField(ResearcherFields.STREET_ADDRESS_1.getValue()).getValueAsString().equals(STREET_1));

--- a/src/test/java/org/broadinstitute/consent/http/service/DataAccessParserTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DataAccessParserTest.java
@@ -49,7 +49,9 @@ public class DataAccessParserTest {
     private final String LINKEDIN = "linkedin-test-id";
     private final String ORCID = "0001-0002-00122";
     private final String RESEARCHER_GATE = "researcher-gate-0001-test";
-    private final String DATA_ACCESS_AGREEMENT = "/url/bucket/id-bucket-test";
+    private final String DATA_ACCESS_AGREEMENT_URL = "/url/bucket/id-bucket-test";
+    private final String DATA_ACCESS_AGREEMENT_NAME = "Researcher Name";
+    private final String TRANSLATED_USE_RESTRICTION = "Translated use restriction.";
     public DataAccessParserTest() {
         this.dataAccessParser = new DataAccessParser();
         this.researcherProperties = new HashMap<>();
@@ -96,7 +98,9 @@ public class DataAccessParserTest {
         dar.put(DarConstants.LINKEDIN, LINKEDIN);
         dar.put(DarConstants.ORCID, ORCID);
         dar.put(DarConstants.RESEARCHER_GATE, RESEARCHER_GATE);
-        dar.put(DarConstants.DATA_ACCESS_AGREEMENT, DATA_ACCESS_AGREEMENT);
+        dar.put(DarConstants.DATA_ACCESS_AGREEMENT_URL, DATA_ACCESS_AGREEMENT_URL);
+        dar.put(DarConstants.DATA_ACCESS_AGREEMENT_NAME, DATA_ACCESS_AGREEMENT_NAME);
+        dar.put(DarConstants.TRANSLATED_RESTRICTION, TRANSLATED_USE_RESTRICTION);
         this.manualReview = false;
         this.role.setStatus("approved");
         this.role.setRationale("granted bonafide");
@@ -135,6 +139,7 @@ public class DataAccessParserTest {
         Assert.isTrue(acroForm.getField(DarConstants.MANUAL_REVIEW).getValueAsString().equals(MANUAL_REVIEW));
         Assert.isTrue(acroForm.getField(DarConstants.USER_STATUS).getValueAsString().equals(USER_STATUS));
         Assert.isTrue(acroForm.getField(DarConstants.ADMIN_COMMENT).getValueAsString().equals(ADMIN_COMMENT));
+        Assert.isTrue(acroForm.getField(DarConstants.TRANSLATED_RESTRICTION).getValueAsString().equals(TRANSLATED_USE_RESTRICTION));
     }
 
     private Document generateDatasetDetails(Integer datasetId, String datasetName, String objectId) {

--- a/src/test/java/org/broadinstitute/consent/http/service/DatabaseDataAccessRequestAPITest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DatabaseDataAccessRequestAPITest.java
@@ -47,6 +47,8 @@ public class DatabaseDataAccessRequestAPITest {
 
     private final String RESEARCHER_GATE = "researcher_gate";
 
+    private final String TRANSLATED_USE_RESTRICTION = "Translated use restriction.";
+
     DatabaseDataAccessRequestAPI databaseDataAccessRequestAPI;
 
     @Before
@@ -97,7 +99,7 @@ public class DatabaseDataAccessRequestAPITest {
     @Test
     public void testCreateDARDocument() throws Exception {
         Document dar = getDocument(null, "845246551313515", null);
-        byte[] doc = databaseDataAccessRequestAPI.createDARDocument(dar, getResearcherProperties(), new DACUserRole(), true);
+        byte[] doc = databaseDataAccessRequestAPI.createDARDocument(dar, getResearcherProperties(), new DACUserRole(), true, TRANSLATED_USE_RESTRICTION);
         Assert.assertNotNull(doc);
     }
 


### PR DESCRIPTION

### Description
In this code we add two new fields to the pdf:
**_Structured Data Use Restriction_** and **_Data Access Agreement_** which is a flag that determines if the user has uploaded its signed Data Access Agreement pdf.

### Related Jira Stories
[BTRX-427](https://broadinstitute.atlassian.net/browse/BTRX-427)
[BTRX-434](https://broadinstitute.atlassian.net/browse/BTRX-434)

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [ ] I've updated Swagger to reflect any API changes

In all cases:

- [x] Get two thumbsworth of review and PO signoff if necessary
- [x] Verify all tests go green
- [x] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
