### PR TITLE
[DUOS-695][risk=no] Use the researcher email from the DAR user 

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/service/DatabaseElectionAPI.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatabaseElectionAPI.java
@@ -683,6 +683,9 @@ public class DatabaseElectionAPI extends AbstractElectionAPI {
      */
     private void sendDataCustodianNotification(String referenceId) {
         DataAccessRequest dar = dataAccessRequestService.findByReferenceId(referenceId);
+        final User researcher = (Objects.nonNull(dar) && Objects.nonNull(dar.getUserId())) ?
+            userDAO.findUserById(dar.getUserId()) :
+            null;
         List<Integer> datasetIdList = dar.getData().getDatasetIds();
         if (CollectionUtils.isNotEmpty(datasetIdList)) {
             Map<Integer, List<DatasetAssociation>> userToAssociationMap = datasetAssociationDAO.
@@ -696,7 +699,9 @@ public class DatabaseElectionAPI extends AbstractElectionAPI {
                         map(d -> new DatasetMailDTO(d.getName(), DatasetUtil.parseAlias(d.getAlias()))).
                         collect(Collectors.toList());
                 try {
-                    String researcherEmail = Objects.nonNull(dar.getData().getAcademicEmail()) ?
+                    String researcherEmail = Objects.nonNull(researcher) ?
+                        researcher.getEmail() :
+                        Objects.nonNull(dar.getData().getAcademicEmail()) ?
                             dar.getData().getAcademicEmail() :
                             dar.getData().getResearcher();
                     String darCode = Objects.nonNull(dar.getData().getDarCode()) ?


### PR DESCRIPTION
## Addresses
https://broadinstitute.atlassian.net/browse/DUOS-695

## Changes
Previously, we looked for the researcher's email in the dar data. Instead, first try ti get the real user from the dar's user id and in case we can't use that, fall back to looking at the dar data as we did previously.