### PR TITLE
DUOS-1245[risk=no] Added exception handler for UnableToExecuteStatementException

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/resources/Resource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/Resource.java
@@ -127,22 +127,19 @@ abstract public class Resource {
 
     //Helper method to process generic JBDI Postgres exceptions for responses
     private static Response unableToExecuteExceptionHandler(Exception e) {
-        //default response definition
-        Response response = Response.status(Response.Status.INTERNAL_SERVER_ERROR)
-            .type(MediaType.APPLICATION_JSON)
-            .entity(new Error("Database Error", Response.Status.INTERNAL_SERVER_ERROR.getStatusCode()))
-            .build();
-        
+        //default status definition
+        Integer status = Response.Status.INTERNAL_SERVER_ERROR.getStatusCode();
+       
         if(e.getCause() instanceof PSQLException) {
             //NOTE: implement more Postgres vendor code handlers as we encounter them
             if(((PSQLException)e.getCause()).getSQLState().equals("23505")) {
-                response = Response.status(Response.Status.CONFLICT)
-                    .type(MediaType.APPLICATION_JSON)
-                    .entity(new Error("Database Error", Response.Status.CONFLICT.getStatusCode()))
-                    .build();
+                status = Response.Status.CONFLICT.getStatusCode();
             }
         }
-        return response;
+        return Response.status(status)
+            .type(MediaType.APPLICATION_JSON)
+            .entity(new Error("Database Error", status))
+            .build();
     }
 
     /**

--- a/src/main/java/org/broadinstitute/consent/http/resources/Resource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/Resource.java
@@ -7,6 +7,7 @@ import java.sql.SQLSyntaxErrorException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.AbstractMap;
 import java.util.stream.Collectors;
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.ForbiddenException;
@@ -27,6 +28,7 @@ import org.glassfish.jersey.media.multipart.FormDataContentDisposition;
 import org.jdbi.v3.core.statement.UnableToExecuteStatementException;
 import org.owasp.fileio.FileValidator;
 import org.postgresql.util.PSQLException;
+import org.postgresql.util.PSQLState;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,11 +49,9 @@ abstract public class Resource {
     public final static String RESEARCHER = "Researcher";
 
     // NOTE: implement more Postgres vendor codes as we encounter them
-    private static Map<String, Integer> vendorCodeStatusMap;
-    static {
-        vendorCodeStatusMap = new HashMap<>();
-        vendorCodeStatusMap.put("23505", Response.Status.CONFLICT.getStatusCode());
-    }
+    private final static Map<String, Integer> vendorCodeStatusMap = Map.ofEntries(
+        new AbstractMap.SimpleEntry<>(PSQLState.UNIQUE_VIOLATION.getState(), Response.Status.CONFLICT.getStatusCode())
+    );
 
     protected Logger logger() {
         return LoggerFactory.getLogger(this.getClass());

--- a/src/main/java/org/broadinstitute/consent/http/resources/Resource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/Resource.java
@@ -50,7 +50,7 @@ abstract public class Resource {
     private static Map<String, Integer> vendorCodeStatusMap;
     static {
         vendorCodeStatusMap = new HashMap<>();
-        vendorCodeStatusMap.put("23505", 409);
+        vendorCodeStatusMap.put("23505", Response.Status.CONFLICT.getStatusCode());
     }
 
     protected Logger logger() {

--- a/src/main/java/org/broadinstitute/consent/http/resources/Resource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/Resource.java
@@ -3,6 +3,7 @@ package org.broadinstitute.consent.http.resources;
 import java.io.IOException;
 import java.io.InputStream;
 import java.sql.SQLException;
+import org.jdbi.v3.core.statement.UnableToExecuteStatementException;
 import java.sql.SQLSyntaxErrorException;
 import java.util.HashMap;
 import java.util.List;
@@ -111,6 +112,8 @@ abstract public class Resource {
                 Response.status(Response.Status.NOT_FOUND).type(MediaType.APPLICATION_JSON).entity(new Error(e.getMessage(), Response.Status.NOT_FOUND.getStatusCode())).build());
         dispatch.put(UpdateConsentException.class, e ->
                 Response.status(Response.Status.BAD_REQUEST).type(MediaType.APPLICATION_JSON).entity(new Error(e.getMessage(), Response.Status.BAD_REQUEST.getStatusCode())).build());
+         dispatch.put(UnableToExecuteStatementException.class, e ->
+                Response.status(Response.Status.CONFLICT).type(MediaType.APPLICATION_JSON).entity(new Error("Database Error", Response.Status.CONFLICT.getStatusCode())).build());
         dispatch.put(SQLSyntaxErrorException.class, e ->
                 Response.serverError().type(MediaType.APPLICATION_JSON).entity(new Error("Database Error", Response.Status.INTERNAL_SERVER_ERROR.getStatusCode())).build());
         dispatch.put(SQLException.class, e ->


### PR DESCRIPTION
Addresses[DUOS-1245](https://broadworkbench.atlassian.net/browse/DUOS-1245)

PR adds custom exception helper method to process JDBI's ```UnableToExecuteStatementException```, which is a wrapper exception that can cover different types of ```PSQLExceptions```. For now the helper method only checks on Unique constraint violations (vendor code ```23505```), but more codes can be added down the line (Scope of the PR is to properly cover the exception that occurs when a Institution POST carries a name value that already exists in the database).

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [x] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
