### PR TITLE
[DUOS-443][risk=no] Part 3 of updating vulnerable researcher APIs

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
@@ -296,7 +296,7 @@ public class ConsentApplication extends Application<ConsentConfiguration> {
         env.jersey().register(HelpReportResource.class);
         env.jersey().register(ApprovalExpirationTimeResource.class);
         env.jersey().register(new UserResource(userAPI));
-        env.jersey().register(new ResearcherResource(researcherService));
+        env.jersey().register(new ResearcherResource(researcherService, userAPI));
         env.jersey().register(WorkspaceResource.class);
         env.jersey().register(new DataAccessAgreementResource(googleStore, researcherService));
         env.jersey().register(new SwaggerResource(config.getGoogleAuthentication()));

--- a/src/main/java/org/broadinstitute/consent/http/models/DACUser.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DACUser.java
@@ -8,6 +8,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.broadinstitute.consent.http.authentication.GoogleUser;
 
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
@@ -195,6 +196,13 @@ public class DACUser {
 
     public void setProfileCompleted(Boolean profileCompleted) {
         this.profileCompleted = profileCompleted;
+    }
+
+    public void addRole(UserRole userRole) {
+        if (this.getRoles() == null) {
+            this.setRoles(new ArrayList<>());
+        }
+        this.getRoles().add(userRole);
     }
 
     @Override

--- a/src/main/java/org/broadinstitute/consent/http/resources/ResearcherResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/ResearcherResource.java
@@ -1,15 +1,21 @@
 package org.broadinstitute.consent.http.resources;
 
 import io.dropwizard.auth.Auth;
+import org.broadinstitute.consent.http.authentication.GoogleUser;
+import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.AuthUser;
+import org.broadinstitute.consent.http.models.DACUser;
 import org.broadinstitute.consent.http.models.ResearcherProperty;
+import org.broadinstitute.consent.http.service.users.UserAPI;
 import org.broadinstitute.consent.http.service.users.handler.ResearcherService;
 
 import javax.annotation.security.PermitAll;
 import javax.annotation.security.RolesAllowed;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
+import javax.ws.rs.ForbiddenException;
 import javax.ws.rs.GET;
+import javax.ws.rs.NotFoundException;
 import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
@@ -19,17 +25,22 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 
 @Path("api/researcher")
 public class ResearcherResource extends Resource {
 
     private ResearcherService researcherService;
+    private final UserAPI userAPI;
 
-    public ResearcherResource(ResearcherService researcherService) {
+    public ResearcherResource(ResearcherService researcherService, UserAPI userAPI) {
         this.researcherService = researcherService;
+        this.userAPI = userAPI;
     }
 
     @POST
@@ -60,8 +71,11 @@ public class ResearcherResource extends Resource {
     @Path("/{userId}")
     @Produces("application/json")
     @RolesAllowed({ADMIN, RESEARCHER, CHAIRPERSON, MEMBER})
-    public Response describeAllResearcherProperties(@PathParam("userId") Integer userId) {
+    public Response describeAllResearcherProperties(@Auth AuthUser user, @PathParam("userId") Integer userId) {
         try {
+            List<UserRoles> authedRoles = Stream.of(UserRoles.CHAIRPERSON, UserRoles.MEMBER, UserRoles.ADMIN).
+                    collect(Collectors.toList());
+            validateAuthedRoleUser(authedRoles, user, userId);
             return Response.ok(researcherService.describeResearcherPropertiesMap(userId)).build();
         } catch (Exception e) {
             return createExceptionResponse(e);
@@ -85,12 +99,45 @@ public class ResearcherResource extends Resource {
     @Path("/{userId}/dar")
     @Produces("application/json")
     @RolesAllowed({ADMIN, RESEARCHER})
-    public Response getResearcherPropertiesForDAR(@PathParam("userId") Integer userId) {
+    public Response getResearcherPropertiesForDAR(@Auth AuthUser user, @PathParam("userId") Integer userId) {
         try {
+            List<UserRoles> authedRoles = Collections.singletonList(UserRoles.ADMIN);
+            validateAuthedRoleUser(authedRoles, user, userId);
             return Response.ok(researcherService.describeResearcherPropertiesForDAR(userId)).build();
         } catch (Exception e) {
             return createExceptionResponse(e);
         }
+    }
+
+    /**
+     * Validate that the current authenticated user can access this resource.
+     * If the user has one of the provided roles, then access is allowed.
+     * If not, then the authenticated user must have the same identity as the
+     * `userId` parameter they are requesting information for.
+     *
+     * @param authedRoles Stream of UserRoles enums
+     * @param user        The AuthUser
+     * @param userId      The id of the DACUser the AuthUser is requesting access to
+     */
+    private void validateAuthedRoleUser(List<UserRoles> authedRoles, AuthUser user, Integer userId) {
+        DACUser authedDacUser = findByAuthUser(user);
+        List<Integer> authedRoleIds = authedRoles.stream().
+                map(UserRoles::getRoleId).
+                collect(Collectors.toList());
+        boolean authedUserHasRole = authedDacUser.getRoles().stream().
+                anyMatch(userRole -> authedRoleIds.contains(userRole.getRoleId()));
+        if (!authedUserHasRole && !authedDacUser.getDacUserId().equals(userId)) {
+            throw new ForbiddenException("User does not have permission");
+        }
+    }
+
+    private DACUser findByAuthUser(AuthUser user) {
+        GoogleUser googleUser = user.getGoogleUser();
+        DACUser dacUser = userAPI.findUserByEmail(googleUser.getEmail());
+        if (dacUser == null) {
+            throw new NotFoundException("Unable to find user :" + user.getName());
+        }
+        return dacUser;
     }
 
 }

--- a/src/test/java/org/broadinstitute/consent/http/resources/ResearcherResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/ResearcherResourceTest.java
@@ -1,8 +1,11 @@
 package org.broadinstitute.consent.http.resources;
 
-import com.google.gson.Gson;
 import org.broadinstitute.consent.http.authentication.GoogleUser;
+import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.AuthUser;
+import org.broadinstitute.consent.http.models.DACUser;
+import org.broadinstitute.consent.http.models.UserRole;
+import org.broadinstitute.consent.http.service.users.UserAPI;
 import org.broadinstitute.consent.http.service.users.handler.ResearcherService;
 import org.junit.Assert;
 import org.junit.Before;
@@ -17,6 +20,7 @@ import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
 import java.net.URI;
 import java.util.Collections;
+import java.util.HashMap;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
@@ -26,6 +30,9 @@ public class ResearcherResourceTest {
 
     @Mock
     ResearcherService researcherService;
+
+    @Mock
+    UserAPI userAPI;
 
     @Mock
     private UriInfo uriInfo;
@@ -50,7 +57,7 @@ public class ResearcherResourceTest {
     }
 
     private void initResource() {
-        resource = new ResearcherResource(researcherService);
+        resource = new ResearcherResource(researcherService, userAPI);
     }
 
     @Test
@@ -101,6 +108,96 @@ public class ResearcherResourceTest {
         initResource();
         Response response = resource.updateProperties(authUser, false, null);
         Assert.assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+    }
+
+    @Test
+    public void testDescribeAllResearcherPropertiesAdmin() {
+        when(researcherService.describeResearcherPropertiesMap(any())).thenReturn(new HashMap<>());
+        DACUser authedDacUser = new DACUser();
+        authedDacUser.setDacUserId(1);
+        authedDacUser.addRole(new UserRole(UserRoles.ADMIN.getRoleId(), UserRoles.ADMIN.getRoleName()));
+        when(userAPI.findUserByEmail(anyString())).thenReturn(authedDacUser);
+        initResource();
+
+        // Request properties for self
+        Response response1 = resource.describeAllResearcherProperties(authUser, 1);
+        Assert.assertEquals(Response.Status.OK.getStatusCode(), response1.getStatus());
+
+        // Request properties for a different user id
+        Response response2 = resource.describeAllResearcherProperties(authUser, 2);
+        Assert.assertEquals(Response.Status.OK.getStatusCode(), response2.getStatus());
+    }
+
+    @Test
+    public void testDescribeAllResearcherPropertiesChair() {
+        when(researcherService.describeResearcherPropertiesMap(any())).thenReturn(new HashMap<>());
+        DACUser authedDacUser = new DACUser();
+        authedDacUser.setDacUserId(1);
+        authedDacUser.addRole(new UserRole(UserRoles.CHAIRPERSON.getRoleId(), UserRoles.CHAIRPERSON.getRoleName()));
+        when(userAPI.findUserByEmail(anyString())).thenReturn(authedDacUser);
+        initResource();
+
+        // Request properties for self
+        Response response1 = resource.describeAllResearcherProperties(authUser, 1);
+        Assert.assertEquals(Response.Status.OK.getStatusCode(), response1.getStatus());
+
+        // Request properties for a different user id
+        Response response2 = resource.describeAllResearcherProperties(authUser, 2);
+        Assert.assertEquals(Response.Status.OK.getStatusCode(), response2.getStatus());
+    }
+
+    @Test
+    public void testDescribeAllResearcherPropertiesResearcher() {
+        when(researcherService.describeResearcherPropertiesMap(any())).thenReturn(new HashMap<>());
+        DACUser authedDacUser = new DACUser();
+        authedDacUser.setDacUserId(1);
+        authedDacUser.addRole(new UserRole(UserRoles.RESEARCHER.getRoleId(), UserRoles.RESEARCHER.getRoleName()));
+        when(userAPI.findUserByEmail(anyString())).thenReturn(authedDacUser);
+        initResource();
+
+        // Request properties for self
+        Response response1 = resource.describeAllResearcherProperties(authUser, 1);
+        Assert.assertEquals(Response.Status.OK.getStatusCode(), response1.getStatus());
+
+        // Request properties for a different user id
+        Response response2 = resource.describeAllResearcherProperties(authUser, 2);
+        Assert.assertEquals(Response.Status.FORBIDDEN.getStatusCode(), response2.getStatus());
+    }
+
+    @Test
+    public void testGetResearcherPropertiesForDARAdmin() {
+        when(researcherService.describeResearcherPropertiesMap(any())).thenReturn(new HashMap<>());
+        DACUser authedDacUser = new DACUser();
+        authedDacUser.setDacUserId(1);
+        authedDacUser.addRole(new UserRole(UserRoles.ADMIN.getRoleId(), UserRoles.ADMIN.getRoleName()));
+        when(userAPI.findUserByEmail(anyString())).thenReturn(authedDacUser);
+        initResource();
+
+        // Request properties for self
+        Response response1 = resource.getResearcherPropertiesForDAR(authUser, 1);
+        Assert.assertEquals(Response.Status.OK.getStatusCode(), response1.getStatus());
+
+        // Request properties for a different user id
+        Response response2 = resource.getResearcherPropertiesForDAR(authUser, 2);
+        Assert.assertEquals(Response.Status.OK.getStatusCode(), response2.getStatus());
+    }
+
+    @Test
+    public void testGetResearcherPropertiesForDARResearcher() {
+        when(researcherService.describeResearcherPropertiesMap(any())).thenReturn(new HashMap<>());
+        DACUser authedDacUser = new DACUser();
+        authedDacUser.setDacUserId(1);
+        authedDacUser.addRole(new UserRole(UserRoles.RESEARCHER.getRoleId(), UserRoles.RESEARCHER.getRoleName()));
+        when(userAPI.findUserByEmail(anyString())).thenReturn(authedDacUser);
+        initResource();
+
+        // Request properties for self
+        Response response1 = resource.getResearcherPropertiesForDAR(authUser, 1);
+        Assert.assertEquals(Response.Status.OK.getStatusCode(), response1.getStatus());
+
+        // Request properties for a different user id
+        Response response2 = resource.getResearcherPropertiesForDAR(authUser, 2);
+        Assert.assertEquals(Response.Status.FORBIDDEN.getStatusCode(), response2.getStatus());
     }
 
 }


### PR DESCRIPTION
## Addresses
https://broadinstitute.atlassian.net/browse/DUOS-443
This completes the updates to `ResearcherResource`. 

See also, these related PRs:
* https://github.com/DataBiosphere/consent/pull/397
* https://github.com/DataBiosphere/consent/pull/398

## Changes
* Update the get properties calls such that if the user does not have certain authed roles, they can only access their own information.
