### PR TITLE
[DUOS-302][risk=no] Move health check to gcs service

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
@@ -223,7 +223,6 @@ public class ConsentApplication extends Application<ConsentConfiguration> {
         final DataAccessRequestService dataAccessRequestService = injector.getProvider(DataAccessRequestService.class).get();
         final DatasetService datasetService = injector.getProvider(DatasetService.class).get();
         final ElectionService electionService = injector.getProvider(ElectionService.class).get();
-        final GCSService gcsService = injector.getProvider(GCSService.class).get();
         final EmailNotifierService emailNotifierService = injector.getProvider(EmailNotifierService.class).get();
         final GCSService gcsService = injector.getProvider(GCSService.class).get();
         final MetricsService metricsService = injector.getProvider(MetricsService.class).get();

--- a/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
@@ -38,6 +38,7 @@ import org.broadinstitute.consent.http.authentication.DefaultAuthenticator;
 import org.broadinstitute.consent.http.authentication.OAuthAuthenticator;
 import org.broadinstitute.consent.http.authentication.OAuthCustomAuthFilter;
 import org.broadinstitute.consent.http.cloudstore.GCSHealthCheck;
+import org.broadinstitute.consent.http.cloudstore.GCSService;
 import org.broadinstitute.consent.http.cloudstore.GCSStore;
 import org.broadinstitute.consent.http.configurations.ConsentConfiguration;
 import org.broadinstitute.consent.http.db.ApprovalExpirationTimeDAO;
@@ -223,6 +224,7 @@ public class ConsentApplication extends Application<ConsentConfiguration> {
         final DatasetService datasetService = injector.getProvider(DatasetService.class).get();
         final ElectionService electionService = injector.getProvider(ElectionService.class).get();
         final EmailNotifierService emailNotifierService = injector.getProvider(EmailNotifierService.class).get();
+        final GCSService gcsService = injector.getProvider(GCSService.class).get();
         final MetricsService metricsService = injector.getProvider(MetricsService.class).get();
         final PendingCaseService pendingCaseService = injector.getProvider(PendingCaseService.class).get();
         final UserRolesHandler userRolesHandler = injector.getProvider(UserRolesHandler.class).get();
@@ -253,7 +255,7 @@ public class ConsentApplication extends Application<ConsentConfiguration> {
         configureCors(env);
 
         // Health Checks
-        env.healthChecks().register("google-cloud-storage", new GCSHealthCheck(googleStore));
+        env.healthChecks().register("google-cloud-storage", new GCSHealthCheck(gcsService));
         env.healthChecks().register("elastic-search", new ElasticSearchHealthCheck(config.getElasticSearchConfiguration()));
 
         final StoreOntologyService storeOntologyService

--- a/src/main/java/org/broadinstitute/consent/http/cloudstore/CloudStore.java
+++ b/src/main/java/org/broadinstitute/consent/http/cloudstore/CloudStore.java
@@ -2,8 +2,6 @@ package org.broadinstitute.consent.http.cloudstore;
 
 import com.google.api.client.http.GenericUrl;
 import com.google.api.client.http.HttpResponse;
-import com.google.api.services.storage.model.Bucket;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URISyntaxException;
@@ -16,8 +14,6 @@ public interface CloudStore {
     HttpResponse getStorageDocument(String documentUrl) throws IOException, GeneralSecurityException;
 
     String putStorageDocument(InputStream stream, String type, String fileName) throws IOException, GeneralSecurityException;
-
-    Bucket getBucketMetadata() throws IOException, GeneralSecurityException;
 
     String postStorageDocument(InputStream stream, String type, String fileName) throws IOException, GeneralSecurityException;
 

--- a/src/main/java/org/broadinstitute/consent/http/cloudstore/GCSHealthCheck.java
+++ b/src/main/java/org/broadinstitute/consent/http/cloudstore/GCSHealthCheck.java
@@ -1,23 +1,23 @@
 package org.broadinstitute.consent.http.cloudstore;
 
 import com.codahale.metrics.health.HealthCheck;
-import com.google.api.services.storage.model.Bucket;
+import com.google.cloud.storage.Bucket;
 
 public class GCSHealthCheck extends HealthCheck {
 
-    private GCSStore store;
+    private final GCSService store;
 
-    public GCSHealthCheck(GCSStore store) {
+    public GCSHealthCheck(GCSService store) {
         this.store = store;
     }
 
     @Override
-    protected Result check() throws Exception {
+    protected Result check() {
 
         Bucket bucket;
 
         try {
-            bucket = store.getBucketMetadata();
+            bucket = store.getRootBucketWithMetadata();
         } catch (Exception e) {
             return Result.unhealthy("GCS bucket unreachable or does not exist: " + e.getMessage());
         }

--- a/src/main/java/org/broadinstitute/consent/http/cloudstore/GCSService.java
+++ b/src/main/java/org/broadinstitute/consent/http/cloudstore/GCSService.java
@@ -11,17 +11,16 @@ import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.inject.Inject;
-import org.broadinstitute.consent.http.configurations.StoreConfiguration;
-import org.broadinstitute.consent.http.service.WhitelistService;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.FileInputStream;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
+import org.broadinstitute.consent.http.configurations.StoreConfiguration;
+import org.broadinstitute.consent.http.service.WhitelistService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class GCSService {
 
@@ -79,6 +78,16 @@ public class GCSService {
             logger.error("Error getting most recent whitelist: " + e.getMessage());
             throw new Exception("Error getting most recent whitelist: " + e.getMessage());
         }
+    }
+
+    /**
+     * Get the root bucket configured for this environment. Returns a Bucket with all possible
+     * metadata values.
+     *
+     * @return Bucket
+     */
+    public Bucket getRootBucketWithMetadata() {
+        return storage.get(config.getBucket(), Storage.BucketGetOption.fields(Storage.BucketField.values()));
     }
 
     private List<Blob> listWhitelistItems() {

--- a/src/main/java/org/broadinstitute/consent/http/cloudstore/GCSStore.java
+++ b/src/main/java/org/broadinstitute/consent/http/cloudstore/GCSStore.java
@@ -11,19 +11,17 @@ import com.google.api.client.http.InputStreamContent;
 import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.api.services.storage.Storage;
 import com.google.api.services.storage.StorageScopes;
-import com.google.api.services.storage.model.Bucket;
 import com.google.api.services.storage.model.ObjectAccessControl;
 import com.google.api.services.storage.model.StorageObject;
 import com.google.inject.Inject;
-import org.broadinstitute.consent.http.configurations.StoreConfiguration;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.security.GeneralSecurityException;
 import java.util.Collections;
+import org.broadinstitute.consent.http.configurations.StoreConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Use `GCSService` instead which uses standard google libraries for GCS access.
@@ -88,12 +86,6 @@ public class GCSStore implements CloudStore {
     @Override
     public String putStorageDocument(InputStream stream, String type, String fileName) throws IOException {
         return getDocumentUrl(stream, type, fileName);
-    }
-
-    @Override
-    public Bucket getBucketMetadata() throws IOException, GeneralSecurityException {
-        Storage client = StorageFactory.getService(sConfig.getPassword());
-        return client.buckets().get(sConfig.getBucket()).execute();
     }
 
     @Override

--- a/src/test/java/org/broadinstitute/consent/http/cloudstore/GCSHealthCheckTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/cloudstore/GCSHealthCheckTest.java
@@ -1,43 +1,43 @@
 package org.broadinstitute.consent.http.cloudstore;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
 import com.codahale.metrics.health.HealthCheck;
-import com.google.api.services.storage.model.Bucket;
+import com.google.cloud.storage.Bucket;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-
-import java.io.IOException;
-import java.security.GeneralSecurityException;
-
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.when;
 
 public class GCSHealthCheckTest {
 
     private GCSHealthCheck healthCheck;
 
     @Mock
-    private GCSStore store;
+    private GCSService store;
+
+    @Mock
+    private Bucket bucket;
 
     @Before
-    public void setUpClass() throws Exception {
+    public void setUpClass() {
         MockitoAnnotations.initMocks(this);
         healthCheck = new GCSHealthCheck(store);
     }
 
     @Test
-    public void testBucketExists() throws IOException, GeneralSecurityException {
-        when(store.getBucketMetadata()).thenReturn(new Bucket());
+    public void testBucketExists() {
+        when(store.getRootBucketWithMetadata()).thenReturn(bucket);
 
         HealthCheck.Result result = healthCheck.execute();
         assertTrue(result.isHealthy());
     }
 
     @Test
-    public void testBucketMissing() throws Exception {
-        when(store.getBucketMetadata()).thenReturn(null);
+    public void testBucketMissing() {
+        when(store.getRootBucketWithMetadata()).thenReturn(null);
 
         HealthCheck.Result result = healthCheck.execute();
         assertFalse(result.isHealthy());


### PR DESCRIPTION
## Addresses
General maintenance work for deprecating `GCSStore` under https://broadinstitute.atlassian.net/browse/DUOS-302

## Changes
* Use `GCSService` for GCS health checks

----

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [ ] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
