### PR TITLE
[DUOS-784][risk=no] Fix default auth filter

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/authentication/DefaultAuthFilter.java
+++ b/src/main/java/org/broadinstitute/consent/http/authentication/DefaultAuthFilter.java
@@ -1,44 +1,36 @@
 package org.broadinstitute.consent.http.authentication;
 
 import io.dropwizard.auth.AuthFilter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
+import java.security.Principal;
 import javax.annotation.Priority;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.container.ContainerRequestContext;
-import java.io.IOException;
-import java.security.Principal;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Priority(1000)
 public class DefaultAuthFilter<P extends Principal> extends AuthFilter<String, P> {
 
-    private static final Logger logger = LoggerFactory.getLogger(DefaultAuthFilter.class);
+  private static final Logger logger = LoggerFactory.getLogger(DefaultAuthFilter.class);
 
-    public DefaultAuthFilter(){
+  public DefaultAuthFilter() {}
 
+  @Override
+  public void filter(ContainerRequestContext requestContext) {
+    String path = requestContext.getUriInfo().getPath();
+    boolean match = path.matches("^(basic/|api/).*");
+    if (!match) {
+      logger.warn("Error processing path: " + path);
+      throw new WebApplicationException(401);
     }
+  }
 
-    @Override
-    public void filter(ContainerRequestContext requestContext) throws IOException {
-        String path = requestContext.getUriInfo().getPath();
-        boolean match = path.matches("^(basic/|api/).*");
-        try{
-            if(!match){
-                throw new WebApplicationException(401);
-            }
-        }catch(Exception e){
-            logger.error("Error authenticating credentials.");
-            throw new WebApplicationException(this.unauthorizedHandler.buildResponse(this.prefix, this.realm));
-        }
+  public static class Builder<P extends Principal>
+      extends AuthFilterBuilder<String, P, DefaultAuthFilter<P>> {
+    public Builder() {}
+
+    protected DefaultAuthFilter<P> newInstance() {
+      return new DefaultAuthFilter();
     }
-
-    public static class Builder<P extends Principal> extends AuthFilterBuilder<String, P, DefaultAuthFilter<P>> {
-        public Builder() {
-        }
-        protected DefaultAuthFilter<P> newInstance() {
-            return new DefaultAuthFilter();
-        }
-    }
-
+  }
 }

--- a/src/main/java/org/broadinstitute/consent/http/authentication/DefaultAuthFilter.java
+++ b/src/main/java/org/broadinstitute/consent/http/authentication/DefaultAuthFilter.java
@@ -13,8 +13,6 @@ public class DefaultAuthFilter<P extends Principal> extends AuthFilter<String, P
 
   private static final Logger logger = LoggerFactory.getLogger(DefaultAuthFilter.class);
 
-  public DefaultAuthFilter() {}
-
   @Override
   public void filter(ContainerRequestContext requestContext) {
     String path = requestContext.getUriInfo().getPath();
@@ -27,7 +25,6 @@ public class DefaultAuthFilter<P extends Principal> extends AuthFilter<String, P
 
   public static class Builder<P extends Principal>
       extends AuthFilterBuilder<String, P, DefaultAuthFilter<P>> {
-    public Builder() {}
 
     protected DefaultAuthFilter<P> newInstance() {
       return new DefaultAuthFilter();


### PR DESCRIPTION
## Addresses
https://broadinstitute.atlassian.net/browse/DUOS-784

## Changes
Refactor the default auth filter so it doesn't log unnecessarily
Suggested that reviewer hide white space changes

----

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [x] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
