### PR TITLE
[DUOS-936][risk=low] Downgrade docker compose version for jenkins

### DIFF
--- a/docker-compose-automation.yml
+++ b/docker-compose-automation.yml
@@ -1,4 +1,4 @@
-version: '3.8'
+version: '3.0'
 services:
   consent-postgres:
     image: postgres:11.6-alpine


### PR DESCRIPTION
**Changes**
Downgraded the version being use in Docker Compose file for automation testing. Jenkins seems to be supporting no higher than version 3.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [ ] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
