### PR TITLE
DUOS-985[risk=no]Fix bug introduced by DUOS-942

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/models/DarDecisionMetrics.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DarDecisionMetrics.java
@@ -76,7 +76,7 @@ public class DarDecisionMetrics implements DecisionMetrics {
       getValue(getDateSubmitted()),
       getValue(getDateApproved()),
       getValue(getDateDenied()),
-      getValue(getTurnaroundTime().toString()),
+      getValue(getTurnaroundTime()),
       getValue(getDacDecision()),
       getValue(getAlgorithmDecision()),
       getValue(getDacDecision().equals(getAlgorithmDecision()) ? "Yes" : "No"),
@@ -245,6 +245,10 @@ public class DarDecisionMetrics implements DecisionMetrics {
 
   private String getValue(String str) {
     return Objects.nonNull(str) ? str : "";
+  }
+
+  private String getValue(Integer i) {
+    return Objects.nonNull(i) ? i.toString() : "";
   }
 
   private String getValue(Date date) {


### PR DESCRIPTION
## Addresses 
https://broadworkbench.atlassian.net/browse/DUOS-985

## Scope
-resolve null pointer caused by .toString()

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [ ] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
