### PR TITLE
[DUOS-720][risk=no] Dataset creation resource layer

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/resources/DataSetResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataSetResource.java
@@ -86,7 +86,7 @@ public class DataSetResource extends Resource {
         if (Objects.isNull(ds)) {
             throw new BadRequestException("Dataset is required");
         }
-        if (Objects.isNull(ds.getProperties())) {
+        if (Objects.isNull(ds.getProperties()) || ds.getProperties().isEmpty()) {
             throw new BadRequestException("Dataset must contain required properties");
         }
         List<DataSetPropertyDTO> invalidProperties = datasetService.findInvalidProperties(ds.getProperties());

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -23,10 +23,6 @@ public class DatasetService {
         this.dataSetDAO = dataSetDAO;
     }
 
-    public DataSet createTestDataSet(String json) {
-        return new DataSet(json);
-    }
-
     public DataSet createDataset(DataSetDTO dataset, String name) {
         Date now = new Date();
         int lastAlias = dataSetDAO.findLastAlias();

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -2219,17 +2219,17 @@ paths:
             application/json:
               schema:
                 type: string
-  /api/dataset/test:
+  /api/dataset/v2:
     post:
       summary: Creates the Dataset from JSON
-      description: Creates the Dataset from JSON (WIP)
-      parameters:
-        - name: json
-          in: body
-          description: Submitted dataset registration form
-          required: true
-          schema:
-            type: string
+      description: Creates the Dataset from JSON
+      requestBody:
+        description: Submitted dataset registration form
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Dataset'
       tags:
         - Datasets
       responses:

--- a/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
@@ -1,7 +1,11 @@
 package org.broadinstitute.consent.http.resources;
 
 import io.dropwizard.testing.ResourceHelpers;
+import java.net.URI;
+import javax.ws.rs.core.UriBuilder;
+import javax.ws.rs.core.UriInfo;
 import org.broadinstitute.consent.http.models.AuthUser;
+import org.broadinstitute.consent.http.models.DataSet;
 import org.broadinstitute.consent.http.service.AbstractDataAccessRequestAPI;
 import org.broadinstitute.consent.http.service.AbstractDataSetAPI;
 import org.broadinstitute.consent.http.service.DataAccessRequestAPI;
@@ -31,6 +35,7 @@ import java.util.Collections;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.when;
 
 @RunWith(PowerMockRunner.class)
@@ -60,6 +65,12 @@ public class DatasetResourceTest {
     @Mock
     private AuthUser authUser;
 
+    @Mock
+    private UriInfo uriInfo;
+
+    @Mock
+    private UriBuilder uriBuilder;
+
     private DataSetResource resource;
 
     @Before
@@ -77,8 +88,16 @@ public class DatasetResourceTest {
 
     @Test
     public void testCreateDataset() throws Exception {
+        DataSet result = new DataSet();
+        when(datasetService.getDatasetByName("test")).thenReturn(null);
+        when(datasetService.createDataset(any(), any())).thenReturn(result);
+        when(uriInfo.getRequestUriBuilder()).thenReturn(uriBuilder);
+        when(uriBuilder.replacePath(anyString())).thenReturn(uriBuilder);
+        when(uriBuilder.build(anyString())).thenReturn(new URI("/api/dataset/1"));
+
         initResource();
-        Response response = resource.createDataset(authUser, "");
+        Response response = resource.createDataset(authUser, uriInfo, "{\"properties\":[{\"propertyName\":\"Dataset Name\",\"propertyValue\":\"test\"}]}");
+
         assertEquals(201,response.getStatus());
     }
 


### PR DESCRIPTION
Adds createDataset v2 at the resource layer with a bunch of checks to validate the json coming in.

JSON input should be in minimum format of some properties (name is required), active: boolean, and objectId: string.
`{
"active": true,
"objectId": "test",
"properties":[
{"propertyName":"Dataset Name","propertyValue":"Dataset Name"},
{"propertyName":"Sample Collection ID","propertyValue":"test"},
{"propertyName":"Data Type","propertyValue":"test"},
{"propertyName":"Species","propertyValue":"test"},
{"propertyName":"Phenotype/Indication","propertyValue":"test"},
{"propertyName":"# of participants","propertyValue":"test"},
{"propertyName":"Description","propertyValue":"test"},
{"propertyName":"dbGAP","propertyValue":"test"},
{"propertyName":"Data Depositor","propertyValue":"test"},
{"propertyName":"Principal Investigator(PI)","propertyValue":"test"},
{"propertyName":"Consent ID","propertyValue":"test"}
]}`

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [x] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
