### PR TITLE
[DUOS-1057][risk=?] Refactor DAR Use Restriction Logic

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
@@ -45,6 +45,7 @@ import org.broadinstitute.consent.http.configurations.ConsentConfiguration;
 import org.broadinstitute.consent.http.db.ApprovalExpirationTimeDAO;
 import org.broadinstitute.consent.http.db.AssociationDAO;
 import org.broadinstitute.consent.http.db.ConsentDAO;
+import org.broadinstitute.consent.http.db.DataAccessRequestDAO;
 import org.broadinstitute.consent.http.db.DataSetAuditDAO;
 import org.broadinstitute.consent.http.db.DataSetDAO;
 import org.broadinstitute.consent.http.db.DatasetAssociationDAO;
@@ -202,6 +203,7 @@ public class ConsentApplication extends Application<ConsentConfiguration> {
         final ConsentDAO consentDAO = injector.getProvider(ConsentDAO.class).get();
         final ElectionDAO electionDAO = injector.getProvider(ElectionDAO.class).get();
         final VoteDAO voteDAO = injector.getProvider(VoteDAO.class).get();
+        final DataAccessRequestDAO dataAccessRequestDAO = injector.getProvider(DataAccessRequestDAO.class).get();
         final DataSetDAO dataSetDAO = injector.getProvider(DataSetDAO.class).get();
         final DatasetAssociationDAO dataSetAssociationDAO = injector.getProvider(
             DatasetAssociationDAO.class).get();
@@ -238,7 +240,7 @@ public class ConsentApplication extends Application<ConsentConfiguration> {
         DatabaseConsentAPI.initInstance(auditService, jdbi, consentDAO, electionDAO, associationDAO, dataSetDAO);
         DatabaseMatchAPI.initInstance(matchDAO, consentDAO);
         DatabaseDataSetAPI.initInstance(dataSetDAO, dataSetAssociationDAO, userRoleDAO, consentDAO, dataSetAuditDAO, electionDAO, config.getDatasets());
-        DatabaseMatchingServiceAPI.initInstance(client, config.getServicesConfiguration());
+        DatabaseMatchingServiceAPI.initInstance(client, dataAccessRequestDAO, config.getServicesConfiguration(), useRestrictionConverter);
         DatabaseMatchProcessAPI.initInstance(consentDAO, dataAccessRequestService);
         DatabaseDACUserAPI.initInstance(userDAO, userRoleDAO, userRolesHandler, userService);
         DatabaseVoteAPI.initInstance(voteDAO, electionDAO);

--- a/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
@@ -263,23 +263,6 @@ public class DataAccessRequestResource extends Resource {
         }
     }
 
-    @GET
-    @Consumes("application/json")
-    @Produces("application/json")
-    @Path("/hasUseRestriction/{referenceId}")
-    @PermitAll
-    public Response hasUseRestriction(@Auth AuthUser authUser, @PathParam("referenceId") String referenceId) {
-        validateAuthedRoleUser(
-            Stream.of(UserRoles.ADMIN, UserRoles.CHAIRPERSON, UserRoles.MEMBER)
-                .collect(Collectors.toList()),
-            authUser, referenceId);
-        try {
-            return Response.ok("{\"hasUseRestriction\":true}").build();
-        } catch (Exception e) {
-            return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(new Error(e.getMessage(), Response.Status.INTERNAL_SERVER_ERROR.getStatusCode())).build();
-        }
-    }
-
     private Integer obtainUserId(Document dar) {
         try {
             return dar.getInteger("userId");

--- a/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
@@ -274,7 +274,7 @@ public class DataAccessRequestResource extends Resource {
                 .collect(Collectors.toList()),
             authUser, referenceId);
         try {
-            return Response.ok("{\"hasUseRestriction\":" + dataAccessRequestAPI.hasUseRestriction(referenceId) + "}").build();
+            return Response.ok("{\"hasUseRestriction\":true}").build();
         } catch (Exception e) {
             return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(new Error(e.getMessage(), Response.Status.INTERNAL_SERVER_ERROR.getStatusCode())).build();
         }

--- a/src/main/java/org/broadinstitute/consent/http/resources/DataRequestVoteResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataRequestVoteResource.java
@@ -46,7 +46,7 @@ import org.broadinstitute.consent.http.util.DarConstants;
 import org.broadinstitute.consent.http.util.DarUtil;
 import org.bson.Document;
 
-@Path("{api : (api/)?}dataRequest/{requestId}/vote")
+@Path("api/dataRequest/{requestId}/vote")
 public class DataRequestVoteResource extends Resource {
 
     private final DACUserAPI dacUserAPI;
@@ -105,8 +105,10 @@ public class DataRequestVoteResource extends Resource {
             Vote vote = api.firstVoteUpdate(rec, id);
             Document access = accessRequestAPI.describeDataAccessRequestById(requestId);
             List<Integer> dataSets = DarUtil.getIntegerList(access, DarConstants.DATASET_ID);
-            List<Vote> votes = vote.getType().equals(VoteType.FINAL.getValue()) ? api.describeVoteByTypeAndElectionId(VoteType.AGREEMENT.getValue(), vote.getElectionId()) :  api.describeVoteByTypeAndElectionId(VoteType.FINAL.getValue(), vote.getElectionId());
-            if(vote.getVote() != null && votes.get(0).getVote() != null){
+            List<Vote> votes = vote.getType().equals(VoteType.FINAL.getValue()) ?
+                api.describeVoteByTypeAndElectionId(VoteType.AGREEMENT.getValue(), vote.getElectionId()) :
+                api.describeVoteByTypeAndElectionId(VoteType.FINAL.getValue(), vote.getElectionId());
+            if (vote.getVote() != null && votes.get(0).getVote() != null) {
                 electionAPI.updateFinalAccessVoteDataRequestElection(rec.getElectionId());
             }
             createDataOwnerElection(requestId, vote, access, dataSets);

--- a/src/main/java/org/broadinstitute/consent/http/resources/DataRequestVoteResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataRequestVoteResource.java
@@ -105,12 +105,8 @@ public class DataRequestVoteResource extends Resource {
             Vote vote = api.firstVoteUpdate(rec, id);
             Document access = accessRequestAPI.describeDataAccessRequestById(requestId);
             List<Integer> dataSets = DarUtil.getIntegerList(access, DarConstants.DATASET_ID);
-            if(access.containsKey(DarConstants.RESTRICTION)){
-                List<Vote> votes = vote.getType().equals(VoteType.FINAL.getValue()) ? api.describeVoteByTypeAndElectionId(VoteType.AGREEMENT.getValue(), vote.getElectionId()) :  api.describeVoteByTypeAndElectionId(VoteType.FINAL.getValue(), vote.getElectionId());
-                if(vote.getVote() != null && votes.get(0).getVote() != null){
-                    electionAPI.updateFinalAccessVoteDataRequestElection(rec.getElectionId());
-                }
-            }else {
+            List<Vote> votes = vote.getType().equals(VoteType.FINAL.getValue()) ? api.describeVoteByTypeAndElectionId(VoteType.AGREEMENT.getValue(), vote.getElectionId()) :  api.describeVoteByTypeAndElectionId(VoteType.FINAL.getValue(), vote.getElectionId());
+            if(vote.getVote() != null && votes.get(0).getVote() != null){
                 electionAPI.updateFinalAccessVoteDataRequestElection(rec.getElectionId());
             }
             createDataOwnerElection(requestId, vote, access, dataSets);

--- a/src/main/java/org/broadinstitute/consent/http/resources/DataRequestVoteResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataRequestVoteResource.java
@@ -4,8 +4,10 @@ import com.google.inject.Inject;
 import freemarker.template.TemplateException;
 import java.io.IOException;
 import java.net.URI;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import javax.annotation.security.PermitAll;
@@ -105,10 +107,17 @@ public class DataRequestVoteResource extends Resource {
             Vote vote = api.firstVoteUpdate(rec, id);
             Document access = accessRequestAPI.describeDataAccessRequestById(requestId);
             List<Integer> dataSets = DarUtil.getIntegerList(access, DarConstants.DATASET_ID);
-            List<Vote> votes = vote.getType().equals(VoteType.FINAL.getValue()) ?
-                api.describeVoteByTypeAndElectionId(VoteType.AGREEMENT.getValue(), vote.getElectionId()) :
-                api.describeVoteByTypeAndElectionId(VoteType.FINAL.getValue(), vote.getElectionId());
-            if (vote.getVote() != null && votes.get(0).getVote() != null) {
+            // Find any final or agreement votes for this election that have a populated vote:
+            List<Vote> votes = voteService
+                  .findVotesByElectionIds(Collections.singletonList(rec.getElectionId()))
+                  .stream()
+                  .filter(v ->
+                      v.getType().equalsIgnoreCase(VoteType.FINAL.getValue()) ||
+                      v.getType().equalsIgnoreCase(VoteType.AGREEMENT.getValue()))
+                  .filter(v -> Objects.nonNull(v.getVote()))
+                  .collect(Collectors.toList());
+            // If we have any votes with a populated vote, we can now update the election.
+            if (!votes.isEmpty()) {
                 electionAPI.updateFinalAccessVoteDataRequestElection(rec.getElectionId());
             }
             createDataOwnerElection(requestId, vote, access, dataSets);

--- a/src/main/java/org/broadinstitute/consent/http/resources/DataRequestVoteResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataRequestVoteResource.java
@@ -46,7 +46,7 @@ import org.broadinstitute.consent.http.util.DarConstants;
 import org.broadinstitute.consent.http.util.DarUtil;
 import org.bson.Document;
 
-@Path("api/dataRequest/{requestId}/vote")
+@Path("{api : (api/)?}dataRequest/{requestId}/vote")
 public class DataRequestVoteResource extends Resource {
 
     private final DACUserAPI dacUserAPI;

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestAPI.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestAPI.java
@@ -20,11 +20,7 @@ public interface DataAccessRequestAPI {
 
     List<Document> describeDraftDataAccessRequestManage(Integer userId);
 
-    Object getField(String requestId, String field);
-
     List<User> getUserEmailAndCancelElection(String referenceId);
-
-    boolean hasUseRestriction(String referenceId);
 
     byte[] createDARDocument(Document dar, Map<String, String> researcherProperties, User user, Boolean manualReview, String sDUR) throws IOException;
 

--- a/src/main/java/org/broadinstitute/consent/http/service/DatabaseDataAccessRequestAPI.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatabaseDataAccessRequestAPI.java
@@ -127,10 +127,10 @@ public class DatabaseDataAccessRequestAPI extends AbstractDataAccessRequestAPI {
      */
     @Override
     public List<Document> describeDataAccessWithDataSetIdAndRestriction(List<Integer> dataSetIds) {
-        return dataAccessRequestService.getAllDataAccessRequestsAsDocuments().stream().
-                filter(d -> !Collections.disjoint(dataSetIds, DarUtil.getIntegerList(d, DarConstants.DATASET_ID))).
-                filter(d -> d.get(DarConstants.RESTRICTION) != null).
-                collect(Collectors.toList());
+        return dataAccessRequestService.findAllDataAccessRequests().stream().
+            filter(d -> !Collections.disjoint(dataSetIds, d.getData().getDatasetIds())).
+            map(dataAccessRequestService::createDocumentFromDar).
+            collect(Collectors.toList());
     }
 
     @Override
@@ -163,17 +163,6 @@ public class DatabaseDataAccessRequestAPI extends AbstractDataAccessRequestAPI {
             users =  userDAO.describeUsersByRoleAndEmailPreference(UserRoles.ADMIN.getRoleName(), true);
         }
         return users;
-    }
-
-    @Override
-    public Object getField(String requestId , String field){
-        Document dar = dataAccessRequestService.getDataAccessRequestByReferenceIdAsDocument(requestId);
-        return dar != null ? dar.get(field) : null;
-    }
-
-    @Override
-    public boolean hasUseRestriction(String referenceId){
-        return getField(referenceId, DarConstants.RESTRICTION) != null ? true : false;
     }
 
     private void updateElection(Election access, Election rp) {

--- a/src/main/java/org/broadinstitute/consent/http/service/DatabaseMatchProcessAPI.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatabaseMatchProcessAPI.java
@@ -1,15 +1,14 @@
 package org.broadinstitute.consent.http.service;
 
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import org.apache.commons.collections.CollectionUtils;
 import org.broadinstitute.consent.http.db.ConsentDAO;
 import org.broadinstitute.consent.http.models.Match;
 import org.broadinstitute.consent.http.util.DarConstants;
 import org.bson.Document;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 
 public class DatabaseMatchProcessAPI extends AbstractMatchProcessAPI {
 

--- a/src/main/java/org/broadinstitute/consent/http/service/DatabaseMatchingServiceAPI.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatabaseMatchingServiceAPI.java
@@ -112,7 +112,7 @@ public class DatabaseMatchingServiceAPI extends AbstractMatchingServiceAPI {
         return matches;
     }
 
-    private Match singleEntitiesMatch(Consent consent, DataAccessRequest dar) throws Exception {
+    private Match singleEntitiesMatch(Consent consent, DataAccessRequest dar) {
         if (consent == null) {
             logger.error("Consent is null");
             throw new IllegalArgumentException("Consent cannot be null");

--- a/src/main/java/org/broadinstitute/consent/http/service/DatabaseMatchingServiceAPI.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatabaseMatchingServiceAPI.java
@@ -162,10 +162,10 @@ public class DatabaseMatchingServiceAPI extends AbstractMatchingServiceAPI {
         return consent;
     }
 
-    private List<DataAccessRequest> findRelatedDars(List<Integer> dataSetIds){
-        return dataAccessRequestDAO.findAllDataAccessRequests().stream().
-            filter(d -> !Collections.disjoint(dataSetIds, d.getData().getDatasetIds())).
-            collect(Collectors.toList());
+    private List<DataAccessRequest> findRelatedDars(List<Integer> dataSetIds) {
+        return dataAccessRequestDAO.findAllDataAccessRequests().stream()
+            .filter(d -> !Collections.disjoint(dataSetIds, d.getData().getDatasetIds()))
+            .collect(Collectors.toList());
     }
 
     private RequestMatchingObject createRequestObject(Consent consent, DataAccessRequest dar) {

--- a/src/main/java/org/broadinstitute/consent/http/service/DatabaseMatchingServiceAPI.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatabaseMatchingServiceAPI.java
@@ -2,9 +2,9 @@ package org.broadinstitute.consent.http.service;
 
 import com.google.gson.Gson;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import javax.ws.rs.client.Client;
@@ -15,6 +15,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import org.apache.commons.collections.CollectionUtils;
 import org.broadinstitute.consent.http.configurations.ServicesConfiguration;
+import org.broadinstitute.consent.http.db.DataAccessRequestDAO;
 import org.broadinstitute.consent.http.models.Consent;
 import org.broadinstitute.consent.http.models.DataAccessRequest;
 import org.broadinstitute.consent.http.models.DataSet;
@@ -23,34 +24,34 @@ import org.broadinstitute.consent.http.models.Match;
 import org.broadinstitute.consent.http.models.grammar.UseRestriction;
 import org.broadinstitute.consent.http.models.matching.RequestMatchingObject;
 import org.broadinstitute.consent.http.models.matching.ResponseMatchingObject;
-import org.broadinstitute.consent.http.util.DarConstants;
-import org.broadinstitute.consent.http.util.DarUtil;
-import org.bson.Document;
 import org.glassfish.jersey.client.ClientProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class DatabaseMatchingServiceAPI extends AbstractMatchingServiceAPI {
 
-    private ConsentAPI consentAPI;
-    private DataAccessRequestAPI dataAccessAPI;
-    private DataSetAPI dsAPI;
-    private WebTarget matchServiceTarget;
-    private GenericType<ResponseMatchingObject> rmo = new GenericType<ResponseMatchingObject>(){};
-    private Logger logger = LoggerFactory.getLogger(this.getClass());
+    private final ConsentAPI consentAPI;
+    private final DataAccessRequestDAO dataAccessRequestDAO;
+    private final DataSetAPI dsAPI;
+    private final WebTarget matchServiceTarget;
+    private final GenericType<ResponseMatchingObject> rmo = new GenericType<>(){};
+    private final UseRestrictionConverter useRestrictionConverter;
+    private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
-    public static void initInstance(Client client, ServicesConfiguration config) {
-        MatchAPIHolder.setInstance(new DatabaseMatchingServiceAPI(client, config, AbstractConsentAPI.getInstance(), AbstractDataAccessRequestAPI.getInstance(), AbstractDataSetAPI.getInstance()));
+    public static void initInstance(Client client, DataAccessRequestDAO dataAccessRequestDAO,
+        ServicesConfiguration config, UseRestrictionConverter useRestrictionConverter) {
+        MatchAPIHolder.setInstance(new DatabaseMatchingServiceAPI(client, dataAccessRequestDAO, config, AbstractConsentAPI.getInstance(), AbstractDataSetAPI.getInstance(), useRestrictionConverter));
     }
 
-    DatabaseMatchingServiceAPI(Client client, ServicesConfiguration config, ConsentAPI consentAPI, DataAccessRequestAPI darAPI, DataSetAPI dsAPI){
-        this.dataAccessAPI = darAPI;
+    DatabaseMatchingServiceAPI(Client client, DataAccessRequestDAO dataAccessRequestDAO, ServicesConfiguration config, ConsentAPI consentAPI, DataSetAPI dsAPI, UseRestrictionConverter useRestrictionConverter){
         this.consentAPI = consentAPI;
+        this.dataAccessRequestDAO = dataAccessRequestDAO;
         this.dsAPI = dsAPI;
         Integer timeout = 1000 * 60 * 3; // 3 minute timeout so ontology can properly do matching.
         client.property(ClientProperties.CONNECT_TIMEOUT, timeout);
         client.property(ClientProperties.READ_TIMEOUT, timeout);
         matchServiceTarget = client.target(config.getMatchURL());
+        this.useRestrictionConverter = useRestrictionConverter;
     }
 
     @Override
@@ -58,7 +59,7 @@ public class DatabaseMatchingServiceAPI extends AbstractMatchingServiceAPI {
         Match match = null;
         try {
             Consent consent = findConsent(consentId);
-            Document dar = dataAccessAPI.describeDataAccessRequestById(purposeId);
+            DataAccessRequest dar = dataAccessRequestDAO.findByReferenceId(purposeId);
             if(consent != null || dar != null) {
                 match = singleEntitiesMatch(consent, dar);
             }
@@ -72,9 +73,9 @@ public class DatabaseMatchingServiceAPI extends AbstractMatchingServiceAPI {
     @Override
     public Match findMatchForPurpose(String purposeId){
         Match match = null;
-        Document dar = dataAccessAPI.describeDataAccessRequestById(purposeId);
+        DataAccessRequest dar = dataAccessRequestDAO.findByReferenceId(purposeId);
         if (Objects.nonNull(dar)) {
-            List<Integer> dataSetIdList = DarUtil.getIntegerList(dar, DarConstants.DATASET_ID);
+            List<Integer> dataSetIdList = dar.getData().getDatasetIds();
             Consent consent = findRelatedConsent(dataSetIdList);
             if (Objects.nonNull(consent)) {
                 try {
@@ -93,10 +94,10 @@ public class DatabaseMatchingServiceAPI extends AbstractMatchingServiceAPI {
         List<Match> matches = new ArrayList<>();
         Consent consent = findConsent(consentId);
         List<DataSet> dataSets = dsAPI.getDataSetsForConsent(consentId);
-        List<Document> dars = findRelatedDars(dataSets.stream().map(DataSet::getDataSetId).collect(Collectors.toList()));
+        List<DataAccessRequest> dars = findRelatedDars(dataSets.stream().map(DataSet::getDataSetId).collect(Collectors.toList()));
         if (consent != null && !dars.isEmpty()) {
             Match match;
-            for (Document dar : dars) {
+            for (DataAccessRequest dar : dars) {
                 try {
                     match = singleEntitiesMatch(consent, dar);
                     if(match != null){
@@ -104,14 +105,14 @@ public class DatabaseMatchingServiceAPI extends AbstractMatchingServiceAPI {
                     }
                 } catch (Exception e) {
                     logger.error("Error finding  matches for consent.", e);
-                    matches.add(createMatch(consentId, dar.getString(DarConstants.REFERENCE_ID), true, false));
+                    matches.add(createMatch(consentId, dar.getReferenceId(), true, false));
                 }
             }
         }
         return matches;
     }
 
-    private Match singleEntitiesMatch(Consent consent, Document dar) throws Exception {
+    private Match singleEntitiesMatch(Consent consent, DataAccessRequest dar) throws Exception {
         if (consent == null) {
             logger.error("Consent is null");
             throw new IllegalArgumentException("Consent cannot be null");
@@ -120,7 +121,7 @@ public class DatabaseMatchingServiceAPI extends AbstractMatchingServiceAPI {
             logger.error("Data Access Request is null");
             throw new IllegalArgumentException("Data Access Request cannot be null");
         }
-        Match match = createMatch(consent.getConsentId(), dar.getString(DarConstants.REFERENCE_ID), false, false);
+        Match match = createMatch(consent.getConsentId(), dar.getReferenceId(), false, false);
         RequestMatchingObject requestObject = createRequestObject(consent, dar);
         String json = new Gson().toJson(requestObject);
         Response res = matchServiceTarget.request(MediaType.APPLICATION_JSON).post(Entity.json(json));
@@ -161,12 +162,15 @@ public class DatabaseMatchingServiceAPI extends AbstractMatchingServiceAPI {
         return consent;
     }
 
-    private List<Document> findRelatedDars(List<Integer> dataSetIds){
-        return dataAccessAPI.describeDataAccessWithDataSetIdAndRestriction(dataSetIds);
+    private List<DataAccessRequest> findRelatedDars(List<Integer> dataSetIds){
+        return dataAccessRequestDAO.findAllDataAccessRequests().stream().
+            filter(d -> !Collections.disjoint(dataSetIds, d.getData().getDatasetIds())).
+            collect(Collectors.toList());
     }
 
-    private RequestMatchingObject createRequestObject(Consent consent, Document dar) throws Exception {
-        String restriction = new Gson().toJson(dar.get(DarConstants.RESTRICTION, Map.class));
-        return new RequestMatchingObject(consent.getUseRestriction(), UseRestriction.parse(restriction));
+    private RequestMatchingObject createRequestObject(Consent consent, DataAccessRequest dar) throws Exception {
+        DataUse dataUse = useRestrictionConverter.parseDataUsePurpose(dar);
+        UseRestriction useRestriction = useRestrictionConverter.parseUseRestriction(dataUse);
+        return new RequestMatchingObject(consent.getUseRestriction(), useRestriction);
     }
 }

--- a/src/main/java/org/broadinstitute/consent/http/service/DatabaseMatchingServiceAPI.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatabaseMatchingServiceAPI.java
@@ -16,7 +16,9 @@ import javax.ws.rs.core.Response;
 import org.apache.commons.collections.CollectionUtils;
 import org.broadinstitute.consent.http.configurations.ServicesConfiguration;
 import org.broadinstitute.consent.http.models.Consent;
+import org.broadinstitute.consent.http.models.DataAccessRequest;
 import org.broadinstitute.consent.http.models.DataSet;
+import org.broadinstitute.consent.http.models.DataUse;
 import org.broadinstitute.consent.http.models.Match;
 import org.broadinstitute.consent.http.models.grammar.UseRestriction;
 import org.broadinstitute.consent.http.models.matching.RequestMatchingObject;
@@ -117,10 +119,6 @@ public class DatabaseMatchingServiceAPI extends AbstractMatchingServiceAPI {
         if (dar == null) {
             logger.error("Data Access Request is null");
             throw new IllegalArgumentException("Data Access Request cannot be null");
-        }
-        if(!dar.containsKey(DarConstants.RESTRICTION)){
-            logger.error("Error finding single matchData Access Request: "+ dar.getString(DarConstants.DAR_CODE) + " does not have a proper Use Restriction.");
-            throw new Exception("Data Access Request: " + dar.getString(DarConstants.DAR_CODE) + " cannot be matched. Missing Use Restriction field.");
         }
         Match match = createMatch(consent.getConsentId(), dar.getString(DarConstants.REFERENCE_ID), false, false);
         RequestMatchingObject requestObject = createRequestObject(consent, dar);

--- a/src/main/java/org/broadinstitute/consent/http/service/DatabaseMatchingServiceAPI.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatabaseMatchingServiceAPI.java
@@ -168,9 +168,9 @@ public class DatabaseMatchingServiceAPI extends AbstractMatchingServiceAPI {
             collect(Collectors.toList());
     }
 
-    private RequestMatchingObject createRequestObject(Consent consent, DataAccessRequest dar) throws Exception {
+    private RequestMatchingObject createRequestObject(Consent consent, DataAccessRequest dar) {
         DataUse dataUse = useRestrictionConverter.parseDataUsePurpose(dar);
-        UseRestriction useRestriction = useRestrictionConverter.parseUseRestriction(dataUse);
-        return new RequestMatchingObject(consent.getUseRestriction(), useRestriction);
+        UseRestriction darUseRestriction = useRestrictionConverter.parseUseRestriction(dataUse);
+        return new RequestMatchingObject(consent.getUseRestriction(), darUseRestriction);
     }
 }

--- a/src/main/java/org/broadinstitute/consent/http/service/VoteService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/VoteService.java
@@ -51,6 +51,16 @@ public class VoteService {
     }
 
     /**
+     * Find all votes for an election id.
+     *
+     * @param electionIds The election ids for the election.
+     * @return Collection of votes for the given reference id
+     */
+    public List<Vote> findVotesByElectionIds(List<Integer> electionIds) {
+        return voteDAO.findVotesByElectionIds(electionIds);
+    }
+
+    /**
      * Update votes such that they have the provided value and rationale.
      *
      * @param voteList  Collection of votes to advance

--- a/src/main/java/org/broadinstitute/consent/http/util/DarConstants.java
+++ b/src/main/java/org/broadinstitute/consent/http/util/DarConstants.java
@@ -25,9 +25,6 @@ public class DarConstants {
 
     public static final String REFERENCE_ID = "referenceId";
 
-    @Deprecated
-    public static final String RESTRICTION = "restriction";
-
     public static final String TRANSLATED_RESTRICTION = "translatedUseRestriction";
 
     public static final String STATUS = "status";

--- a/src/main/java/org/broadinstitute/consent/http/util/DarConstants.java
+++ b/src/main/java/org/broadinstitute/consent/http/util/DarConstants.java
@@ -25,6 +25,7 @@ public class DarConstants {
 
     public static final String REFERENCE_ID = "referenceId";
 
+    @Deprecated
     public static final String RESTRICTION = "restriction";
 
     public static final String TRANSLATED_RESTRICTION = "translatedUseRestriction";

--- a/src/test/java/org/broadinstitute/consent/http/service/DatabaseMatchingServiceAPITest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DatabaseMatchingServiceAPITest.java
@@ -1,17 +1,16 @@
 package org.broadinstitute.consent.http.service;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.when;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.gson.Gson;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
@@ -23,7 +22,10 @@ import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import org.broadinstitute.consent.http.configurations.ServicesConfiguration;
+import org.broadinstitute.consent.http.db.DataAccessRequestDAO;
 import org.broadinstitute.consent.http.models.Consent;
+import org.broadinstitute.consent.http.models.DataAccessRequest;
+import org.broadinstitute.consent.http.models.DataAccessRequestData;
 import org.broadinstitute.consent.http.models.DataSet;
 import org.broadinstitute.consent.http.models.Match;
 import org.broadinstitute.consent.http.models.grammar.And;
@@ -32,8 +34,6 @@ import org.broadinstitute.consent.http.models.grammar.Not;
 import org.broadinstitute.consent.http.models.grammar.UseRestriction;
 import org.broadinstitute.consent.http.models.matching.RequestMatchingObject;
 import org.broadinstitute.consent.http.models.matching.ResponseMatchingObject;
-import org.broadinstitute.consent.http.util.DarConstants;
-import org.bson.Document;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -48,7 +48,7 @@ public class DatabaseMatchingServiceAPITest {
     @Mock
     private ConsentAPI consentAPI;
     @Mock
-    private DataAccessRequestAPI dataAccessAPI;
+    private DataAccessRequestDAO dataAccessRequestDAO;
     @Mock
     private DataSetAPI dsAPI;
 
@@ -60,10 +60,23 @@ public class DatabaseMatchingServiceAPITest {
     private static ResponseMatchingObject resmo2;
 
     private static DatabaseMatchingServiceAPI matchApi;
-    private static Client clientMock;
+
+
+    @Mock
+    private Client clientMock;
+    @Mock
+    private WebTarget target;
+    @Mock
+    private Invocation.Builder builder;
+    @Mock
+    private Response response;
+    @Mock
+    private ResponseMatchingObject rmo;
+    @Mock
+    private UseRestrictionConverter useRestrictionConverter;
 
     @BeforeClass
-    public static void setUpClass() throws IOException {
+    public static void setUpClass() {
         UseRestriction sampleUseRestriction1 = new And(
                 new Not(new Named("http://purl.obolibrary.org/obo/DUO_0000015")),
                 new Not(new Named("http://purl.obolibrary.org/obo/DUO_0000011")),
@@ -89,25 +102,18 @@ public class DatabaseMatchingServiceAPITest {
 
     @Before
     public void setUp() throws UnknownIdentifierException, IOException {
-
         MockitoAnnotations.initMocks(this);
         setUpMockedResponses();
         when(config.getMatchURL()).thenReturn("http://ontology.org/match");
-        matchApi = new DatabaseMatchingServiceAPI(clientMock, config, consentAPI, dataAccessAPI, dsAPI);
-
-        when(dataAccessAPI.describeDataAccessRequestById("NullDar")).thenReturn(null);
-
+        matchApi = new DatabaseMatchingServiceAPI(clientMock, dataAccessRequestDAO, config, consentAPI, dsAPI, useRestrictionConverter);
+        when(dataAccessRequestDAO.findByReferenceId("NullDar")).thenReturn(null);
         when(consentAPI.retrieve("NullConsent")).thenReturn(null);
         when(consentAPI.retrieve("AbsentConsent")).thenThrow(UnknownIdentifierException.class);
-
-        when(dataAccessAPI.describeDataAccessRequestById("DAR-2")).thenReturn(getSampleDar());
-        when(dataAccessAPI.describeDataAccessRequestFieldsById("DAR-2", Arrays.asList(DarConstants.DATASET_ID))).thenReturn(getSampleDar());        when(consentAPI.retrieve("CONS-1")).thenReturn(sampleConsent1);
         when(consentAPI.retrieve("CONS-2")).thenReturn(sampleConsent2);
-
         when(consentAPI.getConsentFromDatasetID(1)).thenReturn(sampleConsent1);
     }
 
-    private void setUpMockedResponses() throws IOException {
+    private void setUpMockedResponses() {
 
         final Invocation.Builder builderMock = Mockito.mock(Invocation.Builder.class);
         final WebTarget webTargetMock = Mockito.mock(WebTarget.class);
@@ -138,107 +144,75 @@ public class DatabaseMatchingServiceAPITest {
     }
 
     @Test
-    public void testFindSingleMatch() throws UnknownIdentifierException, IOException {
-        when(dataAccessAPI.describeDataAccessRequestById("DAR-2")).thenReturn(getSampleDar());
-        when(consentAPI.retrieve("CONS-1")).thenReturn(sampleConsent1);
+    public void testFindSingleMatch() throws Exception {
+        initSingleMatchMocks("DAR-2", sampleConsent1);
         Match match = matchApi.findSingleMatch("CONS-1", "DAR-2");
-        assertTrue(!Objects.isNull(match));
+        assertNotNull(match);
         assertTrue(match.getMatch());
-        assertTrue(!match.getFailed());
-        match = matchApi.findSingleMatch("CONS-2", "DAR-2");
-        assertTrue(Objects.isNull(match));
+        assertFalse(match.getFailed());
     }
 
     @Test
-    public void testFindSingleMatchNoPurpose() throws UnknownIdentifierException, IOException {
-        when(consentAPI.retrieve("CONS-1")).thenReturn(sampleConsent1);
+    public void testFindSingleMatchNoPurpose() throws Exception {
+        initSingleMatchMocks("DAR-2", sampleConsent1);
+
         Match match = matchApi.findSingleMatch("CONS-1", "DAR-2");
-        assertTrue(!Objects.isNull(match));
+        assertNotNull(match);
         assertTrue(match.getMatch());
-        assertTrue(!match.getFailed());
+        assertFalse(match.getFailed());
 
     }
 
     @Test
-    public void testFindMatchForPurpose() {
+    public void testFindMatchForPurpose() throws Exception {
+        initSingleMatchMocks("DAR-2", sampleConsent1);
+
         Match match = matchApi.findMatchForPurpose("DAR-2");
         assertTrue(match.getMatch());
-        assertTrue(!match.getFailed());
+        assertFalse(match.getFailed());
     }
 
     @Test
-    public void testFindMatchesForConsent() throws IOException {
-        DataSet ds = new DataSet(1, "SC-20660", "SC-20660", null, true);
-        List<DataSet> dsList = Collections.singletonList(ds);
-        when(dsAPI.getDataSetsForConsent("CONS-1")).thenReturn(dsList);
-        when(dsAPI.getDataSetsForConsent("CONS-2")).thenReturn(dsList);
-        when(dataAccessAPI.describeDataAccessWithDataSetIdAndRestriction(dsList.stream().map(DataSet::getDataSetId).collect(Collectors.toList()))).thenReturn(new ArrayList<>(Arrays.asList(getSampleDar())));
-        List<Match> matches = matchApi.findMatchesForConsent("CONS-1");
-        assertTrue(matches.size() == 1);
-        assertTrue(!matches.get(0).getFailed());
+    public void testFindMatchesForConsent() throws Exception {
+        initSingleMatchMocks("DAR-2", sampleConsent1);
+        List<Match> matches = matchApi.findMatchesForConsent(sampleConsent1.getConsentId());
+
+        assertEquals(1, matches.size());
+        assertFalse(matches.get(0).getFailed());
         assertTrue(matches.get(0).getMatch());
-        matches = matchApi.findMatchesForConsent("CONS-2");
-        assertTrue(matches.size() == 1);
-        assertTrue(matches.get(0).getFailed());
-        assertTrue(!matches.get(0).getMatch());
-        when(dataAccessAPI.describeDataAccessWithDataSetIdAndRestriction(dsList.stream().map(DataSet::getDataSetId).collect(Collectors.toList()))).thenReturn(new ArrayList<>());
-        matches = matchApi.findMatchesForConsent("CONS-1");
-        assertTrue(matches.size() == 0);
     }
 
-    private static Document getSampleDar() throws IOException {
-        Document document = new Document();
-        document.putAll(jsonAsMap(sampleDar1));
-        return document;
+    @SuppressWarnings("unchecked")
+    private void initSingleMatchMocks(String referenceId, Consent consent) throws Exception {
+        DataAccessRequest dar2 = getSampleDataAccessRequest("DAR-2");
+        when(dataAccessRequestDAO.findAllDataAccessRequests()).thenReturn(Collections.singletonList(dar2));
+        when(dataAccessRequestDAO.findByReferenceId(referenceId)).thenReturn(dar2);
+        when(consentAPI.retrieve(any())).thenReturn(consent);
+        List<DataSet> dataSets = getSampleDataAccessRequest(referenceId)
+            .getData()
+            .getDatasetIds()
+            .stream()
+            .map(id -> {DataSet d = new DataSet(); d.setDataSetId(id); return d;} )
+            .collect(Collectors.toList());
+        when(dsAPI.getDataSetsForConsent(consent.getConsentId())).thenReturn(dataSets);
+        when(rmo.isResult()).thenReturn(true);
+        when(response.readEntity(any(GenericType.class))).thenReturn(rmo);
+        when(response.getStatus()).thenReturn(200);
+        when(builder.post(any())).thenReturn(response);
+        when(target.request(MediaType.APPLICATION_JSON)).thenReturn(builder);
+        when(clientMock.target(config.getMatchURL())).thenReturn(target);
+        matchApi = new DatabaseMatchingServiceAPI(clientMock, dataAccessRequestDAO, config, consentAPI, dsAPI, useRestrictionConverter);
     }
 
-    private static Map<String, Object> jsonAsMap(String jsonSource) throws IOException {
-        return new ObjectMapper().readValue(jsonSource, Map.class);
+    private DataAccessRequest getSampleDataAccessRequest(String referenceId) {
+        DataAccessRequest dar = new DataAccessRequest();
+        dar.setReferenceId(referenceId);
+        DataAccessRequestData data = new DataAccessRequestData();
+        data.setReferenceId(referenceId);
+        data.setHmb(true);
+        data.setDatasetIds(Collections.singletonList(1));
+        dar.setData(data);
+        return dar;
     }
-
-    private static String sampleDar1 = "{\n" +
-            "\t\"_id\": \"5771763734064d282c6600ed\",\n" +
-            "\t\"investigator\": \"frernp\",\n" +
-            "\t\"institution\": \"npn\",\n" +
-            "\t\"department\": \"pon\",\n" +
-            "\t\"division\": \"opn\",\n" +
-            "\t\"address1\": \"pn\",\n" +
-            "\t\"address2\": \"n\",\n" +
-            "\t\"city\": \"pon\",\n" +
-            "\t\"state\": \"pon\",\n" +
-            "\t\"zipcode\": \"p\",\n" +
-            "\t\"country\": \"np\",\n" +
-            "\t\"projectTitle\": \"np\",\n" +
-            "\t\"rus\": \"csvv\",\n" +
-            "\t\"non_tech_rus\": \"vfvdvfdf\",\n" +
-            "\t\"diseases\": true,\n" +
-            "\t\"forProfit\": false,\n" +
-            "\t\"onegender\": false,\n" +
-            "\t\"pediatric\": false,\n" +
-            "\t\"illegalbehave\": false,\n" +
-            "\t\"addiction\": false,\n" +
-            "\t\"sexualdiseases\": false,\n" +
-            "\t\"stigmatizediseases\": false,\n" +
-            "\t\"vulnerablepop\": false,\n" +
-            "\t\"popmigration\": false,\n" +
-            "\t\"psychtraits\": false,\n" +
-            "\t\"nothealth\": false,\n" +
-            "\t\"userId\": 3333,\n" +
-            "\t\"restriction\": {\n" +
-            "\t\t\"type\": \"and\",\n" +
-            "\t\t\"operands\": [{\n" +
-            "\t\t\t\"type\": \"named\",\n" +
-            "\t\t\t\"name\": \"http://purl.obolibrary.org/obo/DUO_0000018\"\n" +
-            "\t\t}]\n" +
-            "\t},\n" +
-            "\t\"datasetId\": [1],\n" +
-            "\t\"datasetIds\": [1],\n" +
-            "\t\"datasetDetail\": [{\n" +
-            "\t\t\"datasetId\": 1,\n" +
-            "\t\t\"name\": \"UHN_AsaWW (University of Toronto)-Carcinoid\"\n" +
-            "\t}],\n" +
-            "\t\"dar_code\": \"DAR-6\",\n" +
-            "\t\"valid_restriction\": true\n" +
-            "}";
 
 }


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-1057
See also: https://github.com/DataBiosphere/duos-ui/pull/910

## Changes
* rm unnecessary `hasUseRestriction` API method
* rm all references to restriction fields
* refactor how we generate the UseRestriction for a DAR when generating a match

---
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [ ] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
