### PR TITLE
[DUOS-368][risk=no] Remove unnecessary empty path

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/resources/SwaggerResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/SwaggerResource.java
@@ -60,7 +60,6 @@ public class SwaggerResource {
     UriInfo uriInfo;
 
     @GET
-    @Path("")
     public Response main() {
         return content("");
     }


### PR DESCRIPTION
Addresses https://broadinstitute.atlassian.net/browse/DUOS-368

Fixes a sentry warning message, example here: https://sentry.io/organizations/broad-institute/issues/964180435

See also https://github.com/DataBiosphere/consent-ontology/pull/141