### PR TITLE
[no jira][risk=no] Address RDF4J Security Vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -795,13 +795,13 @@
     <dependency>
       <groupId>org.eclipse.rdf4j</groupId>
       <artifactId>rdf4j-rio-rdfxml</artifactId>
-      <version>2.4.2</version>
+      <version>3.0.2</version>
     </dependency>
 
     <dependency>
       <groupId>org.eclipse.rdf4j</groupId>
       <artifactId>rdf4j-rio-trix</artifactId>
-      <version>2.4.1</version>
+      <version>3.0.2</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -811,11 +811,35 @@
       <exclusions>
         <exclusion>
           <groupId>org.eclipse.rdf4j</groupId>
-          <artifactId>df4j-rio-rdfxml</artifactId>
+          <artifactId>rdf4j-rio-api</artifactId>
         </exclusion>
         <exclusion>
           <groupId>org.eclipse.rdf4j</groupId>
-          <artifactId>df4j-rio-trix</artifactId>
+          <artifactId>rdf4j-rio-binary</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.eclipse.rdf4j</groupId>
+          <artifactId>rdf4j-util</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.eclipse.rdf4j</groupId>
+          <artifactId>rdf4j-rio-datatypes</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.eclipse.rdf4j</groupId>
+          <artifactId>rdf4j-rio-languages</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.eclipse.rdf4j</groupId>
+          <artifactId>rdf4j-model</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.eclipse.rdf4j</groupId>
+          <artifactId>rdf4j-rio-rdfxml</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.eclipse.rdf4j</groupId>
+          <artifactId>rdf4j-rio-trix</artifactId>
         </exclusion>
         <exclusion>
           <groupId>net.sourceforge.owlapi</groupId>


### PR DESCRIPTION
## Addresses
No Jira

## Changes
Library update due to SC report:

https://www.sourceclear.com/vulnerability-database/vulnerabilities/8050
> Directory Traversal
> 
> rdf4j-util is vulnerable to directory traversal. An attacker is able to overwrite arbitrary files using the characters `../` as an entry in a ZIP archive. The overwrite occurs during decompressing of the ZIP file.
> 
> Update
> 
> This issue was fixed in version 2.4.3 of RDF4J: util. That version is currently considered safe, we suggest that you upgrade to the fixed version.