### PR TITLE
[DUOS-786][risk=no] Find DAC by Id throws a 500 when not found

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/service/DacService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DacService.java
@@ -124,8 +124,10 @@ public class DacService {
         Dac dac = dacDAO.findById(dacId);
         List<User> chairs = dacDAO.findMembersByDacIdAndRoleId(dacId, UserRoles.CHAIRPERSON.getRoleId());
         List<User> members = dacDAO.findMembersByDacIdAndRoleId(dacId, UserRoles.MEMBER.getRoleId());
-        dac.setChairpersons(chairs);
-        dac.setMembers(members);
+        if (dac != null) {
+            dac.setChairpersons(chairs);
+            dac.setMembers(members);
+        }
         return dac;
     }
 

--- a/src/main/java/org/broadinstitute/consent/http/service/DacService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DacService.java
@@ -16,6 +16,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.ws.rs.BadRequestException;
+import javax.ws.rs.NotFoundException;
 import org.broadinstitute.consent.http.db.DacDAO;
 import org.broadinstitute.consent.http.db.DataAccessRequestDAO;
 import org.broadinstitute.consent.http.db.DataSetDAO;
@@ -124,11 +125,12 @@ public class DacService {
         Dac dac = dacDAO.findById(dacId);
         List<User> chairs = dacDAO.findMembersByDacIdAndRoleId(dacId, UserRoles.CHAIRPERSON.getRoleId());
         List<User> members = dacDAO.findMembersByDacIdAndRoleId(dacId, UserRoles.MEMBER.getRoleId());
-        if (dac != null) {
+        if (Objects.nonNull(dac)) {
             dac.setChairpersons(chairs);
             dac.setMembers(members);
+            return dac;
         }
-        return dac;
+        throw new NotFoundException("Could not find DAC with the provided id: " + dacId);
     }
 
     public Integer createDac(String name, String description) {


### PR DESCRIPTION
Addresses: https://broadinstitute.atlassian.net/browse/DUOS-786

At the service level, find DAC by id was setting chairpersons and members without first checking if the dac itself existed. If a dac wasn't properly found, it would hit a NPE here before being flagged as null at the resource level (where the 404 NotFoundException is thrown).

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [ ] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
