### PR TITLE
DUOS-1289[risk=no]NPE on Metrics View for dataset 2

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/service/MetricsService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/MetricsService.java
@@ -241,17 +241,19 @@ public class MetricsService {
     if (userId != null) {
       User user = userDAO.findUserWithPropertiesById(userId);
 
-      Optional<UserProperty> isResearcher = user.getProperties().stream().filter(prop -> prop.getPropertyKey().equals("isThePI") && prop.getPropertyValue().toLowerCase().equals("true")).findFirst();
-      if (isResearcher.isPresent()) {
-        Optional<UserProperty> userName = user.getProperties().stream().filter(prop -> prop.getPropertyKey().equals("profileName")).findFirst();
-        if(userName.isPresent()) {
-          return userName.get().getPropertyValue();
+      if (user != null) {
+        Optional<UserProperty> isResearcher = user.getProperties().stream().filter(prop -> prop.getPropertyKey().equals("isThePI") && prop.getPropertyValue().toLowerCase().equals("true")).findFirst();
+        if (isResearcher.isPresent()) {
+          Optional<UserProperty> userName = user.getProperties().stream().filter(prop -> prop.getPropertyKey().equals("profileName")).findFirst();
+          if(userName.isPresent()) {
+            return userName.get().getPropertyValue();
+          }
         }
-      }
 
-      Optional<UserProperty> piName = user.getProperties().stream().filter(prop -> prop.getPropertyKey().equals("piName")).findFirst();
-      if (piName.isPresent()) {
-        return piName.get().getPropertyValue();
+        Optional<UserProperty> piName = user.getProperties().stream().filter(prop -> prop.getPropertyKey().equals("piName")).findFirst();
+        if (piName.isPresent()) {
+          return piName.get().getPropertyValue();
+        }
       }
     }
     return "- -";


### PR DESCRIPTION
SCOPE:
Dataset 2 was returning a 500 error on the UI because one of its DARs (with id 62) has a userId (55) that no longer exists in the db. The solution is to add a null check after receiving the user before processing the information.

ADDRESSES:
https://broadworkbench.atlassian.net/browse/DUOS-1289

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [ ] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
