### PR TITLE
[DUOS-1069][risk=low] Add hook to apply userid to library card with same email

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
@@ -474,7 +474,8 @@ public class ConsentModule extends AbstractModule {
                 providesResearcherPropertyDAO(),
                 providesUserRoleDAO(),
                 providesVoteDAO(),
-                providesInstitutionDAO());
+                providesInstitutionDAO(),
+                providesLibraryCardDAO());
     }
 
     @Provides

--- a/src/main/java/org/broadinstitute/consent/http/db/LibraryCardDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/LibraryCardDAO.java
@@ -68,4 +68,9 @@ public interface LibraryCardDAO extends Transactional<LibraryCardDAO> {
   @SqlQuery("SELECT * FROM library_card")
   List<LibraryCard> findAllLibraryCards();
 
+  @RegisterBeanMapper(value = LibraryCard.class)
+  @UseRowReducer(LibraryCardReducer.class)
+  @SqlQuery("SELECT * FROM library_card " +
+          "WHERE user_email = :email")
+  List<LibraryCard> findAllLibraryCardsByUserEmail(@Bind("email") String email);
 }

--- a/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
@@ -421,6 +421,14 @@ public class DAOTestHelper {
         return libraryCardDAO.findLibraryCardById(id);
     }
 
+    protected LibraryCard createLibraryCard(User user) {
+        Integer institutionId = createInstitution().getId();
+        String stringValue = "value";
+        Integer id = libraryCardDAO.insertLibraryCard(user.getDacUserId(), institutionId, stringValue, user.getDisplayName(), user.getEmail(), user.getDacUserId(), new Date());
+        createdLibraryCardIds.add(id);
+        return libraryCardDAO.findLibraryCardById(id);
+    }
+
     protected Date yesterday() {
         final Calendar cal = Calendar.getInstance();
         cal.add(Calendar.DATE, -1);

--- a/src/test/java/org/broadinstitute/consent/http/db/LibraryCardDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/LibraryCardDAOTest.java
@@ -10,6 +10,7 @@ import java.util.List;
 
 import com.google.gson.Gson;
 
+import org.broadinstitute.consent.http.models.User;
 import org.postgresql.util.PSQLException;
 import org.postgresql.util.PSQLState;
 import org.apache.commons.lang3.RandomUtils;
@@ -127,5 +128,15 @@ public class LibraryCardDAOTest extends DAOTestHelper {
     createLibraryCard();
     List<LibraryCard> cardListUpdated = libraryCardDAO.findAllLibraryCards();
     assertEquals(1, cardListUpdated.size());
+  }
+
+  @Test
+  public void testFindAllLibraryCardsByUserEmail() {
+    User user = createUser();
+    LibraryCard libraryCard = createLibraryCard(user);
+    List<LibraryCard> libraryCards = libraryCardDAO.findAllLibraryCardsByUserEmail(user.getEmail());
+    assertNotNull(libraryCards);
+    assertEquals(1, libraryCards.size());
+    assertEquals(user.getEmail(), libraryCards.get(0).getUserEmail());
   }
 }


### PR DESCRIPTION
**Addresses**
https://broadworkbench.atlassian.net/browse/DUOS-1069
**Changes**
- Add DAO method to find library cards with same user as the one being created
- Apply new user id to said library cards
- Apply institutionId from library card to new user
- Add unit tests

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [ ] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
