### PR TITLE
[DUOS-420][risk=no] Populate the dataset alias if necessary

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/models/darsummary/DARModalDetailsDTO.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/darsummary/DARModalDetailsDTO.java
@@ -256,7 +256,7 @@ public class DARModalDetailsDTO {
         return this;
     }
 
-    public DARModalDetailsDTO setDatasetDetail(ArrayList<Document> datasetDetail) {
+    public DARModalDetailsDTO setDatasetDetail(List<Document> datasetDetail) {
         Map<String, String> datasetDetailMap = new HashMap<>();
         datasetDetail.forEach((doc) -> {
             String objectId = doc.getString(DarConstants.OBJECT_ID) != null ? doc.getString(DarConstants.OBJECT_ID) : "--";
@@ -265,6 +265,7 @@ public class DARModalDetailsDTO {
         this.datasetDetail = datasetDetailMap;
         return this;
     }
+
     public String getStatus() {
         return status;
     }

--- a/src/main/java/org/broadinstitute/consent/http/service/DatabaseDataAccessRequestAPI.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatabaseDataAccessRequestAPI.java
@@ -586,13 +586,18 @@ public class DatabaseDataAccessRequestAPI extends AbstractDataAccessRequestAPI {
     }
 
     /**
-     * Dataset Detail fields have undergone transition and can have different keys in the mongo source
+     * Dataset Detail fields have undergone transition and can have different keys in the mongo source.
+     * For example, these are two examples from production:
      *
-     * "datasetDetail": [
+     *   "datasetDetail": [
      *     {
-     *       "datasetId": "1",
-     *       "name": "CMG_Manton",
-     *       "objectId": "SC-25537"
+     *       "datasetId": "7",
+     *       "name": "Melanoma_Regev",
+     *       "objectId": "SC-14319"
+     *     },
+     *     {
+     *       "datasetId": "139",
+     *       "name": "MetastaticMelanoma_Regev"
      *     }
      *   ]
      *
@@ -609,7 +614,8 @@ public class DatabaseDataAccessRequestAPI extends AbstractDataAccessRequestAPI {
      *     }
      *   ]
      *
-     *   For backwards compatibility, we need to recreate the "objectId" field if it is missing
+     * For backwards compatibility, we need to recreate the "objectId" field if it is missing
+     * and populate it with the dataset's objectId field
      */
     @SuppressWarnings("unchecked")
     private List<Document> populateDatasetDetailDocuments(Object datasetDetails) {

--- a/src/main/java/org/broadinstitute/consent/http/service/DatabaseDataAccessRequestAPI.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatabaseDataAccessRequestAPI.java
@@ -579,30 +579,22 @@ public class DatabaseDataAccessRequestAPI extends AbstractDataAccessRequestAPI {
      *     }
      *   ]
      *
-     *   For backwards compatibility, we need to recreate the "objectId" field if they are missing
+     *   For backwards compatibility, we need to recreate the "objectId" field if it is missing
      */
     @SuppressWarnings("unchecked")
     private List<Document> populateDatasetDetailDocuments(Object datasetDetails) {
         List<Document> newDetails = new ArrayList<>();
         try {
             ((ArrayList<Document>) datasetDetails).forEach(d -> {
-                // If we already have an objectId, we don't need to do any additional work
-                if (d.containsKey(DarConstants.OBJECT_ID)) {
-                    newDetails.add(d);
-                }
-                // If we have do have a datasetId, we can look it up and populate the object id field
-                else if (d.containsKey(DarConstants.DATASET_ID)) {
+                // If we are missing the object id, but have a dataset id, then we need to look it up:
+                if (d.containsKey(DarConstants.DATASET_ID) && !d.containsKey(DarConstants.OBJECT_ID)) {
                     DataSet dataSet = dataSetDAO.findDataSetById(Integer.valueOf(d.getString(DarConstants.DATASET_ID)));
                     if (dataSet.getAlias() != null) {
                         String aliasString = DatasetUtil.parseAlias(dataSet.getAlias());
                         d.put(DarConstants.OBJECT_ID, aliasString);
-                        newDetails.add(d);
                     }
                 }
-                // Last case - just add the doc and return.
-                else {
-                    newDetails.add(d);
-                }
+                newDetails.add(d);
             });
         } catch (Exception e) {
             logger().warn(e);


### PR DESCRIPTION
## Addresses 
https://broadinstitute.atlassian.net/browse/DUOS-420

## Changes
Due to some updates to how we store data access requests in mongo, some data fields are not getting populated correctly in the DTO that populates a data access request details object. This PR looks for the missing data and populates it if possible.

@vvicario - FYI, this is fallout from https://broadinstitute.atlassian.net/browse/BTRX-323 - would like to have your review on this. 