### PR TITLE
[DUOS-647][risk=no] Fix dataset association query handling

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
@@ -242,7 +242,7 @@ public class ConsentApplication extends Application<ConsentConfiguration> {
         DatabaseConsentAPI.initInstance(jdbi, consentDAO, electionDAO, associationDAO, dataSetDAO);
         DatabaseMatchAPI.initInstance(matchDAO, consentDAO);
         DatabaseDataSetAPI.initInstance(dataSetDAO, dataSetAssociationDAO, userRoleDAO, consentDAO, dataSetAuditDAO, electionDAO, config.getDatasets());
-        DatabaseDataSetAssociationAPI.initInstance(dataSetDAO, dataSetAssociationDAO, dacUserDAO);
+        DatabaseDataSetAssociationAPI.initInstance(dataSetDAO, dataSetAssociationDAO, dacUserDAO, userRoleDAO);
 
         try {
             MailService.initInstance(config.getMailConfiguration());

--- a/src/main/java/org/broadinstitute/consent/http/service/DatabaseDataSetAssociationAPI.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatabaseDataSetAssociationAPI.java
@@ -4,6 +4,7 @@ import org.apache.commons.collections.CollectionUtils;
 import org.broadinstitute.consent.http.db.DACUserDAO;
 import org.broadinstitute.consent.http.db.DataSetAssociationDAO;
 import org.broadinstitute.consent.http.db.DataSetDAO;
+import org.broadinstitute.consent.http.db.UserRoleDAO;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.DACUser;
 import org.broadinstitute.consent.http.models.DataSet;
@@ -30,36 +31,37 @@ public class DatabaseDataSetAssociationAPI extends AbstractDataSetAssociationAPI
     private final DataSetAssociationDAO dsAssociationDAO;
     private final DACUserDAO dacUserDAO;
     private final DataSetDAO dsDAO;
-
+    private final UserRoleDAO userRoleDAO;
 
 
     protected org.apache.log4j.Logger logger() {
         return org.apache.log4j.Logger.getLogger("DataSetResource");
     }
 
-    public static void initInstance(DataSetDAO dsDAO,DataSetAssociationDAO dsAssociationDAO,DACUserDAO dacUserDAO) {
-        DataSetAssociationAPIHolder.setInstance(new DatabaseDataSetAssociationAPI(dsDAO, dsAssociationDAO, dacUserDAO));
+    public static void initInstance(DataSetDAO dsDAO, DataSetAssociationDAO dsAssociationDAO, DACUserDAO dacUserDAO, UserRoleDAO userRoleDAO) {
+        DataSetAssociationAPIHolder.setInstance(new DatabaseDataSetAssociationAPI(dsDAO, dsAssociationDAO, dacUserDAO, userRoleDAO));
     }
 
-    protected DatabaseDataSetAssociationAPI(DataSetDAO dsDAO,DataSetAssociationDAO dsAssociationDAO,DACUserDAO dacUserDAO) {
+    protected DatabaseDataSetAssociationAPI(DataSetDAO dsDAO, DataSetAssociationDAO dsAssociationDAO, DACUserDAO dacUserDAO, UserRoleDAO userRoleDAO) {
         this.dsAssociationDAO = dsAssociationDAO;
         this.dacUserDAO = dacUserDAO;
         this.dsDAO = dsDAO;
+        this.userRoleDAO = userRoleDAO;
     }
 
 
     @Override
-    public  List<DatasetAssociation> createDatasetUsersAssociation(Integer dataSetId, List<Integer> usersIdList){
-        getAndVerifyUsers(usersIdList);
+    public List<DatasetAssociation> createDatasetUsersAssociation(Integer dataSetId, List<Integer> usersIdList) {
+        verifyUsers(usersIdList);
         DataSet d = dsDAO.findDataSetById(dataSetId);
-        if(Objects.isNull(d)){
+        if (Objects.isNull(d)) {
             throw new NotFoundException("Invalid DatasetId");
         }
         Integer datasetId = d.getDataSetId();
         try {
-            dsAssociationDAO.insertDatasetUserAssociation(DatasetAssociation.createDatasetAssociations(datasetId,usersIdList));
-        }catch(UnableToExecuteStatementException e){
-            if(e.getCause().getClass().equals(BatchUpdateException.class)){
+            dsAssociationDAO.insertDatasetUserAssociation(DatasetAssociation.createDatasetAssociations(datasetId, usersIdList));
+        } catch (UnableToExecuteStatementException e) {
+            if (e.getCause().getClass().equals(BatchUpdateException.class)) {
                 throw new BadRequestException("Duplicate entry for an Association");
             }
         }
@@ -67,52 +69,52 @@ public class DatabaseDataSetAssociationAPI extends AbstractDataSetAssociationAPI
     }
 
     @Override
-    public Map<String, Collection<DACUser>> findDataOwnersRelationWithDataset(Integer dataSetId){
+    public Map<String, Collection<DACUser>> findDataOwnersRelationWithDataset(Integer dataSetId) {
         List<DatasetAssociation> associationList = dsAssociationDAO.getDatasetAssociation(dsDAO.findDataSetById(dataSetId).getDataSetId());
         Collection<DACUser> associated_users = new ArrayList<>();
-        if(CollectionUtils.isNotEmpty(associationList)){
-            Collection<Integer> usersIdList  = associationList.stream().map(DatasetAssociation::getDacuserId).collect(Collectors.toList());
+        if (CollectionUtils.isNotEmpty(associationList)) {
+            Collection<Integer> usersIdList = associationList.stream().map(DatasetAssociation::getDacuserId).collect(Collectors.toList());
             associated_users = dacUserDAO.findUsers(usersIdList);
         }
         Map<String, Collection<DACUser>> usersMap = new HashMap<>();
-        usersMap.put("associated_users",associated_users);
+        usersMap.put("associated_users", associated_users);
         Collection<DACUser> dataOwnersList = dacUserDAO.describeUsersByRole(UserRoles.DATAOWNER.getRoleName());
-        usersMap.put("not_associated_users",CollectionUtils.subtract(dataOwnersList, associated_users));
+        usersMap.put("not_associated_users", CollectionUtils.subtract(dataOwnersList, associated_users));
         return usersMap;
     }
 
     @Override
-    public  List<DatasetAssociation> updateDatasetAssociations(Integer dataSetId, List<Integer> usersIdList){
+    public List<DatasetAssociation> updateDatasetAssociations(Integer dataSetId, List<Integer> usersIdList) {
         DataSet d = dsDAO.findDataSetById(dataSetId);
-        if(Objects.isNull(d)){
+        if (Objects.isNull(d)) {
             throw new NotFoundException("Invalid DatasetId");
         }
         Integer datasetId = d.getDataSetId();
         checkAssociationsExist(datasetId);
-        getAndVerifyUsers(usersIdList);
-        try {
-            dsAssociationDAO.begin();
-            dsAssociationDAO.delete(datasetId);
-            if(!usersIdList.isEmpty()){
-            dsAssociationDAO.insertDatasetUserAssociation(DatasetAssociation.createDatasetAssociations(datasetId,usersIdList));
+        verifyUsers(usersIdList);
+        dsAssociationDAO.inTransaction(h -> {
+            try {
+                h.delete(datasetId);
+                if (!usersIdList.isEmpty()) {
+                    dsAssociationDAO.insertDatasetUserAssociation(DatasetAssociation.createDatasetAssociations(datasetId, usersIdList));
+                }
+            } catch (Exception e) {
+                h.rollback();
             }
-            dsAssociationDAO.commit();
-            return dsAssociationDAO.getDatasetAssociation(datasetId);
-        } catch (Exception e) {
-            dsAssociationDAO.rollback();
-            throw e;
-        }
+            return true;
+        });
+        return dsAssociationDAO.getDatasetAssociation(datasetId);
     }
 
     @Override
-    public Map<DACUser, List<DataSet>> findDataOwnersWithAssociatedDataSets(List<Integer> dataSetIdList){
+    public Map<DACUser, List<DataSet>> findDataOwnersWithAssociatedDataSets(List<Integer> dataSetIdList) {
         List<DatasetAssociation> dataSetAssociations = dsAssociationDAO.getDatasetAssociations(dataSetIdList);
         Map<DACUser, List<DataSet>> dataOwnerDataSetMap = new HashMap<>();
-        dataSetAssociations.stream().forEach(dsa ->{
+        dataSetAssociations.stream().forEach(dsa -> {
             DACUser dataOwner = dacUserDAO.findDACUserById(dsa.getDacuserId());
-            if(!dataOwnerDataSetMap.containsKey(dataOwner)){
+            if (!dataOwnerDataSetMap.containsKey(dataOwner)) {
                 dataOwnerDataSetMap.put(dacUserDAO.findDACUserById(dsa.getDacuserId()), new ArrayList<>(Arrays.asList(dsDAO.findDataSetById(dsa.getDatasetId()))));
-            }else{
+            } else {
                 dataOwnerDataSetMap.get(dacUserDAO.findDACUserById(dsa.getDacuserId())).add(dsDAO.findDataSetById(dsa.getDatasetId()));
             }
         });
@@ -121,22 +123,23 @@ public class DatabaseDataSetAssociationAPI extends AbstractDataSetAssociationAPI
 
 
     private void checkAssociationsExist(Integer datasetId) {
-        if (!dsAssociationDAO.exist(datasetId)){
+        if (!dsAssociationDAO.exist(datasetId)) {
             throw new NotFoundException(String.format("Associations related to Dataset with id '%s' not found", datasetId));
         }
     }
 
-    private Collection<DACUser> getAndVerifyUsers(List<Integer> usersIdList){
-        if(usersIdList.isEmpty()) return null;
+    private void verifyUsers(List<Integer> usersIdList) {
+        if (usersIdList.isEmpty()) return;
         Collection<DACUser> dacUserList = dacUserDAO.findUsersWithRoles(usersIdList);
-        if(dacUserList.size() == usersIdList.size()){
-                for (DACUser user : dacUserList) {
-                    if (user.getRoles().stream().noneMatch(role -> role.getName().equalsIgnoreCase(UserRoles.DATAOWNER.getRoleName()))) {
-                        throw new BadRequestException(String.format("User with id %s is not a DATA_OWNER",user.getDacUserId()));
-                    }
+        if (dacUserList.size() == usersIdList.size()) {
+            for (DACUser user : dacUserList) {
+                if (user.getRoles().stream().noneMatch(role -> role.getName().equalsIgnoreCase(UserRoles.DATAOWNER.getRoleName()))) {
+                    userRoleDAO.insertSingleUserRole(UserRoles.DATAOWNER.getRoleId(), user.getDacUserId());
                 }
-                return  dacUserList;
-        }else{
-        throw new BadRequestException("Invalid UserId list.");}
+            }
+        } else {
+            throw new BadRequestException("Invalid UserId list.");
+        }
     }
+
 }

--- a/src/main/java/org/broadinstitute/consent/http/service/DatabaseDataSetAssociationAPI.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatabaseDataSetAssociationAPI.java
@@ -33,11 +33,6 @@ public class DatabaseDataSetAssociationAPI extends AbstractDataSetAssociationAPI
     private final DataSetDAO dsDAO;
     private final UserRoleDAO userRoleDAO;
 
-
-    protected org.apache.log4j.Logger logger() {
-        return org.apache.log4j.Logger.getLogger("DataSetResource");
-    }
-
     public static void initInstance(DataSetDAO dsDAO, DataSetAssociationDAO dsAssociationDAO, DACUserDAO dacUserDAO, UserRoleDAO userRoleDAO) {
         DataSetAssociationAPIHolder.setInstance(new DatabaseDataSetAssociationAPI(dsDAO, dsAssociationDAO, dacUserDAO, userRoleDAO));
     }

--- a/src/test/java/org/broadinstitute/consent/http/service/DatabaseDataSetAssociationAPITest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DatabaseDataSetAssociationAPITest.java
@@ -3,6 +3,7 @@ package org.broadinstitute.consent.http.service;
 import org.broadinstitute.consent.http.db.DACUserDAO;
 import org.broadinstitute.consent.http.db.DataSetAssociationDAO;
 import org.broadinstitute.consent.http.db.DataSetDAO;
+import org.broadinstitute.consent.http.db.UserRoleDAO;
 import org.broadinstitute.consent.http.models.DACUser;
 import org.broadinstitute.consent.http.models.DataSet;
 import org.broadinstitute.consent.http.models.DatasetAssociation;
@@ -23,7 +24,9 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.anyObject;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 
 public class DatabaseDataSetAssociationAPITest {
@@ -34,6 +37,8 @@ public class DatabaseDataSetAssociationAPITest {
     private DACUserDAO dacUserDAO;
     @Mock
     private DataSetDAO dsDAO;
+    @Mock
+    private UserRoleDAO userRoleDAO;
 
     DatabaseDataSetAssociationAPI associationAPI;
 
@@ -44,14 +49,14 @@ public class DatabaseDataSetAssociationAPITest {
     @Before
     public void setUp(){
         MockitoAnnotations.initMocks(this);
-        associationAPI = new DatabaseDataSetAssociationAPI(dsDAO, dsAssociationDAO, dacUserDAO);
+        associationAPI = new DatabaseDataSetAssociationAPI(dsDAO, dsAssociationDAO, dacUserDAO, userRoleDAO);
     }
 
     @Test
-    public void testGetAndVerifyUsersUserNotDataOwner() throws Exception {
+    public void testGetAndVerifyUsersUserNotDataOwner() {
+        when(dsDAO.findDataSetById(any())).thenReturn(ds1);
         when(dacUserDAO.findUsersWithRoles(anyObject())).thenReturn(new HashSet<>(Arrays.asList(member, chairperson)));
-        thrown.expect(BadRequestException.class);
-        thrown.expectMessage("User with id 1 is not a DATA_OWNER");
+        doNothing().when(userRoleDAO).insertSingleUserRole(any(), any());
         associationAPI.createDatasetUsersAssociation(1, Arrays.asList(1, 2));
     }
 


### PR DESCRIPTION
## Addresses
Bug fix for https://broadinstitute.atlassian.net/browse/DUOS-647
See also: https://github.com/DataBiosphere/consent/pull/611
I missed this in the transition from mysql, jdbi2 -> postgres, jdbi3
Recommended to turn off whitespace ... lot of formatting changes.

## Changes
* Fix transaction handling
* Do not fail if the user isn't a data owner. Instead, give the user data owner status.