### PR TITLE
[DUOS-348][risk=no] Update the logic for the number of DAC members

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/service/DatabaseElectionAPI.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatabaseElectionAPI.java
@@ -7,6 +7,7 @@ import com.mongodb.client.MongoCursor;
 import freemarker.template.TemplateException;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.assertj.core.util.VisibleForTesting;
 import org.broadinstitute.consent.http.db.ConsentDAO;
 import org.broadinstitute.consent.http.db.DACUserDAO;
 import org.broadinstitute.consent.http.db.DataSetDAO;
@@ -89,7 +90,8 @@ public class DatabaseElectionAPI extends AbstractElectionAPI {
      *
      * @param dao The Data Access Object used to read/write data.
      */
-    private DatabaseElectionAPI(ElectionDAO dao, ConsentDAO consentDAO, DACUserDAO dacUserDAO, MongoConsentDB mongo, VoteDAO voteDAO, MailMessageDAO mailMessageDAO, DataSetDAO dataSetDAO) {
+    @VisibleForTesting
+    DatabaseElectionAPI(ElectionDAO dao, ConsentDAO consentDAO, DACUserDAO dacUserDAO, MongoConsentDB mongo, VoteDAO voteDAO, MailMessageDAO mailMessageDAO, DataSetDAO dataSetDAO) {
         this.electionDAO = dao;
         this.consentDAO = consentDAO;
         this.dacUserDAO = dacUserDAO;

--- a/src/main/java/org/broadinstitute/consent/http/service/DatabaseElectionAPI.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatabaseElectionAPI.java
@@ -25,8 +25,8 @@ import org.broadinstitute.consent.http.models.DACUser;
 import org.broadinstitute.consent.http.models.DataSet;
 import org.broadinstitute.consent.http.models.Election;
 import org.broadinstitute.consent.http.models.Vote;
-import org.broadinstitute.consent.http.models.dto.ElectionStatusDTO;
 import org.broadinstitute.consent.http.models.dto.DatasetMailDTO;
+import org.broadinstitute.consent.http.models.dto.ElectionStatusDTO;
 import org.broadinstitute.consent.http.models.grammar.UseRestriction;
 import org.broadinstitute.consent.http.util.DarConstants;
 import org.broadinstitute.consent.http.util.DarUtil;
@@ -651,27 +651,19 @@ public class DatabaseElectionAPI extends AbstractElectionAPI {
     }
 
     private void validateAvailableUsers(ElectionType electionType) {
-        if(!electionType.equals(ElectionType.DATA_SET)){
+        if (!electionType.equals(ElectionType.DATA_SET)) {
             Set<DACUser> dacUsers = dacUserDAO.findDACUsersEnabledToVote();
-            if (dacUsers != null && dacUsers.size() >= 4) {
-                boolean existChairperson = false;
-                for (DACUser user : dacUsers) {
-                    if (user.getRoles().stream().anyMatch(role -> role.getName().equalsIgnoreCase(DACUserRoles.CHAIRPERSON.getValue()))) {
-                        existChairperson = true;
-                        break;
-                    }
-                }
-                if (!existChairperson) {
-                    throw new IllegalArgumentException("There has to be a Chairperson.");
-                }
-            } else {
-                throw new IllegalArgumentException(
-                        "There has to be a Chairperson and at least 4 Members cataloged in the system to create an election.");
+            if (dacUsers == null || dacUsers.isEmpty()) {
+                throw new IllegalArgumentException("There are no enabled DAC Members or Chairpersons to hold an election.");
+            }
+            boolean chairpersonExists = dacUsers.stream()
+                    .flatMap(u -> u.getRoles().stream())
+                    .anyMatch(r -> r.getName().equalsIgnoreCase(DACUserRoles.CHAIRPERSON.getValue()));
+            if (!chairpersonExists) {
+                throw new IllegalArgumentException("There has to be a Chairperson.");
             }
         }
-
     }
-
 
     private void updateSortDate(String referenceId, Date createDate){
         if(consentDAO.checkConsentbyId(referenceId) != null){

--- a/src/main/java/org/broadinstitute/consent/http/service/validate/UseRestrictionValidator.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/validate/UseRestrictionValidator.java
@@ -1,9 +1,5 @@
 package org.broadinstitute.consent.http.service.validate;
 
-import javax.ws.rs.client.Client;
-import javax.ws.rs.client.ClientBuilder;
-import javax.ws.rs.client.Entity;
-import javax.ws.rs.core.Response;
 import com.google.gson.Gson;
 import com.mongodb.Block;
 import com.mongodb.client.FindIterable;
@@ -20,6 +16,10 @@ import org.glassfish.jersey.client.ClientProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.Response;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -53,8 +53,8 @@ public class UseRestrictionValidator extends AbstractUseRestrictionValidatorAPI{
             if (!entity.isValid()) {
                 throw new IllegalArgumentException(entity.getErrors().toString());
             }
-        }else{
-            throw new IllegalArgumentException("There was an error posting the use restriction" + (res.readEntity(ValidateResponse.class)).getErrors().toString());
+        } else {
+            throw new IllegalArgumentException("There was an error posting the use restriction" + (res.readEntity(String.class)));
         }
     }
 

--- a/src/test/java/org/broadinstitute/consent/http/AbstractTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/AbstractTest.java
@@ -14,6 +14,8 @@ import de.flapdoodle.embed.mongo.distribution.Version;
 import de.flapdoodle.embed.process.config.IRuntimeConfig;
 import de.flapdoodle.embed.process.config.io.ProcessOutput;
 import de.flapdoodle.embed.process.runtime.Network;
+import io.dropwizard.jdbi.DBIFactory;
+import io.dropwizard.setup.Environment;
 import io.dropwizard.testing.junit.DropwizardAppRule;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
@@ -30,6 +32,7 @@ import org.broadinstitute.consent.http.models.grammar.UseRestriction;
 import org.broadinstitute.consent.http.models.validate.ValidateResponse;
 import org.broadinstitute.consent.http.service.validate.UseRestrictionValidator;
 import org.mockito.Mockito;
+import org.skife.jdbi.v2.DBI;
 
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.Entity;
@@ -236,6 +239,12 @@ abstract public class AbstractTest extends ResourcedTest {
         } catch (IOException e) {
             logger.error("Unable to remove target/mongo directory");
         }
+    }
+
+    DBI getApplicationJdbi() {
+        ConsentConfiguration configuration = rule().getConfiguration();
+        Environment environment = rule().getEnvironment();
+        return new DBIFactory().build(environment, configuration.getDataSourceFactory(), "mysql");
     }
 
 }

--- a/src/test/java/org/broadinstitute/consent/http/AbstractTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/AbstractTest.java
@@ -241,7 +241,7 @@ abstract public class AbstractTest extends ResourcedTest {
         }
     }
 
-    DBI getApplicationJdbi() {
+    protected DBI getApplicationJdbi() {
         ConsentConfiguration configuration = rule().getConfiguration();
         Environment environment = rule().getEnvironment();
         return new DBIFactory().build(environment, configuration.getDataSourceFactory(), "mysql");

--- a/src/test/java/org/broadinstitute/consent/http/ConsentElectionTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/ConsentElectionTest.java
@@ -48,40 +48,6 @@ public class ConsentElectionTest extends ElectionVoteServiceTest {
         return RULE;
     }
 
-    @After
-    public void resetDACMemberRoles() {
-//        insert into user_role(roleId, dacUserId) values(2,1);
-//        insert into user_role(roleId, dacUserId, status) values(5,1,0);
-//        insert into user_role(roleId, dacUserId) values(6,1);
-
-//        insert into user_role(roleId, dacUserId) values(1,2);
-//        insert into user_role(roleId, dacUserId) values(6,2);
-
-//        insert into user_role(roleId, dacUserId) values(1,3);
-
-//        insert into user_role(roleId, dacUserId) values(1,4);
-//        insert into user_role(roleId, dacUserId) values(4,4);
-
-//        insert into user_role(roleId, dacUserId) values(2,5);
-//        insert into user_role(roleId, dacUserId) values(4,5);
-//        insert into user_role(roleId, dacUserId) values(5,5);
-//        insert into user_role(roleId, dacUserId) values(6,5);
-
-        // to avoid integrity constraint violations on insert, delete them all first.
-//        List<Integer> roleList = Arrays.asList(member, chair);
-//        userRoleDAO.removeUserRoles(1, roleList);
-//        userRoleDAO.removeUserRoles(2, roleList);
-//        userRoleDAO.removeUserRoles(3, roleList);
-//        userRoleDAO.removeUserRoles(4, roleList);
-//
-//        // now reset to original seed data.
-//        userRoleDAO.insertSingleUserRole(chair, 1, false);
-//        userRoleDAO.insertSingleUserRole(member, 1, false);
-//        userRoleDAO.insertSingleUserRole(member, 2, false);
-//        userRoleDAO.insertSingleUserRole(member, 3, false);
-//        userRoleDAO.insertSingleUserRole(member, 4, false);
-    }
-
     @Test
     public void testCreateConsentElection() throws IOException {
         Client client = ClientBuilder.newClient();
@@ -164,56 +130,70 @@ public class ConsentElectionTest extends ElectionVoteServiceTest {
                 post(client, electionConsentPath(CONSENT_ID_2), election));
     }
 
-//    @Test
-//    public void createElectionWithSingleChairperson() throws IOException {
-//        // Test Seed Data creates 3 DAC members and 1 chairperson.
-//        // We need to remove the DAC member roles for this test
-//        List<Integer> roleList = Collections.singletonList(member);
-//        userRoleDAO.removeUserRoles(2, roleList);
-//        userRoleDAO.removeUserRoles(3, roleList);
-//        userRoleDAO.removeUserRoles(4, roleList);
-//
-//        Client client = ClientBuilder.newClient();
-//        Election election = new Election();
-//        election.setStatus(ElectionStatus.OPEN.getValue());
-//        election.setElectionType(ElectionType.TRANSLATE_DUL.getValue());
-//        Response response = checkStatus(CREATED,
-//                post(client, electionConsentPath(CONSENT_ID), election));
-//        String createdLocation = checkHeader(response, "Location");
-//        assertThat(createdLocation).isNotNull();
-//        assertThat(createdLocation).isNotEmpty();
-//    }
-//
-//    @Test
-//    public void createElectionWithNoDACMembersOrChair() throws IOException {
-//        // Test Seed Data creates 3 DAC members and 1 chairperson.
-//        // We need to remove all roles for this test
-//        List<Integer> roleList = Arrays.asList(member, chair);
-//        userRoleDAO.removeUserRoles(1, roleList);
-//        userRoleDAO.removeUserRoles(2, roleList);
-//        userRoleDAO.removeUserRoles(3, roleList);
-//        userRoleDAO.removeUserRoles(4, roleList);
-//
-//        Client client = ClientBuilder.newClient();
-//        Election election = new Election();
-//        election.setStatus(ElectionStatus.OPEN.getValue());
-//        election.setElectionType(ElectionType.TRANSLATE_DUL.getValue());
-//        checkStatus(BADREQUEST, post(client, electionConsentPath(CONSENT_ID), election));
-//    }
-//
-//    @Test
-//    public void createElectionWithNoChair() throws IOException {
-//        // Test Seed Data creates 3 DAC members and 1 chairperson.
-//        // We need to remove the chairperson role for this test
-//        List<Integer> roleList = Collections.singletonList(chair);
-//        userRoleDAO.removeUserRoles(1, roleList);
-//
-//        Client client = ClientBuilder.newClient();
-//        Election election = new Election();
-//        election.setStatus(ElectionStatus.OPEN.getValue());
-//        election.setElectionType(ElectionType.TRANSLATE_DUL.getValue());
-//        checkStatus(BADREQUEST, post(client, electionConsentPath(CONSENT_ID), election));
-//    }
+    @Test
+    public void createElectionWithSingleChairperson() throws IOException {
+        // Test Seed Data creates 3 DAC members and 1 chairperson.
+        // We need to remove the DAC member roles for this test
+        List<Integer> roleList = Collections.singletonList(member);
+        userRoleDAO.removeUserRoles(2, roleList);
+        userRoleDAO.removeUserRoles(3, roleList);
+        userRoleDAO.removeUserRoles(4, roleList);
+
+        Client client = ClientBuilder.newClient();
+        Election election = new Election();
+        election.setStatus(ElectionStatus.OPEN.getValue());
+        election.setElectionType(ElectionType.TRANSLATE_DUL.getValue());
+        Response response = checkStatus(CREATED,
+                post(client, electionConsentPath(CONSENT_ID), election));
+        String createdLocation = checkHeader(response, "Location");
+        assertThat(createdLocation).isNotNull();
+        assertThat(createdLocation).isNotEmpty();
+
+        // Reset DAC roles
+        userRoleDAO.insertSingleUserRole(member, 2, false);
+        userRoleDAO.insertSingleUserRole(member, 3, false);
+        userRoleDAO.insertSingleUserRole(member, 4, false);
+    }
+
+    @Test
+    public void createElectionWithNoDACMembersOrChair() throws IOException {
+        // Test Seed Data creates 3 DAC members and 1 chairperson.
+        // We need to remove all roles for this test
+        List<Integer> roleList = Arrays.asList(member, chair);
+        userRoleDAO.removeUserRoles(1, roleList);
+        userRoleDAO.removeUserRoles(2, roleList);
+        userRoleDAO.removeUserRoles(3, roleList);
+        userRoleDAO.removeUserRoles(4, roleList);
+
+        Client client = ClientBuilder.newClient();
+        Election election = new Election();
+        election.setStatus(ElectionStatus.OPEN.getValue());
+        election.setElectionType(ElectionType.TRANSLATE_DUL.getValue());
+        checkStatus(BADREQUEST, post(client, electionConsentPath(CONSENT_ID), election));
+
+        // Reset DAC roles
+        userRoleDAO.insertSingleUserRole(chair, 1, false);
+        userRoleDAO.insertSingleUserRole(member, 2, false);
+        userRoleDAO.insertSingleUserRole(member, 3, false);
+        userRoleDAO.insertSingleUserRole(member, 4, false);
+    }
+
+    @Test
+    public void createElectionWithNoChair() throws IOException {
+        // Test Seed Data creates 3 DAC members and 1 chairperson.
+        // We need to remove the chairperson role for this test
+        List<Integer> roleList = Collections.singletonList(chair);
+        userRoleDAO.removeUserRoles(1, roleList);
+
+        Client client = ClientBuilder.newClient();
+        Election election = new Election();
+        election.setStatus(ElectionStatus.OPEN.getValue());
+        election.setElectionType(ElectionType.TRANSLATE_DUL.getValue());
+        checkStatus(BADREQUEST, post(client, electionConsentPath(CONSENT_ID), election));
+
+        // Reset DAC roles
+        userRoleDAO.insertSingleUserRole(chair, 1, false);
+    }
 
     public Election createElection(String consentId) throws IOException {
         Client client = ClientBuilder.newClient();

--- a/src/test/java/org/broadinstitute/consent/http/ConsentElectionTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/ConsentElectionTest.java
@@ -50,19 +50,36 @@ public class ConsentElectionTest extends ElectionVoteServiceTest {
 
     @After
     public void resetDACMemberRoles() {
-        // to avoid integrity constraint violations on insert, delete them all first.
-        List<Integer> roleList = Arrays.asList(member, chair);
-        userRoleDAO.removeUserRoles(1, roleList);
-        userRoleDAO.removeUserRoles(2, roleList);
-        userRoleDAO.removeUserRoles(3, roleList);
-        userRoleDAO.removeUserRoles(4, roleList);
+//        insert into user_role(roleId, dacUserId) values(2,1);
+//        insert into user_role(roleId, dacUserId, status) values(5,1,0);
+//        insert into user_role(roleId, dacUserId) values(6,1);
 
-        // now reset to original seed data.
-        userRoleDAO.insertSingleUserRole(chair, 1, false);
-        userRoleDAO.insertSingleUserRole(member, 1, false);
-        userRoleDAO.insertSingleUserRole(member, 2, false);
-        userRoleDAO.insertSingleUserRole(member, 3, false);
-        userRoleDAO.insertSingleUserRole(member, 4, false);
+//        insert into user_role(roleId, dacUserId) values(1,2);
+//        insert into user_role(roleId, dacUserId) values(6,2);
+
+//        insert into user_role(roleId, dacUserId) values(1,3);
+
+//        insert into user_role(roleId, dacUserId) values(1,4);
+//        insert into user_role(roleId, dacUserId) values(4,4);
+
+//        insert into user_role(roleId, dacUserId) values(2,5);
+//        insert into user_role(roleId, dacUserId) values(4,5);
+//        insert into user_role(roleId, dacUserId) values(5,5);
+//        insert into user_role(roleId, dacUserId) values(6,5);
+
+        // to avoid integrity constraint violations on insert, delete them all first.
+//        List<Integer> roleList = Arrays.asList(member, chair);
+//        userRoleDAO.removeUserRoles(1, roleList);
+//        userRoleDAO.removeUserRoles(2, roleList);
+//        userRoleDAO.removeUserRoles(3, roleList);
+//        userRoleDAO.removeUserRoles(4, roleList);
+//
+//        // now reset to original seed data.
+//        userRoleDAO.insertSingleUserRole(chair, 1, false);
+//        userRoleDAO.insertSingleUserRole(member, 1, false);
+//        userRoleDAO.insertSingleUserRole(member, 2, false);
+//        userRoleDAO.insertSingleUserRole(member, 3, false);
+//        userRoleDAO.insertSingleUserRole(member, 4, false);
     }
 
     @Test
@@ -147,56 +164,56 @@ public class ConsentElectionTest extends ElectionVoteServiceTest {
                 post(client, electionConsentPath(CONSENT_ID_2), election));
     }
 
-    @Test
-    public void createElectionWithSingleChairperson() throws IOException {
-        // Test Seed Data creates 3 DAC members and 1 chairperson.
-        // We need to remove the DAC member roles for this test
-        List<Integer> roleList = Collections.singletonList(member);
-        userRoleDAO.removeUserRoles(2, roleList);
-        userRoleDAO.removeUserRoles(3, roleList);
-        userRoleDAO.removeUserRoles(4, roleList);
-
-        Client client = ClientBuilder.newClient();
-        Election election = new Election();
-        election.setStatus(ElectionStatus.OPEN.getValue());
-        election.setElectionType(ElectionType.TRANSLATE_DUL.getValue());
-        Response response = checkStatus(CREATED,
-                post(client, electionConsentPath(CONSENT_ID), election));
-        String createdLocation = checkHeader(response, "Location");
-        assertThat(createdLocation).isNotNull();
-        assertThat(createdLocation).isNotEmpty();
-    }
-
-    @Test
-    public void createElectionWithNoDACMembersOrChair() throws IOException {
-        // Test Seed Data creates 3 DAC members and 1 chairperson.
-        // We need to remove all roles for this test
-        List<Integer> roleList = Arrays.asList(member, chair);
-        userRoleDAO.removeUserRoles(1, roleList);
-        userRoleDAO.removeUserRoles(2, roleList);
-        userRoleDAO.removeUserRoles(3, roleList);
-        userRoleDAO.removeUserRoles(4, roleList);
-
-        Client client = ClientBuilder.newClient();
-        Election election = new Election();
-        election.setStatus(ElectionStatus.OPEN.getValue());
-        election.setElectionType(ElectionType.TRANSLATE_DUL.getValue());
-        checkStatus(BADREQUEST, post(client, electionConsentPath(CONSENT_ID), election));
-    }
-
-    @Test
-    public void createElectionWithNoChair() throws IOException {
-        // Test Seed Data creates 3 DAC members and 1 chairperson.
-        // We need to remove the chairperson role for this test
-        List<Integer> roleList = Collections.singletonList(chair);
-        userRoleDAO.removeUserRoles(1, roleList);
-
-        Client client = ClientBuilder.newClient();
-        Election election = new Election();
-        election.setStatus(ElectionStatus.OPEN.getValue());
-        election.setElectionType(ElectionType.TRANSLATE_DUL.getValue());
-        checkStatus(BADREQUEST, post(client, electionConsentPath(CONSENT_ID), election));
-    }
+//    @Test
+//    public void createElectionWithSingleChairperson() throws IOException {
+//        // Test Seed Data creates 3 DAC members and 1 chairperson.
+//        // We need to remove the DAC member roles for this test
+//        List<Integer> roleList = Collections.singletonList(member);
+//        userRoleDAO.removeUserRoles(2, roleList);
+//        userRoleDAO.removeUserRoles(3, roleList);
+//        userRoleDAO.removeUserRoles(4, roleList);
+//
+//        Client client = ClientBuilder.newClient();
+//        Election election = new Election();
+//        election.setStatus(ElectionStatus.OPEN.getValue());
+//        election.setElectionType(ElectionType.TRANSLATE_DUL.getValue());
+//        Response response = checkStatus(CREATED,
+//                post(client, electionConsentPath(CONSENT_ID), election));
+//        String createdLocation = checkHeader(response, "Location");
+//        assertThat(createdLocation).isNotNull();
+//        assertThat(createdLocation).isNotEmpty();
+//    }
+//
+//    @Test
+//    public void createElectionWithNoDACMembersOrChair() throws IOException {
+//        // Test Seed Data creates 3 DAC members and 1 chairperson.
+//        // We need to remove all roles for this test
+//        List<Integer> roleList = Arrays.asList(member, chair);
+//        userRoleDAO.removeUserRoles(1, roleList);
+//        userRoleDAO.removeUserRoles(2, roleList);
+//        userRoleDAO.removeUserRoles(3, roleList);
+//        userRoleDAO.removeUserRoles(4, roleList);
+//
+//        Client client = ClientBuilder.newClient();
+//        Election election = new Election();
+//        election.setStatus(ElectionStatus.OPEN.getValue());
+//        election.setElectionType(ElectionType.TRANSLATE_DUL.getValue());
+//        checkStatus(BADREQUEST, post(client, electionConsentPath(CONSENT_ID), election));
+//    }
+//
+//    @Test
+//    public void createElectionWithNoChair() throws IOException {
+//        // Test Seed Data creates 3 DAC members and 1 chairperson.
+//        // We need to remove the chairperson role for this test
+//        List<Integer> roleList = Collections.singletonList(chair);
+//        userRoleDAO.removeUserRoles(1, roleList);
+//
+//        Client client = ClientBuilder.newClient();
+//        Election election = new Election();
+//        election.setStatus(ElectionStatus.OPEN.getValue());
+//        election.setElectionType(ElectionType.TRANSLATE_DUL.getValue());
+//        checkStatus(BADREQUEST, post(client, electionConsentPath(CONSENT_ID), election));
+//    }
 
     public Election createElection(String consentId) throws IOException {
         Client client = ClientBuilder.newClient();

--- a/src/test/java/org/broadinstitute/consent/http/ConsentElectionTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/ConsentElectionTest.java
@@ -150,9 +150,9 @@ public class ConsentElectionTest extends ElectionVoteServiceTest {
         assertThat(createdLocation).isNotEmpty();
 
         // Reset DAC roles
-        userRoleDAO.insertSingleUserRole(member, 2, false);
-        userRoleDAO.insertSingleUserRole(member, 3, false);
-        userRoleDAO.insertSingleUserRole(member, 4, false);
+        userRoleDAO.insertSingleUserRole(member, 2, true);
+        userRoleDAO.insertSingleUserRole(member, 3, true);
+        userRoleDAO.insertSingleUserRole(member, 4, true);
     }
 
     @Test
@@ -172,10 +172,10 @@ public class ConsentElectionTest extends ElectionVoteServiceTest {
         checkStatus(BADREQUEST, post(client, electionConsentPath(CONSENT_ID), election));
 
         // Reset DAC roles
-        userRoleDAO.insertSingleUserRole(chair, 1, false);
-        userRoleDAO.insertSingleUserRole(member, 2, false);
-        userRoleDAO.insertSingleUserRole(member, 3, false);
-        userRoleDAO.insertSingleUserRole(member, 4, false);
+        userRoleDAO.insertSingleUserRole(chair, 1, true);
+        userRoleDAO.insertSingleUserRole(member, 2, true);
+        userRoleDAO.insertSingleUserRole(member, 3, true);
+        userRoleDAO.insertSingleUserRole(member, 4, true);
     }
 
     @Test
@@ -192,7 +192,7 @@ public class ConsentElectionTest extends ElectionVoteServiceTest {
         checkStatus(BADREQUEST, post(client, electionConsentPath(CONSENT_ID), election));
 
         // Reset DAC roles
-        userRoleDAO.insertSingleUserRole(chair, 1, false);
+        userRoleDAO.insertSingleUserRole(chair, 1, true);
     }
 
     public Election createElection(String consentId) throws IOException {

--- a/src/test/java/org/broadinstitute/consent/http/ConsentElectionTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/ConsentElectionTest.java
@@ -2,9 +2,6 @@ package org.broadinstitute.consent.http;
 
 import io.dropwizard.testing.junit.DropwizardAppRule;
 import org.broadinstitute.consent.http.configurations.ConsentConfiguration;
-import org.broadinstitute.consent.http.db.DACUserRoleDAO;
-import org.broadinstitute.consent.http.db.ElectionDAO;
-import org.broadinstitute.consent.http.db.VoteDAO;
 import org.broadinstitute.consent.http.enumeration.ElectionStatus;
 import org.broadinstitute.consent.http.enumeration.ElectionType;
 import org.broadinstitute.consent.http.models.Election;
@@ -17,29 +14,22 @@ import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.Response;
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ConsentElectionTest extends ElectionVoteServiceTest {
 
-    public static final int CREATED = Response.Status.CREATED.getStatusCode();
+    public static final int CREATED = Response.Status.CREATED
+            .getStatusCode();
     public static final int OK = Response.Status.OK.getStatusCode();
-    public static final int BAD_REQUEST = Response.Status.BAD_REQUEST.getStatusCode();
+    public static final int BADREQUEST = Response.Status.BAD_REQUEST.getStatusCode();
     public static final int NOT_FOUND = Response.Status.NOT_FOUND.getStatusCode();
     private static final String CONSENT_ID = "testId";
     private static final String CONSENT_ID_2 = "testId2";
     private static final String INVALID_CONSENT_ID = "invalidId";
     private static final String INVALID_STATUS = "testStatus";
     private static final String FINAL_RATIONALE = "Test";
-    private DACUserRoleDAO userRoleDAO = getApplicationJdbi().onDemand(DACUserRoleDAO.class);
-    private ElectionDAO electionDAO = getApplicationJdbi().onDemand(ElectionDAO.class);
-    private VoteDAO voteDAO = getApplicationJdbi().onDemand(VoteDAO.class);
-    private static final int member = 1;
-    private static final int chair = 2;
 
     @ClassRule
     public static final DropwizardAppRule<ConsentConfiguration> RULE = new DropwizardAppRule<>(
@@ -62,7 +52,7 @@ public class ConsentElectionTest extends ElectionVoteServiceTest {
         assertThat(created.getElectionId()).isNotNull();
         assertThat(created.getFinalRationale()).isNull();
         // try to create other election for the same consent
-        checkStatus(BAD_REQUEST,
+        checkStatus(BADREQUEST,
                 post(client, electionConsentPath(CONSENT_ID), created));
         testUpdateConsentElection(created);
         deleteElection(created.getElectionId(), CONSENT_ID);
@@ -108,7 +98,7 @@ public class ConsentElectionTest extends ElectionVoteServiceTest {
         election.setElectionType(ElectionType.TRANSLATE_DUL.getValue());
         election.setStatus(ElectionStatus.OPEN.getValue());
         // should return 400 bad request because the consent id does not exist
-        checkStatus(BAD_REQUEST,
+        checkStatus(BADREQUEST,
                 post(client, electionConsentPath(INVALID_CONSENT_ID), election));
     }
 
@@ -130,75 +120,6 @@ public class ConsentElectionTest extends ElectionVoteServiceTest {
         // should return 400 bad request because status is invalid
         checkStatus(BAD_REQUEST,
                 post(client, electionConsentPath(CONSENT_ID_2), election));
-    }
-
-    @Test
-    public void createElectionWithSingleChairperson() throws IOException {
-        // Test Seed Data creates 3 DAC members and 1 chairperson.
-        // We need to remove the DAC member roles for this test
-        List<Integer> roleList = Collections.singletonList(member);
-        userRoleDAO.removeUserRoles(2, roleList);
-        userRoleDAO.removeUserRoles(3, roleList);
-        userRoleDAO.removeUserRoles(4, roleList);
-
-        Client client = ClientBuilder.newClient();
-        Election election = new Election();
-        election.setStatus(ElectionStatus.OPEN.getValue());
-        election.setElectionType(ElectionType.TRANSLATE_DUL.getValue());
-        Response response = checkStatus(CREATED,
-                post(client, electionConsentPath(CONSENT_ID), election));
-        String createdLocation = checkHeader(response, "Location");
-        assertThat(createdLocation).isNotNull();
-        assertThat(createdLocation).isNotEmpty();
-
-        // Reset DAC roles
-        userRoleDAO.insertSingleUserRole(member, 2, true);
-        userRoleDAO.insertSingleUserRole(member, 3, true);
-        userRoleDAO.insertSingleUserRole(member, 4, true);
-
-        Collection<Vote> votes = voteDAO.findVotesByElectionIds(Collections.singletonList(election.getElectionId()));
-        votes.forEach(v -> voteDAO.deleteVoteById(v.getVoteId()));
-        electionDAO.deleteElectionById(election.getElectionId());
-    }
-
-    @Test
-    public void createElectionWithNoDACMembersOrChair() throws IOException {
-        // Test Seed Data creates 3 DAC members and 1 chairperson.
-        // We need to remove all roles for this test
-        List<Integer> roleList = Arrays.asList(member, chair);
-        userRoleDAO.removeUserRoles(1, roleList);
-        userRoleDAO.removeUserRoles(2, roleList);
-        userRoleDAO.removeUserRoles(3, roleList);
-        userRoleDAO.removeUserRoles(4, roleList);
-
-        Client client = ClientBuilder.newClient();
-        Election election = new Election();
-        election.setStatus(ElectionStatus.OPEN.getValue());
-        election.setElectionType(ElectionType.TRANSLATE_DUL.getValue());
-        checkStatus(BAD_REQUEST, post(client, electionConsentPath(CONSENT_ID), election));
-
-        // Reset DAC roles
-        userRoleDAO.insertSingleUserRole(chair, 1, true);
-        userRoleDAO.insertSingleUserRole(member, 2, true);
-        userRoleDAO.insertSingleUserRole(member, 3, true);
-        userRoleDAO.insertSingleUserRole(member, 4, true);
-    }
-
-    @Test
-    public void createElectionWithNoChair() throws IOException {
-        // Test Seed Data creates 3 DAC members and 1 chairperson.
-        // We need to remove the chairperson role for this test
-        List<Integer> roleList = Collections.singletonList(chair);
-        userRoleDAO.removeUserRoles(1, roleList);
-
-        Client client = ClientBuilder.newClient();
-        Election election = new Election();
-        election.setStatus(ElectionStatus.OPEN.getValue());
-        election.setElectionType(ElectionType.TRANSLATE_DUL.getValue());
-        checkStatus(BAD_REQUEST, post(client, electionConsentPath(CONSENT_ID), election));
-
-        // Reset DAC roles
-        userRoleDAO.insertSingleUserRole(chair, 1, true);
     }
 
     public Election createElection(String consentId) throws IOException {

--- a/src/test/java/org/broadinstitute/consent/http/service/ElectionAPITest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/ElectionAPITest.java
@@ -82,10 +82,7 @@ public class ElectionAPITest extends AbstractTest {
         when(dacUserDAO.findDACUsersEnabledToVote()).thenReturn(chairsWithRoles);
         when(consentDAO.checkConsentbyId(consentId)).thenReturn(consentId);
         when(consentDAO.findConsentById(consentId)).thenReturn(consent);
-        Election election = new Election();
-        election.setStatus(ElectionStatus.OPEN.getValue());
-        election.setElectionType(ElectionType.TRANSLATE_DUL.getValue());
-        election.setReferenceId(consentId);
+        Election election = createConsentElection();
         when(electionDAO.findElectionWithFinalVoteById(any())).thenReturn(election);
         Election savedElection = electionAPI.createElection(election, consentId, ElectionType.TRANSLATE_DUL);
         assertNotNull(savedElection);
@@ -94,10 +91,7 @@ public class ElectionAPITest extends AbstractTest {
     @Test(expected = IllegalArgumentException.class)
     public void testCreateConsentElectionNoDACMembers() throws Exception {
         when(dacUserDAO.findDACUsersEnabledToVote()).thenReturn(Collections.emptySet());
-        Election election = new Election();
-        election.setStatus(ElectionStatus.OPEN.getValue());
-        election.setElectionType(ElectionType.TRANSLATE_DUL.getValue());
-        election.setReferenceId(consentId);
+        Election election = createConsentElection();
         electionAPI.createElection(election, consentId, ElectionType.TRANSLATE_DUL);
     }
 
@@ -115,11 +109,16 @@ public class ElectionAPITest extends AbstractTest {
                 .filter(u -> u.getRoles().contains(MEMBER))
                 .collect(Collectors.toSet());
         when(dacUserDAO.findDACUsersEnabledToVote()).thenReturn(membersWithRoles);
+        Election election = createConsentElection();
+        electionAPI.createElection(election, consentId, ElectionType.TRANSLATE_DUL);
+    }
+
+    private Election createConsentElection() {
         Election election = new Election();
         election.setStatus(ElectionStatus.OPEN.getValue());
         election.setElectionType(ElectionType.TRANSLATE_DUL.getValue());
         election.setReferenceId(consentId);
-        electionAPI.createElection(election, consentId, ElectionType.TRANSLATE_DUL);
+        return election;
     }
 
 }

--- a/src/test/java/org/broadinstitute/consent/http/service/ElectionAPITest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/ElectionAPITest.java
@@ -1,0 +1,125 @@
+package org.broadinstitute.consent.http.service;
+
+import com.google.common.io.Resources;
+import io.dropwizard.testing.junit.DropwizardAppRule;
+import org.broadinstitute.consent.http.AbstractTest;
+import org.broadinstitute.consent.http.ConsentApplication;
+import org.broadinstitute.consent.http.configurations.ConsentConfiguration;
+import org.broadinstitute.consent.http.db.ConsentDAO;
+import org.broadinstitute.consent.http.db.DACUserDAO;
+import org.broadinstitute.consent.http.db.DataSetDAO;
+import org.broadinstitute.consent.http.db.ElectionDAO;
+import org.broadinstitute.consent.http.db.MailMessageDAO;
+import org.broadinstitute.consent.http.db.VoteDAO;
+import org.broadinstitute.consent.http.db.mongo.MongoConsentDB;
+import org.broadinstitute.consent.http.enumeration.ElectionStatus;
+import org.broadinstitute.consent.http.enumeration.ElectionType;
+import org.broadinstitute.consent.http.models.Consent;
+import org.broadinstitute.consent.http.models.DACUser;
+import org.broadinstitute.consent.http.models.Election;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static org.broadinstitute.consent.http.enumeration.DACUserRoles.MEMBER;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.when;
+
+public class ElectionAPITest extends AbstractTest {
+
+    @Mock
+    private ElectionDAO electionDAO;
+    @Mock
+    private ConsentDAO consentDAO;
+    @Mock
+    private DACUserDAO dacUserDAO;
+    @Mock
+    private MongoConsentDB mongo;
+    @Mock
+    private VoteDAO voteDAO;
+    @Mock
+    private MailMessageDAO mailMessageDAO;
+    @Mock
+    private DataSetDAO dataSetDAO;
+
+    private DatabaseElectionAPI electionAPI;
+
+    private static final String consentId = UUID.randomUUID().toString();
+    private Consent consent = new Consent();
+
+    @ClassRule
+    public static final DropwizardAppRule<ConsentConfiguration> RULE = new DropwizardAppRule<>(
+            ConsentApplication.class, Resources.getResource("consent-config.yml").getFile());
+
+    @Override
+    public DropwizardAppRule<ConsentConfiguration> rule() {
+        return RULE;
+    }
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+        electionAPI = Mockito.spy(new DatabaseElectionAPI(electionDAO, consentDAO, dacUserDAO, mongo, voteDAO, mailMessageDAO, dataSetDAO));
+        consent.setConsentId(consentId);
+        consent.setTranslatedUseRestriction("Translated");
+    }
+
+    @Test
+    public void testCreateConsentElectionSingleChairperson() throws Exception {
+        DACUserDAO userDAO = getApplicationJdbi().onDemand(DACUserDAO.class);
+        DACUser chair = userDAO.findChairpersonUser();
+        Set<DACUser> chairsWithRoles = userDAO.findUsersWithRoles(Collections.singletonList(chair.getDacUserId()));
+        when(dacUserDAO.findDACUsersEnabledToVote()).thenReturn(chairsWithRoles);
+        when(consentDAO.checkConsentbyId(consentId)).thenReturn(consentId);
+        when(consentDAO.findConsentById(consentId)).thenReturn(consent);
+        Election election = new Election();
+        election.setStatus(ElectionStatus.OPEN.getValue());
+        election.setElectionType(ElectionType.TRANSLATE_DUL.getValue());
+        election.setReferenceId(consentId);
+        when(electionDAO.findElectionWithFinalVoteById(any())).thenReturn(election);
+        Election savedElection = electionAPI.createElection(election, consentId, ElectionType.TRANSLATE_DUL);
+        assertNotNull(savedElection);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testCreateConsentElectionNoDACMembers() throws Exception {
+        when(dacUserDAO.findDACUsersEnabledToVote()).thenReturn(Collections.emptySet());
+        Election election = new Election();
+        election.setStatus(ElectionStatus.OPEN.getValue());
+        election.setElectionType(ElectionType.TRANSLATE_DUL.getValue());
+        election.setReferenceId(consentId);
+        electionAPI.createElection(election, consentId, ElectionType.TRANSLATE_DUL);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testCreateConsentElectionNoChair() throws Exception {
+        DACUserDAO userDAO = getApplicationJdbi().onDemand(DACUserDAO.class);
+        List<Integer> memberIds = userDAO
+                .findDACUsersEnabledToVote()
+                .stream()
+                .map(DACUser::getDacUserId)
+                .collect(Collectors.toList());
+        Set<DACUser> dacMembersWithRoles = userDAO.findUsersWithRoles(memberIds);
+        Set<DACUser> membersWithRoles = dacMembersWithRoles
+                .stream()
+                .filter(u -> u.getRoles().contains(MEMBER))
+                .collect(Collectors.toSet());
+        when(dacUserDAO.findDACUsersEnabledToVote()).thenReturn(membersWithRoles);
+        Election election = new Election();
+        election.setStatus(ElectionStatus.OPEN.getValue());
+        election.setElectionType(ElectionType.TRANSLATE_DUL.getValue());
+        election.setReferenceId(consentId);
+        electionAPI.createElection(election, consentId, ElectionType.TRANSLATE_DUL);
+    }
+
+}


### PR DESCRIPTION
## Addresses
See https://broadinstitute.atlassian.net/browse/DUOS-348

## Changes
* Change the validate number of DAC members such that there is only a requirement that there be a single Chairperson and no minimum number of additional DAC members.
* There were no tests for this section of the code so added conditional tests for consent elections that covers the following cases:
  * Single chairperson and no DAC members (success)
  * No chairperson or DAC members (failure)
  * No chairperson (failure)