### PR TITLE
[DUOS-823][risk=no] Validate user for describe by email

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/resources/DACUserResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DACUserResource.java
@@ -5,6 +5,7 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.google.inject.Inject;
 import io.dropwizard.auth.Auth;
+import java.util.stream.Stream;
 import org.broadinstitute.consent.http.authentication.GoogleUser;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.AuthUser;
@@ -81,8 +82,14 @@ public class DACUserResource extends Resource {
     @Path("/{email}")
     @Produces("application/json")
     @PermitAll
-    public User describe(@PathParam("email") String email) {
-        return userService.findUserByEmail(email);
+    public User describe(@Auth AuthUser authUser, @PathParam("email") String email) {
+        User searchUser = userService.findUserByEmail(email);
+        validateAuthedRoleUser(Stream
+                .of(UserRoles.ADMIN, UserRoles.CHAIRPERSON, UserRoles.MEMBER)
+                .collect(Collectors.toList()),
+            findByAuthUser(authUser),
+            searchUser.getDacUserId());
+        return searchUser;
     }
 
     @PUT

--- a/src/test/java/org/broadinstitute/consent/http/resources/DACUserResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DACUserResourceTest.java
@@ -132,7 +132,7 @@ public class DACUserResourceTest {
     public void testRetrieveDACUserWithInvalidEmail() {
         when(userService.findUserByEmail(any())).thenThrow(new NotFoundException());
         initResource();
-        resource.describe(RandomStringUtils.random(10));
+        resource.describe(authUser, RandomStringUtils.random(10));
     }
 
     @Test


### PR DESCRIPTION
## Addresses
https://broadinstitute.atlassian.net/browse/DUOS-823

## Changes
Ensure that the user is the same as the authed user, or has an appropriate role.

----

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [ ] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
