### PR TITLE
[DUOS-624][risk=no] Set reference id in the right place

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/service/DatabaseDataAccessRequestAPI.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatabaseDataAccessRequestAPI.java
@@ -133,9 +133,6 @@ public class DatabaseDataAccessRequestAPI extends AbstractDataAccessRequestAPI {
             dataAccessRequest.remove(DarConstants.ID);
             dataAccessRequest.remove(DarConstants.PARTIAL_DAR_CODE);
         }
-        if (dataAccessRequest.getString(DarConstants.REFERENCE_ID) == null) {
-            dataAccessRequest.put(DarConstants.REFERENCE_ID, UUID.randomUUID().toString());
-        }
         List<Integer> datasets =  DarUtil.getIntegerList(dataAccessRequest, DarConstants.DATASET_ID);
         if (CollectionUtils.isNotEmpty(datasets)) {
             Set<ConsentDataSet> consentDataSets = consentDAO.getConsentIdAndDataSets(datasets);


### PR DESCRIPTION
## Addresses
https://broadinstitute.atlassian.net/browse/DUOS-624

##
This bug resulted in DARs with multiple datasets all having the same reference id. When creating elections for one, it made updates to all of them.