### PR TITLE
[no-jira][risk=no] Handle null election id

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/resources/DataUseLetterResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataUseLetterResource.java
@@ -9,6 +9,7 @@ import java.io.InputStream;
 import java.security.GeneralSecurityException;
 import java.util.Objects;
 import java.util.UUID;
+import javax.annotation.Nullable;
 import javax.annotation.security.RolesAllowed;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
@@ -140,6 +141,7 @@ public class DataUseLetterResource extends Resource {
     @Produces(MediaType.APPLICATION_OCTET_STREAM)
     @RolesAllowed({ADMIN, CHAIRPERSON, MEMBER, DATAOWNER})
     public Response getDUL(@PathParam("id") String consentId, @QueryParam("electionId") Integer electionId) {
+        // electionId is optional, handle cases where there is no election for the consent.
         String msg = String.format("Getting Data Use Letter for consent with id '%s' and Election Id '%s", consentId, electionId);
         Election election = null;
         try {

--- a/src/main/java/org/broadinstitute/consent/http/resources/DataUseLetterResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataUseLetterResource.java
@@ -9,7 +9,6 @@ import java.io.InputStream;
 import java.security.GeneralSecurityException;
 import java.util.Objects;
 import java.util.UUID;
-import javax.annotation.Nullable;
 import javax.annotation.security.RolesAllowed;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;

--- a/src/main/java/org/broadinstitute/consent/http/resources/DataUseLetterResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataUseLetterResource.java
@@ -7,6 +7,7 @@ import io.dropwizard.auth.Auth;
 import java.io.IOException;
 import java.io.InputStream;
 import java.security.GeneralSecurityException;
+import java.util.Objects;
 import java.util.UUID;
 import javax.annotation.security.RolesAllowed;
 import javax.ws.rs.Consumes;
@@ -140,11 +141,10 @@ public class DataUseLetterResource extends Resource {
     @RolesAllowed({ADMIN, CHAIRPERSON, MEMBER, DATAOWNER})
     public Response getDUL(@PathParam("id") String consentId, @QueryParam("electionId") Integer electionId) {
         String msg = String.format("Getting Data Use Letter for consent with id '%s' and Election Id '%s", consentId, electionId);
-        logger().debug(msg);
         Election election = null;
         try {
             Consent consent = api.retrieve(consentId);
-            if (StringUtils.isNotEmpty(consent.getLastElectionStatus())) {
+            if (StringUtils.isNotEmpty(consent.getLastElectionStatus()) && Objects.nonNull(electionId)) {
                 election = api.retrieveElection(electionId, consentId);
             }
             String fileUrl = election != null ? election.getDataUseLetter() : consent.getDataUseLetter();

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -1511,6 +1511,11 @@ paths:
           description: Id of the consent at which belongs the Data Use Letter.
           required: true
           type: string
+        - name: electionId
+          in: query
+          required: false
+          description: Optional election id for the consent election
+          type: integer
       tags:
         - Consent
       responses:


### PR DESCRIPTION
## Addresses
NPE when getting a DUL for a consent that doesn't have an election.
Staging: https://sentry.io/organizations/broad-institute/issues/1825784751

The UI calls this API method with and without an election id, update API and docs to handle that appropriately.