### PR TITLE
[DUOS-665][risk=no] Prune unused fields from associated consent

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/models/ElectionReview.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/ElectionReview.java
@@ -79,9 +79,6 @@ public class ElectionReview {
         this.associatedConsent = new Document();
         this.associatedConsent.put("electionId", consentElection != null ? consentElection.getElectionId() : null);
         this.associatedConsent.put("consentId", consent.getConsentId());
-        this.associatedConsent.put("useRestriction", consentElection != null ? consentElection.getUseRestriction() : consent.getUseRestriction());
-        this.associatedConsent.put("translatedUseRestriction", consentElection != null ? consentElection.getTranslatedUseRestriction() : consent.getTranslatedUseRestriction());
-        this.associatedConsent.put("dulName", consentElection != null ? consentElection.getDulName() : consent.getDulName());
         this.associatedConsent.put("name", consent.getName());
     }
 }


### PR DESCRIPTION
## Addresses
https://broadinstitute.atlassian.net/browse/DUOS-665
See also: https://github.com/DataBiosphere/duos-ui/pull/723
See also: https://github.com/DataBiosphere/consent/pull/839

## Changes
* Clean up unused properties on election review's associated consent

----

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [ ] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
