### PR TITLE
[DUOS-431][risk=no] Handle upload DAA error

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/resources/DataAccessAgreementResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataAccessAgreementResource.java
@@ -11,7 +11,6 @@ import org.bson.Document;
 import org.glassfish.jersey.media.multipart.FormDataBodyPart;
 import org.glassfish.jersey.media.multipart.FormDataParam;
 
-
 import javax.annotation.security.RolesAllowed;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
@@ -73,9 +72,14 @@ public class DataAccessAgreementResource extends Resource {
             @QueryParam("fileName") String fileName,
             @QueryParam("existentFileUrl") String existentFileUrl) {
         try {
-            if(StringUtils.isNotEmpty(existentFileUrl)) {
+            if (StringUtils.isNotEmpty(existentFileUrl)) {
                 store.deleteStorageDocument(existentFileUrl);
             }
+        } catch (Exception e) {
+            // Warn non-fatal errors so we can manage them through support
+            logger().warn(String.format("Unable to delete storage document with url of '%s' when storing a new document of '%s'", existentFileUrl, fileName));
+        }
+        try {
             String toStoreFileName =  UUID.randomUUID() + "." + FilenameUtils.getExtension(fileName);
             Document dataAccessAgreement = new Document();
             dataAccessAgreement.put(ResearcherFields.URL_DAA.getValue(), store.postStorageDocument(uploadedDAA, part.getMediaType().toString(), toStoreFileName));

--- a/src/test/java/org/broadinstitute/consent/http/resources/DataAccessAgreementResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DataAccessAgreementResourceTest.java
@@ -19,6 +19,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.io.InputStream;
 import java.nio.charset.Charset;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -67,7 +68,15 @@ public class DataAccessAgreementResourceTest {
         when(store.getStorageDocument(any())).thenReturn(response);
 
         Response response = resource.getDAA(1);
-        assertEquals(response.getStatus(), 200);
+        assertEquals(response.getStatus(), Response.Status.OK.getStatusCode());
+    }
+
+    @Test
+    public void testGetDAA_failure_case1() {
+        when(researcherAPI.describeResearcherPropertiesForDAR(anyInt())).thenReturn(Collections.emptyMap());
+
+        Response response = resource.getDAA(1);
+        assertEquals(response.getStatus(), Response.Status.NOT_FOUND.getStatusCode());
     }
 
     @Test
@@ -82,7 +91,7 @@ public class DataAccessAgreementResourceTest {
         String existentFileUrl = "";
 
         Response response = resource.storeDAA(content, part, fileName, existentFileUrl);
-        assertEquals(response.getStatus(), 200);
+        assertEquals(response.getStatus(), Response.Status.OK.getStatusCode());
     }
 
     @Test
@@ -97,7 +106,7 @@ public class DataAccessAgreementResourceTest {
         String existentFileUrl = "undefined";
 
         Response response = resource.storeDAA(content, part, fileName, existentFileUrl);
-        assertEquals(response.getStatus(), 200);
+        assertEquals(response.getStatus(), Response.Status.OK.getStatusCode());
     }
 
     @Test
@@ -112,7 +121,7 @@ public class DataAccessAgreementResourceTest {
         String existentFileUrl = "undefined";
 
         Response response = resource.storeDAA(content, part, fileName, existentFileUrl);
-        assertEquals(response.getStatus(), 200);
+        assertEquals(response.getStatus(), Response.Status.OK.getStatusCode());
     }
 
     @Test
@@ -127,7 +136,7 @@ public class DataAccessAgreementResourceTest {
         String existentFileUrl = "";
 
         Response response = resource.storeDAA(content, part, fileName, existentFileUrl);
-        assertEquals(response.getStatus(), 500);
+        assertEquals(response.getStatus(), Response.Status.INTERNAL_SERVER_ERROR.getStatusCode());
     }
 
 }

--- a/src/test/java/org/broadinstitute/consent/http/resources/DataAccessAgreementResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DataAccessAgreementResourceTest.java
@@ -84,7 +84,6 @@ public class DataAccessAgreementResourceTest {
         Map<String, String> propMap = new HashMap<>();
         propMap.put(ResearcherFields.URL_DAA.getValue(), "gs//url/to/daa");
         propMap.put(ResearcherFields.NAME_DAA.getValue(), "daaName.txt");
-        InputStream content = IOUtils.toInputStream("content", Charset.defaultCharset());
         when(researcherAPI.describeResearcherPropertiesForDAR(anyInt())).thenReturn(propMap);
         doThrow(Exception.class).when(store).getStorageDocument(anyString());
 

--- a/src/test/java/org/broadinstitute/consent/http/resources/DataAccessAgreementResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DataAccessAgreementResourceTest.java
@@ -1,0 +1,4 @@
+package org.broadinstitute.consent.http.resources;
+
+public class DataAccessAgreementResourceTest {
+}

--- a/src/test/java/org/broadinstitute/consent/http/resources/DataAccessAgreementResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DataAccessAgreementResourceTest.java
@@ -1,4 +1,108 @@
 package org.broadinstitute.consent.http.resources;
 
+import org.apache.commons.io.IOUtils;
+import org.broadinstitute.consent.http.cloudstore.GCSStore;
+import org.broadinstitute.consent.http.service.users.handler.DatabaseResearcherAPI;
+import org.glassfish.jersey.media.multipart.FormDataBodyPart;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.io.InputStream;
+import java.nio.charset.Charset;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({
+        DatabaseResearcherAPI.class
+})
 public class DataAccessAgreementResourceTest {
+
+    @Mock
+    GCSStore store;
+
+    @Mock
+    DatabaseResearcherAPI researcherAPI;
+
+    private DataAccessAgreementResource resource;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+        PowerMockito.mockStatic(DatabaseResearcherAPI.class);
+        resource = new DataAccessAgreementResource(store, researcherAPI);
+    }
+
+    @Test
+    public void testStoreDAA_success_case1() throws Exception {
+        when(store.deleteStorageDocument(any())).thenReturn(true);
+        when(store.postStorageDocument(any(), anyString(), anyString())).thenReturn("url");
+
+        InputStream uploadedDAA = IOUtils.toInputStream("content", Charset.defaultCharset());
+        FormDataBodyPart part = new FormDataBodyPart();
+        part.setMediaType(MediaType.TEXT_PLAIN_TYPE);
+        String fileName = "test.txt";
+        String existentFileUrl = "";
+
+        Response response = resource.storeDAA(uploadedDAA, part, fileName, existentFileUrl);
+        assertEquals(response.getStatus(), 200);
+    }
+
+    @Test
+    public void testStoreDAA_success_case2() throws Exception {
+        when(store.deleteStorageDocument(any())).thenReturn(false);
+        when(store.postStorageDocument(any(), anyString(), anyString())).thenReturn("url");
+
+        InputStream uploadedDAA = IOUtils.toInputStream("content", Charset.defaultCharset());
+        FormDataBodyPart part = new FormDataBodyPart();
+        part.setMediaType(MediaType.TEXT_PLAIN_TYPE);
+        String fileName = "test.txt";
+        String existentFileUrl = "undefined";
+
+        Response response = resource.storeDAA(uploadedDAA, part, fileName, existentFileUrl);
+        assertEquals(response.getStatus(), 200);
+    }
+
+    @Test
+    public void testStoreDAA_success_case3() throws Exception {
+        doThrow(Exception.class).when(store).deleteStorageDocument(any());
+        when(store.postStorageDocument(any(), anyString(), anyString())).thenReturn("url");
+
+        InputStream uploadedDAA = IOUtils.toInputStream("content", Charset.defaultCharset());
+        FormDataBodyPart part = new FormDataBodyPart();
+        part.setMediaType(MediaType.TEXT_PLAIN_TYPE);
+        String fileName = "test.txt";
+        String existentFileUrl = "undefined";
+
+        Response response = resource.storeDAA(uploadedDAA, part, fileName, existentFileUrl);
+        assertEquals(response.getStatus(), 200);
+    }
+
+    @Test
+    public void testStoreDAA_failure() throws Exception {
+        doThrow(Exception.class).when(store).deleteStorageDocument(any());
+        doThrow(Exception.class).when(store).postStorageDocument(any(), anyString(), anyString());
+
+        InputStream uploadedDAA = IOUtils.toInputStream("content", Charset.defaultCharset());
+        FormDataBodyPart part = new FormDataBodyPart();
+        part.setMediaType(MediaType.TEXT_PLAIN_TYPE);
+        String fileName = "test.txt";
+        String existentFileUrl = "";
+
+        Response response = resource.storeDAA(uploadedDAA, part, fileName, existentFileUrl);
+        assertEquals(response.getStatus(), 500);
+    }
+
 }

--- a/src/test/java/org/broadinstitute/consent/http/resources/DataAccessAgreementResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DataAccessAgreementResourceTest.java
@@ -80,6 +80,19 @@ public class DataAccessAgreementResourceTest {
     }
 
     @Test
+    public void testGetDAA_failure_case2() throws Exception {
+        Map<String, String> propMap = new HashMap<>();
+        propMap.put(ResearcherFields.URL_DAA.getValue(), "gs//url/to/daa");
+        propMap.put(ResearcherFields.NAME_DAA.getValue(), "daaName.txt");
+        InputStream content = IOUtils.toInputStream("content", Charset.defaultCharset());
+        when(researcherAPI.describeResearcherPropertiesForDAR(anyInt())).thenReturn(propMap);
+        doThrow(Exception.class).when(store).getStorageDocument(anyString());
+
+        Response response = resource.getDAA(1);
+        assertEquals(response.getStatus(), Response.Status.INTERNAL_SERVER_ERROR.getStatusCode());
+    }
+
+    @Test
     public void testStoreDAA_success_case1() throws Exception {
         when(store.deleteStorageDocument(any())).thenReturn(true);
         when(store.postStorageDocument(any(), anyString(), anyString())).thenReturn("url");


### PR DESCRIPTION
## Addresses
Along with https://github.com/DataBiosphere/duos-ui/pull/193, this PR addresses https://broadinstitute.atlassian.net/browse/DUOS-431
Neither PR is dependent upon one another.

## Changes
* Log non-fatal document removal attempts instead of failing outright. 
* Added missing tests