### PR TITLE
[DUOS-392][risk=no] Remove Deprecated Code

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
@@ -287,7 +287,7 @@ public class ConsentApplication extends Application<ConsentConfiguration> {
         env.jersey().register(new ConsentCasesResource(electionService, pendingCaseService));
         env.jersey().register(new DataRequestCasesResource(electionService, pendingCaseService));
         env.jersey().register(new DacResource(dacService));
-        env.jersey().register(new DACUserResource(voteService));
+        env.jersey().register(DACUserResource.class);
         env.jersey().register(ElectionReviewResource.class);
         env.jersey().register(new ConsentManageResource(consentService));
         env.jersey().register(new ElectionResource(voteService));

--- a/src/main/java/org/broadinstitute/consent/http/db/ConsentDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/ConsentDAO.java
@@ -118,11 +118,6 @@ public interface ConsentDAO extends Transactional<ConsentDAO> {
             "where consentId = :consentId and active = true")
     void updateConsentSortDate(@Bind("consentId") String consentId, @Bind("sortDate") Date sortDate);
 
-    @SqlUpdate("update consents set lastUpdate = :lastUpdate, sortDate = :sortDate where consentId in (<consentId>) ")
-    void bulkUpdateConsentSortDate(@BindIn("consentId") List<String> consentId,
-                                   @Bind("lastUpdate") Date lastUpdate,
-                                   @Bind("sortDate") Date sortDate);
-
     // Consent Association Access Methods
 
     @SqlUpdate("insert into consentassociations (consentId, associationType, dataSetId) values (:consentId, :associationType, :dataSetId)")

--- a/src/main/java/org/broadinstitute/consent/http/db/DACUserDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DACUserDAO.java
@@ -63,10 +63,6 @@ public interface DACUserDAO extends Transactional<DACUserDAO> {
     @SqlUpdate("delete from dacuser where email = :email")
     void deleteDACUserByEmail(@Bind("email") String email);
 
-    // TODO: This query can return many user ids, not a single one. See: DUOS-392
-    @SqlQuery("select dr.user_id from user_role dr inner join roles r on r.roleId = dr.role_id where dr.user_id != :dacUserId and r.roleId = :roleId")
-    Integer findDACUserIdByRole(@Bind("roleId") Integer roleId, @Bind("dacUserId") Integer dacUserId);
-
     @Mapper(DACUserRoleMapper.class)
     @SqlQuery("select du.*, r.roleId, r.name, ur.user_role_id, ur.user_id, ur.role_id, ur.dac_id from dacuser du inner join user_role ur on ur.user_id = du.dacUserId " +
               "inner join roles r on r.roleId = ur.role_id order by createDate desc")

--- a/src/main/java/org/broadinstitute/consent/http/db/ElectionDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/ElectionDAO.java
@@ -73,11 +73,6 @@ public interface ElectionDAO extends Transactional<ElectionDAO> {
     @SqlUpdate("update election set finalAccessVote = true where electionId = :electionId ")
     void updateFinalAccessVote(@Bind("electionId") Integer electionId);
 
-
-    @SqlUpdate("update election set lastUpdate = :lastUpdate where electionId in (<electionsId>) ")
-    void bulkUpdateElectionLastUpdate(@BindIn("electionsId") List<Integer> electionsId,
-                                      @Bind("lastUpdate") Date lastUpdate);
-
     @SqlUpdate("update election set status = '"+ CANCELED +"' where referenceId in (<referenceId>) and status = '" + OPEN +"' and electiontype = :electionType")
     void bulkCancelOpenElectionByReferenceIdAndType(@Bind("electionType") String electionType,
                                                     @BindIn("referenceId") List<String> referenceId);
@@ -138,10 +133,6 @@ public interface ElectionDAO extends Transactional<ElectionDAO> {
             + " e.lastUpdate, e.finalAccessVote, e.electionType, e.dataUseLetter, e.dulName, e.archived, e.version  from election e inner join vote v  on v.electionId = e.electionId and v.type = '" + CHAIRPERSON
             + "' where e.electionType = :type and e.finalAccessVote = :vote and e.status != 'Canceled' order by createDate asc")
     List<Election> findElectionsByTypeAndFinalAccessVoteChairPerson(@Bind("type") String type, @Bind("vote") Boolean finalAccessVote);
-
-    @SqlQuery("select e.electionId from election e where e.electionType = :type and e.status = :status ")
-    List<Integer> findElectionsIdByTypeAndStatus(@Bind("type") String type, @Bind("status") String status);
-
 
     @SqlQuery("select count(*) from election e inner join vote v on v.electionId = e.electionId and v.type = '" + CHAIRPERSON + "' where e.electionType = :type and e.status = :status and " +
             " v.vote = :finalVote ")
@@ -251,14 +242,6 @@ public interface ElectionDAO extends Transactional<ElectionDAO> {
 
     @SqlQuery("SELECT v.electionId FROM vote v, election e where v.dacUserId = :dacUserId and e.electionId = v.electionId AND v.vote is null AND e.electionType != '"+ DATASET +"' AND (e.status = '" + OPEN +"' OR e.status = 'Final')")
     List<Integer> findNonDataSetOpenElectionIds(@Bind("dacUserId")Integer dacUserId);
-
-    @SqlQuery("SELECT v.electionId FROM vote v, election e where v.dacUserId = :dacUserId and e.electionId = v.electionId AND v.vote is null AND e.electionType = :type AND (e.status = '" + OPEN +"' OR e.status = 'Final')")
-    List<Integer> findOpenElectionIdByTypeAndUser(@Bind("dacUserId")Integer dacUserId, @Bind("type") String type);
-
-    @Mapper(DatabaseElectionMapper.class)
-    @SqlQuery("SELECT distinct e.* FROM election e  inner join vote v on e.electionId = v.electionId where  (e.electionType = 'DataAccess' OR e.electionType = 'RP') " +
-            " and e.status = '" + OPEN +"' and v.vote is null and v.dacUserId = :dacUserId")
-    List<Election> findAccessRpOpenElectionIds(@Bind("dacUserId")Integer dacUserId);
 
     @SqlQuery("select distinct e.electionId,  e.datasetId, v.vote finalVote, e.status, e.createDate, e.referenceId, e.useRestriction, e.translatedUseRestriction, v.rationale finalRationale, v.createDate finalVoteDate, " +
             "e.lastUpdate, e.finalAccessVote, e.electionType e.dataUseLetter, e.dulName, e.archived, e.version  from election e inner join vote v  on v.electionId = e.electionId where e.electionType = 'DataAccess' "+

--- a/src/main/java/org/broadinstitute/consent/http/resources/DACUserResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DACUserResource.java
@@ -3,16 +3,11 @@ package org.broadinstitute.consent.http.resources;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
-import com.google.inject.Inject;
 import org.apache.log4j.Logger;
 import org.broadinstitute.consent.http.models.DACUser;
-import org.broadinstitute.consent.http.models.Election;
 import org.broadinstitute.consent.http.models.UserRole;
 import org.broadinstitute.consent.http.models.dto.Error;
 import org.broadinstitute.consent.http.models.user.ValidateDelegationResponse;
-import org.broadinstitute.consent.http.service.AbstractElectionAPI;
-import org.broadinstitute.consent.http.service.ElectionAPI;
-import org.broadinstitute.consent.http.service.VoteService;
 import org.broadinstitute.consent.http.service.users.AbstractDACUserAPI;
 import org.broadinstitute.consent.http.service.users.DACUserAPI;
 import org.broadinstitute.consent.http.service.users.handler.DACUserRolesHandler;
@@ -46,15 +41,10 @@ import java.util.stream.Collectors;
 public class DACUserResource extends Resource {
 
     private final DACUserAPI dacUserAPI;
-    private final ElectionAPI electionAPI;
     protected final Logger logger = Logger.getLogger(this.getClass().getName());
-    private final VoteService voteService;
 
-    @Inject
-    public DACUserResource(VoteService voteService) {
-        this.electionAPI = AbstractElectionAPI.getInstance();
+    public DACUserResource() {
         this.dacUserAPI = AbstractDACUserAPI.getInstance();
-        this.voteService = voteService;
     }
 
     @POST
@@ -63,11 +53,6 @@ public class DACUserResource extends Resource {
     public Response createDACUser(@Context UriInfo info, String json) {
         try {
             DACUser dacUser = dacUserAPI.createDACUser(new DACUser(json));
-            if (isChairPerson(dacUser.getRoles())) {
-                dacUserAPI.updateExistentChairPersonToAlumni(dacUser.getDacUserId());
-                List<Election> elections = electionAPI.cancelOpenElectionAndReopen();
-                voteService.createVotesForElections(elections);
-            }
             // Update email preference
             getEmailPreferenceValueFromUserJson(json).ifPresent(aBoolean ->
                     dacUserAPI.updateEmailPreference(aBoolean, dacUser.getDacUserId())

--- a/src/main/java/org/broadinstitute/consent/http/resources/DACUserResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DACUserResource.java
@@ -5,7 +5,6 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import org.apache.log4j.Logger;
 import org.broadinstitute.consent.http.models.DACUser;
-import org.broadinstitute.consent.http.models.UserRole;
 import org.broadinstitute.consent.http.models.dto.Error;
 import org.broadinstitute.consent.http.models.user.ValidateDelegationResponse;
 import org.broadinstitute.consent.http.service.users.AbstractDACUserAPI;
@@ -205,17 +204,6 @@ public class DACUserResource extends Resource {
         } catch (Exception e) {
             return createExceptionResponse(e);
         }
-    }
-
-    private boolean isChairPerson(List<UserRole> userRoles) {
-        boolean isChairPerson = false;
-        for (UserRole role : userRoles) {
-            if (role.getName().equalsIgnoreCase(CHAIRPERSON)) {
-                isChairPerson = true;
-                break;
-            }
-        }
-        return isChairPerson;
     }
 
     /**

--- a/src/main/java/org/broadinstitute/consent/http/service/DatabaseElectionAPI.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatabaseElectionAPI.java
@@ -240,21 +240,6 @@ public class DatabaseElectionAPI extends AbstractElectionAPI {
     }
 
     @Override
-    public List<Election> cancelOpenElectionAndReopen() throws Exception{
-        List<Election> openElections = electionDAO.findElectionsWithFinalVoteByTypeAndStatus(ElectionType.TRANSLATE_DUL.getValue(), ElectionStatus.OPEN.getValue());
-        cancelOpenElection(ElectionType.TRANSLATE_DUL.getValue());
-        List<Integer> electionIds = openElections.stream().map(election -> election.getElectionId()).collect(Collectors.toList());
-        List<String> consentIds = openElections.stream().map(election -> election.getReferenceId()).collect(Collectors.toList());
-        Date sortDate = new Date();
-        if(CollectionUtils.isNotEmpty(electionIds)){
-            consentDAO.bulkUpdateConsentSortDate(consentIds, sortDate, sortDate);
-            electionDAO.bulkUpdateElectionLastUpdate(electionIds, sortDate);
-        }
-        return openElections(openElections);
-    }
-
-
-    @Override
     public Integer findRPElectionByElectionAccessId(Integer electionId) {
         return electionDAO.findRPElectionByElectionAccessId(electionId);
     }
@@ -516,26 +501,9 @@ public class DatabaseElectionAPI extends AbstractElectionAPI {
         mongo.getDataAccessRequestCollection().findOneAndReplace(query, dar);
     }
 
-    private void cancelOpenElection(String electionType){
-        List<Integer> openElectionsIds = electionDAO.findElectionsIdByTypeAndStatus(electionType, ElectionStatus.OPEN.getValue());
-        if (openElectionsIds != null && openElectionsIds.size() > 0) {
-            electionDAO.updateElectionStatus(openElectionsIds, ElectionStatus.CANCELED.getValue());
-        }
-    }
-
     private Document describeDataAccessRequestById(String id){
         BasicDBObject query = new BasicDBObject(DarConstants.ID, new ObjectId(id));
         return mongo.getDataAccessRequestCollection().find(query).first();
-    }
-
-    private List<Election> openElections(List<Election> openElections) throws Exception{
-        List<Election> elections = new ArrayList<>();
-        for (Election existentElection : openElections) {
-            Election election = new Election();
-            election.setReferenceId(existentElection.getReferenceId());
-            elections.add(createElection(election, election.getReferenceId(), ElectionType.TRANSLATE_DUL));
-        }
-        return elections;
     }
 
     private void setGeneralFields(Election election, String referenceId, ElectionType electionType) {

--- a/src/main/java/org/broadinstitute/consent/http/service/ElectionAPI.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ElectionAPI.java
@@ -32,8 +32,6 @@ public interface ElectionAPI {
 
     void deleteElection(String referenceId, Integer electionId) throws IllegalArgumentException, NotFoundException;
 
-    List<Election> cancelOpenElectionAndReopen() throws Exception;
-
     void setMongoDBInstance(MongoConsentDB mongo);
 
     Integer findRPElectionByElectionAccessId(Integer accessElectionId);

--- a/src/main/java/org/broadinstitute/consent/http/service/VoteService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/VoteService.java
@@ -141,19 +141,6 @@ public class VoteService {
     }
 
     /**
-     * Create votes for elections.
-     *
-     * @param elections List of Elections
-     */
-    public void createVotesForElections(List<Election> elections) {
-        if (elections != null) {
-            for (Election election : elections) {
-                createVotes(election, ElectionType.TRANSLATE_DUL, false);
-            }
-        }
-    }
-
-    /**
      * Create Votes for a data owner election
      *
      * @param election Election

--- a/src/main/java/org/broadinstitute/consent/http/service/users/DACUserAPI.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/users/DACUserAPI.java
@@ -28,8 +28,6 @@ public interface DACUserAPI {
 
     void deleteDACUser(String email) throws IllegalArgumentException, NotFoundException;
 
-    void updateExistentChairPersonToAlumni(Integer dacUserID);
-
     Collection<DACUser> describeUsers();
 
     ValidateDelegationResponse validateNeedsDelegation(DACUser user, String role);

--- a/src/main/java/org/broadinstitute/consent/http/service/users/DatabaseDACUserAPI.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/users/DatabaseDACUserAPI.java
@@ -303,16 +303,6 @@ public class DatabaseDACUserAPI extends AbstractDACUserAPI {
     }
 
     @Override
-    public void updateExistentChairPersonToAlumni(Integer dacUserID) {
-        Integer existentRoleId = userRoleDAO.findRoleIdByName(UserRoles.CHAIRPERSON.getRoleName());
-        Integer chairPersonId = dacUserDAO.findDACUserIdByRole(existentRoleId, dacUserID);
-        if (chairPersonId != null) {
-            Integer newRoleId = userRoleDAO.findRoleIdByName(UserRoles.ALUMNI.getRoleName());
-            userRoleDAO.updateUserRoles(newRoleId, chairPersonId, existentRoleId);
-        }
-    }
-
-    @Override
     public Collection<DACUser> describeUsers() {
         Collection<DACUser> users = dacUserDAO.findUsers();
         users.forEach(user -> {

--- a/src/test/java/org/broadinstitute/consent/http/db/ConsentDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/ConsentDAOTest.java
@@ -202,15 +202,6 @@ public class ConsentDAOTest extends DAOTestHelper {
     }
 
     @Test
-    public void testBulkUpdateConsentSortDate() {
-        Consent consent = createConsent(null);
-
-        consentDAO.bulkUpdateConsentSortDate(Collections.singletonList(consent.getConsentId()), new Date(), yesterday());
-        Consent foundConsent = consentDAO.findConsentById(consent.getConsentId());
-        Assert.assertTrue(foundConsent.getSortDate().before(consent.getSortDate()));
-    }
-
-    @Test
     public void testInsertConsentAssociation() {
         // no-op ... tested in `createAssociation()`
     }

--- a/src/test/java/org/broadinstitute/consent/http/db/UserDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/UserDAOTest.java
@@ -137,13 +137,6 @@ public class UserDAOTest extends DAOTestHelper {
     }
 
     @Test
-    public void testFindDACUserIdByRole() {
-        DACUser chair = createUserWithRole(UserRoles.CHAIRPERSON.getRoleId());
-        Integer foundUserId = userDAO.findDACUserIdByRole(UserRoles.CHAIRPERSON.getRoleId(), chair.getDacUserId());
-        Assert.assertNotNull(foundUserId);
-    }
-
-    @Test
     public void testFindUsers_noArgs() {
         createUser();
         Collection<DACUser> users = userDAO.findUsers();

--- a/src/test/java/org/broadinstitute/consent/http/service/VoteServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/VoteServiceTest.java
@@ -196,11 +196,6 @@ public class VoteServiceTest {
     }
 
     @Test
-    public void testCreateVotesForElections() {
-        // No-op ... tested in all of the create vote tests
-    }
-
-    @Test
     public void testCreateDataOwnersReviewVotes() {
         Election e = new Election();
         e.setElectionId(1);


### PR DESCRIPTION
## Addresses
https://broadinstitute.atlassian.net/browse/DUOS-392
Depends on https://github.com/DataBiosphere/consent/pull/394 which also depends on https://github.com/DataBiosphere/consent/pull/393

## Changes
The `DACUserDAO.findDACUserIdByRole` method was in use only to move a chair from chair to alumni when adding a new chairperson. That logic is no longer valid and will be addressed differently in [DUOS-491](https://broadinstitute.atlassian.net/browse/DUOS-491) so we're removing it altogether here. Lots of dead code went along with that.