### PR TITLE
[no jira][risk=no] Update databind

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -334,7 +334,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.9.10</version>
+      <version>2.9.10.1</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Addresses github automated alert:

> 
> 1 com.fasterxml.jackson.core:jackson-databind vulnerability found in pom.xml 2 hours ago
> Remediation
> 
> Upgrade com.fasterxml.jackson.core:jackson-databind to version 2.9.10.1 or later. For example:
> 
> <dependency>
>   <groupId>com.fasterxml.jackson.core</groupId>
>   <artifactId>jackson-databind</artifactId>
>   <version>[2.9.10.1,)</version>
> </dependency>
> 
> Always verify the validity and compatibility of suggestions with your codebase. 
>
> CVE-2019-16942
> More information
> moderate severity
> Vulnerable versions: < 2.9.10.1
> Patched version: 2.9.10.1
> 
> A Polymorphic Typing issue was discovered in FasterXML jackson-databind 2.0.0 through 2.9.10. When Default Typing is enabled (either globally or for a specific property) for an externally exposed JSON endpoint and the service has the commons-dbcp (1.4) jar in the classpath, and an attacker can find an RMI service endpoint to access, it is possible to make the service execute a malicious payload. This issue exists because of org.apache.commons.dbcp.datasources.SharedPoolDataSource and org.apache.commons.dbcp.datasources.PerUserPoolDataSource mishandling.