### PR TITLE
DUOS-1227[risk=no] Filter nulls on Dataset Properties for AutoComplete

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -407,16 +407,19 @@ public class DatasetService {
 
     private boolean filterDatasetOnProperties(DatasetDTO dataset, String term) {
         //datasets need to have consentId, null check to prevent NPE
-        if(Objects.isNull(dataset.getConsentId())) {
-            return false;
-        }
+        Boolean consentIdMatch;
         String consentId = dataset.getConsentId();
+        if(Objects.isNull(consentId)) {
+            consentIdMatch = false;
+        } else {
+            consentIdMatch = consentId.toLowerCase().contains(term);
+        }
         return dataset.getProperties()
         .stream()
         .filter(p -> Objects.nonNull(p.getPropertyValue()))
         .anyMatch(p -> {
-            return (consentId.toLowerCase().contains(term) 
-            || p.getPropertyValue().toLowerCase().contains(term));
+            return consentIdMatch
+            || p.getPropertyValue().toLowerCase().contains(term);
         });
     }
 

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -388,7 +388,13 @@ public class DatasetService {
                     ds.getConsentId().toLowerCase().contains(lowercasePartial) ||
                     ds.getProperties().stream()
                           .anyMatch(
-                                p -> p.getPropertyValue().toLowerCase().contains(lowercasePartial))
+                                p -> {
+                                    String value = p.getPropertyValue();
+                                    if(Objects.isNull(value)) {
+                                        value = "";
+                                    }
+                                    return value.toLowerCase().contains(lowercasePartial);
+                                })
               )).collect(Collectors.toSet());
         return filteredDatasetsContainingPartial.stream().map(ds ->
               {

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -406,6 +406,10 @@ public class DatasetService {
     }
 
     private boolean filterDatasetOnProperties(DatasetDTO dataset, String term) {
+        //datasets need to have consentId, null check to prevent NPE
+        if(Objects.isNull(dataset.getConsentId())) {
+            return false;
+        }
         String consentId = dataset.getConsentId();
         return dataset.getProperties()
         .stream()

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -407,13 +407,8 @@ public class DatasetService {
 
     private boolean filterDatasetOnProperties(DatasetDTO dataset, String term) {
         //datasets need to have consentId, null check to prevent NPE
-        Boolean consentIdMatch;
         String consentId = dataset.getConsentId();
-        if(Objects.isNull(consentId)) {
-            consentIdMatch = false;
-        } else {
-            consentIdMatch = consentId.toLowerCase().contains(term);
-        }
+        Boolean consentIdMatch = Objects.isNull(consentId) ? false : consentId.toLowerCase().contains(term);
         return dataset.getProperties()
             .stream()
             .filter(p -> Objects.nonNull(p.getPropertyValue()))

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -415,12 +415,12 @@ public class DatasetService {
             consentIdMatch = consentId.toLowerCase().contains(term);
         }
         return dataset.getProperties()
-        .stream()
-        .filter(p -> Objects.nonNull(p.getPropertyValue()))
-        .anyMatch(p -> {
-            return consentIdMatch
-            || p.getPropertyValue().toLowerCase().contains(term);
-        });
+            .stream()
+            .filter(p -> Objects.nonNull(p.getPropertyValue()))
+            .anyMatch(p -> {
+                return consentIdMatch
+                || p.getPropertyValue().toLowerCase().contains(term);
+            });
     }
 
     public Set<DatasetDTO> getAllActiveDatasets() {

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -381,21 +381,17 @@ public class DatasetService {
         Set<DatasetDTO> datasets = describeDatasets(dacUserId);
         String lowercasePartial = partial.toLowerCase();
         Set<DatasetDTO> filteredDatasetsContainingPartial = datasets.stream().filter(ds ->
-              (ds.getProperties().stream()
-                    .anyMatch(
-                          p -> p.getPropertyName().equalsIgnoreCase("Principal Investigator(PI)"))
-                    &&
-                    ds.getConsentId().toLowerCase().contains(lowercasePartial) ||
-                    ds.getProperties().stream()
-                          .anyMatch(
-                                p -> {
-                                    String value = p.getPropertyValue();
-                                    if(Objects.isNull(value)) {
-                                        value = "";
-                                    }
-                                    return value.toLowerCase().contains(lowercasePartial);
-                                })
-              )).collect(Collectors.toSet());
+            ds.getProperties().stream().anyMatch(p -> {
+                String propertyValue = p.getPropertyValue();
+                String propertyName = p.getPropertyName();
+                return Objects.nonNull(propertyValue) &&
+                    (
+                        propertyName.equalsIgnoreCase(("Principal Investigator(PI")) 
+                        && ds.getConsentId().toLowerCase().contains(lowercasePartial)
+                        || propertyValue.toLowerCase().contains(lowercasePartial)
+                    );
+            })
+        ).collect(Collectors.toSet());
         return filteredDatasetsContainingPartial.stream().map(ds ->
               {
                   HashMap<String, String> map = new HashMap<>();

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -22,6 +22,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import javax.ws.rs.NotFoundException;
+
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -380,18 +381,9 @@ public class DatasetService {
     public List<Map<String, String>> autoCompleteDatasets(String partial, Integer dacUserId) {
         Set<DatasetDTO> datasets = describeDatasets(dacUserId);
         String lowercasePartial = partial.toLowerCase();
-        Set<DatasetDTO> filteredDatasetsContainingPartial = datasets.stream().filter(ds ->
-            ds.getProperties().stream().anyMatch(p -> {
-                String propertyValue = p.getPropertyValue();
-                String propertyName = p.getPropertyName();
-                return Objects.nonNull(propertyValue) &&
-                    (
-                        propertyName.equalsIgnoreCase(("Principal Investigator(PI")) 
-                        && ds.getConsentId().toLowerCase().contains(lowercasePartial)
-                        || propertyValue.toLowerCase().contains(lowercasePartial)
-                    );
-            })
-        ).collect(Collectors.toSet());
+        Set<DatasetDTO> filteredDatasetsContainingPartial = datasets.stream()
+        .filter(ds -> filterDatasetOnProperties(ds, lowercasePartial))
+        .collect(Collectors.toSet());
         return filteredDatasetsContainingPartial.stream().map(ds ->
               {
                   HashMap<String, String> map = new HashMap<>();
@@ -411,6 +403,17 @@ public class DatasetService {
                   return map;
               }
         ).collect(Collectors.toList());
+    }
+
+    private boolean filterDatasetOnProperties(DatasetDTO dataset, String term) {
+        String consentId = dataset.getConsentId();
+        return dataset.getProperties()
+        .stream()
+        .filter(p -> Objects.nonNull(p.getPropertyValue()))
+        .anyMatch(p -> {
+            return (consentId.toLowerCase().contains(term) 
+            || p.getPropertyValue().toLowerCase().contains(term));
+        });
     }
 
     public Set<DatasetDTO> getAllActiveDatasets() {

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -409,12 +409,11 @@ public class DatasetService {
         //datasets need to have consentId, null check to prevent NPE
         String consentId = dataset.getConsentId();
         Boolean consentIdMatch = Objects.nonNull(consentId) && consentId.toLowerCase().contains(term);
-        return dataset.getProperties()
+        return consentIdMatch || dataset.getProperties()
             .stream()
             .filter(p -> Objects.nonNull(p.getPropertyValue()))
             .anyMatch(p -> {
-                return consentIdMatch
-                || p.getPropertyValue().toLowerCase().contains(term);
+                return p.getPropertyValue().toLowerCase().contains(term);
             });
     }
 

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -408,7 +408,7 @@ public class DatasetService {
     private boolean filterDatasetOnProperties(DatasetDTO dataset, String term) {
         //datasets need to have consentId, null check to prevent NPE
         String consentId = dataset.getConsentId();
-        Boolean consentIdMatch = Objects.isNull(consentId) ? false : consentId.toLowerCase().contains(term);
+        Boolean consentIdMatch = Objects.nonNull(consentId) && consentId.toLowerCase().contains(term);
         return dataset.getProperties()
             .stream()
             .filter(p -> Objects.nonNull(p.getPropertyValue()))

--- a/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
@@ -392,13 +392,25 @@ public class DatasetServiceTest {
     public void testAutoCompleteDatasets() {
         List<DatasetDTO> dtos = getDatasetDTOs();
         Set<DatasetDTO> setOfDtos = dtos.stream().collect(Collectors.toSet());
+        setOfDtos.forEach(dto -> dto.setConsentId("consentId filler value")); 
         when(datasetDAO.findAllDatasets()).thenReturn(setOfDtos);
         when(userRoleDAO.findRoleByNameAndUser(UserRoles.ADMIN.getRoleName(), 0)).thenReturn(UserRoles.ADMIN.getRoleId());
         initService();
-
         List<Map<String, String>> result = datasetService.autoCompleteDatasets("a", 0);
         assertNotNull(result);
         assertEquals(result.size(), dtos.size());
+    }
+    
+    @Test
+    public void testAutoCompleteDatasetsWithNullValues() {
+        List<DatasetDTO> dtos = getDatasetDTOs();
+        Set<DatasetDTO> setOfDtos = dtos.stream().collect(Collectors.toSet());
+        when(datasetDAO.findAllDatasets()).thenReturn(setOfDtos);
+        when(userRoleDAO.findRoleByNameAndUser(UserRoles.ADMIN.getRoleName(), 0)).thenReturn(UserRoles.ADMIN.getRoleId());
+        initService();
+        List<Map<String, String>> result = datasetService.autoCompleteDatasets("a", 0);
+        assertNotNull(result);
+        assertEquals(result.size(), 0);
     }
 
     @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
@@ -392,25 +392,12 @@ public class DatasetServiceTest {
     public void testAutoCompleteDatasets() {
         List<DatasetDTO> dtos = getDatasetDTOs();
         Set<DatasetDTO> setOfDtos = dtos.stream().collect(Collectors.toSet());
-        setOfDtos.forEach(dto -> dto.setConsentId("consentId filler value")); 
         when(datasetDAO.findAllDatasets()).thenReturn(setOfDtos);
         when(userRoleDAO.findRoleByNameAndUser(UserRoles.ADMIN.getRoleName(), 0)).thenReturn(UserRoles.ADMIN.getRoleId());
         initService();
         List<Map<String, String>> result = datasetService.autoCompleteDatasets("a", 0);
         assertNotNull(result);
         assertEquals(result.size(), dtos.size());
-    }
-    
-    @Test
-    public void testAutoCompleteDatasetsWithNullValues() {
-        List<DatasetDTO> dtos = getDatasetDTOs();
-        Set<DatasetDTO> setOfDtos = dtos.stream().collect(Collectors.toSet());
-        when(datasetDAO.findAllDatasets()).thenReturn(setOfDtos);
-        when(userRoleDAO.findRoleByNameAndUser(UserRoles.ADMIN.getRoleName(), 0)).thenReturn(UserRoles.ADMIN.getRoleId());
-        initService();
-        List<Map<String, String>> result = datasetService.autoCompleteDatasets("a", 0);
-        assertNotNull(result);
-        assertEquals(result.size(), 0);
     }
 
     @Test


### PR DESCRIPTION
Addresses [DUOS-1227](https://broadworkbench.atlassian.net/browse/DUOS-1227)

Problematic datasets (the ones that are incomplete or partially saved) may have null values for certain properties. This null value can cause the ```toLowerCase()``` function call in ```DatasetService.autoCompleteDatasets``` (around line 390) to error out. The PR adds an additional null check on those properties within the filter function.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [x] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
