### PR TITLE
[DUOS-515][risk=no] Cached Whitelist Reader

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -544,10 +544,17 @@
       </exclusions>
     </dependency>
 
+    <!-- Deprecated - TODO: Remove this when GCSStore is removed -->
     <dependency>
       <groupId>com.google.apis</groupId>
       <artifactId>google-api-services-storage</artifactId>
       <version>v1-rev20200410-1.30.9</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-storage</artifactId>
+      <version>1.108.0</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
@@ -9,6 +9,7 @@ import io.dropwizard.Configuration;
 import io.dropwizard.client.JerseyClientBuilder;
 import io.dropwizard.jdbi3.JdbiFactory;
 import io.dropwizard.setup.Environment;
+import org.broadinstitute.consent.http.cloudstore.GCSService;
 import org.broadinstitute.consent.http.cloudstore.GCSStore;
 import org.broadinstitute.consent.http.configurations.ConsentConfiguration;
 import org.broadinstitute.consent.http.configurations.MongoConfiguration;
@@ -43,6 +44,7 @@ import org.broadinstitute.consent.http.service.UseRestrictionConverter;
 import org.broadinstitute.consent.http.service.UserService;
 import org.broadinstitute.consent.http.service.VoteService;
 import org.broadinstitute.consent.http.service.WhitelistService;
+import org.broadinstitute.consent.http.util.WhitelistCache;
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.gson2.Gson2Plugin;
 import org.jdbi.v3.guava.GuavaPlugin;
@@ -143,6 +145,11 @@ public class ConsentModule extends AbstractModule {
     @Provides
     GCSStore providesGCSStore() {
         return new GCSStore(config.getCloudStoreConfiguration());
+    }
+
+    @Provides
+    GCSService providesGCSService() {
+        return new GCSService(config.getCloudStoreConfiguration());
     }
 
     @Provides
@@ -341,7 +348,14 @@ public class ConsentModule extends AbstractModule {
 
     @Provides
     WhitelistService providesWhitelistService() {
-        return new WhitelistService(providesGCSStore());
+        return new WhitelistService(
+                providesGCSService(),
+                providesWhitelistCache());
+    }
+
+    @Provides
+    WhitelistCache providesWhitelistCache() {
+        return new WhitelistCache(providesGCSService());
     }
 
     // Private helpers

--- a/src/main/java/org/broadinstitute/consent/http/cloudstore/CloudStore.java
+++ b/src/main/java/org/broadinstitute/consent/http/cloudstore/CloudStore.java
@@ -25,6 +25,4 @@ public interface CloudStore {
 
     String postOntologyDocument(InputStream stream, String type, String fileName) throws IOException, GeneralSecurityException, URISyntaxException;
 
-    GenericUrl postWhitelist(InputStream stream, String fileName) throws IOException, GeneralSecurityException;
-
 }

--- a/src/main/java/org/broadinstitute/consent/http/cloudstore/GCSService.java
+++ b/src/main/java/org/broadinstitute/consent/http/cloudstore/GCSService.java
@@ -1,0 +1,98 @@
+package org.broadinstitute.consent.http.cloudstore;
+
+import com.google.api.client.http.GenericUrl;
+import com.google.api.gax.paging.Page;
+import com.google.auth.oauth2.ServiceAccountCredentials;
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.BlobId;
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.Bucket;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageOptions;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.inject.Inject;
+import org.broadinstitute.consent.http.configurations.StoreConfiguration;
+import org.broadinstitute.consent.http.service.WhitelistService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.FileInputStream;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+
+public class GCSService {
+
+    private final Logger logger = LoggerFactory.getLogger(this.getClass());
+    private StoreConfiguration config;
+    private Storage storage;
+
+    public GCSService() {
+    }
+
+    @Inject
+    public GCSService(StoreConfiguration config) {
+        this.config = config;
+        try {
+            ServiceAccountCredentials credentials = ServiceAccountCredentials.
+                    fromStream(new FileInputStream(config.getPassword()));
+            Storage storage = StorageOptions.newBuilder().
+                    setProjectId(credentials.getProjectId()).
+                    setCredentials(credentials).
+                    build().
+                    getService();
+            this.setStorage(storage);
+        } catch (Exception e) {
+            logger.error("Exception initializing GCSService: " + e.getMessage());
+        }
+    }
+
+    @VisibleForTesting
+    public void setStorage(Storage storage) {
+        this.storage = storage;
+    }
+
+    @VisibleForTesting
+    public void setConfig(StoreConfiguration config) {
+        this.config = config;
+    }
+
+    public GenericUrl postWhitelist(String content, String fileName) {
+        BlobId blobId = BlobId.of(config.getBucket(), "whitelist/" + fileName);
+        BlobInfo blobInfo = BlobInfo.newBuilder(blobId).setContentType("text/plain").build();
+        Blob blob = storage.create(blobInfo, content.getBytes());
+        return new GenericUrl(blob.getMediaLink());
+    }
+
+    public String getMostRecentWhitelist() throws Exception {
+        try {
+            Optional<Blob> whitelist = listWhitelistItems().stream().findFirst();
+            if (whitelist.isPresent()) {
+                return new String(whitelist.get().getContent());
+            } else {
+                logger.error("Most recent whitelist does not exist.");
+                throw new Exception("Most recent whitelist does not exist.");
+            }
+        } catch (Exception e) {
+            logger.error("Error getting most recent whitelist: " + e.getMessage());
+            throw new Exception("Error getting most recent whitelist: " + e.getMessage());
+        }
+    }
+
+    private List<Blob> listWhitelistItems() {
+        Bucket bucket = storage.get(config.getBucket());
+        Page<Blob> blobs = bucket.list();
+        List<Blob> matchingBlobs = new ArrayList<>();
+        for (Blob blob : blobs.iterateAll()) {
+            if (!blob.isDirectory() && blob.getName().contains(WhitelistService.WHITELIST_FILE_PREFIX)) {
+                matchingBlobs.add(blob);
+            }
+        }
+        Comparator<Blob> comparator = Comparator.comparing(BlobInfo::getCreateTime);
+        Comparator<Blob> reversed = comparator.reversed();
+        matchingBlobs.sort(reversed);
+        return matchingBlobs;
+    }
+
+}

--- a/src/main/java/org/broadinstitute/consent/http/cloudstore/GCSStore.java
+++ b/src/main/java/org/broadinstitute/consent/http/cloudstore/GCSStore.java
@@ -19,14 +19,16 @@ import org.broadinstitute.consent.http.configurations.StoreConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.ws.rs.core.MediaType;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.security.GeneralSecurityException;
 import java.util.Collections;
 
-@SuppressWarnings("deprecation")
+/**
+ * Use `GCSService` instead which uses standard google libraries for GCS access.
+ */
+@Deprecated
 public class GCSStore implements CloudStore {
 
     private final static HttpTransport HTTP_TRANSPORT = new NetHttpTransport();
@@ -107,35 +109,6 @@ public class GCSStore implements CloudStore {
         insertRequest.getRequestHeaders().setCacheControl("private");
         insertRequest.execute();
         return generateURLForDocument(fileName).toString();
-    }
-
-    @Override
-    public GenericUrl postWhitelist(InputStream stream, String fileName) throws IOException {
-        GenericUrl url = generateURLForWhitelist(fileName);
-        HttpResponse response = null;
-        try {
-            initializeCloudStore();
-            HttpContent content = new InputStreamContent(MediaType.TEXT_PLAIN, stream);
-            HttpRequest request = buildHttpPutRequest(url, content);
-            request.getHeaders().setCacheControl("private");
-            response = request.execute();
-            if (response.getStatusCode() != 200) {
-                logger.error("Error uploading whitelist: " + response.getStatusMessage());
-            }
-        } finally {
-            if (null != response) {
-                try {
-                    response.disconnect();
-                } catch (IOException e) {
-                    logger.error("Error disconnecting response.", e);
-                }
-            }
-        }
-        return url;
-    }
-
-    private GenericUrl generateURLForWhitelist(String fileName) {
-        return new GenericUrl(sConfig.getEndpoint() + sConfig.getWhitelistBucket() + "/" + fileName);
     }
 
     private void initializeCloudStore() {

--- a/src/main/java/org/broadinstitute/consent/http/util/WhitelistCache.java
+++ b/src/main/java/org/broadinstitute/consent/http/util/WhitelistCache.java
@@ -1,0 +1,77 @@
+package org.broadinstitute.consent.http.util;
+
+import com.google.inject.Inject;
+import org.broadinstitute.consent.http.cloudstore.GCSService;
+import org.broadinstitute.consent.http.models.WhitelistEntry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+public class WhitelistCache {
+
+    private final GCSService gcsService;
+    private final Logger logger = LoggerFactory.getLogger(this.getClass());
+
+    private final Map<String, List<WhitelistEntry>> commonsIdCache = new ConcurrentHashMap<>();
+    private final Map<String, List<WhitelistEntry>> emailCache = new ConcurrentHashMap<>();
+    private final Map<String, List<WhitelistEntry>> organizationCache = new ConcurrentHashMap<>();
+
+    @Inject
+    public WhitelistCache(GCSService gcsService) {
+        this.gcsService = gcsService;
+    }
+
+    /**
+     * Populate all of the query-able caches
+     */
+    public void loadCaches(String whitelistData) {
+        List<WhitelistEntry> entries = new WhitelistParser().parseWhitelist(whitelistData);
+        commonsIdCache.putAll(entries.stream().collect(Collectors.groupingBy(WhitelistEntry::getCommonsId)));
+        emailCache.putAll(entries.stream().collect(Collectors.groupingBy(WhitelistEntry::getEmail)));
+        organizationCache.putAll(entries.stream().collect(Collectors.groupingBy(WhitelistEntry::getOrganization)));
+    }
+
+    public List<WhitelistEntry> queryByCommonsId(String commonsId) {
+        return tryCache(commonsIdCache, commonsId);
+    }
+
+    public List<WhitelistEntry> queryByEmail(String email) {
+        return tryCache(emailCache, email);
+    }
+
+    public List<WhitelistEntry> queryByOrganization(String org) {
+        return tryCache(organizationCache, org);
+    }
+
+    private void loadCachesFromStorage() throws Exception {
+        loadCaches(gcsService.getMostRecentWhitelist());
+    }
+
+    private List<WhitelistEntry> tryCache(Map<String, List<WhitelistEntry>> cache, String value) {
+        if (cache.isEmpty()) {
+            try {
+                loadCachesFromStorage();
+            } catch (Exception e) {
+                logger.error("Unable to load whitelist cache: " + e.getMessage());
+            }
+        }
+        List<WhitelistEntry> matchingEntries = cache.get(value);
+        if (matchingEntries.isEmpty()) {
+            try {
+                loadCachesFromStorage();
+                // Try one more time ...
+                return cache.get(value);
+            } catch (Exception e) {
+                logger.error("Unable to load whitelist cache: " + e.getMessage());
+                return Collections.emptyList();
+            }
+        }
+        return matchingEntries;
+    }
+
+}

--- a/src/main/java/org/broadinstitute/consent/http/util/WhitelistCache.java
+++ b/src/main/java/org/broadinstitute/consent/http/util/WhitelistCache.java
@@ -9,6 +9,7 @@ import org.slf4j.LoggerFactory;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
@@ -61,11 +62,11 @@ public class WhitelistCache {
             }
         }
         List<WhitelistEntry> matchingEntries = cache.get(value);
-        if (matchingEntries.isEmpty()) {
+        if (Objects.isNull(matchingEntries) || matchingEntries.isEmpty()) {
             try {
                 loadCachesFromStorage();
                 // Try one more time ...
-                return cache.get(value);
+                return Objects.isNull(cache.get(value)) ? Collections.emptyList() : cache.get(value);
             } catch (Exception e) {
                 logger.error("Unable to load whitelist cache: " + e.getMessage());
                 return Collections.emptyList();

--- a/src/test/java/org/broadinstitute/consent/http/cloudstore/GCSServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/cloudstore/GCSServiceTest.java
@@ -16,6 +16,7 @@ import org.mockito.MockitoAnnotations;
 
 import java.util.Iterator;
 import java.util.List;
+import java.util.Spliterator;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -77,8 +78,8 @@ public class GCSServiceTest {
     @Test
     public void testGetMostRecentWhitelist() throws Exception {
         int count = 3; // Count value is used in Blob name, create time, and content
-        Iterator<Blob> blobIterator = makeBlobIterator(count);
-        when(iterable.iterator()).thenReturn(blobIterator);
+        Spliterator<Blob> blobSpliterator = makeBlobSpliterator(count);
+        when(iterable.spliterator()).thenReturn(blobSpliterator);
         when(blobs.iterateAll()).thenReturn(iterable);
         when(bucket.list()).thenReturn(blobs);
         when(storage.get(any(String.class))).thenReturn(bucket);
@@ -94,11 +95,11 @@ public class GCSServiceTest {
      * @return Iterator<Blob>
      */
     @SuppressWarnings("SameParameterValue")
-    private Iterator<Blob> makeBlobIterator(int i) {
+    private Spliterator<Blob> makeBlobSpliterator(int i) {
         List<Blob> blobs = IntStream.range(1, i + 1).
                 mapToObj(this::mockBlob).
                 collect(Collectors.toList());
-        return blobs.iterator();
+        return blobs.spliterator();
     }
 
     private Blob mockBlob(int i) {

--- a/src/test/java/org/broadinstitute/consent/http/cloudstore/GCSServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/cloudstore/GCSServiceTest.java
@@ -1,0 +1,114 @@
+package org.broadinstitute.consent.http.cloudstore;
+
+import com.google.api.client.http.GenericUrl;
+import com.google.api.gax.paging.Page;
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.Bucket;
+import com.google.cloud.storage.Storage;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.broadinstitute.consent.http.configurations.StoreConfiguration;
+import org.broadinstitute.consent.http.service.WhitelistService;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+
+public class GCSServiceTest {
+
+    @Mock
+    private Storage storage;
+
+    @Mock
+    private Blob blob;
+
+    @Mock
+    private Bucket bucket;
+
+    @Mock
+    private Page<Blob> blobs;
+
+    @Mock
+    private Iterable<Blob> iterable;
+
+    private StoreConfiguration config;
+
+    private GCSService service;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+        config = new StoreConfiguration();
+        config.setBucket("bucket");
+        config.setEndpoint("http://localhost/");
+        config.setPassword("password");
+    }
+
+    private void initStore() {
+        service = new GCSService();
+        service.setStorage(storage);
+        service.setConfig(config);
+    }
+
+    @Test
+    public void testPostWhitelist() {
+        String filename = "filename.txt";
+        when(blob.getMediaLink()).thenReturn(config.getEndpoint() + filename);
+        when(storage.create(any(BlobInfo.class), any())).thenReturn(blob);
+        when(storage.create(any(BlobInfo.class), any(), new Storage.BlobTargetOption[0])).thenReturn(blob);
+        initStore();
+
+        GenericUrl url = service.postWhitelist("content", filename);
+        assertNotNull(url);
+    }
+
+    @Test
+    public void testGetMostRecentWhitelist() throws Exception {
+        int count = 3; // Count value is used in Blob name, create time, and content
+        Iterator<Blob> blobIterator = makeBlobIterator(count);
+        when(iterable.iterator()).thenReturn(blobIterator);
+        when(blobs.iterateAll()).thenReturn(iterable);
+        when(bucket.list()).thenReturn(blobs);
+        when(storage.get(any(String.class))).thenReturn(bucket);
+
+        initStore();
+        String whitelistData = service.getMostRecentWhitelist();
+        assertNotNull(whitelistData);
+        assertTrue(whitelistData.contains(String.valueOf(count)));
+    }
+
+    /**
+     * Make an iterator of Blobs so we can mock out what Google will return for data.
+     * @return Iterator<Blob>
+     */
+    @SuppressWarnings("SameParameterValue")
+    private Iterator<Blob> makeBlobIterator(int i) {
+        List<Blob> blobs = IntStream.range(1, i + 1).
+                mapToObj(this::mockBlob).
+                collect(Collectors.toList());
+        return blobs.iterator();
+    }
+
+    private Blob mockBlob(int i) {
+        Blob blob = mock(Blob.class);
+        when(blob.isDirectory()).thenReturn(false);
+        when(blob.getMediaLink()).thenReturn("http://localhost/bucket/blob" + i);
+        when(blob.getName()).thenReturn("bucket/blob_" + i + "_" + WhitelistService.WHITELIST_FILE_PREFIX + RandomStringUtils.random(10, false, true));
+        when(blob.getCreateTime()).thenReturn(Long.valueOf(i));
+        when(blob.getContent()).thenReturn(("blob_" + i).getBytes());
+        return blob;
+    }
+
+}

--- a/src/test/java/org/broadinstitute/consent/http/service/WhitelistServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/WhitelistServiceTest.java
@@ -36,27 +36,27 @@ public class WhitelistServiceTest {
 
     @Test
     public void testPostWhitelist_valid() {
-        String fileData = new WhitelistParserTest().makeSampleWhitelistFile(2, false);
+        String fileData = WhitelistParserTest.makeSampleWhitelistFile(2, false);
         GenericUrl url = service.postWhitelist(fileData);
         assertNotNull(url);
     }
 
     @Test(expected = BadRequestException.class)
     public void testPostWhitelist_invalid() {
-        String fileData = new WhitelistParserTest().makeSampleWhitelistFile(2, true);
+        String fileData = WhitelistParserTest.makeSampleWhitelistFile(2, true);
         service.postWhitelist(fileData);
     }
 
     @Test
     public void testValidateWhitelist_valid() {
-        String fileData = new WhitelistParserTest().makeSampleWhitelistFile(2, false);
+        String fileData = WhitelistParserTest.makeSampleWhitelistFile(2, false);
         boolean valid = service.validateWhitelist(fileData);
         assertTrue(valid);
     }
 
     @Test
     public void testValidateWhitelist_invalid() {
-        String fileData = new WhitelistParserTest().makeSampleWhitelistFile(2, true);
+        String fileData = WhitelistParserTest.makeSampleWhitelistFile(2, true);
         boolean valid = service.validateWhitelist(fileData);
         assertFalse(valid);
     }

--- a/src/test/java/org/broadinstitute/consent/http/service/WhitelistServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/WhitelistServiceTest.java
@@ -1,7 +1,8 @@
 package org.broadinstitute.consent.http.service;
 
 import com.google.api.client.http.GenericUrl;
-import org.broadinstitute.consent.http.cloudstore.GCSStore;
+import org.broadinstitute.consent.http.cloudstore.GCSService;
+import org.broadinstitute.consent.http.util.WhitelistCache;
 import org.broadinstitute.consent.http.util.WhitelistParserTest;
 import org.junit.Before;
 import org.junit.Test;
@@ -9,7 +10,6 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import javax.ws.rs.BadRequestException;
-import java.io.IOException;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -20,26 +20,29 @@ import static org.mockito.Mockito.when;
 public class WhitelistServiceTest {
 
     @Mock
-    GCSStore gcsStore;
+    GCSService gcsService;
+
+    @Mock
+    WhitelistCache cache;
 
     WhitelistService service;
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         MockitoAnnotations.initMocks(this);
-        when(gcsStore.postWhitelist(any(), any())).thenReturn(new GenericUrl("http://localhost:8000/whitelist.txt"));
-        service = new WhitelistService(gcsStore);
+        when(gcsService.postWhitelist(any(), any())).thenReturn(new GenericUrl("http://localhost:8000/whitelist.txt"));
+        service = new WhitelistService(gcsService, cache);
     }
 
     @Test
-    public void testPostWhitelist_valid() throws Exception {
+    public void testPostWhitelist_valid() {
         String fileData = new WhitelistParserTest().makeSampleWhitelistFile(2, false);
         GenericUrl url = service.postWhitelist(fileData);
         assertNotNull(url);
     }
 
     @Test(expected = BadRequestException.class)
-    public void testPostWhitelist_invalid() throws IOException {
+    public void testPostWhitelist_invalid() {
         String fileData = new WhitelistParserTest().makeSampleWhitelistFile(2, true);
         service.postWhitelist(fileData);
     }

--- a/src/test/java/org/broadinstitute/consent/http/util/WhitelistCacheTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/util/WhitelistCacheTest.java
@@ -1,0 +1,62 @@
+package org.broadinstitute.consent.http.util;
+
+import org.broadinstitute.consent.http.cloudstore.GCSService;
+import org.broadinstitute.consent.http.models.WhitelistEntry;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+public class WhitelistCacheTest {
+
+    @Mock
+    private GCSService gcsService;
+
+    private WhitelistCache cache;
+
+    private final int count = 4;
+
+    private final String whitelistData = WhitelistParserTest.makeSampleWhitelistFile(count, false);
+
+    private List<WhitelistEntry> whitelistEntries;
+
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+        whitelistEntries = new WhitelistParser().parseWhitelist(whitelistData);
+        when(gcsService.getMostRecentWhitelist()).thenReturn(whitelistData);
+        cache = new WhitelistCache(gcsService);
+    }
+
+    @Test
+    public void testLoadCachesFromService() {
+        testIndividualCacheQueries();
+    }
+
+    @Test
+    public void testLoadCachesFromData() {
+        cache.loadCaches(whitelistData);
+        testIndividualCacheQueries();
+    }
+
+    private void testIndividualCacheQueries() {
+        whitelistEntries.forEach(e -> {
+            List<WhitelistEntry> commonsMatches = cache.queryByCommonsId(e.getCommonsId());
+            assertEquals(1, commonsMatches.size());
+            List<WhitelistEntry> emailMatches = cache.queryByEmail(e.getEmail());
+            assertEquals(1, emailMatches.size());
+            List<WhitelistEntry> orgMatches = cache.queryByOrganization(e.getOrganization());
+            assertEquals(1, orgMatches.size());
+        });
+        assertTrue(cache.queryByCommonsId("").isEmpty());
+        assertTrue(cache.queryByEmail("").isEmpty());
+        assertTrue(cache.queryByOrganization("").isEmpty());
+    }
+
+}

--- a/src/test/java/org/broadinstitute/consent/http/util/WhitelistParserTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/util/WhitelistParserTest.java
@@ -22,7 +22,7 @@ public class WhitelistParserTest {
         assertEquals(numRows, entries.size());
     }
 
-    public String makeSampleWhitelistFile(int rows, boolean invalid) {
+    public static String makeSampleWhitelistFile(int rows, boolean invalid) {
         String tab = "\t";
         String newline = "\n";
         StringBuilder builder = new StringBuilder();


### PR DESCRIPTION
## Addresses
https://broadinstitute.atlassian.net/browse/DUOS-515

## Changes
* Adds a simple cache of whitelist entries by various fields
* Is repopulated when a new whitelist is updated
* Refreshes from GCS if cache is empty or cannot find value
* New `GCSService` to replace old `GCSStore`
  * `GCSStore` is near impossible to unit test due to non-standard GCS client interaction. And, it's very, very old code.