### PR TITLE
[DUOS-395][risk=no] API Support

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/DataSetDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DataSetDAO.java
@@ -31,6 +31,9 @@ public interface DataSetDAO extends Transactional<DataSetDAO> {
     @SqlQuery("select * from dataset where dataSetId = :dataSetId")
     DataSet findDataSetById(@Bind("dataSetId") Integer dataSetId);
 
+    @SqlQuery("select * from dataset where dataSetId in (<dataSetIdList>)")
+    List<DataSet> findDataSetsByIdList(@BindIn("dataSetIdList") List<Integer> dataSetIdList);
+
     @SqlQuery("select * from dataset where objectId = :objectId")
     DataSet findDataSetByObjectId(@Bind("objectId") String objectId);
 

--- a/src/main/java/org/broadinstitute/consent/http/models/darsummary/DARModalDetailsDTO.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/darsummary/DARModalDetailsDTO.java
@@ -3,6 +3,7 @@ package org.broadinstitute.consent.http.models.darsummary;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.commons.collections.CollectionUtils;
 import org.broadinstitute.consent.http.models.DACUser;
+import org.broadinstitute.consent.http.models.DataSet;
 import org.broadinstitute.consent.http.util.DarConstants;
 import org.bson.Document;
 
@@ -35,8 +36,11 @@ public class DARModalDetailsDTO {
     private Integer userId;
 
     @JsonProperty
+    @Deprecated // Use datasets instead
     private Map<String, String> datasetDetail;
     private String needDOApproval = "";
+
+    private List<DataSet> datasets;
 
 
     public DARModalDetailsDTO() {}
@@ -55,7 +59,10 @@ public class DARModalDetailsDTO {
     }
 
     public DARModalDetailsDTO setResearcherName(DACUser owner, String principalInvestigator) {
-        if(owner.getDisplayName().equals(principalInvestigator)){
+        if (owner == null) {
+            return this;
+        }
+        if (owner.getDisplayName().equals(principalInvestigator)) {
             researcherName = principalInvestigator;
         } else {
             researcherName = owner.getDisplayName();
@@ -256,6 +263,7 @@ public class DARModalDetailsDTO {
         return this;
     }
 
+    @Deprecated // Use datasets instead
     public DARModalDetailsDTO setDatasetDetail(List<Document> datasetDetail) {
         Map<String, String> datasetDetailMap = new HashMap<>();
         datasetDetail.forEach((doc) -> {
@@ -263,6 +271,15 @@ public class DARModalDetailsDTO {
             datasetDetailMap.put(doc.getString("name"), objectId);
         });
         this.datasetDetail = datasetDetailMap;
+        return this;
+    }
+
+    public List<DataSet> getDatasets() {
+        return datasets;
+    }
+
+    public DARModalDetailsDTO setDatasets(List<DataSet> datasets) {
+        this.datasets = datasets;
         return this;
     }
 

--- a/src/main/java/org/broadinstitute/consent/http/models/darsummary/DARModalDetailsDTO.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/darsummary/DARModalDetailsDTO.java
@@ -1,15 +1,12 @@
 package org.broadinstitute.consent.http.models.darsummary;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.commons.collections.CollectionUtils;
 import org.broadinstitute.consent.http.models.DACUser;
 import org.broadinstitute.consent.http.models.DataSet;
 import org.broadinstitute.consent.http.models.ResearcherProperty;
-import org.broadinstitute.consent.http.util.DarConstants;
 import org.bson.Document;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -35,14 +32,10 @@ public class DARModalDetailsDTO {
     private boolean sensitivePopulation = false;
     private boolean requiresManualReview = false;
     private Integer userId;
-
-    @JsonProperty
-    @Deprecated // Use datasets instead
-    private Map<String, String> datasetDetail;
     private String needDOApproval = "";
     private List<DataSet> datasets;
     private List<ResearcherProperty> researcherProperties;
-
+    private String rus;
 
     public DARModalDetailsDTO() {}
 
@@ -264,17 +257,6 @@ public class DARModalDetailsDTO {
         return this;
     }
 
-    @Deprecated // Use datasets instead
-    public DARModalDetailsDTO setDatasetDetail(List<Document> datasetDetail) {
-        Map<String, String> datasetDetailMap = new HashMap<>();
-        datasetDetail.forEach((doc) -> {
-            String objectId = doc.getString(DarConstants.OBJECT_ID) != null ? doc.getString(DarConstants.OBJECT_ID) : "--";
-            datasetDetailMap.put(doc.getString("name"), objectId);
-        });
-        this.datasetDetail = datasetDetailMap;
-        return this;
-    }
-
     public List<DataSet> getDatasets() {
         return datasets;
     }
@@ -290,6 +272,15 @@ public class DARModalDetailsDTO {
 
     public DARModalDetailsDTO setResearcherProperties(List<ResearcherProperty> researcherProperties) {
         this.researcherProperties = researcherProperties;
+        return this;
+    }
+
+    public String getRus() {
+        return rus;
+    }
+
+    public DARModalDetailsDTO setRus(String rus) {
+        this.rus = rus;
         return this;
     }
 

--- a/src/main/java/org/broadinstitute/consent/http/models/darsummary/DARModalDetailsDTO.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/darsummary/DARModalDetailsDTO.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.commons.collections.CollectionUtils;
 import org.broadinstitute.consent.http.models.DACUser;
 import org.broadinstitute.consent.http.models.DataSet;
+import org.broadinstitute.consent.http.models.ResearcherProperty;
 import org.broadinstitute.consent.http.util.DarConstants;
 import org.bson.Document;
 
@@ -39,8 +40,8 @@ public class DARModalDetailsDTO {
     @Deprecated // Use datasets instead
     private Map<String, String> datasetDetail;
     private String needDOApproval = "";
-
     private List<DataSet> datasets;
+    private List<ResearcherProperty> researcherProperties;
 
 
     public DARModalDetailsDTO() {}
@@ -280,6 +281,15 @@ public class DARModalDetailsDTO {
 
     public DARModalDetailsDTO setDatasets(List<DataSet> datasets) {
         this.datasets = datasets;
+        return this;
+    }
+
+    public List<ResearcherProperty> getResearcherProperties() {
+        return researcherProperties;
+    }
+
+    public DARModalDetailsDTO setResearcherProperties(List<ResearcherProperty> researcherProperties) {
+        this.researcherProperties = researcherProperties;
         return this;
     }
 

--- a/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
@@ -156,7 +156,12 @@ public class DataAccessRequestResource extends Resource {
     public DARModalDetailsDTO getDataAcessRequestModalSummary(@PathParam("id") String id) {
         Document dar = dataAccessRequestAPI.describeDataAccessRequestById(id);
         Integer userId = obtainUserId(dar);
-        DACUser user = dacUserAPI.describeDACUserById(userId);
+        DACUser user = null;
+        try {
+            user = dacUserAPI.describeDACUserById(userId);
+        } catch (IllegalArgumentException e) {
+            logger.severe("Unable to find userId: " + userId + " for data access request id: " + id);
+        }
         return dataAccessRequestAPI.DARModalDetailsDTOBuilder(dar, user, electionAPI);
     }
 

--- a/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
@@ -153,7 +153,7 @@ public class DataAccessRequestResource extends Resource {
     @Produces("application/json")
     @Path("/modalSummary/{id}")
     @PermitAll
-    public DARModalDetailsDTO getDataAcessRequestModalSummary(@PathParam("id") String id) {
+    public Response getDataAcessRequestModalSummary(@PathParam("id") String id) {
         Document dar = dataAccessRequestAPI.describeDataAccessRequestById(id);
         Integer userId = obtainUserId(dar);
         DACUser user = null;
@@ -162,7 +162,8 @@ public class DataAccessRequestResource extends Resource {
         } catch (NotFoundException e) {
             logger.severe("Unable to find userId: " + userId + " for data access request id: " + id);
         }
-        return dataAccessRequestAPI.DARModalDetailsDTOBuilder(dar, user, electionAPI);
+        DARModalDetailsDTO detailsDTO = dataAccessRequestAPI.DARModalDetailsDTOBuilder(dar, user, electionAPI);
+        return Response.ok().entity(detailsDTO).build();
     }
 
     @GET

--- a/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
@@ -159,7 +159,7 @@ public class DataAccessRequestResource extends Resource {
         DACUser user = null;
         try {
             user = dacUserAPI.describeDACUserById(userId);
-        } catch (IllegalArgumentException e) {
+        } catch (NotFoundException e) {
             logger.severe("Unable to find userId: " + userId + " for data access request id: " + id);
         }
         return dataAccessRequestAPI.DARModalDetailsDTOBuilder(dar, user, electionAPI);

--- a/src/main/java/org/broadinstitute/consent/http/service/DatabaseDataAccessRequestAPI.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatabaseDataAccessRequestAPI.java
@@ -563,8 +563,12 @@ public class DatabaseDataAccessRequestAPI extends AbstractDataAccessRequestAPI {
         DARModalDetailsDTO darModalDetailsDTO = new DARModalDetailsDTO();
         List<Document> datasetDetails = populateDatasetDetailDocuments(dar.get(DarConstants.DATASET_DETAIL));
         List<DataSet> datasets = populateDatasets(dar.get(DarConstants.DATASET_DETAIL));
-        String status = Optional.ofNullable(dacUser).isPresent() ? dacUser.getStatus() : "";
-        String rationale = Optional.ofNullable(dacUser).isPresent() ? dacUser.getRationale() : "";
+        Optional<DACUser> optionalUser = Optional.ofNullable(dacUser);
+        String status = optionalUser.isPresent() ? dacUser.getStatus() : "";
+        String rationale = optionalUser.isPresent() ? dacUser.getRationale() : "";
+        List<ResearcherProperty> researcherProperties = optionalUser.isPresent() ?
+                researcherPropertyDAO.findResearcherPropertiesByUser(dacUser.getDacUserId()) :
+                Collections.emptyList();
         return darModalDetailsDTO
             .setNeedDOApproval(electionApi.darDatasetElectionStatus((dar.get(DarConstants.ID).toString())))
             .setResearcherName(dacUser, dar.getString(DarConstants.INVESTIGATOR))
@@ -586,7 +590,8 @@ public class DatabaseDataAccessRequestAPI extends AbstractDataAccessRequestAPI {
             .setDiseases(dar)
             .setPurposeStatements(dar)
             .setDatasetDetail(datasetDetails)
-            .setDatasets(datasets);
+            .setDatasets(datasets)
+            .setResearcherProperties(researcherProperties);
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/org/broadinstitute/consent/http/service/EmailNotifierService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/EmailNotifierService.java
@@ -367,8 +367,7 @@ public class EmailNotifierService extends AbstractEmailNotifierAPI {
             .setIsTherePurposeStatements(false)
             .setResearchType(access)
             .setDiseases(access)
-            .setPurposeStatements(access)
-            .setDatasetDetail((ArrayList<Document>) access.get(DarConstants.DATASET_DETAIL));
+            .setPurposeStatements(access);
 
         List<String> checkedSentences = (details.getPurposeStatements()).stream().map(SummaryItem::getDescription).collect(Collectors.toList());
         return templateHelper.getApprovedDarTemplate(

--- a/src/test/java/org/broadinstitute/consent/http/models/darsummary/DARModalDetailsDTOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/darsummary/DARModalDetailsDTOTest.java
@@ -10,6 +10,7 @@ import org.mockito.MockitoAnnotations;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -87,7 +88,7 @@ public class DARModalDetailsDTOTest {
             .setResearchType(darDocument)
             .setDiseases(darDocument)
             .setPurposeStatements(darDocument)
-            .setDatasetDetail((ArrayList<Document>) darDocument.get(DarConstants.DATASET_DETAIL));
+            .setDatasets(Collections.emptyList());
         modalDetailsDTO.getDarCode();
         assertTrue(modalDetailsDTO.getDarCode().equals(DAR_CODE));
         assertTrue(modalDetailsDTO.getInstitutionName().equals(INSTITUTION));


### PR DESCRIPTION
## Addresses
API changes in support of https://broadinstitute.atlassian.net/browse/DUOS-395
See also https://github.com/DataBiosphere/duos-ui/pull/171

## Changes
* Due to security testing, we have some invalid data that presents an opportunity to better handle error cases. Log the case of invalid users on a DAR instead of throwing a 404. 