### PR TITLE
Revert "dependency: bump jetty-servlets from 9.4.29.v20200521 to 9.4.30.v20200611"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <liquibase.version>3.9.0</liquibase.version>
     <dropwizard.version>2.0.10</dropwizard.version>
     <pdfbox.version>2.0.19</pdfbox.version>
-    <jetty.version>9.4.30.v20200611</jetty.version>
+    <jetty.version>9.4.29.v20200521</jetty.version>
     <owl.version>5.1.14</owl.version>
     <postgres.version>42.2.14</postgres.version>
     <rdf4j-rio.version>3.2.2</rdf4j-rio.version>


### PR DESCRIPTION
Reverts DataBiosphere/consent#647