### PR TITLE
[DUOS-611][risk=no] Chair console fixes

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/DACUserDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DACUserDAO.java
@@ -19,7 +19,12 @@ import java.util.Set;
 @RegisterRowMapper(DACUserMapper.class)
 public interface DACUserDAO extends Transactional<DACUserDAO> {
 
-    @SqlQuery("select * from dacuser where dacUserId = :dacUserId")
+    @UseRowMapper(DACUserRoleMapper.class)
+    @SqlQuery("select du.*, r.roleid, r.name, ur.user_role_id, ur.user_id, ur.role_id, ur.dac_id " +
+            " from dacuser du " +
+            " left join user_role ur on ur.user_id = du.dacuserid " +
+            " left join roles r on r.roleid = ur.role_id " +
+            " where du.dacuserid = :dacUserId")
     DACUser findDACUserById(@Bind("dacUserId") Integer dacUserId);
 
     @SqlQuery("select * from dacuser where dacUserId IN (<dacUserIds>)")

--- a/src/main/java/org/broadinstitute/consent/http/db/DacDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DacDAO.java
@@ -81,15 +81,6 @@ public interface DacDAO extends Transactional<DacDAO> {
     @SqlQuery("select * from roles where roleId = :roleId")
     Role getRoleById(@Bind("roleId") Integer roleId);
 
-    // TODO: This is a duplicate of DACUserDAO.findDACUserById. Consolidate them.
-    @UseRowMapper(DACUserRoleMapper.class)
-    @SqlQuery("select du.*, r.roleid, r.name, ur.user_role_id, ur.user_id, ur.role_id, ur.dac_id " +
-            " from dacuser du " +
-            " left join user_role ur on ur.user_id = du.dacuserid " +
-            " left join roles r on r.roleid = ur.role_id " +
-            " where du.dacuserid = :dacUserId")
-    DACUser findUserById(@Bind("dacUserId") Integer dacUserId);
-
     @UseRowMapper(UserRoleMapper.class)
     @SqlQuery("select ur.*, r.name from user_role ur inner join roles r on ur.role_id = r.roleId where ur.user_id = :userId")
     List<UserRole> findUserRolesForUser(@Bind("userId") Integer userId);

--- a/src/main/java/org/broadinstitute/consent/http/db/DacDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DacDAO.java
@@ -81,8 +81,13 @@ public interface DacDAO extends Transactional<DacDAO> {
     @SqlQuery("select * from roles where roleId = :roleId")
     Role getRoleById(@Bind("roleId") Integer roleId);
 
-    @UseRowMapper(DACUserMapper.class)
-    @SqlQuery("select du.* from dacuser du where du.dacUserId = :dacUserId")
+    // TODO: This is a duplicate of DACUserDAO.findDACUserById. Consolidate them.
+    @UseRowMapper(DACUserRoleMapper.class)
+    @SqlQuery("select du.*, r.roleid, r.name, ur.user_role_id, ur.user_id, ur.role_id, ur.dac_id " +
+            " from dacuser du " +
+            " left join user_role ur on ur.user_id = du.dacuserid " +
+            " left join roles r on r.roleid = ur.role_id " +
+            " where du.dacuserid = :dacUserId")
     DACUser findUserById(@Bind("dacUserId") Integer dacUserId);
 
     @UseRowMapper(UserRoleMapper.class)

--- a/src/main/java/org/broadinstitute/consent/http/db/ElectionDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/ElectionDAO.java
@@ -4,7 +4,6 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.broadinstitute.consent.http.models.AccessRP;
 import org.broadinstitute.consent.http.models.Dac;
 import org.broadinstitute.consent.http.models.Election;
-import org.broadinstitute.consent.http.resources.Resource;
 import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
 import org.jdbi.v3.sqlobject.customizer.Bind;
 import org.jdbi.v3.sqlobject.customizer.BindList;
@@ -20,17 +19,13 @@ import java.util.List;
 @RegisterRowMapper(ElectionMapper.class)
 public interface ElectionDAO extends Transactional<ElectionDAO> {
 
-    String CHAIRPERSON = Resource.CHAIRPERSON;
-    String FINAL = "FINAL";
-    String DATASET = "DataSet";
-    String OPEN = "Open";
     String CANCELED = "Canceled";
 
-    @SqlQuery("select electionId from election  where referenceId = :referenceId and status = '"+ OPEN +"'")
+    @SqlQuery("select electionId from election where referenceId = :referenceId and lower(status) = 'open'")
     Integer getOpenElectionIdByReferenceId(@Bind("referenceId") String referenceId);
 
     @SqlQuery("select  e.electionId,  e.datasetId, v.vote finalVote, e.status, e.createDate, e.referenceId, e.useRestriction, e.translatedUseRestriction, v.rationale finalRationale, v.createDate finalVoteDate, " +
-            " e.lastUpdate, e.finalAccessVote, e.electionType,  e.dataUseLetter, e.dulName, e.archived, e.version from election e inner join vote v on v.electionId = e.electionId and v.type = '"+ CHAIRPERSON +"' where referenceId = :referenceId")
+            " e.lastUpdate, e.finalAccessVote, e.electionType,  e.dataUseLetter, e.dulName, e.archived, e.version from election e inner join vote v on v.electionId = e.electionId and lower(v.type) = 'chairperson' where referenceId = :referenceId")
     List<Election> findElectionsWithFinalVoteByReferenceId(@Bind("referenceId") String referenceId);
 
     @SqlUpdate("insert into election (electionType, status, createDate, referenceId, datasetId) values " +
@@ -72,26 +67,26 @@ public interface ElectionDAO extends Transactional<ElectionDAO> {
     @SqlUpdate("update election set finalAccessVote = true where electionId = :electionId ")
     void updateFinalAccessVote(@Bind("electionId") Integer electionId);
 
-    @SqlUpdate("update election set status = '"+ CANCELED +"' where referenceId in (<referenceId>) and status = '" + OPEN +"' and electiontype = :electionType")
+    @SqlUpdate("update election set status = '" + CANCELED + "' where referenceId in (<referenceId>) and lower(status) = 'open' and lower(electiontype) = lower(:electionType)")
     void bulkCancelOpenElectionByReferenceIdAndType(@Bind("electionType") String electionType,
                                                     @BindList("referenceId") List<String> referenceId);
 
     @SqlQuery("select e.electionId,  e.datasetId, v.vote finalVote, e.status, e.createDate, e.referenceId, e.useRestriction, e.translatedUseRestriction, v.rationale finalRationale, v.createDate finalVoteDate, "
-            +  "e.lastUpdate, e.finalAccessVote, e.electionType,  e.dataUseLetter, e.dulName, e.archived, e.version   from election e"
-            + " inner join vote v on v.electionId = e.electionId and v.type = '"+ CHAIRPERSON
-            + "'  where   e.referenceId = :referenceId and e.status = '" + OPEN +"' and e.electionType = :type")
+            + "e.lastUpdate, e.finalAccessVote, e.electionType,  e.dataUseLetter, e.dulName, e.archived, e.version   from election e"
+            + " inner join vote v on v.electionId = e.electionId and lower(v.type) = 'chairperson' "
+            + " where e.referenceId = :referenceId and lower(e.status) = 'open' and lower(e.electionType) = lower(:type)")
     Election getOpenElectionWithFinalVoteByReferenceIdAndType(@Bind("referenceId") String referenceId, @Bind("type") String type);
 
     @SqlQuery("select e.electionId,  e.datasetId, v.vote finalVote, e.status, e.createDate, e.referenceId, e.useRestriction, e.translatedUseRestriction, v.rationale finalRationale, v.createDate finalVoteDate, "
-            +  "e.lastUpdate, e.finalAccessVote, e.electionType, e.dataUseLetter, e.dulName, e.archived, e.version  from election e"
-            + " inner join vote v on v.electionId = e.electionId and v.type = '"+ CHAIRPERSON
-            + "' where e.referenceId = :referenceId and e.electionType = :type and e.version = (select MAX(version) from election where referenceId = :referenceId)")
+            + "e.lastUpdate, e.finalAccessVote, e.electionType, e.dataUseLetter, e.dulName, e.archived, e.version  from election e"
+            + " inner join vote v on v.electionId = e.electionId and lower(v.type) = 'chairperson' "
+            + " where e.referenceId = :referenceId and lower(e.electionType) = lower(:type) and e.version = (select MAX(version) from election where referenceId = :referenceId)")
     Election getElectionWithFinalVoteByReferenceIdAndType(@Bind("referenceId") String referenceId, @Bind("type") String type);
 
     @SqlQuery("select e.electionId,  e.datasetId, v.vote finalVote, e.status, e.createDate, e.referenceId, e.useRestriction, e.translatedUseRestriction, v.rationale finalRationale, v.createDate finalVoteDate, "
             + " e.lastUpdate, e.finalAccessVote, e.electionType,  e.dataUseLetter, e.dulName, e.archived, e.version  from election e"
-            + " left join vote v on v.electionId = e.electionId and v.type = '" + CHAIRPERSON
-            + "' where  e.electionId = :electionId")
+            + " left join vote v on v.electionId = e.electionId and lower(v.type) = ''chairperson' "
+            + " where  e.electionId = :electionId")
     Election findElectionWithFinalVoteById(@Bind("electionId") Integer electionId);
 
     @SqlQuery("select e.* from election e inner join vote v on v.electionId = e.electionId where  v.voteId = :voteId")
@@ -100,54 +95,54 @@ public interface ElectionDAO extends Transactional<ElectionDAO> {
 
     @SqlQuery("select distinct e.electionId,  e.datasetId, v.vote finalVote, e.status, e.createDate, e.referenceId, e.useRestriction, e.translatedUseRestriction, v.rationale finalRationale, v.createDate finalVoteDate, "
             + "e.lastUpdate, e.finalAccessVote, e.electionType,  e.dataUseLetter, e.dulName, e.archived, e.version from election e "
-            + "inner join vote v on v.electionId = e.electionId and v.type = '" + CHAIRPERSON
-            + "' where e.electionType = :type and e.status = :status order by createDate asc")
+            + "inner join vote v on v.electionId = e.electionId and lower(v.type) = 'chairperson' "
+            + "where lower(e.electionType) = lower(:type) and lower(e.status) = lower(:status) order by createDate asc")
     List<Election> findElectionsWithFinalVoteByTypeAndStatus(@Bind("type") String type, @Bind("status") String status);
 
     @SqlQuery("select distinct e.electionId,  e.datasetId, v.vote finalVote, e.status, e.createDate, e.referenceId, e.useRestriction, e.translatedUseRestriction, v.rationale finalRationale, v.createDate finalVoteDate, "
-            +" e.lastUpdate, e.finalAccessVote, e.electionType, e.dataUseLetter, e.dulName, e.archived, e.version  from election e inner join vote v on v.electionId = e.electionId and v.type = '"  + CHAIRPERSON
-            +"' inner join (select referenceId, MAX(createDate) maxDate from election e where  e.electionType = :type  group by referenceId) "
+            +" e.lastUpdate, e.finalAccessVote, e.electionType, e.dataUseLetter, e.dulName, e.archived, e.version  from election e inner join vote v on v.electionId = e.electionId and lower(v.type) = 'chairperson' "
+            +" inner join (select referenceId, MAX(createDate) maxDate from election e where  e.electionType = :type  group by referenceId) "
             +" electionView ON electionView.maxDate = e.createDate AND electionView.referenceId = e.referenceId"
-            +" AND e.electionType = :type  order by createDate asc")
+            +" AND lower(e.electionType) = lower(:type)  order by createDate asc")
     List<Election> findLastElectionsWithFinalVoteByType(@Bind("type") String type);
 
     @SqlQuery("select distinct e.electionId,  e.datasetId, v.vote finalVote, e.status, e.createDate, e.referenceId, e.useRestriction, e.translatedUseRestriction, v.rationale finalRationale, v.createDate finalVoteDate, " +
-            "e.lastUpdate, e.finalAccessVote, e.electionType, e.dataUseLetter, e.dulName, e.archived, e.version from election e inner join vote v  on v.electionId = e.electionId where e.electionType = 'DataAccess' "+
-            "and e.finalAccessVote is true  and v.type = 'FINAL'  and e.status = :status order by e.createDate asc")
+            "e.lastUpdate, e.finalAccessVote, e.electionType, e.dataUseLetter, e.dulName, e.archived, e.version from election e inner join vote v on v.electionId = e.electionId where lower(e.electionType) = 'dataaccess' "+
+            "and e.finalAccessVote is true  and lower(v.type) = 'final' and lower(e.status) = lower(:status) order by e.createDate asc")
     List<Election> findRequestElectionsWithFinalVoteByStatus(@Bind("status") String status);
 
     @SqlQuery("select e.electionId,  e.datasetId, e.lastUpdate, v.vote finalVote, e.finalAccessVote, e.translatedUseRestriction, e.useRestriction, e.status, e.createDate, e.referenceId, e.electionType, " +
             "v.rationale finalRationale, v.createDate finalVoteDate, e.dataUseLetter, e.dulName, e.archived, e.version  from election e inner join " +
-            "vote v on v.electionId = e.electionId and v.type = '" + CHAIRPERSON +"' where e.referenceId = :referenceId  " +
-            "and e.status in (<status>) order by createDate desc limit 1")
+            "vote v on v.electionId = e.electionId and lower(v.type) = 'chairperson' where e.referenceId = :referenceId  " +
+            "and lower(e.status) in (<status>) order by createDate desc limit 1")
     Election findLastElectionWithFinalVoteByReferenceIdAndStatus(@Bind("referenceId") String referenceId, @BindList("status") List<String> status);
 
     @SqlQuery("select distinct e.electionId,  e.datasetId, v.vote finalVote, e.status, e.createDate, e.referenceId, e.useRestriction, e.translatedUseRestriction, v.rationale finalRationale, v.createDate finalVoteDate, "
-            + " e.lastUpdate, e.finalAccessVote, e.electionType, e.dataUseLetter, e.dulName, e.archived, e.version  from election e inner join vote v  on v.electionId = e.electionId and v.type = '" + CHAIRPERSON
-            + "' where e.electionType = :type and e.finalAccessVote = :vote and e.status != 'Canceled' order by createDate asc")
+            + " e.lastUpdate, e.finalAccessVote, e.electionType, e.dataUseLetter, e.dulName, e.archived, e.version  from election e inner join vote v  on v.electionId = e.electionId and lower(v.type) = 'chairperson' "
+            + " where lower(e.electionType) = lower(:type) and e.finalAccessVote = :vote and lower(e.status) != 'canceled' order by createDate asc")
     List<Election> findElectionsByTypeAndFinalAccessVoteChairPerson(@Bind("type") String type, @Bind("vote") Boolean finalAccessVote);
 
-    @SqlQuery("select count(*) from election e inner join vote v on v.electionId = e.electionId and v.type = '" + CHAIRPERSON + "' where e.electionType = :type and e.status = :status and " +
+    @SqlQuery("select count(*) from election e inner join vote v on v.electionId = e.electionId and lower(v.type) = 'chairperson' where lower(e.electionType) = lower(:type) and lower(e.status) = lower(:status) and " +
             " v.vote = :finalVote ")
     Integer findTotalElectionsByTypeStatusAndVote(@Bind("type") String type, @Bind("status") String status, @Bind("finalVote") Boolean finalVote);
 
-    @SqlQuery("select count(*) from election e where (e.status = '" + OPEN +"' or e.status = 'Final') and e.electionType != '" + DATASET + "'")
+    @SqlQuery("select count(*) from election e where (lower(e.status) = 'open' or lower(e.status) = 'final') and lower(e.electionType) != 'dataset' ")
     Integer verifyOpenElections();
 
     @SqlQuery("select distinct e.electionId,  e.datasetId, v.vote finalVote, e.status, e.createDate, e.referenceId, e.useRestriction, e.translatedUseRestriction, v.rationale finalRationale, " +
             "v.createDate finalVoteDate, e.lastUpdate, e.finalAccessVote, e.electionType, e.dataUseLetter, e.dulName, e.archived, e.version  from election e " +
             "inner join (select referenceId, MAX(createDate) maxDate from election e where e.electionType = :type group by referenceId) " +
             "electionView ON electionView.maxDate = e.createDate AND electionView.referenceId = e.referenceId  " +
-            "AND e.referenceId in (<referenceIds>) AND e.electionType = :type " +
-            "left join vote v on v.electionId = e.electionId and v.type = '" + FINAL + "'")
+            "AND e.referenceId in (<referenceIds>) AND lower(e.electionType) = lower(:type) " +
+            "left join vote v on v.electionId = e.electionId and lower(v.type) = 'final' ")
     List<Election> findLastElectionsWithFinalVoteByReferenceIdsAndType(@BindList("referenceIds") List<String> referenceIds, @Bind("type") String type);
 
     @SqlQuery("select distinct e.electionId,  e.datasetId, v.vote finalVote, e.status, e.createDate, e.referenceId, e.useRestriction, e.translatedUseRestriction, v.rationale finalRationale, " +
             "v.createDate finalVoteDate, e.lastUpdate, e.finalAccessVote, e.electionType, e.dataUseLetter, e.dulName, e.archived, e.version  from election e " +
-            "inner join (select referenceId, MAX(createDate) maxDate from election e where e.status = :status group by referenceId) " +
+            "inner join (select referenceId, MAX(createDate) maxDate from election e where lower(e.status) = lower(:status) group by referenceId) " +
             "electionView ON electionView.maxDate = e.createDate AND electionView.referenceId = e.referenceId  " +
             "AND e.referenceId in (<referenceIds>) " +
-            "left join vote v on v.electionId = e.electionId and v.type = '" + CHAIRPERSON + "'")
+            "left join vote v on v.electionId = e.electionId and lower(v.type) = 'chairperson' ")
     List<Election> findLastElectionsWithFinalVoteByReferenceIdsTypeAndStatus(@BindList("referenceIds") List<String> referenceIds, @Bind("status") String status);
 
     @SqlQuery("select distinct e.* " +
@@ -158,16 +153,16 @@ public interface ElectionDAO extends Transactional<ElectionDAO> {
     @UseRowMapper(DatabaseElectionMapper.class)
     List<Election> findLastElectionsByReferenceIdAndType(@Bind("referenceId") String referenceId, @Bind("type") String type);
 
-    @SqlQuery("select count(*) from election e where e.status = '" + OPEN +"' and e.referenceId = :referenceId")
+    @SqlQuery("select count(*) from election e where lower(e.status) = 'open' and e.referenceId = :referenceId")
     Integer verifyOpenElectionsForReferenceId(@Bind("referenceId") String referenceId);
 
-    @SqlQuery("select * from election e inner join (select referenceId, MAX(createDate) maxDate from election e where e.status = :status group by referenceId) " +
+    @SqlQuery("select * from election e inner join (select referenceId, MAX(createDate) maxDate from election e where lower(e.status) = lower(:status) group by referenceId) " +
             "electionView ON electionView.maxDate = e.createDate AND electionView.referenceId = e.referenceId  " +
             "AND e.referenceId = :referenceId ")
     @UseRowMapper(DatabaseElectionMapper.class)
     Election findLastElectionByReferenceIdAndStatus(@Bind("referenceId") String referenceIds, @Bind("status") String status);
 
-    @SqlQuery("select * from election e inner join (select referenceId, MAX(createDate) maxDate from election e where e.electionType = :type group by referenceId) " +
+    @SqlQuery("select * from election e inner join (select referenceId, MAX(createDate) maxDate from election e where lower(e.electionType) = lower(:type) group by referenceId) " +
             "electionView ON electionView.maxDate = e.createDate AND electionView.referenceId = e.referenceId  " +
             "AND e.referenceId = :referenceId ")
     @UseRowMapper(DatabaseElectionMapper.class)
@@ -180,11 +175,11 @@ public interface ElectionDAO extends Transactional<ElectionDAO> {
     @SqlQuery(" select electionRPId, electionAccessId from access_rp arp where arp.electionAccessId in (<electionAccessIds>) ")
     List<Pair<Integer, Integer>> findRpAccessElectionIdPairs(@BindList("electionAccessIds") List<Integer> electionAccessIds);
 
-    @SqlUpdate("insert into access_rp (electionAccessId, electionRPId ) values ( :electionAccessId, :electionRPId)")
+    @SqlUpdate("insert into access_rp (electionAccessId, electionRPId ) values (:electionAccessId, :electionRPId)")
     void insertAccessRP(@Bind("electionAccessId") Integer electionAccessId,
                         @Bind("electionRPId") Integer electionRPId);
 
-    @SqlUpdate("insert into accesselection_consentelection (access_election_id, consent_election_id ) values ( :electionAccessId, :electionConsentId)")
+    @SqlUpdate("insert into accesselection_consentelection (access_election_id, consent_election_id ) values (:electionAccessId, :electionConsentId)")
     void insertAccessAndConsentElection(@Bind("electionAccessId") Integer electionAccessId,
                         @Bind("electionConsentId") Integer electionConsentId);
 
@@ -202,8 +197,8 @@ public interface ElectionDAO extends Transactional<ElectionDAO> {
     Integer findAccessElectionByElectionRPId(@Bind("electionRPId") Integer electionRPId);
 
     @SqlQuery("select distinct e.electionId, e.datasetId,  v.vote finalVote, e.status, e.createDate, e.referenceId, e.useRestriction, e.translatedUseRestriction, v.rationale finalRationale, v.createDate finalVoteDate, "
-            + " e.lastUpdate, e.finalAccessVote, e.electionType,  e.dataUseLetter, e.dulName, e.archived, e.version from election e inner join vote v on v.electionId = e.electionId and v.type = '"  + CHAIRPERSON
-            + "' where e.electionType = :type  and e.status in  (<status>) order by createDate asc")
+            + " e.lastUpdate, e.finalAccessVote, e.electionType,  e.dataUseLetter, e.dulName, e.archived, e.version from election e inner join vote v on v.electionId = e.electionId and lower(v.type) = 'chairperson' "
+            + " where lower(e.electionType) = lower(:type)  and lower(e.status) in (<status>) order by createDate asc")
     List<Election> findElectionsWithFinalVoteByTypeAndStatus(@Bind("type") String type, @BindList("status") List<String> status);
 
     @UseRowMapper(DatabaseElectionMapper.class)
@@ -211,21 +206,21 @@ public interface ElectionDAO extends Transactional<ElectionDAO> {
     List<Election> findElectionsByIds(@BindList("electionIds") List<Integer> electionIds);
 
     @UseRowMapper(DatabaseElectionMapper.class)
-    @SqlQuery("select *  from election e where  e.electionId = :electionId")
+    @SqlQuery("select * from election e where e.electionId = :electionId")
     Election findElectionById(@Bind("electionId") Integer electionId);
 
-    @SqlQuery("select electionId from election  where referenceId = :referenceId and status = '" + OPEN +"' and datasetId = :dataSetId")
+    @SqlQuery("select electionId from election  where referenceId = :referenceId and lower(status) = 'open' and datasetId = :dataSetId")
     Integer getOpenElectionByReferenceIdAndDataSet(@Bind("referenceId") String referenceId, @Bind("dataSetId") Integer dataSetId);
 
-    @SqlQuery("select datasetId from election  where electionId = :electionId ")
+    @SqlQuery("select datasetId from election where electionId = :electionId ")
     Integer getDatasetIdByElectionId(@Bind("electionId") Integer electionId);
 
     @UseRowMapper(DatabaseElectionMapper.class)
-    @SqlQuery("select distinct * from election where status = :status and electionType = :electionType")
+    @SqlQuery("select distinct * from election where lower(status) = lower(:status) and lower(electionType) = lower(:electionType)")
     List<Election> getElectionByTypeAndStatus(@Bind("electionType") String electionType, @Bind("status") String status);
 
     @UseRowMapper(DatabaseElectionMapper.class)
-    @SqlQuery("select distinct * from election  where  status = :status and  electionType = :electionType and referenceId = :referenceId")
+    @SqlQuery("select distinct * from election  where lower(status) = lower(:status) and lower(electionType) = lower(:electionType) and referenceId = :referenceId")
     List<Election> getElectionByTypeStatusAndReferenceId(@Bind("electionType") String electionType, @Bind("status") String status, @Bind("referenceId") String referenceId);
 
     @SqlUpdate("update election set status = :status, lastUpdate = :lastUpdate, finalAccessVote = :finalAccessVote where electionId = :electionId ")
@@ -234,35 +229,35 @@ public interface ElectionDAO extends Transactional<ElectionDAO> {
                             @Bind("lastUpdate") Date lastUpdate,
                             @Bind("finalAccessVote") Boolean finalAccessVote);
 
-    @SqlQuery("SELECT v.electionId FROM vote v, election e where v.dacUserId = :dacUserId and e.electionId = v.electionId and v.vote is null AND e.electionType = '"+ DATASET +"' AND e.status = '" + OPEN +"'")
+    @SqlQuery("SELECT v.electionId FROM vote v, election e where v.dacUserId = :dacUserId and e.electionId = v.electionId and v.vote is null AND lower(e.electionType) = 'dataset' AND lower(e.status) = 'open'")
     List<Integer> findDataSetOpenElectionIds(@Bind("dacUserId")Integer dacUserId);
 
     @SqlQuery("select distinct e.electionId,  e.datasetId, v.vote finalVote, e.status, e.createDate, e.referenceId, e.useRestriction, e.translatedUseRestriction, v.rationale finalRationale, v.createDate finalVoteDate, " +
-            "e.lastUpdate, e.finalAccessVote, e.electionType e.dataUseLetter, e.dulName, e.archived, e.version  from election e inner join vote v  on v.electionId = e.electionId where e.electionType = 'DataAccess' "+
-            " and v.type = 'FINAL'  and e.referenceId in (<darIds>) order by e.createDate asc")
+            "e.lastUpdate, e.finalAccessVote, e.electionType e.dataUseLetter, e.dulName, e.archived, e.version from election e inner join vote v  on v.electionId = e.electionId where lower(e.electionType) = 'dataaccess' "+
+            " and lower(v.type) = 'final'  and e.referenceId in (<darIds>) order by e.createDate asc")
     List<Election> findRequestElectionsByReferenceIds(@BindList("darIds") List<String> darIds);
 
     @SqlUpdate("update election set archived = true, lastUpdate = :lastUpdate where electionId = :electionId ")
     void archiveElectionById(@Bind("electionId") Integer electionId, @Bind("lastUpdate") Date lastUpdate);
 
     @SqlQuery("select distinct e.electionId, e.datasetId,  v.vote finalVote, e.status, e.createDate, e.referenceId, e.useRestriction, e.translatedUseRestriction, v.rationale finalRationale, v.createDate finalVoteDate, "
-            + " e.lastUpdate, e.finalAccessVote, e.electionType,  e.dataUseLetter, e.dulName, e.archived, e.version from election e inner join vote v on v.electionId = e.electionId and v.type = '"  + FINAL
-            + "' where v.vote = :isApproved  and e.electionType = 'DataAccess' order by createDate asc")
+            + " e.lastUpdate, e.finalAccessVote, e.electionType,  e.dataUseLetter, e.dulName, e.archived, e.version from election e inner join vote v on v.electionId = e.electionId and lower(v.type) = 'final' "
+            + " where v.vote = :isApproved and lower(e.electionType) = 'dataaccess' order by createDate asc")
     List<Election> findDataAccessClosedElectionsByFinalResult(@Bind("isApproved") Boolean isApproved);
 
-    @SqlQuery("select  MAX(v.createDate) createDate from election e inner join vote v on v.electionId = e.electionId and v.type = 'FINAL'" +
-            "where v.vote = true  and e.electionType = 'DataAccess' and referenceId = :referenceId GROUP BY e.createDate")
+    @SqlQuery("select  MAX(v.createDate) createDate from election e inner join vote v on v.electionId = e.electionId and lower(v.type) = 'final' " +
+            "where v.vote = true and lower(e.electionType) = 'dataaccess' and referenceId = :referenceId GROUP BY e.createDate")
     @UseRowMapper(DateMapper.class)
     Date findApprovalAccessElectionDate(@Bind("referenceId") String referenceId);
 
     @SqlQuery("select * from election e inner join (select referenceId, MAX(createDate) maxDate from election e where e.status = 'Closed' group by referenceId) " +
             "electionView ON electionView.maxDate = e.createDate AND electionView.referenceId = e.referenceId  " +
             "AND e.referenceId = :referenceId " +
-            "inner join vote v on v.electionId = e.electionId and v.vote = true  and v.type = 'CHAIRPERSON'")
+            "inner join vote v on v.electionId = e.electionId and v.vote = true  and lower(v.type) = 'chairperson' ")
     @UseRowMapper(DatabaseElectionMapper.class)
     Election findDULApprovedElectionByReferenceId(@Bind("referenceId") String referenceId);
 
-    @SqlQuery("select  v.vote from vote v where v.electionId = :electionId and v.type = 'FINAL'")
+    @SqlQuery("select  v.vote from vote v where v.electionId = :electionId and lower(v.type) = 'final' ")
     Boolean findFinalAccessVote(@Bind("electionId") Integer electionId);
 
     /**
@@ -295,11 +290,11 @@ public interface ElectionDAO extends Transactional<ElectionDAO> {
     @SqlQuery("select e1.* from election e1 " +
             "   inner join consentassociations a1 on a1.dataSetId = e1.datasetId " +
             "   inner join consents c1 on c1.consentId = a1.consentId and c1.dac_id = :dacId " +
-            "   where e1.status = '" + OPEN + "' " +
+            "   where lower(e1.status) = 'open' " +
             " union " +
             " select e2.* from election e2 " +
             "   inner join consents c2 on c2.consentId = e2.referenceId and c2.dac_id = :dacId " +
-            "   where e2.status = '" + OPEN + "' ")
+            "   where lower(e2.status) = 'open' ")
     List<Election> findOpenElectionsByDacId(@Bind("dacId") Integer dacId);
 
 }

--- a/src/main/java/org/broadinstitute/consent/http/service/DacService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DacService.java
@@ -186,6 +186,7 @@ public class DacService {
 
     public DACUser addDacMember(Role role, DACUser user, Dac dac) throws IllegalArgumentException {
         dacDAO.addDacMember(role.getRoleId(), user.getDacUserId(), dac.getDacId());
+        DACUser updatedUser = dacUserDAO.findDACUserById(user.getDacUserId());
         List<Election> elections = electionDAO.findOpenElectionsByDacId(dac.getDacId());
         for (Election e : elections) {
             Optional<ElectionType> type = EnumSet.allOf(ElectionType.class).stream().
@@ -194,9 +195,9 @@ public class DacService {
                 throw new IllegalArgumentException("Unable to determine election type for election id: " + e.getElectionId());
             }
             boolean isManualReview = type.get().equals(ElectionType.DATA_ACCESS) && hasUseRestriction(e.getReferenceId());
-            voteService.createVotesForUser(user, e, type.get(), isManualReview);
+            voteService.createVotesForUser(updatedUser, e, type.get(), isManualReview);
         }
-        return populatedUserById(user.getDacUserId());
+        return populatedUserById(updatedUser.getDacUserId());
     }
 
     public void removeDacMember(Role role, DACUser user, Dac dac) throws ForbiddenException {

--- a/src/main/java/org/broadinstitute/consent/http/service/DacService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DacService.java
@@ -144,7 +144,7 @@ public class DacService {
     }
 
     public DACUser findUserById(Integer id) throws IllegalArgumentException {
-        return populatedUserById(id);
+        return dacUserDAO.findDACUserById(id);
     }
 
     public Set<DataSetDTO> findDatasetsByDacId(AuthUser authUser, Integer dacId) {
@@ -197,7 +197,7 @@ public class DacService {
             boolean isManualReview = type.get().equals(ElectionType.DATA_ACCESS) && hasUseRestriction(e.getReferenceId());
             voteService.createVotesForUser(updatedUser, e, type.get(), isManualReview);
         }
-        return populatedUserById(updatedUser.getDacUserId());
+        return dacUserDAO.findDACUserById(updatedUser.getDacUserId());
     }
 
     public void removeDacMember(Role role, DACUser user, Dac dac) throws ForbiddenException {
@@ -231,12 +231,6 @@ public class DacService {
         projection.append(DarConstants.RESTRICTION, true);
         Document dar = mongo.getDataAccessRequestCollection().find(query).projection(projection).first();
         return dar.get(DarConstants.RESTRICTION) != null;
-    }
-
-    private DACUser populatedUserById(Integer userId) {
-        DACUser user = dacDAO.findUserById(userId);
-        user.setRoles(dacDAO.findUserRolesForUser(userId));
-        return user;
     }
 
     boolean isAuthUserAdmin(AuthUser authUser) {

--- a/src/main/java/org/broadinstitute/consent/http/service/DatabaseReviewResultsAPI.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatabaseReviewResultsAPI.java
@@ -5,13 +5,15 @@ import org.broadinstitute.consent.http.db.ElectionDAO;
 import org.broadinstitute.consent.http.db.VoteDAO;
 import org.broadinstitute.consent.http.enumeration.ElectionStatus;
 import org.broadinstitute.consent.http.enumeration.VoteType;
+import org.broadinstitute.consent.http.models.Consent;
 import org.broadinstitute.consent.http.models.Election;
 import org.broadinstitute.consent.http.models.ElectionReview;
-import org.broadinstitute.consent.http.models.Vote;
-import org.broadinstitute.consent.http.models.Consent;
 import org.broadinstitute.consent.http.models.ElectionReviewVote;
-import java.util.Arrays;
+import org.broadinstitute.consent.http.models.Vote;
+
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class DatabaseReviewResultsAPI extends AbstractReviewResultsAPI {
 
@@ -62,8 +64,10 @@ public class DatabaseReviewResultsAPI extends AbstractReviewResultsAPI {
 
     @Override
     public ElectionReview describeElectionReviewByReferenceId(String referenceId){
-        List<String> status = Arrays.asList(ElectionStatus.CLOSED.getValue(), ElectionStatus.FINAL.getValue());
-        Election election = electionDAO.findLastElectionWithFinalVoteByReferenceIdAndStatus(referenceId, status);
+        List<String> statuses = Stream.of(ElectionStatus.CLOSED.getValue(), ElectionStatus.FINAL.getValue()).
+                map(String::toLowerCase).
+                collect(Collectors.toList());
+        Election election = electionDAO.findLastElectionWithFinalVoteByReferenceIdAndStatus(referenceId, statuses);
         return getElectionReview(referenceId, election);
     }
 

--- a/src/main/java/org/broadinstitute/consent/http/service/DatabaseSummaryAPI.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatabaseSummaryAPI.java
@@ -37,7 +37,6 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collection;
 import java.util.HashMap;
@@ -47,6 +46,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collector;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.broadinstitute.consent.http.resources.Resource.CHAIRPERSON;
 
@@ -155,8 +155,10 @@ public class DatabaseSummaryAPI extends AbstractSummaryAPI {
 
 
     protected Summary getSummaryCases(String type) {
-        List<String> status = Arrays.asList(ElectionStatus.FINAL.getValue(), ElectionStatus.OPEN.getValue());
-        List<Election> openElections = electionDAO.findElectionsWithFinalVoteByTypeAndStatus(type, status);
+        List<String> statuses = Stream.of(ElectionStatus.FINAL.getValue(), ElectionStatus.OPEN.getValue()).
+                map(String::toLowerCase).
+                collect(Collectors.toList());
+        List<Election> openElections = electionDAO.findElectionsWithFinalVoteByTypeAndStatus(type, statuses);
         Integer totalPendingCases = openElections == null ? 0 : openElections.size();
         Integer totalPositiveCases = electionDAO.findTotalElectionsByTypeStatusAndVote(type, ElectionStatus.CLOSED.getValue(), true);
         Integer totalNegativeCases = electionDAO.findTotalElectionsByTypeStatusAndVote(type, ElectionStatus.CLOSED.getValue(), false);
@@ -164,8 +166,10 @@ public class DatabaseSummaryAPI extends AbstractSummaryAPI {
     }
 
     protected Summary getAccessSummaryCases(String type) {
-        List<String> status = Arrays.asList(ElectionStatus.FINAL.getValue(), ElectionStatus.OPEN.getValue());
-        List<Election> openElections = electionDAO.findElectionsWithFinalVoteByTypeAndStatus(type, status);
+        List<String> statuses = Stream.of(ElectionStatus.FINAL.getValue(), ElectionStatus.OPEN.getValue()).
+                map(String::toLowerCase).
+                collect(Collectors.toList());
+        List<Election> openElections = electionDAO.findElectionsWithFinalVoteByTypeAndStatus(type, statuses);
         Integer totalPendingCases = openElections == null ? 0 : openElections.size();
         Integer totalPositiveCases = voteDAO.findTotalFinalVoteByElectionTypeAndVote(type, true);
         Integer totalNegativeCases = voteDAO.findTotalFinalVoteByElectionTypeAndVote(type, false);
@@ -187,8 +191,10 @@ public class DatabaseSummaryAPI extends AbstractSummaryAPI {
         try {
             file = File.createTempFile("summary", ".txt");
             try (FileWriter summaryWriter = new FileWriter(file)) {
-                List<String> electionStatus = new ArrayList<>(Arrays.asList(ElectionStatus.CLOSED.getValue(), ElectionStatus.CANCELED.getValue()));
-                List<Election> reviewedElections = electionDAO.findElectionsWithFinalVoteByTypeAndStatus(ElectionType.TRANSLATE_DUL.getValue(), electionStatus);
+                List<String> statuses = Stream.of(ElectionStatus.CLOSED.getValue(), ElectionStatus.CANCELED.getValue()).
+                        map(String::toLowerCase).
+                        collect(Collectors.toList());
+                List<Election> reviewedElections = electionDAO.findElectionsWithFinalVoteByTypeAndStatus(ElectionType.TRANSLATE_DUL.getValue(), statuses);
                 if (!CollectionUtils.isEmpty(reviewedElections)) {
                     List<String> consentIds = reviewedElections.stream().map(e -> e.getReferenceId()).collect(Collectors.toList());
                     List<Integer> electionIds = reviewedElections.stream().map(e -> e.getElectionId()).collect(Collectors.toList());

--- a/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
@@ -200,7 +200,7 @@ public class DAOTestHelper {
                 RandomStringUtils.randomAlphabetic(i3);
         Integer userId = userDAO.insertDACUser(email, "display name", new Date());
         createdUserEmails.add(email);
-        return dacDAO.findUserById(userId);
+        return userDAO.findDACUserById(userId);
     }
 
     DACUser createUserWithRole(Integer roleId) {
@@ -215,7 +215,7 @@ public class DAOTestHelper {
         Integer userId = userDAO.insertDACUser(email, "display name", new Date());
         userRoleDAO.insertSingleUserRole(roleId, userId);
         createdUserEmails.add(email);
-        return dacDAO.findUserById(userId);
+        return userDAO.findDACUserById(userId);
     }
 
     DACUser createUserWithRoleInDac(Integer roleId, Integer dacId) {

--- a/src/test/java/org/broadinstitute/consent/http/db/UserDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/UserDAOTest.java
@@ -23,8 +23,10 @@ public class UserDAOTest extends DAOTestHelper {
 
     @Test
     public void testFindDACUserById() {
-        DACUser user = createUser();
+        DACUser user = createUserWithRole(UserRoles.ADMIN.getRoleId());
         Assert.assertNotNull(user);
+        Assert.assertFalse(user.getRoles().isEmpty());
+        Assert.assertEquals(UserRoles.ADMIN.getRoleId(), user.getRoles().get(0).getRoleId());
         DACUser user2 = userDAO.findDACUserById(user.getDacUserId());
         Assert.assertNotNull(user2);
         Assert.assertEquals(user.getEmail(), user2.getEmail());

--- a/src/test/java/org/broadinstitute/consent/http/service/DacServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DacServiceTest.java
@@ -210,7 +210,10 @@ public class DacServiceTest {
     @SuppressWarnings("unchecked")
     @Test
     public void testAddDacMember() {
-        when(dacDAO.findUserById(anyInt())).thenReturn(getDacUsers().get(0));
+        DACUser user = getDacUsers().get(0);
+        Dac dac = getDacs().get(0);
+        when(dacUserDAO.findDACUserById(any())).thenReturn(user);
+        when(dacDAO.findUserById(anyInt())).thenReturn(user);
         when(dacDAO.findUserRolesForUser(anyInt())).thenReturn(getDacUsers().get(0).getRoles());
         List<Election> elections = getElections().stream().
                 peek(e -> e.setElectionType(ElectionType.DATA_ACCESS.getValue())).
@@ -226,9 +229,9 @@ public class DacServiceTest {
         initService();
 
         Role role = new Role(UserRoles.CHAIRPERSON.getRoleId(), UserRoles.CHAIRPERSON.getRoleName());
-        DACUser user = service.addDacMember(role, getDacUsers().get(0), getDacs().get(0));
-        Assert.assertNotNull(user);
-        Assert.assertFalse(user.getRoles().isEmpty());
+        DACUser user1 = service.addDacMember(role, user, dac);
+        Assert.assertNotNull(user1);
+        Assert.assertFalse(user1.getRoles().isEmpty());
         verify(voteService, times(elections.size())).createVotesForUser(any(), any(), any(), anyBoolean());
     }
 

--- a/src/test/java/org/broadinstitute/consent/http/service/DacServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DacServiceTest.java
@@ -175,17 +175,6 @@ public class DacServiceTest {
     }
 
     @Test
-    public void testFindUserById() {
-        when(dacDAO.findUserById(anyInt())).thenReturn(getDacUsers().get(0));
-        when(dacDAO.findUserRolesForUser(anyInt())).thenReturn(getDacUsers().get(0).getRoles());
-        initService();
-
-        DACUser user = service.findUserById(1);
-        Assert.assertNotNull(user);
-        Assert.assertFalse(user.getRoles().isEmpty());
-    }
-
-    @Test
     public void testFindDatasetsByDacId() {
         when(dataSetDAO.findDatasetsByDac(anyInt())).thenReturn(Collections.singleton(getDatasetDTOs().get(0)));
         when(dacDAO.findDacsForEmail(anyString())).thenReturn(getDacs());
@@ -213,7 +202,7 @@ public class DacServiceTest {
         DACUser user = getDacUsers().get(0);
         Dac dac = getDacs().get(0);
         when(dacUserDAO.findDACUserById(any())).thenReturn(user);
-        when(dacDAO.findUserById(anyInt())).thenReturn(user);
+        when(dacUserDAO.findDACUserById(anyInt())).thenReturn(user);
         when(dacDAO.findUserRolesForUser(anyInt())).thenReturn(getDacUsers().get(0).getRoles());
         List<Election> elections = getElections().stream().
                 peek(e -> e.setElectionType(ElectionType.DATA_ACCESS.getValue())).


### PR DESCRIPTION
## Addresses
https://broadinstitute.atlassian.net/browse/DUOS-611

## Changes
* Lower case all of the election dao queries. There are case inconsistencies between several of the enum values that we use for elections and votes so lower casing both sides of the equality checks resolves that. This was the primary cause of the filed bug in that there was a type mismatch that caused an election query to return no results.
  * Discovered secondary bug while testing that when adding a user as a dac member, votes would sometimes not be created properly.
  * When creating votes for a dac chair/member, ensure that we're looking at the user with updated roles.
  * Update the primary get user by id query so it gets the roles.
  * Removed duplicate find user by id method.