### PR TITLE
[DUOS-789][risk=no] Update pending case call for chairs

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/ElectionDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/ElectionDAO.java
@@ -148,9 +148,9 @@ public interface ElectionDAO extends Transactional<ElectionDAO> {
             "     AND electionView.referenceId = e.referenceId " +
             "     AND LOWER(e.electionType) = LOWER(:type) " +
             "     AND e.finalAccessVote = :vote " +
-            "     AND LOWER(e.status) != 'canceled' " +
+            "     AND LOWER(e.status) not in ('canceled', 'closed') " +
             " ORDER BY createDate ASC")
-    List<Election> findLastElectionsByTypeAndFinalAccessVoteChairPerson(@Bind("type") String type, @Bind("vote") Boolean finalAccessVote);
+    List<Election> findOpenLastElectionsByTypeAndFinalAccessVoteForChairPerson(@Bind("type") String type, @Bind("vote") Boolean finalAccessVote);
 
     @SqlQuery("select count(*) from election e inner join vote v on v.electionId = e.electionId and lower(v.type) = 'chairperson' where lower(e.electionType) = lower(:type) and lower(e.status) = lower(:status) and " +
             " v.vote = :finalVote ")

--- a/src/main/java/org/broadinstitute/consent/http/resources/DataRequestCasesResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataRequestCasesResource.java
@@ -36,11 +36,19 @@ public class DataRequestCasesResource extends Resource {
     }
 
     @GET
+    @Path("/pending")
+    @RolesAllowed({CHAIRPERSON, MEMBER})
+    public Response getDataRequestPendingCasesByAuthUser(@Auth AuthUser authUser) {
+        List<PendingCase> pendingCases = pendingCaseService.describeDataRequestPendingCases(authUser);
+        return Response.ok().entity(pendingCases).build();
+    }
+
+    @Deprecated // Use DataRequestCasesResource.getDataRequestPendingCasesByAuthUser
+    @GET
     @Path("/pending/{dacUserId}")
     @RolesAllowed({CHAIRPERSON, MEMBER})
     public Response getDataRequestPendingCases(@PathParam("dacUserId") Integer dacUserId, @Auth AuthUser authUser) {
-        List<PendingCase> pendingCases = pendingCaseService.describeDataRequestPendingCases(authUser);
-        return Response.ok().entity(pendingCases).build();
+        return getDataRequestPendingCasesByAuthUser(authUser);
     }
 
     @GET

--- a/src/main/java/org/broadinstitute/consent/http/service/PendingCaseService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/PendingCaseService.java
@@ -39,16 +39,16 @@ import java.util.stream.Collectors;
 
 public class PendingCaseService {
 
-    private Logger logger = LoggerFactory.getLogger(this.getClass());
-    private ConsentDAO consentDAO;
-    private DataAccessRequestService dataAccessRequestService;
-    private DataSetDAO dataSetDAO;
-    private ElectionDAO electionDAO;
+    private final Logger logger = LoggerFactory.getLogger(this.getClass());
+    private final ConsentDAO consentDAO;
+    private final DataAccessRequestService dataAccessRequestService;
+    private final DataSetDAO dataSetDAO;
+    private final ElectionDAO electionDAO;
 
-    private VoteDAO voteDAO;
-    private DacService dacService;
-    private UserService userService;
-    private VoteService voteService;
+    private final VoteDAO voteDAO;
+    private final DacService dacService;
+    private final UserService userService;
+    private final VoteService voteService;
 
     @Inject
     public PendingCaseService(ConsentDAO consentDAO, DataAccessRequestService dataAccessRequestService,
@@ -103,7 +103,7 @@ public class PendingCaseService {
         Integer dacUserId = user.getDacUserId();
         boolean isChair = dacService.isAuthUserChair(authUser);
         List<Election> unfilteredElections = isChair ?
-                electionDAO.findLastElectionsByTypeAndFinalAccessVoteChairPerson(ElectionType.DATA_ACCESS.getValue(), false) :
+                electionDAO.findOpenLastElectionsByTypeAndFinalAccessVoteForChairPerson(ElectionType.DATA_ACCESS.getValue(), false) :
                 electionDAO.findElectionsWithFinalVoteByTypeAndStatus(ElectionType.DATA_ACCESS.getValue(), ElectionStatus.OPEN.getValue());
         List<Election> elections = dacService.filterElectionsByDAC(unfilteredElections, authUser);
         List<PendingCase> pendingCases = new ArrayList<>();
@@ -118,7 +118,6 @@ public class PendingCaseService {
                 PendingCase pendingCase = new PendingCase();
                 Boolean isReminderSent;
                 if (Objects.nonNull(rpElectionId)) {
-                    Election rpElection = electionDAO.findElectionWithFinalVoteById(rpElectionId);
                     Vote rpVote = voteDAO.findVoteByElectionIdAndDACUserId(rpElectionId, dacUserId);
                     isReminderSent = accessVote.getIsReminderSent() || (Objects.nonNull(rpVote) && rpVote.getIsReminderSent());
                     pendingCase.setRpElectionId(rpElectionId);

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -1743,10 +1743,28 @@ paths:
         500:
           description: Internal Server Error.
 
+  /api/dataRequest/cases/pending:
+    get:
+      summary: Get Data Access Request Pending Cases
+      description: Retrieves the pending cases for open/final elections the user has access to
+      tags:
+        - Data Access Request
+        - Pending Case
+      responses:
+        200:
+          description: A list of Data Access Request Pending Cases
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PendingCase'
   /api/dataRequest/cases/pending/{dacUserId}:
     get:
       summary: getDataRequestPendingCases
-      description: Retrieves the election the user has with votes pending.
+      description: |
+        DEPRECATED: Use GET /api/dataRequest/cases/pending
+        Retrieves the election the user has with votes pending.
       parameters:
         - name: dacUserId
           in: path


### PR DESCRIPTION
## Addresses
Partially addresses https://broadinstitute.atlassian.net/browse/DUOS-789
See also: https://github.com/DataBiosphere/duos-ui/pull/630

## Changes
This PR:
* Updates the database call to filter out closed elections in addition to canceled ones
* Deprecate the pending case endpoint that expects a user id and instead use one that pulls the user from the authenticated user. This is actually a security improvement as we don't want chairs/members querying for data visible to other users.
* Updates api docs

----

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [x] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
