### PR TITLE
[DUOS-499][risk=no] Fix dar filtering for non-dac/admins

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
@@ -43,6 +43,7 @@ import org.bson.types.ObjectId;
 import javax.annotation.security.PermitAll;
 import javax.annotation.security.RolesAllowed;
 import javax.mail.MessagingException;
+import javax.ws.rs.BadRequestException;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
@@ -289,6 +290,13 @@ public class DataAccessRequestResource extends Resource {
     @Path("/manage")
     @RolesAllowed({RESEARCHER, ADMIN})
     public Response describeManageDataAccessRequests(@QueryParam("userId") Integer userId, @Auth AuthUser authUser) {
+        // If a user id is provided, ensure that is the current user.
+        if (userId != null) {
+            DACUser user = dacUserAPI.describeDACUserByEmail(authUser.getName());
+            if (!user.getDacUserId().equals(userId)) {
+                throw new BadRequestException("Unable to query for other users' information.");
+            }
+        }
         List<DataAccessRequestManage> dars = dataAccessRequestService.describeDataAccessRequestManage(userId, authUser);
         return Response.ok().entity(dars).build();
     }

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -1381,6 +1381,10 @@ paths:
               type: array
               items:
                 $ref: '#/definitions/DataAccessRequestManage'
+          400:
+            description: |
+              If optional user id is provided, it must be that of the authenticated user. Non-admin
+              and non-DAC users can only see their own Data Access Requests.
   /api/dar/cases/unreviewed:
       get:
         summary: getTotalUnReviewedDAR

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -1360,8 +1360,18 @@ paths:
           description: The requested couldn't be found or the DAR doesn't exist.
   /api/dar/manage:
       get:
-        summary: describeManageDataAccessRequests
-        description: Returns all the elections created for Data Access Requests
+        summary: Manage Data Access Requests
+        description: |
+          Returns all the elections created for Data Access Requests relevant to the current user.
+          If the user is requesting these as an admin, all are returned. As a DAC member, only those
+          assigned to the DAC are returned. As a general user, only those created by the user are
+          returned.
+        parameters:
+          - name: userId
+            in: query
+            description: Optional user id to filter Data Access Requests by
+            required: false
+            type: integer
         tags:
           - Data Access Request
         responses:

--- a/src/test/java/org/broadinstitute/consent/http/service/DacServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DacServiceTest.java
@@ -337,11 +337,11 @@ public class DacServiceTest {
     @Test
     public void testFilterDarsByDAC_memberCase_1() {
         // Member is not an admin user
-        when(dacUserDAO.findDACUserByEmailAndRoleId(anyString(), anyInt())).thenReturn(null);
+        when(dacUserDAO.findDACUserByEmailAndRoleId(getMember().getEmail(), UserRoles.MEMBER.getRoleId())).thenReturn(getMember());
 
         // Member has access to DataSet 1
         List<DataSet> memberDataSets = Collections.singletonList(getDatasets().get(0));
-        when(dataSetDAO.findDataSetsByAuthUserEmail(anyString())).thenReturn(memberDataSets);
+        when(dataSetDAO.findDataSetsByAuthUserEmail(getMember().getEmail())).thenReturn(memberDataSets);
 
         // There are no additional unassociated datasets
         when(dataSetDAO.findNonDACDataSets()).thenReturn(Collections.emptyList());
@@ -349,7 +349,7 @@ public class DacServiceTest {
 
         List<Document> documents = getDocuments();
 
-        List<Document> filtered = service.filterDarsByDAC(documents, getUser());
+        List<Document> filtered = service.filterDarsByDAC(documents, getMemberAuthUser());
 
         // Filtered documents should only contain the ones the user has direct access to:
         Assert.assertEquals(memberDataSets.size(), filtered.size());
@@ -358,11 +358,11 @@ public class DacServiceTest {
     @Test
     public void testFilterDarsByDAC_memberCase_2() {
         // Member is not an admin user
-        when(dacUserDAO.findDACUserByEmailAndRoleId(anyString(), anyInt())).thenReturn(null);
+        when(dacUserDAO.findDACUserByEmailAndRoleId(getMember().getEmail(), UserRoles.MEMBER.getRoleId())).thenReturn(getMember());
 
         // Member has access to datasets
         List<DataSet> memberDataSets = Collections.singletonList(getDatasets().get(0));
-        when(dataSetDAO.findDataSetsByAuthUserEmail(anyString())).thenReturn(memberDataSets);
+        when(dataSetDAO.findDataSetsByAuthUserEmail(getMember().getEmail())).thenReturn(memberDataSets);
 
         // There are additional unassociated datasets
         List<DataSet> unassociatedDataSets = getDatasets().subList(1, getDatasets().size());
@@ -371,7 +371,7 @@ public class DacServiceTest {
 
         List<Document> documents = getDocuments();
 
-        List<Document> filtered = service.filterDarsByDAC(documents, getUser());
+        List<Document> filtered = service.filterDarsByDAC(documents, getMemberAuthUser());
 
         // Filtered documents should contain the ones the user has direct access to in addition to
         // the unassociated ones:
@@ -381,11 +381,11 @@ public class DacServiceTest {
     @Test
     public void testFilterDarsByDAC_memberCase_3() {
         // Member is not an admin user
-        when(dacUserDAO.findDACUserByEmailAndRoleId(anyString(), anyInt())).thenReturn(null);
+        when(dacUserDAO.findDACUserByEmailAndRoleId(getMember().getEmail(), UserRoles.MEMBER.getRoleId())).thenReturn(getMember());
 
         // Member no direct access to datasets
         List<DataSet> memberDataSets = Collections.emptyList();
-        when(dataSetDAO.findDataSetsByAuthUserEmail(anyString())).thenReturn(memberDataSets);
+        when(dataSetDAO.findDataSetsByAuthUserEmail(getMember().getEmail())).thenReturn(memberDataSets);
 
         // There are additional unassociated datasets
         List<DataSet> unassociatedDataSets = getDatasets().subList(1, getDatasets().size());
@@ -394,7 +394,7 @@ public class DacServiceTest {
 
         List<Document> documents = getDocuments();
 
-        List<Document> filtered = service.filterDarsByDAC(documents, getUser());
+        List<Document> filtered = service.filterDarsByDAC(documents, getMemberAuthUser());
 
         // Filtered documents should contain the ones the user has direct access to in addition to
         // the unassociated ones:
@@ -748,24 +748,31 @@ public class DacServiceTest {
      * @return A list of two users in a single DAC
      */
     private List<DACUser> getDacUsers() {
+        return Arrays.asList(getChair(), getMember());
+    }
+
+    private DACUser getChair() {
         DACUser chair = new DACUser();
         chair.setDacUserId(1);
         chair.setDisplayName("Chair");
         chair.setEmail("chair@duos.org");
         chair.setRoles(new ArrayList<>());
         chair.getRoles().add(new UserRole(1, chair.getDacUserId(), UserRoles.CHAIRPERSON.getRoleId(), UserRoles.CHAIRPERSON.getRoleName(), 1));
+        return chair;
+    }
 
+    private DACUser getMember() {
         DACUser member = new DACUser();
         member.setDacUserId(2);
         member.setDisplayName("Member");
         member.setEmail("member@duos.org");
         member.setRoles(new ArrayList<>());
         member.getRoles().add(new UserRole(2, member.getDacUserId(), UserRoles.MEMBER.getRoleId(), UserRoles.MEMBER.getRoleName(), 1));
+        return member;
+    }
 
-        List<DACUser> users = new ArrayList<>();
-        users.add(chair);
-        users.add(member);
-        return users;
+    private AuthUser getMemberAuthUser() {
+        return new AuthUser(getMember().getEmail());
     }
 
 }


### PR DESCRIPTION
## Addresses
https://github.com/DataBiosphere/consent/pull/new/DUOS-499

## Changes
Updated the filtering logic so that:
* admins can still see all DARs
* dac members can look at all DARs, in their DAC if they're in one
* researchers can see all of their own DARs
* researchers cannot see anyone else's DARs (a big security hole we've had for some time)
* update api docs ... they did not cover the optional user id param
* minor test refactoring to account for the additional user level querying