### PR TITLE
[DUOS-302][risk=no] Remove unused, vulnerable library

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -638,12 +638,6 @@
     </dependency>
 
     <dependency>
-      <groupId>io.dropwizard</groupId>
-      <artifactId>dropwizard-metrics-graphite</artifactId>
-      <version>${dropwizard.version}</version>
-    </dependency>
-
-    <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
       <version>2.8.6</version>


### PR DESCRIPTION
## Addresses
Minor update in service to https://broadinstitute.atlassian.net/browse/DUOS-302

Fixes https://broadinstitute-dsp.sourceclear.io/workspaces/jppForw/issues/vulnerabilities/17870375 by removing the dependency the vulnerability is pulled in from.

> Affected Library: RabbitMQ Java Client, MAVEN, com.rabbitmq amqp-client
> Type: Transitive dependency
> Version In Use: 4.​4.​1
> Released On: Dec 18, 2017
> Latest Version: 5.​8.​0
> Released On: Dec 11, 2019
> Transitive Dependency
> This vulnerability is in a transitive dependency, it can be fixed by overriding and adding a new direct dependency of the library in your project.
> 
> Update
> 
> We do not have a confirmed fix for this issue yet. However, newer versions of the library have been released. We suggest that you upgrade to 5.4.0, which is considered safe.
> 
