### PR TITLE
[DUOS-702][risk=no] Dac Decision Metrics

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
@@ -359,7 +359,11 @@ public class ConsentModule extends AbstractModule {
 
     @Provides
     MetricsService providesMetricsService() {
-        return new MetricsService(providesMetricsDAO());
+        return new MetricsService(
+                providesDacService(),
+                providesDataSetDAO(),
+                providesMetricsDAO()
+        );
     }
 
     @Provides

--- a/src/main/java/org/broadinstitute/consent/http/db/DataSetDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DataSetDAO.java
@@ -235,6 +235,22 @@ public interface DataSetDAO extends Transactional<DataSetDAO> {
 
     /**
      * DACs -> Consents -> Consent Associations -> DataSets
+     * DataSets -> DatasetProperties -> Dictionary
+     *
+     * @return Set of datasets, with properties, that are associated to any Dac.
+     */
+    @UseRowMapper(DataSetPropertiesMapper.class)
+    @SqlQuery("SELECT d.*, k.key, p.propertyvalue, c.consentid, c.dac_id, c.translateduserestriction " +
+            " FROM dataset d " +
+            " LEFT OUTER JOIN datasetproperty p ON p.datasetid = d.datasetid " +
+            " LEFT OUTER JOIN dictionary k ON k.keyid = p.propertykey " +
+            " INNER JOIN consentassociations a ON a.datasetid = d.datasetid " +
+            " INNER JOIN consents c ON c.consentid = a.consentid " +
+            " WHERE c.dac_id IS NOT NULL ")
+    Set<DataSetDTO> findDatasetsWithDacs();
+
+    /**
+     * DACs -> Consents -> Consent Associations -> DataSets
      *
      * @return List of dataset id and its associated dac id
      */

--- a/src/main/java/org/broadinstitute/consent/http/db/DataSetDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DataSetDAO.java
@@ -51,9 +51,6 @@ public interface DataSetDAO extends Transactional<DataSetDAO> {
     @SqlQuery("select * from dataset where objectId = :objectId")
     DataSet findDataSetByObjectId(@Bind("objectId") String objectId);
 
-    @SqlQuery("select objectId from dataset where dataSetId = :dataSetId")
-    String findObjectIdByDataSetId(@Bind("dataSetId") Integer dataSetId);
-
     @SqlQuery("select * from dataset where objectId = :objectId")
     Integer findDataSetIdByObjectId(@Bind("objectId") String objectId);
 
@@ -89,14 +86,14 @@ public interface DataSetDAO extends Transactional<DataSetDAO> {
     void updateDataSetNeedsApproval(@Bind("dataSetId") Integer dataSetId, @Bind("needs_approval") Boolean needs_approval);
 
     @UseRowMapper(DataSetPropertiesMapper.class)
-    @SqlQuery("select d.*, k.key, dp.propertyValue, ca.consentId , c.translatedUseRestriction " +
+    @SqlQuery("select d.*, k.key, dp.propertyValue, ca.consentId, c.dac_id, c.translatedUseRestriction " +
             "from dataset d inner join datasetproperty dp on dp.dataSetId = d.dataSetId and d.name is not null inner join dictionary k on k.keyId = dp.propertyKey " +
             "inner join consentassociations ca on ca.dataSetId = d.dataSetId inner join consents c on c.consentId = ca.consentId " +
             "order by d.dataSetId, k.displayOrder")
     Set<DataSetDTO> findDataSets();
 
     @UseRowMapper(DataSetPropertiesMapper.class)
-    @SqlQuery("select d.*, k.key, dp.propertyValue, ca.consentId , c.translatedUseRestriction " +
+    @SqlQuery("select d.*, k.key, dp.propertyValue, ca.consentId, c.dac_id, c.translatedUseRestriction " +
             "from dataset d inner join datasetproperty dp on dp.dataSetId = d.dataSetId inner join dictionary k on k.keyId = dp.propertyKey " +
             "inner join consentassociations ca on ca.dataSetId = d.dataSetId inner join consents c on c.consentId = ca.consentId " +
             "where d.dataSetId = :dataSetId order by d.dataSetId, k.displayOrder")
@@ -110,7 +107,7 @@ public interface DataSetDAO extends Transactional<DataSetDAO> {
     Set<DataSetDTO> findDataSetsForResearcher();
 
     @UseRowMapper(DataSetPropertiesMapper.class)
-    @SqlQuery("select d.*, k.key, dp.propertyValue, ca.consentId , c.translatedUseRestriction " +
+    @SqlQuery("select d.*, k.key, dp.propertyValue, ca.consentId, c.dac_id, c.translatedUseRestriction " +
             "from dataset d inner join datasetproperty dp on dp.dataSetId = d.dataSetId inner join dictionary k on k.keyId = dp.propertyKey " +
             "inner join consentassociations ca on ca.dataSetId = d.dataSetId inner join consents c on c.consentId = ca.consentId " +
             "where d.dataSetId in (<dataSetIdList>) order by d.dataSetId, k.receiveOrder")
@@ -225,7 +222,7 @@ public interface DataSetDAO extends Transactional<DataSetDAO> {
      * @return Set of datasets, with properties, that are associated to a single DAC.
      */
     @UseRowMapper(DataSetPropertiesMapper.class)
-    @SqlQuery("select d.*, k.key, p.propertyValue, c.consentId , c.translatedUseRestriction from dataset d " +
+    @SqlQuery("select d.*, k.key, p.propertyValue, c.consentId, c.dac_id, c.translatedUseRestriction from dataset d " +
             " left outer join datasetproperty p on p.dataSetId = d.dataSetId " +
             " left outer join dictionary k on k.keyId = p.propertyKey " +
             " inner join consentassociations a on a.dataSetId = d.dataSetId " +

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DataSetPropertiesMapper.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DataSetPropertiesMapper.java
@@ -5,7 +5,6 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.Objects;
 import org.broadinstitute.consent.http.models.dto.DataSetDTO;
 import org.broadinstitute.consent.http.models.dto.DataSetPropertyDTO;
 import org.jdbi.v3.core.mapper.RowMapper;
@@ -13,7 +12,7 @@ import org.jdbi.v3.core.statement.StatementContext;
 
 public class DataSetPropertiesMapper implements RowMapper<DataSetDTO> {
 
-  private Map<Integer, DataSetDTO> dataSets = new LinkedHashMap<>();
+  private final Map<Integer, DataSetDTO> dataSets = new LinkedHashMap<>();
   private static final String PROPERTY_KEY = "key";
   private static final String PROPERTY_PROPERTYVALUE = "propertyValue";
 

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DataSetPropertiesMapper.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DataSetPropertiesMapper.java
@@ -5,6 +5,7 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Objects;
 import org.broadinstitute.consent.http.models.dto.DataSetDTO;
 import org.broadinstitute.consent.http.models.dto.DataSetPropertyDTO;
 import org.jdbi.v3.core.mapper.RowMapper;
@@ -19,11 +20,15 @@ public class DataSetPropertiesMapper implements RowMapper<DataSetDTO> {
   public DataSetDTO map(ResultSet r, StatementContext ctx) throws SQLException {
 
     DataSetDTO dataSetDTO;
+    int dacId = r.getInt("dac_id");
     Integer dataSetId = r.getInt("dataSetId");
     String consentId = r.getString("consentId");
     Integer alias = r.getInt("alias");
     if (!dataSets.containsKey(dataSetId)) {
       dataSetDTO = new DataSetDTO(new ArrayList<>());
+      if (dacId > 0) {
+        dataSetDTO.setDacId(dacId);
+      }
       dataSetDTO.setConsentId(consentId);
       dataSetDTO.setAlias(alias);
       dataSetDTO.setDataSetId(dataSetId);

--- a/src/main/java/org/broadinstitute/consent/http/models/DacDecisionMetrics.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DacDecisionMetrics.java
@@ -6,7 +6,12 @@ import java.util.stream.Collectors;
 import org.apache.commons.lang3.time.DurationFormatUtils;
 import org.broadinstitute.consent.http.models.dto.DataSetDTO;
 
-public class DarDecisionMetricsSummary {
+/**
+ * Generate a row of dac decision data.
+ *
+ * <p>TODO: Future task to add Used DUOS Algorithm for Decision Support: Yes/No
+ */
+public class DacDecisionMetrics {
 
   Dac dac;
   List<DataSetDTO> datasets;
@@ -54,22 +59,14 @@ public class DarDecisionMetricsSummary {
         "\n");
   }
 
-  private String getValue(String str) {
-    return Objects.nonNull(str) ? str : "";
-  }
-
-  private String getValue(Integer i) {
-    return Objects.nonNull(i) ? i.toString() : "";
-  }
-
-  public DarDecisionMetricsSummary(
+  public DacDecisionMetrics(
       Dac dac, List<DataSetDTO> datasets, List<DarDecisionMetrics> metrics) {
     this.setDac(dac);
     this.setDatasets(datasets);
     this.setMetrics(metrics);
     this.setChairCount(dac);
     this.setMemberCount(dac);
-    this.setDatasets(datasets);
+    this.setDatasetCount(datasets);
 
     this.setDarsReceived(metrics.size());
     List<DarDecisionMetrics> completedDarMetrics =
@@ -105,7 +102,7 @@ public class DarDecisionMetricsSummary {
     return dac;
   }
 
-  public void setDac(Dac dac) {
+  private void setDac(Dac dac) {
     this.dac = dac;
   }
 
@@ -113,7 +110,7 @@ public class DarDecisionMetricsSummary {
     return datasets;
   }
 
-  public void setDatasets(List<DataSetDTO> datasets) {
+  private void setDatasets(List<DataSetDTO> datasets) {
     this.datasets = datasets;
   }
 
@@ -121,7 +118,7 @@ public class DarDecisionMetricsSummary {
     return metrics;
   }
 
-  public void setMetrics(List<DarDecisionMetrics> metrics) {
+  private void setMetrics(List<DarDecisionMetrics> metrics) {
     this.metrics = metrics;
   }
 
@@ -129,7 +126,7 @@ public class DarDecisionMetricsSummary {
     return chairCount;
   }
 
-  public void setChairCount(Dac dac) {
+  private void setChairCount(Dac dac) {
     if (Objects.nonNull(dac.getChairpersons()) && !dac.getChairpersons().isEmpty()) {
       this.chairCount = dac.getChairpersons().size();
     }
@@ -139,7 +136,7 @@ public class DarDecisionMetricsSummary {
     return memberCount;
   }
 
-  public void setMemberCount(Dac dac) {
+  private void setMemberCount(Dac dac) {
     if (Objects.nonNull(dac.getMembers()) && !dac.getMembers().isEmpty()) {
       this.memberCount = dac.getMembers().size();
     }
@@ -149,7 +146,7 @@ public class DarDecisionMetricsSummary {
     return datasetCount;
   }
 
-  public void setDatasetCount(List<DataSet> datasets) {
+  private void setDatasetCount(List<DataSetDTO> datasets) {
     if (Objects.nonNull(datasets) && !datasets.isEmpty()) {
       this.datasetCount = datasets.size();
     }
@@ -159,7 +156,7 @@ public class DarDecisionMetricsSummary {
     return darsReceived;
   }
 
-  public void setDarsReceived(Integer darsReceived) {
+  private void setDarsReceived(Integer darsReceived) {
     this.darsReceived = darsReceived;
   }
 
@@ -167,7 +164,7 @@ public class DarDecisionMetricsSummary {
     return percentDARsReviewed;
   }
 
-  public void setPercentDARsReviewed(Integer percentDARsReviewed) {
+  private void setPercentDARsReviewed(Integer percentDARsReviewed) {
     this.percentDARsReviewed = percentDARsReviewed;
   }
 
@@ -175,7 +172,7 @@ public class DarDecisionMetricsSummary {
     return averageTurnaroundTimeMillis;
   }
 
-  public void setAverageTurnaroundTimeMillis(Double averageTurnaroundTimeMillis) {
+  private void setAverageTurnaroundTimeMillis(Double averageTurnaroundTimeMillis) {
     this.averageTurnaroundTimeMillis = averageTurnaroundTimeMillis;
   }
 
@@ -183,7 +180,7 @@ public class DarDecisionMetricsSummary {
     return averageTurnaroundTime;
   }
 
-  public void setAverageTurnaroundTime() {
+  private void setAverageTurnaroundTime() {
     if (Objects.nonNull(this.getAverageTurnaroundTimeMillis())) {
       this.averageTurnaroundTime =
           DurationFormatUtils.formatDurationWords(
@@ -195,7 +192,7 @@ public class DarDecisionMetricsSummary {
     return percentRevealAlgorithm;
   }
 
-  public void setPercentRevealAlgorithm(Integer percentRevealAlgorithm) {
+  private void setPercentRevealAlgorithm(Integer percentRevealAlgorithm) {
     this.percentRevealAlgorithm = percentRevealAlgorithm;
   }
 
@@ -203,7 +200,7 @@ public class DarDecisionMetricsSummary {
     return percentAgreementAlgorithm;
   }
 
-  public void setPercentAgreementAlgorithm(Integer percentAgreementAlgorithm) {
+  private void setPercentAgreementAlgorithm(Integer percentAgreementAlgorithm) {
     this.percentAgreementAlgorithm = percentAgreementAlgorithm;
   }
 
@@ -211,7 +208,15 @@ public class DarDecisionMetricsSummary {
     return percentSRPAccurate;
   }
 
-  public void setPercentSRPAccurate(Integer percentSRPAccurate) {
+  private void setPercentSRPAccurate(Integer percentSRPAccurate) {
     this.percentSRPAccurate = percentSRPAccurate;
+  }
+
+  private String getValue(String str) {
+    return Objects.nonNull(str) ? str : "";
+  }
+
+  private String getValue(Integer i) {
+    return Objects.nonNull(i) ? i.toString() : "";
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/models/DacDecisionMetrics.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DacDecisionMetrics.java
@@ -85,6 +85,8 @@ public class DacDecisionMetrics {
 
     List<DarDecisionMetrics> agreementMetrics =
         completedDarMetrics.stream()
+            .filter(m -> Objects.nonNull(m.getAlgorithmDecision()))
+            .filter(m -> Objects.nonNull(m.getDacDecision()))
             .filter(m -> m.getAlgorithmDecision().equalsIgnoreCase(m.getDacDecision()))
             .collect(Collectors.toList());
 
@@ -94,6 +96,7 @@ public class DacDecisionMetrics {
 
       List<DarDecisionMetrics> srpMetrics =
           completedDarMetrics.stream()
+              .filter(m -> Objects.nonNull(m.getSrpDecision()))
               .filter(m -> m.getSrpDecision().equalsIgnoreCase("yes"))
               .collect(Collectors.toList());
       long percentSrp = (long) srpMetrics.size() / (long) completedDarMetrics.size();

--- a/src/main/java/org/broadinstitute/consent/http/models/DacDecisionMetrics.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DacDecisionMetrics.java
@@ -13,19 +13,19 @@ import org.broadinstitute.consent.http.models.dto.DataSetDTO;
  */
 public class DacDecisionMetrics {
 
-  Dac dac;
-  List<DataSetDTO> datasets;
-  List<DarDecisionMetrics> metrics;
-  Integer chairCount;
-  Integer memberCount;
-  Integer datasetCount;
-  Integer darsReceived;
-  Integer percentDARsReviewed;
-  Double averageTurnaroundTimeMillis;
-  String averageTurnaroundTime;
-  Integer percentRevealAlgorithm;
-  Integer percentAgreementAlgorithm;
-  Integer percentSRPAccurate;
+  private Dac dac;
+  private List<DataSetDTO> datasets;
+  private List<DarDecisionMetrics> metrics;
+  private Integer chairCount;
+  private Integer memberCount;
+  private Integer datasetCount;
+  private Integer darsReceived;
+  private Integer percentDARsReviewed;
+  private Double averageTurnaroundTimeMillis;
+  private String averageTurnaroundTime;
+  private Integer percentRevealAlgorithm;
+  private Integer percentAgreementAlgorithm;
+  private Integer percentSRPAccurate;
 
   public static String getHeaderRow(String joiner) {
     return String.join(
@@ -53,7 +53,7 @@ public class DacDecisionMetrics {
         getValue(getDarsReceived()),
         getValue(getPercentDARsReviewed()),
         getValue(getAverageTurnaroundTime()),
-        "",
+        getValue(getPercentRevealAlgorithm()),
         getValue(getPercentAgreementAlgorithm()),
         getValue(getPercentSRPAccurate()),
         "\n");
@@ -102,6 +102,7 @@ public class DacDecisionMetrics {
       long percentSrp = (long) srpMetrics.size() / (long) completedDarMetrics.size();
       this.setPercentSRPAccurate((int) percentSrp);
     }
+    setPercentRevealAlgorithm(0); // Placeholder for "% Reveal DUOS Algorithm"
   }
 
   public Dac getDac() {

--- a/src/main/java/org/broadinstitute/consent/http/models/DacDecisionMetrics.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DacDecisionMetrics.java
@@ -59,8 +59,7 @@ public class DacDecisionMetrics {
         "\n");
   }
 
-  public DacDecisionMetrics(
-      Dac dac, List<DataSetDTO> datasets, List<DarDecisionMetrics> metrics) {
+  public DacDecisionMetrics(Dac dac, List<DataSetDTO> datasets, List<DarDecisionMetrics> metrics) {
     this.setDac(dac);
     this.setDatasets(datasets);
     this.setMetrics(metrics);
@@ -73,8 +72,10 @@ public class DacDecisionMetrics {
         metrics.stream()
             .filter(m -> Objects.nonNull(m.getDacDecision()))
             .collect(Collectors.toList());
-    long percentReviewed = (long) completedDarMetrics.size() / (long) metrics.size() * 100;
-    this.setPercentDARsReviewed((int) percentReviewed);
+    if (!metrics.isEmpty()) {
+      long percentReviewed = (long) completedDarMetrics.size() / (long) metrics.size() * 100;
+      this.setPercentDARsReviewed((int) percentReviewed);
+    }
     completedDarMetrics.stream()
         .filter(m -> Objects.nonNull(m.getTurnaroundTimeMillis()))
         .mapToLong(DarDecisionMetrics::getTurnaroundTimeMillis)
@@ -87,15 +88,17 @@ public class DacDecisionMetrics {
             .filter(m -> m.getAlgorithmDecision().equalsIgnoreCase(m.getDacDecision()))
             .collect(Collectors.toList());
 
-    long percentAgreement = (long) agreementMetrics.size() / (long) completedDarMetrics.size();
-    this.setPercentAgreementAlgorithm((int) percentAgreement);
+    if (!completedDarMetrics.isEmpty()) {
+      long percentAgreement = (long) agreementMetrics.size() / (long) completedDarMetrics.size();
+      this.setPercentAgreementAlgorithm((int) percentAgreement);
 
-    List<DarDecisionMetrics> srpMetrics =
-        completedDarMetrics.stream()
-            .filter(m -> m.getSrpDecision().equalsIgnoreCase("yes"))
-            .collect(Collectors.toList());
-    long percentSrp = (long) srpMetrics.size() / (long) completedDarMetrics.size();
-    this.setPercentSRPAccurate((int) percentSrp);
+      List<DarDecisionMetrics> srpMetrics =
+          completedDarMetrics.stream()
+              .filter(m -> m.getSrpDecision().equalsIgnoreCase("yes"))
+              .collect(Collectors.toList());
+      long percentSrp = (long) srpMetrics.size() / (long) completedDarMetrics.size();
+      this.setPercentSRPAccurate((int) percentSrp);
+    }
   }
 
   public Dac getDac() {

--- a/src/main/java/org/broadinstitute/consent/http/models/DacDecisionMetrics.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DacDecisionMetrics.java
@@ -8,8 +8,6 @@ import org.broadinstitute.consent.http.models.dto.DataSetDTO;
 
 /**
  * Generate a row of dac decision data.
- *
- * <p>TODO: Future task to add Used DUOS Algorithm for Decision Support: Yes/No
  */
 public class DacDecisionMetrics {
 

--- a/src/main/java/org/broadinstitute/consent/http/models/DarDecisionMetrics.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DarDecisionMetrics.java
@@ -21,7 +21,7 @@ public class DarDecisionMetrics {
 
   private static final SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
   private String darId;
-  private String dacId;
+  private String dacName;
   private String datasetId;
   private Date dateSubmitted;
   private Date dateApproved;
@@ -40,7 +40,7 @@ public class DarDecisionMetrics {
       Election rpElection,
       Match match) {
     this.setDarId(dar);
-    this.setDacId(dac);
+    this.setDacName(dac);
     this.setDatasetId(dataset);
     this.setDacDecision(accessElection);
     this.setDateSubmitted(accessElection);
@@ -64,12 +64,12 @@ public class DarDecisionMetrics {
         "Algorithm Decision",
         "Structured Research Purpose Decision",
         "\n");
-
   }
+
   public String toString(String joiner) {
     return String.join(joiner,
         getValue(this.getDarId()),
-        getValue(getDacId()),
+        getValue(getDacName()),
         getValue(getDatasetId()),
         getValue(getDateSubmitted()),
         getValue(getDateApproved()),
@@ -98,13 +98,13 @@ public class DarDecisionMetrics {
       this.darId = dar.getData().getDarCode();
   }
 
-  public String getDacId() {
-    return dacId;
+  public String getDacName() {
+    return dacName;
   }
 
-  private void setDacId(Dac dac) {
+  private void setDacName(Dac dac) {
     if (Objects.nonNull(dac)) {
-      this.dacId = dac.getName();
+      this.dacName = dac.getName();
     }
   }
 

--- a/src/main/java/org/broadinstitute/consent/http/models/DarDecisionMetrics.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DarDecisionMetrics.java
@@ -14,8 +14,6 @@ import org.broadinstitute.consent.http.util.DatasetUtil;
  * <p>DAR ID: DAR-123-A-0 DAC ID: Broad DAC Dataset ID: DS-00001 Date Submitted: 01-01-2020 Date
  * Approved: 01-02-2020 Date Denied: 01-02-2020 DAR ToT: 1 day DAC Decision: Yes/No Algorithm
  * Decision: Yes/No Structured Research Purpose Decision: Yes/No
- *
- * <p>TODO: Future task to add Used DUOS Algorithm for Decision Support: Yes/No
  */
 public class DarDecisionMetrics {
 

--- a/src/main/java/org/broadinstitute/consent/http/models/DarDecisionMetrics.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DarDecisionMetrics.java
@@ -9,7 +9,7 @@ import org.apache.commons.lang3.time.DurationFormatUtils;
 import org.broadinstitute.consent.http.util.DatasetUtil;
 
 /**
- * Generate a row of summary data in the form of:
+ * Generate a row of dar decision data in the form of:
  *
  * <p>DAR ID: DAR-123-A-0 DAC ID: Broad DAC Dataset ID: DS-00001 Date Submitted: 01-01-2020 Date
  * Approved: 01-02-2020 Date Denied: 01-02-2020 DAR ToT: 1 day DAC Decision: Yes/No Algorithm
@@ -52,7 +52,8 @@ public class DarDecisionMetrics {
   }
 
   public static String getHeaderRow(String joiner) {
-    return String.join(joiner,
+    return String.join(
+        joiner,
         "DAR ID",
         "DAC ID",
         "Dataset ID",
@@ -67,7 +68,8 @@ public class DarDecisionMetrics {
   }
 
   public String toString(String joiner) {
-    return String.join(joiner,
+    return String.join(
+        joiner,
         getValue(this.getDarId()),
         getValue(getDacName()),
         getValue(getDatasetId()),
@@ -79,14 +81,6 @@ public class DarDecisionMetrics {
         getValue(getAlgorithmDecision()),
         getValue(getSrpDecision()),
         "\n");
-  }
-
-  private String getValue(String str) {
-    return Objects.nonNull(str) ? str : "";
-  }
-
-  private String getValue(Date date) {
-    return Objects.nonNull(date) ? sdf.format(date) : "";
   }
 
   public String getDarId() {
@@ -247,5 +241,13 @@ public class DarDecisionMetrics {
         this.srpDecision = rpVote ? "Yes" : "No";
       }
     }
+  }
+
+  private String getValue(String str) {
+    return Objects.nonNull(str) ? str : "";
+  }
+
+  private String getValue(Date date) {
+    return Objects.nonNull(date) ? sdf.format(date) : "";
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/models/DarDecisionMetricsSummary.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DarDecisionMetricsSummary.java
@@ -1,0 +1,217 @@
+package org.broadinstitute.consent.http.models;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.time.DurationFormatUtils;
+import org.broadinstitute.consent.http.models.dto.DataSetDTO;
+
+public class DarDecisionMetricsSummary {
+
+  Dac dac;
+  List<DataSetDTO> datasets;
+  List<DarDecisionMetrics> metrics;
+  Integer chairCount;
+  Integer memberCount;
+  Integer datasetCount;
+  Integer darsReceived;
+  Integer percentDARsReviewed;
+  Double averageTurnaroundTimeMillis;
+  String averageTurnaroundTime;
+  Integer percentRevealAlgorithm;
+  Integer percentAgreementAlgorithm;
+  Integer percentSRPAccurate;
+
+  public static String getHeaderRow(String joiner) {
+    return String.join(
+        joiner,
+        "DAC ID",
+        "# of DAC Members",
+        "# of DAC Chairs",
+        "# of Datasets",
+        "# of DARs Received",
+        "% of DARs Reviewed",
+        "Average DAR Turnaround Time",
+        "% Reveal DUOS Algorithm",
+        "% Agreement with DUOS Algorithm",
+        "% Structured Research Purpose Accurate",
+        "\n");
+  }
+
+  public String toString(String joiner) {
+    return String.join(
+        joiner,
+        getValue(this.getDac().getName()),
+        getValue(getMemberCount()),
+        getValue(getChairCount()),
+        getValue(getDatasetCount()),
+        getValue(getDarsReceived()),
+        getValue(getPercentDARsReviewed()),
+        getValue(getAverageTurnaroundTime()),
+        "",
+        getValue(getPercentAgreementAlgorithm()),
+        getValue(getPercentSRPAccurate()),
+        "\n");
+  }
+
+  private String getValue(String str) {
+    return Objects.nonNull(str) ? str : "";
+  }
+
+  private String getValue(Integer i) {
+    return Objects.nonNull(i) ? i.toString() : "";
+  }
+
+  public DarDecisionMetricsSummary(
+      Dac dac, List<DataSetDTO> datasets, List<DarDecisionMetrics> metrics) {
+    this.setDac(dac);
+    this.setDatasets(datasets);
+    this.setMetrics(metrics);
+    this.setChairCount(dac);
+    this.setMemberCount(dac);
+    this.setDatasets(datasets);
+
+    this.setDarsReceived(metrics.size());
+    List<DarDecisionMetrics> completedDarMetrics =
+        metrics.stream()
+            .filter(m -> Objects.nonNull(m.getDacDecision()))
+            .collect(Collectors.toList());
+    long percentReviewed = (long) completedDarMetrics.size() / (long) metrics.size() * 100;
+    this.setPercentDARsReviewed((int) percentReviewed);
+    completedDarMetrics.stream()
+        .filter(m -> Objects.nonNull(m.getTurnaroundTimeMillis()))
+        .mapToLong(DarDecisionMetrics::getTurnaroundTimeMillis)
+        .average()
+        .ifPresent(this::setAverageTurnaroundTimeMillis);
+    this.setAverageTurnaroundTime();
+
+    List<DarDecisionMetrics> agreementMetrics =
+        completedDarMetrics.stream()
+            .filter(m -> m.getAlgorithmDecision().equalsIgnoreCase(m.getDacDecision()))
+            .collect(Collectors.toList());
+
+    long percentAgreement = (long) agreementMetrics.size() / (long) completedDarMetrics.size();
+    this.setPercentAgreementAlgorithm((int) percentAgreement);
+
+    List<DarDecisionMetrics> srpMetrics =
+        completedDarMetrics.stream()
+            .filter(m -> m.getSrpDecision().equalsIgnoreCase("yes"))
+            .collect(Collectors.toList());
+    long percentSrp = (long) srpMetrics.size() / (long) completedDarMetrics.size();
+    this.setPercentSRPAccurate((int) percentSrp);
+  }
+
+  public Dac getDac() {
+    return dac;
+  }
+
+  public void setDac(Dac dac) {
+    this.dac = dac;
+  }
+
+  public List<DataSetDTO> getDatasets() {
+    return datasets;
+  }
+
+  public void setDatasets(List<DataSetDTO> datasets) {
+    this.datasets = datasets;
+  }
+
+  public List<DarDecisionMetrics> getMetrics() {
+    return metrics;
+  }
+
+  public void setMetrics(List<DarDecisionMetrics> metrics) {
+    this.metrics = metrics;
+  }
+
+  public Integer getChairCount() {
+    return chairCount;
+  }
+
+  public void setChairCount(Dac dac) {
+    if (Objects.nonNull(dac.getChairpersons()) && !dac.getChairpersons().isEmpty()) {
+      this.chairCount = dac.getChairpersons().size();
+    }
+  }
+
+  public Integer getMemberCount() {
+    return memberCount;
+  }
+
+  public void setMemberCount(Dac dac) {
+    if (Objects.nonNull(dac.getMembers()) && !dac.getMembers().isEmpty()) {
+      this.memberCount = dac.getMembers().size();
+    }
+  }
+
+  public Integer getDatasetCount() {
+    return datasetCount;
+  }
+
+  public void setDatasetCount(List<DataSet> datasets) {
+    if (Objects.nonNull(datasets) && !datasets.isEmpty()) {
+      this.datasetCount = datasets.size();
+    }
+  }
+
+  public Integer getDarsReceived() {
+    return darsReceived;
+  }
+
+  public void setDarsReceived(Integer darsReceived) {
+    this.darsReceived = darsReceived;
+  }
+
+  public Integer getPercentDARsReviewed() {
+    return percentDARsReviewed;
+  }
+
+  public void setPercentDARsReviewed(Integer percentDARsReviewed) {
+    this.percentDARsReviewed = percentDARsReviewed;
+  }
+
+  public Double getAverageTurnaroundTimeMillis() {
+    return averageTurnaroundTimeMillis;
+  }
+
+  public void setAverageTurnaroundTimeMillis(Double averageTurnaroundTimeMillis) {
+    this.averageTurnaroundTimeMillis = averageTurnaroundTimeMillis;
+  }
+
+  public String getAverageTurnaroundTime() {
+    return averageTurnaroundTime;
+  }
+
+  public void setAverageTurnaroundTime() {
+    if (Objects.nonNull(this.getAverageTurnaroundTimeMillis())) {
+      this.averageTurnaroundTime =
+          DurationFormatUtils.formatDurationWords(
+              this.getAverageTurnaroundTimeMillis().longValue(), true, true);
+    }
+  }
+
+  public Integer getPercentRevealAlgorithm() {
+    return percentRevealAlgorithm;
+  }
+
+  public void setPercentRevealAlgorithm(Integer percentRevealAlgorithm) {
+    this.percentRevealAlgorithm = percentRevealAlgorithm;
+  }
+
+  public Integer getPercentAgreementAlgorithm() {
+    return percentAgreementAlgorithm;
+  }
+
+  public void setPercentAgreementAlgorithm(Integer percentAgreementAlgorithm) {
+    this.percentAgreementAlgorithm = percentAgreementAlgorithm;
+  }
+
+  public Integer getPercentSRPAccurate() {
+    return percentSRPAccurate;
+  }
+
+  public void setPercentSRPAccurate(Integer percentSRPAccurate) {
+    this.percentSRPAccurate = percentSRPAccurate;
+  }
+}

--- a/src/main/java/org/broadinstitute/consent/http/models/dto/DataSetDTO.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/dto/DataSetDTO.java
@@ -1,15 +1,16 @@
 package org.broadinstitute.consent.http.models.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.broadinstitute.consent.http.models.DataSetProperty;
-import org.broadinstitute.consent.http.util.DatasetUtil;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import org.broadinstitute.consent.http.util.DatasetUtil;
 
 
 public class DataSetDTO {
+
+    @JsonProperty
+    private Integer dacId;
 
     @JsonProperty
     private Integer dataSetId;
@@ -45,6 +46,14 @@ public class DataSetDTO {
     private String objectId;
 
     public DataSetDTO() {
+    }
+
+    public Integer getDacId() {
+        return dacId;
+    }
+
+    public void setDacId(Integer dacId) {
+        this.dacId = dacId;
     }
 
     public DataSetDTO(List<DataSetPropertyDTO> properties) {

--- a/src/main/java/org/broadinstitute/consent/http/resources/MetricsResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/MetricsResource.java
@@ -23,7 +23,7 @@ public class MetricsResource extends Resource {
   @GET
   @Path("/dar/decision")
   @Produces(MediaType.TEXT_PLAIN)
-  public Response getMetricsData() {
+  public Response getDarMetricsData() {
     String joiner = "\t";
     StringBuilder tsv = new StringBuilder(DarDecisionMetrics.getHeaderRow(joiner));
     metricsService.generateDarDecisionMetrics().forEach(m -> tsv.append(m.toString(joiner)));

--- a/src/main/java/org/broadinstitute/consent/http/resources/MetricsResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/MetricsResource.java
@@ -6,6 +6,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import org.broadinstitute.consent.http.models.DacDecisionMetrics;
 import org.broadinstitute.consent.http.models.DarDecisionMetrics;
 import org.broadinstitute.consent.http.service.MetricsService;
 
@@ -26,6 +27,16 @@ public class MetricsResource extends Resource {
     String joiner = "\t";
     StringBuilder tsv = new StringBuilder(DarDecisionMetrics.getHeaderRow(joiner));
     metricsService.generateDarDecisionMetrics().forEach(m -> tsv.append(m.toString(joiner)));
+    return Response.ok(tsv.toString()).build();
+  }
+
+  @GET
+  @Path("/dac/decision")
+  @Produces(MediaType.TEXT_PLAIN)
+  public Response getDacMetricsData() {
+    String joiner = "\t";
+    StringBuilder tsv = new StringBuilder(DacDecisionMetrics.getHeaderRow(joiner));
+    metricsService.generateDacDecisionMetrics().forEach(m -> tsv.append(m.toString(joiner)));
     return Response.ok(tsv.toString()).build();
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/service/MetricsService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/MetricsService.java
@@ -11,8 +11,8 @@ import org.broadinstitute.consent.http.db.DataSetDAO;
 import org.broadinstitute.consent.http.db.MetricsDAO;
 import org.broadinstitute.consent.http.enumeration.ElectionType;
 import org.broadinstitute.consent.http.models.Dac;
+import org.broadinstitute.consent.http.models.DacDecisionMetrics;
 import org.broadinstitute.consent.http.models.DarDecisionMetrics;
-import org.broadinstitute.consent.http.models.DarDecisionMetricsSummary;
 import org.broadinstitute.consent.http.models.DataAccessRequest;
 import org.broadinstitute.consent.http.models.DataAccessRequestData;
 import org.broadinstitute.consent.http.models.DataSet;
@@ -109,7 +109,7 @@ public class MetricsService {
         .collect(Collectors.toList());
   }
 
-  public List<DarDecisionMetricsSummary> generateDarDecisionMetricSummaries() {
+  public List<DacDecisionMetrics> generateDacDecisionMetrics() {
     List<Dac> dacs = dacService.findAllDacsWithMembers();
     List<DarDecisionMetrics> metrics = generateDarDecisionMetrics();
     Set<DataSetDTO> datasets = dataSetDAO.findDatasetsWithDacs();
@@ -125,7 +125,7 @@ public class MetricsService {
                   datasets.stream()
                       .filter(ds -> ds.getDacId().equals(dac.getDacId()))
                       .collect(Collectors.toList());
-              return new DarDecisionMetricsSummary(dac, dacFilteredDatasets, dacFilteredMetrics);
+              return new DacDecisionMetrics(dac, dacFilteredDatasets, dacFilteredMetrics);
             })
         .collect(Collectors.toList());
   }

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -2620,6 +2620,19 @@ paths:
           description: Improper whitelist format
         500:
           description: Internal Server Error
+  /metrics/dac/decision:
+    get:
+      summary: Dac Decision Metrics
+      description: Dac Decision Metrics
+      produces:
+        - "text/plain"
+      tags:
+        - Metrics
+      responses:
+        200:
+          description: Dac Decision Metrics
+        500:
+          description: Internal Server Error
   /metrics/dar/decision:
     get:
       summary: DAR Decision Metrics

--- a/src/test/java/org/broadinstitute/consent/http/db/DataSetDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DataSetDAOTest.java
@@ -80,6 +80,25 @@ public class DataSetDAOTest extends DAOTestHelper {
     }
 
     @Test
+    public void testFindDatasetsWithDacsCase1() {
+        Set<DataSetDTO> datasets = dataSetDAO.findDatasetsWithDacs();
+        assertTrue(datasets.isEmpty());
+    }
+
+    @Test
+    public void testFindDatasetsWithDacsCase2() {
+        DataSet dataset = createDataset();
+        DataSet dataset2 = createDataset();
+        Dac dac = createDac();
+        Consent consent = createConsent(dac.getDacId());
+        createAssociation(consent.getConsentId(), dataset.getDataSetId());
+        createAssociation(consent.getConsentId(), dataset2.getDataSetId());
+        Set<DataSetDTO> datasets = dataSetDAO.findDatasetsWithDacs();
+        assertFalse(datasets.isEmpty());
+        assertEquals(2, datasets.size());
+    }
+
+    @Test
     public void testFindDatasetAndDacIds() {
         DataSet dataset = createDataset();
         Dac dac = createDac();

--- a/src/test/java/org/broadinstitute/consent/http/resources/MetricsResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/MetricsResourceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.Collections;
 import javax.ws.rs.core.Response;
+import org.broadinstitute.consent.http.models.DacDecisionMetrics;
 import org.broadinstitute.consent.http.models.DarDecisionMetrics;
 import org.broadinstitute.consent.http.service.MetricsService;
 import org.junit.Before;
@@ -30,12 +31,22 @@ public class MetricsResourceTest {
   }
 
   @Test
-  public void testGetMetricsData() {
+  public void testGetDarMetricsData() {
     when(service.generateDarDecisionMetrics()).thenReturn(Collections.emptyList());
     initResource();
-    Response response = resource.getMetricsData();
+    Response response = resource.getDarMetricsData();
     assertEquals(200, response.getStatus());
     assertFalse(response.getEntity().toString().isEmpty());
     assertTrue(response.getEntity().toString().contains(DarDecisionMetrics.getHeaderRow("\t")));
+  }
+
+  @Test
+  public void testGetDacMetricsData() {
+    when(service.generateDarDecisionMetrics()).thenReturn(Collections.emptyList());
+    initResource();
+    Response response = resource.getDacMetricsData();
+    assertEquals(200, response.getStatus());
+    assertFalse(response.getEntity().toString().isEmpty());
+    assertTrue(response.getEntity().toString().contains(DacDecisionMetrics.getHeaderRow("\t")));
   }
 }

--- a/src/test/java/org/broadinstitute/consent/http/service/MetricsServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/MetricsServiceTest.java
@@ -11,6 +11,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.commons.lang3.RandomUtils;
+import org.broadinstitute.consent.http.db.DataSetDAO;
 import org.broadinstitute.consent.http.db.MetricsDAO;
 import org.broadinstitute.consent.http.models.DarDecisionMetrics;
 import org.broadinstitute.consent.http.models.DataAccessRequest;
@@ -23,7 +24,14 @@ import org.mockito.MockitoAnnotations;
 
 public class MetricsServiceTest {
 
-  @Mock private MetricsDAO metricsDAO;
+  @Mock
+  private DacService dacService;
+
+  @Mock
+  private DataSetDAO dataSetDAO;
+
+  @Mock
+  private MetricsDAO metricsDAO;
 
   private MetricsService service;
 
@@ -33,7 +41,7 @@ public class MetricsServiceTest {
   }
 
   private void initService() {
-    service = new MetricsService(metricsDAO);
+    service = new MetricsService(dacService, dataSetDAO, metricsDAO);
   }
 
   @Test

--- a/src/test/resources/consent-config.yml
+++ b/src/test/resources/consent-config.yml
@@ -24,11 +24,7 @@ logging:
   level: WARN
   # logger specific levels
   loggers:
-    ConsentAssociationResource: WARN
-    AllAssociationsResource: WARN
-    ConsentApplication: WARN
-    ConsentModule: WARN
-    DatabaseResearchPurposeAPI: WARN
+    "org.broadinstitute.consent.http.cloudstore.GCSService": OFF
 services:
     ontologyURL: http://localhost:8180/
     localURL: http://localhost:8000/#/


### PR DESCRIPTION
## Addresses
https://broadinstitute.atlassian.net/browse/DUOS-702

## Changes
* New metrics object and resource for dac decisions in the form of:

```
DAC ID	# of DAC Members	# of DAC Chairs	# of Datasets	# of DARs Received	% of DARs Reviewed	Average DAR Turnaround Time	% Reveal DUOS Algorithm	% Agreement with DUOS Algorithm	% Structured Research Purpose Accurate	
UI Test		1		0						
DAC 0001	2	2	2	8	0	0 seconds		0	0	
New Dac		1	3	0						
DAC 0002		3	3	7	0	0 seconds		0	0	
Demo Dac New		2	4	5	0	0 seconds		1	0
```

## See Also:
Story for implementing `Used DUOS Algorithm for Decision Support: Yes/No`: https://broadinstitute.atlassian.net/browse/DUOS-712