### PR TITLE
DUOS-842 [risk=no] Timestamp and Partial DAR Code bugfixes

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequestData.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequestData.java
@@ -125,6 +125,9 @@ public class DataAccessRequestData {
     private List<Collaborator> labCollaborators;
     private List<Collaborator> internalCollaborators;
     private List<Collaborator> externalCollaborators;
+    private Boolean dsAcknowledgement;
+    private Boolean gsoAcknowledgement;
+    private Boolean pubAcknowledgement;
 
     @Override
     public String toString() {
@@ -810,6 +813,30 @@ public class DataAccessRequestData {
 
     public void setSigningOfficial(String signingOfficial) {
         this.signingOfficial = signingOfficial;
+    }
+
+    public void setDSAcknowledgement(Boolean dsAcknowledgement) {
+        this.dsAcknowledgement = dsAcknowledgement;
+    }
+
+    public Boolean getDSAcknowledgement() {
+        return dsAcknowledgement;
+    }
+
+    public void setGSOAcknowledgement(Boolean gsoAcknowledgement) {
+        this.gsoAcknowledgement = gsoAcknowledgement;
+    }
+
+    public Boolean getGSOAcknowledgement() {
+        return gsoAcknowledgement;
+    }
+
+    public void setPubAcknowledgement(Boolean pubAcknowledgement) {
+        this.pubAcknowledgement = pubAcknowledgement;
+    }
+
+    public Boolean getPubAcknowledgement() {
+        return pubAcknowledgement;
     }
 
     // Validate all ontology entries

--- a/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequestData.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequestData.java
@@ -16,7 +16,6 @@ public class DataAccessRequestData {
      * or duplicate existing DAR fields.
      * See https://broadinstitute.atlassian.net/browse/DUOS-728 for more info.
      */
-    public static final String partialDarCodePrefix = "temp_DAR_";
     public static final List<String> DEPRECATED_PROPS = Arrays
         .asList("referenceId", "investigator",
             "institution", "department", "address1", "address2", "city", "zipcode", "zipCode",
@@ -25,6 +24,10 @@ public class DataAccessRequestData {
             "eraAuthorized", "nihUsername", "linkedIn", "orcid", "researcherGate", "datasetDetail",
             "datasets", "datasetId", "validRestriction", "restriction", "translatedUseRestriction",
             "createDate", "sortDate");
+
+    // prefix for partialDarCode, should be pulled by functions that generate/update ONLY
+    // since class is used within both drafts and submitted dars, it's best to control its implementation on the outer function call
+    public static final String partialDarCodePrefix = "temp_DAR_";
 
     private String referenceId;
     private String investigator;

--- a/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequestData.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequestData.java
@@ -16,6 +16,7 @@ public class DataAccessRequestData {
      * or duplicate existing DAR fields.
      * See https://broadinstitute.atlassian.net/browse/DUOS-728 for more info.
      */
+    public static final String partialDarCodePrefix = "temp_DAR_";
     public static final List<String> DEPRECATED_PROPS = Arrays
         .asList("referenceId", "investigator",
             "institution", "department", "address1", "address2", "city", "zipcode", "zipCode",

--- a/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceVersion2.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceVersion2.java
@@ -6,8 +6,6 @@ import io.dropwizard.auth.Auth;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
-import java.text.SimpleDateFormat;
-import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
@@ -313,11 +311,9 @@ public class DataAccessRequestResourceVersion2 extends Resource {
         data.setReferenceId(referenceId);
       }
     } else {
-      SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
       String referenceId = UUID.randomUUID().toString();
       newDar.setReferenceId(referenceId);
       data.setReferenceId(referenceId);
-      data.setPartialDarCode("temp_DAR_" + sdf.format(new Date()));
     }
     newDar.setData(data);
     return newDar;

--- a/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceVersion2.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceVersion2.java
@@ -6,6 +6,8 @@ import io.dropwizard.auth.Auth;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
@@ -311,9 +313,11 @@ public class DataAccessRequestResourceVersion2 extends Resource {
         data.setReferenceId(referenceId);
       }
     } else {
+      SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
       String referenceId = UUID.randomUUID().toString();
       newDar.setReferenceId(referenceId);
       data.setReferenceId(referenceId);
+      data.setPartialDarCode("temp_DAR_" + sdf.format(new Date()));
     }
     newDar.setData(data);
     return newDar;

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
@@ -1,7 +1,7 @@
 package org.broadinstitute.consent.http.service;
 
 import static java.util.stream.Collectors.toList;
-
+import java.text.SimpleDateFormat;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.inject.Inject;
@@ -291,6 +291,8 @@ public class DataAccessRequestService {
             throw new IllegalArgumentException("User and DataAccessRequest are required");
         }
         Date now = new Date();
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
+        dar.getData().setPartialDarCode(DataAccessRequestData.partialDarCodePrefix + sdf.format(now));
         dataAccessRequestDAO.insertVersion2(
             dar.getReferenceId(),
             user.getDacUserId(),

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
@@ -246,7 +246,7 @@ public class DataAccessRequestService {
         document.put(DarConstants.DATA_ACCESS_REQUEST_ID, d.getId());
         document.put(DarConstants.REFERENCE_ID, d.getReferenceId());
         document.put(DarConstants.CREATE_DATE, d.getCreateDate());
-        document.put(DarConstants.SORT_DATE, d.getCreateDate());
+        document.put(DarConstants.SORT_DATE, d.getSortDate());
         return document;
     }
 

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
@@ -245,6 +245,8 @@ public class DataAccessRequestService {
         Document document = Document.parse(gson.toJson(d.getData()));
         document.put(DarConstants.DATA_ACCESS_REQUEST_ID, d.getId());
         document.put(DarConstants.REFERENCE_ID, d.getReferenceId());
+        document.put(DarConstants.CREATE_DATE, d.getCreateDate());
+        document.put(DarConstants.SORT_DATE, d.getCreateDate());
         return document;
     }
 

--- a/src/main/java/org/broadinstitute/consent/http/service/DatabaseDataAccessRequestAPI.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatabaseDataAccessRequestAPI.java
@@ -267,7 +267,6 @@ public class DatabaseDataAccessRequestAPI extends AbstractDataAccessRequestAPI {
     @Override
     public Document createDraftDataAccessRequest(User user, Document draftDar) {
         Date now = new Date();
-        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
         Gson gson = new Gson();
         DataAccessRequest dar = new DataAccessRequest();
         DataAccessRequestData darData = DataAccessRequestData.fromString(gson.toJson(draftDar));
@@ -276,7 +275,6 @@ public class DatabaseDataAccessRequestAPI extends AbstractDataAccessRequestAPI {
         if (referenceId == null) {
             referenceId = UUID.randomUUID().toString();
         }
-        darData.setPartialDarCode("temp_DAR_" + sdf.format(now));
         darData.setReferenceId(referenceId);
         draftDar.put(DarConstants.REFERENCE_ID, referenceId);
         dar.setData(darData);

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -3894,6 +3894,15 @@ components:
         irbProtocolExpiration:
           type: string
           description: IRB Protocol Expiration
+        dsAcknowledgement:
+          type: boolean
+          description: Boolean value that represents user acknowledgement of disease studies restrictions (if applciable)
+        gsoAcknowledgement:
+          type: boolean
+          description: Boolean value that represents user acknowledgement of genetic studies limitations (if applicable)
+        pubAcknowledgement:
+          type: boolean
+          description: Boolean value that represents user acknowledgement of publication requirements (if applicable)
         itDirector:
           type: string
           description: IT Director


### PR DESCRIPTION
Addresses [DUOS-842](https://broadinstitute.atlassian.net/browse/DUOS-842)

PR adds create date and sort date to document records on GET requests, PR also generates partialDarCode for new drafts (v2 resource file). Additions address the current issue on the UI where requested DARs do not have partialDarCodes assigned on generation and does not have create and sort dates added to document returns, resulting in blank fields and occasional component breakage due to missing attributes.

As mentioned on the ticket, the PR is a companion piece to DUOS-681 since that PR utilizes the new v2 endpoints (which is how the bug was initially discovered), so testing alongside that ticket is advised.

Branch is also based off of DUOS-832, which is another companion piece to DUOS-681

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [x] I've updated Swagger to reflect any API changes

In all cases:

- [x] Get two thumbsworth of review and PO signoff if necessary
- [x] Verify all tests go green
- [x] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
