### PR TITLE
[DUOS-688][risk=no] Prevent duplicate entries from being returned. 

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/resources/ResearcherResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/ResearcherResource.java
@@ -89,6 +89,7 @@ public class ResearcherResource extends Resource {
                     collect(Collectors.toMap(ResearcherProperty::getPropertyKey, ResearcherProperty::getPropertyValue));
             List<String> orgs = entries.stream().
                     map(WhitelistEntry::getOrganization).
+                    distinct().
                     collect(Collectors.toList());
             propMap.put(ResearcherFields.LIBRARY_CARDS, orgs);
             return Response.ok(propMap).build();

--- a/src/main/java/org/broadinstitute/consent/http/service/WhitelistService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/WhitelistService.java
@@ -87,14 +87,6 @@ public class WhitelistService {
                         filter(Objects::nonNull).
                         distinct().
                         collect(Collectors.toList()));
-        entries.addAll(
-                props.stream().
-                        filter(p -> p.getPropertyKey().equalsIgnoreCase(ResearcherFields.INSTITUTION.getValue())).
-                        map(p -> cache.queryByOrganization(p.getPropertyValue())).
-                        flatMap(List::stream).
-                        filter(Objects::nonNull).
-                        distinct().
-                        collect(Collectors.toList()));
         return entries.stream().distinct().collect(Collectors.toList());
     }
 

--- a/src/main/java/org/broadinstitute/consent/http/util/WhitelistCache.java
+++ b/src/main/java/org/broadinstitute/consent/http/util/WhitelistCache.java
@@ -20,7 +20,6 @@ public class WhitelistCache {
 
     private final Map<String, List<WhitelistEntry>> commonsIdCache = new ConcurrentHashMap<>();
     private final Map<String, List<WhitelistEntry>> emailCache = new ConcurrentHashMap<>();
-    private final Map<String, List<WhitelistEntry>> organizationCache = new ConcurrentHashMap<>();
 
     @Inject
     public WhitelistCache(GCSService gcsService) {
@@ -34,7 +33,6 @@ public class WhitelistCache {
         List<WhitelistEntry> entries = new WhitelistParser().parseWhitelist(whitelistData);
         commonsIdCache.putAll(entries.stream().collect(Collectors.groupingBy(WhitelistEntry::getCommonsId)));
         emailCache.putAll(entries.stream().collect(Collectors.groupingBy(WhitelistEntry::getEmail)));
-        organizationCache.putAll(entries.stream().collect(Collectors.groupingBy(WhitelistEntry::getOrganization)));
     }
 
     public List<WhitelistEntry> queryByCommonsId(String commonsId) {
@@ -43,10 +41,6 @@ public class WhitelistCache {
 
     public List<WhitelistEntry> queryByEmail(String email) {
         return tryCache(emailCache, email);
-    }
-
-    public List<WhitelistEntry> queryByOrganization(String org) {
-        return tryCache(organizationCache, org);
     }
 
     private void loadCachesFromStorage() throws Exception {
@@ -65,7 +59,7 @@ public class WhitelistCache {
         if (Objects.isNull(matchingEntries) || matchingEntries.isEmpty()) {
             return Collections.emptyList();
         }
-        return matchingEntries;
+        return matchingEntries.stream().distinct().collect(Collectors.toList());
     }
 
 }

--- a/src/test/java/org/broadinstitute/consent/http/service/WhitelistServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/WhitelistServiceTest.java
@@ -116,22 +116,6 @@ public class WhitelistServiceTest {
     }
 
     @Test
-    public void testFindWhitelistEntriesForUser_Org() {
-        String matchField = "org";
-        String fileData = generateWhitelistWithData(matchField);
-        DACUser user = new DACUser();
-        user.setDacUserId(1);
-        user.setEmail("email");
-        List<ResearcherProperty> properties = new ArrayList<>();
-        properties.add(new ResearcherProperty(1, ResearcherFields.INSTITUTION.getValue(), matchField));
-
-        initServices(fileData);
-        service.postWhitelist(fileData);
-        List<WhitelistEntry> entries = service.findWhitelistEntriesForUser(user, properties);
-        assertEquals(1, entries.size());
-    }
-
-    @Test
     public void testFindWhitelistEntriesForUser_NoResults() {
         String matchField = RandomStringUtils.random(5, true, true);
         String fileData = WhitelistParserTest.makeSampleWhitelistFile(2, false);

--- a/src/test/java/org/broadinstitute/consent/http/util/WhitelistCacheTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/util/WhitelistCacheTest.java
@@ -45,18 +45,23 @@ public class WhitelistCacheTest {
         testIndividualCacheQueries();
     }
 
+    @Test
+    public void testEnsureDistinctEntries() {
+        // Doubling up the string data means we'll have duplicate raw entries.
+        // The individual cache queries should each ensure distinct values.
+        cache.loadCaches(whitelistData + whitelistData);
+        testIndividualCacheQueries();
+    }
+
     private void testIndividualCacheQueries() {
         whitelistEntries.forEach(e -> {
             List<WhitelistEntry> commonsMatches = cache.queryByCommonsId(e.getCommonsId());
             assertEquals(1, commonsMatches.size());
             List<WhitelistEntry> emailMatches = cache.queryByEmail(e.getEmail());
             assertEquals(1, emailMatches.size());
-            List<WhitelistEntry> orgMatches = cache.queryByOrganization(e.getOrganization());
-            assertEquals(1, orgMatches.size());
         });
         assertTrue(cache.queryByCommonsId("").isEmpty());
         assertTrue(cache.queryByEmail("").isEmpty());
-        assertTrue(cache.queryByOrganization("").isEmpty());
     }
 
 }


### PR DESCRIPTION
## Addresses
https://broadinstitute.atlassian.net/browse/DUOS-688

See also: https://github.com/DataBiosphere/duos-ui/pull/474

## Changes
* Distinct where necessary
* Stop finding entries by org ... this is a clear logic bug where N different entries in the same org would be returned for each user in that org.