### PR TITLE
[DUOS-614] Fix query to match running environments

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/ConsentDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/ConsentDAO.java
@@ -86,7 +86,7 @@ public interface ConsentDAO extends Transactional<ConsentDAO> {
             " sortDate = :sortDate, " +
             " translatedUseRestriction = :translatedUseRestriction, " +
             " groupName = :groupName, " +
-            " updated = (:updated::int)::bit(1), " +
+            " updated = :updated, " +
             " dac_id = :dacId " +
             " where consentId = :consentId " +
             " and active = true ")

--- a/src/main/resources/changesets/changelog-consent-42.0.xml
+++ b/src/main/resources/changesets/changelog-consent-42.0.xml
@@ -5,8 +5,9 @@
     http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <changeSet author="lforconesi" id="120">
+        <validCheckSum>ANY</validCheckSum>
         <addColumn tableName="consents">
-            <column name="updated" type="BIT(1)">
+            <column name="updated" type="boolean">
                 <constraints nullable="true"/>
             </column>
         </addColumn>


### PR DESCRIPTION
## Addresses
https://github.com/DataBiosphere/consent/pull/new/DUOS-614

This error shows up in the UI as an error when updating the consent:
![Screen Shot 2020-03-31 at 1 08 24 PM](https://user-images.githubusercontent.com/116679/78055106-0a441280-7351-11ea-8fb8-851b2f79f167.png)
And when that happens, the endpoint creates an election, but doesn't create votes for the election. See https://github.com/DataBiosphere/consent/pull/new/DUOS-616 for handling that error case.

## Changes
The query was written to pass tests, but the test db was not being set up correctly. It was being converted to bit instead of what it is in production environments, boolean. 