### PR TITLE
[DUOS-527][risk=no] Clean up rdf4j and owlapi-distribution

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -787,7 +787,6 @@
       <version>3.0.4</version>
     </dependency>
 
-    <!-- Pulling in directly to evict older, transitive dependencies -->
     <dependency>
       <groupId>org.eclipse.rdf4j</groupId>
       <artifactId>rdf4j-rio-datatypes</artifactId>
@@ -800,68 +799,60 @@
       <version>3.0.4</version>
     </dependency>
 
-    <!-- Pulling in directly to evict older, transitive dependencies -->
     <dependency>
       <groupId>org.eclipse.rdf4j</groupId>
       <artifactId>rdf4j-rio-jsonld</artifactId>
       <version>3.0.4</version>
     </dependency>
 
-    <!-- Pulling in directly to evict older, transitive dependencies -->
     <dependency>
       <groupId>org.eclipse.rdf4j</groupId>
       <artifactId>rdf4j-rio-languages</artifactId>
       <version>3.0.4</version>
     </dependency>
 
-    <!-- Pulling in directly to evict older, transitive dependencies -->
     <dependency>
       <groupId>org.eclipse.rdf4j</groupId>
       <artifactId>rdf4j-rio-n3</artifactId>
       <version>3.0.4</version>
     </dependency>
 
-    <!-- Pulling in directly to evict older, transitive dependencies -->
     <dependency>
       <groupId>org.eclipse.rdf4j</groupId>
       <artifactId>rdf4j-rio-nquads</artifactId>
       <version>3.0.4</version>
     </dependency>
 
-    <!-- Pulling in directly to evict older, transitive dependencies -->
     <dependency>
       <groupId>org.eclipse.rdf4j</groupId>
       <artifactId>rdf4j-rio-ntriples</artifactId>
       <version>3.0.4</version>
     </dependency>
 
-    <!-- Pulling in directly to evict older, transitive dependencies -->
     <dependency>
       <groupId>org.eclipse.rdf4j</groupId>
       <artifactId>rdf4j-rio-rdfjson</artifactId>
       <version>3.0.4</version>
     </dependency>
 
-    <!-- Pulling in directly to evict older, transitive dependencies -->
     <dependency>
       <groupId>org.eclipse.rdf4j</groupId>
       <artifactId>rdf4j-rio-rdfxml</artifactId>
       <version>3.0.4</version>
     </dependency>
 
-    <!-- Pulling in directly to evict older, transitive dependencies -->
     <dependency>
       <groupId>org.eclipse.rdf4j</groupId>
       <artifactId>rdf4j-rio-trig</artifactId>
       <version>3.0.4</version>
     </dependency>
 
-    <!-- Pulling in directly to evict older, transitive dependencies -->
     <dependency>
       <groupId>org.eclipse.rdf4j</groupId>
       <artifactId>rdf4j-rio-turtle</artifactId>
       <version>3.0.4</version>
     </dependency>
+    <!-- End of rdf4j-rio-* fixes -->
 
     <dependency>
       <groupId>net.sourceforge.owlapi</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -781,7 +781,6 @@
 
     <!-- See https://broadinstitute-dsp.sourceclear.io/workspaces/jppForw/issues/vulnerabilities/11441966 -->
     <!-- For all `rdf4j-rio-*` libraries, pulling in directly to evict older, transitive dependencies -->
-    <!-- Pulling in directly to evict older, transitive dependencies -->
     <dependency>
       <groupId>org.eclipse.rdf4j</groupId>
       <artifactId>rdf4j-rio-binary</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -779,9 +779,19 @@
       </exclusions>
     </dependency>
 
+    <!-- See https://broadinstitute-dsp.sourceclear.io/workspaces/jppForw/issues/vulnerabilities/11441966 -->
+    <!-- For all `rdf4j-rio-*` libraries, pulling in directly to evict older, transitive dependencies -->
+    <!-- Pulling in directly to evict older, transitive dependencies -->
     <dependency>
       <groupId>org.eclipse.rdf4j</groupId>
-      <artifactId>rdf4j-rio-rdfxml</artifactId>
+      <artifactId>rdf4j-rio-binary</artifactId>
+      <version>3.0.4</version>
+    </dependency>
+
+    <!-- Pulling in directly to evict older, transitive dependencies -->
+    <dependency>
+      <groupId>org.eclipse.rdf4j</groupId>
+      <artifactId>rdf4j-rio-datatypes</artifactId>
       <version>3.0.4</version>
     </dependency>
 
@@ -791,81 +801,73 @@
       <version>3.0.4</version>
     </dependency>
 
+    <!-- Pulling in directly to evict older, transitive dependencies -->
+    <dependency>
+      <groupId>org.eclipse.rdf4j</groupId>
+      <artifactId>rdf4j-rio-jsonld</artifactId>
+      <version>3.0.4</version>
+    </dependency>
+
+    <!-- Pulling in directly to evict older, transitive dependencies -->
+    <dependency>
+      <groupId>org.eclipse.rdf4j</groupId>
+      <artifactId>rdf4j-rio-languages</artifactId>
+      <version>3.0.4</version>
+    </dependency>
+
+    <!-- Pulling in directly to evict older, transitive dependencies -->
+    <dependency>
+      <groupId>org.eclipse.rdf4j</groupId>
+      <artifactId>rdf4j-rio-n3</artifactId>
+      <version>3.0.4</version>
+    </dependency>
+
+    <!-- Pulling in directly to evict older, transitive dependencies -->
+    <dependency>
+      <groupId>org.eclipse.rdf4j</groupId>
+      <artifactId>rdf4j-rio-nquads</artifactId>
+      <version>3.0.4</version>
+    </dependency>
+
+    <!-- Pulling in directly to evict older, transitive dependencies -->
+    <dependency>
+      <groupId>org.eclipse.rdf4j</groupId>
+      <artifactId>rdf4j-rio-ntriples</artifactId>
+      <version>3.0.4</version>
+    </dependency>
+
+    <!-- Pulling in directly to evict older, transitive dependencies -->
+    <dependency>
+      <groupId>org.eclipse.rdf4j</groupId>
+      <artifactId>rdf4j-rio-rdfjson</artifactId>
+      <version>3.0.4</version>
+    </dependency>
+
+    <!-- Pulling in directly to evict older, transitive dependencies -->
+    <dependency>
+      <groupId>org.eclipse.rdf4j</groupId>
+      <artifactId>rdf4j-rio-rdfxml</artifactId>
+      <version>3.0.4</version>
+    </dependency>
+
+    <!-- Pulling in directly to evict older, transitive dependencies -->
+    <dependency>
+      <groupId>org.eclipse.rdf4j</groupId>
+      <artifactId>rdf4j-rio-trig</artifactId>
+      <version>3.0.4</version>
+    </dependency>
+
+    <!-- Pulling in directly to evict older, transitive dependencies -->
+    <dependency>
+      <groupId>org.eclipse.rdf4j</groupId>
+      <artifactId>rdf4j-rio-turtle</artifactId>
+      <version>3.0.4</version>
+    </dependency>
+
     <dependency>
       <groupId>net.sourceforge.owlapi</groupId>
       <artifactId>owlapi-distribution</artifactId>
       <version>${owl.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>com.fasterxml.jackson.core</groupId>
-          <artifactId>jackson-databind</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.google.guava</groupId>
-          <artifactId>guava</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.eclipse.rdf4j</groupId>
-          <artifactId>rdf4j-rio-api</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.eclipse.rdf4j</groupId>
-          <artifactId>rdf4j-rio-binary</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.eclipse.rdf4j</groupId>
-          <artifactId>rdf4j-util</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.eclipse.rdf4j</groupId>
-          <artifactId>rdf4j-rio-datatypes</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.eclipse.rdf4j</groupId>
-          <artifactId>rdf4j-rio-languages</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.eclipse.rdf4j</groupId>
-          <artifactId>rdf4j-model</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.eclipse.rdf4j</groupId>
-          <artifactId>rdf4j-rio-rdfxml</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.eclipse.rdf4j</groupId>
-          <artifactId>rdf4j-rio-trix</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>net.sourceforge.owlapi</groupId>
-          <artifactId>owlapi-api</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>net.sourceforge.owlapi</groupId>
-          <artifactId>owlapi-parsers</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>net.sourceforge.owlapi</groupId>
-          <artifactId>owlapi-apibinding</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>net.sourceforge.owlapi</groupId>
-          <artifactId>owlapi-impl</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>net.sourceforge.owlapi</groupId>
-          <artifactId>owlapi-tools</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>net.sourceforge.owlapi</groupId>
-          <artifactId>owlapi-oboformat</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>net.sourceforge.owlapi</groupId>
-          <artifactId>owlapi-apibinding</artifactId>
-        </exclusion>
-      </exclusions>
-
     </dependency>
 
     <dependency>


### PR DESCRIPTION
## Addresses
https://broadinstitute.atlassian.net/browse/DUOS-527
See also: https://github.com/DataBiosphere/consent-ontology/pull/196

## Changes
* Cleaned up the dependencies around `rdf4j-rio-*` and `owlapi-distribution`
* Removed exclusions because they were not pulled in by the latest owl version
* Ran owasp and `rdf4j-rio-n3-2.3.2.jar` is no longer reported