### PR TITLE
DUOS-1246[risk=no]List Institutes should also return create user information

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/InstitutionDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/InstitutionDAO.java
@@ -6,11 +6,11 @@ import org.broadinstitute.consent.http.models.Institution;
 import org.broadinstitute.consent.http.models.User;
 import org.jdbi.v3.sqlobject.config.RegisterBeanMapper;
 import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
-import org.jdbi.v3.sqlobject.statement.UseRowReducer;
 import org.jdbi.v3.sqlobject.customizer.Bind;
 import org.jdbi.v3.sqlobject.statement.GetGeneratedKeys;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
+import org.jdbi.v3.sqlobject.statement.UseRowReducer;
 import org.jdbi.v3.sqlobject.transaction.Transactional;
 
 import java.util.Date;
@@ -51,14 +51,23 @@ public interface InstitutionDAO extends Transactional<InstitutionDAO> {
   Institution findInstitutionById(@Bind("institutionId") Integer institutionId);
 
   @RegisterBeanMapper(value = User.class, prefix = "u")
-  @RegisterBeanMapper(value = User.class, prefix = "u2")
+//  @RegisterBeanMapper(value = User.class, prefix = "u2")
   @UseRowReducer(InstitutionWithUsersReducer.class)
-  @SqlQuery("SELECT i.*, u.*, u2.dacuserid AS updateUserId, u2.email AS updateUserEmail, " +
-  " u2.displayName AS updateUserName, u2.createdate AS updateUserCreateDate, " +
-  " u2.additional_email as updateUserAdditionalEmail, u2.email_preference as updateUserEmailPreference, " +
-  " u2.status as updateUserStatus, u2.rationale as updateUserRationale " +
-  " FROM institution i" +
-  " LEFT JOIN dacuser u ON u.dacuserid = i.create_user" +
-  " LEFT JOIN dacuser u2 ON u2.dacuserid = i.update_user")
+  @SqlQuery(
+      "SELECT i.*, "
+          + " u.dacuserid AS u_dacuserid, u.email AS u_email, "
+          + " u.displayname AS u_displayname, u.createdate AS u_createdate, "
+          + " u.additional_email AS u_additional_email, u.email_preference AS u_email_preference, "
+          + " u.status AS u_status, u.rationale AS u_rationale, "
+
+          + " u2.dacuserid AS u2_dacuserid, u2.email AS u2_email, "
+          + " u2.displayname AS u2_displayname, u2.createdate AS u2_createdate, "
+          + " u2.additional_email AS u2_additional_email, u2.email_preference AS u2_email_preference, "
+          + " u2.status AS u2_status, u2.rationale AS u2_rationale "
+
+          + " FROM institution i "
+          + " LEFT JOIN dacuser u ON u.dacuserid = i.create_user "
+          + " LEFT JOIN dacuser u2 ON u2.dacuserid = i.update_user"
+  )
   List<Institution> findAllInstitutions();
 }

--- a/src/main/java/org/broadinstitute/consent/http/db/InstitutionDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/InstitutionDAO.java
@@ -1,8 +1,12 @@
 package org.broadinstitute.consent.http.db;
 
 import org.broadinstitute.consent.http.db.mapper.InstitutionMapper;
+import org.broadinstitute.consent.http.db.mapper.InstitutionWithUsersReducer;
 import org.broadinstitute.consent.http.models.Institution;
+import org.broadinstitute.consent.http.models.User;
+import org.jdbi.v3.sqlobject.config.RegisterBeanMapper;
 import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
+import org.jdbi.v3.sqlobject.statement.UseRowReducer;
 import org.jdbi.v3.sqlobject.customizer.Bind;
 import org.jdbi.v3.sqlobject.statement.GetGeneratedKeys;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
@@ -46,6 +50,9 @@ public interface InstitutionDAO extends Transactional<InstitutionDAO> {
   @SqlQuery("SELECT * FROM institution WHERE institution_id = :institutionId")
   Institution findInstitutionById(@Bind("institutionId") Integer institutionId);
 
+  @RegisterBeanMapper(value = User.class, prefix = "u")
+  @RegisterBeanMapper(value = User.class, prefix = "u2")
+  @UseRowReducer(InstitutionWithUsersReducer.class)
   @SqlQuery("SELECT i.*, u.*, u2.dacuserid AS updateUserId, u2.email AS updateUserEmail, " +
   " u2.displayName AS updateUserName, u2.createdate AS updateUserCreateDate, " +
   " u2.additional_email as updateUserAdditionalEmail, u2.email_preference as updateUserEmailPreference, " +

--- a/src/main/java/org/broadinstitute/consent/http/db/InstitutionDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/InstitutionDAO.java
@@ -46,7 +46,12 @@ public interface InstitutionDAO extends Transactional<InstitutionDAO> {
   @SqlQuery("SELECT * FROM institution WHERE institution_id = :institutionId")
   Institution findInstitutionById(@Bind("institutionId") Integer institutionId);
 
-  @SqlQuery("SELECT * FROM institution i" +
-  " LEFT JOIN dacuser u ON u.dacuserid = i.create_user")
+  @SqlQuery("SELECT i.*, u.*, u2.dacuserid AS updateUserId, u2.email AS updateUserEmail, " +
+  " u2.displayName AS updateUserName, u2.createdate AS updateUserCreateDate, " +
+  " u2.additional_email as updateUserAdditionalEmail, u2.email_preference as updateUserEmailPreference, " +
+  " u2.status as updateUserStatus, u2.rationale as updateUserRationale " +
+  " FROM institution i" +
+  " LEFT JOIN dacuser u ON u.dacuserid = i.create_user" +
+  " LEFT JOIN dacuser u2 ON u.dacuserid = i.update_user")
   List<Institution> findAllInstitutions();
 }

--- a/src/main/java/org/broadinstitute/consent/http/db/InstitutionDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/InstitutionDAO.java
@@ -47,6 +47,6 @@ public interface InstitutionDAO extends Transactional<InstitutionDAO> {
   Institution findInstitutionById(@Bind("institutionId") Integer institutionId);
 
   @SqlQuery("SELECT * FROM institution i" +
-  " LEFT JOIN user u ON u.dacuserid = i.create_user")
+  " LEFT JOIN dacuser u ON u.dacuserid = i.create_user")
   List<Institution> findAllInstitutions();
 }

--- a/src/main/java/org/broadinstitute/consent/http/db/InstitutionDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/InstitutionDAO.java
@@ -51,7 +51,6 @@ public interface InstitutionDAO extends Transactional<InstitutionDAO> {
   Institution findInstitutionById(@Bind("institutionId") Integer institutionId);
 
   @RegisterBeanMapper(value = User.class, prefix = "u")
-//  @RegisterBeanMapper(value = User.class, prefix = "u2")
   @UseRowReducer(InstitutionWithUsersReducer.class)
   @SqlQuery(
       "SELECT i.*, "

--- a/src/main/java/org/broadinstitute/consent/http/db/InstitutionDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/InstitutionDAO.java
@@ -46,6 +46,7 @@ public interface InstitutionDAO extends Transactional<InstitutionDAO> {
   @SqlQuery("SELECT * FROM institution WHERE institution_id = :institutionId")
   Institution findInstitutionById(@Bind("institutionId") Integer institutionId);
 
-  @SqlQuery("SELECT * FROM institution")
+  @SqlQuery("SELECT * FROM institution i" +
+  " LEFT JOIN user u ON u.dacuserid = i.create_user")
   List<Institution> findAllInstitutions();
 }

--- a/src/main/java/org/broadinstitute/consent/http/db/InstitutionDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/InstitutionDAO.java
@@ -52,6 +52,6 @@ public interface InstitutionDAO extends Transactional<InstitutionDAO> {
   " u2.status as updateUserStatus, u2.rationale as updateUserRationale " +
   " FROM institution i" +
   " LEFT JOIN dacuser u ON u.dacuserid = i.create_user" +
-  " LEFT JOIN dacuser u2 ON u.dacuserid = i.update_user")
+  " LEFT JOIN dacuser u2 ON u2.dacuserid = i.update_user")
   List<Institution> findAllInstitutions();
 }

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/InstitutionMapper.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/InstitutionMapper.java
@@ -50,48 +50,85 @@ public class InstitutionMapper implements RowMapper<Institution>, RowMapperHelpe
       institution.setUpdateDate(resultSet.getDate("update_date"));
     }
 
-    User user = new User();;
+    User createUser = new User();
 
     if (hasColumn(resultSet, "dacUserId")) {
-      user.setDacUserId(resultSet.getInt("dacUserId"));
+      createUser.setDacUserId(resultSet.getInt("dacUserId"));
     } 
     if (hasColumn(resultSet, "email")) {
-      user.setEmail(resultSet.getString("email"));
+      createUser.setEmail(resultSet.getString("email"));
     }
     if (hasColumn(resultSet, "displayName")) {
-      user.setDisplayName(resultSet.getString("displayName"));
+      createUser.setDisplayName(resultSet.getString("displayName"));
     }
     if (hasColumn(resultSet, "createDate")) {
-      user.setCreateDate(resultSet.getDate("createDate"));
+      createUser.setCreateDate(resultSet.getDate("createDate"));
     }
     if (hasColumn(resultSet, "additional_email")) {
-      user.setAdditionalEmail(resultSet.getString("additional_email"));
+      createUser.setAdditionalEmail(resultSet.getString("additional_email"));
     }
     if (hasColumn(resultSet, "email_preference")) {
-      user.setEmailPreference(resultSet.getBoolean("email_preference"));
+      createUser.setEmailPreference(resultSet.getBoolean("email_preference"));
     }
     if (hasColumn(resultSet, "status")) {
-      user.setStatus(getStatus(resultSet));
+      createUser.setStatus(getCreateStatus(resultSet));
     }
     if (hasColumn(resultSet, "rationale")) {
-      user.setRationale(resultSet.getString("rationale"));
+      createUser.setRationale(resultSet.getString("rationale"));
     }
     //user model does not currently have an institutionId field or methods
     // if (hasColumn(resultSet, "institute")) {
     //   user.setInstitutionId(resultSet.getInt("update_user"));
     // }
 
-    institution.setCreateUser(user);
+    User updateUser = new User();
+
+    if (hasColumn(resultSet, "updateUserId")) {
+      updateUser.setDacUserId(resultSet.getInt("updateUserId"));
+    } 
+    if (hasColumn(resultSet, "updateUserEmail")) {
+      updateUser.setEmail(resultSet.getString("updateUserEmail"));
+    }
+    if (hasColumn(resultSet, "updateUserName")) {
+      updateUser.setDisplayName(resultSet.getString("updateUserName"));
+    }
+    if (hasColumn(resultSet, "updateUserCreateDate")) {
+      updateUser.setCreateDate(resultSet.getDate("updateUserCreateDate"));
+    }
+    if (hasColumn(resultSet, "updateUserAdditionalEmail")) {
+      updateUser.setAdditionalEmail(resultSet.getString("updateUserAdditionalEmail"));
+    }
+    if (hasColumn(resultSet, "updateUserEmailPreference")) {
+      updateUser.setEmailPreference(resultSet.getBoolean("updateUserEmailPreference"));
+    }
+    if (hasColumn(resultSet, "updateUserStatus")) {
+      updateUser.setStatus(getUpdateStatus(resultSet));
+    }
+    if (hasColumn(resultSet, "updateUserRationale")) {
+      updateUser.setRationale(resultSet.getString("updateUserRationale"));
+    }
+
+    institution.setCreateUser(createUser);
+    institution.setUpdateUser(updateUser);
 
     institutionMap.put(institution.getId(), institution);
     return institution;
   }
 
-  private String getStatus(ResultSet r) {
+  private String getCreateStatus(ResultSet r) {
     try {
       return RoleStatus.getStatusByValue(r.getInt("status"));
     } catch (Exception e) {
       return null;
     }
   }
+
+  private String getUpdateStatus(ResultSet r) {
+    try {
+      return RoleStatus.getStatusByValue(r.getInt("updateUserStatus"));
+    } catch (Exception e) {
+      return null;
+    }
+  }
+
 }

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/InstitutionMapper.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/InstitutionMapper.java
@@ -1,8 +1,6 @@
 package org.broadinstitute.consent.http.db.mapper;
 
-//import org.broadinstitute.consent.http.enumeration.RoleStatus;
 import org.broadinstitute.consent.http.models.Institution;
-//import org.broadinstitute.consent.http.models.User;
 import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.core.statement.StatementContext;
 
@@ -50,81 +48,8 @@ public class InstitutionMapper implements RowMapper<Institution>, RowMapperHelpe
       institution.setUpdateDate(resultSet.getDate("update_date"));
     }
 
-    // User createUser = new User();
-
-    // if (hasColumn(resultSet, "dacUserId")) {
-    //   createUser.setDacUserId(resultSet.getInt("dacUserId"));
-    // } 
-    // if (hasColumn(resultSet, "email")) {
-    //   createUser.setEmail(resultSet.getString("email"));
-    // }
-    // if (hasColumn(resultSet, "displayName")) {
-    //   createUser.setDisplayName(resultSet.getString("displayName"));
-    // }
-    // if (hasColumn(resultSet, "createDate")) {
-    //   createUser.setCreateDate(resultSet.getDate("createDate"));
-    // }
-    // if (hasColumn(resultSet, "additional_email")) {
-    //   createUser.setAdditionalEmail(resultSet.getString("additional_email"));
-    // }
-    // if (hasColumn(resultSet, "email_preference")) {
-    //   createUser.setEmailPreference(resultSet.getBoolean("email_preference"));
-    // }
-    // if (hasColumn(resultSet, "status")) {
-    //   createUser.setStatus(getCreateStatus(resultSet));
-    // }
-    // if (hasColumn(resultSet, "rationale")) {
-    //   createUser.setRationale(resultSet.getString("rationale"));
-    // }
-
-    // User updateUser = new User();
-
-    // if (hasColumn(resultSet, "updateUserId")) {
-    //   updateUser.setDacUserId(resultSet.getInt("updateUserId"));
-    // } 
-    // if (hasColumn(resultSet, "updateUserEmail")) {
-    //   updateUser.setEmail(resultSet.getString("updateUserEmail"));
-    // }
-    // if (hasColumn(resultSet, "updateUserName")) {
-    //   updateUser.setDisplayName(resultSet.getString("updateUserName"));
-    // }
-    // if (hasColumn(resultSet, "updateUserCreateDate")) {
-    //   updateUser.setCreateDate(resultSet.getDate("updateUserCreateDate"));
-    // }
-    // if (hasColumn(resultSet, "updateUserAdditionalEmail")) {
-    //   updateUser.setAdditionalEmail(resultSet.getString("updateUserAdditionalEmail"));
-    // }
-    // if (hasColumn(resultSet, "updateUserEmailPreference")) {
-    //   updateUser.setEmailPreference(resultSet.getBoolean("updateUserEmailPreference"));
-    // }
-    // if (hasColumn(resultSet, "updateUserStatus")) {
-    //   updateUser.setStatus(getUpdateStatus(resultSet));
-    // }
-    // if (hasColumn(resultSet, "updateUserRationale")) {
-    //   updateUser.setRationale(resultSet.getString("updateUserRationale"));
-    // }
-
-    // institution.setCreateUser(createUser);
-    // institution.setUpdateUser(updateUser);
-
     institutionMap.put(institution.getId(), institution);
     return institution;
   }
-
-  // private String getCreateStatus(ResultSet r) {
-  //   try {
-  //     return RoleStatus.getStatusByValue(r.getInt("status"));
-  //   } catch (Exception e) {
-  //     return null;
-  //   }
-  // }
-
-  // private String getUpdateStatus(ResultSet r) {
-  //   try {
-  //     return RoleStatus.getStatusByValue(r.getInt("updateUserStatus"));
-  //   } catch (Exception e) {
-  //     return null;
-  //   }
-  // }
 
 }

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/InstitutionMapper.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/InstitutionMapper.java
@@ -1,8 +1,8 @@
 package org.broadinstitute.consent.http.db.mapper;
 
-import org.broadinstitute.consent.http.enumeration.RoleStatus;
+//import org.broadinstitute.consent.http.enumeration.RoleStatus;
 import org.broadinstitute.consent.http.models.Institution;
-import org.broadinstitute.consent.http.models.User;
+//import org.broadinstitute.consent.http.models.User;
 import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.core.statement.StatementContext;
 
@@ -50,85 +50,81 @@ public class InstitutionMapper implements RowMapper<Institution>, RowMapperHelpe
       institution.setUpdateDate(resultSet.getDate("update_date"));
     }
 
-    User createUser = new User();
+    // User createUser = new User();
 
-    if (hasColumn(resultSet, "dacUserId")) {
-      createUser.setDacUserId(resultSet.getInt("dacUserId"));
-    } 
-    if (hasColumn(resultSet, "email")) {
-      createUser.setEmail(resultSet.getString("email"));
-    }
-    if (hasColumn(resultSet, "displayName")) {
-      createUser.setDisplayName(resultSet.getString("displayName"));
-    }
-    if (hasColumn(resultSet, "createDate")) {
-      createUser.setCreateDate(resultSet.getDate("createDate"));
-    }
-    if (hasColumn(resultSet, "additional_email")) {
-      createUser.setAdditionalEmail(resultSet.getString("additional_email"));
-    }
-    if (hasColumn(resultSet, "email_preference")) {
-      createUser.setEmailPreference(resultSet.getBoolean("email_preference"));
-    }
-    if (hasColumn(resultSet, "status")) {
-      createUser.setStatus(getCreateStatus(resultSet));
-    }
-    if (hasColumn(resultSet, "rationale")) {
-      createUser.setRationale(resultSet.getString("rationale"));
-    }
-    //user model does not currently have an institutionId field or methods
-    // if (hasColumn(resultSet, "institute")) {
-    //   user.setInstitutionId(resultSet.getInt("update_user"));
+    // if (hasColumn(resultSet, "dacUserId")) {
+    //   createUser.setDacUserId(resultSet.getInt("dacUserId"));
+    // } 
+    // if (hasColumn(resultSet, "email")) {
+    //   createUser.setEmail(resultSet.getString("email"));
+    // }
+    // if (hasColumn(resultSet, "displayName")) {
+    //   createUser.setDisplayName(resultSet.getString("displayName"));
+    // }
+    // if (hasColumn(resultSet, "createDate")) {
+    //   createUser.setCreateDate(resultSet.getDate("createDate"));
+    // }
+    // if (hasColumn(resultSet, "additional_email")) {
+    //   createUser.setAdditionalEmail(resultSet.getString("additional_email"));
+    // }
+    // if (hasColumn(resultSet, "email_preference")) {
+    //   createUser.setEmailPreference(resultSet.getBoolean("email_preference"));
+    // }
+    // if (hasColumn(resultSet, "status")) {
+    //   createUser.setStatus(getCreateStatus(resultSet));
+    // }
+    // if (hasColumn(resultSet, "rationale")) {
+    //   createUser.setRationale(resultSet.getString("rationale"));
     // }
 
-    User updateUser = new User();
+    // User updateUser = new User();
 
-    if (hasColumn(resultSet, "updateUserId")) {
-      updateUser.setDacUserId(resultSet.getInt("updateUserId"));
-    } 
-    if (hasColumn(resultSet, "updateUserEmail")) {
-      updateUser.setEmail(resultSet.getString("updateUserEmail"));
-    }
-    if (hasColumn(resultSet, "updateUserName")) {
-      updateUser.setDisplayName(resultSet.getString("updateUserName"));
-    }
-    if (hasColumn(resultSet, "updateUserCreateDate")) {
-      updateUser.setCreateDate(resultSet.getDate("updateUserCreateDate"));
-    }
-    if (hasColumn(resultSet, "updateUserAdditionalEmail")) {
-      updateUser.setAdditionalEmail(resultSet.getString("updateUserAdditionalEmail"));
-    }
-    if (hasColumn(resultSet, "updateUserEmailPreference")) {
-      updateUser.setEmailPreference(resultSet.getBoolean("updateUserEmailPreference"));
-    }
-    if (hasColumn(resultSet, "updateUserStatus")) {
-      updateUser.setStatus(getUpdateStatus(resultSet));
-    }
-    if (hasColumn(resultSet, "updateUserRationale")) {
-      updateUser.setRationale(resultSet.getString("updateUserRationale"));
-    }
+    // if (hasColumn(resultSet, "updateUserId")) {
+    //   updateUser.setDacUserId(resultSet.getInt("updateUserId"));
+    // } 
+    // if (hasColumn(resultSet, "updateUserEmail")) {
+    //   updateUser.setEmail(resultSet.getString("updateUserEmail"));
+    // }
+    // if (hasColumn(resultSet, "updateUserName")) {
+    //   updateUser.setDisplayName(resultSet.getString("updateUserName"));
+    // }
+    // if (hasColumn(resultSet, "updateUserCreateDate")) {
+    //   updateUser.setCreateDate(resultSet.getDate("updateUserCreateDate"));
+    // }
+    // if (hasColumn(resultSet, "updateUserAdditionalEmail")) {
+    //   updateUser.setAdditionalEmail(resultSet.getString("updateUserAdditionalEmail"));
+    // }
+    // if (hasColumn(resultSet, "updateUserEmailPreference")) {
+    //   updateUser.setEmailPreference(resultSet.getBoolean("updateUserEmailPreference"));
+    // }
+    // if (hasColumn(resultSet, "updateUserStatus")) {
+    //   updateUser.setStatus(getUpdateStatus(resultSet));
+    // }
+    // if (hasColumn(resultSet, "updateUserRationale")) {
+    //   updateUser.setRationale(resultSet.getString("updateUserRationale"));
+    // }
 
-    institution.setCreateUser(createUser);
-    institution.setUpdateUser(updateUser);
+    // institution.setCreateUser(createUser);
+    // institution.setUpdateUser(updateUser);
 
     institutionMap.put(institution.getId(), institution);
     return institution;
   }
 
-  private String getCreateStatus(ResultSet r) {
-    try {
-      return RoleStatus.getStatusByValue(r.getInt("status"));
-    } catch (Exception e) {
-      return null;
-    }
-  }
+  // private String getCreateStatus(ResultSet r) {
+  //   try {
+  //     return RoleStatus.getStatusByValue(r.getInt("status"));
+  //   } catch (Exception e) {
+  //     return null;
+  //   }
+  // }
 
-  private String getUpdateStatus(ResultSet r) {
-    try {
-      return RoleStatus.getStatusByValue(r.getInt("updateUserStatus"));
-    } catch (Exception e) {
-      return null;
-    }
-  }
+  // private String getUpdateStatus(ResultSet r) {
+  //   try {
+  //     return RoleStatus.getStatusByValue(r.getInt("updateUserStatus"));
+  //   } catch (Exception e) {
+  //     return null;
+  //   }
+  // }
 
 }

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/InstitutionMapper.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/InstitutionMapper.java
@@ -76,13 +76,11 @@ public class InstitutionMapper implements RowMapper<Institution>, RowMapperHelpe
     if (hasColumn(resultSet, "rationale")) {
       user.setRationale(resultSet.getString("rationale"));
     }
-    //currently the user model does not have setInstitutionId or getInstitutionId methods
-    //but the dacuser table does have institution_id, it seems out of the scope of this PR
-    //but I could file a ticket to add the field to the user if that is something we want
+    //user model does not currently have an institutionId field or methods
     // if (hasColumn(resultSet, "institute")) {
     //   user.setInstitutionId(resultSet.getInt("update_user"));
     // }
-    
+
     institution.setCreateUser(user);
 
     institutionMap.put(institution.getId(), institution);

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/InstitutionMapper.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/InstitutionMapper.java
@@ -1,6 +1,8 @@
 package org.broadinstitute.consent.http.db.mapper;
 
+import org.broadinstitute.consent.http.enumeration.RoleStatus;
 import org.broadinstitute.consent.http.models.Institution;
+import org.broadinstitute.consent.http.models.User;
 import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.core.statement.StatementContext;
 
@@ -36,18 +38,62 @@ public class InstitutionMapper implements RowMapper<Institution>, RowMapperHelpe
       institution.setItDirectorEmail(resultSet.getString("it_director_email"));
     }
     if (hasColumn(resultSet, "create_user")) {
-      institution.setCreateUser(resultSet.getInt("create_user"));
+      institution.setCreateUserId(resultSet.getInt("create_user"));
     }
     if (hasColumn(resultSet, "create_date")) {
       institution.setCreateDate(resultSet.getDate("create_date"));
     } 
     if (hasColumn(resultSet, "update_user")) {
-      institution.setUpdateUser(resultSet.getInt("update_user"));
+      institution.setUpdateUserId(resultSet.getInt("update_user"));
     }
     if (hasColumn(resultSet, "update_date")) {
       institution.setUpdateDate(resultSet.getDate("update_date"));
     }
+
+    User user = new User();;
+
+    if (hasColumn(resultSet, "dacUserId")) {
+      user.setDacUserId(resultSet.getInt("dacUserId"));
+    } 
+    if (hasColumn(resultSet, "email")) {
+      user.setEmail(resultSet.getString("email"));
+    }
+    if (hasColumn(resultSet, "displayName")) {
+      user.setDisplayName(resultSet.getString("displayName"));
+    }
+    if (hasColumn(resultSet, "createDate")) {
+      user.setCreateDate(resultSet.getDate("createDate"));
+    }
+    if (hasColumn(resultSet, "additional_email")) {
+      user.setAdditionalEmail(resultSet.getString("additional_email"));
+    }
+    if (hasColumn(resultSet, "email_preference")) {
+      user.setEmailPreference(resultSet.getBoolean("email_preference"));
+    }
+    if (hasColumn(resultSet, "status")) {
+      user.setStatus(getStatus(resultSet));
+    }
+    if (hasColumn(resultSet, "rationale")) {
+      user.setRationale(resultSet.getString("rationale"));
+    }
+    //currently the user model does not have setInstitutionId or getInstitutionId methods
+    //but the dacuser table does have institution_id, it seems out of the scope of this PR
+    //but I could file a ticket to add the field to the user if that is something we want
+    // if (hasColumn(resultSet, "institute")) {
+    //   user.setInstitutionId(resultSet.getInt("update_user"));
+    // }
+    
+    institution.setCreateUser(user);
+
     institutionMap.put(institution.getId(), institution);
     return institution;
+  }
+
+  private String getStatus(ResultSet r) {
+    try {
+      return RoleStatus.getStatusByValue(r.getInt("status"));
+    } catch (Exception e) {
+      return null;
+    }
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/InstitutionWithUsersReducer.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/InstitutionWithUsersReducer.java
@@ -23,28 +23,28 @@ public class InstitutionWithUsersReducer implements LinkedHashMapRowReducer<Inte
         id -> rowView.getRow(Institution.class));
 
     User create_user = new User();
-    if (Objects.nonNull(rowView.getColumn("dacuserid", Integer.class))) {
+    if (Objects.nonNull(rowView.getColumn("u_dacuserid", Integer.class))) {
         create_user = rowView.getRow(User.class);
     }
 
     // Status is an enum type and we need to get the string value
     try {
-      if (Objects.nonNull(rowView.getColumn("status", Integer.class))) {
-        create_user.setStatus(getCreateStatus(rowView));
+      if (Objects.nonNull(rowView.getColumn("u_status", Integer.class))) {
+        create_user.setStatus(getStatus(rowView, "u_status"));
       }
     } catch (MappingException e) {
       // Ignore any attempt to map a column that doesn't exist
     }
 
     User update_user = new User();
-    if (Objects.nonNull(rowView.getColumn("updateUserId", Integer.class))) {
+    if (Objects.nonNull(rowView.getColumn("u2_dacuserid", Integer.class))) {
         update_user = rowView.getRow(User.class);
     }
 
     // Status is an enum type and we need to get the string value
     try {
-      if (Objects.nonNull(rowView.getColumn("updateUserStatus", Integer.class))) {
-        update_user.setStatus(getUpdateStatus(rowView));
+      if (Objects.nonNull(rowView.getColumn("u2_status", Integer.class))) {
+        update_user.setStatus(getStatus(rowView, "u2_status"));
       }
     } catch (MappingException e) {
       // Ignore any attempt to map a column that doesn't exist
@@ -54,17 +54,9 @@ public class InstitutionWithUsersReducer implements LinkedHashMapRowReducer<Inte
     institution.setUpdateUser(update_user);
   }
 
-  private String getCreateStatus(RowView r) {
+  private String getStatus(RowView r, String columnName) {
     try {
-      return RoleStatus.getStatusByValue(r.getColumn("status", Integer.class));
-    } catch (Exception e) {
-      return null;
-    }
-  }
-
-  private String getUpdateStatus(RowView r) {
-    try {
-      return RoleStatus.getStatusByValue(r.getColumn("updateUserStatus", Integer.class));
+      return RoleStatus.getStatusByValue(r.getColumn(columnName, Integer.class));
     } catch (Exception e) {
       return null;
     }

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/InstitutionWithUsersReducer.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/InstitutionWithUsersReducer.java
@@ -1,0 +1,73 @@
+package org.broadinstitute.consent.http.db.mapper;
+
+import java.util.Map;
+import java.util.Objects;
+
+import org.broadinstitute.consent.http.enumeration.RoleStatus;
+import org.broadinstitute.consent.http.models.Institution;
+import org.broadinstitute.consent.http.models.User;
+import org.jdbi.v3.core.mapper.MappingException;
+import org.jdbi.v3.core.result.LinkedHashMapRowReducer;
+import org.jdbi.v3.core.result.RowView;
+
+/**
+ *  Set the create user and update user on an institution
+ */
+public class InstitutionWithUsersReducer implements LinkedHashMapRowReducer<Integer, Institution> {
+
+  @Override
+  public void accumulate(Map<Integer, Institution> map, RowView rowView) {
+
+    Institution institution = map.computeIfAbsent(
+        rowView.getColumn("institution_id", Integer.class),
+        id -> rowView.getRow(Institution.class));
+
+    User create_user = new User();
+    if (Objects.nonNull(rowView.getColumn("dacuserid", Integer.class))) {
+        create_user = rowView.getRow(User.class);
+    }
+
+    // Status is an enum type and we need to get the string value
+    try {
+      if (Objects.nonNull(rowView.getColumn("status", Integer.class))) {
+        create_user.setStatus(getCreateStatus(rowView));
+      }
+    } catch (MappingException e) {
+      // Ignore any attempt to map a column that doesn't exist
+    }
+
+    User update_user = new User();
+    if (Objects.nonNull(rowView.getColumn("updateUserId", Integer.class))) {
+        update_user = rowView.getRow(User.class);
+    }
+
+    // Status is an enum type and we need to get the string value
+    try {
+      if (Objects.nonNull(rowView.getColumn("updateUserStatus", Integer.class))) {
+        update_user.setStatus(getUpdateStatus(rowView));
+      }
+    } catch (MappingException e) {
+      // Ignore any attempt to map a column that doesn't exist
+    }
+
+    institution.setCreateUser(create_user);
+    institution.setUpdateUser(update_user);
+  }
+
+  private String getCreateStatus(RowView r) {
+    try {
+      return RoleStatus.getStatusByValue(r.getColumn("status", Integer.class));
+    } catch (Exception e) {
+      return null;
+    }
+  }
+
+  private String getUpdateStatus(RowView r) {
+    try {
+      return RoleStatus.getStatusByValue(r.getColumn("updateUserStatus", Integer.class));
+    } catch (Exception e) {
+      return null;
+    }
+  }
+
+}

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/InstitutionWithUsersReducer.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/InstitutionWithUsersReducer.java
@@ -44,8 +44,17 @@ public class InstitutionWithUsersReducer implements LinkedHashMapRowReducer<Inte
     update_user.setCreateDate(rowView.getColumn("u2_createdate", Timestamp.class));
     update_user.setAdditionalEmail(rowView.getColumn("u2_additional_email", String.class));
     update_user.setEmailPreference(rowView.getColumn("u2_email_preference", Boolean.class));
-    update_user.setStatus(getStatus(rowView, "u2_status"));
     update_user.setRationale(rowView.getColumn("u2_rationale", String.class));
+
+    // Status is an enum type and we need to get the string value
+    try {
+      if (Objects.nonNull(rowView.getColumn("u_status", Integer.class))) {
+        update_user.setStatus(getStatus(rowView, "u2_status"));
+      }
+    } catch (MappingException e) {
+      // Ignore any attempt to map a column that doesn't exist
+
+    }
 
     institution.setCreateUser(create_user);
     institution.setUpdateUser(update_user);

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/InstitutionWithUsersReducer.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/InstitutionWithUsersReducer.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.consent.http.db.mapper;
 
+import java.sql.Timestamp;
 import java.util.Map;
 import java.util.Objects;
 
@@ -37,18 +38,14 @@ public class InstitutionWithUsersReducer implements LinkedHashMapRowReducer<Inte
     }
 
     User update_user = new User();
-    if (Objects.nonNull(rowView.getColumn("u2_dacuserid", Integer.class))) {
-        update_user = rowView.getRow(User.class);
-    }
-
-    // Status is an enum type and we need to get the string value
-    try {
-      if (Objects.nonNull(rowView.getColumn("u2_status", Integer.class))) {
-        update_user.setStatus(getStatus(rowView, "u2_status"));
-      }
-    } catch (MappingException e) {
-      // Ignore any attempt to map a column that doesn't exist
-    }
+    update_user.setDacUserId(rowView.getColumn("u2_dacuserid", Integer.class));
+    update_user.setEmail(rowView.getColumn("u2_email", String.class));
+    update_user.setDisplayName(rowView.getColumn("u2_displayname", String.class));
+    update_user.setCreateDate(rowView.getColumn("u2_createdate", Timestamp.class));
+    update_user.setAdditionalEmail(rowView.getColumn("u2_additional_email", String.class));
+    update_user.setEmailPreference(rowView.getColumn("u2_email_preference", Boolean.class));
+    update_user.setStatus(getStatus(rowView, "u2_status"));
+    update_user.setRationale(rowView.getColumn("u2_rationale", String.class));
 
     institution.setCreateUser(create_user);
     institution.setUpdateUser(update_user);

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/InstitutionWithUsersReducer.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/InstitutionWithUsersReducer.java
@@ -53,7 +53,6 @@ public class InstitutionWithUsersReducer implements LinkedHashMapRowReducer<Inte
       }
     } catch (MappingException e) {
       // Ignore any attempt to map a column that doesn't exist
-
     }
 
     institution.setCreateUser(create_user);

--- a/src/main/java/org/broadinstitute/consent/http/models/Institution.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/Institution.java
@@ -11,36 +11,38 @@ public class Institution {
   private String itDirectorName;
   private String itDirectorEmail;
   private Date createDate;
-  private Integer createUser;
+  private Integer createUserId;
   private Date updateDate;
-  private Integer updateUser;
+  private Integer updateUserId;
+
+  private User createUser;
 
   //empty constructor sets all null values except create Date
   public Institution() {
     this.createDate = new Date();
   }
 
-  public Institution(Integer id, String name, String itDirectorName, String itDirectorEmail, Integer createUser, Date createDate) {
+  public Institution(Integer id, String name, String itDirectorName, String itDirectorEmail, Integer createUserId, Date createDate) {
     this.id = id;
     this.name = name;
     this.itDirectorName = itDirectorName;
     this.itDirectorEmail = itDirectorEmail;
     this.createDate = createDate;
-    this.createUser = createUser;
+    this.createUserId = createUserId;
     this.updateDate = this.createDate;
-    this.updateUser = this.createUser;
+    this.updateUserId = this.createUserId;
   }
 
   public Institution(Integer id, String name, String itDirectorName, String itDirectorEmail,
-                     Integer createUser, Date createDate, Integer updateUser, Date updateDate) {
+                     Integer createUserId, Date createDate, Integer updateUserId, Date updateDate) {
     this.id = id;
     this.name = name;
     this.itDirectorName = itDirectorName;
     this.itDirectorEmail = itDirectorEmail;
     this.createDate = createDate;
-    this.createUser = createUser;
+    this.createUserId = createUserId;
     this.updateDate = updateDate;
-    this.updateUser = updateUser;
+    this.updateUserId = updateUserId;
   }
 
   public void setId(Integer id) {
@@ -59,20 +61,24 @@ public class Institution {
     this.itDirectorName = itDirectorName;
   }
 
-  public void setCreateUser(Integer createUser) {
-    this.createUser = createUser;
+  public void setCreateUserId(Integer createUserId) {
+    this.createUserId = createUserId;
   }
 
   public void setCreateDate(Date date) {
     this.createDate = date;
   }
 
-  public void setUpdateUser(Integer updateUser) {
-    this.updateUser = updateUser;
+  public void setUpdateUserId(Integer updateUserId) {
+    this.updateUserId = updateUserId;
   }
 
   public void setUpdateDate(Date updateDate) {
     this.updateDate = updateDate;
+  }
+
+  public void setCreateUser(User createUser) {
+    this.createUser = createUser;
   }
 
   public Integer getId() { return id; }
@@ -93,16 +99,20 @@ public class Institution {
     return createDate;
   }
 
-  public Integer getCreateUser() {
-    return createUser;
+  public Integer getCreateUserId() {
+    return createUserId;
   }
 
   public Date getUpdateDate() {
     return updateDate;
   }
 
-  public Integer getUpdateUser() {
-    return updateUser;
+  public Integer getUpdateUserId() {
+    return updateUserId;
+  }
+
+  public User getCreateUser() {
+    return createUser;
   }
 
   @Override

--- a/src/main/java/org/broadinstitute/consent/http/models/Institution.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/Institution.java
@@ -16,6 +16,7 @@ public class Institution {
   private Integer updateUserId;
 
   private User createUser;
+  private User updateUser;
 
   //empty constructor sets all null values except create Date
   public Institution() {
@@ -81,6 +82,10 @@ public class Institution {
     this.createUser = createUser;
   }
 
+  public void setUpdateUser(User updateUser) {
+    this.updateUser = updateUser;
+  }
+
   public Integer getId() { return id; }
 
   public String getName() {
@@ -113,6 +118,10 @@ public class Institution {
 
   public User getCreateUser() {
     return createUser;
+  }
+
+  public User getUpdateUser() {
+    return updateUser;
   }
 
   @Override

--- a/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
@@ -344,18 +344,22 @@ public class DAOTestHelper {
     }
 
     protected Institution createInstitution() {
-        Integer userId = createUser().getDacUserId();
-        String email = RandomStringUtils.randomAlphabetic(6) +
-                "@" +
-                RandomStringUtils.randomAlphabetic(6) +
-                "." +
-                RandomStringUtils.randomAlphabetic(3);
+        User createUser = createUser();
         Integer id = institutionDAO.insertInstitution(
           "Test_" + RandomStringUtils.random(20, true, true),
           "Test_" + RandomStringUtils.random(20, true, true),
-          email,
-          userId,
+          createUser.getEmail(),
+          createUser.getDacUserId(),
           new Date());
+        Institution institution = institutionDAO.findInstitutionById(id);
+        User updateUser = createUser();
+        institutionDAO.updateInstitutionById(
+                institution.getId(),
+                institution.getName(),
+                institution.getItDirectorName(),
+                institution.getItDirectorEmail(),
+                updateUser.getDacUserId(),
+                new Date());
         createdInstitutionIds.add(id);
         return institutionDAO.findInstitutionById(id);
     }

--- a/src/test/java/org/broadinstitute/consent/http/db/InstitutionDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/InstitutionDAOTest.java
@@ -24,7 +24,7 @@ public class InstitutionDAOTest extends DAOTestHelper {
   @Test
   public void testInsertInstitutionDuplicateName() {
     Institution institution = createInstitution();
-    Integer userId = institution.getCreateUser();
+    Integer userId = institution.getCreateUserId();
     try{
       institutionDAO.insertInstitution(
         institution.getName(), 
@@ -58,7 +58,7 @@ public class InstitutionDAOTest extends DAOTestHelper {
     Institution institution = createInstitution();
     Institution secondInstitution = createInstitution();
     try{
-      institutionDAO.updateInstitutionById(secondInstitution.getId(), institution.getName(), secondInstitution.getItDirectorName(), secondInstitution.getItDirectorEmail(), secondInstitution.getUpdateUser(), secondInstitution.getUpdateDate());
+      institutionDAO.updateInstitutionById(secondInstitution.getId(), institution.getName(), secondInstitution.getItDirectorName(), secondInstitution.getItDirectorEmail(), secondInstitution.getUpdateUserId(), secondInstitution.getUpdateDate());
       Assert.fail("UPDATE should fail due to UNIQUE constraint violation (name)");
     }catch(Exception e) {
       assertEquals("23505", ((PSQLException) e.getCause()).getSQLState());
@@ -82,7 +82,7 @@ public class InstitutionDAOTest extends DAOTestHelper {
     assertEquals(institutionFromDAO.getName(), institution.getName());
     assertEquals(institutionFromDAO.getItDirectorName(), institution.getItDirectorName());
     assertEquals(institutionFromDAO.getItDirectorEmail(), institution.getItDirectorEmail());
-    assertEquals(institutionFromDAO.getCreateUser(), institution.getCreateUser());
+    assertEquals(institutionFromDAO.getCreateUserId(), institution.getCreateUserId());
     assertEquals(institutionFromDAO.getCreateDate(), institution.getCreateDate());
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/db/InstitutionDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/InstitutionDAOTest.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.consent.http.db;
 
+import com.google.gson.Gson;
 import org.broadinstitute.consent.http.models.Institution;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -27,9 +28,9 @@ public class InstitutionDAOTest extends DAOTestHelper {
     Integer userId = institution.getCreateUserId();
     try{
       institutionDAO.insertInstitution(
-        institution.getName(), 
-        institution.getItDirectorName(), 
-        institution.getItDirectorEmail(), 
+        institution.getName(),
+        institution.getItDirectorName(),
+        institution.getItDirectorEmail(),
         userId,
         institution.getCreateDate()
       );

--- a/src/test/java/org/broadinstitute/consent/http/resources/InstitutionResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/InstitutionResourceTest.java
@@ -55,9 +55,9 @@ public class InstitutionResourceTest {
     Institution mockInstitution = new Institution();
     mockInstitution.setName("Test Name");
     mockInstitution.setCreateDate(new Date());
-    mockInstitution.setCreateUser(1);
+    mockInstitution.setCreateUserId(1);
     mockInstitution.setUpdateDate(new Date());
-    mockInstitution.setUpdateUser(1);
+    mockInstitution.setUpdateUserId(1);
     mockInstitution.setId(1);
     return mockInstitution;
   }

--- a/src/test/java/org/broadinstitute/consent/http/util/InstitutionUtilTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/util/InstitutionUtilTest.java
@@ -30,9 +30,9 @@ public class InstitutionUtilTest {
     Institution mockInstitution = new Institution();
     mockInstitution.setName("Test Name");
     mockInstitution.setCreateDate(new Date());
-    mockInstitution.setCreateUser(1);
+    mockInstitution.setCreateUserId(1);
     mockInstitution.setUpdateDate(new Date());
-    mockInstitution.setUpdateUser(1);
+    mockInstitution.setUpdateUserId(1);
     mockInstitution.setId(1);
     return mockInstitution;
   }
@@ -57,8 +57,8 @@ public class InstitutionUtilTest {
     String json = builder.toJson(mockInstitution);
     Institution deserialized = new Gson().fromJson(json, Institution.class);
     assertEquals(mockInstitution.getName(), deserialized.getName());
-    assertEquals(mockInstitution.getCreateUser(), deserialized.getCreateUser());
-    assertEquals(mockInstitution.getUpdateUser(), deserialized.getUpdateUser());
+    assertEquals(mockInstitution.getCreateUserId(), deserialized.getCreateUserId());
+    assertEquals(mockInstitution.getUpdateUserId(), deserialized.getUpdateUserId());
     assertEquals(mockInstitution.getCreateDate().toString(), deserialized.getCreateDate().toString());
     assertEquals(mockInstitution.getUpdateDate().toString(), deserialized.getUpdateDate().toString());
     assertEquals(mockInstitution.getId(), deserialized.getId());


### PR DESCRIPTION
SCOPE:
add dacuser information to InstitutionDAO call for createuser and updateuser
update institutionmapper to set createuser and updateuser information
add create user and update user fields to institution
renamed the id fields in institution to reflect that they are ids

ADDRESSES:
https://broadworkbench.atlassian.net/browse/DUOS-1246

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [ ] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
