### PR TITLE
[DUOS-870][risk=low] Handle DAR election NPE bugs

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/VoteDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/VoteDAO.java
@@ -45,6 +45,9 @@ public interface VoteDAO extends Transactional<VoteDAO> {
     @SqlQuery("select * from vote v where v.electionId IN (<electionIds>) and lower(v.type) = lower(:voteType)")
     List<Vote> findVotesByTypeAndElectionIds(@BindList("electionIds") List<Integer> electionIds, @Bind("voteType") String type);
 
+    @SqlQuery("SELECT * FROM vote v WHERE v.electionid = :electionId")
+    List<Vote> findVotesByElectionId(@Bind("electionId") Integer electionId);
+
     @SqlQuery("select * from vote v where v.electionId = :electionId and lower(v.type) = lower(:type)")
     List<Vote> findVotesByElectionIdAndType(@Bind("electionId") Integer electionId, @Bind("type") String type);
 

--- a/src/main/java/org/broadinstitute/consent/http/resources/DataRequestElectionResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataRequestElectionResource.java
@@ -60,7 +60,7 @@ public class DataRequestElectionResource extends Resource {
     public Response createDataRequestElection(@Context UriInfo info, Election rec,
                                               @PathParam("requestId") String requestId) {
         URI uri;
-        Election accessElection;
+        Election accessElection = null;
         try {
             accessElection = api.createElection(rec, requestId, ElectionType.DATA_ACCESS);
             List<Vote> votes;
@@ -78,6 +78,13 @@ public class DataRequestElectionResource extends Resource {
             emailNotifierService.sendNewCaseMessageToList(darVotes, accessElection);
             uri = info.getRequestUriBuilder().build();
         } catch (Exception e) {
+            try {
+                if (Objects.nonNull(accessElection)) {
+                    api.deleteElection(requestId, accessElection.getElectionId());
+                }
+            } catch (Exception e2) {
+                logger().warn("Error deleting created access election: ", e2);
+            }
             return createExceptionResponse(e);
         }
         return Response.created(uri).entity(accessElection).build();

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
@@ -258,26 +258,11 @@ public class DataAccessRequestService {
         return dataAccessRequestDAO.findByReferenceId(referencedId);
     }
 
+    @Deprecated // Use updateByReferenceIdVersion2
     public DataAccessRequest updateByReferenceId(String referencedId, DataAccessRequestData darData) {
         darData.setSortDate(new Date().getTime());
         dataAccessRequestDAO.updateDataByReferenceId(referencedId, darData);
         return findByReferenceId(referencedId);
-    }
-
-    /**
-     * TODO: Cleanup with https://broadinstitute.atlassian.net/browse/DUOS-604
-     *
-     * Convenience method during transition away from `Document` and to `DataAccessRequest`
-     */
-    public Document updateDocumentByReferenceId(String referenceId, Document document) {
-        if (findByReferenceId(referenceId) == null) {
-            throw new NotFoundException("Data access for the specified id does not exist");
-        }
-        document.put(DarConstants.REFERENCE_ID, referenceId);
-        String documentJson = gson.toJson(document);
-        DataAccessRequestData darData = DataAccessRequestData.fromString(documentJson);
-        updateByReferenceId(referenceId, darData);
-        return getDataAccessRequestByReferenceIdAsDocument(referenceId);
     }
 
     public DataAccessRequest insertDraftDataAccessRequest(User user, DataAccessRequest dar) {


### PR DESCRIPTION
## Addresses
https://broadinstitute.atlassian.net/browse/DUOS-870

## Changes
* Fixed the primary bug in `updateSortDate` where it would fail to set the DAR fields properly and throw NFEs that would then be misinterpreted by the Respource class
* Add some error handling and cleanup in the resource in case of create election failure
* When creating a DAR election, do not fail when there is no consent election backing the DAR's dataset. This is essentially a new feature we need for when DACs upload their own datasets w/o consent elections
* Minor `Document` -> `DataAccessRequest` refactoring in some of the private create election methods
* More pruning of unused code due to ☝🏽 
* Added deletion of votes to the delete election endpoint so we don't end up with FK constraint violations/dangling votes

----

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [ ] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
