### PR TITLE
DUOS-1262/DUOS-1261[risk=no]API: Validate Library Card before updating Vote

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
@@ -277,6 +277,7 @@ public class ConsentModule extends AbstractModule {
                 providesVoteDAO(),
                 providesUserDAO(),
                 providesDataSetDAO(),
+                providesLibraryCardDAO(),
                 providesDatasetAssociationDAO(),
                 providesMailMessageDAO(),
                 providesDacService(),

--- a/src/main/java/org/broadinstitute/consent/http/resources/DataRequestVoteResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataRequestVoteResource.java
@@ -102,8 +102,8 @@ public class DataRequestVoteResource extends Resource {
         String json) {
         try {
             Vote voteRecord = new Gson().fromJson(json, Vote.class);
+            electionService.submitFinalAccessVoteDataRequestElection(voteRecord.getElectionId(), referenceId);
             Vote updatedVote = voteService.updateVoteById(voteRecord, id);
-            electionService.submitFinalAccessVoteDataRequestElection(updatedVote.getElectionId());
             DataAccessRequest dar = dataAccessRequestService.findByReferenceId(referenceId);
             createDataOwnerElection(updatedVote, dar);
             return Response.ok(updatedVote).build();

--- a/src/main/java/org/broadinstitute/consent/http/resources/DataRequestVoteResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataRequestVoteResource.java
@@ -102,7 +102,7 @@ public class DataRequestVoteResource extends Resource {
         String json) {
         try {
             Vote voteRecord = new Gson().fromJson(json, Vote.class);
-            electionService.submitFinalAccessVoteDataRequestElection(voteRecord.getElectionId(), referenceId);
+            electionService.submitFinalAccessVoteDataRequestElection(voteRecord.getElectionId());
             Vote updatedVote = voteService.updateVoteById(voteRecord, id);
             DataAccessRequest dar = dataAccessRequestService.findByReferenceId(referenceId);
             createDataOwnerElection(updatedVote, dar);

--- a/src/main/java/org/broadinstitute/consent/http/service/ElectionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ElectionService.java
@@ -199,7 +199,7 @@ public class ElectionService {
             throw new NotFoundException("Data Access Request for specified id does not exist");
         } 
         Integer userId = dar.getUserId();
-        List<LibraryCard> libraryCards = Objects.nonNull(userId) ? libraryCardDAO.findLibraryCardsByUserId(userId) : new ArrayList<>();
+        List<LibraryCard> libraryCards = Objects.nonNull(userId) ? libraryCardDAO.findLibraryCardsByUserId(userId) : Collections.emptyList();
         if (libraryCards.isEmpty()) {
             throw new NotFoundException("No Library cards exist for the researcher on this DAR");
         }

--- a/src/main/java/org/broadinstitute/consent/http/service/ElectionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ElectionService.java
@@ -194,7 +194,7 @@ public class ElectionService {
             throw new NotFoundException("Election for specified id does not exist");
         }
         String darId = election.getReferenceId();
-        DataAccessRequest dar = dataAccessRequestService.findByReferenceId(darId);
+        DataAccessRequest dar = Objects.nonNull(darId) ? dataAccessRequestService.findByReferenceId(darId) : null;
         if (dar == null) {
             throw new NotFoundException("Data Access Request for specified id does not exist");
         } 

--- a/src/main/java/org/broadinstitute/consent/http/service/ElectionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ElectionService.java
@@ -8,6 +8,7 @@ import org.broadinstitute.consent.http.db.ConsentDAO;
 import org.broadinstitute.consent.http.db.DatasetDAO;
 import org.broadinstitute.consent.http.db.DatasetAssociationDAO;
 import org.broadinstitute.consent.http.db.ElectionDAO;
+import org.broadinstitute.consent.http.db.LibraryCardDAO;
 import org.broadinstitute.consent.http.db.MailMessageDAO;
 import org.broadinstitute.consent.http.db.UserDAO;
 import org.broadinstitute.consent.http.db.VoteDAO;
@@ -24,6 +25,7 @@ import org.broadinstitute.consent.http.models.DataSet;
 import org.broadinstitute.consent.http.models.DatasetAssociation;
 import org.broadinstitute.consent.http.models.DatasetDetailEntry;
 import org.broadinstitute.consent.http.models.Election;
+import org.broadinstitute.consent.http.models.LibraryCard;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.UserRole;
 import org.broadinstitute.consent.http.models.Vote;
@@ -58,6 +60,7 @@ public class ElectionService {
     private final VoteDAO voteDAO;
     private final UserDAO userDAO;
     private final DatasetDAO dataSetDAO;
+    private final LibraryCardDAO libraryCardDAO;
     private final DatasetAssociationDAO datasetAssociationDAO;
     private DacService dacService;
     private DataAccessRequestService dataAccessRequestService;
@@ -67,7 +70,7 @@ public class ElectionService {
 
     @Inject
     public ElectionService(ConsentDAO consentDAO, ElectionDAO electionDAO, VoteDAO voteDAO, UserDAO userDAO,
-                           DatasetDAO dataSetDAO, DatasetAssociationDAO datasetAssociationDAO, MailMessageDAO mailMessageDAO,
+                           DatasetDAO dataSetDAO, LibraryCardDAO libraryCardDAO, DatasetAssociationDAO datasetAssociationDAO, MailMessageDAO mailMessageDAO,
                            DacService dacService, EmailNotifierService emailNotifierService,
                            DataAccessRequestService dataAccessRequestService) {
         this.consentDAO = consentDAO;
@@ -75,6 +78,7 @@ public class ElectionService {
         this.voteDAO = voteDAO;
         this.userDAO = userDAO;
         this.dataSetDAO = dataSetDAO;
+        this.libraryCardDAO = libraryCardDAO;
         this.datasetAssociationDAO = datasetAssociationDAO;
         this.mailMessageDAO = mailMessageDAO;
         this.emailNotifierService = emailNotifierService;
@@ -184,10 +188,19 @@ public class ElectionService {
         return electionDAO.findElectionWithFinalVoteById(electionId);
     }
 
-    public Election submitFinalAccessVoteDataRequestElection(Integer electionId) throws Exception {
+    public Election submitFinalAccessVoteDataRequestElection(Integer electionId, String darId) throws Exception {
         Election election = electionDAO.findElectionWithFinalVoteById(electionId);
         if (election == null) {
             throw new NotFoundException("Election for specified id does not exist");
+        }
+        DataAccessRequest dar = dataAccessRequestService.findByReferenceId(darId);
+        if (dar == null) {
+            throw new NotFoundException("Data Access Request for specified id does not exist");
+        } 
+        Integer userId = dar.getUserId();
+        List<LibraryCard> libraryCards = Objects.nonNull(userId) ? libraryCardDAO.findLibraryCardsByUserId(userId) : new ArrayList<>();
+        if (libraryCards.isEmpty()) {
+            throw new NotFoundException("No Library cards exist for the researcher on this dar");
         }
         List<Vote> finalVotes = voteDAO.findFinalVotesByElectionId(electionId);
         // The first final vote to be submitted is what determines the approval/denial of the election

--- a/src/main/java/org/broadinstitute/consent/http/service/ElectionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ElectionService.java
@@ -188,11 +188,12 @@ public class ElectionService {
         return electionDAO.findElectionWithFinalVoteById(electionId);
     }
 
-    public Election submitFinalAccessVoteDataRequestElection(Integer electionId, String darId) throws Exception {
+    public Election submitFinalAccessVoteDataRequestElection(Integer electionId) throws Exception {
         Election election = electionDAO.findElectionWithFinalVoteById(electionId);
         if (election == null) {
             throw new NotFoundException("Election for specified id does not exist");
         }
+        String darId = election.getReferenceId();
         DataAccessRequest dar = dataAccessRequestService.findByReferenceId(darId);
         if (dar == null) {
             throw new NotFoundException("Data Access Request for specified id does not exist");
@@ -200,7 +201,7 @@ public class ElectionService {
         Integer userId = dar.getUserId();
         List<LibraryCard> libraryCards = Objects.nonNull(userId) ? libraryCardDAO.findLibraryCardsByUserId(userId) : new ArrayList<>();
         if (libraryCards.isEmpty()) {
-            throw new NotFoundException("No Library cards exist for the researcher on this dar");
+            throw new NotFoundException("No Library cards exist for the researcher on this DAR");
         }
         List<Vote> finalVotes = voteDAO.findFinalVotesByElectionId(electionId);
         // The first final vote to be submitted is what determines the approval/denial of the election

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -2270,6 +2270,8 @@ paths:
           description: Required parameter is null
         404:
           description: Election for specified id does not exist
+          description: Data Access Request for specified id does not exist
+          description: No Library cards exist for the researcher on this DAR
   /api/dataRequest/{requestId}/vote/final:
     get:
       summary: describeFinalAccessVote

--- a/src/test/java/org/broadinstitute/consent/http/service/ElectionServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/ElectionServiceTest.java
@@ -8,6 +8,7 @@ import org.broadinstitute.consent.http.db.DataAccessRequestDAO;
 import org.broadinstitute.consent.http.db.DatasetDAO;
 import org.broadinstitute.consent.http.db.DatasetAssociationDAO;
 import org.broadinstitute.consent.http.db.ElectionDAO;
+import org.broadinstitute.consent.http.db.LibraryCardDAO;
 import org.broadinstitute.consent.http.db.MailMessageDAO;
 import org.broadinstitute.consent.http.db.UserDAO;
 import org.broadinstitute.consent.http.db.VoteDAO;
@@ -31,6 +32,7 @@ import org.broadinstitute.consent.http.models.DataSet;
 import org.broadinstitute.consent.http.models.DatasetDetailEntry;
 import org.broadinstitute.consent.http.models.DatasetEntry;
 import org.broadinstitute.consent.http.models.Election;
+import org.broadinstitute.consent.http.models.LibraryCard;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.UserRole;
 import org.broadinstitute.consent.http.models.Vote;
@@ -70,6 +72,8 @@ public class ElectionServiceTest {
     @Mock
     private DatasetDAO dataSetDAO;
     @Mock
+    private LibraryCardDAO libraryCardDAO;
+    @Mock
     private DatasetAssociationDAO datasetAssociationDAO;
     @Mock
     private DacService dacService;
@@ -97,6 +101,7 @@ public class ElectionServiceTest {
     private static Vote sampleVoteChairperson;
     private static Vote sampleVoteMember;
     private static Vote sampleVoteRP;
+    private static LibraryCard sampleLibraryCard;
 
     @BeforeClass
     public static void setUpClass() {
@@ -106,6 +111,8 @@ public class ElectionServiceTest {
                 new Not(new Named("http://www.broadinstitute.org/ontologies/DUOS/control"))
         );
         String referenceId = "CONS-1";
+
+        sampleLibraryCard = new LibraryCard();
 
         sampleDataset1 = new DataSet();
         sampleDataset1.setDataSetId(1);
@@ -246,6 +253,7 @@ public class ElectionServiceTest {
         when(userDAO.findUsersForElectionsByRoles(Arrays.asList(sampleVoteChairperson.getElectionId()),
                 Arrays.asList(UserRoles.CHAIRPERSON.getRoleName(), UserRoles.MEMBER.getRoleName())))
                 .thenReturn(Set.of(sampleUserChairperson, sampleUserMember));
+        when(libraryCardDAO.findLibraryCardsByUserId(any())).thenReturn(List.of(sampleLibraryCard));
     }
 
     private void electionStubs() {
@@ -289,7 +297,7 @@ public class ElectionServiceTest {
     }
 
     private void initService() {
-        service = new ElectionService(consentDAO, electionDAO, voteDAO, userDAO, dataSetDAO, datasetAssociationDAO, mailMessageDAO, dacService, emailNotifierService, dataAccessRequestService);
+        service = new ElectionService(consentDAO, electionDAO, voteDAO, userDAO, dataSetDAO, libraryCardDAO, datasetAssociationDAO, mailMessageDAO, dacService, emailNotifierService, dataAccessRequestService);
     }
 
     @Test
@@ -334,7 +342,7 @@ public class ElectionServiceTest {
     @Test
     public void testSubmitFinalAccessVoteDataRequestElection() throws Exception {
         initService();
-        Election election = service.submitFinalAccessVoteDataRequestElection(sampleElection1.getElectionId());
+        Election election = service.submitFinalAccessVoteDataRequestElection(sampleElection1.getElectionId(), sampleDataAccessRequest1.getReferenceId());
         assertNotNull(election);
         assertEquals(sampleElection1.getElectionId(), election.getElectionId());
     }

--- a/src/test/java/org/broadinstitute/consent/http/service/ElectionServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/ElectionServiceTest.java
@@ -343,7 +343,7 @@ public class ElectionServiceTest {
     public void testSubmitFinalAccessVoteDataRequestElection() throws Exception {
         initService();
         when(libraryCardDAO.findLibraryCardsByUserId(any())).thenReturn(List.of(sampleLibraryCard));
-        Election election = service.submitFinalAccessVoteDataRequestElection(sampleElection1.getElectionId(), sampleDataAccessRequest1.getReferenceId());
+        Election election = service.submitFinalAccessVoteDataRequestElection(sampleElection1.getElectionId());
         assertNotNull(election);
         assertEquals(sampleElection1.getElectionId(), election.getElectionId());
     }
@@ -352,7 +352,7 @@ public class ElectionServiceTest {
     public void testSubmitFinalAccessVoteDataRequestElection_noLibraryCard() throws Exception {
         initService();
         when(libraryCardDAO.findLibraryCardsByUserId(any())).thenReturn(List.of());
-        service.submitFinalAccessVoteDataRequestElection(sampleElection1.getElectionId(), sampleDataAccessRequest1.getReferenceId());
+        service.submitFinalAccessVoteDataRequestElection(sampleElection1.getElectionId());
     }
 
     @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/ElectionServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/ElectionServiceTest.java
@@ -254,7 +254,6 @@ public class ElectionServiceTest {
         when(userDAO.findUsersForElectionsByRoles(Arrays.asList(sampleVoteChairperson.getElectionId()),
                 Arrays.asList(UserRoles.CHAIRPERSON.getRoleName(), UserRoles.MEMBER.getRoleName())))
                 .thenReturn(Set.of(sampleUserChairperson, sampleUserMember));
-                when(libraryCardDAO.findLibraryCardsByUserId(any())).thenReturn(List.of(sampleLibraryCard));
     }
 
     private void electionStubs() {

--- a/src/test/java/org/broadinstitute/consent/http/service/ElectionServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/ElectionServiceTest.java
@@ -149,6 +149,7 @@ public class ElectionServiceTest {
         sampleConsent1.setConsentId(sampleDataset1.getConsentName());
 
         sampleDataAccessRequest1 = new DataAccessRequest();
+        sampleDataAccessRequest1.setUserId(2);
         DataAccessRequestData data = new DataAccessRequestData();
         data.setReferenceId(sampleElection1.getReferenceId());
         data.setDatasetIds(Arrays.asList(sampleDataset1.getDataSetId()));
@@ -253,7 +254,7 @@ public class ElectionServiceTest {
         when(userDAO.findUsersForElectionsByRoles(Arrays.asList(sampleVoteChairperson.getElectionId()),
                 Arrays.asList(UserRoles.CHAIRPERSON.getRoleName(), UserRoles.MEMBER.getRoleName())))
                 .thenReturn(Set.of(sampleUserChairperson, sampleUserMember));
-        when(libraryCardDAO.findLibraryCardsByUserId(any())).thenReturn(List.of(sampleLibraryCard));
+                when(libraryCardDAO.findLibraryCardsByUserId(any())).thenReturn(List.of(sampleLibraryCard));
     }
 
     private void electionStubs() {
@@ -342,9 +343,17 @@ public class ElectionServiceTest {
     @Test
     public void testSubmitFinalAccessVoteDataRequestElection() throws Exception {
         initService();
+        when(libraryCardDAO.findLibraryCardsByUserId(any())).thenReturn(List.of(sampleLibraryCard));
         Election election = service.submitFinalAccessVoteDataRequestElection(sampleElection1.getElectionId(), sampleDataAccessRequest1.getReferenceId());
         assertNotNull(election);
         assertEquals(sampleElection1.getElectionId(), election.getElectionId());
+    }
+
+    @Test(expected = NotFoundException.class)
+    public void testSubmitFinalAccessVoteDataRequestElection_noLibraryCard() throws Exception {
+        initService();
+        when(libraryCardDAO.findLibraryCardsByUserId(any())).thenReturn(List.of());
+        service.submitFinalAccessVoteDataRequestElection(sampleElection1.getElectionId(), sampleDataAccessRequest1.getReferenceId());
     }
 
     @Test


### PR DESCRIPTION
SCOPE:
In resource class, pass additional reference id param to service class.
In service class, retrieve the dar using the reference id, get the user id on dar, retrieve all Library cards for that user, if the list of library cards is empty then throw a not found exception.
In test class, mock the libraryCardDAO.findLibraryCardByUserId call for the submitFinalAccessVote test, and add a test for submitFinalAccessVote when the researcher does not have a library card.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [ ] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
