### PR TITLE
DUOS-1066[risk=no]Legacy Code Updates

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
@@ -233,8 +233,8 @@ public class ConsentApplication extends Application<ConsentConfiguration> {
         env.jersey().register(new ApprovalExpirationTimeResource(approvalExpirationTimeService, userService));
         env.jersey().register(new MatchResource(matchService));
         env.jersey().register(new MetricsResource(metricsService));
-        env.jersey().register(new UserResource(userService, whitelistService));
-        env.jersey().register(new ResearcherResource(researcherService, userService, whitelistService));
+        env.jersey().register(new UserResource(userService, libraryCardService));
+        env.jersey().register(new ResearcherResource(researcherService, userService, libraryCardService));
         env.jersey().register(new SwaggerResource(config.getGoogleAuthentication()));
         env.jersey().register(new NihAccountResource(nihService, userService));
         env.jersey().register(new WhitelistResource(whitelistService));

--- a/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
@@ -516,16 +516,4 @@ public class ConsentModule extends AbstractModule {
         );
     }
 
-    @Provides
-    WhitelistService providesWhitelistService() {
-        return new WhitelistService(
-                providesGCSService(),
-                providesWhitelistCache());
-    }
-
-    @Provides
-    WhitelistCache providesWhitelistCache() {
-        return new WhitelistCache(providesGCSService());
-    }
-
 }

--- a/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
@@ -59,8 +59,6 @@ import org.broadinstitute.consent.http.service.UseRestrictionConverter;
 import org.broadinstitute.consent.http.service.UseRestrictionValidator;
 import org.broadinstitute.consent.http.service.UserService;
 import org.broadinstitute.consent.http.service.VoteService;
-import org.broadinstitute.consent.http.service.WhitelistService;
-import org.broadinstitute.consent.http.util.WhitelistCache;
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.gson2.Gson2Plugin;
 import org.jdbi.v3.guava.GuavaPlugin;

--- a/src/main/java/org/broadinstitute/consent/http/cloudstore/GCSService.java
+++ b/src/main/java/org/broadinstitute/consent/http/cloudstore/GCSService.java
@@ -63,6 +63,8 @@ public class GCSService {
         this.config = config;
     }
 
+    //method only called by whitelist service 
+    //deprecated, to be removed along with whitelist classes
     public GenericUrl postWhitelist(String content, String fileName) {
         BlobId blobId = BlobId.of(config.getBucket(), "whitelist/" + fileName);
         BlobInfo blobInfo = BlobInfo.newBuilder(blobId).setContentType("text/plain").build();
@@ -70,6 +72,8 @@ public class GCSService {
         return new GenericUrl(blob.getMediaLink());
     }
 
+    //method only called by whitelist cache
+    //deprecated, to be removed along with whitelist classes
     public String getMostRecentWhitelist() throws Exception {
         try {
             Optional<Blob> whitelist = listWhitelistItems().stream().findFirst();
@@ -95,6 +99,8 @@ public class GCSService {
         return storage.get(config.getBucket(), Storage.BucketGetOption.fields(Storage.BucketField.values()));
     }
 
+    //method only called by whitelist service 
+    //deprecated, to be removed along with whitelist service and resource classes
     private List<Blob> listWhitelistItems() {
         Bucket bucket = storage.get(config.getBucket());
         Page<Blob> blobs = bucket.list();

--- a/src/main/java/org/broadinstitute/consent/http/resources/ResearcherResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/ResearcherResource.java
@@ -82,11 +82,10 @@ public class ResearcherResource extends Resource {
             List<UserRoles> authedRoles = Stream.of(UserRoles.CHAIRPERSON, UserRoles.MEMBER, UserRoles.ADMIN).
                     collect(Collectors.toList());
             validateAuthedRoleUser(authedRoles, findByAuthUser(authUser), userId);
-            User user = userService.findUserById(userId);
             List<UserProperty> props = userService.findAllUserProperties(userId);
             Map<String, Object> propMap = props.stream().
                 collect(Collectors.toMap(UserProperty::getPropertyKey, UserProperty::getPropertyValue));
-            List<LibraryCard> entries = libraryCardService.findLibraryCardsByUserId(user.getDacUserId());
+            List<LibraryCard> entries = libraryCardService.findLibraryCardsByUserId(userId);
             propMap.put(UserFields.LIBRARY_CARD_ENTRIES, entries);
             List<Integer> orgs = entries.stream().
                     map(LibraryCard::getInstitutionId).

--- a/src/main/java/org/broadinstitute/consent/http/resources/ResearcherResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/ResearcherResource.java
@@ -6,11 +6,11 @@ import org.broadinstitute.consent.http.authentication.GoogleUser;
 import org.broadinstitute.consent.http.enumeration.UserFields;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.AuthUser;
+import org.broadinstitute.consent.http.models.LibraryCard;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.UserProperty;
-import org.broadinstitute.consent.http.models.WhitelistEntry;
 import org.broadinstitute.consent.http.service.UserService;
-import org.broadinstitute.consent.http.service.WhitelistService;
+import org.broadinstitute.consent.http.service.LibraryCardService;
 import org.broadinstitute.consent.http.service.ResearcherService;
 
 import javax.annotation.security.PermitAll;
@@ -40,13 +40,13 @@ public class ResearcherResource extends Resource {
 
     private final ResearcherService researcherService;
     private final UserService userService;
-    private final WhitelistService whitelistService;
+    private final LibraryCardService libraryCardService;
 
     @Inject
-    public ResearcherResource(ResearcherService researcherService, UserService userService, WhitelistService whitelistService) {
+    public ResearcherResource(ResearcherService researcherService, UserService userService, LibraryCardService libraryCardService) {
         this.researcherService = researcherService;
         this.userService = userService;
-        this.whitelistService = whitelistService;
+        this.libraryCardService = libraryCardService;
     }
 
     @POST
@@ -86,10 +86,10 @@ public class ResearcherResource extends Resource {
             List<UserProperty> props = userService.findAllUserProperties(userId);
             Map<String, Object> propMap = props.stream().
                 collect(Collectors.toMap(UserProperty::getPropertyKey, UserProperty::getPropertyValue));
-            List<WhitelistEntry> entries = whitelistService.findWhitelistEntriesForUser(user, props);
+            List<LibraryCard> entries = libraryCardService.findLibraryCardsByUserId(user.getDacUserId());
             propMap.put(UserFields.LIBRARY_CARD_ENTRIES, entries);
-            List<String> orgs = entries.stream().
-                    map(WhitelistEntry::getOrganization).
+            List<Integer> orgs = entries.stream().
+                    map(LibraryCard::getInstitutionId).
                     distinct().
                     collect(Collectors.toList());
             propMap.put(UserFields.LIBRARY_CARDS, orgs);

--- a/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
@@ -31,25 +31,25 @@ import javax.ws.rs.core.UriInfo;
 import org.broadinstitute.consent.http.authentication.GoogleUser;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.AuthUser;
+import org.broadinstitute.consent.http.models.LibraryCard;
 import org.broadinstitute.consent.http.models.UserProperty;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.UserRole;
-import org.broadinstitute.consent.http.models.WhitelistEntry;
 import org.broadinstitute.consent.http.models.dto.Error;
+import org.broadinstitute.consent.http.service.LibraryCardService;
 import org.broadinstitute.consent.http.service.UserService;
-import org.broadinstitute.consent.http.service.WhitelistService;
 
 @Path("{api : (api/)?}user")
 public class UserResource extends Resource {
 
     private final UserService userService;
-    private final WhitelistService whitelistService;
+    private final LibraryCardService libraryCardService;
     private final Gson gson;
 
     @Inject
-    public UserResource(UserService userService, WhitelistService whitelistService) {
+    public UserResource(UserService userService, LibraryCardService libraryCardService) {
         this.userService = userService;
-        this.whitelistService = whitelistService;
+        this.libraryCardService = libraryCardService;
         this.gson = new Gson();
     }
 
@@ -165,16 +165,16 @@ public class UserResource extends Resource {
     /**
      * Convenience method for a generic user object with custom properties added
      * @param user The User
-     * @return JsonObject version of the user with researcher properties and whitelist entries
+     * @return JsonObject version of the user with researcher properties and library card entries
      */
     private JsonObject constructUserJsonObject(User user) {
         List<UserProperty> props = userService.findAllUserProperties(user.getDacUserId());
-        List<WhitelistEntry> entries = whitelistService.findWhitelistEntriesForUser(user, props);
+        List<LibraryCard> entries = libraryCardService.findLibraryCardsByUserId(user.getDacUserId());
         JsonObject userJson = gson.toJsonTree(user).getAsJsonObject();
         JsonArray propsJson = gson.toJsonTree(props).getAsJsonArray();
         JsonArray entriesJson = gson.toJsonTree(entries).getAsJsonArray();
         userJson.add("researcherProperties", propsJson);
-        userJson.add("whitelistEntries", entriesJson);
+        userJson.add("libraryCards", entriesJson);
         return userJson;
     }
 

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -3034,7 +3034,7 @@ paths:
         - User
       responses:
         200:
-          description: The user, along with researcher properties and whitelist entries
+          description: The user, along with researcher properties and library cards
           content:
             application/json:
               schema:
@@ -3058,7 +3058,7 @@ paths:
         - User
       responses:
         200:
-          description: The user, along with researcher properties and whitelist entries
+          description: The user, along with researcher properties and library cards
           content:
             application/json:
               schema:
@@ -3094,7 +3094,7 @@ paths:
         - User
       responses:
         200:
-          description: Updated user along with researcher properties and whitelist entries
+          description: Updated user along with researcher properties and library cards
           content:
             application/json:
               schema:

--- a/src/test/java/org/broadinstitute/consent/http/resources/ResearcherResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/ResearcherResourceTest.java
@@ -6,7 +6,7 @@ import org.broadinstitute.consent.http.models.AuthUser;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.UserRole;
 import org.broadinstitute.consent.http.service.UserService;
-import org.broadinstitute.consent.http.service.WhitelistService;
+import org.broadinstitute.consent.http.service.LibraryCardService;
 import org.broadinstitute.consent.http.service.ResearcherService;
 import org.junit.Assert;
 import org.junit.Before;
@@ -36,7 +36,7 @@ public class ResearcherResourceTest {
     UserService userService;
 
     @Mock
-    WhitelistService whitelistService;
+    LibraryCardService libraryCardService;
 
     @Mock
     private UriInfo uriInfo;
@@ -61,7 +61,7 @@ public class ResearcherResourceTest {
     }
 
     private void initResource() {
-        resource = new ResearcherResource(researcherService, userService, whitelistService);
+        resource = new ResearcherResource(researcherService, userService, libraryCardService);
     }
 
     @Test

--- a/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
@@ -22,7 +22,6 @@ import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.broadinstitute.consent.http.authentication.GoogleUser;
-import org.broadinstitute.consent.http.db.mapper.LibraryCardReducer;
 import org.broadinstitute.consent.http.enumeration.UserFields;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.AuthUser;

--- a/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
@@ -13,6 +13,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Random;
 import java.util.stream.Collectors;
 import javax.ws.rs.NotFoundException;
 import javax.ws.rs.core.Response;
@@ -21,15 +22,16 @@ import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.broadinstitute.consent.http.authentication.GoogleUser;
+import org.broadinstitute.consent.http.db.mapper.LibraryCardReducer;
 import org.broadinstitute.consent.http.enumeration.UserFields;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.AuthUser;
+import org.broadinstitute.consent.http.models.LibraryCard;
 import org.broadinstitute.consent.http.models.UserProperty;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.UserRole;
-import org.broadinstitute.consent.http.models.WhitelistEntry;
+import org.broadinstitute.consent.http.service.LibraryCardService;
 import org.broadinstitute.consent.http.service.UserService;
-import org.broadinstitute.consent.http.service.WhitelistService;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -40,7 +42,7 @@ public class UserResourceTest {
 
   @Mock private UserService userService;
 
-  @Mock private WhitelistService whitelistService;
+  @Mock private LibraryCardService libraryCardService;
 
   private UserResource userResource;
 
@@ -65,7 +67,7 @@ public class UserResourceTest {
   }
 
   private void initResource() {
-    userResource = new UserResource(userService, whitelistService);
+    userResource = new UserResource(userService, libraryCardService);
   }
 
   @Test
@@ -73,8 +75,8 @@ public class UserResourceTest {
     User user = createUserWithRole();
     when(userService.findUserByEmail(any())).thenReturn(user);
     when(userService.findAllUserProperties(any())).thenReturn(createResearcherProperties());
-    when(whitelistService.findWhitelistEntriesForUser(any(), any()))
-        .thenReturn(createWhitelistEntries());
+    when(libraryCardService.findLibraryCardsByUserId(any()))
+        .thenReturn(createLibraryCards());
     initResource();
 
     Response response = userResource.getUser(authUser);
@@ -86,8 +88,8 @@ public class UserResourceTest {
     User user = createUserWithRole();
     when(userService.findUserById(any())).thenReturn(user);
     when(userService.findAllUserProperties(any())).thenReturn(createResearcherProperties());
-    when(whitelistService.findWhitelistEntriesForUser(any(), any()))
-        .thenReturn(createWhitelistEntries());
+    when(libraryCardService.findLibraryCardsByUserId(any()))
+        .thenReturn(createLibraryCards());;
     initResource();
 
     Response response = userResource.getUserById(authUser, 1);
@@ -163,8 +165,8 @@ public class UserResourceTest {
     User user = createUserWithRole();
     when(userService.findUserById(any())).thenReturn(user);
     when(userService.findAllUserProperties(any())).thenReturn(createResearcherProperties());
-    when(whitelistService.findWhitelistEntriesForUser(any(), any()))
-        .thenReturn(createWhitelistEntries());
+    when(libraryCardService.findLibraryCardsByUserId(any()))
+        .thenReturn(createLibraryCards());
     initResource();
     Response response = userResource.addRoleToUser(authUser, 1, UserRoles.ADMIN.getRoleId());
     assertEquals(200, response.getStatus());
@@ -183,8 +185,8 @@ public class UserResourceTest {
     User user = createUserWithRole();
     when(userService.findUserById(any())).thenReturn(user);
     when(userService.findAllUserProperties(any())).thenReturn(createResearcherProperties());
-    when(whitelistService.findWhitelistEntriesForUser(any(), any()))
-        .thenReturn(createWhitelistEntries());
+    when(libraryCardService.findLibraryCardsByUserId(any()))
+        .thenReturn(createLibraryCards());
     initResource();
     Response response = userResource.addRoleToUser(authUser, 1, UserRoles.RESEARCHER.getRoleId());
     assertEquals(304, response.getStatus());
@@ -195,8 +197,8 @@ public class UserResourceTest {
     User user = createUserWithRole();
     when(userService.findUserById(any())).thenReturn(user);
     when(userService.findAllUserProperties(any())).thenReturn(createResearcherProperties());
-    when(whitelistService.findWhitelistEntriesForUser(any(), any()))
-        .thenReturn(createWhitelistEntries());
+    when(libraryCardService.findLibraryCardsByUserId(any()))
+        .thenReturn(createLibraryCards());
     initResource();
     Response response = userResource.addRoleToUser(authUser, 1, 1000);
     assertEquals(400, response.getStatus());
@@ -223,17 +225,13 @@ public class UserResourceTest {
         .collect(Collectors.toList());
   }
 
-  private List<WhitelistEntry> createWhitelistEntries() {
-    WhitelistEntry e = new WhitelistEntry();
+  private List<LibraryCard> createLibraryCards() {
+    LibraryCard e = new LibraryCard();
     String randomValue = RandomStringUtils.random(10, true, false);
-    e.setCommonsId(randomValue);
-    e.setEmail(randomValue);
-    e.setItDirectorEmail(randomValue);
-    e.setItDirectorName(randomValue);
-    e.setName(randomValue);
-    e.setOrganization(randomValue);
-    e.setSigningOfficialEmail(randomValue);
-    e.setSigningOfficialName(randomValue);
+    e.setEraCommonsId(randomValue);
+    e.setUserEmail(randomValue);
+    e.setUserName(randomValue);
+    e.setInstitutionId(new Random().nextInt());
     return Collections.singletonList(e);
   }
 }


### PR DESCRIPTION
SCOPE:
- All references to WhitelistService (except in WhitelistResource which is to be deleted in DUOS-1067) are converted to references to LibraryCardService
- All references WhitelistEntry (except in WhitelistResource, WhitelistService, WhitelistParser, WhitelistCache which are all to be deleted in DUOS-1067) are converted to references to LibraryCard
- Reviewed delete user functionality to ensure there is no FK constraint on the dacuser table regarding whitelist entries

This PR will have an accompaniment on the UI
UPDATE: the PR on the UI was going to be addressing whitelist references but there are no references so it is not needed. 

https://broadworkbench.atlassian.net/browse/DUOS-1066

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [ ] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
