### PR TITLE
[risk=no] Security patches for jackson-mapper

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -319,6 +319,13 @@
 
     <!-- Pulling in directly to evict older, transitive dependencies -->
     <dependency>
+      <groupId>org.codehaus.jackson</groupId>
+      <artifactId>jackson-mapper-asl</artifactId>
+      <version>1.9.13</version>
+    </dependency>
+
+    <!-- Pulling in directly to evict older, transitive dependencies -->
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
       <version>2.9.9.3</version>
@@ -698,8 +705,12 @@
       <version>1.4.2</version>
       <exclusions>
         <exclusion>
-          <groupId>fasterxml.jackson.core</groupId>
+          <groupId>com.fasterxml.jackson.core</groupId>
           <artifactId>jackson-databind</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.codehaus.jackson</groupId>
+          <artifactId>jackson-mapper-asl</artifactId>
         </exclusion>
         <exclusion>
           <groupId>org.mongodb</groupId>


### PR DESCRIPTION
## Changes
Pull in the latest `jackson-mapper-asl`. From the CVEs, `This issue has not yet been fixed in a released version of the library.` but this should help mitigate the risk to some degree.

## Mitigates
* CVE-2017-15095: https://broadinstitute-dsp.sourceclear.io/workspaces/jppForw/issues/vulnerabilities/7039263/6580954
* CVE-2017-7525: https://broadinstitute-dsp.sourceclear.io/workspaces/jppForw/issues/vulnerabilities/7039263/6580953
* CVE-2018-11307: https://broadinstitute-dsp.sourceclear.io/workspaces/jppForw/issues/vulnerabilities/7039263/6580952
* CVE-2017-17485: https://broadinstitute-dsp.sourceclear.io/workspaces/jppForw/issues/vulnerabilities/7039263/6580950
* CVE-2018-7489: https://broadinstitute-dsp.sourceclear.io/workspaces/jppForw/issues/vulnerabilities/7039263/6580955
