### PR TITLE
[DUOS-820][risk=no] API docs for updated endpoint

### DIFF
--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -1756,6 +1756,8 @@ paths:
           description: Returns the updated partial Data Access Request, json file.
         403:
           description: Forbidden
+        404:
+          description: DAR or User Not Found
         500:
           description: Internal Server Error.
   /api/dar/partial/{id}:

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -1734,6 +1734,30 @@ paths:
           description: Returns the created partial Data Access Request, json file.
         500:
           description: Internal Server Error.
+    put:
+      summary: Update Partial Data Access Request
+      description: |
+        DEPRECATED: Use PUT /api/dar/v2/draft/{referenceId}:
+        Update Partial Data Access Request
+      parameters:
+        - name: dar
+          in: body
+          description: |
+            The fields that represent a DAR, json format.
+            Must contain a `referenceId` for the updated DAR.
+            User must be the creator of the DAR.
+          required: true
+          schema:
+            $ref: '#/components/schemas/DataAccessRequest'
+      tags:
+        - Data Access Request
+      responses:
+        200:
+          description: Returns the updated partial Data Access Request, json file.
+        403:
+          description: Forbidden
+        500:
+          description: Internal Server Error.
   /api/dar/partial/{id}:
     delete:
       summary: Delete Partial Data Access Request


### PR DESCRIPTION
## Addresses
https://broadinstitute.atlassian.net/browse/DUOS-820

Adds api docs for `PUT /api/dar/partial` endpoint that was previously undocumented.

----

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [ ] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
