### PR TITLE
[DUOS-302][risk=no] Add api docs and test for Notifier Endpoint

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/resources/EmailNotifierResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/EmailNotifierResource.java
@@ -9,7 +9,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.core.Response;
 
-@Path("{api : (api/)?}emailNotifier")
+@Path("api/emailNotifier")
 public class EmailNotifierResource extends Resource {
 
     EmailNotifierAPI emailApi;

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -2182,6 +2182,25 @@ paths:
           description: ElectionReview
           schema:
             $ref: '#/definitions/ElectionReview'
+  /api/emailNotifier/reminderMessage/{voteId}:
+    post:
+      summary: Send Reminder Email
+      description: Send a reminder email to the owner of a vote
+      parameters:
+        - name: voteId
+          in: path
+          description: The vote id for a user's vote in an election
+          required: true
+          type: integer
+      tags:
+        - Notifier
+      responses:
+        200:
+          description: Email successfully sent
+        500:
+          description: Server error.
+          schema:
+            $ref: '#/definitions/ErrorResponse'
   /api/match/{consentId}/{purposeId}:
     get:
       summary: getMatches

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -2189,9 +2189,9 @@ paths:
       parameters:
         - name: voteId
           in: path
-          description: The vote id for a user's vote in an election
+          description: String value of the vote id for a user's vote in an election
           required: true
-          type: integer
+          type: string
       tags:
         - Notifier
       responses:

--- a/src/test/java/org/broadinstitute/consent/http/resources/EmailNotifierResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/EmailNotifierResourceTest.java
@@ -1,0 +1,54 @@
+package org.broadinstitute.consent.http.resources;
+
+import org.apache.commons.lang3.RandomUtils;
+import org.broadinstitute.consent.http.service.AbstractEmailNotifierAPI;
+import org.broadinstitute.consent.http.service.EmailNotifierAPI;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import javax.ws.rs.core.Response;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({
+        AbstractEmailNotifierAPI.class
+})
+public class EmailNotifierResourceTest {
+
+    @Mock
+    private EmailNotifierAPI emailApi;
+
+    private EmailNotifierResource resource;
+
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+        PowerMockito.mockStatic(AbstractEmailNotifierAPI.class);
+        when(AbstractEmailNotifierAPI.getInstance()).thenReturn(emailApi);
+        doNothing().when(emailApi).sendReminderMessage(any());
+        resource = new EmailNotifierResource();
+    }
+
+    @Test
+    public void testResourceSuccess() {
+        Response response = resource.sendReminderMessage(String.valueOf(RandomUtils.nextInt(100, 1000)));
+        assertEquals(200, response.getStatus());
+    }
+
+    @Test
+    public void testResourceFailure() {
+        Response response = resource.sendReminderMessage("invalidVoteId");
+        assertEquals(500, response.getStatus());
+    }
+
+}


### PR DESCRIPTION
## Addresses
Small story in service to https://broadinstitute.atlassian.net/browse/DUOS-302

## Changes
* New test for endpoint
* API docs for endpoint
* Only support `api` based calls.