### PR TITLE
[DUOS-720] DatasetService layer

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/DataSetDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DataSetDAO.java
@@ -180,7 +180,10 @@ public interface DataSetDAO extends Transactional<DataSetDAO> {
     String getAssociatedConsentIdByDataSetId(@Bind("dataSetId") Integer dataSetId);
 
     @SqlQuery("SELECT dataSetId FROM dataset WHERE name = :name")
-    Integer getDataSetByName(@Bind("name") String name);
+    Integer getDatasetIdByName(@Bind("name") String name);
+
+    @SqlQuery("SELECT * FROM dataset WHERE name = :name")
+    DataSet getDatasetByName(@Bind("name") String name);
 
     @SqlQuery("select *  from dataset where name in (<names>) ")
     List<DataSet> searchDataSetsByNameList(@BindList("names") List<String> names);

--- a/src/main/java/org/broadinstitute/consent/http/service/DatabaseDataSetAPI.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatabaseDataSetAPI.java
@@ -390,7 +390,7 @@ public class DatabaseDataSetAPI extends AbstractDataSetAPI {
                     // missing consent if consent id is present
                     || StringUtils.isNotEmpty(dataSet.getConsentName()) && consentDAO.getIdByName(dataSet.getConsentName()) == null
                     // dataset name should be unique
-                    || !overwrite && dsDAO.getDataSetByName(dataSet.getName()) != null) {
+                    || !overwrite && dsDAO.getDatasetIdByName(dataSet.getName()) != null) {
                 isValid = false;
                 break;
             }
@@ -402,7 +402,7 @@ public class DatabaseDataSetAPI extends AbstractDataSetAPI {
     private void processAssociation(List<DataSet> dataSetList) {
         dataSetList.forEach(dataSet -> {
             if (StringUtils.isNotEmpty(dataSet.getConsentName())) {
-                Integer datasetId = dsDAO.getDataSetByName(dataSet.getName());
+                Integer datasetId = dsDAO.getDatasetIdByName(dataSet.getName());
                 if (consentDAO.findAssociationsByDataSetId(datasetId) == null) {
                     consentDAO.insertConsentAssociation(consentDAO.getIdByName(dataSet.getConsentName()), AssociationType.SAMPLESET.getValue(), datasetId);
                 }

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -72,4 +72,13 @@ public class DatasetService {
             .collect(Collectors.toList());
     }
 
+    public List<DataSetPropertyDTO> findInvalidProperties(List<DataSetPropertyDTO> properties) {
+        List<Dictionary> dictionaries = dataSetDAO.getMappedFieldsOrderByReceiveOrder();
+        List<String> keys = dictionaries.stream().map(d -> d.getKey()).collect(Collectors.toList());
+
+        return properties.stream()
+            .filter(p -> !keys.contains(p.getPropertyName()))
+            .collect(Collectors.toList());
+    }
+
 }

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -1,12 +1,11 @@
 package org.broadinstitute.consent.http.service;
 
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 import org.broadinstitute.consent.http.db.DataSetDAO;
 
 import javax.inject.Inject;
-import java.util.Date;
+
 import org.broadinstitute.consent.http.models.DataSet;
 import org.broadinstitute.consent.http.models.DataSetProperty;
 import org.broadinstitute.consent.http.models.Dictionary;
@@ -67,7 +66,7 @@ public class DatasetService {
         return properties.stream()
             .filter(p -> keys.contains(p.getPropertyName()) && !p.getPropertyName().equals("Dataset Name"))
             .map(p ->
-                new DataSetProperty(datasetId, null, p.getPropertyValue(), createDate)
+                new DataSetProperty(datasetId, dictionaries.get(keys.indexOf(p.getPropertyName())).getKeyId(), p.getPropertyValue(), createDate)
             )
             .collect(Collectors.toList());
     }

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -1,6 +1,5 @@
 package org.broadinstitute.consent.http.service;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -61,7 +60,6 @@ public class DatasetService {
         return dataset;
     }
 
-    // convert dsp DTO -> dsp by associating with extra fields from dictionary def
     public List<DataSetProperty> processDatasetProperties(Integer datasetId, Date createDate, List<DataSetPropertyDTO> properties) {
         List<Dictionary> dictionaries = dataSetDAO.getMappedFieldsOrderByReceiveOrder();
         List<String> keys = dictionaries.stream().map(d -> d.getKey()).collect(Collectors.toList());

--- a/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
@@ -112,6 +112,20 @@ public class DatasetServiceTest {
         Assert.assertEquals(properties.size(), getDatasetPropertiesDTO().size());
     }
 
+    @Test
+    public void testFindInvalidProperties() {
+        when(datasetDAO.getMappedFieldsOrderByReceiveOrder()).thenReturn(getDictionaries());
+        initService();
+
+        List<DataSetPropertyDTO> input = getDatasetPropertiesDTO().stream()
+            .peek(p -> p.setPropertyKey("Invalid Key"))
+            .collect(Collectors.toList());
+
+        List<DataSetPropertyDTO> properties = datasetService.findInvalidProperties(input);
+
+        Assert.assertTrue(!properties.isEmpty());
+    }
+
     /* Helper functions */
 
     private List<DataSet> getDatasets() {

--- a/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
@@ -12,7 +12,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import liquibase.pro.packaged.D;
+
 import org.broadinstitute.consent.http.db.DataSetDAO;
 import org.broadinstitute.consent.http.models.DataSet;
 import org.broadinstitute.consent.http.models.DataSetProperty;
@@ -27,128 +27,133 @@ import org.mockito.MockitoAnnotations;
 
 public class DatasetServiceTest {
 
-  private DatasetService datasetService;
+    private DatasetService datasetService;
 
-  @Mock
-  DataSetDAO datasetDAO;
+    @Mock
+    DataSetDAO datasetDAO;
 
-  @Before
-  public void setUp() {
-    MockitoAnnotations.initMocks(this);
-  }
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+    }
 
-  private void initService() {
-    datasetService = new DatasetService(datasetDAO);
-  }
+    private void initService() {
+        datasetService = new DatasetService(datasetDAO);
+    }
 
-  @Test
-  public void testCreateDataset() {
-    int datasetId = 1;
-    when(datasetDAO.insertDataset(anyString(), any(), anyString(), anyBoolean(), anyInt())).thenReturn(datasetId);
-    when(datasetDAO.findDataSetById(datasetId)).thenReturn(getDatasets().get(0));
-    when(datasetDAO.findDatasetPropertiesByDatasetId(datasetId)).thenReturn(getDatasetProperties());
-    initService();
+    @Test
+    public void testCreateDataset() {
+        int datasetId = 1;
+        when(datasetDAO.insertDataset(anyString(), any(), anyString(), anyBoolean(), anyInt()))
+            .thenReturn(datasetId);
+        when(datasetDAO.findDataSetById(datasetId)).thenReturn(getDatasets().get(0));
+        when(datasetDAO.findDatasetPropertiesByDatasetId(datasetId)).thenReturn(getDatasetProperties());
+        initService();
 
-    DataSet result = datasetService.createDataset(getDatasetDTO(), "Test Dataset 1");
+        DataSet result = datasetService.createDataset(getDatasetDTO(), "Test Dataset 1");
 
-    Assert.assertNotNull(result);
-    Assert.assertEquals(result.getName(), getDatasets().get(0).getName());
-    Assert.assertNotNull(result.getProperties());
-    Assert.assertTrue(!result.getProperties().isEmpty());
-  }
+        Assert.assertNotNull(result);
+        Assert.assertEquals(result.getName(), getDatasets().get(0).getName());
+        Assert.assertNotNull(result.getProperties());
+        Assert.assertTrue(!result.getProperties().isEmpty());
+    }
 
-  @Test
-  public void testGetDatasetByName() {
-    when(datasetDAO.getDatasetByName(getDatasets().get(0).getName())).thenReturn(getDatasets().get(0));
-    initService();
+    @Test
+    public void testGetDatasetByName() {
+        when(datasetDAO.getDatasetByName(getDatasets().get(0).getName()))
+            .thenReturn(getDatasets().get(0));
+        initService();
 
-    DataSet dataset = datasetService.getDatasetByName("Test Dataset 1");
+        DataSet dataset = datasetService.getDatasetByName("Test Dataset 1");
 
-    Assert.assertNotNull(dataset);
-    Assert.assertEquals(dataset.getDataSetId(), getDatasets().get(0).getDataSetId());
-  }
+        Assert.assertNotNull(dataset);
+        Assert.assertEquals(dataset.getDataSetId(), getDatasets().get(0).getDataSetId());
+    }
 
-  @Test
-  public void testFindDatasetById() {
-    when(datasetDAO.findDataSetById(getDatasets().get(0).getDataSetId())).thenReturn(getDatasets().get(0));
-    initService();
+    @Test
+    public void testFindDatasetById() {
+        when(datasetDAO.findDataSetById(getDatasets().get(0).getDataSetId()))
+            .thenReturn(getDatasets().get(0));
+        initService();
 
-    DataSet dataset = datasetService.findDatasetById(1);
+        DataSet dataset = datasetService.findDatasetById(1);
 
-    Assert.assertNotNull(dataset);
-    Assert.assertEquals(dataset.getName(), getDatasets().get(0).getName());
-  }
+        Assert.assertNotNull(dataset);
+        Assert.assertEquals(dataset.getName(), getDatasets().get(0).getName());
+    }
 
-  @Test
-  public void testGetDatasetProperties() {
-    when(datasetDAO.findDatasetPropertiesByDatasetId(anyInt())).thenReturn(Collections.emptySet());
-    initService();
+    @Test
+    public void testGetDatasetProperties() {
+        when(datasetDAO.findDatasetPropertiesByDatasetId(anyInt())).thenReturn(Collections.emptySet());
+        initService();
 
-    Assert.assertTrue(datasetService.getDatasetProperties(1).isEmpty());
-  }
+        Assert.assertTrue(datasetService.getDatasetProperties(1).isEmpty());
+    }
 
-  @Test
-  public void testGetDatasetWithPropertiesById() {
-    int datasetId = 1;
-    when(datasetDAO.findDatasetPropertiesByDatasetId(datasetId)).thenReturn(getDatasetProperties());
-    when(datasetDAO.findDataSetById(datasetId)).thenReturn(getDatasets().get(0));
-    initService();
+    @Test
+    public void testGetDatasetWithPropertiesById() {
+        int datasetId = 1;
+        when(datasetDAO.findDatasetPropertiesByDatasetId(datasetId)).thenReturn(getDatasetProperties());
+        when(datasetDAO.findDataSetById(datasetId)).thenReturn(getDatasets().get(0));
+        initService();
 
-    Assert.assertTrue(datasetService.getDatasetProperties(datasetId).equals(datasetDAO.findDatasetPropertiesByDatasetId(1)));
-  }
+        Assert.assertTrue(datasetService.getDatasetProperties(datasetId)
+                .equals(datasetDAO.findDatasetPropertiesByDatasetId(1)));
+    }
 
-  @Test
-  public void testProcessDatasetProperties() {
-    when(datasetDAO.getMappedFieldsOrderByReceiveOrder()).thenReturn(getDictionaries());
-    initService();
+    @Test
+    public void testProcessDatasetProperties() {
+        when(datasetDAO.getMappedFieldsOrderByReceiveOrder()).thenReturn(getDictionaries());
+        initService();
 
-    List<DataSetProperty> properties = datasetService.processDatasetProperties(1, new Date(), getDatasetPropertiesDTO());
+        List<DataSetProperty> properties = datasetService
+            .processDatasetProperties(1, new Date(), getDatasetPropertiesDTO());
 
-    Assert.assertEquals(properties.size(), getDatasetPropertiesDTO().size());
-  }
+        Assert.assertEquals(properties.size(), getDatasetPropertiesDTO().size());
+    }
 
-  /* Helper functions */
+    /* Helper functions */
 
-  private List<DataSet> getDatasets() {
-    return IntStream.range(1,3)
-        .mapToObj(i -> {
-          DataSet dataset = new DataSet();
-          dataset.setDataSetId(i);
-          dataset.setName("Test Dataset " + i);
-          dataset.setActive(true);
-          dataset.setNeedsApproval(false);
-          dataset.setProperties(Collections.emptySet());
-          return dataset;
-        }).collect(Collectors.toList());
-  }
+    private List<DataSet> getDatasets() {
+        return IntStream.range(1, 3)
+            .mapToObj(i -> {
+                DataSet dataset = new DataSet();
+                dataset.setDataSetId(i);
+                dataset.setName("Test Dataset " + i);
+                dataset.setActive(true);
+                dataset.setNeedsApproval(false);
+                dataset.setProperties(Collections.emptySet());
+                return dataset;
+            }).collect(Collectors.toList());
+    }
 
-  private Set<DataSetProperty> getDatasetProperties() {
-    return IntStream.range(1, 11)
-        .mapToObj(i ->
-            new DataSetProperty(1, i, "Test Value", new Date())
-        ).collect(Collectors.toSet());
-  }
+    private Set<DataSetProperty> getDatasetProperties() {
+        return IntStream.range(1, 11)
+            .mapToObj(i ->
+                new DataSetProperty(1, i, "Test Value", new Date())
+            ).collect(Collectors.toSet());
+    }
 
-  private List<DataSetPropertyDTO> getDatasetPropertiesDTO() {
-    return IntStream.range(1, 11)
-        .mapToObj(i ->
-            new DataSetPropertyDTO(String.valueOf(i), "Test Value")
-        ).collect(Collectors.toList());
-  }
-
-  private DataSetDTO getDatasetDTO() {
-    DataSetDTO datasetDTO = new DataSetDTO();
-    datasetDTO.setObjectId("Test ObjectId");
-    datasetDTO.setActive(true);
-    datasetDTO.setProperties(getDatasetPropertiesDTO());
-    return datasetDTO;
-  }
-
-  private List<Dictionary> getDictionaries() {
-    return IntStream.range(1, 11)
-        .mapToObj(i ->
-            new Dictionary(String.valueOf(i), true, i, i)
+    private List<DataSetPropertyDTO> getDatasetPropertiesDTO() {
+        return IntStream.range(1, 11)
+            .mapToObj(i ->
+                new DataSetPropertyDTO(String.valueOf(i), "Test Value")
             ).collect(Collectors.toList());
-  }
+    }
+
+    private DataSetDTO getDatasetDTO() {
+        DataSetDTO datasetDTO = new DataSetDTO();
+        datasetDTO.setObjectId("Test ObjectId");
+        datasetDTO.setActive(true);
+        datasetDTO.setProperties(getDatasetPropertiesDTO());
+        return datasetDTO;
+    }
+
+    private List<Dictionary> getDictionaries() {
+        return IntStream.range(1, 11)
+            .mapToObj(i ->
+                new Dictionary(String.valueOf(i), true, i, i)
+            ).collect(Collectors.toList());
+    }
 
 }

--- a/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
@@ -1,0 +1,69 @@
+package org.broadinstitute.consent.http.service;
+
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.Date;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.broadinstitute.consent.http.db.DataSetDAO;
+import org.broadinstitute.consent.http.models.DataSet;
+import org.broadinstitute.consent.http.models.DataSetProperty;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class DatasetServiceTest {
+
+  private DatasetService datasetService;
+
+  @Mock
+  DataSetDAO datasetDAO;
+
+  @Before
+  public void setUp() {
+    MockitoAnnotations.initMocks(this);
+  }
+
+  private void initService() {
+    datasetService = new DatasetService(datasetDAO);
+  }
+
+  @Test
+  public void testGetDatasetProperties() {
+    when(datasetDAO.findDatasetPropertiesByDatasetId(anyInt())).thenReturn(Collections.emptySet());
+    initService();
+
+    Assert.assertTrue(datasetService.getDatasetProperties(1).isEmpty());
+  }
+
+  @Test
+  public void testGetDatasetWithPropertiesById() {
+    when(datasetDAO.findDatasetPropertiesByDatasetId(anyInt())).thenReturn(getDatasetProperties());
+    when(datasetDAO.findDataSetById(anyInt())).thenReturn(getDataset());
+    initService();
+
+    Assert.assertTrue(datasetService.getDatasetProperties(1).equals(datasetDAO.findDatasetPropertiesByDatasetId(1)));
+  }
+
+  private DataSet getDataset() {
+    DataSet dataset = new DataSet();
+    dataset.setName("Test Dataset");
+    dataset.setActive(true);
+    dataset.setNeedsApproval(false);
+    dataset.setProperties(Collections.emptySet());
+    return dataset;
+  }
+
+  private Set<DataSetProperty> getDatasetProperties() {
+    return IntStream.range(1, 11)
+        .mapToObj(i ->
+            new DataSetProperty(1, i, "Test Value", new Date())
+        ).collect(Collectors.toSet());
+  }
+
+}

--- a/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
@@ -30,7 +30,7 @@ public class DatasetServiceTest {
     private DatasetService datasetService;
 
     @Mock
-    DataSetDAO datasetDAO;
+    private DataSetDAO datasetDAO;
 
     @Before
     public void setUp() {

--- a/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
@@ -55,7 +55,7 @@ public class DatasetServiceTest {
         Assert.assertNotNull(result);
         Assert.assertEquals(result.getName(), getDatasets().get(0).getName());
         Assert.assertNotNull(result.getProperties());
-        Assert.assertTrue(!result.getProperties().isEmpty());
+        Assert.assertFalse(result.getProperties().isEmpty());
     }
 
     @Test
@@ -97,8 +97,7 @@ public class DatasetServiceTest {
         when(datasetDAO.findDataSetById(datasetId)).thenReturn(getDatasets().get(0));
         initService();
 
-        Assert.assertTrue(datasetService.getDatasetProperties(datasetId)
-                .equals(datasetDAO.findDatasetPropertiesByDatasetId(1)));
+        Assert.assertEquals(datasetService.getDatasetProperties(datasetId), datasetDAO.findDatasetPropertiesByDatasetId(1));
     }
 
     @Test
@@ -107,7 +106,7 @@ public class DatasetServiceTest {
         initService();
 
         List<DataSetProperty> properties = datasetService
-            .processDatasetProperties(1, new Date(), getDatasetPropertiesDTO());
+            .processDatasetProperties(1, getDatasetPropertiesDTO());
 
         Assert.assertEquals(properties.size(), getDatasetPropertiesDTO().size());
     }
@@ -123,7 +122,7 @@ public class DatasetServiceTest {
 
         List<DataSetPropertyDTO> properties = datasetService.findInvalidProperties(input);
 
-        Assert.assertTrue(!properties.isEmpty());
+        Assert.assertFalse(properties.isEmpty());
     }
 
     /* Helper functions */


### PR DESCRIPTION
Separates out service layer changes from https://github.com/DataBiosphere/consent/pull/705, with some changes to return a Dataset instead of a DatasetDTO. Also includes tests for the new DatasetService and a new sql query in the dao to return a dataset (rather than just its id) when searching by name.


Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [ ] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
