### PR TITLE
[DUOS-545][risk=medium] Add Chairpersons to the roles allowed for updating DAC membership

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
@@ -289,7 +289,7 @@ public class ConsentApplication extends Application<ConsentConfiguration> {
         env.jersey().register(new DataRequestVoteResource(datasetAssociationService, emailNotifierService, voteService));
         env.jersey().register(new DataUseLetterResource(auditService, googleStore, userService));
         env.jersey().register(new DataRequestCasesResource(electionService, pendingCaseService, summaryService));
-        env.jersey().register(new DacResource(dacService));
+        env.jersey().register(new DacResource(dacService, userService));
         env.jersey().register(new DACUserResource(userService));
         env.jersey().register(new ElectionReviewResource(dataAccessRequestService));
         env.jersey().register(new ElectionResource(voteService));

--- a/src/main/java/org/broadinstitute/consent/http/resources/DacResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DacResource.java
@@ -117,9 +117,9 @@ public class DacResource extends Resource {
 
     @POST
     @Path("{dacId}/member/{userId}")
-    @RolesAllowed({ADMIN})
+    @RolesAllowed({ADMIN, CHAIRPERSON})
     public Response addDacMember(@Auth AuthUser authUser, @PathParam("dacId") Integer dacId, @PathParam("userId") Integer userId) {
-        checkMembership(dacId, userId);
+        checkUserInDac(dacId, userId);
         Role role = dacService.getMemberRole();
         User user = findDacUser(userId);
         Dac dac = findDacById(dacId);
@@ -133,7 +133,7 @@ public class DacResource extends Resource {
 
     @DELETE
     @Path("{dacId}/member/{userId}")
-    @RolesAllowed({ADMIN})
+    @RolesAllowed({ADMIN, CHAIRPERSON})
     public Response removeDacMember(@Auth AuthUser authUser, @PathParam("dacId") Integer dacId, @PathParam("userId") Integer userId) {
         Role role = dacService.getMemberRole();
         User user = findDacUser(userId);
@@ -148,9 +148,9 @@ public class DacResource extends Resource {
 
     @POST
     @Path("{dacId}/chair/{userId}")
-    @RolesAllowed({ADMIN})
+    @RolesAllowed({ADMIN, CHAIRPERSON})
     public Response addDacChair(@Auth AuthUser authUser, @PathParam("dacId") Integer dacId, @PathParam("userId") Integer userId) {
-        checkMembership(dacId, userId);
+        checkUserInDac(dacId, userId);
         Role role = dacService.getChairpersonRole();
         User user = findDacUser(userId);
         Dac dac = findDacById(dacId);
@@ -164,7 +164,7 @@ public class DacResource extends Resource {
 
     @DELETE
     @Path("{dacId}/chair/{userId}")
-    @RolesAllowed({ADMIN})
+    @RolesAllowed({ADMIN, CHAIRPERSON})
     public Response removeDacChair(@Auth AuthUser authUser, @PathParam("dacId") Integer dacId, @PathParam("userId") Integer userId) {
         Role role = dacService.getChairpersonRole();
         User user = findDacUser(userId);
@@ -222,7 +222,13 @@ public class DacResource extends Resource {
         return dac;
     }
 
-    private void checkMembership(Integer dacId, Integer userId) {
+    /**
+     * Validate that a user is not already a member of a DAC. If they are, throw a conflict
+     * exception.
+     * @param dacId The DAC Id
+     * @param userId The User Id
+     */
+    private void checkUserInDac(Integer dacId, Integer userId) {
         List<User> currentMembers = dacService.findMembersByDacId(dacId);
         Optional<User> isMember = currentMembers.
                 stream().

--- a/src/main/java/org/broadinstitute/consent/http/resources/DacResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DacResource.java
@@ -27,7 +27,6 @@ import org.broadinstitute.consent.http.models.AuthUser;
 import org.broadinstitute.consent.http.models.Dac;
 import org.broadinstitute.consent.http.models.Role;
 import org.broadinstitute.consent.http.models.User;
-import org.broadinstitute.consent.http.models.UserRole;
 import org.broadinstitute.consent.http.models.dto.DataSetDTO;
 import org.broadinstitute.consent.http.service.DacService;
 import org.broadinstitute.consent.http.service.UserService;

--- a/src/main/java/org/broadinstitute/consent/http/resources/DacResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DacResource.java
@@ -42,7 +42,7 @@ public class DacResource extends Resource {
     @Produces("application/json")
     @RolesAllowed({ADMIN, MEMBER, CHAIRPERSON, RESEARCHER})
     public Response findAll(@Auth AuthUser authUser, @QueryParam("withUsers") Optional<Boolean> withUsers) {
-        final Boolean includeUsers = withUsers.isPresent() ? withUsers.get() : true;
+        final Boolean includeUsers = withUsers.orElse(true);
         List<Dac> dacs = dacService.findDacsWithMembersOption(includeUsers);
         return Response.ok().entity(dacs).build();
     }

--- a/src/test/java/org/broadinstitute/consent/http/resources/DacResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DacResourceTest.java
@@ -1,10 +1,12 @@
 package org.broadinstitute.consent.http.resources;
 
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.isA;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 
+import com.google.api.client.http.HttpStatusCodes;
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import java.util.Collections;
@@ -54,9 +56,9 @@ public class DacResourceTest {
         when(dacService.findDacsWithMembersOption(true)).thenReturn(Collections.emptyList());
 
         Response response = dacResource.findAll(authUser, Optional.of(true));
-        Assert.assertEquals(200, response.getStatus());
+        assertEquals(200, response.getStatus());
         JsonArray dacs = getListFromEntityString(response.getEntity().toString());
-        Assert.assertEquals(0, dacs.size());
+        assertEquals(0, dacs.size());
     }
 
     @Test
@@ -68,9 +70,9 @@ public class DacResourceTest {
         when(dacService.findDacsWithMembersOption(true)).thenReturn(Collections.singletonList(dac));
 
         Response response = dacResource.findAll(authUser, Optional.of(true));
-        Assert.assertEquals(200, response.getStatus());
+        assertEquals(200, response.getStatus());
         JsonArray dacs = getListFromEntityString(response.getEntity().toString());
-        Assert.assertEquals(1, dacs.size());
+        assertEquals(1, dacs.size());
     }
 
     @Test
@@ -78,9 +80,9 @@ public class DacResourceTest {
         when(dacService.findDacsWithMembersOption(false)).thenReturn(Collections.emptyList());
 
         Response response = dacResource.findAll(authUser, Optional.of(false));
-        Assert.assertEquals(200, response.getStatus());
+        assertEquals(200, response.getStatus());
         JsonArray dacs = getListFromEntityString(response.getEntity().toString());
-        Assert.assertEquals(0, dacs.size());
+        assertEquals(0, dacs.size());
     }
 
     @Test
@@ -93,7 +95,7 @@ public class DacResourceTest {
         when(dacService.findById(1)).thenReturn(dac);
 
         Response response = dacResource.createDac(authUser, gson.toJson(dac));
-        Assert.assertEquals(200, response.getStatus());
+        assertEquals(200, response.getStatus());
     }
 
     @Test(expected = BadRequestException.class)
@@ -137,7 +139,7 @@ public class DacResourceTest {
         when(dacService.findById(1)).thenReturn(dac);
 
         Response response = dacResource.updateDac(authUser, gson.toJson(dac));
-        Assert.assertEquals(200, response.getStatus());
+        assertEquals(200, response.getStatus());
     }
 
     @Test(expected = BadRequestException.class)
@@ -185,7 +187,7 @@ public class DacResourceTest {
         when(dacService.findById(1)).thenReturn(dac);
 
         Response response = dacResource.findById(dac.getDacId());
-        Assert.assertEquals(200, response.getStatus());
+        assertEquals(200, response.getStatus());
     }
 
     @Test(expected = NotFoundException.class)
@@ -205,7 +207,7 @@ public class DacResourceTest {
         when(dacService.findById(1)).thenReturn(dac);
 
         Response response = dacResource.deleteDac(dac.getDacId());
-        Assert.assertEquals(200, response.getStatus());
+        assertEquals(200, response.getStatus());
 
     }
 
@@ -225,7 +227,8 @@ public class DacResourceTest {
         when(userService.findUserByEmail(authUser.getName())).thenReturn(admin);
         when(dacService.findUserById(member.getDacUserId())).thenReturn(member);
 
-        dacResource.addDacMember(authUser, dac.getDacId(), member.getDacUserId());
+        Response response = dacResource.addDacMember(authUser, dac.getDacId(), member.getDacUserId());
+        assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
     }
 
     @Test
@@ -237,7 +240,8 @@ public class DacResourceTest {
         when(userService.findUserByEmail(authUser.getName())).thenReturn(chair);
         when(dacService.findUserById(member.getDacUserId())).thenReturn(member);
 
-        dacResource.addDacMember(authUser, dac.getDacId(), member.getDacUserId());
+        Response response = dacResource.addDacMember(authUser, dac.getDacId(), member.getDacUserId());
+        assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
     }
 
     @Test(expected = NotAuthorizedException.class)
@@ -261,7 +265,8 @@ public class DacResourceTest {
         when(userService.findUserByEmail(authUser.getName())).thenReturn(admin);
         when(dacService.findUserById(member.getDacUserId())).thenReturn(member);
 
-        dacResource.removeDacMember(authUser, dac.getDacId(), member.getDacUserId());
+        Response response = dacResource.removeDacMember(authUser, dac.getDacId(), member.getDacUserId());
+        assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
     }
 
     @Test
@@ -273,7 +278,8 @@ public class DacResourceTest {
         when(userService.findUserByEmail(authUser.getName())).thenReturn(chair);
         when(dacService.findUserById(member.getDacUserId())).thenReturn(member);
 
-        dacResource.removeDacMember(authUser, dac.getDacId(), member.getDacUserId());
+        Response response = dacResource.removeDacMember(authUser, dac.getDacId(), member.getDacUserId());
+        assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
     }
 
     @Test(expected = NotAuthorizedException.class)
@@ -297,7 +303,8 @@ public class DacResourceTest {
         when(userService.findUserByEmail(authUser.getName())).thenReturn(admin);
         when(dacService.findUserById(member.getDacUserId())).thenReturn(member);
 
-        dacResource.addDacChair(authUser, dac.getDacId(), member.getDacUserId());
+        Response response = dacResource.addDacChair(authUser, dac.getDacId(), member.getDacUserId());
+        assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
     }
 
     @Test
@@ -309,7 +316,8 @@ public class DacResourceTest {
         when(userService.findUserByEmail(authUser.getName())).thenReturn(chair);
         when(dacService.findUserById(member.getDacUserId())).thenReturn(member);
 
-        dacResource.addDacChair(authUser, dac.getDacId(), member.getDacUserId());
+        Response response = dacResource.addDacChair(authUser, dac.getDacId(), member.getDacUserId());
+        assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
     }
 
     @Test(expected = NotAuthorizedException.class)
@@ -333,7 +341,8 @@ public class DacResourceTest {
         when(userService.findUserByEmail(authUser.getName())).thenReturn(admin);
         when(dacService.findUserById(member.getDacUserId())).thenReturn(member);
 
-        dacResource.removeDacChair(authUser, dac.getDacId(), member.getDacUserId());
+        Response response = dacResource.removeDacChair(authUser, dac.getDacId(), member.getDacUserId());
+        assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
     }
 
     @Test
@@ -345,7 +354,8 @@ public class DacResourceTest {
         when(userService.findUserByEmail(authUser.getName())).thenReturn(chair);
         when(dacService.findUserById(member.getDacUserId())).thenReturn(member);
 
-        dacResource.removeDacChair(authUser, dac.getDacId(), member.getDacUserId());
+        Response response = dacResource.removeDacChair(authUser, dac.getDacId(), member.getDacUserId());
+        assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
     }
 
     @Test(expected = NotAuthorizedException.class)


### PR DESCRIPTION
## Addresses
Partially addresses https://broadworkbench.atlassian.net/browse/DUOS-545

* Added chairperson roles to the member update endpoints
* Added validation so chairpersons can only update members WITHIN THEIR OWN Dacs
* Added tests for admin success, chairperson success, and chairperson failure cases for each of those endpoints

----

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [ ] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
