### PR TITLE
[DUOS-404][risk=no] Fix describe all users call

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
@@ -255,7 +255,7 @@ public class ConsentApplication extends Application<ConsentConfiguration> {
         DatabaseMatchProcessAPI.initInstance(consentDAO, dataAccessRequestService);
         DatabaseSummaryAPI.initInstance(dataAccessRequestService, voteDAO, electionDAO, dacUserDAO, consentDAO, dataSetDAO, matchDAO);
         DACUserRolesHandler.initInstance(dacUserDAO, userRoleDAO, electionDAO, voteDAO, dataSetAssociationDAO, AbstractEmailNotifierAPI.getInstance(), AbstractDataAccessRequestAPI.getInstance());
-        DatabaseDACUserAPI.initInstance(dacUserDAO, userRoleDAO, AbstractUserRolesHandler.getInstance(), researcherPropertyDAO, userService);
+        DatabaseDACUserAPI.initInstance(dacUserDAO, userRoleDAO, AbstractUserRolesHandler.getInstance(), userService);
         DatabaseVoteAPI.initInstance(voteDAO, electionDAO);
         DatabaseReviewResultsAPI.initInstance(electionDAO, voteDAO, consentDAO);
         TranslateServiceImpl.initInstance(useRestrictionConverter);
@@ -284,7 +284,7 @@ public class ConsentApplication extends Application<ConsentConfiguration> {
         final IndexOntologyService indexOntologyService = new IndexOntologyService(config.getElasticSearchConfiguration());
         final IndexerService indexerService = new IndexerServiceImpl(storeOntologyService, indexOntologyService);
         final ResearcherService researcherService = new ResearcherPropertyHandler(researcherPropertyDAO, dacUserDAO, AbstractEmailNotifierAPI.getInstance());
-        final UserAPI userAPI = new DatabaseUserAPI(dacUserDAO, userRoleDAO, AbstractUserRolesHandler.getInstance(), researcherPropertyDAO, userService);
+        final UserAPI userAPI = new DatabaseUserAPI(dacUserDAO, userRoleDAO, AbstractUserRolesHandler.getInstance(), userService);
         final NihAuthApi nihAuthApi = new NihServiceAPI(researcherService);
 
         // Now register our resources.

--- a/src/main/java/org/broadinstitute/consent/http/db/DACUserDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DACUserDAO.java
@@ -66,9 +66,16 @@ public interface DACUserDAO extends Transactional<DACUserDAO> {
     @SqlUpdate("delete from dacuser where email = :email")
     void deleteDACUserByEmail(@Bind("email") String email);
 
+    @SqlUpdate("delete from dacuser where dacuserid = :id")
+    void deleteDACUserById(@Bind("id") Integer id);
+
     @UseRowMapper(DACUserRoleMapper.class)
-    @SqlQuery("select du.*, r.roleId, r.name, ur.user_role_id, ur.user_id, ur.role_id, ur.dac_id from dacuser du inner join user_role ur on ur.user_id = du.dacUserId " +
-              "inner join roles r on r.roleId = ur.role_id order by createDate desc")
+    @SqlQuery("SELECT du.*, r.roleid, r.name, ur.user_role_id, ur.user_id, ur.role_id, ur.dac_id, p.propertyvalue AS completed " +
+            " FROM dacuser du " +
+            " LEFT JOIN user_role ur ON ur.user_id = du.dacuserid " +
+            " LEFT JOIN roles r ON r.roleid = ur.role_id " +
+            " LEFT JOIN researcher_property p ON p.userid = du.dacuserid AND lower(propertykey) = 'completed' " +
+            " ORDER BY createdate DESC ")
     Set<DACUser> findUsers();
 
     @SqlQuery("select count(*) from user_role dr inner join roles r on r.roleId = dr.role_id where r.name = 'Admin'")

--- a/src/main/java/org/broadinstitute/consent/http/db/DACUserRoleMapper.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DACUserRoleMapper.java
@@ -37,6 +37,7 @@ public class DACUserRoleMapper implements RowMapper<DACUser>, RowMapperHelper {
         } else {
             user = users.get(r.getInt("dacUserId"));
             addRole(r, user);
+            users.put(user.getDacUserId(), user);
         }
         return user;
     }

--- a/src/main/java/org/broadinstitute/consent/http/db/DACUserRoleMapper.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DACUserRoleMapper.java
@@ -33,12 +33,11 @@ public class DACUserRoleMapper implements RowMapper<DACUser>, RowMapperHelper {
             if (hasColumn(r, "completed")) {
                 user.setProfileCompleted(Boolean.valueOf(r.getString("completed")));
             }
-            users.put(user.getDacUserId(), user);
         } else {
             user = users.get(r.getInt("dacUserId"));
             addRole(r, user);
-            users.put(user.getDacUserId(), user);
         }
+        users.put(user.getDacUserId(), user);
         return user;
     }
 

--- a/src/main/java/org/broadinstitute/consent/http/db/DACUserRoleMapper.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DACUserRoleMapper.java
@@ -12,7 +12,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
-public class DACUserRoleMapper implements RowMapper<DACUser> {
+public class DACUserRoleMapper implements RowMapper<DACUser>, RowMapperHelper {
 
     private Map<Integer, DACUser> users = new HashMap<>();
 
@@ -29,17 +29,26 @@ public class DACUserRoleMapper implements RowMapper<DACUser> {
             user.setStatus(getStatus(r));
             user.setRationale(r.getString("rationale"));
             user.setRoles(new ArrayList<>());
-            Integer dacId = (r.getObject("dac_id") == null) ? null : r.getInt("dac_id");
-            UserRole role = new UserRole(r.getInt("user_role_id"), r.getInt("user_id"), r.getInt("roleId"), r.getString("name"), dacId);
-            user.getRoles().add(role);
+            addRole(r, user);
+            if (hasColumn(r, "completed")) {
+                user.setProfileCompleted(Boolean.valueOf(r.getString("completed")));
+            }
             users.put(user.getDacUserId(), user);
         } else {
             user = users.get(r.getInt("dacUserId"));
+            addRole(r, user);
+        }
+        return user;
+    }
+
+    private void addRole(ResultSet r, DACUser user) throws SQLException {
+        if (r.getObject("user_role_id") != null &&
+                r.getObject("user_id") != null &&
+                r.getObject("roleId") != null) {
             Integer dacId = (r.getObject("dac_id") == null) ? null : r.getInt("dac_id");
             UserRole role = new UserRole(r.getInt("user_role_id"), r.getInt("user_id"), r.getInt("roleId"), r.getString("name"), dacId);
             user.getRoles().add(role);
         }
-        return user;
     }
 
     private String getStatus(ResultSet r) {

--- a/src/main/java/org/broadinstitute/consent/http/resources/DACUserResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DACUserResource.java
@@ -75,7 +75,7 @@ public class DACUserResource extends Resource {
     @Produces("application/json")
     @RolesAllowed(ADMIN)
     public Collection<DACUser> describeAllUsers() {
-        return dacUserAPI.describeUsers();
+        return userService.describeUsers();
     }
 
     @GET

--- a/src/main/java/org/broadinstitute/consent/http/service/UserService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/UserService.java
@@ -5,6 +5,7 @@ import org.broadinstitute.consent.http.db.UserRoleDAO;
 import org.broadinstitute.consent.http.models.DACUser;
 
 import javax.ws.rs.NotFoundException;
+import java.util.Collection;
 
 public class UserService {
 
@@ -32,6 +33,10 @@ public class UserService {
         }
         dacUser.setRoles(roleDAO.findRolesByUserId(dacUser.getDacUserId()));
         return dacUser;
+    }
+
+    public Collection<DACUser> describeUsers() {
+        return userDAO.findUsers();
     }
 
 }

--- a/src/main/java/org/broadinstitute/consent/http/service/users/DACUserAPI.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/users/DACUserAPI.java
@@ -7,7 +7,6 @@ import org.broadinstitute.consent.http.service.users.handler.UserRoleHandlerExce
 import javax.mail.MessagingException;
 import javax.ws.rs.NotFoundException;
 import java.io.IOException;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -24,8 +23,6 @@ public interface DACUserAPI {
     DACUser updateDACUserById(Map<String, DACUser> dac, Integer userId) throws IllegalArgumentException, NotFoundException, UserRoleHandlerException, MessagingException, IOException, TemplateException;
 
     void deleteDACUser(String email) throws IllegalArgumentException, NotFoundException;
-
-    Collection<DACUser> describeUsers();
 
     DACUser updateUserStatus(String status, Integer userId);
 

--- a/src/main/java/org/broadinstitute/consent/http/service/users/DatabaseDACUserAPI.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/users/DatabaseDACUserAPI.java
@@ -4,7 +4,6 @@ package org.broadinstitute.consent.http.service.users;
 import freemarker.template.TemplateException;
 import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.consent.http.db.DACUserDAO;
-import org.broadinstitute.consent.http.db.ResearcherPropertyDAO;
 import org.broadinstitute.consent.http.db.UserRoleDAO;
 import org.broadinstitute.consent.http.enumeration.RoleStatus;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
@@ -18,7 +17,6 @@ import org.jdbi.v3.core.statement.UnableToExecuteStatementException;
 import javax.mail.MessagingException;
 import javax.ws.rs.NotFoundException;
 import java.io.IOException;
-import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -34,11 +32,10 @@ public class DatabaseDACUserAPI extends AbstractDACUserAPI {
     protected final DACUserDAO dacUserDAO;
     protected final UserRoleDAO userRoleDAO;
     private final UserHandlerAPI rolesHandler;
-    private final ResearcherPropertyDAO researcherPropertyDAO;
     private final UserService userService;
 
-    public static void initInstance(DACUserDAO userDao, UserRoleDAO userRoleDAO, UserHandlerAPI userHandlerAPI, ResearcherPropertyDAO researcherPropertyDAO, UserService userService) {
-        DACUserAPIHolder.setInstance(new DatabaseDACUserAPI(userDao, userRoleDAO, userHandlerAPI, researcherPropertyDAO, userService));
+    public static void initInstance(DACUserDAO userDao, UserRoleDAO userRoleDAO, UserHandlerAPI userHandlerAPI, UserService userService) {
+        DACUserAPIHolder.setInstance(new DatabaseDACUserAPI(userDao, userRoleDAO, userHandlerAPI, userService));
     }
 
     protected org.apache.log4j.Logger logger() {
@@ -51,11 +48,10 @@ public class DatabaseDACUserAPI extends AbstractDACUserAPI {
      *
      * @param userDAO The Data Access Object used to read/write data.
      */
-    DatabaseDACUserAPI(DACUserDAO userDAO, UserRoleDAO userRoleDAO, UserHandlerAPI userHandlerAPI, ResearcherPropertyDAO researcherPropertyDAO, UserService userService) {
+    DatabaseDACUserAPI(DACUserDAO userDAO, UserRoleDAO userRoleDAO, UserHandlerAPI userHandlerAPI, UserService userService) {
         this.dacUserDAO = userDAO;
         this.userRoleDAO = userRoleDAO;
         this.rolesHandler = userHandlerAPI;
-        this.researcherPropertyDAO = researcherPropertyDAO;
         this.userService = userService;
     }
 
@@ -136,17 +132,6 @@ public class DatabaseDACUserAPI extends AbstractDACUserAPI {
             userRoleDAO.removeUserRoles(user.getDacUserId(), roleIds);
         }
         dacUserDAO.deleteDACUserByEmail(email);
-    }
-
-    @Override
-    public Collection<DACUser> describeUsers() {
-        Collection<DACUser> users = dacUserDAO.findUsers();
-        users.forEach(user -> {
-            // TODO: This nested dao call isn't scalable. See DUOS-404
-            String isProfileCompleted = researcherPropertyDAO.isProfileCompleted(user.getDacUserId());
-            user.setProfileCompleted(isProfileCompleted == null ? false : Boolean.valueOf(isProfileCompleted));
-        });
-        return users;
     }
 
     @Override

--- a/src/main/java/org/broadinstitute/consent/http/service/users/DatabaseUserAPI.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/users/DatabaseUserAPI.java
@@ -3,7 +3,6 @@ package org.broadinstitute.consent.http.service.users;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.consent.http.db.DACUserDAO;
-import org.broadinstitute.consent.http.db.ResearcherPropertyDAO;
 import org.broadinstitute.consent.http.db.UserRoleDAO;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.DACUser;
@@ -20,8 +19,8 @@ import java.util.List;
 @Deprecated
 public class DatabaseUserAPI extends DatabaseDACUserAPI implements UserAPI {
 
-    public DatabaseUserAPI(DACUserDAO userDAO, UserRoleDAO roleDAO, UserHandlerAPI userHandlerAPI, ResearcherPropertyDAO researcherPropertyDAO, UserService userService) {
-        super(userDAO, roleDAO, userHandlerAPI, researcherPropertyDAO, userService);
+    public DatabaseUserAPI(DACUserDAO userDAO, UserRoleDAO roleDAO, UserHandlerAPI userHandlerAPI, UserService userService) {
+        super(userDAO, roleDAO, userHandlerAPI, userService);
     }
 
     @Override

--- a/src/main/resources/changesets/changelog-consent-10.0.xml
+++ b/src/main/resources/changesets/changelog-consent-10.0.xml
@@ -7,16 +7,6 @@
     <!--Admin user-->
     <changeSet author="vvicario" id="41">
         <validCheckSum>ANY</validCheckSum>
-        <insert tableName="dacuser">
-            <column name="dacuserid" value="3333"/>
-            <column name="displayname" value="Moran Cabili-Kalmar"/>
-            <column name="email" value="nmcabili@broadinstitute.org"/>
-            <column name="createdate" value="2015-08-21 13:58:50"/>
-        </insert>
-        <insert tableName="user_role">
-            <column name="roleid" value="4"/>
-            <column name="dacuserid" value="3333"/>
-        </insert>
     </changeSet>
 
 </databaseChangeLog>

--- a/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
@@ -61,12 +61,13 @@ public class DAOTestHelper {
     static VoteDAO voteDAO;
     static DataAccessRequestDAO dataAccessRequestDAO;
     static MailMessageDAO mailMessageDAO;
+    static ResearcherPropertyDAO researcherPropertyDAO;
 
     private static List<Integer> createdDataSetIds = new ArrayList<>();
     private static List<Integer> createdDacIds = new ArrayList<>();
     private static List<String> createdConsentIds = new ArrayList<>();
     private static List<Integer> createdElectionIds = new ArrayList<>();
-    private static List<String> createdUserEmails = new ArrayList<>();
+    private static List<Integer> createdUserIds = new ArrayList<>();
     private static List<String> createdDataAccessRequestReferenceIds = new ArrayList<>();
 
     String ASSOCIATION_TYPE_TEST = RandomStringUtils.random(10, true, false);
@@ -111,6 +112,7 @@ public class DAOTestHelper {
         voteDAO = jdbi.onDemand(VoteDAO.class);
         dataAccessRequestDAO = jdbi.onDemand(DataAccessRequestDAO.class);
         mailMessageDAO = jdbi.onDemand(MailMessageDAO.class);
+        researcherPropertyDAO = jdbi.onDemand(ResearcherPropertyDAO.class);
     }
 
     @AfterClass
@@ -133,10 +135,11 @@ public class DAOTestHelper {
             dacDAO.deleteDacMembers(id);
             dacDAO.deleteDac(id);
         });
-        createdUserEmails.forEach(email -> {
-            userRoleDAO.findRolesByUserEmail(email).
+        createdUserIds.forEach(id -> {
+            researcherPropertyDAO.deleteAllPropertiesByUser(id);
+            userRoleDAO.findRolesByUserId(id).
                     forEach(ur -> userRoleDAO.removeSingleUserRole(ur.getUserId(), ur.getRoleId()));
-            userDAO.deleteDACUserByEmail(email);
+            userDAO.deleteDACUserById(id);
         });
         createdDataAccessRequestReferenceIds.forEach(d ->
                 dataAccessRequestDAO.deleteByReferenceId(d));
@@ -222,7 +225,7 @@ public class DAOTestHelper {
                 "." +
                 RandomStringUtils.randomAlphabetic(i3);
         Integer userId = userDAO.insertDACUser(email, "display name", new Date());
-        createdUserEmails.add(email);
+        createdUserIds.add(userId);
         return userDAO.findDACUserById(userId);
     }
 
@@ -237,7 +240,7 @@ public class DAOTestHelper {
                 RandomStringUtils.randomAlphabetic(i3);
         Integer userId = userDAO.insertDACUser(email, "display name", new Date());
         userRoleDAO.insertSingleUserRole(roleId, userId);
-        createdUserEmails.add(email);
+        createdUserIds.add(userId);
         return userDAO.findDACUserById(userId);
     }
 

--- a/src/test/java/org/broadinstitute/consent/http/service/users/DatabaseDACUserAPITest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/users/DatabaseDACUserAPITest.java
@@ -54,7 +54,7 @@ public class DatabaseDACUserAPITest {
     @Before
     public void setUp() throws URISyntaxException {
         MockitoAnnotations.initMocks(this);
-        databaseDACUserAPI = new DatabaseDACUserAPI(dacUserDAO, userRoleDAO, userHandlerAPI, null, userService);
+        databaseDACUserAPI = new DatabaseDACUserAPI(dacUserDAO, userRoleDAO, userHandlerAPI, userService);
     }
 
     @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/users/DatabaseUserAPITest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/users/DatabaseUserAPITest.java
@@ -40,7 +40,7 @@ public class DatabaseUserAPITest {
     @Before
     public void setUp() {
         MockitoAnnotations.initMocks(this);
-        userAPI = new DatabaseUserAPI(dacUserDAO, userRoleDAO, userHandlerAPI, null, userService);
+        userAPI = new DatabaseUserAPI(dacUserDAO, userRoleDAO, userHandlerAPI, userService);
     }
 
 


### PR DESCRIPTION
## Addresses
https://broadinstitute.atlassian.net/browse/DUOS-404

Mostly a refactoring PR but necessary in the. multi-DAC world.

## Changes
* Refactor call from api to service
* Refactor query to get completed from profile
* Refactor user mapper so we don't add null user roles
* Additional tests
* Remove Moran from the default list of admin users while testing
  * This required a test update since there was an admin user set up by default.