### PR TITLE
[DUOS-910][risk=no] Use auth user to retrieve datasets

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/resources/DataSetResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataSetResource.java
@@ -226,13 +226,10 @@ public class DataSetResource extends Resource {
     @GET
     @Produces("application/json")
     @PermitAll
-    public Response describeDataSets(@Context HttpServletRequest request, @QueryParam("dacUserId") Integer dacUserId){
-        if (StringUtils.isEmpty(request.getParameter("dacUserId"))) {
-            return Response.status(Response.Status.NOT_FOUND).build();
-        } else {
-            Collection<DataSetDTO> dataSetList = datasetService.describeDatasets(dacUserId);
-            return Response.ok(dataSetList, MediaType.APPLICATION_JSON).build();
-        }
+    public Response describeDataSets(@Auth AuthUser authUser) {
+        User user = userService.findUserByEmail(authUser.getName());
+        Collection<DataSetDTO> dataSetList = datasetService.describeDatasets(user.getDacUserId());
+        return Response.ok(dataSetList, MediaType.APPLICATION_JSON).build();
     }
 
     @GET

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -2433,28 +2433,19 @@ paths:
           description: Could not find a vote with this id.
   /api/dataset:
     get:
-      summary: describeDatasets
-      description: Returns Dataset list filtering by Role.
-      parameters:
-        - name: dacUserId
-          in: query
-          description: UserId used to retrieve the user's roles
-          required: true
-          schema:
-            type: integer
+      summary: Get Datasets
+      description: Returns Dataset list filtered by authenticated user.
       tags:
         - Datasets
       responses:
         200:
-          description: An array of Datasets
+          description: A list of Datasets
           content:
             application/json:
               schema:
                 type: array
                 items:
                   $ref: '#/components/schemas/Dataset'
-        404:
-          description: Required parameter is null.
     post:
       summary: createDataSet
       description: Creates the Datasets defined in the input .TSV /.txt file.

--- a/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
@@ -18,7 +18,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -88,9 +87,6 @@ public class DatasetResourceTest {
 
     @Mock
     private UriBuilder uriBuilder;
-
-    @Mock
-    private HttpServletRequest httpServletRequest;
 
     private DataSetResource resource;
 
@@ -284,18 +280,12 @@ public class DatasetResourceTest {
 
     @Test
     public void testDescribeDatasetsSuccess() {
-        when(httpServletRequest.getParameter("dacUserId")).thenReturn("0");
+        when(authUser.getName()).thenReturn("authUserEmail");
+        when(userService.findUserByEmail(any())).thenReturn(dacUser);
         when(datasetService.describeDatasets(anyInt())).thenReturn(Collections.emptySet());
         initResource();
-        Response response = resource.describeDataSets(httpServletRequest, 0);
+        Response response = resource.describeDataSets(authUser);
         assertEquals(200, response.getStatus());
-    }
-
-    @Test
-    public void testDescribeDatasetsNotFound() {
-        initResource();
-        Response response = resource.describeDataSets(httpServletRequest, 0);
-        assertEquals(404, response.getStatus());
     }
 
     private MultiPart createFormData(File file) {


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-910

Removes security hole where a user can query datasets under a different user's id
Requires: https://github.com/DataBiosphere/duos-ui/pull/783

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [ ] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
