### PR TITLE
[DUOS-218] Serve swagger from root

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.broadinstitute</groupId>
   <artifactId>consent</artifactId>
-  <version>1.0.0</version>
+  <version>1.0.1</version>
   <packaging>jar</packaging>
   <name>Consent Management Services</name>
 

--- a/src/main/java/org/broadinstitute/consent/http/resources/SwaggerResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/SwaggerResource.java
@@ -10,12 +10,15 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
 import java.io.InputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Properties;
 import java.util.logging.Logger;
 
-@Path("/swagger")
+@Path("/")
 public class SwaggerResource {
 
     private static final Logger logger = Logger.getLogger(SwaggerResource.class.getName());
@@ -55,6 +58,19 @@ public class SwaggerResource {
 
     @Context
     UriInfo uriInfo;
+
+    @GET
+    @Path("")
+    public Response main() {
+        return content("");
+    }
+
+    @GET
+    @Path("swagger")
+    public Response swagger() {
+        URI uri = UriBuilder.fromPath("/").scheme("https").build();
+        return Response.seeOther(uri).build();
+    }
 
     @GET
     @Path("{path:.*}")


### PR DESCRIPTION
See https://broadinstitute.atlassian.net/browse/DUOS-218
See also https://github.com/DataBiosphere/consent-ontology/pull/132

Currently, the root url is a 404. Instead, serve the swagger page.
