### PR TITLE
[DUOS-615][risk=no] Consolidate find user calls to single service

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
@@ -302,7 +302,7 @@ public class ConsentApplication extends Application<ConsentConfiguration> {
         env.jersey().register(new ConsentCasesResource(electionService, pendingCaseService));
         env.jersey().register(new DataRequestCasesResource(electionService, pendingCaseService));
         env.jersey().register(new DacResource(dacService));
-        env.jersey().register(DACUserResource.class);
+        env.jersey().register(new DACUserResource(userService));
         env.jersey().register(ElectionReviewResource.class);
         env.jersey().register(new ConsentManageResource(consentService));
         env.jersey().register(new ElectionResource(voteService));

--- a/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
@@ -331,7 +331,7 @@ public class ConsentApplication extends Application<ConsentConfiguration> {
         env.jersey().register(RolesAllowedDynamicFeature.class);
         env.jersey().register(new AuthValueFactoryProvider.Binder<>(AuthUser.class));
         env.jersey().register(new StatusResource(env.healthChecks()));
-        env.jersey().register(new DataRequestReportsResource(researcherService, DatabaseDACUserAPI.getInstance()));
+        env.jersey().register(new DataRequestReportsResource(researcherService, userService));
         // Register a listener to catch an application stop and clear out the API instance created above.
         // For normal exit, this is a no-op, but the junit tests that use the DropWizardAppRule will
         // repeatedly start and stop the application, all within the same JVM, causing the run() method to be

--- a/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
@@ -125,6 +125,7 @@ import org.broadinstitute.consent.http.service.NihServiceAPI;
 import org.broadinstitute.consent.http.service.PendingCaseService;
 import org.broadinstitute.consent.http.service.TranslateServiceImpl;
 import org.broadinstitute.consent.http.service.UseRestrictionConverter;
+import org.broadinstitute.consent.http.service.UserService;
 import org.broadinstitute.consent.http.service.VoteService;
 import org.broadinstitute.consent.http.service.ontology.ElasticSearchHealthCheck;
 import org.broadinstitute.consent.http.service.ontology.IndexOntologyService;
@@ -235,6 +236,7 @@ public class ConsentApplication extends Application<ConsentConfiguration> {
         final ElectionService electionService = injector.getProvider(ElectionService.class).get();
         final PendingCaseService pendingCaseService = injector.getProvider(PendingCaseService.class).get();
         final VoteService voteService = injector.getProvider(VoteService.class).get();
+        final UserService userService = injector.getProvider(UserService.class).get();
         DatabaseAuditServiceAPI.initInstance(workspaceAuditDAO, dacUserDAO, associationDAO);
         DatabaseDataAccessRequestAPI.initInstance(dataAccessRequestService, mongoInstance, useRestrictionConverter, electionDAO, consentDAO, voteDAO, dacUserDAO, dataSetDAO, researcherPropertyDAO);
         DatabaseConsentAPI.initInstance(jdbi, consentDAO, electionDAO, associationDAO, dataSetDAO);

--- a/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
@@ -255,7 +255,7 @@ public class ConsentApplication extends Application<ConsentConfiguration> {
         DatabaseMatchProcessAPI.initInstance(consentDAO, dataAccessRequestService);
         DatabaseSummaryAPI.initInstance(dataAccessRequestService, voteDAO, electionDAO, dacUserDAO, consentDAO, dataSetDAO, matchDAO);
         DACUserRolesHandler.initInstance(dacUserDAO, userRoleDAO, electionDAO, voteDAO, dataSetAssociationDAO, AbstractEmailNotifierAPI.getInstance(), AbstractDataAccessRequestAPI.getInstance());
-        DatabaseDACUserAPI.initInstance(dacUserDAO, userRoleDAO, AbstractUserRolesHandler.getInstance(), researcherPropertyDAO);
+        DatabaseDACUserAPI.initInstance(dacUserDAO, userRoleDAO, AbstractUserRolesHandler.getInstance(), researcherPropertyDAO, userService);
         DatabaseVoteAPI.initInstance(voteDAO, electionDAO);
         DatabaseReviewResultsAPI.initInstance(electionDAO, voteDAO, consentDAO);
         TranslateServiceImpl.initInstance(useRestrictionConverter);
@@ -284,17 +284,17 @@ public class ConsentApplication extends Application<ConsentConfiguration> {
         final IndexOntologyService indexOntologyService = new IndexOntologyService(config.getElasticSearchConfiguration());
         final IndexerService indexerService = new IndexerServiceImpl(storeOntologyService, indexOntologyService);
         final ResearcherService researcherService = new ResearcherPropertyHandler(researcherPropertyDAO, dacUserDAO, AbstractEmailNotifierAPI.getInstance());
-        final UserAPI userAPI = new DatabaseUserAPI(dacUserDAO, userRoleDAO, AbstractUserRolesHandler.getInstance(), researcherPropertyDAO);
+        final UserAPI userAPI = new DatabaseUserAPI(dacUserDAO, userRoleDAO, AbstractUserRolesHandler.getInstance(), researcherPropertyDAO, userService);
         final NihAuthApi nihAuthApi = new NihServiceAPI(researcherService);
 
         // Now register our resources.
         env.jersey().register(new IndexerResource(indexerService, googleStore));
-        env.jersey().register(new DataAccessRequestResource(dataAccessRequestService, googleStore));
+        env.jersey().register(new DataAccessRequestResource(dataAccessRequestService, googleStore, userService));
         env.jersey().register(DataSetResource.class);
         env.jersey().register(DataSetAssociationsResource.class);
-        env.jersey().register(ConsentResource.class);
-        env.jersey().register(ConsentAssociationResource.class);
-        env.jersey().register(new DataUseLetterResource(googleStore));
+        env.jersey().register(new ConsentResource(userService));
+        env.jersey().register(new ConsentAssociationResource(userService));
+        env.jersey().register(new DataUseLetterResource(googleStore, userService));
         env.jersey().register(new ConsentElectionResource(consentService, dacService, voteService));
         env.jersey().register(new DataRequestElectionResource(voteService));
         env.jersey().register(ConsentVoteResource.class);
@@ -310,12 +310,12 @@ public class ConsentApplication extends Application<ConsentConfiguration> {
         env.jersey().register(EmailNotifierResource.class);
         env.jersey().register(HelpReportResource.class);
         env.jersey().register(ApprovalExpirationTimeResource.class);
-        env.jersey().register(new UserResource(userAPI));
-        env.jersey().register(new ResearcherResource(researcherService, userAPI));
+        env.jersey().register(new UserResource(userAPI, userService));
+        env.jersey().register(new ResearcherResource(researcherService, userService));
         env.jersey().register(WorkspaceResource.class);
         env.jersey().register(new DataAccessAgreementResource(googleStore, researcherService));
         env.jersey().register(new SwaggerResource(config.getGoogleAuthentication()));
-        env.jersey().register(new NihAccountResource(nihAuthApi, DatabaseDACUserAPI.getInstance()));
+        env.jersey().register(new NihAccountResource(nihAuthApi, userService));
         env.jersey().register(injector.getInstance(VersionResource.class));
 
         // Authentication filters

--- a/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
@@ -195,13 +195,12 @@ public class ConsentModule extends AbstractModule {
     PendingCaseService providesPendingCaseService() {
         return new PendingCaseService(
                 providesConsentDAO(),
-                providesDACUserDAO(),
                 providesDataAccessRequestService(),
                 providesDataSetDAO(),
                 providesElectionDAO(),
-                providesUserRoleDAO(),
                 providesVoteDAO(),
                 providesDacService(),
+                providesUserService(),
                 providesVoteService());
     }
 

--- a/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
@@ -37,6 +37,7 @@ import org.broadinstitute.consent.http.service.DataAccessRequestService;
 import org.broadinstitute.consent.http.service.ElectionService;
 import org.broadinstitute.consent.http.service.PendingCaseService;
 import org.broadinstitute.consent.http.service.UseRestrictionConverter;
+import org.broadinstitute.consent.http.service.UserService;
 import org.broadinstitute.consent.http.service.VoteService;
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.gson2.Gson2Plugin;
@@ -305,6 +306,11 @@ public class ConsentModule extends AbstractModule {
     @Provides
     AssociationDAO providesAssociationDAO() {
         return associationDAO;
+    }
+
+    @Provides
+    UserService providesUserService() {
+        return new UserService(providesDACUserDAO(), providesUserRoleDAO());
     }
 
     // Private helpers

--- a/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
@@ -178,6 +178,7 @@ public class ConsentModule extends AbstractModule {
                 providesElectionDAO(),
                 providesMongo(),
                 providesDacService(),
+                providesUserService(),
                 providesVoteDAO());
     }
 
@@ -255,6 +256,7 @@ public class ConsentModule extends AbstractModule {
                 providesDataSetDAO(),
                 providesElectionDAO(),
                 providesDataAccessRequestDAO(),
+                providesUserService(),
                 providesVoteService());
     }
 

--- a/src/main/java/org/broadinstitute/consent/http/enumeration/UserRoles.java
+++ b/src/main/java/org/broadinstitute/consent/http/enumeration/UserRoles.java
@@ -36,4 +36,13 @@ public enum UserRoles {
         return null;
     }
 
+    public static UserRoles getUserRoleFromId(Integer roleId) {
+        for (UserRoles e : UserRoles.values()) {
+            if (e.getRoleId().equals(roleId)) {
+                return e;
+            }
+        }
+        return null;
+    }
+
 }

--- a/src/main/java/org/broadinstitute/consent/http/resources/ConsentAssociationResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/ConsentAssociationResource.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.consent.http.resources;
 
+import com.google.inject.Inject;
 import io.dropwizard.auth.Auth;
 import org.apache.log4j.Logger;
 import org.broadinstitute.consent.http.enumeration.AssociationType;
@@ -9,6 +10,7 @@ import org.broadinstitute.consent.http.models.DACUser;
 import org.broadinstitute.consent.http.models.dto.Error;
 import org.broadinstitute.consent.http.service.AbstractConsentAPI;
 import org.broadinstitute.consent.http.service.ConsentAPI;
+import org.broadinstitute.consent.http.service.UserService;
 import org.broadinstitute.consent.http.service.users.AbstractDACUserAPI;
 import org.broadinstitute.consent.http.service.users.DACUserAPI;
 
@@ -35,10 +37,13 @@ public class ConsentAssociationResource extends Resource {
 
     private final ConsentAPI api;
     private final DACUserAPI dacUserAPI;
+    private final UserService userService;
 
-    public ConsentAssociationResource() {
+    @Inject
+    public ConsentAssociationResource(UserService userService) {
         this.api = AbstractConsentAPI.getInstance();
         this.dacUserAPI = AbstractDACUserAPI.getInstance();
+        this.userService = userService;
     }
 
     @POST
@@ -54,7 +59,7 @@ public class ConsentAssociationResource extends Resource {
                 }
             }
             logger().debug(msg);
-            DACUser dacUser = dacUserAPI.describeDACUserByEmail(user.getName());
+            DACUser dacUser = userService.findUserByEmail(user.getName());
             List<ConsentAssociation> result = api.createAssociation(consentId, body, dacUser.getEmail());
             URI assocURI = buildConsentAssociationURI(consentId);
             return Response.ok(result).location(assocURI).build();

--- a/src/main/java/org/broadinstitute/consent/http/resources/DACUserResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DACUserResource.java
@@ -3,6 +3,7 @@ package org.broadinstitute.consent.http.resources;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import com.google.inject.Inject;
 import io.dropwizard.auth.Auth;
 import org.apache.log4j.Logger;
 import org.broadinstitute.consent.http.authentication.GoogleUser;
@@ -10,6 +11,7 @@ import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.AuthUser;
 import org.broadinstitute.consent.http.models.DACUser;
 import org.broadinstitute.consent.http.models.dto.Error;
+import org.broadinstitute.consent.http.service.UserService;
 import org.broadinstitute.consent.http.service.users.AbstractDACUserAPI;
 import org.broadinstitute.consent.http.service.users.DACUserAPI;
 import org.broadinstitute.consent.http.service.users.handler.DACUserRolesHandler;
@@ -43,10 +45,13 @@ import java.util.stream.Collectors;
 public class DACUserResource extends Resource {
 
     private final DACUserAPI dacUserAPI;
+    private final UserService userService;
     protected final Logger logger = Logger.getLogger(this.getClass().getName());
 
-    public DACUserResource() {
+    @Inject
+    public DACUserResource(UserService userService) {
         this.dacUserAPI = AbstractDACUserAPI.getInstance();
+        this.userService = userService;
     }
 
     @POST
@@ -78,7 +83,7 @@ public class DACUserResource extends Resource {
     @Produces("application/json")
     @PermitAll
     public DACUser describe(@PathParam("email") String email) {
-        return dacUserAPI.describeDACUserByEmail(email);
+        return userService.findUserByEmail(email);
     }
 
     @PUT
@@ -229,7 +234,7 @@ public class DACUserResource extends Resource {
 
     private DACUser findByAuthUser(AuthUser user) {
         GoogleUser googleUser = user.getGoogleUser();
-        DACUser dacUser = dacUserAPI.describeDACUserByEmail(googleUser.getEmail());
+        DACUser dacUser = userService.findUserByEmail(googleUser.getEmail());
         if (dacUser == null) {
             throw new NotFoundException("Unable to find user :" + user.getName());
         }

--- a/src/main/java/org/broadinstitute/consent/http/resources/DACUserResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DACUserResource.java
@@ -127,7 +127,7 @@ public class DACUserResource extends Resource {
     public Response updateStatus(@PathParam("userId") Integer userId, String json) {
         Optional<String> statusOpt = getMemberNameStringFromJson(json, "status");
         Optional<String> rationaleOpt = getMemberNameStringFromJson(json, "rationale");
-        DACUser user = dacUserAPI.describeDACUserById(userId);
+        DACUser user = userService.findUserById(userId);
         if (statusOpt.isPresent()) {
             try {
                 user = dacUserAPI.updateUserStatus(statusOpt.get(), userId);
@@ -153,7 +153,7 @@ public class DACUserResource extends Resource {
     @RolesAllowed(ADMIN)
     public Response getUserStatus(@PathParam("userId") Integer userId) {
         try {
-            return Response.ok(dacUserAPI.describeDACUserById(userId)).build();
+            return Response.ok(userService.findUserById(userId)).build();
         } catch (Exception e) {
             return createExceptionResponse(e);
         }

--- a/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
@@ -177,7 +177,7 @@ public class DataAccessRequestResource extends Resource {
         Integer userId = obtainUserId(dar);
         DACUser user = null;
         try {
-            user = dacUserAPI.describeDACUserById(userId);
+            user = userService.findUserById(userId);
         } catch (NotFoundException e) {
             logger.severe("Unable to find userId: " + userId + " for data access request id: " + id);
         }

--- a/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
@@ -35,6 +35,7 @@ import org.broadinstitute.consent.http.service.ElectionAPI;
 import org.broadinstitute.consent.http.service.EmailNotifierAPI;
 import org.broadinstitute.consent.http.service.MatchProcessAPI;
 import org.broadinstitute.consent.http.service.TranslateService;
+import org.broadinstitute.consent.http.service.UserService;
 import org.broadinstitute.consent.http.service.users.AbstractDACUserAPI;
 import org.broadinstitute.consent.http.service.users.DACUserAPI;
 import org.broadinstitute.consent.http.service.validate.AbstractUseRestrictionValidatorAPI;
@@ -90,9 +91,10 @@ public class DataAccessRequestResource extends Resource {
     private final DACUserAPI dacUserAPI;
     private final ElectionAPI electionAPI;
     private final GCSStore store;
+    private final UserService userService;
 
     @Inject
-    public DataAccessRequestResource(DataAccessRequestService dataAccessRequestService, GCSStore store) {
+    public DataAccessRequestResource(DataAccessRequestService dataAccessRequestService, GCSStore store, UserService userService) {
         this.dataAccessRequestService = dataAccessRequestService;
         this.dataAccessRequestAPI = AbstractDataAccessRequestAPI.getInstance();
         this.consentAPI = AbstractConsentAPI.getInstance();
@@ -102,6 +104,7 @@ public class DataAccessRequestResource extends Resource {
         this.dacUserAPI = AbstractDACUserAPI.getInstance();
         this.electionAPI = AbstractElectionAPI.getInstance();
         this.store = store;
+        this.userService = userService;
     }
 
     @POST
@@ -350,7 +353,7 @@ public class DataAccessRequestResource extends Resource {
     public Response describeManageDataAccessRequests(@QueryParam("userId") Integer userId, @Auth AuthUser authUser) {
         // If a user id is provided, ensure that is the current user.
         if (userId != null) {
-            DACUser user = dacUserAPI.describeDACUserByEmail(authUser.getName());
+            DACUser user = userService.findUserByEmail(authUser.getName());
             if (!user.getDacUserId().equals(userId)) {
                 throw new BadRequestException("Unable to query for other users' information.");
             }

--- a/src/main/java/org/broadinstitute/consent/http/resources/DataRequestReportsResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataRequestReportsResource.java
@@ -1,9 +1,10 @@
 package org.broadinstitute.consent.http.resources;
 
+import com.google.inject.Inject;
 import org.broadinstitute.consent.http.models.DACUser;
 import org.broadinstitute.consent.http.service.AbstractDataAccessRequestAPI;
 import org.broadinstitute.consent.http.service.DataAccessRequestAPI;
-import org.broadinstitute.consent.http.service.users.DACUserAPI;
+import org.broadinstitute.consent.http.service.UserService;
 import org.broadinstitute.consent.http.service.users.handler.ResearcherService;
 import org.broadinstitute.consent.http.util.DarConstants;
 import org.broadinstitute.consent.http.util.DarUtil;
@@ -26,13 +27,13 @@ public class DataRequestReportsResource extends Resource {
 
     private final ResearcherService researcherService;
 
-    private final DACUserAPI dacUserAPI;
+    private final UserService userService;
 
-
-    public DataRequestReportsResource(ResearcherService researcherService, DACUserAPI dacUserAPI) {
+    @Inject
+    public DataRequestReportsResource(ResearcherService researcherService, UserService userService) {
         this.darApi = AbstractDataAccessRequestAPI.getInstance();
         this.researcherService = researcherService;
-        this.dacUserAPI = dacUserAPI;
+        this.userService = userService;
     }
 
     // TODO: Undocumented
@@ -43,7 +44,7 @@ public class DataRequestReportsResource extends Resource {
     public Response downloadDataRequestPdfFile(@PathParam("requestId") String requestId) {
         Document dar = darApi.describeDataAccessRequestById(requestId);
         Map<String, String> researcherProperties = researcherService.describeResearcherPropertiesForDAR(dar.getInteger(DarConstants.USER_ID));
-        DACUser user = dacUserAPI.describeDACUserById(dar.getInteger(DarConstants.USER_ID));
+        DACUser user = userService.findUserById(dar.getInteger(DarConstants.USER_ID));
         String fileName = "FullDARApplication-" + dar.getString(DarConstants.DAR_CODE);
         try {
             String sDUR = darApi.getStructuredDURForPdf(dar);

--- a/src/main/java/org/broadinstitute/consent/http/resources/NihAccountResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/NihAccountResource.java
@@ -1,29 +1,30 @@
 package org.broadinstitute.consent.http.resources;
 
+import com.google.inject.Inject;
 import io.dropwizard.auth.Auth;
 import org.broadinstitute.consent.http.models.AuthUser;
 import org.broadinstitute.consent.http.models.DACUser;
 import org.broadinstitute.consent.http.models.NIHUserAccount;
 import org.broadinstitute.consent.http.service.NihAuthApi;
-import org.broadinstitute.consent.http.service.users.DACUserAPI;
+import org.broadinstitute.consent.http.service.UserService;
 
 import javax.annotation.security.RolesAllowed;
-
-import javax.ws.rs.Path;
-import javax.ws.rs.POST;
-import javax.ws.rs.Produces;
 import javax.ws.rs.DELETE;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
 import javax.ws.rs.core.Response;
 
 @Path("api/nih")
 public class NihAccountResource extends Resource {
 
     private NihAuthApi nihAuthApi;
-    private DACUserAPI dacUserAPI;
+    private UserService userService;
 
-    public NihAccountResource(NihAuthApi nihAuthApi, DACUserAPI dacUserAPI) {
+    @Inject
+    public NihAccountResource(NihAuthApi nihAuthApi, UserService userService) {
         this.nihAuthApi = nihAuthApi;
-        this.dacUserAPI = dacUserAPI;
+        this.userService = userService;
     }
 
     @POST
@@ -31,7 +32,7 @@ public class NihAccountResource extends Resource {
     @RolesAllowed(RESEARCHER)
     public Response registerResearcher(NIHUserAccount nihAccount, @Auth AuthUser user) {
         try {
-            dacUserAPI.describeDACUserByEmail(user.getName());
+            userService.findUserByEmail(user.getName());
             return Response.ok(nihAuthApi.authenticateNih(nihAccount, user)).build();
         } catch (Exception e){
             return createExceptionResponse(e);
@@ -43,7 +44,7 @@ public class NihAccountResource extends Resource {
     @RolesAllowed(RESEARCHER)
     public Response deleteNihAccount(@Auth AuthUser user) {
         try {
-            DACUser dacUser = dacUserAPI.describeDACUserByEmail(user.getName());
+            DACUser dacUser = userService.findUserByEmail(user.getName());
             nihAuthApi.deleteNihAccountById(dacUser.getDacUserId());
             return Response.ok().build();
         } catch (Exception e) {

--- a/src/main/java/org/broadinstitute/consent/http/resources/ResearcherResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/ResearcherResource.java
@@ -1,12 +1,13 @@
 package org.broadinstitute.consent.http.resources;
 
+import com.google.inject.Inject;
 import io.dropwizard.auth.Auth;
 import org.broadinstitute.consent.http.authentication.GoogleUser;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.AuthUser;
 import org.broadinstitute.consent.http.models.DACUser;
 import org.broadinstitute.consent.http.models.ResearcherProperty;
-import org.broadinstitute.consent.http.service.users.UserAPI;
+import org.broadinstitute.consent.http.service.UserService;
 import org.broadinstitute.consent.http.service.users.handler.ResearcherService;
 
 import javax.annotation.security.PermitAll;
@@ -35,11 +36,12 @@ import java.util.stream.Stream;
 public class ResearcherResource extends Resource {
 
     private ResearcherService researcherService;
-    private final UserAPI userAPI;
+    private final UserService userService;
 
-    public ResearcherResource(ResearcherService researcherService, UserAPI userAPI) {
+    @Inject
+    public ResearcherResource(ResearcherService researcherService, UserService userService) {
         this.researcherService = researcherService;
-        this.userAPI = userAPI;
+        this.userService = userService;
     }
 
     @POST
@@ -110,7 +112,7 @@ public class ResearcherResource extends Resource {
 
     private DACUser findByAuthUser(AuthUser user) {
         GoogleUser googleUser = user.getGoogleUser();
-        DACUser dacUser = userAPI.findUserByEmail(googleUser.getEmail());
+        DACUser dacUser = userService.findUserByEmail(googleUser.getEmail());
         if (dacUser == null) {
             throw new NotFoundException("Unable to find user :" + user.getName());
         }

--- a/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
@@ -1,6 +1,7 @@
 package org.broadinstitute.consent.http.resources;
 
 
+import com.google.inject.Inject;
 import io.dropwizard.auth.Auth;
 import org.broadinstitute.consent.http.authentication.GoogleUser;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
@@ -8,6 +9,7 @@ import org.broadinstitute.consent.http.models.AuthUser;
 import org.broadinstitute.consent.http.models.DACUser;
 import org.broadinstitute.consent.http.models.UserRole;
 import org.broadinstitute.consent.http.models.dto.Error;
+import org.broadinstitute.consent.http.service.UserService;
 import org.broadinstitute.consent.http.service.users.UserAPI;
 
 import javax.annotation.security.PermitAll;
@@ -25,9 +27,12 @@ import java.util.Collections;
 public class UserResource extends Resource {
 
     private final UserAPI userAPI;
+    private final UserService userService;
 
-    public UserResource(UserAPI userAPI) {
+    @Inject
+    public UserResource(UserAPI userAPI, UserService userService) {
         this.userAPI = userAPI;
+        this.userService = userService;
     }
 
     @POST
@@ -42,7 +47,7 @@ public class UserResource extends Resource {
                     entity(new Error("Unable to verify google identity", Response.Status.BAD_REQUEST.getStatusCode())).
                     build();
         }
-        if (userAPI.findUserByEmail(googleUser.getEmail()) != null) {
+        if (userService.findUserByEmail(googleUser.getEmail()) != null) {
             return Response.
                     status(Response.Status.CONFLICT).
                     entity(new Error("Registered user exists", Response.Status.CONFLICT.getStatusCode())).

--- a/src/main/java/org/broadinstitute/consent/http/service/DacService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DacService.java
@@ -46,16 +46,19 @@ public class DacService {
     private DataSetDAO dataSetDAO;
     private ElectionDAO electionDAO;
     private DataAccessRequestDAO dataAccessRequestDAO;
+    private UserService userService;
     private VoteService voteService;
 
     @Inject
     public DacService(DacDAO dacDAO, DACUserDAO dacUserDAO, DataSetDAO dataSetDAO,
-                      ElectionDAO electionDAO, DataAccessRequestDAO dataAccessRequestDAO, VoteService voteService) {
+                      ElectionDAO electionDAO, DataAccessRequestDAO dataAccessRequestDAO, UserService userService,
+                      VoteService voteService) {
         this.dacDAO = dacDAO;
         this.dacUserDAO = dacUserDAO;
         this.dataSetDAO = dataSetDAO;
         this.electionDAO = electionDAO;
         this.dataAccessRequestDAO = dataAccessRequestDAO;
+        this.userService = userService;
         this.voteService = voteService;
     }
 
@@ -143,7 +146,7 @@ public class DacService {
     }
 
     public DACUser findUserById(Integer id) throws IllegalArgumentException {
-        return dacUserDAO.findDACUserById(id);
+        return userService.findUserById(id);
     }
 
     public Set<DataSetDTO> findDatasetsByDacId(AuthUser authUser, Integer dacId) {
@@ -185,7 +188,7 @@ public class DacService {
 
     public DACUser addDacMember(Role role, DACUser user, Dac dac) throws IllegalArgumentException {
         dacDAO.addDacMember(role.getRoleId(), user.getDacUserId(), dac.getDacId());
-        DACUser updatedUser = dacUserDAO.findDACUserById(user.getDacUserId());
+        DACUser updatedUser = userService.findUserById(user.getDacUserId());
         List<Election> elections = electionDAO.findOpenElectionsByDacId(dac.getDacId());
         for (Election e : elections) {
             Optional<ElectionType> type = EnumSet.allOf(ElectionType.class).stream().
@@ -196,7 +199,7 @@ public class DacService {
             boolean isManualReview = type.get().equals(ElectionType.DATA_ACCESS) && hasUseRestriction(e.getReferenceId());
             voteService.createVotesForUser(updatedUser, e, type.get(), isManualReview);
         }
-        return dacUserDAO.findDACUserById(updatedUser.getDacUserId());
+        return userService.findUserById(updatedUser.getDacUserId());
     }
 
     public void removeDacMember(Role role, DACUser user, Dac dac) throws ForbiddenException {

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
@@ -62,6 +62,7 @@ public class DataAccessRequestService {
     private ElectionDAO electionDAO;
     private MongoConsentDB mongo;
     private DacService dacService;
+    private UserService userService;
     private VoteDAO voteDAO;
 
     private static final Gson gson = new GsonBuilder().setDateFormat("MMM d, yyyy").create();
@@ -73,7 +74,7 @@ public class DataAccessRequestService {
     @Inject
     public DataAccessRequestService(ConsentDAO consentDAO, DataAccessRequestDAO dataAccessRequestDAO, DacDAO dacDAO, DACUserDAO dacUserDAO, DataSetDAO dataSetDAO,
                                     ElectionDAO electionDAO, MongoConsentDB mongo, DacService dacService,
-                                    VoteDAO voteDAO) {
+                                    UserService userService, VoteDAO voteDAO) {
         this.consentDAO = consentDAO;
         this.dacDAO = dacDAO;
         this.dacUserDAO = dacUserDAO;
@@ -82,6 +83,7 @@ public class DataAccessRequestService {
         this.electionDAO = electionDAO;
         this.mongo = mongo;
         this.dacService = dacService;
+        this.userService = userService;
         this.voteDAO = voteDAO;
     }
 
@@ -300,7 +302,7 @@ public class DataAccessRequestService {
             List<Document> documents,
             Map<String, Election> referenceIdElectionMap,
             AuthUser authUser) {
-        DACUser user = dacUserDAO.findDACUserByEmail(authUser.getName());
+        DACUser user = userService.findUserByEmail(authUser.getName());
         List<DataAccessRequestManage> requestsManage = new ArrayList<>();
         List<Integer> datasetIdsForDatasetsToApprove = documents.stream().
                 map(d -> DarUtil.getIntegerList(d, DarConstants.DATASET_ID)).

--- a/src/main/java/org/broadinstitute/consent/http/service/UserService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/UserService.java
@@ -14,7 +14,7 @@ public class UserService {
         this.roleDAO = roleDAO;
     }
 
-    DACUser findUserById(Integer id) {
+    public DACUser findUserById(Integer id) {
         DACUser dacUser = userDAO.findDACUserById(id);
         if (dacUser == null) {
             return null;
@@ -23,7 +23,7 @@ public class UserService {
         return dacUser;
     }
 
-    DACUser findUserByEmail(String email) {
+    public DACUser findUserByEmail(String email) {
         DACUser dacUser = userDAO.findDACUserByEmail(email);
         if (dacUser == null) {
             return null;

--- a/src/main/java/org/broadinstitute/consent/http/service/UserService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/UserService.java
@@ -1,0 +1,35 @@
+package org.broadinstitute.consent.http.service;
+
+import org.broadinstitute.consent.http.db.DACUserDAO;
+import org.broadinstitute.consent.http.db.UserRoleDAO;
+import org.broadinstitute.consent.http.models.DACUser;
+
+public class UserService {
+
+    private DACUserDAO userDAO;
+    private UserRoleDAO roleDAO;
+
+    public UserService(DACUserDAO userDAO, UserRoleDAO roleDAO) {
+        this.userDAO = userDAO;
+        this.roleDAO = roleDAO;
+    }
+
+    DACUser findUserById(Integer id) {
+        DACUser dacUser = userDAO.findDACUserById(id);
+        if (dacUser == null) {
+            return null;
+        }
+        dacUser.setRoles(roleDAO.findRolesByUserId(dacUser.getDacUserId()));
+        return dacUser;
+    }
+
+    DACUser findUserByEmail(String email) {
+        DACUser dacUser = userDAO.findDACUserByEmail(email);
+        if (dacUser == null) {
+            return null;
+        }
+        dacUser.setRoles(roleDAO.findRolesByUserId(dacUser.getDacUserId()));
+        return dacUser;
+    }
+
+}

--- a/src/main/java/org/broadinstitute/consent/http/service/UserService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/UserService.java
@@ -4,6 +4,8 @@ import org.broadinstitute.consent.http.db.DACUserDAO;
 import org.broadinstitute.consent.http.db.UserRoleDAO;
 import org.broadinstitute.consent.http.models.DACUser;
 
+import javax.ws.rs.NotFoundException;
+
 public class UserService {
 
     private DACUserDAO userDAO;
@@ -14,19 +16,19 @@ public class UserService {
         this.roleDAO = roleDAO;
     }
 
-    public DACUser findUserById(Integer id) {
+    public DACUser findUserById(Integer id) throws NotFoundException {
         DACUser dacUser = userDAO.findDACUserById(id);
         if (dacUser == null) {
-            return null;
+            throw new NotFoundException("Unable to find user with id: " + id);
         }
         dacUser.setRoles(roleDAO.findRolesByUserId(dacUser.getDacUserId()));
         return dacUser;
     }
 
-    public DACUser findUserByEmail(String email) {
+    public DACUser findUserByEmail(String email) throws NotFoundException {
         DACUser dacUser = userDAO.findDACUserByEmail(email);
         if (dacUser == null) {
-            return null;
+            throw new NotFoundException("Unable to find user with email: " + email);
         }
         dacUser.setRoles(roleDAO.findRolesByUserId(dacUser.getDacUserId()));
         return dacUser;

--- a/src/main/java/org/broadinstitute/consent/http/service/users/AbstractDACUserAPI.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/users/AbstractDACUserAPI.java
@@ -1,9 +1,11 @@
 package org.broadinstitute.consent.http.service.users;
 
 /**
+ * @deprecated Use UserService
  * Implement a skeleton for ConsentAPI interface that implements the singleton
  * object management.
  */
+@Deprecated
 public abstract class AbstractDACUserAPI implements DACUserAPI {
 
     /**

--- a/src/main/java/org/broadinstitute/consent/http/service/users/DACUserAPI.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/users/DACUserAPI.java
@@ -11,6 +11,10 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * @deprecated Use UserService
+ */
+@Deprecated
 public interface DACUserAPI {
 
     DACUser createDACUser(DACUser dacUser) throws IllegalArgumentException;

--- a/src/main/java/org/broadinstitute/consent/http/service/users/DACUserAPI.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/users/DACUserAPI.java
@@ -21,8 +21,6 @@ public interface DACUserAPI {
 
     List<DACUser> describeAdminUsersThatWantToReceiveMails();
 
-    DACUser describeDACUserById(Integer id) throws IllegalArgumentException;
-
     DACUser updateDACUserById(Map<String, DACUser> dac, Integer userId) throws IllegalArgumentException, NotFoundException, UserRoleHandlerException, MessagingException, IOException, TemplateException;
 
     void deleteDACUser(String email) throws IllegalArgumentException, NotFoundException;

--- a/src/main/java/org/broadinstitute/consent/http/service/users/DACUserAPI.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/users/DACUserAPI.java
@@ -19,8 +19,6 @@ public interface DACUserAPI {
 
     DACUser createDACUser(DACUser dacUser) throws IllegalArgumentException;
 
-    DACUser describeDACUserByEmail(String email) throws NotFoundException;
-
     List<DACUser> describeAdminUsersThatWantToReceiveMails();
 
     DACUser describeDACUserById(Integer id) throws IllegalArgumentException;

--- a/src/main/java/org/broadinstitute/consent/http/service/users/DatabaseDACUserAPI.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/users/DatabaseDACUserAPI.java
@@ -24,8 +24,10 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 /**
+ * @deprecated Use UserService
  * Implementation class for DACUserAPI on top of DACUserDAO database support.
  */
+@Deprecated
 public class DatabaseDACUserAPI extends AbstractDACUserAPI {
 
     protected final DACUserDAO dacUserDAO;

--- a/src/main/java/org/broadinstitute/consent/http/service/users/DatabaseDACUserAPI.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/users/DatabaseDACUserAPI.java
@@ -83,16 +83,6 @@ public class DatabaseDACUserAPI extends AbstractDACUserAPI {
     }
 
     @Override
-    public DACUser describeDACUserById(Integer id) throws IllegalArgumentException {
-        DACUser dacUser = dacUserDAO.findDACUserById(id);
-        if (dacUser == null) {
-            throw new NotFoundException("Could not find dacUser for specified id : " + id);
-        }
-        dacUser.setRoles(userRoleDAO.findRolesByUserId(dacUser.getDacUserId()));
-        return dacUser;
-    }
-
-    @Override
     public DACUser updateUserStatus(String status, Integer userId) {
         Integer statusId = RoleStatus.getValueByStatus(status);
         validateExistentUserById(userId);
@@ -100,7 +90,7 @@ public class DatabaseDACUserAPI extends AbstractDACUserAPI {
             throw new IllegalArgumentException(status + " is not a valid status.");
         }
         dacUserDAO.updateUserStatus(statusId, userId);
-        return describeDACUserById(userId);
+        return userService.findUserById(userId);
     }
 
     @Override
@@ -110,7 +100,7 @@ public class DatabaseDACUserAPI extends AbstractDACUserAPI {
             throw new IllegalArgumentException("Rationale is required.");
         }
         dacUserDAO.updateUserRationale(rationale, userId);
-        return describeDACUserById(userId);
+        return userService.findUserById(userId);
     }
 
     @Override

--- a/src/main/java/org/broadinstitute/consent/http/service/users/DatabaseUserAPI.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/users/DatabaseUserAPI.java
@@ -13,7 +13,10 @@ import org.broadinstitute.consent.http.service.users.handler.UserHandlerAPI;
 import javax.ws.rs.BadRequestException;
 import java.util.List;
 
-
+/**
+ * @deprecated Use UserService
+ */
+@Deprecated
 public class DatabaseUserAPI extends DatabaseDACUserAPI implements UserAPI {
 
     public DatabaseUserAPI(DACUserDAO userDAO, UserRoleDAO roleDAO, UserHandlerAPI userHandlerAPI, ResearcherPropertyDAO researcherPropertyDAO) {

--- a/src/main/java/org/broadinstitute/consent/http/service/users/DatabaseUserAPI.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/users/DatabaseUserAPI.java
@@ -8,6 +8,7 @@ import org.broadinstitute.consent.http.db.UserRoleDAO;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.DACUser;
 import org.broadinstitute.consent.http.models.UserRole;
+import org.broadinstitute.consent.http.service.UserService;
 import org.broadinstitute.consent.http.service.users.handler.UserHandlerAPI;
 
 import javax.ws.rs.BadRequestException;
@@ -19,8 +20,8 @@ import java.util.List;
 @Deprecated
 public class DatabaseUserAPI extends DatabaseDACUserAPI implements UserAPI {
 
-    public DatabaseUserAPI(DACUserDAO userDAO, UserRoleDAO roleDAO, UserHandlerAPI userHandlerAPI, ResearcherPropertyDAO researcherPropertyDAO) {
-        super(userDAO, roleDAO, userHandlerAPI, researcherPropertyDAO);
+    public DatabaseUserAPI(DACUserDAO userDAO, UserRoleDAO roleDAO, UserHandlerAPI userHandlerAPI, ResearcherPropertyDAO researcherPropertyDAO, UserService userService) {
+        super(userDAO, roleDAO, userHandlerAPI, researcherPropertyDAO, userService);
     }
 
     @Override
@@ -28,16 +29,6 @@ public class DatabaseUserAPI extends DatabaseDACUserAPI implements UserAPI {
         validateEmail(user.getEmail());
         validateRoles(user.getRoles());
         return createDACUser(user);
-    }
-
-    @Override
-    public DACUser findUserByEmail(String email) {
-        DACUser dacUser = dacUserDAO.findDACUserByEmail(email);
-        if (dacUser == null) {
-            return null;
-        }
-        dacUser.setRoles(userRoleDAO.findRolesByUserId(dacUser.getDacUserId()));
-        return dacUser;
     }
 
     private void validateEmail(String emailToValidate) {

--- a/src/main/java/org/broadinstitute/consent/http/service/users/UserAPI.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/users/UserAPI.java
@@ -12,6 +12,4 @@ public interface UserAPI {
 
     DACUser createUser(DACUser user);
 
-    DACUser findUserByEmail(String email);
-
 }

--- a/src/main/java/org/broadinstitute/consent/http/service/users/UserAPI.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/users/UserAPI.java
@@ -3,6 +3,10 @@ package org.broadinstitute.consent.http.service.users;
 import com.google.inject.ImplementedBy;
 import org.broadinstitute.consent.http.models.DACUser;
 
+/**
+ * @deprecated Use UserService
+ */
+@Deprecated
 @ImplementedBy(DatabaseUserAPI.class)
 public interface UserAPI {
 

--- a/src/test/java/org/broadinstitute/consent/http/resources/ConsentAssociationResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/ConsentAssociationResourceTest.java
@@ -6,6 +6,7 @@ import org.broadinstitute.consent.http.models.ConsentAssociation;
 import org.broadinstitute.consent.http.models.DACUser;
 import org.broadinstitute.consent.http.service.AbstractConsentAPI;
 import org.broadinstitute.consent.http.service.ConsentAPI;
+import org.broadinstitute.consent.http.service.UserService;
 import org.broadinstitute.consent.http.service.users.AbstractDACUserAPI;
 import org.broadinstitute.consent.http.service.users.DACUserAPI;
 import org.junit.Assert;
@@ -40,6 +41,9 @@ public class ConsentAssociationResourceTest {
     @Mock
     private DACUserAPI dacUserAPI;
 
+    @Mock
+    private UserService userService;
+
     private ConsentAssociationResource resource;
 
     @Before
@@ -52,7 +56,7 @@ public class ConsentAssociationResourceTest {
     }
 
     private void initResource() {
-        resource = new ConsentAssociationResource();
+        resource = new ConsentAssociationResource(userService);
     }
 
     @Test
@@ -60,7 +64,7 @@ public class ConsentAssociationResourceTest {
         DACUser user = new DACUser();
         user.setEmail("test");
         when(api.hasWorkspaceAssociation(any())).thenReturn(false);
-        when(dacUserAPI.describeDACUserByEmail(any())).thenReturn(user);
+        when(userService.findUserByEmail(any())).thenReturn(user);
         when(api.createAssociation(any(), any(), any())).thenReturn(Collections.emptyList());
         initResource();
         AuthUser authUser = new AuthUser(user.getEmail());
@@ -75,7 +79,7 @@ public class ConsentAssociationResourceTest {
         DACUser user = new DACUser();
         user.setEmail("test");
         when(api.hasWorkspaceAssociation(any())).thenReturn(false);
-        when(dacUserAPI.describeDACUserByEmail(any())).thenReturn(user);
+        when(userService.findUserByEmail(any())).thenReturn(user);
         when(api.createAssociation(any(), any(), any())).thenReturn(Collections.emptyList());
         initResource();
         AuthUser authUser = new AuthUser(user.getEmail());

--- a/src/test/java/org/broadinstitute/consent/http/resources/ConsentResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/ConsentResourceTest.java
@@ -14,6 +14,7 @@ import org.broadinstitute.consent.http.service.ConsentAPI;
 import org.broadinstitute.consent.http.service.ElectionAPI;
 import org.broadinstitute.consent.http.service.MatchAPI;
 import org.broadinstitute.consent.http.service.MatchProcessAPI;
+import org.broadinstitute.consent.http.service.UserService;
 import org.broadinstitute.consent.http.service.users.AbstractDACUserAPI;
 import org.broadinstitute.consent.http.service.users.DACUserAPI;
 import org.broadinstitute.consent.http.service.validate.AbstractUseRestrictionValidatorAPI;
@@ -67,6 +68,8 @@ public class ConsentResourceTest {
     @Mock
     private ElectionAPI electionAPI;
     @Mock
+    private UserService userService;
+    @Mock
     UriInfo info;
     @Mock
     UriBuilder builder;
@@ -96,7 +99,7 @@ public class ConsentResourceTest {
         when(AbstractMatchAPI.getInstance()).thenReturn(matchAPI);
         when(AbstractUseRestrictionValidatorAPI.getInstance()).thenReturn(useRestrictionValidatorAPI);
         when(AbstractElectionAPI.getInstance()).thenReturn(electionAPI);
-        resource = new ConsentResource();
+        resource = new ConsentResource(userService);
     }
 
     @Test
@@ -108,7 +111,7 @@ public class ConsentResourceTest {
         consent.setConsentId(UUID.randomUUID().toString());
         consent.setDataUse(new DataUseBuilder().setGeneralUse(true).build());
 
-        when(dacUserAPI.describeDACUserByEmail(any())).thenReturn(dacUser);
+        when(userService.findUserByEmail(any())).thenReturn(dacUser);
         doNothing().when(useRestrictionValidatorAPI).validateUseRestriction(any());
         when(api.create(any())).thenReturn(consent);
         doNothing().when(auditServiceAPI).saveConsentAudit(any(), any(), any(), any());
@@ -130,7 +133,7 @@ public class ConsentResourceTest {
         consent.setConsentId(UUID.randomUUID().toString());
         consent.setDataUse(new DataUseBuilder().setGeneralUse(true).build());
 
-        when(dacUserAPI.describeDACUserByEmail(any())).thenReturn(dacUser);
+        when(userService.findUserByEmail(any())).thenReturn(dacUser);
         doNothing().when(useRestrictionValidatorAPI).validateUseRestriction(any());
         when(api.retrieve(any())).thenReturn(consent);
         when(api.update(any(), any())).thenReturn(consent);
@@ -159,7 +162,7 @@ public class ConsentResourceTest {
         AuthUser user = new AuthUser(dacUser.getEmail());
         Consent consent = new Consent();
         consent.setConsentId(UUID.randomUUID().toString());
-        when(dacUserAPI.describeDACUserByEmail(any())).thenReturn(dacUser);
+        when(userService.findUserByEmail(any())).thenReturn(dacUser);
         doNothing().when(useRestrictionValidatorAPI).validateUseRestriction(any());
         initResource();
 
@@ -175,7 +178,7 @@ public class ConsentResourceTest {
         Consent consent = new Consent();
         consent.setConsentId(UUID.randomUUID().toString());
         when(api.retrieve(any())).thenReturn(consent);
-        when(dacUserAPI.describeDACUserByEmail(any())).thenReturn(dacUser);
+        when(userService.findUserByEmail(any())).thenReturn(dacUser);
         doNothing().when(useRestrictionValidatorAPI).validateUseRestriction(any());
         initResource();
 
@@ -193,7 +196,7 @@ public class ConsentResourceTest {
         consent.setConsentId(UUID.randomUUID().toString());
         consent.setDataUseLetter(UUID.randomUUID().toString());
         when(api.retrieve(any())).thenReturn(consent);
-        when(dacUserAPI.describeDACUserByEmail(any())).thenReturn(dacUser);
+        when(userService.findUserByEmail(any())).thenReturn(dacUser);
         doNothing().when(useRestrictionValidatorAPI).validateUseRestriction(any());
         initResource();
 
@@ -210,7 +213,7 @@ public class ConsentResourceTest {
         consent.setConsentId(UUID.randomUUID().toString());
         consent.setDataUseLetter(UUID.randomUUID().toString());
         when(api.retrieve(any())).thenReturn(consent);
-        when(dacUserAPI.describeDACUserByEmail(any())).thenReturn(dacUser);
+        when(userService.findUserByEmail(any())).thenReturn(dacUser);
         doNothing().when(useRestrictionValidatorAPI).validateUseRestriction(any());
         initResource();
 

--- a/src/test/java/org/broadinstitute/consent/http/resources/DACUserResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DACUserResourceTest.java
@@ -145,7 +145,7 @@ public class DACUserResourceTest {
 
     @Test
     public void testGetUserStatusWithInvalidId() {
-        when(dacUserAPI.describeDACUserById(any())).thenThrow(new NotFoundException());
+        when(userService.findUserById(any())).thenThrow(new NotFoundException());
         initResource();
         Response response = resource.getUserStatus(RandomUtils.nextInt(1, 10));
         assertEquals(404, response.getStatus());
@@ -157,7 +157,7 @@ public class DACUserResourceTest {
         user.setDacUserId(RandomUtils.nextInt(1, 10));
         user.setStatus("pending");
         user.setRationale("rationale");
-        when(dacUserAPI.describeDACUserById(any())).thenReturn(user);
+        when(userService.findUserById(any())).thenReturn(user);
         when(dacUserAPI.updateUserStatus(any(), any())).thenReturn(user);
         when(dacUserAPI.updateUserRationale(any(), any())).thenReturn(user);
         initResource();
@@ -169,7 +169,7 @@ public class DACUserResourceTest {
     public void testUpdateStatusUserNotFound() {
         DACUser user = createDacUser(UserRoles.RESEARCHER);
         user.setDacUserId(RandomUtils.nextInt(1, 10));
-        when(dacUserAPI.describeDACUserById(any())).thenThrow(new NotFoundException());
+        when(userService.findUserById(any())).thenThrow(new NotFoundException());
         initResource();
         Response response = resource.updateStatus(user.getDacUserId(), user.toString());
         assertEquals(200, response.getStatus());
@@ -180,7 +180,7 @@ public class DACUserResourceTest {
         DACUser user = createDacUser(UserRoles.RESEARCHER);
         user.setDacUserId(RandomUtils.nextInt(1, 10));
         user.setStatus("Bad Status");
-        when(dacUserAPI.describeDACUserById(any())).thenReturn(user);
+        when(userService.findUserById(any())).thenReturn(user);
         when(dacUserAPI.updateUserStatus(any(), any())).thenThrow(new IllegalArgumentException());
         initResource();
         Response response = resource.updateStatus(user.getDacUserId(), user.toString());

--- a/src/test/java/org/broadinstitute/consent/http/resources/DACUserResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DACUserResourceTest.java
@@ -11,6 +11,7 @@ import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.AuthUser;
 import org.broadinstitute.consent.http.models.DACUser;
 import org.broadinstitute.consent.http.models.UserRole;
+import org.broadinstitute.consent.http.service.UserService;
 import org.broadinstitute.consent.http.service.users.AbstractDACUserAPI;
 import org.broadinstitute.consent.http.service.users.DACUserAPI;
 import org.broadinstitute.consent.http.service.users.handler.DACUserRolesHandler;
@@ -49,6 +50,9 @@ public class DACUserResourceTest {
     DACUserAPI dacUserAPI;
 
     @Mock
+    UserService userService;
+
+    @Mock
     private UriInfo uriInfo;
 
     @Mock
@@ -73,7 +77,7 @@ public class DACUserResourceTest {
 
     private void initResource() {
         when(AbstractDACUserAPI.getInstance()).thenReturn(dacUserAPI);
-        resource = new DACUserResource();
+        resource = new DACUserResource(userService);
     }
 
     @Test
@@ -83,7 +87,7 @@ public class DACUserResourceTest {
         JsonElement userJson = new Gson().toJsonTree(researcher);
         json.add(DACUserRolesHandler.UPDATED_USER_KEY, userJson);
 
-        when(dacUserAPI.describeDACUserByEmail(any())).thenReturn(researcher);
+        when(userService.findUserByEmail(any())).thenReturn(researcher);
         when(dacUserAPI.updateDACUserById(any(), anyInt())).thenReturn(researcher);
         doNothing().when(dacUserAPI).updateEmailPreference(anyBoolean(), anyInt());
         initResource();
@@ -99,7 +103,7 @@ public class DACUserResourceTest {
         JsonElement userJson = new Gson().toJsonTree(researcher);
         json.add(DACUserRolesHandler.UPDATED_USER_KEY, userJson);
 
-        when(dacUserAPI.describeDACUserByEmail(any())).thenReturn(researcher);
+        when(userService.findUserByEmail(any())).thenReturn(researcher);
         when(dacUserAPI.updateDACUserById(any(), anyInt())).thenReturn(researcher);
         doNothing().when(dacUserAPI).updateEmailPreference(anyBoolean(), anyInt());
         initResource();
@@ -115,7 +119,7 @@ public class DACUserResourceTest {
         JsonElement userJson = new Gson().toJsonTree(admin);
         json.add(DACUserRolesHandler.UPDATED_USER_KEY, userJson);
 
-        when(dacUserAPI.describeDACUserByEmail(any())).thenReturn(admin);
+        when(userService.findUserByEmail(any())).thenReturn(admin);
         when(dacUserAPI.updateDACUserById(any(), anyInt())).thenReturn(admin);
         doNothing().when(dacUserAPI).updateEmailPreference(anyBoolean(), anyInt());
         initResource();
@@ -134,7 +138,7 @@ public class DACUserResourceTest {
 
     @Test(expected = NotFoundException.class)
     public void testRetrieveDACUserWithInvalidEmail() {
-        when(dacUserAPI.describeDACUserByEmail(any())).thenThrow(new NotFoundException());
+        when(userService.findUserByEmail(any())).thenThrow(new NotFoundException());
         initResource();
         resource.describe(RandomStringUtils.random(10));
     }

--- a/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceTest.java
@@ -15,6 +15,7 @@ import org.broadinstitute.consent.http.service.DataAccessRequestAPI;
 import org.broadinstitute.consent.http.service.DataAccessRequestService;
 import org.broadinstitute.consent.http.service.DataSetAPI;
 import org.broadinstitute.consent.http.service.ElectionAPI;
+import org.broadinstitute.consent.http.service.UserService;
 import org.broadinstitute.consent.http.service.users.AbstractDACUserAPI;
 import org.broadinstitute.consent.http.service.users.DACUserAPI;
 import org.broadinstitute.consent.http.service.validate.AbstractUseRestrictionValidatorAPI;
@@ -65,6 +66,8 @@ public class DataAccessRequestResourceTest {
     DataAccessRequestAPI dataAccessRequestAPI;
     @Mock
     DataSetAPI dataSetAPI;
+    @Mock
+    UserService userService;
 
     private DataAccessRequestResource resource;
     private Document dar;
@@ -98,7 +101,7 @@ public class DataAccessRequestResourceTest {
         when(AbstractDataSetAPI.getInstance()).thenReturn(dataSetAPI);
         when(AbstractDACUserAPI.getInstance()).thenReturn(dacUserAPI);
         when(AbstractElectionAPI.getInstance()).thenReturn(electionAPI);
-        resource = new DataAccessRequestResource(dataAccessRequestService, store);
+        resource = new DataAccessRequestResource(dataAccessRequestService, store, userService);
         Consent consent = resource.describeConsentForDAR(darId);
         assertNotNull(consent);
     }
@@ -121,7 +124,7 @@ public class DataAccessRequestResourceTest {
         when(AbstractDataSetAPI.getInstance()).thenReturn(dataSetAPI);
         when(AbstractDACUserAPI.getInstance()).thenReturn(dacUserAPI);
         when(AbstractElectionAPI.getInstance()).thenReturn(electionAPI);
-        resource = new DataAccessRequestResource(dataAccessRequestService, store);
+        resource = new DataAccessRequestResource(dataAccessRequestService, store, userService);
         Consent consent = resource.describeConsentForDAR(darId);
         assertNotNull(consent);
     }
@@ -139,7 +142,7 @@ public class DataAccessRequestResourceTest {
         when(AbstractConsentAPI.getInstance()).thenReturn(consentAPI);
         when(AbstractDACUserAPI.getInstance()).thenReturn(dacUserAPI);
         when(AbstractElectionAPI.getInstance()).thenReturn(electionAPI);
-        resource = new DataAccessRequestResource(dataAccessRequestService, store);
+        resource = new DataAccessRequestResource(dataAccessRequestService, store, userService);
         resource.describeConsentForDAR(darId);
     }
 
@@ -155,7 +158,7 @@ public class DataAccessRequestResourceTest {
         when(AbstractDataAccessRequestAPI.getInstance()).thenReturn(dataAccessRequestAPI);
         when(AbstractDACUserAPI.getInstance()).thenReturn(dacUserAPI);
         when(AbstractElectionAPI.getInstance()).thenReturn(electionAPI);
-        resource = new DataAccessRequestResource(dataAccessRequestService, store);
+        resource = new DataAccessRequestResource(dataAccessRequestService, store, userService);
         resource.describeConsentForDAR(darId);
     }
 

--- a/src/test/java/org/broadinstitute/consent/http/resources/DataUseLetterResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DataUseLetterResourceTest.java
@@ -11,6 +11,7 @@ import org.broadinstitute.consent.http.service.AbstractAuditServiceAPI;
 import org.broadinstitute.consent.http.service.AbstractConsentAPI;
 import org.broadinstitute.consent.http.service.AuditServiceAPI;
 import org.broadinstitute.consent.http.service.ConsentAPI;
+import org.broadinstitute.consent.http.service.UserService;
 import org.broadinstitute.consent.http.service.users.AbstractDACUserAPI;
 import org.broadinstitute.consent.http.service.users.DACUserAPI;
 import org.glassfish.jersey.media.multipart.FormDataBodyPart;
@@ -55,6 +56,8 @@ public class DataUseLetterResourceTest {
     private DACUserAPI dacUserAPI;
     @Mock
     private AuditServiceAPI auditServiceAPI;
+    @Mock
+    private UserService userService;
 
     private AuthUser user = new AuthUser("oauthuser@broadinstitute.org");
     private DataUseLetterResource resource;
@@ -71,11 +74,11 @@ public class DataUseLetterResourceTest {
         DACUser dacUser = new DACUser();
         dacUser.setEmail(user.getName());
         dacUser.setDacUserId(1);
-        when(dacUserAPI.describeDACUserByEmail(any())).thenReturn(dacUser);
+        when(userService.findUserByEmail(any())).thenReturn(dacUser);
         when(AbstractConsentAPI.getInstance()).thenReturn(consentAPI);
         when(AbstractDACUserAPI.getInstance()).thenReturn(dacUserAPI);
         when(AbstractAuditServiceAPI.getInstance()).thenReturn(auditServiceAPI);
-        resource = new DataUseLetterResource(store);
+        resource = new DataUseLetterResource(store, userService);
     }
 
     @Test

--- a/src/test/java/org/broadinstitute/consent/http/resources/ResearcherResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/ResearcherResourceTest.java
@@ -5,7 +5,7 @@ import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.AuthUser;
 import org.broadinstitute.consent.http.models.DACUser;
 import org.broadinstitute.consent.http.models.UserRole;
-import org.broadinstitute.consent.http.service.users.UserAPI;
+import org.broadinstitute.consent.http.service.UserService;
 import org.broadinstitute.consent.http.service.users.handler.ResearcherService;
 import org.junit.Assert;
 import org.junit.Before;
@@ -32,7 +32,7 @@ public class ResearcherResourceTest {
     ResearcherService researcherService;
 
     @Mock
-    UserAPI userAPI;
+    UserService userService;
 
     @Mock
     private UriInfo uriInfo;
@@ -57,7 +57,7 @@ public class ResearcherResourceTest {
     }
 
     private void initResource() {
-        resource = new ResearcherResource(researcherService, userAPI);
+        resource = new ResearcherResource(researcherService, userService);
     }
 
     @Test
@@ -116,7 +116,7 @@ public class ResearcherResourceTest {
         DACUser authedDacUser = new DACUser();
         authedDacUser.setDacUserId(1);
         authedDacUser.addRole(new UserRole(UserRoles.ADMIN.getRoleId(), UserRoles.ADMIN.getRoleName()));
-        when(userAPI.findUserByEmail(anyString())).thenReturn(authedDacUser);
+        when(userService.findUserByEmail(anyString())).thenReturn(authedDacUser);
         initResource();
 
         // Request properties for self
@@ -134,7 +134,7 @@ public class ResearcherResourceTest {
         DACUser authedDacUser = new DACUser();
         authedDacUser.setDacUserId(1);
         authedDacUser.addRole(new UserRole(UserRoles.CHAIRPERSON.getRoleId(), UserRoles.CHAIRPERSON.getRoleName()));
-        when(userAPI.findUserByEmail(anyString())).thenReturn(authedDacUser);
+        when(userService.findUserByEmail(anyString())).thenReturn(authedDacUser);
         initResource();
 
         // Request properties for self
@@ -152,7 +152,7 @@ public class ResearcherResourceTest {
         DACUser authedDacUser = new DACUser();
         authedDacUser.setDacUserId(1);
         authedDacUser.addRole(new UserRole(UserRoles.RESEARCHER.getRoleId(), UserRoles.RESEARCHER.getRoleName()));
-        when(userAPI.findUserByEmail(anyString())).thenReturn(authedDacUser);
+        when(userService.findUserByEmail(anyString())).thenReturn(authedDacUser);
         initResource();
 
         // Request properties for self
@@ -170,7 +170,7 @@ public class ResearcherResourceTest {
         DACUser authedDacUser = new DACUser();
         authedDacUser.setDacUserId(1);
         authedDacUser.addRole(new UserRole(UserRoles.ADMIN.getRoleId(), UserRoles.ADMIN.getRoleName()));
-        when(userAPI.findUserByEmail(anyString())).thenReturn(authedDacUser);
+        when(userService.findUserByEmail(anyString())).thenReturn(authedDacUser);
         initResource();
 
         // Request properties for self
@@ -188,7 +188,7 @@ public class ResearcherResourceTest {
         DACUser authedDacUser = new DACUser();
         authedDacUser.setDacUserId(1);
         authedDacUser.addRole(new UserRole(UserRoles.RESEARCHER.getRoleId(), UserRoles.RESEARCHER.getRoleName()));
-        when(userAPI.findUserByEmail(anyString())).thenReturn(authedDacUser);
+        when(userService.findUserByEmail(anyString())).thenReturn(authedDacUser);
         initResource();
 
         // Request properties for self

--- a/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
@@ -5,6 +5,7 @@ import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.AuthUser;
 import org.broadinstitute.consent.http.models.DACUser;
 import org.broadinstitute.consent.http.models.UserRole;
+import org.broadinstitute.consent.http.service.UserService;
 import org.broadinstitute.consent.http.service.users.UserAPI;
 import org.junit.Assert;
 import org.junit.Before;
@@ -29,6 +30,9 @@ public class UserResourceTest {
     @Mock
     private UserAPI userAPI;
 
+    @Mock
+    private UserService userService;
+
     private UserResource userResource;
 
     @Mock
@@ -51,7 +55,7 @@ public class UserResourceTest {
         when(uriInfo.getRequestUriBuilder()).thenReturn(uriBuilder);
         when(uriBuilder.path(Mockito.anyString())).thenReturn(uriBuilder);
         when(uriBuilder.build(anyString())).thenReturn(new URI("http://localhost:8180/dacuser/api"));
-        userResource = new UserResource(userAPI);
+        userResource = new UserResource(userAPI, userService);
     }
 
     @Test
@@ -66,7 +70,7 @@ public class UserResourceTest {
         roles.add(researcher);
         roles.add(admin);
         user.setRoles(roles);
-        when(userAPI.findUserByEmail(user.getEmail())).thenReturn(user);
+        when(userService.findUserByEmail(user.getEmail())).thenReturn(user);
         Response response = userResource.createResearcher(uriInfo, authUser);
         Assert.assertEquals(Response.Status.CONFLICT.getStatusCode(), response.getStatus());
     }

--- a/src/test/java/org/broadinstitute/consent/http/service/DacServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DacServiceTest.java
@@ -71,6 +71,9 @@ public class DacServiceTest {
     DataAccessRequestDAO dataAccessRequestDAO;
 
     @Mock
+    private UserService userService;
+
+    @Mock
     private VoteService voteService;
 
     @Before
@@ -79,7 +82,7 @@ public class DacServiceTest {
     }
 
     private void initService() {
-        service = new DacService(dacDAO, dacUserDAO, dataSetDAO, electionDAO, dataAccessRequestDAO, voteService);
+        service = new DacService(dacDAO, dacUserDAO, dataSetDAO, electionDAO, dataAccessRequestDAO, userService, voteService);
     }
 
     @Test
@@ -191,9 +194,9 @@ public class DacServiceTest {
     public void testAddDacMember() {
         DACUser user = getDacUsers().get(0);
         Dac dac = getDacs().get(0);
-        when(dacUserDAO.findDACUserById(any())).thenReturn(user);
-        when(dacUserDAO.findDACUserById(anyInt())).thenReturn(user);
-        when(dacDAO.findUserRolesForUser(anyInt())).thenReturn(getDacUsers().get(0).getRoles());
+        when(userService.findUserById(any())).thenReturn(user);
+        when(userService.findUserById(any())).thenReturn(user);
+        when(dacDAO.findUserRolesForUser(any())).thenReturn(getDacUsers().get(0).getRoles());
         List<Election> elections = getElections().stream().
                 peek(e -> e.setElectionType(ElectionType.DATA_ACCESS.getValue())).
                 peek(e -> e.setReferenceId(new ObjectId().toHexString())).

--- a/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
@@ -12,6 +12,7 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+import javax.ws.rs.NotFoundException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -74,14 +75,13 @@ public class UserServiceTest {
         assertEquals(2, u.getRoles().size());
     }
 
-    @Test
+    @Test(expected = NotFoundException.class)
     public void testFindUserByIdNotFound() {
         DACUser u = createUser();
         when(userDAO.findDACUserById(any())).thenReturn(null);
         initService();
 
-        DACUser user = service.findUserById(u.getDacUserId());
-        assertNull(user);
+        service.findUserById(u.getDacUserId());
     }
 
     @Test
@@ -115,14 +115,13 @@ public class UserServiceTest {
         assertEquals(2, u.getRoles().size());
     }
 
-    @Test
+    @Test(expected = NotFoundException.class)
     public void testFindUserByEmailNotFound() {
         DACUser u = createUser();
         when(userDAO.findDACUserByEmail(any())).thenReturn(null);
         initService();
 
-        DACUser user = service.findUserByEmail(u.getEmail());
-        assertNull(user);
+        service.findUserByEmail(u.getEmail());
     }
 
     private DACUser createUser() {

--- a/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
@@ -1,0 +1,149 @@
+package org.broadinstitute.consent.http.service;
+
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.RandomUtils;
+import org.broadinstitute.consent.http.db.DACUserDAO;
+import org.broadinstitute.consent.http.db.UserRoleDAO;
+import org.broadinstitute.consent.http.enumeration.UserRoles;
+import org.broadinstitute.consent.http.models.DACUser;
+import org.broadinstitute.consent.http.models.UserRole;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.when;
+
+public class UserServiceTest {
+
+    @Mock
+    private DACUserDAO userDAO;
+
+    @Mock
+    private UserRoleDAO roleDAO;
+
+    private UserService service;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    private void initService() {
+        service = new UserService(userDAO, roleDAO);
+    }
+
+    @Test
+    public void testFindUserByIdNoRoles() {
+        DACUser u = createUser();
+        when(userDAO.findDACUserById(any())).thenReturn(u);
+        when(roleDAO.findRolesByUserId(any())).thenReturn(Collections.emptyList());
+        initService();
+
+        DACUser user = service.findUserById(u.getDacUserId());
+        assertNotNull(user);
+        assertEquals(u.getEmail(), user.getEmail());
+        assertTrue(u.getRoles().isEmpty());
+    }
+
+    @Test
+    public void testFindUserByIdWithRoles() {
+        DACUser u = createUser();
+        List<UserRole> roleList = Arrays.asList(
+                createRole(UserRoles.RESEARCHER.getRoleId()),
+                createRole(UserRoles.MEMBER.getRoleId())
+        );
+        when(userDAO.findDACUserById(any())).thenReturn(u);
+        when(roleDAO.findRolesByUserId(any())).thenReturn(roleList);
+        initService();
+
+        DACUser user = service.findUserById(u.getDacUserId());
+        assertNotNull(user);
+        assertEquals(u.getEmail(), user.getEmail());
+        assertFalse(u.getRoles().isEmpty());
+        assertEquals(2, u.getRoles().size());
+    }
+
+    @Test
+    public void testFindUserByIdNotFound() {
+        DACUser u = createUser();
+        when(userDAO.findDACUserById(any())).thenReturn(null);
+        initService();
+
+        DACUser user = service.findUserById(u.getDacUserId());
+        assertNull(user);
+    }
+
+    @Test
+    public void testFindUserByEmailNoRoles() {
+        DACUser u = createUser();
+        when(userDAO.findDACUserByEmail(any())).thenReturn(u);
+        when(roleDAO.findRolesByUserId(any())).thenReturn(Collections.emptyList());
+        initService();
+
+        DACUser user = service.findUserByEmail(u.getEmail());
+        assertNotNull(user);
+        assertEquals(u.getEmail(), user.getEmail());
+        assertTrue(u.getRoles().isEmpty());
+    }
+
+    @Test
+    public void testFindUserByEmailWithRoles() {
+        DACUser u = createUser();
+        List<UserRole> roleList = Arrays.asList(
+                createRole(UserRoles.RESEARCHER.getRoleId()),
+                createRole(UserRoles.MEMBER.getRoleId())
+        );
+        when(userDAO.findDACUserByEmail(any())).thenReturn(u);
+        when(roleDAO.findRolesByUserId(any())).thenReturn(roleList);
+        initService();
+
+        DACUser user = service.findUserByEmail(u.getEmail());
+        assertNotNull(user);
+        assertEquals(u.getEmail(), user.getEmail());
+        assertFalse(u.getRoles().isEmpty());
+        assertEquals(2, u.getRoles().size());
+    }
+
+    @Test
+    public void testFindUserByEmailNotFound() {
+        DACUser u = createUser();
+        when(userDAO.findDACUserByEmail(any())).thenReturn(null);
+        initService();
+
+        DACUser user = service.findUserByEmail(u.getEmail());
+        assertNull(user);
+    }
+
+    private DACUser createUser() {
+        DACUser u = new DACUser();
+        int i1 = RandomUtils.nextInt(5, 10);
+        int i2 = RandomUtils.nextInt(5, 10);
+        int i3 = RandomUtils.nextInt(3, 5);
+        String email = RandomStringUtils.randomAlphabetic(i1) +
+                "@" +
+                RandomStringUtils.randomAlphabetic(i2) +
+                "." +
+                RandomStringUtils.randomAlphabetic(i3);
+        u.setEmail(email);
+        u.setDacUserId(RandomUtils.nextInt(1, 100));
+        return u;
+    }
+
+    private UserRole createRole(int roleId) {
+        UserRoles rolesEnum = UserRoles.getUserRoleFromId(roleId);
+        assert rolesEnum != null;
+        return new UserRole(rolesEnum.getRoleId(), rolesEnum.getRoleName());
+    }
+
+}

--- a/src/test/java/org/broadinstitute/consent/http/service/users/DatabaseDACUserAPITest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/users/DatabaseDACUserAPITest.java
@@ -104,23 +104,4 @@ public class DatabaseDACUserAPITest {
         }
     }
 
-    @Test
-    public void describeUserByNonExistentId() {
-        int id = 1;
-        when(dacUserDAO.findDACUserById(id)).thenReturn(null);
-        try {
-            databaseDACUserAPI.describeDACUserById(id);
-        } catch (NotFoundException e) {
-            assertTrue(e.getMessage().equals("Could not find dacUser for specified id : " + id));
-        }
-    }
-
-    @Test
-    public void describeUserById() {
-        DACUser dacUser = new DACUser(1, EMAIL, DISPLAY_NAME, new Date(), null);
-        when(dacUserDAO.findDACUserById(1)).thenReturn(dacUser);
-        DACUser user = databaseDACUserAPI.describeDACUserById(1);
-        assertNotNull(user);
-    }
-
 }

--- a/src/test/java/org/broadinstitute/consent/http/service/users/DatabaseDACUserAPITest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/users/DatabaseDACUserAPITest.java
@@ -105,24 +105,6 @@ public class DatabaseDACUserAPITest {
     }
 
     @Test
-    public void describeUserByNonExistentEmail() {
-        when(dacUserDAO.findDACUserByEmail(EMAIL)).thenReturn(null);
-        try {
-            userService.findUserByEmail(EMAIL);
-        } catch (NotFoundException e) {
-            assertTrue(e.getMessage().equals("Could not find dacUser for specified email : " + EMAIL));
-        }
-    }
-
-    @Test
-    public void describeUserByEmail() {
-        DACUser dacUser = new DACUser(1, EMAIL, DISPLAY_NAME, new Date(), null);
-        when(dacUserDAO.findDACUserByEmail(EMAIL)).thenReturn(dacUser);
-        DACUser user = userService.findUserByEmail(EMAIL);
-        assertNotNull(user);
-    }
-
-    @Test
     public void describeUserByNonExistentId() {
         int id = 1;
         when(dacUserDAO.findDACUserById(id)).thenReturn(null);

--- a/src/test/java/org/broadinstitute/consent/http/service/users/DatabaseDACUserAPITest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/users/DatabaseDACUserAPITest.java
@@ -5,6 +5,7 @@ import org.broadinstitute.consent.http.db.UserRoleDAO;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.DACUser;
 import org.broadinstitute.consent.http.models.UserRole;
+import org.broadinstitute.consent.http.service.UserService;
 import org.broadinstitute.consent.http.service.users.handler.UserHandlerAPI;
 import org.jdbi.v3.core.statement.UnableToExecuteStatementException;
 import org.junit.Before;
@@ -42,6 +43,9 @@ public class DatabaseDACUserAPITest {
     @Mock
     UserHandlerAPI userHandlerAPI;
 
+    @Mock
+    UserService userService;
+
     private final String EMAIL = "test@gmail.com";
 
     private final String DISPLAY_NAME = "test";
@@ -50,7 +54,7 @@ public class DatabaseDACUserAPITest {
     @Before
     public void setUp() throws URISyntaxException {
         MockitoAnnotations.initMocks(this);
-        databaseDACUserAPI = new DatabaseDACUserAPI(dacUserDAO, userRoleDAO, userHandlerAPI, null);
+        databaseDACUserAPI = new DatabaseDACUserAPI(dacUserDAO, userRoleDAO, userHandlerAPI, null, userService);
     }
 
     @Test
@@ -104,7 +108,7 @@ public class DatabaseDACUserAPITest {
     public void describeUserByNonExistentEmail() {
         when(dacUserDAO.findDACUserByEmail(EMAIL)).thenReturn(null);
         try {
-            databaseDACUserAPI.describeDACUserByEmail(EMAIL);
+            userService.findUserByEmail(EMAIL);
         } catch (NotFoundException e) {
             assertTrue(e.getMessage().equals("Could not find dacUser for specified email : " + EMAIL));
         }
@@ -114,7 +118,7 @@ public class DatabaseDACUserAPITest {
     public void describeUserByEmail() {
         DACUser dacUser = new DACUser(1, EMAIL, DISPLAY_NAME, new Date(), null);
         when(dacUserDAO.findDACUserByEmail(EMAIL)).thenReturn(dacUser);
-        DACUser user = databaseDACUserAPI.describeDACUserByEmail(EMAIL);
+        DACUser user = userService.findUserByEmail(EMAIL);
         assertNotNull(user);
     }
 

--- a/src/test/java/org/broadinstitute/consent/http/service/users/DatabaseUserAPITest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/users/DatabaseUserAPITest.java
@@ -5,6 +5,7 @@ import org.broadinstitute.consent.http.db.UserRoleDAO;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.DACUser;
 import org.broadinstitute.consent.http.models.UserRole;
+import org.broadinstitute.consent.http.service.UserService;
 import org.broadinstitute.consent.http.service.users.handler.UserHandlerAPI;
 import org.junit.Before;
 import org.junit.Test;
@@ -29,6 +30,9 @@ public class DatabaseUserAPITest {
     @Mock
     UserHandlerAPI userHandlerAPI;
 
+    @Mock
+    UserService userService;
+
     private UserAPI userAPI;
 
     private final String DISPLAY_NAME = "test";
@@ -36,7 +40,7 @@ public class DatabaseUserAPITest {
     @Before
     public void setUp() {
         MockitoAnnotations.initMocks(this);
-        userAPI = new DatabaseUserAPI(dacUserDAO, userRoleDAO, userHandlerAPI, null);
+        userAPI = new DatabaseUserAPI(dacUserDAO, userRoleDAO, userHandlerAPI, null, userService);
     }
 
 


### PR DESCRIPTION
## Addresses
https://broadinstitute.atlassian.net/browse/DUOS-615

Also partially addresses https://broadinstitute.atlassian.net/browse/DUOS-403

## Changes
Mostly a refactoring PR, but this also helps us prevent unintended bugs from non-standard user lookups.
* Migrated all user related api calls that returned users by id or email to new `UserService` class
* Migrated/updated tests
* Deprecate old api classes