### PR TITLE
[DUOS-518][risk=no] Update to latest jetty

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <liquibase.version>3.6.2</liquibase.version>
     <dropwizard.version>1.3.14</dropwizard.version>
     <pdfbox.version>2.0.15</pdfbox.version>
-    <jetty.version>9.4.14.v20181114</jetty.version>
+    <jetty.version>9.4.25.v20191220</jetty.version>
     <owl.version>5.1.7</owl.version>
     <mysql.version>8.0.16</mysql.version>
     <swagger.ui.version>2.2.8</swagger.ui.version>


### PR DESCRIPTION
## Addresses
https://broadinstitute.atlassian.net/browse/DUOS-518

## Changes
The older version was missing a field for `MOST_SPECIFIC_MIME_ORDERING`. Upgrading to the latest pulled in a version of `ErrorHandler` that has `MOST_SPECIFIC_MIME_ORDERING` and doesn't throw log errors.