### PR TITLE
[DUOS-780][risk=no] Use constants instead of string vals

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
@@ -94,6 +94,11 @@ public class DataAccessRequestResource extends Resource {
     public Response createDataAccessRequest(@Context UriInfo info, Document dar) {
         UseRestriction useRestriction;
         try {
+            // See https://broadinstitute.atlassian.net/browse/DUOS-780
+            // Temporarily remove unnecessary fields until fully deprecated.
+            dar.remove(DarConstants.CREATE_DATE);
+            dar.remove(DarConstants.SORT_DATE);
+            dar.remove(DarConstants.DATA_ACCESS_REQUEST_ID);
             Boolean needsManualReview = DarUtil.requiresManualReview(dar);
             try {
                 if (!needsManualReview) {

--- a/src/main/java/org/broadinstitute/consent/http/util/DarUtil.java
+++ b/src/main/java/org/broadinstitute/consent/http/util/DarUtil.java
@@ -34,16 +34,16 @@ public class DarUtil {
     public static boolean requiresManualReview(Document dar) throws IOException {
         Map<String, Object> form = parseAsMap(dar.toJson());
         List<String> fieldsForManualReview = Arrays.asList(
-                        "population",
-                        "other",
-                        "illegalbehave",
-                        "addiction",
-                        "sexualdiseases",
-                        "stigmatizediseases",
-                        "vulnerablepop",
-                        "popmigration",
-                        "psychtraits",
-                        "nothealth");
+            DarConstants.POPULATION,
+            DarConstants.OTHER,
+            DarConstants.ILLEGAL_BEHAVE,
+            DarConstants.ADDICTION,
+            DarConstants.SEXUAL_DISEASES,
+            DarConstants.STIGMATIZED_DISEASES,
+            DarConstants.VULNERABLE_POP,
+            DarConstants.POP_MIGRATION,
+            DarConstants.PSYCH_TRAITS,
+            DarConstants.NOT_HEALTH);
 
         return !fieldsForManualReview.stream().
                 filter(field -> form.containsKey(field) && Boolean.valueOf(form.get(field).toString())).collect(Collectors.toList()).isEmpty();


### PR DESCRIPTION
## Addresses
https://broadinstitute.atlassian.net/browse/DUOS-780
See also: https://github.com/DataBiosphere/duos-ui/pull/616

## Changes
* Use constants to determine manual review state

----

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [ ] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
