### PR TITLE
[BTRX-589][risk=low] Update consents with missing data use

### DIFF
--- a/src/main/resources/changelog-master.xml
+++ b/src/main/resources/changelog-master.xml
@@ -47,4 +47,5 @@
     <include file="changesets/changelog-consent-42.0.xml" relativeToChangelogFile="true"/>
     <include file="changesets/changelog-consent-43.0.xml" relativeToChangelogFile="true"/>
     <include file="changesets/changelog-consent-44.0.xml" relativeToChangelogFile="true"/>
+    <include file="changesets/changelog-consent-45.0.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/changesets/changelog-consent-45.0.xml
+++ b/src/main/resources/changesets/changelog-consent-45.0.xml
@@ -1,0 +1,41 @@
+<databaseChangeLog
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet author="grushton" id="132">
+        <sql dbms="hsql, mysql">
+            UPDATE consents SET dataUse = '{ "diseaseRestrictions": [ "http://purl.obolibrary.org/obo/DOID_4961" ], "populationOriginsAncestry": true, "controlSetOption": "Yes", "genomicPhenotypicData": "Yes" }' where consentId = '7db478df-35cc-441c-942a-a54ae23bae39';
+            UPDATE consents SET dataUse = '{ "hmbResearch": true, "genomicPhenotypicData": "Yes" }' where consentId = '79c29af0-6710-41aa-ba45-65412b9726ac';
+            UPDATE consents SET dataUse = '{ "diseaseRestrictions": [ "http://purl.obolibrary.org/obo/DOID_77" ], "populationOriginsAncestry": true, "commercialUse": false, "methodsResearch": true, "controlSetOption": "Yes", "ethicsApprovalRequired": true, "other": "Requestor must agree to make results of studies using the data available to \nthe larger scientific community." }' where consentId = '90539faf-35ca-4915-b82f-8968ddd8787e';
+            UPDATE consents SET dataUse = '{ "hmbResearch": true, "genomicPhenotypicData": "Yes", "other": "Data is limited to use for research in adults over the age of 18" }' where consentId = 'd67d9dd5-a8ed-4224-bd73-0f474e668254';
+            UPDATE consents SET dataUse = '{ "hmbResearch": true, "genomicPhenotypicData": "Yes" }' where consentId = 'f1f5191e-3f67-4e39-8d87-7d47b825c71c';
+            UPDATE consents SET dataUse = '{ "hmbResearch": true, "commercialUse": false, "methodsResearch": true, "genomicPhenotypicData": "Yes" }' where consentId = '4132b7bd-4e2f-4c18-8422-43b8627f17ef';
+            UPDATE consents SET dataUse = '{ "diseaseRestrictions": [ "http://purl.obolibrary.org/obo/DOID_0060041", "http://purl.obolibrary.org/obo/DOID_1094", "http://purl.obolibrary.org/obo/DOID_1826", "http://purl.obolibrary.org/obo/DOID_5419", "http://purl.obolibrary.org/obo/DOID_12995", "http://purl.obolibrary.org/obo/DOID_2030", "http://purl.obolibrary.org/obo/DOID_1596" ], "populationOriginsAncestry": true, "controlSetOption": "Yes" }' where consentId = '1e8fe70a-fcf2-47c8-804e-01a11605d7d3';
+            UPDATE consents SET dataUse = '{ "diseaseRestrictions": [ "http://purl.obolibrary.org/obo/DOID_0050589" ], "populationOriginsAncestry": true, "controlSetOption": "Yes" }' where consentId = 'f86f14c4-0c30-44d4-9b0d-f8765e0e3e82';
+            UPDATE consents SET dataUse = '{ "hmbResearch": true, "genomicPhenotypicData": "Yes" }' where consentId = '9a83ff25-c201-4c24-a5fa-a8b40f2be375';
+            UPDATE consents SET dataUse = '{ "hmbResearch": true, "genomicPhenotypicData": "Yes" }' where consentId = '453aaece-8961-4ba1-a2ba-131b12ef6412';
+            UPDATE consents SET dataUse = '{ "diseaseRestrictions": [ "http://purl.obolibrary.org/obo/DOID_1319", "http://purl.obolibrary.org/obo/DOID_936", "http://purl.obolibrary.org/obo/DOID_162", "http://purl.obolibrary.org/obo/DOID_0080015" ], "populationOriginsAncestry": true, "controlSetOption": "Yes", "otherRestrictions": true }' where consentId = '2ef3fa9b-a070-4ea9-94a5-6c0952d232d4';
+            UPDATE consents SET dataUse = '{ "diseaseRestrictions": [ "http://purl.obolibrary.org/obo/DOID_863" ], "populationOriginsAncestry": true, "controlSetOption": "Yes", "dateRestriction": "2011-02-01T00:00:00-05:00" }' where consentId = 'a785873d-b860-41b5-ad72-98995468857d';
+            UPDATE consents SET dataUse = '{ "diseaseRestrictions": ["http://purl.obolibrary.org/obo/DOID_162"],"populationOriginsAncestry": true,"aggregateResearch": "Yes","controlSetOption": "Yes","genomicPhenotypicData": "Yes","other": "\"All data is to be used for studies investigating genetic susceptibility to \ncancer.  Proposed studies should explicitly intend to assess the impact of germ \nline variation on individual cancer risk.\""}' where consentId = '54cdd301-1b38-4cf4-a2e4-9ad3597518a5';
+            UPDATE consents SET dataUse = '{ "hmbResearch": true, "commercialUse": false, "genomicPhenotypicData": "Yes" }' where consentId = 'd66f1c6a-e2da-4ef7-9c68-59e1771ec042';
+            UPDATE consents SET dataUse = '{ "diseaseRestrictions": [ "http://purl.obolibrary.org/obo/DOID_2914" ], "aggregateResearch": "Yes", "controlSetOption": "Yes", "dateRestriction": "2009-11-30T00:00:00-05:00" }' where consentId = '93d62221-1a7c-4fe3-aeee-c271ad3851c2';
+            UPDATE consents SET dataUse = '{ "diseaseRestrictions": [ "http://purl.obolibrary.org/obo/DOID_162" ], "aggregateResearch": "Yes", "controlSetOption": "Yes" }' where consentId = '219c95bd-4152-4bf4-9d8e-e5f2b2e8a519';
+            UPDATE consents SET dataUse = '{ "diseaseRestrictions": [ "http://purl.obolibrary.org/obo/DOID_3827" ], "populationOriginsAncestry": true, "aggregateResearch": "Yes", "controlSetOption": "Yes" }' where consentId = '83eebb6e-1b71-4ae1-8dac-0635a625e4f0';
+            UPDATE consents SET dataUse = '{ "diseaseRestrictions": [ "http://purl.obolibrary.org/obo/DOID_1287", "http://purl.obolibrary.org/obo/DOID_0014667" ], "populationOriginsAncestry": true, "commercialUse": false, "genomicPhenotypicData": "Yes", "ethicsApprovalRequired": true, "other": "Collaboration required: \"Requestor must provide a letter of collaboration with \nthe primary study investigator.\"" }' where consentId = '8a166948-7e48-489f-916a-eb89a27c1191';
+            UPDATE consents SET dataUse = '{ "hmbResearch": true, "genomicPhenotypicData": "Yes" }' where consentId = '436fa46f-b16e-4bf6-a08d-230e3d4fefc9';
+            UPDATE consents SET dataUse = '{ "diseaseRestrictions": [ "http://purl.obolibrary.org/obo/DOID_1287" ], "populationOriginsAncestry": true, "other": "Genetic research only per Data Use Limitation Record." }' where consentId = '05cea8b6-0d38-4fd2-b67e-6c5f1df6b08b';
+            UPDATE consents SET dataUse = '{ "diseaseRestrictions": [ "http://purl.obolibrary.org/obo/DOID_0050589" ], "populationOriginsAncestry": true, "controlSetOption": "Yes", "genomicPhenotypicData": "Yes" }' where consentId = 'f9a90276-6b34-423d-9288-61e5cbacd37a';
+            UPDATE consents SET dataUse = '{ "generalUse": true, "controlSetOption": "Yes" }' where consentId = '2b54bb24-7785-4b11-91eb-46c6a777bb7e';
+            UPDATE consents SET dataUse = '{ "hmbResearch": true, "otherRestrictions": true, "other": "Only available to qualified scientists and health care professionals." }' where consentId = 'b6403243-7dda-408d-88e6-89a1c32b7e9b';
+            UPDATE consents SET dataUse = '{ "diseaseRestrictions": [ "http://purl.obolibrary.org/obo/DOID_1612" ], "controlSetOption": "Yes", "otherRestrictions": true, "dateRestriction": "2001-08-07T00:00:00-04:00" }' where consentId = '48306e65-fd91-4025-845c-1deb27e5b465';
+            UPDATE consents SET dataUse = '{ "diseaseRestrictions": [ "http://purl.obolibrary.org/obo/DOID_10283" ], "controlSetOption": "Yes" }' where consentId = 'fb8445b1-db03-4723-9200-a2f030368730';
+            UPDATE consents SET dataUse = '{ "diseaseRestrictions": [ "http://purl.obolibrary.org/obo/DOID_162" ], "aggregateResearch": "Yes", "controlSetOption": "Yes" }' where consentId = 'efbade12-58da-4c17-9c0f-cbe688492722';
+            UPDATE consents SET dataUse = '{ "diseaseRestrictions": [ "http://purl.obolibrary.org/obo/DOID_162" ], "aggregateResearch": "Yes", "controlSetOption": "Yes" }' where consentId = '457b0733-8c76-44bb-ba41-a8cf3be04a73';
+            UPDATE consents SET dataUse = '{ "diseaseRestrictions": [ "http://purl.obolibrary.org/obo/DOID_162" ], "aggregateResearch": "Yes", "controlSetOption": "Yes" }' where consentId = '7e748d9c-f702-4f20-9ed5-1d03c1d9517a';
+            UPDATE consents SET dataUse = '{ "generalUse": true }' where consentId = '9be76fa5-37c2-4d7d-8299-270331569845';
+        </sql>
+    </changeSet>
+
+</databaseChangeLog>


### PR DESCRIPTION
See https://broadinstitute.atlassian.net/browse/BTRX-589

There are a number of consents with missing data use objects. This updates that data directly via sql. After this update, there will be one more consent (OD-323) that does not have a real production case and looks like dev data that made it to prod somehow. 

I tested the queries themselves on dev where the consent ids do not exist and they all ran successfully.  I also tested these statements on production with autocommit turned off and rolled everything back.