### PR TITLE
DUOS-1229[risk=no]Restore Vote Statistics Download functions

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
@@ -494,6 +494,7 @@ public class ConsentModule extends AbstractModule {
             providesVoteDAO(),
             providesElectionDAO(),
             providesUserDAO(),
+            providesConsentDAO(),
             providesDataSetDAO(),
             providesMatchDAO()
         );

--- a/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
@@ -1,11 +1,13 @@
 package org.broadinstitute.consent.http.db;
 
 import org.apache.commons.lang3.tuple.Pair;
+import org.broadinstitute.consent.http.db.mapper.AssociationMapper;
 import org.broadinstitute.consent.http.db.mapper.DataSetMapper;
 import org.broadinstitute.consent.http.db.mapper.DataSetPropertiesMapper;
 import org.broadinstitute.consent.http.db.mapper.DatasetPropertyMapper;
 import org.broadinstitute.consent.http.db.mapper.DictionaryMapper;
 import org.broadinstitute.consent.http.db.mapper.ImmutablePairOfIntsMapper;
+import org.broadinstitute.consent.http.models.Association;
 import org.broadinstitute.consent.http.models.DataSet;
 import org.broadinstitute.consent.http.models.DataSetAudit;
 import org.broadinstitute.consent.http.models.DataSetProperty;
@@ -179,6 +181,10 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
 
     @SqlQuery("SELECT * FROM dataset WHERE datasetid in (<dataSetIds>) ")
     List<DataSet> findDatasetsByIdList(@BindList("dataSetIds") List<Integer> dataSetIds);
+
+    @RegisterRowMapper(AssociationMapper.class)
+    @SqlQuery("SELECT * FROM consentassociations ca inner join dataset ds on ds.dataSetId = ca.dataSetId WHERE ds.dataSetId IN (<dataSetIdList>)")
+    List<Association> getAssociationsForDataSetIdList(@BindList("dataSetIdList") List<Integer> dataSetIdList);
 
     /**
      * User -> UserRoles -> DACs -> Consents -> Consent Associations -> DataSets

--- a/src/main/java/org/broadinstitute/consent/http/db/ElectionDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/ElectionDAO.java
@@ -1,11 +1,13 @@
 package org.broadinstitute.consent.http.db;
 
 import org.apache.commons.lang3.tuple.Pair;
+import org.broadinstitute.consent.http.db.mapper.AccessRPMapper;
 import org.broadinstitute.consent.http.db.mapper.DacMapper;
 import org.broadinstitute.consent.http.db.mapper.DateMapper;
 import org.broadinstitute.consent.http.db.mapper.ImmutablePairOfIntsMapper;
 import org.broadinstitute.consent.http.db.mapper.SimpleElectionMapper;
 import org.broadinstitute.consent.http.db.mapper.ElectionMapper;
+import org.broadinstitute.consent.http.models.AccessRP;
 import org.broadinstitute.consent.http.models.Dac;
 import org.broadinstitute.consent.http.models.Election;
 import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
@@ -194,6 +196,21 @@ public interface ElectionDAO extends Transactional<ElectionDAO> {
             " AND lower(e.electiontype) = lower(:type)")
     @UseRowMapper(SimpleElectionMapper.class)
     List<Election> findLastElectionsByReferenceIdsAndType(@BindList("referenceIds") List<String> referenceIds, @Bind("type") String type);
+
+    @SqlQuery("select distinct e.electionId,  e.datasetId, v.vote finalVote, e.status, e.createDate, e.referenceId, v.rationale finalRationale, " +
+            "v.createDate finalVoteDate, e.lastUpdate, e.finalAccessVote, e.electionType, e.dataUseLetter, e.dulName, e.archived, e.version  from election e " +
+            "inner join (select referenceId, MAX(createDate) maxDate from election e where lower(e.status) = lower(:status) group by referenceId) " +
+            "electionView ON electionView.maxDate = e.createDate AND electionView.referenceId = e.referenceId  " +
+            "AND e.referenceId in (<referenceIds>) " +
+            "left join vote v on v.electionId = e.electionId and lower(v.type) = 'chairperson' ")
+     List<Election> findLastElectionsWithFinalVoteByReferenceIdsTypeAndStatus(@BindList("referenceIds") List<String> referenceIds, @Bind("status") String status);
+
+     @SqlQuery("select count(*) from election e where lower(e.status) = 'open' and e.referenceId = :referenceId")
+     Integer verifyOpenElectionsForReferenceId(@Bind("referenceId") String referenceId); 
+
+     @RegisterRowMapper(AccessRPMapper.class)
+     @SqlQuery("select * from access_rp where electionAccessId in (<electionAccessIds>) ")
+     List<AccessRP> findAccessRPbyElectionAccessId(@BindList("electionAccessIds") List<Integer> electionAccessIds); 
 
     @SqlQuery("select * from election e inner join (select referenceId, MAX(createDate) maxDate from election e where lower(e.electionType) = lower(:type) group by referenceId) " +
             "electionView ON electionView.maxDate = e.createDate AND electionView.referenceId = e.referenceId  " +

--- a/src/main/java/org/broadinstitute/consent/http/db/MatchDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/MatchDAO.java
@@ -31,6 +31,9 @@ public interface MatchDAO extends Transactional<MatchDAO> {
     @SqlQuery("select * from match_entity where matchId = :id ")
     Match  findMatchById(@Bind("id") Integer id);
 
+    @SqlQuery("select * from match_entity where purpose  IN (<purposeId>)")
+    List<Match>  findMatchesPurposeId(@BindList("purposeId") List<String> purposeId);
+
     @SqlUpdate("insert into match_entity " +
             "(consent, purpose, matchEntity, failed, date) values " +
             "(:consentId, :purposeId, :match, :failed, :createDate)")

--- a/src/main/java/org/broadinstitute/consent/http/db/VoteDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/VoteDAO.java
@@ -127,6 +127,9 @@ public interface VoteDAO extends Transactional<VoteDAO> {
             + " lower(v.type) = 'final' and v.vote = :finalVote ")
     Integer findTotalFinalVoteByElectionTypeAndVote(@Bind("type") String type, @Bind("finalVote") Boolean finalVote);
 
+    @SqlQuery("SELECT MAX(c) FROM (SELECT COUNT(vote) as c FROM vote WHERE lower(type) = 'dac' and electionId IN (<electionIds>) GROUP BY electionId) as members")
+    Integer findMaxNumberOfDACMembers(@BindList("electionIds") List<Integer> electionIds);
+
     @SqlBatch("insert into vote (dacUserId, electionId, type) values (:dacUserId, :electionId, :type)")
     void insertVotes(@Bind("dacUserId") List<Integer> dacUserIds, @Bind("electionId") Integer electionId, @Bind("type") String type);
 

--- a/src/main/java/org/broadinstitute/consent/http/resources/ConsentCasesResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/ConsentCasesResource.java
@@ -2,6 +2,8 @@ package org.broadinstitute.consent.http.resources;
 
 import com.google.inject.Inject;
 import io.dropwizard.auth.Auth;
+
+import java.io.File;
 import java.util.List;
 import javax.annotation.security.PermitAll;
 import javax.annotation.security.RolesAllowed;
@@ -9,7 +11,10 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.ResponseBuilder;
+
 import org.broadinstitute.consent.http.enumeration.ElectionType;
 import org.broadinstitute.consent.http.models.AuthUser;
 import org.broadinstitute.consent.http.models.Election;
@@ -48,6 +53,27 @@ public class ConsentCasesResource extends Resource {
         Summary summary = summaryService.describeConsentSummaryCases();
         return Response.ok().entity(summary).build();
     }
+
+    @GET
+    @Path("/summary/file")
+    @Produces("text/plain")
+    @PermitAll
+    public Response getConsentSummaryDetailFile(@QueryParam("fileType") String fileType, @Auth AuthUser authUser) {
+        ResponseBuilder response;
+        File fileToSend = null;
+        if (fileType.equals(ElectionType.TRANSLATE_DUL.getValue())) {
+            fileToSend = summaryService.describeConsentSummaryDetail();
+        } else if (fileType.equals(ElectionType.DATA_ACCESS.getValue())) {
+            fileToSend = summaryService.describeDataAccessRequestSummaryDetail();
+        }
+        if ((fileToSend != null)) {
+            response = Response.ok(fileToSend);
+        } else {
+            response = Response.ok();
+        }
+        return response.build();
+    }
+
 
     @GET
     @Path("/closed")

--- a/src/main/java/org/broadinstitute/consent/http/service/SummaryService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/SummaryService.java
@@ -39,7 +39,6 @@ import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.Vote;
 import org.broadinstitute.consent.http.util.DarConstants;
 import org.broadinstitute.consent.http.util.DarUtil;
-import org.broadinstitute.consent.http.util.DatasetUtil;
 import org.bson.Document;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/org/broadinstitute/consent/http/service/SummaryService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/SummaryService.java
@@ -1,19 +1,24 @@
 package org.broadinstitute.consent.http.service;
 
+import static org.broadinstitute.consent.http.resources.Resource.CHAIRPERSON;
 import com.google.inject.Inject;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Collector;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.broadinstitute.consent.http.db.ConsentDAO;
 import org.broadinstitute.consent.http.db.DatasetDAO;
 import org.broadinstitute.consent.http.db.ElectionDAO;
 import org.broadinstitute.consent.http.db.MatchDAO;
@@ -23,11 +28,19 @@ import org.broadinstitute.consent.http.enumeration.ElectionStatus;
 import org.broadinstitute.consent.http.enumeration.ElectionType;
 import org.broadinstitute.consent.http.enumeration.HeaderSummary;
 import org.broadinstitute.consent.http.enumeration.VoteType;
+import org.broadinstitute.consent.http.models.AccessRP;
+import org.broadinstitute.consent.http.models.Association;
+import org.broadinstitute.consent.http.models.Consent;
 import org.broadinstitute.consent.http.models.DataSet;
 import org.broadinstitute.consent.http.models.Election;
+import org.broadinstitute.consent.http.models.Match;
 import org.broadinstitute.consent.http.models.Summary;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.Vote;
+import org.broadinstitute.consent.http.util.DarConstants;
+import org.broadinstitute.consent.http.util.DarUtil;
+import org.broadinstitute.consent.http.util.DatasetUtil;
+import org.bson.Document;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,22 +49,25 @@ public class SummaryService {
     private final VoteDAO voteDAO;
     private final ElectionDAO electionDAO;
     private final UserDAO userDAO;
+    private final ConsentDAO consentDAO;
     private final DatasetDAO datasetDAO;
     private final MatchDAO matchDAO;
     private final DataAccessRequestService dataAccessRequestService;
     private static final String SEPARATOR = "\t";
     private static final String TEXT_DELIMITER = "\"";
     private static final String END_OF_LINE = System.lineSeparator();
+    private static final String MANUAL_REVIEW = "Manual Review";
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
     @Inject
     public SummaryService(DataAccessRequestService dataAccessRequestService, VoteDAO dao,
-        ElectionDAO electionDAO, UserDAO userDAO, DatasetDAO datasetDAO,
+        ElectionDAO electionDAO, UserDAO userDAO, ConsentDAO consentDAO, DatasetDAO datasetDAO,
         MatchDAO matchDAO) {
         this.dataAccessRequestService = dataAccessRequestService;
         this.voteDAO = dao;
         this.electionDAO = electionDAO;
         this.userDAO = userDAO;
+        this.consentDAO = consentDAO;
         this.datasetDAO = datasetDAO;
         this.matchDAO = matchDAO;
     }
@@ -137,6 +153,204 @@ public class SummaryService {
         return summary;
     }
 
+    public File describeConsentSummaryDetail() {
+        File file = null;
+        try {
+            file = File.createTempFile("summary", ".txt");
+            try (FileWriter summaryWriter = new FileWriter(file)) {
+                List<String> statuses = Stream.of(ElectionStatus.CLOSED.getValue(), ElectionStatus.CANCELED.getValue()).
+                        map(String::toLowerCase).
+                        collect(Collectors.toList());
+                List<Election> reviewedElections = electionDAO.findElectionsWithFinalVoteByTypeAndStatus(ElectionType.TRANSLATE_DUL.getValue(), statuses);
+                if (!CollectionUtils.isEmpty(reviewedElections)) {
+                    List<String> consentIds = reviewedElections.stream().map(Election::getReferenceId).collect(Collectors.toList());
+                    List<Integer> electionIds = reviewedElections.stream().map(Election::getElectionId).collect(Collectors.toList());
+                    Integer maxNumberOfDACMembers = voteDAO.findMaxNumberOfDACMembers(electionIds);
+                    setSummaryHeader(summaryWriter, maxNumberOfDACMembers);
+                    Collection<Consent> consents = consentDAO.findConsentsFromConsentsIDs(consentIds);
+                    List<Vote> votes = voteDAO.findVotesByElectionIds(electionIds);
+                    Collection<Integer> dacUserIds = votes.stream().map(Vote::getDacUserId).collect(Collectors.toSet());
+                    Collection<User> users = userDAO.findUsers(dacUserIds);
+                    for (Election election : reviewedElections) {
+                        Consent electionConsent = consents.stream().filter(c -> c.getConsentId().equals(election.getReferenceId())).collect(singletonCollector());
+                        List<Vote> electionVotes = votes.stream().filter(ev -> ev.getElectionId().equals(election.getElectionId())).collect(Collectors.toList());
+                        List<Integer> electionVotesUserIds = electionVotes.stream().map(Vote::getDacUserId).collect(Collectors.toList());
+                        Collection<User> electionUsers = users.stream().filter(du -> electionVotesUserIds.contains(du.getDacUserId())).collect(Collectors.toSet());
+                        List<Vote> electionDACVotes = electionVotes.stream().filter(ev -> ev.getType().equals("DAC")).collect(Collectors.toList());
+                        Vote chairPersonVote =  electionVotes.stream().filter(ev -> ev.getType().equals(CHAIRPERSON)).collect(singletonCollector());
+                        User chairPerson =  users.stream().filter(du -> du.getDacUserId().equals(chairPersonVote.getDacUserId())).collect(singletonCollector());
+                        summaryWriter.write(delimiterCheck(electionConsent.getName()) + SEPARATOR);
+                        summaryWriter.write(election.getVersion() + SEPARATOR);
+                        summaryWriter.write(election.getStatus() + SEPARATOR);
+                        summaryWriter.write(booleanToString(election.getArchived()) + SEPARATOR);
+                        summaryWriter.write(delimiterCheck(electionConsent.getTranslatedUseRestriction())+ SEPARATOR);
+                        summaryWriter.write(formatLongToDate(electionConsent.getCreateDate().getTime()) + SEPARATOR);
+                        summaryWriter.write( chairPerson.getDisplayName() + SEPARATOR);
+                        summaryWriter.write( booleanToString(chairPersonVote.getVote()) + SEPARATOR);
+                        summaryWriter.write( nullToString(chairPersonVote.getRationale()) + SEPARATOR);
+                        if (CollectionUtils.isNotEmpty(electionDACVotes)) {
+                            for (Vote vote : electionDACVotes) {
+                                List<User> user = electionUsers.stream().filter(du -> du.getDacUserId().equals(vote.getDacUserId())).collect(Collectors.toList());
+                                summaryWriter.write( user.get(0).getDisplayName() + SEPARATOR);
+                                summaryWriter.write( booleanToString(vote.getVote()) + SEPARATOR);
+                                summaryWriter.write( nullToString(vote.getRationale())+ SEPARATOR);
+                            }
+                            for (int i = 0; i < (maxNumberOfDACMembers - electionVotes.size()); i++) {
+                                summaryWriter.write(
+                                        SEPARATOR);
+                            }
+                        }
+                        summaryWriter.write(END_OF_LINE);
+                    }
+                }else file = null;
+                summaryWriter.flush();
+            }
+            return file;
+        } catch (Exception e) {
+            logger.error("There is an error trying to create statistics file, error: "+ e.getMessage());
+        }
+        return file;
+    }
+
+    public File describeDataAccessRequestSummaryDetail() {
+        File file = null;
+        try {
+            file = File.createTempFile("DAR_summary", ".txt");
+            try (FileWriter summaryWriter = new FileWriter(file)) {
+                List<Election> reviewedElections = electionDAO.findElectionsWithFinalVoteByTypeAndStatus(ElectionType.DATA_ACCESS.getValue(), ElectionStatus.CLOSED.getValue());
+                List<Election> reviewedRPElections = electionDAO.findElectionsWithFinalVoteByTypeAndStatus(ElectionType.RP.getValue(), ElectionStatus.CLOSED.getValue());
+                if (!CollectionUtils.isEmpty(reviewedElections)) {
+                    List<String> referenceIds = reviewedElections.stream().map(Election::getReferenceId).collect(Collectors.toList());
+                    List<Document> dataAccessRequests = dataAccessRequestService.getDataAccessRequestsByReferenceIdsAsDocuments(referenceIds);
+                    List<Integer> datasetIds = dataAccessRequests.stream().
+                            map(dar -> DarUtil.getIntegerList(dar, DarConstants.DATASET_ID)).
+                            flatMap(List::stream).
+                            collect(Collectors.toList());
+                    List<Association> associations = datasetDAO.getAssociationsForDataSetIdList(new ArrayList<>(datasetIds));
+                    List<String> associatedConsentIds =   associations.stream().map(Association::getConsentId).collect(Collectors.toList());
+                    List<Election> reviewedConsentElections = electionDAO.findLastElectionsWithFinalVoteByReferenceIdsTypeAndStatus(associatedConsentIds, ElectionStatus.CLOSED.getValue());
+                    List<Integer> darElectionIds = reviewedElections.stream().map(Election::getElectionId).collect(Collectors.toList());
+                    List<Integer> consentElectionIds = reviewedConsentElections.stream().map(Election::getElectionId).collect(Collectors.toList());
+                    List<AccessRP> accessRPList = electionDAO.findAccessRPbyElectionAccessId(darElectionIds);
+                    List<Vote> votes = voteDAO.findVotesByElectionIds(darElectionIds);
+                    List<Integer> rpElectionIds = reviewedRPElections.stream().map(Election::getElectionId).collect(Collectors.toList());
+                    List<Vote> rpVotes;
+                    if (CollectionUtils.isNotEmpty(rpElectionIds)) {
+                        rpVotes = voteDAO.findVotesByElectionIds(rpElectionIds);
+                    } else rpVotes = null;
+                    List<Vote> consentVotes = voteDAO.findVotesByElectionIds(consentElectionIds);
+                    List<Match> matchList = matchDAO.findMatchesPurposeId(referenceIds);
+                    Collection<Integer> dacUserIds = votes.stream().map(Vote::getDacUserId).collect(Collectors.toSet());
+                    Collection<User> users = userDAO.findUsers(dacUserIds);
+                    Integer maxNumberOfDACMembers = voteDAO.findMaxNumberOfDACMembers(darElectionIds);
+                    setSummaryHeaderDataAccessRequest(summaryWriter, maxNumberOfDACMembers);
+                    for (Election election : reviewedElections) {
+
+                        List<Vote> electionVotes = votes.stream().filter(ev -> ev.getElectionId().equals(election.getElectionId())).collect(Collectors.toList());
+                        List<Integer> electionVotesUserIds = electionVotes.stream().filter(v -> v.getType().equalsIgnoreCase(VoteType.DAC.getValue())).map(Vote::getDacUserId).collect(Collectors.toList());
+                        Collection<User> electionUsers = users.stream().filter(du -> electionVotesUserIds.contains(du.getDacUserId())).collect(Collectors.toSet());
+
+                        Vote finalVote =  electionVotes.stream().filter(v -> v.getType().equalsIgnoreCase(VoteType.FINAL.getValue())).collect(singletonCollector());
+                        Vote chairPersonVote =  electionVotes.stream().filter(v -> v.getType().equalsIgnoreCase(VoteType.CHAIRPERSON.getValue())).collect(singletonCollector());
+                        Vote  chairPersonRPVote = null;
+                        Vote agreementVote = null;
+                        if (CollectionUtils.isNotEmpty(reviewedRPElections) && CollectionUtils.isNotEmpty(accessRPList)) {
+                            agreementVote =  electionVotes.stream().filter(v -> v.getType().equalsIgnoreCase(VoteType.AGREEMENT.getValue())).collect(singletonCollector());
+                            AccessRP accessRP =  accessRPList.stream().filter(arp -> arp.getElectionAccessId().equals(election.getElectionId())).collect(singletonCollector());
+                            if (Objects.nonNull(accessRP) && Objects.nonNull(rpVotes)) {
+                                chairPersonRPVote = rpVotes.stream()
+                                    .filter(v -> v.getElectionId().equals(accessRP.getElectionRPId()))
+                                    .filter(v -> v.getType().equalsIgnoreCase(VoteType.CHAIRPERSON.getValue()))
+                                    .collect(singletonCollector());
+                            }
+                        }
+                        User chairPerson =  users.stream().filter(du -> du.getDacUserId().equals(finalVote.getDacUserId())).collect(singletonCollector());
+                        Match match;
+                        try {
+                            match = matchList.stream().filter(m -> m.getPurpose().equals(election.getReferenceId())).collect(singletonCollector());
+                        } catch (IllegalStateException e){
+                            match = null;
+                        }
+                        Document dar = findAssociatedDAR(dataAccessRequests, election.getReferenceId());
+                        if (dar != null && !dar.isEmpty()) {
+                            List<Integer> datasetId =   DarUtil.getIntegerList(dar, DarConstants.DATASET_ID);
+                            if (CollectionUtils.isNotEmpty(datasetId)) {
+                                Association association = associations.stream().filter((as) -> as.getDataSetId().equals(datasetId.get(0))).collect(singletonCollector());
+                                Election consentElection = reviewedConsentElections.stream().filter(re -> re.getReferenceId().equals(association.getConsentId())).collect(singletonCollector());
+                                List<Vote> electionConsentVotes = consentVotes.stream().filter(cv -> cv.getElectionId().equals(consentElection.getElectionId())).collect(Collectors.toList());
+                                Vote chairPersonConsentVote =  electionConsentVotes.stream().filter(v -> v.getType().equalsIgnoreCase(VoteType.CHAIRPERSON.getValue())).collect(singletonCollector());
+                                summaryWriter.write(dar.get(DarConstants.DAR_CODE) + SEPARATOR);
+                                summaryWriter.write(formatLongToDate(election.getCreateDate().getTime()) + SEPARATOR);
+                                summaryWriter.write(chairPerson.getDisplayName() + SEPARATOR);
+                                summaryWriter.write( booleanToString(finalVote.getVote()) + SEPARATOR);
+                                summaryWriter.write( nullToString(finalVote.getRationale()) + SEPARATOR);
+                                if (match != null) {
+                                    summaryWriter.write(booleanToString(match.getMatch()) + SEPARATOR);
+                                } else {
+                                    summaryWriter.write(MANUAL_REVIEW + SEPARATOR);
+                                }
+                                if (agreementVote != null) {
+                                    summaryWriter.write(booleanToString(agreementVote.getVote()) + SEPARATOR);
+                                    summaryWriter.write(nullToString(agreementVote.getRationale()) + SEPARATOR);
+                                } else {
+                                    summaryWriter.write("-" + SEPARATOR);
+                                    summaryWriter.write("-" + SEPARATOR);
+                                }
+                                summaryWriter.write( dar.get(DarConstants.INVESTIGATOR)  + SEPARATOR);
+                                summaryWriter.write( dar.get(DarConstants.PROJECT_TITLE)  + SEPARATOR);
+                                List<Integer> dataSetIds = DarUtil.getIntegerList(dar, DarConstants.DATASET_ID);
+                                List<String> dataSetUUIds = new ArrayList<>();
+                                for (Integer id : dataSetIds) {
+                                    dataSetUUIds.add(DataSet.parseAliasToIdentifier(id));
+                                }
+                                summaryWriter.write( StringUtils.join(dataSetUUIds, ",")  + SEPARATOR);
+                                summaryWriter.write( formatLongToDate(dar.getLong(DarConstants.SORT_DATE))  + SEPARATOR);
+                                for (User user : electionUsers){
+                                    summaryWriter.write( user.getDisplayName() + SEPARATOR);
+                                }
+                                for (int i = 0; i < (maxNumberOfDACMembers - electionUsers.size()); i++) {
+                                    summaryWriter.write(
+                                            SEPARATOR);
+                                }
+                                summaryWriter.write( booleanToString(!dar.containsKey(DarConstants.RESTRICTION))+ SEPARATOR);
+
+                                if (Objects.nonNull(chairPersonVote)) {
+                                    summaryWriter.write(booleanToString(chairPersonVote.getVote()) + SEPARATOR);
+                                    summaryWriter.write(nullToString(chairPersonVote.getRationale()) + SEPARATOR);
+                                } else {
+                                    summaryWriter.write(nullToString(null) + SEPARATOR);
+                                    summaryWriter.write(nullToString(null) + SEPARATOR);
+                                }
+
+                                if (Objects.nonNull(chairPersonRPVote)) {
+                                    summaryWriter.write(booleanToString(chairPersonRPVote.getVote()) + SEPARATOR);
+                                    summaryWriter.write(nullToString(chairPersonRPVote.getRationale()) + SEPARATOR);
+                                } else {
+                                    summaryWriter.write(nullToString(null) + SEPARATOR);
+                                    summaryWriter.write(nullToString(null) + SEPARATOR);
+                                }
+
+                                if (Objects.nonNull(chairPersonConsentVote)) {
+                                    summaryWriter.write(booleanToString(chairPersonConsentVote.getVote()) + SEPARATOR);
+                                    summaryWriter.write(nullToString(chairPersonConsentVote.getRationale()) + SEPARATOR);
+                                } else {
+                                    summaryWriter.write(nullToString(null) + SEPARATOR);
+                                    summaryWriter.write(nullToString(null) + SEPARATOR);
+                                }
+                            }
+                        }
+                        summaryWriter.write(END_OF_LINE);
+                    }
+                }else file = null;
+                summaryWriter.flush();
+            }
+            return file;
+        } catch (Exception e) {
+            logger.error(e.getMessage());
+        }
+        return file;
+    }
+
     public File describeDataSetElectionsVotesForDar(String referenceId) {
         File file = null;
         try {
@@ -214,6 +428,29 @@ public class SummaryService {
         }
     }
 
+    private void setSummaryHeader(FileWriter summaryWriter , Integer maxNumberOfDACMembers) throws IOException {
+        summaryWriter.write(
+                HeaderSummary.CONSENT.getValue() + SEPARATOR +
+                        HeaderSummary.VERSION.getValue() + SEPARATOR +
+                        HeaderSummary.STATUS.getValue() + SEPARATOR +
+                        HeaderSummary.ARCHIVED.getValue() + SEPARATOR +
+                        HeaderSummary.STRUCT_LIMITATIONS.getValue() + SEPARATOR +
+                        HeaderSummary.DATE.getValue() + SEPARATOR +
+                        HeaderSummary.CHAIRPERSON.getValue() + SEPARATOR +
+                        HeaderSummary.FINAL_DECISION.getValue() + SEPARATOR +
+                        HeaderSummary.FINAL_DECISION_RATIONALE.getValue() + SEPARATOR);
+        for (int i = 1; i < maxNumberOfDACMembers; i++) {
+            summaryWriter.write(
+                    HeaderSummary.USER.getValue() + SEPARATOR +
+                    HeaderSummary.VOTE.getValue() + SEPARATOR +
+                    HeaderSummary.RATIONALE.getValue() + SEPARATOR);
+        }
+        summaryWriter.write(
+                HeaderSummary.USER.getValue() + SEPARATOR +
+                HeaderSummary.VOTE.getValue() + SEPARATOR +
+                HeaderSummary.RATIONALE.getValue()+ END_OF_LINE);
+    }
+
     private void setDatasetElectionsHeader(FileWriter summaryWriter , Integer maxNumberOfVotes) throws IOException {
         summaryWriter.write(
                 HeaderSummary.DATA_REQUEST_ID.getValue() + SEPARATOR +
@@ -231,6 +468,34 @@ public class SummaryService {
         summaryWriter.write(END_OF_LINE);
     }
 
+    private void setSummaryHeaderDataAccessRequest(FileWriter summaryWriter , Integer maxNumberOfDACMembers) throws IOException {
+        summaryWriter.write(
+                HeaderSummary.DATA_REQUEST_ID.getValue() + SEPARATOR +
+                        HeaderSummary.DATE.getValue() + SEPARATOR +
+                        HeaderSummary.CHAIRPERSON.getValue() + SEPARATOR +
+                        HeaderSummary.FINAL_DECISION.getValue() + SEPARATOR +
+                        HeaderSummary.FINAL_DECISION_RATIONALE.getValue() + SEPARATOR +
+                        HeaderSummary.VAULT_DECISION.getValue() + SEPARATOR +
+                        HeaderSummary.VAULT_VS_DAC_AGREEMENT.getValue() + SEPARATOR +
+                        HeaderSummary.CHAIRPERSON_FEEDBACK.getValue() + SEPARATOR +
+                        HeaderSummary.RESEARCHER.getValue() + SEPARATOR +
+                        HeaderSummary.PROJECT_TITLE.getValue() + SEPARATOR +
+                        HeaderSummary.DATASET_ID.getValue() + SEPARATOR +
+                        HeaderSummary.DATA_ACCESS_SUBM_DATE.getValue() + SEPARATOR);
+        for (int i = 1; i <= maxNumberOfDACMembers; i++) {
+            summaryWriter.write(
+                    HeaderSummary.DAC_MEMBERS.getValue() + SEPARATOR);
+        }
+        summaryWriter.write(
+                HeaderSummary.REQUIRE_MANUAL_REVIEW.getValue() + SEPARATOR +
+                        HeaderSummary.FINAL_DECISION_DAR.getValue() + SEPARATOR +
+                        HeaderSummary.FINAL_RATIONALE_DAR.getValue() + SEPARATOR +
+                        HeaderSummary.FINAL_DECISION_RP.getValue() + SEPARATOR +
+                        HeaderSummary.FINAL_RATIONALE_RP.getValue() + SEPARATOR +
+                        HeaderSummary.FINAL_DECISION_DUL.getValue() + SEPARATOR +
+                        HeaderSummary.FINAL_RATIONALE_DUL.getValue() + END_OF_LINE);
+    }
+
     public static <T> Collector<T, ?, T> singletonCollector() {
         return Collectors.collectingAndThen(
                 Collectors.toList(),
@@ -245,6 +510,25 @@ public class SummaryService {
                 }
         );
     }
+
+    private Document findAssociatedDAR(List<Document> dataAccessRequests, String referenceId) {
+        Optional<Document> documentOption = dataAccessRequests.stream().
+                filter(d -> d.getString(DarConstants.REFERENCE_ID).equalsIgnoreCase(referenceId)).
+                findFirst();
+        return documentOption.orElse(null);
+    }
+
+    private String booleanToString(Boolean b) {
+        if(b != null) {
+            return b ? "YES" : "NO";
+        }
+        return "-";
+    }
+
+    private String nullToString(String b) {
+        return b != null && !b.isEmpty()  ? b : "-";
+    }
+
 
     public String formatLongToDate(long time) {
         Calendar cal = Calendar.getInstance();

--- a/src/main/java/org/broadinstitute/consent/http/util/DarConstants.java
+++ b/src/main/java/org/broadinstitute/consent/http/util/DarConstants.java
@@ -23,6 +23,8 @@ public class DarConstants {
 
     public static final String REFERENCE_ID = "referenceId";
 
+    public static final String RESTRICTION = "restriction";
+
     public static final String TRANSLATED_RESTRICTION = "translatedUseRestriction";
 
     public static final String STATUS = "status";

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -396,6 +396,26 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Summary'
+  /api/consent/cases/summary/file:
+      get:
+        summary: Get Consent Summary Detail File
+        description: Returns a file with the detail of the reviewed cases whose type will be specified by fileType param.
+        parameters:
+         - name: fileType
+           in: query
+           description: DataAccess / TranslateDUL , defines the type of the reviewed cases info required.
+           required: true
+           schema:
+             type: string
+        tags:
+          - Summary File
+        responses:
+          200:
+            description: Export data to a txt file.
+            content:
+              text/plain:
+                schema:
+                  type: string
   /api/consent/cases/closed:
     get:
       summary: Describe Closed Elections

--- a/src/test/java/org/broadinstitute/consent/http/db/VoteDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/VoteDAOTest.java
@@ -428,6 +428,31 @@ public class VoteDAOTest extends DAOTestHelper {
     }
 
     @Test
+    public void testFindMaxNumberOfDACMembers() {
+        User user = createUser();
+        DataSet dataset = createDataset();
+        Dac dac = createDac();
+        Consent consent = createConsent(dac.getDacId());
+        Election election = createAccessElection(consent.getConsentId(), dataset.getDataSetId());
+        closeElection(election);
+        Vote v = createDacVote(user.getDacUserId(), election.getElectionId());
+        boolean voteValue = true;
+        voteDAO.updateVote(
+                voteValue,
+                RandomStringUtils.random(10),
+                new Date(),
+                v.getVoteId(),
+                false,
+                election.getElectionId(),
+                v.getCreateDate(),
+                false
+        );
+
+        int count = voteDAO.findMaxNumberOfDACMembers(Collections.singletonList(election.getElectionId()));
+        assertEquals(1, count);
+    }
+
+    @Test
     public void testInsertVotes() {
         User user1 = createUserWithRole(UserRoles.CHAIRPERSON.getRoleId());
         User user2 = createUserWithRole(UserRoles.MEMBER.getRoleId());

--- a/src/test/java/org/broadinstitute/consent/http/resources/ConsentCasesResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/ConsentCasesResourceTest.java
@@ -4,10 +4,12 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.notNull;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
-
+import java.io.File;
 import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
 import javax.ws.rs.core.Response;
+import org.broadinstitute.consent.http.enumeration.ElectionType;
 import org.broadinstitute.consent.http.models.Summary;
 import org.broadinstitute.consent.http.service.ElectionService;
 import org.broadinstitute.consent.http.service.PendingCaseService;
@@ -56,7 +58,36 @@ public class ConsentCasesResourceTest {
         Assert.assertNotNull(summary);
     }
 
+    @Test
+    public void testGetConsentSummaryDetailFileInvalid() {
+        initResource();
+        Response response = resource.getConsentSummaryDetailFile(UUID.randomUUID().toString(), null);
+        Assert.assertEquals(200, response.getStatus());
+        Object summaryFile = response.getEntity();
+        Assert.assertNull(summaryFile);
+    }
 
+    @Test
+    public void testGetConsentSummaryDetailFileDUL() throws Exception {
+        File file = File.createTempFile("temp", ".txt");
+        when(summaryService.describeConsentSummaryDetail()).thenReturn(file);
+        initResource();
+        Response response = resource.getConsentSummaryDetailFile(ElectionType.TRANSLATE_DUL.getValue(), null);
+        Assert.assertEquals(200, response.getStatus());
+        Object summaryFile = response.getEntity();
+        Assert.assertNotNull(summaryFile);
+    }
+
+    @Test
+    public void testGetConsentSummaryDetailFileDataAccess() throws Exception {
+        File file = File.createTempFile("temp", ".txt");
+        when(summaryService.describeDataAccessRequestSummaryDetail()).thenReturn(file);
+        initResource();
+        Response response = resource.getConsentSummaryDetailFile(ElectionType.DATA_ACCESS.getValue(), null);
+        Assert.assertEquals(200, response.getStatus());
+        Object summaryFile = response.getEntity();
+        Assert.assertNotNull(summaryFile);
+    }
     @Test
     public void testDescribeClosedElections() {
         when(electionService.describeClosedElectionsByType(anyString(), notNull())).thenReturn(Collections.emptyList());

--- a/src/test/java/org/broadinstitute/consent/http/service/SummaryServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/SummaryServiceTest.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Objects;
 import org.apache.commons.collections.ListUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.broadinstitute.consent.http.db.ConsentDAO;
 import org.broadinstitute.consent.http.db.DatasetDAO;
 import org.broadinstitute.consent.http.db.ElectionDAO;
 import org.broadinstitute.consent.http.db.MatchDAO;
@@ -40,6 +41,8 @@ public class SummaryServiceTest {
     @Mock
     private UserDAO userDAO;
     @Mock
+    private ConsentDAO consentDAO;
+    @Mock
     private DatasetDAO dataSetDAO;
     @Mock
     private MatchDAO matchDAO;
@@ -51,7 +54,7 @@ public class SummaryServiceTest {
     @Before
     public void setUp() throws Exception {
         MockitoAnnotations.initMocks(this);
-        summaryService = Mockito.spy(new SummaryService(dataAccessRequestService, voteDAO, electionDAO, userDAO, dataSetDAO, matchDAO));
+        summaryService = Mockito.spy(new SummaryService(dataAccessRequestService, voteDAO, electionDAO, userDAO, consentDAO, dataSetDAO, matchDAO));
     }
 
     // In this tests we won't validate the resulting file, we will just validate the methods being called for each response given by the mocks is accurate.


### PR DESCRIPTION
ADDDRESES: 
https://broadworkbench.atlassian.net/browse/DUOS-1229 

SCOPE:
- ConsentCasesResource.getConsentSummaryDetailFile was deleted in another PR. This PR adds that deleted code back, that includes all of the helper methods, constants, and tests associated.
- Add back getConsentSummaryDetailFile in ConsentCasesResource which calls two summaryService methods, and its tests
- Add back describeConsentSummaryDetail() and describeDataAccessRequestSummaryDetail() in SummaryService, and its helper methods and its tests. This method calls several DAO methods listed below.
- Add back getAssociationsForDataSetIdList in DatasetDAO
- Add back findLastElectionsWithFinalVoteByReferenceIdsTypeAndStatus, verifyOpenElectionsForReferenceId, findAccessRPbyElectionAccessId in ElectionDAO
- Add back findMatchesPurposeId in MatchDAO
- Add back findMaxNumberOfDACMembers in VoteDAO, and its test
- Add ConsentCasesResource.getConsentSummaryDetailFile to api-docs


Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [ ] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
