### PR TITLE
DUOS-1271[risk=no] Adds institution to LC Index Query

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
@@ -59,6 +59,7 @@ import org.broadinstitute.consent.http.resources.EmailNotifierResource;
 import org.broadinstitute.consent.http.resources.ErrorResource;
 import org.broadinstitute.consent.http.resources.IndexerResource;
 import org.broadinstitute.consent.http.resources.InstitutionResource;
+import org.broadinstitute.consent.http.resources.LibraryCardResource;
 import org.broadinstitute.consent.http.resources.MatchResource;
 import org.broadinstitute.consent.http.resources.MetricsResource;
 import org.broadinstitute.consent.http.resources.NihAccountResource;
@@ -230,6 +231,7 @@ public class ConsentApplication extends Application<ConsentConfiguration> {
         env.jersey().register(new ElectionResource(voteService, electionService));
         env.jersey().register(new EmailNotifierResource(emailNotifierService));
         env.jersey().register(new InstitutionResource(userService, institutionService));
+        env.jersey().register(new LibraryCardResource(userService, libraryCardService));
         env.jersey().register(new ApprovalExpirationTimeResource(approvalExpirationTimeService, userService));
         env.jersey().register(new MatchResource(matchService));
         env.jersey().register(new MetricsResource(metricsService));

--- a/src/main/java/org/broadinstitute/consent/http/db/LibraryCardDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/LibraryCardDAO.java
@@ -65,7 +65,10 @@ public interface LibraryCardDAO extends Transactional<LibraryCardDAO> {
 
   @RegisterBeanMapper(value = LibraryCard.class)
   @UseRowReducer(LibraryCardReducer.class)
-  @SqlQuery("SELECT * FROM library_card")
+  @SqlQuery("SELECT lc.*, institution.institution_name institutionName FROM library_card AS lc " +
+    "INNER JOIN institution " +
+    "ON lc.institution_id = institution.institution_id"
+  )
   List<LibraryCard> findAllLibraryCards();
 
 }

--- a/src/main/java/org/broadinstitute/consent/http/db/LibraryCardDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/LibraryCardDAO.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.consent.http.db;
 import org.broadinstitute.consent.http.db.mapper.LibraryCardReducer;
+import org.broadinstitute.consent.http.models.Institution;
 import org.broadinstitute.consent.http.models.LibraryCard;
 import org.jdbi.v3.sqlobject.config.RegisterBeanMapper;
 import org.jdbi.v3.sqlobject.customizer.Bind;
@@ -64,9 +65,19 @@ public interface LibraryCardDAO extends Transactional<LibraryCardDAO> {
   List<LibraryCard> findLibraryCardsByInstitutionId(@Bind("institutionId") Integer institutionId);
 
   @RegisterBeanMapper(value = LibraryCard.class)
+  @RegisterBeanMapper(value = Institution.class, prefix = "i")
   @UseRowReducer(LibraryCardReducer.class)
-  @SqlQuery("SELECT lc.*, institution.institution_name institutionName FROM library_card AS lc " +
-    "INNER JOIN institution " +
+  @SqlQuery("SELECT lc.*, " + 
+    "institution.institution_id AS i_institution_id, " +
+    "institution.institution_name AS i_name, " +
+    "institution.it_director_name AS i_it_director_name, " +
+    "institution.it_director_email AS i_it_director_email, " +
+    "institution.create_user AS i_create_user_id, " +
+    "institution.create_date AS i_create_date, " +
+    "institution.update_date AS i_update_date, " +
+    "institution.update_user AS i_update_user_id " +
+    "FROM library_card AS lc " +
+    "LEFT JOIN institution " +
     "ON lc.institution_id = institution.institution_id"
   )
   List<LibraryCard> findAllLibraryCards();

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/LibraryCardReducer.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/LibraryCardReducer.java
@@ -1,8 +1,11 @@
 package org.broadinstitute.consent.http.db.mapper;
 
+import org.broadinstitute.consent.http.models.Institution;
 import org.broadinstitute.consent.http.models.LibraryCard;
+import org.jdbi.v3.core.mapper.MappingException;
 import org.jdbi.v3.core.result.LinkedHashMapRowReducer;
 import org.jdbi.v3.core.result.RowView;
+import java.util.Objects;
 
 import java.util.Map;
 
@@ -10,9 +13,21 @@ public class LibraryCardReducer implements LinkedHashMapRowReducer<Integer, Libr
 
   @Override
   public void accumulate(Map<Integer, LibraryCard> map, RowView rowView) {
-        map.computeIfAbsent(
-            rowView.getColumn("id", Integer.class),
-            id -> rowView.getRow(LibraryCard.class));
+    Institution institution = null;
+    LibraryCard card = map.computeIfAbsent(
+        rowView.getColumn("id", Integer.class),
+        id -> rowView.getRow(LibraryCard.class));
+    
+    try{
+      if(Objects.nonNull(card) && Objects.nonNull(rowView.getColumn("i_institution_id", Integer.class))) {
+        institution = rowView.getRow(Institution.class);
+        institution.setId(rowView.getColumn("i_institution_id", Integer.class));
+      }
+    } catch(MappingException e) {
+    }
+    
+    if(Objects.nonNull(institution)) {
+      card.setInstitution(institution);
+    }
   }
-
 }

--- a/src/main/java/org/broadinstitute/consent/http/models/LibraryCard.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/LibraryCard.java
@@ -18,7 +18,7 @@ public class LibraryCard {
     private Date updateDate;
     private Integer updateUserId;
 
-    private String institutionName;
+    private Institution institution;
 
   public LibraryCard() {
     this.createDate = new Date();
@@ -104,12 +104,12 @@ public class LibraryCard {
     this.updateUserId = updateUser;
   }
 
-  public String getInstitutionName() {
-    return institutionName;
+  public Institution getInstitution() {
+    return institution;
   }
 
-  public void setInstitutionName(String institutionName) {
-    this.institutionName = institutionName;
+  public void setInstitution(Institution institution) {
+    this.institution = institution;
   }
 
   @Override

--- a/src/main/java/org/broadinstitute/consent/http/models/LibraryCard.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/LibraryCard.java
@@ -18,6 +18,8 @@ public class LibraryCard {
     private Date updateDate;
     private Integer updateUserId;
 
+    private String institutionName;
+
   public LibraryCard() {
     this.createDate = new Date();
   }
@@ -100,6 +102,14 @@ public class LibraryCard {
 
   public void setUpdateUserId(Integer updateUser) {
     this.updateUserId = updateUser;
+  }
+
+  public String getInstitutionName() {
+    return institutionName;
+  }
+
+  public void setInstitutionName(String institutionName) {
+    this.institutionName = institutionName;
   }
 
   @Override

--- a/src/main/java/org/broadinstitute/consent/http/resources/LibraryCardResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/LibraryCardResource.java
@@ -106,7 +106,7 @@ public class LibraryCardResource extends Resource{
 
   @DELETE
   @Produces("application/json")
-  @Path("/{id")
+  @Path("/{id}")
   @RolesAllowed(ADMIN)
   public Response deleteLibraryCard(@Auth AuthUser authUser, @PathParam("id") Integer id) {
     try {

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -2927,6 +2927,13 @@ paths:
       description: Creates new institution record based on json payload
       tags:
         - Institutions
+      requestBody:
+        description: Required JSON payload representing updated Institution
+        required: true
+        content:
+          application/json:
+            schema: 
+              $ref: '#/components/schemas/Institution'
       responses:
         201:
           description: Creates and returns newly created record.
@@ -2967,6 +2974,13 @@ paths:
           required: true
           schema:
             type: string
+      requestBody:
+        description: Required JSON payload representing updated Institution
+        required: true
+        content:
+          application/json:
+            schema: 
+              $ref: '#/components/schemas/Institution'
       responses:
         200:
           description: Updates and returns target institution
@@ -3016,13 +3030,13 @@ paths:
     post:
       summary: Library Card CREATE resource
       description: Creates a new Library Card based on user-provided json
-      parameters:
-        - name: LibraryCard
-          in: body
-          description: JSON representation of libraryCard payload
-          required: true
-          schema:
-            $ref: '#/components/schemas/LibraryCard'
+      requestBody:
+        description: JSON representation of libraryCard payload
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LibraryCard'
       tags:
         - Library Card
         - Admin
@@ -3081,12 +3095,16 @@ paths:
         required: true
         schema:
           type: integer
-      - name: libraryCard
-        in: body
-        description: JSON representation of Library Card
-        required: true
-        schema:
-          $ref: '#/components/schemas/LibraryCard'
+      requestBody:
+          description: 'JSON representation of updated Library Card state'
+          required: true
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LibraryCard'
+              example:
+                libraryCard:
+                  $ref: '#/components/schemas/LibraryCard'
       responses: 
         200:
           description: Library Card PUT request success
@@ -3132,7 +3150,7 @@ paths:
       description: Returns all Library Cards with institution_id equal to provided id
       tags:
         - Library Card
-        - Institution
+        - Institutions
       parameters:
       - name: id
         in: path
@@ -4596,7 +4614,7 @@ components:
           items:
             $ref: '#/components/schemas/User'
     Institution:
-      type: Object
+      type: object
       properties:
           id:
             type: integer

--- a/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
@@ -421,6 +421,17 @@ public class DAOTestHelper {
         return libraryCardDAO.findLibraryCardById(id);
     }
 
+    //overloaded method, helper for INDEX SQL call
+    //createInstitution called outside of helper for institution reference/data checks
+    protected LibraryCard createLibraryCardForIndex(Integer institutionId) {
+        Integer userId = createUser().getDacUserId();
+        String stringValue = "value";
+        Integer id = libraryCardDAO.insertLibraryCard(userId, institutionId, stringValue, stringValue, stringValue,
+                userId, new Date());
+        createdLibraryCardIds.add(id);
+        return libraryCardDAO.findLibraryCardById(id);
+    }
+
     protected Date yesterday() {
         final Calendar cal = Calendar.getInstance();
         cal.add(Calendar.DATE, -1);

--- a/src/test/java/org/broadinstitute/consent/http/db/LibraryCardDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/LibraryCardDAOTest.java
@@ -130,7 +130,8 @@ public class LibraryCardDAOTest extends DAOTestHelper {
     List<LibraryCard> cardListUpdated = libraryCardDAO.findAllLibraryCards();
     assertEquals(1, cardListUpdated.size());
     LibraryCard card = cardListUpdated.get(0);
-    assertEquals(institution.getId(), card.getInstitutionId());
-    assertEquals(institution.getName(), card.getInstitutionName());
+    Institution cardInstitution = card.getInstitution();
+    assertEquals(institution.getId(), cardInstitution.getId());
+    assertEquals(institution.getName(), cardInstitution.getName());
   }
 }

--- a/src/test/java/org/broadinstitute/consent/http/db/LibraryCardDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/LibraryCardDAOTest.java
@@ -13,6 +13,7 @@ import com.google.gson.Gson;
 import org.postgresql.util.PSQLException;
 import org.postgresql.util.PSQLState;
 import org.apache.commons.lang3.RandomUtils;
+import org.broadinstitute.consent.http.models.Institution;
 import org.broadinstitute.consent.http.models.LibraryCard;
 import org.junit.Test;
 
@@ -124,8 +125,12 @@ public class LibraryCardDAOTest extends DAOTestHelper {
   public void testFindAllLibraryCards() {
     List<LibraryCard> cardList = libraryCardDAO.findAllLibraryCards();
     assertEquals(0, cardList.size());
-    createLibraryCard();
+    Institution institution = createInstitution();
+    createLibraryCardForIndex(institution.getId());
     List<LibraryCard> cardListUpdated = libraryCardDAO.findAllLibraryCards();
     assertEquals(1, cardListUpdated.size());
+    LibraryCard card = cardListUpdated.get(0);
+    assertEquals(institution.getId(), card.getInstitutionId());
+    assertEquals(institution.getName(), card.getInstitutionName());
   }
 }


### PR DESCRIPTION
Addresses [DUOS-1271](https://broadworkbench.atlassian.net/browse/DUOS-1271)

PR adds `institution` to Library Cards returned from `LibraryCardDAO.findAllLibraryCards()`. As such there has been updates to the model, DAO method, and associated tests and test helpers to account for the new field.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [ ] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
