### PR TITLE
[DUOS-751][risk=no] Get consent's data use when querying for dataset dtos

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/DataSetDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DataSetDAO.java
@@ -1,6 +1,11 @@
 package org.broadinstitute.consent.http.db;
 
 import java.sql.Timestamp;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import org.apache.commons.lang3.tuple.Pair;
 import org.broadinstitute.consent.http.db.mapper.AssociationMapper;
 import org.broadinstitute.consent.http.db.mapper.AutocompleteMapper;
@@ -28,12 +33,6 @@ import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 import org.jdbi.v3.sqlobject.statement.UseRowMapper;
 import org.jdbi.v3.sqlobject.transaction.Transactional;
-
-import java.util.Collection;
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
 
 @RegisterRowMapper(DataSetMapper.class)
 public interface DataSetDAO extends Transactional<DataSetDAO> {
@@ -92,14 +91,14 @@ public interface DataSetDAO extends Transactional<DataSetDAO> {
     void updateDataSetNeedsApproval(@Bind("dataSetId") Integer dataSetId, @Bind("needs_approval") Boolean needs_approval);
 
     @UseRowMapper(DataSetPropertiesMapper.class)
-    @SqlQuery("select d.*, k.key, dp.propertyValue, ca.consentId, c.dac_id, c.translatedUseRestriction " +
+    @SqlQuery("select d.*, k.key, dp.propertyValue, ca.consentId, c.dac_id, c.translatedUseRestriction, c.datause " +
             "from dataset d inner join datasetproperty dp on dp.dataSetId = d.dataSetId and d.name is not null inner join dictionary k on k.keyId = dp.propertyKey " +
             "inner join consentassociations ca on ca.dataSetId = d.dataSetId inner join consents c on c.consentId = ca.consentId " +
             "order by d.dataSetId, k.displayOrder")
     Set<DataSetDTO> findDataSets();
 
     @UseRowMapper(DataSetPropertiesMapper.class)
-    @SqlQuery("SELECT d.*, k.key, dp.propertyvalue, ca.consentid, c.dac_id, c.translateduserestriction " +
+    @SqlQuery("SELECT d.*, k.key, dp.propertyvalue, ca.consentid, c.dac_id, c.translateduserestriction, c.datause " +
           "FROM dataset d " +
           "LEFT OUTER JOIN datasetproperty dp on dp.datasetid = d.datasetid " +
           "LEFT OUTER JOIN dictionary k on k.keyid = dp.propertykey " +
@@ -109,7 +108,7 @@ public interface DataSetDAO extends Transactional<DataSetDAO> {
     Set<DataSetDTO> findDatasetDTOWithPropertiesByDatasetId(@Bind("dataSetId") Integer dataSetId);
 
     @UseRowMapper(DataSetPropertiesMapper.class)
-    @SqlQuery("select d.*, k.key, dp.propertyValue, ca.consentId, c.dac_id, c.translatedUseRestriction " +
+    @SqlQuery("select d.*, k.key, dp.propertyValue, ca.consentId, c.dac_id, c.translatedUseRestriction, c.datause " +
             "from dataset d inner join datasetproperty dp on dp.dataSetId = d.dataSetId inner join dictionary k on k.keyId = dp.propertyKey " +
             "inner join consentassociations ca on ca.dataSetId = d.dataSetId inner join consents c on c.consentId = ca.consentId " +
             "where d.dataSetId = :dataSetId order by d.dataSetId, k.displayOrder")
@@ -122,14 +121,14 @@ public interface DataSetDAO extends Transactional<DataSetDAO> {
     Set<DataSetProperty> findDatasetPropertiesByDatasetId(@Bind("datasetId") Integer datasetId);
 
     @UseRowMapper(DataSetPropertiesMapper.class)
-    @SqlQuery(" select d.*, k.key, dp.propertyValue, ca.consentId, c.dac_id, c.translatedUseRestriction from dataset  d inner join datasetproperty dp on dp.dataSetId = d.dataSetId " +
+    @SqlQuery(" select d.*, k.key, dp.propertyValue, ca.consentId, c.dac_id, c.translatedUseRestriction, c.datause from dataset  d inner join datasetproperty dp on dp.dataSetId = d.dataSetId " +
             " inner join dictionary k on k.keyId = dp.propertyKey inner join consentassociations ca on ca.dataSetId = d.dataSetId inner join consents c on c.consentId = ca.consentId inner join election e on e.referenceId = ca.consentId " +
             " inner join vote v on v.electionId = e.electionId and v.type = '" + CHAIRPERSON  + "' inner join (SELECT referenceId,MAX(createDate) maxDate FROM election where status ='Closed' group by referenceId) ev on ev.maxDate = e.createDate " +
             " and ev.referenceId = e.referenceId and v.vote = true and d.active = true order by d.dataSetId, k.displayOrder")
     Set<DataSetDTO> findDataSetsForResearcher();
 
     @UseRowMapper(DataSetPropertiesMapper.class)
-    @SqlQuery("select d.*, k.key, dp.propertyValue, ca.consentId, c.dac_id, c.translatedUseRestriction " +
+    @SqlQuery("select d.*, k.key, dp.propertyValue, ca.consentId, c.dac_id, c.translatedUseRestriction, c.datause " +
             "from dataset d inner join datasetproperty dp on dp.dataSetId = d.dataSetId inner join dictionary k on k.keyId = dp.propertyKey " +
             "inner join consentassociations ca on ca.dataSetId = d.dataSetId inner join consents c on c.consentId = ca.consentId " +
             "where d.dataSetId in (<dataSetIdList>) order by d.dataSetId, k.receiveOrder")
@@ -247,7 +246,7 @@ public interface DataSetDAO extends Transactional<DataSetDAO> {
      * @return Set of datasets, with properties, that are associated to a single DAC.
      */
     @UseRowMapper(DataSetPropertiesMapper.class)
-    @SqlQuery("select d.*, k.key, p.propertyValue, c.consentId, c.dac_id, c.translatedUseRestriction from dataset d " +
+    @SqlQuery("select d.*, k.key, p.propertyValue, c.consentId, c.dac_id, c.translatedUseRestriction, c.datause from dataset d " +
             " left outer join datasetproperty p on p.dataSetId = d.dataSetId " +
             " left outer join dictionary k on k.keyId = p.propertyKey " +
             " inner join consentassociations a on a.dataSetId = d.dataSetId " +
@@ -262,7 +261,7 @@ public interface DataSetDAO extends Transactional<DataSetDAO> {
      * @return Set of datasets, with properties, that are associated to any Dac.
      */
     @UseRowMapper(DataSetPropertiesMapper.class)
-    @SqlQuery("SELECT d.*, k.key, p.propertyvalue, c.consentid, c.dac_id, c.translateduserestriction " +
+    @SqlQuery("SELECT d.*, k.key, p.propertyvalue, c.consentid, c.dac_id, c.translateduserestriction, c.datause " +
             " FROM dataset d " +
             " LEFT OUTER JOIN datasetproperty p ON p.datasetid = d.datasetid " +
             " LEFT OUTER JOIN dictionary k ON k.keyid = p.propertykey " +

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DataSetPropertiesMapper.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DataSetPropertiesMapper.java
@@ -5,6 +5,7 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import org.broadinstitute.consent.http.models.DataUse;
 import org.broadinstitute.consent.http.models.dto.DataSetDTO;
 import org.broadinstitute.consent.http.models.dto.DataSetPropertyDTO;
 import org.jdbi.v3.core.mapper.RowMapper;
@@ -35,6 +36,9 @@ public class DataSetPropertiesMapper implements RowMapper<DataSetDTO>, RowMapper
       dataSetDTO.setDataSetId(dataSetId);
       dataSetDTO.setActive(r.getBoolean("active"));
       dataSetDTO.setTranslatedUseRestriction(r.getString("translatedUseRestriction"));
+      if (hasColumn(r, "datause")) {
+        dataSetDTO.setDataUse(DataUse.parseDataUse(r.getString("datause")).orElse(null));
+      }
       if (hasColumn(r, "createdate")) {
           dataSetDTO.setCreateDate(r.getDate("createdate"));
       }

--- a/src/main/java/org/broadinstitute/consent/http/models/dto/DataSetDTO.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/dto/DataSetDTO.java
@@ -6,6 +6,7 @@ import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import org.broadinstitute.consent.http.models.DataUse;
 import org.broadinstitute.consent.http.util.DatasetUtil;
 
 
@@ -58,6 +59,9 @@ public class DataSetDTO {
 
     @JsonProperty
     private Integer updateUserId;
+
+    @JsonProperty
+    public DataUse dataUse;
 
     public DataSetDTO() {
     }
@@ -187,6 +191,14 @@ public class DataSetDTO {
             this.setProperties(new ArrayList<>());
         }
         this.getProperties().add(property);
+    }
+
+    public DataUse getDataUse() {
+        return dataUse;
+    }
+
+    public void setDataUse(DataUse dataUse) {
+        this.dataUse = dataUse;
     }
 
     @Override

--- a/src/test/java/org/broadinstitute/consent/http/db/DataSetDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DataSetDAOTest.java
@@ -1,41 +1,25 @@
 package org.broadinstitute.consent.http.db;
 
-import org.apache.commons.lang3.tuple.Pair;
-import org.broadinstitute.consent.http.enumeration.UserRoles;
-import org.broadinstitute.consent.http.models.Consent;
-import org.broadinstitute.consent.http.models.DataSetProperty;
-import org.broadinstitute.consent.http.models.User;
-import org.broadinstitute.consent.http.models.Dac;
-import org.broadinstitute.consent.http.models.DataSet;
-import org.broadinstitute.consent.http.models.dto.DataSetDTO;
-import org.junit.Assert;
-import org.junit.Test;
-
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.tuple.Pair;
+import org.broadinstitute.consent.http.enumeration.UserRoles;
+import org.broadinstitute.consent.http.models.Consent;
+import org.broadinstitute.consent.http.models.Dac;
+import org.broadinstitute.consent.http.models.DataSet;
+import org.broadinstitute.consent.http.models.DataSetProperty;
+import org.broadinstitute.consent.http.models.User;
+import org.broadinstitute.consent.http.models.dto.DataSetDTO;
+import org.junit.Assert;
+import org.junit.Test;
+
 public class DataSetDAOTest extends DAOTestHelper {
-
-    @Test
-    public void testInsertDataset() {
-        // No-op ... tested in `createDataset()`
-    }
-
-    @Test
-    public void testFindDatasetById() {
-        // No-op ... tested in `createDataset()`
-    }
-
-    @Test
-    public void testDeleteDataSets() {
-        // No-op ... tested in `tearDown()`
-    }
 
     // User -> UserRoles -> DACs -> Consents -> Consent Associations -> DataSets
     @Test
@@ -172,6 +156,19 @@ public class DataSetDAOTest extends DAOTestHelper {
         DataSet d = createDataset();
         Set<DataSetProperty> properties = dataSetDAO.findDatasetPropertiesByDatasetId(d.getDataSetId());
         assertEquals(properties.size(), 1);
+    }
+
+    @Test
+    public void testFindDatasetWithPropertiesByDatasetId() {
+        Dac dac = createDac();
+        Consent c = createConsent(dac.getDacId());
+        DataSet d = createDataset();
+        createAssociation(c.getConsentId(), d.getDataSetId());
+        Set<DataSetDTO> dataSetDTOs = dataSetDAO.findDataSetWithPropertiesByDataSetId(d.getDataSetId());
+        DataSetDTO dataSetDTO = dataSetDTOs.stream().findFirst().orElse(null);
+        assertNotNull(dataSetDTO);
+        assertNotNull(dataSetDTO.getDataUse());
+        assertEquals(c.getDataUse().getGeneralUse(), dataSetDTO.getDataUse().getGeneralUse());
     }
 
     private void createUserRole(Integer roleId, Integer userId, Integer dacId) {


### PR DESCRIPTION
## Addresses
https://broadinstitute.atlassian.net/browse/DUOS-751

## Changes
Added the `dataUse` object from the associated consent to the datasetDTO in all responses that query for datasetDTO.

## Sample output

Local testing against https://local.broadinstitute.org:27443/api/dataset/369

```
{
  "dacId": 4,
  "dataSetId": 369,
  "consentId": "c6a75108-8c67-40bc-b355-088f1b2ec93b",
  "translatedUseRestriction": "Samples are restricted for use under the following conditions:\nData is available for general research use. [GRU]\nCommercial use is not prohibited.\nData use for methods development research irrespective of the specified data use limitations is not prohibited.\nFuture use as a control set for any type of health/medical/biomedical study is not prohibited.\nOther restrictions: IRB Approval Required.",
  "deletable": null,
  "properties": [
    {
      "propertyName": "Dataset Name",
      "propertyValue": "TOPMed CCAF_GRU_IRB_phs001189.v1.p1.c1"
    }...
  ],
  "active": true,
  "needsApproval": false,
  "isAssociatedToDataOwners": null,
  "updateAssociationToDataOwnerAllowed": null,
  "alias": "DUOS-000012",
  "objectId": null,
  "createDate": 1557878400000,
  "createUserId": null,
  "updateDate": null,
  "updateUserId": null,
  "dataUse": {
    "generalUse": true,
    "genomicPhenotypicData": "Yes",
    "other": "IRB Approval Required"
  }
}
```

----

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [ ] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
