### PR TITLE
[DUOS-1282][risk=low] Post LC Fix

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/resources/LibraryCardResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/LibraryCardResource.java
@@ -85,10 +85,6 @@ public class LibraryCardResource extends Resource{
       LibraryCard payload = new Gson().fromJson(libraryCard, LibraryCard.class);
       User lcUser = userService.findUserByEmail(payload.getUserEmail());
 
-      if (Objects.isNull(lcUser)) {
-        throw new BadRequestException("User email does not belong to a valid user.");
-      }
-
       payload.setUserId(lcUser.getDacUserId());
       LibraryCard newLibraryCard = libraryCardService.createLibraryCard(payload, user.getDacUserId());
       return Response.status(HttpStatusCodes.STATUS_CODE_CREATED).entity(newLibraryCard).build();

--- a/src/main/java/org/broadinstitute/consent/http/resources/LibraryCardResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/LibraryCardResource.java
@@ -5,7 +5,9 @@ import com.google.gson.Gson;
 import com.google.inject.Inject;
 import io.dropwizard.auth.Auth;
 import java.util.List;
+import java.util.Objects;
 import javax.annotation.security.RolesAllowed;
+import javax.ws.rs.BadRequestException;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
@@ -81,6 +83,13 @@ public class LibraryCardResource extends Resource{
     try{
       User user = userService.findUserByEmail(authUser.getName());
       LibraryCard payload = new Gson().fromJson(libraryCard, LibraryCard.class);
+      User lcUser = userService.findUserByEmail(payload.getUserEmail());
+
+      if (Objects.isNull(lcUser)) {
+        throw new BadRequestException("User email does not belong to a valid user.");
+      }
+
+      payload.setUserId(lcUser.getDacUserId());
       LibraryCard newLibraryCard = libraryCardService.createLibraryCard(payload, user.getDacUserId());
       return Response.status(HttpStatusCodes.STATUS_CODE_CREATED).entity(newLibraryCard).build();
     } catch(Exception e) {

--- a/src/test/java/org/broadinstitute/consent/http/resources/LibraryCardResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/LibraryCardResourceTest.java
@@ -149,7 +149,7 @@ public class LibraryCardResourceTest {
     when(libraryCardService.createLibraryCard(any(LibraryCard.class), anyInt())).thenReturn(mockCard);
     initResource();
     Response response = resource.createLibraryCard(authUser, payload);
-    assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
+    assertEquals(HttpStatusCodes.STATUS_CODE_SERVER_ERROR, response.getStatus());
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/resources/LibraryCardResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/LibraryCardResourceTest.java
@@ -56,6 +56,7 @@ public class LibraryCardResourceTest {
     LibraryCard mockCard = new LibraryCard();
     mockCard.setUserId(2);
     mockCard.setCreateUserId(1);
+    mockCard.setUserEmail(lcUser.getEmail());
     return mockCard;
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/resources/LibraryCardResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/LibraryCardResourceTest.java
@@ -10,7 +10,10 @@ import static org.mockito.Mockito.when;
 
 import com.google.api.client.http.HttpStatusCodes;
 import com.google.gson.Gson;
+
+import java.util.Arrays;
 import java.util.Collections;
+import javax.ws.rs.BadRequestException;
 import javax.ws.rs.core.UriInfo;
 import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.NotFoundException;
@@ -38,6 +41,9 @@ public class LibraryCardResourceTest {
     new UserRole(UserRoles.ADMIN.getRoleId(), UserRoles.ADMIN.getRoleName())
   );
   private final User user = new User(1, authUser.getName(), "Display Name", new Date(), adminRoles, authUser.getName());
+  private final User lcUser = new User(2, "testuser@gmail.com", "Test User", new Date(), Collections.singletonList(
+          new UserRole(UserRoles.RESEARCHER.getRoleId(), UserRoles.RESEARCHER.getRoleName())
+  ), "testuser@gmail.com");
   private LibraryCardResource resource;
 
   @Mock private UserService userService;
@@ -120,14 +126,29 @@ public class LibraryCardResourceTest {
   @Test
   public void testCreateLibraryCard() {
     LibraryCard mockCard = mockLibraryCardSetup();
+    mockCard.setUserEmail(lcUser.getEmail());
     String payload = new Gson().toJson(mockCard);
-    when(userService.findUserByEmail(anyString())).thenReturn(user);
+    when(userService.findUserByEmail(authUser.getName())).thenReturn(user);
+    when(userService.findUserByEmail(mockCard.getUserEmail())).thenReturn(lcUser);
     when(libraryCardService.createLibraryCard(any(LibraryCard.class), anyInt())).thenReturn(mockCard);
     initResource();
     Response response = resource.createLibraryCard(authUser, payload);
     String json = response.getEntity().toString();
     assertEquals(HttpStatusCodes.STATUS_CODE_CREATED, response.getStatus());
     assertNotNull(json);
+  }
+
+  @Test
+  public void testCreateLibraryCardInvalidEmail() {
+    LibraryCard mockCard = mockLibraryCardSetup();
+    mockCard.setUserEmail("wrongemail@gmail.com");
+    String payload = new Gson().toJson(mockCard);
+    when(userService.findUserByEmail(authUser.getName())).thenReturn(user);
+    when(userService.findUserByEmail(lcUser.getEmail())).thenReturn(lcUser);
+    when(libraryCardService.createLibraryCard(any(LibraryCard.class), anyInt())).thenReturn(mockCard);
+    initResource();
+    Response response = resource.createLibraryCard(authUser, payload);
+    assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
   }
 
   @Test


### PR DESCRIPTION
**Addresses**
https://broadworkbench.atlassian.net/browse/DUOS-1282
**Changes**
- Change Library Card resource to look up library card user by email and ignore the userId field from the payload
- Update tests to accommodate

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [ ] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
