### PR TITLE
[DUOS-720][risk=no] Add create/update date, user id to Dataset model

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/DataSetDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DataSetDAO.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.consent.http.db;
 
+import java.sql.Timestamp;
 import org.apache.commons.lang3.tuple.Pair;
 import org.broadinstitute.consent.http.db.mapper.AssociationMapper;
 import org.broadinstitute.consent.http.db.mapper.AutocompleteMapper;
@@ -42,6 +43,10 @@ public interface DataSetDAO extends Transactional<DataSetDAO> {
     @SqlUpdate("insert into dataset (name, createDate, objectId, active, alias) values (:name, :createDate, :objectId, :active, :alias)")
     @GetGeneratedKeys
     Integer insertDataset(@Bind("name") String name, @Bind("createDate") Date createDate, @Bind("objectId") String objectId, @Bind("active") Boolean active, @Bind("alias") Integer alias);
+
+    @SqlUpdate("INSERT INTO dataset (name, createdate, create_user_id, update_date, update_user_id, objectId, active, alias) VALUES (:name, :createDate, :createUserId, :createDate, :createUserId, :objectId, :active, :alias)")
+    @GetGeneratedKeys
+    Integer insertDatasetV2(@Bind("name") String name, @Bind("createDate") Timestamp createDate, @Bind("createUserId") Integer createUserId, @Bind("objectId") String objectId, @Bind("active") Boolean active, @Bind("alias") Integer alias);
 
     @SqlQuery("select * from dataset where dataSetId = :dataSetId")
     DataSet findDataSetById(@Bind("dataSetId") Integer dataSetId);

--- a/src/main/java/org/broadinstitute/consent/http/db/DataSetDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DataSetDAO.java
@@ -99,6 +99,13 @@ public interface DataSetDAO extends Transactional<DataSetDAO> {
     Set<DataSetDTO> findDataSets();
 
     @UseRowMapper(DataSetPropertiesMapper.class)
+    @SqlQuery("SELECT d.*, k.key, dp.propertyvalue, ca.consentid, c.dac_id, c.translateduserestriction " +
+          "FROM dataset d LEFT OUTER JOIN datasetproperty dp on dp.datasetid = d.datasetid LEFT OUTER JOIN dictionary k on k.keyid = dp.propertykey " +
+          "LEFT OUTER JOIN consentassociations ca on ca.datasetid = d.datasetid LEFT OUTER JOIN consents c on c.consentid = ca.consentid " +
+          "WHERE d.datasetid = :dataSetId ORDER BY d.datasetid, k.displayorder")
+    Set<DataSetDTO> findDatasetDTOWithPropertiesByDatasetId(@Bind("dataSetId") Integer dataSetId);
+
+    @UseRowMapper(DataSetPropertiesMapper.class)
     @SqlQuery("select d.*, k.key, dp.propertyValue, ca.consentId, c.dac_id, c.translatedUseRestriction " +
             "from dataset d inner join datasetproperty dp on dp.dataSetId = d.dataSetId inner join dictionary k on k.keyId = dp.propertyKey " +
             "inner join consentassociations ca on ca.dataSetId = d.dataSetId inner join consents c on c.consentId = ca.consentId " +

--- a/src/main/java/org/broadinstitute/consent/http/db/DataSetDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DataSetDAO.java
@@ -100,8 +100,11 @@ public interface DataSetDAO extends Transactional<DataSetDAO> {
 
     @UseRowMapper(DataSetPropertiesMapper.class)
     @SqlQuery("SELECT d.*, k.key, dp.propertyvalue, ca.consentid, c.dac_id, c.translateduserestriction " +
-          "FROM dataset d LEFT OUTER JOIN datasetproperty dp on dp.datasetid = d.datasetid LEFT OUTER JOIN dictionary k on k.keyid = dp.propertykey " +
-          "LEFT OUTER JOIN consentassociations ca on ca.datasetid = d.datasetid LEFT OUTER JOIN consents c on c.consentid = ca.consentid " +
+          "FROM dataset d " +
+          "LEFT OUTER JOIN datasetproperty dp on dp.datasetid = d.datasetid " +
+          "LEFT OUTER JOIN dictionary k on k.keyid = dp.propertykey " +
+          "LEFT OUTER JOIN consentassociations ca on ca.datasetid = d.datasetid " +
+          "LEFT OUTER JOIN consents c on c.consentid = ca.consentid " +
           "WHERE d.datasetid = :dataSetId ORDER BY d.datasetid, k.displayorder")
     Set<DataSetDTO> findDatasetDTOWithPropertiesByDatasetId(@Bind("dataSetId") Integer dataSetId);
 

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DataSetMapper.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DataSetMapper.java
@@ -13,7 +13,10 @@ public class DataSetMapper implements RowMapper<DataSet> {
         r.getInt("dataSetId"),
         r.getString("objectId"),
         r.getString("name"),
-        r.getTimestamp("createDate"),
+        r.getTimestamp("createdate"),
+        r.getInt("create_user_id"),
+        r.getTimestamp("update_date"),
+        r.getInt("update_user_id"),
         r.getBoolean("active"),
         r.getInt("alias"));
   }

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DataSetMapper.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DataSetMapper.java
@@ -6,18 +6,34 @@ import org.broadinstitute.consent.http.models.DataSet;
 import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.core.statement.StatementContext;
 
-public class DataSetMapper implements RowMapper<DataSet> {
+public class DataSetMapper implements RowMapper<DataSet>, RowMapperHelper {
 
   public DataSet map(ResultSet r, StatementContext ctx) throws SQLException {
-    return new DataSet(
-        r.getInt("dataSetId"),
-        r.getString("objectId"),
-        r.getString("name"),
-        r.getTimestamp("createdate"),
-        r.getInt("create_user_id"),
-        r.getTimestamp("update_date"),
-        r.getInt("update_user_id"),
-        r.getBoolean("active"),
-        r.getInt("alias"));
+      DataSet dataset = new DataSet();
+      dataset.setDataSetId(r.getInt("dataSetId"));
+      dataset.setObjectId(r.getString("objectId"));
+      dataset.setName(r.getString("name"));
+      if (hasColumn(r, "createdate")) {
+          dataset.setCreateDate(r.getDate("createdate"));
+      }
+      if (hasColumn(r, "create_user_id")) {
+          int userId = r.getInt("create_user_id");
+          if (userId > 0) {
+              dataset.setCreateUserId(userId);
+          }
+      }
+      if (hasColumn(r, "update_date")) {
+          dataset.setUpdateDate(r.getTimestamp("update_date"));
+      }
+      if (hasColumn(r, "update_user_id")) {
+          int userId = r.getInt("update_user_id");
+          if (userId > 0) {
+              dataset.setUpdateUserId(userId);
+          }
+      }
+      dataset.setActive(r.getBoolean("active"));
+      dataset.setAlias(r.getInt("alias"));
+
+      return dataset;
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DataSetPropertiesMapper.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DataSetPropertiesMapper.java
@@ -35,10 +35,24 @@ public class DataSetPropertiesMapper implements RowMapper<DataSetDTO>, RowMapper
       dataSetDTO.setDataSetId(dataSetId);
       dataSetDTO.setActive(r.getBoolean("active"));
       dataSetDTO.setTranslatedUseRestriction(r.getString("translatedUseRestriction"));
-      dataSetDTO.setCreateDate(r.getDate("createdate"));
-      dataSetDTO.setCreateUserId(r.getInt("create_user_id"));
-      dataSetDTO.setUpdateDate(r.getTimestamp("update_date"));
-      dataSetDTO.setUpdateUserId(r.getInt("update_user_id"));
+      if (hasColumn(r, "createdate")) {
+          dataSetDTO.setCreateDate(r.getDate("createdate"));
+      }
+      if (hasColumn(r, "create_user_id")) {
+          int userId = r.getInt("create_user_id");
+          if (userId > 0) {
+              dataSetDTO.setCreateUserId(userId);
+          }
+      }
+      if (hasColumn(r, "update_date")) {
+          dataSetDTO.setUpdateDate(r.getTimestamp("update_date"));
+      }
+      if (hasColumn(r, "update_user_id")) {
+          int userId = r.getInt("update_user_id");
+          if (userId > 0) {
+              dataSetDTO.setUpdateUserId(userId);
+          }
+      }
       DataSetPropertyDTO property = new DataSetPropertyDTO("Dataset Name", r.getString("name"));
       dataSetDTO.addProperty(property);
       property =

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DataSetPropertiesMapper.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DataSetPropertiesMapper.java
@@ -35,6 +35,10 @@ public class DataSetPropertiesMapper implements RowMapper<DataSetDTO>, RowMapper
       dataSetDTO.setDataSetId(dataSetId);
       dataSetDTO.setActive(r.getBoolean("active"));
       dataSetDTO.setTranslatedUseRestriction(r.getString("translatedUseRestriction"));
+      dataSetDTO.setCreateDate(r.getDate("createdate"));
+      dataSetDTO.setCreateUserId(r.getInt("create_user_id"));
+      dataSetDTO.setUpdateDate(r.getTimestamp("update_date"));
+      dataSetDTO.setUpdateUserId(r.getInt("update_user_id"));
       DataSetPropertyDTO property = new DataSetPropertyDTO("Dataset Name", r.getString("name"));
       dataSetDTO.addProperty(property);
       property =

--- a/src/main/java/org/broadinstitute/consent/http/models/DataSet.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DataSet.java
@@ -20,6 +20,15 @@ public class DataSet {
     private Date createDate;
 
     @JsonProperty
+    private Integer createUserId;
+
+    @JsonProperty
+    private Date updateDate;
+
+    @JsonProperty
+    private Integer updateUserId;
+
+    @JsonProperty
     private Boolean active;
 
     @JsonProperty
@@ -34,6 +43,18 @@ public class DataSet {
     private Set<DataSetProperty> properties;
 
     public DataSet() {
+    }
+
+    public DataSet(Integer dataSetId, String objectId, String name, Date createDate, Integer createUserId, Date updateDate, Integer updateUserId, Boolean active, Integer alias) {
+        this.dataSetId = dataSetId;
+        this.objectId = objectId;
+        this.name = name;
+        this.createDate = createDate;
+        this.createUserId = createUserId;
+        this.updateDate = updateDate;
+        this.updateUserId = updateUserId;
+        this.active = active;
+        this.alias = alias;
     }
 
     public DataSet(Integer dataSetId, String objectId, String name, Date createDate, Boolean active, Integer alias) {
@@ -88,6 +109,22 @@ public class DataSet {
     public void setCreateDate(Date createDate) {
         this.createDate = createDate;
     }
+
+    public Integer getCreateUserId() { return createUserId; }
+
+    public void setCreateUserId(Integer createUserId) { this.createUserId = createUserId; }
+
+    public Date getUpdateDate() {
+        return updateDate;
+    }
+
+    public void setUpdateDate(Date updateDate) {
+        this.updateDate = updateDate;
+    }
+
+    public Integer getUpdateUserId() { return updateUserId; }
+
+    public void setUpdateUserId(Integer updateUserId) { this.updateUserId = updateUserId; }
 
     public Set<DataSetProperty> getProperties() {
         return properties;

--- a/src/main/java/org/broadinstitute/consent/http/models/dto/DataSetDTO.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/dto/DataSetDTO.java
@@ -1,6 +1,8 @@
 package org.broadinstitute.consent.http.models.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.sql.Date;
+import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -44,6 +46,18 @@ public class DataSetDTO {
 
     @JsonProperty
     private String objectId;
+
+    @JsonProperty
+    private Date createDate;
+
+    @JsonProperty
+    private Integer createUserId;
+
+    @JsonProperty
+    private Timestamp updateDate;
+
+    @JsonProperty
+    private Integer updateUserId;
 
     public DataSetDTO() {
     }
@@ -151,6 +165,22 @@ public class DataSetDTO {
     public void setObjectId(String objectId) {
         this.objectId = objectId;
     }
+
+    public Date getCreateDate() { return createDate; }
+
+    public void setCreateDate(Date createDate) { this.createDate = createDate; }
+
+    public Integer getCreateUserId() { return createUserId; }
+
+    public void setCreateUserId(Integer createUserId) { this.createUserId = createUserId; }
+
+    public Timestamp getUpdateDate() { return updateDate; }
+
+    public void setUpdateDate(Timestamp updateDate) { this.updateDate = updateDate; }
+
+    public Integer getUpdateUserId() { return updateUserId; }
+
+    public void setUpdateUserId(Integer updateUserId) { this.updateUserId = updateUserId; }
 
     public void addProperty(DataSetPropertyDTO property) {
         if (this.getProperties() == null) {

--- a/src/main/java/org/broadinstitute/consent/http/resources/DataSetResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataSetResource.java
@@ -178,7 +178,8 @@ public class DataSetResource extends Resource {
     @PermitAll
     public Response describeDataSet( @PathParam("datasetId") Integer datasetId){
         try {
-            return Response.ok(datasetService.getDatasetDTO(datasetId), MediaType.APPLICATION_JSON).build();
+            DataSetDTO datasetDTO = datasetService.getDatasetDTO(datasetId);
+            return Response.ok(datasetDTO, MediaType.APPLICATION_JSON).build();
         } catch (Exception e){
             return createExceptionResponse(e);
         }

--- a/src/main/java/org/broadinstitute/consent/http/resources/DataSetResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataSetResource.java
@@ -103,7 +103,9 @@ public class DataSetResource extends Resource {
         if (Objects.nonNull(datasetNameAlreadyUsed)) {
             throw new NotFoundException("Dataset name: " + name + " is already in use");
         }
-        DataSet dataset = datasetService.createDataset(ds, name);
+        User dacUser = userService.findUserByEmail(user.getGoogleUser().getEmail());
+        Integer userId = dacUser.getDacUserId();
+        DataSet dataset = datasetService.createDataset(ds, name, userId);
         URI uri = info.getRequestUriBuilder().replacePath("api/dataset/{datasetId}").build(ds.getDataSetId());
         return Response.created(uri).entity(dataset).build();
     }

--- a/src/main/java/org/broadinstitute/consent/http/resources/DataSetResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataSetResource.java
@@ -178,8 +178,7 @@ public class DataSetResource extends Resource {
     @PermitAll
     public Response describeDataSet( @PathParam("datasetId") Integer datasetId){
         try {
-            return Response.ok(datasetService.findDatasetById(datasetId), MediaType.APPLICATION_JSON).build();
-//            return Response.ok(api.getDataSetDTO(datasetId), MediaType.APPLICATION_JSON).build();
+            return Response.ok(datasetService.getDatasetDTO(datasetId), MediaType.APPLICATION_JSON).build();
         } catch (Exception e){
             return createExceptionResponse(e);
         }

--- a/src/main/java/org/broadinstitute/consent/http/resources/DataSetResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataSetResource.java
@@ -178,7 +178,8 @@ public class DataSetResource extends Resource {
     @PermitAll
     public Response describeDataSet( @PathParam("datasetId") Integer datasetId){
         try {
-            return Response.ok(api.getDataSetDTO(datasetId), MediaType.APPLICATION_JSON).build();
+            return Response.ok(datasetService.findDatasetById(datasetId), MediaType.APPLICATION_JSON).build();
+//            return Response.ok(api.getDataSetDTO(datasetId), MediaType.APPLICATION_JSON).build();
         } catch (Exception e){
             return createExceptionResponse(e);
         }

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -1,6 +1,7 @@
 package org.broadinstitute.consent.http.service;
 
 import java.util.Date;
+import java.sql.Timestamp;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -24,7 +25,9 @@ public class DatasetService {
     }
 
     public DataSet createDataset(DataSetDTO dataset, String name) {
-        Date now = new Date();
+        Date date = new Date();
+        long time = date.getTime();
+        Timestamp now = new Timestamp(time);
         int lastAlias = dataSetDAO.findLastAlias();
         int alias = lastAlias + 1;
 

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -61,11 +61,12 @@ public class DatasetService {
     }
 
     public DataSetDTO getDatasetDTO(Integer datasetId) {
-        Set<DataSetDTO> dataSet = dataSetDAO.findDatasetDTOWithPropertiesByDatasetId(datasetId);
-        for (DataSetDTO d : dataSet) {
-            return d;
+        Set<DataSetDTO> dataset = dataSetDAO.findDatasetDTOWithPropertiesByDatasetId(datasetId);
+        DataSetDTO result = new DataSetDTO();
+        for (DataSetDTO d : dataset) {
+            result = d;
         }
-        throw new NotFoundException();
+        return result;
     }
 
     public List<DataSetProperty> processDatasetProperties(Integer datasetId, List<DataSetPropertyDTO> properties) {

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -25,9 +25,7 @@ public class DatasetService {
     }
 
     public DataSet createDataset(DataSetDTO dataset, String name, Integer userId) {
-        Date date = new Date();
-        long time = date.getTime();
-        Timestamp now = new Timestamp(time);
+        Timestamp now = new Timestamp(new Date().getTime());
         int lastAlias = dataSetDAO.findLastAlias();
         int alias = lastAlias + 1;
 

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -5,6 +5,7 @@ import java.sql.Timestamp;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+import javax.ws.rs.NotFoundException;
 import org.broadinstitute.consent.http.db.DataSetDAO;
 
 import javax.inject.Inject;
@@ -57,6 +58,14 @@ public class DatasetService {
         Set<DataSetProperty> properties = getDatasetProperties(datasetId);
         dataset.setProperties(properties);
         return dataset;
+    }
+
+    public DataSetDTO getDatasetDTO(Integer datasetId) {
+        Set<DataSetDTO> dataSet = dataSetDAO.findDatasetDTOWithPropertiesByDatasetId(datasetId);
+        for (DataSetDTO d : dataSet) {
+            return d;
+        }
+        throw new NotFoundException();
     }
 
     public List<DataSetProperty> processDatasetProperties(Integer datasetId, List<DataSetPropertyDTO> properties) {

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -5,7 +5,6 @@ import java.sql.Timestamp;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
-import javax.ws.rs.NotFoundException;
 import org.broadinstitute.consent.http.db.DataSetDAO;
 
 import javax.inject.Inject;

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -24,7 +24,7 @@ public class DatasetService {
         this.dataSetDAO = dataSetDAO;
     }
 
-    public DataSet createDataset(DataSetDTO dataset, String name) {
+    public DataSet createDataset(DataSetDTO dataset, String name, Integer userId) {
         Date date = new Date();
         long time = date.getTime();
         Timestamp now = new Timestamp(time);
@@ -32,7 +32,7 @@ public class DatasetService {
         int alias = lastAlias + 1;
 
         Integer id = dataSetDAO
-            .insertDataset(name, now, dataset.getObjectId(), dataset.getActive(), alias);
+            .insertDatasetV2(name, now, userId, dataset.getObjectId(), dataset.getActive(), alias);
 
         List<DataSetProperty> propertyList = processDatasetProperties(id, dataset.getProperties());
         dataSetDAO.insertDataSetsProperties(propertyList);

--- a/src/main/resources/changelog-master.xml
+++ b/src/main/resources/changelog-master.xml
@@ -56,4 +56,5 @@
     <include file="changesets/changelog-consent-51.0.xml" relativeToChangelogFile="true"/>
     <include file="changesets/changelog-consent-52.0.xml" relativeToChangelogFile="true"/>
     <include file="changesets/changelog-consent-53.0.xml" relativeToChangelogFile="true"/>
+    <include file="changesets/changelog-consent-54.0.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/changesets/changelog-consent-54.0.xml
+++ b/src/main/resources/changesets/changelog-consent-54.0.xml
@@ -1,0 +1,34 @@
+<databaseChangeLog
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+  <changeSet dbms="postgresql" author="lzhang" id="54.0">
+    <addColumn tableName="dataset">
+      <column name="create_user_id" type="bigint">
+        <constraints foreignKeyName="fk_dataset_user_id" references="dacuser(dacuserid)" />
+      </column>
+    </addColumn>
+    <rollback>
+      <dropColumn columnName="create_user_id" tableName="dataset" />
+    </rollback>
+  </changeSet>
+  <changeSet dbms="postgresql" author="lzhang" id="54.1">
+    <addColumn tableName="dataset">
+      <column name="update_date" type="timestamptz" />
+    </addColumn>
+    <rollback>
+      <dropColumn columnName="update_date" tableName="dataset" />
+    </rollback>
+  </changeSet>
+  <changeSet dbms="postgresql" author="lzhang" id="54.2">
+    <addColumn tableName="dataset">
+      <column name="update_user_id" type="bigint" />
+    </addColumn>
+    <rollback>
+      <dropColumn columnName="update_user_id" tableName="dataset" />
+    </rollback>
+  </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/changesets/changelog-consent-54.0.xml
+++ b/src/main/resources/changesets/changelog-consent-54.0.xml
@@ -9,24 +9,12 @@
       <column name="create_user_id" type="bigint">
         <constraints foreignKeyName="fk_dataset_user_id" references="dacuser(dacuserid)" />
       </column>
-    </addColumn>
-    <rollback>
-      <dropColumn columnName="create_user_id" tableName="dataset" />
-    </rollback>
-  </changeSet>
-  <changeSet dbms="postgresql" author="lzhang" id="54.1">
-    <addColumn tableName="dataset">
       <column name="update_date" type="timestamptz" />
-    </addColumn>
-    <rollback>
-      <dropColumn columnName="update_date" tableName="dataset" />
-    </rollback>
-  </changeSet>
-  <changeSet dbms="postgresql" author="lzhang" id="54.2">
-    <addColumn tableName="dataset">
       <column name="update_user_id" type="bigint" />
     </addColumn>
     <rollback>
+      <dropColumn columnName="create_user_id" tableName="dataset" />
+      <dropColumn columnName="update_date" tableName="dataset" />
       <dropColumn columnName="update_user_id" tableName="dataset" />
     </rollback>
   </changeSet>

--- a/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
@@ -5,8 +5,10 @@ import java.net.URI;
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
+import org.broadinstitute.consent.http.authentication.GoogleUser;
 import org.broadinstitute.consent.http.models.AuthUser;
 import org.broadinstitute.consent.http.models.DataSet;
+import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.service.AbstractDataAccessRequestAPI;
 import org.broadinstitute.consent.http.service.AbstractDataSetAPI;
 import org.broadinstitute.consent.http.service.DataAccessRequestAPI;
@@ -36,6 +38,7 @@ import java.util.Collections;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.when;
 
@@ -67,6 +70,12 @@ public class DatasetResourceTest {
     private AuthUser authUser;
 
     @Mock
+    private GoogleUser googleUser;
+
+    @Mock
+    private User dacUser;
+
+    @Mock
     private UriInfo uriInfo;
 
     @Mock
@@ -91,7 +100,11 @@ public class DatasetResourceTest {
     public void testCreateDataset() throws Exception {
         DataSet result = new DataSet();
         when(datasetService.getDatasetByName("test")).thenReturn(null);
-        when(datasetService.createDataset(any(), any())).thenReturn(result);
+        when(datasetService.createDataset(any(), any(), anyInt())).thenReturn(result);
+        when(authUser.getGoogleUser()).thenReturn(googleUser);
+        when(googleUser.getEmail()).thenReturn("email@email.com");
+        when(userService.findUserByEmail(any())).thenReturn(dacUser);
+        when(dacUser.getDacUserId()).thenReturn(1);
         when(uriInfo.getRequestUriBuilder()).thenReturn(uriBuilder);
         when(uriBuilder.replacePath(anyString())).thenReturn(uriBuilder);
         when(uriBuilder.build(anyString())).thenReturn(new URI("/api/dataset/1"));

--- a/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
@@ -44,13 +44,13 @@ public class DatasetServiceTest {
     @Test
     public void testCreateDataset() {
         int datasetId = 1;
-        when(datasetDAO.insertDataset(anyString(), any(), anyString(), anyBoolean(), anyInt()))
+        when(datasetDAO.insertDatasetV2(anyString(), any(), anyInt(), anyString(), anyBoolean(), anyInt()))
             .thenReturn(datasetId);
         when(datasetDAO.findDataSetById(datasetId)).thenReturn(getDatasets().get(0));
         when(datasetDAO.findDatasetPropertiesByDatasetId(datasetId)).thenReturn(getDatasetProperties());
         initService();
 
-        DataSet result = datasetService.createDataset(getDatasetDTO(), "Test Dataset 1");
+        DataSet result = datasetService.createDataset(getDatasetDTO(), "Test Dataset 1", 1);
 
         Assert.assertNotNull(result);
         Assert.assertEquals(result.getName(), getDatasets().get(0).getName());

--- a/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.Collections;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -125,6 +126,19 @@ public class DatasetServiceTest {
         Assert.assertFalse(properties.isEmpty());
     }
 
+    @Test
+    public void testGetDatasetDTO() {
+        Set<DataSetDTO> set = new HashSet<>();
+        set.add(getDatasetDTO());
+        when(datasetDAO.findDatasetDTOWithPropertiesByDatasetId(anyInt())).thenReturn(set);
+        initService();
+
+        DataSetDTO datasetDTO = datasetService.getDatasetDTO(1);
+
+        Assert.assertNotNull(datasetDTO);
+        Assert.assertFalse(datasetDTO.getProperties().isEmpty());
+    }
+
     /* Helper functions */
 
     private List<DataSet> getDatasets() {
@@ -156,6 +170,7 @@ public class DatasetServiceTest {
 
     private DataSetDTO getDatasetDTO() {
         DataSetDTO datasetDTO = new DataSetDTO();
+        datasetDTO.setDataSetId(1);
         datasetDTO.setObjectId("Test ObjectId");
         datasetDTO.setActive(true);
         datasetDTO.setProperties(getDatasetPropertiesDTO());


### PR DESCRIPTION
Addresses additional requirements: https://broadinstitute.atlassian.net/browse/DUOS-720

As part of pushing out the new POST v2 endpoint, we want to start capturing the create and update dates and user ids for the datasets created. This PR adds these 4 fields to the Dataset and DatasetDTO models both in code and postgres, and any necessary changes to calculate them from a POST request or return them in a response. We also change the format of the "date" to Timestamp, so that we can get time of day sent (instead of just the calendar date).

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [ ] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
