### PR TITLE
[DUOS-767][risk=no] New /me endpoint

### DIFF
--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -2771,6 +2771,23 @@ paths:
                 $ref: '#/components/schemas/MatchResult'
         500:
           description: Server error.
+  /api/user/me:
+    get:
+      summary: Find currently authenticated user
+      description: Find currently authenticated user
+      tags:
+        - User
+      responses:
+        200:
+          description: The user, along with researcher properties and whitelist entries
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+        404:
+          description: User not found
+        500:
+          description: Server error.
   /api/user/{id}:
     get:
       summary: Find user by id

--- a/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
@@ -45,7 +45,7 @@ public class UserResourceTest {
 
   @Mock private UriInfo uriInfo;
 
-  @Mock UriBuilder uriBuilder;
+  @Mock private UriBuilder uriBuilder;
 
   private final String TEST_EMAIL = "test@gmail.com";
 

--- a/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
@@ -9,8 +9,10 @@ import static org.mockito.Mockito.when;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 import javax.ws.rs.NotFoundException;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
@@ -35,133 +37,156 @@ import org.mockito.MockitoAnnotations;
 
 public class UserResourceTest {
 
-    @Mock
-    private UserService userService;
+  @Mock private UserService userService;
 
-    @Mock
-    private WhitelistService whitelistService;
+  @Mock private WhitelistService whitelistService;
 
-    private UserResource userResource;
+  private UserResource userResource;
 
-    @Mock
-    private UriInfo uriInfo;
+  @Mock private UriInfo uriInfo;
 
-    @Mock
-    UriBuilder uriBuilder;
+  @Mock UriBuilder uriBuilder;
 
-    private final String TEST_EMAIL = "test@gmail.com";
+  private final String TEST_EMAIL = "test@gmail.com";
 
-    private AuthUser authUser;
+  private AuthUser authUser;
 
-    @Before
-    public void setUp() throws URISyntaxException {
-        GoogleUser googleUser = new GoogleUser();
-        googleUser.setName("Test User");
-        googleUser.setEmail(TEST_EMAIL);
-        authUser = new AuthUser(googleUser);
-        MockitoAnnotations.initMocks(this);
-        when(uriInfo.getRequestUriBuilder()).thenReturn(uriBuilder);
-        when(uriBuilder.path(anyString())).thenReturn(uriBuilder);
-        when(uriBuilder.build(anyString())).thenReturn(new URI("http://localhost:8180/dacuser/api"));
-    }
+  @Before
+  public void setUp() throws URISyntaxException {
+    GoogleUser googleUser = new GoogleUser();
+    googleUser.setName("Test User");
+    googleUser.setEmail(TEST_EMAIL);
+    authUser = new AuthUser(googleUser);
+    MockitoAnnotations.initMocks(this);
+    when(uriInfo.getRequestUriBuilder()).thenReturn(uriBuilder);
+    when(uriBuilder.path(anyString())).thenReturn(uriBuilder);
+    when(uriBuilder.build(anyString())).thenReturn(new URI("http://localhost:8180/dacuser/api"));
+  }
 
-    private void initResource() {
-        userResource = new UserResource(userService, whitelistService);
-    }
+  private void initResource() {
+    userResource = new UserResource(userService, whitelistService);
+  }
 
-    @Test
-    public void testGetUserById() {
-        User user = new User();
-        user.setDisplayName("Test");
-        UserRole researcher = new UserRole();
-        List<UserRole> roles = new ArrayList<>();
-        researcher.setName(UserRoles.RESEARCHER.getRoleName());
-        roles.add(researcher);
-        user.setRoles(roles);
-        ResearcherProperty prop = new ResearcherProperty();
-        prop.setPropertyId(1);
-        prop.setPropertyKey(ResearcherFields.ORCID.getValue());
-        prop.setPropertyValue("orcid");
-        WhitelistEntry e = new WhitelistEntry();
-        String randomValue = RandomStringUtils.random(10, true, false);
-        e.setCommonsId(randomValue);
-        e.setEmail(randomValue);
-        e.setItDirectorEmail(randomValue);
-        e.setItDirectorName(randomValue);
-        e.setName(randomValue);
-        e.setOrganization(randomValue);
-        e.setSigningOfficialEmail(randomValue);
-        e.setSigningOfficialName(randomValue);
-        when(userService.findUserById(any())).thenReturn(user);
-        when(userService.findAllUserProperties(any())).thenReturn(Collections.singletonList(prop));
-        when(whitelistService.findWhitelistEntriesForUser(any(), any())).thenReturn(Collections.singletonList(e));
-        initResource();
+  @Test
+  public void testGetMe() {
+    User user = createUserWithRole();
+    when(userService.findUserByEmail(any())).thenReturn(user);
+    when(userService.findAllUserProperties(any())).thenReturn(createResearcherProperties());
+    when(whitelistService.findWhitelistEntriesForUser(any(), any()))
+        .thenReturn(createWhitelistEntries());
+    initResource();
 
-        Response response = userResource.getUserById(authUser, 1);
-        assertEquals(Status.OK.getStatusCode(), response.getStatus());
-    }
+    Response response = userResource.getUser(authUser);
+    assertEquals(Status.OK.getStatusCode(), response.getStatus());
+  }
 
-    @Test
-    public void testGetUserByIdNotFound() {
-        when(userService.findUserById(any())).thenThrow(new NotFoundException());
-        initResource();
+  @Test
+  public void testGetUserById() {
+    User user = createUserWithRole();
+    when(userService.findUserById(any())).thenReturn(user);
+    when(userService.findAllUserProperties(any())).thenReturn(createResearcherProperties());
+    when(whitelistService.findWhitelistEntriesForUser(any(), any()))
+        .thenReturn(createWhitelistEntries());
+    initResource();
 
-        Response response = userResource.getUserById(authUser, 1);
-        assertEquals(Status.NOT_FOUND.getStatusCode(), response.getStatus());
-    }
+    Response response = userResource.getUserById(authUser, 1);
+    assertEquals(Status.OK.getStatusCode(), response.getStatus());
+  }
 
-    @Test
-    public void testCreateExistingUser() {
-        User user = new User();
-        user.setEmail(TEST_EMAIL);
-        List<UserRole> roles = new ArrayList<>();
-        UserRole admin = new UserRole();
-        admin.setName(UserRoles.ADMIN.getRoleName());
-        UserRole researcher = new UserRole();
-        researcher.setName(UserRoles.RESEARCHER.getRoleName());
-        roles.add(researcher);
-        roles.add(admin);
-        user.setRoles(roles);
-        when(userService.findUserByEmail(user.getEmail())).thenReturn(user);
-        initResource();
+  @Test
+  public void testGetUserByIdNotFound() {
+    when(userService.findUserById(any())).thenThrow(new NotFoundException());
+    initResource();
 
-        Response response = userResource.createResearcher(uriInfo, authUser);
-        Assert.assertEquals(Response.Status.CONFLICT.getStatusCode(), response.getStatus());
-    }
+    Response response = userResource.getUserById(authUser, 1);
+    assertEquals(Status.NOT_FOUND.getStatusCode(), response.getStatus());
+  }
 
-    @Test
-    public void testCreateFailingGoogleIdentity() {
-        User user = new User();
-        user.setEmail(TEST_EMAIL);
-        initResource();
+  @Test
+  public void testCreateExistingUser() {
+    User user = new User();
+    user.setEmail(TEST_EMAIL);
+    List<UserRole> roles = new ArrayList<>();
+    UserRole admin = new UserRole();
+    admin.setName(UserRoles.ADMIN.getRoleName());
+    UserRole researcher = new UserRole();
+    researcher.setName(UserRoles.RESEARCHER.getRoleName());
+    roles.add(researcher);
+    roles.add(admin);
+    user.setRoles(roles);
+    when(userService.findUserByEmail(user.getEmail())).thenReturn(user);
+    initResource();
 
-        Response response = userResource.createResearcher(uriInfo, new AuthUser(TEST_EMAIL));
-        Assert.assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
-    }
+    Response response = userResource.createResearcher(uriInfo, authUser);
+    Assert.assertEquals(Response.Status.CONFLICT.getStatusCode(), response.getStatus());
+  }
 
-    @Test
-    public void createUserSuccess() {
-        User user = new User();
-        user.setDisplayName("Test");
-        UserRole researcher = new UserRole();
-        List<UserRole> roles = new ArrayList<>();
-        researcher.setName(UserRoles.RESEARCHER.getRoleName());
-        roles.add(researcher);
-        user.setRoles(roles);
-        when(userService.findUserByEmail(any())).thenThrow(new NotFoundException());
-        when(userService.createUser(user)).thenReturn(user);
-        initResource();
+  @Test
+  public void testCreateFailingGoogleIdentity() {
+    User user = new User();
+    user.setEmail(TEST_EMAIL);
+    initResource();
 
-        Response response = userResource.createResearcher(uriInfo, authUser);
-        Assert.assertEquals(Response.Status.CREATED.getStatusCode(), response.getStatus());
-    }
+    Response response = userResource.createResearcher(uriInfo, new AuthUser(TEST_EMAIL));
+    Assert.assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+  }
 
-    @Test
-    public void testDeleteUser() {
-        doNothing().when(userService).deleteUserByEmail(any());
-        initResource();
-        Response response = userResource.delete(RandomStringUtils.random(10), uriInfo);
-        assertEquals(200, response.getStatus());
-    }
+  @Test
+  public void createUserSuccess() {
+    User user = new User();
+    user.setDisplayName("Test");
+    UserRole researcher = new UserRole();
+    List<UserRole> roles = new ArrayList<>();
+    researcher.setName(UserRoles.RESEARCHER.getRoleName());
+    roles.add(researcher);
+    user.setRoles(roles);
+    when(userService.findUserByEmail(any())).thenThrow(new NotFoundException());
+    when(userService.createUser(user)).thenReturn(user);
+    initResource();
 
+    Response response = userResource.createResearcher(uriInfo, authUser);
+    Assert.assertEquals(Response.Status.CREATED.getStatusCode(), response.getStatus());
+  }
+
+  @Test
+  public void testDeleteUser() {
+    doNothing().when(userService).deleteUserByEmail(any());
+    initResource();
+    Response response = userResource.delete(RandomStringUtils.random(10), uriInfo);
+    assertEquals(200, response.getStatus());
+  }
+
+  private User createUserWithRole() {
+    User user = new User();
+    user.setDacUserId(1);
+    user.setDisplayName("Test");
+    user.setEmail("Test");
+    UserRole researcher = new UserRole();
+    List<UserRole> roles = new ArrayList<>();
+    researcher.setName(UserRoles.RESEARCHER.getRoleName());
+    roles.add(researcher);
+    user.setRoles(roles);
+    return user;
+  }
+
+  private List<ResearcherProperty> createResearcherProperties() {
+    return Arrays.stream(ResearcherFields.values())
+        .filter(ResearcherFields::getRequired)
+        .map(f -> new ResearcherProperty(1, f.getValue(), f.getValue()))
+        .collect(Collectors.toList());
+  }
+
+  private List<WhitelistEntry> createWhitelistEntries() {
+    WhitelistEntry e = new WhitelistEntry();
+    String randomValue = RandomStringUtils.random(10, true, false);
+    e.setCommonsId(randomValue);
+    e.setEmail(randomValue);
+    e.setItDirectorEmail(randomValue);
+    e.setItDirectorName(randomValue);
+    e.setName(randomValue);
+    e.setOrganization(randomValue);
+    e.setSigningOfficialEmail(randomValue);
+    e.setSigningOfficialName(randomValue);
+    return Collections.singletonList(e);
+  }
 }


### PR DESCRIPTION
## Addresses
A bonus addition to https://broadinstitute.atlassian.net/browse/DUOS-767

## Changes
New `/me` endpoint that should simplify the profile page load and reduce the number of APi calls required for it.

---- 

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [ ] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
