### PR TITLE
[DUOS-936][risk=no] Update project name to match jenkins

### DIFF
--- a/jenkins/jenkins-run-tests.sh
+++ b/jenkins/jenkins-run-tests.sh
@@ -13,14 +13,14 @@ mkdir -p target
 docker build -f Dockerfile -t ${TEST_IMAGE} .
 
 # Run Tests
-docker-compose -p consent_automation -f ../docker-compose-automation.yml up --build -d
-if docker run -v "${PWD}/target":/app/target --net consent_automation_default -e CONSENT_API_URL='http://consent-api:8000/' ${TEST_IMAGE} 
+docker-compose -p consentautomation -f ../docker-compose-automation.yml up --build -d
+if docker run -v "${PWD}/target":/app/target --net consentautomation_default -e CONSENT_API_URL='http://consent-api:8000/' ${TEST_IMAGE} 
 then
     TEST_EXIT_CODE=$?
-    docker-compose -p consent_automation -f ../docker-compose-automation.yml down
+    docker-compose -p consentautomation -f ../docker-compose-automation.yml down
 else
     TEST_EXIT_CODE=$?
-    docker-compose -p consent_automation -f ../docker-compose-automation.yml down
+    docker-compose -p consentautomation -f ../docker-compose-automation.yml down
 fi
 
 # Parse Tests


### PR DESCRIPTION
**Changes**
Update the project name being used in automation scripts to match the jenkins environment.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [ ] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
