### PR TITLE
[DUOS-778][risk=no] Fix swagger syntax

### DIFF
--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -3002,19 +3002,17 @@ paths:
   /api/whitelist:
     post:
       summary: postWhitelist
-      description: Uploads Library Card Whitelist tsv to bucket - NEW!
+      description: Uploads Library Card Whitelist tsv to bucket
       requestBody:
+        description: TSV file that contains whitelist information
         content:
           multipart/form-data:
             schema:
               type: object
-      parameters:
-        - name: data
-          in: formData
-          description: TSV file that contains whitelist information
-          required: true
-          schema:
-            type: file
+              properties:
+                data:
+                  type: string
+                  format: binary
       tags:
         - Whitelist
       responses:

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -3004,7 +3004,6 @@ paths:
       summary: postWhitelist
       description: Uploads Library Card Whitelist tsv to bucket
       requestBody:
-        description: TSV file that contains whitelist information
         content:
           multipart/form-data:
             schema:


### PR DESCRIPTION
## Addresses
https://broadinstitute.atlassian.net/browse/DUOS-778

## Changes
Minor update to the swagger doc for fixing the syntax of the file upload.

----

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [ ] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
