### PR TITLE
[DUOS-797][risk=no] Return 409 Conflict error if dataset name in use

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/resources/DataSetResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataSetResource.java
@@ -19,6 +19,7 @@ import javax.annotation.security.PermitAll;
 import javax.annotation.security.RolesAllowed;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.BadRequestException;
+import javax.ws.rs.ClientErrorException;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.DefaultValue;
@@ -34,6 +35,7 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriInfo;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.io.FileUtils;
@@ -101,7 +103,7 @@ public class DataSetResource extends Resource {
         }
         DataSet datasetNameAlreadyUsed = datasetService.getDatasetByName(name);
         if (Objects.nonNull(datasetNameAlreadyUsed)) {
-            throw new NotFoundException("Dataset name: " + name + " is already in use");
+            throw new ClientErrorException("Dataset name: " + name + " is already in use", Status.CONFLICT);
         }
         User dacUser = userService.findUserByEmail(user.getGoogleUser().getEmail());
         Integer userId = dacUser.getDacUserId();

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -2327,6 +2327,8 @@ paths:
                 $ref: '#/components/schemas/Dataset'
         400:
           description: External Error (invalid input)
+        409:
+          description: Dataset Name given is already in use by another dataset
         500:
           description: Internal Error (something went wrong processing a valid input)
   /api/dataset/sample:

--- a/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
@@ -136,7 +136,7 @@ public class DatasetResourceTest {
 
         Response responseNameInUse = resource.createDataset(authUser, uriInfo,
               "{\"properties\":[{\"propertyName\":\"Dataset Name\",\"propertyValue\":\"test\"}]}");
-        assertEquals(400, responseNameInUse.getStatus());
+        assertEquals(409, responseNameInUse.getStatus());
     }
 
     @Test


### PR DESCRIPTION
Addresses: https://broadinstitute.atlassian.net/browse/DUOS-797

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [x] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
