### PR TITLE
DUOS-1064[risk=medium] Implemented Library Card Resource

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/resources/LibraryCardResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/LibraryCardResource.java
@@ -4,7 +4,6 @@ import com.google.gson.Gson;
 import com.google.inject.Inject;
 import io.dropwizard.auth.Auth;
 import java.util.List;
-import javax.annotation.security.PermitAll;
 import javax.annotation.security.RolesAllowed;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
@@ -18,7 +17,7 @@ import javax.ws.rs.core.Response;
 import org.broadinstitute.consent.http.models.AuthUser;
 import org.broadinstitute.consent.http.models.LibraryCard;
 import org.broadinstitute.consent.http.models.User;
-// import org.broadinstitute.consent.http.service.LibraryCardService;
+import org.broadinstitute.consent.http.service.LibraryCardService;
 import org.broadinstitute.consent.http.service.UserService;
 
 @Path("api/libraryCards")
@@ -40,8 +39,7 @@ public class LibraryCardResource extends Resource{
   @RolesAllowed(ADMIN)
   public Response getLibraryCards(@Auth AuthUser authUser) {
     try{
-      User user = userService.findUserByEmail(authUser.getName()); //NOTE: may not need this? Check tech doc to make sure
-      List<LibraryCard> libraryCards = libraryCardService.getLibraryCards();
+      List<LibraryCard> libraryCards = libraryCardService.findAllLibraryCards();
       return Response.ok().entity(libraryCards).build();
     } catch(Exception e) {
       return createExceptionResponse(e);
@@ -54,8 +52,7 @@ public class LibraryCardResource extends Resource{
   @RolesAllowed(ADMIN)
   public Response getLibraryCardById(@Auth AuthUser authUser, @PathParam("id") Integer id) {
     try {
-      User user = userService.findUserByEmail(authUser.getName());
-      LibraryCard libraryCard = libraryCardService.getLibraryCardById(id);
+      LibraryCard libraryCard = libraryCardService.findLibraryCardById(id);
       return Response.ok().entity(libraryCard).build();
     } catch(Exception e) {
       return createExceptionResponse(e);
@@ -68,11 +65,10 @@ public class LibraryCardResource extends Resource{
   @RolesAllowed(ADMIN)
   public Response getLibraryCardsByInstitutionId(@Auth AuthUser authUser, @PathParam("id") Integer id) {
     try{
-      User user = userService.findUserByEmail(authUser.getName());
-      List<LibraryCard> libraryCards = libraryCardService.getLibraryCardsByInstitutionId(id);
+      List<LibraryCard> libraryCards = libraryCardService.findLibraryCardsByInstitutionId(id);
       return Response.ok().entity(libraryCards).build();
     } catch(Exception e) {
-      createExceptionResponse(e);
+      return createExceptionResponse(e);
     }
   }
 
@@ -84,7 +80,7 @@ public class LibraryCardResource extends Resource{
     try{
       User user = userService.findUserByEmail(authUser.getName());
       LibraryCard payload = new Gson().fromJson(libraryCard, LibraryCard.class);
-      LibraryCard newLibraryCard = libraryCardService.createLibraryCard(payload, user);
+      LibraryCard newLibraryCard = libraryCardService.createLibraryCard(payload, user.getDacUserId());
       return Response.ok().entity(newLibraryCard).build();
     } catch(Exception e) {
       return createExceptionResponse(e);
@@ -100,7 +96,7 @@ public class LibraryCardResource extends Resource{
     try {
       User user = userService.findUserByEmail(authUser.getName());
       LibraryCard payload = new Gson().fromJson(libraryCard, LibraryCard.class);
-      LibraryCard updatedLibraryCard = libraryCardService.updateLibraryCard(id, payload);
+      LibraryCard updatedLibraryCard = libraryCardService.updateLibraryCard(payload, id, user.getDacUserId());
       return Response.ok().entity(updatedLibraryCard).build();
     } catch(Exception e) {
       return createExceptionResponse(e);
@@ -113,7 +109,7 @@ public class LibraryCardResource extends Resource{
   @RolesAllowed(ADMIN)
   public Response deleteLibraryCard(@Auth AuthUser authUser, @PathParam("id") Integer id) {
     try {
-      libraryCardService.deleteLibraryCard(id);
+      libraryCardService.deleteLibraryCardById(id);
       return Response.status(204).build();
     } catch(Exception e) {
       return createExceptionResponse(e);

--- a/src/main/java/org/broadinstitute/consent/http/resources/LibraryCardResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/LibraryCardResource.java
@@ -1,0 +1,122 @@
+package org.broadinstitute.consent.http.resources;
+
+import com.google.gson.Gson;
+import com.google.inject.Inject;
+import io.dropwizard.auth.Auth;
+import java.util.List;
+import javax.annotation.security.PermitAll;
+import javax.annotation.security.RolesAllowed;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Response;
+import org.broadinstitute.consent.http.models.AuthUser;
+import org.broadinstitute.consent.http.models.LibraryCard;
+import org.broadinstitute.consent.http.models.User;
+// import org.broadinstitute.consent.http.service.LibraryCardService;
+import org.broadinstitute.consent.http.service.UserService;
+
+@Path("api/libraryCards")
+public class LibraryCardResource extends Resource{
+  private final UserService userService;
+  private final LibraryCardService libraryCardService;
+
+  @Inject
+  public LibraryCardResource(
+    UserService userService,
+    LibraryCardService libraryCardService
+  ) {
+    this.userService = userService;
+    this.libraryCardService = libraryCardService;
+  }
+
+  @GET
+  @Produces("application/json")
+  @RolesAllowed(ADMIN)
+  public Response getLibraryCards(@Auth AuthUser authUser) {
+    try{
+      User user = userService.findUserByEmail(authUser.getName()); //NOTE: may not need this? Check tech doc to make sure
+      List<LibraryCard> libraryCards = libraryCardService.getLibraryCards();
+      return Response.ok().entity(libraryCards).build();
+    } catch(Exception e) {
+      return createExceptionResponse(e);
+    }
+  }
+
+  @GET
+  @Produces("application/json")
+  @Path("/{id}")
+  @RolesAllowed(ADMIN)
+  public Response getLibraryCardById(@Auth AuthUser authUser, @PathParam("id") Integer id) {
+    try {
+      User user = userService.findUserByEmail(authUser.getName());
+      LibraryCard libraryCard = libraryCardService.getLibraryCardById(id);
+      return Response.ok().entity(libraryCard).build();
+    } catch(Exception e) {
+      return createExceptionResponse(e);
+    }
+  }
+
+  @GET
+  @Produces("application/json")
+  @Path("/institution/{id}")
+  @RolesAllowed(ADMIN)
+  public Response getLibraryCardsByInstitutionId(@Auth AuthUser authUser, @PathParam("id") Integer id) {
+    try{
+      User user = userService.findUserByEmail(authUser.getName());
+      List<LibraryCard> libraryCards = libraryCardService.getLibraryCardsByInstitutionId(id);
+      return Response.ok().entity(libraryCards).build();
+    } catch(Exception e) {
+      createExceptionResponse(e);
+    }
+  }
+
+  @POST
+  @Consumes("application/json")
+  @Produces("application/json")
+  @RolesAllowed(ADMIN)
+  public Response createLibraryCard(@Auth AuthUser authUser, String libraryCard) {
+    try{
+      User user = userService.findUserByEmail(authUser.getName());
+      LibraryCard payload = new Gson().fromJson(libraryCard, LibraryCard.class);
+      LibraryCard newLibraryCard = libraryCardService.createLibraryCard(payload, user);
+      return Response.ok().entity(newLibraryCard).build();
+    } catch(Exception e) {
+      return createExceptionResponse(e);
+    }
+  }
+
+  @PUT
+  @Consumes("application/json")
+  @Produces("application/json")
+  @Path("/{id}")
+  @RolesAllowed(ADMIN)
+  public Response updateLibraryCard(@Auth AuthUser authUser, @PathParam("id") Integer id, String libraryCard) {
+    try {
+      User user = userService.findUserByEmail(authUser.getName());
+      LibraryCard payload = new Gson().fromJson(libraryCard, LibraryCard.class);
+      LibraryCard updatedLibraryCard = libraryCardService.updateLibraryCard(id, payload);
+      return Response.ok().entity(updatedLibraryCard).build();
+    } catch(Exception e) {
+      return createExceptionResponse(e);
+    }
+  }
+
+  @DELETE
+  @Produces("application/json")
+  @Path("/{id")
+  @RolesAllowed(ADMIN)
+  public Response deleteLibraryCard(@Auth AuthUser authUser, @PathParam("id") Integer id) {
+    try {
+      libraryCardService.deleteLibraryCard(id);
+      return Response.status(204).build();
+    } catch(Exception e) {
+      return createExceptionResponse(e);
+    }
+  }
+}

--- a/src/main/java/org/broadinstitute/consent/http/resources/LibraryCardResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/LibraryCardResource.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.consent.http.resources;
 
+import com.google.api.client.http.HttpStatusCodes;
 import com.google.gson.Gson;
 import com.google.inject.Inject;
 import io.dropwizard.auth.Auth;
@@ -81,7 +82,7 @@ public class LibraryCardResource extends Resource{
       User user = userService.findUserByEmail(authUser.getName());
       LibraryCard payload = new Gson().fromJson(libraryCard, LibraryCard.class);
       LibraryCard newLibraryCard = libraryCardService.createLibraryCard(payload, user.getDacUserId());
-      return Response.ok().entity(newLibraryCard).build();
+      return Response.status(HttpStatusCodes.STATUS_CODE_CREATED).entity(newLibraryCard).build();
     } catch(Exception e) {
       return createExceptionResponse(e);
     }

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -2976,7 +2976,7 @@ paths:
   /api/libraryCards:
     get:
       summary: Library Card INDEX resource
-      description: Returns all library cards in database
+      description: Returns all saved library cards
       tags:
         - Library Card
         - Admin
@@ -3021,7 +3021,8 @@ paths:
           description: Internal server error
   /api/libraryCards/{id}:
     get:
-      description: Library Card GET resource
+      summary: Library Card GET Resource
+      description: Fetch library card bases on id parameter
       tags:
         - Library Card
         - Admin
@@ -3046,7 +3047,8 @@ paths:
         500:
           description: Internal server error
     put:
-      description: Library Card PUT resource
+      summary: Library Card PUT resource
+      description: Update target Library Card based on id parameter and user provided json
       tags:
         - Library Card
         - Admin
@@ -3082,7 +3084,8 @@ paths:
         500:
           description: Internal server error
     delete:
-      description: Library Card DELETE
+      summary: Library Card DELETE resource
+      description: Delete target Library Card based on id parameter
       tag:
         - Library Card
         - Admin
@@ -3104,8 +3107,8 @@ paths:
           description: Internal server error
   /api/libraryCards/institution/{id}:
     get:
-      summary: GET Library Cards with Institution ID
-      description: Returns all Library Cards with institution_id equal to provided parameter
+      summary: Library Card GET based on Institution
+      description: Returns all Library Cards with institution_id equal to provided id
       parameter:
         name: id
         in: path

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -2997,9 +2997,10 @@ paths:
       parameters:
         - name: LibraryCard
           in: body
-          type: string
           description: JSON representation of libraryCard payload
-          $ref: '#/components/schemas/LibraryCard'
+          required: true
+          schema:
+            $ref: '#/components/schemas/LibraryCard'
       tags:
         - Library Card
         - Admin
@@ -3063,7 +3064,6 @@ paths:
         description: JSON representation of Library Card
         required: true
         schema:
-          type: String
           $ref: '#/components/schemas/LibraryCard'
       responses: 
         200:

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -2924,7 +2924,7 @@ paths:
           description: Institution ID
           required: true
           schema:
-            type: String
+            type: string
       responses:
         200:
           description: Returns target institution.
@@ -2985,7 +2985,6 @@ paths:
           description: Library Card INDEX request success
           content:
             application/json:
-              type: array
               schema:
                 $ref: '#/components/schemas/LibraryCard'
         401:
@@ -3014,7 +3013,7 @@ paths:
         400:
           description: Bad request (Issues with json payload)
         401:
-          descritpion: User not authorized
+          description: User not authorized
         409:
           description: Library Card payload conflicts with an existing record
         500:
@@ -3086,11 +3085,11 @@ paths:
     delete:
       summary: Library Card DELETE resource
       description: Delete target Library Card based on id parameter
-      tag:
+      tags:
         - Library Card
         - Admin
       parameters:
-        name: id
+      - name: id
         in: path
         description: Library Card ID
         required: true
@@ -3107,10 +3106,13 @@ paths:
           description: Internal server error
   /api/libraryCards/institution/{id}:
     get:
-      summary: Library Card GET based on Institution
+      summary: Library Card GET based on Institution ID
       description: Returns all Library Cards with institution_id equal to provided id
-      parameter:
-        name: id
+      tags:
+        - Library Card
+        - Institution
+      parameters:
+      - name: id
         in: path
         description: Institution ID
         required: true
@@ -3121,7 +3123,6 @@ paths:
           description: Library Card GET request success
           content:
             application/json:
-              type: array
               schema:
                 $ref: '#/components/schemas/LibraryCard'
         401:

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -2983,29 +2983,42 @@ paths:
       responses:
         200:
           description: Library Card INDEX request success
+          content:
+            application/json:
+              type: array
+              schema:
+                $ref: '#/components/schemas/LibraryCard'
         401:
           description: User not authorized
-        403:
-          description: User does not have permission to access endpoint
         500:
-          description: Internal Server Error
+          description: Internal server error
     post:
       summary: Library Card CREATE resource
       description: Creates a new Library Card based on user-provided json
+      parameters:
+        - name: LibraryCard
+          in: body
+          type: string
+          description: JSON representation of libraryCard payload
+          $ref: '#/components/schemas/LibraryCard'
       tags:
         - Library Card
         - Admin
       responses:
         200:
-          description: Library Card Create Success
+          description: Library Card CREATE success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LibraryCard'
+        400:
+          description: Bad request (Issues with json payload)
         401:
           descritpion: User not authorized
-        403:
-          description: User does not have permission to access endpoint
         409:
           description: Library Card payload conflicts with an existing record
         500:
-          description: Internal Server Error
+          description: Internal server error
   /api/libraryCards/{id}:
     get:
       description: Library Card GET resource
@@ -3013,7 +3026,7 @@ paths:
         - Library Card
         - Admin
       parameters:
-        name: id
+      - name: id
         in: path
         description: Library Card ID
         required: true
@@ -3021,40 +3034,53 @@ paths:
           type: integer
       responses:
         200:
-          description: Library Card GET Success
+          description: Library Card GET success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LibraryCard'
         401:
           description: User not authorized
-        403:
-          description: User does not have permission to access endpoint
         404:
           description: Library Card not found
         500:
-          description: Internal Server Error
+          description: Internal server error
     put:
       description: Library Card PUT resource
       tags:
         - Library Card
         - Admin
       parameters:
-        name: id
+      - name: id
         in: path
         description: Library Card ID
         required: true
         schema:
           type: integer
+      - name: libraryCard
+        in: body
+        description: JSON representation of Library Card
+        required: true
+        schema:
+          type: String
+          $ref: '#/components/schemas/LibraryCard'
       responses: 
         200:
-          description: Library Card Update Request Success
+          description: Library Card PUT request success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LibraryCard'
+        400:
+          description: Bad request (Issues with json payload)
         401:
           description: User not authorized
-        403:
-          description: User does not have permission to access endpoint
         404:
           description: Library Card not found
         409:
           description: Library Card payload conflicts with an existing record
         500:
-          description: Internal Server Error
+          description: Internal server error
     delete:
       description: Library Card DELETE
       tag:
@@ -3069,37 +3095,38 @@ paths:
           type: integer
       responses:
         204:
-          description: Delete Request Success
+          description: Library Card DELETE request success
         401:
           description: User not authorized
-        403: 
-          description: User does not have permission to access endpoint
         404:
           description: Library Card not found
         500:
-          description: Internal Server Error
+          description: Internal server error
   /api/libraryCards/institution/{id}:
     get:
       summary: GET Library Cards with Institution ID
       description: Returns all Library Cards with institution_id equal to provided parameter
       parameter:
-          name: id
-          in: path
-          description: Institution ID
-          required: true
-          schema:
-              type: integer
+        name: id
+        in: path
+        description: Institution ID
+        required: true
+        schema:
+          type: integer
       responses:
         200:
           description: Library Card GET request success
+          content:
+            application/json:
+              type: array
+              schema:
+                $ref: '#/components/schemas/LibraryCard'
         401:
           description: User not authorized
-        403:
-          description: User does not have permission to access endpoint
         404:
           description: Institution not found
         500:
-          description: Internal Server Error
+          description: Internal server error
   /api/match/{consentId}/{purposeId}:
     get:
       summary: getMatches
@@ -4484,6 +4511,41 @@ components:
             type: string
             format: Date
             description: Institution's last update date
+    LibraryCard:
+      type: object
+      properties:
+        id:
+          type: integer
+          description: ID of Library Card
+        userId:
+          type: integer
+          description: ID of associated user
+        institutionId:
+          type: integer
+          description: ID of associated institution
+        eraCommonsId:
+          type: string
+          description: eraCommonsId of associated User
+        userName:
+          type: string
+          decription: Name of associated user
+        userEmail:
+          type: string
+          description: Email of associated user
+        createDate:
+          type: string
+          format: date
+          description: Date the library card was created
+        createUserId:
+          type: integer
+          description: ID of user who created the Library Card record
+        updateDate:
+          type: string
+          format: Date
+          description: Last update date of Library card
+        updateUserId:
+          type: integer
+          description: User who last updated the LibraryCard
     User:
       type: object
       properties:

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -3005,7 +3005,7 @@ paths:
         - Library Card
         - Admin
       responses:
-        200:
+        201:
           description: Library Card CREATE success
           content:
             application/json:

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -2973,6 +2973,133 @@ paths:
           description: Institution not found
         500:
           description: Internal Server Error
+  /api/libraryCards:
+    get:
+      summary: Library Card INDEX resource
+      description: Returns all library cards in database
+      tags:
+        - Library Card
+        - Admin
+      responses:
+        200:
+          description: Library Card INDEX request success
+        401:
+          description: User not authorized
+        403:
+          description: User does not have permission to access endpoint
+        500:
+          description: Internal Server Error
+    post:
+      summary: Library Card CREATE resource
+      description: Creates a new Library Card based on user-provided json
+      tags:
+        - Library Card
+        - Admin
+      responses:
+        200:
+          description: Library Card Create Success
+        401:
+          descritpion: User not authorized
+        403:
+          description: User does not have permission to access endpoint
+        409:
+          description: Library Card payload conflicts with an existing record
+        500:
+          description: Internal Server Error
+  /api/libraryCards/{id}:
+    get:
+      description: Library Card GET resource
+      tags:
+        - Library Card
+        - Admin
+      parameters:
+        name: id
+        in: path
+        description: Library Card ID
+        required: true
+        schema:
+          type: integer
+      responses:
+        200:
+          description: Library Card GET Success
+        401:
+          description: User not authorized
+        403:
+          description: User does not have permission to access endpoint
+        404:
+          description: Library Card not found
+        500:
+          description: Internal Server Error
+    put:
+      description: Library Card PUT resource
+      tags:
+        - Library Card
+        - Admin
+      parameters:
+        name: id
+        in: path
+        description: Library Card ID
+        required: true
+        schema:
+          type: integer
+      responses: 
+        200:
+          description: Library Card Update Request Success
+        401:
+          description: User not authorized
+        403:
+          description: User does not have permission to access endpoint
+        404:
+          description: Library Card not found
+        409:
+          description: Library Card payload conflicts with an existing record
+        500:
+          description: Internal Server Error
+    delete:
+      description: Library Card DELETE
+      tag:
+        - Library Card
+        - Admin
+      parameters:
+        name: id
+        in: path
+        description: Library Card ID
+        required: true
+        schema:
+          type: integer
+      responses:
+        204:
+          description: Delete Request Success
+        401:
+          description: User not authorized
+        403: 
+          description: User does not have permission to access endpoint
+        404:
+          description: Library Card not found
+        500:
+          description: Internal Server Error
+  /api/libraryCards/institution/{id}:
+    get:
+      summary: GET Library Cards with Institution ID
+      description: Returns all Library Cards with institution_id equal to provided parameter
+      parameter:
+          name: id
+          in: path
+          description: Institution ID
+          required: true
+          schema:
+              type: integer
+      responses:
+        200:
+          description: Library Card GET request success
+        401:
+          description: User not authorized
+        403:
+          description: User does not have permission to access endpoint
+        404:
+          description: Institution not found
+        500:
+          description: Internal Server Error
   /api/match/{consentId}/{purposeId}:
     get:
       summary: getMatches

--- a/src/test/java/org/broadinstitute/consent/http/resources/LibraryCardResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/LibraryCardResourceTest.java
@@ -110,6 +110,14 @@ public class LibraryCardResourceTest {
   }
 
   @Test
+  public void testGetLibraryCardByInstitutionIdThrowsNotFoundException() {
+    when(libraryCardService.findLibraryCardsByInstitutionId(anyInt())).thenThrow(new NotFoundException());
+    initResource();
+    Response response = resource.getLibraryCardsByInstitutionId(authUser, 1);
+    assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
+  }
+
+  @Test
   public void testCreateLibraryCard() {
     LibraryCard mockCard = mockLibraryCardSetup();
     String payload = new Gson().toJson(mockCard);

--- a/src/test/java/org/broadinstitute/consent/http/resources/LibraryCardResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/LibraryCardResourceTest.java
@@ -93,7 +93,7 @@ public class LibraryCardResourceTest {
   }
 
   @Test
-  public void testGetLibraryCardsByIdNotFound() {
+  public void testGetLibraryCardsByIdThrowsNotFoundException() {
     when(libraryCardService.findLibraryCardById(anyInt())).thenThrow(new NotFoundException());
     initResource();
     Response response = resource.getLibraryCardById(authUser, 1);
@@ -123,7 +123,7 @@ public class LibraryCardResourceTest {
   }
 
   @Test
-  public void testCreateLibraryCardThrowsConflictExceptionOnDuplicate() {
+  public void testCreateLibraryCardThrowsConflictException() {
     UnableToExecuteStatementException exception = generateUniqueViolationException();
     String json = new Gson().toJson(mockLibraryCardSetup());
     when(userService.findUserByEmail(anyString())).thenReturn(user);
@@ -148,7 +148,7 @@ public class LibraryCardResourceTest {
   }
 
   @Test
-  public void testUpdateLibraryCardNotFound() {
+  public void testUpdateLibraryCardThrowsNotFoundException() {
     when(userService.findUserByEmail(anyString())).thenReturn(user);
     when(libraryCardService.updateLibraryCard(any(LibraryCard.class), anyInt(), anyInt()))
       .thenThrow(new NotFoundException());

--- a/src/test/java/org/broadinstitute/consent/http/resources/LibraryCardResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/LibraryCardResourceTest.java
@@ -1,0 +1,187 @@
+package org.broadinstitute.consent.http.resources;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+
+import com.google.api.client.http.HttpStatusCodes;
+import com.google.gson.Gson;
+import java.util.Collections;
+import javax.ws.rs.core.UriInfo;
+import javax.ws.rs.core.UriBuilder;
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.core.Response;
+import java.util.List;
+import java.util.Date;
+import org.jdbi.v3.core.statement.UnableToExecuteStatementException;
+import org.broadinstitute.consent.http.enumeration.UserRoles;
+import org.broadinstitute.consent.http.models.AuthUser;
+import org.broadinstitute.consent.http.models.User;
+import org.broadinstitute.consent.http.models.UserRole;
+import org.broadinstitute.consent.http.models.LibraryCard;
+import org.broadinstitute.consent.http.service.UserService;
+import org.broadinstitute.consent.http.service.LibraryCardService;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.postgresql.util.PSQLException;
+import org.postgresql.util.PSQLState;
+
+public class LibraryCardResourceTest {
+  private final AuthUser authUser = new AuthUser("test@test.com");
+  private final List<UserRole> adminRoles = Collections.singletonList(
+    new UserRole(UserRoles.ADMIN.getRoleId(), UserRoles.ADMIN.getRoleName())
+  );
+  private final User user = new User(1, authUser.getName(), "Display Name", new Date(), adminRoles, authUser.getName());
+  private LibraryCardResource resource;
+
+  @Mock private UserService userService;
+  @Mock private LibraryCardService libraryCardService;
+  @Mock private UriInfo info;
+  @Mock private UriBuilder builder;
+  @Mock private User mockUser;
+
+  private LibraryCard mockLibraryCardSetup() {
+    LibraryCard mockCard = new LibraryCard();
+    mockCard.setUserId(2);
+    mockCard.setCreateUserId(1);
+    return mockCard;
+  }
+
+  private void initResource() {
+    resource = new LibraryCardResource(userService, libraryCardService);
+  }
+
+  private UnableToExecuteStatementException generateUniqueViolationException() {
+    PSQLState uniqueViolationEnum = PSQLState.UNIQUE_VIOLATION;
+    PSQLException uniqueViolationException = new PSQLException(
+      "Error", uniqueViolationEnum
+    );
+    return new UnableToExecuteStatementException(uniqueViolationException, null);
+  };
+
+  @Before
+  public void setUp(){
+    MockitoAnnotations.initMocks(this);
+  }
+
+  @Test
+  public void testGetLibraryCardsAsAdmin() {
+    List<LibraryCard> libraryCards = Collections.singletonList(mockLibraryCardSetup());
+    when(libraryCardService.findAllLibraryCards()).thenReturn(libraryCards);
+    initResource();
+    Response response = resource.getLibraryCards(authUser);
+    String json = response.getEntity().toString();
+    assertEquals(200, response.getStatus());
+    assertNotNull(json);
+  }
+
+  @Test
+  public void testGetLibraryCardsById() {
+    LibraryCard card = mockLibraryCardSetup();
+    when(libraryCardService.findLibraryCardById(anyInt())).thenReturn(card);
+    initResource();
+    Response response = resource.getLibraryCardById(authUser, 1);
+    String json = response.getEntity().toString();
+    assertEquals(200, response.getStatus());
+    assertNotNull(json);
+  }
+
+  @Test
+  public void testGetLibraryCardsByIdNotFound() {
+    when(libraryCardService.findLibraryCardById(anyInt())).thenThrow(new NotFoundException());
+    initResource();
+    Response response = resource.getLibraryCardById(authUser, 1);
+    assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
+  }
+
+  @Test
+  public void testGetLibraryCardByInstitutionId() {
+    List<LibraryCard> cards = Collections.singletonList(mockLibraryCardSetup());
+    when(libraryCardService.findLibraryCardsByInstitutionId(anyInt())).thenReturn(cards);
+    initResource();
+    Response response = resource.getLibraryCardsByInstitutionId(authUser, 1);
+    assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+  }
+
+  @Test
+  public void testCreateLibraryCard() {
+    LibraryCard mockCard = mockLibraryCardSetup();
+    String payload = new Gson().toJson(mockCard);
+    when(userService.findUserByEmail(anyString())).thenReturn(user);
+    when(libraryCardService.createLibraryCard(any(LibraryCard.class), anyInt())).thenReturn(mockCard);
+    initResource();
+    Response response = resource.createLibraryCard(authUser, payload);
+    String json = response.getEntity().toString();
+    assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+    assertNotNull(json);
+  }
+
+  @Test
+  public void testCreateLibraryCardThrowsConflictExceptionOnDuplicate() {
+    UnableToExecuteStatementException exception = generateUniqueViolationException();
+    String json = new Gson().toJson(mockLibraryCardSetup());
+    when(userService.findUserByEmail(anyString())).thenReturn(user);
+    when(libraryCardService.createLibraryCard(any(LibraryCard.class), anyInt())).thenThrow(exception);
+    initResource();
+    Response response = resource.createLibraryCard(authUser, json);
+    assertEquals(HttpStatusCodes.STATUS_CODE_CONFLICT, response.getStatus());
+  }
+
+  @Test
+  public void testUpdateLibraryCard() {
+    LibraryCard mockCard = mockLibraryCardSetup();
+    String payload = new Gson().toJson(mockCard);
+    when(userService.findUserByEmail(anyString())).thenReturn(user);
+    when(libraryCardService.updateLibraryCard(any(LibraryCard.class), anyInt(), anyInt()))
+      .thenReturn(mockCard);
+    initResource();
+    Response response = resource.updateLibraryCard(authUser, 1, payload);
+    String json = response.getEntity().toString();
+    assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+    assertNotNull(json);
+  }
+
+  @Test
+  public void testUpdateLibraryCardNotFound() {
+    when(userService.findUserByEmail(anyString())).thenReturn(user);
+    when(libraryCardService.updateLibraryCard(any(LibraryCard.class), anyInt(), anyInt()))
+      .thenThrow(new NotFoundException());
+    String payload = new Gson().toJson(mockLibraryCardSetup());
+    initResource();
+    Response response = resource.updateLibraryCard(authUser, 1, payload);
+    assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
+  }
+
+  @Test
+  public void testUpdateLibraryCardThrowsUniqueViolation() {
+    UnableToExecuteStatementException exception = generateUniqueViolationException();
+    when(userService.findUserByEmail(anyString())).thenReturn(user);
+    when(libraryCardService.updateLibraryCard(any(LibraryCard.class), anyInt(), anyInt()))
+      .thenThrow(exception);
+    String payload = new Gson().toJson(mockLibraryCardSetup());
+    initResource();
+    Response response = resource.updateLibraryCard(authUser, 1, payload);
+    assertEquals(HttpStatusCodes.STATUS_CODE_CONFLICT, response.getStatus());
+  }
+
+  @Test
+  public void deleteLibraryCard() {
+    initResource();
+    Response response = resource.deleteLibraryCard(authUser, 1);
+    assertEquals(HttpStatusCodes.STATUS_CODE_NO_CONTENT, response.getStatus());
+  }
+
+  @Test
+  public void deleteLibraryCardThrowsNotFoundException() {
+    doThrow(new NotFoundException()).when(libraryCardService).deleteLibraryCardById(anyInt());
+    initResource();
+    Response response = resource.deleteLibraryCard(authUser, 1);
+    assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
+  }
+}

--- a/src/test/java/org/broadinstitute/consent/http/resources/LibraryCardResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/LibraryCardResourceTest.java
@@ -126,7 +126,7 @@ public class LibraryCardResourceTest {
     initResource();
     Response response = resource.createLibraryCard(authUser, payload);
     String json = response.getEntity().toString();
-    assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+    assertEquals(HttpStatusCodes.STATUS_CODE_CREATED, response.getStatus());
     assertNotNull(json);
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/resources/LibraryCardResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/LibraryCardResourceTest.java
@@ -77,7 +77,7 @@ public class LibraryCardResourceTest {
     initResource();
     Response response = resource.getLibraryCards(authUser);
     String json = response.getEntity().toString();
-    assertEquals(200, response.getStatus());
+    assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
     assertNotNull(json);
   }
 
@@ -88,7 +88,7 @@ public class LibraryCardResourceTest {
     initResource();
     Response response = resource.getLibraryCardById(authUser, 1);
     String json = response.getEntity().toString();
-    assertEquals(200, response.getStatus());
+    assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
     assertNotNull(json);
   }
 
@@ -131,6 +131,17 @@ public class LibraryCardResourceTest {
   }
 
   @Test
+  public void testCreateLibraryCardThrowsIllegalArgumentException() {
+    LibraryCard mockCard = mockLibraryCardSetup();
+    String payload = new Gson().toJson(mockCard);
+    when(userService.findUserByEmail(anyString())).thenReturn(user);
+    when(libraryCardService.createLibraryCard(any(LibraryCard.class), anyInt())).thenThrow(new IllegalArgumentException());
+    initResource();
+    Response response = resource.createLibraryCard(authUser, payload);
+    assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
+  }
+
+  @Test
   public void testCreateLibraryCardThrowsConflictException() {
     UnableToExecuteStatementException exception = generateUniqueViolationException();
     String json = new Gson().toJson(mockLibraryCardSetup());
@@ -153,6 +164,18 @@ public class LibraryCardResourceTest {
     String json = response.getEntity().toString();
     assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
     assertNotNull(json);
+  }
+
+  @Test
+  public void testUpdateLibraryCardThrowsIllegalArgumentException() {
+    LibraryCard mockCard = mockLibraryCardSetup();
+    String payload = new Gson().toJson(mockCard);
+    when(userService.findUserByEmail(anyString())).thenReturn(user);
+    when(libraryCardService.updateLibraryCard(any(LibraryCard.class), anyInt(), anyInt()))
+      .thenThrow(new IllegalArgumentException());
+    initResource();
+    Response response = resource.updateLibraryCard(authUser, 1, payload);
+    assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
   }
 
   @Test


### PR DESCRIPTION
Addresses [DUOS-1064](https://broadworkbench.atlassian.net/browse/DUOS-1064)

PR adds LC Resource endpoints alongside tests and updates to ```api-docs.yaml```. 

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [ ] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
