### PR TITLE
DUOS-1135[risk=no]Bug on Admin Manage Access and New Chair Console when creating Election

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/ElectionDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/ElectionDAO.java
@@ -79,7 +79,7 @@ public interface ElectionDAO extends Transactional<ElectionDAO> {
     @SqlQuery("SELECT e.electionId,  e.datasetId, v.vote finalVote, e.status, e.createDate, e.referenceId, v.rationale finalRationale, v.createDate finalVoteDate, "
             + " e.lastUpdate, e.finalAccessVote, e.electionType, e.dataUseLetter, e.dulName, e.archived, e.version FROM election e"
             + " INNER JOIN vote v on v.electionId = e.electionId and LOWER(v.type) = 'chairperson' "
-            + " WHERE e.referenceId = :referenceId AND lower(e.electionType) = LOWER(:type) LIMIT 1")
+            + " WHERE e.referenceId = :referenceId AND lower(e.electionType) = LOWER(:type) ORDER BY createDate desc LIMIT 1")
     Election getElectionWithFinalVoteByReferenceIdAndType(@Bind("referenceId") String referenceId, @Bind("type") String type);
 
     @SqlQuery("SELECT distinct "

--- a/src/main/java/org/broadinstitute/consent/http/db/ElectionDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/ElectionDAO.java
@@ -76,10 +76,10 @@ public interface ElectionDAO extends Transactional<ElectionDAO> {
             + " where e.referenceId = :referenceId and lower(e.status) = 'open' and lower(e.electionType) = lower(:type)")
     Election getOpenElectionWithFinalVoteByReferenceIdAndType(@Bind("referenceId") String referenceId, @Bind("type") String type);
 
-    @SqlQuery("select e.electionId,  e.datasetId, v.vote finalVote, e.status, e.createDate, e.referenceId, v.rationale finalRationale, v.createDate finalVoteDate, "
-            + "e.lastUpdate, e.finalAccessVote, e.electionType, e.dataUseLetter, e.dulName, e.archived, e.version  from election e"
-            + " inner join vote v on v.electionId = e.electionId and lower(v.type) = 'chairperson' "
-            + " where e.referenceId = :referenceId and lower(e.electionType) = lower(:type) and e.version = (select MAX(version) from election where referenceId = :referenceId)")
+    @SqlQuery("SELECT e.electionId,  e.datasetId, v.vote finalVote, e.status, e.createDate, e.referenceId, v.rationale finalRationale, v.createDate finalVoteDate, "
+            + " e.lastUpdate, e.finalAccessVote, e.electionType, e.dataUseLetter, e.dulName, e.archived, e.version FROM election e"
+            + " INNER JOIN vote v on v.electionId = e.electionId and LOWER(v.type) = 'chairperson' "
+            + " WHERE e.referenceId = :referenceId AND lower(e.electionType) = LOWER(:type) LIMIT 1")
     Election getElectionWithFinalVoteByReferenceIdAndType(@Bind("referenceId") String referenceId, @Bind("type") String type);
 
     @SqlQuery("SELECT distinct "


### PR DESCRIPTION
SCOPE:
-remove breaking subquery for version in ElectionDAO.getElectionWithFinalVoteByReferenceIdAndType

ADDRESSES:
https://broadworkbench.atlassian.net/browse/DUOS-1135

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [ ] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
