### PR TITLE
[DUOS-512][risk=low] - model fix, better error handling, access review page

### DIFF
--- a/automation/configs/application.conf.ctmpl
+++ b/automation/configs/application.conf.ctmpl
@@ -3,7 +3,8 @@
 consent {
   baseUrl = {{if eq $environment "local"}}"https://local.broadinstitute.org:27443/"{{else}}"https://consent.dsde-dev.broadinstitute.org/"{{end}},
   fireCloudUrl = "https://firecloud-orchestration.dsde-dev.broadinstitute.org/",
-  profileUrl = "https://profile-dot-broad-shibboleth-prod.appspot.com/dev"
+  profileUrl = "https://profile-dot-broad-shibboleth-prod.appspot.com/dev",
+  ontologyUrl = "https://consent-ontology.dsde-dev.broadinstitute.org/"
 }
 
 {{end}}

--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -4,8 +4,13 @@ object Dependencies {
 
   val gatlingV = "3.4.1"
 
+  private val netty = "io.netty" % "netty-codec-http" % "4.1.56.Final"
+  private val nettyHandler = netty.organization % "netty-handler" % netty.revision
+
   val rootDependencies: Seq[ModuleID] = Seq(
     "org.scalatest"        %% "scalatest" % "3.2.0" % Test,
+    netty,
+    nettyHandler,
     "io.gatling"            % "gatling-core" % gatlingV,
     "io.gatling"            % "gatling-http" % gatlingV,
     "io.gatling.highcharts" % "gatling-charts-highcharts" % gatlingV % "test",

--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
 
-  val gatlingV = "3.3.1"
+  val gatlingV = "3.4.1"
 
   val rootDependencies: Seq[ModuleID] = Seq(
     "org.scalatest"        %% "scalatest" % "3.2.0" % Test,

--- a/automation/src/test/scala/org/broadinstitute/dsp/consent/TestConfig.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsp/consent/TestConfig.scala
@@ -40,6 +40,7 @@ object TestConfig {
 
   lazy val fireCloudUrl: String = config.getString("consent.fireCloudUrl")
   lazy val profileUrl: String = config.getString("consent.profileUrl")
+  lazy val ontologyUrl: String = config.getString("consent.ontologyUrl")
   lazy val adminHeader: Map[String, String] = Map("Authorization" -> s"Bearer ${getAccessToken("/accounts/duos-automation-admin.json")}")
   lazy val chairHeader: Map[String, String] = Map("Authorization" -> s"Bearer ${getAccessToken("/accounts/duos-automation-chair.json")}")
   lazy val memberHeader: Map[String, String] = Map("Authorization" -> s"Bearer ${getAccessToken("/accounts/duos-automation-member.json")}")

--- a/automation/src/test/scala/org/broadinstitute/dsp/consent/TestRunner.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsp/consent/TestRunner.scala
@@ -1,22 +1,34 @@
 package org.broadinstitute.dsp.consent
 
 import io.gatling.core.Predef.{Simulation, atOnceUsers, _}
-import io.gatling.core.structure.ScenarioBuilder
+import io.gatling.core.structure.{ScenarioBuilder, PopulationBuilder}
 
 
 trait TestRunner extends Simulation {
+
+  def runPopulations(populations: List[PopulationBuilder],
+                     assertions: List[Assertion] = List(global.failedRequests.count.is(0))): SetUp = {
+    setUp(
+      populations
+    )
+      .protocols(TestConfig.defaultHttpProtocol)
+      .assertions(assertions)
+  }
 
   def runScenarios(scenarios: List[ScenarioBuilder],
                    assertions: List[Assertion] = List(global.failedRequests.count.is(0))): SetUp = {
     setUp(
       scenarios.map { scn =>
-        scn
-          .pause(TestConfig.defaultPause)
-          .inject(atOnceUsers(TestConfig.defaultUsers))
+        defaultPopulation(scn)
       }
     )
       .protocols(TestConfig.defaultHttpProtocol)
       .assertions(assertions)
   }
 
+  def defaultPopulation(scenario: ScenarioBuilder): PopulationBuilder = {
+    scenario
+      .pause(TestConfig.defaultPause)
+      .inject(atOnceUsers(TestConfig.defaultUsers))
+  }
 }

--- a/automation/src/test/scala/org/broadinstitute/dsp/consent/chains/AccessReviewChains.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsp/consent/chains/AccessReviewChains.scala
@@ -9,6 +9,7 @@ import org.broadinstitute.dsp.consent.models.PendingModels._
 import org.broadinstitute.dsp.consent.models.JsonProtocols
 import org.broadinstitute.dsp.consent.services._
 import scala.concurrent.duration._
+import io.netty.handler.codec.http.HttpResponseStatus._
 
 object AccessReviewChains {
     val referenceId: String = "darReferenceId"
@@ -16,19 +17,19 @@ object AccessReviewChains {
 
     def init(additionalHeaders: Map[String, String]): ChainBuilder = {
         exec(
-            Requests.Votes.getDarVote(200, "${darReferenceId}", "${voteId}", additionalHeaders)
+            Requests.Votes.getDarVote(OK.code, "${darReferenceId}", "${voteId}", additionalHeaders)
         )
         .exec(
-            Requests.Election.getDataAccessElectionReview(200, "${darElectionId}", "false", additionalHeaders)
+            Requests.Election.getDataAccessElectionReview(OK.code, "${darElectionId}", "false", additionalHeaders)
         )
         .exec(
             DarChains.describeDarWithConsent(additionalHeaders)
         )
         .exec(
-            Requests.Votes.getDarVoteList(200, "${darReferenceId}", additionalHeaders)
+            Requests.Votes.getDarVoteList(OK.code, "${darReferenceId}", additionalHeaders)
         )
         .exec(
-            Requests.Researcher.getResearcherProperties(200, "${dataAccessUserId}", additionalHeaders)
+            Requests.Researcher.getResearcherProperties(OK.code, "${dataAccessUserId}", additionalHeaders)
         )
     }
 }

--- a/automation/src/test/scala/org/broadinstitute/dsp/consent/chains/AccessReviewChains.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsp/consent/chains/AccessReviewChains.scala
@@ -1,0 +1,34 @@
+package org.broadinstitute.dsp.consent.chains
+
+import io.gatling.core.Predef._
+import io.gatling.core.structure.ChainBuilder
+import org.broadinstitute.dsp.consent.requests.Requests
+import spray.json._
+import DefaultJsonProtocol._
+import org.broadinstitute.dsp.consent.models.PendingModels._
+import org.broadinstitute.dsp.consent.models.JsonProtocols
+import org.broadinstitute.dsp.consent.services._
+import scala.concurrent.duration._
+
+object AccessReviewChains {
+    val referenceId: String = "darReferenceId"
+    val voteId: String = "voteId"
+
+    def init(additionalHeaders: Map[String, String]): ChainBuilder = {
+        exec(
+            Requests.Votes.getDarVote(200, "${darReferenceId}", "${voteId}", additionalHeaders)
+        )
+        .exec(
+            Requests.Election.getDataAccessElectionReview(200, "${darElectionId}", "false", additionalHeaders)
+        )
+        .exec(
+            DarChains.describeDarWithConsent(additionalHeaders)
+        )
+        .exec(
+            Requests.Votes.getDarVoteList(200, "${darReferenceId}", additionalHeaders)
+        )
+        .exec(
+            Requests.Researcher.getResearcherProperties(200, "${dataAccessUserId}", additionalHeaders)
+        )
+    }
+}

--- a/automation/src/test/scala/org/broadinstitute/dsp/consent/chains/AdminChains.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsp/consent/chains/AdminChains.scala
@@ -10,21 +10,22 @@ import org.broadinstitute.dsp.consent.models.ElectionModels._
 import org.broadinstitute.dsp.consent.models.JsonProtocols
 import org.broadinstitute.dsp.consent.services._
 import scala.concurrent.duration._
+import io.netty.handler.codec.http.HttpResponseStatus._
 
 object AdminChains {
     def loginToConsole(additionalHeaders: Map[String, String]): ChainBuilder = {
         exec(
-            Requests.User.me(200, additionalHeaders)
+            Requests.User.me(OK.code, additionalHeaders)
         )
         .pause(1)
         .exec(
-            Requests.Admin.initConsole(200, additionalHeaders)
+            Requests.Admin.initConsole(OK.code, additionalHeaders)
         )
     }
 
     def manageAccess(additionalHeaders: Map[String, String]): ChainBuilder = {
         exec(
-            Requests.Dar.manageDar(200, additionalHeaders)
+            Requests.Dar.manageDar(OK.code, additionalHeaders)
         )
         .exitBlockOnFail {
             exec { session =>
@@ -46,7 +47,7 @@ object AdminChains {
             }
         }   
         .exec(
-            Requests.Dac.list(200, additionalHeaders)
+            Requests.Dac.list(OK.code, additionalHeaders)
         )
     }
 
@@ -59,7 +60,7 @@ object AdminChains {
                 session.set("dataRequestId", manageDars(darIndex).dataRequestId.getOrElse(""))
             }
             .exec(
-                Requests.Election.createElection(201, "${dataRequestId}", "${electionStatusBody}", additionalHeaders)
+                Requests.Election.createElection(CREATED.code, "${dataRequestId}", "${electionStatusBody}", additionalHeaders)
             )
         }
     }

--- a/automation/src/test/scala/org/broadinstitute/dsp/consent/chains/AdminChains.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsp/consent/chains/AdminChains.scala
@@ -40,7 +40,7 @@ object AdminChains {
                 val newManageDars: Seq[DataAccessRequestManage] = DarService.setManageRolesByOwner(manageDars)
 
                 val researcherDars: Seq[DataAccessRequestManage] = DarService.getPendingDARsByMostRecent(newManageDars, 2)
-                val electionStatus: ElectionStatus = ElectionStatus(status = "Open", finalAccessVote = false)
+                val electionStatus: ElectionStatus = ElectionStatus(status = Status.OPEN, finalAccessVote = false)
                 
                 val newSession = session.set(Requests.Dar.manageDarResponse, researcherDars)
                 newSession.set("electionStatusBody", electionStatus.toJson.compactPrint)

--- a/automation/src/test/scala/org/broadinstitute/dsp/consent/chains/DarChains.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsp/consent/chains/DarChains.scala
@@ -7,6 +7,8 @@ import org.broadinstitute.dsp.consent.models.DataAccessRequestModels._
 import org.broadinstitute.dsp.consent.models.JsonProtocols
 import org.broadinstitute.dsp.consent.models.ResearcherModels._
 import org.broadinstitute.dsp.consent.models.DataSetModels._
+import org.broadinstitute.dsp.consent.models.DataUseModels._
+import org.broadinstitute.dsp.consent.models.ConsentModels._
 import spray.json._
 import DefaultJsonProtocol._
 import org.broadinstitute.dsp.consent.services.DarService
@@ -27,38 +29,80 @@ object DarChains {
     )
 
     def finalDarSubmit(additionalHeaders: Map[String, String]): ChainBuilder = {
-        exec { session =>
-            implicit val researchFormat: JsonProtocols.researcherPropertyFormat.type = JsonProtocols.researcherPropertyFormat
-            implicit val researcherFormat: JsonProtocols.ResearcherInfoFormat.type = JsonProtocols.ResearcherInfoFormat
-            implicit val dataAccessRequestDataFormat: JsonProtocols.DataAccessRequestDataFormat.type = JsonProtocols.DataAccessRequestDataFormat
-            implicit val dataAccessFormat: JsonProtocols.dataAccessRequestFormat.type = JsonProtocols.dataAccessRequestFormat
-            implicit val dataSetFormat: JsonProtocols.dataSetFormat.type = JsonProtocols.dataSetFormat
-            implicit val dataSetEntryFormat: JsonProtocols.dataSetEntryFormat.type = JsonProtocols.dataSetEntryFormat
+        exitBlockOnFail {
+            exec { session =>
+                implicit val researchFormat: JsonProtocols.researcherPropertyFormat.type = JsonProtocols.researcherPropertyFormat
+                implicit val researcherFormat: JsonProtocols.ResearcherInfoFormat.type = JsonProtocols.ResearcherInfoFormat
+                implicit val dataAccessRequestDataFormat: JsonProtocols.DataAccessRequestDataFormat.type = JsonProtocols.DataAccessRequestDataFormat
+                implicit val dataAccessFormat: JsonProtocols.dataAccessRequestFormat.type = JsonProtocols.dataAccessRequestFormat
+                implicit val dataSetFormat: JsonProtocols.dataSetFormat.type = JsonProtocols.dataSetFormat
+                implicit val dataSetEntryFormat: JsonProtocols.dataSetEntryFormat.type = JsonProtocols.dataSetEntryFormat
 
-            val researcherPropsStr: String = session(Requests.Researcher.researcherPropertiesResponse).as[String]
-            val researcherInfo: ResearcherInfo = researcherPropsStr.parseJson.convertTo[ResearcherInfo]
-            val partialDar: DataAccessRequest = session(Requests.Dar.darPartialJson).as[String]
-                .parseJson.convertTo[DataAccessRequest];
-            val referenceId: String = session("darReferenceId").as[String]
+                val researcherPropsStr: String = session(Requests.Researcher.researcherPropertiesResponse).as[String]
+                val researcherInfo: ResearcherInfo = researcherPropsStr.parseJson.convertTo[ResearcherInfo]
+                val partialDar: DataAccessRequest = session(Requests.Dar.darPartialJson).as[String]
+                    .parseJson.convertTo[DataAccessRequest];
+                val referenceId: String = session("darReferenceId").as[String]
 
-            val indices: Seq[Int] = Seq(0, 1)
-            val dataSets: Seq[DataSet] = indices.map(idx => {
-                val dataSetStr: String = session(Requests.DataSet.dataSetsByDataSetId + idx).as[String]
-                val dataSet: DataSet = dataSetStr.parseJson.convertTo[DataSet]
-                dataSet
-            }).toSeq
-            val dsIds:Seq[Int] = dataSets.map(_.dataSetId).toSeq
+                val indices: Seq[Int] = Seq(0, 1)
+                val dataSets: Seq[DataSet] = indices.map(idx => {
+                    val dataSetStr: String = session(Requests.DataSet.dataSetsByDataSetId + idx).as[String]
+                    val dataSet: DataSet = dataSetStr.parseJson.convertTo[DataSet]
+                    dataSet
+                }).toSeq
+                val dsIds:Seq[Int] = dataSets.map(_.dataSetId).toSeq
 
-            val partialUpdate: DataAccessRequest = DarService.createDar(partialDar, researcherInfo, partialDar.userId, referenceId, dsIds, dataSets, false)
-            val newSession = session.set("dataAccessRequestJson", partialUpdate.data.toJson.compactPrint)
-            val finalDar: DataAccessRequest = DarService.createDar(partialDar, researcherInfo, partialDar.userId, referenceId, dsIds, dataSets, true)
-            newSession.set("dataAccessRequestSubmit", finalDar.data.toJson.compactPrint)
+                val partialUpdate: DataAccessRequest = DarService.createDar(partialDar, researcherInfo, partialDar.userId, referenceId, dsIds, dataSets, false)
+                val newSession = session.set("dataAccessRequestJson", partialUpdate.data.toJson.compactPrint)
+                val finalDar: DataAccessRequest = DarService.createDar(partialDar, researcherInfo, partialDar.userId, referenceId, dsIds, dataSets, true)
+                newSession.set("dataAccessRequestSubmit", finalDar.data.toJson.compactPrint)
+            }
+            .exec(
+                Requests.Dar.updatePartial(200, "${darReferenceId}", "${dataAccessRequestJson}", additionalHeaders)
+            )
+            .exec(
+                Requests.Dar.saveFinal(201, "${dataAccessRequestSubmit}", additionalHeaders)
+            )
         }
-        .exec(
-            Requests.Dar.updatePartial(200, "${darReferenceId}", "${dataAccessRequestJson}", additionalHeaders)
-        )
-        .exec(
-            Requests.Dar.saveFinal(201, "${dataAccessRequestSubmit}", additionalHeaders)
-        )
+    }
+
+    def describeDar(additionalHeaders: Map[String, String]): ChainBuilder = {
+        exitBlockOnFail {
+            exec(
+                Requests.Dar.getPartial(200, "${darReferenceId}", additionalHeaders)
+            )
+            .exec { session =>
+                implicit val darFormat: JsonProtocols.DataAccessRequestDataFormat.type = JsonProtocols.DataAccessRequestDataFormat
+                val darStr: String = session(Requests.Dar.darPartialJson).as[String]
+                val dar: DataAccessRequestData = darStr.parseJson.convertTo[DataAccessRequestData]
+
+                session.set("dataAccessUserId", dar.userId.getOrElse(0))
+            }
+            .exec(
+                Requests.User.getById(200, "${dataAccessUserId}", additionalHeaders)
+            )
+        }
+    }
+
+    def describeDarWithConsent(additionalHeaders: Map[String, String]): ChainBuilder = {
+        exitBlockOnFail {
+            exec(
+                describeDar(additionalHeaders)
+            )
+            .exec(
+                Requests.Dar.getConsent(200, "${darReferenceId}", additionalHeaders)
+            )
+            .exec { session =>
+                implicit val consentFormat: JsonProtocols.consentFormat.type = JsonProtocols.consentFormat
+                implicit val dataUseFormat: JsonProtocols.dataUseFormat.type = JsonProtocols.dataUseFormat
+                val consentStr: String = session(Requests.Dar.darConsentResponse).as[String]
+                val consent: Consent = consentStr.parseJson.convertTo[Consent]
+                
+                session.set("consentDataUse", consent.dataUse.getOrElse(DataUseBuilder.empty).toJson.compactPrint)
+            }
+            .exec(
+                Requests.Dar.translateDataUse(200, "${consentDataUse}", additionalHeaders)
+            )
+        }
     }
 }

--- a/automation/src/test/scala/org/broadinstitute/dsp/consent/chains/DataSetChains.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsp/consent/chains/DataSetChains.scala
@@ -12,38 +12,40 @@ import org.broadinstitute.dsp.consent.services._
 
 object DataSetChains {
     def dataSetCatalogPickTwo(additionalHeaders: Map[String, String]): ChainBuilder = {
-        exec(
-            Requests.User.dataSetCatalog(200, "${dacUserId}", additionalHeaders)
-        )
-        .exec { session =>
-            implicit val dataSetFormatJson: JsonProtocols.dataSetFormat.type = JsonProtocols.dataSetFormat
-            implicit val dataSetEntryJson: JsonProtocols.dataSetEntryFormat.type = JsonProtocols.dataSetEntryFormat
-            implicit val dataAccessRequestJson: JsonProtocols.dataAccessRequestDraftFormat.type = JsonProtocols.dataAccessRequestDraftFormat
-
-            val dataSetStr: String = session(Requests.DataSet.dataSetResponse).as[String]
-            val dataSets: Seq[DataSet] = dataSetStr.parseJson.convertTo[Seq[DataSet]]
-            
-            val chosenSets: Seq[DataSet] = dataSets
-                .filter(ds => ds.active && !ds.dataUse.collaboratorRequired.getOrElse(false))
-                .groupBy(_.dacId)
-                .map(_._2.head)
-                .take(2)
-                .toSeq
-
-            val setIds: Seq[Int] = chosenSets.map(s => s.dataSetId).toSeq
-            val entrySets: Seq[DataSetEntry] = chosenSets.map(s => DataSetEntryBuilder.fromDataSet(s)).toSeq
-            
-            val dacUserId: Int = session("dacUserId").as[Int]
-            val dar: DataAccessRequestDraft = DataAccessRequestDraft(
-                userId = dacUserId, 
-                datasets = entrySets, 
-                datasetId = setIds
+        exitBlockOnFail {
+            exec(
+                Requests.User.dataSetCatalog(200, "${dacUserId}", additionalHeaders)
             )
-            val newSession: Session = session.set("darRequestBody", dar.toJson.compactPrint)
-            newSession.set("dataSetIds", setIds)
+            .exec { session =>
+                implicit val dataSetFormatJson: JsonProtocols.dataSetFormat.type = JsonProtocols.dataSetFormat
+                implicit val dataSetEntryJson: JsonProtocols.dataSetEntryFormat.type = JsonProtocols.dataSetEntryFormat
+                implicit val dataAccessRequestJson: JsonProtocols.dataAccessRequestDraftFormat.type = JsonProtocols.dataAccessRequestDraftFormat
+
+                val dataSetStr: String = session(Requests.DataSet.dataSetResponse).as[String]
+                val dataSets: Seq[DataSet] = dataSetStr.parseJson.convertTo[Seq[DataSet]]
+                
+                val chosenSets: Seq[DataSet] = dataSets
+                    .filter(ds => ds.active && !ds.dataUse.collaboratorRequired.getOrElse(false))
+                    .groupBy(_.dacId)
+                    .map(_._2.head)
+                    .take(2)
+                    .toSeq
+
+                val setIds: Seq[Int] = chosenSets.map(s => s.dataSetId).toSeq
+                val entrySets: Seq[DataSetEntry] = chosenSets.map(s => DataSetEntryBuilder.fromDataSet(s)).toSeq
+                
+                val dacUserId: Int = session("dacUserId").as[Int]
+                val dar: DataAccessRequestDraft = DataAccessRequestDraft(
+                    userId = dacUserId, 
+                    datasets = entrySets, 
+                    datasetId = setIds
+                )
+                val newSession: Session = session.set("darRequestBody", dar.toJson.compactPrint)
+                newSession.set("dataSetIds", setIds)
+            }
+            .exec(
+                Requests.Dar.partialSave(201, """${darRequestBody}""", additionalHeaders)
+            )
         }
-        .exec(
-            Requests.Dar.partialSave(201, """${darRequestBody}""", additionalHeaders)
-        )
     }
 }

--- a/automation/src/test/scala/org/broadinstitute/dsp/consent/chains/DataSetChains.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsp/consent/chains/DataSetChains.scala
@@ -9,12 +9,13 @@ import org.broadinstitute.dsp.consent.models.JsonProtocols
 import org.broadinstitute.dsp.consent.models.DataSetModels._
 import org.broadinstitute.dsp.consent.models.DataAccessRequestModels._
 import org.broadinstitute.dsp.consent.services._
+import io.netty.handler.codec.http.HttpResponseStatus._
 
 object DataSetChains {
     def dataSetCatalogPickTwo(additionalHeaders: Map[String, String]): ChainBuilder = {
         exitBlockOnFail {
             exec(
-                Requests.User.dataSetCatalog(200, "${dacUserId}", additionalHeaders)
+                Requests.User.dataSetCatalog(OK.code, "${dacUserId}", additionalHeaders)
             )
             .exec { session =>
                 implicit val dataSetFormatJson: JsonProtocols.dataSetFormat.type = JsonProtocols.dataSetFormat
@@ -44,7 +45,7 @@ object DataSetChains {
                 newSession.set("dataSetIds", setIds)
             }
             .exec(
-                Requests.Dar.partialSave(201, """${darRequestBody}""", additionalHeaders)
+                Requests.Dar.partialSave(CREATED.code, """${darRequestBody}""", additionalHeaders)
             )
         }
     }

--- a/automation/src/test/scala/org/broadinstitute/dsp/consent/chains/MemberChains.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsp/consent/chains/MemberChains.scala
@@ -9,18 +9,19 @@ import org.broadinstitute.dsp.consent.models.PendingModels._
 import org.broadinstitute.dsp.consent.models.JsonProtocols
 import org.broadinstitute.dsp.consent.services.{DarService}
 import scala.concurrent.duration._
+import io.netty.handler.codec.http.HttpResponseStatus._
 
 object MemberChains {
     def loginToConsole(additionalHeaders: Map[String, String]): ChainBuilder = {
         exec(
-            Requests.User.me(200, additionalHeaders)
+            Requests.User.me(OK.code, additionalHeaders)
         )
         .pause(1)
         .exec(
-            Requests.PendingCases.getPendingDataRequestsByUserId(200, "${dacUserId}", additionalHeaders)
+            Requests.PendingCases.getPendingDataRequestsByUserId(OK.code, "${dacUserId}", additionalHeaders)
         )
         .exec(
-            Requests.PendingCases.getPendingCasesByUserId(200, "${dacUserId}", additionalHeaders)
+            Requests.PendingCases.getPendingCasesByUserId(OK.code, "${dacUserId}", additionalHeaders)
         )
     }
 

--- a/automation/src/test/scala/org/broadinstitute/dsp/consent/chains/MemberChains.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsp/consent/chains/MemberChains.scala
@@ -1,0 +1,65 @@
+package org.broadinstitute.dsp.consent.chains
+
+import io.gatling.core.Predef._
+import io.gatling.core.structure.ChainBuilder
+import org.broadinstitute.dsp.consent.requests.Requests
+import spray.json._
+import DefaultJsonProtocol._
+import org.broadinstitute.dsp.consent.models.PendingModels._
+import org.broadinstitute.dsp.consent.models.JsonProtocols
+import org.broadinstitute.dsp.consent.services.{DarService}
+import scala.concurrent.duration._
+
+object MemberChains {
+    def loginToConsole(additionalHeaders: Map[String, String]): ChainBuilder = {
+        exec(
+            Requests.User.me(200, additionalHeaders)
+        )
+        .pause(1)
+        .exec(
+            Requests.PendingCases.getPendingDataRequestsByUserId(200, "${dacUserId}", additionalHeaders)
+        )
+        .exec(
+            Requests.PendingCases.getPendingCasesByUserId(200, "${dacUserId}", additionalHeaders)
+        )
+    }
+
+    def voteOnPendingDars(additionalHeaders: Map[String, String], limit: Int = 2): ChainBuilder = {
+        exitBlockOnFail {
+            exec { session => 
+                implicit val pendingCaseFormat: JsonProtocols.pendingCaseFormat.type = JsonProtocols.pendingCaseFormat
+                implicit val dacFormat: JsonProtocols.dacFormat.type = JsonProtocols.dacFormat
+                implicit val userRoleFormat: JsonProtocols.userRoleFormat.type = JsonProtocols.userRoleFormat
+                implicit val userFormat: JsonProtocols.userFormat.type = JsonProtocols.userFormat
+                val pendingCasesStr: String = session(Requests.PendingCases.dataRequestPendingResponse).as[String]
+                val pendingCases: Seq[PendingCase] = pendingCasesStr.parseJson.convertTo[Seq[PendingCase]]
+
+                val automationPending: Seq[PendingCase] = pendingCases.filter { pc =>
+                    pc.projectTitle.getOrElse("") == DarService.projectTitle && !pc.alreadyVoted.getOrElse(false)
+                }
+                .sortWith { (pc1, pc2) =>
+                    pc1.createDate.getOrElse(0L) > pc2.createDate.getOrElse(0L)
+                }
+                .take(limit).toSeq
+
+                session.set("pendingCases", automationPending)
+            }
+            .repeat(session => session("pendingCases").as[Seq[PendingCase]].size, "pendingIndex") {
+                exitBlockOnFail {
+                    exec { session =>
+                        val pendingCases: Seq[PendingCase] = session("pendingCases").as[Seq[PendingCase]]
+                        val index: Int = session("pendingIndex").as[Int]
+                        val pendingCase: PendingCase = pendingCases(index)
+
+                        val session1 = session.set(AccessReviewChains.referenceId, pendingCase.referenceId.getOrElse(""))
+                        val session2 = session1.set(AccessReviewChains.voteId, pendingCase.voteId.getOrElse(0))
+                        session2
+                    }
+                    .exec(
+                        AccessReviewChains.init(additionalHeaders)
+                    )
+                }
+            }
+        }
+    }
+}

--- a/automation/src/test/scala/org/broadinstitute/dsp/consent/chains/NihChains.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsp/consent/chains/NihChains.scala
@@ -13,67 +13,69 @@ import org.broadinstitute.dsp.consent.services._
 
 object NihChains {
     def authenticate(additionalHeaders: Map[String, String]): ChainBuilder = {
-        exec { session =>
-            implicit val researcherInfoFormat: JsonProtocols.ResearcherInfoFormat.type = JsonProtocols.ResearcherInfoFormat
-            implicit val fireCloudProfileFormat: JsonProtocols.fireCloudProfileFormat.type = JsonProtocols.fireCloudProfileFormat
+        exitBlockOnFail {
+            exec { session =>
+                implicit val researcherInfoFormat: JsonProtocols.ResearcherInfoFormat.type = JsonProtocols.ResearcherInfoFormat
+                implicit val fireCloudProfileFormat: JsonProtocols.fireCloudProfileFormat.type = JsonProtocols.fireCloudProfileFormat
 
-            val researcherPropStr: String = session(Requests.Researcher.researcherPropertiesResponse).as[String]
-            val researcherInfo: ResearcherInfo = researcherPropStr.parseJson.convertTo[ResearcherInfo]
+                val researcherPropStr: String = session(Requests.Researcher.researcherPropertiesResponse).as[String]
+                val researcherInfo: ResearcherInfo = researcherPropStr.parseJson.convertTo[ResearcherInfo]
 
-            implicit val userFormat: JsonProtocols.userFormat.type = JsonProtocols.userFormat
-            val userStr: String = session("userResponse").as[String]
-            val user: User = userStr.parseJson.convertTo[User]
+                implicit val userFormat: JsonProtocols.userFormat.type = JsonProtocols.userFormat
+                val userStr: String = session("userResponse").as[String]
+                val user: User = userStr.parseJson.convertTo[User]
 
-            val registerUserBody: FireCloudProfile = NihService.parseProfile(researcherInfo, user, "test")
+                val registerUserBody: FireCloudProfile = NihService.parseProfile(researcherInfo, user, "test")
 
-            session.set("fireCloudRegisterUserBody", registerUserBody.toJson.compactPrint)
-        }
-        .doIf { session => 
-            implicit val researchFormat: JsonProtocols.researcherPropertyFormat.type = JsonProtocols.researcherPropertyFormat
-            implicit val researcherFormat: JsonProtocols.ResearcherInfoFormat.type = JsonProtocols.ResearcherInfoFormat
-            val researcherPropsStr: String = session(Requests.Researcher.researcherPropertiesResponse).as[String]
-            val researcherInfo: ResearcherInfo = researcherPropsStr.parseJson.convertTo[ResearcherInfo]
-            
-            val expCount: Int = NihService.expirationCount(researcherInfo.eraExpiration.getOrElse("0").toLong)
-            !researcherInfo.eraAuthorized.getOrElse("false").toBoolean || expCount <= 0
-        } {
-            exec(
-                Requests.FireCloud.verifyUser(additionalHeaders)
-            )
-            .exec { session => 
-                val verifyStatus: String = session(Requests.FireCloud.fireCloudVerifyStatus).as[String]
-                val isFCUser: Boolean = if (verifyStatus == "200") true else false
-                session.set("isFCUser", isFCUser)
+                session.set("fireCloudRegisterUserBody", registerUserBody.toJson.compactPrint)
             }
-            .doIfEquals("${isFCUser}", false) {
-                exitBlockOnFail {
-                    exec(
-                        Requests.FireCloud.registerUser(200, "${fireCloudRegisterUserBody}", additionalHeaders)
-                    )
-                    .exec{ session =>
-                        session.set("isFCUser", true)
+            .doIf { session => 
+                implicit val researchFormat: JsonProtocols.researcherPropertyFormat.type = JsonProtocols.researcherPropertyFormat
+                implicit val researcherFormat: JsonProtocols.ResearcherInfoFormat.type = JsonProtocols.ResearcherInfoFormat
+                val researcherPropsStr: String = session(Requests.Researcher.researcherPropertiesResponse).as[String]
+                val researcherInfo: ResearcherInfo = researcherPropsStr.parseJson.convertTo[ResearcherInfo]
+                
+                val expCount: Int = NihService.expirationCount(researcherInfo.eraExpiration.getOrElse("0").toLong)
+                !researcherInfo.eraAuthorized.getOrElse("false").toBoolean || expCount <= 0
+            } {
+                exec(
+                    Requests.FireCloud.verifyUser(additionalHeaders)
+                )
+                .exec { session => 
+                    val verifyStatus: String = session(Requests.FireCloud.fireCloudVerifyStatus).as[String]
+                    val isFCUser: Boolean = if (verifyStatus == "200") true else false
+                    session.set("isFCUser", isFCUser)
+                }
+                .doIfEquals("${isFCUser}", false) {
+                    exitBlockOnFail {
+                        exec(
+                            Requests.FireCloud.registerUser(200, "${fireCloudRegisterUserBody}", additionalHeaders)
+                        )
+                        .exec{ session =>
+                            session.set("isFCUser", true)
+                        }
                     }
                 }
-            }
-            .doIfEquals("${isFCUser}", true) {
-                exec { session =>
-                    implicit val userFormat: JsonProtocols.userFormat.type = JsonProtocols.userFormat
-                    implicit val nihUserFormat: JsonProtocols.nihUserFormat.type = JsonProtocols.nihUserFormat
+                .doIfEquals("${isFCUser}", true) {
+                    exec { session =>
+                        implicit val userFormat: JsonProtocols.userFormat.type = JsonProtocols.userFormat
+                        implicit val nihUserFormat: JsonProtocols.nihUserFormat.type = JsonProtocols.nihUserFormat
 
-                    val userStr: String = session("userResponse").as[String]
-                    val user: User = userStr.parseJson.convertTo[User]
+                        val userStr: String = session("userResponse").as[String]
+                        val user: User = userStr.parseJson.convertTo[User]
 
-                    val nihUser: NihUserAccount = NihUserAccount(
-                        linkedNihUsername = user.email.getOrElse(""), 
-                        datasetPermissions = None, 
-                        linkExpireTime = NihService.nextDate.toString, 
-                        status = true
+                        val nihUser: NihUserAccount = NihUserAccount(
+                            linkedNihUsername = user.email.getOrElse(""), 
+                            datasetPermissions = None, 
+                            linkExpireTime = NihService.nextDate.toString, 
+                            status = true
+                        )
+                        session.set("nihUserBody", nihUser.toJson.compactPrint)
+                    }
+                    .exec(
+                        Requests.FireCloud.saveNihUser(200, "${nihUserBody}", additionalHeaders)
                     )
-                    session.set("nihUserBody", nihUser.toJson.compactPrint)
                 }
-                .exec(
-                    Requests.FireCloud.saveNihUser(200, "${nihUserBody}", additionalHeaders)
-                )
             }
         }
     }

--- a/automation/src/test/scala/org/broadinstitute/dsp/consent/chains/NihChains.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsp/consent/chains/NihChains.scala
@@ -10,6 +10,7 @@ import org.broadinstitute.dsp.consent.models.NihModels._
 import org.broadinstitute.dsp.consent.models.ResearcherModels._
 import org.broadinstitute.dsp.consent.models.UserModels._
 import org.broadinstitute.dsp.consent.services._
+import io.netty.handler.codec.http.HttpResponseStatus._
 
 object NihChains {
     def authenticate(additionalHeaders: Map[String, String]): ChainBuilder = {
@@ -43,13 +44,13 @@ object NihChains {
                 )
                 .exec { session => 
                     val verifyStatus: String = session(Requests.FireCloud.fireCloudVerifyStatus).as[String]
-                    val isFCUser: Boolean = if (verifyStatus == "200") true else false
+                    val isFCUser: Boolean = if (verifyStatus == OK.code.toString) true else false
                     session.set("isFCUser", isFCUser)
                 }
                 .doIfEquals("${isFCUser}", false) {
                     exitBlockOnFail {
                         exec(
-                            Requests.FireCloud.registerUser(200, "${fireCloudRegisterUserBody}", additionalHeaders)
+                            Requests.FireCloud.registerUser(OK.code, "${fireCloudRegisterUserBody}", additionalHeaders)
                         )
                         .exec{ session =>
                             session.set("isFCUser", true)
@@ -73,7 +74,7 @@ object NihChains {
                         session.set("nihUserBody", nihUser.toJson.compactPrint)
                     }
                     .exec(
-                        Requests.FireCloud.saveNihUser(200, "${nihUserBody}", additionalHeaders)
+                        Requests.FireCloud.saveNihUser(OK.code, "${nihUserBody}", additionalHeaders)
                     )
                 }
             }

--- a/automation/src/test/scala/org/broadinstitute/dsp/consent/models/ConsentModels.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsp/consent/models/ConsentModels.scala
@@ -1,0 +1,23 @@
+package org.broadinstitute.dsp.consent.models
+
+import org.broadinstitute.dsp.consent.models.DataUseModels._
+
+object ConsentModels {
+    case class Consent(
+        consentId: String,
+        lastElectionStatus: Option[String] = None,
+        lastElectionArchived: Option[Boolean] = None,
+        requiresManualReview: Option[Boolean] = None,
+        dataUseLetter: Option[String] = None,
+        name: String,
+        dulName: Option[String] = None,
+        createDate: Option[Long] = None,
+        lastUpdate: Option[Long] = None,
+        sortDate: Option[Long] = None,
+        translatedUseRestriction: Option[String] = None,
+        dataUse: Option[DataUse] = None,
+        groupName: Option[String] = None,
+        updateStatus: Option[Boolean] = None,
+        dacId: Option[Int] = None
+    )
+}

--- a/automation/src/test/scala/org/broadinstitute/dsp/consent/models/DacModels.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsp/consent/models/DacModels.scala
@@ -9,8 +9,8 @@ object DacModels {
         description: Option[String],
         createDate: Option[Long],
         updateDate: Option[Long],
-        chairpersons: Option[User],
-        members: Option[User],
+        chairpersons: Option[Seq[User]],
+        members: Option[Seq[User]],
         electionIds: Option[Seq[Int]]
     )
 }

--- a/automation/src/test/scala/org/broadinstitute/dsp/consent/models/DataSetModels.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsp/consent/models/DataSetModels.scala
@@ -9,7 +9,7 @@ object DataSetModels {
     )
 
     case class DataSet(
-        dacId: Int,
+        dacId: Option[Int] = None,
         dataSetId: Int,
         consentId: String,
         translatedUseRestriction: Option[String],

--- a/automation/src/test/scala/org/broadinstitute/dsp/consent/models/DataUseModels.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsp/consent/models/DataUseModels.scala
@@ -8,4 +8,15 @@ object DataUseModels {
         pediatric: Option[Boolean],
         collaboratorRequired: Option[Boolean]
     )
+    object DataUseBuilder {
+        def empty(): DataUse = {
+            DataUse(
+                hmbResearch = Some(false), 
+                populationOriginsAncestry = Some(false), 
+                commercialUse = Some(false), 
+                pediatric = Some(false), 
+                collaboratorRequired = Some(false)
+            )
+        }
+    }
 }

--- a/automation/src/test/scala/org/broadinstitute/dsp/consent/models/ElectionModels.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsp/consent/models/ElectionModels.scala
@@ -1,6 +1,15 @@
 package org.broadinstitute.dsp.consent.models
 
 object ElectionModels {
+    object Status extends Enumeration {
+        type Status = String
+        val OPEN = "Open"
+        val CLOSED = "Closed"
+        val CANCELED = "Canceled"
+        val FINAL = "Final"
+        val PENDING_APPROVAL = "PendingApproval"
+    }
+
     case class ElectionStatus(
         status: String,
         finalAccessVote: Boolean

--- a/automation/src/test/scala/org/broadinstitute/dsp/consent/models/JsonProtocols.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsp/consent/models/JsonProtocols.scala
@@ -11,6 +11,8 @@ import org.broadinstitute.dsp.consent.models.DataAccessRequestModels._
 import org.broadinstitute.dsp.consent.models.NihModels._
 import org.broadinstitute.dsp.consent.models.DacModels._
 import org.broadinstitute.dsp.consent.models.ElectionModels._
+import org.broadinstitute.dsp.consent.models.PendingModels._
+import org.broadinstitute.dsp.consent.models.ConsentModels._
 
 
 import scala.util.{Failure, Success, Try}
@@ -33,6 +35,8 @@ object JsonProtocols extends DefaultJsonProtocol {
     implicit val nihVerify: JsonFormat[NihVerify] = jsonFormat1(NihVerify)
     implicit val dacFormat: JsonFormat[Dac] = jsonFormat8(Dac)
     implicit val electionStatusFormat: JsonFormat[ElectionStatus] = jsonFormat2(ElectionStatus)
+    implicit val pendingCaseFormat: JsonFormat[PendingCase] = jsonFormat18(PendingCase)
+    implicit val consentFormat: JsonFormat[Consent] = jsonFormat15(Consent)
 
     def optionalEntryReader[T](fieldName: String, data: Map[String,JsValue], converter: JsValue => T, default: T): T = {
         data.getOrElse(fieldName, None) match {

--- a/automation/src/test/scala/org/broadinstitute/dsp/consent/models/PendingModels.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsp/consent/models/PendingModels.scala
@@ -1,0 +1,26 @@
+package org.broadinstitute.dsp.consent.models
+
+import org.broadinstitute.dsp.consent.models.DacModels._
+
+object PendingModels {
+    case class PendingCase(
+        referenceId: Option[String] = None,
+        frontEndId: Option[String] = None,
+        logged: Option[String] = None,
+        alreadyVoted: Option[Boolean] = None,
+        isReminderSent: Option[Boolean] = None,
+        isFinalVote: Option[Boolean] = None,
+        status: Option[String] = None,
+        electionStatus: Option[String] = None,
+        electionId: Option[Int] = None,
+        voteId: Option[Int] = None,
+        totalVotes: Option[Int] = None,
+        votesLogged: Option[Int] = None,
+        rpElectionId: Option[Int] = None,
+        rpVoteId: Option[Int] = None,
+        consentGroupName: Option[String] = None,
+        projectTitle: Option[String] = None,
+        dac: Option[Dac] = None,
+        createDate: Option[Long] = None
+    )
+}

--- a/automation/src/test/scala/org/broadinstitute/dsp/consent/requests/Requests.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsp/consent/requests/Requests.scala
@@ -6,27 +6,28 @@ import io.gatling.core.Predef._
 import io.gatling.http.request.builder._
 import io.gatling.http.Predef._
 import org.broadinstitute.dsp.consent.TestConfig
+import io.netty.handler.codec.http.HttpResponseStatus._
 
 object Requests {
 
   val rootRequest: HttpRequestBuilder = {
     http("Root URL")
       .get("/")
-      .check(status.is(session => 200))
+      .check(status.is(session => OK.code))
   }
 
   val statusRequest: HttpRequestBuilder = {
     http("Status Request")
       .get("/status")
       .headers(TestConfig.jsonHeader)
-      .check(status.is(session => 200))
+      .check(status.is(session => OK.code))
   }
 
   val versionRequest: HttpRequestBuilder = {
     http("Version Request")
       .get("/version")
       .headers(TestConfig.jsonHeader)
-      .check(status.is(session => 200))
+      .check(status.is(session => OK.code))
   }
 
   private def encode(term: String): String = {

--- a/automation/src/test/scala/org/broadinstitute/dsp/consent/requests/Requests.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsp/consent/requests/Requests.scala
@@ -60,6 +60,8 @@ object Requests {
   object User {
     val userResponse: String = "userResponse"
     val dacUserId: String = "dacUserId"
+    val userByIdResponse: String = "userByIdResponse"
+
     def me(expectedStatus: Int, additionalHeaders: Map[String, String]): HttpRequestBuilder = {
       http("Get User")
         .get("/api/user/me")
@@ -67,6 +69,15 @@ object Requests {
         .headers(additionalHeaders)
         .check(bodyString.saveAs(userResponse))
         .check(jsonPath("$.dacUserId").saveAs(dacUserId))
+        .check(status.is(expectedStatus))
+    }
+
+    def getById(expectedStatus: Int, userId: String, additionalHeaders: Map[String, String]): HttpRequestBuilder = {
+      http("Get User By Id")
+        .get(s"api/user/$userId")
+        .headers(TestConfig.jsonHeader)
+        .headers(additionalHeaders)
+        .check(bodyString.saveAs(userByIdResponse))
         .check(status.is(expectedStatus))
     }
 
@@ -135,6 +146,8 @@ object Requests {
     val darReferenceId: String = "darReferenceId"
     val darId: String = "darId"
     val manageDarResponse: String = "manageDarResponse"
+    val darConsentResponse: String = "darConsentResponse"
+    val translateResponse: String = "translateResponse"
 
     def getPartial(expectedStatus: Int, referenceId: String, additionalHeaders: Map[String, String]): HttpRequestBuilder = {
       http("Get Partial Dar")
@@ -186,10 +199,31 @@ object Requests {
         .check(status.is(expectedStatus))
 
     }
+
+    def getConsent(expectedStatus: Int, referenceId: String, additionalHeaders: Map[String, String]): HttpRequestBuilder = {
+      http("Get DAR Consent")
+        .get(s"api/dar/find/$referenceId/consent")
+        .headers(TestConfig.jsonHeader)
+        .headers(additionalHeaders)
+        .check(bodyString.saveAs(darConsentResponse))
+        .check(status.is(expectedStatus))
+    }
+
+    def translateDataUse(expectedStatus: Int, body: String, additionalHeaders: Map[String, String]): HttpRequestBuilder = {
+      http("Translate Data Use")
+        .post(s"${TestConfig.ontologyUrl}translate/summary")
+        .headers(TestConfig.jsonHeader)
+        .headers(additionalHeaders)
+        .body(StringBody(body))
+        .asJson
+        .check(bodyString.saveAs(translateResponse))
+        .check(status.is(expectedStatus))
+    }
   }
 
   object Researcher {
     val researcherPropertiesResponse: String = "researcherPropertiesResponse"
+    val researcherProfileResponse: String = "researcherProfileResponse"
 
     def getResearcherProperties(expectedStatus: Int, userId: String, additionalHeaders: Map[String, String]): HttpRequestBuilder = {
       http("Get Researcher Properties")
@@ -283,6 +317,7 @@ object Requests {
 
   object Election {
     val createElectionResponse: String = "createElectionResponse"
+    val getDataAccessElectionReviewResponse: String = "getElectionReviewResponse"
 
     def createElection(expectedStatus: Int, dataRequestId: String, body: String, additionalHeaders: Map[String, String]): HttpRequestBuilder = {
       http("Create Elections")
@@ -291,6 +326,63 @@ object Requests {
         .headers(additionalHeaders)
         .body(StringBody(body)).asJson
         .check(bodyString.saveAs(createElectionResponse))
+        .check(status.is(expectedStatus))
+    }
+
+    def getDataAccessElectionReview(expectedStatus: Int, electionId: String, isFinalAccess: String, additionalHeaders: Map[String, String]): HttpRequestBuilder = {
+      http("Get Election Review")
+        .get(s"api/electionReview/access/$electionId?isFinalVote=$isFinalAccess")
+        .headers(TestConfig.jsonHeader)
+        .headers(additionalHeaders)
+        .check(bodyString.saveAs(getDataAccessElectionReviewResponse))
+        .check(status.is(expectedStatus))
+    }
+  }
+
+  object PendingCases {
+    val consentPendingResponse: String = "consentPendingResponse"
+    val dataRequestPendingResponse: String = "dataRequestPendingResponse"
+
+    def getPendingCasesByUserId(expectedStatus: Int, userId: String, additionalHeaders: Map[String, String]): HttpRequestBuilder = {
+      http("Get Pending Cases")
+        .get(s"api/consent/cases/pending/$userId")
+        .headers(TestConfig.jsonHeader)
+        .headers(additionalHeaders)
+        .check(bodyString.saveAs(consentPendingResponse))
+        .check(status.is(expectedStatus))
+    }
+
+    def getPendingDataRequestsByUserId(expectedStatus: Int, userId: String, additionalHeaders: Map[String, String]): HttpRequestBuilder = {
+      http("Get Pending Data Requests")
+        .get(s"api/dataRequest/cases/pending/$userId")
+        .headers(TestConfig.jsonHeader)
+        .headers(additionalHeaders)
+        .check(bodyString.saveAs(dataRequestPendingResponse))
+        .check(status.is(expectedStatus))
+    }
+  }
+
+  object Votes {
+    val getDarVoteResponse: String = "getDarVotesResponse"
+    val darElectionId: String = "darElectionId"
+    val getDarVoteListResponse: String = "getDarVoteListResponse"
+
+    def getDarVote(expectedStatus: Int, requestId: String, voteId: String, additionalHeaders: Map[String, String]): HttpRequestBuilder = {
+      http("Get DAR Vote")
+        .get(s"api/dataRequest/$requestId/vote/$voteId")
+        .headers(TestConfig.jsonHeader)
+        .headers(additionalHeaders)
+        .check(bodyString.saveAs(getDarVoteResponse))
+        .check(jsonPath("$.electionId").saveAs(darElectionId))
+        .check(status.is(expectedStatus))
+    }
+
+    def getDarVoteList(expectedStatus: Int, requestId: String, additionalHeaders: Map[String, String]): HttpRequestBuilder = {
+      http("Get DAR Votes")
+        .get(s"api/dataRequest/$requestId/vote")
+        .headers(TestConfig.jsonHeader)
+        .headers(additionalHeaders)
+        .check(bodyString.saveAs(getDarVoteListResponse))
         .check(status.is(expectedStatus))
     }
   }

--- a/automation/src/test/scala/org/broadinstitute/dsp/consent/scenarios/AdminScenarios.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsp/consent/scenarios/AdminScenarios.scala
@@ -2,24 +2,15 @@ package org.broadinstitute.dsp.consent.scenarios
 
 import io.gatling.core.Predef._
 import org.broadinstitute.dsp.consent.{TestConfig, TestRunner}
-import scala.concurrent.duration._
 import org.broadinstitute.dsp.consent.chains.AdminChains
 
 class AdminScenarios extends Simulation with TestRunner {
     runScenarios(
         List(
-            scenario("Admins Voting")
-                .exec(
-                    AdminChains.loginToConsole(TestConfig.adminHeader)
-                )
-                .pause(1)
-                .exec(
-                    AdminChains.manageAccess(TestConfig.adminHeader)
-                )
-                .pause(1)
-                .exec(
-                    AdminChains.createElections(TestConfig.adminHeader)
-                )
+            scenario("Admin Login")
+            .exec(
+                AdminChains.loginToConsole(TestConfig.adminHeader)
+            )
         )
     )
 }

--- a/automation/src/test/scala/org/broadinstitute/dsp/consent/scenarios/DacScenarios.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsp/consent/scenarios/DacScenarios.scala
@@ -3,12 +3,13 @@ package org.broadinstitute.dsp.consent.scenarios
 import io.gatling.core.Predef.{Simulation, scenario}
 import org.broadinstitute.dsp.consent.{TestConfig, TestRunner}
 import org.broadinstitute.dsp.consent.requests.Requests
+import io.netty.handler.codec.http.HttpResponseStatus._
 
 class DacScenarios  extends Simulation with TestRunner {
 
   runScenarios(
     List(
-      scenario("Dac List Scenario").exec(Requests.Dac.list(200, TestConfig.adminHeader))
+      scenario("Dac List Scenario").exec(Requests.Dac.list(OK.code, TestConfig.adminHeader))
     )
   )
 

--- a/automation/src/test/scala/org/broadinstitute/dsp/consent/scenarios/DataAccessScenarios.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsp/consent/scenarios/DataAccessScenarios.scala
@@ -1,0 +1,68 @@
+package org.broadinstitute.dsp.consent.scenarios
+
+import io.gatling.core.Predef._
+import org.broadinstitute.dsp.consent.{TestConfig, TestRunner}
+import org.broadinstitute.dsp.consent.requests.Requests
+import scala.concurrent.duration._
+import org.broadinstitute.dsp.consent.chains.{DarChains, DataSetChains, NihChains, AdminChains, MemberChains}
+
+class DataAccessScenarios extends Simulation with TestRunner {
+    runPopulations(
+        List(
+            defaultPopulation(
+                scenario("Researcher DAR with 2 DataSets")
+                .exitBlockOnFail {
+                    exec(
+                        Requests.User.me(200, TestConfig.researcherHeader)
+                    )
+                    .pause(1 second)
+                    .exec(
+                        DataSetChains.dataSetCatalogPickTwo(TestConfig.researcherHeader)
+                    )
+                    .pause(1)
+                    .exec(
+                        DarChains.darApplicationPageLoad(TestConfig.researcherHeader)
+                    )
+                    .exec(
+                        NihChains.authenticate(TestConfig.researcherHeader)
+                    )
+                    .exec(
+                        DarChains.finalDarSubmit(TestConfig.researcherHeader)
+                    )
+                }
+            )
+            .andThen(
+                defaultPopulation(
+                    scenario("Admins Election Creation")
+                    .exitBlockOnFail {
+                        exec(
+                            AdminChains.loginToConsole(TestConfig.adminHeader)
+                        )
+                        .pause(1)
+                        .exec(
+                            AdminChains.manageAccess(TestConfig.adminHeader)
+                        )
+                        .pause(1)
+                        .exec(
+                            AdminChains.createElections(TestConfig.adminHeader)
+                        )
+                    }
+                )
+                .andThen(
+                    defaultPopulation(
+                        scenario("Member Voting")
+                        .exitBlockOnFail {
+                            exec(
+                                MemberChains.loginToConsole(TestConfig.memberHeader)
+                            )
+                            .pause(1)
+                            .exec(
+                                MemberChains.voteOnPendingDars(TestConfig.memberHeader)
+                            )
+                        }
+                    )
+                )
+            )
+        )
+    )
+}

--- a/automation/src/test/scala/org/broadinstitute/dsp/consent/scenarios/DataAccessScenarios.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsp/consent/scenarios/DataAccessScenarios.scala
@@ -5,6 +5,7 @@ import org.broadinstitute.dsp.consent.{TestConfig, TestRunner}
 import org.broadinstitute.dsp.consent.requests.Requests
 import scala.concurrent.duration._
 import org.broadinstitute.dsp.consent.chains.{DarChains, DataSetChains, NihChains, AdminChains, MemberChains}
+import io.netty.handler.codec.http.HttpResponseStatus._
 
 class DataAccessScenarios extends Simulation with TestRunner {
     runPopulations(
@@ -13,7 +14,7 @@ class DataAccessScenarios extends Simulation with TestRunner {
                 scenario("Researcher DAR with 2 DataSets")
                 .exitBlockOnFail {
                     exec(
-                        Requests.User.me(200, TestConfig.researcherHeader)
+                        Requests.User.me(OK.code, TestConfig.researcherHeader)
                     )
                     .pause(1 second)
                     .exec(

--- a/automation/src/test/scala/org/broadinstitute/dsp/consent/scenarios/DataSetScenarios.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsp/consent/scenarios/DataSetScenarios.scala
@@ -3,13 +3,14 @@ package org.broadinstitute.dsp.consent.scenarios
 import io.gatling.core.Predef.{Simulation, scenario}
 import org.broadinstitute.dsp.consent.{TestConfig, TestRunner}
 import org.broadinstitute.dsp.consent.requests.Requests
+import io.netty.handler.codec.http.HttpResponseStatus._
 
 class DataSetScenarios extends Simulation with TestRunner {
     runScenarios(
         List(
             scenario("DataSet By DAC User Id Scenario")
-                .exec(Requests.User.me(200, TestConfig.researcherHeader))
-                .exec(Requests.DataSet.byUserId(200, "${dacUserId}", TestConfig.researcherHeader))
+                .exec(Requests.User.me(OK.code, TestConfig.researcherHeader))
+                .exec(Requests.DataSet.byUserId(OK.code, "${dacUserId}", TestConfig.researcherHeader))
         )
     )
 }

--- a/automation/src/test/scala/org/broadinstitute/dsp/consent/scenarios/DataSetScenarios.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsp/consent/scenarios/DataSetScenarios.scala
@@ -7,9 +7,9 @@ import org.broadinstitute.dsp.consent.requests.Requests
 class DataSetScenarios extends Simulation with TestRunner {
     runScenarios(
         List(
-            scenario("DatSet By DAC User Id Scenario")
+            scenario("DataSet By DAC User Id Scenario")
                 .exec(Requests.User.me(200, TestConfig.researcherHeader))
-                
+                .exec(Requests.DataSet.byUserId(200, "${dacUserId}", TestConfig.researcherHeader))
         )
     )
 }

--- a/automation/src/test/scala/org/broadinstitute/dsp/consent/scenarios/UserScenarios.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsp/consent/scenarios/UserScenarios.scala
@@ -3,32 +3,12 @@ package org.broadinstitute.dsp.consent.scenarios
 import io.gatling.core.Predef._
 import org.broadinstitute.dsp.consent.{TestConfig, TestRunner}
 import org.broadinstitute.dsp.consent.requests.Requests
-import scala.concurrent.duration._
-import org.broadinstitute.dsp.consent.chains.{DarChains, DataSetChains, NihChains}
 
 class UserScenarios extends Simulation with TestRunner {
     runScenarios(
         List(
-            scenario("User Login Scenario")
-                .exec(Requests.User.me(200, TestConfig.researcherHeader)),
-            scenario("Researcher DAR with 2 DataSets")
-                .exec(
-                    Requests.User.me(200, TestConfig.researcherHeader)
-                )
-                .pause(1 second)
-                .exec(
-                    DataSetChains.dataSetCatalogPickTwo(TestConfig.researcherHeader)
-                )
-                .pause(1)
-                .exec(
-                    DarChains.darApplicationPageLoad(TestConfig.researcherHeader)
-                )
-                .exec(
-                    NihChains.authenticate(TestConfig.researcherHeader)
-                )
-                .exec(
-                    DarChains.finalDarSubmit(TestConfig.researcherHeader)
-                )
+            scenario("User Login")
+                .exec(Requests.User.me(200, TestConfig.researcherHeader))
         )
     )
 }

--- a/automation/src/test/scala/org/broadinstitute/dsp/consent/scenarios/UserScenarios.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsp/consent/scenarios/UserScenarios.scala
@@ -8,8 +8,7 @@ import io.netty.handler.codec.http.HttpResponseStatus._
 class UserScenarios extends Simulation with TestRunner {
     runScenarios(
         List(
-            scenario("User Login")
-                .exec(Requests.User.me(OK.code, TestConfig.researcherHeader))
+            scenario("User Login").exec(Requests.User.me(OK.code, TestConfig.researcherHeader))
         )
     )
 }

--- a/automation/src/test/scala/org/broadinstitute/dsp/consent/scenarios/UserScenarios.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsp/consent/scenarios/UserScenarios.scala
@@ -3,12 +3,13 @@ package org.broadinstitute.dsp.consent.scenarios
 import io.gatling.core.Predef._
 import org.broadinstitute.dsp.consent.{TestConfig, TestRunner}
 import org.broadinstitute.dsp.consent.requests.Requests
+import io.netty.handler.codec.http.HttpResponseStatus._
 
 class UserScenarios extends Simulation with TestRunner {
     runScenarios(
         List(
             scenario("User Login")
-                .exec(Requests.User.me(200, TestConfig.researcherHeader))
+                .exec(Requests.User.me(OK.code, TestConfig.researcherHeader))
         )
     )
 }

--- a/automation/src/test/scala/org/broadinstitute/dsp/consent/services/DarService.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsp/consent/services/DarService.scala
@@ -9,6 +9,8 @@ import spray.json._
 import DefaultJsonProtocol._
 
 object DarService {
+    val projectTitle: String = "Test Automation Project"
+
     def createDar(dar: DataAccessRequest,
                   researcherInfo: ResearcherInfo, 
                   userId: Int, 
@@ -65,7 +67,7 @@ object DarService {
         dataMap += ("anvilUse" -> JsBoolean(false))
         dataMap += ("cloudUse" -> JsBoolean(false))
         dataMap += ("localUse" -> JsBoolean(true))
-        dataMap += ("projectTitle" -> JsString("Test Project"))
+        dataMap += ("projectTitle" -> JsString(projectTitle))
         dataMap += ("rus" -> JsString("test"))
         dataMap += ("nonTechRus" -> JsString("test non technical"))
         dataMap += ("hmb" -> JsBoolean(false))


### PR DESCRIPTION
**Addresses**
Partially addresses https://broadinstitute.atlassian.net/browse/DUOS-512 

**Changes**

- Made a small model fix
- Wrapped many chains in exitBlockOnFail to ensure errors properly fail the scenario
- Added more chains to simulate member login and access review

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [ ] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
