### PR TITLE
DUOS-832 [risk=no] Added DAR acknowledgement set and get methods

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequestData.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequestData.java
@@ -125,6 +125,9 @@ public class DataAccessRequestData {
     private List<Collaborator> labCollaborators;
     private List<Collaborator> internalCollaborators;
     private List<Collaborator> externalCollaborators;
+    private Boolean dsAcknowledgement;
+    private Boolean gsoAcknowledgement;
+    private Boolean pubAcknowledgement;
 
     @Override
     public String toString() {
@@ -810,6 +813,30 @@ public class DataAccessRequestData {
 
     public void setSigningOfficial(String signingOfficial) {
         this.signingOfficial = signingOfficial;
+    }
+
+    public void setDSAcknowledgement(Boolean dsAcknowledgement) {
+        this.dsAcknowledgement = dsAcknowledgement;
+    }
+
+    public Boolean getDSAcknowledgement() {
+        return dsAcknowledgement;
+    }
+
+    public void setGSOAcknowledgement(Boolean gsoAcknowledgement) {
+        this.gsoAcknowledgement = gsoAcknowledgement;
+    }
+
+    public Boolean getGSOAcknowledgement() {
+        return gsoAcknowledgement;
+    }
+
+    public void setPubAcknowledgement(Boolean pubAcknowledgement) {
+        this.pubAcknowledgement = pubAcknowledgement;
+    }
+
+    public Boolean getPubAcknowledgement() {
+        return pubAcknowledgement;
     }
 
     // Validate all ontology entries

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -3894,6 +3894,15 @@ components:
         irbProtocolExpiration:
           type: string
           description: IRB Protocol Expiration
+        dsAcknowledgement:
+          type: boolean
+          description: Boolean value that represents user acknowledgement of disease studies restrictions (if applciable)
+        gsoAcknowledgement:
+          type: boolean
+          description: Boolean value that represents user acknowledgement of genetic studies limitations (if applicable)
+        pubAcknowledgement:
+          type: boolean
+          description: Boolean value that represents user acknowledgement of publication requirements (if applicable)
         itDirector:
           type: string
           description: IT Director


### PR DESCRIPTION
Addresses [DUOS-832](https://broadinstitute.atlassian.net/browse/DUOS-832)

PR looks to add set and get methods for DAR acknowledgement questions added to the UI for question 2.7. Also includes schema updates to reflect the additions.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [x] I've updated Swagger to reflect any API changes

In all cases:

- [x] Get two thumbsworth of review and PO signoff if necessary
- [x] Verify all tests go green
- [x] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
