### PR TITLE
[no jira][risk=no] Update Guava

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -429,6 +429,10 @@
       <version>${dropwizard.version}</version>
       <exclusions>
         <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+        </exclusion>
+        <exclusion>
           <groupId>com.google.code.findbugs</groupId>
           <artifactId>jsr305</artifactId>
         </exclusion>
@@ -582,7 +586,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>27.0-jre</version>
+      <version>28.1-jre</version>
     </dependency>
 
     <dependency>
@@ -783,6 +787,12 @@
       <artifactId>mockserver-netty</artifactId>
       <version>3.10.8</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
@@ -809,6 +819,10 @@
       <artifactId>owlapi-distribution</artifactId>
       <version>${owl.version}</version>
       <exclusions>
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+        </exclusion>
         <exclusion>
           <groupId>org.eclipse.rdf4j</groupId>
           <artifactId>df4j-rio-rdfxml</artifactId>


### PR DESCRIPTION
No Jira
Update vulnerable guava library as reported by source clear.

https://www.sourceclear.com/vulnerability-database/vulnerabilities/6202

> Denial Of Service (DoS)
> 
> Guava is vulnerable to denial of service (DoS). The attacks are possible because `AtomicDoubleArray` and `CompoundOrdering` classes perform memory allocations without checking user provided data and its size.
> 
> View more details in the SourceClear Vulnerability Database
> 
> Update
> 
> This issue was fixed in version 24.1.1-android. That version is currently considered safe, we suggest that you upgrade to the fixed version.
> 
> 