### PR TITLE
[DUOS-642][risk=no] Update pending case query

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/ElectionDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/ElectionDAO.java
@@ -125,12 +125,12 @@ public interface ElectionDAO extends Transactional<ElectionDAO> {
             " FROM election e " +
             " INNER JOIN vote v ON v.electionId = e.electionId AND LOWER(v.type) = 'chairperson' " +
             " INNER JOIN (SELECT referenceId, MAX(createDate) maxDate FROM election e WHERE LOWER(e.electionType) = LOWER(:type) GROUP BY referenceId) electionView " +
-            "     ON electionView.maxDate = e.createDate  " +
+            "     ON electionView.maxDate = e.createDate " +
             "     AND electionView.referenceId = e.referenceId " +
             "     AND LOWER(e.electionType) = LOWER(:type) " +
             "     AND e.finalAccessVote = :vote " +
             "     AND LOWER(e.status) != 'canceled' " +
-            "     ORDER BY createDate ASC")
+            " ORDER BY createDate ASC")
     List<Election> findLastElectionsByTypeAndFinalAccessVoteChairPerson(@Bind("type") String type, @Bind("vote") Boolean finalAccessVote);
 
     @SqlQuery("select count(*) from election e inner join vote v on v.electionId = e.electionId and lower(v.type) = 'chairperson' where lower(e.electionType) = lower(:type) and lower(e.status) = lower(:status) and " +

--- a/src/main/java/org/broadinstitute/consent/http/db/ElectionDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/ElectionDAO.java
@@ -119,10 +119,19 @@ public interface ElectionDAO extends Transactional<ElectionDAO> {
             "and lower(e.status) in (<status>) order by createDate desc limit 1")
     Election findLastElectionWithFinalVoteByReferenceIdAndStatus(@Bind("referenceId") String referenceId, @BindList("status") List<String> status);
 
-    @SqlQuery("select distinct e.electionId,  e.datasetId, v.vote finalVote, e.status, e.createDate, e.referenceId, e.useRestriction, e.translatedUseRestriction, v.rationale finalRationale, v.createDate finalVoteDate, "
-            + " e.lastUpdate, e.finalAccessVote, e.electionType, e.dataUseLetter, e.dulName, e.archived, e.version  from election e inner join vote v  on v.electionId = e.electionId and lower(v.type) = 'chairperson' "
-            + " where lower(e.electionType) = lower(:type) and e.finalAccessVote = :vote and lower(e.status) != 'canceled' order by createDate asc")
-    List<Election> findElectionsByTypeAndFinalAccessVoteChairPerson(@Bind("type") String type, @Bind("vote") Boolean finalAccessVote);
+    @SqlQuery("SELECT DISTINCT e.electionId, e.datasetId, v.vote finalVote, e.status, e.createDate, e.referenceId, e.useRestriction, " +
+            "       e.translatedUseRestriction, v.rationale finalRationale, v.createDate finalVoteDate, e.lastUpdate, e.finalAccessVote, " +
+            "       e.electionType, e.dataUseLetter, e.dulName, e.archived, e.version " +
+            " FROM election e " +
+            " INNER JOIN vote v ON v.electionId = e.electionId AND LOWER(v.type) = 'chairperson' " +
+            " INNER JOIN (SELECT referenceId, MAX(createDate) maxDate FROM election e WHERE LOWER(e.electionType) = LOWER(:type) GROUP BY referenceId) electionView " +
+            "     ON electionView.maxDate = e.createDate  " +
+            "     AND electionView.referenceId = e.referenceId " +
+            "     AND LOWER(e.electionType) = LOWER(:type) " +
+            "     AND e.finalAccessVote = :vote " +
+            "     AND LOWER(e.status) != 'canceled' " +
+            "     ORDER BY createDate ASC")
+    List<Election> findLastElectionsByTypeAndFinalAccessVoteChairPerson(@Bind("type") String type, @Bind("vote") Boolean finalAccessVote);
 
     @SqlQuery("select count(*) from election e inner join vote v on v.electionId = e.electionId and lower(v.type) = 'chairperson' where lower(e.electionType) = lower(:type) and lower(e.status) = lower(:status) and " +
             " v.vote = :finalVote ")

--- a/src/main/java/org/broadinstitute/consent/http/service/PendingCaseService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/PendingCaseService.java
@@ -103,7 +103,7 @@ public class PendingCaseService {
         Integer dacUserId = dacUser.getDacUserId();
         boolean isChair = dacService.isAuthUserChair(authUser);
         List<Election> unfilteredElections = isChair ?
-                electionDAO.findElectionsByTypeAndFinalAccessVoteChairPerson(ElectionType.DATA_ACCESS.getValue(), false) :
+                electionDAO.findLastElectionsByTypeAndFinalAccessVoteChairPerson(ElectionType.DATA_ACCESS.getValue(), false) :
                 electionDAO.findElectionsWithFinalVoteByTypeAndStatus(ElectionType.DATA_ACCESS.getValue(), ElectionStatus.OPEN.getValue());
         List<Election> elections = dacService.filterElectionsByDAC(unfilteredElections, authUser);
         List<PendingCase> pendingCases = new ArrayList<>();


### PR DESCRIPTION
## Addresses
Partial fix for https://broadinstitute.atlassian.net/browse/DUOS-642

## Changes
Updated the pending case query so we get the last version of the election by type and vote, not all elections that fit the general criteria. Previously, this query would find previously closed elections and when generating the PendingCase object, it would incorrectly filter out one or the other. Discovered when testing DUOS-642. Closing/re-opening a DAR election was showing a link in the UI for the previously closed election, not the latest open election.
