### PR TITLE
DUOS-1104[risk=no]Cancel Election does not update all of the election's votes correctly

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/service/DatabaseElectionAPI.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatabaseElectionAPI.java
@@ -611,11 +611,21 @@ public class DatabaseElectionAPI extends AbstractElectionAPI {
 
     private void updateFinalVote(Election rec, Integer electionId) {
         if (rec.getFinalVote() != null) {
-            Vote vote = voteDAO.findVoteByElectionIdAndType(electionId, VoteType.CHAIRPERSON.getValue());
-            vote.setVote(rec.getFinalVote());
-            vote.setCreateDate(rec.getFinalVoteDate());
-            vote.setRationale(rec.getFinalRationale());
-            voteDAO.updateVote(vote.getVote(), vote.getRationale(), vote.getUpdateDate(), vote.getVoteId(), vote.getIsReminderSent(), vote.getElectionId(), vote.getCreateDate(), vote.getHasConcerns());
+            List<Vote> finalVotes = voteDAO.findVotesByElectionIdAndType(electionId, VoteType.FINAL.getValue());
+            Date finalVoteDate = rec.getFinalVoteDate();
+            if(finalVoteDate == null) {
+                finalVoteDate = new Date();
+            }
+            for (Vote vote : finalVotes) {
+                vote.setVote(rec.getFinalVote());
+                vote.setUpdateDate(finalVoteDate);
+                vote.setRationale(rec.getFinalRationale());
+                voteDAO.updateVote(
+                    vote.getVote(), vote.getRationale(), vote.getUpdateDate(), vote.getVoteId(),
+                    vote.getIsReminderSent(), vote.getElectionId(), vote.getCreateDate(),
+                    vote.getHasConcerns()
+                );
+            }
         }
     }
 

--- a/src/main/java/org/broadinstitute/consent/http/service/DatabaseElectionAPI.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatabaseElectionAPI.java
@@ -148,7 +148,6 @@ public class DatabaseElectionAPI extends AbstractElectionAPI {
         } else if (rec.getStatus().equals(ElectionStatus.CLOSED.getValue()) || rec.getStatus().equals(ElectionStatus.FINAL.getValue())) {
             rec.setFinalVoteDate(new Date());
         }
-        updateFinalVote(rec, electionId);
         Election election = electionDAO.findElectionWithFinalVoteById(electionId);
         if (election == null) {
             throw new NotFoundException("Election for specified id does not exist");
@@ -605,27 +604,6 @@ public class DatabaseElectionAPI extends AbstractElectionAPI {
         }
         if (CollectionUtils.isNotEmpty(ids)) {
             electionDAO.updateElectionStatus(ids, status);
-        }
-    }
-
-
-    private void updateFinalVote(Election rec, Integer electionId) {
-        if (rec.getFinalVote() != null) {
-            List<Vote> finalVotes = voteDAO.findVotesByElectionIdAndType(electionId, VoteType.FINAL.getValue());
-            Date finalVoteDate = rec.getFinalVoteDate();
-            if(finalVoteDate == null) {
-                finalVoteDate = new Date();
-            }
-            for (Vote vote : finalVotes) {
-                vote.setVote(rec.getFinalVote());
-                vote.setUpdateDate(finalVoteDate);
-                vote.setRationale(rec.getFinalRationale());
-                voteDAO.updateVote(
-                    vote.getVote(), vote.getRationale(), vote.getUpdateDate(), vote.getVoteId(),
-                    vote.getIsReminderSent(), vote.getElectionId(), vote.getCreateDate(),
-                    vote.getHasConcerns()
-                );
-            }
         }
     }
 


### PR DESCRIPTION
Addresses [DUOS-1104](https://broadworkbench.atlassian.net/browse/DUOS-1104)

PR corrects vote assignments on votes with `type == 'FINAL'` via `updateFinalVote` method within `DatabaseElectionAPI`. Instead of finding a single Final vote, the method will now query for a list of final votes and perform attribute updates based on the election argument. 

**Note:** Method feels like it should belong in a Vote or Election service, and it's only referenced in a single method so moving shouldn't be difficult. I'll write the test up as a follow-up to the feedback.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [ ] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
