### PR TITLE
[DUOS-661][risk=no] Add library card information to researcher properties list

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/enumeration/ResearcherFields.java
+++ b/src/main/java/org/broadinstitute/consent/http/enumeration/ResearcherFields.java
@@ -4,73 +4,71 @@ import java.util.ArrayList;
 import java.util.List;
 
 public enum ResearcherFields {
+  PROFILE_NAME("profileName", false),
+  ACADEMIC_BUSINESS_EMAIL("academicEmail", true),
+  INSTITUTION("institution", true),
+  DEPARTMENT("department", true),
+  STREET_ADDRESS_1("address1", true),
+  CITY("city", true),
+  ZIP_POSTAL_CODE("zipcode", true),
+  ARE_YOU_PRINCIPAL_INVESTIGATOR("isThePI", true),
+  COUNTRY("country", true),
+  DIVISION("division", false),
+  STREET_ADDRESS_2("address2", false),
+  STATE("state", false),
+  ERA_COMMONS_ID("eRACommonsID", false),
+  PUBMED_ID("pubmedID", false),
+  SCIENTIFIC_URL("scientificURL", false),
+  DO_YOU_HAVE_PI("havePI", false),
+  PI_NAME("piName", false),
+  PI_EMAIL("piEmail", false),
+  PI_eRA_COMMONS_ID("piERACommonsID", false),
+  COMPLETED("completed", false),
+  INVESTIGATOR("investigator", false),
+  ERA_EXPIRATION_DATE("eraExpiration", false),
+  ERA_STATUS("eraAuthorized", false),
+  ERA_USERNAME("nihUsername", false),
+  LINKEDIN_PROFILE("linkedIn", false),
+  RESEARCHER_GATE("researcherGate", false),
+  ORCID("orcid", false),
+  CHECK_NOTIFICATIONS("checkNotifications", false),
+  URL_DAA("urlDAA", false),
+  NAME_DAA("nameDAA", false);
 
-    PROFILE_NAME("profileName", false),
-    ACADEMIC_BUSINESS_EMAIL("academicEmail", true),
-    INSTITUTION("institution", true),
-    DEPARTMENT("department", true),
-    STREET_ADDRESS_1("address1", true),
-    CITY("city", true),
-    ZIP_POSTAL_CODE("zipcode", true),
-    ARE_YOU_PRINCIPAL_INVESTIGATOR("isThePI", true),
-    COUNTRY("country", true),
-    DIVISION("division", false),
-    STREET_ADDRESS_2("address2", false),
-    STATE("state", false),
-    ERA_COMMONS_ID("eRACommonsID", false),
-    PUBMED_ID("pubmedID", false),
-    SCIENTIFIC_URL("scientificURL", false),
-    DO_YOU_HAVE_PI("havePI", false),
-    PI_NAME("piName", false),
-    PI_EMAIL("piEmail", false),
-    PI_eRA_COMMONS_ID("piERACommonsID", false),
-    COMPLETED("completed", false),
-    INVESTIGATOR("investigator", false),
-    ERA_EXPIRATION_DATE("eraExpiration",false),
-    ERA_STATUS("eraAuthorized",false),
-    ERA_USERNAME("nihUsername", false),
-    LINKEDIN_PROFILE("linkedIn", false),
-    RESEARCHER_GATE("researcherGate", false),
-    ORCID("orcid", false),
-    CHECK_NOTIFICATIONS("checkNotifications", false),
-    URL_DAA("urlDAA", false),
-    NAME_DAA("nameDAA", false);
+  public static final String LIBRARY_CARDS = "libraryCards";
+  public static final String LIBRARY_CARD_ENTRIES = "libraryCardEntries";
+  private final String value;
+  private final Boolean required;
 
+  ResearcherFields(String value, Boolean required) {
+    this.value = value;
+    this.required = required;
+  }
 
-    public static final String LIBRARY_CARDS = "libraryCards";
-    private String value;
-    private Boolean required;
+  public String getValue() {
+    return value;
+  }
 
-    ResearcherFields(String value, Boolean required) {
-        this.value = value;
-        this.required = required;
+  public Boolean getRequired() {
+    return required;
+  }
+
+  public static List<ResearcherFields> getRequiredFields() {
+    List<ResearcherFields> requiredValues = new ArrayList<>();
+    for (ResearcherFields researcherField : ResearcherFields.values()) {
+      if (researcherField.getRequired()) {
+        requiredValues.add(researcherField);
+      }
     }
+    return requiredValues;
+  }
 
-    public String getValue() {
-        return value;
+  public static Boolean containsValue(String value) {
+    for (ResearcherFields researcherField : ResearcherFields.values()) {
+      if (researcherField.getValue().equals(value)) {
+        return true;
+      }
     }
-
-    public Boolean getRequired() {return required;}
-
-    public static List<ResearcherFields> getRequiredFields(){
-        List<ResearcherFields> requiredValues = new ArrayList<>();
-        for (ResearcherFields researcherField : ResearcherFields.values()) {
-            if(researcherField.getRequired()){
-                requiredValues.add(researcherField);
-            }
-        }
-        return requiredValues;
-    }
-
-    public static Boolean containsValue(String value){
-        for (ResearcherFields researcherField : ResearcherFields.values()) {
-            if(researcherField.getValue().equals(value)){
-                return true;
-            }
-        }
-        return false;
-    }
-
-
-
+    return false;
+  }
 }

--- a/src/main/java/org/broadinstitute/consent/http/resources/ResearcherResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/ResearcherResource.java
@@ -84,9 +84,10 @@ public class ResearcherResource extends Resource {
             validateAuthedRoleUser(authedRoles, findByAuthUser(authUser), userId);
             User user = userService.findUserById(userId);
             List<ResearcherProperty> props = userService.findAllUserProperties(userId);
-            List<WhitelistEntry> entries = whitelistService.findWhitelistEntriesForUser(user, props);
             Map<String, Object> propMap = props.stream().
-                    collect(Collectors.toMap(ResearcherProperty::getPropertyKey, ResearcherProperty::getPropertyValue));
+                collect(Collectors.toMap(ResearcherProperty::getPropertyKey, ResearcherProperty::getPropertyValue));
+            List<WhitelistEntry> entries = whitelistService.findWhitelistEntriesForUser(user, props);
+            propMap.put(ResearcherFields.LIBRARY_CARD_ENTRIES, entries);
             List<String> orgs = entries.stream().
                     map(WhitelistEntry::getOrganization).
                     distinct().


### PR DESCRIPTION
## Addresses
https://broadinstitute.atlassian.net/browse/DUOS-661

I suggest hiding whitespace changes.

## Changes
Adds a new field, `libraryCardEntries`, to the list of researcher properties in the `/api/researcher/{userId}` endpoint:
```
{
  "profileName": "Gregory Rushton",
  "country": "United States",
  "city": "Cambridge",
  "address1": "75 Ames St",
  "completed": "true",
  "libraryCards": [
    "Broad"
  ],
  "zipcode": "02356",
  "libraryCardEntries": [
    {
      "organization": "Broad",
      "commonsId": "GREGORYRUSHTON",
      "name": "Gregory Rushton",
      "email": "",
      "signingOfficialName": "Stacey",
      "signingOfficialEmail": "",
      "itDirectorName": "Bill",
      "itDirectorEmail": ""
    }
  ],
  "institution": "Broad",
  "nihUsername": "",
  "academicEmail": "",
  "state": "Massachusetts",
  "eraAuthorized": "true",
  "isThePI": "true",
  "department": "DSP",
  "checkNotifications": "false",
  "eraExpiration": "1572805848990"
}
```