### PR TITLE
[DUOS-507][risk=no] Set dataset id for DUL elections

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/DataSetDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DataSetDAO.java
@@ -261,9 +261,8 @@ public interface DataSetDAO extends Transactional<DataSetDAO> {
 
     @Mapper(DataSetMapper.class)
     @SqlQuery("select d.* from dataset d " +
-            " inner join consentassociations a on a.dataSetId = d.dataSetId " +
-            " where d.active = true " +
-            " and a.consentId = :consentId ")
+            " inner join consentassociations a on a.dataSetId = d.dataSetId and a.consentId = :consentId " +
+            " where d.active = true ")
     Set<DataSet> findDatasetsForConsentId(@Bind("consentId") String consentId);
 
 }

--- a/src/main/java/org/broadinstitute/consent/http/db/DataSetDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DataSetDAO.java
@@ -259,4 +259,11 @@ public interface DataSetDAO extends Transactional<DataSetDAO> {
             " limit 1 ")
     Dac findDacForDataset(@Bind("datasetId") Integer datasetId);
 
+    @Mapper(DataSetMapper.class)
+    @SqlQuery("select d.* from dataset d " +
+            " inner join consentassociations a on a.dataSetId = d.dataSetId " +
+            " where d.active = true " +
+            " and a.consentId = :consentId ")
+    Set<DataSet> findDatasetsForConsentId(@Bind("consentId") String consentId);
+
 }

--- a/src/main/java/org/broadinstitute/consent/http/resources/ConsentElectionResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/ConsentElectionResource.java
@@ -7,6 +7,7 @@ import org.broadinstitute.consent.http.enumeration.VoteType;
 import org.broadinstitute.consent.http.models.AuthUser;
 import org.broadinstitute.consent.http.models.Consent;
 import org.broadinstitute.consent.http.models.Dac;
+import org.broadinstitute.consent.http.models.DataSet;
 import org.broadinstitute.consent.http.models.Election;
 import org.broadinstitute.consent.http.models.Vote;
 import org.broadinstitute.consent.http.models.dto.Error;
@@ -37,6 +38,7 @@ import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriInfo;
 import java.net.URI;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 
@@ -84,6 +86,12 @@ public class ConsentElectionResource extends Resource {
                 logger().error("Exception updating consent id: '" + consentId + "', with dac id: '" + dacId + "'");
                 throw new InternalServerErrorException("Unable to associate consent to dac.");
             }
+            // For a consent election, any dataset associated to the consent is
+            // appropriate for assignment to this election.
+            Optional<DataSet> dataset = dacService.findDatasetsByConsentId(consentId).
+                    stream().
+                    findFirst();
+            dataset.ifPresent(dataSetDTO -> election.setDataSetId(dataSetDTO.getDataSetId()));
             uri = createElectionURI(info, election, consentId);
         } catch (Exception e) {
             return createExceptionResponse(e);

--- a/src/main/java/org/broadinstitute/consent/http/resources/ConsentElectionResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/ConsentElectionResource.java
@@ -86,12 +86,6 @@ public class ConsentElectionResource extends Resource {
                 logger().error("Exception updating consent id: '" + consentId + "', with dac id: '" + dacId + "'");
                 throw new InternalServerErrorException("Unable to associate consent to dac.");
             }
-            // For a consent election, any dataset associated to the consent is
-            // appropriate for assignment to this election.
-            Optional<DataSet> dataset = dacService.findDatasetsByConsentId(consentId).
-                    stream().
-                    findFirst();
-            dataset.ifPresent(dataSet -> election.setDataSetId(dataSet.getDataSetId()));
             uri = createElectionURI(info, election, consentId);
         } catch (Exception e) {
             return createExceptionResponse(e);
@@ -141,6 +135,12 @@ public class ConsentElectionResource extends Resource {
     }
 
     private URI createElectionURI(UriInfo info, Election election, String consentId) throws Exception {
+        // For a consent election, any dataset associated to the consent is
+        // appropriate for assignment to this election.
+        Optional<DataSet> dataset = dacService.findDatasetsByConsentId(consentId).
+                stream().
+                findFirst();
+        dataset.ifPresent(dataSet -> election.setDataSetId(dataSet.getDataSetId()));
         Election newElection = api.createElection(election, consentId, ElectionType.TRANSLATE_DUL);
         List<Vote> votes = voteService.createVotes(newElection, ElectionType.TRANSLATE_DUL, false);
         List<Vote> dulVotes = votes.stream().

--- a/src/main/java/org/broadinstitute/consent/http/resources/ConsentElectionResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/ConsentElectionResource.java
@@ -91,7 +91,7 @@ public class ConsentElectionResource extends Resource {
             Optional<DataSet> dataset = dacService.findDatasetsByConsentId(consentId).
                     stream().
                     findFirst();
-            dataset.ifPresent(dataSetDTO -> election.setDataSetId(dataSetDTO.getDataSetId()));
+            dataset.ifPresent(dataSet -> election.setDataSetId(dataSet.getDataSetId()));
             uri = createElectionURI(info, election, consentId);
         } catch (Exception e) {
             return createExceptionResponse(e);

--- a/src/main/java/org/broadinstitute/consent/http/service/DacService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DacService.java
@@ -159,6 +159,10 @@ public class DacService {
         return Collections.emptySet();
     }
 
+    public Set<DataSet> findDatasetsByConsentId(String consentId) {
+        return dataSetDAO.findDatasetsForConsentId(consentId);
+    }
+
     public List<DACUser> findMembersByDacId(Integer dacId) {
         List<DACUser> dacUsers = dacDAO.findMembersByDacId(dacId);
         List<Integer> allUserIds = dacUsers.

--- a/src/test/java/org/broadinstitute/consent/http/db/DataSetDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DataSetDAOTest.java
@@ -108,6 +108,39 @@ public class DataSetDAOTest extends DAOTestHelper {
         Assert.assertNull(foundDac);
     }
 
+    @Test
+    public void testFindDatasetsForConsentId_case0() {
+        Dac dac = createDac();
+        Consent c = createConsent(dac.getDacId());
+
+        Set<DataSet> datasets = dataSetDAO.findDatasetsForConsentId(c.getConsentId());
+        Assert.assertEquals(datasets.size(), 0);
+    }
+
+    @Test
+    public void testFindDatasetsForConsentId_case1() {
+        Dac dac = createDac();
+        Consent c = createConsent(dac.getDacId());
+        DataSet d = createDataset();
+        createAssociation(c.getConsentId(), d.getDataSetId());
+
+        Set<DataSet> datasets = dataSetDAO.findDatasetsForConsentId(c.getConsentId());
+        Assert.assertEquals(datasets.size(), 1);
+    }
+
+    @Test
+    public void testFindDatasetsForConsentId_case2() {
+        Dac dac = createDac();
+        Consent c = createConsent(dac.getDacId());
+        DataSet d = createDataset();
+        createAssociation(c.getConsentId(), d.getDataSetId());
+        DataSet d2 = createDataset();
+        createAssociation(c.getConsentId(), d2.getDataSetId());
+
+        Set<DataSet> datasets = dataSetDAO.findDatasetsForConsentId(c.getConsentId());
+        Assert.assertEquals(datasets.size(), 2);
+    }
+
     private void createUserRole(Integer roleId, Integer userId, Integer dacId) {
         dacDAO.addDacMember(roleId, userId, dacId);
     }


### PR DESCRIPTION
## Addresses
https://broadinstitute.atlassian.net/browse/DUOS-507

## Changes
This fixes a regression. Previously, we were finding the dacs by the associated consent. When moving to DAR elections, we changed that to find them by dataset, which was not present in consent elections. This fixes that by looking for a dataset on the consent and using that for the election.