### PR TITLE
[DUOS-816] Create new consent during create dataset v2

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
@@ -216,7 +216,7 @@ public class ConsentModule extends AbstractModule {
 
     @Provides
     DatasetService providesDatasetService() {
-        return new DatasetService(providesConsentDAO(), providesDataSetDAO());
+        return new DatasetService(providesConsentDAO(), providesDataSetDAO(), providesUseRestrictionConverter());
     }
 
     @Provides

--- a/src/main/java/org/broadinstitute/consent/http/models/DataUse.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DataUse.java
@@ -40,6 +40,7 @@ public class DataUse {
     private Boolean collaboratorRequired;
     private String geographicalRestrictions;
     private String other;
+    private String secondaryOther;
     private Boolean illegalBehavior;
     private Boolean addiction;
     private Boolean sexualDiseases;
@@ -53,6 +54,7 @@ public class DataUse {
     private Boolean genomicResults;
     private String genomicSummaryResults;
     private Boolean collaborationInvestigators;
+    private String publicationMoratorium;
 
     public Boolean getGeneralUse() {
         return generalUse;
@@ -238,6 +240,14 @@ public class DataUse {
         this.other = other;
     }
 
+    public String getSecondaryOther() {
+        return secondaryOther;
+    }
+
+    public void setSecondaryOther(String secondaryOther) {
+        this.secondaryOther = secondaryOther;
+    }
+
     public Boolean getIllegalBehavior() {
         return illegalBehavior;
     }
@@ -340,6 +350,14 @@ public class DataUse {
 
     public void setCollaborationInvestigators(Boolean collaborationInvestigators) {
         this.collaborationInvestigators = collaborationInvestigators;
+    }
+
+    public String getPublicationMoratorium() {
+        return publicationMoratorium;
+    }
+
+    public void setPublicationMoratorium(String publicationMoratorium) {
+        this.publicationMoratorium = publicationMoratorium;
     }
 
     @Override

--- a/src/main/java/org/broadinstitute/consent/http/models/DataUseBuilder.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DataUseBuilder.java
@@ -133,7 +133,12 @@ public class DataUseBuilder {
         du.setOther(other);
         return this;
     }
-    
+
+    public DataUseBuilder setSecondaryOther(String secondaryOther) {
+        du.setSecondaryOther(secondaryOther);
+        return this;
+    }
+
     public DataUseBuilder setIllegalBehavior(Boolean illegalBehavior) {
         du.setIllegalBehavior(illegalBehavior);
         return this;
@@ -196,6 +201,11 @@ public class DataUseBuilder {
 
     public DataUseBuilder setCollaborationInvestigators(Boolean collaborationInvestigators) {
         du.setCollaborationInvestigators(collaborationInvestigators);
+        return this;
+    }
+
+    public DataUseBuilder setPublicationMoratorium(String publicationMoratorium) {
+        du.setPublicationMoratorium(publicationMoratorium);
         return this;
     }
 

--- a/src/main/java/org/broadinstitute/consent/http/resources/DataSetResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataSetResource.java
@@ -42,6 +42,7 @@ import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.consent.http.models.AuthUser;
+import org.broadinstitute.consent.http.models.Consent;
 import org.broadinstitute.consent.http.models.DataSet;
 import org.broadinstitute.consent.http.models.Dictionary;
 import org.broadinstitute.consent.http.models.User;
@@ -112,9 +113,11 @@ public class DataSetResource extends Resource {
         }
         User dacUser = userService.findUserByEmail(user.getGoogleUser().getEmail());
         Integer userId = dacUser.getDacUserId();
-        DataSet createdDataset = datasetService.createDataset(inputDataset, name, userId);
-        URI uri = info.getRequestUriBuilder().replacePath("api/dataset/{datasetId}").build(createdDataset.getDataSetId());
-        return Response.created(uri).entity(createdDataset).build();
+        DataSetDTO createdDataset = datasetService.createDataset(inputDataset, name, userId);
+        Consent createdConsent = datasetService.createConsentForDataset(createdDataset);
+        DataSetDTO createdDatasetWithConsent = datasetService.getDatasetDTO(createdDataset.getDataSetId());
+        URI uri = info.getRequestUriBuilder().replacePath("api/dataset/{datasetId}").build(createdDatasetWithConsent.getDataSetId());
+        return Response.created(uri).entity(createdDatasetWithConsent).build();
     }
 
     @PUT

--- a/src/main/java/org/broadinstitute/consent/http/resources/DataSetResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataSetResource.java
@@ -115,6 +115,9 @@ public class DataSetResource extends Resource {
         Integer userId = dacUser.getDacUserId();
         DataSetDTO createdDataset = datasetService.createDataset(inputDataset, name, userId);
         Consent createdConsent = datasetService.createConsentForDataset(createdDataset);
+        if (Objects.isNull(createdConsent)) {
+            throw new ClientErrorException("Consent was not able to be created for newly created dataset with id: " + createdDataset.getDataSetId(), Status.CONFLICT);
+        }
         DataSetDTO createdDatasetWithConsent = datasetService.getDatasetDTO(createdDataset.getDataSetId());
         URI uri = info.getRequestUriBuilder().replacePath("api/dataset/{datasetId}").build(createdDatasetWithConsent.getDataSetId());
         return Response.created(uri).entity(createdDatasetWithConsent).build();

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -215,4 +215,10 @@ public class DatasetService {
         }
         return Collections.emptyList();
     }
+
+    public void deleteDataset(Integer datasetId) {
+        List<Integer> idList = Collections.singletonList(datasetId);
+        dataSetDAO.deleteDataSetsProperties(idList);
+        dataSetDAO.deleteDataSets(idList);
+    }
 }

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -2405,7 +2405,7 @@ paths:
       summary: Creates the Dataset from JSON
       description: Creates the Dataset from JSON
       requestBody:
-        description: Submitted dataset registration form. Dataset must contain the property Dataset Name with a unique value.
+        description: Submitted dataset registration form. Dataset must contain the property Dataset Name with a unique value and a valid DataUse object.
         required: true
         content:
           application/json:
@@ -4105,8 +4105,6 @@ components:
               propertyValue: NHLBI
             - propertyName: Sample Collection ID
               propertyValue: SC-000
-
-
         active:
           type: boolean
           description: The Dataset is active
@@ -4125,6 +4123,9 @@ components:
         objectId:
           type: string
           description: The sample collection ID, if defined
+        dataUse:
+          type: object
+          description: The Data Use question/answer set for this dataset (used for the associated consent).
     DatasetProperty:
       type: object
       properties:

--- a/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
@@ -25,6 +25,7 @@ import javax.ws.rs.core.UriInfo;
 import org.apache.commons.io.IOUtils;
 import org.broadinstitute.consent.http.authentication.GoogleUser;
 import org.broadinstitute.consent.http.models.AuthUser;
+import org.broadinstitute.consent.http.models.Consent;
 import org.broadinstitute.consent.http.models.DataSet;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.dto.DataSetDTO;
@@ -103,14 +104,17 @@ public class DatasetResourceTest {
 
     @Test
     public void testCreateDataset() throws Exception {
-        DataSet result = new DataSet();
+        DataSetDTO result = new DataSetDTO();
         DataSetDTO json = new DataSetDTO();
+        Consent consent = new Consent();
         List<DataSetPropertyDTO> jsonProperties = new ArrayList<>();
         jsonProperties.add(new DataSetPropertyDTO("Dataset Name", "test"));
         json.setProperties(jsonProperties);
 
         when(datasetService.getDatasetByName("test")).thenReturn(null);
         when(datasetService.createDataset(any(), any(), anyInt())).thenReturn(result);
+        when(datasetService.createConsentForDataset(any())).thenReturn(consent);
+        when(datasetService.getDatasetDTO(any())).thenReturn(result);
         when(authUser.getGoogleUser()).thenReturn(googleUser);
         when(googleUser.getEmail()).thenReturn("email@email.com");
         when(userService.findUserByEmail(any())).thenReturn(dacUser);


### PR DESCRIPTION
When creating a new dataset through the v2 path, we want to also create a new consent and consent association from scratch for that dataset. This PR takes the previously written code for creating a consent from a dataset and integrates it to the v2 pathway, as well as updating the consent definition for DataUse to include new fields added in consent-ontology (`secondaryOther` and `publicationMoratorium`).

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [x] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
