### PR TITLE
[DUOS-329][risk=no] Allow chairpersons to open/close elections

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/resources/ConsentElectionResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/ConsentElectionResource.java
@@ -34,7 +34,7 @@ public class ConsentElectionResource extends Resource {
 
     @POST
     @Consumes("application/json")
-    @RolesAllowed("ADMIN")
+    @RolesAllowed({ADMIN, CHAIRPERSON})
     public Response createConsentElection(@Context UriInfo info, Election rec,
                                           @PathParam("consentId") String consentId) {
         URI uri;
@@ -76,7 +76,7 @@ public class ConsentElectionResource extends Resource {
     @DELETE
     @Produces(MediaType.APPLICATION_JSON)
     @Path("/{id}")
-    @RolesAllowed("ADMIN")
+    @RolesAllowed({ADMIN, CHAIRPERSON})
     public Response deleteElection(@PathParam("consentId") String consentId, @Context UriInfo info, @PathParam("id") Integer id) {
         try {
             api.deleteElection(consentId, id);

--- a/src/main/java/org/broadinstitute/consent/http/resources/DataRequestElectionResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataRequestElectionResource.java
@@ -40,7 +40,7 @@ public class DataRequestElectionResource extends Resource {
 
     @POST
     @Consumes("application/json")
-    @RolesAllowed("ADMIN")
+    @RolesAllowed({ADMIN, CHAIRPERSON})
     public Response createDataRequestElection(@Context UriInfo info, Election rec,
                                               @PathParam("requestId") String requestId) {
         URI uri;
@@ -80,7 +80,7 @@ public class DataRequestElectionResource extends Resource {
     @DELETE
     @Produces(MediaType.APPLICATION_JSON)
     @Path("/{id}")
-    @RolesAllowed("ADMIN")
+    @RolesAllowed({ADMIN, CHAIRPERSON})
     public Response deleteElection(@PathParam("requestId") String requestId, @PathParam("id") Integer id, @Context UriInfo info) {
         try {
             api.deleteElection(requestId, id);

--- a/src/main/java/org/broadinstitute/consent/http/resources/Resource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/Resource.java
@@ -23,6 +23,10 @@ import java.util.Map;
  */
 abstract public class Resource {
 
+    // Resource based role names
+    protected final static String ADMIN = "ADMIN";
+    protected final static String CHAIRPERSON = "CHAIRPERSON";
+
     protected Logger logger() {
         return Logger.getLogger("consent");
     }


### PR DESCRIPTION
See https://broadinstitute.atlassian.net/browse/DUOS-329

Allow for chairpersons to open/close consent and dar elections. 

Manually tested creating consent and data access requests as a chairperson - both worked. Canceling them is currently done via the PUT in `ElectionResource` and had the correct permissions already so no additional work is needed there. 