### PR TITLE
[DUOS-1226][risk=no] Update Roles Allowed Query

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/authentication/UserAuthorizer.java
+++ b/src/main/java/org/broadinstitute/consent/http/authentication/UserAuthorizer.java
@@ -22,7 +22,7 @@ public class UserAuthorizer implements Authorizer<AuthUser> {
     public boolean authorize(AuthUser user, String role) {
         boolean authorize = false;
         if (StringUtils.isNotEmpty(role)) {
-            List<String> roles = userRoleDAO.findRoleNamessByUserEmail(user.getName());
+            List<String> roles = userRoleDAO.findRoleNamesByUserEmail(user.getName());
             List<String> existentRole = roles.stream()
                     .filter(r -> r.equalsIgnoreCase(role))
                     .collect(Collectors.toCollection(ArrayList::new));

--- a/src/main/java/org/broadinstitute/consent/http/authentication/UserAuthorizer.java
+++ b/src/main/java/org/broadinstitute/consent/http/authentication/UserAuthorizer.java
@@ -23,10 +23,9 @@ public class UserAuthorizer implements Authorizer<AuthUser> {
     public boolean authorize(AuthUser user, String role) {
         boolean authorize = false;
         if (StringUtils.isNotEmpty(role)) {
-            List<UserRole> roles = userRoleDAO.findRolesByUserEmail(user.getName());
+            List<String> roles = userRoleDAO.findRolesByUserEmail(user.getName());
             List<String> existentRole = roles.stream()
-                    .filter(r -> r.getName().equalsIgnoreCase(role))
-                    .map(UserRole::getName)
+                    .filter(r -> r.equalsIgnoreCase(role))
                     .collect(Collectors.toCollection(ArrayList::new));
             if (CollectionUtils.isNotEmpty(existentRole)) {
                 authorize = true;

--- a/src/main/java/org/broadinstitute/consent/http/authentication/UserAuthorizer.java
+++ b/src/main/java/org/broadinstitute/consent/http/authentication/UserAuthorizer.java
@@ -5,7 +5,6 @@ import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.consent.http.db.UserRoleDAO;
 import org.broadinstitute.consent.http.models.AuthUser;
-import org.broadinstitute.consent.http.models.UserRole;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -23,7 +22,7 @@ public class UserAuthorizer implements Authorizer<AuthUser> {
     public boolean authorize(AuthUser user, String role) {
         boolean authorize = false;
         if (StringUtils.isNotEmpty(role)) {
-            List<String> roles = userRoleDAO.findRolesByUserEmail(user.getName());
+            List<String> roles = userRoleDAO.findRoleNamessByUserEmail(user.getName());
             List<String> existentRole = roles.stream()
                     .filter(r -> r.equalsIgnoreCase(role))
                     .collect(Collectors.toCollection(ArrayList::new));

--- a/src/main/java/org/broadinstitute/consent/http/db/UserDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/UserDAO.java
@@ -91,7 +91,8 @@ public interface UserDAO extends Transactional<UserDAO> {
                        @Bind("id") Integer id,
                        @Bind("additionalEmail") String additionalEmail);
 
-    @SqlUpdate("delete from dacuser where email = :email")
+    @Deprecated // Use deleteUserById instead
+    @SqlUpdate("DELETE FROM dacuser WHERE LOWER(email) = LOWER(:email)")
     void deleteUserByEmail(@Bind("email") String email);
 
     @SqlUpdate("delete from dacuser where dacuserid = :id")

--- a/src/main/java/org/broadinstitute/consent/http/db/UserRoleDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/UserRoleDAO.java
@@ -27,7 +27,7 @@ public interface UserRoleDAO extends Transactional<UserRoleDAO> {
             "  INNER JOIN user_role ur ON ur.role_id = r.roleid " +
             "  INNER JOIN dacuser u ON u.dacuserid = ur.user_id " +
             "  WHERE LOWER(u.email) = LOWER(:email)")
-    List<String> findRoleNamessByUserEmail(@Bind("email") String email);
+    List<String> findRoleNamesByUserEmail(@Bind("email") String email);
 
     @UseRowMapper(DatabaseRoleMapper.class)
     @SqlQuery("select * from roles")

--- a/src/main/java/org/broadinstitute/consent/http/db/UserRoleDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/UserRoleDAO.java
@@ -22,9 +22,12 @@ public interface UserRoleDAO extends Transactional<UserRoleDAO> {
     @SqlQuery("select * from roles r inner join user_role ur on ur.role_id = r.roleId where ur.user_id = :userId")
     List<UserRole> findRolesByUserId(@Bind("userId") Integer userId);
 
-    @SqlQuery("select * from roles r inner join user_role ur on ur.role_id = r.roleId  " +
-              "inner join dacuser u on u.dacUserId = ur.user_id where u.email = :email")
-    List<UserRole> findRolesByUserEmail(@Bind("email") String email);
+    @SqlQuery("SELECT DISTINCT name " +
+            "  FROM roles r " +
+            "  INNER JOIN user_role ur ON ur.role_id = r.roleid " +
+            "  INNER JOIN dacuser u ON u.dacuserid = ur.user_id " +
+            "  WHERE LOWER(u.email) = LOWER(:email)")
+    List<String> findRolesByUserEmail(@Bind("email") String email);
 
     @UseRowMapper(DatabaseRoleMapper.class)
     @SqlQuery("select * from roles")

--- a/src/main/java/org/broadinstitute/consent/http/db/UserRoleDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/UserRoleDAO.java
@@ -27,7 +27,7 @@ public interface UserRoleDAO extends Transactional<UserRoleDAO> {
             "  INNER JOIN user_role ur ON ur.role_id = r.roleid " +
             "  INNER JOIN dacuser u ON u.dacuserid = ur.user_id " +
             "  WHERE LOWER(u.email) = LOWER(:email)")
-    List<String> findRolesByUserEmail(@Bind("email") String email);
+    List<String> findRoleNamessByUserEmail(@Bind("email") String email);
 
     @UseRowMapper(DatabaseRoleMapper.class)
     @SqlQuery("select * from roles")

--- a/src/test/java/org/broadinstitute/consent/http/authentication/UserAuthorizerTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/authentication/UserAuthorizerTest.java
@@ -30,8 +30,8 @@ public class UserAuthorizerTest {
         openMocks(this);
         when(authorizedUser.getName()).thenReturn("Authorized User");
         when(unauthorizedUser.getName()).thenReturn("Unauthorized User");
-        when(userRoleDAO.findRoleNamessByUserEmail("Authorized User")).thenReturn(Collections.singletonList(getChairpersonRole().getName()));
-        when(userRoleDAO.findRoleNamessByUserEmail("Unauthorized User")).thenReturn(Collections.singletonList(getChairpersonRole().getName()));
+        when(userRoleDAO.findRoleNamesByUserEmail("Authorized User")).thenReturn(Collections.singletonList(getChairpersonRole().getName()));
+        when(userRoleDAO.findRoleNamesByUserEmail("Unauthorized User")).thenReturn(Collections.singletonList(getChairpersonRole().getName()));
         authorizer = new UserAuthorizer(userRoleDAO);
     }
 

--- a/src/test/java/org/broadinstitute/consent/http/authentication/UserAuthorizerTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/authentication/UserAuthorizerTest.java
@@ -7,13 +7,13 @@ import org.broadinstitute.consent.http.resources.Resource;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 
 import java.util.Collections;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 public class UserAuthorizerTest {
 
@@ -27,11 +27,11 @@ public class UserAuthorizerTest {
 
     @Before
     public void setUp() {
-        MockitoAnnotations.initMocks(this);
+        openMocks(this);
         when(authorizedUser.getName()).thenReturn("Authorized User");
         when(unauthorizedUser.getName()).thenReturn("Unauthorized User");
-        when(userRoleDAO.findRolesByUserEmail("Authorized User")).thenReturn(Collections.singletonList(getChairpersonRole().getName()));
-        when(userRoleDAO.findRolesByUserEmail("Unauthorized User")).thenReturn(Collections.singletonList(getChairpersonRole().getName()));
+        when(userRoleDAO.findRoleNamessByUserEmail("Authorized User")).thenReturn(Collections.singletonList(getChairpersonRole().getName()));
+        when(userRoleDAO.findRoleNamessByUserEmail("Unauthorized User")).thenReturn(Collections.singletonList(getChairpersonRole().getName()));
         authorizer = new UserAuthorizer(userRoleDAO);
     }
 

--- a/src/test/java/org/broadinstitute/consent/http/authentication/UserAuthorizerTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/authentication/UserAuthorizerTest.java
@@ -30,8 +30,8 @@ public class UserAuthorizerTest {
         MockitoAnnotations.initMocks(this);
         when(authorizedUser.getName()).thenReturn("Authorized User");
         when(unauthorizedUser.getName()).thenReturn("Unauthorized User");
-        when(userRoleDAO.findRolesByUserEmail("Authorized User")).thenReturn(Collections.singletonList(getChairpersonRole()));
-        when(userRoleDAO.findRolesByUserEmail("Unauthorized User")).thenReturn(Collections.singletonList(getChairpersonRole()));
+        when(userRoleDAO.findRolesByUserEmail("Authorized User")).thenReturn(Collections.singletonList(getChairpersonRole().getName()));
+        when(userRoleDAO.findRolesByUserEmail("Unauthorized User")).thenReturn(Collections.singletonList(getChairpersonRole().getName()));
         authorizer = new UserAuthorizer(userRoleDAO);
     }
 

--- a/src/test/java/org/broadinstitute/consent/http/db/UserRoleDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/UserRoleDAOTest.java
@@ -27,7 +27,7 @@ public class UserRoleDAOTest extends DAOTestHelper {
     public void testFindRolesByUserEmail() {
         User user = createUserWithRole(UserRoles.RESEARCHER.getRoleId());
 
-        List<UserRole> roles = userRoleDAO.findRolesByUserEmail(user.getEmail());
+        List<String> roles = userRoleDAO.findRolesByUserEmail(user.getEmail());
         Assert.assertEquals(1, roles.size());
     }
 

--- a/src/test/java/org/broadinstitute/consent/http/db/UserRoleDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/UserRoleDAOTest.java
@@ -10,7 +10,9 @@ import org.junit.Test;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
+import java.util.Random;
 import java.util.stream.Collectors;
 
 public class UserRoleDAOTest extends DAOTestHelper {
@@ -29,6 +31,22 @@ public class UserRoleDAOTest extends DAOTestHelper {
 
         List<String> roles = userRoleDAO.findRoleNamesByUserEmail(user.getEmail());
         Assert.assertEquals(1, roles.size());
+    }
+
+    @Test
+    public void testFindRolesByUserMixedCaseEmail() {
+        User user = createUserWithRole(UserRoles.ADMIN.getRoleId());
+        user.setEmail(randomizeCase(user.getEmail()));
+        List<String> roles = userRoleDAO.findRoleNamesByUserEmail(user.getEmail());
+        Assert.assertEquals(1, roles.size());
+    }
+
+    private String randomizeCase(String string) {
+        Random random = new Random();
+        return Arrays
+                .stream(string.split(""))
+                .map(l -> random.nextBoolean() ? l.toUpperCase(Locale.ROOT) : l.toLowerCase(Locale.ROOT))
+                .collect(Collectors.joining(""));
     }
 
     @Test

--- a/src/test/java/org/broadinstitute/consent/http/db/UserRoleDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/UserRoleDAOTest.java
@@ -27,7 +27,7 @@ public class UserRoleDAOTest extends DAOTestHelper {
     public void testFindRolesByUserEmail() {
         User user = createUserWithRole(UserRoles.RESEARCHER.getRoleId());
 
-        List<String> roles = userRoleDAO.findRolesByUserEmail(user.getEmail());
+        List<String> roles = userRoleDAO.findRoleNamessByUserEmail(user.getEmail());
         Assert.assertEquals(1, roles.size());
     }
 

--- a/src/test/java/org/broadinstitute/consent/http/db/UserRoleDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/UserRoleDAOTest.java
@@ -27,7 +27,7 @@ public class UserRoleDAOTest extends DAOTestHelper {
     public void testFindRolesByUserEmail() {
         User user = createUserWithRole(UserRoles.RESEARCHER.getRoleId());
 
-        List<String> roles = userRoleDAO.findRoleNamessByUserEmail(user.getEmail());
+        List<String> roles = userRoleDAO.findRoleNamesByUserEmail(user.getEmail());
         Assert.assertEquals(1, roles.size());
     }
 


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-1226

## Changes
Minor update to the underlying query that gets a user's role names. Previously, with a case sensitive search, if the email address the user used to authenticate with is different from what was initially saved in our user table, then an authenticated user would experience 403 errors when hitting any `@RolesAllowed` endpoint. When that same authenticated user hit a `@PermitAll` endpoint, the APIs would respond correctly. This was because the role names query is a different code path from the `AuthUser` query. 

This PR: 
* Standardizes how we match on email
* Streamlines the role name query since we don't need full `UserRole`s for what we're doing, we only need the names
* Adds a test to ensure case doesn't matter when querying for roles

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [ ] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
