### PR TITLE
[DUOS-863][risk=no] Set dac id and needs approval during create dataset v2

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/resources/DataSetResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataSetResource.java
@@ -120,6 +120,7 @@ public class DataSetResource extends Resource {
         try {
             createdDataset = datasetService.createDataset(inputDataset, name, userId);
             createdDataset.setDataUse(inputDataset.getDataUse());
+            createdDataset.setDacId(inputDataset.getDacId());
             createdConsent = datasetService.createConsentForDataset(createdDataset);
             createdDatasetWithConsent = datasetService.getDatasetDTO(createdDataset.getDataSetId());
             URI uri = info.getRequestUriBuilder().replacePath("api/dataset/{datasetId}").build(createdDatasetWithConsent.getDataSetId());

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -103,7 +103,7 @@ public class DatasetService {
 
         List<DataSetProperty> propertyList = processDatasetProperties(id, dataset.getProperties());
         dataSetDAO.insertDataSetsProperties(propertyList);
-
+        dataSetDAO.updateDataSetNeedsApproval(id, dataset.getNeedsApproval());
         return getDatasetDTO(id);
     }
 

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -4080,6 +4080,9 @@ components:
           type: integer
           format: int32
           description: The dataset id, integer format
+        dacId:
+          type: string
+          description: The id of the DAC this dataset belongs to, if defined.
         consentId:
           type: string
           description: The consent id.


### PR DESCRIPTION
Addresses: https://broadinstitute.atlassian.net/browse/DUOS-863

Small fix to actually use any remaining fields left unaccounted for on the dataset registration form on the backend (dac id, needsApproval).

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [ ] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
