### PR TITLE
[DUOS-1121][risk=no] Deprecate DARData user id

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequestData.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequestData.java
@@ -47,7 +47,6 @@ public class DataAccessRequestData {
     private String projectTitle;
     private Boolean checkCollaborator;
     private String researcher;
-    private Integer userId;
     private String isThePi;
     private String havePi;
     private String piEmail;
@@ -257,14 +256,6 @@ public class DataAccessRequestData {
 
     public void setResearcher(String researcher) {
         this.researcher = researcher;
-    }
-
-    public Integer getUserId() {
-        return userId;
-    }
-
-    public void setUserId(Integer userId) {
-        this.userId = userId;
     }
 
     public String getIsThePi() {

--- a/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
@@ -303,7 +303,7 @@ public class DataAccessRequestResource extends Resource {
             super.validateAuthedRoleUser(allowableRoles, user, dataAccessRequest.getUserId());
         } else {
             logger.warning("DataAccessRequest '" + referenceId + "' has an invalid userId" );
-            super.validateAuthedRoleUser(allowableRoles, user, dataAccessRequest.getData().getUserId());
+            super.validateAuthedRoleUser(allowableRoles, user, dataAccessRequest.getUserId());
         }
     }
 }

--- a/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceVersion2.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceVersion2.java
@@ -416,7 +416,7 @@ public class DataAccessRequestResourceVersion2 extends Resource {
       super.validateAuthedRoleUser(allowableRoles, user, dataAccessRequest.getUserId());
     } else {
       logger.warn("DataAccessRequest '" + referenceId + "' has an invalid userId" );
-      super.validateAuthedRoleUser(allowableRoles, user, dataAccessRequest.getData().getUserId());
+      super.validateAuthedRoleUser(allowableRoles, user, dataAccessRequest.getUserId());
     }
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
@@ -156,8 +156,8 @@ public class DataAccessRequestService {
             filteredAccessList = dacService.filterDataAccessRequestsByDac(allDars, authUser);
         } else {
             filteredAccessList = allDars.stream().
-                    filter(d -> d.getData().getUserId() != null).
-                    filter(d -> d.getData().getUserId().equals(userId)).
+                    filter(d -> d.getUserId() != null).
+                    filter(d -> d.getUserId().equals(userId)).
                     collect(Collectors.toList());
         }
         filteredAccessList.sort(sortTimeComparator());
@@ -452,7 +452,7 @@ public class DataAccessRequestService {
             } else {
                 darManage.setElectionStatus(UN_REVIEWED);
             }
-            darManage.setOwnerUser(getOwnerUser(dar.getData().getUserId()).orElse(null));
+            darManage.setOwnerUser(getOwnerUser(dar.getUserId()).orElse(null));
             if (darManage.getOwnerUser() == null) {
                 logger.error("DAR: " + darManage.getFrontEndId() + " has an invalid owner");
             }
@@ -483,7 +483,6 @@ public class DataAccessRequestService {
         List<DataAccessRequest> newDARList = new ArrayList<>();
         DataAccessRequestData darData = dataAccessRequest.getData();
         darData.setPartialDarCode(null);
-        darData.setUserId(user.getDacUserId());
         if (Objects.isNull(darData.getCreateDate())) {
             darData.setCreateDate(nowTime);
         }


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-1121

Minor refactoring to refer directly to the user id on the DAR object.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [ ] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
