### PR TITLE
[DUOS-629][risk=no] Clean up 'otherText' handling

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/models/darsummary/DARModalDetailsDTO.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/darsummary/DARModalDetailsDTO.java
@@ -4,6 +4,7 @@ import org.apache.commons.collections.CollectionUtils;
 import org.broadinstitute.consent.http.models.DACUser;
 import org.broadinstitute.consent.http.models.DataSet;
 import org.broadinstitute.consent.http.models.ResearcherProperty;
+import org.broadinstitute.consent.http.util.DarConstants;
 import org.bson.Document;
 
 import java.util.ArrayList;
@@ -170,7 +171,7 @@ public class DARModalDetailsDTO {
             manualReviewIsTrue();
         }
         if(darDocument.containsKey("other") && darDocument.getBoolean("other")){
-            researchList.add(new SummaryItem(SummaryConstants.RT_OTHER, darDocument.getString("othertext"), true));
+            researchList.add(new SummaryItem(SummaryConstants.RT_OTHER, darDocument.getString(DarConstants.OTHER_TEXT), true));
             manualReviewIsTrue();
         }
         return researchList;

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessParser.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessParser.java
@@ -4,8 +4,8 @@ import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pdfbox.pdmodel.interactive.form.PDAcroForm;
 import org.apache.pdfbox.pdmodel.interactive.form.PDField;
+import org.broadinstitute.consent.http.enumeration.ResearcherFields;
 import org.broadinstitute.consent.http.models.DACUser;
-import org.broadinstitute.consent.http.models.UserRole;
 import org.broadinstitute.consent.http.util.DarConstants;
 import org.bson.Document;
 
@@ -109,7 +109,7 @@ class DataAccessParser {
                     break;
                 }
                 case DarConstants.PI_EMAIL: {
-                    if(Boolean.valueOf(researcherProperties.get("isThePI"))){
+                    if(Boolean.parseBoolean(researcherProperties.get(ResearcherFields.ARE_YOU_PRINCIPAL_INVESTIGATOR.getValue()))){
                         field.setValue(getDefaultValue(researcherProperties.get(DarConstants.ACADEMIC_BUSINESS_EMAIL)));
                     } else {
                         field.setValue(getDefaultValue(researcherProperties.get(DarConstants.PI_EMAIL)));
@@ -118,7 +118,7 @@ class DataAccessParser {
                     break;
                 }
                 case DarConstants.INVESTIGATOR: {
-                    if(Boolean.valueOf(researcherProperties.get("isThePI"))){
+                    if(Boolean.parseBoolean(researcherProperties.get(ResearcherFields.ARE_YOU_PRINCIPAL_INVESTIGATOR.getValue()))){
                         field.setValue(getDefaultValue(researcherProperties.get(DarConstants.PROFILE_NAME)));
                     } else {
                         field.setValue(getDefaultValue(dar.getString(DarConstants.INVESTIGATOR)));

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessParser.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessParser.java
@@ -83,6 +83,11 @@ class DataAccessParser {
                     field.setValue(getDefaultValue(dar.getString(DarConstants.OTHER_TEXT)));
                     break;
                 }
+                // Handle legacy all lower cased case
+                case "othertext": {
+                    field.setValue(getDefaultValue(dar.getString(DarConstants.OTHER_TEXT)));
+                    break;
+                }
                 case DarConstants.PROFILE_NAME: {
                     field.setValue(getDefaultValue(researcherProperties.get(DarConstants.PROFILE_NAME)));
                     break;
@@ -258,7 +263,7 @@ class DataAccessParser {
         }
         return value;
     }
-    
+
     @SuppressWarnings("unchecked")
     private String parseDatasetDetail(Document dar) {
         ArrayList<Document> datasetDetail = (ArrayList<Document>) dar.get(DarConstants.DATASET_DETAIL);

--- a/src/main/java/org/broadinstitute/consent/http/util/DarConstants.java
+++ b/src/main/java/org/broadinstitute/consent/http/util/DarConstants.java
@@ -91,7 +91,7 @@ public class DarConstants {
 
     public static final String OTHER = "other";
 
-    public static final String OTHER_TEXT = "othertext";
+    public static final String OTHER_TEXT = "otherText";
 
     public static final String ONTOLOGIES = "ontologies";
 

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -2909,7 +2909,7 @@ definitions:
       other:
         type: boolean
         description: 'Defines if the purpose of the study is other than the above. If TRUE, triggers MANUAL REVIEW.'
-      othertext:
+      otherText:
         type: string
         description: 'Describes above field.'
       ontologies:

--- a/src/test/java/org/broadinstitute/consent/http/models/darsummary/DARModalDetailsDTOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/darsummary/DARModalDetailsDTOTest.java
@@ -50,7 +50,7 @@ public class DARModalDetailsDTOTest {
         when(darDocument.getBoolean("population")).thenReturn(true);
         when(darDocument.containsKey("other")).thenReturn(true);
         when(darDocument.getBoolean("other")).thenReturn(true);
-        when(darDocument.getString("othertext")).thenReturn(OTHERTEXT);
+        when(darDocument.getString("otherText")).thenReturn(OTHERTEXT);
 
         when(darDocument.get("ontologies")).thenReturn(ontologies());
 

--- a/src/test/java/org/broadinstitute/consent/http/service/DataAccessParserTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DataAccessParserTest.java
@@ -5,7 +5,6 @@ import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.interactive.form.PDAcroForm;
 import org.broadinstitute.consent.http.enumeration.ResearcherFields;
 import org.broadinstitute.consent.http.models.DACUser;
-import org.broadinstitute.consent.http.models.UserRole;
 import org.broadinstitute.consent.http.util.DarConstants;
 import org.bson.Document;
 import org.junit.Test;
@@ -94,7 +93,8 @@ public class DataAccessParserTest {
         Assert.isTrue(acroForm.getField(DarConstants.ORCID).getValueAsString().equals(ORCID));
         Assert.isTrue(acroForm.getField(DarConstants.RESEARCHER_GATE).getValueAsString().equals(RESEARCHER_GATE));
         Assert.isTrue(acroForm.getField(DarConstants.DATA_ACCESS_AGREEMENT).getValueAsString().equals("Yes"));
-        Assert.isTrue(acroForm.getField(DarConstants.OTHER_TEXT).getValueAsString().equals(RESEARCH_OTHER_TEXT));
+        // Handle legacy all lower cased case
+        Assert.isTrue(acroForm.getField(DarConstants.OTHER_TEXT.toLowerCase()).getValueAsString().equals(RESEARCH_OTHER_TEXT));
         Assert.isTrue(acroForm.getField(DarConstants.ORIGINS).getValueAsString().equals("Yes"));
         Assert.isTrue(acroForm.getField(DarConstants.HEALTH).getValueAsString().equals("Yes"));
         Assert.isTrue(acroForm.getField(DarConstants.MANUAL_REVIEW).getValueAsString().equals(MANUAL_REVIEW));


### PR DESCRIPTION
## Addresses
https://broadinstitute.atlassian.net/browse/DUOS-629

## Changes
Minor fixes in support of https://github.com/DataBiosphere/duos-ui/pull/397