### PR TITLE
[DUOS-970][risk=low] Update DAR "datasetId" fields

### DIFF
--- a/src/main/resources/changelog-master.xml
+++ b/src/main/resources/changelog-master.xml
@@ -60,4 +60,5 @@
     <include file="changesets/changelog-consent-55.0.xml" relativeToChangelogFile="true"/>
     <include file="changesets/changelog-consent-56.0.xml" relativeToChangelogFile="true"/>
     <include file="changesets/changelog-consent-57.0.xml" relativeToChangelogFile="true"/>
+    <include file="changesets/changelog-consent-58.0.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/changesets/changelog-consent-58.0.xml
+++ b/src/main/resources/changesets/changelog-consent-58.0.xml
@@ -1,0 +1,16 @@
+<databaseChangeLog
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet dbms="postgresql" author="grushton" id="58.0">
+        <!-- Back populate the datasetIds for all DARs -->
+        <sql>
+            UPDATE data_access_request
+            SET data = replace(data::TEXT,'\"datasetId\"','\"datasetIds\"')::jsonb
+            WHERE (data #>> '{}')::jsonb->>'datasetId' is not null;
+        </sql>
+    </changeSet>
+
+</databaseChangeLog>


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-970

We have data access requests with the old form of the dataset ids field
```
SELECT id, reference_id, draft, submission_date, (data #>> '{}')::jsonb->>'datasetIds', (data #>> '{}')::jsonb->>'datasetId' 
FROM data_access_request
WHERE not (data #>> '{}')::jsonb ?| array['partial_dar_code', 'partialDarCode']
AND draft != true;
...
 id  |             reference_id             | draft |     submission_date     | ?column? | ?column? 
-----+--------------------------------------+-------+-------------------------+----------+----------
 1   | blah                                 | f     | 2019-10-18 02:48:23.945 |          | [2]   <--- outdated
 2   | blah                                 | f     | 2020-01-07 15:22:02.028 |          | [380] <--- outdated
 3   | blah                                 | f     | 2020-03-30 12:00:17.878 | [385]    | 
 4   | blah                                 | f     | 2020-02-11 18:55:03.842 |          | [386] <--- outdated
 5   | blah                                 | f     | 2020-03-04 16:57:38.802 |          | [369] <--- outdated
```

This PR migrates the `datasetId` to `datasetIds` so the datasets for the DARs are picked up correctly.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [ ] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
