### PR TITLE
[DUOS-455][risk=no] Fix approved users download

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/service/DatabaseDataAccessRequestAPI.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatabaseDataAccessRequestAPI.java
@@ -639,9 +639,10 @@ public class DatabaseDataAccessRequestAPI extends AbstractDataAccessRequestAPI {
     }
 
     private List<Document> describeDataAccessByDataSetId(Integer dataSetId) {
-        List<Document> response = new ArrayList<>();
-        response.addAll(mongo.getDataAccessRequestCollection().find(eq(DarConstants.DATASET_ID, dataSetId.toString())).into(new ArrayList<>()));
-        return response;
+        FindIterable<Document> filterable = mongo
+                .getDataAccessRequestCollection()
+                .find(in(DarConstants.DATASET_ID, dataSetId));
+        return new ArrayList<>(filterable.into(new ArrayList<>()));
     }
 
     private void insertDataAccess(List<Document> dataAccessRequestList) {

--- a/src/main/java/org/broadinstitute/consent/http/service/DatabaseDataAccessRequestAPI.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatabaseDataAccessRequestAPI.java
@@ -639,10 +639,10 @@ public class DatabaseDataAccessRequestAPI extends AbstractDataAccessRequestAPI {
     }
 
     private List<Document> describeDataAccessByDataSetId(Integer dataSetId) {
-        FindIterable<Document> filterable = mongo
+        FindIterable<Document> results = mongo
                 .getDataAccessRequestCollection()
                 .find(in(DarConstants.DATASET_ID, dataSetId));
-        return new ArrayList<>(filterable.into(new ArrayList<>()));
+        return results.into(new ArrayList<>());
     }
 
     private void insertDataAccess(List<Document> dataAccessRequestList) {

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -1838,12 +1838,12 @@ paths:
               $ref: '#/definitions/Dictionary'
         500:
           description: Server error.
-  /api/dataset/{datasetObjectId}:
+  /api/dataset/{id}:
     delete:
       summary: delete
-      description: Deletes Dataset and DatasetProperties of the Dataset specified by datasetObjectId .
+      description: Deletes Dataset and DatasetProperties of the Dataset specified by id.
       parameters:
-        - name: datasetObjectId
+        - name: id
           in: path
           description: ObjectId of the Dataset
           required: true
@@ -1853,6 +1853,34 @@ paths:
       responses:
         200:
           description: The Dataset was deleted.
+        500:
+          description: Server error.
+  /api/dataset/{id}/approved/users:
+    get:
+      summary: Dataset Approved Users
+      description: Dataset Approved Users
+      produces:
+        - text/plain
+      parameters:
+        - name: id
+          in: path
+          description: The dataset id
+          required: true
+          type: integer
+      tags:
+        - Datasets
+      responses:
+        200:
+          description: Dataset Approved Users
+          schema:
+            type: file
+          headers:
+            Content-type:
+              type: string
+              description: text/plain
+            Content-Disposition:
+              type: string
+              description: attachment; filename=DatasetApprovedUsers.tsv
         500:
           description: Server error.
   /api/dataset/download:
@@ -1896,12 +1924,12 @@ paths:
               type: string
         500:
           description: Server error.
-  /api/dataset/disable/{datasetObjectId}/{active}:
+  /api/dataset/disable/{id}/{active}:
         delete:
           summary: disableDataSet
-          description: 'Updates the Active status of the Dataset specified by datasetObjectId'
+          description: 'Updates the Active status of the Dataset specified by id'
           parameters:
-            - name: datasetObjectId
+            - name: id
               in: path
               description: the Id of the Dataset to Update.
               required: true


### PR DESCRIPTION
## Addresses
See https://broadinstitute.atlassian.net/browse/DUOS-455

## Changes
* Added swagger doc. Note that swagger still sends an incorrect accept header in my local testing even with a correct `produces` spec ... it should not be. 
* Fix the dar query. DARs were modified to contain a list of dataset ids and this query was not updated to match the new model. 