### PR TITLE
[DUOS-865][risk=no] Bug fix for Find Dataset By Name

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/DataSetDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DataSetDAO.java
@@ -196,7 +196,7 @@ public interface DataSetDAO extends Transactional<DataSetDAO> {
     @SqlQuery("SELECT dataSetId FROM dataset WHERE name = :name")
     Integer getDatasetIdByName(@Bind("name") String name);
 
-    @SqlQuery("SELECT * FROM dataset WHERE LOWER(name) LIKE LOWER(:name)")
+    @SqlQuery("SELECT * FROM dataset WHERE LOWER(name) LIKE CONCAT('%', LOWER(:name), '%')")
     DataSet getDatasetByName(@Bind("name") String name);
 
     @SqlQuery("select *  from dataset where name in (<names>) ")

--- a/src/main/java/org/broadinstitute/consent/http/db/DataSetDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DataSetDAO.java
@@ -196,7 +196,7 @@ public interface DataSetDAO extends Transactional<DataSetDAO> {
     @SqlQuery("SELECT dataSetId FROM dataset WHERE name = :name")
     Integer getDatasetIdByName(@Bind("name") String name);
 
-    @SqlQuery("SELECT * FROM dataset WHERE name LIKE LOWER(:name)")
+    @SqlQuery("SELECT * FROM dataset WHERE LOWER(name) LIKE LOWER(:name)")
     DataSet getDatasetByName(@Bind("name") String name);
 
     @SqlQuery("select *  from dataset where name in (<names>) ")

--- a/src/main/java/org/broadinstitute/consent/http/db/DataSetDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DataSetDAO.java
@@ -196,7 +196,7 @@ public interface DataSetDAO extends Transactional<DataSetDAO> {
     @SqlQuery("SELECT dataSetId FROM dataset WHERE name = :name")
     Integer getDatasetIdByName(@Bind("name") String name);
 
-    @SqlQuery("SELECT * FROM dataset WHERE LOWER(name) LIKE CONCAT('%', LOWER(:name), '%')")
+    @SqlQuery("SELECT * FROM dataset WHERE LOWER(name) = LOWER(:name);")
     DataSet getDatasetByName(@Bind("name") String name);
 
     @SqlQuery("select *  from dataset where name in (<names>) ")

--- a/src/main/java/org/broadinstitute/consent/http/db/DataSetDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DataSetDAO.java
@@ -196,7 +196,7 @@ public interface DataSetDAO extends Transactional<DataSetDAO> {
     @SqlQuery("SELECT dataSetId FROM dataset WHERE name = :name")
     Integer getDatasetIdByName(@Bind("name") String name);
 
-    @SqlQuery("SELECT * FROM dataset WHERE LOWER(name) = LOWER(:name);")
+    @SqlQuery("SELECT * FROM dataset WHERE LOWER(name) = LOWER(:name)")
     DataSet getDatasetByName(@Bind("name") String name);
 
     @SqlQuery("select *  from dataset where name in (<names>) ")


### PR DESCRIPTION
Follow up to: https://broadworkbench.atlassian.net/browse/DUOS-865

### Scope of Changes
---
- We wanted to match dataset names irrespective of case, but it was implemented only removing case from one half. This change compares both names as lowercase.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [ ] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
