### PR TITLE
[DUOS-302][risk=no] Remove unused dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -599,13 +599,6 @@
       <version>5.5.3</version>
     </dependency>
 
-    <!-- Required for asynchronous elastic search rest queries -->
-    <dependency>
-      <groupId>com.twitter</groupId>
-      <artifactId>util-core_2.11</artifactId>
-      <version>20.10.0</version>
-    </dependency>
-
     <!-- Required for mocking ontology and elastic search responses -->
     <dependency>
       <groupId>org.mock-server</groupId>


### PR DESCRIPTION
## Addresses
Maintenance task as part of https://broadinstitute.atlassian.net/browse/DUOS-302
Dependency is unused. See also: https://github.com/DataBiosphere/consent/pull/859

----

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [ ] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
