### PR TITLE
Exclude old jackson-databind for mongo-jackson

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -610,13 +610,17 @@
     <dependency>
       <groupId>net.vz.mongodb.jackson</groupId>
       <artifactId>mongo-jackson-mapper</artifactId>
-      <version>1.4.2</version><exclusions>
-      <exclusion>
-        <groupId>org.mongodb</groupId>
-        <artifactId>mongo-java-driver</artifactId>
-      </exclusion>
-    </exclusions>
-
+      <version>1.4.2</version>
+      <exclusions>
+        <exclusion>
+          <groupId>fasterxml.jackson.core</groupId>
+          <artifactId>jackson-databind</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.mongodb</groupId>
+          <artifactId>mongo-java-driver</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
This should address the following high-vulnerability source clear warnings. We explicitly pull in the latest jackson-databind but the latest `mongo-jackson-mapper` relies on the old version.
* https://broadinstitute-dsp.sourceclear.io/teams/jppForw/issues/vulnerabilities/5391952/6580950
* https://broadinstitute-dsp.sourceclear.io/teams/jppForw/issues/vulnerabilities/5391952/6580953
* https://broadinstitute-dsp.sourceclear.io/teams/jppForw/issues/vulnerabilities/5391952/6580954
* https://broadinstitute-dsp.sourceclear.io/teams/jppForw/issues/vulnerabilities/5391952/6580955