### PR TITLE
[DUOS-528][risk=no] Remove jackson asl

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -326,19 +326,6 @@
 
     <!-- Pulling in directly to evict older, transitive dependencies -->
     <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-mapper-asl</artifactId>
-      <version>1.9.13</version>
-      <exclusions>
-        <exclusion>
-          <groupId>com.fasterxml.jackson.core</groupId>
-          <artifactId>jackson-databind</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-
-    <!-- Pulling in directly to evict older, transitive dependencies -->
-    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
       <version>2.9.10.2</version>
@@ -695,6 +682,10 @@
         <exclusion>
           <groupId>org.codehaus.jackson</groupId>
           <artifactId>jackson-mapper-asl</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.codehaus.jackson</groupId>
+          <artifactId>jackson-core-asl</artifactId>
         </exclusion>
         <exclusion>
           <groupId>org.mongodb</groupId>


### PR DESCRIPTION
## Addresses
https://broadinstitute.atlassian.net/browse/DUOS-528

## Changes
* Remove direct reference (no longer necessary)
* Exclude from mongo - required dependencies are in `jackson-core`