### PR TITLE
DUOS-715[risk=no]Tech Debt: Delete help table

### DIFF
--- a/migration/postgres/README.md
+++ b/migration/postgres/README.md
@@ -57,7 +57,6 @@ consent.accesselection_consentelection          0        168     1.2 kB         
                consent.researchpurpose          0          0                     0.738s
                      consent.user_role          0        100     1.9 kB          0.797s
                           consent.vote          0       2327   145.6 kB          0.884s
-                   consent.help_report          0         13     0.6 kB          0.513s
            consent.researcher_property          0        217     7.2 kB          0.614s
                          consent.roles          0          6     0.1 kB          0.698s
                  consent.user_role_bak          0         84     1.1 kB          0.788s
@@ -122,7 +121,6 @@ consent.accesselection_consentelection          0        177     1.3 kB         
                   consent.match_entity          0        148    12.9 kB          4.278s
                consent.researchpurpose          0          0                     4.184s
                      consent.user_role          0        107     2.1 kB          4.475s
-                   consent.help_report          0         13     0.6 kB          2.726s
                           consent.vote          0       2392   148.3 kB          4.671s
            consent.researcher_property          0        220     7.3 kB          3.268s
                          consent.roles          0          6     0.1 kB          3.338s
@@ -247,9 +245,6 @@ select count(*) from user_role
 count(*)
 107
 
-select count(*) from help_report
-count(*)
-13
 
 select count(*) from vote
 count(*)

--- a/migration/postgres/README.md
+++ b/migration/postgres/README.md
@@ -57,6 +57,7 @@ consent.accesselection_consentelection          0        168     1.2 kB         
                consent.researchpurpose          0          0                     0.738s
                      consent.user_role          0        100     1.9 kB          0.797s
                           consent.vote          0       2327   145.6 kB          0.884s
+                   consent.help_report          0         13     0.6 kB          0.513s
            consent.researcher_property          0        217     7.2 kB          0.614s
                          consent.roles          0          6     0.1 kB          0.698s
                  consent.user_role_bak          0         84     1.1 kB          0.788s
@@ -121,6 +122,7 @@ consent.accesselection_consentelection          0        177     1.3 kB         
                   consent.match_entity          0        148    12.9 kB          4.278s
                consent.researchpurpose          0          0                     4.184s
                      consent.user_role          0        107     2.1 kB          4.475s
+                   consent.help_report          0         13     0.6 kB          2.726s
                           consent.vote          0       2392   148.3 kB          4.671s
            consent.researcher_property          0        220     7.3 kB          3.268s
                          consent.roles          0          6     0.1 kB          3.338s
@@ -245,6 +247,9 @@ select count(*) from user_role
 count(*)
 107
 
+select count(*) from help_report
+count(*)
+13
 
 select count(*) from vote
 count(*)

--- a/src/main/resources/changelog-master.xml
+++ b/src/main/resources/changelog-master.xml
@@ -62,4 +62,5 @@
     <include file="changesets/changelog-consent-57.0.xml" relativeToChangelogFile="true"/>
     <include file="changesets/changelog-consent-58.0.xml" relativeToChangelogFile="true"/>
     <include file="changesets/changelog-consent-59.0.xml" relativeToChangelogFile="true"/>
+    <include file="changesets/changelog-consent-60.0.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/changesets/changelog-consent-60.0.xml
+++ b/src/main/resources/changesets/changelog-consent-60.0.xml
@@ -1,0 +1,11 @@
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet id="60.0" author="raejohanek">
+        <dropTable tableName="help_report"/>
+    </changeSet>
+
+</databaseChangeLog>


### PR DESCRIPTION
Scope:
add changeset 60 to drop the help_report table 
dropping the help_report table removes the help_report_report_id_seq sequence as well
add the changeset to the master file

Addresses:
https://broadworkbench.atlassian.net/browse/DUOS-715

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [ ] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
