### PR TITLE
[DUOS-875][risk=low] Back-populate DAR submission dates

### DIFF
--- a/src/main/resources/changelog-master.xml
+++ b/src/main/resources/changelog-master.xml
@@ -59,4 +59,5 @@
     <include file="changesets/changelog-consent-54.0.xml" relativeToChangelogFile="true"/>
     <include file="changesets/changelog-consent-55.0.xml" relativeToChangelogFile="true"/>
     <include file="changesets/changelog-consent-56.0.xml" relativeToChangelogFile="true"/>
+    <include file="changesets/changelog-consent-57.0.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/changesets/changelog-consent-57.0.xml
+++ b/src/main/resources/changesets/changelog-consent-57.0.xml
@@ -1,0 +1,16 @@
+<databaseChangeLog
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet dbms="postgresql" author="grushton" id="57.0">
+        <!-- Back populate the submission date for all submitted DARs -->
+        <sql>
+            update data_access_request
+            set submission_date = update_date
+            where draft = false and submission_date is null
+        </sql>
+    </changeSet>
+
+</databaseChangeLog>


### PR DESCRIPTION
## Addresses
https://broadinstitute.atlassian.net/browse/DUOS-875

## Changes
* Back populate missing submission dates for all submitted DARs

----

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [ ] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
