### PR TITLE
[DUOS-820][risk=no] Add user validation to legacy DAR modification calls

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
@@ -334,7 +334,8 @@ public class DataAccessRequestResource extends Resource {
     @Deprecated // Use DataAccessRequestResourceVersion2.updateDraftDataAccessRequest
     public Response updatePartialDataAccessRequest(@Auth AuthUser authUser, @Context UriInfo info, Document dar) {
         String referenceId = dar.getString(DarConstants.REFERENCE_ID);
-        validateAuthedRoleUser(Collections.emptyList(), authUser, referenceId);        try {
+        validateAuthedRoleUser(Collections.emptyList(), authUser, referenceId);
+        try {
             dar = dataAccessRequestAPI.updateDraftDataAccessRequest(dar);
             return Response.ok().entity(dar).build();
         } catch (Exception e) {
@@ -355,7 +356,8 @@ public class DataAccessRequestResource extends Resource {
     @Produces("application/json")
     @Path("/partial/{id}")
     @RolesAllowed(RESEARCHER)
-    public Response deleteDraftDar(@PathParam("id") String id, @Context UriInfo info) {
+    public Response deleteDraftDar(@Auth AuthUser authUser, @PathParam("id") String id, @Context UriInfo info) {
+        validateAuthedRoleUser(Collections.emptyList(), authUser, id);
         try {
             dataAccessRequestService.deleteByReferenceId(id);
             return Response.ok().build();

--- a/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
@@ -455,7 +455,7 @@ public class DataAccessRequestResource extends Resource {
                 .collect(Collectors.toList());
             if (userRoleIds.stream().noneMatch(superUserRoleIds::contains)) {
                 if (!dataAccessRequest.getUserId().equals(user.getDacUserId())) {
-                    throw new ForbiddenException("User does not have permission to update resource");
+                    throw new ForbiddenException("User does not have permission to access this resource");
                 }
             }
         } catch (Exception e) {

--- a/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
@@ -485,9 +485,12 @@ public class DataAccessRequestResource extends Resource {
     }
 
     /**
-     * Custom handler for validating that a user can access a DAR.
-     * If the DAR create user is the same as the Auth User, then the user can access the resource.
-     * If the user has any of the roles in allowableRoles, then the user can access the resource.
+     * Custom handler for validating that a user can access a DAR. User will have access if ANY
+     * of these conditions are met:
+     *      If the DAR create user is the same as the Auth User, then the user can access the resource.
+     *      If the user has any of the roles in allowableRoles, then the user can access the resource.
+     * In practice, pass in allowableRoles for users that are not the create user (i.e. Admin) so
+     * they can also have access to the DAR.
      *
      * @param allowableRoles List of roles that would allow the user to access the resource
      * @param authUser The AuthUser

--- a/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
@@ -499,6 +499,11 @@ public class DataAccessRequestResource extends Resource {
     private void validateAuthedRoleUser(final List<UserRoles> allowableRoles, AuthUser authUser, String referenceId) {
         DataAccessRequest dataAccessRequest = findDataAccessRequestById(referenceId);
         User user = findUserByEmail(authUser.getName());
-        super.validateAuthedRoleUser(allowableRoles, user, dataAccessRequest.getUserId());
+        if (Objects.nonNull(dataAccessRequest.getUserId()) && dataAccessRequest.getUserId() > 0) {
+            super.validateAuthedRoleUser(allowableRoles, user, dataAccessRequest.getUserId());
+        } else {
+            logger.warning("DataAccessRequest '" + referenceId + "' has an invalid userId" );
+            super.validateAuthedRoleUser(allowableRoles, user, dataAccessRequest.getData().getUserId());
+        }
     }
 }

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -1537,11 +1537,11 @@ paths:
       summary: updateDataAccessRequest
       description: |
         DEPRECATED: Use PUT /api/dar/v2/{referenceId}
-        Updates the DAR identified by the dar_code.
+        Updates the DAR identified by the id
       parameters:
         - name: id
           in: path
-          description: dar_code that identifies univocally
+          description: The id of the DAR
           required: true
           schema:
             type: string
@@ -1557,9 +1557,11 @@ paths:
           description: Returns the updated DAR.
         400:
           description: Bad request.
+        403:
+          description: Forbidden
     delete:
       summary: delete
-      description: Deletes the DAR identified by the ID
+      description: Deletes the DAR identified by the id
       parameters:
         - name: id
           in: path
@@ -1576,6 +1578,8 @@ paths:
             application/json:
               schema:
                 type: string
+        403:
+          description: Forbidden
         404:
           description: The requested DAR couldn't be found.
   /api/dar/cancel/{id}:
@@ -1598,6 +1602,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DataAccessRequest'
+        403:
+          description: Forbidden
         404:
           description: Unable to find the Data Access Request with the provided id
         500:
@@ -1726,6 +1732,26 @@ paths:
       responses:
         200:
           description: Returns the created partial Data Access Request, json file.
+        500:
+          description: Internal Server Error.
+  /api/dar/partial/{id}:
+    delete:
+      summary: Delete Partial Data Access Request
+      description: Delete Partial Data Access Request
+      parameters:
+        - name: id
+          in: path
+          description: The id of the DAR
+          required: true
+          schema:
+            type: string
+      tags:
+        - Data Access Request
+      responses:
+        200:
+          description: Data Access Request was deleted
+        403:
+          description: Forbidden
         500:
           description: Internal Server Error.
 


### PR DESCRIPTION
## Addresses
https://broadinstitute.atlassian.net/browse/DUOS-820

## Changes
* Validate that the user is the create user for the DAR or an admin in these methods:
  * PUT /api/dar/{id}
  * PUT /api/dar/partial
  * PUT /api/dar/cancel/{id}
  * DELETE /api/dar/{id}
  * DELETE /api/dar/partial/{id}  

## Reviewer Notes
The codacy checks that are failing are unrelated legacy code that I do not want to address as part of this PR. Please ignore the following:

> Avoid reassigning parameters such as 'dar'
> public Response updateDataAccessRequest(@Auth AuthUser authUser, Document dar, @PathParam("id") String id) {
 
> Avoid reassigning parameters such as 'dar'
> public Response updatePartialDataAccessRequest(@Auth AuthUser authUser, @Context UriInfo info, Document dar) {


----

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [ ] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
