### PR TITLE
[DUOS-390][risk=no] Handle legacy dataset id formats

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -464,6 +464,28 @@
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <version>1.10.19</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4</artifactId>
+      <version>1.7.4</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-core</artifactId>
+      <version>1.7.4</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito</artifactId>
+      <version>1.7.4</version>
+      <scope>test</scope>
     </dependency>
 
     <dependency>

--- a/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
@@ -464,7 +464,7 @@ public class DataAccessRequestResource extends Resource {
         List datasetIdList = dataAccessRequestAPI.
                 describeDataAccessRequestFieldsById(id, Collections.singletonList(DarConstants.DATASET_ID)).
                 get("datasetId", List.class);
-        if (datasetIdList.isEmpty()) {
+        if (datasetIdList == null || datasetIdList.isEmpty()) {
             return Optional.empty();
         } else {
             Object datasetId = datasetIdList.get(0);

--- a/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
@@ -239,6 +239,14 @@ public class DataAccessRequestResource extends Resource {
         }
     }
 
+    /**
+     * Note that this method assumes a single consent for a DAR. The UI doesn't curently handle the
+     * case where there are multiple datasets associated to a DAR.
+     * See https://broadinstitute.atlassian.net/browse/BTRX-717 to handle that condition.
+     *
+     * @param id The Data Access Request ID
+     * @return consent The consent associated to the first dataset id the DAR refers to.
+     */
     @GET
     @Path("/find/{id}/consent")
     @Produces("application/json")

--- a/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
@@ -7,6 +7,7 @@ import org.broadinstitute.consent.http.enumeration.ResearcherFields;
 import org.broadinstitute.consent.http.models.Consent;
 import org.broadinstitute.consent.http.models.DACUser;
 import org.broadinstitute.consent.http.models.DACUserRole;
+import org.broadinstitute.consent.http.models.DataSet;
 import org.broadinstitute.consent.http.models.darsummary.DARModalDetailsDTO;
 import org.broadinstitute.consent.http.models.dto.DataSetDTO;
 import org.broadinstitute.consent.http.models.dto.Error;
@@ -54,9 +55,11 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -241,11 +244,10 @@ public class DataAccessRequestResource extends Resource {
     @Produces("application/json")
     @PermitAll
     public Consent describeConsentForDAR(@PathParam("id") String id) {
-        List<Integer> dataSetIdList = (dataAccessRequestAPI.describeDataAccessRequestFieldsById(id, Arrays.asList(DarConstants.DATASET_ID))).get("datasetId", List.class);
-        Integer dataSetId = dataSetIdList.get(0);
+        Optional<Integer> dataSetId = getDatasetIdForDarId(id);
         Consent c;
-        if (CollectionUtils.isNotEmpty(dataSetIdList)) {
-            c = consentAPI.getConsentFromDatasetID(dataSetId);
+        if (dataSetId.isPresent()) {
+            c = consentAPI.getConsentFromDatasetID(dataSetId.get());
             if (c == null) {
                 throw new NotFoundException("Unable to find the consent related to the datasetId present in the DAR.");
             }
@@ -443,5 +445,31 @@ public class DataAccessRequestResource extends Resource {
         }
     }
 
+    /**
+     * Data Access Requests have a `datasetId` that can refer to either a numeric id (newer model) or to
+     * a string value pointing to the sample collection id (legacy model).
+     *
+     * @param id The DAR document id
+     * @return Optional integer value of the referenced dataset.
+     */
+    private Optional<Integer> getDatasetIdForDarId(String id) {
+        List datasetIdList = dataAccessRequestAPI.
+                describeDataAccessRequestFieldsById(id, Collections.singletonList(DarConstants.DATASET_ID)).
+                get("datasetId", List.class);
+        if (datasetIdList.isEmpty()) {
+            return Optional.empty();
+        } else {
+            Object datasetId = datasetIdList.get(0);
+            try {
+                return Optional.of(Integer.valueOf(datasetId.toString()));
+            } catch (NumberFormatException e) {
+                DataSet dataset = dataSetAPI.findDataSetByObjectId(datasetId.toString());
+                if (dataset != null) {
+                    return Optional.of(dataset.getDataSetId());
+                }
+            }
+        }
+        return Optional.empty();
+    }
 
 }

--- a/src/main/java/org/broadinstitute/consent/http/service/DataSetAPI.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataSetAPI.java
@@ -39,4 +39,6 @@ public interface DataSetAPI {
 
     List<DataSet>findNeedsApprovalDataSetByObjectId(List<Integer> dataSetIdList);
 
+    DataSet findDataSetByObjectId(String objectId);
+
 }

--- a/src/main/java/org/broadinstitute/consent/http/service/DatabaseDataSetAPI.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatabaseDataSetAPI.java
@@ -1,24 +1,43 @@
 package org.broadinstitute.consent.http.service;
 
-import java.io.File;
-import java.util.*;
-import java.util.stream.Collectors;
-import javax.ws.rs.NotFoundException;
-
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.consent.http.DataSetAudit;
-import org.broadinstitute.consent.http.db.*;
-import org.broadinstitute.consent.http.enumeration.*;
+import org.broadinstitute.consent.http.db.ConsentDAO;
+import org.broadinstitute.consent.http.db.DACUserRoleDAO;
+import org.broadinstitute.consent.http.db.DataSetAssociationDAO;
+import org.broadinstitute.consent.http.db.DataSetAuditDAO;
+import org.broadinstitute.consent.http.db.DataSetDAO;
+import org.broadinstitute.consent.http.db.ElectionDAO;
+import org.broadinstitute.consent.http.enumeration.AssociationType;
+import org.broadinstitute.consent.http.enumeration.ElectionStatus;
 import org.broadinstitute.consent.http.enumeration.ElectionType;
-import org.broadinstitute.consent.http.models.*;
+import org.broadinstitute.consent.http.enumeration.UserRoles;
+import org.broadinstitute.consent.http.models.Association;
+import org.broadinstitute.consent.http.models.Consent;
+import org.broadinstitute.consent.http.models.DataSet;
+import org.broadinstitute.consent.http.models.DataSetAuditProperty;
+import org.broadinstitute.consent.http.models.DataSetProperty;
 import org.broadinstitute.consent.http.models.Dictionary;
+import org.broadinstitute.consent.http.models.Election;
 import org.broadinstitute.consent.http.models.dto.DataSetDTO;
 import org.broadinstitute.consent.http.util.DarConstants;
-
 import org.bson.Document;
-import org.skife.jdbi.v2.sqlobject.Bind;
+
+import javax.ws.rs.NotFoundException;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Implementation class for DataSetAPI database support.

--- a/src/main/java/org/broadinstitute/consent/http/service/DatabaseDataSetAPI.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatabaseDataSetAPI.java
@@ -18,6 +18,7 @@ import org.broadinstitute.consent.http.models.dto.DataSetDTO;
 import org.broadinstitute.consent.http.util.DarConstants;
 
 import org.bson.Document;
+import org.skife.jdbi.v2.sqlobject.Bind;
 
 /**
  * Implementation class for DataSetAPI database support.
@@ -298,6 +299,11 @@ public class DatabaseDataSetAPI extends AbstractDataSetAPI {
     @Override
     public List<DataSet> findNeedsApprovalDataSetByObjectId(List<Integer> dataSetIdList) {
         return dsDAO.findNeedsApprovalDataSetByDataSetId(dataSetIdList);
+    }
+
+    @Override
+    public DataSet findDataSetByObjectId(String objectId) {
+        return dsDAO.findDataSetByObjectId(objectId);
     }
 
     public DataSetDTO getDataSetDTO(Integer dataSetId) {

--- a/src/main/java/org/broadinstitute/consent/http/util/DarUtil.java
+++ b/src/main/java/org/broadinstitute/consent/http/util/DarUtil.java
@@ -3,6 +3,8 @@ package org.broadinstitute.consent.http.util;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import org.bson.Document;
+import org.bson.types.ObjectId;
+
 import java.io.IOException;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -41,6 +43,16 @@ public class DarUtil {
                 filter(Integer.class::isInstance).
                 map(Integer.class::cast).
                 collect(Collectors.toList());
+    }
+
+    public static ObjectId getObjectIdFromDocument(Document document) {
+        LinkedHashMap id = (LinkedHashMap) document.get(DarConstants.ID);
+        return new ObjectId(
+                Integer.valueOf(id.get("timestamp").toString()),
+                Integer.valueOf(id.get("machineIdentifier").toString()),
+                Short.valueOf(id.get("processIdentifier").toString()),
+                Integer.valueOf(id.get("counter").toString())
+        );
     }
 
 }

--- a/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceTest.java
@@ -9,6 +9,7 @@ import org.broadinstitute.consent.http.models.DataAccessRequestManage;
 import org.broadinstitute.consent.http.models.dto.UseRestrictionDTO;
 import org.broadinstitute.consent.http.service.DatabaseDataAccessRequestAPI;
 import org.broadinstitute.consent.http.util.DarConstants;
+import org.broadinstitute.consent.http.util.DarUtil;
 import org.bson.Document;
 import org.bson.types.ObjectId;
 import org.junit.After;
@@ -121,7 +122,7 @@ public class DataAccessRequestResourceTest extends DataAccessRequestServiceTest 
         Client client = ClientBuilder.newClient();
         post(client, darPath(), DataRequestSamplesHolder.getSampleDar());
         Document created = retrieveDars(client, darPath()).get(0);
-        ObjectId objectId = getObjectIdFromDocument(created);
+        ObjectId objectId = DarUtil.getObjectIdFromDocument(created);
 
         // Make sure the DAR can be retrieved using the ID
         Response response = getJson(client, darPath(objectId.toHexString()));
@@ -145,16 +146,6 @@ public class DataAccessRequestResourceTest extends DataAccessRequestServiceTest 
 
     private List<Document> retrieveDars(Client client, String url) throws IOException {
         return getJson(client, url).readEntity(new GenericType<List<Document>>() {});
-    }
-
-    private ObjectId getObjectIdFromDocument(Document document) {
-        LinkedHashMap id = (LinkedHashMap) document.get(DarConstants.ID);
-        return new ObjectId(
-                Integer.valueOf(id.get("timestamp").toString()),
-                Integer.valueOf(id.get("machineIdentifier").toString()),
-                Short.valueOf(id.get("processIdentifier").toString()),
-                Integer.valueOf(id.get("counter").toString())
-        );
     }
 
 }

--- a/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceUnitTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceUnitTest.java
@@ -48,26 +48,20 @@ public class DataAccessRequestResourceUnitTest {
 
     @Mock
     DACUserAPI dacUserAPI;
-
     @Mock
     ElectionAPI electionAPI;
-
     @Mock
     GCSStore store;
-
     @Mock
     ConsentAPI consentAPI;
-
     @Mock
     DataAccessRequestAPI dataAccessRequestAPI;
-
     @Mock
     DataSetAPI dataSetAPI;
 
     private DataAccessRequestResource resource;
     private Document dar;
     private String darId;
-    private DataSet dataSet;
 
     @Before
     public void setUp() {
@@ -106,7 +100,7 @@ public class DataAccessRequestResourceUnitTest {
         dar = DataRequestSamplesHolder.getSampleDarWithId();
         dar.put(DarConstants.DATASET_ID, Collections.singletonList("SC-12345"));
         darId = DarUtil.getObjectIdFromDocument(dar).toHexString();
-        dataSet = new DataSet();
+        DataSet dataSet = new DataSet();
         dataSet.setDataSetId(1);
         when(dataAccessRequestAPI.describeDataAccessRequestFieldsById(any(), any())).thenReturn(dar);
         when(consentAPI.getConsentFromDatasetID(any())).thenReturn(new Consent());
@@ -124,8 +118,14 @@ public class DataAccessRequestResourceUnitTest {
      */
     @Test(expected = NotFoundException.class)
     public void testDescribeConsentForDAR_case3() throws Exception {
-
-        throw new NotFoundException();
+        dar = DataRequestSamplesHolder.getSampleDarWithId();
+        darId = DarUtil.getObjectIdFromDocument(dar).toHexString();
+        when(dataAccessRequestAPI.describeDataAccessRequestFieldsById(any(), any())).thenReturn(dar);
+        when(consentAPI.getConsentFromDatasetID(any())).thenReturn(null);
+        when(AbstractDataAccessRequestAPI.getInstance()).thenReturn(dataAccessRequestAPI);
+        when(AbstractConsentAPI.getInstance()).thenReturn(consentAPI);
+        resource = new DataAccessRequestResource(dacUserAPI, electionAPI, store);
+        resource.describeConsentForDAR(darId);
     }
 
     /**
@@ -133,8 +133,13 @@ public class DataAccessRequestResourceUnitTest {
      */
     @Test(expected = NotFoundException.class)
     public void testDescribeConsentForDAR_case4() throws Exception {
-
-        throw new NotFoundException();
+        dar = DataRequestSamplesHolder.getSampleDarWithId();
+        dar.remove(DarConstants.DATASET_ID);
+        darId = DarUtil.getObjectIdFromDocument(dar).toHexString();
+        when(dataAccessRequestAPI.describeDataAccessRequestFieldsById(any(), any())).thenReturn(dar);
+        when(AbstractDataAccessRequestAPI.getInstance()).thenReturn(dataAccessRequestAPI);
+        resource = new DataAccessRequestResource(dacUserAPI, electionAPI, store);
+        resource.describeConsentForDAR(darId);
     }
 
 

--- a/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceUnitTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceUnitTest.java
@@ -70,8 +70,7 @@ public class DataAccessRequestResourceUnitTest {
     private DataSet dataSet;
 
     @Before
-    public void setUp() throws Exception {
-
+    public void setUp() {
         MockitoAnnotations.initMocks(this);
         PowerMockito.mockStatic(AbstractDataAccessRequestAPI.class);
         PowerMockito.mockStatic(AbstractConsentAPI.class);
@@ -80,8 +79,6 @@ public class DataAccessRequestResourceUnitTest {
         PowerMockito.mockStatic(AbstractUseRestrictionValidatorAPI.class);
         PowerMockito.mockStatic(AbstractTranslateService.class);
         PowerMockito.mockStatic(AbstractDataSetAPI.class);
-
-
     }
 
     /**
@@ -89,7 +86,7 @@ public class DataAccessRequestResourceUnitTest {
      */
     @Test
     public void testDescribeConsentForDAR_case1() throws Exception {
-        dar = DataRequestSamplesHolder.getSampleDar();
+        dar = DataRequestSamplesHolder.getSampleDarWithId();
         darId = DarUtil.getObjectIdFromDocument(dar).toHexString();
         when(dataAccessRequestAPI.describeDataAccessRequestFieldsById(any(), any())).thenReturn(dar);
         when(consentAPI.getConsentFromDatasetID(any())).thenReturn(new Consent());
@@ -106,7 +103,7 @@ public class DataAccessRequestResourceUnitTest {
      */
     @Test
     public void testDescribeConsentForDAR_case2() throws Exception {
-        dar = DataRequestSamplesHolder.getSampleDar();
+        dar = DataRequestSamplesHolder.getSampleDarWithId();
         dar.put(DarConstants.DATASET_ID, Collections.singletonList("SC-12345"));
         darId = DarUtil.getObjectIdFromDocument(dar).toHexString();
         dataSet = new DataSet();

--- a/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceUnitTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceUnitTest.java
@@ -1,0 +1,144 @@
+package org.broadinstitute.consent.http.resources;
+
+import org.broadinstitute.consent.http.cloudstore.GCSStore;
+import org.broadinstitute.consent.http.models.Consent;
+import org.broadinstitute.consent.http.models.DataSet;
+import org.broadinstitute.consent.http.service.AbstractConsentAPI;
+import org.broadinstitute.consent.http.service.AbstractDataAccessRequestAPI;
+import org.broadinstitute.consent.http.service.AbstractDataSetAPI;
+import org.broadinstitute.consent.http.service.AbstractEmailNotifierAPI;
+import org.broadinstitute.consent.http.service.AbstractMatchProcessAPI;
+import org.broadinstitute.consent.http.service.AbstractTranslateService;
+import org.broadinstitute.consent.http.service.ConsentAPI;
+import org.broadinstitute.consent.http.service.DataAccessRequestAPI;
+import org.broadinstitute.consent.http.service.DataSetAPI;
+import org.broadinstitute.consent.http.service.ElectionAPI;
+import org.broadinstitute.consent.http.service.users.DACUserAPI;
+import org.broadinstitute.consent.http.service.validate.AbstractUseRestrictionValidatorAPI;
+import org.broadinstitute.consent.http.util.DarConstants;
+import org.broadinstitute.consent.http.util.DarUtil;
+import org.bson.Document;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import javax.ws.rs.NotFoundException;
+import java.util.Collections;
+
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.when;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({
+        AbstractDataAccessRequestAPI.class,
+        AbstractConsentAPI.class,
+        AbstractMatchProcessAPI.class,
+        AbstractEmailNotifierAPI.class,
+        AbstractUseRestrictionValidatorAPI.class,
+        AbstractTranslateService.class,
+        AbstractDataSetAPI.class
+})
+public class DataAccessRequestResourceUnitTest {
+
+    @Mock
+    DACUserAPI dacUserAPI;
+
+    @Mock
+    ElectionAPI electionAPI;
+
+    @Mock
+    GCSStore store;
+
+    @Mock
+    ConsentAPI consentAPI;
+
+    @Mock
+    DataAccessRequestAPI dataAccessRequestAPI;
+
+    @Mock
+    DataSetAPI dataSetAPI;
+
+    private DataAccessRequestResource resource;
+    private Document dar;
+    private String darId;
+    private DataSet dataSet;
+
+    @Before
+    public void setUp() throws Exception {
+
+        MockitoAnnotations.initMocks(this);
+        PowerMockito.mockStatic(AbstractDataAccessRequestAPI.class);
+        PowerMockito.mockStatic(AbstractConsentAPI.class);
+        PowerMockito.mockStatic(AbstractMatchProcessAPI.class);
+        PowerMockito.mockStatic(AbstractEmailNotifierAPI.class);
+        PowerMockito.mockStatic(AbstractUseRestrictionValidatorAPI.class);
+        PowerMockito.mockStatic(AbstractTranslateService.class);
+        PowerMockito.mockStatic(AbstractDataSetAPI.class);
+
+
+    }
+
+    /**
+     * Positive case where a DAR references a numeric dataset id
+     */
+    @Test
+    public void testDescribeConsentForDAR_case1() throws Exception {
+        dar = DataRequestSamplesHolder.getSampleDar();
+        darId = DarUtil.getObjectIdFromDocument(dar).toHexString();
+        when(dataAccessRequestAPI.describeDataAccessRequestFieldsById(any(), any())).thenReturn(dar);
+        when(consentAPI.getConsentFromDatasetID(any())).thenReturn(new Consent());
+        when(AbstractDataAccessRequestAPI.getInstance()).thenReturn(dataAccessRequestAPI);
+        when(AbstractConsentAPI.getInstance()).thenReturn(consentAPI);
+        when(AbstractDataSetAPI.getInstance()).thenReturn(dataSetAPI);
+        resource = new DataAccessRequestResource(dacUserAPI, electionAPI, store);
+        Consent consent = resource.describeConsentForDAR(darId);
+        assertNotNull(consent);
+    }
+
+    /**
+     * Positive case where a DAR references a string dataset id
+     */
+    @Test
+    public void testDescribeConsentForDAR_case2() throws Exception {
+        dar = DataRequestSamplesHolder.getSampleDar();
+        dar.put(DarConstants.DATASET_ID, Collections.singletonList("SC-12345"));
+        darId = DarUtil.getObjectIdFromDocument(dar).toHexString();
+        dataSet = new DataSet();
+        dataSet.setDataSetId(1);
+        when(dataAccessRequestAPI.describeDataAccessRequestFieldsById(any(), any())).thenReturn(dar);
+        when(consentAPI.getConsentFromDatasetID(any())).thenReturn(new Consent());
+        when(dataSetAPI.findDataSetByObjectId(any())).thenReturn(dataSet);
+        when(AbstractDataAccessRequestAPI.getInstance()).thenReturn(dataAccessRequestAPI);
+        when(AbstractConsentAPI.getInstance()).thenReturn(consentAPI);
+        when(AbstractDataSetAPI.getInstance()).thenReturn(dataSetAPI);
+        resource = new DataAccessRequestResource(dacUserAPI, electionAPI, store);
+        Consent consent = resource.describeConsentForDAR(darId);
+        assertNotNull(consent);
+    }
+
+    /**
+     * Negative case where a DAR references an invalid dataset id
+     */
+    @Test(expected = NotFoundException.class)
+    public void testDescribeConsentForDAR_case3() throws Exception {
+
+        throw new NotFoundException();
+    }
+
+    /**
+     * Negative case where a DAR does not reference a dataset id
+     */
+    @Test(expected = NotFoundException.class)
+    public void testDescribeConsentForDAR_case4() throws Exception {
+
+        throw new NotFoundException();
+    }
+
+
+}

--- a/src/test/java/org/broadinstitute/consent/http/resources/DataRequestSamplesHolder.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DataRequestSamplesHolder.java
@@ -9,15 +9,6 @@ import java.util.HashMap;
 class DataRequestSamplesHolder {
 
     private static final String completeDARJson = "{\n" +
-            "    \"_id\": {\n" +
-            "        \"timestamp\": 1559053204,\n" +
-            "        \"machineIdentifier\": 4645115,\n" +
-            "        \"processIdentifier\": 1,\n" +
-            "        \"counter\": 16183289,\n" +
-            "        \"time\": 1559053204000,\n" +
-            "        \"date\": 1559053204000,\n" +
-            "        \"timeSecond\": 1559053204\n" +
-            "      }," +
             "    \"investigator\" : \"Somenone\",\n" +
             "    \"institution\" : \"npsrpn\",\n" +
             "    \"department\" : \"pnifnpvdpi\",\n" +

--- a/src/test/java/org/broadinstitute/consent/http/resources/DataRequestSamplesHolder.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DataRequestSamplesHolder.java
@@ -8,7 +8,32 @@ import java.util.HashMap;
 
 class DataRequestSamplesHolder {
 
-    private static final String completeDARJson = "{\n" +
+    @SuppressWarnings("unchecked")
+    static Document getSampleDarWithId() throws IOException {
+        HashMap<String, Object> jsonMap = new ObjectMapper().readValue(darWithIDJson, HashMap.class);
+        Document document = new Document();
+        document.putAll(jsonMap);
+        return document;
+    }
+
+    @SuppressWarnings("unchecked")
+    static Document getSampleDar() throws IOException {
+        HashMap<String, Object> jsonMap = new ObjectMapper().readValue(completeDARJson, HashMap.class);
+        Document document = new Document();
+        document.putAll(jsonMap);
+        return document;
+    }
+
+    private static final String darWithIDJson = "{\n" +
+            "    \"_id\": {\n" +
+            "        \"timestamp\": 1559053204,\n" +
+            "        \"machineIdentifier\": 4645115,\n" +
+            "        \"processIdentifier\": 1,\n" +
+            "        \"counter\": 16183289,\n" +
+            "        \"time\": 1559053204000,\n" +
+            "        \"date\": 1559053204000,\n" +
+            "        \"timeSecond\": 1559053204\n" +
+            "      }," +
             "    \"investigator\" : \"Somenone\",\n" +
             "    \"institution\" : \"npsrpn\",\n" +
             "    \"department\" : \"pnifnpvdpi\",\n" +
@@ -47,12 +72,44 @@ class DataRequestSamplesHolder {
             "    \"dar_code\" : \"DAR-1\"\n" +
             "}";
 
-    @SuppressWarnings("unchecked")
-    static Document getSampleDar() throws IOException {
-        HashMap<String, Object> jsonMap = new ObjectMapper().readValue(completeDARJson, HashMap.class);
-        Document document = new Document();
-        document.putAll(jsonMap);
-        return document;
-    }
+
+    private static final String completeDARJson = "{\n" +
+            "    \"investigator\" : \"Somenone\",\n" +
+            "    \"institution\" : \"npsrpn\",\n" +
+            "    \"department\" : \"pnifnpvdpi\",\n" +
+            "    \"division\" : \"noyon\",\n" +
+            "    \"address1\" : \"lñubbi\",\n" +
+            "    \"address2\" : \"uoñn\",\n" +
+            "    \"city\" : \"n\",\n" +
+            "    \"state\" : \"b\",\n" +
+            "    \"zipcode\" : \"bj\",\n" +
+            "    \"country\" : \"bubu\",\n" +
+            "    \"projectTitle\" : \"bb\",\n" +
+            "    \"rus\" : \"cerrefer\",\n" +
+            "    \"non_tech_rus\" : \"frevrvre\",\n" +
+            "    \"diseases\" : true,\n" +
+            "    \"controls\" : true,\n" +
+            "    \"onegender\" : false,\n" +
+            "    \"forProfit\" : false,\n" +
+            "    \"pediatric\" : true,\n" +
+            "    \"illegalbehave\" : false,\n" +
+            "    \"sexualdiseases\" : false,\n" +
+            "    \"stigmatizediseases\" : true,\n" +
+            "    \"popmigration\" : false,\n" +
+            "    \"vulnerablepop\" : false,\n" +
+            "    \"psychtraits\" : true,\n" +
+            "    \"nothealth\" : true,\n" +
+            "    \"userId\" : 1,\n" +
+            "    \"addiction\" : false,\n" +
+            "    \"translated_restriction\" : \"Samples will be used under the following conditions:<br>Needs Manual Review.<br>Data will be used for health/medical/biomedical research [HMB(CC)]<br>Data will be used as a control sample set [NCTRL=0]<br>Data will not be used for commercial purpose<br>Data will be used to study ONLY a pediatric population [RS-[PEDIATRIC]]<br>\",\n" +
+            "    \"datasetId\" : [1],\n" +
+            "    \"datasetDetail\" : [ \n" +
+            "        {\n" +
+            "            \"datasetId\" : \"SC-20660\",\n" +
+            "            \"name\" : \"test\"\n" +
+            "        }\n" +
+            "    ],\n" +
+            "    \"dar_code\" : \"DAR-1\"\n" +
+            "}";
 
 }

--- a/src/test/java/org/broadinstitute/consent/http/resources/DataRequestSamplesHolder.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DataRequestSamplesHolder.java
@@ -9,6 +9,15 @@ import java.util.HashMap;
 class DataRequestSamplesHolder {
 
     private static final String completeDARJson = "{\n" +
+            "    \"_id\": {\n" +
+            "        \"timestamp\": 1559053204,\n" +
+            "        \"machineIdentifier\": 4645115,\n" +
+            "        \"processIdentifier\": 1,\n" +
+            "        \"counter\": 16183289,\n" +
+            "        \"time\": 1559053204000,\n" +
+            "        \"date\": 1559053204000,\n" +
+            "        \"timeSecond\": 1559053204\n" +
+            "      }," +
             "    \"investigator\" : \"Somenone\",\n" +
             "    \"institution\" : \"npsrpn\",\n" +
             "    \"department\" : \"pnifnpvdpi\",\n" +


### PR DESCRIPTION
## Addresses
Ticket: https://broadinstitute.atlassian.net/browse/DUOS-390

## Changes
This PR checks for the type of dataset id the Data Access Request has stored and then queries appropriately for it, whether it is an integer value or a string value. 