### PR TITLE
DUOS-1187[risk=no] Updated Researcher Manage Endpoint (removed userId as queryParam)

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
@@ -16,7 +16,6 @@ import java.util.stream.Stream;
 import javax.annotation.security.PermitAll;
 import javax.annotation.security.RolesAllowed;
 import javax.mail.MessagingException;
-import javax.ws.rs.BadRequestException;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.ForbiddenException;
 import javax.ws.rs.GET;

--- a/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
@@ -144,16 +144,16 @@ public class DataAccessRequestResource extends Resource {
     @Path("/manage")
     @RolesAllowed({ADMIN, CHAIRPERSON, RESEARCHER})
     @Deprecated // Use describeManageDataAccessRequestsV2
-    public Response describeManageDataAccessRequests(@QueryParam("userId") Integer userId, @Auth AuthUser authUser) {
+    public Response describeManageDataAccessRequests(@Auth AuthUser authUser) {
         // If a user id is provided, ensure that is the current user.
-        if (userId != null) {
+        try{
             User user = userService.findUserByEmail(authUser.getName());
-            if (!user.getDacUserId().equals(userId)) {
-                throw new BadRequestException("Unable to query for other users' information.");
-            }
+            Integer userId = user.getDacUserId();
+            List<DataAccessRequestManage> dars = dataAccessRequestService.describeDataAccessRequestManage(userId, authUser);
+            return Response.ok().entity(dars).build();
+        } catch(Exception e) {
+            return createExceptionResponse(e);
         }
-        List<DataAccessRequestManage> dars = dataAccessRequestService.describeDataAccessRequestManage(userId, authUser);
-        return Response.ok().entity(dars).build();
     }
 
     @GET

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -1630,13 +1630,6 @@ paths:
           If the user is requesting these as an admin, all are returned. As a DAC member, only those
           assigned to the DAC are returned. As a general user, only those created by the user are
           returned.
-        parameters:
-          - name: userId
-            in: query
-            description: Optional user id to filter Data Access Requests by
-            required: false
-            schema:
-              type: integer
         tags:
           - Data Access Request
         responses:


### PR DESCRIPTION
Addresses [DUOS-1187](https://broadworkbench.atlassian.net/browse/DUOS-1187)

PR removes userId query param in favor of relying on current user stored in session as source of userId, a change that [has been implemented on the front-end](https://github.com/DataBiosphere/duos-ui/pull/991/files). PR also implements the use of ```try...catch``` and ```createExceptionResponse``` for error response handling.

Problem with initial code stemmed from the fact that the statement ```userId != null``` would evaluate to false, even though inspection of ```userId``` shows it to be ```null```. This incorrect evaluation would affect the filter conditionals in ```DataAccessRequestService.describeDataAccessRequestManage```

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [x] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
