### PR TITLE
[DUOS-654][risk=no] Disable Notification

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/resources/DataRequestVoteResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataRequestVoteResource.java
@@ -233,7 +233,9 @@ public class DataRequestVoteResource extends Resource {
                 if(CollectionUtils.isNotEmpty(admins)) {
                     emailNotifierService.sendAdminFlaggedDarApproved(access.getString(DarConstants.DAR_CODE), admins, dataOwnerDataSet);
                 }
-                emailNotifierService.sendNeedsPIApprovalMessage(dataOwnerDataSet, access, approvalExpirationTimeAPI.findApprovalExpirationTime().getAmountOfDays());
+                // See DUOS-654. We are temporarily disabling notifications to data owners, so commenting this code
+                // instead of deleting the code path completely.
+//                emailNotifierService.sendNeedsPIApprovalMessage(dataOwnerDataSet, access, approvalExpirationTimeAPI.findApprovalExpirationTime().getAmountOfDays());
             }
         }
     }


### PR DESCRIPTION
## Addresses
https://broadinstitute.atlassian.net/browse/DUOS-654

## Changes
Disable notification that is normally sent out when creating a data owner election.
Keeping code in place for when this needs to be re-enabled.