### PR TITLE
[no-jira][risk=no] Turn down log level for dars with multiple datasets 

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/service/DatabaseElectionAPI.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatabaseElectionAPI.java
@@ -512,7 +512,7 @@ public class DatabaseElectionAPI extends AbstractElectionAPI {
                 List<Integer> datasetIdList = DarUtil.getIntegerList(dar, DarConstants.DATASET_ID);
                 if (datasetIdList != null && !datasetIdList.isEmpty()) {
                     if (datasetIdList.size() > 1) {
-                        logger.error("DAR " +
+                        logger.warn("DAR " +
                                 referenceId +
                                 " contains multiple datasetId values: " +
                                 StringUtils.join(datasetIdList, ", "));


### PR DESCRIPTION
Error level logs for this case are needlessly going to Sentry -> Slack.