### PR TITLE
[DUOS-1072][DUOS-1076][risk=no] Update the dac on the consent when creating/updating datasets

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -148,6 +148,13 @@ public class DatasetService {
     public Optional<DataSet> updateDataset(DataSetDTO dataset, Integer datasetId, Integer userId) {
         Timestamp now = new Timestamp(new Date().getTime());
 
+        if (Objects.nonNull(dataset.getDacId())) {
+            Consent consent = consentDAO.findConsentFromDatasetID(datasetId);
+            if (Objects.nonNull(consent)) {
+                consentDAO.updateConsentDac(consent.getConsentId(), dataset.getDacId());
+            }
+        }
+
         DataSet old = getDatasetWithPropertiesById(datasetId);
         Set<DataSetProperty> oldProperties = old.getProperties();
 

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -80,6 +80,9 @@ public class DatasetService {
                   null, name, null, createDate, createDate, null,
                   groupName, dataset.getDacId());
             String associationType = AssociationType.SAMPLESET.getValue();
+            if (Objects.nonNull(dataset.getDacId())) {
+                consentDAO.updateConsentDac(consentId, dataset.getDacId());
+            }
             consentDAO.insertConsentAssociation(consentId, associationType, dataset.getDataSetId());
             return consentDAO.findConsentById(consentId);
         } else {


### PR DESCRIPTION
## Addresses
API bug found in https://broadworkbench.atlassian.net/browse/DUOS-1072
See also: https://github.com/DataBiosphere/duos-ui/pull/922
Also addresses https://broadworkbench.atlassian.net/browse/DUOS-1076

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [ ] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
