### PR TITLE
[no jira][risk=no] Fix maven enforcer warning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,10 +9,6 @@
   <packaging>jar</packaging>
   <name>Consent Management Services</name>
 
-  <prerequisites>
-    <maven>3.0.0</maven>
-  </prerequisites>
-
   <properties>
     <java.version>1.8</java.version>
     <lucene.version>7.5.0</lucene.version>
@@ -45,6 +41,30 @@
     </testResources>
 
     <plugins>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>3.0.0-M3</version>
+        <executions>
+          <execution>
+            <id>enforce-versions</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireMavenVersion>
+                  <version>3.0.0</version>
+                </requireMavenVersion>
+                <requireJavaVersion>
+                  <version>{java.version}</version>
+                </requireJavaVersion>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
 
       <plugin>
         <groupId>pl.project13.maven</groupId>


### PR DESCRIPTION
## Addresses
Fixes:

> [WARNING] The project org.broadinstitute:consent:jar:1.0.1 uses prerequisites which is only intended for maven-plugin projects but not for non maven-plugin projects. For such purposes you should use the maven-enforcer-plugin. See https://maven.apache.org/enforcer/enforcer-rules/requireMavenVersion.html
