### PR TITLE
[DUOS-720][risk=no] wrong id used when returning created dataset

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/resources/DataSetResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataSetResource.java
@@ -106,7 +106,7 @@ public class DataSetResource extends Resource {
         User dacUser = userService.findUserByEmail(user.getGoogleUser().getEmail());
         Integer userId = dacUser.getDacUserId();
         DataSet dataset = datasetService.createDataset(ds, name, userId);
-        URI uri = info.getRequestUriBuilder().replacePath("api/dataset/{datasetId}").build(ds.getDataSetId());
+        URI uri = info.getRequestUriBuilder().replacePath("api/dataset/{datasetId}").build(dataset.getDataSetId());
         return Response.created(uri).entity(dataset).build();
     }
 

--- a/src/main/java/org/broadinstitute/consent/http/resources/DataSetResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataSetResource.java
@@ -82,20 +82,20 @@ public class DataSetResource extends Resource {
     @Path("/v2")
     @PermitAll
     public Response createDataset(@Auth AuthUser user, @Context UriInfo info, String json) {
-        DataSetDTO ds = new Gson().fromJson(json, DataSetDTO.class);
-        if (Objects.isNull(ds)) {
+        DataSetDTO inputDataset = new Gson().fromJson(json, DataSetDTO.class);
+        if (Objects.isNull(inputDataset)) {
             throw new BadRequestException("Dataset is required");
         }
-        if (Objects.isNull(ds.getProperties()) || ds.getProperties().isEmpty()) {
+        if (Objects.isNull(inputDataset.getProperties()) || inputDataset.getProperties().isEmpty()) {
             throw new BadRequestException("Dataset must contain required properties");
         }
-        List<DataSetPropertyDTO> invalidProperties = datasetService.findInvalidProperties(ds.getProperties());
+        List<DataSetPropertyDTO> invalidProperties = datasetService.findInvalidProperties(inputDataset.getProperties());
         if (invalidProperties.size() > 0) {
             List<String> invalidKeys = invalidProperties.stream().map(p -> p.getPropertyName()).collect(
                   Collectors.toList());
             throw new BadRequestException("Dataset contains invalid properties that could not be recognized or associated with a key: " + invalidKeys.toString());
         }
-        String name = ds.getPropertyValue("Dataset Name");
+        String name = inputDataset.getPropertyValue("Dataset Name");
         if (Objects.isNull(name)) {
             throw new BadRequestException("Dataset name is required");
         }
@@ -105,9 +105,9 @@ public class DataSetResource extends Resource {
         }
         User dacUser = userService.findUserByEmail(user.getGoogleUser().getEmail());
         Integer userId = dacUser.getDacUserId();
-        DataSet dataset = datasetService.createDataset(ds, name, userId);
-        URI uri = info.getRequestUriBuilder().replacePath("api/dataset/{datasetId}").build(dataset.getDataSetId());
-        return Response.created(uri).entity(dataset).build();
+        DataSet createdDataset = datasetService.createDataset(inputDataset, name, userId);
+        URI uri = info.getRequestUriBuilder().replacePath("api/dataset/{datasetId}").build(createdDataset.getDataSetId());
+        return Response.created(uri).entity(createdDataset).build();
     }
 
     @POST


### PR DESCRIPTION
createDataset v2 errors out on a successful insert into the database because we try to return the dataset by searching for the id given in the json input (which shouldn't exist). Renamed the variables to be more clear about which dataset is which and to grab the correct id.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [ ] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
