### PR TITLE
DUOS-1213[risk=no] DAR Metrics adjustments on Service and DAO methods

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/MetricsDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/MetricsDAO.java
@@ -36,7 +36,7 @@ public interface MetricsDAO extends Transactional<MetricsDAO> {
         + "WHEN LOWER(e.electiontype) = 'dataset' THEN 'data_owner' "
         + "ELSE 'chairperson' "
       + "END = LOWER(v.type) "
-      + "WHERE e.referenceid = '6cbdf037-eb6d-4c61-afb5-c0b3b1620cdd' "
+      + "WHERE e.referenceid in(<referenceIds>) "
     + ") AS results "
     + "WHERE results.latest = results.electionid"
   )

--- a/src/main/java/org/broadinstitute/consent/http/db/MetricsDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/MetricsDAO.java
@@ -38,7 +38,12 @@ public interface MetricsDAO extends Transactional<MetricsDAO> {
       + "END = LOWER(v.type) "
       + "WHERE e.referenceid in(<referenceIds>) "
     + ") AS results "
-    + "WHERE results.latest = results.electionid"
+    + "WHERE results.latest = results.electionid "
+    + "ORDER BY results.electionid DESC, "
+    + "CASE "
+      + "WHEN results.finalvotedate IS NULL THEN results.lastupdate "
+      + "ELSE results.finalvotedate "
+    + "END DESC"
   )
   @UseRowMapper(ElectionMapper.class)
   List<Election> findLastElectionsByReferenceIds(

--- a/src/main/java/org/broadinstitute/consent/http/db/MetricsDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/MetricsDAO.java
@@ -26,19 +26,22 @@ public interface MetricsDAO extends Transactional<MetricsDAO> {
   List<DataAccessRequest> findAllDars();
 
   @SqlQuery(
-    " SELECT e.*, v.vote finalvote, v.rationale finalrationale, v.createdate finalvotedate "
-      + " FROM election e "
-      + " INNER JOIN "
-      + "   (SELECT e.referenceid, MAX(e.createdate) AS maxDate "
-      + "    FROM election e "
-      + "    GROUP BY e.referenceid ) electionView ON electionView.maxDate = e.createdate AND electionView.referenceid = e.referenceid "
-      + " LEFT JOIN vote v ON v.electionid = e.electionid AND "
-      + "    CASE "
-      + "        WHEN LOWER(e.electiontype) = 'dataaccess' THEN 'final' "
-      + "        WHEN LOWER(e.electiontype) = 'dataset' THEN 'data_owner' "
-      + "        ELSE 'chairperson' "
-      + "    END = LOWER(v.type)"
-      + " WHERE e.referenceid in (<referenceIds>) ")
+    "SELECT e.*, v.vote finalvote, v.rationale finalrationale, v.createdate finalvotedate "
+    + "FROM election e "
+    + "INNER JOIN ( "
+    + "    SELECT e.referenceid, max(e.electionid) "
+    + "    FROM election e "
+    + "    GROUP BY e.referenceid " 
+    + ") electionView "
+    + "ON electionView.referenceid = e.referenceid "
+    + "LEFT JOIN vote v ON e.electionid = v.electionid AND "
+    + "CASE " 
+    + "    WHEN LOWER(e.electiontype) = 'dataaccess' THEN 'final' "
+    + "    WHEN LOWER(e.electiontype) = 'dataset' THEN 'data_owner' "
+    + "    ELSE 'chairperson' "
+    + "END = LOWER(v.type) "
+    + "WHERE e.referenceid IN (<referenceIds>) "
+  )
   @UseRowMapper(ElectionMapper.class)
   List<Election> findLastElectionsByReferenceIds(
       @BindList("referenceIds") List<String> referenceIds);

--- a/src/main/java/org/broadinstitute/consent/http/models/DarDecisionMetrics.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DarDecisionMetrics.java
@@ -227,8 +227,10 @@ public class DarDecisionMetrics implements DecisionMetrics {
   }
 
   private void setDacDecision(Election election) {
-    if (Objects.nonNull(election) && election.getFinalAccessVote()) {
-      this.dacDecision = election.getFinalAccessVote() ? YES : NO;
+    //NOTE: finalVote is pulled from the associated vote
+    //Vote records are vastly more reliable than election vote status 
+    if (Objects.nonNull(election) && election.getFinalVote()) {
+      this.dacDecision = election.getFinalVote() ? YES : NO;
     }
   }
 

--- a/src/main/java/org/broadinstitute/consent/http/resources/MetricsResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/MetricsResource.java
@@ -36,9 +36,13 @@ public class MetricsResource extends Resource {
   }
 
   private Response getMetricsData(Type type) {
-    String header = metricsService.getHeaderRow(type);
-    StringBuilder tsv = new StringBuilder(header);
-    metricsService.generateDecisionMetrics(type).forEach(m -> tsv.append(m.toString(JOINER)));
-    return Response.ok(tsv.toString()).build();
+    try{
+      String header = metricsService.getHeaderRow(type);
+      StringBuilder tsv = new StringBuilder(header);
+      metricsService.generateDecisionMetrics(type).forEach(m -> tsv.append(m.toString(JOINER)));
+      return Response.ok(tsv.toString()).build();
+    } catch(Exception e) {
+      return createExceptionResponse(e);
+    }
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/service/MetricsService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/MetricsService.java
@@ -16,6 +16,8 @@ import org.broadinstitute.consent.http.models.Election;
 import org.broadinstitute.consent.http.models.Match;
 import org.broadinstitute.consent.http.models.DecisionMetrics;
 
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -75,27 +77,28 @@ public class MetricsService {
               .findFirst()
               .orElse(null);
 
-          Optional<Election> accessElection =
-            elections.stream()
-              .filter(
-                e ->
-                  e.getReferenceId()
-                    .equalsIgnoreCase(dataAccessRequest.getReferenceId()))
-              .filter(
-                e ->
-                  e.getElectionType()
-                    .equalsIgnoreCase(ElectionType.DATA_ACCESS.getValue()))
-              .findFirst();
+          List<Election> associatedElections = elections.stream()
+            .filter(e -> 
+              e.getReferenceId()
+                .equalsIgnoreCase(dataAccessRequest.getReferenceId())
+            ).collect(Collectors.toList());
 
-          Optional<Election> rpElection =
-            elections.stream()
-              .filter(
-                e ->
-                  e.getReferenceId()
-                    .equalsIgnoreCase(dataAccessRequest.getReferenceId()))
-              .filter(e -> e.getElectionType().equalsIgnoreCase(ElectionType.RP.getValue()))
-              .findFirst();
+          List<Election> filteredAccessElections = associatedElections
+            .stream()
+            .filter(e -> e.getElectionType()
+              .equalsIgnoreCase(ElectionType.DATA_ACCESS.getValue())
+            ).collect(Collectors.toList());
+              
 
+          List<Election> filteredRpElections = associatedElections
+            .stream()
+            .filter(e -> e.getElectionType()
+              .equalsIgnoreCase(ElectionType.RP.getValue())
+            ).collect(Collectors.toList());
+
+          Optional<Election> accessElection = searchFilteredElectionList(filteredAccessElections);
+          Optional<Election> rpElection = searchFilteredElectionList(filteredRpElections);
+          
           Optional<Match> match =
             matches.stream()
               .filter(
@@ -142,5 +145,28 @@ public class MetricsService {
           })
         .collect(Collectors.toList());
     }
+  }
+
+  private static Optional<Election> searchFilteredElectionList(List<Election> electionList) {
+
+    //Search for instance where election.finalVote is true
+    //Order does not matter, so parallel steam makes sense
+    Optional<Election> election = electionList
+      .stream()
+      .filter(e -> Objects.nonNull(e.getFinalVote()) && e.getFinalVote())
+      .findAny();
+    
+    //if no vote was found, return the earliest vote
+    if(Objects.isNull(election)) {
+      Collections.sort(electionList, new DateComparator());
+      election = electionList.stream().findFirst();
+    }
+    return election;
+  }
+}
+
+class DateComparator implements Comparator<Election> {
+  public int compare(Election a, Election b) {
+    return (a.getFinalVoteDate()).compareTo(b.getFinalVoteDate());
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/service/MetricsService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/MetricsService.java
@@ -16,8 +16,6 @@ import org.broadinstitute.consent.http.models.Election;
 import org.broadinstitute.consent.http.models.Match;
 import org.broadinstitute.consent.http.models.DecisionMetrics;
 
-import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -158,15 +156,8 @@ public class MetricsService {
     
     //if no vote was found, return the earliest vote
     if(Objects.isNull(election)) {
-      Collections.sort(electionList, new DateComparator());
       election = electionList.stream().findFirst();
     }
     return election;
-  }
-}
-
-class DateComparator implements Comparator<Election> {
-  public int compare(Election a, Election b) {
-    return (a.getFinalVoteDate()).compareTo(b.getFinalVoteDate());
   }
 }


### PR DESCRIPTION
Addresses [DUOS-1213](https://broadworkbench.atlassian.net/browse/DUOS-1213)

PR refactors DAR Metrics methods on associated metrics and DAO classes in order to correct Metrics output. Tests on the ```MetricsDAO.findLastElectionsByReferenceIds``` have been refactored as well to better test the SQL query

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [ ] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
