### PR TITLE
[no-jira][risk=low] Fix 405 not-allowed-error when storing DAAs

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/resources/DataAccessAgreementResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataAccessAgreementResource.java
@@ -26,7 +26,7 @@ import java.io.InputStream;
 import java.util.Map;
 import java.util.UUID;
 
-@Path("{api : (api/)?}dar")
+@Path("api/dar")
 public class DataAccessAgreementResource extends Resource {
 
     private final GCSStore store;


### PR DESCRIPTION
Due to confusing `@Path` params, the storeDAA endpoint was not discovered correctly by dropwizard. This fixes that.