### PR TITLE
[DUOS-283] Another HMB is not manual review case

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/models/darsummary/DARModalDetailsDTO.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/darsummary/DARModalDetailsDTO.java
@@ -162,7 +162,7 @@ public class DARModalDetailsDTO {
             manualReviewIsTrue();
         }
         if(darDocument.containsKey("hmb") && darDocument.getBoolean("hmb")){
-            researchList.add(new SummaryItem(SummaryConstants.RT_HEALTH_BIOMEDICAL, SummaryConstants.RT_HEALTH_BIOMEDICAL_DETAIL, true));
+            researchList.add(new SummaryItem(SummaryConstants.RT_HEALTH_BIOMEDICAL, SummaryConstants.RT_HEALTH_BIOMEDICAL_DETAIL, false));
         }
         if(darDocument.containsKey("poa") && darDocument.getBoolean("poa")){
             researchList.add(new SummaryItem(SummaryConstants.RT_POPULATION_ORIGINS, SummaryConstants.RT_POPULATION_ORIGINS_DETAIL, true));


### PR DESCRIPTION
## Addresses
https://broadinstitute.atlassian.net/browse/DUOS-283

## Changes
* The DAR summary was incorrectly setting this value for HMB research. This led to a simple display bug that this should fix. 

## See Also
Filed https://broadinstitute.atlassian.net/browse/DUOS-335 to cover the cleanup here - we should not be setting this value in two different places - the UI should read it from the same place consistently.