### PR TITLE
[DUOS-819][risk=no] Change 304 -> 204 when updating a dataset with no changes

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/resources/DataSetResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataSetResource.java
@@ -152,7 +152,7 @@ public class DataSetResource extends Resource {
             return Response.ok(uri).entity(updatedDataset.get()).build();
         }
         else {
-            return Response.notModified().build();
+            return Response.noContent().build();
         }
     }
 

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -2462,7 +2462,7 @@ paths:
       responses:
         200:
           description: Successfully updated Dataset
-        304:
+        204:
           description: Not modified
         400:
           description: Bad Request (invalid input)

--- a/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
@@ -175,7 +175,7 @@ public class DatasetResourceTest {
     }
 
     @Test
-    public void testUpdateDatasetNotModified() {
+    public void testUpdateDatasetNoContent() {
         DataSet preexistingDataset = new DataSet();
         DataSetDTO json = new DataSetDTO();
         List<DataSetPropertyDTO> jsonProperties = new ArrayList<>();
@@ -190,8 +190,8 @@ public class DatasetResourceTest {
         when(uriInfo.getRequestUriBuilder()).thenReturn(uriBuilder);
         when(uriBuilder.replacePath(anyString())).thenReturn(uriBuilder);
         initResource();
-        Response responseNotModified = resource.updateDataset(authUser, uriInfo, 1, new Gson().toJson(json));
-        assertEquals(304, responseNotModified.getStatus());
+        Response responseNoContent = resource.updateDataset(authUser, uriInfo, 1, new Gson().toJson(json));
+        assertEquals(204, responseNoContent.getStatus());
     }
 
     @Test


### PR DESCRIPTION


Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [x] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
