### PR TITLE
[DUOS-1191][risk=no] Log 500 and database errors at Error level

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/resources/Resource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/Resource.java
@@ -143,13 +143,13 @@ abstract public class Resource {
         //default status definition
         LoggerFactory.getLogger(Resource.class.getName()).error(e.getMessage());
         Integer status = Response.Status.INTERNAL_SERVER_ERROR.getStatusCode();
-       
+
         try {
-            if(e.getCause() instanceof PSQLException) {
+            if (e.getCause() instanceof PSQLException) {
                 String vendorCode = ((PSQLException) e.getCause()).getSQLState();
                 status = vendorCodeStatusMap.get(vendorCode);
             }
-        } catch(Exception error) {
+        } catch (Exception error) {
             //no need to handle, default status already assigned
         }
 


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-1191

## Changes
Explicitly add error logging for 500 and database errors. We were always logging them at the warning level, but it's easier to find them when they are flagged as real errors.

----

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [ ] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
