### PR TITLE
[risk=no] Upgrade rdf4j lib for sourceclear

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -776,6 +776,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.eclipse.rdf4j</groupId>
+      <artifactId>rdf4j-rio-trix</artifactId>
+      <version>2.4.1</version>
+    </dependency>
+
+    <dependency>
       <groupId>net.sourceforge.owlapi</groupId>
       <artifactId>owlapi-distribution</artifactId>
       <version>${owl.version}</version>
@@ -783,6 +789,10 @@
         <exclusion>
           <groupId>org.eclipse.rdf4j</groupId>
           <artifactId>df4j-rio-rdfxml</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.eclipse.rdf4j</groupId>
+          <artifactId>df4j-rio-trix</artifactId>
         </exclusion>
         <exclusion>
           <groupId>net.sourceforge.owlapi</groupId>


### PR DESCRIPTION
## Addresses
Sourceclear fix for:

> XML External Entity (XXE)
> rdf4j-rio-trix is vulnerable to XML external entities (XXE) attacks. The library does not disable entities and document type declarations, allowing a malicious user to conduct an XXE injection attack.

See https://broadinstitute-dsp.sourceclear.io/workspaces/jppForw/issues/vulnerabilities/6984202/11157931