### PR TITLE
[DUOS-228] Handle invalid dar ids better

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
@@ -186,12 +186,11 @@ public class DataAccessRequestResource extends Resource {
         try {
             new ObjectId(id);
         } catch (IllegalArgumentException e) {
-            logger.log(Level.INFO, "Returning DAR not found response to client from exception: " + e.getMessage());
+            String message = "The provided id is not a valid Data Access Request Id: " + id;
+            logger.log(Level.INFO, message + "; " + e.getMessage());
             return Response
                     .status(Response.Status.BAD_REQUEST)
-                    .entity(new Error(
-                            "The provided id is not a valid Data Access Request Id: " + id,
-                            Response.Status.BAD_REQUEST.getStatusCode()))
+                    .entity(new Error(message, Response.Status.BAD_REQUEST.getStatusCode()))
                     .build();
         }
         try {

--- a/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
@@ -184,15 +184,22 @@ public class DataAccessRequestResource extends Resource {
     public Response describe(@PathParam("id") String id) {
         try {
             Document document = dataAccessRequestAPI.describeDataAccessRequestById(id);
-            return Response.status(Response.Status.OK).entity(document).build();
+            if (document != null) {
+                return Response.status(Response.Status.OK).entity(document).build();
+            }
+            return Response
+                    .status(Response.Status.NOT_FOUND)
+                    .entity("Unable to find Data Access Request with id: " + id)
+                    .build();
         } catch (IllegalArgumentException e) {
+            // This exception is thrown when mongo can't coerce the string value to an ObjectId.
             logger.log(Level.INFO, "Returning DAR not found response to client from exception: " + e.getMessage());
             return Response
                     .status(Response.Status.NOT_FOUND)
                     .entity("Unable to find Data Access Request with id: " + id)
                     .build();
         } catch (Exception e) {
-            return createExceptionResponse(new NotFoundException("Unable to find Data Access Request with id: " + id));
+            return createExceptionResponse(e);
         }
     }
 

--- a/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
@@ -2,7 +2,7 @@ package org.broadinstitute.consent.http.resources;
 
 import freemarker.template.TemplateException;
 import org.apache.commons.collections.CollectionUtils;
-
+import org.broadinstitute.consent.http.cloudstore.GCSStore;
 import org.broadinstitute.consent.http.enumeration.ResearcherFields;
 import org.broadinstitute.consent.http.models.Consent;
 import org.broadinstitute.consent.http.models.DACUser;
@@ -30,7 +30,6 @@ import org.broadinstitute.consent.http.service.validate.UseRestrictionValidatorA
 import org.broadinstitute.consent.http.util.DarConstants;
 import org.broadinstitute.consent.http.util.DarUtil;
 import org.bson.Document;
-import org.broadinstitute.consent.http.cloudstore.GCSStore;
 
 import javax.annotation.security.PermitAll;
 import javax.annotation.security.RolesAllowed;
@@ -51,12 +50,12 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 import java.io.IOException;
 import java.net.URI;
-import java.util.List;
-import java.util.Map;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
-import java.util.Arrays;
-import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -163,9 +162,9 @@ public class DataAccessRequestResource extends Resource {
     @Path("/invalid")
     @RolesAllowed("ADMIN")
     public Response getInvalidDataAccessRequest() {
-        try{
+        try {
             return Response.status(Response.Status.OK).entity(dataAccessRequestAPI.getInvalidDataAccessRequest()).build();
-        }catch (Exception e){
+        } catch (Exception e) {
             return createExceptionResponse(e);
         }
 
@@ -182,10 +181,20 @@ public class DataAccessRequestResource extends Resource {
     @Path("/{id}")
     @Produces("application/json")
     @PermitAll
-    public Document describe(@PathParam("id") String id) {
-        return dataAccessRequestAPI.describeDataAccessRequestById(id);
+    public Response describe(@PathParam("id") String id) {
+        try {
+            Document document = dataAccessRequestAPI.describeDataAccessRequestById(id);
+            return Response.status(Response.Status.OK).entity(document).build();
+        } catch (IllegalArgumentException e) {
+            logger.log(Level.INFO, "Returning DAR not found response to client from exception: " + e.getMessage());
+            return Response
+                    .status(Response.Status.NOT_FOUND)
+                    .entity("Unable to find Data Access Request with id: " + id)
+                    .build();
+        } catch (Exception e) {
+            return createExceptionResponse(new NotFoundException("Unable to find Data Access Request with id: " + id));
+        }
     }
-
 
     @DELETE
     @Produces(MediaType.APPLICATION_JSON)
@@ -268,15 +277,14 @@ public class DataAccessRequestResource extends Resource {
     public Response createPartialDataAccessRequest(@Context UriInfo info, Document dar) {
         URI uri;
         Document result = null;
-        if((dar.size() == 1 && dar.containsKey("userId")) || (dar.size() == 0)){
+        if ((dar.size() == 1 && dar.containsKey("userId")) || (dar.size() == 0)) {
             return Response.status(Response.Status.BAD_REQUEST).entity(new Error("The Data Access Request is empty. Please, complete the form with the information you want to save.", Response.Status.BAD_REQUEST.getStatusCode())).build();
         }
         try {
             result = savePartialDarRequest(dar);
             uri = info.getRequestUriBuilder().path("{id}").build(result.get(DarConstants.ID));
             return Response.created(uri).entity(result).build();
-        }
-        catch (Exception e) {
+        } catch (Exception e) {
             dataAccessRequestAPI.deleteDataAccessRequest(result);
             return createExceptionResponse(e);
         }
@@ -290,7 +298,7 @@ public class DataAccessRequestResource extends Resource {
     /*
      * Note: Run this endpoint only once, in order to apply datasets correspondent alias Id
      * in MySql and replace objectId to datasetId in Mongodb
-    */
+     */
     public Response createPartialDataAccessRequestFromCatalog(@QueryParam("userId") Integer userId, List<Integer> datasetIds) {
         Document dar = new Document();
         Collection<DataSetDTO> dataSets = dataSetAPI.describeDataSetsByReceiveOrder(datasetIds);
@@ -298,14 +306,14 @@ public class DataAccessRequestResource extends Resource {
         dar.append(DarConstants.USER_ID, userId);
         try {
             List<Map<String, String>> datasets = new ArrayList<>();
-            for(String datasetName: dataSetNames){
+            for (String datasetName : dataSetNames) {
                 List<Map<String, String>> ds = dataSetAPI.getCompleteDataSet(datasetName);
                 datasets.add(ds.get(0));
             }
             dar.append(DarConstants.DATASET_ID, datasets);
             return Response.ok().entity(dar).build();
         } catch (Exception e) {
-            logger.log(Level.SEVERE, " while fetching dataset details to export to DAR formulary. UserId: " + userId + ", datasets: " + datasetIds.toString()+". Cause: "+ e.getLocalizedMessage());
+            logger.log(Level.SEVERE, " while fetching dataset details to export to DAR formulary. UserId: " + userId + ", datasets: " + datasetIds.toString() + ". Cause: " + e.getLocalizedMessage());
             return createExceptionResponse(e);
         }
     }
@@ -356,7 +364,6 @@ public class DataAccessRequestResource extends Resource {
     }
 
 
-
     @PUT
     @Consumes("application/json")
     @Produces("application/json")
@@ -366,13 +373,13 @@ public class DataAccessRequestResource extends Resource {
         try {
             List<DACUser> usersToNotify = dataAccessRequestAPI.getUserEmailAndCancelElection(referenceId);
             Document dar = dataAccessRequestAPI.cancelDataAccessRequest(referenceId);
-            if(CollectionUtils.isNotEmpty(usersToNotify)) {
+            if (CollectionUtils.isNotEmpty(usersToNotify)) {
                 emailApi.sendCancelDARRequestMessage(usersToNotify, dar.getString(DarConstants.DAR_CODE));
             }
             return Response.ok().entity(dar).build();
         } catch (MessagingException | TemplateException | IOException e) {
             return Response.status(Response.Status.BAD_REQUEST).entity(new Error("The Data Access Request was cancelled but the DAC/Admin couldn't be notified. Contact Support. ", Response.Status.BAD_REQUEST.getStatusCode())).build();
-        } catch (Exception e){
+        } catch (Exception e) {
             return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(new Error("Internal server error on delete. Please try again later. ", Response.Status.INTERNAL_SERVER_ERROR.getStatusCode())).build();
         }
     }
@@ -382,10 +389,10 @@ public class DataAccessRequestResource extends Resource {
     @Produces("application/json")
     @Path("/hasUseRestriction/{referenceId}")
     @PermitAll
-    public Response hasUseRestriction(@PathParam("referenceId") String referenceId){
-        try{
-            return Response.ok("{\"hasUseRestriction\":"+dataAccessRequestAPI.hasUseRestriction(referenceId)+"}").build();
-        }catch (Exception e){
+    public Response hasUseRestriction(@PathParam("referenceId") String referenceId) {
+        try {
+            return Response.ok("{\"hasUseRestriction\":" + dataAccessRequestAPI.hasUseRestriction(referenceId) + "}").build();
+        } catch (Exception e) {
             return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(new Error(e.getMessage(), Response.Status.INTERNAL_SERVER_ERROR.getStatusCode())).build();
         }
     }
@@ -396,29 +403,29 @@ public class DataAccessRequestResource extends Resource {
     @Path("/restriction")
     @PermitAll
     public Response getUseRestrictionFromQuestions(Document dar) {
-        try{
+        try {
             Boolean needsManualReview = DarUtil.requiresManualReview(dar);
-            if (!needsManualReview){
+            if (!needsManualReview) {
                 UseRestriction useRestriction = dataAccessRequestAPI.createStructuredResearchPurpose(dar);
                 dar.append(DarConstants.RESTRICTION, Document.parse(useRestriction.toString()));
                 return Response.ok(useRestriction).build();
-            }else{
+            } else {
                 return Response.ok("{\"useRestriction\":\"Manual Review\"}").build();
             }
-        }catch(Exception e){
+        } catch (Exception e) {
             return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(new Error(e.getMessage(), Response.Status.INTERNAL_SERVER_ERROR.getStatusCode())).build();
         }
     }
 
-    private Document savePartialDarRequest(Document dar) throws Exception{
-        dar.append(DarConstants.SORT_DATE,new Date());
+    private Document savePartialDarRequest(Document dar) throws Exception {
+        dar.append(DarConstants.SORT_DATE, new Date());
         return dataAccessRequestAPI.createPartialDataAccessRequest(dar);
     }
 
-    private Integer obtainUserId (Document dar) {
-        try{
+    private Integer obtainUserId(Document dar) {
+        try {
             return dar.getInteger("userId");
-        }catch (Exception e) {
+        } catch (Exception e) {
             return Integer.valueOf(dar.getString("userId"));
         }
     }

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -875,7 +875,15 @@ paths:
         - Data Access Request
       responses:
         '200':
-          description: Returns the DAR collection, an array where each field is a json object that represents a DAR.
+          description: Returns a Data Access Request
+          schema:
+            $ref: '#/definitions/DataAccessRequest'
+        '400':
+          description: The provided ID is not a valid DAR identifier
+        '404':
+          description: No DAR can be found with the provided identifier
+        '500':
+          description: Server Error
     put:
           summary: updateDataAccessRequest
           description: Updates the DAR identified by the dar_code.

--- a/src/test/java/org/broadinstitute/consent/http/WithMockServer.java
+++ b/src/test/java/org/broadinstitute/consent/http/WithMockServer.java
@@ -1,0 +1,20 @@
+package org.broadinstitute.consent.http;
+
+import org.mockserver.integration.ClientAndServer;
+
+import static org.mockserver.integration.ClientAndServer.startClientAndServer;
+
+public interface WithMockServer {
+
+    default ClientAndServer startMockServer(int port) {
+        // Mockserver doesn't respect dropwizard log settings
+        ((ch.qos.logback.classic.Logger) org.slf4j.LoggerFactory
+                .getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME))
+                .setLevel(ch.qos.logback.classic.Level.OFF);
+        ((ch.qos.logback.classic.Logger) org.slf4j.LoggerFactory
+                .getLogger("org.mockserver"))
+                .setLevel(ch.qos.logback.classic.Level.OFF);
+        return startClientAndServer(port);
+    }
+
+}

--- a/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceTest.java
@@ -23,10 +23,11 @@ import javax.ws.rs.core.Response;
 import java.io.IOException;
 import java.util.List;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doReturn;
 
-public class DataAccessRequestResourceTest extends DataAccessRequestServiceTest{
+public class DataAccessRequestResourceTest extends DataAccessRequestServiceTest {
 
     private static final String TEST_DATABASE_NAME = "TestConsent";
     private long mongoDocuments;
@@ -65,9 +66,6 @@ public class DataAccessRequestResourceTest extends DataAccessRequestServiceTest{
         checkStatus(CREATED, post(client, darPath(), sampleDar));
         List<Document> created = retrieveDars(client, darPath());
         assertTrue(created.size() == ++mongoDocuments);
-        Document insertedDocument = created.get(created.size()-1);
-        System.out.println(insertedDocument.get("_id"));
-
     }
 
     @Test
@@ -117,9 +115,24 @@ public class DataAccessRequestResourceTest extends DataAccessRequestServiceTest{
         assertTrue(res.equals("{\"useRestriction\":\"Manual Review\"}"));
     }
 
+    @Test
+    public void testDarFound() throws Exception {
+        Client client = ClientBuilder.newClient();
+        String darId = DataRequestSamplesHolder.getSampleDar().getString(DarConstants.ID);
+        System.out.println("DAR ID: " + darId);
+        Response response = getJson(client, darPath(darId));
+        assertEquals(200, response.getStatus());
+    }
+
+    @Test
+    public void testDarNotFound() throws Exception {
+        Client client = ClientBuilder.newClient();
+        Response response = getJson(client, darPath("invalid-5998-id"));
+        assertEquals(404, response.getStatus());
+    }
 
     private List<Document> retrieveDars(Client client, String url) throws IOException {
-        return getJson(client, url).readEntity(new GenericType<List<Document>>(){});
+        return getJson(client, url).readEntity(new GenericType<List<Document>>() {});
     }
 
 }

--- a/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceTest.java
@@ -63,7 +63,7 @@ public class DataAccessRequestResourceTest extends DataAccessRequestServiceTest 
     public void testDarOperations() throws IOException {
         Client client = ClientBuilder.newClient();
         Document sampleDar = DataRequestSamplesHolder.getSampleDar();
-        long  mongoDocuments = retrieveDars(client, darPath()).size();
+        long mongoDocuments = retrieveDars(client, darPath()).size();
         checkStatus(CREATED, post(client, darPath(), sampleDar));
         List<Document> created = retrieveDars(client, darPath());
         assertTrue(created.size() == ++mongoDocuments);
@@ -120,8 +120,8 @@ public class DataAccessRequestResourceTest extends DataAccessRequestServiceTest 
         // Create a DAR
         Client client = ClientBuilder.newClient();
         post(client, darPath(), DataRequestSamplesHolder.getSampleDar());
-        Document newDoc = retrieveDars(client, darPath()).get(0);
-        ObjectId objectId = getObjectIdFromDocument(newDoc);
+        Document created = retrieveDars(client, darPath()).get(0);
+        ObjectId objectId = getObjectIdFromDocument(created);
 
         // Make sure the DAR can be retrieved using the ID
         Response response = getJson(client, darPath(objectId.toHexString()));

--- a/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceTest.java
@@ -129,9 +129,17 @@ public class DataAccessRequestResourceTest extends DataAccessRequestServiceTest 
     }
 
     @Test
-    public void testDarNotFound() throws Exception {
+    public void testInvalidDARFormat() throws Exception {
         Client client = ClientBuilder.newClient();
         Response response = getJson(client, darPath("invalid-5998-id"));
+        assertEquals(400, response.getStatus());
+    }
+
+    @Test
+    public void testDARNotFound() throws Exception {
+        ObjectId id = new ObjectId();
+        Client client = ClientBuilder.newClient();
+        Response response = getJson(client, darPath(id.toHexString()));
         assertEquals(404, response.getStatus());
     }
 

--- a/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceTest.java
@@ -10,11 +10,15 @@ import org.broadinstitute.consent.http.models.dto.UseRestrictionDTO;
 import org.broadinstitute.consent.http.service.DatabaseDataAccessRequestAPI;
 import org.broadinstitute.consent.http.util.DarConstants;
 import org.bson.Document;
+import org.bson.types.ObjectId;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Mockito;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
@@ -29,8 +33,8 @@ import static org.mockito.Mockito.doReturn;
 
 public class DataAccessRequestResourceTest extends DataAccessRequestServiceTest {
 
+    private final static Logger log = LoggerFactory.getLogger(DataAccessRequestResourceTest.class);
     private static final String TEST_DATABASE_NAME = "TestConsent";
-    private long mongoDocuments;
 
     @ClassRule
     public static final DropwizardAppRule<ConsentConfiguration> RULE = new DropwizardAppRule<>(
@@ -58,16 +62,18 @@ public class DataAccessRequestResourceTest extends DataAccessRequestServiceTest 
     }
 
 
+    @Ignore
     @Test
     public void testDarOperations() throws IOException {
         Client client = ClientBuilder.newClient();
         Document sampleDar = DataRequestSamplesHolder.getSampleDar();
-        mongoDocuments = retrieveDars(client, darPath()).size();
+        long  mongoDocuments = retrieveDars(client, darPath()).size();
         checkStatus(CREATED, post(client, darPath(), sampleDar));
         List<Document> created = retrieveDars(client, darPath());
         assertTrue(created.size() == ++mongoDocuments);
     }
 
+    @Ignore
     @Test
     public void testPartialDarOperations() throws IOException {
         Client client = ClientBuilder.newClient();
@@ -78,6 +84,7 @@ public class DataAccessRequestResourceTest extends DataAccessRequestServiceTest 
         assertTrue(created.size() == ++partialDocumentsCount);
     }
 
+    @Ignore
     @Test
     public void testInvalidDars() throws IOException {
         Client client = ClientBuilder.newClient();
@@ -86,6 +93,7 @@ public class DataAccessRequestResourceTest extends DataAccessRequestServiceTest 
     }
 
 
+    @Ignore
     @Test
     public void testManageDars() throws IOException {
         Client client = ClientBuilder.newClient();
@@ -97,6 +105,7 @@ public class DataAccessRequestResourceTest extends DataAccessRequestServiceTest 
 
     }
 
+    @Ignore
     @Test
     public void testManagePartialDars() throws IOException {
         Client client = ClientBuilder.newClient();
@@ -107,6 +116,7 @@ public class DataAccessRequestResourceTest extends DataAccessRequestServiceTest 
         assertTrue(manageDars.size() == 1);
     }
 
+    @Ignore
     @Test
     public void testRestrictionFromQuestions() throws IOException {
         Client client = ClientBuilder.newClient();
@@ -117,13 +127,39 @@ public class DataAccessRequestResourceTest extends DataAccessRequestServiceTest 
 
     @Test
     public void testDarFound() throws Exception {
+        // Create a DAR
         Client client = ClientBuilder.newClient();
-        String darId = DataRequestSamplesHolder.getSampleDar().getString(DarConstants.ID);
-        System.out.println("DAR ID: " + darId);
-        Response response = getJson(client, darPath(darId));
-        assertEquals(200, response.getStatus());
+        Document sampleDar = DataRequestSamplesHolder.getSampleDar();
+        checkStatus(CREATED, post(client, darPath(), sampleDar));
+        List<Document> created = retrieveDars(client, darPath());
+        System.out.println("Created Size: " + created.size());
+        assertEquals(1, created.size());
+        Document newDoc = created.get(0);
+
+        // TODO: Figure out how to
+//        System.out.println(newDoc.toJson());
+//        System.out.println("***********************************************************");
+
+//        System.out.println(newDoc.get(DarConstants.ID).toString());
+//        System.out.println("***********************************************************");
+
+//        System.out.println(newDoc.get(DarConstants.ID, ObjectId.class).toString());
+//        System.out.println("***********************************************************");
+
+//        Object id = newDoc.get(DarConstants.ID);
+//        ObjectId objectId = newDoc.getObjectId(DarConstants.ID);
+//        ObjectId objectId = new ObjectId(id.toString());
+
+//        System.out.println(objectId);
+//        System.out.println("***********************************************************");
+
+        // TODO: This is the test I want to pass:
+//        Response response = getJson(client, darPath(newDoc.getString(DarConstants.ID)));
+//        assertEquals(200, response.getStatus());
+
     }
 
+    @Ignore
     @Test
     public void testDarNotFound() throws Exception {
         Client client = ClientBuilder.newClient();

--- a/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestServiceTest.java
@@ -2,9 +2,9 @@ package org.broadinstitute.consent.http.resources;
 
 import org.broadinstitute.consent.http.AbstractTest;
 
-public abstract class DataAccessRequestServiceTest extends AbstractTest{
+abstract class DataAccessRequestServiceTest extends AbstractTest{
 
-    public String darPath() {
+    String darPath() {
         return path2Url("/dar");
     }
 
@@ -12,30 +12,30 @@ public abstract class DataAccessRequestServiceTest extends AbstractTest{
         return path2Url(String.format("/dar/%s", id));
     }
 
-    public String invalidDarsPath() {
-        return path2Url(String.format("/dar/invalid"));
+    String invalidDarsPath() {
+        return path2Url("/dar/invalid");
     }
 
-    public String darManagePath(String id) {
+    String darManagePath(String id) {
         return path2Url(String.format("/dar/manage?userId=%s", id));
     }
 
     /* Partials */
 
-    public String partialsPath() {
-        return path2Url(String.format("/dar/partials"));
+    String partialsPath() {
+        return path2Url("/dar/partials");
     }
 
-    public String partialsManagePath(String id) {
+    String partialsManagePath(String id) {
         return path2Url(String.format("/dar/partials/manage?userId=%s", id));
     }
 
-    public String partialPath() {
-        return path2Url(String.format("/dar/partial"));
+    String partialPath() {
+        return path2Url("/dar/partial");
     }
 
-    public String restrictionFromQuestionsUrl() {
-        return path2Url(String.format("/dar/restriction"));
+    String restrictionFromQuestionsUrl() {
+        return path2Url("/dar/restriction");
     }
 
 }

--- a/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestServiceTest.java
@@ -8,6 +8,10 @@ public abstract class DataAccessRequestServiceTest extends AbstractTest{
         return path2Url("/dar");
     }
 
+    String darPath(String id) {
+        return path2Url(String.format("/dar/%s", id));
+    }
+
     public String invalidDarsPath() {
         return path2Url(String.format("/dar/invalid"));
     }

--- a/src/test/java/org/broadinstitute/consent/http/resources/DataRequestSamplesHolder.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DataRequestSamplesHolder.java
@@ -1,6 +1,7 @@
 package org.broadinstitute.consent.http.resources;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.broadinstitute.consent.http.util.DarConstants;
 import org.bson.Document;
 
 import java.io.IOException;
@@ -44,11 +45,10 @@ public class DataRequestSamplesHolder {
             "            \"name\" : \"test\"\n" +
             "        }\n" +
             "    ],\n" +
-            "    \"dar_code\" : \"DAR-1\",\n" +
-            "    \"_id\" : \"5c9ba56146e0fb0001c09466\"\n" +
+            "    \"dar_code\" : \"DAR-1\"\n" +
             "}";
 
-    public static Document getSampleDar() throws IOException {
+    static Document getSampleDar() throws IOException {
         Document document = new Document();
         document.putAll(jsonAsMap(completeDARJson));
         return document;

--- a/src/test/java/org/broadinstitute/consent/http/resources/DataRequestSamplesHolder.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DataRequestSamplesHolder.java
@@ -44,7 +44,8 @@ public class DataRequestSamplesHolder {
             "            \"name\" : \"test\"\n" +
             "        }\n" +
             "    ],\n" +
-            "    \"dar_code\" : \"DAR-1\"\n" +
+            "    \"dar_code\" : \"DAR-1\",\n" +
+            "    \"_id\" : \"5c9ba56146e0fb0001c09466\"\n" +
             "}";
 
     public static Document getSampleDar() throws IOException {

--- a/src/test/java/org/broadinstitute/consent/http/resources/DataRequestSamplesHolder.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DataRequestSamplesHolder.java
@@ -1,13 +1,12 @@
 package org.broadinstitute.consent.http.resources;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.broadinstitute.consent.http.util.DarConstants;
 import org.bson.Document;
 
 import java.io.IOException;
 import java.util.HashMap;
 
-public class DataRequestSamplesHolder {
+class DataRequestSamplesHolder {
 
     private static final String completeDARJson = "{\n" +
             "    \"investigator\" : \"Somenone\",\n" +
@@ -48,15 +47,12 @@ public class DataRequestSamplesHolder {
             "    \"dar_code\" : \"DAR-1\"\n" +
             "}";
 
+    @SuppressWarnings("unchecked")
     static Document getSampleDar() throws IOException {
+        HashMap<String, Object> jsonMap = new ObjectMapper().readValue(completeDARJson, HashMap.class);
         Document document = new Document();
-        document.putAll(jsonAsMap(completeDARJson));
+        document.putAll(jsonMap);
         return document;
-    }
-
-    private static HashMap<String,Object> jsonAsMap(String jsonSource) throws IOException {
-        HashMap<String,Object> result = new ObjectMapper().readValue(jsonSource, HashMap.class);
-        return result;
     }
 
 }

--- a/src/test/java/org/broadinstitute/consent/http/service/IndexOntologyServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/IndexOntologyServiceTest.java
@@ -1,6 +1,7 @@
 package org.broadinstitute.consent.http.service;
 
 import com.google.common.io.Resources;
+import org.broadinstitute.consent.http.WithMockServer;
 import org.broadinstitute.consent.http.configurations.ElasticSearchConfiguration;
 import org.broadinstitute.consent.http.models.ontology.StreamRec;
 import org.broadinstitute.consent.http.models.ontology.Term;
@@ -30,11 +31,10 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static org.mockserver.integration.ClientAndServer.startClientAndServer;
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
 
-public class IndexOntologyServiceTest {
+public class IndexOntologyServiceTest implements WithMockServer {
 
     private static final String INDEX_NAME = "test-index";
     private IndexOntologyService ontologyService;
@@ -49,7 +49,7 @@ public class IndexOntologyServiceTest {
         configuration.setServers(Collections.singletonList("localhost"));
         client = ElasticSearchSupport.createRestClient(configuration);
         this.ontologyService = new IndexOntologyService(configuration);
-        server = startClientAndServer(9200);
+        server = startMockServer(9200);
         server.when(request()).respond(response().withStatusCode(200));
     }
 

--- a/src/test/java/org/broadinstitute/consent/http/service/UseRestrictionConverterTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/UseRestrictionConverterTest.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.consent.http.service;
 
+import org.broadinstitute.consent.http.WithMockServer;
 import org.broadinstitute.consent.http.configurations.ServicesConfiguration;
 import org.broadinstitute.consent.http.models.DataUseDTO;
 import org.broadinstitute.consent.http.models.grammar.Everything;
@@ -17,18 +18,17 @@ import javax.ws.rs.core.MediaType;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import static org.mockserver.integration.ClientAndServer.startClientAndServer;
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
 
-public class UseRestrictionConverterTest {
+public class UseRestrictionConverterTest implements WithMockServer {
 
     private ClientAndServer mockServer;
     private Integer port = 9000;
 
     @Before
     public void startUp() {
-        mockServer = startClientAndServer(port);
+        mockServer = startMockServer(port);
     }
 
     @After

--- a/src/test/resources/consent-config.yml
+++ b/src/test/resources/consent-config.yml
@@ -39,6 +39,7 @@ logging:
     "net.sourceforge": ERROR
     "org.apache": ERROR
     "org.liquibase": ERROR
+    "de.flapdoodle.embed.mongo": ERROR
     "org.mongodb": ERROR
     "org.reflections": ERROR
     "org.semanticweb": ERROR


### PR DESCRIPTION
## Addresses
https://broadinstitute.atlassian.net/browse/DUOS-228

## Changes
* Handle the lookup of the dar by document id better. If we can't find it, or if it is not an id we can look up, return a 404. Otherwise, return the exception through the normal exception response mechanism. 
* Added tests.
* Lots of minor formatting cleanup for the files touched.
* While I'm at it ... addressing some long-standing test logging problems in mongo and mockserver.

## Manual Testing
* Spin up and go to the dar lookup page which is `Data_Access_Request/get_api_dar_id`
* Try entering gibberish into the id field and ensure that you get a 404. 
* Enter a real id (look one up from duos dev) and ensure that you still get a valid document.