### PR TITLE
[DUOS-376][risk=no] Update dac-for-election queries

### DIFF
--- a/src/test/java/org/broadinstitute/consent/http/db/ElectionDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/ElectionDAOTest.java
@@ -25,6 +25,18 @@ public class ElectionDAOTest extends DAOTestHelper {
     }
 
     @Test
+    public void testFindDacForConsentElectionWithNoAssociation() {
+        Dac dac = createDac();
+        Consent consent = createConsent(dac.getDacId());
+        DataSet dataset = createDataset();
+        Election election = createElection(consent.getConsentId(), dataset.getDataSetId());
+
+        Dac foundDac = electionDAO.findDacForElection(election.getElectionId());
+        Assert.assertNotNull(foundDac);
+        Assert.assertEquals(dac.getDacId(), foundDac.getDacId());
+    }
+
+    @Test
     public void testFindDacForConsentElectionNotFound() {
         Consent consent = createConsent(null);
         DataSet dataset = createDataset();

--- a/src/test/java/org/broadinstitute/consent/http/db/ElectionDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/ElectionDAOTest.java
@@ -60,6 +60,18 @@ public class ElectionDAOTest extends DAOTestHelper {
     }
 
     @Test
+    public void testFindElectionByDacIdWithNoAssociation() {
+        Dac dac = createDac();
+        Consent consent = createConsent(dac.getDacId());
+        DataSet dataset = createDataset();
+        Election election = createElection(consent.getConsentId(), dataset.getDataSetId());
+
+        List<Election> foundElections = electionDAO.findOpenElectionsByDacId(dac.getDacId());
+        Assert.assertNotNull(foundElections);
+        Assert.assertEquals(election.getElectionId(), foundElections.get(0).getElectionId());
+    }
+
+    @Test
     public void testFindElectionByDacIdNotFound() {
         Dac dac = createDac();
         Consent consent = createConsent(null);


### PR DESCRIPTION
## Addresses
Minor fixup for https://broadinstitute.atlassian.net/browse/DUOS-376
Does not complete the above epic - task is too small for it's own story.

## Changes
The query for dacs by election was not sufficient. We need to be able to find elections that may not have had a dataset id associated to it yet. This happens in the case of DUL elections. In that case, we first vote on the DUL, then we make the dataset association later on. This update allows us to find elections for dacs where that association hasn't been made yet.