### PR TITLE
[DUOS-443][risk=no] Part 2 of updating vulnerable researcher APIs

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
@@ -296,7 +296,7 @@ public class ConsentApplication extends Application<ConsentConfiguration> {
         env.jersey().register(HelpReportResource.class);
         env.jersey().register(ApprovalExpirationTimeResource.class);
         env.jersey().register(new UserResource(userAPI));
-        env.jersey().register(new ResearcherResource(researcherService));
+        env.jersey().register(new ResearcherResource(researcherService, userAPI));
         env.jersey().register(WorkspaceResource.class);
         env.jersey().register(new DataAccessAgreementResource(googleStore, researcherService));
         env.jersey().register(new SwaggerResource(config.getGoogleAuthentication()));

--- a/src/main/java/org/broadinstitute/consent/http/models/DACUser.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DACUser.java
@@ -8,6 +8,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.broadinstitute.consent.http.authentication.GoogleUser;
 
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
@@ -195,6 +196,13 @@ public class DACUser {
 
     public void setProfileCompleted(Boolean profileCompleted) {
         this.profileCompleted = profileCompleted;
+    }
+
+    public void addRole(UserRole userRole) {
+        if (this.getRoles() == null) {
+            this.setRoles(new ArrayList<>());
+        }
+        this.getRoles().add(userRole);
     }
 
     @Override

--- a/src/main/java/org/broadinstitute/consent/http/resources/NihAccountResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/NihAccountResource.java
@@ -31,8 +31,8 @@ public class NihAccountResource extends Resource {
     @RolesAllowed(RESEARCHER)
     public Response registerResearcher(NIHUserAccount nihAccount, @Auth AuthUser user) {
         try {
-            DACUser dacUser = dacUserAPI.describeDACUserByEmail(user.getName());
-            return Response.ok(nihAuthApi.authenticateNih(nihAccount, dacUser.getDacUserId())).build();
+            dacUserAPI.describeDACUserByEmail(user.getName());
+            return Response.ok(nihAuthApi.authenticateNih(nihAccount, user)).build();
         } catch (Exception e){
             return createExceptionResponse(e);
         }

--- a/src/main/java/org/broadinstitute/consent/http/resources/ResearcherResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/ResearcherResource.java
@@ -1,15 +1,21 @@
 package org.broadinstitute.consent.http.resources;
 
 import io.dropwizard.auth.Auth;
+import org.broadinstitute.consent.http.authentication.GoogleUser;
+import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.AuthUser;
+import org.broadinstitute.consent.http.models.DACUser;
 import org.broadinstitute.consent.http.models.ResearcherProperty;
+import org.broadinstitute.consent.http.service.users.UserAPI;
 import org.broadinstitute.consent.http.service.users.handler.ResearcherService;
 
 import javax.annotation.security.PermitAll;
 import javax.annotation.security.RolesAllowed;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
+import javax.ws.rs.ForbiddenException;
 import javax.ws.rs.GET;
+import javax.ws.rs.NotFoundException;
 import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
@@ -19,17 +25,22 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 
 @Path("api/researcher")
 public class ResearcherResource extends Resource {
 
     private ResearcherService researcherService;
+    private final UserAPI userAPI;
 
-    public ResearcherResource(ResearcherService researcherService) {
+    public ResearcherResource(ResearcherService researcherService, UserAPI userAPI) {
         this.researcherService = researcherService;
+        this.userAPI = userAPI;
     }
 
     @POST
@@ -60,8 +71,11 @@ public class ResearcherResource extends Resource {
     @Path("/{userId}")
     @Produces("application/json")
     @RolesAllowed({ADMIN, RESEARCHER, CHAIRPERSON, MEMBER})
-    public Response describeAllResearcherProperties(@PathParam("userId") Integer userId) {
+    public Response describeAllResearcherProperties(@Auth AuthUser user, @PathParam("userId") Integer userId) {
         try {
+            List<UserRoles> authedRoles = Stream.of(UserRoles.CHAIRPERSON, UserRoles.MEMBER, UserRoles.ADMIN).
+                    collect(Collectors.toList());
+            validateAuthedRoleUser(authedRoles, user, userId);
             return Response.ok(researcherService.describeResearcherPropertiesMap(userId)).build();
         } catch (Exception e) {
             return createExceptionResponse(e);
@@ -85,12 +99,45 @@ public class ResearcherResource extends Resource {
     @Path("/{userId}/dar")
     @Produces("application/json")
     @RolesAllowed({ADMIN, RESEARCHER})
-    public Response getResearcherPropertiesForDAR(@PathParam("userId") Integer userId) {
+    public Response getResearcherPropertiesForDAR(@Auth AuthUser user, @PathParam("userId") Integer userId) {
         try {
+            List<UserRoles> authedRoles = Collections.singletonList(UserRoles.ADMIN);
+            validateAuthedRoleUser(authedRoles, user, userId);
             return Response.ok(researcherService.describeResearcherPropertiesForDAR(userId)).build();
         } catch (Exception e) {
             return createExceptionResponse(e);
         }
+    }
+
+    /**
+     * Validate that the current authenticated user can access this resource.
+     * If the user has one of the provided roles, then access is allowed.
+     * If not, then the authenticated user must have the same identity as the
+     * `userId` parameter they are requesting information for.
+     *
+     * @param authedRoles Stream of UserRoles enums
+     * @param user        The AuthUser
+     * @param userId      The id of the DACUser the AuthUser is requesting access to
+     */
+    private void validateAuthedRoleUser(List<UserRoles> authedRoles, AuthUser user, Integer userId) {
+        DACUser authedDacUser = findByAuthUser(user);
+        List<Integer> authedRoleIds = authedRoles.stream().
+                map(UserRoles::getRoleId).
+                collect(Collectors.toList());
+        boolean authedUserHasRole = authedDacUser.getRoles().stream().
+                anyMatch(userRole -> authedRoleIds.contains(userRole.getRoleId()));
+        if (!authedUserHasRole && !authedDacUser.getDacUserId().equals(userId)) {
+            throw new ForbiddenException("User does not have permission");
+        }
+    }
+
+    private DACUser findByAuthUser(AuthUser user) {
+        GoogleUser googleUser = user.getGoogleUser();
+        DACUser dacUser = userAPI.findUserByEmail(googleUser.getEmail());
+        if (dacUser == null) {
+            throw new NotFoundException("Unable to find user :" + user.getName());
+        }
+        return dacUser;
     }
 
 }

--- a/src/main/java/org/broadinstitute/consent/http/resources/ResearcherResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/ResearcherResource.java
@@ -5,6 +5,7 @@ import org.broadinstitute.consent.http.models.AuthUser;
 import org.broadinstitute.consent.http.models.ResearcherProperty;
 import org.broadinstitute.consent.http.service.users.handler.ResearcherService;
 
+import javax.annotation.security.PermitAll;
 import javax.annotation.security.RolesAllowed;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
@@ -33,7 +34,7 @@ public class ResearcherResource extends Resource {
 
     @POST
     @Consumes("application/json")
-    @RolesAllowed({ADMIN, RESEARCHER, CHAIRPERSON, MEMBER})
+    @PermitAll
     public Response registerProperties(@Auth AuthUser user, @Context UriInfo info, Map<String, String> researcherPropertiesMap) {
         try {
             List<ResearcherProperty> props = researcherService.setProperties(researcherPropertiesMap, user);
@@ -45,7 +46,7 @@ public class ResearcherResource extends Resource {
 
     @PUT
     @Consumes("application/json")
-    @RolesAllowed({ADMIN, RESEARCHER, CHAIRPERSON, MEMBER})
+    @PermitAll
     public Response updateProperties(@Auth AuthUser user, @QueryParam("validate") Boolean validate, Map<String, String> researcherProperties) {
         try {
             List<ResearcherProperty> props = researcherService.updateProperties(researcherProperties, user, validate);

--- a/src/main/java/org/broadinstitute/consent/http/resources/ResearcherResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/ResearcherResource.java
@@ -22,7 +22,7 @@ import java.util.List;
 import java.util.Map;
 
 
-@Path("api/researcher/{userId}")
+@Path("api/researcher")
 public class ResearcherResource extends Resource {
 
     private ResearcherService researcherService;
@@ -33,7 +33,7 @@ public class ResearcherResource extends Resource {
 
     @POST
     @Consumes("application/json")
-    @RolesAllowed(RESEARCHER)
+    @RolesAllowed({ADMIN, RESEARCHER, CHAIRPERSON, MEMBER})
     public Response registerProperties(@Auth AuthUser user, @Context UriInfo info, Map<String, String> researcherPropertiesMap) {
         try {
             List<ResearcherProperty> props = researcherService.setProperties(researcherPropertiesMap, user);
@@ -45,16 +45,18 @@ public class ResearcherResource extends Resource {
 
     @PUT
     @Consumes("application/json")
-    @RolesAllowed(RESEARCHER)
-    public Response updateResearcher(@QueryParam("validate") Boolean validate, @PathParam("userId") Integer userId, Map<String, String> researcherProperties) {
+    @RolesAllowed({ADMIN, RESEARCHER, CHAIRPERSON, MEMBER})
+    public Response updateProperties(@Auth AuthUser user, @QueryParam("validate") Boolean validate, Map<String, String> researcherProperties) {
         try {
-            return Response.ok(researcherService.updateResearcher(researcherProperties, userId, validate)).build();
+            List<ResearcherProperty> props = researcherService.updateProperties(researcherProperties, user, validate);
+            return Response.ok(props).build();
         } catch (Exception e) {
             return createExceptionResponse(e);
         }
     }
 
     @GET
+    @Path("/{userId}")
     @Produces("application/json")
     @RolesAllowed({ADMIN, RESEARCHER, CHAIRPERSON, MEMBER})
     public Response describeAllResearcherProperties(@PathParam("userId") Integer userId) {
@@ -66,6 +68,7 @@ public class ResearcherResource extends Resource {
     }
 
     @DELETE
+    @Path("/{userId}")
     @Produces("application/json")
     @RolesAllowed(ADMIN)
     public Response deleteAllProperties(@PathParam("userId") Integer userId) {
@@ -78,7 +81,7 @@ public class ResearcherResource extends Resource {
     }
 
     @GET
-    @Path("/dar")
+    @Path("/{userId}/dar")
     @Produces("application/json")
     @RolesAllowed({ADMIN, RESEARCHER})
     public Response getResearcherPropertiesForDAR(@PathParam("userId") Integer userId) {

--- a/src/main/java/org/broadinstitute/consent/http/service/NihAuthApi.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/NihAuthApi.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.consent.http.service;
 
+import org.broadinstitute.consent.http.models.AuthUser;
 import org.broadinstitute.consent.http.models.NIHUserAccount;
 import org.broadinstitute.consent.http.models.ResearcherProperty;
 
@@ -8,7 +9,7 @@ import java.util.List;
 
 public interface NihAuthApi {
 
-    List<ResearcherProperty> authenticateNih(NIHUserAccount nihAccount, Integer userId) throws BadRequestException;
+    List<ResearcherProperty> authenticateNih(NIHUserAccount nihAccount, AuthUser user) throws BadRequestException;
 
     void deleteNihAccountById(Integer userId);
 }

--- a/src/main/java/org/broadinstitute/consent/http/service/NihServiceAPI.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/NihServiceAPI.java
@@ -2,15 +2,16 @@ package org.broadinstitute.consent.http.service;
 
 import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.consent.http.enumeration.ResearcherFields;
+import org.broadinstitute.consent.http.models.AuthUser;
 import org.broadinstitute.consent.http.models.NIHUserAccount;
 import org.broadinstitute.consent.http.models.ResearcherProperty;
 import org.broadinstitute.consent.http.service.users.handler.ResearcherService;
 
 import javax.ws.rs.BadRequestException;
-import java.util.List;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.List;
 
 public class NihServiceAPI implements NihAuthApi {
 
@@ -21,13 +22,13 @@ public class NihServiceAPI implements NihAuthApi {
     }
 
     @Override
-    public List<ResearcherProperty> authenticateNih(NIHUserAccount nihAccount, Integer userId){
+    public List<ResearcherProperty> authenticateNih(NIHUserAccount nihAccount, AuthUser user) {
         if (StringUtils.isNotEmpty(nihAccount.getNihUsername()) && !nihAccount.getNihUsername().isEmpty()) {
             nihAccount.setEraExpiration(generateEraExpirationDates());
             nihAccount.setStatus(true);
-            return researcherService.updateResearcher(nihAccount.getNihMap(), userId, false);
+            return researcherService.updateProperties(nihAccount.getNihMap(), user, false);
         } else {
-            throw new BadRequestException("Invalid NIH UserName for user : " + userId);
+            throw new BadRequestException("Invalid NIH UserName for user : " + user.getName());
         }
     }
 

--- a/src/main/java/org/broadinstitute/consent/http/service/users/DatabaseDACUserAPI.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/users/DatabaseDACUserAPI.java
@@ -95,7 +95,7 @@ public class DatabaseDACUserAPI extends AbstractDACUserAPI {
     }
 
     @Override
-    public DACUser describeDACUserByEmail(String email) throws IllegalArgumentException {
+    public DACUser describeDACUserByEmail(String email) throws NotFoundException {
         DACUser dacUser = dacUserDAO.findDACUserByEmail(email);
         if (dacUser == null) {
             throw new NotFoundException("Could not find dacUser for specified email : " + email);

--- a/src/main/java/org/broadinstitute/consent/http/service/users/handler/ResearcherService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/users/handler/ResearcherService.java
@@ -12,7 +12,7 @@ public interface ResearcherService {
 
     List<ResearcherProperty> setProperties(Map<String, String> researcherProperties, AuthUser authUser) throws NotFoundException, IllegalArgumentException;
 
-    List<ResearcherProperty> updateResearcher(Map<String, String> researcherProperties, Integer userId, Boolean validate) throws NotFoundException, IllegalArgumentException;
+    List<ResearcherProperty> updateProperties(Map<String, String> researcherProperties, AuthUser authUser, Boolean validate) throws NotFoundException, IllegalArgumentException;
 
     Map<String, String> describeResearcherPropertiesMap(Integer userId) throws NotFoundException;
 

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -2346,11 +2346,6 @@ paths:
           description: Defines if the endpoint should validate if all the required fields are present. If not, it will fail.
           required: true
           type: boolean
-        - name: userId
-          in: path
-          required: true
-          type: integer
-          format: int32
         - name: researcherProperties
           in: body
           required: true
@@ -2377,6 +2372,7 @@ paths:
           description: Server error.
           schema:
             $ref: '#/definitions/ErrorResponse'
+  /api/researcher/{userId}:
     get:
       summary: Return researcher properties.
       description: Describes all the properties for a reseacher user.

--- a/src/test/java/org/broadinstitute/consent/http/db/VoteDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/VoteDAOTest.java
@@ -62,7 +62,6 @@ public class VoteDAOTest extends AbstractTest {
         voteDAO.updateVote(true, rationale, now, voteId, true,
                 election.getElectionId(), now, true);
         Vote vote = voteDAO.findVoteById(voteId);
-        System.out.println(vote);
         Assert.assertTrue(vote.getVote());
         Assert.assertTrue(vote.getHasConcerns());
         Assert.assertTrue(vote.getIsReminderSent());

--- a/src/test/java/org/broadinstitute/consent/http/resources/ResearcherResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/ResearcherResourceTest.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.consent.http.resources;
 
+import com.google.gson.Gson;
 import org.broadinstitute.consent.http.authentication.GoogleUser;
 import org.broadinstitute.consent.http.models.AuthUser;
 import org.broadinstitute.consent.http.service.users.handler.ResearcherService;
@@ -74,6 +75,16 @@ public class ResearcherResourceTest {
         initResource();
         Response response = resource.registerProperties(authUser, uriInfo, null);
         Assert.assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+    }
+
+    @Test
+    public void testUpdateProperties() {
+        initResource();
+
+        Response response1 = resource.updateProperties(authUser, false, null);
+        Assert.assertEquals(Response.Status.OK.getStatusCode(), response1.getStatus());
+        Response response2 = resource.updateProperties(authUser, true, null);
+        Assert.assertEquals(Response.Status.OK.getStatusCode(), response2.getStatus());
     }
 
 }

--- a/src/test/java/org/broadinstitute/consent/http/resources/ResearcherResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/ResearcherResourceTest.java
@@ -87,4 +87,20 @@ public class ResearcherResourceTest {
         Assert.assertEquals(Response.Status.OK.getStatusCode(), response2.getStatus());
     }
 
+    @Test
+    public void testUpdatePropertiesNotFound() {
+        when(researcherService.updateProperties(any(), any(), any())).thenThrow(new NotFoundException("User Not Found"));
+        initResource();
+        Response response = resource.updateProperties(authUser, false, null);
+        Assert.assertEquals(Response.Status.NOT_FOUND.getStatusCode(), response.getStatus());
+    }
+
+    @Test
+    public void testUpdatePropertiesInvalidFields() {
+        when(researcherService.updateProperties(any(), any(), any())).thenThrow(new IllegalArgumentException("Invalid Fields"));
+        initResource();
+        Response response = resource.updateProperties(authUser, false, null);
+        Assert.assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+    }
+
 }

--- a/src/test/java/org/broadinstitute/consent/http/resources/ResearcherResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/ResearcherResourceTest.java
@@ -1,8 +1,11 @@
 package org.broadinstitute.consent.http.resources;
 
-import com.google.gson.Gson;
 import org.broadinstitute.consent.http.authentication.GoogleUser;
+import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.AuthUser;
+import org.broadinstitute.consent.http.models.DACUser;
+import org.broadinstitute.consent.http.models.UserRole;
+import org.broadinstitute.consent.http.service.users.UserAPI;
 import org.broadinstitute.consent.http.service.users.handler.ResearcherService;
 import org.junit.Assert;
 import org.junit.Before;
@@ -17,6 +20,7 @@ import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
 import java.net.URI;
 import java.util.Collections;
+import java.util.HashMap;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
@@ -26,6 +30,9 @@ public class ResearcherResourceTest {
 
     @Mock
     ResearcherService researcherService;
+
+    @Mock
+    UserAPI userAPI;
 
     @Mock
     private UriInfo uriInfo;
@@ -50,7 +57,7 @@ public class ResearcherResourceTest {
     }
 
     private void initResource() {
-        resource = new ResearcherResource(researcherService);
+        resource = new ResearcherResource(researcherService, userAPI);
     }
 
     @Test
@@ -101,6 +108,96 @@ public class ResearcherResourceTest {
         initResource();
         Response response = resource.updateProperties(authUser, false, null);
         Assert.assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+    }
+
+    @Test
+    public void testDescribeAllResearcherPropertiesAdmin() {
+        when(researcherService.describeResearcherPropertiesMap(any())).thenReturn(new HashMap<>());
+        DACUser authedDacUser = new DACUser();
+        authedDacUser.setDacUserId(1);
+        authedDacUser.addRole(new UserRole(UserRoles.ADMIN.getRoleId(), UserRoles.ADMIN.getRoleName()));
+        when(userAPI.findUserByEmail(anyString())).thenReturn(authedDacUser);
+        initResource();
+
+        // Request properties for self
+        Response response1 = resource.describeAllResearcherProperties(authUser, 1);
+        Assert.assertEquals(Response.Status.OK.getStatusCode(), response1.getStatus());
+
+        // Request properties for a different user id
+        Response response2 = resource.describeAllResearcherProperties(authUser, 2);
+        Assert.assertEquals(Response.Status.OK.getStatusCode(), response2.getStatus());
+    }
+
+    @Test
+    public void testDescribeAllResearcherPropertiesChair() {
+        when(researcherService.describeResearcherPropertiesMap(any())).thenReturn(new HashMap<>());
+        DACUser authedDacUser = new DACUser();
+        authedDacUser.setDacUserId(1);
+        authedDacUser.addRole(new UserRole(UserRoles.CHAIRPERSON.getRoleId(), UserRoles.CHAIRPERSON.getRoleName()));
+        when(userAPI.findUserByEmail(anyString())).thenReturn(authedDacUser);
+        initResource();
+
+        // Request properties for self
+        Response response1 = resource.describeAllResearcherProperties(authUser, 1);
+        Assert.assertEquals(Response.Status.OK.getStatusCode(), response1.getStatus());
+
+        // Request properties for a different user id
+        Response response2 = resource.describeAllResearcherProperties(authUser, 2);
+        Assert.assertEquals(Response.Status.OK.getStatusCode(), response2.getStatus());
+    }
+
+    @Test
+    public void testDescribeAllResearcherPropertiesResearcher() {
+        when(researcherService.describeResearcherPropertiesMap(any())).thenReturn(new HashMap<>());
+        DACUser authedDacUser = new DACUser();
+        authedDacUser.setDacUserId(1);
+        authedDacUser.addRole(new UserRole(UserRoles.RESEARCHER.getRoleId(), UserRoles.RESEARCHER.getRoleName()));
+        when(userAPI.findUserByEmail(anyString())).thenReturn(authedDacUser);
+        initResource();
+
+        // Request properties for self
+        Response response1 = resource.describeAllResearcherProperties(authUser, 1);
+        Assert.assertEquals(Response.Status.OK.getStatusCode(), response1.getStatus());
+
+        // Request properties for a different user id
+        Response response2 = resource.describeAllResearcherProperties(authUser, 2);
+        Assert.assertEquals(Response.Status.FORBIDDEN.getStatusCode(), response2.getStatus());
+    }
+
+    @Test
+    public void testGetResearcherPropertiesForDARAdmin() {
+        when(researcherService.describeResearcherPropertiesMap(any())).thenReturn(new HashMap<>());
+        DACUser authedDacUser = new DACUser();
+        authedDacUser.setDacUserId(1);
+        authedDacUser.addRole(new UserRole(UserRoles.ADMIN.getRoleId(), UserRoles.ADMIN.getRoleName()));
+        when(userAPI.findUserByEmail(anyString())).thenReturn(authedDacUser);
+        initResource();
+
+        // Request properties for self
+        Response response1 = resource.getResearcherPropertiesForDAR(authUser, 1);
+        Assert.assertEquals(Response.Status.OK.getStatusCode(), response1.getStatus());
+
+        // Request properties for a different user id
+        Response response2 = resource.getResearcherPropertiesForDAR(authUser, 2);
+        Assert.assertEquals(Response.Status.OK.getStatusCode(), response2.getStatus());
+    }
+
+    @Test
+    public void testGetResearcherPropertiesForDARResearcher() {
+        when(researcherService.describeResearcherPropertiesMap(any())).thenReturn(new HashMap<>());
+        DACUser authedDacUser = new DACUser();
+        authedDacUser.setDacUserId(1);
+        authedDacUser.addRole(new UserRole(UserRoles.RESEARCHER.getRoleId(), UserRoles.RESEARCHER.getRoleName()));
+        when(userAPI.findUserByEmail(anyString())).thenReturn(authedDacUser);
+        initResource();
+
+        // Request properties for self
+        Response response1 = resource.getResearcherPropertiesForDAR(authUser, 1);
+        Assert.assertEquals(Response.Status.OK.getStatusCode(), response1.getStatus());
+
+        // Request properties for a different user id
+        Response response2 = resource.getResearcherPropertiesForDAR(authUser, 2);
+        Assert.assertEquals(Response.Status.FORBIDDEN.getStatusCode(), response2.getStatus());
     }
 
 }

--- a/src/test/java/org/broadinstitute/consent/http/service/ResearcherServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/ResearcherServiceTest.java
@@ -226,12 +226,10 @@ public class ResearcherServiceTest {
         List<ResearcherProperty> props = new ArrayList<>();
         Map<String, String> propMap = new HashMap<>();
         for (ResearcherFields researcherField : ResearcherFields.values()) {
-            if (researcherField.getRequired()) {
-                String val1 = RandomStringUtils.random(10, true, false);
-                String val2 = RandomStringUtils.random(10, true, false);
-                props.add(new ResearcherProperty(dacUser.getDacUserId(), researcherField.getValue(), val1));
-                propMap.put(researcherField.getValue(), val2);
-            }
+            String val1 = RandomStringUtils.random(10, true, false);
+            String val2 = RandomStringUtils.random(10, true, false);
+            props.add(new ResearcherProperty(dacUser.getDacUserId(), researcherField.getValue(), val1));
+            propMap.put(researcherField.getValue(), val2);
         }
         props.add(new ResearcherProperty(dacUser.getDacUserId(), ResearcherFields.COMPLETED.getValue(), Boolean.TRUE.toString()));
         propMap.put(ResearcherFields.COMPLETED.getValue(), Boolean.TRUE.toString());
@@ -249,7 +247,7 @@ public class ResearcherServiceTest {
         List<ResearcherProperty> foundProps = service.updateProperties(propMap, authUser, true);
         Assert.assertFalse(foundProps.isEmpty());
         Assert.assertEquals(props.size(), foundProps.size());
-        verify(emailApi, atLeast(1));
+        verify(emailApi, atLeast(1)).sendNewResearcherCreatedMessage(any(), any());
     }
 
 }


### PR DESCRIPTION
## Addresses
https://broadinstitute.atlassian.net/browse/DUOS-443
This PR only addresses the `PUT` call in `ResearcherResource`. Other vulnerable endpoints will be addressed in follow-on PRs.
UI PR also required: https://github.com/DataBiosphere/duos-ui/pull/226

See also, these related PRs:
* https://github.com/DataBiosphere/consent/pull/397
* https://github.com/DataBiosphere/duos-ui/pull/225

## Changes
* Use `AuthUser` instead of using a url parameter to determine the ID of the user to update properties for. The previous approach allowed for any researcher user to update a different researcher user's properties.
* Updated the resource so any user role can update their own profile.
* Changing the interface to use `AuthUser` required some additional minor changes to the NIH service as well.
