### PR TITLE
DUOS-731 Minor fix for turnaround times that can be less than 0

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/models/DarDecisionMetrics.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DarDecisionMetrics.java
@@ -170,9 +170,9 @@ public class DarDecisionMetrics implements DecisionMetrics {
         submittedDate.setTime(this.getDateSubmitted());
         finalDate.setTime(finalVoteDate);
         Duration duration = Duration.between(submittedDate.toInstant(), finalDate.toInstant());
-        this.turnaroundTimeMillis = duration.toMillis();
+        this.turnaroundTimeMillis = (duration.toMillis() < 0) ? 0 : duration.toMillis();
         this.turnaroundTime =
-            DurationFormatUtils.formatDurationWords(duration.toMillis(), true, true);
+            DurationFormatUtils.formatDurationWords(this.turnaroundTimeMillis, true, true);
       }
     }
   }


### PR DESCRIPTION
There can be the case where the election update date/final vote date is truncated and the submission date is not which looks like the turnaround time is negative, and cannot be formatted. Set those cases to 0 so we can format the turnaround time correctly.

----

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [ ] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
