### PR TITLE
[risk=no] Address jackson security alert

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <pdfbox.version>2.0.15</pdfbox.version>
     <jetty.version>9.4.14.v20181114</jetty.version>
     <owl.version>5.1.7</owl.version>
-    <jackson.version>2.9.9</jackson.version>
+    <jackson.version>2.9.9.1</jackson.version>
     <swagger.ui.version>2.2.8</swagger.ui.version>
     <swagger.ui.path>META-INF/resources/webjars/swagger-ui/${swagger.ui.version}/</swagger.ui.path>
 


### PR DESCRIPTION
## Addresses
```
CVE-2019-12814
More information
moderate severity
Vulnerable versions: >= 2.0.0, < 2.9.9.1
Patched version: 2.9.9.1

A Polymorphic Typing issue was discovered in FasterXML jackson-databind 2.x through 2.9.9. When Default Typing is enabled (either globally or for a specific property) for an externally exposed JSON endpoint and the service has JDOM 1.x or 2.x jar in the classpath, an attacker can send a specifically crafted JSON message that allows them to read arbitrary local files on the server.
```