### PR TITLE
[No Jira][risk=no] Exclude the old version of databind from jackson-mapper-asl

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -322,6 +322,12 @@
       <groupId>org.codehaus.jackson</groupId>
       <artifactId>jackson-mapper-asl</artifactId>
       <version>1.9.13</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-databind</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <!-- Pulling in directly to evict older, transitive dependencies -->


### PR DESCRIPTION
Mitigates https://www.sourceclear.com/vulnerability-database/vulnerabilities/5364
According to SC, there is no real fix so excluding old versions from mapper-asl. We're already at 2.9.9.3

> Update
> This issue has not yet been fixed in a released version of the library. Please use the following steps to mitigate the issue:
> To mitigate this issue, upgrade to com:fasterxml.jackson.core:jackson-databind:2.9.5, or com:fasterxml.jackson.core:jackson-databind:2.8.9.