### PR TITLE
[no-jira][risk=no] don't disable sni

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -6,7 +6,7 @@ echo $SBT_CMD
 
 set -o pipefail
 
-sbt -Djsse.enableSNIExtension=false clean "${SBT_CMD}"
+sbt clean "${SBT_CMD}"
 TEST_EXIT_CODE=$?
 
 if [[ $TEST_EXIT_CODE != 0 ]]; then exit $TEST_EXIT_CODE; fi


### PR DESCRIPTION
## Addresses
Integration tests fail with SNI disabled due to the inability to connect to maven correctly.

See also: 
* https://github.com/DataBiosphere/consent-ontology/pull/303
* https://broadworkbench.atlassian.net/browse/DDO-641
* Latest [successful ontology run](https://fc-jenkins.dsp-techops.broadinstitute.org/view/Testing/view/Test%20Runners/job/ontology-test-runner/521/)


See [slack conversation](https://broadinstitute.slack.com/archives/C53JYBV9A/p1598312087063400?thread_ts=1598279507.059100&cid=C53JYBV9A) for more info.