### PR TITLE
[DUOS-859][risk=no] Use v2 insert for all submitted dars

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/DataAccessRequestDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DataAccessRequestDAO.java
@@ -124,20 +124,6 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
   void deleteByReferenceId(@Bind("referenceId") String referenceId);
 
   /**
-   * Insert DataAccessRequest by reference id and provided DataAccessRequestData
-   * Deprecated. Use `insertVersion2`
-   *
-   * @param referenceId String
-   * @param data DataAccessRequestData
-   */
-  @Deprecated
-  @RegisterArgumentFactory(JsonArgumentFactory.class)
-  @SqlUpdate(
-      "INSERT INTO data_access_request (reference_id, data) VALUES (:referenceId, to_jsonb(:data)) ")
-  void insert(
-      @Bind("referenceId") String referenceId, @Bind("data") @Json DataAccessRequestData data);
-
-  /**
    * Create new DataAccessRequest.
    * This version supercedes `insert`
    *

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
@@ -280,12 +280,6 @@ public class DataAccessRequestService {
         return getDataAccessRequestByReferenceIdAsDocument(referenceId);
     }
 
-    @Deprecated
-    public DataAccessRequest insertDataAccessRequest(String referencedId, DataAccessRequestData darData) {
-        dataAccessRequestDAO.insert(referencedId, darData);
-        return findByReferenceId(referencedId);
-    }
-
     public DataAccessRequest insertDraftDataAccessRequest(User user, DataAccessRequest dar) {
         if (Objects.isNull(user) || Objects.isNull(dar) || Objects.isNull(dar.getReferenceId()) || Objects.isNull(dar.getData())) {
             throw new IllegalArgumentException("User and DataAccessRequest are required");
@@ -442,31 +436,30 @@ public class DataAccessRequestService {
                         newDARList.add(findByReferenceId(dataAccessRequest.getReferenceId()));
                     } else {
                         String referenceId = UUID.randomUUID().toString();
-                        dataAccessRequestDAO.insertVersion2(
-                            referenceId,
-                            user.getDacUserId(),
-                            new Date(darData.getCreateDate()),
-                            new Date(darData.getSortDate()),
-                            now,
-                            now,
-                            darData);
-                        newDARList.add(findByReferenceId(referenceId));
+                        DataAccessRequest createdDar = insertSubmittedDataAccessRequest(user, referenceId, darData);
+                        newDARList.add(createdDar);
                     }
                 } else {
                     String referenceId = UUID.randomUUID().toString();
-                    dataAccessRequestDAO.insertVersion2(
-                        referenceId,
-                        user.getDacUserId(),
-                        new Date(darData.getCreateDate()),
-                        new Date(darData.getSortDate()),
-                        now,
-                        now,
-                        darData);
-                    newDARList.add(findByReferenceId(referenceId));
+                    DataAccessRequest createdDar = insertSubmittedDataAccessRequest(user, referenceId, darData);
+                    newDARList.add(createdDar);
                 }
             }
         }
         return newDARList;
+    }
+
+    public DataAccessRequest insertSubmittedDataAccessRequest(User user, String referencedId, DataAccessRequestData darData) {
+        Date now = new Date();
+        dataAccessRequestDAO.insertVersion2(
+            referencedId,
+            user.getDacUserId(),
+            new Date(darData.getCreateDate()),
+            new Date(darData.getSortDate()),
+            now,
+            now,
+            darData);
+        return findByReferenceId(referencedId);
     }
 
     /**

--- a/src/main/java/org/broadinstitute/consent/http/service/DatabaseDataAccessRequestAPI.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatabaseDataAccessRequestAPI.java
@@ -6,7 +6,6 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
-import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -560,10 +559,12 @@ public class DatabaseDataAccessRequestAPI extends AbstractDataAccessRequestAPI {
             }
             Gson gson = new Gson();
             dataAccessRequestList.forEach(d -> {
+                Integer userId = d.getInteger(DarConstants.USER_ID);
+                User user = userDAO.findUserById(userId);
                 String referenceId = d.getString(DarConstants.REFERENCE_ID);
                 DataAccessRequestData darData = DataAccessRequestData.fromString(gson.toJson(d));
                 darData.setReferenceId(referenceId);
-                dataAccessRequestService.insertDataAccessRequest(referenceId, darData);
+                dataAccessRequestService.insertSubmittedDataAccessRequest(user, referenceId, darData);
             });
         }
     }

--- a/src/main/resources/changelog-master.xml
+++ b/src/main/resources/changelog-master.xml
@@ -58,4 +58,5 @@
     <include file="changesets/changelog-consent-53.0.xml" relativeToChangelogFile="true"/>
     <include file="changesets/changelog-consent-54.0.xml" relativeToChangelogFile="true"/>
     <include file="changesets/changelog-consent-55.0.xml" relativeToChangelogFile="true"/>
+    <include file="changesets/changelog-consent-56.0.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/changesets/changelog-consent-56.0.xml
+++ b/src/main/resources/changesets/changelog-consent-56.0.xml
@@ -1,0 +1,30 @@
+<databaseChangeLog
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet dbms="postgresql" author="grushton" id="56.0">
+        <sql>
+            update data_access_request
+            set user_id = ((data #>> '{}')::jsonb->>'userId')::numeric
+            where user_id is null
+        </sql>
+        <sql>
+            update data_access_request
+            set create_date = to_timestamp(((data #>> '{}')::jsonb->>'createDate')::numeric/1000)
+            where create_date is null
+        </sql>
+        <sql>
+            update data_access_request
+            set sort_date = to_timestamp(((data #>> '{}')::jsonb->>'sortDate')::numeric/1000)
+            where sort_date is null
+        </sql>
+        <sql>
+            update data_access_request
+            set update_date = to_timestamp(((data #>> '{}')::jsonb->>'sortDate')::numeric/1000)
+            where update_date is null
+        </sql>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
@@ -298,24 +298,6 @@ public class DAOTestHelper {
         return cal.getTime();
     }
 
-    protected DataAccessRequest createDataAccessRequest() {
-        DataAccessRequestData data;
-        try {
-            String darDataString = FileUtils.readFileToString(
-                    new File(ResourceHelpers.resourceFilePath("dataset/dar.json")),
-                    Charset.defaultCharset());
-            data = DataAccessRequestData.fromString(darDataString);
-            String referenceId = UUID.randomUUID().toString();
-            dataAccessRequestDAO.insert(referenceId, data);
-            createdDataAccessRequestReferenceIds.add(referenceId);
-            return dataAccessRequestDAO.findByReferenceId(referenceId);
-        } catch (IOException e) {
-            logger.error("Exception parsing dar data: " + e.getMessage());
-            fail("Unable to create a Data Access Request from sample data: " + e.getMessage());
-        }
-        return null;
-    }
-
     protected DataAccessRequest createDataAccessRequestV2() {
         DataAccessRequestData data;
         Date now = new Date();

--- a/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
@@ -21,7 +21,7 @@ public class DataAccessRequestDAOTest extends DAOTestHelper {
         List<DataAccessRequest> dars = dataAccessRequestDAO.findAllDataAccessRequests();
         assertTrue(dars.isEmpty());
 
-        createDataAccessRequest();
+        createDataAccessRequestV2();
         createDraftDataAccessRequest();
         List<DataAccessRequest> newDars = dataAccessRequestDAO.findAllDataAccessRequests();
         assertFalse(newDars.isEmpty());
@@ -33,7 +33,7 @@ public class DataAccessRequestDAOTest extends DAOTestHelper {
         List<DataAccessRequest> dars = dataAccessRequestDAO.findAllDraftDataAccessRequests();
         assertTrue(dars.isEmpty());
 
-        createDataAccessRequest();
+        createDataAccessRequestV2();
         createDraftDataAccessRequest();
         List<DataAccessRequest> newDars = dataAccessRequestDAO.findAllDraftDataAccessRequests();
         assertFalse(newDars.isEmpty());
@@ -68,7 +68,7 @@ public class DataAccessRequestDAOTest extends DAOTestHelper {
 
     @Test
     public void updateNonDraftToDraft() {
-        DataAccessRequest dar = createDataAccessRequest();
+        DataAccessRequest dar = createDataAccessRequestV2();
 
         List<DataAccessRequest> draftDars1 = dataAccessRequestDAO.findAllDraftDataAccessRequests();
         assertTrue(draftDars1.isEmpty());
@@ -81,7 +81,7 @@ public class DataAccessRequestDAOTest extends DAOTestHelper {
 
     @Test
     public void testCreate() {
-        DataAccessRequest dar = createDataAccessRequest();
+        DataAccessRequest dar = createDataAccessRequestV2();
         DataAccessRequest foundDar = dataAccessRequestDAO.findByReferenceId(dar.getReferenceId());
         assertNotNull(foundDar);
         assertNotNull(foundDar.getData());
@@ -89,9 +89,9 @@ public class DataAccessRequestDAOTest extends DAOTestHelper {
 
     @Test
     public void testFindByReferenceIds() {
-        DataAccessRequest dar1 = createDataAccessRequest();
-        DataAccessRequest dar2 = createDataAccessRequest();
-        DataAccessRequest dar3 = createDataAccessRequest();
+        DataAccessRequest dar1 = createDataAccessRequestV2();
+        DataAccessRequest dar2 = createDataAccessRequestV2();
+        DataAccessRequest dar3 = createDataAccessRequestV2();
         List<String> referenceIds = Arrays.asList(dar1.getReferenceId(), dar2.getReferenceId(), dar3.getReferenceId());
 
         List<DataAccessRequest> dars = dataAccessRequestDAO.findByReferenceIds(referenceIds);
@@ -102,7 +102,7 @@ public class DataAccessRequestDAOTest extends DAOTestHelper {
 
     @Test
     public void testUpdateByReferenceId() {
-        DataAccessRequest dar = createDataAccessRequest();
+        DataAccessRequest dar = createDataAccessRequestV2();
         String rus = RandomStringUtils.random(10, true, false);
         dar.getData().setRus(rus);
         dar.getData().setValidRestriction(false);
@@ -127,12 +127,6 @@ public class DataAccessRequestDAOTest extends DAOTestHelper {
     }
 
     @Test
-    public void testInsert() {
-        DataAccessRequest dar = createDataAccessRequest();
-        assertNotNull(dar);
-    }
-
-    @Test
     public void testInsertVersion2() {
         DataAccessRequest dar = createDataAccessRequestV2();
         assertNotNull(dar);
@@ -140,7 +134,7 @@ public class DataAccessRequestDAOTest extends DAOTestHelper {
 
     @Test
     public void testEscapedCharacters() {
-        DataAccessRequest dar = createDataAccessRequest();
+        DataAccessRequest dar = createDataAccessRequestV2();
         DataAccessRequest foundDar = dataAccessRequestDAO.findByReferenceId(dar.getReferenceId());
         assertNotNull(foundDar);
         assertNotNull(foundDar.getData());

--- a/src/test/java/org/broadinstitute/consent/http/db/MetricsDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/MetricsDAOTest.java
@@ -23,7 +23,7 @@ public class MetricsDAOTest extends DAOTestHelper {
     List<DataAccessRequest> dars = metricsDAO.findAllDars();
     assertTrue(dars.isEmpty());
 
-    createDataAccessRequest();
+    createDataAccessRequestV2();
     createDraftDataAccessRequest();
     List<DataAccessRequest> newDars = metricsDAO.findAllDars();
     assertFalse(newDars.isEmpty());
@@ -35,7 +35,7 @@ public class MetricsDAOTest extends DAOTestHelper {
     Dac dac = createDac();
     Consent consent = createConsent(dac.getDacId());
     DataSet dataset = createDataset();
-    DataAccessRequest dar = createDataAccessRequest();
+    DataAccessRequest dar = createDataAccessRequestV2();
     dar.getData().setDatasetIds(Collections.singletonList(dataset.getDataSetId()));
     dataAccessRequestDAO.updateDataByReferenceId(dar.getReferenceId(), dar.getData());
     createAssociation(consent.getConsentId(), dataset.getDataSetId());
@@ -53,7 +53,7 @@ public class MetricsDAOTest extends DAOTestHelper {
   public void testFindMatchesForReferenceIds() {
     Dac dac = createDac();
     Consent consent = createConsent(dac.getDacId());
-    DataAccessRequest dar = createDataAccessRequest();
+    DataAccessRequest dar = createDataAccessRequestV2();
     Match m = new Match();
     m.setConsent(consent.getConsentId());
     m.setPurpose(dar.getReferenceId());
@@ -73,7 +73,7 @@ public class MetricsDAOTest extends DAOTestHelper {
     Dac dac = createDac();
     Consent consent = createConsent(dac.getDacId());
     DataSet dataset = createDataset();
-    DataAccessRequest dar = createDataAccessRequest();
+    DataAccessRequest dar = createDataAccessRequestV2();
     dar.getData().setDatasetIds(Collections.singletonList(dataset.getDataSetId()));
     dataAccessRequestDAO.updateDataByReferenceId(dar.getReferenceId(), dar.getData());
     createAssociation(consent.getConsentId(), dataset.getDataSetId());


### PR DESCRIPTION
## Addresses
https://broadinstitute.atlassian.net/browse/DUOS-859

## Changes
* Use the v2 insert for the old v1 endpoint so it saves the same way as the new endpoint
* Some minor refactoring to make that easier
* Update tests to use the v2 insert
* Remove unused code

----

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [ ] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
