### PR TITLE
[DUOS-732][risk=no] Find Dacs By User

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/resources/DacResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DacResource.java
@@ -204,6 +204,15 @@ public class DacResource extends Resource {
         return Response.ok().entity(users).build();
     }
 
+    @GET
+    @Path("partial")
+    @Produces("application/json")
+    @RolesAllowed({ADMIN, CHAIRPERSON})
+    public Response findDacsByUser(@Auth AuthUser authUser) {
+        List<Dac> dacs = dacService.findDacsByUser(authUser);
+        return Response.ok().entity(dacs).build();
+    }
+
     private User findDacUser(Integer userId) {
         User user = dacService.findUserById(userId);
         if (user == null) {

--- a/src/main/java/org/broadinstitute/consent/http/service/DacService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DacService.java
@@ -126,7 +126,7 @@ public class DacService {
             List<Dac> allDacs = dacDAO.findAll();
             return allDacs;
         }
-        List<Dac> dacs = dacDAO.findDacsForEmail(authUser.getGoogleUser().getEmail());
+        List<Dac> dacs = dacDAO.findDacsForEmail(authUser.getName());
         return dacs;
     }
 

--- a/src/main/java/org/broadinstitute/consent/http/service/DacService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DacService.java
@@ -121,6 +121,15 @@ public class DacService {
         return dacToUserMap;
     }
 
+    public List<Dac> findDacsByUser(AuthUser authUser) {
+        if (isAuthUserAdmin(authUser)) {
+            List<Dac> allDacs = dacDAO.findAll();
+            return allDacs;
+        }
+        List<Dac> dacs = dacDAO.findDacsForEmail(authUser.getGoogleUser().getEmail());
+        return dacs;
+    }
+
     public Dac findById(Integer dacId) {
         Dac dac = dacDAO.findById(dacId);
         List<User> chairs = dacDAO.findMembersByDacIdAndRoleId(dacId, UserRoles.CHAIRPERSON.getRoleId());

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -1113,6 +1113,25 @@ paths:
                  $ref: '#/components/schemas/User'
         500:
           description: Internal Server Error
+  /api/dac/partial:
+    get:
+      summary: Get dacs
+      description: Get only the dacs available to this user
+      tags:
+        - DAC
+      responses:
+        200:
+          description: The list of dacs available to this user
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Dac'
+        403:
+          description: User not authorized (not admin or chairperson)
+        500:
+          description: Internal Server Error
   /api/dacuser:
     post:
       summary: Create User

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -826,6 +826,8 @@ paths:
                 $ref: '#/components/schemas/Dac'
         400:
           description: Bad Request. DAC Name and Description are required.
+        403:
+          description: User not authorized to request all dacs.
         500:
           description: Internal Server Error
     put:
@@ -854,6 +856,12 @@ paths:
     get:
       summary: Get all DACs
       description: All Data Access Committees with a list of chairpersons and members
+      parameters:
+        - name: withUsers
+          in: query
+          required: false
+          schema:
+            type: boolean
       tags:
         - DAC
       responses:
@@ -1111,25 +1119,6 @@ paths:
                 type: array
                 items:
                  $ref: '#/components/schemas/User'
-        500:
-          description: Internal Server Error
-  /api/dac/partial:
-    get:
-      summary: Get dacs
-      description: Get only the dacs available to this user
-      tags:
-        - DAC
-      responses:
-        200:
-          description: The list of dacs available to this user
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/Dac'
-        403:
-          description: User not authorized (not admin or chairperson)
         500:
           description: Internal Server Error
   /api/dacuser:

--- a/src/test/java/org/broadinstitute/consent/http/resources/DacResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DacResourceTest.java
@@ -196,4 +196,17 @@ public class DacResourceTest {
         dacResource.deleteDac(1);
     }
 
+    @Test
+    public void testFindDacsByUser() {
+        Dac dac = new DacBuilder()
+              .setName("name")
+              .setDescription("description")
+              .build();
+        List<Dac> dacs =  Collections.singletonList(dac);
+        when(dacService.findDacsByUser(authUser)).thenReturn(dacs);
+
+        Response response = dacResource.findDacsByUser(authUser);
+        Assert.assertEquals(200, response.getStatus());
+    }
+
 }

--- a/src/test/java/org/broadinstitute/consent/http/resources/DacResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DacResourceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.when;
 import com.google.gson.Gson;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.NotFoundException;
 import javax.ws.rs.core.Response;
@@ -42,7 +43,7 @@ public class DacResourceTest {
     public void testFindAll_success_1() {
         when(dacService.findAll()).thenReturn(Collections.emptyList());
 
-        Response response = dacResource.findAll();
+        Response response = dacResource.findAll(authUser, Optional.empty());
         Assert.assertEquals(200, response.getStatus());
         List dacs = ((List) response.getEntity());
         Assert.assertTrue(dacs.isEmpty());
@@ -57,10 +58,20 @@ public class DacResourceTest {
         when(dacService.findAll()).thenReturn(Collections.singletonList(dac));
         when(dacService.findAllDacsWithMembers()).thenReturn(Collections.singletonList(dac));
 
-        Response response = dacResource.findAll();
+        Response response = dacResource.findAll(authUser, Optional.empty());
         Assert.assertEquals(200, response.getStatus());
         List dacs = ((List) response.getEntity());
         Assert.assertEquals(1, dacs.size());
+    }
+
+    @Test
+    public void testFindAllWithUsers() {
+        when(dacService.findAll()).thenReturn(Collections.emptyList());
+
+        Response response = dacResource.findAll(authUser, Optional.of(false));
+        Assert.assertEquals(200, response.getStatus());
+        List dacs = ((List) response.getEntity());
+        Assert.assertTrue(dacs.isEmpty());
     }
 
     @Test
@@ -194,19 +205,6 @@ public class DacResourceTest {
         when(dacService.findById(1)).thenReturn(null);
 
         dacResource.deleteDac(1);
-    }
-
-    @Test
-    public void testFindDacsByUser() {
-        Dac dac = new DacBuilder()
-              .setName("name")
-              .setDescription("description")
-              .build();
-        List<Dac> dacs =  Collections.singletonList(dac);
-        when(dacService.findDacsByUser(authUser)).thenReturn(dacs);
-
-        Response response = dacResource.findDacsByUser(authUser);
-        Assert.assertEquals(200, response.getStatus());
     }
 
 }

--- a/src/test/java/org/broadinstitute/consent/http/service/DacServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DacServiceTest.java
@@ -711,7 +711,7 @@ public class DacServiceTest {
     }
 
     @Test
-    public void testFindDacsByUser_adminCase() {
+    public void testFindDacsByUserAdminCase() {
         List<Dac> dacs = getDacs();
         when(dacDAO.findDacsForEmail(anyString())).thenReturn(dacs);
         when(dacDAO.findAll()).thenReturn(dacs);
@@ -724,7 +724,7 @@ public class DacServiceTest {
     }
 
     @Test
-    public void testFindDacsByUser_chairCase() {
+    public void testFindDacsByUserChairCase() {
         List<Dac> dacs = getDacs();
         when(dacDAO.findDacsForEmail(anyString())).thenReturn(dacs);
         when(dacDAO.findAll()).thenReturn(dacs);

--- a/src/test/java/org/broadinstitute/consent/http/service/DacServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DacServiceTest.java
@@ -710,6 +710,32 @@ public class DacServiceTest {
         Assert.assertEquals(unassociatedElections.size(), filtered.size());
     }
 
+    @Test
+    public void testFindDacsByUser_adminCase() {
+        List<Dac> dacs = getDacs();
+        when(dacDAO.findDacsForEmail(anyString())).thenReturn(dacs);
+        when(dacDAO.findAll()).thenReturn(dacs);
+        // User is an admin user
+        when(userDAO.findUserByEmailAndRoleId(anyString(), anyInt())).thenReturn(getDacUsers().get(0));
+        initService();
+
+        List<Dac> dacsForUser = service.findDacsByUser(getUser());
+        Assert.assertEquals(dacsForUser.size(), dacs.size());
+    }
+
+    @Test
+    public void testFindDacsByUser_chairCase() {
+        List<Dac> dacs = getDacs();
+        when(dacDAO.findDacsForEmail(anyString())).thenReturn(dacs);
+        when(dacDAO.findAll()).thenReturn(dacs);
+        // User is a chairperson user
+        when(userDAO.findUserByEmailAndRoleId(anyString(), anyInt())).thenReturn(getChair());
+        initService();
+
+        List<Dac> dacsForUser = service.findDacsByUser(getUser());
+        Assert.assertEquals(dacsForUser.size(), dacs.size());
+    }
+
 
     /* Helper functions */
 


### PR DESCRIPTION
Addresses https://broadinstitute.atlassian.net/browse/DUOS-732

The updated Dataset Catalog page adds a DAC column naming the owning DAC for a given dataset. I thought it was unnecessary to use the available `findAll` that also returns the list of members inside the DAC just to populate this field, so I made a new endpoint instead to return a minimal list of dacs available to a user, restricted to only admins and chairpersons. 
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [x] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
