### PR TITLE
DUOS-1085[risk=no]Update consent/ontology ES health to report healthy on yellow status

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/service/ontology/ElasticSearchHealthCheck.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ontology/ElasticSearchHealthCheck.java
@@ -57,7 +57,7 @@ public class ElasticSearchHealthCheck extends HealthCheck implements Managed {
                 return Result.unhealthy("ClusterHealth is RED\n" + jsonResponse.toString());
             }
             if (status.equalsIgnoreCase("yellow")) {
-                return Result.unhealthy("ClusterHealth is YELLOW\n" + jsonResponse.toString());
+                return Result.healthy("ClusterHealth is YELLOW\n" + jsonResponse.toString());
             }
         } catch (IOException e) {
             logger.error(e.getMessage());


### PR DESCRIPTION
SCOPE:
- Change status to be healthy instead of unhealthy when clusterhealth is yellow
- https://broadworkbench.atlassian.net/browse/DUOS-1085

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [ ] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
