### PR TITLE
[DUOS-894][risk=no] Minor java 11 fixes

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -7,6 +7,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 11 # The JDK version to make available on the path.
       - name: Install
         run: |
           sudo apt update

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -10,6 +10,12 @@ jobs:
       - uses: actions/setup-java@v1
         with:
           java-version: 11
+      - uses: actions/cache@v1
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
       - name: Test Report
         env:
           COVERALLS_TOKEN: ${{ secrets.COVERALLS_TOKEN }}

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -9,7 +9,7 @@ jobs:
         uses: actions/checkout@v2
       - uses: actions/setup-java@v1
         with:
-          java-version: 11 # The JDK version to make available on the path.
+          java-version: 11
       - name: Install
         run: |
           sudo apt update

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -16,4 +16,5 @@ jobs:
           COVERALLS_TOKEN: ${{ secrets.COVERALLS_TOKEN }}
           MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
         run: |
+          mvn -v
           mvn clean jacoco:prepare-agent test jacoco:report coveralls:report -DrepoToken=$COVERALLS_TOKEN

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -10,10 +10,6 @@ jobs:
       - uses: actions/setup-java@v1
         with:
           java-version: 11
-      - name: Install
-        run: |
-          sudo apt update
-          sudo apt install maven
       - name: Test Report
         env:
           COVERALLS_TOKEN: ${{ secrets.COVERALLS_TOKEN }}

--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -10,10 +10,6 @@ jobs:
       - uses: actions/setup-java@v1
         with:
           java-version: 11
-      - name: Install
-        run: |
-          sudo apt update
-          sudo apt install maven
       - name: Package
         env:
           MAVEN_OPTS: -Dmaven.test.skip=true -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120

--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -10,6 +10,12 @@ jobs:
       - uses: actions/setup-java@v1
         with:
           java-version: 11
+      - uses: actions/cache@v1
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
       - name: Package
         env:
           MAVEN_OPTS: -Dmaven.test.skip=true -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120

--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -7,6 +7,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 11 # The JDK version to make available on the path.
       - name: Install
         run: |
           sudo apt update

--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -15,4 +15,5 @@ jobs:
         env:
           MAVEN_OPTS: -Dmaven.test.skip=true -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
         run: |
+          mvn -v
           mvn clean package

--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -9,7 +9,7 @@ jobs:
         uses: actions/checkout@v2
       - uses: actions/setup-java@v1
         with:
-          java-version: 11 # The JDK version to make available on the path.
+          java-version: 11
       - name: Install
         run: |
           sudo apt update

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -14,6 +14,7 @@ jobs:
         run: |
           sudo apt update
           sudo apt install maven
+          mvn -v
           mvn package -Dmaven.test.skip=true
 
       - name: Build an image from Dockerfile

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -14,11 +14,9 @@ jobs:
         run: |
           mvn -v
           mvn package -Dmaven.test.skip=true
-
       - name: Build an image from Dockerfile
         run: |
           docker build -t docker.io/broadinstitute/consent:${{ github.sha }} .
-
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
         with:

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -7,7 +7,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 11
       - name: Maven build
         run: |
           sudo apt update

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -3,7 +3,7 @@ on: [pull_request]
 jobs:
   build:
     name: Scan for Vulnerabilities
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -12,8 +12,6 @@ jobs:
           java-version: 11
       - name: Maven build
         run: |
-          sudo apt update
-          sudo apt install maven
           mvn -v
           mvn package -Dmaven.test.skip=true
 

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -10,6 +10,12 @@ jobs:
       - uses: actions/setup-java@v1
         with:
           java-version: 11
+      - uses: actions/cache@v1
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
       - name: Maven build
         run: |
           mvn -v

--- a/pom.xml
+++ b/pom.xml
@@ -123,6 +123,14 @@
         <groupId>org.eluder.coveralls</groupId>
         <artifactId>coveralls-maven-plugin</artifactId>
         <version>4.3.0</version>
+        <!-- java 11 requirement for coveralls support-->
+        <dependencies>
+          <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.1</version>
+          </dependency>
+        </dependencies>
       </plugin>
 
       <plugin>
@@ -737,13 +745,6 @@
       <groupId>cglib</groupId>
       <artifactId>cglib-nodep</artifactId>
       <version>3.3.0</version>
-    </dependency>
-
-    <!-- java 11 requirement for coveralls support-->
-    <dependency>
-      <groupId>javax.xml.bind</groupId>
-      <artifactId>jaxb-api</artifactId>
-      <version>2.3.1</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -144,8 +144,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.8.1</version>
         <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
+          <release>11</release>
         </configuration>
       </plugin>
 
@@ -155,7 +154,8 @@
         <version>2.22.2</version>
         <configuration>
           <!-- @{argLine} is necessary here so that that the jacoco:prepare-agent output is included for tests -->
-          <argLine>@{argLine} -Xmx1024m -Xverify:none -XX:TieredStopAtLevel=1</argLine>
+          <!-- illegal-access=permit required for java 11 -->
+          <argLine>@{argLine} -Xmx1024m -Xverify:none -XX:TieredStopAtLevel=1 --illegal-access=permit</argLine>
         </configuration>
       </plugin>
 
@@ -554,7 +554,6 @@
       <groupId>com.google.inject</groupId>
       <artifactId>guice</artifactId>
       <version>4.2.3</version>
-      <classifier>no_aop</classifier>
     </dependency>
 
     <dependency>
@@ -726,10 +725,18 @@
       <version>${swagger.ui.version}</version>
     </dependency>
 
+    <!-- java 11 requirement -->
     <dependency>
       <groupId>org.javassist</groupId>
       <artifactId>javassist</artifactId>
       <version>3.27.0-GA</version>
+    </dependency>
+
+    <!-- java 11 requirement -->
+    <dependency>
+      <groupId>cglib</groupId>
+      <artifactId>cglib-nodep</artifactId>
+      <version>3.3.0</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -739,6 +739,13 @@
       <version>3.3.0</version>
     </dependency>
 
+    <!-- java 11 requirement for coveralls support-->
+    <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+      <version>2.3.1</version>
+    </dependency>
+
     <dependency>
       <groupId>org.apache.pdfbox</groupId>
       <artifactId>pdfbox</artifactId>

--- a/src/test/java/org/broadinstitute/consent/http/resources/ConsentAssociationResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/ConsentAssociationResourceTest.java
@@ -23,11 +23,13 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 @SuppressWarnings("deprecation")
 @RunWith(PowerMockRunner.class)
+@PowerMockIgnore("jdk.internal.reflect.*")
 @PrepareForTest({
         AbstractConsentAPI.class,
         AbstractDACUserAPI.class

--- a/src/test/java/org/broadinstitute/consent/http/resources/ConsentCasesResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/ConsentCasesResourceTest.java
@@ -13,6 +13,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -28,6 +29,7 @@ import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.when;
 
 @RunWith(PowerMockRunner.class)
+@PowerMockIgnore("jdk.internal.reflect.*")
 @PrepareForTest({AbstractSummaryAPI.class})
 public class ConsentCasesResourceTest {
 

--- a/src/test/java/org/broadinstitute/consent/http/resources/ConsentElectionResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/ConsentElectionResourceTest.java
@@ -1,5 +1,24 @@
 package org.broadinstitute.consent.http.resources;
 
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyList;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+
+import java.net.URI;
+import java.sql.Timestamp;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriBuilder;
+import javax.ws.rs.core.UriInfo;
 import org.apache.commons.lang3.RandomUtils;
 import org.broadinstitute.consent.http.enumeration.ElectionStatus;
 import org.broadinstitute.consent.http.enumeration.ElectionType;
@@ -27,34 +46,14 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
-import javax.ws.rs.NotFoundException;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.UriBuilder;
-import javax.ws.rs.core.UriInfo;
-import java.net.URI;
-import java.sql.Timestamp;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.List;
-import java.util.UUID;
-
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyBoolean;
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.anyList;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.when;
-
 @SuppressWarnings("deprecation")
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({
-        AbstractElectionAPI.class,
-        AbstractVoteAPI.class})
+@PowerMockIgnore("jdk.internal.reflect.*")
+@PrepareForTest({AbstractElectionAPI.class, AbstractVoteAPI.class})
 public class ConsentElectionResourceTest {
 
     @Mock

--- a/src/test/java/org/broadinstitute/consent/http/resources/ConsentResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/ConsentResourceTest.java
@@ -24,6 +24,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -41,6 +42,7 @@ import static org.mockito.Mockito.when;
 
 @SuppressWarnings("deprecation")
 @RunWith(PowerMockRunner.class)
+@PowerMockIgnore("jdk.internal.reflect.*")
 @PrepareForTest({
         AbstractConsentAPI.class,
         AbstractDACUserAPI.class,

--- a/src/test/java/org/broadinstitute/consent/http/resources/ConsentVoteResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/ConsentVoteResourceTest.java
@@ -15,6 +15,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -28,6 +29,7 @@ import static org.mockito.Mockito.when;
 
 @SuppressWarnings("deprecation")
 @RunWith(PowerMockRunner.class)
+@PowerMockIgnore("jdk.internal.reflect.*")
 @PrepareForTest({
         AbstractVoteAPI.class,
         AbstractElectionAPI.class

--- a/src/test/java/org/broadinstitute/consent/http/resources/DACUserResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DACUserResourceTest.java
@@ -23,6 +23,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -43,6 +44,7 @@ import static org.mockito.Mockito.when;
 
 
 @RunWith(PowerMockRunner.class)
+@PowerMockIgnore("jdk.internal.reflect.*")
 @PrepareForTest({AbstractDACUserAPI.class})
 public class DACUserResourceTest {
 

--- a/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceTest.java
@@ -41,10 +41,12 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 @RunWith(PowerMockRunner.class)
+@PowerMockIgnore("jdk.internal.reflect.*")
 @PrepareForTest({
         AbstractDataAccessRequestAPI.class,
         AbstractConsentAPI.class,

--- a/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceVersion2Test.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceVersion2Test.java
@@ -43,10 +43,12 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 @RunWith(PowerMockRunner.class)
+@PowerMockIgnore("jdk.internal.reflect.*")
 @PrepareForTest({AbstractMatchProcessAPI.class})
 public class DataAccessRequestResourceVersion2Test {
 

--- a/src/test/java/org/broadinstitute/consent/http/resources/DataRequestCasesResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DataRequestCasesResourceTest.java
@@ -12,6 +12,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -26,6 +27,7 @@ import static org.mockito.Matchers.anyObject;
 import static org.mockito.Mockito.when;
 
 @RunWith(PowerMockRunner.class)
+@PowerMockIgnore("jdk.internal.reflect.*")
 @PrepareForTest({AbstractSummaryAPI.class})
 public class DataRequestCasesResourceTest {
 

--- a/src/test/java/org/broadinstitute/consent/http/resources/DataRequestElectionResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DataRequestElectionResourceTest.java
@@ -20,6 +20,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -44,6 +45,7 @@ import static org.mockito.Mockito.when;
 
 @SuppressWarnings("deprecation")
 @RunWith(PowerMockRunner.class)
+@PowerMockIgnore("jdk.internal.reflect.*")
 @PrepareForTest({
         AbstractElectionAPI.class,
         AbstractVoteAPI.class,

--- a/src/test/java/org/broadinstitute/consent/http/resources/DataSetAssociationsResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DataSetAssociationsResourceTest.java
@@ -11,6 +11,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -23,6 +24,7 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.when;
 
 @RunWith(PowerMockRunner.class)
+@PowerMockIgnore("jdk.internal.reflect.*")
 @PrepareForTest({AbstractDataSetAssociationAPI.class})
 public class DataSetAssociationsResourceTest {
 

--- a/src/test/java/org/broadinstitute/consent/http/resources/DataUseLetterResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DataUseLetterResourceTest.java
@@ -21,6 +21,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -38,6 +39,7 @@ import static org.mockito.Mockito.when;
 
 @SuppressWarnings("deprecation")
 @RunWith(PowerMockRunner.class)
+@PowerMockIgnore("jdk.internal.reflect.*")
 @PrepareForTest({
         AbstractConsentAPI.class,
         AbstractDACUserAPI.class

--- a/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
@@ -47,10 +47,12 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 @RunWith(PowerMockRunner.class)
+@PowerMockIgnore("jdk.internal.reflect.*")
 @PrepareForTest({
         AbstractDataSetAPI.class,
         AbstractDataAccessRequestAPI.class

--- a/src/test/java/org/broadinstitute/consent/http/resources/ElectionResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/ElectionResourceTest.java
@@ -14,6 +14,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -30,9 +31,10 @@ import static org.mockito.Mockito.when;
 
 @SuppressWarnings("FieldCanBeLocal")
 @RunWith(PowerMockRunner.class)
+@PowerMockIgnore("jdk.internal.reflect.*")
 @PrepareForTest({AbstractElectionAPI.class})
 public class ElectionResourceTest {
-    
+
     private final int OK = HttpStatusCodes.STATUS_CODE_OK;
     private final int NOT_FOUND = HttpStatusCodes.STATUS_CODE_NOT_FOUND;
     private final int ERROR = HttpStatusCodes.STATUS_CODE_SERVER_ERROR;

--- a/src/test/java/org/broadinstitute/consent/http/resources/ElectionReviewResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/ElectionReviewResourceTest.java
@@ -23,6 +23,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -35,6 +36,7 @@ import static org.mockito.Mockito.when;
 
 @SuppressWarnings("deprecation")
 @RunWith(PowerMockRunner.class)
+@PowerMockIgnore("jdk.internal.reflect.*")
 @PrepareForTest({
         AbstractConsentAPI.class,
         AbstractDataAccessRequestAPI.class,

--- a/src/test/java/org/broadinstitute/consent/http/service/ResearcherServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/ResearcherServiceTest.java
@@ -34,10 +34,12 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 @RunWith(PowerMockRunner.class)
+@PowerMockIgnore("jdk.internal.reflect.*")
 @PrepareForTest({
         AbstractDACUserAPI.class
 })


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-894

See also: https://github.com/DataBiosphere/consent-ontology/pull/372

## Changes
* Minor pom fixes for java 11 support
* Needed to add ignores for any test that uses `PowerMock` so it would run under java 11
  * `PowerMock` will need to go away at some point once we finish migrating away from the singleton service holder pattern
* Needed to update all of the actions that do builds as they were running java 8
  * Added caching to help speed up the builds ... they are horribly slow when pulling down maven resources
  * Removed unnecessary maven installs since it is already on the `ubuntu-latest` image
  * Update each one to set java 11 as the default
  * Standardize all actions on `ubuntu-latest`
  * Added a `mvn -v` for helpful debugging/run info

----

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [ ] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
