### PR TITLE
[DUOS-894][risk=no] Fix copy command in builder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,4 @@ RUN mvn clean package -Dmaven.test.skip=true
 
 # Published
 FROM us.gcr.io/broad-dsp-gcr-public/base/jre:11-alpine
-COPY target/consent.jar /opt/consent.jar
+COPY --from=build /usr/src/app/target/consent.jar /opt/consent.jar


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-894

This is a cleanup PR from https://github.com/DataBiosphere/consent/pull/881 where we should have been copying from the builder.

----

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [ ] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
