### PR TITLE
[DUOS-732][risk=no] Allow Researchers to see DACs

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/resources/DacResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DacResource.java
@@ -3,7 +3,6 @@ package org.broadinstitute.consent.http.resources;
 import com.google.gson.Gson;
 import com.google.inject.Inject;
 import io.dropwizard.auth.Auth;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -41,7 +40,7 @@ public class DacResource extends Resource {
 
     @GET
     @Produces("application/json")
-    @RolesAllowed({ADMIN, MEMBER, CHAIRPERSON})
+    @RolesAllowed({ADMIN, MEMBER, CHAIRPERSON, RESEARCHER})
     public Response findAll(@Auth AuthUser authUser, @QueryParam("withUsers") Optional<Boolean> withUsers) {
         final Boolean includeUsers = withUsers.isPresent() ? withUsers.get() : true;
         List<Dac> dacs = dacService.findDacsByUser(authUser, includeUsers);


### PR DESCRIPTION
## Addresses
https://broadinstitute.atlassian.net/browse/DUOS-732

## Changes
For a researcher to see the DACs associated to datasets, the get dacs endpoint needs to be opened up.

----

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [ ] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
