### PR TITLE
DUOS-941[risk=no] Fix SRPs that all show mis-matching results

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/models/DarDecisionMetrics.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DarDecisionMetrics.java
@@ -230,7 +230,7 @@ public class DarDecisionMetrics implements DecisionMetrics {
    * @param election The election
    */
   private void setSrpDecision(Election election) {
-    if (Objects.nonNull(election)) {
+    if (Objects.nonNull(dacDecision) && Objects.nonNull(election) && election.getElectionType().equals("RP")) {
       Boolean rpVote =
         Objects.nonNull(election.getFinalVote())
           ? election.getFinalVote()

--- a/src/main/java/org/broadinstitute/consent/http/models/DarDecisionMetrics.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DarDecisionMetrics.java
@@ -230,7 +230,7 @@ public class DarDecisionMetrics implements DecisionMetrics {
    * @param election The election
    */
   private void setSrpDecision(Election election) {
-    if (Objects.nonNull(dacDecision) && Objects.nonNull(election) && election.getElectionType().equals("RP")) {
+    if (Objects.nonNull(dacDecision) && Objects.nonNull(election) && election.getElectionType().equals(ElectionType.RP.getValue())) {
       Boolean rpVote =
         Objects.nonNull(election.getFinalVote())
           ? election.getFinalVote()

--- a/src/main/java/org/broadinstitute/consent/http/models/DarDecisionMetrics.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DarDecisionMetrics.java
@@ -230,7 +230,7 @@ public class DarDecisionMetrics implements DecisionMetrics {
    * @param election The election
    */
   private void setSrpDecision(Election election) {
-    if (Objects.nonNull(dacDecision) && Objects.nonNull(election) && election.getElectionType().equals(ElectionType.RP.getValue())) {
+    if (Objects.nonNull(dacDecision) && Objects.nonNull(election)) {
       Boolean rpVote =
         Objects.nonNull(election.getFinalVote())
           ? election.getFinalVote()


### PR DESCRIPTION
Scope:
-ensure election is correct type
-ensure dac decision has already been made

Addresses:
https://broadworkbench.atlassian.net/browse/DUOS-941

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [ ] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
