### PR TITLE
[DUOS-1258][risk=no] Use a test container instead of a locally managed mock server

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -520,6 +520,22 @@
       <scope>test</scope>
     </dependency>
 
+    <!-- Required for mocking ontology and elastic search instances -->
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>mockserver</artifactId>
+      <version>1.15.3</version>
+      <scope>test</scope>
+    </dependency>
+
+    <!-- Required for mocking client calls against ontology and elastic search -->
+    <dependency>
+      <groupId>org.mock-server</groupId>
+      <artifactId>mockserver-client-java</artifactId>
+      <version>5.11.2</version>
+      <scope>test</scope>
+    </dependency>
+
     <dependency>
       <groupId>com.google.api-client</groupId>
       <artifactId>google-api-client</artifactId>
@@ -614,32 +630,6 @@
       <groupId>org.elasticsearch.client</groupId>
       <artifactId>elasticsearch-rest-client</artifactId>
       <version>7.12.1</version>
-    </dependency>
-
-    <!-- Required for mocking ontology and elastic search responses -->
-    <dependency>
-      <groupId>org.mock-server</groupId>
-      <artifactId>mockserver-netty</artifactId>
-      <version>5.11.2</version>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>com.fasterxml.jackson.core</groupId>
-          <artifactId>jackson-databind</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.google.guava</groupId>
-          <artifactId>guava</artifactId>
-        </exclusion>
-        <!--
-          The following clashes with jakarta.validation:jakarta.validation-api and
-          prevents configurations from loading when running locally
-        -->
-        <exclusion>
-          <groupId>javax.validation</groupId>
-          <artifactId>validation-api</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
 
     <!-- See https://broadinstitute-dsp.sourceclear.io/workspaces/jppForw/issues/vulnerabilities/11441966 -->

--- a/pom.xml
+++ b/pom.xml
@@ -528,6 +528,7 @@
       <scope>test</scope>
     </dependency>
 
+
     <!-- Required for mocking client calls against ontology and elastic search -->
     <dependency>
       <groupId>org.mock-server</groupId>

--- a/src/main/java/org/broadinstitute/consent/http/configurations/ElasticSearchConfiguration.java
+++ b/src/main/java/org/broadinstitute/consent/http/configurations/ElasticSearchConfiguration.java
@@ -1,7 +1,7 @@
 package org.broadinstitute.consent.http.configurations;
 
-import java.util.List;
 import javax.validation.constraints.NotNull;
+import java.util.List;
 
 public class ElasticSearchConfiguration {
 
@@ -10,6 +10,11 @@ public class ElasticSearchConfiguration {
 
     @NotNull
     private List<String> servers;
+
+    /**
+     * This is configurable for testing purposes
+     */
+    private int port = 9200;
 
     public List<String> getServers() {
         return servers;
@@ -25,5 +30,13 @@ public class ElasticSearchConfiguration {
 
     public void setIndexName(String indexName) {
         this.indexName = indexName;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    public void setPort(int port) {
+        this.port = port;
     }
 }

--- a/src/main/java/org/broadinstitute/consent/http/service/ontology/ElasticSearchSupport.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ontology/ElasticSearchSupport.java
@@ -1,6 +1,5 @@
 package org.broadinstitute.consent.http.service.ontology;
 
-import java.nio.charset.Charset;
 import org.apache.http.Header;
 import org.apache.http.HttpHost;
 import org.apache.http.message.BasicHeader;
@@ -9,6 +8,7 @@ import org.elasticsearch.client.RestClient;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
+import java.nio.charset.Charset;
 import java.util.stream.Collectors;
 
 @SuppressWarnings("WeakerAccess")
@@ -18,7 +18,7 @@ public class ElasticSearchSupport {
         HttpHost[] hosts = configuration.
             getServers().
             stream().
-            map(server -> new HttpHost(server, 9200, "http")).
+            map(server -> new HttpHost(server, configuration.getPort(), "http")).
             collect(Collectors.toList()).toArray(new HttpHost[configuration.getServers().size()]);
         return RestClient.builder(hosts).build();
     }

--- a/src/test/java/org/broadinstitute/consent/http/WithMockServer.java
+++ b/src/test/java/org/broadinstitute/consent/http/WithMockServer.java
@@ -1,20 +1,21 @@
 package org.broadinstitute.consent.http;
 
-import org.mockserver.integration.ClientAndServer;
+import org.testcontainers.containers.MockServerContainer;
+import org.testcontainers.utility.DockerImageName;
 
-import static org.mockserver.integration.ClientAndServer.startClientAndServer;
+import java.util.Objects;
 
 public interface WithMockServer {
 
-    default ClientAndServer startMockServer(int port) {
-        // Mockserver doesn't respect dropwizard log settings
-        ((ch.qos.logback.classic.Logger) org.slf4j.LoggerFactory
-                .getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME))
-                .setLevel(ch.qos.logback.classic.Level.OFF);
-        ((ch.qos.logback.classic.Logger) org.slf4j.LoggerFactory
-                .getLogger("org.mockserver"))
-                .setLevel(ch.qos.logback.classic.Level.OFF);
-        return startClientAndServer(port);
-    }
+  DockerImageName IMAGE = DockerImageName.parse("mockserver/mockserver:mockserver-5.11.2");
 
+  default void stop(MockServerContainer container) {
+    if (Objects.nonNull(container) && container.isRunning()) {
+      container.stop();
+    }
+  }
+
+  default String getRootUrl(MockServerContainer container) {
+    return container.getEndpoint() + "/";
+  }
 }

--- a/src/test/java/org/broadinstitute/consent/http/service/IndexOntologyServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/IndexOntologyServiceTest.java
@@ -41,7 +41,7 @@ public class IndexOntologyServiceTest implements WithMockServer {
     private static final String INDEX_NAME = "test-index";
     private IndexOntologyService ontologyService;
     private final IndexerUtils indexUtils = new IndexerUtils();
-    private RestClient restClient;
+    private RestClient client;
 
     @Rule
     public MockServerContainer container = new MockServerContainer(IMAGE);
@@ -52,7 +52,7 @@ public class IndexOntologyServiceTest implements WithMockServer {
         configuration.setIndexName(INDEX_NAME);
         configuration.setServers(Collections.singletonList("localhost"));
         configuration.setPort(container.getServerPort());
-        restClient = ElasticSearchSupport.createRestClient(configuration);
+        client = ElasticSearchSupport.createRestClient(configuration);
         this.ontologyService = new IndexOntologyService(configuration);
         MockServerClient mockServerClient = new MockServerClient(container.getHost(), container.getServerPort());
         mockServerClient.when(request()).respond(response().withStatusCode(200));
@@ -157,7 +157,7 @@ public class IndexOntologyServiceTest implements WithMockServer {
     public void testBulkUploadTerms() {
         try {
             Collection<Term> terms = getTerms();
-            indexUtils.bulkUploadTerms(restClient, INDEX_NAME, terms);
+            indexUtils.bulkUploadTerms(client, INDEX_NAME, terms);
         } catch (Exception e) {
             Assert.fail(e.getMessage());
         }
@@ -166,7 +166,7 @@ public class IndexOntologyServiceTest implements WithMockServer {
     @Test
     public void testBulkDeprecateTerms() {
         try {
-            indexUtils.bulkDeprecateTerms(restClient, INDEX_NAME, "organization");
+            indexUtils.bulkDeprecateTerms(client, INDEX_NAME, "organization");
         } catch (Exception e) {
             Assert.fail(e.getMessage());
         }

--- a/src/test/java/org/broadinstitute/consent/http/service/IndexOntologyServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/IndexOntologyServiceTest.java
@@ -12,8 +12,9 @@ import org.elasticsearch.client.RestClient;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
-import org.mockserver.integration.ClientAndServer;
+import org.mockserver.client.MockServerClient;
 import org.semanticweb.owlapi.apibinding.OWLManager;
 import org.semanticweb.owlapi.model.OWLClass;
 import org.semanticweb.owlapi.model.OWLOntology;
@@ -22,6 +23,7 @@ import org.semanticweb.owlapi.model.OWLOntologyManager;
 import org.semanticweb.owlapi.reasoner.OWLReasoner;
 import org.semanticweb.owlapi.reasoner.OWLReasonerFactory;
 import org.semanticweb.owlapi.reasoner.structural.StructuralReasonerFactory;
+import org.testcontainers.containers.MockServerContainer;
 
 import java.io.IOException;
 import java.net.URL;
@@ -38,26 +40,27 @@ public class IndexOntologyServiceTest implements WithMockServer {
 
     private static final String INDEX_NAME = "test-index";
     private IndexOntologyService ontologyService;
-    private IndexerUtils indexUtils = new IndexerUtils();
-    private ClientAndServer server;
-    private RestClient client;
+    private final IndexerUtils indexUtils = new IndexerUtils();
+    private RestClient restClient;
+
+    @Rule
+    public MockServerContainer container = new MockServerContainer(IMAGE);
 
     @Before
     public void setUp() throws Exception {
         ElasticSearchConfiguration configuration = new ElasticSearchConfiguration();
         configuration.setIndexName(INDEX_NAME);
         configuration.setServers(Collections.singletonList("localhost"));
-        client = ElasticSearchSupport.createRestClient(configuration);
+        configuration.setPort(container.getServerPort());
+        restClient = ElasticSearchSupport.createRestClient(configuration);
         this.ontologyService = new IndexOntologyService(configuration);
-        server = startMockServer(9200);
-        server.when(request()).respond(response().withStatusCode(200));
+        MockServerClient mockServerClient = new MockServerClient(container.getHost(), container.getServerPort());
+        mockServerClient.when(request()).respond(response().withStatusCode(200));
     }
 
     @After
-    public void shutDown() throws Exception {
-        if (server != null && server.isRunning()) {
-            server.stop();
-        }
+    public void tearDown() {
+        stop(container);
     }
 
     @Test
@@ -154,7 +157,7 @@ public class IndexOntologyServiceTest implements WithMockServer {
     public void testBulkUploadTerms() {
         try {
             Collection<Term> terms = getTerms();
-            indexUtils.bulkUploadTerms(client, INDEX_NAME, terms);
+            indexUtils.bulkUploadTerms(restClient, INDEX_NAME, terms);
         } catch (Exception e) {
             Assert.fail(e.getMessage());
         }
@@ -163,7 +166,7 @@ public class IndexOntologyServiceTest implements WithMockServer {
     @Test
     public void testBulkDeprecateTerms() {
         try {
-            indexUtils.bulkDeprecateTerms(client, INDEX_NAME, "organization");
+            indexUtils.bulkDeprecateTerms(restClient, INDEX_NAME, "organization");
         } catch (Exception e) {
             Assert.fail(e.getMessage());
         }

--- a/src/test/java/org/broadinstitute/consent/http/service/UseRestrictionConverterTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/UseRestrictionConverterTest.java
@@ -1,15 +1,5 @@
 package org.broadinstitute.consent.http.service;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.mockserver.model.HttpRequest.request;
-import static org.mockserver.model.HttpResponse.response;
-
-import javax.ws.rs.client.Client;
-import javax.ws.rs.client.ClientBuilder;
-import javax.ws.rs.core.MediaType;
 import org.broadinstitute.consent.http.WithMockServer;
 import org.broadinstitute.consent.http.configurations.ServicesConfiguration;
 import org.broadinstitute.consent.http.models.DataUse;
@@ -17,28 +7,43 @@ import org.broadinstitute.consent.http.models.grammar.Everything;
 import org.broadinstitute.consent.http.models.grammar.UseRestriction;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
-import org.mockserver.integration.ClientAndServer;
+import org.mockserver.client.MockServerClient;
 import org.mockserver.model.Header;
+import org.testcontainers.containers.MockServerContainer;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.core.MediaType;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockserver.model.HttpRequest.request;
+import static org.mockserver.model.HttpResponse.response;
 
 public class UseRestrictionConverterTest implements WithMockServer {
 
-    private ClientAndServer mockServer;
-    private final Integer port = 9300;
+    private MockServerClient client;
+
+    @Rule
+    public MockServerContainer container = new MockServerContainer(IMAGE);
 
     @Before
     public void startUp() {
-        mockServer = startMockServer(port);
+        client = new MockServerClient(container.getHost(), container.getServerPort());
     }
 
     @After
     public void tearDown() {
-        mockServer.stop();
+        stop(container);
     }
 
     private void mockSuccess() {
-        mockServer.reset();
-        mockServer.when(
+        client.reset();
+        client.when(
             request()
                 .withMethod("POST")
                 .withPath("/schemas/data-use/dar/translate")
@@ -51,8 +56,8 @@ public class UseRestrictionConverterTest implements WithMockServer {
     }
 
     private void mockFailure() {
-        mockServer.reset();
-        mockServer.when(
+        client.reset();
+        client.when(
             request()
                 .withMethod("POST")
                 .withPath("/schemas/data-use/dar/translate")
@@ -67,7 +72,7 @@ public class UseRestrictionConverterTest implements WithMockServer {
     public ServicesConfiguration config() {
         ServicesConfiguration config = new ServicesConfiguration();
         config.setLocalURL("http://localhost:8180/");
-        config.setOntologyURL("http://localhost:" + port + "/");
+        config.setOntologyURL(getRootUrl(container));
         return config;
     }
 

--- a/src/test/java/org/broadinstitute/consent/http/service/UseRestrictionValidatorTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/UseRestrictionValidatorTest.java
@@ -2,11 +2,14 @@ package org.broadinstitute.consent.http.service;
 
 import org.broadinstitute.consent.http.WithMockServer;
 import org.broadinstitute.consent.http.configurations.ServicesConfiguration;
+import org.broadinstitute.consent.http.models.grammar.Everything;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
-import org.mockserver.integration.ClientAndServer;
+import org.mockserver.client.MockServerClient;
 import org.mockserver.model.Header;
+import org.testcontainers.containers.MockServerContainer;
 
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.core.MediaType;
@@ -16,34 +19,34 @@ import static org.mockserver.model.HttpResponse.response;
 
 public class UseRestrictionValidatorTest implements WithMockServer {
 
-    private ClientAndServer mockServer;
-    private final Integer port = 9300;
     private UseRestrictionValidator validator;
+    private MockServerClient client;
+    private final String useRestriction = new Everything().toString();
+
+    @Rule
+    public MockServerContainer container = new MockServerContainer(IMAGE);
 
     @Before
     public void startUp() {
-        mockServer = startMockServer(port);
+        client = new MockServerClient(container.getHost(), container.getServerPort());
+        this.validator = new UseRestrictionValidator(ClientBuilder.newClient(), config());
     }
 
     @After
     public void tearDown() {
-        mockServer.stop();
+        stop(container);
     }
 
     public ServicesConfiguration config() {
         ServicesConfiguration config = new ServicesConfiguration();
         config.setLocalURL("http://localhost:8180/");
-        config.setOntologyURL("http://localhost:" + port + "/");
+        config.setOntologyURL(getRootUrl(container));
         return config;
     }
 
-    public void initValidator() {
-        this.validator = new UseRestrictionValidator(ClientBuilder.newClient(), config());
-    }
-
     private void mockSuccess() {
-        mockServer.reset();
-        mockServer.when(
+        client.reset();
+        client.when(
             request()
                 .withMethod("POST")
                 .withPath("/validate/userestriction")
@@ -56,8 +59,8 @@ public class UseRestrictionValidatorTest implements WithMockServer {
     }
 
     private void mockInvalid() {
-        mockServer.reset();
-        mockServer.when(
+        client.reset();
+        client.when(
                 request()
                         .withMethod("POST")
                         .withPath("/validate/userestriction")
@@ -70,8 +73,8 @@ public class UseRestrictionValidatorTest implements WithMockServer {
     }
 
     private void mockFailure() {
-        mockServer.reset();
-        mockServer.when(
+        client.reset();
+        client.when(
             request()
                 .withMethod("POST")
                 .withPath("/validate/userestriction")
@@ -86,24 +89,18 @@ public class UseRestrictionValidatorTest implements WithMockServer {
     @Test(expected = IllegalArgumentException.class)
     public void testValidateUseRestriction_Failure() {
         mockFailure();
-        initValidator();
-        validator.validateUseRestriction("{ \"type\": \"everything\" }");
+        validator.validateUseRestriction(useRestriction);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testValidateUseRestriction_Invalid() {
-        String useRestriction = "{ \"type\": \"everything\" }";
         mockInvalid();
-        initValidator();
         validator.validateUseRestriction(useRestriction);
     }
 
     @Test
     public void testValidateUseRestriction_Success() {
-        String useRestriction = "{ \"type\": \"everything\" }";
         mockSuccess();
-        initValidator();
-
         try {
             validator.validateUseRestriction(useRestriction);
             assert true;

--- a/src/test/java/org/broadinstitute/consent/http/service/UseRestrictionValidatorTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/UseRestrictionValidatorTest.java
@@ -19,9 +19,9 @@ import static org.mockserver.model.HttpResponse.response;
 
 public class UseRestrictionValidatorTest implements WithMockServer {
 
-    private UseRestrictionValidator validator;
-    private MockServerClient client;
     private final String useRestriction = new Everything().toString();
+    private MockServerClient client;
+    private UseRestrictionValidator validator;
 
     @Rule
     public MockServerContainer container = new MockServerContainer(IMAGE);
@@ -29,7 +29,7 @@ public class UseRestrictionValidatorTest implements WithMockServer {
     @Before
     public void startUp() {
         client = new MockServerClient(container.getHost(), container.getServerPort());
-        this.validator = new UseRestrictionValidator(ClientBuilder.newClient(), config());
+        validator = new UseRestrictionValidator(ClientBuilder.newClient(), config());
     }
 
     @After


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-1258

## Changes
* Migrated from spinning up a local server to using a test container to do the same work. Test containers have been very stable in CI but local servers have not. 
* Update tests to use the container.
* Minor refactoring for easier maintenance.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [ ] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
