### PR TITLE
[DUOS-866][risk=no] Update get consent by name

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/resources/ConsentResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/ConsentResource.java
@@ -10,7 +10,6 @@ import javax.annotation.security.RolesAllowed;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
-import javax.ws.rs.NotFoundException;
 import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
@@ -26,15 +25,12 @@ import org.broadinstitute.consent.http.enumeration.AuditTable;
 import org.broadinstitute.consent.http.exceptions.UpdateConsentException;
 import org.broadinstitute.consent.http.models.AuthUser;
 import org.broadinstitute.consent.http.models.Consent;
-import org.broadinstitute.consent.http.models.Election;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.dto.Error;
-import org.broadinstitute.consent.http.service.AbstractElectionAPI;
 import org.broadinstitute.consent.http.service.AbstractMatchAPI;
 import org.broadinstitute.consent.http.service.AbstractMatchProcessAPI;
 import org.broadinstitute.consent.http.service.AuditService;
 import org.broadinstitute.consent.http.service.ConsentService;
-import org.broadinstitute.consent.http.service.ElectionAPI;
 import org.broadinstitute.consent.http.service.MatchAPI;
 import org.broadinstitute.consent.http.service.MatchProcessAPI;
 import org.broadinstitute.consent.http.service.UnknownIdentifierException;
@@ -50,7 +46,6 @@ public class ConsentResource extends Resource {
     private final MatchProcessAPI matchProcessAPI;
     private final MatchAPI matchAPI;
     private final UseRestrictionValidatorAPI useRestrictionValidatorAPI;
-    private final ElectionAPI electionAPI;
     private final UserService userService;
 
     @Inject
@@ -60,7 +55,6 @@ public class ConsentResource extends Resource {
         this.matchProcessAPI = AbstractMatchProcessAPI.getInstance();
         this.matchAPI = AbstractMatchAPI.getInstance();
         this.useRestrictionValidatorAPI = AbstractUseRestrictionValidatorAPI.getInstance();
-        this.electionAPI = AbstractElectionAPI.getInstance();
         this.userService = userService;
     }
 

--- a/src/main/java/org/broadinstitute/consent/http/resources/ConsentResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/ConsentResource.java
@@ -164,18 +164,9 @@ public class ConsentResource extends Resource {
     public Response getByName(@QueryParam("name") String name, @Context UriInfo info) {
         try {
             Consent consent = consentService.getByName(name);
-            Election election = electionAPI.describeConsentElection(consent.consentId);
-            if (election.getFinalVote() != null && election.getFinalVote()) {
-                return Response.ok(consent).build();
-            } else {
-                // electionAPI.describeConsentElection will throw NotFoundException if no election exists, and we catch
-                // that below. Here, we have an existing-but-failed election. Let's send it to the same catch clause.
-                throw new NotFoundException();
-            }
+            return Response.ok(consent).build();
         } catch (UnknownIdentifierException ex) {
             return Response.status(Response.Status.NOT_FOUND).entity(new Error(String.format("Consent with a name of '%s' was not found.", name), Response.Status.NOT_FOUND.getStatusCode())).build();
-        } catch (NotFoundException nfe) {
-            return Response.status(Response.Status.BAD_REQUEST).entity(new Error(String.format("Consent with a name of '%s' is not approved.", name), Response.Status.BAD_REQUEST.getStatusCode())).build();
         }
     }
 

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -829,6 +829,28 @@ paths:
                 type: string
         404:
           description: The votes for the consent ID couldn't be found
+  /api/consent/{name}:
+    get:
+      summary: Get Consent by Name
+      description: Returns the consent identified by the Name.
+      parameters:
+        - name: name
+          in: path
+          description: Consent Name
+          required: true
+          schema:
+            type: string
+      tags:
+        - Consent
+      responses:
+        200:
+          description: Returns the requested consent.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Consent'
+        404:
+          description: The consent associated with the name couldn't be found.
   /api/dac:
     post:
       summary: Create a DAC

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -829,28 +829,6 @@ paths:
                 type: string
         404:
           description: The votes for the consent ID couldn't be found
-  /api/consent/{name}:
-    get:
-      summary: Get Consent by Name
-      description: Returns the consent identified by the Name.
-      parameters:
-        - name: name
-          in: path
-          description: Consent Name
-          required: true
-          schema:
-            type: string
-      tags:
-        - Consent
-      responses:
-        200:
-          description: Returns the requested consent.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Consent'
-        404:
-          description: The consent associated with the name couldn't be found.
   /api/dac:
     post:
       summary: Create a DAC

--- a/src/test/java/org/broadinstitute/consent/http/resources/ConsentResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/ConsentResourceTest.java
@@ -46,8 +46,7 @@ import static org.mockito.Mockito.when;
         AbstractDACUserAPI.class,
         AbstractMatchProcessAPI.class,
         AbstractMatchAPI.class,
-        AbstractUseRestrictionValidatorAPI.class,
-        AbstractElectionAPI.class,
+        AbstractUseRestrictionValidatorAPI.class
 })
 public class ConsentResourceTest {
 
@@ -64,8 +63,6 @@ public class ConsentResourceTest {
     @Mock
     private UseRestrictionValidatorAPI useRestrictionValidatorAPI;
     @Mock
-    private ElectionAPI electionAPI;
-    @Mock
     private UserService userService;
     @Mock
     UriInfo info;
@@ -81,7 +78,6 @@ public class ConsentResourceTest {
         PowerMockito.mockStatic(AbstractMatchProcessAPI.class);
         PowerMockito.mockStatic(AbstractMatchAPI.class);
         PowerMockito.mockStatic(AbstractUseRestrictionValidatorAPI.class);
-        PowerMockito.mockStatic(AbstractElectionAPI.class);
     }
 
     private void initResource() {
@@ -92,7 +88,6 @@ public class ConsentResourceTest {
         when(AbstractMatchProcessAPI.getInstance()).thenReturn(matchProcessAPI);
         when(AbstractMatchAPI.getInstance()).thenReturn(matchAPI);
         when(AbstractUseRestrictionValidatorAPI.getInstance()).thenReturn(useRestrictionValidatorAPI);
-        when(AbstractElectionAPI.getInstance()).thenReturn(electionAPI);
         resource = new ConsentResource(auditService, userService, consentService);
     }
 


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-866

Updates the get by name API to really get the consent by its name.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [ ] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
