### PR TITLE
[risk=no] Fix election archive status bug

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/ElectionDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/ElectionDAO.java
@@ -186,12 +186,6 @@ public interface ElectionDAO extends Transactional<ElectionDAO> {
     @Mapper(DatabaseElectionMapper.class)
     Election findLastElectionByReferenceIdAndType(@Bind("referenceId") String referenceId, @Bind("type") String type);
 
-    @SqlQuery("select * from election e inner join (select referenceId, MAX(version) maxVersion from election e where e.electionType = :type group by referenceId) " +
-            "electionView ON electionView.maxVersion = e.version AND electionView.referenceId = e.referenceId  " +
-            "AND e.referenceId = :referenceId ")
-    @Mapper(DatabaseElectionMapper.class)
-    Election findLastElectionVersionByReferenceIdAndType(@Bind("referenceId") String referenceId, @Bind("type") String type);
-
     @SqlQuery("select electionRPId from access_rp arp where arp.electionAccessId = :electionAccessId ")
     Integer findRPElectionByElectionAccessId(@Bind("electionAccessId") Integer electionAccessId);
 

--- a/src/main/java/org/broadinstitute/consent/http/service/DatabaseConsentAPI.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatabaseConsentAPI.java
@@ -112,7 +112,7 @@ public class DatabaseConsentAPI extends AbstractConsentAPI {
             throw new UnknownIdentifierException(String.format("Could not find consent with id %s", id));
         }
 
-        Election election = electionDAO.findLastElectionVersionByReferenceIdAndType(id, ElectionType.TRANSLATE_DUL.getValue());
+        Election election = electionDAO.findLastElectionByReferenceIdAndType(id, ElectionType.TRANSLATE_DUL.getValue());
         if (election != null) {
             consent.setLastElectionStatus(election.getStatus());
             consent.setLastElectionArchived(election.getArchived());

--- a/src/main/java/org/broadinstitute/consent/http/service/DatabaseDataAccessRequestAPI.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatabaseDataAccessRequestAPI.java
@@ -434,7 +434,7 @@ public class DatabaseDataAccessRequestAPI extends AbstractDataAccessRequestAPI {
     @Override
     public String getStructuredDURForPdf(Document dar) {
         List<Integer> dataSetId = DarUtil.getIntegerList(dar, DarConstants.DATASET_ID);
-        Election accessElection = electionDAO.findLastElectionVersionByReferenceIdAndType(dar.get(DarConstants.ID).toString(), ElectionType.DATA_ACCESS.getValue());
+        Election accessElection = electionDAO.findLastElectionByReferenceIdAndType(dar.get(DarConstants.ID).toString(), ElectionType.DATA_ACCESS.getValue());
         String sDUR;
         if (accessElection != null) {
             Integer electionId = electionDAO.getElectionConsentIdByDARElectionId(accessElection.getElectionId());


### PR DESCRIPTION
## Changes
Update the query used to get the last election for entities when determining their archive status. The removed query was not reliable and sometimes returned incorrect results. 