### PR TITLE
[DUOS-445][risk=no] Remove unused API and code - Part 2

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/DACUserDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DACUserDAO.java
@@ -75,10 +75,6 @@ public interface DACUserDAO extends Transactional<DACUserDAO> {
     @SqlQuery("select du.*, r.roleId, r.name, ur.user_role_id, ur.user_id, ur.role_id, ur.dac_id from dacuser du inner join user_role ur on ur.user_id = du.dacUserId inner join roles r on r.roleId = ur.role_id where r.name = :roleName and du.email_preference = :emailPreference")
     List<DACUser> describeUsersByRoleAndEmailPreference(@Bind("roleName") String roleName, @Bind("emailPreference") Boolean emailPreference);
 
-    @SqlUpdate("update dacuser set displayName=:displayName where dacUserId = :id")
-    void updateDACUser(@Bind("displayName") String displayName,
-                          @Bind("id") Integer id);
-
     @SqlUpdate("update dacuser set email_preference = :emailPreference where dacUserId = :userId")
     void updateEmailPreference(@Bind("emailPreference") Boolean emailPreference, @Bind("userId") Integer userId);
 

--- a/src/main/java/org/broadinstitute/consent/http/resources/DACUserResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DACUserResource.java
@@ -127,7 +127,6 @@ public class DACUserResource extends Resource {
         return Response.ok().entity("User was deleted").build();
     }
 
-
     @Deprecated // Use update instead
     @PUT
     @Path("/status/{userId}")

--- a/src/main/java/org/broadinstitute/consent/http/resources/DACUserResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DACUserResource.java
@@ -168,23 +168,6 @@ public class DACUserResource extends Resource {
         }
     }
 
-    // TODO: Undocumented: See DUOS-403
-    @Deprecated // Use update instead
-    @PUT
-    @Path("/name/{id}")
-    @Consumes("application/json")
-    @Produces("application/json")
-    @RolesAllowed({ADMIN, RESEARCHER})
-    public Response updateName(String json, @PathParam("id") Integer id) {
-        DACUser user = new DACUser(json);
-        try {
-            DACUser dacUser = dacUserAPI.updateNameById(user, id);
-            return Response.ok().entity(dacUser).build();
-        } catch (Exception e) {
-            return createExceptionResponse(e);
-        }
-    }
-
     /**
      * Convenience method to find a member from legacy json structure.
      *

--- a/src/main/java/org/broadinstitute/consent/http/resources/DACUserResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DACUserResource.java
@@ -127,6 +127,7 @@ public class DACUserResource extends Resource {
         return Response.ok().entity("User was deleted").build();
     }
 
+
     @Deprecated // Use update instead
     @PUT
     @Path("/status/{userId}")

--- a/src/main/java/org/broadinstitute/consent/http/service/users/DACUserAPI.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/users/DACUserAPI.java
@@ -33,8 +33,6 @@ public interface DACUserAPI {
 
     DACUser updateUserRationale(String rationale, Integer userId);
 
-    DACUser updateNameById(DACUser user, Integer id);
-
     void updateEmailPreference(boolean preference, Integer userId);
 
 }

--- a/src/main/java/org/broadinstitute/consent/http/service/users/DatabaseDACUserAPI.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/users/DatabaseDACUserAPI.java
@@ -119,16 +119,6 @@ public class DatabaseDACUserAPI extends AbstractDACUserAPI {
     }
 
     @Override
-    public DACUser updateNameById(DACUser user, Integer id) {
-        validateExistentUserById(id);
-        if (StringUtils.isEmpty(user.getDisplayName())) {
-            throw new IllegalArgumentException();
-        }
-        dacUserDAO.updateDACUser(user.getDisplayName(), id);
-        return describeDACUserById(id);
-    }
-
-    @Override
     public DACUser updateDACUserById(Map<String, DACUser> dac, Integer id) throws IllegalArgumentException, NotFoundException, UserRoleHandlerException, MessagingException, IOException, TemplateException {
         DACUser updatedUser = dac.get("updatedUser");
         // validate user exists

--- a/src/test/java/org/broadinstitute/consent/http/DACUserTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/DACUserTest.java
@@ -25,7 +25,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class DACUserTest extends DACUserServiceTest {
@@ -157,39 +156,6 @@ public class DACUserTest extends DACUserServiceTest {
         DACUser postUser = new DACUser();
         postUser.setStatus("Test");
         Response response = put(client, statusValue(4), postUser);
-        checkStatus(BAD_REQUEST, response);
-    }
-
-    @Test
-    public void testUpdateDisplayNameSuccess() throws IOException {
-        final String displayName = "Test";
-        Client client = ClientBuilder.newClient();
-        DACUser user = new DACUser();
-        user.setDisplayName(displayName);
-        user.setDacUserId(4);
-        Response response = put(client, dacUserPath()+ "/name/4", user);
-        checkStatus(OK, response);
-        DACUser dacUser = response.readEntity(DACUser.class);
-        assertEquals(dacUser.getDisplayName(), displayName);
-    }
-
-    @Test
-    public void testUpdateDisplayNameWithInvalidUser() throws IOException {
-        final String displayName = "Test";
-        Client client = ClientBuilder.newClient();
-        DACUser user = new DACUser();
-        user.setDisplayName(displayName);
-        user.setDacUserId(4);
-        Response response = put(client, dacUserPath()+ "/name/99", user);
-        checkStatus(NOT_FOUND, response);
-    }
-
-    @Test
-    public void testUpdateDisplayNameWithEmptyName() throws IOException {
-        Client client = ClientBuilder.newClient();
-        DACUser user = new DACUser();
-        user.setDacUserId(4);
-        Response response = put(client, dacUserPath() + "/name/4", user);
         checkStatus(BAD_REQUEST, response);
     }
 

--- a/src/test/java/org/broadinstitute/consent/http/db/UserDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/UserDAOTest.java
@@ -166,15 +166,6 @@ public class UserDAOTest extends DAOTestHelper {
     }
 
     @Test
-    public void testUpdateDACUser_case2() {
-        DACUser user = createUser();
-        String displayName = RandomStringUtils.random(10, true, false);
-        userDAO.updateDACUser(displayName, user.getDacUserId());
-        DACUser user2 = userDAO.findDACUserById(user.getDacUserId());
-        Assert.assertEquals(displayName, user2.getDisplayName());
-    }
-
-    @Test
     public void testUpdateEmailPreference() {
         // No-op ... tested in `testDescribeUsersByRoleAndEmailPreference()`
     }


### PR DESCRIPTION
## Addresses
Only addresses the `PUT updateName` part of https://broadinstitute.atlassian.net/browse/DUOS-445

## Changes
Lots of code deletion around this unused api call so this whole vulnerable code path can be removed.

Requires corresponding [UI PR](https://github.com/DataBiosphere/duos-ui/pull/233)