### PR TITLE
[DUOS-825][risk=no] Set user id from the authenticated user

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
@@ -91,9 +91,11 @@ public class DataAccessRequestResource extends Resource {
     @Produces("application/json")
     @RolesAllowed(RESEARCHER)
     @Deprecated // Use DataAccessRequestResourceVersion2
-    public Response createDataAccessRequest(@Context UriInfo info, Document dar) {
+    public Response createDataAccessRequest(@Auth AuthUser authUser, @Context UriInfo info, Document dar) {
         UseRestriction useRestriction;
+        User user = findUserByEmail(authUser.getName());
         try {
+            dar.put(DarConstants.USER_ID, user.getDacUserId());
             // See https://broadinstitute.atlassian.net/browse/DUOS-780
             // Temporarily remove unnecessary fields until fully deprecated.
             dar.remove(DarConstants.CREATE_DATE);
@@ -132,8 +134,10 @@ public class DataAccessRequestResource extends Resource {
     @Path("/{id}")
     @RolesAllowed(RESEARCHER)
     @Deprecated // Use DataAccessRequestResourceVersion2
-    public Response updateDataAccessRequest(Document dar, @PathParam("id") String id) {
+    public Response updateDataAccessRequest(@Auth AuthUser authUser, Document dar, @PathParam("id") String id) {
+        User user = findUserByEmail(authUser.getName());
         try {
+            dar.put(DarConstants.USER_ID, user.getDacUserId());
             dar.remove(DarConstants.RESTRICTION);
             Boolean needsManualReview = DarUtil.requiresManualReview(dar);
             if (!needsManualReview) {
@@ -329,8 +333,10 @@ public class DataAccessRequestResource extends Resource {
     @Path("/partial")
     @RolesAllowed(RESEARCHER)
     @Deprecated // Use DataAccessRequestResourceVersion2.updateDraftDataAccessRequest
-    public Response updatePartialDataAccessRequest(@Context UriInfo info, Document dar) {
+    public Response updatePartialDataAccessRequest(@Auth AuthUser authUser, @Context UriInfo info, Document dar) {
+        User user = findUserByEmail(authUser.getName());
         try {
+            dar.put(DarConstants.USER_ID, user.getDacUserId());
             dar = dataAccessRequestAPI.updateDraftDataAccessRequest(dar);
             return Response.ok().entity(dar).build();
         } catch (Exception e) {


### PR DESCRIPTION
## Addresses
https://broadinstitute.atlassian.net/browse/DUOS-825

## Changes
Set the user id property of a DAR in the legacy dar creation APIs to the user we get from OAuth for these endpoints
* POST /api/dar
* PUT /api/dar/{id}
* PUT /api/dar/partial

## Reviewer Notes
The codacy checks that are failing are unrelated legacy code that I do not want to address as part of this PR. Please ignore the following:

> Avoid reassigning parameters such as 'dar'
> public Response updateDataAccessRequest(@Auth AuthUser authUser, Document dar, @PathParam("id") String id) {

> Avoid reassigning parameters such as 'dar'
> public Response updatePartialDataAccessRequest(@Auth AuthUser authUser, @context UriInfo info, Document dar) {

----

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [ ] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
