### PR TITLE
[no-jira][risk=no] SC Warning Fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -315,6 +315,19 @@
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
       <version>4.5.12</version>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-codec</groupId>
+          <artifactId>commons-codec</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <!-- SourceClear fix https://broadinstitute-dsp.sourceclear.io/workspaces/jppForw/issues/vulnerabilities/31917576 -->
+    <dependency>
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
+      <version>1.14</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
## Addresses
https://broadinstitute-dsp.sourceclear.io/workspaces/jppForw/issues/vulnerabilities/31920195

> Update
> This issue was fixed in version 1.13 of Apache Commons Codec. That version is currently considered safe, we suggest that you upgrade to the fixed version.