### PR TITLE
[DUOS-973][risk=no] Split automation tests into two scripts

### DIFF
--- a/jenkins/jenkins-render-configs.sh
+++ b/jenkins/jenkins-render-configs.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -e
+
+# This script is specific to DSP's jenkins CI server.
+# Although this script lives in a `jenkins` directory, it is intended to be run from `automation`.
+# It is here because it is only intended to be run from a jenkins job and not by developers.
+
+ENV=${1:-$ENV}
+
+# Render Configurations
+docker run --rm \
+  -e ENVIRONMENT="$ENV" \
+  -e ROOT_DIR="${PWD}" \
+  -v /etc/vault-token-dsde:/root/.vault-token \
+  -e OUT_PATH=/output/src/test/resources \
+  -v "$PWD":/output \
+  -e INPUT_PATH=/input \
+  -v "$PWD"/configs:/input \
+  broadinstitute/dsde-toolbox:dev render-templates.sh
+
+# render role service account credential files
+secretPath="/secret/dsde/firecloud/${ENV}/consent/automation"
+
+listOfRoles="admin
+chair
+member
+researcher"
+
+for role in $listOfRoles; do
+  echo "Writing $role file from $secretPath/duos-automation-$role.json"
+  docker run --rm \
+    -v "$HOME":/root \
+    -v /etc/vault-token-dsde:/root/.vault-token \
+    broadinstitute/dsde-toolbox:dev vault read \
+    --format=json \
+    "$secretPath"/duos-automation-"$role".json |
+    jq .data \
+    >src/test/resources/accounts/duos-automation-"$role".json
+done

--- a/jenkins/jenkins-run-tests.sh
+++ b/jenkins/jenkins-run-tests.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -e
+
+# This script is specific to DSP's jenkins CI server.
+# Although this script lives in a `jenkins` directory, it is intended to be run from `automation`.
+# It is here because it is only intended to be run from a jenkins job and not by developers.
+
+TEST_IMAGE=automation-consent
+
+mkdir -p target
+
+# Build Test Image
+docker build -f Dockerfile -t ${TEST_IMAGE} .
+
+# Run Tests
+docker run -v "${PWD}/target":/app/target ${TEST_IMAGE}
+TEST_EXIT_CODE=$?
+
+# Parse Tests
+docker run -v "${PWD}/scripts":/working -v "${PWD}/target":/working/target -w /working broadinstitute/dsp-toolbox python interpret_results.py
+
+# exit with exit code of test script
+exit $TEST_EXIT_CODE


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-973

Follow up task will be to remove the original script. We can't do that until these are in place and functional.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [ ] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
