### PR TITLE
[DUOS-720] New DAO DatasetProperty getter + mapper

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/DataSetDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DataSetDAO.java
@@ -7,6 +7,7 @@ import org.broadinstitute.consent.http.db.mapper.BatchMapper;
 import org.broadinstitute.consent.http.db.mapper.DacMapper;
 import org.broadinstitute.consent.http.db.mapper.DataSetMapper;
 import org.broadinstitute.consent.http.db.mapper.DataSetPropertiesMapper;
+import org.broadinstitute.consent.http.db.mapper.DatasetPropertyMapper;
 import org.broadinstitute.consent.http.db.mapper.DictionaryMapper;
 import org.broadinstitute.consent.http.db.mapper.ImmutablePairOfIntsMapper;
 import org.broadinstitute.consent.http.models.Association;
@@ -15,7 +16,6 @@ import org.broadinstitute.consent.http.models.DataSet;
 import org.broadinstitute.consent.http.models.DataSetProperty;
 import org.broadinstitute.consent.http.models.Dictionary;
 import org.broadinstitute.consent.http.models.dto.DataSetDTO;
-import org.broadinstitute.consent.http.models.dto.DataSetPropertyDTO;
 import org.broadinstitute.consent.http.resources.Resource;
 import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
 import org.jdbi.v3.sqlobject.customizer.Bind;
@@ -100,12 +100,11 @@ public interface DataSetDAO extends Transactional<DataSetDAO> {
             "where d.dataSetId = :dataSetId order by d.dataSetId, k.displayOrder")
     Set<DataSetDTO> findDataSetWithPropertiesByDataSetId(@Bind("dataSetId") Integer dataSetId);
 
+    @UseRowMapper(DatasetPropertyMapper.class)
     @SqlQuery(
-        "SELECT k.key, dp.propertyvalue FROM dataset d "
-            + "INNER JOIN datasetproperty dp on dp.datasetid = d.datasetid WHERE d.datasetid = :datasetId "
-            + "INNER JOIN dictionary k on k.keyid = dp.propertykey"
+        "SELECT * FROM datasetproperty WHERE datasetid = :datasetId"
     )
-    Set<DataSetPropertyDTO> findDatasetPropertiesByDatasetId(@Bind("datasetId") Integer datasetId);
+    Set<DataSetProperty> findDatasetPropertiesByDatasetId(@Bind("datasetId") Integer datasetId);
 
     @UseRowMapper(DataSetPropertiesMapper.class)
     @SqlQuery(" select d.*, k.key, dp.propertyValue, ca.consentId, c.dac_id, c.translatedUseRestriction from dataset  d inner join datasetproperty dp on dp.dataSetId = d.dataSetId " +

--- a/src/main/java/org/broadinstitute/consent/http/db/DataSetDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DataSetDAO.java
@@ -15,6 +15,7 @@ import org.broadinstitute.consent.http.models.DataSet;
 import org.broadinstitute.consent.http.models.DataSetProperty;
 import org.broadinstitute.consent.http.models.Dictionary;
 import org.broadinstitute.consent.http.models.dto.DataSetDTO;
+import org.broadinstitute.consent.http.models.dto.DataSetPropertyDTO;
 import org.broadinstitute.consent.http.resources.Resource;
 import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
 import org.jdbi.v3.sqlobject.customizer.Bind;
@@ -98,6 +99,13 @@ public interface DataSetDAO extends Transactional<DataSetDAO> {
             "inner join consentassociations ca on ca.dataSetId = d.dataSetId inner join consents c on c.consentId = ca.consentId " +
             "where d.dataSetId = :dataSetId order by d.dataSetId, k.displayOrder")
     Set<DataSetDTO> findDataSetWithPropertiesByDataSetId(@Bind("dataSetId") Integer dataSetId);
+
+    @SqlQuery(
+        "SELECT k.key, dp.propertyvalue FROM dataset d "
+            + "INNER JOIN datasetproperty dp on dp.datasetid = d.datasetid WHERE d.datasetid = :datasetId "
+            + "INNER JOIN dictionary k on k.keyid = dp.propertykey"
+    )
+    Set<DataSetPropertyDTO> findDatasetPropertiesByDatasetId(@Bind("datasetId") Integer datasetId);
 
     @UseRowMapper(DataSetPropertiesMapper.class)
     @SqlQuery(" select d.*, k.key, dp.propertyValue, ca.consentId, c.dac_id, c.translatedUseRestriction from dataset  d inner join datasetproperty dp on dp.dataSetId = d.dataSetId " +

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DatasetPropertyMapper.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DatasetPropertyMapper.java
@@ -1,0 +1,20 @@
+package org.broadinstitute.consent.http.db.mapper;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import org.broadinstitute.consent.http.models.DataSetProperty;
+import org.jdbi.v3.core.mapper.RowMapper;
+import org.jdbi.v3.core.statement.StatementContext;
+
+public class DatasetPropertyMapper implements RowMapper<DataSetProperty> {
+
+    public DataSetProperty map(ResultSet r, StatementContext ctx) throws SQLException {
+      return new DataSetProperty(
+          r.getInt("propertyid"),
+          r.getInt("datasetid"),
+          r.getInt("propertykey"),
+          r.getString("propertyvalue"),
+          r.getTimestamp("createdate")
+      );
+    }
+}

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -37,10 +37,8 @@ public class DatasetService {
     }
 
     public Set<DataSetProperty> getDatasetProperties(Integer datasetId) {
-        Set<DataSetPropertyDTO> properties = dataSetDAO.findDatasetPropertiesByDatasetId(datasetId);
-        return properties.stream().map(property ->
-            new DataSetProperty(null, null, property.getPropertyValue(), null)
-        ).collect(Collectors.toSet());
+        Set<DataSetProperty> properties = dataSetDAO.findDatasetPropertiesByDatasetId(datasetId);
+        return properties;
     }
 
     public DataSet getDatasetWithPropertiesById(Integer datasetId) {

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -1,10 +1,14 @@
 package org.broadinstitute.consent.http.service;
 
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.broadinstitute.consent.http.db.DataSetDAO;
 
 import javax.inject.Inject;
 import java.util.Date;
 import org.broadinstitute.consent.http.models.DataSet;
+import org.broadinstitute.consent.http.models.DataSetProperty;
+import org.broadinstitute.consent.http.models.dto.DataSetPropertyDTO;
 
 
 public class DatasetService {
@@ -30,6 +34,20 @@ public class DatasetService {
         //     @Bind("active") Boolean active,
         //     @Bind("alias") Integer alias);
         return dataSetDAO.insertDataset(name, now, objectId, active, alias);
+    }
+
+    public Set<DataSetProperty> getDatasetProperties(Integer datasetId) {
+        Set<DataSetPropertyDTO> properties = dataSetDAO.findDatasetPropertiesByDatasetId(datasetId);
+        return properties.stream().map(property ->
+            new DataSetProperty(null, null, property.getPropertyValue(), null)
+        ).collect(Collectors.toSet());
+    }
+
+    public DataSet getDatasetWithPropertiesById(Integer datasetId) {
+        DataSet dataset = dataSetDAO.findDataSetById(datasetId);
+        Set<DataSetProperty> properties = getDatasetProperties(datasetId);
+        dataset.setProperties(properties);
+        return dataset;
     }
 
 }

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -1,15 +1,12 @@
 package org.broadinstitute.consent.http.service;
 
 import java.util.Set;
-import java.util.stream.Collectors;
 import org.broadinstitute.consent.http.db.DataSetDAO;
 
 import javax.inject.Inject;
 import java.util.Date;
 import org.broadinstitute.consent.http.models.DataSet;
 import org.broadinstitute.consent.http.models.DataSetProperty;
-import org.broadinstitute.consent.http.models.dto.DataSetPropertyDTO;
-
 
 public class DatasetService {
 

--- a/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
@@ -29,6 +29,7 @@ import org.broadinstitute.consent.http.models.Dac;
 import org.broadinstitute.consent.http.models.DataAccessRequest;
 import org.broadinstitute.consent.http.models.DataAccessRequestData;
 import org.broadinstitute.consent.http.models.DataSet;
+import org.broadinstitute.consent.http.models.DataSetProperty;
 import org.broadinstitute.consent.http.models.Election;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.Vote;
@@ -136,6 +137,7 @@ public class DAOTestHelper {
         });
         createdElectionIds.forEach(id -> electionDAO.deleteAccessRP(id));
         createdElectionIds.forEach(id -> electionDAO.deleteElectionById(id));
+        dataSetDAO.deleteDataSetsProperties(createdDataSetIds);
         dataSetDAO.deleteDataSets(createdDataSetIds);
         createdDacIds.forEach(id -> {
             dacDAO.deleteDacMembers(id);
@@ -266,6 +268,17 @@ public class DAOTestHelper {
         return dacDAO.findById(id);
     }
 
+    protected void createDatasetProperties(Integer datasetId) {
+        List<DataSetProperty> list = new ArrayList<>();
+        DataSetProperty dsp = new DataSetProperty();
+        dsp.setDataSetId(datasetId);
+        dsp.setPropertyKey(1);
+        dsp.setPropertyValue("Test_PropertyValue");
+        dsp.setCreateDate(new Date());
+        list.add(dsp);
+        dataSetDAO.insertDataSetsProperties(list);
+    }
+
     protected DataSet createDataset() {
         DataSet ds = new DataSet();
         ds.setName("Name_" + RandomStringUtils.random(20, true, true));
@@ -275,6 +288,7 @@ public class DAOTestHelper {
         ds.setAlias(RandomUtils.nextInt(1, 1000));
         Integer id = dataSetDAO.insertDataset(ds.getName(), ds.getCreateDate(), ds.getObjectId(), ds.getActive(), ds.getAlias());
         createdDataSetIds.add(id);
+        createDatasetProperties(id);
         return dataSetDAO.findDataSetById(id);
     }
 

--- a/src/test/java/org/broadinstitute/consent/http/db/DataSetDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DataSetDAOTest.java
@@ -174,7 +174,6 @@ public class DataSetDAOTest extends DAOTestHelper {
         assertEquals(properties.size(), 1);
     }
 
-
     private void createUserRole(Integer roleId, Integer userId, Integer dacId) {
         dacDAO.addDacMember(roleId, userId, dacId);
     }

--- a/src/test/java/org/broadinstitute/consent/http/db/DataSetDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DataSetDAOTest.java
@@ -3,6 +3,7 @@ package org.broadinstitute.consent.http.db;
 import org.apache.commons.lang3.tuple.Pair;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.Consent;
+import org.broadinstitute.consent.http.models.DataSetProperty;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.Dac;
 import org.broadinstitute.consent.http.models.DataSet;
@@ -165,6 +166,14 @@ public class DataSetDAOTest extends DAOTestHelper {
         Set<DataSet> datasets = dataSetDAO.findDatasetsForConsentId(c.getConsentId());
         assertEquals(datasets.size(), 2);
     }
+
+    @Test
+    public void testFindDatasetPropertiesByDatasetId() {
+        DataSet d = createDataset();
+        Set<DataSetProperty> properties = dataSetDAO.findDatasetPropertiesByDatasetId(d.getDataSetId());
+        assertEquals(properties.size(), 1);
+    }
+
 
     private void createUserRole(Integer roleId, Integer userId, Integer dacId) {
         dacDAO.addDacMember(roleId, userId, dacId);


### PR DESCRIPTION
DataSetPropertiesMapper doesn't work properly unless it returns a set, despite mapping down to a single object. Instead, we want to make a new mapper for a single DataSetProperty, retrieve a set of DataSetProperties that way, and associate a dataset with its properties in the service layer. Also includes a simple test for the new dao method.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [ ] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
