### PR TITLE
[DUOS-795][risk=no] Healthcheck for Consent's use of Ontology

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
@@ -259,7 +259,7 @@ public class ConsentApplication extends Application<ConsentConfiguration> {
         // Health Checks
         env.healthChecks().register("google-cloud-storage", new GCSHealthCheck(gcsService));
         env.healthChecks().register("elastic-search", new ElasticSearchHealthCheck(config.getElasticSearchConfiguration()));
-        env.healthChecks().register("ontology", new OntologyHealthCheck(client, config.getServicesConfiguration()));
+        env.healthChecks().register("ontology", new OntologyHealthCheck(config.getServicesConfiguration()));
 
         final StoreOntologyService storeOntologyService
                 = new StoreOntologyService(googleStore,

--- a/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
@@ -144,6 +144,7 @@ import org.broadinstitute.consent.http.service.users.handler.ResearcherService;
 import org.broadinstitute.consent.http.service.users.handler.UserRolesHandler;
 import org.broadinstitute.consent.http.service.validate.AbstractUseRestrictionValidatorAPI;
 import org.broadinstitute.consent.http.service.validate.UseRestrictionValidator;
+import org.broadinstitute.consent.http.util.HttpClientUtil;
 import org.dhatim.dropwizard.sentry.logging.SentryBootstrap;
 import org.dhatim.dropwizard.sentry.logging.UncaughtExceptionHandlers;
 import org.eclipse.jetty.servlet.ErrorPageErrorHandler;
@@ -199,6 +200,7 @@ public class ConsentApplication extends Application<ConsentConfiguration> {
         final Jdbi jdbi = injector.getProvider(Jdbi.class).get();
         final Client client = injector.getProvider(Client.class).get();
         final UseRestrictionConverter useRestrictionConverter = injector.getProvider(UseRestrictionConverter.class).get();
+        final HttpClientUtil clientUtil = new HttpClientUtil();
         final GCSStore googleStore = injector.getProvider(GCSStore.class).get();
 
         // DAOs
@@ -259,7 +261,7 @@ public class ConsentApplication extends Application<ConsentConfiguration> {
         // Health Checks
         env.healthChecks().register("google-cloud-storage", new GCSHealthCheck(gcsService));
         env.healthChecks().register("elastic-search", new ElasticSearchHealthCheck(config.getElasticSearchConfiguration()));
-        env.healthChecks().register("ontology", new OntologyHealthCheck(config.getServicesConfiguration()));
+        env.healthChecks().register("ontology", new OntologyHealthCheck(clientUtil, config.getServicesConfiguration()));
 
         final StoreOntologyService storeOntologyService
                 = new StoreOntologyService(googleStore,

--- a/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
@@ -135,6 +135,7 @@ import org.broadinstitute.consent.http.service.ontology.ElasticSearchHealthCheck
 import org.broadinstitute.consent.http.service.ontology.IndexOntologyService;
 import org.broadinstitute.consent.http.service.ontology.IndexerService;
 import org.broadinstitute.consent.http.service.ontology.IndexerServiceImpl;
+import org.broadinstitute.consent.http.service.ontology.OntologyHealthCheck;
 import org.broadinstitute.consent.http.service.ontology.StoreOntologyService;
 import org.broadinstitute.consent.http.service.users.AbstractDACUserAPI;
 import org.broadinstitute.consent.http.service.users.DatabaseDACUserAPI;
@@ -258,6 +259,7 @@ public class ConsentApplication extends Application<ConsentConfiguration> {
         // Health Checks
         env.healthChecks().register("google-cloud-storage", new GCSHealthCheck(gcsService));
         env.healthChecks().register("elastic-search", new ElasticSearchHealthCheck(config.getElasticSearchConfiguration()));
+        env.healthChecks().register("ontology", new OntologyHealthCheck(client, config.getServicesConfiguration()));
 
         final StoreOntologyService storeOntologyService
                 = new StoreOntologyService(googleStore,

--- a/src/main/java/org/broadinstitute/consent/http/service/ontology/OntologyHealthCheck.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ontology/OntologyHealthCheck.java
@@ -2,33 +2,45 @@ package org.broadinstitute.consent.http.service.ontology;
 
 import com.codahale.metrics.health.HealthCheck;
 import com.google.api.client.http.HttpStatusCodes;
+import com.google.common.annotations.VisibleForTesting;
 import io.dropwizard.lifecycle.Managed;
-import javax.ws.rs.client.Client;
-import javax.ws.rs.client.WebTarget;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
+import java.util.Objects;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
 import org.broadinstitute.consent.http.configurations.ServicesConfiguration;
 
 public class OntologyHealthCheck extends HealthCheck implements Managed {
 
-  private final Client client;
   private final ServicesConfiguration servicesConfiguration;
+  private CloseableHttpClient httpClient;
 
-  public OntologyHealthCheck(Client client, ServicesConfiguration servicesConfiguration) {
-    this.client = client;
+  public OntologyHealthCheck(ServicesConfiguration servicesConfiguration) {
     this.servicesConfiguration = servicesConfiguration;
+  }
+
+  @VisibleForTesting
+  public void setHttpClient(CloseableHttpClient httpClient) {
+    this.httpClient = httpClient;
   }
 
   @Override
   public Result check() {
     try {
       String statusUrl = servicesConfiguration.getOntologyURL() + "status";
-      WebTarget target = client.target(statusUrl);
-      Response response = target.request(MediaType.APPLICATION_JSON).get();
-      if (response.getStatus() == HttpStatusCodes.STATUS_CODE_OK) {
-        return Result.healthy();
-      } else {
-        return Result.unhealthy("Ontology status is unhealthy: " + response.getStatusInfo());
+      HttpGet httpGet = new HttpGet(statusUrl);
+      if (Objects.isNull(httpClient)) {
+        setHttpClient(HttpClients.createDefault());
+      }
+      try (CloseableHttpResponse response = httpClient.execute(httpGet)) {
+        if (response.getStatusLine().getStatusCode() == HttpStatusCodes.STATUS_CODE_OK) {
+          return Result.healthy();
+        } else {
+          return Result.unhealthy("Ontology status is unhealthy: " + response.getStatusLine());
+        }
+      } catch (Exception e) {
+        return Result.unhealthy(e);
       }
     } catch (Exception e) {
       return Result.unhealthy(e);

--- a/src/main/java/org/broadinstitute/consent/http/service/ontology/OntologyHealthCheck.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ontology/OntologyHealthCheck.java
@@ -1,0 +1,43 @@
+package org.broadinstitute.consent.http.service.ontology;
+
+import com.codahale.metrics.health.HealthCheck;
+import com.google.api.client.http.HttpStatusCodes;
+import io.dropwizard.lifecycle.Managed;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import org.broadinstitute.consent.http.configurations.ServicesConfiguration;
+
+public class OntologyHealthCheck extends HealthCheck implements Managed {
+
+  private final Client client;
+  private final ServicesConfiguration servicesConfiguration;
+
+  public OntologyHealthCheck(Client client, ServicesConfiguration servicesConfiguration) {
+    this.client = client;
+    this.servicesConfiguration = servicesConfiguration;
+  }
+
+  @Override
+  public Result check() {
+    String statusUrl = servicesConfiguration.getOntologyURL() + "status";
+    WebTarget target = client.target(statusUrl);
+    Response response = target.request(MediaType.APPLICATION_JSON).get();
+    try {
+      if (response.getStatus() == HttpStatusCodes.STATUS_CODE_OK) {
+        return Result.healthy();
+      } else {
+        return Result.unhealthy("Ontology status");
+      }
+    } catch (Exception e) {
+      return Result.unhealthy(e.getMessage());
+    }
+  }
+
+  @Override
+  public void start() {}
+
+  @Override
+  public void stop() {}
+}

--- a/src/main/java/org/broadinstitute/consent/http/service/ontology/OntologyHealthCheck.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ontology/OntologyHealthCheck.java
@@ -28,10 +28,10 @@ public class OntologyHealthCheck extends HealthCheck implements Managed {
       if (response.getStatus() == HttpStatusCodes.STATUS_CODE_OK) {
         return Result.healthy();
       } else {
-        return Result.unhealthy("Ontology status");
+        return Result.unhealthy("Ontology status is unhealthy: " + response.getStatusInfo());
       }
     } catch (Exception e) {
-      return Result.unhealthy(e.getMessage());
+      return Result.unhealthy(e);
     }
   }
 

--- a/src/main/java/org/broadinstitute/consent/http/service/ontology/OntologyHealthCheck.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ontology/OntologyHealthCheck.java
@@ -36,8 +36,12 @@ public class OntologyHealthCheck extends HealthCheck implements Managed {
   }
 
   @Override
-  public void start() {}
+  public void start() {
+    // no-op
+  }
 
   @Override
-  public void stop() {}
+  public void stop() {
+    // no-op
+  }
 }

--- a/src/main/java/org/broadinstitute/consent/http/service/ontology/OntologyHealthCheck.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ontology/OntologyHealthCheck.java
@@ -2,27 +2,20 @@ package org.broadinstitute.consent.http.service.ontology;
 
 import com.codahale.metrics.health.HealthCheck;
 import com.google.api.client.http.HttpStatusCodes;
-import com.google.common.annotations.VisibleForTesting;
 import io.dropwizard.lifecycle.Managed;
-import java.util.Objects;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClients;
 import org.broadinstitute.consent.http.configurations.ServicesConfiguration;
+import org.broadinstitute.consent.http.util.HttpClientUtil;
 
 public class OntologyHealthCheck extends HealthCheck implements Managed {
 
+  private final HttpClientUtil clientUtil;
   private final ServicesConfiguration servicesConfiguration;
-  private CloseableHttpClient httpClient;
 
-  public OntologyHealthCheck(ServicesConfiguration servicesConfiguration) {
+  public OntologyHealthCheck(HttpClientUtil clientUtil, ServicesConfiguration servicesConfiguration) {
+    this.clientUtil = clientUtil;
     this.servicesConfiguration = servicesConfiguration;
-  }
-
-  @VisibleForTesting
-  public void setHttpClient(CloseableHttpClient httpClient) {
-    this.httpClient = httpClient;
   }
 
   @Override
@@ -30,10 +23,7 @@ public class OntologyHealthCheck extends HealthCheck implements Managed {
     try {
       String statusUrl = servicesConfiguration.getOntologyURL() + "status";
       HttpGet httpGet = new HttpGet(statusUrl);
-      if (Objects.isNull(httpClient)) {
-        setHttpClient(HttpClients.createDefault());
-      }
-      try (CloseableHttpResponse response = httpClient.execute(httpGet)) {
+      try (CloseableHttpResponse response = clientUtil.getHttpResponse(httpGet)) {
         if (response.getStatusLine().getStatusCode() == HttpStatusCodes.STATUS_CODE_OK) {
           return Result.healthy();
         } else {

--- a/src/main/java/org/broadinstitute/consent/http/service/ontology/OntologyHealthCheck.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ontology/OntologyHealthCheck.java
@@ -21,10 +21,10 @@ public class OntologyHealthCheck extends HealthCheck implements Managed {
 
   @Override
   public Result check() {
-    String statusUrl = servicesConfiguration.getOntologyURL() + "status";
-    WebTarget target = client.target(statusUrl);
-    Response response = target.request(MediaType.APPLICATION_JSON).get();
     try {
+      String statusUrl = servicesConfiguration.getOntologyURL() + "status";
+      WebTarget target = client.target(statusUrl);
+      Response response = target.request(MediaType.APPLICATION_JSON).get();
       if (response.getStatus() == HttpStatusCodes.STATUS_CODE_OK) {
         return Result.healthy();
       } else {

--- a/src/main/java/org/broadinstitute/consent/http/util/HttpClientUtil.java
+++ b/src/main/java/org/broadinstitute/consent/http/util/HttpClientUtil.java
@@ -1,0 +1,14 @@
+package org.broadinstitute.consent.http.util;
+
+import java.io.IOException;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.impl.client.HttpClients;
+
+public class HttpClientUtil {
+
+  public CloseableHttpResponse getHttpResponse(HttpUriRequest request) throws IOException {
+    return HttpClients.createMinimal().execute(request);
+  }
+
+}

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -3140,7 +3140,13 @@ paths:
   /status:
     get:
       summary: System Health Status
-      description: A detailed description of the various subsystem statuses that Consent relies upon.
+      description: |
+        A detailed description of the various subsystem statuses that Consent relies upon.
+        Current systems include:
+          * Elastic Search
+          * GCS
+          * Ontology
+          * Postgres DB
       tags:
         - Status
       responses:

--- a/src/test/java/org/broadinstitute/consent/http/resources/StatusResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/StatusResourceTest.java
@@ -18,6 +18,8 @@ import static org.mockito.Mockito.when;
 public class StatusResourceTest {
 
     private Result postgresql;
+    private Result ontology;
+    private final static String ONT_ENV = "ontology";
 
     @Mock
     private HealthCheckRegistry healthChecks;
@@ -25,6 +27,7 @@ public class StatusResourceTest {
     @Before
     public void setUp() {
         postgresql = Result.healthy();
+        ontology = Result.healthy();
     }
 
     private StatusResource initStatusResource(SortedMap<String, Result> checks) {
@@ -37,6 +40,7 @@ public class StatusResourceTest {
     public void testHealthy() {
         SortedMap<String, Result> checks = new TreeMap<>();
         checks.put(DB_ENV, postgresql);
+        checks.put(ONT_ENV, ontology);
         StatusResource statusResource = initStatusResource(checks);
 
         Response response = statusResource.getStatus();
@@ -48,10 +52,24 @@ public class StatusResourceTest {
         postgresql = Result.unhealthy(new Exception("Cannot connect to the postgresql database"));
         SortedMap<String, Result> checks = new TreeMap<>();
         checks.put(DB_ENV, postgresql);
+        checks.put(ONT_ENV, ontology);
         StatusResource statusResource = initStatusResource(checks);
 
         Response response = statusResource.getStatus();
         Assert.assertEquals(500, response.getStatus());
+    }
+
+    @Test
+    public void testUnhealthyOntology() {
+        ontology = Result.unhealthy("Ontology is down");
+        SortedMap<String, Result> checks = new TreeMap<>();
+        checks.put(DB_ENV, postgresql);
+        checks.put(ONT_ENV, ontology);
+        StatusResource statusResource = initStatusResource(checks);
+
+        Response response = statusResource.getStatus();
+        // A failing ontology check should not fail the status
+        Assert.assertEquals(200, response.getStatus());
     }
 
 }

--- a/src/test/java/org/broadinstitute/consent/http/util/OntologyHealthCheckTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/util/OntologyHealthCheckTest.java
@@ -25,11 +25,11 @@ public class OntologyHealthCheckTest {
 
   @Mock private ServicesConfiguration servicesConfiguration;
 
-  @Mock WebTarget target;
+  @Mock private WebTarget target;
 
-  @Mock Invocation.Builder builder;
+  @Mock private Invocation.Builder builder;
 
-  @Mock Response response;
+  @Mock private Response response;
 
   private OntologyHealthCheck healthCheck;
 

--- a/src/test/java/org/broadinstitute/consent/http/util/OntologyHealthCheckTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/util/OntologyHealthCheckTest.java
@@ -1,0 +1,75 @@
+package org.broadinstitute.consent.http.util;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+
+import com.codahale.metrics.health.HealthCheck;
+import com.google.api.client.http.HttpStatusCodes;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.Invocation;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
+import org.broadinstitute.consent.http.configurations.ServicesConfiguration;
+import org.broadinstitute.consent.http.service.ontology.OntologyHealthCheck;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class OntologyHealthCheckTest {
+
+  @Mock private Client client;
+
+  @Mock private ServicesConfiguration servicesConfiguration;
+
+  @Mock WebTarget target;
+
+  @Mock Invocation.Builder builder;
+
+  @Mock Response response;
+
+  private OntologyHealthCheck healthCheck;
+
+  @Before
+  public void setUp() {
+    MockitoAnnotations.initMocks(this);
+  }
+
+  private void initHealthCheck() {
+    when(builder.get()).thenReturn(response);
+    when(target.request(anyString())).thenReturn(builder);
+    when(client.target(anyString())).thenReturn(target);
+    when(servicesConfiguration.getOntologyURL()).thenReturn("http://localhost:8000/");
+    healthCheck = new OntologyHealthCheck(client, servicesConfiguration);
+  }
+
+  @Test
+  public void testCheckSuccess() {
+    when(response.getStatus()).thenReturn(HttpStatusCodes.STATUS_CODE_OK);
+    initHealthCheck();
+
+    HealthCheck.Result result = healthCheck.check();
+    assertTrue(result.isHealthy());
+  }
+
+  @Test
+  public void testCheckFailure() {
+    when(response.getStatus()).thenReturn(HttpStatusCodes.STATUS_CODE_SERVER_ERROR);
+    initHealthCheck();
+
+    HealthCheck.Result result = healthCheck.check();
+    assertFalse(result.isHealthy());
+  }
+
+  @Test
+  public void testCheckException() {
+    doThrow(new RuntimeException()).when(response).getStatus();
+    initHealthCheck();
+
+    HealthCheck.Result result = healthCheck.check();
+    assertFalse(result.isHealthy());
+  }
+}

--- a/src/test/java/org/broadinstitute/consent/http/util/OntologyHealthCheckTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/util/OntologyHealthCheckTest.java
@@ -11,7 +11,6 @@ import com.codahale.metrics.health.HealthCheck;
 import com.google.api.client.http.HttpStatusCodes;
 import org.apache.http.StatusLine;
 import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.impl.client.CloseableHttpClient;
 import org.broadinstitute.consent.http.configurations.ServicesConfiguration;
 import org.broadinstitute.consent.http.service.ontology.OntologyHealthCheck;
 import org.junit.Before;
@@ -21,7 +20,7 @@ import org.mockito.MockitoAnnotations;
 
 public class OntologyHealthCheckTest {
 
-  @Mock private CloseableHttpClient httpClient;
+  @Mock private HttpClientUtil clientUtil;
 
   @Mock private CloseableHttpResponse response;
 
@@ -38,17 +37,16 @@ public class OntologyHealthCheckTest {
 
   private void initHealthCheck() {
     try {
-      when(httpClient.execute(any())).thenReturn(response);
+      when(clientUtil.getHttpResponse(any())).thenReturn(response);
       when(servicesConfiguration.getOntologyURL()).thenReturn("http://localhost:8000/");
-      healthCheck = new OntologyHealthCheck(servicesConfiguration);
-      healthCheck.setHttpClient(httpClient);
+      healthCheck = new OntologyHealthCheck(clientUtil, servicesConfiguration);
     } catch (Exception e) {
       fail(e.getMessage());
     }
   }
 
   @Test
-  public void testCheckSuccess() throws Exception {
+  public void testCheckSuccess() {
     when(statusLine.getStatusCode()).thenReturn(HttpStatusCodes.STATUS_CODE_OK);
     when(response.getStatusLine()).thenReturn(statusLine);
     initHealthCheck();


### PR DESCRIPTION
## Addresses
https://broadinstitute.atlassian.net/browse/DUOS-795

This PR re-introduces changes in #769 that were reverted in #782
Also makes a minor change to the http client that we use to check ontology.

----

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [ ] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
