### PR TITLE
[no jira][risk=no] Jackson exclusions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -429,6 +429,10 @@
       <version>${dropwizard.version}</version>
       <exclusions>
         <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-databind</artifactId>
+        </exclusion>
+        <exclusion>
           <groupId>com.google.code.findbugs</groupId>
           <artifactId>jsr305</artifactId>
         </exclusion>
@@ -736,6 +740,12 @@
       <artifactId>fongo</artifactId>
       <version>2.0.6</version>
       <type>jar</type>
+      <exclusions>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-databind</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
@@ -783,6 +793,12 @@
       <artifactId>mockserver-netty</artifactId>
       <version>3.10.8</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-databind</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
@@ -809,6 +825,10 @@
       <artifactId>owlapi-distribution</artifactId>
       <version>${owl.version}</version>
       <exclusions>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-databind</artifactId>
+        </exclusion>
         <exclusion>
           <groupId>org.eclipse.rdf4j</groupId>
           <artifactId>df4j-rio-rdfxml</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -843,6 +843,10 @@
         </exclusion>
         <exclusion>
           <groupId>org.eclipse.rdf4j</groupId>
+          <artifactId>rdf4j-rio-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.eclipse.rdf4j</groupId>
           <artifactId>rdf4j-rio-binary</artifactId>
         </exclusion>
         <exclusion>


### PR DESCRIPTION
No Jira
Add exclusions to force clear the vulnerable jackson libraries as reported by source clear.

https://www.sourceclear.com/vulnerability-database/vulnerabilities/5732

> Remote Code Execution (RCE)
> 
> jackson-databind is vulnerable to remote code execution (RCE) attacks. Attackers can exploit an incomplete fix of `CVE-2017-7525` and `CVE-2017-17485` to bypass the blacklist during Jackson deserialization. In order to be vulnerable to this attack, either the use of `@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)` or `@JsonTypeInfo(use = JsonTypeInfo.Id.MINIMAL_CLASS)` or a call to `ObjectMapper.enableDefaultTyping(...)` is needed.
> 
> Update
> 
> This issue has not yet been fixed in a released version of the library. Please use the following steps to mitigate the issue:
> To mitigate this issue, upgrade to com:fasterxml.jackson.core:jackson-databind:2.9.5, or com:fasterxml.jackson.core:jackson-databind:2.8.9.