### PR TITLE
[DUOS-403][risk=no] Move Delete User Endpoint

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
@@ -311,7 +311,10 @@ public class ConsentModule extends AbstractModule {
 
     @Provides
     UserService providesUserService() {
-        return new UserService(providesDACUserDAO(), providesUserRoleDAO());
+        return new UserService(
+                providesDACUserDAO(),
+                providesUserRoleDAO(),
+                providesVoteDAO());
     }
 
     // Private helpers

--- a/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
@@ -313,6 +313,7 @@ public class ConsentModule extends AbstractModule {
     UserService providesUserService() {
         return new UserService(
                 providesDACUserDAO(),
+                providesResearcherPropertyDAO(),
                 providesUserRoleDAO(),
                 providesVoteDAO());
     }

--- a/src/main/java/org/broadinstitute/consent/http/db/VoteDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/VoteDAO.java
@@ -141,6 +141,9 @@ public interface VoteDAO extends Transactional<VoteDAO> {
             + " and v.electionId IN (<electionIds>)")
     List<Vote> findVotesByElectionIdsAndUser(@BindList("electionIds") List<Integer> electionIds, @Bind("dacUserId") Integer dacUserId);
 
+    @SqlQuery("select * from vote v where v.dacUserId = :dacUserId ")
+    List<Vote> findVotesByUserId(@Bind("dacUserId") Integer dacUserId);
+
     @SqlQuery("select vote from vote v where v.electionId = :electionId and lower(v.type) = 'chairperson'")
     Boolean findChairPersonVoteByElectionId(@Bind("electionId") Integer electionId);
 

--- a/src/main/java/org/broadinstitute/consent/http/db/VoteDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/VoteDAO.java
@@ -141,7 +141,7 @@ public interface VoteDAO extends Transactional<VoteDAO> {
             + " and v.electionId IN (<electionIds>)")
     List<Vote> findVotesByElectionIdsAndUser(@BindList("electionIds") List<Integer> electionIds, @Bind("dacUserId") Integer dacUserId);
 
-    @SqlQuery("select * from vote v where v.dacUserId = :dacUserId ")
+    @SqlQuery("SELECT * FROM vote v WHERE v.dacuserid = :dacUserId ")
     List<Vote> findVotesByUserId(@Bind("dacUserId") Integer dacUserId);
 
     @SqlQuery("select vote from vote v where v.electionId = :electionId and lower(v.type) = 'chairperson'")

--- a/src/main/java/org/broadinstitute/consent/http/resources/DACUserResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DACUserResource.java
@@ -19,7 +19,6 @@ import org.broadinstitute.consent.http.service.users.handler.DACUserRolesHandler
 import javax.annotation.security.PermitAll;
 import javax.annotation.security.RolesAllowed;
 import javax.ws.rs.Consumes;
-import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.NotFoundException;
 import javax.ws.rs.POST;
@@ -28,7 +27,6 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 import java.net.URI;
@@ -107,15 +105,6 @@ public class DACUserResource extends Resource {
         } catch (Exception e) {
             return createExceptionResponse(e);
         }
-    }
-
-    @DELETE
-    @Produces(MediaType.APPLICATION_JSON)
-    @Path("/{email}")
-    @RolesAllowed(ADMIN)
-    public Response delete(@PathParam("email") String email, @Context UriInfo info) {
-        dacUserAPI.deleteDACUser(email);
-        return Response.ok().entity("User was deleted").build();
     }
 
     @Deprecated // Use update instead

--- a/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
@@ -81,7 +81,7 @@ public class UserResource extends Resource {
     @RolesAllowed(ADMIN)
     public Response delete(@PathParam("email") String email, @Context UriInfo info) {
         userService.deleteUserByEmail(email);
-        return Response.ok().entity("User was deleted").build();
+        return Response.ok().build();
     }
 
 }

--- a/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
@@ -13,12 +13,16 @@ import org.broadinstitute.consent.http.service.UserService;
 import org.broadinstitute.consent.http.service.users.UserAPI;
 
 import javax.annotation.security.PermitAll;
+import javax.annotation.security.RolesAllowed;
 import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
 import javax.ws.rs.NotFoundException;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 import java.net.URI;
@@ -69,6 +73,15 @@ public class UserResource extends Resource {
         } catch (Exception e) {
             return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(new Error(e.getMessage(), Response.Status.INTERNAL_SERVER_ERROR.getStatusCode())).build();
         }
+    }
+
+    @DELETE
+    @Produces(MediaType.APPLICATION_JSON)
+    @Path("/{email}")
+    @RolesAllowed(ADMIN)
+    public Response delete(@PathParam("email") String email, @Context UriInfo info) {
+        userService.deleteUserByEmail(email);
+        return Response.ok().entity("User was deleted").build();
     }
 
 }

--- a/src/main/java/org/broadinstitute/consent/http/service/UserService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/UserService.java
@@ -3,6 +3,7 @@ package org.broadinstitute.consent.http.service;
 import com.google.inject.Inject;
 import org.broadinstitute.consent.http.db.DACUserDAO;
 import org.broadinstitute.consent.http.db.ElectionDAO;
+import org.broadinstitute.consent.http.db.ResearcherPropertyDAO;
 import org.broadinstitute.consent.http.db.UserRoleDAO;
 import org.broadinstitute.consent.http.db.VoteDAO;
 import org.broadinstitute.consent.http.models.DACUser;
@@ -17,12 +18,14 @@ import java.util.stream.Collectors;
 public class UserService {
 
     private DACUserDAO userDAO;
+    private ResearcherPropertyDAO researcherPropertyDAO;
     private UserRoleDAO roleDAO;
     private VoteDAO voteDAO;
 
     @Inject
-    public UserService(DACUserDAO userDAO, UserRoleDAO roleDAO, VoteDAO voteDAO) {
+    public UserService(DACUserDAO userDAO, ResearcherPropertyDAO researcherPropertyDAO, UserRoleDAO roleDAO, VoteDAO voteDAO) {
         this.userDAO = userDAO;
+        this.researcherPropertyDAO = researcherPropertyDAO;
         this.roleDAO = roleDAO;
         this.voteDAO = voteDAO;
     }
@@ -67,6 +70,7 @@ public class UserService {
             List<Integer> voteIds = votes.stream().map(Vote::getVoteId).collect(Collectors.toList());
             voteDAO.removeVotesByIds(voteIds);
         }
+        researcherPropertyDAO.deleteAllPropertiesByUser(user.getDacUserId());
         userDAO.deleteDACUserByEmail(email);
     }
 

--- a/src/main/java/org/broadinstitute/consent/http/service/users/DACUserAPI.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/users/DACUserAPI.java
@@ -22,8 +22,6 @@ public interface DACUserAPI {
 
     DACUser updateDACUserById(Map<String, DACUser> dac, Integer userId) throws IllegalArgumentException, NotFoundException, UserRoleHandlerException, MessagingException, IOException, TemplateException;
 
-    void deleteDACUser(String email) throws IllegalArgumentException, NotFoundException;
-
     DACUser updateUserStatus(String status, Integer userId);
 
     DACUser updateUserRationale(String rationale, Integer userId);

--- a/src/main/java/org/broadinstitute/consent/http/service/users/DatabaseDACUserAPI.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/users/DatabaseDACUserAPI.java
@@ -20,7 +20,6 @@ import java.io.IOException;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 /**
  * @deprecated Use UserService
@@ -115,23 +114,6 @@ public class DatabaseDACUserAPI extends AbstractDACUserAPI {
         DACUser dacUser = userService.findUserByEmail(updatedUser.getEmail());
         dacUser.setRoles(userRoleDAO.findRolesByUserId(dacUser.getDacUserId()));
         return dacUser;
-    }
-
-    @Override
-    public void deleteDACUser(String email) throws IllegalArgumentException, NotFoundException {
-        DACUser user = dacUserDAO.findDACUserByEmail(email);
-        if (user == null) {
-            throw new NotFoundException("The user for the specified E-Mail address does not exist");
-        }
-        List<Integer> roleIds = userRoleDAO.
-                findRolesByUserId(user.getDacUserId()).
-                stream().
-                map(UserRole::getRoleId).
-                collect(Collectors.toList());
-        if (!roleIds.isEmpty()) {
-            userRoleDAO.removeUserRoles(user.getDacUserId(), roleIds);
-        }
-        dacUserDAO.deleteDACUserByEmail(email);
     }
 
     @Override

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -1040,22 +1040,6 @@ paths:
           description: Returns the user.
           schema:
             $ref: '#/definitions/DACUser'
-    delete:
-      summary: delete
-      description: Deletes the user identified by the email.
-      parameters:
-        - name: email
-          in: path
-          description: The email of the user.
-          required: true
-          type: string
-      tags:
-        - User
-      responses:
-        200:
-          description: Response = User was deleted
-          schema:
-            type: string
   /api/dacuser/{id}:
     put:
       summary: update
@@ -2302,6 +2286,23 @@ paths:
                   type: array
                   items:
                     $ref: '#/definitions/HelpReport'
+  /api/user/{email}:
+    delete:
+      summary: Delete User by email
+      description: Deletes the user identified by the email.
+      parameters:
+        - name: email
+          in: path
+          description: The email of the user.
+          required: true
+          type: string
+      tags:
+        - User
+      responses:
+        200:
+          description: Successful operation
+          schema:
+            type: string
   /api/user:
     post:
       summary: createResearcher

--- a/src/test/java/org/broadinstitute/consent/http/db/VoteDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/VoteDAOTest.java
@@ -587,6 +587,20 @@ public class VoteDAOTest extends DAOTestHelper {
     }
 
     @Test
+    public void testFindVotesByUserId() {
+        DACUser user = createUserWithRole(UserRoles.CHAIRPERSON.getRoleId());
+        DataSet dataset = createDataset();
+        Dac dac = createDac();
+        Consent consent = createConsent(dac.getDacId());
+        Election election = createElection(consent.getConsentId(), dataset.getDataSetId());
+        createChairpersonVote(user.getDacUserId(), election.getElectionId());
+
+        List<Vote> userVotes = voteDAO.findVotesByUserId(user.getDacUserId());
+        assertNotNull(userVotes);
+        assertFalse(userVotes.isEmpty());
+    }
+
+    @Test
     public void testFindChairPersonVoteByElectionId() {
         DACUser user = createUserWithRole(UserRoles.CHAIRPERSON.getRoleId());
         DataSet dataset = createDataset();

--- a/src/test/java/org/broadinstitute/consent/http/resources/DACUserResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DACUserResourceTest.java
@@ -128,14 +128,6 @@ public class DACUserResourceTest {
         assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
     }
 
-    @Test
-    public void testDeleteUser() {
-        doNothing().when(dacUserAPI).deleteDACUser(any());
-        initResource();
-        Response response = resource.delete(RandomStringUtils.random(10), uriInfo);
-        assertEquals(200, response.getStatus());
-    }
-
     @Test(expected = NotFoundException.class)
     public void testRetrieveDACUserWithInvalidEmail() {
         when(userService.findUserByEmail(any())).thenThrow(new NotFoundException());

--- a/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.consent.http.resources;
 
+import org.apache.commons.lang3.RandomStringUtils;
 import org.broadinstitute.consent.http.authentication.GoogleUser;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.AuthUser;
@@ -22,8 +23,10 @@ import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 
 public class UserResourceTest {
@@ -106,6 +109,14 @@ public class UserResourceTest {
 
         Response response = userResource.createResearcher(uriInfo, authUser);
         Assert.assertEquals(Response.Status.CREATED.getStatusCode(), response.getStatus());
+    }
+
+    @Test
+    public void testDeleteUser() {
+        doNothing().when(userService).deleteUserByEmail(any());
+        initResource();
+        Response response = userResource.delete(RandomStringUtils.random(10), uriInfo);
+        assertEquals(200, response.getStatus());
     }
 
 }

--- a/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
@@ -3,6 +3,7 @@ package org.broadinstitute.consent.http.service;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.RandomUtils;
 import org.broadinstitute.consent.http.db.DACUserDAO;
+import org.broadinstitute.consent.http.db.ResearcherPropertyDAO;
 import org.broadinstitute.consent.http.db.UserRoleDAO;
 import org.broadinstitute.consent.http.db.VoteDAO;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
@@ -24,12 +25,16 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 
 public class UserServiceTest {
 
     @Mock
     private DACUserDAO userDAO;
+
+    @Mock
+    private ResearcherPropertyDAO researcherPropertyDAO;
 
     @Mock
     private UserRoleDAO roleDAO;
@@ -45,7 +50,7 @@ public class UserServiceTest {
     }
 
     private void initService() {
-        service = new UserService(userDAO, roleDAO, voteDAO);
+        service = new UserService(userDAO, researcherPropertyDAO, roleDAO, voteDAO);
     }
 
     @Test
@@ -131,6 +136,7 @@ public class UserServiceTest {
     @Test
     public void testDeleteUser() {
         DACUser u = createUser();
+        doNothing().when(researcherPropertyDAO).deleteAllPropertiesByUser(any());
         when(userDAO.findDACUserByEmail(any())).thenReturn(u);
         initService();
 

--- a/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
@@ -4,6 +4,7 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.RandomUtils;
 import org.broadinstitute.consent.http.db.DACUserDAO;
 import org.broadinstitute.consent.http.db.UserRoleDAO;
+import org.broadinstitute.consent.http.db.VoteDAO;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.DACUser;
 import org.broadinstitute.consent.http.models.UserRole;
@@ -20,8 +21,8 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.when;
 
@@ -33,6 +34,9 @@ public class UserServiceTest {
     @Mock
     private UserRoleDAO roleDAO;
 
+    @Mock
+    private VoteDAO voteDAO;
+
     private UserService service;
 
     @Before
@@ -41,7 +45,7 @@ public class UserServiceTest {
     }
 
     private void initService() {
-        service = new UserService(userDAO, roleDAO);
+        service = new UserService(userDAO, roleDAO, voteDAO);
     }
 
     @Test
@@ -122,6 +126,26 @@ public class UserServiceTest {
         initService();
 
         service.findUserByEmail(u.getEmail());
+    }
+
+    @Test
+    public void testDeleteUser() {
+        DACUser u = createUser();
+        when(userDAO.findDACUserByEmail(any())).thenReturn(u);
+        initService();
+
+        try {
+            service.deleteUserByEmail(RandomStringUtils.random(10, true, false));
+        } catch (Exception e) {
+            fail("Should not fail: " + e.getMessage());
+        }
+    }
+
+    @Test(expected = NotFoundException.class)
+    public void testDeleteUserFailure() {
+        when(userDAO.findDACUserByEmail(any())).thenThrow(new NotFoundException());
+        initService();
+        service.deleteUserByEmail(RandomStringUtils.random(10, true, false));
     }
 
     private DACUser createUser() {


### PR DESCRIPTION
## Addresses
Partially addresses https://broadinstitute.atlassian.net/browse/DUOS-403

The delete user endpoint is not in use by the UI at the moment. This move adds slightly more functionality in that it removes votes and researcher properties for the user.