### PR TITLE
DUOS-1131[risk=no]Remove email updates from user APIs

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/UserDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/UserDAO.java
@@ -86,7 +86,7 @@ public interface UserDAO extends Transactional<UserDAO> {
                           @Bind("displayName") String displayName,
                           @Bind("createDate") Date createDate);
 
-    @SqlUpdate("update dacuser set displayName=:displayName, additional_email=:additionalEmail where dacUserId=:id")
+    @SqlUpdate("UPDATE dacuser SET displayname=:displayName, additional_email=:additionalEmail WHERE dacuserid=:id")
     void updateUser(@Bind("displayName") String displayName,
                        @Bind("id") Integer id,
                        @Bind("additionalEmail") String additionalEmail);

--- a/src/main/java/org/broadinstitute/consent/http/db/UserDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/UserDAO.java
@@ -86,9 +86,8 @@ public interface UserDAO extends Transactional<UserDAO> {
                           @Bind("displayName") String displayName,
                           @Bind("createDate") Date createDate);
 
-    @SqlUpdate("update dacuser set email=:email, displayName=:displayName, additional_email=:additionalEmail where dacUserId=:id")
-    void updateUser(@Bind("email") String email,
-                       @Bind("displayName") String displayName,
+    @SqlUpdate("update dacuser set displayName=:displayName, additional_email=:additionalEmail where dacUserId=:id")
+    void updateUser(@Bind("displayName") String displayName,
                        @Bind("id") Integer id,
                        @Bind("additionalEmail") String additionalEmail);
 

--- a/src/main/java/org/broadinstitute/consent/http/service/users/DatabaseDACUserAPI.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/users/DatabaseDACUserAPI.java
@@ -81,7 +81,7 @@ public class DatabaseDACUserAPI extends AbstractDACUserAPI {
         // validate required fields are not null or empty
         validateRequiredFields(updatedUser);
         try {
-            userDAO.updateUser(updatedUser.getEmail(), updatedUser.getDisplayName(), id, updatedUser.getAdditionalEmail());
+            userDAO.updateUser(updatedUser.getDisplayName(), id, updatedUser.getAdditionalEmail());
         } catch (UnableToExecuteStatementException e) {
             throw new IllegalArgumentException("Email shoud be unique.");
         }

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -1180,10 +1180,10 @@ paths:
       description: |
         Updates the user identified by the ID. Requires the authenticated user to have the same id
         as that of the user being updated except in the admin case - admins can update information
-        for other users. Role changes are not allowed for Chairperson and Member roles using this endpoint.
-        All Chairperson and Member changes (additions or removals) are ignored. See
-        [DAC](/#!/DAC) endpoints for **POST/DELETE** endpoints for **/api/dac/{dacId}/chair/{userId}** and
-        **/api/dac/{dacId}/member/{userId}** calls.
+        for other users. A user's email cannot be updated. Role changes are not allowed for Chairperson
+        and Member roles using this endpoint. All Chairperson and Member changes (additions or removals) 
+        are ignored. See [DAC](/#!/DAC) endpoints for **POST/DELETE** endpoints for
+        **/api/dac/{dacId}/chair/{userId}** and **/api/dac/{dacId}/member/{userId}** calls.
       parameters:
         - name: id
           in: path

--- a/src/test/java/org/broadinstitute/consent/http/db/UserDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/UserDAOTest.java
@@ -174,12 +174,11 @@ public class UserDAOTest extends DAOTestHelper {
         User user = createUser();
         String newEmail = getRandomEmailAddress();
         userDAO.updateUser(
-                newEmail,
                 "Dac User Test",
                 user.getDacUserId(),
                 newEmail);
         User user2 = userDAO.findUserById(user.getDacUserId());
-        assertEquals(user2.getEmail(), newEmail);
+        assertEquals(user2.getAdditionalEmail(), newEmail);
     }
 
     @Test


### PR DESCRIPTION
SCOPE:
the email should not be updatable
remove email field from update call
merge before DUOS-1131 in UI

Addresses:
https://broadworkbench.atlassian.net/browse/DUOS-1131
With DUOS-1131 in UI

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [ ] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
