### PR TITLE
[DUOS-894][risk=no] Add Builder to Dockerfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,18 +9,6 @@
 /*.iml
 .vscode/
 .metals/
-# if you remove the above rule, at least ignore user-specific stuff:
-# .idea/workspace.xml
-# .idea/tasks.xml
-# .idea/dictionaries
-# and these sensitive or high-churn files:
-# .idea/dataSources.ids
-# .idea/dataSources.xml
-# .idea/sqlDataSources.xml
-# .idea/dynamic.xml
-# and, if using gradle::
-# .idea/gradle.xml
-# .idea/libraries
 
 ## File-based project format
 *.ipr
@@ -108,7 +96,7 @@ local.properties
 # PDT-specific
 .buildpath
 
-# sbteclipse plugin 
+# sbteclipse plugin
 .target
 
 # TeXlipse plugin
@@ -164,3 +152,4 @@ automation/src/test/resources/accounts/*.json
 
 /config/
 /config_postgres/
+/env.properties

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,15 @@
-FROM us.gcr.io/broad-dsp-gcr-public/base/jre:11-alpine
+# Builder
+FROM adoptopenjdk/maven-openjdk11:latest AS build
 
+RUN mkdir /usr/src/app
+WORKDIR /usr/src/app
+
+COPY .git /usr/src/app/.git
+COPY pom.xml /usr/src/app/pom.xml
+COPY src /usr/src/app/src
+
+RUN mvn clean package -Dmaven.test.skip=true
+
+# Published
+FROM us.gcr.io/broad-dsp-gcr-public/base/jre:11-alpine
 COPY target/consent.jar /opt/consent.jar


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-894

## Changes
Added a build step to the Dockerfile so that we don't need to build the jar in the jenkins environment. The current jenkins build includes a maven step that uses java 8, so we need to do the java 11 build here before we can remove the maven step in the current build. See https://github.com/broadinstitute/dsp-jenkins/blob/master/jobs/fc-jenkins/BuildService.groovy#L87 for where we are injecting a maven step in the current build. Will be following up with a PR in that repo to remove that step once this is merged.

Build Script PR: https://github.com/broadinstitute/dsp-jenkins/pull/480

----

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [ ] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
