### PR TITLE
[DUOS-767][risk=low] Get User by ID Endpoint

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
@@ -291,7 +291,7 @@ public class ConsentApplication extends Application<ConsentConfiguration> {
         env.jersey().register(ApprovalExpirationTimeResource.class);
         env.jersey().register(MatchResource.class);
         env.jersey().register(new MetricsResource(metricsService));
-        env.jersey().register(new UserResource(userService));
+        env.jersey().register(new UserResource(userService, whitelistService));
         env.jersey().register(new ResearcherResource(researcherService, userService, whitelistService));
         env.jersey().register(WorkspaceResource.class);
         env.jersey().register(new DataAccessAgreementResource(googleStore, researcherService));

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -2790,7 +2790,7 @@ paths:
           content:
             application/json:
               schema:
-                type: string
+                $ref: '#/components/schemas/User'
         404:
           description: User not found
         500:

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -2771,6 +2771,30 @@ paths:
                 $ref: '#/components/schemas/MatchResult'
         500:
           description: Server error.
+  /api/user/{id}:
+    get:
+      summary: Find user by id
+      description: Finds user by the user id. Available to Admin, Chair, and Member roles
+      parameters:
+        - name: id
+          in: path
+          description: The id of the user
+          required: true
+          schema:
+            type: number
+      tags:
+        - User
+      responses:
+        200:
+          description: The user, along with researcher properties and whitelist entries
+          content:
+            application/json:
+              schema:
+                type: string
+        404:
+          description: User not found
+        500:
+          description: Server error.
   /api/user/{email}:
     delete:
       summary: Delete User by email

--- a/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
@@ -98,7 +98,7 @@ public class UserResourceTest {
         initResource();
 
         Response response = userResource.getUserById(authUser, 1);
-        Assert.assertEquals(Status.OK.getStatusCode(), response.getStatus());
+        assertEquals(Status.OK.getStatusCode(), response.getStatus());
     }
 
     @Test
@@ -107,7 +107,7 @@ public class UserResourceTest {
         initResource();
 
         Response response = userResource.getUserById(authUser, 1);
-        Assert.assertEquals(Status.NOT_FOUND.getStatusCode(), response.getStatus());
+        assertEquals(Status.NOT_FOUND.getStatusCode(), response.getStatus());
     }
 
     @Test


### PR DESCRIPTION
## Addresses
https://broadinstitute.atlassian.net/browse/DUOS-767

## Changes
New api to get a user by id, along with all researcher properties and whitelist entries.

Sample output:
```
{
  "dacUserId": ---------,
  "email": "grushton@broadinstitute.org",
  "displayName": "Gregory Rushton",
  "createDate": "Jan 6, 2016",
  "additionalEmail": "grushton@broadinstitute.org",
  "roles": [
    {
      "userRoleId": ---------,
      "userId": ---------,
      "roleId": ---------,
      "name": "Researcher"
    }
  ],
  "emailPreference": false,
  "status": "pending",
  "researcherProperties": [
    {
      "propertyId": ---------,
      "userId": ---------,
      "propertyKey": "academicEmail",
      "propertyValue": "grushton@broadinstitute.org"
    } ...
  ],
  "whitelistEntries": [
    {
      "organization": "Broad",
      "commonsId": "---------",
      "name": "Gregory Rushton",
      "email": "grushton@broadinstitute.org",
      "signingOfficialName": "---------",
      "signingOfficialEmail": "---------",
      "itDirectorName": "---------",
      "itDirectorEmail": "---------"
    }
  ]
}
```