### PR TITLE
[DUOS-865][risk=low] Find Dataset By Name

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/DataSetDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DataSetDAO.java
@@ -196,7 +196,7 @@ public interface DataSetDAO extends Transactional<DataSetDAO> {
     @SqlQuery("SELECT dataSetId FROM dataset WHERE name = :name")
     Integer getDatasetIdByName(@Bind("name") String name);
 
-    @SqlQuery("SELECT * FROM dataset WHERE name = :name")
+    @SqlQuery("SELECT * FROM dataset WHERE name LIKE LOWER(:name)")
     DataSet getDatasetByName(@Bind("name") String name);
 
     @SqlQuery("select *  from dataset where name in (<names>) ")

--- a/src/main/java/org/broadinstitute/consent/http/resources/DataSetResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataSetResource.java
@@ -248,6 +248,19 @@ public class DataSetResource extends Resource {
         }
     }
 
+    @GET
+    @Consumes("application/json")
+    @Produces("application/json")
+    @Path("/validate")
+    @PermitAll
+    public Response validateDatasetName(@QueryParam("name") String name) {
+        try {
+            DataSet datasetWithName = datasetService.getDatasetByName(name);
+            return Response.ok().entity(datasetWithName.getDataSetId()).build();
+        } catch (Exception e) {
+            throw new NotFoundException("Could not find the dataset with name: " + name);
+        }
+    }
 
     @GET
     @Path("/sample")

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -126,7 +126,8 @@ public class DatasetService {
     }
 
     public DataSet getDatasetByName(String name) {
-        return dataSetDAO.getDatasetByName(name);
+        String lowercaseName = name.toLowerCase();
+        return dataSetDAO.getDatasetByName(lowercaseName);
     }
 
     public DataSet findDatasetById(Integer id) {

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -2519,6 +2519,28 @@ paths:
           description: Dataset Name given is already in use by another dataset
         500:
           description: Internal Error (something went wrong processing a valid input)
+  /api/dataset/validate:
+    get:
+      summary: validateDatasetName
+      description: Returns the dataset id if one exists for the given name (ignores case).
+      parameters:
+        - name: name
+          in: query
+          description: The name of the dataset to search for.
+          required: true
+          schema:
+            type: string
+      tags:
+        - Datasets
+      responses:
+        200:
+          description: dataset id
+          content:
+            application/json:
+              schema:
+                type: integer
+        404:
+          description: Dataset not found
   /api/dataset/sample:
     get:
       summary: getDataSetSample

--- a/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.Optional;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.BadRequestException;
+import javax.ws.rs.NotFoundException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriBuilder;
@@ -308,7 +309,7 @@ public class DatasetResourceTest {
         assertEquals(200, response.getStatus());
     }
 
-    @Test
+    @Test(expected = NotFoundException.class)
     public void testValidateDatasetNameNotFound() {
         initResource();
         Response response = resource.validateDatasetName("test");

--- a/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
@@ -298,6 +298,23 @@ public class DatasetResourceTest {
         assertEquals(404, response.getStatus());
     }
 
+    @Test
+    public void testValidateDatasetNameSuccess() {
+        DataSet testDataset = new DataSet();
+        testDataset.setDataSetId(1);
+        when(datasetService.getDatasetByName("test")).thenReturn(testDataset);
+        initResource();
+        Response response = resource.validateDatasetName("test");
+        assertEquals(200, response.getStatus());
+    }
+
+    @Test
+    public void testValidateDatasetNameNotFound() {
+        initResource();
+        Response response = resource.validateDatasetName("test");
+        assertEquals(404, response.getStatus());
+    }
+
     private MultiPart createFormData(File file) {
         MultiPart multiPart = new MultiPart();
         multiPart.setMediaType(MediaType.MULTIPART_FORM_DATA_TYPE);

--- a/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
@@ -86,7 +86,7 @@ public class DatasetServiceTest {
 
     @Test
     public void testGetDatasetByName() {
-        when(datasetDAO.getDatasetByName(getDatasets().get(0).getName()))
+        when(datasetDAO.getDatasetByName(getDatasets().get(0).getName().toLowerCase()))
             .thenReturn(getDatasets().get(0));
         initService();
 


### PR DESCRIPTION
Addresses: https://broadworkbench.atlassian.net/browse/DUOS-865

Adds a new API endpoint to check if a dataset already exists or not by a query string matched to its name at `/api/dataset/validate`. If the dataset exists, return its dataset id. If a dataset does not exist for the given string, return a 404. Also modifies the `getDatasetByName` method to ignore case.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [x] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
