### PR TITLE
DUOS-1274[risk=no] Refactored searchFilteredElectionList in MetricsService for correct % SRP Approved

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/MetricsDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/MetricsDAO.java
@@ -27,7 +27,7 @@ public interface MetricsDAO extends Transactional<MetricsDAO> {
 
   @SqlQuery(
     "SELECT * from ( "
-      + "SELECT e.*, v.vote finalvote, v.rationale finalrationale, v.createdate finalvotedate, MAX(e.electionid) "
+      + "SELECT e.*, v.vote finalvote, v.rationale finalrationale, v.updatedate finalvotedate, MAX(e.electionid) "
       + "OVER (PARTITION BY e.referenceid, e.electiontype) AS latest "
       + "FROM election e "
       + "LEFT JOIN vote v ON e.electionid = v.electionid AND "

--- a/src/main/java/org/broadinstitute/consent/http/db/MetricsDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/MetricsDAO.java
@@ -54,18 +54,14 @@ public interface MetricsDAO extends Transactional<MetricsDAO> {
   List<Match> findMatchesForPurposeIds(@BindList("referenceIds") List<String> referenceIds);
 
   @SqlQuery(
-      "SELECT d.*, e.electionid as electionid "
-          + "FROM dac d "
-          + "INNER JOIN consents c on d.dac_id = c.dac_id "
-          + "INNER JOIN consentassociations a on a.consentid = c.consentid "
-          + "INNER JOIN election e on e.datasetid = a.datasetid "
-          + "WHERE e.electionid in (<electionIds>)"
-          + "UNION "
-          + "SELECT d.*, e.electionid as electionid "
-          + "FROM dac d "
-          + "INNER JOIN consents c on d.dac_id = c.dac_id "
-          + "INNER JOIN election e on e.referenceid = c.consentid "
-          + "WHERE e.electionid in (<electionIds>)")
+    "SELECT d.*, e.electionid as electionid "
+    + "FROM election e "
+    + "INNER JOIN accesselection_consentelection a ON a.access_election_id = e.electionid "
+    + "INNER JOIN election consentElection ON a.consent_election_id = consentElection.electionid "
+    + "INNER JOIN consents c ON consentElection.referenceId = c.consentid "
+    + "INNER JOIN dac d on d.dac_id = c.dac_id "
+    + "WHERE e.electionId IN (<electionIds>) "
+  )
   @UseRowMapper(DacMapper.class)
   List<Dac> findAllDacsForElectionIds(@BindList("electionIds") List<Integer> electionIds);
 

--- a/src/main/java/org/broadinstitute/consent/http/db/MetricsDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/MetricsDAO.java
@@ -27,7 +27,12 @@ public interface MetricsDAO extends Transactional<MetricsDAO> {
 
   @SqlQuery(
     "SELECT * from ( "
-      + "SELECT e.*, v.vote finalvote, v.rationale finalrationale, v.updatedate finalvotedate, MAX(e.electionid) "
+      + "SELECT e.*, v.vote finalvote, "
+      + "CASE "
+        + "WHEN v.updatedate IS NULL THEN v.createdate "
+        + "ELSE v.updatedate "
+      + "END as finalvotedate, "
+      + "v.rationale finalrationale, MAX(e.electionid) "
       + "OVER (PARTITION BY e.referenceid, e.electiontype) AS latest "
       + "FROM election e "
       + "LEFT JOIN vote v ON e.electionid = v.electionid AND "

--- a/src/main/java/org/broadinstitute/consent/http/models/DarDecisionMetrics.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DarDecisionMetrics.java
@@ -229,7 +229,7 @@ public class DarDecisionMetrics implements DecisionMetrics {
   private void setDacDecision(Election election) {
     //NOTE: finalVote is pulled from the associated vote
     //Vote records are vastly more reliable than election vote status 
-    if (Objects.nonNull(election) && election.getFinalVote()) {
+    if (Objects.nonNull(election) && Objects.nonNull(election.getFinalVote())) {
       this.dacDecision = election.getFinalVote() ? YES : NO;
     }
   }

--- a/src/main/java/org/broadinstitute/consent/http/service/MetricsService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/MetricsService.java
@@ -146,17 +146,19 @@ public class MetricsService {
   }
 
   private static Optional<Election> searchFilteredElectionList(List<Election> electionList) {
-
-    //Search for instance where election.finalVote is true
-    //Order does not matter, so parallel steam makes sense
+    //Search for first instance where finalVote is non-null
+    //Only one chairperson vote is registered with current flow (later votes won't be registered due to closed status of election)
+    //Legacy vote flow had odd behavior where, upon Chair vote submission, all Chair votes within an election would have their vote updated
+    //Example: Chair A submits YES, vote for CHAIR A, CHAIR B, CHAIR C would all be YES
+    //This has already been corrected in a previous PR so newer votes will not have this issue
+    //As such, the above pattern largely holds to older records, (maybe Q3 2020 and earlier)
+    //In this instance findFirst is still appropriate since the vote value is still accurate
+    //Currently user id is not used in the DataAccess/RP analysis (% agreement, % accurate, etc), so user-vote attribution isn't a concern
+    //That said if, for whatever reason, you want to do vote tracking/analysis by user, legacy pattern/records will make the task difficult
     Optional<Election> election = electionList
       .stream()
-      .filter(e -> Objects.nonNull(e.getFinalVote()) && e.getFinalVote())
-      .findAny();
-    //if no vote was found, return the earliest vote
-    if(!election.isPresent()) {
-      election = electionList.stream().findFirst();
-    }
+      .filter(e -> Objects.nonNull(e.getFinalVote()))
+      .findFirst();
     return election;
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/service/MetricsService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/MetricsService.java
@@ -96,7 +96,7 @@ public class MetricsService {
 
           Optional<Election> accessElection = searchFilteredElectionList(filteredAccessElections);
           Optional<Election> rpElection = searchFilteredElectionList(filteredRpElections);
-          
+
           Optional<Match> match =
             matches.stream()
               .filter(
@@ -153,9 +153,8 @@ public class MetricsService {
       .stream()
       .filter(e -> Objects.nonNull(e.getFinalVote()) && e.getFinalVote())
       .findAny();
-    
     //if no vote was found, return the earliest vote
-    if(Objects.isNull(election)) {
+    if(!election.isPresent()) {
       election = electionList.stream().findFirst();
     }
     return election;


### PR DESCRIPTION
Addresses [DUOS-1274](https://broadworkbench.atlassian.net/browse/DUOS-1274)

PR corrects null check in searchFilteredElectionList and date references in associated MetricsDAO query.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [ ] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
