### PR TITLE
[DUOS-939][risk=no] Add script to parse results of gatling tests

### DIFF
--- a/automation/scripts/interpret_results.py
+++ b/automation/scripts/interpret_results.py
@@ -3,6 +3,18 @@ import xmltodict, json
 import pprint
 import datetime
 
+"""
+This script parses gatling automated test results into a format expected by 
+https://github.com/broadinstitute/firecloud-automated-testing. Gatling does not
+print the "type" attribute that is desired on the failures, and therefore the failures do
+not get picked up and sent to BQ.
+
+TODO: This script will also serve as a way of parsing the results to measure the performance
+over time of these tests.
+
+Auther: @rfricke-asymmetrik
+"""
+
 pp = pprint.PrettyPrinter()
 
 def get_assertions_xml(test_dir, simulation):

--- a/automation/scripts/parse_results.py
+++ b/automation/scripts/parse_results.py
@@ -1,0 +1,71 @@
+import sys, os
+import xmltodict, json
+import pprint
+import datetime
+
+pp = pprint.PrettyPrinter()
+
+def get_assertions_xml(test_dir, simulation):
+    sim_dir = os.path.join(test_dir, "test-reports", "TEST-" + simulation + ".xml")
+    return xmltodict.parse(open(sim_dir, 'rb'), force_list={'testcase'})
+
+def get_test_case(line, className):
+    message = line[line.find('KO\t') + 3:].replace('\n', '')
+    text = message
+    sim_split = line.split('\t')
+    start = float(sim_split[3])
+    end = float(sim_split[4])
+    time = end - start
+    name = className.split('.')[len(className.split('.')) - 1]
+
+    return {
+        '@class': className,
+        '@name': name,
+        '@time': time,
+        'failure': {
+            '@message': message,
+            '@type': 'class ' + className,
+            '#text': text
+        }
+    }
+
+def get_failures(lines, className):
+    failures = filter(lambda l: l.find("\tKO\t") > -1, lines)
+    return list(map(lambda k: get_test_case(k, className), failures))
+
+def parse_gatling_results(gatling_dir):
+    scenarios = {}
+    for file_path in os.listdir(os.path.join(gatling_dir, "gatling")):
+        scenario_path = os.path.join(gatling_dir, "gatling", file_path)
+        simulation_path = os.path.join(scenario_path, 'simulation.log')
+        js_path = os.path.join(scenario_path, 'js')
+
+        assertion_json = json.load(open(os.path.join(js_path, 'assertions.json'), 'r'))
+        simulation_log_lines = open(simulation_path, 'r').readlines()
+
+        simulation = assertion_json['simulation']
+
+        failures = get_failures(simulation_log_lines, simulation)
+
+        assertions_xml = get_assertions_xml(gatling_dir, simulation)
+        test_suite = assertions_xml['testsuite']
+        if len(failures) > 0:
+            test_suite.pop('testcase', None)
+            test_suite['testcase'] = failures
+            test_suite['@failures'] = len(failures)
+            test_suite['@tests'] = len(failures)
+            assertions_xml['testsuite'] = test_suite
+
+        scenarios[simulation] = xmltodict.unparse(assertions_xml, pretty=True)
+    return scenarios
+
+if __name__ == '__main__':
+    r = parse_gatling_results("target")
+    for scn in r:
+        sim_dir = os.path.join("target/test-reports", "TEST-" + scn + ".xml")
+        with open(sim_dir, 'w') as wf:
+            wf.write(r[scn])
+            wf.write('\n')
+        
+        print(sim_dir)
+        

--- a/jenkins/jenkins-automation-tests.sh
+++ b/jenkins/jenkins-automation-tests.sh
@@ -49,7 +49,7 @@ docker run -v "${PWD}/target":/app/target ${TEST_IMAGE}
 TEST_EXIT_CODE=$?
 
 # Parse Tests
-docker run -v "${PWD}/scripts":/working -v "${PWD}/target":/working/target -w /working broadinstitute/dsp-toolbox python parse_results.py
+docker run -v "${PWD}/scripts":/working -v "${PWD}/target":/working/target -w /working broadinstitute/dsp-toolbox python interpret_results.py
 
 # exit with exit code of test script
 exit $TEST_EXIT_CODE

--- a/jenkins/jenkins-automation-tests.sh
+++ b/jenkins/jenkins-automation-tests.sh
@@ -48,5 +48,8 @@ docker build -f Dockerfile -t ${TEST_IMAGE} .
 docker run -v "${PWD}/target":/app/target ${TEST_IMAGE}
 TEST_EXIT_CODE=$?
 
+# Parse Tests
+docker run -v "${PWD}/scripts":/working -v "${PWD}/target":/working/target -w /working broadinstitute/dsp-toolbox python parse_results.py
+
 # exit with exit code of test script
 exit $TEST_EXIT_CODE


### PR DESCRIPTION
**Address**
https://broadworkbench.atlassian.net/browse/DUOS-939

**Changes**
Added python script to process results of gatling tests. The Failures should now be written with the correct attributes.
Modified automation test script to call python script via dsp toolbox docker container.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [ ] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
