### PR TITLE
[DUOS-1179][risk=no] Set the deletable property on datasets

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
@@ -238,7 +238,14 @@ public class ConsentModule extends AbstractModule {
 
     @Provides
     DatasetService providesDatasetService() {
-        return new DatasetService(providesConsentDAO(), providesDataSetDAO(), providesUserRoleDAO(), providesDataSetAuditDAO(), providesDatasetAssociationDAO(), providesUseRestrictionConverter());
+        return new DatasetService(
+                providesConsentDAO(),
+                providesDataAccessRequestDAO(),
+                providesDataSetDAO(),
+                providesUserRoleDAO(),
+                providesDataSetAuditDAO(),
+                providesDatasetAssociationDAO(),
+                providesUseRestrictionConverter());
     }
 
     @Provides

--- a/src/main/java/org/broadinstitute/consent/http/db/DataAccessRequestDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DataAccessRequestDAO.java
@@ -2,6 +2,8 @@ package org.broadinstitute.consent.http.db;
 
 import java.util.Date;
 import java.util.List;
+
+import org.broadinstitute.consent.http.db.mapper.DataAccessRequestDataMapper;
 import org.broadinstitute.consent.http.db.mapper.DataAccessRequestMapper;
 import org.broadinstitute.consent.http.models.DataAccessRequest;
 import org.broadinstitute.consent.http.models.DataAccessRequestData;
@@ -166,4 +168,8 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
    */
   @SqlUpdate("UPDATE data_access_request SET draft = :draft WHERE reference_id = :referenceId ")
   void updateDraftByReferenceId(@Bind("referenceId") String referenceId, @Bind("draft") Boolean draft);
+
+  @RegisterRowMapper(DataAccessRequestDataMapper.class)
+  @SqlQuery(" SELECT (data #>> '{}')::jsonb AS data FROM data_access_request ")
+  List<DataAccessRequestData> findAllDataAccessRequestDatas();
 }

--- a/src/main/java/org/broadinstitute/consent/http/db/DataSetDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DataSetDAO.java
@@ -63,6 +63,9 @@ public interface DataSetDAO extends Transactional<DataSetDAO> {
     @SqlBatch("delete from datasetproperty where dataSetId = :dataSetId")
     void deleteDataSetsProperties(@Bind("dataSetId") Collection<Integer> dataSetsIds);
 
+    @SqlUpdate("DELETE FROM datasetproperty WHERE datasetid = :datasetId")
+    void deleteDatasetPropertiesByDatasetId(@Bind("datasetId") Integer datasetId);
+
     @SqlUpdate("UPDATE datasetproperty SET propertyvalue = :propertyValue WHERE datasetid = :datasetId AND propertykey = :propertyKey")
     void updateDatasetProperty(@Bind("datasetId") Integer datasetId, @Bind("propertyKey") Integer propertyKey, @Bind("propertyValue") String propertyValue);
 
@@ -71,6 +74,9 @@ public interface DataSetDAO extends Transactional<DataSetDAO> {
 
     @SqlBatch("delete from dataset where dataSetId = :dataSetId")
     void deleteDataSets(@Bind("dataSetId") Collection<Integer> dataSetsIds);
+
+    @SqlUpdate("DELETE FROM dataset WHERE datasetid = :datasetId")
+    void deleteDatasetById(@Bind("datasetId") Integer datasetId);
 
     @SqlUpdate("UPDATE dataset SET active = null, name = null, createdate = null, needs_approval = 0 WHERE datasetid = :dataSetId")
     void logicalDatasetDelete(@Bind("dataSetId") Integer dataSetId);

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DataAccessRequestDataMapper.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DataAccessRequestDataMapper.java
@@ -1,0 +1,39 @@
+package org.broadinstitute.consent.http.db.mapper;
+
+import com.google.gson.JsonSyntaxException;
+import org.broadinstitute.consent.http.models.DataAccessRequestData;
+import org.jdbi.v3.core.mapper.RowMapper;
+import org.jdbi.v3.core.statement.StatementContext;
+import org.postgresql.util.PGobject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Objects;
+
+public class DataAccessRequestDataMapper implements RowMapper<DataAccessRequestData>, RowMapperHelper {
+
+    private final Logger logger = LoggerFactory.getLogger(this.getClass());
+
+    @Override
+    public DataAccessRequestData map(ResultSet resultSet, StatementContext statementContext) throws SQLException {
+        DataAccessRequestData data = null;
+        String darDataString = resultSet.getObject("data", PGobject.class).getValue();
+        if (Objects.nonNull(darDataString)) {
+            // Handle nested quotes
+            String quoteFixedDataString = darDataString.replaceAll("\\\\\"", "'");
+            // Inserted json data ends up double-escaped via standard jdbi insert.
+            String escapedDataString = unescapeJava(quoteFixedDataString);
+            try {
+                data = DataAccessRequestData.fromString(escapedDataString);
+            } catch (JsonSyntaxException | NullPointerException e) {
+                String message = "Unable to parse Data Access Request; error: " + e.getMessage();
+                logger.error(message);
+                throw new SQLException(message);
+            }
+        }
+        return data;
+    }
+
+}

--- a/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
@@ -25,6 +25,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import org.broadinstitute.consent.http.db.ConsentDAO;
+import org.broadinstitute.consent.http.db.DataAccessRequestDAO;
 import org.broadinstitute.consent.http.db.DataSetAuditDAO;
 import org.broadinstitute.consent.http.db.DataSetDAO;
 import org.broadinstitute.consent.http.db.DatasetAssociationDAO;
@@ -52,6 +53,9 @@ public class DatasetServiceTest {
     private ConsentDAO consentDAO;
 
     @Mock
+    DataAccessRequestDAO dataAccessRequestDAO;
+
+    @Mock
     private DataSetDAO datasetDAO;
 
     @Mock
@@ -72,7 +76,7 @@ public class DatasetServiceTest {
     }
 
     private void initService() {
-        datasetService = new DatasetService(consentDAO, datasetDAO, userRoleDAO, dataSetAuditDAO, datasetAssociationDAO, useRestrictionConverter);
+        datasetService = new DatasetService(consentDAO, dataAccessRequestDAO, datasetDAO, userRoleDAO, dataSetAuditDAO, datasetAssociationDAO, useRestrictionConverter);
     }
 
     @Test


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-1179

Depends on https://github.com/DataBiosphere/consent/pull/1013 and will rebase once that's in place.

## Changes
* Added a new query for DataAccessRequestData objects. Only needed this so I could get the dataset ids. I tried getting *just* the dataset ids, but ran into jdbi issues so I took this route instead.
* Added a check when getting datasets to see if their ids are in use in any DAR. If they are, `deletable` is set to `false`.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [ ] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
