### PR TITLE
[DUOS-544][risk=no] Handle annoying NPE stack trace in error logs

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/service/DataSetFileParser.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataSetFileParser.java
@@ -54,7 +54,7 @@ public class DataSetFileParser {
                 ds.setProperties(properties);
                 datasets.add(ds);
             }
-        } catch (IOException e) {
+        } catch (Exception e) {
             logger().error("An unexpected error had occurred in DataSetFileParser", e);
             errors.add("An unexpected error had occurred in DataSetFileParser - Contact Support");
         }
@@ -66,6 +66,15 @@ public class DataSetFileParser {
 
     private List<String> validateHeaderFields(String[] record, List<String> keys) {
         List<String> errors = new ArrayList<>();
+        if (record == null) {
+            errors.add("Invalid records");
+        }
+        if (keys == null) {
+            errors.add("Invalid keys");
+        }
+        if (!errors.isEmpty()) {
+            return errors;
+        }
         if ((record.length < keys.size()) || (record.length > keys.size())) {
             errors.add(String.format(MISSING_COLUMNS, keys.size()));
         } else {

--- a/src/test/java/org/broadinstitute/consent/http/DataSetResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/DataSetResourceTest.java
@@ -1,9 +1,9 @@
 package org.broadinstitute.consent.http;
 
 import com.google.common.io.Resources;
+import com.google.gson.Gson;
 import io.dropwizard.testing.junit.DropwizardAppRule;
 import org.broadinstitute.consent.http.configurations.ConsentConfiguration;
-import org.broadinstitute.consent.http.models.DataSet;
 import org.glassfish.jersey.media.multipart.MultiPart;
 import org.glassfish.jersey.media.multipart.MultiPartFeature;
 import org.glassfish.jersey.media.multipart.file.FileDataBodyPart;
@@ -23,6 +23,8 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class DataSetResourceTest extends DataSetServiceTest {
@@ -47,10 +49,8 @@ public class DataSetResourceTest extends DataSetServiceTest {
                 .header("Authorization", "Bearer access_token")
                 .post(Entity.entity(mp, mp.getMediaType()));
         ArrayList<String> result = response.readEntity(new GenericType<ArrayList<String>>() {});
-        assertTrue(result.size() == 2);
-        assertTrue(response.getStatus() == (BAD_REQUEST));
-        assertTrue(result.get(0).equals("A problem has occurred while uploading datasets - Contact Support"));
-        assertTrue(result.get(1).equals("The file type is not the expected one. Please download the Dataset Spreadsheet Model from the 'Add Datasets' window."));
+        assertFalse(result.isEmpty());
+        assertEquals(response.getStatus(), BAD_REQUEST);
     }
 
     @Test

--- a/src/test/java/org/broadinstitute/consent/http/DataSetResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/DataSetResourceTest.java
@@ -1,7 +1,6 @@
 package org.broadinstitute.consent.http;
 
 import com.google.common.io.Resources;
-import com.google.gson.Gson;
 import io.dropwizard.testing.junit.DropwizardAppRule;
 import org.broadinstitute.consent.http.configurations.ConsentConfiguration;
 import org.glassfish.jersey.media.multipart.MultiPart;


### PR DESCRIPTION
## Addresses
See https://broadinstitute.atlassian.net/browse/DUOS-544

## Changes
* Handle potential NPEs
* Update test. This should eventually go away when we tackle the dataset import revamp