### PR TITLE
[DUOS-895][risk=no] Add 'X-Content-Type-Options' header to outbound responses

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
@@ -54,6 +54,7 @@ import org.broadinstitute.consent.http.db.ResearcherPropertyDAO;
 import org.broadinstitute.consent.http.db.UserDAO;
 import org.broadinstitute.consent.http.db.UserRoleDAO;
 import org.broadinstitute.consent.http.db.VoteDAO;
+import org.broadinstitute.consent.http.filters.ResponseServerFilter;
 import org.broadinstitute.consent.http.models.AuthUser;
 import org.broadinstitute.consent.http.resources.ApprovalExpirationTimeResource;
 import org.broadinstitute.consent.http.resources.ConsentAssociationResource;
@@ -273,6 +274,7 @@ public class ConsentApplication extends Application<ConsentConfiguration> {
         final ErrorPageErrorHandler errorHandler = new ErrorPageErrorHandler();
         errorHandler.addErrorPage(404, "/error/404");
         env.getApplicationContext().setErrorHandler(errorHandler);
+        env.jersey().register(ResponseServerFilter.class);
         env.jersey().register(ErrorResource.class);
 
         // Register standard application resources.

--- a/src/main/java/org/broadinstitute/consent/http/filters/ResponseServerFilter.java
+++ b/src/main/java/org/broadinstitute/consent/http/filters/ResponseServerFilter.java
@@ -13,6 +13,7 @@ public class ResponseServerFilter implements ContainerResponseFilter {
   public void filter(
       ContainerRequestContext requestContext,
       ContainerResponseContext responseContext) throws IOException {
+    // When the no-sniff header is on the swagger-ui files, it breaks the overall UI
     if (!requestContext.getUriInfo().getPath().contains("swagger-ui")) {
       responseContext.getHeaders().add("X-Content-Type-Options", "nosniff");
     }

--- a/src/main/java/org/broadinstitute/consent/http/filters/ResponseServerFilter.java
+++ b/src/main/java/org/broadinstitute/consent/http/filters/ResponseServerFilter.java
@@ -1,0 +1,20 @@
+package org.broadinstitute.consent.http.filters;
+
+import java.io.IOException;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.ext.Provider;
+
+@Provider
+public class ResponseServerFilter implements ContainerResponseFilter {
+
+  @Override
+  public void filter(
+      ContainerRequestContext requestContext,
+      ContainerResponseContext responseContext) throws IOException {
+    if (!requestContext.getUriInfo().getPath().contains("swagger-ui")) {
+      responseContext.getHeaders().add("X-Content-Type-Options", "nosniff");
+    }
+  }
+}


### PR DESCRIPTION
## Addresses
Consent component to https://broadinstitute.atlassian.net/browse/DUOS-895

This adds a standard header to all outgoing requests, except for the Swagger UI code. Without that exception, the Swagger UI breaks.
See also: https://github.com/DataBiosphere/consent-ontology/pull/360

---- 

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [ ] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
