### PR TITLE
[DUOS=302][risk=no] Fix test flakiness

### DIFF
--- a/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
@@ -411,6 +411,7 @@ public class DAOTestHelper {
     }
 
     protected DataAccessRequest createDraftDataAccessRequest() {
+        User user = createUser();
         DataAccessRequestData data;
         try {
             String darDataString = FileUtils.readFileToString(
@@ -420,7 +421,7 @@ public class DAOTestHelper {
             String referenceId = UUID.randomUUID().toString();
             dataAccessRequestDAO.insertVersion2(
                 referenceId,
-                1,
+                user.getDacUserId(),
                 new Date(),
                 new Date(),
                 new Date(),

--- a/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
@@ -1,18 +1,18 @@
 package org.broadinstitute.consent.http.db;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.broadinstitute.consent.http.models.DataAccessRequest;
+import org.broadinstitute.consent.http.models.User;
+import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
-import org.apache.commons.lang3.RandomStringUtils;
-import org.apache.commons.lang3.RandomUtils;
-import org.broadinstitute.consent.http.models.DataAccessRequest;
-import org.broadinstitute.consent.http.models.User;
-import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 public class DataAccessRequestDAOTest extends DAOTestHelper {
 
@@ -49,7 +49,7 @@ public class DataAccessRequestDAOTest extends DAOTestHelper {
         assertFalse(newDars.isEmpty());
         assertEquals(1, newDars.size());
 
-        List<DataAccessRequest> missingDars = dataAccessRequestDAO.findAllDraftsByUserId(RandomUtils.nextInt(1, 100));
+        List<DataAccessRequest> missingDars = dataAccessRequestDAO.findAllDraftsByUserId(0);
         assertTrue(missingDars.isEmpty());
     }
 


### PR DESCRIPTION
## Addresses
Cleanup related to https://broadworkbench.atlassian.net/browse/DUOS-302

The updated test has failed in at least one dependabot run due to the fact that there could be a user id between the random integers of 1 -> 100. This PR ensures that we're saving a real user for the DAR and that the user id we try to find missing DARs for doesn't exist.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [ ] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
