### PR TITLE
[DUOS-872][risk=no] Ontology Term Definitions are Nullable

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequestData.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequestData.java
@@ -853,7 +853,6 @@ public class DataAccessRequestData {
                     .filter(Objects::nonNull)
                     .filter(e -> Objects.nonNull(e.getId()))
                     .filter(e -> Objects.nonNull(e.getLabel()))
-                    .filter(e -> Objects.nonNull(e.getDefinition()))
                     .collect(Collectors.toList());
             if (filteredEntries.isEmpty()) {
                 data.setOntologies(Collections.emptyList());

--- a/src/main/java/org/broadinstitute/consent/http/service/TranslateServiceImpl.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/TranslateServiceImpl.java
@@ -31,7 +31,6 @@ public class TranslateServiceImpl extends AbstractTranslateService {
                 .stream()
                 .filter(Objects::nonNull)
                 .filter(e -> Objects.nonNull(e.getId()))
-                .filter(e -> Objects.nonNull(e.getDefinition()))
                 .filter(e -> Objects.nonNull(e.getLabel()))
                 .collect(Collectors.toList()) :
             Collections.emptyList();


### PR DESCRIPTION
## Addresses
Consent side of https://broadinstitute.atlassian.net/browse/DUOS-872

## Changes
Ontology terms can have null definitions, so we can't filter on non-null values.

----

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [ ] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
