### PR TITLE
[DUOS-509][risk=no] Create new dac member votes at the user level

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/service/DacService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DacService.java
@@ -190,7 +190,7 @@ public class DacService {
                 throw new IllegalArgumentException("Unable to determine election type for election id: " + e.getElectionId());
             }
             boolean isManualReview = type.get().equals(ElectionType.DATA_ACCESS) && hasUseRestriction(e.getReferenceId());
-            voteService.createVotes(e, type.get(), isManualReview);
+            voteService.createVotesForUser(user, e, type.get(), isManualReview);
         }
         return populatedUserById(user.getDacUserId());
     }

--- a/src/main/java/org/broadinstitute/consent/http/service/VoteService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/VoteService.java
@@ -107,20 +107,36 @@ public class VoteService {
         List<Vote> votes = new ArrayList<>();
         if (dacUsers != null) {
             for (DACUser user : dacUsers) {
-                Integer dacVoteId = voteDAO.insertVote(user.getDacUserId(), election.getElectionId(), VoteType.DAC.getValue());
-                votes.add(voteDAO.findVoteById(dacVoteId));
-                if (isDacChairPerson(dac, user)) {
-                    Integer chairVoteId = voteDAO.insertVote(user.getDacUserId(), election.getElectionId(), VoteType.CHAIRPERSON.getValue());
-                    votes.add(voteDAO.findVoteById(chairVoteId));
-                    // Requires Chairperson role to create a final and agreement vote in the Data Access case
-                    if (electionType.equals(ElectionType.DATA_ACCESS)) {
-                        Integer finalVoteId = voteDAO.insertVote(user.getDacUserId(), election.getElectionId(), VoteType.FINAL.getValue());
-                        votes.add(voteDAO.findVoteById(finalVoteId));
-                        if (!isManualReview) {
-                            Integer agreementVoteId = voteDAO.insertVote(user.getDacUserId(), election.getElectionId(), VoteType.AGREEMENT.getValue());
-                            votes.add(voteDAO.findVoteById(agreementVoteId));
-                        }
-                    }
+                votes.addAll(createVotesForUser(user, election, electionType, isManualReview));
+            }
+        }
+        return votes;
+    }
+
+    /**
+     * Create election votes for a user
+     *
+     * @param user DACUser
+     * @param election Election
+     * @param electionType ElectionType
+     * @param isManualReview Is election manual review
+     * @return List of created votes
+     */
+    List<Vote> createVotesForUser(DACUser user, Election election, ElectionType electionType, Boolean isManualReview) {
+        Dac dac = electionDAO.findDacForElection(election.getElectionId());
+        List<Vote> votes = new ArrayList<>();
+        Integer dacVoteId = voteDAO.insertVote(user.getDacUserId(), election.getElectionId(), VoteType.DAC.getValue());
+        votes.add(voteDAO.findVoteById(dacVoteId));
+        if (isDacChairPerson(dac, user)) {
+            Integer chairVoteId = voteDAO.insertVote(user.getDacUserId(), election.getElectionId(), VoteType.CHAIRPERSON.getValue());
+            votes.add(voteDAO.findVoteById(chairVoteId));
+            // Requires Chairperson role to create a final and agreement vote in the Data Access case
+            if (electionType.equals(ElectionType.DATA_ACCESS)) {
+                Integer finalVoteId = voteDAO.insertVote(user.getDacUserId(), election.getElectionId(), VoteType.FINAL.getValue());
+                votes.add(voteDAO.findVoteById(finalVoteId));
+                if (!isManualReview) {
+                    Integer agreementVoteId = voteDAO.insertVote(user.getDacUserId(), election.getElectionId(), VoteType.AGREEMENT.getValue());
+                    votes.add(voteDAO.findVoteById(agreementVoteId));
                 }
             }
         }

--- a/src/test/java/org/broadinstitute/consent/http/service/DacServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DacServiceTest.java
@@ -229,7 +229,7 @@ public class DacServiceTest {
         DACUser user = service.addDacMember(role, getDacUsers().get(0), getDacs().get(0));
         Assert.assertNotNull(user);
         Assert.assertFalse(user.getRoles().isEmpty());
-        verify(voteService, times(elections.size())).createVotes(any(), any(), anyBoolean());
+        verify(voteService, times(elections.size())).createVotesForUser(any(), any(), any(), anyBoolean());
     }
 
     @Test


### PR DESCRIPTION
## Addresses
https://broadinstitute.atlassian.net/browse/DUOS-509

## Changes
* Fixes a bug where duplicate votes are created when adding dac chair/member
* Instead of creating votes for an election (which creates votes for all users in the election), only create votes for the individual user when adding a dac chair or member.