### PR TITLE
[DUOS-795][risk=no] Healthcheck for Consent's use of Ontology

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
@@ -135,6 +135,7 @@ import org.broadinstitute.consent.http.service.ontology.ElasticSearchHealthCheck
 import org.broadinstitute.consent.http.service.ontology.IndexOntologyService;
 import org.broadinstitute.consent.http.service.ontology.IndexerService;
 import org.broadinstitute.consent.http.service.ontology.IndexerServiceImpl;
+import org.broadinstitute.consent.http.service.ontology.OntologyHealthCheck;
 import org.broadinstitute.consent.http.service.ontology.StoreOntologyService;
 import org.broadinstitute.consent.http.service.users.AbstractDACUserAPI;
 import org.broadinstitute.consent.http.service.users.DatabaseDACUserAPI;
@@ -258,6 +259,7 @@ public class ConsentApplication extends Application<ConsentConfiguration> {
         // Health Checks
         env.healthChecks().register("google-cloud-storage", new GCSHealthCheck(gcsService));
         env.healthChecks().register("elastic-search", new ElasticSearchHealthCheck(config.getElasticSearchConfiguration()));
+        env.healthChecks().register("ontology", new OntologyHealthCheck(client, config.getServicesConfiguration()));
 
         final StoreOntologyService storeOntologyService
                 = new StoreOntologyService(googleStore,

--- a/src/main/java/org/broadinstitute/consent/http/service/ontology/OntologyHealthCheck.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ontology/OntologyHealthCheck.java
@@ -1,0 +1,43 @@
+package org.broadinstitute.consent.http.service.ontology;
+
+import com.codahale.metrics.health.HealthCheck;
+import com.google.api.client.http.HttpStatusCodes;
+import io.dropwizard.lifecycle.Managed;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import org.broadinstitute.consent.http.configurations.ServicesConfiguration;
+
+public class OntologyHealthCheck extends HealthCheck implements Managed {
+
+  private final Client client;
+  private final ServicesConfiguration servicesConfiguration;
+
+  public OntologyHealthCheck(Client client, ServicesConfiguration servicesConfiguration) {
+    this.client = client;
+    this.servicesConfiguration = servicesConfiguration;
+  }
+
+  @Override
+  public Result check() {
+    String statusUrl = servicesConfiguration.getOntologyURL() + "status";
+    WebTarget target = client.target(statusUrl);
+    Response response = target.request(MediaType.APPLICATION_JSON).get();
+    try {
+      if (response.getStatus() == HttpStatusCodes.STATUS_CODE_OK) {
+        return Result.healthy();
+      } else {
+        return Result.unhealthy("Ontology status");
+      }
+    } catch (Exception e) {
+      return Result.unhealthy(e.getMessage());
+    }
+  }
+
+  @Override
+  public void start() {}
+
+  @Override
+  public void stop() {}
+}

--- a/src/main/java/org/broadinstitute/consent/http/service/ontology/OntologyHealthCheck.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ontology/OntologyHealthCheck.java
@@ -28,10 +28,10 @@ public class OntologyHealthCheck extends HealthCheck implements Managed {
       if (response.getStatus() == HttpStatusCodes.STATUS_CODE_OK) {
         return Result.healthy();
       } else {
-        return Result.unhealthy("Ontology status");
+        return Result.unhealthy("Ontology status is unhealthy: " + response.getStatusInfo());
       }
     } catch (Exception e) {
-      return Result.unhealthy(e.getMessage());
+      return Result.unhealthy(e);
     }
   }
 

--- a/src/main/java/org/broadinstitute/consent/http/service/ontology/OntologyHealthCheck.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ontology/OntologyHealthCheck.java
@@ -36,8 +36,12 @@ public class OntologyHealthCheck extends HealthCheck implements Managed {
   }
 
   @Override
-  public void start() {}
+  public void start() {
+    // no-op
+  }
 
   @Override
-  public void stop() {}
+  public void stop() {
+    // no-op
+  }
 }

--- a/src/main/java/org/broadinstitute/consent/http/service/ontology/OntologyHealthCheck.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ontology/OntologyHealthCheck.java
@@ -21,10 +21,10 @@ public class OntologyHealthCheck extends HealthCheck implements Managed {
 
   @Override
   public Result check() {
-    String statusUrl = servicesConfiguration.getOntologyURL() + "status";
-    WebTarget target = client.target(statusUrl);
-    Response response = target.request(MediaType.APPLICATION_JSON).get();
     try {
+      String statusUrl = servicesConfiguration.getOntologyURL() + "status";
+      WebTarget target = client.target(statusUrl);
+      Response response = target.request(MediaType.APPLICATION_JSON).get();
       if (response.getStatus() == HttpStatusCodes.STATUS_CODE_OK) {
         return Result.healthy();
       } else {

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -3140,7 +3140,13 @@ paths:
   /status:
     get:
       summary: System Health Status
-      description: A detailed description of the various subsystem statuses that Consent relies upon.
+      description: |
+        A detailed description of the various subsystem statuses that Consent relies upon.
+        Current systems include:
+          * Elastic Search
+          * GCS
+          * Ontology
+          * Postgres DB
       tags:
         - Status
       responses:

--- a/src/test/java/org/broadinstitute/consent/http/resources/StatusResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/StatusResourceTest.java
@@ -18,6 +18,8 @@ import static org.mockito.Mockito.when;
 public class StatusResourceTest {
 
     private Result postgresql;
+    private Result ontology;
+    private final static String ONT_ENV = "ontology";
 
     @Mock
     private HealthCheckRegistry healthChecks;
@@ -25,6 +27,7 @@ public class StatusResourceTest {
     @Before
     public void setUp() {
         postgresql = Result.healthy();
+        ontology = Result.healthy();
     }
 
     private StatusResource initStatusResource(SortedMap<String, Result> checks) {
@@ -37,6 +40,7 @@ public class StatusResourceTest {
     public void testHealthy() {
         SortedMap<String, Result> checks = new TreeMap<>();
         checks.put(DB_ENV, postgresql);
+        checks.put(ONT_ENV, ontology);
         StatusResource statusResource = initStatusResource(checks);
 
         Response response = statusResource.getStatus();
@@ -48,10 +52,24 @@ public class StatusResourceTest {
         postgresql = Result.unhealthy(new Exception("Cannot connect to the postgresql database"));
         SortedMap<String, Result> checks = new TreeMap<>();
         checks.put(DB_ENV, postgresql);
+        checks.put(ONT_ENV, ontology);
         StatusResource statusResource = initStatusResource(checks);
 
         Response response = statusResource.getStatus();
         Assert.assertEquals(500, response.getStatus());
+    }
+
+    @Test
+    public void testUnhealthyOntology() {
+        ontology = Result.unhealthy("Ontology is down");
+        SortedMap<String, Result> checks = new TreeMap<>();
+        checks.put(DB_ENV, postgresql);
+        checks.put(ONT_ENV, ontology);
+        StatusResource statusResource = initStatusResource(checks);
+
+        Response response = statusResource.getStatus();
+        // A failing ontology check should not fail the status
+        Assert.assertEquals(200, response.getStatus());
     }
 
 }

--- a/src/test/java/org/broadinstitute/consent/http/util/OntologyHealthCheckTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/util/OntologyHealthCheckTest.java
@@ -25,11 +25,11 @@ public class OntologyHealthCheckTest {
 
   @Mock private ServicesConfiguration servicesConfiguration;
 
-  @Mock WebTarget target;
+  @Mock private WebTarget target;
 
-  @Mock Invocation.Builder builder;
+  @Mock private Invocation.Builder builder;
 
-  @Mock Response response;
+  @Mock private Response response;
 
   private OntologyHealthCheck healthCheck;
 

--- a/src/test/java/org/broadinstitute/consent/http/util/OntologyHealthCheckTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/util/OntologyHealthCheckTest.java
@@ -1,0 +1,75 @@
+package org.broadinstitute.consent.http.util;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+
+import com.codahale.metrics.health.HealthCheck;
+import com.google.api.client.http.HttpStatusCodes;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.Invocation;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
+import org.broadinstitute.consent.http.configurations.ServicesConfiguration;
+import org.broadinstitute.consent.http.service.ontology.OntologyHealthCheck;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class OntologyHealthCheckTest {
+
+  @Mock private Client client;
+
+  @Mock private ServicesConfiguration servicesConfiguration;
+
+  @Mock WebTarget target;
+
+  @Mock Invocation.Builder builder;
+
+  @Mock Response response;
+
+  private OntologyHealthCheck healthCheck;
+
+  @Before
+  public void setUp() {
+    MockitoAnnotations.initMocks(this);
+  }
+
+  private void initHealthCheck() {
+    when(builder.get()).thenReturn(response);
+    when(target.request(anyString())).thenReturn(builder);
+    when(client.target(anyString())).thenReturn(target);
+    when(servicesConfiguration.getOntologyURL()).thenReturn("http://localhost:8000/");
+    healthCheck = new OntologyHealthCheck(client, servicesConfiguration);
+  }
+
+  @Test
+  public void testCheckSuccess() {
+    when(response.getStatus()).thenReturn(HttpStatusCodes.STATUS_CODE_OK);
+    initHealthCheck();
+
+    HealthCheck.Result result = healthCheck.check();
+    assertTrue(result.isHealthy());
+  }
+
+  @Test
+  public void testCheckFailure() {
+    when(response.getStatus()).thenReturn(HttpStatusCodes.STATUS_CODE_SERVER_ERROR);
+    initHealthCheck();
+
+    HealthCheck.Result result = healthCheck.check();
+    assertFalse(result.isHealthy());
+  }
+
+  @Test
+  public void testCheckException() {
+    doThrow(new RuntimeException()).when(response).getStatus();
+    initHealthCheck();
+
+    HealthCheck.Result result = healthCheck.check();
+    assertFalse(result.isHealthy());
+  }
+}


### PR DESCRIPTION
## Addresses
https://broadinstitute.atlassian.net/browse/DUOS-795

## Changes
* Add a health check for Ontology
* Ontology is not a critical component, so failure does not indicate a consent failure

## Example Success
```
{
  "deadlocks": {
    "healthy": true,
    "message": null,
    "error": null,
    "details": null,
    "time": 1602248383760,
    "duration": 0,
    "timestamp": "2020-10-09T12:59:43.760Z"
  },
  "elastic-search": {
    "healthy": true,
    "message": "ClusterHealth is GREEN",
    "error": null,
    "details": null,
    "time": 1602248382723,
    "duration": 299,
    "timestamp": "2020-10-09T12:59:42.723Z"
  },
  "google-cloud-storage": {
    "healthy": true,
    "message": null,
    "error": null,
    "details": null,
    "time": 1602248383759,
    "duration": 890,
    "timestamp": "2020-10-09T12:59:43.759Z"
  },
  "ontology": {
    "healthy": true,
    "message": null,
    "error": null,
    "details": null,
    "time": 1602248384244,
    "duration": 484,
    "timestamp": "2020-10-09T12:59:44.244Z"
  },
  "postgresql": {
    "healthy": true,
    "message": null,
    "error": null,
    "details": null,
    "time": 1602248382867,
    "duration": 145,
    "timestamp": "2020-10-09T12:59:42.867Z"
  }
}
```

## Example Failure
```
{
  "deadlocks": {
    "healthy": true,
    "message": null,
    "error": null,
    "details": null,
    "time": 1602248293830,
    "duration": 2,
    "timestamp": "2020-10-09T12:58:13.830Z"
  },
  "elastic-search": {
    "healthy": true,
    "message": "ClusterHealth is GREEN",
    "error": null,
    "details": null,
    "time": 1602248293631,
    "duration": 166,
    "timestamp": "2020-10-09T12:58:13.631Z"
  },
  "google-cloud-storage": {
    "healthy": true,
    "message": null,
    "error": null,
    "details": null,
    "time": 1602248293828,
    "duration": 193,
    "timestamp": "2020-10-09T12:58:13.828Z"
  },
  "ontology": {
    "healthy": false,
    "message": "Ontology status is unhealthy: Not Found",
    "error": null,
    "details": null,
    "time": 1602248293923,
    "duration": 93,
    "timestamp": "2020-10-09T12:58:13.923Z"
  },
  "postgresql": {
    "healthy": true,
    "message": null,
    "error": null,
    "details": null,
    "time": 1602248293634,
    "duration": 2,
    "timestamp": "2020-10-09T12:58:13.634Z"
  }
}

```

----

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [x] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
