### PR TITLE
DUOS-1070[risk=no]eRA Commons Auth Hook

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
@@ -494,7 +494,7 @@ public class ConsentModule extends AbstractModule {
 
     @Provides
     NihService providesNihService() {
-        return new NihService(providesResearcherService());
+        return new NihService(providesResearcherService(), providesLibraryCardDAO());
     }
 
     @Provides

--- a/src/main/java/org/broadinstitute/consent/http/db/LibraryCardDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/LibraryCardDAO.java
@@ -87,4 +87,9 @@ public interface LibraryCardDAO extends Transactional<LibraryCardDAO> {
   @SqlQuery("SELECT * FROM library_card " +
           "WHERE user_email = :email")
   List<LibraryCard> findAllLibraryCardsByUserEmail(@Bind("email") String email);
+
+  @SqlUpdate("UPDATE library_card SET " +
+          " era_commons_id = :eraCommonsId " +
+          " WHERE user_id = :userId")
+  void updateEraCommonsForUser(@Bind("userId") Integer userId, @Bind("eraCommonsId") String eraCommonsId);
 }

--- a/src/main/java/org/broadinstitute/consent/http/resources/NihAccountResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/NihAccountResource.java
@@ -4,9 +4,12 @@ import com.google.inject.Inject;
 import io.dropwizard.auth.Auth;
 import org.broadinstitute.consent.http.models.AuthUser;
 import org.broadinstitute.consent.http.models.User;
+import org.broadinstitute.consent.http.models.UserProperty;
 import org.broadinstitute.consent.http.models.NIHUserAccount;
 import org.broadinstitute.consent.http.service.NihService;
 import org.broadinstitute.consent.http.service.UserService;
+
+import java.util.List;
 
 import javax.annotation.security.RolesAllowed;
 import javax.ws.rs.DELETE;
@@ -32,8 +35,9 @@ public class NihAccountResource extends Resource {
     @RolesAllowed(RESEARCHER)
     public Response registerResearcher(NIHUserAccount nihAccount, @Auth AuthUser user) {
         try {
-            userService.findUserByEmail(user.getName());
-            return Response.ok(nihService.authenticateNih(nihAccount, user)).build();
+            User u = userService.findUserByEmail(user.getName());
+            List<UserProperty> authUserProps = nihService.authenticateNih(nihAccount, user, u.getDacUserId());
+            return Response.ok(authUserProps).build();
         } catch (Exception e){
             return createExceptionResponse(e);
         }

--- a/src/main/java/org/broadinstitute/consent/http/resources/NihAccountResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/NihAccountResource.java
@@ -21,8 +21,8 @@ import javax.ws.rs.core.Response;
 @Path("api/nih")
 public class NihAccountResource extends Resource {
 
-    private NihService nihService;
-    private UserService userService;
+    private final NihService nihService;
+    private final UserService userService;
 
     @Inject
     public NihAccountResource(NihService nihService, UserService userService) {
@@ -33,10 +33,10 @@ public class NihAccountResource extends Resource {
     @POST
     @Produces("application/json")
     @RolesAllowed(RESEARCHER)
-    public Response registerResearcher(NIHUserAccount nihAccount, @Auth AuthUser user) {
+    public Response registerResearcher(NIHUserAccount nihAccount, @Auth AuthUser authUser) {
         try {
-            User u = userService.findUserByEmail(user.getName());
-            List<UserProperty> authUserProps = nihService.authenticateNih(nihAccount, user, u.getDacUserId());
+            User user = userService.findUserByEmail(authUser.getName());
+            List<UserProperty> authUserProps = nihService.authenticateNih(nihAccount, authUser, user.getDacUserId());
             return Response.ok(authUserProps).build();
         } catch (Exception e){
             return createExceptionResponse(e);

--- a/src/main/java/org/broadinstitute/consent/http/service/NihService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/NihService.java
@@ -32,7 +32,7 @@ public class NihService {
             nihAccount.setEraExpiration(generateEraExpirationDates());
             nihAccount.setStatus(true);
             List<UserProperty> updatedProps = researcherService.updateProperties(nihAccount.getNihMap(), authUser, false);
-            Optional<UserProperty> eraCommonsProp = updatedProps.stream().filter((prop) -> prop.getPropertyKey() == UserFields.ERA_COMMONS_ID.getValue()).findFirst();
+            Optional<UserProperty> eraCommonsProp = updatedProps.stream().filter((prop) -> prop.getPropertyKey().equalsIgnoreCase(UserFields.ERA_USERNAME.getValue())).findFirst();
             String eraCommonsId = (eraCommonsProp.isPresent()) ? eraCommonsProp.get().getPropertyValue() : "";
             if (!eraCommonsId.equals("")) {
               libraryCardDAO.updateEraCommonsForUser(userId, eraCommonsId);

--- a/src/main/java/org/broadinstitute/consent/http/service/NihService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/NihService.java
@@ -14,6 +14,7 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 public class NihService {
 
@@ -30,12 +31,13 @@ public class NihService {
         if (StringUtils.isNotEmpty(nihAccount.getNihUsername()) && !nihAccount.getNihUsername().isEmpty()) {
             nihAccount.setEraExpiration(generateEraExpirationDates());
             nihAccount.setStatus(true);
-            Map<String, String> userProp = researcherService.describeResearcherPropertiesMap(userId);
-            String eraCommonsId = (userProp == null) ? "" : userProp.getOrDefault(UserFields.ERA_COMMONS_ID.getValue(), "");
+            List<UserProperty> updatedProps = researcherService.updateProperties(nihAccount.getNihMap(), authUser, false);
+            Optional<UserProperty> eraCommonsProp = updatedProps.stream().filter((prop) -> prop.getPropertyKey() == UserFields.ERA_COMMONS_ID.getValue()).findFirst();
+            String eraCommonsId = (eraCommonsProp.isPresent()) ? eraCommonsProp.get().getPropertyValue() : "";
             if (!eraCommonsId.equals("")) {
               libraryCardDAO.updateEraCommonsForUser(userId, eraCommonsId);
             }
-            return researcherService.updateProperties(nihAccount.getNihMap(), authUser, false);
+            return updatedProps;
         } else {
             throw new BadRequestException("Invalid NIH UserName for user : " + authUser.getName());
         }

--- a/src/main/java/org/broadinstitute/consent/http/service/NihService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/NihService.java
@@ -31,7 +31,7 @@ public class NihService {
             nihAccount.setEraExpiration(generateEraExpirationDates());
             nihAccount.setStatus(true);
             Map<String, String> userProp = researcherService.describeResearcherPropertiesMap(userId);
-            String eraCommonsId = userProp.getOrDefault(UserFields.ERA_COMMONS_ID.getValue(), "");
+            String eraCommonsId = (userProp == null) ? "" : userProp.getOrDefault(UserFields.ERA_COMMONS_ID.getValue(), "");
             if (!eraCommonsId.equals("")) {
               libraryCardDAO.updateEraCommonsForUser(userId, eraCommonsId);
             }

--- a/src/test/java/org/broadinstitute/consent/http/db/LibraryCardDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/LibraryCardDAOTest.java
@@ -8,8 +8,6 @@ import static org.junit.Assert.assertTrue;
 import java.util.Date;
 import java.util.List;
 
-import com.google.gson.Gson;
-
 import org.broadinstitute.consent.http.models.User;
 import org.postgresql.util.PSQLException;
 import org.postgresql.util.PSQLState;
@@ -145,4 +143,14 @@ public class LibraryCardDAOTest extends DAOTestHelper {
     assertEquals(1, libraryCards.size());
     assertEquals(user.getEmail(), libraryCards.get(0).getUserEmail());
   }
+
+  @Test
+  public void testUpdateEraCommonsForUser() {
+    User user = createUser();
+    LibraryCard card = createLibraryCard(user);
+    assertEquals("value", card.getEraCommonsId());
+    libraryCardDAO.updateEraCommonsForUser(user.getDacUserId(), "newEraCommonsId");
+    assertEquals("newEraCommonsId", libraryCardDAO.findLibraryCardById(card.getId()).getEraCommonsId());
+  }
 }
+

--- a/src/test/java/org/broadinstitute/consent/http/service/NihServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/NihServiceTest.java
@@ -75,7 +75,7 @@ public class NihServiceTest extends TestCase {
     @Test
     public void testAuthenticateNih_LibraryCardUpdate() {
         Map<String, String> props = new HashMap<>();
-        props.put(UserFields.ERA_COMMONS_ID.getValue(), "10");
+        props.put(UserFields.ERA_USERNAME.getValue(), "eracommonsid");
         when(researcherService.updateProperties(any(), any(),any()))
                 .thenReturn(Arrays.asList(new UserProperty(1, 1, "test", "value")));
         when(researcherService.describeResearcherPropertiesForDAR(any())).thenReturn(props);

--- a/src/test/java/org/broadinstitute/consent/http/service/NihServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/NihServiceTest.java
@@ -1,6 +1,9 @@
 package org.broadinstitute.consent.http.service;
 
 import junit.framework.TestCase;
+
+import org.broadinstitute.consent.http.db.LibraryCardDAO;
+import org.broadinstitute.consent.http.enumeration.UserFields;
 import org.broadinstitute.consent.http.models.AuthUser;
 import org.broadinstitute.consent.http.models.NIHUserAccount;
 import org.broadinstitute.consent.http.models.UserProperty;
@@ -13,7 +16,9 @@ import javax.ws.rs.BadRequestException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
@@ -23,6 +28,9 @@ public class NihServiceTest extends TestCase {
 
     @Mock
     private ResearcherService researcherService;
+
+    @Mock
+    private LibraryCardDAO libraryCardDAO;
 
     private NihService service;
     private NIHUserAccount nihUserAccount;
@@ -36,14 +44,14 @@ public class NihServiceTest extends TestCase {
     }
 
     private void initService() {
-        service = new NihService(researcherService);
+        service = new NihService(researcherService, libraryCardDAO);
     }
 
     @Test
     public void testAuthenticateNih_InvalidUser() {
         initService();
         try {
-            service.authenticateNih(new NIHUserAccount(), new AuthUser("test@test.com"));
+            service.authenticateNih(new NIHUserAccount(), new AuthUser("test@test.com"), 1);
             assert false;
         } catch (BadRequestException bre) {
             assert true;
@@ -56,7 +64,24 @@ public class NihServiceTest extends TestCase {
                 .thenReturn(Arrays.asList(new UserProperty(1, 1, "test", "value")));
         initService();
         try {
-            List<UserProperty> properties = service.authenticateNih(nihUserAccount, authUser);
+            List<UserProperty> properties = service.authenticateNih(nihUserAccount, authUser, 1);
+            assertEquals(1, properties.size());
+            assertEquals(Integer.valueOf(1), properties.get(0).getPropertyId());
+        } catch (BadRequestException bre) {
+            assert false;
+        }
+    }
+
+    @Test
+    public void testAuthenticateNih_LibraryCardUpdate() {
+        Map<String, String> props = new HashMap<>();
+        props.put(UserFields.ERA_COMMONS_ID.getValue(), "10");
+        when(researcherService.updateProperties(any(), any(),any()))
+                .thenReturn(Arrays.asList(new UserProperty(1, 1, "test", "value")));
+        when(researcherService.describeResearcherPropertiesForDAR(any())).thenReturn(props);
+        initService();
+        try {
+            List<UserProperty> properties = service.authenticateNih(nihUserAccount, authUser, 1);
             assertEquals(1, properties.size());
             assertEquals(Integer.valueOf(1), properties.get(0).getPropertyId());
         } catch (BadRequestException bre) {


### PR DESCRIPTION
SCOPE:
- get the eraCommonsId from the user properties
- update all library cards that belong to that user with their eraCommonsId
ADDRESSES:
https://broadworkbench.atlassian.net/browse/DUOS-1070

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
