### PR TITLE
[DUOS-813][risk=low] Handle known date formats for user parsing

### DIFF
--- a/src/test/java/org/broadinstitute/consent/http/resources/DACUserResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DACUserResourceTest.java
@@ -172,11 +172,44 @@ public class DACUserResourceTest {
     }
 
     @Test
-    public void testConvertJsonToDACUser() {
+    public void testConvertJsonToDACUserNumericDateCase() {
         String jsonRole = "[{\"roleId\": 1, \"name\":\"name\", \"what\": \"Huh?\", \"rationale\": \"rationale\", \"status\": \"pending\"}]";
         String json = "{\"dacUserId\": 1, \"email\":\"email\", \"what\": \"Huh?\", \"createDate\": 1302828677828, \"additionalEmail\": \"additionalEmail\", \"emailPreference\": false, \"roles\": " + jsonRole + "}";
         User user = new User(json);
         Assert.assertNotNull(user);
+        Assert.assertNotNull(user.getCreateDate());
+        Assert.assertEquals(user.getDacUserId().intValue(), 1);
+        Assert.assertEquals(user.getEmail(), "email");
+        Assert.assertEquals(user.getAdditionalEmail(), "additionalEmail");
+        Assert.assertEquals(user.getEmailPreference(), false);
+        Assert.assertFalse(user.getRoles().isEmpty());
+        Assert.assertEquals(user.getRoles().get(0).getRoleId().intValue(), 1);
+        System.out.println(user.toString());
+    }
+
+    @Test
+    public void testConvertJsonToDACUserStringDateCase() {
+        String jsonRole = "[{\"roleId\": 1, \"name\":\"name\", \"what\": \"Huh?\", \"rationale\": \"rationale\", \"status\": \"pending\"}]";
+        String json = "{\"dacUserId\": 1, \"email\":\"email\", \"what\": \"Huh?\", \"createDate\": \"Oct 28, 2020\", \"additionalEmail\": \"additionalEmail\", \"emailPreference\": false, \"roles\": " + jsonRole + "}";
+        User user = new User(json);
+        Assert.assertNotNull(user);
+        Assert.assertNotNull(user.getCreateDate());
+        Assert.assertEquals(user.getDacUserId().intValue(), 1);
+        Assert.assertEquals(user.getEmail(), "email");
+        Assert.assertEquals(user.getAdditionalEmail(), "additionalEmail");
+        Assert.assertEquals(user.getEmailPreference(), false);
+        Assert.assertFalse(user.getRoles().isEmpty());
+        Assert.assertEquals(user.getRoles().get(0).getRoleId().intValue(), 1);
+        System.out.println(user.toString());
+    }
+
+    @Test
+    public void testConvertJsonToDACUserNoCreateDate() {
+        String jsonRole = "[{\"roleId\": 1, \"name\":\"name\", \"what\": \"Huh?\", \"rationale\": \"rationale\", \"status\": \"pending\"}]";
+        String json = "{\"dacUserId\": 1, \"email\":\"email\", \"what\": \"Huh?\", \"additionalEmail\": \"additionalEmail\", \"emailPreference\": false, \"roles\": " + jsonRole + "}";
+        User user = new User(json);
+        Assert.assertNotNull(user);
+        Assert.assertNull(user.getCreateDate());
         Assert.assertEquals(user.getDacUserId().intValue(), 1);
         Assert.assertEquals(user.getEmail(), "email");
         Assert.assertEquals(user.getAdditionalEmail(), "additionalEmail");


### PR DESCRIPTION
## Addresses
https://broadinstitute.atlassian.net/browse/DUOS-813

## Changes
Minor update to parsing a user from json string and tests for the known formats it can come in.

----

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [ ] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
