### PR TITLE
[DUOS-940][risk=low] Conditional election final vote query fix

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/ElectionDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/ElectionDAO.java
@@ -95,10 +95,10 @@ public interface ElectionDAO extends Transactional<ElectionDAO> {
           + "FROM election e "
           + "LEFT JOIN vote v ON v.electionid = e.electionid AND "
           + "    CASE "
-          + "        WHEN LOWER(e.electiontype) = 'dataaccess' THEN LOWER(v.type) = 'final' "
-          + "        WHEN LOWER(e.electiontype) = 'dataset' THEN LOWER(v.type) = 'data_owner' "
-          + "        ELSE LOWER(v.type) = 'chairperson' "
-          + "    END "
+          + "        WHEN LOWER(e.electiontype) = 'dataaccess' THEN 'final' "
+          + "        WHEN LOWER(e.electiontype) = 'dataset' THEN 'data_owner' "
+          + "        ELSE 'chairperson' "
+          + "    END = LOWER(v.type)"
           + "WHERE e.electionid = :electionId LIMIT 1 ")
     Election findElectionWithFinalVoteById(@Bind("electionId") Integer electionId);
 

--- a/src/main/java/org/broadinstitute/consent/http/db/ElectionDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/ElectionDAO.java
@@ -91,15 +91,15 @@ public interface ElectionDAO extends Transactional<ElectionDAO> {
           + "    e.electionid,  e.datasetid, v.vote finalvote, e.status, e.createdate, "
           + "    e.referenceid, v.rationale finalrationale, v.createdate finalvotedate, "
           + "    e.lastupdate, e.finalaccessvote, e.electiontype,  e.datauseletter, e.dulname, "
-          + "    e.archived, e.version"
-          + "FROM election e"
+          + "    e.archived, e.version "
+          + "FROM election e "
           + "LEFT JOIN vote v ON v.electionid = e.electionid AND "
           + "    CASE "
-          + "        WHEN LOWER(e.electiontype) = 'dataaccess' THEN LOWER(v.type) = 'final'"
-          + "        WHEN LOWER(e.electiontype) = 'dataset' THEN LOWER(v.type) = 'data_owner'"
-          + "        ELSE LOWER(v.type) = 'chairperson'"
+          + "        WHEN LOWER(e.electiontype) = 'dataaccess' THEN LOWER(v.type) = 'final' "
+          + "        WHEN LOWER(e.electiontype) = 'dataset' THEN LOWER(v.type) = 'data_owner' "
+          + "        ELSE LOWER(v.type) = 'chairperson' "
           + "    END "
-          + "WHERE e.electionid = :electionId LIMIT 1")
+          + "WHERE e.electionid = :electionId LIMIT 1 ")
     Election findElectionWithFinalVoteById(@Bind("electionId") Integer electionId);
 
     @SqlQuery("select e.* from election e inner join vote v on v.electionId = e.electionId where  v.voteId = :voteId")

--- a/src/main/java/org/broadinstitute/consent/http/db/ElectionDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/ElectionDAO.java
@@ -88,7 +88,7 @@ public interface ElectionDAO extends Transactional<ElectionDAO> {
     Election getElectionWithFinalVoteByReferenceIdAndType(@Bind("referenceId") String referenceId, @Bind("type") String type);
 
     @SqlQuery("SELECT distinct "
-          + "    e.electionid,  e.datasetid, v.vote finalvote, e.status, e.createdate, "
+          + "    e.electionid, e.datasetid, v.vote finalvote, e.status, e.createdate, "
           + "    e.referenceid, v.rationale finalrationale, v.createdate finalvotedate, "
           + "    e.lastupdate, e.finalaccessvote, e.electiontype,  e.datauseletter, e.dulname, "
           + "    e.archived, e.version "

--- a/src/main/java/org/broadinstitute/consent/http/db/ElectionDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/ElectionDAO.java
@@ -87,10 +87,19 @@ public interface ElectionDAO extends Transactional<ElectionDAO> {
             + " where e.referenceId = :referenceId and lower(e.electionType) = lower(:type) and e.version = (select MAX(version) from election where referenceId = :referenceId)")
     Election getElectionWithFinalVoteByReferenceIdAndType(@Bind("referenceId") String referenceId, @Bind("type") String type);
 
-    @SqlQuery("select e.electionId,  e.datasetId, v.vote finalVote, e.status, e.createDate, e.referenceId, v.rationale finalRationale, v.createDate finalVoteDate, "
-            + " e.lastUpdate, e.finalAccessVote, e.electionType,  e.dataUseLetter, e.dulName, e.archived, e.version  from election e"
-            + " left join vote v on v.electionId = e.electionId and lower(v.type) = 'chairperson' "
-            + " where  e.electionId = :electionId")
+    @SqlQuery("SELECT distinct "
+          + "    e.electionid,  e.datasetid, v.vote finalvote, e.status, e.createdate, "
+          + "    e.referenceid, v.rationale finalrationale, v.createdate finalvotedate, "
+          + "    e.lastupdate, e.finalaccessvote, e.electiontype,  e.datauseletter, e.dulname, "
+          + "    e.archived, e.version"
+          + "FROM election e"
+          + "LEFT JOIN vote v ON v.electionid = e.electionid AND "
+          + "    CASE "
+          + "        WHEN LOWER(e.electiontype) = 'dataaccess' THEN LOWER(v.type) = 'final'"
+          + "        WHEN LOWER(e.electiontype) = 'dataset' THEN LOWER(v.type) = 'data_owner'"
+          + "        ELSE LOWER(v.type) = 'chairperson'"
+          + "    END "
+          + "WHERE e.electionid = :electionId LIMIT 1")
     Election findElectionWithFinalVoteById(@Bind("electionId") Integer electionId);
 
     @SqlQuery("select e.* from election e inner join vote v on v.electionId = e.electionId where  v.voteId = :voteId")

--- a/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
@@ -238,12 +238,15 @@ public class DAOTestHelper {
 
     protected Vote createDacVote(Integer userId, Integer electionId) {
         Integer voteId = voteDAO.insertVote(userId, electionId, VoteType.DAC.getValue());
-        voteDAO.updateVote(true, "rationale", new Date(), voteId, false, electionId, new Date(), false);
         return voteDAO.findVoteById(voteId);
-
     }
 
     protected Vote createFinalVote(Integer userId, Integer electionId) {
+        Integer voteId = voteDAO.insertVote(userId, electionId, VoteType.FINAL.getValue());
+        return voteDAO.findVoteById(voteId);
+    }
+
+    protected Vote createPopulatedFinalVote(Integer userId, Integer electionId) {
         Integer voteId = voteDAO.insertVote(userId, electionId, VoteType.FINAL.getValue());
         voteDAO.updateVote(true, "rationale", new Date(), voteId, false, electionId, new Date(), false);
         return voteDAO.findVoteById(voteId);
@@ -251,11 +254,16 @@ public class DAOTestHelper {
 
     protected Vote createChairpersonVote(Integer userId, Integer electionId) {
         Integer voteId = voteDAO.insertVote(userId, electionId, VoteType.CHAIRPERSON.getValue());
+        return voteDAO.findVoteById(voteId);
+    }
+
+    protected Vote createPopulatedChairpersonVote(Integer userId, Integer electionId) {
+        Integer voteId = voteDAO.insertVote(userId, electionId, VoteType.CHAIRPERSON.getValue());
         voteDAO.updateVote(true, "rationale", new Date(), voteId, false, electionId, new Date(), false);
         return voteDAO.findVoteById(voteId);
     }
 
-    protected Vote createDataOwnerVote(Integer userId, Integer electionId) {
+    protected Vote createPopulatedDataOwnerVote(Integer userId, Integer electionId) {
         Integer voteId = voteDAO.insertVote(userId, electionId, VoteType.DATA_OWNER.getValue());
         voteDAO.updateVote(true, "rationale", new Date(), voteId, false, electionId, new Date(), false);
         return voteDAO.findVoteById(voteId);

--- a/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
@@ -217,7 +217,7 @@ public class DAOTestHelper {
         return electionDAO.findElectionById(electionId);
     }
 
-    protected Election createDataSetLElection(String referenceId, Integer datasetId) {
+    protected Election createDatasetElection(String referenceId, Integer datasetId) {
         Integer electionId = electionDAO.insertElection(
                 ElectionType.DATA_SET.getValue(),
                 ElectionStatus.OPEN.getValue(),

--- a/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
@@ -205,6 +205,30 @@ public class DAOTestHelper {
         return electionDAO.findElectionById(electionId);
     }
 
+    protected Election createDULElection(String referenceId, Integer datasetId) {
+        Integer electionId = electionDAO.insertElection(
+                ElectionType.TRANSLATE_DUL.getValue(),
+                ElectionStatus.OPEN.getValue(),
+                new Date(),
+                referenceId,
+                datasetId
+        );
+        createdElectionIds.add(electionId);
+        return electionDAO.findElectionById(electionId);
+    }
+
+    protected Election createDataSetLElection(String referenceId, Integer datasetId) {
+        Integer electionId = electionDAO.insertElection(
+                ElectionType.DATA_SET.getValue(),
+                ElectionStatus.OPEN.getValue(),
+                new Date(),
+                referenceId,
+                datasetId
+        );
+        createdElectionIds.add(electionId);
+        return electionDAO.findElectionById(electionId);
+    }
+
     protected void closeElection(Election election) {
         electionDAO.updateElectionById(
                 election.getElectionId(),
@@ -214,16 +238,26 @@ public class DAOTestHelper {
 
     protected Vote createDacVote(Integer userId, Integer electionId) {
         Integer voteId = voteDAO.insertVote(userId, electionId, VoteType.DAC.getValue());
+        voteDAO.updateVote(true, "rationale", new Date(), voteId, false, electionId, new Date(), false);
         return voteDAO.findVoteById(voteId);
+
     }
 
     protected Vote createFinalVote(Integer userId, Integer electionId) {
         Integer voteId = voteDAO.insertVote(userId, electionId, VoteType.FINAL.getValue());
+        voteDAO.updateVote(true, "rationale", new Date(), voteId, false, electionId, new Date(), false);
         return voteDAO.findVoteById(voteId);
     }
 
     protected Vote createChairpersonVote(Integer userId, Integer electionId) {
         Integer voteId = voteDAO.insertVote(userId, electionId, VoteType.CHAIRPERSON.getValue());
+        voteDAO.updateVote(true, "rationale", new Date(), voteId, false, electionId, new Date(), false);
+        return voteDAO.findVoteById(voteId);
+    }
+
+    protected Vote createDataOwnerVote(Integer userId, Integer electionId) {
+        Integer voteId = voteDAO.insertVote(userId, electionId, VoteType.DATA_OWNER.getValue());
+        voteDAO.updateVote(true, "rationale", new Date(), voteId, false, electionId, new Date(), false);
         return voteDAO.findVoteById(voteId);
     }
 

--- a/src/test/java/org/broadinstitute/consent/http/db/ElectionDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/ElectionDAOTest.java
@@ -154,7 +154,7 @@ public class ElectionDAOTest extends DAOTestHelper {
     Consent c = createConsent(dac.getDacId());
     DataSet d = createDataset();
     createAssociation(c.getConsentId(), d.getDataSetId());
-    Election e = createDataSetLElection(c.getConsentId(), d.getDataSetId());
+    Election e = createDatasetElection(c.getConsentId(), d.getDataSetId());
     Vote v = createPopulatedDataOwnerVote(u.getDacUserId(), e.getElectionId());
 
     Election election = electionDAO.findElectionWithFinalVoteById(e.getElectionId());

--- a/src/test/java/org/broadinstitute/consent/http/db/ElectionDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/ElectionDAOTest.java
@@ -15,6 +15,8 @@ import org.broadinstitute.consent.http.models.Dac;
 import org.broadinstitute.consent.http.models.DataAccessRequest;
 import org.broadinstitute.consent.http.models.DataSet;
 import org.broadinstitute.consent.http.models.Election;
+import org.broadinstitute.consent.http.models.User;
+import org.broadinstitute.consent.http.models.Vote;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -113,16 +115,67 @@ public class ElectionDAOTest extends DAOTestHelper {
   }
 
   @Test
-  public void testFindElectionWithFinalVoteById() {
+  public void testFindAccessElectionWithFinalVoteById() {
+    User u = createUser();
     Dac dac = createDac();
     Consent c = createConsent(dac.getDacId());
     DataSet d = createDataset();
     createAssociation(c.getConsentId(), d.getDataSetId());
     Election e = createAccessElection(c.getConsentId(), d.getDataSetId());
+    Vote v = createFinalVote(u.getDacUserId(), e.getElectionId());
 
     Election election = electionDAO.findElectionWithFinalVoteById(e.getElectionId());
     assertNotNull(election);
     assertEquals(e.getElectionId(), election.getElectionId());
+    assertEquals(v.getVote(), election.getFinalVote());
+  }
+
+  @Test
+  public void testRPFindElectionWithFinalVoteById() {
+    User u = createUser();
+    Dac dac = createDac();
+    Consent c = createConsent(dac.getDacId());
+    DataSet d = createDataset();
+    createAssociation(c.getConsentId(), d.getDataSetId());
+    Election e = createRPElection(c.getConsentId(), d.getDataSetId());
+    Vote v = createChairpersonVote(u.getDacUserId(), e.getElectionId());
+
+    Election election = electionDAO.findElectionWithFinalVoteById(e.getElectionId());
+    assertNotNull(election);
+    assertEquals(e.getElectionId(), election.getElectionId());
+    assertEquals(v.getVote(), election.getFinalVote());
+  }
+
+  @Test
+  public void testDataSetFindElectionWithFinalVoteById() {
+    User u = createUser();
+    Dac dac = createDac();
+    Consent c = createConsent(dac.getDacId());
+    DataSet d = createDataset();
+    createAssociation(c.getConsentId(), d.getDataSetId());
+    Election e = createDataSetLElection(c.getConsentId(), d.getDataSetId());
+    Vote v = createDataOwnerVote(u.getDacUserId(), e.getElectionId());
+
+    Election election = electionDAO.findElectionWithFinalVoteById(e.getElectionId());
+    assertNotNull(election);
+    assertEquals(e.getElectionId(), election.getElectionId());
+    assertEquals(v.getVote(), election.getFinalVote());
+  }
+
+  @Test
+  public void testDULFindElectionWithFinalVoteById() {
+    User u = createUser();
+    Dac dac = createDac();
+    Consent c = createConsent(dac.getDacId());
+    DataSet d = createDataset();
+    createAssociation(c.getConsentId(), d.getDataSetId());
+    Election e = createDULElection(c.getConsentId(), d.getDataSetId());
+    Vote v = createChairpersonVote(u.getDacUserId(), e.getElectionId());
+
+    Election election = electionDAO.findElectionWithFinalVoteById(e.getElectionId());
+    assertNotNull(election);
+    assertEquals(e.getElectionId(), election.getElectionId());
+    assertEquals(v.getVote(), election.getFinalVote());
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/db/ElectionDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/ElectionDAOTest.java
@@ -148,7 +148,7 @@ public class ElectionDAOTest extends DAOTestHelper {
   }
 
   @Test
-  public void testDataSetFindElectionWithFinalVoteById() {
+  public void testDatasetFindElectionWithFinalVoteById() {
     User u = createUserWithRole(UserRoles.DATAOWNER.getRoleId());
     Dac dac = createDac();
     Consent c = createConsent(dac.getDacId());

--- a/src/test/java/org/broadinstitute/consent/http/db/ElectionDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/ElectionDAOTest.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.UUID;
 import org.apache.commons.lang3.tuple.Pair;
 import org.broadinstitute.consent.http.enumeration.ElectionType;
+import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.Consent;
 import org.broadinstitute.consent.http.models.Dac;
 import org.broadinstitute.consent.http.models.DataAccessRequest;
@@ -116,7 +117,7 @@ public class ElectionDAOTest extends DAOTestHelper {
 
   @Test
   public void testFindAccessElectionWithFinalVoteById() {
-    User u = createUser();
+    User u = createUserWithRole(UserRoles.CHAIRPERSON.getRoleId());
     Dac dac = createDac();
     Consent c = createConsent(dac.getDacId());
     DataSet d = createDataset();
@@ -132,7 +133,7 @@ public class ElectionDAOTest extends DAOTestHelper {
 
   @Test
   public void testRPFindElectionWithFinalVoteById() {
-    User u = createUser();
+    User u = createUserWithRole(UserRoles.CHAIRPERSON.getRoleId());
     Dac dac = createDac();
     Consent c = createConsent(dac.getDacId());
     DataSet d = createDataset();
@@ -148,7 +149,7 @@ public class ElectionDAOTest extends DAOTestHelper {
 
   @Test
   public void testDataSetFindElectionWithFinalVoteById() {
-    User u = createUser();
+    User u = createUserWithRole(UserRoles.DATAOWNER.getRoleId());
     Dac dac = createDac();
     Consent c = createConsent(dac.getDacId());
     DataSet d = createDataset();
@@ -164,7 +165,7 @@ public class ElectionDAOTest extends DAOTestHelper {
 
   @Test
   public void testDULFindElectionWithFinalVoteById() {
-    User u = createUser();
+    User u = createUserWithRole(UserRoles.CHAIRPERSON.getRoleId());
     Dac dac = createDac();
     Consent c = createConsent(dac.getDacId());
     DataSet d = createDataset();

--- a/src/test/java/org/broadinstitute/consent/http/db/ElectionDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/ElectionDAOTest.java
@@ -123,7 +123,7 @@ public class ElectionDAOTest extends DAOTestHelper {
     DataSet d = createDataset();
     createAssociation(c.getConsentId(), d.getDataSetId());
     Election e = createAccessElection(c.getConsentId(), d.getDataSetId());
-    Vote v = createFinalVote(u.getDacUserId(), e.getElectionId());
+    Vote v = createPopulatedFinalVote(u.getDacUserId(), e.getElectionId());
 
     Election election = electionDAO.findElectionWithFinalVoteById(e.getElectionId());
     assertNotNull(election);
@@ -139,7 +139,7 @@ public class ElectionDAOTest extends DAOTestHelper {
     DataSet d = createDataset();
     createAssociation(c.getConsentId(), d.getDataSetId());
     Election e = createRPElection(c.getConsentId(), d.getDataSetId());
-    Vote v = createChairpersonVote(u.getDacUserId(), e.getElectionId());
+    Vote v = createPopulatedChairpersonVote(u.getDacUserId(), e.getElectionId());
 
     Election election = electionDAO.findElectionWithFinalVoteById(e.getElectionId());
     assertNotNull(election);
@@ -155,7 +155,7 @@ public class ElectionDAOTest extends DAOTestHelper {
     DataSet d = createDataset();
     createAssociation(c.getConsentId(), d.getDataSetId());
     Election e = createDataSetLElection(c.getConsentId(), d.getDataSetId());
-    Vote v = createDataOwnerVote(u.getDacUserId(), e.getElectionId());
+    Vote v = createPopulatedDataOwnerVote(u.getDacUserId(), e.getElectionId());
 
     Election election = electionDAO.findElectionWithFinalVoteById(e.getElectionId());
     assertNotNull(election);
@@ -171,7 +171,7 @@ public class ElectionDAOTest extends DAOTestHelper {
     DataSet d = createDataset();
     createAssociation(c.getConsentId(), d.getDataSetId());
     Election e = createDULElection(c.getConsentId(), d.getDataSetId());
-    Vote v = createChairpersonVote(u.getDacUserId(), e.getElectionId());
+    Vote v = createPopulatedChairpersonVote(u.getDacUserId(), e.getElectionId());
 
     Election election = electionDAO.findElectionWithFinalVoteById(e.getElectionId());
     assertNotNull(election);


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-940

## Changes
The get-election-by-id query was pulling the final vote from the chairperson vote. That is technically incorrect as that only applies to RP and DUL elections. DAR elections have a final vote based on a vote type of final. Data Owner elections have a final vote based on the data owner vote type.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [ ] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
