### PR TITLE
[DUOS-1028][risk=no] Support json logging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -360,6 +360,20 @@
       <version>2.0.12-1</version>
     </dependency>
 
+    <!-- Support for JSON logging -->
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <version>1.2.3</version>
+    </dependency>
+
+    <!-- Support for JSON logging -->
+    <dependency>
+      <groupId>io.dropwizard</groupId>
+      <artifactId>dropwizard-json-logging</artifactId>
+      <version>${dropwizard.version}</version>
+    </dependency>
+
     <dependency>
       <groupId>io.dropwizard</groupId>
       <artifactId>dropwizard-dependencies</artifactId>

--- a/src/test/resources/consent-config.yml
+++ b/src/test/resources/consent-config.yml
@@ -5,6 +5,11 @@ server:
   connector:
     type: http
     port: 8180
+  requestLog:
+    appenders:
+      - type: console
+        layout:
+          type: access-json
 database:
   driverClass: org.postgresql.Driver
   user: consent
@@ -22,6 +27,12 @@ googleStore:
 logging:
   # default logging level
   level: WARN
+  appenders:
+    - type: console
+      threshold: INFO
+      target: stdout
+      layout:
+        type: json
   # logger specific levels
   loggers:
     "org.broadinstitute.consent.http.cloudstore.GCSService": OFF


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-1028

Pull in the libraries and update test config to support json logging. This does not implement the logging, that has to happen in the helm chart.

Example output to STDOUT:
```
{
  "level": "INFO", 
  "logger": "io.dropwizard.jersey.DropwizardResourceConfig", 
  "message": "The following paths were found for the configured resources:

    GET     / (org.broadinstitute.consent.http.resources.SwaggerResource)
    GET     /api/consent/{consentId}/election (org.broadinstitute.consent.http.resources.ConsentElectionResource)
    POST    /api/consent/{consentId}/election (org.broadinstitute.consent.http.resources.ConsentElectionResource)
    POST    /api/consent/{consentId}/election/dac/{dacId} (org.broadinstitute.consent.http.resources.ConsentElectionResource)
    DELETE  /api/consent/{consentId}/election/{id} (org.broadinstitute.consent.http.resources.ConsentElectionResource)
    POST    /api/consent/{id}/dul (org.broadinstitute.consent.http.resources.DataUseLetterResource)
    GET     /api/dac (org.broadinstitute.consent.http.resources.DacResource)
    POST    /api/dac (org.broadinstitute.consent.http.resources.DacResource)
    PUT     /api/dac (org.broadinstitute.consent.http.resources.DacResource)
    GET     /api/dac/users/{term} (org.broadinstitute.consent.http.resources.DacResource)
    DELETE  /api/dac/{dacId} (org.broadinstitute.consent.http.resources.DacResource)
    GET     /api/dac/{dacId} (org.broadinstitute.consent.http.resources.DacResource)
    DELETE  /api/dac/{dacId}/chair/{userId} (org.broadinstitute.consent.http.resources.DacResource)
    POST    /api/dac/{dacId}/chair/{userId} (org.broadinstitute.consent.http.resources.DacResource)
    GET     /api/dac/{dacId}/datasets (org.broadinstitute.consent.http.resources.DacResource)
    DELETE  /api/dac/{dacId}/member/{userId} (org.broadinstitute.consent.http.resources.DacResource)
    POST    /api/dac/{dacId}/member/{userId} (org.broadinstitute.consent.http.resources.DacResource)
    GET     /api/dac/{dacId}/membership (org.broadinstitute.consent.http.resources.DacResource)
    GET     /api/dacuser (org.broadinstitute.consent.http.resources.DACUserResource)
    POST    /api/dacuser (org.broadinstitute.consent.http.resources.DACUserResource)
    PUT     /api/dacuser/status/{userId} (org.broadinstitute.consent.http.resources.DACUserResource)
    GET     /api/dacuser/{email} (org.broadinstitute.consent.http.resources.DACUserResource)
    PUT     /api/dacuser/{id} (org.broadinstitute.consent.http.resources.DACUserResource)
    GET     /api/dar (org.broadinstitute.consent.http.resources.DataAccessRequestResource)
    PUT     /api/dar/cancel/{referenceId} (org.broadinstitute.consent.http.resources.DataAccessRequestResource)
    GET     /api/dar/cases/unreviewed (org.broadinstitute.consent.http.resources.DataAccessRequestResource)
    GET     /api/dar/find/{id} (org.broadinstitute.consent.http.resources.DataAccessRequestResource)
    GET     /api/dar/find/{id}/consent (org.broadinstitute.consent.http.resources.DataAccessRequestResource)
    GET     /api/dar/hasUseRestriction/{referenceId} (org.broadinstitute.consent.http.resources.DataAccessRequestResource)
    GET     /api/dar/manage (org.broadinstitute.consent.http.resources.DataAccessRequestResource)
    GET     /api/dar/manage/v2 (org.broadinstitute.consent.http.resources.DataAccessRequestResource)
    GET     /api/dar/modalSummary/{id} (org.broadinstitute.consent.http.resources.DataAccessRequestResource)
    GET     /api/dar/partial/{id} (org.broadinstitute.consent.http.resources.DataAccessRequestResource)
    GET     /api/dar/partials (org.broadinstitute.consent.http.resources.DataAccessRequestResource)
    GET     /api/dar/partials/manage (org.broadinstitute.consent.http.resources.DataAccessRequestResource)
    PUT     /api/dar/restriction (org.broadinstitute.consent.http.resources.DataAccessRequestResource)
    POST    /api/dar/v2 (org.broadinstitute.consent.http.resources.DataAccessRequestResourceVersion2)
    POST    /api/dar/v2/draft (org.broadinstitute.consent.http.resources.DataAccessRequestResourceVersion2)
    PUT     /api/dar/v2/draft/{referenceId} (org.broadinstitute.consent.http.resources.DataAccessRequestResourceVersion2)
    DELETE  /api/dar/v2/{referenceId} (org.broadinstitute.consent.http.resources.DataAccessRequestResourceVersion2)
    GET     /api/dar/v2/{referenceId} (org.broadinstitute.consent.http.resources.DataAccessRequestResourceVersion2)
    PUT     /api/dar/v2/{referenceId} (org.broadinstitute.consent.http.resources.DataAccessRequestResourceVersion2)
    GET     /api/dar/v2/{referenceId}/collaborationDocument (org.broadinstitute.consent.http.resources.DataAccessRequestResourceVersion2)
    POST    /api/dar/v2/{referenceId}/collaborationDocument (org.broadinstitute.consent.http.resources.DataAccessRequestResourceVersion2)
    GET     /api/dar/v2/{referenceId}/irbDocument (org.broadinstitute.consent.http.resources.DataAccessRequestResourceVersion2)
    POST    /api/dar/v2/{referenceId}/irbDocument (org.broadinstitute.consent.http.resources.DataAccessRequestResourceVersion2)
    GET     /api/dar/{id} (org.broadinstitute.consent.http.resources.DataAccessRequestResource)
    GET     /api/dataset (org.broadinstitute.consent.http.resources.DatasetResource)
    PUT     /api/dataset (org.broadinstitute.consent.http.resources.DatasetResource)
    GET     /api/dataset/autocomplete/{partial} (org.broadinstitute.consent.http.resources.DatasetResource)
    GET     /api/dataset/dictionary (org.broadinstitute.consent.http.resources.DatasetResource)
    DELETE  /api/dataset/disable/{datasetObjectId}/{active} (org.broadinstitute.consent.http.resources.DatasetResource)
    POST    /api/dataset/download (org.broadinstitute.consent.http.resources.DatasetResource)
    GET     /api/dataset/sample (org.broadinstitute.consent.http.resources.DatasetResource)
    POST    /api/dataset/v2 (org.broadinstitute.consent.http.resources.DatasetResource)
    GET     /api/dataset/validate (org.broadinstitute.consent.http.resources.DatasetResource)
    DELETE  /api/dataset/{datasetId} (org.broadinstitute.consent.http.resources.DatasetResource)
    GET     /api/dataset/{datasetId} (org.broadinstitute.consent.http.resources.DatasetResource)
    PUT     /api/dataset/{datasetId} (org.broadinstitute.consent.http.resources.DatasetResource)
    GET     /api/dataset/{datasetId}/approved/users (org.broadinstitute.consent.http.resources.DatasetResource)
    POST    /api/dataset/{userId} (org.broadinstitute.consent.http.resources.DatasetResource)
    GET     /api/datasetAssociation/{dataSetId} (org.broadinstitute.consent.http.resources.DatasetAssociationsResource)
    PUT     /api/datasetAssociation/{dataSetId} (org.broadinstitute.consent.http.resources.DatasetAssociationsResource)
    POST    /api/datasetAssociation/{datasetId} (org.broadinstitute.consent.http.resources.DatasetAssociationsResource)
    GET     /api/electionReview (org.broadinstitute.consent.http.resources.ElectionReviewResource)
    GET     /api/electionReview/access/{electionId} (org.broadinstitute.consent.http.resources.ElectionReviewResource)
    GET     /api/electionReview/last/{referenceId} (org.broadinstitute.consent.http.resources.ElectionReviewResource)
    GET     /api/electionReview/openElection (org.broadinstitute.consent.http.resources.ElectionReviewResource)
    GET     /api/electionReview/rp/{electionId} (org.broadinstitute.consent.http.resources.ElectionReviewResource)
    GET     /api/electionReview/{electionId} (org.broadinstitute.consent.http.resources.ElectionReviewResource)
    POST    /api/emailNotifier/reminderMessage/{voteId} (org.broadinstitute.consent.http.resources.EmailNotifierResource)
    DELETE  /api/nih (org.broadinstitute.consent.http.resources.NihAccountResource)
    POST    /api/nih (org.broadinstitute.consent.http.resources.NihAccountResource)
    POST    /api/researcher (org.broadinstitute.consent.http.resources.ResearcherResource)
    PUT     /api/researcher (org.broadinstitute.consent.http.resources.ResearcherResource)
    DELETE  /api/researcher/{userId} (org.broadinstitute.consent.http.resources.ResearcherResource)
    GET     /api/researcher/{userId} (org.broadinstitute.consent.http.resources.ResearcherResource)
    GET     /api/researcher/{userId}/dar (org.broadinstitute.consent.http.resources.ResearcherResource)
    POST    /api/whitelist (org.broadinstitute.consent.http.resources.WhitelistResource)
    GET     /error/404 (org.broadinstitute.consent.http.resources.ErrorResource)
    GET     /metrics/dac/decision (org.broadinstitute.consent.http.resources.MetricsResource)
    GET     /metrics/dar/decision (org.broadinstitute.consent.http.resources.MetricsResource)
    GET     /status (org.broadinstitute.consent.http.resources.StatusResource)
    GET     /swagger (org.broadinstitute.consent.http.resources.SwaggerResource)
    GET     /version (org.broadinstitute.consent.http.resources.VersionResource)
    GET     /{api : (api/)?}approvalExpirationTime (org.broadinstitute.consent.http.resources.ApprovalExpirationTimeResource)
    POST    /{api : (api/)?}approvalExpirationTime (org.broadinstitute.consent.http.resources.ApprovalExpirationTimeResource)
    DELETE  /{api : (api/)?}approvalExpirationTime/{id} (org.broadinstitute.consent.http.resources.ApprovalExpirationTimeResource)
    GET     /{api : (api/)?}approvalExpirationTime/{id} (org.broadinstitute.consent.http.resources.ApprovalExpirationTimeResource)
    PUT     /{api : (api/)?}approvalExpirationTime/{id} (org.broadinstitute.consent.http.resources.ApprovalExpirationTimeResource)
    GET     /{api : (api/)?}consent/cases/closed (org.broadinstitute.consent.http.resources.ConsentCasesResource)
    GET     /{api : (api/)?}consent/cases/pending/{dacUserId} (org.broadinstitute.consent.http.resources.ConsentCasesResource)
    GET     /{api : (api/)?}consent/cases/summary (org.broadinstitute.consent.http.resources.ConsentCasesResource)
    GET     /{api : (api/)?}consent/cases/summary/file (org.broadinstitute.consent.http.resources.ConsentCasesResource)
    DELETE  /{api : (api/)?}consent/{consentId}/vote (org.broadinstitute.consent.http.resources.ConsentVoteResource)
    GET     /{api : (api/)?}consent/{consentId}/vote (org.broadinstitute.consent.http.resources.ConsentVoteResource)
    DELETE  /{api : (api/)?}consent/{consentId}/vote/{id} (org.broadinstitute.consent.http.resources.ConsentVoteResource)
    GET     /{api : (api/)?}consent/{consentId}/vote/{id} (org.broadinstitute.consent.http.resources.ConsentVoteResource)
    POST    /{api : (api/)?}consent/{consentId}/vote/{id} (org.broadinstitute.consent.http.resources.ConsentVoteResource)
    PUT     /{api : (api/)?}consent/{consentId}/vote/{id} (org.broadinstitute.consent.http.resources.ConsentVoteResource)
    GET     /{api : (api/)?}dataRequest/approved (org.broadinstitute.consent.http.resources.DataRequestReportsResource)
    GET     /{api : (api/)?}dataRequest/cases/closed (org.broadinstitute.consent.http.resources.DataRequestCasesResource)
    GET     /{api : (api/)?}dataRequest/cases/matchsummary (org.broadinstitute.consent.http.resources.DataRequestCasesResource)
    GET     /{api : (api/)?}dataRequest/cases/pending (org.broadinstitute.consent.http.resources.DataRequestCasesResource)
    GET     /{api : (api/)?}dataRequest/cases/pending/dataOwner/{dataOwnerId} (org.broadinstitute.consent.http.resources.DataRequestCasesResource)
    GET     /{api : (api/)?}dataRequest/cases/pending/{dacUserId} (org.broadinstitute.consent.http.resources.DataRequestCasesResource)
    GET     /{api : (api/)?}dataRequest/cases/summary/{type} (org.broadinstitute.consent.http.resources.DataRequestCasesResource)
    GET     /{api : (api/)?}dataRequest/reviewed (org.broadinstitute.consent.http.resources.DataRequestReportsResource)
    GET     /{api : (api/)?}dataRequest/{requestId}/election (org.broadinstitute.consent.http.resources.DataRequestElectionResource)
    POST    /{api : (api/)?}dataRequest/{requestId}/election (org.broadinstitute.consent.http.resources.DataRequestElectionResource)
    GET     /{api : (api/)?}dataRequest/{requestId}/election/dataSetVotes (org.broadinstitute.consent.http.resources.DataRequestElectionResource)
    DELETE  /{api : (api/)?}dataRequest/{requestId}/election/{id} (org.broadinstitute.consent.http.resources.DataRequestElectionResource)
    GET     /{api : (api/)?}dataRequest/{requestId}/pdf (org.broadinstitute.consent.http.resources.DataRequestReportsResource)
    DELETE  /{api : (api/)?}dataRequest/{requestId}/vote (org.broadinstitute.consent.http.resources.DataRequestVoteResource)
    GET     /{api : (api/)?}dataRequest/{requestId}/vote (org.broadinstitute.consent.http.resources.DataRequestVoteResource)
    GET     /{api : (api/)?}dataRequest/{requestId}/vote/dataOwner/{dataOwnerId} (org.broadinstitute.consent.http.resources.DataRequestVoteResource)
    GET     /{api : (api/)?}dataRequest/{requestId}/vote/final (org.broadinstitute.consent.http.resources.DataRequestVoteResource)
    DELETE  /{api : (api/)?}dataRequest/{requestId}/vote/{id} (org.broadinstitute.consent.http.resources.DataRequestVoteResource)
    GET     /{api : (api/)?}dataRequest/{requestId}/vote/{id} (org.broadinstitute.consent.http.resources.DataRequestVoteResource)
    POST    /{api : (api/)?}dataRequest/{requestId}/vote/{id} (org.broadinstitute.consent.http.resources.DataRequestVoteResource)
    PUT     /{api : (api/)?}dataRequest/{requestId}/vote/{id} (org.broadinstitute.consent.http.resources.DataRequestVoteResource)
    POST    /{api : (api/)?}dataRequest/{requestId}/vote/{id}/final (org.broadinstitute.consent.http.resources.DataRequestVoteResource)
    GET     /{api : (api/)?}election/checkdataset (org.broadinstitute.consent.http.resources.ElectionResource)
    GET     /{api : (api/)?}election/consent/{requestElectionId} (org.broadinstitute.consent.http.resources.ElectionResource)
    GET     /{api : (api/)?}election/vote/{voteId} (org.broadinstitute.consent.http.resources.ElectionResource)
    GET     /{api : (api/)?}election/{id} (org.broadinstitute.consent.http.resources.ElectionResource)
    PUT     /{api : (api/)?}election/{id} (org.broadinstitute.consent.http.resources.ElectionResource)
    POST    /{api : (api/)?}election/{referenceId}/advance/{vote} (org.broadinstitute.consent.http.resources.ElectionResource)
    GET     /{api : (api/)?}match/{consentId}/{purposeId} (org.broadinstitute.consent.http.resources.MatchResource)
    GET     /{api : (api/)?}ontology (org.broadinstitute.consent.http.resources.IndexerResource)
    POST    /{api : (api/)?}ontology (org.broadinstitute.consent.http.resources.IndexerResource)
    PUT     /{api : (api/)?}ontology (org.broadinstitute.consent.http.resources.IndexerResource)
    GET     /{api : (api/)?}ontology/file (org.broadinstitute.consent.http.resources.IndexerResource)
    GET     /{api : (api/)?}ontology/types (org.broadinstitute.consent.http.resources.IndexerResource)
    POST    /{api : (api/)?}user (org.broadinstitute.consent.http.resources.UserResource)
    GET     /{api : (api/)?}user/me (org.broadinstitute.consent.http.resources.UserResource)
    DELETE  /{api : (api/)?}user/{email} (org.broadinstitute.consent.http.resources.UserResource)
    GET     /{api : (api/)?}user/{userId} (org.broadinstitute.consent.http.resources.UserResource)
    PUT     /{api : (api/)?}user/{userId}/{roleId} (org.broadinstitute.consent.http.resources.UserResource)
    GET     /{auth: (basic/|api/)?}consent (org.broadinstitute.consent.http.resources.ConsentResource)
    POST    /{auth: (basic/|api/)?}consent (org.broadinstitute.consent.http.resources.ConsentResource)
    GET     /{auth: (basic/|api/)?}consent/manage (org.broadinstitute.consent.http.resources.ConsentManageResource)
    GET     /{auth: (basic/|api/)?}consent/unreviewed (org.broadinstitute.consent.http.resources.ConsentManageResource)
    DELETE  /{auth: (basic/|api/)?}consent/{id} (org.broadinstitute.consent.http.resources.ConsentResource)
    GET     /{auth: (basic/|api/)?}consent/{id} (org.broadinstitute.consent.http.resources.ConsentResource)
    PUT     /{auth: (basic/|api/)?}consent/{id} (org.broadinstitute.consent.http.resources.ConsentResource)
    DELETE  /{auth: (basic/|api/)?}consent/{id}/association (org.broadinstitute.consent.http.resources.ConsentAssociationResource)
    GET     /{auth: (basic/|api/)?}consent/{id}/association (org.broadinstitute.consent.http.resources.ConsentAssociationResource)
    POST    /{auth: (basic/|api/)?}consent/{id}/association (org.broadinstitute.consent.http.resources.ConsentAssociationResource)
    PUT     /{auth: (basic/|api/)?}consent/{id}/association (org.broadinstitute.consent.http.resources.ConsentAssociationResource)
    GET     /{auth: (basic/|api/)?}consent/{id}/matches (org.broadinstitute.consent.http.resources.ConsentResource)
    GET     /{path:.*} (org.broadinstitute.consent.http.resources.SwaggerResource)
", 
  "thread": "main", 
  "timestamp": 1612978511534
}
```
----

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [ ] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
