### PR TITLE
DUOS-1215[risk=no]Add missing final vote info to Review_Results page

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/VoteDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/VoteDAO.java
@@ -28,8 +28,10 @@ public interface VoteDAO extends Transactional<VoteDAO> {
     @UseRowMapper(ElectionReviewVoteMapper.class)
     List<ElectionReviewVote> findElectionReviewVotesByElectionId(@Bind("electionId") Integer electionId);
 
-    @SqlQuery("select v.*, u.email, u.displayName from vote v inner join election on election.electionId = v.electionId inner join dacuser u on u.dacUserId = v.dacUserId "
-            + "where election.electionId = :electionId")
+    @SqlQuery("SELECT v.*, u.email, u.displayName FROM vote v " 
+            + " INNER JOIN election ON election.electionId = v.electionId "
+            + " INNER JOIN dacuser u ON u.dacUserId = v.dacUserId "
+            + " WHERE election.electionId = :electionId")
     @UseRowMapper(ElectionReviewVoteMapper.class)
     List<ElectionReviewVote> findAllElectionReviewVotesByElectionId(@Bind("electionId") Integer electionId);
 

--- a/src/main/java/org/broadinstitute/consent/http/db/VoteDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/VoteDAO.java
@@ -26,6 +26,11 @@ public interface VoteDAO extends Transactional<VoteDAO> {
     @SqlQuery("select v.*, u.email, u.displayName from vote v inner join election on election.electionId = v.electionId inner join dacuser u on u.dacUserId = v.dacUserId "
             + "where election.electionId = :electionId")
     @UseRowMapper(ElectionReviewVoteMapper.class)
+    List<ElectionReviewVote> findAllElectionReviewVotesByElectionId(@Bind("electionId") Integer electionId);
+
+    @SqlQuery("select v.*, u.email, u.displayName from vote v inner join election on election.electionId = v.electionId inner join dacuser u on u.dacUserId = v.dacUserId "
+    + "where election.electionId = :electionId and lower(v.type) != 'chairperson'")
+    @UseRowMapper(ElectionReviewVoteMapper.class)
     List<ElectionReviewVote> findElectionReviewVotesByElectionId(@Bind("electionId") Integer electionId);
 
     @SqlQuery("select v.*, u.email, u.displayName from vote v inner join election on election.electionId = v.electionId inner join dacuser u on u.dacUserId = v.dacUserId "

--- a/src/main/java/org/broadinstitute/consent/http/db/VoteDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/VoteDAO.java
@@ -24,7 +24,7 @@ public interface VoteDAO extends Transactional<VoteDAO> {
     List<Vote> findVotesByReferenceId(@Bind("referenceId") String referenceId);
 
     @SqlQuery("select v.*, u.email, u.displayName from vote v inner join election on election.electionId = v.electionId inner join dacuser u on u.dacUserId = v.dacUserId "
-            + "where election.electionId = :electionId and lower(v.type) != 'chairperson'")
+            + "where election.electionId = :electionId")
     @UseRowMapper(ElectionReviewVoteMapper.class)
     List<ElectionReviewVote> findElectionReviewVotesByElectionId(@Bind("electionId") Integer electionId);
 

--- a/src/main/java/org/broadinstitute/consent/http/db/VoteDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/VoteDAO.java
@@ -24,14 +24,14 @@ public interface VoteDAO extends Transactional<VoteDAO> {
     List<Vote> findVotesByReferenceId(@Bind("referenceId") String referenceId);
 
     @SqlQuery("select v.*, u.email, u.displayName from vote v inner join election on election.electionId = v.electionId inner join dacuser u on u.dacUserId = v.dacUserId "
-            + "where election.electionId = :electionId")
-    @UseRowMapper(ElectionReviewVoteMapper.class)
-    List<ElectionReviewVote> findAllElectionReviewVotesByElectionId(@Bind("electionId") Integer electionId);
-
-    @SqlQuery("select v.*, u.email, u.displayName from vote v inner join election on election.electionId = v.electionId inner join dacuser u on u.dacUserId = v.dacUserId "
     + "where election.electionId = :electionId and lower(v.type) != 'chairperson'")
     @UseRowMapper(ElectionReviewVoteMapper.class)
     List<ElectionReviewVote> findElectionReviewVotesByElectionId(@Bind("electionId") Integer electionId);
+
+    @SqlQuery("select v.*, u.email, u.displayName from vote v inner join election on election.electionId = v.electionId inner join dacuser u on u.dacUserId = v.dacUserId "
+            + "where election.electionId = :electionId")
+    @UseRowMapper(ElectionReviewVoteMapper.class)
+    List<ElectionReviewVote> findAllElectionReviewVotesByElectionId(@Bind("electionId") Integer electionId);
 
     @SqlQuery("select v.*, u.email, u.displayName from vote v inner join election on election.electionId = v.electionId inner join dacuser u on u.dacUserId = v.dacUserId "
             + "where election.electionId = :electionId and lower(v.type) = lower(:type)")

--- a/src/main/java/org/broadinstitute/consent/http/db/VoteDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/VoteDAO.java
@@ -24,7 +24,7 @@ public interface VoteDAO extends Transactional<VoteDAO> {
     List<Vote> findVotesByReferenceId(@Bind("referenceId") String referenceId);
 
     @SqlQuery("select v.*, u.email, u.displayName from vote v inner join election on election.electionId = v.electionId inner join dacuser u on u.dacUserId = v.dacUserId "
-    + "where election.electionId = :electionId and lower(v.type) != 'chairperson'")
+            + "where election.electionId = :electionId and lower(v.type) != 'chairperson'")
     @UseRowMapper(ElectionReviewVoteMapper.class)
     List<ElectionReviewVote> findElectionReviewVotesByElectionId(@Bind("electionId") Integer electionId);
 

--- a/src/main/java/org/broadinstitute/consent/http/resources/ElectionReviewResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/ElectionReviewResource.java
@@ -59,7 +59,7 @@ public class ElectionReviewResource extends Resource {
     @Produces("application/json")
     @RolesAllowed({ADMIN, MEMBER, CHAIRPERSON, ALUMNI})
     public ElectionReview getElectionReviewByElectionId(@PathParam("electionId") Integer electionId) {
-        return service.describeElectionReviewByElectionId(electionId, null);
+        return service.describeElectionReviewByElectionId(electionId);
     }
 
     @GET
@@ -75,7 +75,7 @@ public class ElectionReviewResource extends Resource {
             dataSetId.addAll(dar.getData().getDatasetIds());
         }
         Consent consent = consentService.getConsentFromDatasetID(dataSetId.get(0));
-        ElectionReview accessElectionReview = service.describeElectionReviewByElectionId(electionId, null);
+        ElectionReview accessElectionReview = service.describeElectionReviewByElectionId(electionId);
         List<Vote> agreementVote = service.describeAgreementVote(electionId);
         accessElectionReview.setConsent(consent);
         accessElectionReview.setVoteAgreement(CollectionUtils.isNotEmpty(agreementVote) ? agreementVote.get(0) : null);
@@ -87,10 +87,10 @@ public class ElectionReviewResource extends Resource {
     @Path("rp/{electionId}")
     @Produces("application/json")
     @RolesAllowed({ADMIN, MEMBER, CHAIRPERSON, ALUMNI})
-    public ElectionReview getRPElectionReviewByReferenceId(@PathParam("electionId") Integer electionId, @QueryParam("isFinalAccess") Boolean isFinalAccess) {
+    public ElectionReview getRPElectionReviewByReferenceId(@PathParam("electionId") Integer electionId) {
         Integer rpElectionId = electionService.findRPElectionByElectionAccessId(electionId);
         if (Objects.nonNull(rpElectionId)) {
-            return service.describeElectionReviewByElectionId(rpElectionId, isFinalAccess);
+            return service.describeElectionReviewByElectionId(rpElectionId);
         } else return null;
     }
 

--- a/src/main/java/org/broadinstitute/consent/http/resources/ElectionReviewResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/ElectionReviewResource.java
@@ -66,7 +66,7 @@ public class ElectionReviewResource extends Resource {
     @Path("access/{electionId}")
     @Produces("application/json")
     @RolesAllowed({ADMIN, MEMBER, CHAIRPERSON, ALUMNI})
-    public ElectionReview getAccessElectionReviewByReferenceId(@PathParam("electionId") Integer electionId, @QueryParam("isFinalAccess") Boolean isFinalAccess) {
+    public ElectionReview getAccessElectionReviewByReferenceId(@PathParam("electionId") Integer electionId) {
         Election election = electionService.describeElectionById(electionId);
         Election consentElection = electionService.getConsentElectionByDARElectionId(election.getElectionId());
         DataAccessRequest dar = darService.findByReferenceId(election.getReferenceId());
@@ -75,7 +75,7 @@ public class ElectionReviewResource extends Resource {
             dataSetId.addAll(dar.getData().getDatasetIds());
         }
         Consent consent = consentService.getConsentFromDatasetID(dataSetId.get(0));
-        ElectionReview accessElectionReview = service.describeElectionReviewByElectionId(electionId, isFinalAccess);
+        ElectionReview accessElectionReview = service.describeElectionReviewByElectionId(electionId, null);
         List<Vote> agreementVote = service.describeAgreementVote(electionId);
         accessElectionReview.setConsent(consent);
         accessElectionReview.setVoteAgreement(CollectionUtils.isNotEmpty(agreementVote) ? agreementVote.get(0) : null);

--- a/src/main/java/org/broadinstitute/consent/http/resources/ElectionReviewResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/ElectionReviewResource.java
@@ -66,7 +66,7 @@ public class ElectionReviewResource extends Resource {
     @Path("access/{electionId}")
     @Produces("application/json")
     @RolesAllowed({ADMIN, MEMBER, CHAIRPERSON, ALUMNI})
-    public ElectionReview getAccessElectionReviewByReferenceId(@PathParam("electionId") Integer electionId) {
+    public ElectionReview getAccessElectionReviewByReferenceId(@PathParam("electionId") Integer electionId, @QueryParam("isFinalAccess") Boolean isFinalAccess) {
         Election election = electionService.describeElectionById(electionId);
         Election consentElection = electionService.getConsentElectionByDARElectionId(election.getElectionId());
         DataAccessRequest dar = darService.findByReferenceId(election.getReferenceId());
@@ -87,7 +87,7 @@ public class ElectionReviewResource extends Resource {
     @Path("rp/{electionId}")
     @Produces("application/json")
     @RolesAllowed({ADMIN, MEMBER, CHAIRPERSON, ALUMNI})
-    public ElectionReview getRPElectionReviewByReferenceId(@PathParam("electionId") Integer electionId) {
+    public ElectionReview getRPElectionReviewByReferenceId(@PathParam("electionId") Integer electionId, @QueryParam("isFinalAccess") Boolean isFinalAccess) {
         Integer rpElectionId = electionService.findRPElectionByElectionAccessId(electionId);
         if (Objects.nonNull(rpElectionId)) {
             return service.describeElectionReviewByElectionId(rpElectionId);

--- a/src/main/java/org/broadinstitute/consent/http/service/ReviewResultsService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ReviewResultsService.java
@@ -48,7 +48,10 @@ public class ReviewResultsService {
             review = new ElectionReview();
             review.setElection(election);
             Consent consent = consentDAO.findConsentById(review.getElection().getReferenceId());
-            List<ElectionReviewVote> rVotes = (isFinalAccess == null || isFinalAccess == false) ? voteDAO.findElectionReviewVotesByElectionId(electionId, VoteType.DAC.getValue()) :  voteDAO.findElectionReviewVotesByElectionId(electionId, VoteType.FINAL.getValue());
+            List<ElectionReviewVote> rVotes = isFinalAccess == null ? 
+              voteDAO.findElectionReviewVotesByElectionId(electionId)
+              : isFinalAccess == false ? voteDAO.findElectionReviewVotesByElectionId(electionId, VoteType.DAC.getValue())
+                : voteDAO.findElectionReviewVotesByElectionId(electionId, VoteType.FINAL.getValue());
             review.setReviewVote(rVotes);
             review.setConsent(consent);
         }

--- a/src/main/java/org/broadinstitute/consent/http/service/ReviewResultsService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ReviewResultsService.java
@@ -48,7 +48,7 @@ public class ReviewResultsService {
             review = new ElectionReview();
             review.setElection(election);
             Consent consent = consentDAO.findConsentById(review.getElection().getReferenceId());
-            List<ElectionReviewVote> rVotes = voteDAO.findElectionReviewVotesByElectionId(electionId);
+            List<ElectionReviewVote> rVotes = voteDAO.findAllElectionReviewVotesByElectionId(electionId);
             review.setReviewVote(rVotes);
             review.setConsent(consent);
         }

--- a/src/main/java/org/broadinstitute/consent/http/service/ReviewResultsService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ReviewResultsService.java
@@ -41,17 +41,14 @@ public class ReviewResultsService {
         return openElections;
     }
 
-    public ElectionReview describeElectionReviewByElectionId(Integer electionId, Boolean isFinalAccess) {
+    public ElectionReview describeElectionReviewByElectionId(Integer electionId) {
         ElectionReview review = null;
         Election election = electionDAO.findElectionWithFinalVoteById(electionId);
         if(election != null){
             review = new ElectionReview();
             review.setElection(election);
             Consent consent = consentDAO.findConsentById(review.getElection().getReferenceId());
-            List<ElectionReviewVote> rVotes = isFinalAccess == null ? 
-              voteDAO.findElectionReviewVotesByElectionId(electionId)
-              : isFinalAccess == false ? voteDAO.findElectionReviewVotesByElectionId(electionId, VoteType.DAC.getValue())
-                : voteDAO.findElectionReviewVotesByElectionId(electionId, VoteType.FINAL.getValue());
+            List<ElectionReviewVote> rVotes = voteDAO.findElectionReviewVotesByElectionId(electionId);
             review.setReviewVote(rVotes);
             review.setConsent(consent);
         }

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -2782,12 +2782,6 @@ paths:
           required: true
           schema:
             type: integer
-        - name: isFinalAccess
-          in: query
-          description: Defines if the reviewVote array of the retrieved ElectionReview will contain or not the isFinalAccess = TRUE Vote.
-          required: true
-          schema:
-            type: integer
       tags:
         - ElectionReview
       responses:
@@ -2827,12 +2821,6 @@ paths:
           description: |
             Election Id for the associated Data Access Election
             (and not the associated RP Election, this is legacy behavior).
-          required: true
-          schema:
-            type: integer
-        - name: isFinalAccess
-          in: query
-          description: Defines if the reviewVote array of the retrieved ElectionReview will contain or not the isFinalAccess = TRUE Vote.
           required: true
           schema:
             type: integer

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -2773,7 +2773,7 @@ paths:
                 $ref: '#/components/schemas/ElectionReview'
   /api/electionReview/access/{electionId}:
     get:
-      summary: getAccessElectionReviewByReferenceId
+      summary: get ElectionReview for access election identified by electionId
       description: Returns the ElectionReview from an Election identified by ElectionId. This endpoint can be used only for DataAccess elections.
       parameters:
         - name: electionId
@@ -2819,7 +2819,7 @@ paths:
                 $ref: '#/components/schemas/ElectionReview'
   /api/electionReview/rp/{electionId}:
     get:
-      summary: getRPElectionReviewByReferenceId
+      summary: get ElectionReview for rp election identified by electionId
       description: Returns the ElectionReview from an Election identified by ElectionId. This endpoint can be used only for Research Purpose elections.
       parameters:
         - name: electionId

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -2773,7 +2773,7 @@ paths:
                 $ref: '#/components/schemas/ElectionReview'
   /api/electionReview/access/{electionId}:
     get:
-      summary: describeElectionById
+      summary: getAccessElectionReviewByReferenceId
       description: Returns the ElectionReview from an Election identified by ElectionId. This endpoint can be used only for DataAccess elections.
       parameters:
         - name: electionId
@@ -2782,6 +2782,12 @@ paths:
           required: true
           schema:
             type: integer
+        - name: isFinalAccess
+          in: query
+          description: Defines if the reviewVote array of the retrieved ElectionReview will contain or not the isFinalAccess = TRUE Vote.
+          required: true
+          schema:
+            type: boolean
       tags:
         - ElectionReview
       responses:
@@ -2813,7 +2819,7 @@ paths:
                 $ref: '#/components/schemas/ElectionReview'
   /api/electionReview/rp/{electionId}:
     get:
-      summary: describeElectionById
+      summary: getRPElectionReviewByReferenceId
       description: Returns the ElectionReview from an Election identified by ElectionId. This endpoint can be used only for Research Purpose elections.
       parameters:
         - name: electionId
@@ -2824,6 +2830,12 @@ paths:
           required: true
           schema:
             type: integer
+        - name: isFinalAccess
+          in: query
+          description: Defines if the reviewVote array of the retrieved ElectionReview will contain or not the isFinalAccess = TRUE Vote.
+          required: true
+          schema:
+            type: boolean
       tags:
         - ElectionReview
       responses:

--- a/src/test/java/org/broadinstitute/consent/http/resources/ElectionReviewResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/ElectionReviewResourceTest.java
@@ -64,7 +64,7 @@ public class ElectionReviewResourceTest {
 
     @Test
     public void testGetElectionReviewByElectionId() {
-        when(reviewResultsService.describeElectionReviewByElectionId(any(), any())).thenReturn(new ElectionReview());
+        when(reviewResultsService.describeElectionReviewByElectionId(any())).thenReturn(new ElectionReview());
         initResource();
         ElectionReview response = resource.getElectionReviewByElectionId(RandomUtils.nextInt(100, 1000));
         assertNotNull(response);
@@ -86,7 +86,7 @@ public class ElectionReviewResourceTest {
         dar.setData(data);
         when(darService.findByReferenceId(any())).thenReturn(dar);
         when(consentService.getConsentFromDatasetID(any())).thenReturn(new Consent());
-        when(reviewResultsService.describeElectionReviewByElectionId(any(), any())).thenReturn(new ElectionReview());
+        when(reviewResultsService.describeElectionReviewByElectionId(any())).thenReturn(new ElectionReview());
         when(reviewResultsService.describeAgreementVote(any())).thenReturn(Collections.singletonList(new Vote()));
         initResource();
         ElectionReview response = resource.getAccessElectionReviewByReferenceId(RandomUtils.nextInt(100, 1000));
@@ -96,9 +96,9 @@ public class ElectionReviewResourceTest {
     @Test
     public void testGetRPElectionReviewByReferenceId() {
         when(electionService.findRPElectionByElectionAccessId(any())).thenReturn(1);
-        when(reviewResultsService.describeElectionReviewByElectionId(any(), any())).thenReturn(new ElectionReview());
+        when(reviewResultsService.describeElectionReviewByElectionId(any())).thenReturn(new ElectionReview());
         initResource();
-        ElectionReview response = resource.getRPElectionReviewByReferenceId(RandomUtils.nextInt(100, 1000), true);
+        ElectionReview response = resource.getRPElectionReviewByReferenceId(RandomUtils.nextInt(100, 1000));
         assertNotNull(response);
     }
 

--- a/src/test/java/org/broadinstitute/consent/http/resources/ElectionReviewResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/ElectionReviewResourceTest.java
@@ -89,7 +89,7 @@ public class ElectionReviewResourceTest {
         when(reviewResultsService.describeElectionReviewByElectionId(any())).thenReturn(new ElectionReview());
         when(reviewResultsService.describeAgreementVote(any())).thenReturn(Collections.singletonList(new Vote()));
         initResource();
-        ElectionReview response = resource.getAccessElectionReviewByReferenceId(RandomUtils.nextInt(100, 1000));
+        ElectionReview response = resource.getAccessElectionReviewByReferenceId(RandomUtils.nextInt(100, 1000), true);
         assertNotNull(response);
     }
 
@@ -98,7 +98,7 @@ public class ElectionReviewResourceTest {
         when(electionService.findRPElectionByElectionAccessId(any())).thenReturn(1);
         when(reviewResultsService.describeElectionReviewByElectionId(any())).thenReturn(new ElectionReview());
         initResource();
-        ElectionReview response = resource.getRPElectionReviewByReferenceId(RandomUtils.nextInt(100, 1000));
+        ElectionReview response = resource.getRPElectionReviewByReferenceId(RandomUtils.nextInt(100, 1000), true);
         assertNotNull(response);
     }
 

--- a/src/test/java/org/broadinstitute/consent/http/resources/ElectionReviewResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/ElectionReviewResourceTest.java
@@ -89,7 +89,7 @@ public class ElectionReviewResourceTest {
         when(reviewResultsService.describeElectionReviewByElectionId(any(), any())).thenReturn(new ElectionReview());
         when(reviewResultsService.describeAgreementVote(any())).thenReturn(Collections.singletonList(new Vote()));
         initResource();
-        ElectionReview response = resource.getAccessElectionReviewByReferenceId(RandomUtils.nextInt(100, 1000), true);
+        ElectionReview response = resource.getAccessElectionReviewByReferenceId(RandomUtils.nextInt(100, 1000));
         assertNotNull(response);
     }
 

--- a/src/test/java/org/broadinstitute/consent/http/service/ReviewResultsServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/ReviewResultsServiceTest.java
@@ -87,7 +87,7 @@ public class ReviewResultsServiceTest {
     public void testDescribeElectionReviewByElectionId() throws Exception {
         initService();
         sampleElection.setElectionId(123);
-        ElectionReview review = service.describeElectionReviewByElectionId(1, false);
+        ElectionReview review = service.describeElectionReviewByElectionId(1);
         assertTrue("Consent should be equal to mocked response ", review.getConsent().equals(consent));
         assertTrue("Sample Election should be equal to mocked response ", review.getElection().equals(sampleElection));
 


### PR DESCRIPTION
SCOPE:
Currently, the UI calls getAccessElectionReviewByReferenceId to render the votes on the access review and review result page, with the boolean flag true meaning isfinalaccess. Due to this, the call in consent was filtering for only votes with FINAL type. These are all chair votes. This means that we are not receiving the votes for the members. 
This PR removes that boolean flag.
By switching to use this DAO call that has no boolean flag, we receive the DAC votes and the FINAL votes. This update is needed for this PR so that we can display both member and chair votes distinctly on the review page. Currently, the pages say "How members voted" but only show chair votes, so this will allow the page to be more accurate. 

DO NOT MERGE WITHOUT DUOS-1215 on UI

ADDRESSES:
https://broadworkbench.atlassian.net/browse/DUOS-1215

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [ ] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
