### PR TITLE
[DUOS-302][risk=no] Address jackson-databind issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -320,11 +320,14 @@
 
   <dependencies>
 
-    <!-- Pulling in directly to evict older, transitive dependencies -->
+    <!--
+        Pulling in directly to evict older, transitive dependencies
+        See https://broadinstitute-dsp.sourceclear.io/workspaces/jppForw/issues/vulnerabilities/28254959
+    -->
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.9.10.2</version>
+      <version>2.10.2</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
## Addresses
Maintenance for https://broadinstitute.atlassian.net/browse/DUOS-302

Fixes:
> Remote Code Execution
jackson-databind is vulnerable to remote code execution. The vulnerability exists because it does not restrict the data sources for the `org.apache.xbean.propertyeditor.JndiConverter` object type, leading to deserialisation of arbitrary data from external untrusted sources which would allow an attacker to execute arbitrary code.
> 
> This vulnerability is in a direct dependency. Vulnerable library jackson-databind was found in pom.xml It can be fixed by updating the version of the library in your project and rebuilding it.