### PR TITLE
DUOS-1192[risk=no]Cancelled DARs visible in Manage Screens

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
@@ -362,9 +362,10 @@ public class DataAccessRequestService {
         }
         DataAccessRequestData darData = dar.getData();
         List<Election> elections = electionDAO.findElectionsByReferenceId(referenceId);
-        List<Election> openElections = elections.stream().filter(e -> e.getStatus() == "Open").collect(Collectors.toCollection(ArrayList::new));
+        List<Integer> openElectionIds = elections.stream().filter(e -> e.getStatus() == ElectionStatus.OPEN.getValue()).map(Election::getElectionId).collect(Collectors.toCollection(ArrayList::new));
         darData.setStatus(ElectionStatus.CANCELED.getValue());
         updateByReferenceId(referenceId, darData);
+        electionDAO.updateElectionStatus(openElectionIds, ElectionStatus.CANCELED.getValue());
         return findByReferenceId(referenceId);
     }
 

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
@@ -143,14 +143,14 @@ public class DataAccessRequestService {
      */
     public List<DataAccessRequestManage> describeDataAccessRequestManageV2(AuthUser authUser) {
         List<DataAccessRequest> allDars = findAllDataAccessRequests();
-        List<DataAccessRequest> filteredAccessList = 
-        dacService.filterDataAccessRequestsByDac(allDars, authUser)
-          .stream()
-          .filter(dar -> dar.getData().getStatus() != "Canceled")
-          .collect(Collectors.toList());
-        filteredAccessList.sort(sortTimeComparator());
-        if (CollectionUtils.isNotEmpty(filteredAccessList)) {
-            return createAccessRequestManageV2(filteredAccessList);
+        List<DataAccessRequest> filteredAccessList = dacService.filterDataAccessRequestsByDac(allDars, authUser);
+        List<DataAccessRequest> openDarList = filteredAccessList.stream().filter(dar -> {
+            DataAccessRequestData data = dar.getData();
+            return (Objects.isNull(data) ? true : (Objects.isNull(data.getStatus())));
+        }).collect(Collectors.toList());
+        openDarList.sort(sortTimeComparator());
+        if (CollectionUtils.isNotEmpty(openDarList)) {
+            return createAccessRequestManageV2(openDarList);
         }
         return Collections.emptyList();
     }

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
@@ -361,6 +361,8 @@ public class DataAccessRequestService {
             throw new NotFoundException("Unable to find Data Access Request with the provided id: " + referenceId);
         }
         DataAccessRequestData darData = dar.getData();
+        List<Election> elections = electionDAO.findElectionsByReferenceId(referenceId);
+        List<Election> openElections = elections.stream().filter(e -> e.getStatus() == "Open").collect(Collectors.toCollection(ArrayList::new));
         darData.setStatus(ElectionStatus.CANCELED.getValue());
         updateByReferenceId(referenceId, darData);
         return findByReferenceId(referenceId);

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
@@ -145,8 +145,7 @@ public class DataAccessRequestService {
         List<DataAccessRequest> allDars = findAllDataAccessRequests();
         List<DataAccessRequest> filteredAccessList = dacService.filterDataAccessRequestsByDac(allDars, authUser);
         List<DataAccessRequest> openDarList = filteredAccessList.stream().filter(dar -> {
-            DataAccessRequestData data = dar.getData();
-            return (Objects.isNull(data) ? true : (Objects.isNull(data.getStatus())));
+            return !ElectionStatus.CANCELED.getValue().equals(dar.getData().getStatus());
         }).collect(Collectors.toList());
         openDarList.sort(sortTimeComparator());
         if (CollectionUtils.isNotEmpty(openDarList)) {


### PR DESCRIPTION
SCOPE:
- filter out dars that have a cancelled status (any dar that has a status that is not null has a canceled status)

ADDRESS:
https://broadworkbench.atlassian.net/browse/DUOS-1192?

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [ ] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
