### PR TITLE
[DUOS-452][risk=no] Stream content instead of writing files

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/resources/DataAccessAgreementResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataAccessAgreementResource.java
@@ -60,6 +60,7 @@ public class DataAccessAgreementResource extends Resource {
             return createExceptionResponse(new NotFoundException());
         }
     }
+
     @POST
     @Consumes(MediaType.MULTIPART_FORM_DATA)
     @Produces(MediaType.APPLICATION_JSON)

--- a/src/main/java/org/broadinstitute/consent/http/resources/DataAccessAgreementResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataAccessAgreementResource.java
@@ -1,8 +1,8 @@
 package org.broadinstitute.consent.http.resources;
 
 import com.google.api.client.http.HttpResponse;
-import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.consent.http.cloudstore.GCSStore;
 import org.broadinstitute.consent.http.enumeration.ResearcherFields;
@@ -22,7 +22,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import java.io.File;
+import javax.ws.rs.core.StreamingOutput;
 import java.io.InputStream;
 import java.util.Map;
 import java.util.UUID;
@@ -47,11 +47,11 @@ public class DataAccessAgreementResource extends Resource {
         if (researcherProperties.containsKey(ResearcherFields.URL_DAA.getValue())) {
             try {
                 HttpResponse r = store.getStorageDocument(researcherProperties.get(ResearcherFields.URL_DAA.getValue()));
-                File targetFile = new File(researcherProperties.get(ResearcherFields.NAME_DAA.getValue()));
-                FileUtils.copyInputStreamToFile(r.getContent(), targetFile);
-                return Response.ok(targetFile)
+                String filename = researcherProperties.get(ResearcherFields.NAME_DAA.getValue());
+                StreamingOutput stream = createStreamingOutput(r.getContent());
+                return Response.ok(stream)
                         .type(r.getContentType())
-                        .header("Content-Disposition", "attachment; filename=" + targetFile.getName())
+                        .header("Content-Disposition", "attachment; filename=" + filename)
                         .build();
             } catch (Exception e) {
                 return createExceptionResponse(e);
@@ -60,7 +60,6 @@ public class DataAccessAgreementResource extends Resource {
             return createExceptionResponse(new NotFoundException());
         }
     }
-
     @POST
     @Consumes(MediaType.MULTIPART_FORM_DATA)
     @Produces(MediaType.APPLICATION_JSON)

--- a/src/main/java/org/broadinstitute/consent/http/resources/DataUseLetterResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataUseLetterResource.java
@@ -24,6 +24,7 @@ import javax.annotation.security.RolesAllowed;
 import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.StreamingOutput;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -138,11 +139,10 @@ public class DataUseLetterResource extends Resource {
             String fileUrl = election != null ? election.getDataUseLetter() : consent.getDataUseLetter();
             String fileName = election != null ? election.getDulName() : consent.getDulName();
             HttpResponse r = store.getStorageDocument(fileUrl);
-            File targetFile = new File(fileName);
-            FileUtils.copyInputStreamToFile(r.getContent(), targetFile);
-            return Response.ok(targetFile)
+            StreamingOutput stream = createStreamingOutput(r.getContent());
+            return Response.ok(stream)
                     .type(r.getContentType())
-                    .header("Content-Disposition", "attachment; filename=" + targetFile.getName())
+                    .header("Content-Disposition", "attachment; filename=" + fileName)
                     .build();
         } catch (UnknownIdentifierException e) {
             throw new NotFoundException(e);

--- a/src/main/java/org/broadinstitute/consent/http/resources/IndexerResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/IndexerResource.java
@@ -13,6 +13,7 @@ import javax.annotation.security.RolesAllowed;
 import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.StreamingOutput;
 import java.io.File;
 import java.net.URLDecoder;
 import java.util.List;
@@ -80,11 +81,10 @@ public class IndexerResource extends Resource {
         try {
             String url = URLDecoder.decode(fileUrl, "UTF-8");
             HttpResponse r = store.getStorageDocument(url);
-            File targetFile = new File(fileName);
-            FileUtils.copyInputStreamToFile(r.getContent(), targetFile);
-            return Response.ok(targetFile)
+            StreamingOutput stream = createStreamingOutput(r.getContent());
+            return Response.ok(stream)
                 .type(r.getContentType())
-                .header("Content-Disposition", "attachment; filename=" + targetFile.getName())
+                .header("Content-Disposition", "attachment; filename=" + fileName)
                 .build();
         } catch (Exception e) {
             return createExceptionResponse(e);

--- a/src/main/java/org/broadinstitute/consent/http/resources/Resource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/Resource.java
@@ -1,6 +1,7 @@
 package org.broadinstitute.consent.http.resources;
 
 import com.mysql.jdbc.exceptions.jdbc4.MySQLSyntaxErrorException;
+import org.apache.commons.io.IOUtils;
 import org.apache.log4j.Logger;
 import org.broadinstitute.consent.http.exceptions.UpdateConsentException;
 import org.broadinstitute.consent.http.models.dto.Error;
@@ -10,7 +11,9 @@ import javax.ws.rs.ForbiddenException;
 import javax.ws.rs.NotAuthorizedException;
 import javax.ws.rs.NotFoundException;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.StreamingOutput;
 import java.io.IOException;
+import java.io.InputStream;
 import java.sql.SQLException;
 import java.sql.SQLSyntaxErrorException;
 import java.util.HashMap;
@@ -32,7 +35,7 @@ abstract public class Resource {
     public final static String RESEARCHER = "RESEARCHER";
 
     protected Logger logger() {
-        return Logger.getLogger("consent");
+        return Logger.getLogger(this.getClass().getName());
     }
 
     protected Response createExceptionResponse(Exception e) {
@@ -48,6 +51,17 @@ abstract public class Resource {
             logger().error(t.getMessage());
             return Response.serverError().entity(new Error(e.getMessage(), Response.Status.INTERNAL_SERVER_ERROR.getStatusCode())).build();
         }
+    }
+
+    StreamingOutput createStreamingOutput(InputStream inputStream) {
+        return output -> {
+            try {
+                output.write(IOUtils.toByteArray(inputStream));
+            } catch (Exception e) {
+                logger().error(e);
+                throw e;
+            }
+        };
     }
 
     private interface ExceptionHandler {


### PR DESCRIPTION
## Addresses
This covers the API part of https://github.com/DataBiosphere/consent/pull/new/DUOS-452
It does not cover `DataSetResource.createDataSet()` ... I will deal with that in a different story that we have for revamping the data set upload/download feature.

## Changes
Use a stream to capture the output from GCS instead of writing to a temp file. 