### PR TITLE
[DUOS-548][risk=no] Sendgrid Library Update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -360,7 +360,7 @@
     <dependency>
       <groupId>com.sendgrid</groupId>
       <artifactId>sendgrid-java</artifactId>
-      <version>4.3.0</version>
+      <version>4.4.1</version>
       <exclusions>
           <exclusion>
               <groupId>com.fasterxml.jackson.core</groupId>
@@ -378,7 +378,7 @@
     <dependency>
       <groupId>com.sendgrid</groupId>
       <artifactId>java-http-client</artifactId>
-      <version>4.2.0</version>
+      <version>4.3.0</version>
       <exclusions>
         <exclusion>
           <artifactId>org.apache.httpcomponents</artifactId>

--- a/src/main/java/org/broadinstitute/consent/http/mail/MailService.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/MailService.java
@@ -1,9 +1,24 @@
 package org.broadinstitute.consent.http.mail;
 
-import com.sendgrid.*;
+import com.sendgrid.Method;
+import com.sendgrid.Request;
+import com.sendgrid.Response;
+import com.sendgrid.SendGrid;
+import com.sendgrid.helpers.mail.Mail;
 import org.apache.log4j.Logger;
 import org.broadinstitute.consent.http.configurations.MailConfiguration;
-import org.broadinstitute.consent.http.mail.message.*;
+import org.broadinstitute.consent.http.mail.message.ClosedDatasetElectionMessage;
+import org.broadinstitute.consent.http.mail.message.CollectMessage;
+import org.broadinstitute.consent.http.mail.message.DarCancelMessage;
+import org.broadinstitute.consent.http.mail.message.DelegateResponsibilitiesMessage;
+import org.broadinstitute.consent.http.mail.message.DisabledDatasetMessage;
+import org.broadinstitute.consent.http.mail.message.FlaggedDarApprovedMessage;
+import org.broadinstitute.consent.http.mail.message.HelpReportMessage;
+import org.broadinstitute.consent.http.mail.message.NewCaseMessage;
+import org.broadinstitute.consent.http.mail.message.NewDARRequestMessage;
+import org.broadinstitute.consent.http.mail.message.NewResearcherCreatedMessage;
+import org.broadinstitute.consent.http.mail.message.ReminderMessage;
+import org.broadinstitute.consent.http.mail.message.ResearcherApprovedMessage;
 
 import javax.mail.MessagingException;
 import java.io.IOException;
@@ -64,7 +79,10 @@ public class MailService extends AbstractMailServiceAPI {
                 for (String key : sendGrid.getRequestHeaders().keySet())
                     request.addHeader(key, sendGrid.getRequestHeaders().get(key));
                 // send
-                sendGrid.makeCall(request);
+                Response response = sendGrid.makeCall(request);
+                if (response.getStatusCode() >= 400) {
+                    throw new MessagingException(response.getBody());
+                }
             } catch (IOException ex) {
                 logger().error("Exception sending email: " + ex.getMessage());
                 throw new MessagingException(ex.getMessage());

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/ClosedDatasetElectionMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/ClosedDatasetElectionMessage.java
@@ -1,11 +1,10 @@
 package org.broadinstitute.consent.http.mail.message;
 
-import com.sendgrid.Mail;
+import com.sendgrid.helpers.mail.Mail;
 
 import javax.mail.MessagingException;
 import java.io.Writer;
 import java.util.Collection;
-import java.util.List;
 import java.util.Set;
 
 public class ClosedDatasetElectionMessage extends MailMessage {

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/CollectMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/CollectMessage.java
@@ -1,6 +1,6 @@
 package org.broadinstitute.consent.http.mail.message;
 
-import com.sendgrid.Mail;
+import com.sendgrid.helpers.mail.Mail;
 
 import javax.mail.MessagingException;
 import java.io.Writer;

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/DarCancelMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/DarCancelMessage.java
@@ -1,11 +1,10 @@
 package org.broadinstitute.consent.http.mail.message;
 
-import com.sendgrid.Mail;
+import com.sendgrid.helpers.mail.Mail;
 
 import javax.mail.MessagingException;
 import java.io.Writer;
 import java.util.Collection;
-import java.util.List;
 import java.util.Set;
 
 public class DarCancelMessage extends MailMessage {

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/DelegateResponsibilitiesMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/DelegateResponsibilitiesMessage.java
@@ -1,6 +1,6 @@
 package org.broadinstitute.consent.http.mail.message;
 
-import com.sendgrid.Mail;
+import com.sendgrid.helpers.mail.Mail;
 
 import javax.mail.MessagingException;
 import java.io.Writer;

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/DisabledDatasetMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/DisabledDatasetMessage.java
@@ -1,6 +1,6 @@
 package org.broadinstitute.consent.http.mail.message;
 
-import com.sendgrid.Mail;
+import com.sendgrid.helpers.mail.Mail;
 
 import javax.mail.MessagingException;
 import java.io.Writer;

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/FlaggedDarApprovedMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/FlaggedDarApprovedMessage.java
@@ -1,6 +1,6 @@
 package org.broadinstitute.consent.http.mail.message;
 
-import com.sendgrid.Mail;
+import com.sendgrid.helpers.mail.Mail;
 
 import javax.mail.MessagingException;
 import java.io.Writer;

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/HelpReportMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/HelpReportMessage.java
@@ -1,6 +1,6 @@
 package org.broadinstitute.consent.http.mail.message;
 
-import com.sendgrid.Mail;
+import com.sendgrid.helpers.mail.Mail;
 
 import javax.mail.MessagingException;
 import java.io.Writer;

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/MailMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/MailMessage.java
@@ -1,8 +1,8 @@
 package org.broadinstitute.consent.http.mail.message;
 
-import com.sendgrid.Content;
-import com.sendgrid.Email;
-import com.sendgrid.Mail;
+import com.sendgrid.helpers.mail.Mail;
+import com.sendgrid.helpers.mail.objects.Content;
+import com.sendgrid.helpers.mail.objects.Email;
 
 import javax.mail.MessagingException;
 import java.io.Writer;

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/NewCaseMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/NewCaseMessage.java
@@ -1,6 +1,6 @@
 package org.broadinstitute.consent.http.mail.message;
 
-import com.sendgrid.Mail;
+import com.sendgrid.helpers.mail.Mail;
 
 import javax.mail.MessagingException;
 import java.io.Writer;

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/NewDARRequestMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/NewDARRequestMessage.java
@@ -1,11 +1,10 @@
 package org.broadinstitute.consent.http.mail.message;
 
-import com.sendgrid.Mail;
+import com.sendgrid.helpers.mail.Mail;
 
 import javax.mail.MessagingException;
 import java.io.Writer;
 import java.util.Collection;
-import java.util.List;
 import java.util.Set;
 
 public class NewDARRequestMessage extends MailMessage{

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/NewResearcherCreatedMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/NewResearcherCreatedMessage.java
@@ -1,6 +1,6 @@
 package org.broadinstitute.consent.http.mail.message;
 
-import com.sendgrid.Mail;
+import com.sendgrid.helpers.mail.Mail;
 
 import javax.mail.MessagingException;
 import java.io.Writer;

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/ReminderMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/ReminderMessage.java
@@ -1,6 +1,6 @@
 package org.broadinstitute.consent.http.mail.message;
 
-import com.sendgrid.Mail;
+import com.sendgrid.helpers.mail.Mail;
 
 import javax.mail.MessagingException;
 import java.io.Writer;

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/ResearcherApprovedMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/ResearcherApprovedMessage.java
@@ -1,6 +1,6 @@
 package org.broadinstitute.consent.http.mail.message;
 
-import com.sendgrid.Mail;
+import com.sendgrid.helpers.mail.Mail;
 
 import javax.mail.MessagingException;
 import java.io.Writer;

--- a/src/test/java/org/broadinstitute/consent/http/mail/message/ClosedDatasetElectionMessageTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mail/message/ClosedDatasetElectionMessageTest.java
@@ -1,6 +1,6 @@
 package org.broadinstitute.consent.http.mail.message;
 
-import com.sendgrid.Mail;
+import com.sendgrid.helpers.mail.Mail;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -10,6 +10,7 @@ import javax.mail.MessagingException;
 import java.io.Writer;
 import java.util.Collection;
 import java.util.Collections;
+
 import static org.junit.Assert.assertTrue;
 
 public class ClosedDatasetElectionMessageTest {

--- a/src/test/java/org/broadinstitute/consent/http/mail/message/CollectMessageTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mail/message/CollectMessageTest.java
@@ -1,6 +1,6 @@
 package org.broadinstitute.consent.http.mail.message;
 
-import com.sendgrid.Mail;
+import com.sendgrid.helpers.mail.Mail;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;

--- a/src/test/java/org/broadinstitute/consent/http/mail/message/DarCancelMessageTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mail/message/DarCancelMessageTest.java
@@ -1,6 +1,6 @@
 package org.broadinstitute.consent.http.mail.message;
 
-import com.sendgrid.Mail;
+import com.sendgrid.helpers.mail.Mail;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;

--- a/src/test/java/org/broadinstitute/consent/http/mail/message/DelegateResponsibilitiesMessageTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mail/message/DelegateResponsibilitiesMessageTest.java
@@ -1,6 +1,6 @@
 package org.broadinstitute.consent.http.mail.message;
 
-import com.sendgrid.Mail;
+import com.sendgrid.helpers.mail.Mail;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;

--- a/src/test/java/org/broadinstitute/consent/http/mail/message/DisabledDatasetMessageTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mail/message/DisabledDatasetMessageTest.java
@@ -1,6 +1,6 @@
 package org.broadinstitute.consent.http.mail.message;
 
-import com.sendgrid.Mail;
+import com.sendgrid.helpers.mail.Mail;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;

--- a/src/test/java/org/broadinstitute/consent/http/mail/message/FlaggedDarApprovedMessageTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mail/message/FlaggedDarApprovedMessageTest.java
@@ -1,6 +1,6 @@
 package org.broadinstitute.consent.http.mail.message;
 
-import com.sendgrid.Mail;
+import com.sendgrid.helpers.mail.Mail;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;

--- a/src/test/java/org/broadinstitute/consent/http/mail/message/NewCaseMessageTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mail/message/NewCaseMessageTest.java
@@ -1,6 +1,6 @@
 package org.broadinstitute.consent.http.mail.message;
 
-import com.sendgrid.Mail;
+import com.sendgrid.helpers.mail.Mail;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;

--- a/src/test/java/org/broadinstitute/consent/http/mail/message/NewDARRequestMessageTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mail/message/NewDARRequestMessageTest.java
@@ -1,6 +1,6 @@
 package org.broadinstitute.consent.http.mail.message;
 
-import com.sendgrid.Mail;
+import com.sendgrid.helpers.mail.Mail;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;

--- a/src/test/java/org/broadinstitute/consent/http/mail/message/NewResearcherCreatedTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mail/message/NewResearcherCreatedTest.java
@@ -1,6 +1,6 @@
 package org.broadinstitute.consent.http.mail.message;
 
-import com.sendgrid.Mail;
+import com.sendgrid.helpers.mail.Mail;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;

--- a/src/test/java/org/broadinstitute/consent/http/mail/message/ReminderMessageTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mail/message/ReminderMessageTest.java
@@ -1,10 +1,11 @@
 package org.broadinstitute.consent.http.mail.message;
 
-import com.sendgrid.Mail;
+import com.sendgrid.helpers.mail.Mail;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+
 import javax.mail.MessagingException;
 import java.io.Writer;
 import java.util.Collections;

--- a/src/test/java/org/broadinstitute/consent/http/mail/message/ResearcherApprovedMessageTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mail/message/ResearcherApprovedMessageTest.java
@@ -1,6 +1,6 @@
 package org.broadinstitute.consent.http.mail.message;
 
-import com.sendgrid.Mail;
+import com.sendgrid.helpers.mail.Mail;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;


### PR DESCRIPTION
## Addresses
Ticket: https://broadinstitute.atlassian.net/browse/DUOS-548
See also these failed dependabot PRs:
* https://github.com/DataBiosphere/consent/pull/430
* https://github.com/DataBiosphere/consent/pull/500

## Changes
* Lots of package updates due to the major version bump
* Error handling is slightly changed - sendgrid no longer throws an `IOException` on non-200 responses.