### PR TITLE
[DUOS-821][risk=no] Validate user for read DAR apis

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
@@ -241,7 +241,7 @@ public class DataAccessRequestService {
         return dataAccessRequestDAO.findByReferenceIds(referenceIds);
     }
 
-    private Document createDocumentFromDar(DataAccessRequest d) {
+    public Document createDocumentFromDar(DataAccessRequest d) {
         Document document = Document.parse(gson.toJson(d.getData()));
         document.put(DarConstants.DATA_ACCESS_REQUEST_ID, d.getId());
         document.put(DarConstants.REFERENCE_ID, d.getReferenceId());

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -1780,6 +1780,23 @@ paths:
           description: Forbidden
         500:
           description: Internal Server Error.
+  /api/dar/partials/manage:
+    get:
+      summary: Get Partial Data Access Requests for user
+      description: Get Partial Data Access Requests for user
+      tags:
+        - Data Access Request
+      responses:
+        200:
+          description: Partial Data Access Requests
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/DataAccessRequest'
+        500:
+          description: Internal Server Error.
 
   /api/dataRequest/cases/pending:
     get:

--- a/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceTest.java
@@ -12,6 +12,7 @@ import org.broadinstitute.consent.http.models.Consent;
 import org.broadinstitute.consent.http.models.DataAccessRequest;
 import org.broadinstitute.consent.http.models.DataAccessRequestData;
 import org.broadinstitute.consent.http.models.DataSet;
+import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.service.AbstractConsentAPI;
 import org.broadinstitute.consent.http.service.AbstractDataAccessRequestAPI;
 import org.broadinstitute.consent.http.service.AbstractDataSetAPI;
@@ -68,6 +69,8 @@ public class DataAccessRequestResourceTest {
     private UserService userService;
     @Mock
     private AuthUser authUser;
+    @Mock
+    private User user;
 
     private DataAccessRequestResource resource;
 
@@ -97,6 +100,8 @@ public class DataAccessRequestResourceTest {
         when(AbstractDataSetAPI.getInstance()).thenReturn(dataSetAPI);
         when(AbstractDACUserAPI.getInstance()).thenReturn(dacUserAPI);
         when(AbstractElectionAPI.getInstance()).thenReturn(electionAPI);
+        when(user.getDacUserId()).thenReturn(dar.getUserId());
+        when(userService.findUserByEmail(any())).thenReturn(user);
         resource = new DataAccessRequestResource(dataAccessRequestService, emailNotifierService, userService);
         Consent consent = resource.describeConsentForDAR(authUser, dar.getReferenceId());
         assertNotNull(consent);
@@ -117,6 +122,8 @@ public class DataAccessRequestResourceTest {
         when(AbstractDataSetAPI.getInstance()).thenReturn(dataSetAPI);
         when(AbstractDACUserAPI.getInstance()).thenReturn(dacUserAPI);
         when(AbstractElectionAPI.getInstance()).thenReturn(electionAPI);
+        when(user.getDacUserId()).thenReturn(dar.getUserId());
+        when(userService.findUserByEmail(any())).thenReturn(user);
         resource = new DataAccessRequestResource(dataAccessRequestService, emailNotifierService, userService);
         Consent consent = resource.describeConsentForDAR(authUser, dar.getReferenceId());
         assertNotNull(consent);
@@ -160,6 +167,7 @@ public class DataAccessRequestResourceTest {
         data.setReferenceId(dar.getReferenceId());
         data.setDatasetIds(Arrays.asList(1, 2));
         dar.setData(data);
+        dar.setUserId(1);
         return dar;
     }
 

--- a/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.when;
 import java.util.Arrays;
 import java.util.UUID;
 import javax.ws.rs.NotFoundException;
+import org.broadinstitute.consent.http.models.AuthUser;
 import org.broadinstitute.consent.http.models.Consent;
 import org.broadinstitute.consent.http.models.DataAccessRequest;
 import org.broadinstitute.consent.http.models.DataAccessRequestData;
@@ -65,6 +66,8 @@ public class DataAccessRequestResourceTest {
     private DataSetAPI dataSetAPI;
     @Mock
     private UserService userService;
+    @Mock
+    private AuthUser authUser;
 
     private DataAccessRequestResource resource;
 
@@ -95,7 +98,7 @@ public class DataAccessRequestResourceTest {
         when(AbstractDACUserAPI.getInstance()).thenReturn(dacUserAPI);
         when(AbstractElectionAPI.getInstance()).thenReturn(electionAPI);
         resource = new DataAccessRequestResource(dataAccessRequestService, emailNotifierService, userService);
-        Consent consent = resource.describeConsentForDAR(dar.getReferenceId());
+        Consent consent = resource.describeConsentForDAR(authUser, dar.getReferenceId());
         assertNotNull(consent);
     }
 
@@ -115,7 +118,7 @@ public class DataAccessRequestResourceTest {
         when(AbstractDACUserAPI.getInstance()).thenReturn(dacUserAPI);
         when(AbstractElectionAPI.getInstance()).thenReturn(electionAPI);
         resource = new DataAccessRequestResource(dataAccessRequestService, emailNotifierService, userService);
-        Consent consent = resource.describeConsentForDAR(dar.getReferenceId());
+        Consent consent = resource.describeConsentForDAR(authUser, dar.getReferenceId());
         assertNotNull(consent);
     }
 
@@ -132,7 +135,7 @@ public class DataAccessRequestResourceTest {
         when(AbstractDACUserAPI.getInstance()).thenReturn(dacUserAPI);
         when(AbstractElectionAPI.getInstance()).thenReturn(electionAPI);
         resource = new DataAccessRequestResource(dataAccessRequestService, emailNotifierService, userService);
-        resource.describeConsentForDAR(dar.getReferenceId());
+        resource.describeConsentForDAR(authUser, dar.getReferenceId());
     }
 
     /**
@@ -147,7 +150,7 @@ public class DataAccessRequestResourceTest {
         when(AbstractDACUserAPI.getInstance()).thenReturn(dacUserAPI);
         when(AbstractElectionAPI.getInstance()).thenReturn(electionAPI);
         resource = new DataAccessRequestResource(dataAccessRequestService, emailNotifierService, userService);
-        resource.describeConsentForDAR(dar.getReferenceId());
+        resource.describeConsentForDAR(authUser, dar.getReferenceId());
     }
 
     private DataAccessRequest generateDataAccessRequest() {

--- a/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceVersion2Test.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceVersion2Test.java
@@ -16,16 +16,19 @@ import java.sql.Timestamp;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
+import java.util.List;
 import java.util.UUID;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
 import org.apache.commons.io.IOUtils;
 import org.broadinstitute.consent.http.cloudstore.GCSService;
+import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.AuthUser;
 import org.broadinstitute.consent.http.models.DataAccessRequest;
 import org.broadinstitute.consent.http.models.DataAccessRequestData;
 import org.broadinstitute.consent.http.models.User;
+import org.broadinstitute.consent.http.models.UserRole;
 import org.broadinstitute.consent.http.service.AbstractMatchProcessAPI;
 import org.broadinstitute.consent.http.service.DataAccessRequestService;
 import org.broadinstitute.consent.http.service.EmailNotifierService;
@@ -55,7 +58,8 @@ public class DataAccessRequestResourceVersion2Test {
   @Mock private UriBuilder builder;
 
   private final AuthUser authUser = new AuthUser("test@test.com");
-  private final User user = new User(1, authUser.getName(), "Display Name", new Date());
+  private final List<UserRole> roles = Collections.singletonList(new UserRole(UserRoles.RESEARCHER.getRoleId(), UserRoles.RESEARCHER.getRoleName()));
+  private final User user = new User(1, authUser.getName(), "Display Name", new Date(), roles, authUser.getName());
 
   private DataAccessRequestResourceVersion2 resource;
 
@@ -97,6 +101,7 @@ public class DataAccessRequestResourceVersion2Test {
 
   @Test
   public void testGetByReferenceId() {
+    when(userService.findUserByEmail(any())).thenReturn(user);
     when(dataAccessRequestService.findByReferenceId(any())).thenReturn(generateDataAccessRequest());
     initResource();
     Response response = resource.getByReferenceId(authUser, "");

--- a/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceVersion2Test.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceVersion2Test.java
@@ -18,6 +18,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.UUID;
+import javax.ws.rs.ForbiddenException;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
@@ -56,6 +57,7 @@ public class DataAccessRequestResourceVersion2Test {
   @Mock private UserService userService;
   @Mock private UriInfo info;
   @Mock private UriBuilder builder;
+  @Mock private User mockUser;
 
   private final AuthUser authUser = new AuthUser("test@test.com");
   private final List<UserRole> roles = Collections.singletonList(new UserRole(UserRoles.RESEARCHER.getRoleId(), UserRoles.RESEARCHER.getRoleName()));
@@ -106,6 +108,15 @@ public class DataAccessRequestResourceVersion2Test {
     initResource();
     Response response = resource.getByReferenceId(authUser, "");
     assertEquals(200, response.getStatus());
+  }
+
+  @Test(expected = ForbiddenException.class)
+  public void testGetByReferenceIdForbidden() {
+    when(mockUser.getDacUserId()).thenReturn(user.getDacUserId() + 1);
+    when(userService.findUserByEmail(any())).thenReturn(mockUser);
+    when(dataAccessRequestService.findByReferenceId(any())).thenReturn(generateDataAccessRequest());
+    initResource();
+    resource.getByReferenceId(authUser, "");
   }
 
   @Test


### PR DESCRIPTION
## Addresses
https://broadinstitute.atlassian.net/browse/DUOS-821
See also: https://github.com/DataBiosphere/duos-ui/pull/694 which depends on this PR.

## Changes
Add user validation for all DAR read endpoints
Allows for a change in the UI to not send over a user id in `/api/dar/partials/manage`

----

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [ ] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
