### PR TITLE
[DUOS-485][risk=no] DAC Endpoints: Filter by user level

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/resources/DacResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DacResource.java
@@ -43,9 +43,8 @@ public class DacResource extends Resource {
     @Produces("application/json")
     @RolesAllowed({ADMIN, MEMBER, CHAIRPERSON})
     public Response findAll(@Auth AuthUser authUser, @QueryParam("withUsers") Optional<Boolean> withUsers) {
-        List<Dac> dacs = new ArrayList<>();
         final Boolean includeUsers = withUsers.isPresent() ? withUsers.get() : true;
-        dacs.addAll(dacService.findDacsByUser(authUser, includeUsers));
+        List<Dac> dacs = dacService.findDacsByUser(authUser, includeUsers);
         return Response.ok().entity(dacs).build();
     }
 

--- a/src/main/java/org/broadinstitute/consent/http/resources/DacResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DacResource.java
@@ -45,12 +45,7 @@ public class DacResource extends Resource {
     public Response findAll(@Auth AuthUser authUser, @QueryParam("withUsers") Optional<Boolean> withUsers) {
         List<Dac> dacs = new ArrayList<>();
         final Boolean includeUsers = withUsers.isPresent() ? withUsers.get() : true;
-        if (includeUsers) {
-            dacs.addAll(dacService.findAllDacsWithMembers());
-        }
-        else {
-            dacs.addAll(dacService.findDacsByUser(authUser));
-        }
+        dacs.addAll(dacService.findDacsByUser(authUser, includeUsers));
         return Response.ok().entity(dacs).build();
     }
 

--- a/src/test/java/org/broadinstitute/consent/http/resources/DacResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DacResourceTest.java
@@ -41,9 +41,9 @@ public class DacResourceTest {
 
     @Test
     public void testFindAll_success_1() {
-        when(dacService.findAll()).thenReturn(Collections.emptyList());
+        when(dacService.findDacsByUser(authUser, true)).thenReturn(Collections.emptyList());
 
-        Response response = dacResource.findAll(authUser, Optional.empty());
+        Response response = dacResource.findAll(authUser, Optional.of(true));
         Assert.assertEquals(200, response.getStatus());
         List dacs = ((List) response.getEntity());
         Assert.assertTrue(dacs.isEmpty());
@@ -55,10 +55,9 @@ public class DacResourceTest {
                 .setName("name")
                 .setDescription("description")
                 .build();
-        when(dacService.findAll()).thenReturn(Collections.singletonList(dac));
-        when(dacService.findAllDacsWithMembers()).thenReturn(Collections.singletonList(dac));
+        when(dacService.findDacsByUser(authUser, true)).thenReturn(Collections.singletonList(dac));
 
-        Response response = dacResource.findAll(authUser, Optional.empty());
+        Response response = dacResource.findAll(authUser, Optional.of(true));
         Assert.assertEquals(200, response.getStatus());
         List dacs = ((List) response.getEntity());
         Assert.assertEquals(1, dacs.size());
@@ -66,7 +65,7 @@ public class DacResourceTest {
 
     @Test
     public void testFindAllWithUsers() {
-        when(dacService.findAll()).thenReturn(Collections.emptyList());
+        when(dacService.findDacsByUser(authUser, false)).thenReturn(Collections.emptyList());
 
         Response response = dacResource.findAll(authUser, Optional.of(false));
         Assert.assertEquals(200, response.getStatus());

--- a/src/test/java/org/broadinstitute/consent/http/service/DacServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DacServiceTest.java
@@ -719,7 +719,7 @@ public class DacServiceTest {
         when(userDAO.findUserByEmailAndRoleId(anyString(), anyInt())).thenReturn(getDacUsers().get(0));
         initService();
 
-        List<Dac> dacsForUser = service.findDacsByUser(getUser());
+        List<Dac> dacsForUser = service.findDacsByUser(getUser(), false);
         Assert.assertEquals(dacsForUser.size(), dacs.size());
     }
 
@@ -732,7 +732,7 @@ public class DacServiceTest {
         when(userDAO.findUserByEmailAndRoleId(anyString(), anyInt())).thenReturn(getChair());
         initService();
 
-        List<Dac> dacsForUser = service.findDacsByUser(getUser());
+        List<Dac> dacsForUser = service.findDacsByUser(getUser(), false);
         Assert.assertEquals(dacsForUser.size(), dacs.size());
     }
 


### PR DESCRIPTION
Addresses: https://broadinstitute.atlassian.net/browse/DUOS-485
Before, DAC findAll would find all DACs, irregardless of user role. We would rather find DACS specific to a user. 

I separated out the logic that adds member information and attached it to the DACS returned by findDacsByUser if flagged. I kept the original findAllDacsWithMembers, since the MetricsService uses it.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [ ] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
