### PR TITLE
[no jira][risk=no] Minor bug fix

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
@@ -353,6 +353,7 @@ public class DataAccessRequestService {
             darManage.setCreateDate(dar.getData().getCreateDate());
             darManage.setRus(dar.getData().getRus());
             darManage.setProjectTitle(dar.getData().getProjectTitle());
+            darManage.setReferenceId(referenceId);
             darManage.setDataRequestId(referenceId);
             darManage.setFrontEndId(dar.getData().getDarCode());
             darManage.setSortDate(dar.getData().getSortDate());


### PR DESCRIPTION
Set the `referenceId` for the dar manage objects being returned to the user. The UI uses the `dataRequestId` value now but for consistency, we should be using the `referenceId` throughout.