### PR TITLE
[BTRX-525][risk=no] Version Endpoint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.broadinstitute</groupId>
   <artifactId>consent</artifactId>
-  <version>0.1.0-SNAPSHOT</version>
+  <version>1.0.0</version>
   <packaging>jar</packaging>
   <name>Consent Management Services</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,42 @@
     </testResources>
 
     <plugins>
-      
+
+      <plugin>
+        <groupId>pl.project13.maven</groupId>
+        <artifactId>git-commit-id-plugin</artifactId>
+        <version>2.2.5</version>
+        <executions>
+          <execution>
+            <id>get-the-git-infos</id>
+            <goals>
+              <goal>revision</goal>
+            </goals>
+            <phase>compile</phase>
+          </execution>
+          <execution>
+            <id>validate-the-git-infos</id>
+            <goals>
+              <goal>validateRevision</goal>
+            </goals>
+            <phase>package</phase>
+          </execution>
+        </executions>
+        <configuration>
+          <dotGitDirectory>${project.basedir}/.git</dotGitDirectory>
+          <prefix>git</prefix>
+          <verbose>false</verbose>
+          <generateGitPropertiesFile>true</generateGitPropertiesFile>
+          <generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties</generateGitPropertiesFilename>
+          <format>json</format>
+          <gitDescribe>
+            <skip>true</skip>
+            <always>false</always>
+            <dirty>-dirty</dirty>
+          </gitDescribe>
+        </configuration>
+      </plugin>
+
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>properties-maven-plugin</artifactId>
@@ -553,7 +588,7 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.5</version>
+      <version>2.6</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
@@ -77,6 +77,7 @@ import org.broadinstitute.consent.http.resources.ResearcherResource;
 import org.broadinstitute.consent.http.resources.StatusResource;
 import org.broadinstitute.consent.http.resources.SwaggerResource;
 import org.broadinstitute.consent.http.resources.UserResource;
+import org.broadinstitute.consent.http.resources.VersionResource;
 import org.broadinstitute.consent.http.resources.WorkspaceResource;
 import org.broadinstitute.consent.http.service.AbstractApprovalExpirationTimeAPI;
 import org.broadinstitute.consent.http.service.AbstractAuditServiceAPI;
@@ -288,6 +289,7 @@ public class ConsentApplication extends Application<ConsentConfiguration> {
         env.jersey().register(new DataAccessAgreementResource(googleStore, researcherAPI));
         env.jersey().register(new SwaggerResource(config.getGoogleAuthentication()));
         env.jersey().register(new NihAccountResource(nihAuthApi, DatabaseDACUserAPI.getInstance()));
+        env.jersey().register(injector.getInstance(VersionResource.class));
 
         // Authentication filters
         AuthFilter defaultAuthFilter = new DefaultAuthFilter.Builder<User>()

--- a/src/main/java/org/broadinstitute/consent/http/resources/VersionResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/VersionResource.java
@@ -1,0 +1,64 @@
+package org.broadinstitute.consent.http.resources;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import org.apache.commons.io.IOUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Response;
+import java.nio.charset.Charset;
+import java.util.Optional;
+
+@Path("/version")
+public class VersionResource {
+
+    private final Logger log = LoggerFactory.getLogger(VersionResource.class);
+
+    @GET
+    @Produces("application/json")
+    public Response content() {
+        Version version = new Version(getGitProperties());
+        return Response.ok().entity(version).build();
+    }
+
+    private String getGitProperties() {
+        try {
+            return IOUtils.resourceToString("/git.properties", Charset.defaultCharset());
+        } catch (Exception e) {
+            log.error(e.getMessage());
+        }
+        return null;
+    }
+
+    private class Version {
+        String hash;
+        String version;
+
+        Version(String props) {
+            if (props == null) {
+                this.hash = "error";
+                this.version = "error";
+            } else {
+                JsonObject jsonObject = new Gson().fromJson(props, JsonObject.class);
+                JsonElement shortHash = jsonObject.get("git.commit.id.abbrev");
+                JsonElement buildVersion = jsonObject.get("git.build.version");
+                this.hash = Optional.ofNullable(shortHash.getAsString()).orElse("error");
+                this.version = Optional.ofNullable(buildVersion.getAsString()).orElse("error");
+            }
+        }
+
+        public String getHash() {
+            return hash;
+        }
+
+        public String getVersion() {
+            return version;
+        }
+    }
+
+}

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -2079,12 +2079,12 @@ paths:
       responses:
         '200':
           description: Returns eRA Commons Account information. Map<String, String> format
-          schema:
-            $ref: '#/definitions/EraProperties'
+#          schema:
+#            $ref: '#/definitions/EraProperties'
         '404':
           description: The user doesn't exist in the system
           schema:
-          $ref: '#/definitions/ErrorResponse'
+            $ref: '#/definitions/ErrorResponse'
   /status:
     get:
       summary: System Health Status
@@ -2094,6 +2094,20 @@ paths:
       responses:
         200: All systems are OK
         500: Some number of subsystems are not OK.
+
+  /version:
+    get:
+      summary: Current application version
+      description: The current short hash and version of the application.
+      tags:
+        - Status
+      responses:
+        200:
+          description: Successful Response
+          schema:
+            $ref: '#/definitions/Version'
+        500: Internal Server Error
+
 definitions:
   UserProperties:
     type: array
@@ -2718,12 +2732,14 @@ definitions:
       profileCompleted:
         type: boolean
         description: The profile is completed. Researchers only.
+
   ErrorResponse:
     required:
       - "message"
     properties:
       message:
         type: string
+
   HelpReport:
     type: object
     properties:
@@ -2775,3 +2791,12 @@ definitions:
       ontology_file:
         type: object
         $ref: '#/definitions/OntologyFileMetaData'
+  Version:
+    type: object
+    properties:
+      hash:
+        type: string
+        description: Current short hash of this version
+      version:
+        type: string
+        description: Current version

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -2732,14 +2732,12 @@ definitions:
       profileCompleted:
         type: boolean
         description: The profile is completed. Researchers only.
-
   ErrorResponse:
     required:
       - "message"
     properties:
       message:
         type: string
-
   HelpReport:
     type: object
     properties:

--- a/src/test/java/org/broadinstitute/consent/http/resources/VersionResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/VersionResourceTest.java
@@ -1,0 +1,24 @@
+package org.broadinstitute.consent.http.resources;
+
+import io.dropwizard.testing.junit.ResourceTestRule;
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import javax.ws.rs.core.Response;
+
+public class VersionResourceTest {
+
+    @ClassRule
+    public static final ResourceTestRule resources = ResourceTestRule.builder()
+            .addResource(new VersionResource())
+            .build();
+
+
+    @Test
+    public void testGetVersion() {
+        Response response = resources.target("/version").request().get();
+        Assert.assertEquals(response.getStatus(), 200);
+    }
+
+}

--- a/src/test/resources/git.properties
+++ b/src/test/resources/git.properties
@@ -1,0 +1,21 @@
+{
+    "git.branch" : "test",
+    "git.build.host" : "host",
+    "git.build.time" : "2019-01-25T11:15:09-0500",
+    "git.build.user.email" : "grushton@broadinstitute.org",
+    "git.build.user.name" : "Greg Rushton",
+    "git.build.version" : "0.1.0-SNAPSHOT",
+    "git.closest.tag.commit.count" : "",
+    "git.closest.tag.name" : "",
+    "git.commit.id" : "long-hash",
+    "git.commit.id.abbrev" : "short-hash",
+    "git.commit.message.full" : "long commit",
+    "git.commit.message.short" : "short commit",
+    "git.commit.time" : "2019-01-24T09:07:21-0500",
+    "git.commit.user.email" : "rushtong@users.noreply.github.com",
+    "git.commit.user.name" : "Greg Rushton",
+    "git.dirty" : "true",
+    "git.remote.origin.url" : "git@github.com:DataBiosphere/consent.git",
+    "git.tags" : "",
+    "git.total.commit.count" : "237"
+}


### PR DESCRIPTION
## Addresses
The ontology component of [BTRX-525](https://broadinstitute.atlassian.net/browse/BTRX-525)
Adds a simple unauthenticated `/version` endpoint that returns a short hash and the version as defined in pom.xml

See also: https://github.com/DataBiosphere/consent-ontology/pull/131

```
{
    "hash": "efcd627",
    "version": "0.1.0-SNAPSHOT"
}
```