### PR TITLE
DUOS-1311[risk=no]Replace references to deprecated user properties with fields on User

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
@@ -486,6 +486,7 @@ public class ConsentModule extends AbstractModule {
         return new ResearcherService(
                 providesResearcherPropertyDAO(),
                 providesUserDAO(),
+                providesInstitutionDAO(),
                 providesEmailNotifierService(),
                 providesUserService()
         );

--- a/src/main/java/org/broadinstitute/consent/http/db/UserPropertyDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/UserPropertyDAO.java
@@ -44,14 +44,13 @@ public interface UserPropertyDAO extends Transactional<UserPropertyDAO> {
     void deletePropertyByUser(@BindList("propertyKeyList") List<String> propertyKeyList, @Bind("userId") Integer userId);
 
     @SqlQuery(value = "SELECT * FROM user_property WHERE " +
-            "(propertykey = '" + INSTITUTION + "' AND propertyvalue != :institutionName) OR " +
             "(propertykey = '" + ARE_YOU_PRINCIPAL_INVESTIGATOR + "' AND  propertyvalue != :isThePI) OR " +
             "(propertykey = '" + DO_YOU_HAVE_PI + "' AND  propertyvalue != :havePI) OR " +
             "(propertykey = '" + ERA_COMMONS_ID + "' AND  propertyvalue != :eRACommonsID) OR " +
             "(propertykey = '" + PUBMED_ID + "' AND  propertyvalue != :pubmedID) OR " +
             "(propertykey = '" + SCIENTIFIC_URL + "' AND  propertyvalue != :scientificURL) " +
             " AND userid = :userId")
-    List<UserProperty> findResearcherProperties(@Bind("userId") Integer userId, @Bind("institutionName") String institutionName,@Bind("isThePI") String isThePI,
+    List<UserProperty> findResearcherProperties(@Bind("userId") Integer userId, @Bind("isThePI") String isThePI,
                                                       @Bind("havePI") String havePI, @Bind("eRACommonsID") String eRACommonsID, @Bind("pubmedID") String pubmedID, @Bind("scientificURL") String scientificURL);
 
     @SqlQuery("SELECT propertyvalue FROM user_property WHERE userid = :userId and propertykey = :propertyKey")

--- a/src/main/java/org/broadinstitute/consent/http/enumeration/UserFields.java
+++ b/src/main/java/org/broadinstitute/consent/http/enumeration/UserFields.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 public enum UserFields {
+  @Deprecated //display name is stored on user
   PROFILE_NAME("profileName", false),
   ACADEMIC_BUSINESS_EMAIL("academicEmail", true),
   @Deprecated //instiution id is stored on user

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessReportsParser.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessReportsParser.java
@@ -8,6 +8,7 @@ import org.broadinstitute.consent.http.util.DarConstants;
 import org.broadinstitute.consent.http.util.DarUtil;
 import org.bson.Document;
 import java.io.*;
+import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
@@ -61,7 +62,7 @@ public class DataAccessReportsParser {
     public void addApprovedDARLine(FileWriter darWriter, Election election, Document dar, String profileName, String institution, String consentName, String translatedUseRestriction) throws IOException {        String rusSummary = StringUtils.isNotEmpty( dar.getString(DarConstants.NON_TECH_RUS)) ?  dar.getString(DarConstants.NON_TECH_RUS).replace("\n", " ") : "";
         String content1 =  profileName + DEFAULT_SEPARATOR + institution + DEFAULT_SEPARATOR;
         String content2 = rusSummary + DEFAULT_SEPARATOR +
-                formatTimeToDate(new Date(dar.getLong(DarConstants.SORT_DATE)).getTime()) + DEFAULT_SEPARATOR +
+                formatTimeToDate(((Timestamp) dar.get(DarConstants.SORT_DATE)).getTime()) + DEFAULT_SEPARATOR +
                 formatTimeToDate(election.getFinalVoteDate().getTime()) + DEFAULT_SEPARATOR +
                 "--";
         addDARLine(darWriter, dar, content1, content2, consentName, translatedUseRestriction);
@@ -97,13 +98,17 @@ public class DataAccessReportsParser {
     private void addDARLine(FileWriter darWriter, Document dar, String customContent1, String customContent2, String consentName, String translatedUseRestriction) throws IOException {
         List<Document> dataSetDetails = dar.get(DarConstants.DATASET_DETAIL, ArrayList.class);
         List<String> datasetNames = new ArrayList<>();
-        for(Document detail : dataSetDetails) {
-            datasetNames.add(StringUtils.defaultString(detail.getString("name")));
+        if (dataSetDetails != null) {
+            for (Document detail : dataSetDetails) {
+                datasetNames.add(StringUtils.defaultString(detail.getString("name")));
+            }
         }
         List<Integer> dataSetIds = DarUtil.getIntegerList(dar, DarConstants.DATASET_ID);
         List<String> dataSetUUIds = new ArrayList<>();
-        for(Integer id : dataSetIds) {
-            dataSetUUIds.add(DataSet.parseAliasToIdentifier(id));
+        if (dataSetIds != null) {
+            for (Integer id : dataSetIds) {
+                dataSetUUIds.add(DataSet.parseAliasToIdentifier(id));
+            }
         }
         String sDUL = StringUtils.isNotEmpty(translatedUseRestriction) ?  translatedUseRestriction.replace("\n", " ") : "";
         String translatedRestriction = StringUtils.isNotEmpty(dar.getString(DarConstants.TRANSLATED_RESTRICTION)) ? dar.getString(DarConstants.TRANSLATED_RESTRICTION).replace("<br>", " ") :  "";

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessReportsParser.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessReportsParser.java
@@ -7,12 +7,14 @@ import org.broadinstitute.consent.http.models.Election;
 import org.broadinstitute.consent.http.util.DarConstants;
 import org.broadinstitute.consent.http.util.DarUtil;
 import org.bson.Document;
-import java.io.*;
+import java.io.FileWriter;
+import java.io.IOException;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
+import java.util.Objects;
 
 public class DataAccessReportsParser {
 
@@ -98,14 +100,14 @@ public class DataAccessReportsParser {
     private void addDARLine(FileWriter darWriter, Document dar, String customContent1, String customContent2, String consentName, String translatedUseRestriction) throws IOException {
         List<Document> dataSetDetails = dar.get(DarConstants.DATASET_DETAIL, ArrayList.class);
         List<String> datasetNames = new ArrayList<>();
-        if (dataSetDetails != null) {
+        if (Objects.nonNull(dataSetDetails)) {
             for (Document detail : dataSetDetails) {
                 datasetNames.add(StringUtils.defaultString(detail.getString("name")));
             }
         }
         List<Integer> dataSetIds = DarUtil.getIntegerList(dar, DarConstants.DATASET_ID);
         List<String> dataSetUUIds = new ArrayList<>();
-        if (dataSetIds != null) {
+        if (Objects.nonNull(dataSetIds)) {
             for (Integer id : dataSetIds) {
                 dataSetUUIds.add(DataSet.parseAliasToIdentifier(id));
             }

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
@@ -614,15 +614,15 @@ public class DataAccessRequestService {
                 DataAccessRequest dataAccessRequest = findByReferenceId(election.getReferenceId());
                 User user = userDAO.findUserById(dataAccessRequest.getUserId());
                 try {
-                    if (dar != null && user != null) {
+                    if (Objects.nonNull(dar) && Objects.nonNull(user)) {
                         Integer datasetId = dataAccessRequest.getData().getDatasetIds().get(0);
                         String consentId = dataSetDAO.getAssociatedConsentIdByDataSetId(datasetId);
                         Consent consent = consentDAO.findConsentById(consentId);
                         String profileName = user.getDisplayName();
-                        if (user.getInstitutionId() == null) {
+                        if (Objects.isNull(user.getInstitutionId())) {
                           logger.warn("No institution found for creator of this Data Access Request");
                         }
-                        String institution = (user.getInstitutionId() == null) ? "" : institutionDAO.findInstitutionById(user.getInstitutionId()).getName();
+                        String institution = Objects.isNull(user.getInstitutionId()) ? "" : institutionDAO.findInstitutionById(user.getInstitutionId()).getName();
                         dataAccessReportsParser.addApprovedDARLine(darWriter, election, dar, profileName, institution, consent.getName(), consent.getTranslatedUseRestriction());
                     }
                 } catch (Exception e) {
@@ -669,11 +669,11 @@ public class DataAccessRequestService {
                 DataAccessRequest dataAccessRequest = findByReferenceId(referenceId);
                 User user = userDAO.findUserById(dataAccessRequest.getUserId());
                 Date approvalDate = electionDAO.findApprovalAccessElectionDate(referenceId);
-                if (approvalDate != null) {
+                if (Objects.nonNull(approvalDate)) {
                     String email = userPropertyDAO
                             .findPropertyValueByPK(dataAccessRequest.getUserId(), DarConstants.ACADEMIC_BUSINESS_EMAIL);
-                    String name = (user == null) ? "" : user.getDisplayName();
-                    String institution = (user == null || user.getInstitutionId() == null) ? "" : institutionDAO.findInstitutionById(user.getInstitutionId()).getName();
+                    String name = Objects.isNull(user) ? "" : user.getDisplayName();
+                    String institution = (Objects.isNull(user) || Objects.isNull(user.getInstitutionId())) ? "" : institutionDAO.findInstitutionById(user.getInstitutionId()).getName();
                     String darCode = dataAccessRequest.getData().getDarCode();
                     dataAccessReportsParser.addDataSetApprovedUsersLine(darWriter, email, name, institution, darCode, approvalDate);
                 }

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
@@ -619,7 +619,10 @@ public class DataAccessRequestService {
                         String consentId = dataSetDAO.getAssociatedConsentIdByDataSetId(datasetId);
                         Consent consent = consentDAO.findConsentById(consentId);
                         String profileName = user.getDisplayName();
-                        String institution = institutionDAO.findInstitutionById(user.getInstitutionId()).getName();
+                        if (user.getInstitutionId() == null) {
+                          logger.warn("No institution found for creator of this Data Access Request");
+                        }
+                        String institution = (user.getInstitutionId() == null) ? "" : institutionDAO.findInstitutionById(user.getInstitutionId()).getName();
                         dataAccessReportsParser.addApprovedDARLine(darWriter, election, dar, profileName, institution, consent.getName(), consent.getTranslatedUseRestriction());
                     }
                 } catch (Exception e) {

--- a/src/main/java/org/broadinstitute/consent/http/service/ResearcherService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ResearcherService.java
@@ -24,6 +24,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 
@@ -107,7 +108,7 @@ public class ResearcherService {
         Map<String, String> rpForDAR = new HashMap<>();
         User user =  userDAO.findUserById(userId);
         rpForDAR.put(UserFields.INVESTIGATOR.getValue(), properties.getOrDefault(UserFields.PI_NAME.getValue(), (user == null) ? "" : user.getDisplayName()));
-        rpForDAR.put(UserFields.INSTITUTION.getValue(), (user == null || user.getInstitutionId() == null) ? "" : institutionDAO.findInstitutionById(user.getInstitutionId()).getName());
+        rpForDAR.put(UserFields.INSTITUTION.getValue(), (Objects.isNull(user) || Objects.isNull(user.getInstitutionId())) ? "" : institutionDAO.findInstitutionById(user.getInstitutionId()).getName());
         rpForDAR.put(UserFields.DEPARTMENT.getValue(), properties.getOrDefault(UserFields.DEPARTMENT.getValue(), null));
         rpForDAR.put(UserFields.STREET_ADDRESS_1.getValue(), properties.getOrDefault(UserFields.STREET_ADDRESS_1.getValue(), null));
         rpForDAR.put(
@@ -120,7 +121,7 @@ public class ResearcherService {
         rpForDAR.put(UserFields.DIVISION.getValue(), properties.getOrDefault(UserFields.DIVISION.getValue(), null));
         rpForDAR.put(UserFields.ERA_COMMONS_ID.getValue(), properties.getOrDefault(UserFields.ERA_COMMONS_ID.getValue(), null));
         rpForDAR.put(UserFields.PUBMED_ID.getValue(), properties.getOrDefault(UserFields.PUBMED_ID.getValue(), null));
-        rpForDAR.put(UserFields.PROFILE_NAME.getValue(), (user == null) ? "" : user.getDisplayName());
+        rpForDAR.put(UserFields.PROFILE_NAME.getValue(), Objects.isNull(user) ? "" : user.getDisplayName());
         rpForDAR.put(
                 UserFields.ACADEMIC_BUSINESS_EMAIL.getValue(), properties.getOrDefault(UserFields.ACADEMIC_BUSINESS_EMAIL.getValue(), null));
         rpForDAR.put(UserFields.SCIENTIFIC_URL.getValue(), properties.getOrDefault(UserFields.SCIENTIFIC_URL.getValue(), null));

--- a/src/main/java/org/broadinstitute/consent/http/service/ResearcherService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ResearcherService.java
@@ -107,7 +107,7 @@ public class ResearcherService {
         Map<String, String> rpForDAR = new HashMap<>();
         User user =  userDAO.findUserById(userId);
         rpForDAR.put(UserFields.INVESTIGATOR.getValue(), properties.getOrDefault(UserFields.PI_NAME.getValue(), user.getDisplayName()));
-        rpForDAR.put(DarConstants.INSTITUTION, institutionDAO.findInstitutionById(user.getInstitutionId()).getName());
+        rpForDAR.put(UserFields.INSTITUTION.getValue(), (user.getInstitutionId() == null) ? "" : institutionDAO.findInstitutionById(user.getInstitutionId()).getName());
         rpForDAR.put(UserFields.DEPARTMENT.getValue(), properties.getOrDefault(UserFields.DEPARTMENT.getValue(), null));
         rpForDAR.put(UserFields.STREET_ADDRESS_1.getValue(), properties.getOrDefault(UserFields.STREET_ADDRESS_1.getValue(), null));
         rpForDAR.put(
@@ -120,7 +120,7 @@ public class ResearcherService {
         rpForDAR.put(UserFields.DIVISION.getValue(), properties.getOrDefault(UserFields.DIVISION.getValue(), null));
         rpForDAR.put(UserFields.ERA_COMMONS_ID.getValue(), properties.getOrDefault(UserFields.ERA_COMMONS_ID.getValue(), null));
         rpForDAR.put(UserFields.PUBMED_ID.getValue(), properties.getOrDefault(UserFields.PUBMED_ID.getValue(), null));
-        rpForDAR.put(DarConstants.PROFILE_NAME, user.getDisplayName());
+        rpForDAR.put(UserFields.PROFILE_NAME.getValue(), user.getDisplayName());
         rpForDAR.put(
                 UserFields.ACADEMIC_BUSINESS_EMAIL.getValue(), properties.getOrDefault(UserFields.ACADEMIC_BUSINESS_EMAIL.getValue(), null));
         rpForDAR.put(UserFields.SCIENTIFIC_URL.getValue(), properties.getOrDefault(UserFields.SCIENTIFIC_URL.getValue(), null));

--- a/src/main/java/org/broadinstitute/consent/http/service/ResearcherService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ResearcherService.java
@@ -106,8 +106,8 @@ public class ResearcherService {
     private Map<String, String> getResearcherPropertiesForDAR(Map<String, String> properties, Integer userId) {
         Map<String, String> rpForDAR = new HashMap<>();
         User user =  userDAO.findUserById(userId);
-        rpForDAR.put(UserFields.INVESTIGATOR.getValue(), properties.getOrDefault(UserFields.PI_NAME.getValue(), user.getDisplayName()));
-        rpForDAR.put(UserFields.INSTITUTION.getValue(), (user.getInstitutionId() == null) ? "" : institutionDAO.findInstitutionById(user.getInstitutionId()).getName());
+        rpForDAR.put(UserFields.INVESTIGATOR.getValue(), properties.getOrDefault(UserFields.PI_NAME.getValue(), (user == null) ? "" : user.getDisplayName()));
+        rpForDAR.put(UserFields.INSTITUTION.getValue(), (user == null || user.getInstitutionId() == null) ? "" : institutionDAO.findInstitutionById(user.getInstitutionId()).getName());
         rpForDAR.put(UserFields.DEPARTMENT.getValue(), properties.getOrDefault(UserFields.DEPARTMENT.getValue(), null));
         rpForDAR.put(UserFields.STREET_ADDRESS_1.getValue(), properties.getOrDefault(UserFields.STREET_ADDRESS_1.getValue(), null));
         rpForDAR.put(
@@ -120,7 +120,7 @@ public class ResearcherService {
         rpForDAR.put(UserFields.DIVISION.getValue(), properties.getOrDefault(UserFields.DIVISION.getValue(), null));
         rpForDAR.put(UserFields.ERA_COMMONS_ID.getValue(), properties.getOrDefault(UserFields.ERA_COMMONS_ID.getValue(), null));
         rpForDAR.put(UserFields.PUBMED_ID.getValue(), properties.getOrDefault(UserFields.PUBMED_ID.getValue(), null));
-        rpForDAR.put(UserFields.PROFILE_NAME.getValue(), user.getDisplayName());
+        rpForDAR.put(UserFields.PROFILE_NAME.getValue(), (user == null) ? "" : user.getDisplayName());
         rpForDAR.put(
                 UserFields.ACADEMIC_BUSINESS_EMAIL.getValue(), properties.getOrDefault(UserFields.ACADEMIC_BUSINESS_EMAIL.getValue(), null));
         rpForDAR.put(UserFields.SCIENTIFIC_URL.getValue(), properties.getOrDefault(UserFields.SCIENTIFIC_URL.getValue(), null));

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -1944,6 +1944,34 @@ paths:
                 type: string
         404:
           description: The DAR or the election couldn't be found.
+  /api/dataRequest/approved:
+    get:
+      summary: Get a list of approved DARs
+      description: Get a list of approved DARs
+      tags:
+        - Data Access Request
+      responses:
+        200:
+          description: A list of approved DARs
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+  /api/dataRequest/reviewed:
+    get:
+      summary: Get a list of reviewed DARs
+      description: Get a list of reviewed DARs
+      tags:
+        - Data Access Request
+      responses:
+        200:
+          description: A list of reviewed DARs
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
   /api/consent/{id}/dul:
     get:
       summary: getDUL

--- a/src/test/java/org/broadinstitute/consent/http/service/DataAccessReportsParserTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DataAccessReportsParserTest.java
@@ -11,6 +11,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.Iterator;
@@ -182,7 +183,7 @@ public class DataAccessReportsParserTest {
         dar.put(DarConstants.DAR_CODE, DAR_CODE);
         dar.put(DarConstants.TRANSLATED_RESTRICTION, TRANSLATED_USE_RESTRICTION);
         dar.put(DarConstants.NON_TECH_RUS, RUS_SUMMARY);
-        dar.put(DarConstants.SORT_DATE, currentDate);
+        dar.put(DarConstants.SORT_DATE, new Timestamp(currentDate.getTime()));
         return dar;
     }
 }

--- a/src/test/java/org/broadinstitute/consent/http/service/DataAccessReportsParserTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DataAccessReportsParserTest.java
@@ -182,7 +182,7 @@ public class DataAccessReportsParserTest {
         dar.put(DarConstants.DAR_CODE, DAR_CODE);
         dar.put(DarConstants.TRANSLATED_RESTRICTION, TRANSLATED_USE_RESTRICTION);
         dar.put(DarConstants.NON_TECH_RUS, RUS_SUMMARY);
-        dar.put(DarConstants.SORT_DATE, currentDate.getTime());
+        dar.put(DarConstants.SORT_DATE, currentDate);
         return dar;
     }
 }

--- a/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
@@ -491,7 +491,7 @@ public class DataAccessRequestServiceTest {
         researcherProperties.put(DarConstants.PUBMED_ID, randomString());
         researcherProperties.put(DarConstants.SCIENTIFIC_URL, randomString());
         researcherProperties.put(UserFields.ARE_YOU_PRINCIPAL_INVESTIGATOR.getValue(), "true");
-        researcherProperties.put(DarConstants.PROFILE_NAME, randomString());
+        researcherProperties.put(UserFields.PROFILE_NAME.getValue(), randomString());
         return researcherProperties;
     }
 

--- a/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
@@ -297,11 +297,6 @@ public class DataAccessRequestServiceTest {
         when(consentDAO.findConsentById("CONS-1")).thenReturn(consent);
 
         Map<String, String> researcherProperties = getResearcherProperties();
-        when(userPropertyDAO.findPropertyValueByPK(dar.getUserId(), DarConstants.PROFILE_NAME))
-                .thenReturn(researcherProperties.get(DarConstants.PROFILE_NAME));
-        when(userPropertyDAO.findPropertyValueByPK(dar.getUserId(), DarConstants.INSTITUTION))
-                .thenReturn(researcherProperties.get(DarConstants.INSTITUTION));
-
         initService();
         try {
             File file = service.createApprovedDARDocument();
@@ -356,10 +351,6 @@ public class DataAccessRequestServiceTest {
         Map<String, String> researcherProperties = getResearcherProperties();
         when(userPropertyDAO.findPropertyValueByPK(dar.getUserId(), DarConstants.ACADEMIC_BUSINESS_EMAIL))
             .thenReturn(researcherProperties.get(DarConstants.ACADEMIC_BUSINESS_EMAIL));
-        when(userPropertyDAO.findPropertyValueByPK(dar.getUserId(), DarConstants.PROFILE_NAME))
-            .thenReturn(researcherProperties.get(DarConstants.PROFILE_NAME));
-        when(userPropertyDAO.findPropertyValueByPK(dar.getUserId(), DarConstants.INSTITUTION))
-            .thenReturn(researcherProperties.get(DarConstants.INSTITUTION));
 
         initService();
 
@@ -401,6 +392,8 @@ public class DataAccessRequestServiceTest {
     private DataAccessRequest generateDataAccessRequest() {
         DataAccessRequest dar = new DataAccessRequest();
         DataAccessRequestData data = new DataAccessRequestData();
+        Integer userId = userDAO.insertUser(UUID.randomUUID().toString(), "displayName", new Date());
+        dar.setUserId(userId);
         dar.setReferenceId(UUID.randomUUID().toString());
         data.setReferenceId(dar.getReferenceId());
         data.setDatasetIds(Collections.singletonList(1));
@@ -485,7 +478,6 @@ public class DataAccessRequestServiceTest {
 
     private Map<String, String> getResearcherProperties() {
         Map<String, String> researcherProperties = new HashMap<>();
-        researcherProperties.put(UserFields.INSTITUTION.getValue(), randomString());
         researcherProperties.put(UserFields.DEPARTMENT.getValue(), randomString());
         researcherProperties.put(UserFields.STREET_ADDRESS_1.getValue(), randomString());
         researcherProperties.put(UserFields.CITY.getValue(), randomString());
@@ -499,7 +491,7 @@ public class DataAccessRequestServiceTest {
         researcherProperties.put(DarConstants.PUBMED_ID, randomString());
         researcherProperties.put(DarConstants.SCIENTIFIC_URL, randomString());
         researcherProperties.put(UserFields.ARE_YOU_PRINCIPAL_INVESTIGATOR.getValue(), "true");
-        researcherProperties.put(UserFields.PROFILE_NAME.getValue(), randomString());
+        researcherProperties.put(DarConstants.PROFILE_NAME, randomString());
         return researcherProperties;
     }
 

--- a/src/test/java/org/broadinstitute/consent/http/service/ResearcherServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/ResearcherServiceTest.java
@@ -18,6 +18,7 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.RandomUtils;
 import org.broadinstitute.consent.http.authentication.GoogleUser;
 import org.broadinstitute.consent.http.db.UserPropertyDAO;
+import org.broadinstitute.consent.http.db.InstitutionDAO;
 import org.broadinstitute.consent.http.db.UserDAO;
 import org.broadinstitute.consent.http.enumeration.UserFields;
 import org.broadinstitute.consent.http.models.AuthUser;
@@ -36,6 +37,9 @@ public class ResearcherServiceTest {
 
     @Mock
     private UserDAO userDAO;
+
+    @Mock
+    private InstitutionDAO institutionDAO;
 
     @Mock
     private EmailNotifierService emailNotifierService;
@@ -64,14 +68,14 @@ public class ResearcherServiceTest {
     }
 
     private void initService() {
-        service = new ResearcherService(userPropertyDAO, userDAO, emailNotifierService, userService);
+        service = new ResearcherService(userPropertyDAO, userDAO, institutionDAO, emailNotifierService, userService);
     }
 
     @Test
     public void testSetProperties() {
         UserProperty prop = new UserProperty(
                 user.getDacUserId(),
-                UserFields.INSTITUTION.getValue(),
+                UserFields.DEPARTMENT.getValue(),
                 RandomStringUtils.random(10, true, false));
         Map<String, String> propMap = new HashMap<>();
         propMap.put(prop.getPropertyKey(), prop.getPropertyValue());
@@ -118,7 +122,7 @@ public class ResearcherServiceTest {
     public void testUpdatePropertiesNoValidation() {
         UserProperty prop = new UserProperty(
                 user.getDacUserId(),
-                UserFields.INSTITUTION.getValue(),
+                UserFields.DEPARTMENT.getValue(),
                 RandomStringUtils.random(10, true, false));
         Map<String, String> propMap = new HashMap<>();
         propMap.put(prop.getPropertyKey(), prop.getPropertyValue());
@@ -136,7 +140,7 @@ public class ResearcherServiceTest {
     public void testUpdatePropertiesMissingFields() {
         UserProperty prop = new UserProperty(
                 user.getDacUserId(),
-                UserFields.INSTITUTION.getValue(),
+                UserFields.DEPARTMENT.getValue(),
                 RandomStringUtils.random(10, true, false));
         Map<String, String> propMap = new HashMap<>();
         propMap.put(prop.getPropertyKey(), prop.getPropertyValue());

--- a/src/test/java/org/broadinstitute/consent/http/service/WhitelistServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/WhitelistServiceTest.java
@@ -124,7 +124,7 @@ public class WhitelistServiceTest {
         List<UserProperty> properties = new ArrayList<>();
         properties.add(new UserProperty(1, UserFields.ERA_COMMONS_ID.getValue(), matchField));
         properties.add(new UserProperty(1, UserFields.ACADEMIC_BUSINESS_EMAIL.getValue(), matchField));
-        properties.add(new UserProperty(1, UserFields.INSTITUTION.getValue(), matchField));
+        properties.add(new UserProperty(1, UserFields.DEPARTMENT.getValue(), matchField));
 
         initServices(fileData);
         service.postWhitelist(fileData);


### PR DESCRIPTION
SCOPE:
- Everywhere institution is populated from user properties replace with institution name by getting the institution from the institution id on the user:
-- in ResearcherService.hasUpdatedFields and  ResearcherService.getResearcherPropertiesForDAR. Also, remove field references in  ResearcherServiceTest, DataAccessRequestServiceTest, and WhitelistServiceTest. DataAccessRequestService.createApprovedDARDocument and createDataSetApprovedUsersDocument. Also, remove field references in DataAccessRequestServiceTest.
- Everywhere a users name is populated from user properties replace with the display name on the user:
-- DataAccessRequestService.createApprovedDARDocument and createDataSetApprovedUsersDocument. Also, remove field references in DataAccessRequestServiceTest.


ADDRESSES: 
https://broadworkbench.atlassian.net/browse/DUOS-1311
----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
