### PR TITLE
[DUOS-891][risk=no] Any user role can see all dacs

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/resources/DacResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DacResource.java
@@ -43,7 +43,7 @@ public class DacResource extends Resource {
     @RolesAllowed({ADMIN, MEMBER, CHAIRPERSON, RESEARCHER})
     public Response findAll(@Auth AuthUser authUser, @QueryParam("withUsers") Optional<Boolean> withUsers) {
         final Boolean includeUsers = withUsers.isPresent() ? withUsers.get() : true;
-        List<Dac> dacs = dacService.findDacsByUser(authUser, includeUsers);
+        List<Dac> dacs = dacService.findDacsWithMembersOption(includeUsers);
         return Response.ok().entity(dacs).build();
     }
 

--- a/src/main/java/org/broadinstitute/consent/http/service/DacService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DacService.java
@@ -125,8 +125,8 @@ public class DacService {
         return dacToUserMap;
     }
 
-    public List<Dac> findDacsByUser(AuthUser authUser, Boolean withMembers) {
-        List<Dac> dacs = isAuthUserAdmin(authUser) ? dacDAO.findAll() : dacDAO.findDacsForEmail(authUser.getName());
+    public List<Dac> findDacsWithMembersOption(Boolean withMembers) {
+        List<Dac> dacs = dacDAO.findAll();
         if (withMembers) {
             return addMemberInfoToDacs(dacs);
         }

--- a/src/test/java/org/broadinstitute/consent/http/resources/DacResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DacResourceTest.java
@@ -41,7 +41,7 @@ public class DacResourceTest {
 
     @Test
     public void testFindAll_success_1() {
-        when(dacService.findDacsByUser(authUser, true)).thenReturn(Collections.emptyList());
+        when(dacService.findDacsWithMembersOption(true)).thenReturn(Collections.emptyList());
 
         Response response = dacResource.findAll(authUser, Optional.of(true));
         Assert.assertEquals(200, response.getStatus());
@@ -55,7 +55,7 @@ public class DacResourceTest {
                 .setName("name")
                 .setDescription("description")
                 .build();
-        when(dacService.findDacsByUser(authUser, true)).thenReturn(Collections.singletonList(dac));
+        when(dacService.findDacsWithMembersOption(true)).thenReturn(Collections.singletonList(dac));
 
         Response response = dacResource.findAll(authUser, Optional.of(true));
         Assert.assertEquals(200, response.getStatus());
@@ -65,7 +65,7 @@ public class DacResourceTest {
 
     @Test
     public void testFindAllWithUsers() {
-        when(dacService.findDacsByUser(authUser, false)).thenReturn(Collections.emptyList());
+        when(dacService.findDacsWithMembersOption(false)).thenReturn(Collections.emptyList());
 
         Response response = dacResource.findAll(authUser, Optional.of(false));
         Assert.assertEquals(200, response.getStatus());

--- a/src/test/java/org/broadinstitute/consent/http/service/DacServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DacServiceTest.java
@@ -719,7 +719,7 @@ public class DacServiceTest {
         when(userDAO.findUserByEmailAndRoleId(anyString(), anyInt())).thenReturn(getDacUsers().get(0));
         initService();
 
-        List<Dac> dacsForUser = service.findDacsByUser(getUser(), false);
+        List<Dac> dacsForUser = service.findDacsWithMembersOption(false);
         Assert.assertEquals(dacsForUser.size(), dacs.size());
     }
 
@@ -732,7 +732,7 @@ public class DacServiceTest {
         when(userDAO.findUserByEmailAndRoleId(anyString(), anyInt())).thenReturn(getChair());
         initService();
 
-        List<Dac> dacsForUser = service.findDacsByUser(getUser(), false);
+        List<Dac> dacsForUser = service.findDacsWithMembersOption(false);
         Assert.assertEquals(dacsForUser.size(), dacs.size());
     }
 


### PR DESCRIPTION
## Addresses
https://broadinstitute.atlassian.net/browse/DUOS-891

## Changes
* Stop filtering DACs on user role. Anyone should be able to see all DACs so they can see who owns which dataset.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [ ] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
