### PR TITLE
[DUOS-642][risk=no] Fix find final vote for election

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/VoteDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/VoteDAO.java
@@ -66,7 +66,7 @@ public interface VoteDAO extends Transactional<VoteDAO> {
     @Deprecated // This query can return a list of votes and should be avoided
     Vote findVoteByElectionIdAndType(@Bind("electionId") Integer electionId, @Bind("type") String type);
 
-    @SqlQuery("select * from vote v where v.electionId = :electionId and lower(v.type) = 'final'")
+    @SqlQuery("SELECT * FROM vote v WHERE v.electionid = :electionId AND LOWER(v.type) = 'final'")
     List<Vote> findFinalVotesByElectionId(@Bind("electionId") Integer electionId);
 
     @SqlQuery("select * from vote v where v.electionId = :electionId and v.dacUserId = :dacUserId and lower(v.type) = 'final'")

--- a/src/main/java/org/broadinstitute/consent/http/db/VoteDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/VoteDAO.java
@@ -63,7 +63,11 @@ public interface VoteDAO extends Transactional<VoteDAO> {
                                             @Bind("voteType") String voteType);
 
     @SqlQuery("select * from vote v where v.electionId = :electionId and lower(v.type) = lower(:type)")
+    @Deprecated // This query can return a list of votes and should be avoided
     Vote findVoteByElectionIdAndType(@Bind("electionId") Integer electionId, @Bind("type") String type);
+
+    @SqlQuery("select * from vote v where v.electionId = :electionId and lower(v.type) = 'final'")
+    List<Vote> findFinalVotesByElectionId(@Bind("electionId") Integer electionId);
 
     @SqlQuery("select * from vote v where v.electionId = :electionId and v.dacUserId = :dacUserId and lower(v.type) = 'final'")
     Vote findChairPersonVoteByElectionIdAndDACUserId(@Bind("electionId") Integer electionId,

--- a/src/main/java/org/broadinstitute/consent/http/resources/DataRequestVoteResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataRequestVoteResource.java
@@ -157,9 +157,8 @@ public class DataRequestVoteResource extends Resource {
     @Produces("application/json")
     @Path("/final")
     @PermitAll
-    public Vote describeFinalAccessVote(@PathParam("requestId") Integer requestId){
-        return api.describeVoteFinalAccessVoteById(requestId);
-
+    public Vote describeFinalAccessVote(@PathParam("requestId") Integer requestId) {
+        return voteService.describeFinalAccessVoteByElectionId(requestId);
     }
 
     @GET

--- a/src/main/java/org/broadinstitute/consent/http/service/DatabaseVoteAPI.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatabaseVoteAPI.java
@@ -85,18 +85,6 @@ public class DatabaseVoteAPI extends AbstractVoteAPI {
         return vote;
     }
 
-
-    @Override
-    public Vote describeVoteFinalAccessVoteById(Integer voteId)
-            throws IllegalArgumentException {
-        Vote vote = voteDAO.findVoteByElectionIdAndType(voteId, VoteType.FINAL.getValue());
-        if (vote == null) {
-            throw new NotFoundException("Could not find vote for specified id. Vote id: " + voteId);
-        }
-        return vote;
-    }
-
-
     @Override
     public void deleteVote(Integer voteId, String referenceId) {
         if (voteDAO.checkVoteById(referenceId, voteId) == null) {

--- a/src/main/java/org/broadinstitute/consent/http/service/VoteAPI.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/VoteAPI.java
@@ -16,8 +16,6 @@ public interface VoteAPI {
 
     Vote describeVoteById(Integer voteId, String referenceId) throws NotFoundException;
 
-    Vote describeVoteFinalAccessVoteById(Integer requestId) throws NotFoundException;
-
     void deleteVote(Integer voteId, String referenceId) throws IllegalArgumentException, UnknownIdentifierException;
 
     void deleteVotes(String referenceId) throws IllegalArgumentException, UnknownIdentifierException;

--- a/src/main/java/org/broadinstitute/consent/http/service/VoteService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/VoteService.java
@@ -13,20 +13,23 @@ import org.broadinstitute.consent.http.models.Dac;
 import org.broadinstitute.consent.http.models.Election;
 import org.broadinstitute.consent.http.models.Vote;
 
+import javax.ws.rs.NotFoundException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 public class VoteService {
 
-    private DACUserDAO dacUserDAO;
-    private DataSetAssociationDAO dataSetAssociationDAO;
-    private ElectionDAO electionDAO;
-    private VoteDAO voteDAO;
+    private final DACUserDAO dacUserDAO;
+    private final DataSetAssociationDAO dataSetAssociationDAO;
+    private final ElectionDAO electionDAO;
+    private final VoteDAO voteDAO;
 
     @Inject
     public VoteService(DACUserDAO dacUserDAO, DataSetAssociationDAO dataSetAssociationDAO,
@@ -88,7 +91,7 @@ public class VoteService {
 
     /**
      * Create votes for an election
-     * <p>
+     *
      * TODO: Refactor duplicated code when DatabaseElectionAPI is fully replaced by ElectionService
      *
      * @param election       The Election
@@ -155,6 +158,34 @@ public class VoteService {
         List<Integer> dataOwners = dataSetAssociationDAO.getDataOwnersOfDataSet(election.getDataSetId());
         voteDAO.insertVotes(dataOwners, election.getElectionId(), VoteType.DATA_OWNER.getValue());
         return voteDAO.findVotesByElectionIdAndType(election.getElectionId(), VoteType.DATA_OWNER.getValue());
+    }
+
+    /**
+     * Find the final access vote for this election. In practice, there can be more than one final vote
+     * if multiple chairpersons exist. If no one has voted yet, then they are effectively all the same
+     * null vote, so any one can be returned. If any chair(s) has voted, then we need to get the most recent
+     * vote as that will reflect the latest decision point of the chair(s).
+     *
+     * @param electionId Election Id
+     * @return Final Access Vote
+     * @throws NotFoundException No final vote exists for this election
+     */
+    public Vote describeFinalAccessVoteByElectionId(Integer electionId) throws NotFoundException {
+        List<Vote> votes = voteDAO.findFinalVotesByElectionId(electionId);
+        if (Objects.isNull(votes) || votes.isEmpty()) {
+            throw new NotFoundException("Could not find vote for specified id. Election id: " + electionId);
+        }
+        // Look for the most recent vote with a value if there are more than one.
+        // If there's only one, or all votes null, then return the first one
+        if (votes.size() == 1 || votes.stream().allMatch(v -> Objects.isNull(v.getVote()))) {
+            return votes.get(0);
+        }
+        // Look for votes with a value, find by the most recent (max update date)
+        // Fall back to the first list vote if we can't find what we're looking for.
+        Optional<Vote> mostRecentVote = votes.stream().
+                filter(v -> Objects.nonNull(v.getVote())).
+                max(Comparator.comparing(Vote::getUpdateDate));
+        return mostRecentVote.orElse(votes.get(0));
     }
 
     /**

--- a/src/main/java/org/broadinstitute/consent/http/service/VoteService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/VoteService.java
@@ -175,11 +175,6 @@ public class VoteService {
         if (Objects.isNull(votes) || votes.isEmpty()) {
             throw new NotFoundException("Could not find vote for specified id. Election id: " + electionId);
         }
-        // Look for the most recent vote with a value if there are more than one.
-        // If there's only one, or all votes null, then return the first one
-        if (votes.size() == 1 || votes.stream().allMatch(v -> Objects.isNull(v.getVote()))) {
-            return votes.get(0);
-        }
         // Look for votes with a value, find by the most recent (max update date)
         // Fall back to the first list vote if we can't find what we're looking for.
         Optional<Vote> mostRecentVote = votes.stream().


### PR DESCRIPTION
## Addresses
Fixes a minor bug discovered during development of https://broadinstitute.atlassian.net/browse/DUOS-642

## Changes
* Previous version of the query assumed there would ever only be a single `FINAL` vote for an election. That is incorrect in the world of multi-chair dacs. 
* Instead of just returning the first vote that comes up, look for the right one to return.
  * The one if there is only one
  * The most recent one with a vote if there are multiple
  * The first one if there are multiple and none have been voted upon yet.