### PR TITLE
DUOS-1198[risk=no] DAR Cancel Not Allowed if Open/Approved/Denied elections exist

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
@@ -2,9 +2,7 @@ package org.broadinstitute.consent.http.resources;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.inject.Inject;
-import freemarker.template.TemplateException;
 import io.dropwizard.auth.Auth;
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -15,7 +13,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.security.PermitAll;
 import javax.annotation.security.RolesAllowed;
-import javax.mail.MessagingException;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.ForbiddenException;
 import javax.ws.rs.GET;
@@ -34,7 +31,6 @@ import org.broadinstitute.consent.http.models.DataAccessRequest;
 import org.broadinstitute.consent.http.models.DataAccessRequestManage;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.darsummary.DARModalDetailsDTO;
-import org.broadinstitute.consent.http.models.dto.Error;
 import org.broadinstitute.consent.http.service.ConsentService;
 import org.broadinstitute.consent.http.service.DataAccessRequestService;
 import org.broadinstitute.consent.http.service.ElectionService;
@@ -217,14 +213,8 @@ public class DataAccessRequestResource extends Resource {
     public Response cancelDataAccessRequest(@Auth AuthUser authUser, @PathParam("referenceId") String referenceId) {
         validateAuthedRoleUser(Collections.emptyList(), authUser, referenceId);
         try {
-            List<User> usersToNotify = dataAccessRequestService.getUserEmailAndCancelElection(referenceId);
             DataAccessRequest dar = dataAccessRequestService.cancelDataAccessRequest(referenceId);
-            if (CollectionUtils.isNotEmpty(usersToNotify)) {
-                emailNotifierService.sendCancelDARRequestMessage(usersToNotify, dar.getData().getDarCode());
-            }
             return Response.ok().entity(dar).build();
-        } catch (MessagingException | TemplateException | IOException e) {
-            return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(new Error("The Data Access Request was cancelled but the DAC/Admin couldn't be notified. Contact Support. ", Response.Status.BAD_REQUEST.getStatusCode())).build();
         } catch (Exception e) {
             return createExceptionResponse(e);
         }

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
@@ -25,6 +25,7 @@ import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import javax.ws.rs.NotAcceptableException;
+import javax.ws.rs.NotAllowedException;
 import javax.ws.rs.NotFoundException;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.ArrayUtils;
@@ -362,6 +363,11 @@ public class DataAccessRequestService {
         DataAccessRequest dar = findByReferenceId(referenceId);
         if (Objects.isNull(dar)) {
             throw new NotFoundException("Unable to find Data Access Request with the provided id: " + referenceId);
+        }
+        List<Election> elections = electionDAO.findElectionsByReferenceId(referenceId);
+        if (!elections.isEmpty()) {
+            //Is this the right exception to use?
+            throw new IllegalArgumentException("Cancelling this DAR is not allowed");
         }
         DataAccessRequestData darData = dar.getData();
         darData.setStatus(ElectionStatus.CANCELED.getValue());

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
@@ -25,7 +25,6 @@ import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import javax.ws.rs.NotAcceptableException;
-import javax.ws.rs.NotAllowedException;
 import javax.ws.rs.NotFoundException;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.ArrayUtils;
@@ -43,7 +42,6 @@ import org.broadinstitute.consent.http.db.UserPropertyDAO;
 import org.broadinstitute.consent.http.db.VoteDAO;
 import org.broadinstitute.consent.http.enumeration.ElectionStatus;
 import org.broadinstitute.consent.http.enumeration.ElectionType;
-import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.enumeration.VoteType;
 import org.broadinstitute.consent.http.models.AuthUser;
 import org.broadinstitute.consent.http.models.Consent;
@@ -367,7 +365,7 @@ public class DataAccessRequestService {
         List<Election> elections = electionDAO.findElectionsByReferenceId(referenceId);
         if (!elections.isEmpty()) {
             //Is this the right exception to use?
-            throw new IllegalArgumentException("Cancelling this DAR is not allowed");
+            throw new UnsupportedOperationException("Cancelling this DAR is not allowed");
         }
         DataAccessRequestData darData = dar.getData();
         darData.setStatus(ElectionStatus.CANCELED.getValue());
@@ -608,32 +606,6 @@ public class DataAccessRequestService {
             }
         }
         return darManage;
-    }
-
-    public List<User> getUserEmailAndCancelElection(String referenceId) {
-        Election access = electionDAO.getOpenElectionWithFinalVoteByReferenceIdAndType(referenceId, ElectionType.DATA_ACCESS.getValue());
-        Election rp = electionDAO.getOpenElectionWithFinalVoteByReferenceIdAndType(referenceId, ElectionType.RP.getValue());
-        updateElection(access, rp);
-        List<User> users = new ArrayList<>();
-        if (access != null){
-            List<Vote> votes = voteDAO.findDACVotesByElectionId(access.getElectionId());
-            List<Integer> userIds = votes.stream().map(Vote::getDacUserId).collect(Collectors.toList());
-            users.addAll(userDAO.findUsers(userIds));
-        } else {
-            users =  userDAO.describeUsersByRoleAndEmailPreference(UserRoles.ADMIN.getRoleName(), true);
-        }
-        return users;
-    }
-
-    private void updateElection(Election access, Election rp) {
-        if (access != null) {
-            access.setStatus(ElectionStatus.CANCELED.getValue());
-            electionDAO.updateElectionStatus(new ArrayList<>(Collections.singletonList(access.getElectionId())), access.getStatus());
-        }
-        if (rp != null){
-            rp.setStatus(ElectionStatus.CANCELED.getValue());
-            electionDAO.updateElectionStatus(new ArrayList<>(Collections.singletonList(rp.getElectionId())), rp.getStatus());
-        }
     }
 
     public File createApprovedDARDocument() throws IOException {

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
@@ -364,7 +364,6 @@ public class DataAccessRequestService {
         }
         List<Election> elections = electionDAO.findElectionsByReferenceId(referenceId);
         if (!elections.isEmpty()) {
-            //Is this the right exception to use?
             throw new UnsupportedOperationException("Cancelling this DAR is not allowed");
         }
         DataAccessRequestData darData = dar.getData();

--- a/src/main/java/org/broadinstitute/consent/http/service/EmailNotifierService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/EmailNotifierService.java
@@ -191,13 +191,6 @@ public class EmailNotifierService {
         }
     }
 
-    public void sendCancelDARRequestMessage(List<User> users, String dataAcessRequestId) throws MessagingException, IOException, TemplateException {
-        if(isServiceActive){
-            Writer template = templateHelper.getCancelledDarTemplate("DAC Member", dataAcessRequestId, SERVER_URL);
-            mailService.sendCancelDARRequestMessage(getEmails(users), dataAcessRequestId, null, template);
-        }
-    }
-
     public void sendClosedDataSetElectionsMessage(List<Election> elections) throws MessagingException, IOException, TemplateException {
         if(isServiceActive){
             Map<String, List<Election>> reviewedDatasets = new HashMap<>();

--- a/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
@@ -33,7 +33,6 @@ import org.broadinstitute.consent.http.db.UserDAO;
 import org.broadinstitute.consent.http.db.UserPropertyDAO;
 import org.broadinstitute.consent.http.db.VoteDAO;
 import org.broadinstitute.consent.http.enumeration.ElectionStatus;
-import org.broadinstitute.consent.http.enumeration.ElectionType;
 import org.broadinstitute.consent.http.enumeration.UserFields;
 import org.broadinstitute.consent.http.models.AuthUser;
 import org.broadinstitute.consent.http.models.Consent;
@@ -149,7 +148,7 @@ public class DataAccessRequestServiceTest {
         assertEquals(ElectionStatus.CANCELED.getValue(), updated.getData().getStatus());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expected = UnsupportedOperationException.class)
     public void testCancelDataAccessRequestWithElectionPresentFail() {
         List<Election> electionList = new ArrayList<Election>();
         electionList.add(new Election());
@@ -280,62 +279,6 @@ public class DataAccessRequestServiceTest {
         assertNotNull(docs);
         assertEquals(1, docs.size());
         assertEquals(dar.getReferenceId(), docs.get(0).get(DarConstants.REFERENCE_ID));
-    }
-
-    @Test
-    public void testGetUserEmailAndCancelElection_DataAccess() {
-        Election daElection = generateElection(1);
-
-        when(electionDAO.getOpenElectionWithFinalVoteByReferenceIdAndType(daElection.getReferenceId(), ElectionType.DATA_ACCESS.getValue()))
-                .thenReturn(daElection);
-        when(electionDAO.getOpenElectionWithFinalVoteByReferenceIdAndType(daElection.getReferenceId(), ElectionType.RP.getValue()))
-                .thenReturn(null);
-
-        Vote vote = new Vote();
-        vote.setDacUserId(1);
-        vote.setVoteId(1);
-        vote.setElectionId(daElection.getElectionId());
-        when(voteDAO.findDACVotesByElectionId(daElection.getElectionId()))
-                .thenReturn(Collections.singletonList(vote));
-
-        User user = new User();
-        user.setDacUserId(1);
-        user.setEmail("test@test.com");
-        when(userDAO.findUsers(Collections.singletonList(1)))
-                .thenReturn(Collections.singletonList(user));
-        initService();
-
-        List<User> users = service.getUserEmailAndCancelElection(daElection.getReferenceId());
-        assertNotNull(users);
-        assertEquals(1, users.size());
-    }
-
-    @Test
-    public void testGetUserEmailAndCancelElection_RP() {
-        Election rpElection = generateElection(1);
-
-        when(electionDAO.getOpenElectionWithFinalVoteByReferenceIdAndType(rpElection.getReferenceId(), ElectionType.DATA_ACCESS.getValue()))
-                .thenReturn(null);
-        when(electionDAO.getOpenElectionWithFinalVoteByReferenceIdAndType(rpElection.getReferenceId(), ElectionType.RP.getValue()))
-                .thenReturn(rpElection);
-
-        Vote vote = new Vote();
-        vote.setDacUserId(1);
-        vote.setVoteId(1);
-        vote.setElectionId(rpElection.getElectionId());
-        when(voteDAO.findDACVotesByElectionId(rpElection.getElectionId()))
-                .thenReturn(Collections.singletonList(vote));
-
-        User user = new User();
-        user.setDacUserId(1);
-        user.setEmail("test@test.com");
-        when(userDAO.describeUsersByRoleAndEmailPreference(any(), any()))
-                .thenReturn(Collections.singletonList(user));
-        initService();
-
-        List<User> users = service.getUserEmailAndCancelElection(rpElection.getReferenceId());
-        assertNotNull(users);
-        assertEquals(1, users.size());
     }
 
     @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 
@@ -133,7 +134,9 @@ public class DataAccessRequestServiceTest {
     }
 
     @Test
-    public void testCancelDataAccessRequest() {
+    public void testCancelDataAccessRequestSuccess() {
+        List<Election> electionList = new ArrayList<Election>();
+        when(electionDAO.findElectionsByReferenceId(anyString())).thenReturn(electionList);
         DataAccessRequest dar = generateDataAccessRequest();
         when(dataAccessRequestDAO.findByReferenceId(any())).thenReturn(dar);
         doNothing().when(dataAccessRequestDAO).updateDataByReferenceId(any(), any());
@@ -146,6 +149,19 @@ public class DataAccessRequestServiceTest {
         assertEquals(ElectionStatus.CANCELED.getValue(), updated.getData().getStatus());
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void testCancelDataAccessRequestWithElectionPresentFail() {
+        List<Election> electionList = new ArrayList<Election>();
+        electionList.add(new Election());
+        when(electionDAO.findElectionsByReferenceId(anyString())).thenReturn(electionList);
+        DataAccessRequest dar = generateDataAccessRequest();
+        when(dataAccessRequestDAO.findByReferenceId(any())).thenReturn(dar);
+        doNothing().when(dataAccessRequestDAO).updateDataByReferenceId(any(), any());
+        initService();
+
+        service.cancelDataAccessRequest(dar.getReferenceId());
+    }
+    
     @Test(expected = NotFoundException.class)
     public void testCancelDataAccessRequestNotFound() {
         DataAccessRequest dar = generateDataAccessRequest();


### PR DESCRIPTION
Addresses [DUOS-1198](https://broadworkbench.atlassian.net/browse/DUOS-1198)

PR prevents researchers from canceling a submitted DAR if an election has been created for that DAR. New criteria is checked for in ```DataAccessRequestService.cancelDataAccessRequest```. Tests have also been updated to account for this new condition. 

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [x] I've updated Swagger to reflect any API changes

In all cases:

- [x] Get two thumbsworth of review and PO signoff if necessary
- [x] Verify all tests go green
- [x] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
