### PR TITLE
DUOS-1313[risk=low]Consent: Replace Document references with DAR

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
@@ -212,7 +212,7 @@ public class ConsentApplication extends Application<ConsentConfiguration> {
         // Register standard application resources.
         env.jersey().register(new IndexerResource(indexerService, googleStore));
         env.jersey().register(new DataAccessRequestResourceVersion2(dataAccessRequestService, emailNotifierService, gcsService, userService, matchService));
-        env.jersey().register(new DataAccessRequestResource(dataAccessRequestService, emailNotifierService, userService, consentService, electionService));
+        env.jersey().register(new DataAccessRequestResource(dataAccessRequestService, userService, consentService, electionService));
         env.jersey().register(new DatasetResource(datasetService, userService, dataAccessRequestService));
         env.jersey().register(new DatasetAssociationsResource(datasetAssociationService));
         env.jersey().register(new ConsentResource(auditService, userService, consentService, matchService, useRestrictionValidator));

--- a/src/main/java/org/broadinstitute/consent/http/db/DataAccessRequestDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DataAccessRequestDAO.java
@@ -47,7 +47,7 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
           + "(data #>> '{}')::jsonb AS data FROM data_access_request "
           + " WHERE draft = false" 
           + " AND ((data #>> '{}')::jsonb->>'datasetIds')::jsonb @> :datasetId::jsonb")
-  List<DataAccessRequest> findAllDataAccessRequestsForDatasetMetrics(@Bind("datasetId") String datasetId);
+  List<DataAccessRequest> findAllDataAccessRequestsByDatasetId(@Bind("datasetId") String datasetId);
 
   /**
    * Find all draft/partial DataAccessRequests, sorted descending order

--- a/src/main/java/org/broadinstitute/consent/http/models/darsummary/DARModalDetailsDTO.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/darsummary/DARModalDetailsDTO.java
@@ -1,15 +1,12 @@
 package org.broadinstitute.consent.http.models.darsummary;
 
 import org.apache.commons.collections.CollectionUtils;
-import org.broadinstitute.consent.http.models.User;
+import org.broadinstitute.consent.http.models.DataAccessRequest;
 import org.broadinstitute.consent.http.models.DataSet;
+import org.broadinstitute.consent.http.models.OntologyEntry;
 import org.broadinstitute.consent.http.models.UserProperty;
-import org.broadinstitute.consent.http.util.DarConstants;
-import org.bson.Document;
-
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 public class DARModalDetailsDTO {
 
@@ -53,15 +50,8 @@ public class DARModalDetailsDTO {
         return researcherName;
     }
 
-    public DARModalDetailsDTO setResearcherName(User owner, String principalInvestigator) {
-        if (owner == null) {
-            return this;
-        }
-        if (owner.getDisplayName().equals(principalInvestigator)) {
-            researcherName = principalInvestigator;
-        } else {
-            researcherName = owner.getDisplayName();
-        }
+    public DARModalDetailsDTO setResearcherName(String researcherName) {
+      this.researcherName = researcherName;
         return this;
     }
 
@@ -82,50 +72,50 @@ public class DARModalDetailsDTO {
         return sensitivePopulation;
     }
 
-    public List<SummaryItem> generatePurposeStatementsSummary(Document darDocument) {
+    public List<SummaryItem> generatePurposeStatementsSummary(DataAccessRequest dar) {
         List<SummaryItem> psList = new ArrayList<>();
-        if(darDocument.getBoolean(DarConstants.FOR_PROFIT)){
+        if(dar.data.getForProfit()){
             psList.add(new SummaryItem(SummaryConstants.PS_FOR_PROFIT, false));
         }
-        if(darDocument.getBoolean(DarConstants.ONE_GENDER)) {
-            if (darDocument.getString(DarConstants.GENDER).equalsIgnoreCase("F")) {
+        if(dar.data.getOneGender()) {
+            if (dar.data.getGender().equalsIgnoreCase("F")) {
                 psList.add(new SummaryItem("Gender: ", SummaryConstants.PS_GENDER_FEMALE, false));
             } else {
                 psList.add(new SummaryItem("Gender: ", SummaryConstants.PS_GENDER_MALE, false));
             }
         }
-        if(darDocument.getBoolean(DarConstants.PEDIATRIC)){
+        if(dar.data.getPediatric()){
             psList.add(new SummaryItem("Pediatric: ", SummaryConstants.PS_PEDIATRIC_STUDY, false));
         }
-        if(darDocument.getBoolean(DarConstants.ILLEGAL_BEHAVE)){
+        if(dar.data.getIllegalBehavior()){
             psList.add(new SummaryItem("Illegal Behavior: ", SummaryConstants.PS_ILLEGAL_BEHAVIOR_STUDY, true));
             sensitivePopulationIsTrue();
         }
-        if(darDocument.getBoolean(DarConstants.ADDICTION)){
+        if(dar.data.getAddiction()){
             psList.add(new SummaryItem("Addiction: ", SummaryConstants.PS_ADDICTIONS_STUDY, true));
             sensitivePopulationIsTrue();
         }
-        if(darDocument.getBoolean(DarConstants.SEXUAL_DISEASES)){
+        if(dar.data.getSexualDiseases()){
             psList.add(new SummaryItem("Sexual Diseases: ", SummaryConstants.PS_SEXUAL_DISEASES_STUDY, true));
             sensitivePopulationIsTrue();
         }
-        if(darDocument.getBoolean(DarConstants.STIGMATIZED_DISEASES)){
+        if(dar.data.getStigmatizedDiseases()){
             psList.add(new SummaryItem("Stigmatized Diseases: ", SummaryConstants.PS_STIGMATIZING_ILLNESSES_STUDY, true));
             sensitivePopulationIsTrue();
         }
-        if(darDocument.getBoolean(DarConstants.VULNERABLE_POP)){
+        if(dar.data.getVulnerablePopulation()){
             psList.add(new SummaryItem("Vulnerable Population: ", SummaryConstants.PS_VULNERABLE_POPULATION_STUDY, true));
             sensitivePopulationIsTrue();
         }
-        if(darDocument.getBoolean(DarConstants.POP_MIGRATION)){
+        if(dar.data.getPopulationMigration()){
             psList.add(new SummaryItem("Population Migration: ", SummaryConstants.PS_POPULATION_MIGRATION_STUDY, true));
             sensitivePopulationIsTrue();
         }
-        if(darDocument.getBoolean(DarConstants.PSYCH_TRAITS)){
+        if(dar.data.getPsychiatricTraits()){
             psList.add(new SummaryItem("Psychological Traits: ", SummaryConstants.PS_PSYCOLOGICAL_TRAITS_STUDY, true));
             sensitivePopulationIsTrue();
         }
-        if(darDocument.getBoolean(DarConstants.NOT_HEALTH)){
+        if(dar.data.getNotHealth()){
             psList.add(new SummaryItem("Not Health Related: ", SummaryConstants.PS_NOT_HEALT_RELATED_STUDY
                     , true));
             sensitivePopulationIsTrue();
@@ -136,42 +126,42 @@ public class DARModalDetailsDTO {
         return psList;
     }
 
-    private List<String> generateDiseasesSummary(Document darDocument) {
-        List<Map<String, String>> ontologies = (List<Map<String, String>>) darDocument.get(DarConstants.ONTOLOGIES);
+    private List<String> generateDiseasesSummary(DataAccessRequest dar) {
+        List<OntologyEntry> ontologies =  dar.data.getOntologies();
         List<String> diseases = new ArrayList<>();
         if(!CollectionUtils.isEmpty(ontologies)) {
             setIsThereDiseases(true);
-            for (Map<String, String> ontology : ontologies) {
-                diseases.add(ontology.get("label"));
+            for (OntologyEntry ontology : ontologies) {
+                diseases.add(ontology.getLabel());
             }
         }
         return diseases;
     }
 
-    private List<SummaryItem> generateResearchTypeSummary(Document darDocument) {
+    private List<SummaryItem> generateResearchTypeSummary(DataAccessRequest dar) {
         List<SummaryItem> researchList = new ArrayList<>();
-        if(darDocument.containsKey(DarConstants.DISEASES) && darDocument.getBoolean(DarConstants.DISEASES)){
+        if(dar.data.getDiseases() != null && dar.data.getDiseases()){
             researchList.add(new SummaryItem(SummaryConstants.RT_DISEASE_RELATED, SummaryConstants.RT_DISEASE_RELATED_DETAIL, false));
         }
-        if(darDocument.containsKey(DarConstants.METHODS) && darDocument.getBoolean(DarConstants.METHODS)){
+        if(dar.data.getMethods() != null && dar.data.getMethods()){
             researchList.add(new SummaryItem(SummaryConstants.RT_METHODS_DEVELOPMENT, SummaryConstants.RT_METHODS_DEVELOPMENT_DETAIL, false));
         }
-        if(darDocument.containsKey(DarConstants.CONTROLS) && darDocument.getBoolean(DarConstants.CONTROLS)){
+        if(dar.data.getControls() != null && dar.data.getControls()){
             researchList.add(new SummaryItem(SummaryConstants.RT_CONTROLS, SummaryConstants.RT_CONTROLS_DETAIL, false));
         }
-        if(darDocument.containsKey(DarConstants.POPULATION) && darDocument.getBoolean(DarConstants.POPULATION)){
+        if(dar.data.getPopulation() != null && dar.data.getPopulation()){
             researchList.add(new SummaryItem(SummaryConstants.RT_POPULATION, SummaryConstants.RT_POPULATION_DETAIL, true));
             manualReviewIsTrue();
         }
-        if(darDocument.containsKey(DarConstants.HMB) && darDocument.getBoolean(DarConstants.HMB)){
+        if(dar.data.getHmb() != null && dar.data.getHmb()){
             researchList.add(new SummaryItem(SummaryConstants.RT_HEALTH_BIOMEDICAL, SummaryConstants.RT_HEALTH_BIOMEDICAL_DETAIL, false));
         }
-        if(darDocument.containsKey(DarConstants.POA) && darDocument.getBoolean(DarConstants.POA)){
+        if(dar.data.getPoa() != null && dar.data.getPoa()){
             researchList.add(new SummaryItem(SummaryConstants.RT_POPULATION_ORIGINS, SummaryConstants.RT_POPULATION_ORIGINS_DETAIL, true));
             manualReviewIsTrue();
         }
-        if(darDocument.containsKey(DarConstants.OTHER) && darDocument.getBoolean(DarConstants.OTHER)){
-            researchList.add(new SummaryItem(SummaryConstants.RT_OTHER, darDocument.getString(DarConstants.OTHER_TEXT), true));
+        if(dar.data.getOther() != null && dar.data.getOther()){
+            researchList.add(new SummaryItem(SummaryConstants.RT_OTHER, dar.data.getOtherText(), true));
             manualReviewIsTrue();
         }
         return researchList;
@@ -217,7 +207,7 @@ public class DARModalDetailsDTO {
         return researchType;
     }
 
-    public DARModalDetailsDTO setResearchType(Document dar) {
+    public DARModalDetailsDTO setResearchType(DataAccessRequest dar) {
         this.researchType = generateResearchTypeSummary(dar);
         return this;
     }
@@ -226,7 +216,7 @@ public class DARModalDetailsDTO {
         return diseases;
     }
 
-    public DARModalDetailsDTO setDiseases(Document darDocument) {
+    public DARModalDetailsDTO setDiseases(DataAccessRequest darDocument) {
         this.diseases = generateDiseasesSummary(darDocument);
         return this;
     }
@@ -235,7 +225,7 @@ public class DARModalDetailsDTO {
         return purposeStatements;
     }
 
-    public DARModalDetailsDTO setPurposeStatements(Document darDocuement) {
+    public DARModalDetailsDTO setPurposeStatements(DataAccessRequest darDocuement) {
         this.purposeStatements = generatePurposeStatementsSummary(darDocuement);
         return this;
     }

--- a/src/main/java/org/broadinstitute/consent/http/models/darsummary/DARModalDetailsDTO.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/darsummary/DARModalDetailsDTO.java
@@ -1,6 +1,7 @@
 package org.broadinstitute.consent.http.models.darsummary;
 
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang3.BooleanUtils;
 import org.broadinstitute.consent.http.models.DataAccessRequest;
 import org.broadinstitute.consent.http.models.DataSet;
 import org.broadinstitute.consent.http.models.OntologyEntry;
@@ -77,48 +78,48 @@ public class DARModalDetailsDTO {
         List<SummaryItem> psList = new ArrayList<>();
         if (Objects.nonNull(dar) && Objects.nonNull(dar.getData())) {
 
-            if (dar.getData().getForProfit()) {
+            if (isTrue(dar.getData().getForProfit())) {
                 psList.add(new SummaryItem(SummaryConstants.PS_FOR_PROFIT, false));
             }
-            if (dar.getData().getOneGender()) {
+            if (isTrue(dar.getData().getOneGender())) {
                 if (dar.getData().getGender().equalsIgnoreCase("F")) {
                     psList.add(new SummaryItem("Gender: ", SummaryConstants.PS_GENDER_FEMALE, false));
                 } else {
                     psList.add(new SummaryItem("Gender: ", SummaryConstants.PS_GENDER_MALE, false));
                 }
             }
-            if (dar.getData().getPediatric()) {
+            if (isTrue(dar.getData().getPediatric())) {
                 psList.add(new SummaryItem("Pediatric: ", SummaryConstants.PS_PEDIATRIC_STUDY, false));
             }
-            if (dar.getData().getIllegalBehavior()) {
+            if (isTrue(dar.getData().getIllegalBehavior())) {
                 psList.add(new SummaryItem("Illegal Behavior: ", SummaryConstants.PS_ILLEGAL_BEHAVIOR_STUDY, true));
                 sensitivePopulationIsTrue();
             }
-            if (dar.getData().getAddiction()) {
+            if (isTrue(dar.getData().getAddiction())) {
                 psList.add(new SummaryItem("Addiction: ", SummaryConstants.PS_ADDICTIONS_STUDY, true));
                 sensitivePopulationIsTrue();
             }
-            if (dar.getData().getSexualDiseases()) {
+            if (isTrue(dar.getData().getSexualDiseases())) {
                 psList.add(new SummaryItem("Sexual Diseases: ", SummaryConstants.PS_SEXUAL_DISEASES_STUDY, true));
                 sensitivePopulationIsTrue();
             }
-            if (dar.getData().getStigmatizedDiseases()) {
+            if (isTrue(dar.getData().getStigmatizedDiseases())) {
                 psList.add(new SummaryItem("Stigmatized Diseases: ", SummaryConstants.PS_STIGMATIZING_ILLNESSES_STUDY, true));
                 sensitivePopulationIsTrue();
             }
-            if (dar.getData().getVulnerablePopulation()) {
+            if (isTrue(dar.getData().getVulnerablePopulation())) {
                 psList.add(new SummaryItem("Vulnerable Population: ", SummaryConstants.PS_VULNERABLE_POPULATION_STUDY, true));
                 sensitivePopulationIsTrue();
             }
-            if (dar.getData().getPopulationMigration()) {
+            if (isTrue(dar.getData().getPopulationMigration())) {
                 psList.add(new SummaryItem("Population Migration: ", SummaryConstants.PS_POPULATION_MIGRATION_STUDY, true));
                 sensitivePopulationIsTrue();
             }
-            if (dar.getData().getPsychiatricTraits()) {
+            if (isTrue(dar.getData().getPsychiatricTraits())) {
                 psList.add(new SummaryItem("Psychological Traits: ", SummaryConstants.PS_PSYCOLOGICAL_TRAITS_STUDY, true));
                 sensitivePopulationIsTrue();
             }
-            if (dar.getData().getNotHealth()) {
+            if (isTrue(dar.getData().getNotHealth())) {
                 psList.add(new SummaryItem("Not Health Related: ", SummaryConstants.PS_NOT_HEALT_RELATED_STUDY
                   , true));
                 sensitivePopulationIsTrue();
@@ -147,27 +148,27 @@ public class DARModalDetailsDTO {
     private List<SummaryItem> generateResearchTypeSummary(DataAccessRequest dar) {
         List<SummaryItem> researchList = new ArrayList<>();
         if (Objects.nonNull(dar) && Objects.nonNull(dar.getData())) {
-            if (dar.getData().getDiseases() != null && dar.getData().getDiseases()) {
+            if (isTrue(dar.getData().getDiseases())) {
                 researchList.add(new SummaryItem(SummaryConstants.RT_DISEASE_RELATED, SummaryConstants.RT_DISEASE_RELATED_DETAIL, false));
             }
-            if (dar.getData().getMethods() != null && dar.getData().getMethods()) {
+            if (isTrue(dar.getData().getMethods())) {
                 researchList.add(new SummaryItem(SummaryConstants.RT_METHODS_DEVELOPMENT, SummaryConstants.RT_METHODS_DEVELOPMENT_DETAIL, false));
             }
-            if (dar.getData().getControls() != null && dar.getData().getControls()) {
+            if (isTrue(dar.getData().getControls())) {
                 researchList.add(new SummaryItem(SummaryConstants.RT_CONTROLS, SummaryConstants.RT_CONTROLS_DETAIL, false));
             }
-            if (dar.getData().getPopulation() != null && dar.getData().getPopulation()) {
+            if (isTrue(dar.getData().getPopulation())) {
                 researchList.add(new SummaryItem(SummaryConstants.RT_POPULATION, SummaryConstants.RT_POPULATION_DETAIL, true));
                 manualReviewIsTrue();
             }
-            if (dar.getData().getHmb() != null && dar.getData().getHmb()) {
+            if (isTrue(dar.getData().getHmb())) {
                 researchList.add(new SummaryItem(SummaryConstants.RT_HEALTH_BIOMEDICAL, SummaryConstants.RT_HEALTH_BIOMEDICAL_DETAIL, false));
             }
-            if (dar.getData().getPoa() != null && dar.getData().getPoa()) {
+            if (isTrue(dar.getData().getPoa())) {
                 researchList.add(new SummaryItem(SummaryConstants.RT_POPULATION_ORIGINS, SummaryConstants.RT_POPULATION_ORIGINS_DETAIL, true));
                 manualReviewIsTrue();
             }
-            if (dar.getData().getOther() != null && dar.getData().getOther()) {
+            if (isTrue(dar.getData().getOther())) {
                 researchList.add(new SummaryItem(SummaryConstants.RT_OTHER, dar.getData().getOtherText(), true));
                 manualReviewIsTrue();
             }
@@ -354,6 +355,10 @@ public class DARModalDetailsDTO {
     public DARModalDetailsDTO setNihUsername(String nihUsername) {
         this.nihUsername = nihUsername;
         return this;
+    }
+
+    private boolean isTrue(Boolean obj) {
+        return BooleanUtils.isTrue(obj);
     }
 
 }

--- a/src/main/java/org/broadinstitute/consent/http/models/darsummary/DARModalDetailsDTO.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/darsummary/DARModalDetailsDTO.java
@@ -7,6 +7,7 @@ import org.broadinstitute.consent.http.models.OntologyEntry;
 import org.broadinstitute.consent.http.models.UserProperty;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 public class DARModalDetailsDTO {
 
@@ -74,51 +75,54 @@ public class DARModalDetailsDTO {
 
     public List<SummaryItem> generatePurposeStatementsSummary(DataAccessRequest dar) {
         List<SummaryItem> psList = new ArrayList<>();
-        if(dar.data.getForProfit()){
-            psList.add(new SummaryItem(SummaryConstants.PS_FOR_PROFIT, false));
-        }
-        if(dar.data.getOneGender()) {
-            if (dar.data.getGender().equalsIgnoreCase("F")) {
-                psList.add(new SummaryItem("Gender: ", SummaryConstants.PS_GENDER_FEMALE, false));
-            } else {
-                psList.add(new SummaryItem("Gender: ", SummaryConstants.PS_GENDER_MALE, false));
+        if (Objects.nonNull(dar) && Objects.nonNull(dar.getData())) {
+
+            if (dar.getData().getForProfit()) {
+                psList.add(new SummaryItem(SummaryConstants.PS_FOR_PROFIT, false));
             }
-        }
-        if(dar.data.getPediatric()){
-            psList.add(new SummaryItem("Pediatric: ", SummaryConstants.PS_PEDIATRIC_STUDY, false));
-        }
-        if(dar.data.getIllegalBehavior()){
-            psList.add(new SummaryItem("Illegal Behavior: ", SummaryConstants.PS_ILLEGAL_BEHAVIOR_STUDY, true));
-            sensitivePopulationIsTrue();
-        }
-        if(dar.data.getAddiction()){
-            psList.add(new SummaryItem("Addiction: ", SummaryConstants.PS_ADDICTIONS_STUDY, true));
-            sensitivePopulationIsTrue();
-        }
-        if(dar.data.getSexualDiseases()){
-            psList.add(new SummaryItem("Sexual Diseases: ", SummaryConstants.PS_SEXUAL_DISEASES_STUDY, true));
-            sensitivePopulationIsTrue();
-        }
-        if(dar.data.getStigmatizedDiseases()){
-            psList.add(new SummaryItem("Stigmatized Diseases: ", SummaryConstants.PS_STIGMATIZING_ILLNESSES_STUDY, true));
-            sensitivePopulationIsTrue();
-        }
-        if(dar.data.getVulnerablePopulation()){
-            psList.add(new SummaryItem("Vulnerable Population: ", SummaryConstants.PS_VULNERABLE_POPULATION_STUDY, true));
-            sensitivePopulationIsTrue();
-        }
-        if(dar.data.getPopulationMigration()){
-            psList.add(new SummaryItem("Population Migration: ", SummaryConstants.PS_POPULATION_MIGRATION_STUDY, true));
-            sensitivePopulationIsTrue();
-        }
-        if(dar.data.getPsychiatricTraits()){
-            psList.add(new SummaryItem("Psychological Traits: ", SummaryConstants.PS_PSYCOLOGICAL_TRAITS_STUDY, true));
-            sensitivePopulationIsTrue();
-        }
-        if(dar.data.getNotHealth()){
-            psList.add(new SummaryItem("Not Health Related: ", SummaryConstants.PS_NOT_HEALT_RELATED_STUDY
-                    , true));
-            sensitivePopulationIsTrue();
+            if (dar.getData().getOneGender()) {
+                if (dar.getData().getGender().equalsIgnoreCase("F")) {
+                    psList.add(new SummaryItem("Gender: ", SummaryConstants.PS_GENDER_FEMALE, false));
+                } else {
+                    psList.add(new SummaryItem("Gender: ", SummaryConstants.PS_GENDER_MALE, false));
+                }
+            }
+            if (dar.getData().getPediatric()) {
+                psList.add(new SummaryItem("Pediatric: ", SummaryConstants.PS_PEDIATRIC_STUDY, false));
+            }
+            if (dar.getData().getIllegalBehavior()) {
+                psList.add(new SummaryItem("Illegal Behavior: ", SummaryConstants.PS_ILLEGAL_BEHAVIOR_STUDY, true));
+                sensitivePopulationIsTrue();
+            }
+            if (dar.getData().getAddiction()) {
+                psList.add(new SummaryItem("Addiction: ", SummaryConstants.PS_ADDICTIONS_STUDY, true));
+                sensitivePopulationIsTrue();
+            }
+            if (dar.getData().getSexualDiseases()) {
+                psList.add(new SummaryItem("Sexual Diseases: ", SummaryConstants.PS_SEXUAL_DISEASES_STUDY, true));
+                sensitivePopulationIsTrue();
+            }
+            if (dar.getData().getStigmatizedDiseases()) {
+                psList.add(new SummaryItem("Stigmatized Diseases: ", SummaryConstants.PS_STIGMATIZING_ILLNESSES_STUDY, true));
+                sensitivePopulationIsTrue();
+            }
+            if (dar.getData().getVulnerablePopulation()) {
+                psList.add(new SummaryItem("Vulnerable Population: ", SummaryConstants.PS_VULNERABLE_POPULATION_STUDY, true));
+                sensitivePopulationIsTrue();
+            }
+            if (dar.getData().getPopulationMigration()) {
+                psList.add(new SummaryItem("Population Migration: ", SummaryConstants.PS_POPULATION_MIGRATION_STUDY, true));
+                sensitivePopulationIsTrue();
+            }
+            if (dar.getData().getPsychiatricTraits()) {
+                psList.add(new SummaryItem("Psychological Traits: ", SummaryConstants.PS_PSYCOLOGICAL_TRAITS_STUDY, true));
+                sensitivePopulationIsTrue();
+            }
+            if (dar.getData().getNotHealth()) {
+                psList.add(new SummaryItem("Not Health Related: ", SummaryConstants.PS_NOT_HEALT_RELATED_STUDY
+                  , true));
+                sensitivePopulationIsTrue();
+            }
         }
         if(!CollectionUtils.isEmpty(psList)){
             setIsTherePurposeStatements(true);
@@ -127,12 +131,14 @@ public class DARModalDetailsDTO {
     }
 
     private List<String> generateDiseasesSummary(DataAccessRequest dar) {
-        List<OntologyEntry> ontologies =  dar.data.getOntologies();
         List<String> diseases = new ArrayList<>();
-        if(!CollectionUtils.isEmpty(ontologies)) {
-            setIsThereDiseases(true);
-            for (OntologyEntry ontology : ontologies) {
-                diseases.add(ontology.getLabel());
+        if (Objects.nonNull(dar) && Objects.nonNull(dar.getData())) {
+            List<OntologyEntry> ontologies =  dar.getData().getOntologies();
+            if(!CollectionUtils.isEmpty(ontologies)) {
+                setIsThereDiseases(true);
+                for (OntologyEntry ontology : ontologies) {
+                    diseases.add(ontology.getLabel());
+                }
             }
         }
         return diseases;
@@ -140,29 +146,31 @@ public class DARModalDetailsDTO {
 
     private List<SummaryItem> generateResearchTypeSummary(DataAccessRequest dar) {
         List<SummaryItem> researchList = new ArrayList<>();
-        if(dar.data.getDiseases() != null && dar.data.getDiseases()){
-            researchList.add(new SummaryItem(SummaryConstants.RT_DISEASE_RELATED, SummaryConstants.RT_DISEASE_RELATED_DETAIL, false));
-        }
-        if(dar.data.getMethods() != null && dar.data.getMethods()){
-            researchList.add(new SummaryItem(SummaryConstants.RT_METHODS_DEVELOPMENT, SummaryConstants.RT_METHODS_DEVELOPMENT_DETAIL, false));
-        }
-        if(dar.data.getControls() != null && dar.data.getControls()){
-            researchList.add(new SummaryItem(SummaryConstants.RT_CONTROLS, SummaryConstants.RT_CONTROLS_DETAIL, false));
-        }
-        if(dar.data.getPopulation() != null && dar.data.getPopulation()){
-            researchList.add(new SummaryItem(SummaryConstants.RT_POPULATION, SummaryConstants.RT_POPULATION_DETAIL, true));
-            manualReviewIsTrue();
-        }
-        if(dar.data.getHmb() != null && dar.data.getHmb()){
-            researchList.add(new SummaryItem(SummaryConstants.RT_HEALTH_BIOMEDICAL, SummaryConstants.RT_HEALTH_BIOMEDICAL_DETAIL, false));
-        }
-        if(dar.data.getPoa() != null && dar.data.getPoa()){
-            researchList.add(new SummaryItem(SummaryConstants.RT_POPULATION_ORIGINS, SummaryConstants.RT_POPULATION_ORIGINS_DETAIL, true));
-            manualReviewIsTrue();
-        }
-        if(dar.data.getOther() != null && dar.data.getOther()){
-            researchList.add(new SummaryItem(SummaryConstants.RT_OTHER, dar.data.getOtherText(), true));
-            manualReviewIsTrue();
+        if (Objects.nonNull(dar) && Objects.nonNull(dar.getData())) {
+            if (dar.getData().getDiseases() != null && dar.getData().getDiseases()) {
+                researchList.add(new SummaryItem(SummaryConstants.RT_DISEASE_RELATED, SummaryConstants.RT_DISEASE_RELATED_DETAIL, false));
+            }
+            if (dar.getData().getMethods() != null && dar.getData().getMethods()) {
+                researchList.add(new SummaryItem(SummaryConstants.RT_METHODS_DEVELOPMENT, SummaryConstants.RT_METHODS_DEVELOPMENT_DETAIL, false));
+            }
+            if (dar.getData().getControls() != null && dar.getData().getControls()) {
+                researchList.add(new SummaryItem(SummaryConstants.RT_CONTROLS, SummaryConstants.RT_CONTROLS_DETAIL, false));
+            }
+            if (dar.getData().getPopulation() != null && dar.getData().getPopulation()) {
+                researchList.add(new SummaryItem(SummaryConstants.RT_POPULATION, SummaryConstants.RT_POPULATION_DETAIL, true));
+                manualReviewIsTrue();
+            }
+            if (dar.getData().getHmb() != null && dar.getData().getHmb()) {
+                researchList.add(new SummaryItem(SummaryConstants.RT_HEALTH_BIOMEDICAL, SummaryConstants.RT_HEALTH_BIOMEDICAL_DETAIL, false));
+            }
+            if (dar.getData().getPoa() != null && dar.getData().getPoa()) {
+                researchList.add(new SummaryItem(SummaryConstants.RT_POPULATION_ORIGINS, SummaryConstants.RT_POPULATION_ORIGINS_DETAIL, true));
+                manualReviewIsTrue();
+            }
+            if (dar.getData().getOther() != null && dar.getData().getOther()) {
+                researchList.add(new SummaryItem(SummaryConstants.RT_OTHER, dar.getData().getOtherText(), true));
+                manualReviewIsTrue();
+            }
         }
         return researchList;
     }

--- a/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
@@ -78,20 +78,11 @@ public class DataAccessRequestResource extends Resource {
     @GET
     @Produces("application/json")
     @PermitAll
-    @Deprecated //instead use getDataAccessRequests
+    @Deprecated //instead use V2Resource.getDataAccessRequests
     public Response describeDataAccessRequests(@Auth AuthUser authUser) {
         List<Document> documents = dataAccessRequestService.describeDataAccessRequests(authUser);
         return Response.ok().entity(documents).build();
     }
-
-    @GET
-    @Produces("application/json")
-    @PermitAll
-    public Response getDataAccessRequests(@Auth AuthUser authUser) {
-        List<DataAccessRequest> dars = dataAccessRequestService.getDataAccessRequests(authUser);
-        return Response.ok().entity(dars).build();
-    }
-
 
     @GET
     @Path("/find/{id}")
@@ -184,20 +175,10 @@ public class DataAccessRequestResource extends Resource {
     @Produces("application/json")
     @Path("/partials")
     @RolesAllowed(RESEARCHER)
-    @Deprecated //instead use getDraftDataAccessRequests
+    @Deprecated //instead use V2Resource.getDraftDataAccessRequests
     public List<Document> describeDraftDataAccessRequests(@Auth AuthUser authUser) {
         User user = findUserByEmail(authUser.getName());
         return dataAccessRequestService.findAllDraftDataAccessRequestDocumentsByUser(user.getDacUserId());
-    }
-
-    @GET
-    @Produces("application/json")
-    @Path("/partials")
-    @RolesAllowed(RESEARCHER)
-    public Response getDraftDataAccessRequests(@Auth AuthUser authUser) {
-        User user = findUserByEmail(authUser.getName());
-        List<DataAccessRequest> draftDars = dataAccessRequestService.findAllDraftDataAccessRequestsByUser(user.getDacUserId());
-        return Response.ok().entity(draftDars).build();
     }
 
     @GET
@@ -216,38 +197,14 @@ public class DataAccessRequestResource extends Resource {
 
     @GET
     @Produces("application/json")
-    @Path("/partial/{id}")
-    @RolesAllowed(RESEARCHER)
-    public Response getDraftDar(@Auth AuthUser authUser, @PathParam("id") String id) {
-        User user = findUserByEmail(authUser.getName());
-        DataAccessRequest dar = dataAccessRequestService.findByReferenceId(id);
-        if (dar.getUserId().equals(user.getDacUserId())) {
-            return Response.ok().entity(dar).build();
-        }
-        throw new ForbiddenException("User does not have permission");
-    }
-
-    @GET
-    @Produces("application/json")
     @Path("/partials/manage")
     @RolesAllowed(RESEARCHER)
-    @Deprecated //instead use getDraftManageDataAccessRequests
+    @Deprecated //instead use V2Resource.getDraftManageDataAccessRequests
     public Response describeDraftManageDataAccessRequests(@Auth AuthUser authUser) {
         User user = findUserByEmail(authUser.getName());
         List<Document> partials = dataAccessRequestService.describeDraftDataAccessRequestManage(user.getDacUserId());
         return Response.ok().entity(partials).build();
     }
-
-    @GET
-    @Produces("application/json")
-    @Path("/partials/manage")
-    @RolesAllowed(RESEARCHER)
-    public Response getDraftManageDataAccessRequests(@Auth AuthUser authUser) {
-        User user = findUserByEmail(authUser.getName());
-        List<DataAccessRequestManage> partials = dataAccessRequestService.getDraftDataAccessRequestManage(user.getDacUserId());
-        return Response.ok().entity(partials).build();
-    }
-
 
     @PUT
     @Consumes("application/json")

--- a/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
@@ -34,7 +34,6 @@ import org.broadinstitute.consent.http.models.darsummary.DARModalDetailsDTO;
 import org.broadinstitute.consent.http.service.ConsentService;
 import org.broadinstitute.consent.http.service.DataAccessRequestService;
 import org.broadinstitute.consent.http.service.ElectionService;
-import org.broadinstitute.consent.http.service.EmailNotifierService;
 import org.broadinstitute.consent.http.service.UserService;
 import org.bson.Document;
 
@@ -44,14 +43,12 @@ public class DataAccessRequestResource extends Resource {
     private static final Logger logger = Logger.getLogger(DataAccessRequestResource.class.getName());
     private final DataAccessRequestService dataAccessRequestService;
     private final ConsentService consentService;
-    private final EmailNotifierService emailNotifierService;
     private final ElectionService electionService;
     private final UserService userService;
 
     @Inject
-    public DataAccessRequestResource(DataAccessRequestService dataAccessRequestService, EmailNotifierService emailNotifierService, UserService userService, ConsentService consentService, ElectionService electionService) {
+    public DataAccessRequestResource(DataAccessRequestService dataAccessRequestService, UserService userService, ConsentService consentService, ElectionService electionService) {
         this.dataAccessRequestService = dataAccessRequestService;
-        this.emailNotifierService = emailNotifierService;
         this.consentService = consentService;
         this.electionService = electionService;
         this.userService = userService;
@@ -66,8 +63,8 @@ public class DataAccessRequestResource extends Resource {
             Stream.of(UserRoles.ADMIN, UserRoles.CHAIRPERSON, UserRoles.MEMBER)
                 .collect(Collectors.toList()),
             authUser, id);
-        Document dar = dataAccessRequestService.getDataAccessRequestByReferenceIdAsDocument(id);
-        Integer userId = obtainUserId(dar);
+        DataAccessRequest dar = findDataAccessRequestById(id);
+        Integer userId = dar.getUserId();
         User user = null;
         try {
             user = userService.findUserById(userId);
@@ -81,15 +78,26 @@ public class DataAccessRequestResource extends Resource {
     @GET
     @Produces("application/json")
     @PermitAll
+    @Deprecated //instead use getDataAccessRequests
     public Response describeDataAccessRequests(@Auth AuthUser authUser) {
         List<Document> documents = dataAccessRequestService.describeDataAccessRequests(authUser);
         return Response.ok().entity(documents).build();
     }
 
     @GET
-    @Path("/find/{id}")
     @Produces("application/json")
     @PermitAll
+    public Response getDataAccessRequests(@Auth AuthUser authUser) {
+        List<DataAccessRequest> dars = dataAccessRequestService.getDataAccessRequests(authUser);
+        return Response.ok().entity(dars).build();
+    }
+
+
+    @GET
+    @Path("/find/{id}")
+    @Produces("application/json")
+    @PermitAll 
+    @Deprecated // instead use DataAccessRequestResourceVersion2.getByReferenceId
     public Document describeSpecificFields(@Auth AuthUser authUser, @PathParam("id") String id, @QueryParam("fields") List<String> fields) {
         validateAuthedRoleUser(
             Stream.of(UserRoles.ADMIN, UserRoles.CHAIRPERSON, UserRoles.MEMBER)
@@ -176,6 +184,7 @@ public class DataAccessRequestResource extends Resource {
     @Produces("application/json")
     @Path("/partials")
     @RolesAllowed(RESEARCHER)
+    @Deprecated //instead use getDraftDataAccessRequests
     public List<Document> describeDraftDataAccessRequests(@Auth AuthUser authUser) {
         User user = findUserByEmail(authUser.getName());
         return dataAccessRequestService.findAllDraftDataAccessRequestDocumentsByUser(user.getDacUserId());
@@ -183,8 +192,19 @@ public class DataAccessRequestResource extends Resource {
 
     @GET
     @Produces("application/json")
+    @Path("/partials")
+    @RolesAllowed(RESEARCHER)
+    public Response getDraftDataAccessRequests(@Auth AuthUser authUser) {
+        User user = findUserByEmail(authUser.getName());
+        List<DataAccessRequest> draftDars = dataAccessRequestService.findAllDraftDataAccessRequestsByUser(user.getDacUserId());
+        return Response.ok().entity(draftDars).build();
+    }
+
+    @GET
+    @Produces("application/json")
     @Path("/partial/{id}")
     @RolesAllowed(RESEARCHER)
+    @Deprecated //instead use getDraftDar
     public Document describeDraftDar(@Auth AuthUser authUser, @PathParam("id") String id) {
         User user = findUserByEmail(authUser.getName());
         DataAccessRequest dar = dataAccessRequestService.findByReferenceId(id);
@@ -196,11 +216,35 @@ public class DataAccessRequestResource extends Resource {
 
     @GET
     @Produces("application/json")
+    @Path("/partial/{id}")
+    @RolesAllowed(RESEARCHER)
+    public Response getDraftDar(@Auth AuthUser authUser, @PathParam("id") String id) {
+        User user = findUserByEmail(authUser.getName());
+        DataAccessRequest dar = dataAccessRequestService.findByReferenceId(id);
+        if (dar.getUserId().equals(user.getDacUserId())) {
+            return Response.ok().entity(dar).build();
+        }
+        throw new ForbiddenException("User does not have permission");
+    }
+
+    @GET
+    @Produces("application/json")
     @Path("/partials/manage")
     @RolesAllowed(RESEARCHER)
+    @Deprecated //instead use getDraftManageDataAccessRequests
     public Response describeDraftManageDataAccessRequests(@Auth AuthUser authUser) {
         User user = findUserByEmail(authUser.getName());
         List<Document> partials = dataAccessRequestService.describeDraftDataAccessRequestManage(user.getDacUserId());
+        return Response.ok().entity(partials).build();
+    }
+
+    @GET
+    @Produces("application/json")
+    @Path("/partials/manage")
+    @RolesAllowed(RESEARCHER)
+    public Response getDraftManageDataAccessRequests(@Auth AuthUser authUser) {
+        User user = findUserByEmail(authUser.getName());
+        List<DataAccessRequestManage> partials = dataAccessRequestService.getDraftDataAccessRequestManage(user.getDacUserId());
         return Response.ok().entity(partials).build();
     }
 
@@ -217,14 +261,6 @@ public class DataAccessRequestResource extends Resource {
             return Response.ok().entity(dar).build();
         } catch (Exception e) {
             return createExceptionResponse(e);
-        }
-    }
-
-    private Integer obtainUserId(Document dar) {
-        try {
-            return dar.getInteger("userId");
-        } catch (Exception e) {
-            return Integer.valueOf(dar.getString("userId"));
         }
     }
 

--- a/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
@@ -78,7 +78,7 @@ public class DataAccessRequestResource extends Resource {
     @GET
     @Produces("application/json")
     @PermitAll
-    @Deprecated //instead use V2Resource.getDataAccessRequests
+    @Deprecated //instead use V2Resource.getDataAccessRequestsForUser
     public Response describeDataAccessRequests(@Auth AuthUser authUser) {
         List<Document> documents = dataAccessRequestService.describeDataAccessRequests(authUser);
         return Response.ok().entity(documents).build();

--- a/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
@@ -78,7 +78,7 @@ public class DataAccessRequestResource extends Resource {
     @GET
     @Produces("application/json")
     @PermitAll
-    @Deprecated //instead use V2Resource.getDataAccessRequestsForUser
+    @Deprecated //instead use V2Resource.getDataAccessRequestsByUserRole
     public Response describeDataAccessRequests(@Auth AuthUser authUser) {
         List<Document> documents = dataAccessRequestService.describeDataAccessRequests(authUser);
         return Response.ok().entity(documents).build();

--- a/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceVersion2.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceVersion2.java
@@ -163,7 +163,7 @@ public class DataAccessRequestResourceVersion2 extends Resource {
 
   @GET
   @Produces("application/json")
-  @Path("/partials")
+  @Path("/draft")
   @RolesAllowed(RESEARCHER)
   public Response getDraftDataAccessRequests(@Auth AuthUser authUser) {
     try {
@@ -177,9 +177,9 @@ public class DataAccessRequestResourceVersion2 extends Resource {
 
   @GET
   @Produces("application/json")
-  @Path("/partial/{id}")
+  @Path("/draft/{referenceId}")
   @RolesAllowed(RESEARCHER)
-  public Response getDraftDar(@Auth AuthUser authUser, @PathParam("id") String id) {
+  public Response getDraftDar(@Auth AuthUser authUser, @PathParam("referenceId") String id) {
     try {
       User user = findUserByEmail(authUser.getName());
       DataAccessRequest dar = dataAccessRequestService.findByReferenceId(id);
@@ -213,7 +213,7 @@ public class DataAccessRequestResourceVersion2 extends Resource {
 
   @GET
   @Produces("application/json")
-  @Path("/partials/manage")
+  @Path("/draft/manage")
   @RolesAllowed(RESEARCHER)
   public Response getDraftManageDataAccessRequests(@Auth AuthUser authUser) {
     try {

--- a/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceVersion2.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceVersion2.java
@@ -75,7 +75,7 @@ public class DataAccessRequestResourceVersion2 extends Resource {
   @Produces("application/json")
   @RolesAllowed(ADMIN)
   public Response getDataAccessRequests(@Auth AuthUser authUser) {
-    List<DataAccessRequest> dars = dataAccessRequestService.getDataAccessRequests(authUser);
+    List<DataAccessRequest> dars = dataAccessRequestService.getDataAccessRequestsForUser(authUser);
     return Response.ok().entity(dars).build();
   }
 

--- a/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceVersion2.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceVersion2.java
@@ -75,8 +75,12 @@ public class DataAccessRequestResourceVersion2 extends Resource {
   @Produces("application/json")
   @RolesAllowed(ADMIN)
   public Response getDataAccessRequests(@Auth AuthUser authUser) {
-    List<DataAccessRequest> dars = dataAccessRequestService.getDataAccessRequestsForUser(authUser);
-    return Response.ok().entity(dars).build();
+    try {
+      List<DataAccessRequest> dars = dataAccessRequestService.getDataAccessRequestsForUser(authUser);
+      return Response.ok().entity(dars).build();
+    } catch (Exception e) {
+      return createExceptionResponse(e);
+    }
   }
 
   @POST
@@ -162,9 +166,13 @@ public class DataAccessRequestResourceVersion2 extends Resource {
   @Path("/partials")
   @RolesAllowed(RESEARCHER)
   public Response getDraftDataAccessRequests(@Auth AuthUser authUser) {
-    User user = findUserByEmail(authUser.getName());
-    List<DataAccessRequest> draftDars = dataAccessRequestService.findAllDraftDataAccessRequestsByUser(user.getDacUserId());
-    return Response.ok().entity(draftDars).build();
+    try {
+      User user = findUserByEmail(authUser.getName());
+      List<DataAccessRequest> draftDars = dataAccessRequestService.findAllDraftDataAccessRequestsByUser(user.getDacUserId());
+      return Response.ok().entity(draftDars).build();
+    } catch (Exception e) {
+      return createExceptionResponse(e);
+    }
   }
 
   @GET
@@ -172,12 +180,16 @@ public class DataAccessRequestResourceVersion2 extends Resource {
   @Path("/partial/{id}")
   @RolesAllowed(RESEARCHER)
   public Response getDraftDar(@Auth AuthUser authUser, @PathParam("id") String id) {
-    User user = findUserByEmail(authUser.getName());
-    DataAccessRequest dar = dataAccessRequestService.findByReferenceId(id);
-    if (dar.getUserId().equals(user.getDacUserId())) {
-      return Response.ok().entity(dar).build();
+    try {
+      User user = findUserByEmail(authUser.getName());
+      DataAccessRequest dar = dataAccessRequestService.findByReferenceId(id);
+      if (dar.getUserId().equals(user.getDacUserId())) {
+        return Response.ok().entity(dar).build();
+      }
+      throw new ForbiddenException("User does not have permission");
+    } catch (Exception e) {
+      return createExceptionResponse(e);
     }
-    throw new ForbiddenException("User does not have permission");
   }
 
   @POST
@@ -204,9 +216,13 @@ public class DataAccessRequestResourceVersion2 extends Resource {
   @Path("/partials/manage")
   @RolesAllowed(RESEARCHER)
   public Response getDraftManageDataAccessRequests(@Auth AuthUser authUser) {
-    User user = findUserByEmail(authUser.getName());
-    List<DataAccessRequestManage> partials = dataAccessRequestService.getDraftDataAccessRequestManage(user.getDacUserId());
-    return Response.ok().entity(partials).build();
+    try {
+      User user = findUserByEmail(authUser.getName());
+      List<DataAccessRequestManage> partials = dataAccessRequestService.getDraftDataAccessRequestManage(user.getDacUserId());
+      return Response.ok().entity(partials).build();
+    } catch (Exception e) {
+      return createExceptionResponse(e);
+    }
   }
 
   @PUT

--- a/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceVersion2.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceVersion2.java
@@ -76,7 +76,7 @@ public class DataAccessRequestResourceVersion2 extends Resource {
   @PermitAll
   public Response getDataAccessRequests(@Auth AuthUser authUser) {
     try {
-      List<DataAccessRequest> dars = dataAccessRequestService.getDataAccessRequestsForUser(authUser);
+      List<DataAccessRequest> dars = dataAccessRequestService.getDataAccessRequestsByUserRole(authUser);
       return Response.ok().entity(dars).build();
     } catch (Exception e) {
       return createExceptionResponse(e);

--- a/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceVersion2.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceVersion2.java
@@ -73,7 +73,7 @@ public class DataAccessRequestResourceVersion2 extends Resource {
 
   @GET
   @Produces("application/json")
-  @RolesAllowed(ADMIN)
+  @PermitAll
   public Response getDataAccessRequests(@Auth AuthUser authUser) {
     try {
       List<DataAccessRequest> dars = dataAccessRequestService.getDataAccessRequestsForUser(authUser);

--- a/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceVersion2.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceVersion2.java
@@ -73,7 +73,7 @@ public class DataAccessRequestResourceVersion2 extends Resource {
 
   @GET
   @Produces("application/json")
-  @PermitAll
+  @RolesAllowed(ADMIN)
   public Response getDataAccessRequests(@Auth AuthUser authUser) {
     List<DataAccessRequest> dars = dataAccessRequestService.getDataAccessRequests(authUser);
     return Response.ok().entity(dars).build();

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessReportsParser.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessReportsParser.java
@@ -68,7 +68,7 @@ public class DataAccessReportsParser {
         String content1 =  profileName + DEFAULT_SEPARATOR + institution + DEFAULT_SEPARATOR;
         String electionDate = (Objects.nonNull(election.getFinalVoteDate())) ? formatTimeToDate(election.getFinalVoteDate().getTime()) : "";
         String content2 = rusSummary + DEFAULT_SEPARATOR +
-                dar.getSortDate() + DEFAULT_SEPARATOR +
+                formatTimeToDate(dar.getSortDate().getTime()) + DEFAULT_SEPARATOR +
                 electionDate + DEFAULT_SEPARATOR +
                 "--";
         addDARLine(darWriter, dar, content1, content2, consentName, translatedUseRestriction);
@@ -102,32 +102,34 @@ public class DataAccessReportsParser {
     }
 
     private void addDARLine(FileWriter darWriter, DataAccessRequest dar, String customContent1, String customContent2, String consentName, String translatedUseRestriction) throws IOException {
-        List<DatasetDetailEntry> dataSetDetails = dar.data.getDatasetDetail();
         List<String> datasetNames = new ArrayList<>();
         List<Integer> dataSetIds = new ArrayList<>();
         List<String> dataSetUUIds = new ArrayList<>();
-        for(DatasetDetailEntry detail : dataSetDetails) {
-            try {
-                Integer id = Integer.parseInt(detail.getDatasetId());
-                dataSetIds.add(id);
-                dataSetUUIds.add(DataSet.parseAliasToIdentifier(id));
-            } catch (Exception e) {
-                logger.warn("Invalid Dataset ID");
+        if (Objects.nonNull(dar) && Objects.nonNull(dar.getData())) {
+            List<DatasetDetailEntry> dataSetDetails = dar.getData().getDatasetDetail();
+            for (DatasetDetailEntry detail : dataSetDetails) {
+                try {
+                    Integer id = Integer.parseInt(detail.getDatasetId());
+                    dataSetIds.add(id);
+                    dataSetUUIds.add(DataSet.parseAliasToIdentifier(id));
+                } catch (Exception e) {
+                    logger.warn("Invalid Dataset ID");
+                }
+                datasetNames.add(detail.getName());
             }
-            datasetNames.add(detail.getName());
-        }
-        String sDUL = StringUtils.isNotEmpty(translatedUseRestriction) ?  translatedUseRestriction.replace("\n", " ") : "";
-        String translatedRestriction = StringUtils.isNotEmpty(dar.data.getTranslatedUseRestriction()) ? dar.data.getTranslatedUseRestriction().replace("<br>", " ") :  "";
-        darWriter.write(
-                dar.data.getDarCode() + DEFAULT_SEPARATOR +
-                        StringUtils.join(datasetNames, ",") + DEFAULT_SEPARATOR +
-                        StringUtils.join(dataSetUUIds, ",") + DEFAULT_SEPARATOR +
-                        consentName + DEFAULT_SEPARATOR +
-                        customContent1 +
-                        sDUL + DEFAULT_SEPARATOR +
-                        translatedRestriction + DEFAULT_SEPARATOR +
-                        customContent2 + END_OF_LINE);
+            String sDUL = StringUtils.isNotEmpty(translatedUseRestriction) ? translatedUseRestriction.replace("\n", " ") : "";
+            String translatedRestriction = StringUtils.isNotEmpty(dar.getData().getTranslatedUseRestriction()) ? dar.getData().getTranslatedUseRestriction().replace("<br>", " ") : "";
+            darWriter.write(
+              dar.getData().getDarCode() + DEFAULT_SEPARATOR +
+                StringUtils.join(datasetNames, ",") + DEFAULT_SEPARATOR +
+                StringUtils.join(dataSetUUIds, ",") + DEFAULT_SEPARATOR +
+                consentName + DEFAULT_SEPARATOR +
+                customContent1 +
+                sDUL + DEFAULT_SEPARATOR +
+                translatedRestriction + DEFAULT_SEPARATOR +
+                customContent2 + END_OF_LINE);
 
+        }
     }
 
 

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessReportsParser.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessReportsParser.java
@@ -14,6 +14,7 @@ import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
+import java.util.Objects;
 
 public class DataAccessReportsParser {
 
@@ -63,11 +64,12 @@ public class DataAccessReportsParser {
     }
 
     public void addApprovedDARLine(FileWriter darWriter, Election election, DataAccessRequest dar, String profileName, String institution, String consentName, String translatedUseRestriction) throws IOException {       
-        String rusSummary = StringUtils.isNotEmpty(dar.data.getNonTechRus()) ?  dar.data.getNonTechRus().replace("\n", " ") : "";
+        String rusSummary = Objects.nonNull(dar.getData()) && StringUtils.isNotEmpty(dar.data.getNonTechRus()) ?  dar.data.getNonTechRus().replace("\n", " ") : "";
         String content1 =  profileName + DEFAULT_SEPARATOR + institution + DEFAULT_SEPARATOR;
+        String electionDate = (Objects.nonNull(election.getFinalVoteDate())) ? formatTimeToDate(election.getFinalVoteDate().getTime()) : "";
         String content2 = rusSummary + DEFAULT_SEPARATOR +
                 dar.getSortDate() + DEFAULT_SEPARATOR +
-                formatTimeToDate(election.getFinalVoteDate().getTime()) + DEFAULT_SEPARATOR +
+                electionDate + DEFAULT_SEPARATOR +
                 "--";
         addDARLine(darWriter, dar, content1, content2, consentName, translatedUseRestriction);
     }

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessReportsParser.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessReportsParser.java
@@ -114,7 +114,7 @@ public class DataAccessReportsParser {
                     dataSetIds.add(id);
                     dataSetUUIds.add(DataSet.parseAliasToIdentifier(id));
                 } catch (Exception e) {
-                    logger.warn("Invalid Dataset ID");
+                    logger.warn("Invalid Dataset ID: " + detail.getDatasetId());
                 }
                 datasetNames.add(detail.getName());
             }

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessReportsParser.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessReportsParser.java
@@ -2,11 +2,13 @@ package org.broadinstitute.consent.http.service;
 
 import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.consent.http.enumeration.HeaderDAR;
+import org.broadinstitute.consent.http.models.DataAccessRequest;
 import org.broadinstitute.consent.http.models.DataSet;
+import org.broadinstitute.consent.http.models.DatasetDetailEntry;
 import org.broadinstitute.consent.http.models.Election;
-import org.broadinstitute.consent.http.util.DarConstants;
-import org.broadinstitute.consent.http.util.DarUtil;
-import org.bson.Document;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.*;
 import java.util.ArrayList;
 import java.util.Calendar;
@@ -14,6 +16,8 @@ import java.util.Date;
 import java.util.List;
 
 public class DataAccessReportsParser {
+
+    private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
     private static final String DEFAULT_SEPARATOR =  "\t";
 
@@ -58,16 +62,17 @@ public class DataAccessReportsParser {
                         HeaderDAR.RENEWAL_DATE.getValue() + END_OF_LINE);
     }
 
-    public void addApprovedDARLine(FileWriter darWriter, Election election, Document dar, String profileName, String institution, String consentName, String translatedUseRestriction) throws IOException {        String rusSummary = StringUtils.isNotEmpty( dar.getString(DarConstants.NON_TECH_RUS)) ?  dar.getString(DarConstants.NON_TECH_RUS).replace("\n", " ") : "";
+    public void addApprovedDARLine(FileWriter darWriter, Election election, DataAccessRequest dar, String profileName, String institution, String consentName, String translatedUseRestriction) throws IOException {       
+        String rusSummary = StringUtils.isNotEmpty(dar.data.getNonTechRus()) ?  dar.data.getNonTechRus().replace("\n", " ") : "";
         String content1 =  profileName + DEFAULT_SEPARATOR + institution + DEFAULT_SEPARATOR;
         String content2 = rusSummary + DEFAULT_SEPARATOR +
-                formatTimeToDate(new Date(dar.getLong(DarConstants.SORT_DATE)).getTime()) + DEFAULT_SEPARATOR +
+                dar.getSortDate() + DEFAULT_SEPARATOR +
                 formatTimeToDate(election.getFinalVoteDate().getTime()) + DEFAULT_SEPARATOR +
                 "--";
         addDARLine(darWriter, dar, content1, content2, consentName, translatedUseRestriction);
     }
 
-    public void addReviewedDARLine(FileWriter darWriter, Election election, Document dar, String consentName, String translatedUseRestriction) throws IOException {
+    public void addReviewedDARLine(FileWriter darWriter, Election election, DataAccessRequest dar, String consentName, String translatedUseRestriction) throws IOException {
         String finalVote = election.getFinalVote() ? "Yes" : "No";
         String content2 = formatTimeToDate(election.getFinalVoteDate().getTime()) + DEFAULT_SEPARATOR +
                           finalVote;
@@ -94,21 +99,25 @@ public class DataAccessReportsParser {
         return month.toString() + "/" + day.toString() + "/" + year.toString();
     }
 
-    private void addDARLine(FileWriter darWriter, Document dar, String customContent1, String customContent2, String consentName, String translatedUseRestriction) throws IOException {
-        List<Document> dataSetDetails = dar.get(DarConstants.DATASET_DETAIL, ArrayList.class);
+    private void addDARLine(FileWriter darWriter, DataAccessRequest dar, String customContent1, String customContent2, String consentName, String translatedUseRestriction) throws IOException {
+        List<DatasetDetailEntry> dataSetDetails = dar.data.getDatasetDetail();
         List<String> datasetNames = new ArrayList<>();
-        for(Document detail : dataSetDetails) {
-            datasetNames.add(StringUtils.defaultString(detail.getString("name")));
-        }
-        List<Integer> dataSetIds = DarUtil.getIntegerList(dar, DarConstants.DATASET_ID);
+        List<Integer> dataSetIds = new ArrayList<>();
         List<String> dataSetUUIds = new ArrayList<>();
-        for(Integer id : dataSetIds) {
-            dataSetUUIds.add(DataSet.parseAliasToIdentifier(id));
+        for(DatasetDetailEntry detail : dataSetDetails) {
+            try {
+                Integer id = Integer.parseInt(detail.getDatasetId());
+                dataSetIds.add(id);
+                dataSetUUIds.add(DataSet.parseAliasToIdentifier(id));
+            } catch (Exception e) {
+                logger.warn("Invalid Dataset ID");
+            }
+            datasetNames.add(detail.getName());
         }
         String sDUL = StringUtils.isNotEmpty(translatedUseRestriction) ?  translatedUseRestriction.replace("\n", " ") : "";
-        String translatedRestriction = StringUtils.isNotEmpty(dar.getString(DarConstants.TRANSLATED_RESTRICTION)) ? dar.getString(DarConstants.TRANSLATED_RESTRICTION).replace("<br>", " ") :  "";
+        String translatedRestriction = StringUtils.isNotEmpty(dar.data.getTranslatedUseRestriction()) ? dar.data.getTranslatedUseRestriction().replace("<br>", " ") :  "";
         darWriter.write(
-                dar.getString(DarConstants.DAR_CODE) + DEFAULT_SEPARATOR +
+                dar.data.getDarCode() + DEFAULT_SEPARATOR +
                         StringUtils.join(datasetNames, ",") + DEFAULT_SEPARATOR +
                         StringUtils.join(dataSetUUIds, ",") + DEFAULT_SEPARATOR +
                         consentName + DEFAULT_SEPARATOR +

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessReportsParser.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessReportsParser.java
@@ -8,14 +8,8 @@ import org.broadinstitute.consent.http.models.DatasetDetailEntry;
 import org.broadinstitute.consent.http.models.Election;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.*;
-import org.broadinstitute.consent.http.util.DarConstants;
-import org.broadinstitute.consent.http.util.DarUtil;
-import org.bson.Document;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collections;

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
@@ -355,7 +355,7 @@ public class DataAccessRequestService {
      * @param authUser AuthUser
      * @return List<Document>
      */
-    @Deprecated //use getDataAccessRequests
+    @Deprecated //use getDataAccessRequestsForUser
     public List<Document> describeDataAccessRequests(AuthUser authUser) {
         List<Document> documents = getAllDataAccessRequestsAsDocuments();
         return dacService.filterDarsByDAC(documents, authUser);
@@ -366,8 +366,8 @@ public class DataAccessRequestService {
      * @param authUser AuthUser
      * @return List<DataAccessRequest>
      */
-    public List<DataAccessRequest> getDataAccessRequests(AuthUser authUser) {
-        List<DataAccessRequest> dars = findAllDataAccessRequests();
+    public List<DataAccessRequest> getDataAccessRequestsForUser(AuthUser authUser) {
+        List<DataAccessRequest> dars = dataAccessRequestDAO.findAllDataAccessRequests();
         return dacService.filterDataAccessRequestsByDac(dars, authUser);
     }
 
@@ -630,8 +630,8 @@ public class DataAccessRequestService {
 
     public List<DataAccessRequestManage> getDraftDataAccessRequestManage(Integer userId) {
         List<DataAccessRequest> accessList = userId == null
-                ? findAllDraftDataAccessRequests()
-                : findAllDraftDataAccessRequestsByUser(userId);
+                ? dataAccessRequestDAO.findAllDraftDataAccessRequests()
+                : dataAccessRequestDAO.findAllDraftsByUserId(userId);
         return createAccessRequestManageV2(accessList);
     }
 

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
@@ -355,7 +355,7 @@ public class DataAccessRequestService {
      * @param authUser AuthUser
      * @return List<Document>
      */
-    @Deprecated //use getDataAccessRequestsForUser
+    @Deprecated //use getDataAccessRequestsByUserRole
     public List<Document> describeDataAccessRequests(AuthUser authUser) {
         List<Document> documents = getAllDataAccessRequestsAsDocuments();
         return dacService.filterDarsByDAC(documents, authUser);
@@ -366,7 +366,7 @@ public class DataAccessRequestService {
      * @param authUser AuthUser
      * @return List<DataAccessRequest>
      */
-    public List<DataAccessRequest> getDataAccessRequestsForUser(AuthUser authUser) {
+    public List<DataAccessRequest> getDataAccessRequestsByUserRole(AuthUser authUser) {
         List<DataAccessRequest> dars = dataAccessRequestDAO.findAllDataAccessRequests();
         return dacService.filterDataAccessRequestsByDac(dars, authUser);
     }
@@ -652,7 +652,8 @@ public class DataAccessRequestService {
                         Consent consent = Objects.nonNull(consentId) ? consentDAO.findConsentById(consentId) : null;
                         String profileName = user.getDisplayName();
                         if (Objects.isNull(user.getInstitutionId())) {
-                            logger.warn("No institution found for creator of this Data Access Request");
+                            logger.warn("No institution found for creator (user: " + user.getDisplayName() + ", " + user.getDacUserId() + ") "
+                              + "of this Data Access Request (DAR: " + dataAccessRequest.getReferenceId() + ")");
                         }
                         String institution = Objects.isNull(user.getInstitutionId()) ? "" : institutionDAO.findInstitutionById(user.getInstitutionId()).getName();
                         dataAccessReportsParser.addApprovedDARLine(darWriter, election, dataAccessRequest, profileName, institution, consent.getName(), consent.getTranslatedUseRestriction());

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
@@ -655,7 +655,7 @@ public class DataAccessRequestService {
                             logger.warn("No institution found for creator of this Data Access Request");
                         }
                         String institution = Objects.isNull(user.getInstitutionId()) ? "" : institutionDAO.findInstitutionById(user.getInstitutionId()).getName();
-                        dataAccessReportsParser.addApprovedDARLine(darWriter, election, dar, profileName, institution, consent.getName(), consent.getTranslatedUseRestriction());
+                        dataAccessReportsParser.addApprovedDARLine(darWriter, election, dataAccessRequest, profileName, institution, consent.getName(), consent.getTranslatedUseRestriction());
                     }
                 } catch (Exception e) {
                     logger.error("Exception generating Approved DAR Document", e);

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
@@ -762,7 +762,7 @@ public class DataAccessRequestService {
     }
 
     private List<DataSet> populateDatasets(DataAccessRequest dar) {
-        List<Integer> datasetIds = dar.data.getDatasetIds();
+        List<Integer> datasetIds = Objects.nonNull(dar.getData()) ? dar.getData().getDatasetIds() : Collections.emptyList();
         if (!datasetIds.isEmpty()) {
             return dataSetDAO.findDataSetsByIdList(datasetIds);
         }
@@ -908,7 +908,7 @@ public class DataAccessRequestService {
      */
     private List<DataAccessRequest> getUnReviewedDarsForUser(AuthUser authUser) {
         List<DataAccessRequest> activeDars = dataAccessRequestDAO.findAllDataAccessRequests().stream().
-                filter(d -> !ElectionStatus.CANCELED.getValue().equalsIgnoreCase(d.data.getStatus())).
+                filter(d -> !ElectionStatus.CANCELED.getValue().equalsIgnoreCase(Objects.nonNull(d.getData()) ? d.getData().getStatus() : "")).
                 collect(Collectors.toList());
         if (dacService.isAuthUserAdmin(authUser)) {
             return activeDars;

--- a/src/main/java/org/broadinstitute/consent/http/service/EmailNotifierService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/EmailNotifierService.java
@@ -217,15 +217,15 @@ public class EmailNotifierService {
         }
     }
 
-    public void sendNeedsPIApprovalMessage(Map<User, List<DataSet>> dataSetMap, Document access, Integer amountOfTime) throws MessagingException, IOException, TemplateException {
-        if(isServiceActive){
-            for(User owner: dataSetMap.keySet()){
-                String dataOwnerConsoleURL = SERVER_URL + DATA_OWNER_CONSOLE_URL;
-                Writer template =  getPIApprovalMessageTemplate(access, dataSetMap.get(owner), owner, amountOfTime, dataOwnerConsoleURL);
-                mailService.sendFlaggedDarAdminApprovedMessage(getEmails(Collections.singletonList(owner)), access.getString(DarConstants.DAR_CODE), SERVER_URL, template);
-            }
-        }
-    }
+    // public void sendNeedsPIApprovalMessage(Map<User, List<DataSet>> dataSetMap, Document access, Integer amountOfTime) throws MessagingException, IOException, TemplateException {
+    //     if(isServiceActive){
+    //         for(User owner: dataSetMap.keySet()){
+    //             String dataOwnerConsoleURL = SERVER_URL + DATA_OWNER_CONSOLE_URL;
+    //             Writer template =  getPIApprovalMessageTemplate(access, dataSetMap.get(owner), owner, amountOfTime, dataOwnerConsoleURL);
+    //             mailService.sendFlaggedDarAdminApprovedMessage(getEmails(Collections.singletonList(owner)), access.getString(DarConstants.DAR_CODE), SERVER_URL, template);
+    //         }
+    //     }
+    // }
 
     public void sendUserDelegateResponsibilitiesMessage(User user, Integer oldUser, String newRole, List<Vote> delegatedVotes) throws MessagingException, IOException, TemplateException {
         if(isServiceActive){
@@ -332,46 +332,46 @@ public class EmailNotifierService {
     }
 
 
-    private Writer getPIApprovalMessageTemplate(Document access, List<DataSet> dataSets, User user, int daysToApprove, String URL) throws IOException, TemplateException {
-        List<DataSetPIMailModel> dsPIModelList = new ArrayList<>();
-        for (DataSet ds: dataSets) {
-            dsPIModelList.add(new DataSetPIMailModel(ds.getObjectId(), ds.getName(), ds.getDatasetIdentifier()));
-        }
+    // private Writer getPIApprovalMessageTemplate(Document access, List<DataSet> dataSets, User user, int daysToApprove, String URL) throws IOException, TemplateException {
+    //     List<DataSetPIMailModel> dsPIModelList = new ArrayList<>();
+    //     for (DataSet ds: dataSets) {
+    //         dsPIModelList.add(new DataSetPIMailModel(ds.getObjectId(), ds.getName(), ds.getDatasetIdentifier()));
+    //     }
 
-        DARModalDetailsDTO details = new DARModalDetailsDTO()
-            .setDarCode(access.getString(DarConstants.DAR_CODE))
-            .setPrincipalInvestigator(access.getString(DarConstants.INVESTIGATOR))
-            .setInstitutionName(access.getString(DarConstants.INSTITUTION))
-            .setProjectTitle(access.getString(DarConstants.PROJECT_TITLE))
-            .setDepartment(access.getString(DarConstants.DEPARTMENT))
-            .setCity(access.getString(DarConstants.CITY))
-            .setCountry(access.getString(DarConstants.COUNTRY))
-            .setNihUsername(access.getString(DarConstants.NIH_USERNAME))
-            .setHaveNihUsername(StringUtils.isNotEmpty(access.getString(DarConstants.NIH_USERNAME)))
-            .setIsThereDiseases(false)
-            .setIsTherePurposeStatements(false)
-            .setResearchType(access)
-            .setDiseases(access)
-            .setPurposeStatements(access);
+    //     DARModalDetailsDTO details = new DARModalDetailsDTO()
+    //         .setDarCode(access.getString(DarConstants.DAR_CODE))
+    //         .setPrincipalInvestigator(access.getString(DarConstants.INVESTIGATOR))
+    //         .setInstitutionName(access.getString(DarConstants.INSTITUTION))
+    //         .setProjectTitle(access.getString(DarConstants.PROJECT_TITLE))
+    //         .setDepartment(access.getString(DarConstants.DEPARTMENT))
+    //         .setCity(access.getString(DarConstants.CITY))
+    //         .setCountry(access.getString(DarConstants.COUNTRY))
+    //         .setNihUsername(access.getString(DarConstants.NIH_USERNAME))
+    //         .setHaveNihUsername(StringUtils.isNotEmpty(access.getString(DarConstants.NIH_USERNAME)))
+    //         .setIsThereDiseases(false)
+    //         .setIsTherePurposeStatements(false)
+    //         .setResearchType(access)
+    //         .setDiseases(access)
+    //         .setPurposeStatements(access);
 
-        List<String> checkedSentences = (details.getPurposeStatements()).stream().map(SummaryItem::getDescription).collect(Collectors.toList());
-        Consent consent = consentDAO.findConsentFromDatasetID(dataSets.get(0).getDataSetId());
-        String translatedUseRestriction = Objects.nonNull(consent) ? consent.getTranslatedUseRestriction() : "";
-        return templateHelper.getApprovedDarTemplate(
-                user.getDisplayName(),
-                getDateString(daysToApprove),
-                details.getDarCode(),
-                details.getPrincipalInvestigator(),
-                details.getInstitutionName(),
-                access.getString(DarConstants.RUS),
-                details.getResearchType(),
-                generateDiseasesString(details.getDiseases()),
-                checkedSentences,
-                translatedUseRestriction,
-                dsPIModelList,
-                String.valueOf(daysToApprove),
-                URL);
-    }
+    //     List<String> checkedSentences = (details.getPurposeStatements()).stream().map(SummaryItem::getDescription).collect(Collectors.toList());
+    //     Consent consent = consentDAO.findConsentFromDatasetID(dataSets.get(0).getDataSetId());
+    //     String translatedUseRestriction = Objects.nonNull(consent) ? consent.getTranslatedUseRestriction() : "";
+    //     return templateHelper.getApprovedDarTemplate(
+    //             user.getDisplayName(),
+    //             getDateString(daysToApprove),
+    //             details.getDarCode(),
+    //             details.getPrincipalInvestigator(),
+    //             details.getInstitutionName(),
+    //             access.getString(DarConstants.RUS),
+    //             details.getResearchType(),
+    //             generateDiseasesString(details.getDiseases()),
+    //             checkedSentences,
+    //             translatedUseRestriction,
+    //             dsPIModelList,
+    //             String.valueOf(daysToApprove),
+    //             URL);
+    // }
 
     private String getDateString(int daysToApprove) {
         DateTimeFormatter dtfOut = DateTimeFormat.forPattern("MM/dd/yyyy");

--- a/src/main/java/org/broadinstitute/consent/http/service/EmailNotifierService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/EmailNotifierService.java
@@ -217,16 +217,6 @@ public class EmailNotifierService {
         }
     }
 
-    // public void sendNeedsPIApprovalMessage(Map<User, List<DataSet>> dataSetMap, Document access, Integer amountOfTime) throws MessagingException, IOException, TemplateException {
-    //     if(isServiceActive){
-    //         for(User owner: dataSetMap.keySet()){
-    //             String dataOwnerConsoleURL = SERVER_URL + DATA_OWNER_CONSOLE_URL;
-    //             Writer template =  getPIApprovalMessageTemplate(access, dataSetMap.get(owner), owner, amountOfTime, dataOwnerConsoleURL);
-    //             mailService.sendFlaggedDarAdminApprovedMessage(getEmails(Collections.singletonList(owner)), access.getString(DarConstants.DAR_CODE), SERVER_URL, template);
-    //         }
-    //     }
-    // }
-
     public void sendUserDelegateResponsibilitiesMessage(User user, Integer oldUser, String newRole, List<Vote> delegatedVotes) throws MessagingException, IOException, TemplateException {
         if(isServiceActive){
             String delegateURL = SERVER_URL + delegateURL(newRole);
@@ -330,48 +320,6 @@ public class EmailNotifierService {
     private Writer getUserDelegateResponsibilitiesTemplate(User user, String newRole, List<VoteAndElectionModel> delegatedVotes, String URL) throws IOException, TemplateException {
         return templateHelper.getUserDelegateResponsibilitiesTemplate(user.getDisplayName(), delegatedVotes, newRole, URL);
     }
-
-
-    // private Writer getPIApprovalMessageTemplate(Document access, List<DataSet> dataSets, User user, int daysToApprove, String URL) throws IOException, TemplateException {
-    //     List<DataSetPIMailModel> dsPIModelList = new ArrayList<>();
-    //     for (DataSet ds: dataSets) {
-    //         dsPIModelList.add(new DataSetPIMailModel(ds.getObjectId(), ds.getName(), ds.getDatasetIdentifier()));
-    //     }
-
-    //     DARModalDetailsDTO details = new DARModalDetailsDTO()
-    //         .setDarCode(access.getString(DarConstants.DAR_CODE))
-    //         .setPrincipalInvestigator(access.getString(DarConstants.INVESTIGATOR))
-    //         .setInstitutionName(access.getString(DarConstants.INSTITUTION))
-    //         .setProjectTitle(access.getString(DarConstants.PROJECT_TITLE))
-    //         .setDepartment(access.getString(DarConstants.DEPARTMENT))
-    //         .setCity(access.getString(DarConstants.CITY))
-    //         .setCountry(access.getString(DarConstants.COUNTRY))
-    //         .setNihUsername(access.getString(DarConstants.NIH_USERNAME))
-    //         .setHaveNihUsername(StringUtils.isNotEmpty(access.getString(DarConstants.NIH_USERNAME)))
-    //         .setIsThereDiseases(false)
-    //         .setIsTherePurposeStatements(false)
-    //         .setResearchType(access)
-    //         .setDiseases(access)
-    //         .setPurposeStatements(access);
-
-    //     List<String> checkedSentences = (details.getPurposeStatements()).stream().map(SummaryItem::getDescription).collect(Collectors.toList());
-    //     Consent consent = consentDAO.findConsentFromDatasetID(dataSets.get(0).getDataSetId());
-    //     String translatedUseRestriction = Objects.nonNull(consent) ? consent.getTranslatedUseRestriction() : "";
-    //     return templateHelper.getApprovedDarTemplate(
-    //             user.getDisplayName(),
-    //             getDateString(daysToApprove),
-    //             details.getDarCode(),
-    //             details.getPrincipalInvestigator(),
-    //             details.getInstitutionName(),
-    //             access.getString(DarConstants.RUS),
-    //             details.getResearchType(),
-    //             generateDiseasesString(details.getDiseases()),
-    //             checkedSentences,
-    //             translatedUseRestriction,
-    //             dsPIModelList,
-    //             String.valueOf(daysToApprove),
-    //             URL);
-    // }
 
     private String getDateString(int daysToApprove) {
         DateTimeFormatter dtfOut = DateTimeFormat.forPattern("MM/dd/yyyy");

--- a/src/main/java/org/broadinstitute/consent/http/util/DarUtil.java
+++ b/src/main/java/org/broadinstitute/consent/http/util/DarUtil.java
@@ -4,6 +4,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
+import java.util.Optional;
+import org.broadinstitute.consent.http.models.User;
+import org.broadinstitute.consent.http.models.UserProperty;
 import org.bson.Document;
 
 public class DarUtil {
@@ -17,6 +20,24 @@ public class DarUtil {
                 collect(Collectors.toList());
         }
         return Collections.emptyList();
+    }
+
+    public static String findPI(User user) {
+        if (user != null && user.getProperties() != null) {
+            Optional<UserProperty> isResearcher = user.getProperties().stream().filter(prop -> prop.getPropertyKey().equals("isThePI") && prop.getPropertyValue().equalsIgnoreCase("true")).findFirst();
+            if (isResearcher.isPresent()) {
+                Optional<UserProperty> userName = user.getProperties().stream().filter(prop -> prop.getPropertyKey().equals("profileName")).findFirst();
+                if (userName.isPresent()) {
+                    return userName.get().getPropertyValue();
+                }
+            }
+    
+            Optional<UserProperty> piName = user.getProperties().stream().filter(prop -> prop.getPropertyKey().equals("piName")).findFirst();
+            if (piName.isPresent()) {
+              return piName.get().getPropertyValue();
+            }
+        }
+        return "- -";
     }
 
 }

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -1411,12 +1411,12 @@ paths:
       responses:
         200:
           description: Returns a list of Draft Data Access Requests
-            content:
-              application/json:
-                schema:
-                  type: array
-                  items:
-                    $ref: '#/components/schemas/DataAccessRequest'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/DataAccessRequest'
         500:
           description: Internal Server Error.
   /api/dar/v2/draft/{referenceId}:

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -1781,7 +1781,7 @@ paths:
         - Data Access Request
       responses:
         200:
-          description: Returns the created of partial Data Access Requests
+          description: Returns the created partial Data Access Requests
         500:
           description: Internal Server Error.
     put:

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -1541,7 +1541,7 @@ paths:
         500:
           description: Internal Server Error.
     get:
-      summary: describeDataAccessRequests
+      summary: get all Data Access Requests
       description: Retrieves all the existent DARs
       tags:
         - Data Access Request
@@ -1756,6 +1756,39 @@ paths:
           description: Data Access Request was deleted
         403:
           description: Forbidden
+        500:
+          description: Internal Server Error.
+    get:
+      summary: Get Partial Data Access Request By Reference Id
+      description: Return the draft DAR specified by the given Id if it exists
+      tags: 
+        - Data Access Request
+      responses:
+        200:
+          description: Partial Data Access Request
+          content:
+            application/json:
+              schema:
+                  ref: '#/components/schemas/DataAccessRequest'
+        404: 
+          description: Cannot find draft data access request with specified reference Id.
+        500:
+          description: Internal Server Error.
+  /api/dar/partials:
+    get:
+      summary: get Draft Data Access Requests
+      description: Get all Partial Data Access Requests for user
+      tags:
+        - Data Access Request
+      responses:
+        200:
+          description: Partial Data Access Requests
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/DataAccessRequest'
         500:
           description: Internal Server Error.
   /api/dar/partials/manage:

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -1287,6 +1287,24 @@ paths:
                   $ref: '#/components/schemas/DataAccessRequest'
         500:
           description: Internal Server Error.
+    get:
+      summary: Get all Data Access Requests
+      description: Returns the list of all Data Access Requests
+      tags:
+        - Data Access Request
+      responses:
+        200:
+          description: Returns a list of Data Access Requests
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/DataAccessRequest'
+        403:
+          description: The user is not authorized to see all DARs
+        500:
+          description: Server Error
   /api/dar/v2/{referenceId}:
     get:
       summary: Get a Data Access Request by Reference Id
@@ -1385,6 +1403,22 @@ paths:
           description: Returns the created draft Data Access Request.
         500:
           description: Internal Server Error.
+    get:
+      summary: Get all Draft Data Access Requests
+      description: Returns a list of all Draft Data Access Request
+      tags:
+        - Data Access Request
+      responses:
+        200:
+          description: Returns a list of Draft Data Access Requests
+            content:
+              application/json:
+                schema:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/DataAccessRequest'
+        500:
+          description: Internal Server Error.
   /api/dar/v2/draft/{referenceId}:
     put:
       summary: Update Draft Data Access Request
@@ -1409,6 +1443,44 @@ paths:
           description: Returns the upated draft Data Access Request.
         403:
           description: Updates are restricted to the create user.
+        500:
+          description: Internal Server Error.
+    get:
+      summary: Get a Draft Data Access Request
+      description: Returns the Draft Data Access Request specified by the referencId
+      parameters:
+        - name: referenceId
+          in: path
+          description: The referenceId of the Data Access Request
+          required: true
+          schema:
+            type: string
+      tags:
+        - Data Access Request
+      responses:
+        201:
+          description: Returns the draft Data Access Request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DataAccessRequest'
+        500:
+          description: Internal Server Error.
+  /api/dar/v2/draft/manage:
+    get:
+      summary: Get all Draft Data Access Request Manage Objects
+      description: Returns a list of information (Dar Manage Objects) on Draft DARs
+      tags:
+        - Data Access Request
+      responses:
+        201:
+          description: Returns the draft Data Access Request Manage objects.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/DataAccessRequestManage'
         500:
           description: Internal Server Error.
   /api/dar/v2/{referenceId}/irbDocument:
@@ -1692,15 +1764,24 @@ paths:
         responses:
          200:
            description: 'Returns an integer corresponding to the amount of unreviewed DARs'
-  /api/dar/partials:
-    get:
-      summary: Get all Draft Data Access Requests
-      description: Returns list of all partial DARs
+  /api/dar/partial:
+    post:
+      summary: Create Partial Data Access Request
+      description: |
+        DEPRECATED: Use POST /api/dar/v2/draft
+        Create Partial Data Access Request
+      parameters:
+        - name: dar
+          in: body
+          description: The fields that represent a DAR, json format.
+          required: true
+          schema:
+            $ref: '#/components/schemas/DataAccessRequest'
       tags:
         - Data Access Request
       responses:
         200:
-          description: Returns the list of partial Data Access Requests
+          description: Returns the created of partial Data Access Requests
         500:
           description: Internal Server Error.
     put:
@@ -1727,28 +1808,6 @@ paths:
           description: Forbidden
         404:
           description: DAR or User Not Found
-        500:
-          description: Internal Server Error.
-  /api/dar/draft:
-    post:
-      summary: Create a Draft Data Access Request
-      description: Returns the created partial DAR
-      tags:
-        - Data Access Request
-      responses:
-        200:
-          description: Returns the created partial Data Access Requests
-        500:
-          description: Internal Server Error.
-  /api/dar/draft/{referenceId}:
-    put:
-      summary: Update a Draft Data Access Request
-      description: Returns the updated partial DAR
-      tags:
-        - Data Access Request
-      responses:
-        200:
-          description: Returns the updated partial Data Access Requests
         500:
           description: Internal Server Error.
   /api/dar/partial/{id}:
@@ -1769,32 +1828,6 @@ paths:
           description: Data Access Request was deleted
         403:
           description: Forbidden
-        500:
-          description: Internal Server Error.
-    put:
-      summary: Update Partial Data Access Request
-      description: |
-        DEPRECATED: Use PUT /api/dar/v2/draft/{referenceId}:
-        Update Partial Data Access Request
-      parameters:
-        - name: dar
-          in: body
-          description: |
-            The fields that represent a DAR, json format.
-            Must contain a `referenceId` for the updated DAR.
-            User must be the creator of the DAR.
-          required: true
-          schema:
-            $ref: '#/components/schemas/DataAccessRequest'
-      tags:
-        - Data Access Request
-      responses:
-        200:
-          description: Returns the updated partial Data Access Request, json file.
-        403:
-          description: Forbidden
-        404:
-          description: DAR or User Not Found
         500:
           description: Internal Server Error.
   /api/dar/partials/manage:

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -1692,24 +1692,15 @@ paths:
         responses:
          200:
            description: 'Returns an integer corresponding to the amount of unreviewed DARs'
-  /api/dar/partial:
-    post:
-      summary: Create Partial Data Access Request
-      description: |
-        DEPRECATED: Use POST /api/dar/v2/draft
-        Create Partial Data Access Request
-      parameters:
-        - name: dar
-          in: body
-          description: The fields that represent a DAR, json format.
-          required: true
-          schema:
-            $ref: '#/components/schemas/DataAccessRequest'
+  /api/dar/partials:
+    get:
+      summary: Get all Draft Data Access Requests
+      description: Returns list of all partial DARs
       tags:
         - Data Access Request
       responses:
         200:
-          description: Returns the created partial Data Access Request, json file.
+          description: Returns the list of partial Data Access Requests
         500:
           description: Internal Server Error.
     put:
@@ -1738,6 +1729,28 @@ paths:
           description: DAR or User Not Found
         500:
           description: Internal Server Error.
+  /api/dar/draft:
+    post:
+      summary: Create a Draft Data Access Request
+      description: Returns the created partial DAR
+      tags:
+        - Data Access Request
+      responses:
+        200:
+          description: Returns the created partial Data Access Requests
+        500:
+          description: Internal Server Error.
+  /api/dar/draft/{referenceId}:
+    put:
+      summary: Update a Draft Data Access Request
+      description: Returns the updated partial DAR
+      tags:
+        - Data Access Request
+      responses:
+        200:
+          description: Returns the updated partial Data Access Requests
+        500:
+          description: Internal Server Error.
   /api/dar/partial/{id}:
     delete:
       summary: Delete Partial Data Access Request
@@ -1758,43 +1771,36 @@ paths:
           description: Forbidden
         500:
           description: Internal Server Error.
-    get:
-      summary: Get Partial Data Access Request By Reference Id
-      description: Return the draft DAR specified by the given Id if it exists
-      tags: 
-        - Data Access Request
-      responses:
-        200:
-          description: Partial Data Access Request
-          content:
-            application/json:
-              schema:
-                  ref: '#/components/schemas/DataAccessRequest'
-        404: 
-          description: Cannot find draft data access request with specified reference Id.
-        500:
-          description: Internal Server Error.
-  /api/dar/partials:
-    get:
-      summary: get Draft Data Access Requests
-      description: Get all Partial Data Access Requests for user
+    put:
+      summary: Update Partial Data Access Request
+      description: |
+        DEPRECATED: Use PUT /api/dar/v2/draft/{referenceId}:
+        Update Partial Data Access Request
+      parameters:
+        - name: dar
+          in: body
+          description: |
+            The fields that represent a DAR, json format.
+            Must contain a `referenceId` for the updated DAR.
+            User must be the creator of the DAR.
+          required: true
+          schema:
+            $ref: '#/components/schemas/DataAccessRequest'
       tags:
         - Data Access Request
       responses:
         200:
-          description: Partial Data Access Requests
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/DataAccessRequest'
+          description: Returns the updated partial Data Access Request, json file.
+        403:
+          description: Forbidden
+        404:
+          description: DAR or User Not Found
         500:
           description: Internal Server Error.
   /api/dar/partials/manage:
     get:
-      summary: Get Partial Data Access Requests for user
-      description: Get Partial Data Access Requests for user
+      summary: Get Partial Data Access Request Manage Object for user
+      description: Get information on Partial Data Access Requests for user
       tags:
         - Data Access Request
       responses:

--- a/src/test/java/org/broadinstitute/consent/http/models/darsummary/DARModalDetailsDTOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/darsummary/DARModalDetailsDTOTest.java
@@ -72,16 +72,16 @@ public class DARModalDetailsDTOTest {
     @Test
     public void generateModalDetailsDTO(){
         DARModalDetailsDTO modalDetailsDTO = new DARModalDetailsDTO()
-            .setDarCode(dar.data.getDarCode())
+            .setDarCode(dar.getData().getDarCode())
             .setPrincipalInvestigator(DarUtil.findPI(user))
             .setInstitutionName((user.getInstitutionId() == null) ?
             "" 
             : institutionDAO.findInstitutionById(user.getInstitutionId()).getName())
-            .setProjectTitle(dar.data.getProjectTitle())
-            .setDepartment(dar.data.getDepartment())
-            .setCity(dar.data.getCity())
-            .setCountry(dar.data.getCountry())
-            .setNihUsername(dar.data.getNihUsername())
+            .setProjectTitle(dar.getData().getProjectTitle())
+            .setDepartment(dar.getData().getDepartment())
+            .setCity(dar.getData().getCity())
+            .setCountry(dar.getData().getCountry())
+            .setNihUsername(dar.getData().getNihUsername())
             .setIsThereDiseases(false)
             .setIsTherePurposeStatements(false)
             .setResearchType(dar)

--- a/src/test/java/org/broadinstitute/consent/http/models/darsummary/DARModalDetailsDTOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/darsummary/DARModalDetailsDTOTest.java
@@ -1,17 +1,21 @@
 package org.broadinstitute.consent.http.models.darsummary;
 
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import org.apache.commons.lang3.StringUtils;
-import org.broadinstitute.consent.http.util.DarConstants;
-import org.bson.Document;
+import java.util.Date;
+
+import org.broadinstitute.consent.http.db.InstitutionDAO;
+import org.broadinstitute.consent.http.db.UserDAO;
+import org.broadinstitute.consent.http.models.DataAccessRequest;
+import org.broadinstitute.consent.http.models.DataAccessRequestData;
+import org.broadinstitute.consent.http.models.DatasetDetailEntry;
+import org.broadinstitute.consent.http.models.OntologyEntry;
+import org.broadinstitute.consent.http.models.User;
+import org.broadinstitute.consent.http.util.DarUtil;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -20,73 +24,74 @@ import org.mockito.MockitoAnnotations;
 public class DARModalDetailsDTOTest {
 
     @Mock
-    Document darDocument;
+    UserDAO userDAO;
 
-    ArrayList<Document> datasetDetail;
+    @Mock
+    InstitutionDAO institutionDAO;
 
     private final String DAR_CODE = "DAR-1";
-    private final String INVESTIGATOR = "Mocked Investigator";
-    private final String INSTITUTION = "Mocked Institution";
     private final String TITLE = "Mocked Title";
     private final String OTHERTEXT = "Other text";
+    private final DataAccessRequest dar = new DataAccessRequest();
+    private final DataAccessRequestData data = new DataAccessRequestData();
+    private final User user = new User();
 
     @Before
     public void setUp() {
         MockitoAnnotations.initMocks(this);
-        when(darDocument.getString(DarConstants.DAR_CODE)).thenReturn(DAR_CODE);
-        when(darDocument.getString(DarConstants.INVESTIGATOR)).thenReturn(INVESTIGATOR);
-        when(darDocument.getString(DarConstants.INSTITUTION)).thenReturn(INSTITUTION);
-        when(darDocument.getString(DarConstants.PROJECT_TITLE)).thenReturn(TITLE);
-        when(darDocument.get(DarConstants.DATASET_DETAIL)).thenReturn(datasetDetail);
-        when(darDocument.containsKey(DarConstants.DISEASES)).thenReturn(true);
-        when(darDocument.getBoolean(DarConstants.DISEASES)).thenReturn(true);
-        when(darDocument.containsKey(DarConstants.METHODS)).thenReturn(true);
-        when(darDocument.getBoolean(DarConstants.METHODS)).thenReturn(true);
-        when(darDocument.containsKey(DarConstants.CONTROLS)).thenReturn(true);
-        when(darDocument.getBoolean(DarConstants.CONTROLS)).thenReturn(true);
-        when(darDocument.containsKey(DarConstants.POPULATION)).thenReturn(true);
-        when(darDocument.getBoolean(DarConstants.POPULATION)).thenReturn(true);
-        when(darDocument.containsKey(DarConstants.OTHER)).thenReturn(true);
-        when(darDocument.getBoolean(DarConstants.OTHER)).thenReturn(true);
-        when(darDocument.getString(DarConstants.OTHER_TEXT)).thenReturn(OTHERTEXT);
-        when(darDocument.get(DarConstants.ONTOLOGIES)).thenReturn(ontologies());
-        when(darDocument.getBoolean(DarConstants.FOR_PROFIT)).thenReturn(false);
-        when(darDocument.getBoolean(DarConstants.ONE_GENDER)).thenReturn(true);
-        when(darDocument.getString(DarConstants.GENDER)).thenReturn("F");
-        when(darDocument.getBoolean(DarConstants.PEDIATRIC)).thenReturn(true);
-        when(darDocument.getBoolean(DarConstants.ILLEGAL_BEHAVE)).thenReturn(true);
-        when(darDocument.getBoolean(DarConstants.ADDICTION)).thenReturn(true);
-        when(darDocument.getBoolean(DarConstants.SEXUAL_DISEASES)).thenReturn(true);
-        when(darDocument.getBoolean(DarConstants.STIGMATIZED_DISEASES)).thenReturn(true);
-        when(darDocument.getBoolean(DarConstants.VULNERABLE_POP)).thenReturn(true);
-        when(darDocument.getBoolean(DarConstants.POP_MIGRATION)).thenReturn(true);
-        when(darDocument.getBoolean(DarConstants.PSYCH_TRAITS)).thenReturn(true);
-        when(darDocument.getBoolean(DarConstants.NOT_HEALTH)).thenReturn(true);
-        when(darDocument.get(DarConstants.DATASET_DETAIL)).thenReturn(getDatasetDetail());
+        Integer userId = userDAO.insertUser("email", "name", new Date());
+        User user = userDAO.findUserById(userId);
+        dar.setUserId(userId);
+        data.setProfileName("name");
+        data.setInstitution("");
+        data.setDarCode(DAR_CODE);
+        data.setProjectTitle(TITLE);
+        data.setDiseases(true);
+        data.setMethods(true);
+        data.setControls(true);
+        data.setPopulation(true);
+        data.setOther(true);
+        data.setOtherText(OTHERTEXT);
+        data.setOntologies(ontologies());
+        data.setForProfit(false);
+        data.setOneGender(true);
+        data.setGender("F");
+        data.setPediatric(true);
+        data.setIllegalBehavior(true);
+        data.setAddiction(true);
+        data.setSexualDiseases(true);
+        data.setStigmatizedDiseases(true);
+        data.setVulnerablePopulation(true);
+        data.setPopulationMigration(true);
+        data.setPsychiatricTraits(true);
+        data.setNotHealth(true);
+        data.setDatasetDetail(getDatasetDetail());
+        dar.setData(data);
     }
 
     @Test
     public void generateModalDetailsDTO(){
         DARModalDetailsDTO modalDetailsDTO = new DARModalDetailsDTO()
-            .setDarCode(darDocument.getString(DarConstants.DAR_CODE))
-            .setPrincipalInvestigator(darDocument.getString(DarConstants.INVESTIGATOR))
-            .setInstitutionName(darDocument.getString(DarConstants.INSTITUTION))
-            .setProjectTitle(darDocument.getString(DarConstants.PROJECT_TITLE))
-            .setDepartment(darDocument.getString(DarConstants.DEPARTMENT))
-            .setCity(darDocument.getString(DarConstants.CITY))
-            .setCountry(darDocument.getString(DarConstants.COUNTRY))
-            .setNihUsername(darDocument.getString(DarConstants.NIH_USERNAME))
-            .setHaveNihUsername(StringUtils.isNotEmpty(darDocument.getString(DarConstants.NIH_USERNAME)))
+            .setDarCode(dar.data.getDarCode())
+            .setPrincipalInvestigator(DarUtil.findPI(user))
+            .setInstitutionName((user.getInstitutionId() == null) ?
+            "" 
+            : institutionDAO.findInstitutionById(user.getInstitutionId()).getName())
+            .setProjectTitle(dar.data.getProjectTitle())
+            .setDepartment(dar.data.getDepartment())
+            .setCity(dar.data.getCity())
+            .setCountry(dar.data.getCountry())
+            .setNihUsername(dar.data.getNihUsername())
             .setIsThereDiseases(false)
             .setIsTherePurposeStatements(false)
-            .setResearchType(darDocument)
-            .setDiseases(darDocument)
-            .setPurposeStatements(darDocument)
+            .setResearchType(dar)
+            .setDiseases(dar)
+            .setPurposeStatements(dar)
             .setDatasets(Collections.emptyList());
         modalDetailsDTO.getDarCode();
         assertTrue(modalDetailsDTO.getDarCode().equals(DAR_CODE));
-        assertTrue(modalDetailsDTO.getInstitutionName().equals(INSTITUTION));
-        assertTrue(modalDetailsDTO.getPrincipalInvestigator().equals(INVESTIGATOR));
+        assertTrue(modalDetailsDTO.getInstitutionName().equals(""));
+        assertTrue(modalDetailsDTO.getPrincipalInvestigator().equals("- -"));
         assertTrue(modalDetailsDTO.getProjectTitle().equals(TITLE));
         assertTrue(modalDetailsDTO.isTherePurposeStatements());
         assertTrue(modalDetailsDTO.isRequiresManualReview());
@@ -103,27 +108,30 @@ public class DARModalDetailsDTOTest {
         assertTrue(modalDetailsDTO.getResearchType().size() == 5);
     }
 
-    private List<Map<String, String>> ontologies(){
-        Map<String, String> ontology1 = new HashMap<>();
-        ontology1.put("label", "OD-1: Ontology One");
-        Map<String, String> ontology2 = new HashMap<>();
-        ontology2.put("label", "OD-2: Ontology Two");
-        Map<String, String> ontology3 = new HashMap<>();
-        ontology3.put("label", "OD-3: Ontology Three");
-        return Arrays.asList(ontology1, ontology2, ontology3);
+    private List<OntologyEntry> ontologies(){
+        OntologyEntry ont1 = new OntologyEntry();
+        ont1.setLabel("OD-1: Ontology One");
+        OntologyEntry ont2 = new OntologyEntry();
+        ont2.setLabel("OD-2: Ontology Two");
+        OntologyEntry ont3 = new OntologyEntry();
+        ont3.setLabel("OD-3: Ontology Three");
+        return Arrays.asList(ont1, ont2, ont3);
     }
 
-    private ArrayList<Document> getDatasetDetail(){
-        Document document = new Document();
-        document.put("First:", "First Sample Detail");
-        Document document1 = new Document();
-        document.put("Second:", "Second Sample Detail");
-        Document document2 = new Document();
-        document.put("Third", "Thirs Sample Detail");
-        ArrayList<Document> list = new ArrayList<>();
-        list.add(document);
-        list.add(document1);
-        list.add(document2);
+    private ArrayList<DatasetDetailEntry> getDatasetDetail(){
+        DatasetDetailEntry entry1 = new DatasetDetailEntry();
+        entry1.setName("First:");
+        entry1.setDatasetId("First Sample Detail");
+        DatasetDetailEntry entry2 = new DatasetDetailEntry();
+        entry2.setName("Second:");
+        entry2.setDatasetId("Second Sample Detail");
+        DatasetDetailEntry entry3 = new DatasetDetailEntry();
+        entry3.setName("First:");
+        entry3.setDatasetId("First Sample Detail");
+        ArrayList<DatasetDetailEntry> list = new ArrayList<>();
+        list.add(entry1);
+        list.add(entry2);
+        list.add(entry3);
         return list;
     }
 }

--- a/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceTest.java
@@ -66,7 +66,7 @@ public class DataAccessRequestResourceTest {
         when(consentService.getConsentFromDatasetID(any())).thenReturn(new Consent());
         when(user.getDacUserId()).thenReturn(dar.getUserId());
         when(userService.findUserByEmail(any())).thenReturn(user);
-        resource = new DataAccessRequestResource(dataAccessRequestService, emailNotifierService, userService, consentService, electionService);
+        resource = new DataAccessRequestResource(dataAccessRequestService, userService, consentService, electionService);
         Consent consent = resource.describeConsentForDAR(authUser, dar.getReferenceId());
         assertNotNull(consent);
     }
@@ -83,7 +83,7 @@ public class DataAccessRequestResourceTest {
         when(consentService.getConsentFromDatasetID(any())).thenReturn(new Consent());
         when(user.getDacUserId()).thenReturn(dar.getUserId());
         when(userService.findUserByEmail(any())).thenReturn(user);
-        resource = new DataAccessRequestResource(dataAccessRequestService, emailNotifierService, userService, consentService, electionService);
+        resource = new DataAccessRequestResource(dataAccessRequestService, userService, consentService, electionService);
         Consent consent = resource.describeConsentForDAR(authUser, dar.getReferenceId());
         assertNotNull(consent);
     }
@@ -96,7 +96,7 @@ public class DataAccessRequestResourceTest {
         DataAccessRequest dar = generateDataAccessRequest();
         when(dataAccessRequestService.findByReferenceId(any())).thenReturn(dar);
         when(consentService.getConsentFromDatasetID(any())).thenReturn(null);
-        resource = new DataAccessRequestResource(dataAccessRequestService, emailNotifierService, userService, consentService, electionService);
+        resource = new DataAccessRequestResource(dataAccessRequestService, userService, consentService, electionService);
         resource.describeConsentForDAR(authUser, dar.getReferenceId());
     }
 
@@ -108,7 +108,7 @@ public class DataAccessRequestResourceTest {
         DataAccessRequest dar = generateDataAccessRequest();
         dar.getData().setDatasetIds(null);
         when(dataAccessRequestService.findByReferenceId(any())).thenReturn(dar);
-        resource = new DataAccessRequestResource(dataAccessRequestService, emailNotifierService, userService, consentService, electionService);
+        resource = new DataAccessRequestResource(dataAccessRequestService, userService, consentService, electionService);
         resource.describeConsentForDAR(authUser, dar.getReferenceId());
     }
 
@@ -124,7 +124,7 @@ public class DataAccessRequestResourceTest {
         when(consentService.getConsentFromDatasetID(any())).thenReturn(new Consent());
         when(user.getDacUserId()).thenReturn(dar.getUserId() + 1);
         when(userService.findUserByEmail(any())).thenReturn(user);
-        resource = new DataAccessRequestResource(dataAccessRequestService, emailNotifierService, userService, consentService, electionService);
+        resource = new DataAccessRequestResource(dataAccessRequestService,userService, consentService, electionService);
         resource.describeConsentForDAR(authUser, dar.getReferenceId());
     }
 
@@ -137,7 +137,6 @@ public class DataAccessRequestResourceTest {
             .thenReturn(Collections.singletonList(manage));
         resource = new DataAccessRequestResource(
             dataAccessRequestService,
-            emailNotifierService,
             userService,
             consentService, electionService);
         Response response = resource.describeManageDataAccessRequestsV2(authUser);

--- a/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceVersion2Test.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceVersion2Test.java
@@ -379,7 +379,7 @@ public class DataAccessRequestResourceVersion2Test {
   public void getDataAccessRequests() {
     initResource();
     List list = Collections.emptyList();
-    when(dataAccessRequestService.getDataAccessRequestsForUser(any())).thenReturn(list);
+    when(dataAccessRequestService.getDataAccessRequestsByUserRole(any())).thenReturn(list);
     Response res = resource.getDataAccessRequests(authUser);
     assertEquals(HttpStatusCodes.STATUS_CODE_OK, res.getStatus());
     assertEquals(true, res.hasEntity());

--- a/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceVersion2Test.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceVersion2Test.java
@@ -379,7 +379,7 @@ public class DataAccessRequestResourceVersion2Test {
   public void getDataAccessRequests() {
     initResource();
     List list = Collections.emptyList();
-    when(dataAccessRequestService.getDataAccessRequests(any())).thenReturn(list);
+    when(dataAccessRequestService.getDataAccessRequestsForUser(any())).thenReturn(list);
     Response res = resource.getDataAccessRequests(authUser);
     assertEquals(HttpStatusCodes.STATUS_CODE_OK, res.getStatus());
     assertEquals(true, res.hasEntity());

--- a/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceVersion2Test.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceVersion2Test.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.consent.http.resources;
 
+import com.google.api.client.http.HttpStatusCodes;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
@@ -19,6 +20,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.UUID;
 import javax.ws.rs.ForbiddenException;
+import javax.ws.rs.NotFoundException;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
@@ -371,5 +373,98 @@ public class DataAccessRequestResourceVersion2Test {
     dar.setUpdateDate(now);
     dar.setSortDate(now);
     return dar;
+  }
+
+  @Test
+  public void getDataAccessRequests() {
+    initResource();
+    List list = Collections.emptyList();
+    when(dataAccessRequestService.getDataAccessRequests(any())).thenReturn(list);
+    Response res = resource.getDataAccessRequests(authUser);
+    assertEquals(HttpStatusCodes.STATUS_CODE_OK, res.getStatus());
+    assertEquals(true, res.hasEntity());
+  }
+
+  @Test
+  public void getDraftDataAccessRequests() {
+    initResource();
+    List list = Collections.emptyList();
+    User user = new User();
+    user.setDacUserId(1);
+    when(userService.findUserByEmail(any())).thenReturn(user);
+    when(dataAccessRequestService.findAllDraftDataAccessRequestsByUser(any())).thenReturn(list);
+    Response res = resource.getDraftDataAccessRequests(authUser);
+    assertEquals(HttpStatusCodes.STATUS_CODE_OK, res.getStatus());
+    assertEquals(true, res.hasEntity());
+  }
+
+  @Test(expected = NotFoundException.class)
+  public void getDraftDataAccessRequests_UserNotFound() {
+    initResource();
+    when(userService.findUserByEmail(any())).thenThrow(new NotFoundException());
+    resource.getDraftDataAccessRequests(authUser);
+  }
+
+  @Test
+  public void getDraftDar() {
+    initResource();
+    User user = new User();
+    user.setDacUserId(10);
+    DataAccessRequest dar = new DataAccessRequest();
+    dar.setUserId(10);
+    when(userService.findUserByEmail(any())).thenReturn(user);
+    when(dataAccessRequestService.findByReferenceId(any())).thenReturn(dar);
+    Response res = resource.getDraftDar(authUser, "id");
+    assertEquals(HttpStatusCodes.STATUS_CODE_OK, res.getStatus());
+    assertEquals(true, res.hasEntity());
+  }
+
+  @Test(expected = NotFoundException.class)
+  public void getDraftDar_UserNotFound() {
+    initResource();
+    when(userService.findUserByEmail(any())).thenThrow(new NotFoundException());
+    resource.getDraftDar(authUser, "id");
+  }
+
+  @Test(expected = NotFoundException.class)
+  public void getDraftDar_DarNotFound() {
+    initResource();
+    User user = new User();
+    user.setDacUserId(10);
+    when(userService.findUserByEmail(any())).thenReturn(user);
+    when(dataAccessRequestService.findByReferenceId(any())).thenThrow(new NotFoundException());
+    resource.getDraftDar(authUser, "id");
+  }
+
+  @Test(expected = ForbiddenException.class)
+  public void getDraftDar_UserNotAllowed() {
+    initResource();
+    User user = new User();
+    user.setDacUserId(10);
+    DataAccessRequest dar = new DataAccessRequest();
+    dar.setUserId(11);
+    when(userService.findUserByEmail(any())).thenReturn(user);
+    when(dataAccessRequestService.findByReferenceId(any())).thenReturn(dar);
+    resource.getDraftDar(authUser, "id");
+  }
+
+  @Test
+  public void getDraftManageDataAccessRequests() {
+    initResource();
+    List list = Collections.emptyList();
+    User user = new User();
+    user.setDacUserId(10);
+    when(userService.findUserByEmail(any())).thenReturn(user);
+    when(dataAccessRequestService.getDraftDataAccessRequestManage(any())).thenReturn(list);
+    Response res = resource.getDraftManageDataAccessRequests(authUser);
+    assertEquals(HttpStatusCodes.STATUS_CODE_OK, res.getStatus());
+    assertEquals(true, res.hasEntity());
+  }
+
+  @Test(expected = NotFoundException.class)
+  public void getDraftManageDataAccessRequests_UserNotFound() {
+    initResource();
+    when(userService.findUserByEmail(any())).thenThrow(new NotFoundException());
+    resource.getDraftManageDataAccessRequests(authUser);
   }
 }

--- a/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceVersion2Test.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceVersion2Test.java
@@ -398,11 +398,13 @@ public class DataAccessRequestResourceVersion2Test {
     assertEquals(true, res.hasEntity());
   }
 
-  @Test(expected = NotFoundException.class)
+  @Test
   public void getDraftDataAccessRequests_UserNotFound() {
     initResource();
     when(userService.findUserByEmail(any())).thenThrow(new NotFoundException());
     resource.getDraftDataAccessRequests(authUser);
+    Response res = resource.getDraftDataAccessRequests(authUser);
+    assertEquals(res.getStatus(), HttpStatusCodes.STATUS_CODE_NOT_FOUND);
   }
 
   @Test
@@ -419,24 +421,26 @@ public class DataAccessRequestResourceVersion2Test {
     assertEquals(true, res.hasEntity());
   }
 
-  @Test(expected = NotFoundException.class)
+  @Test
   public void getDraftDar_UserNotFound() {
     initResource();
     when(userService.findUserByEmail(any())).thenThrow(new NotFoundException());
-    resource.getDraftDar(authUser, "id");
+    Response res = resource.getDraftDar(authUser, "id");
+    assertEquals(res.getStatus(), HttpStatusCodes.STATUS_CODE_NOT_FOUND);
   }
 
-  @Test(expected = NotFoundException.class)
+  @Test
   public void getDraftDar_DarNotFound() {
     initResource();
     User user = new User();
     user.setDacUserId(10);
     when(userService.findUserByEmail(any())).thenReturn(user);
     when(dataAccessRequestService.findByReferenceId(any())).thenThrow(new NotFoundException());
-    resource.getDraftDar(authUser, "id");
+    Response res = resource.getDraftDar(authUser, "id");
+    assertEquals(res.getStatus(), HttpStatusCodes.STATUS_CODE_NOT_FOUND);
   }
 
-  @Test(expected = ForbiddenException.class)
+  @Test
   public void getDraftDar_UserNotAllowed() {
     initResource();
     User user = new User();
@@ -445,7 +449,8 @@ public class DataAccessRequestResourceVersion2Test {
     dar.setUserId(11);
     when(userService.findUserByEmail(any())).thenReturn(user);
     when(dataAccessRequestService.findByReferenceId(any())).thenReturn(dar);
-    resource.getDraftDar(authUser, "id");
+    Response res = resource.getDraftDar(authUser, "id");
+    assertEquals(res.getStatus(), HttpStatusCodes.STATUS_CODE_FORBIDDEN);
   }
 
   @Test
@@ -461,10 +466,11 @@ public class DataAccessRequestResourceVersion2Test {
     assertEquals(true, res.hasEntity());
   }
 
-  @Test(expected = NotFoundException.class)
+  @Test
   public void getDraftManageDataAccessRequests_UserNotFound() {
     initResource();
     when(userService.findUserByEmail(any())).thenThrow(new NotFoundException());
-    resource.getDraftManageDataAccessRequests(authUser);
+    Response res = resource.getDraftManageDataAccessRequests(authUser);
+    assertEquals(res.getStatus(), HttpStatusCodes.STATUS_CODE_NOT_FOUND);
   }
 }

--- a/src/test/java/org/broadinstitute/consent/http/service/DataAccessReportsParserTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DataAccessReportsParserTest.java
@@ -1,9 +1,10 @@
 package org.broadinstitute.consent.http.service;
 
 import org.broadinstitute.consent.http.enumeration.HeaderDAR;
+import org.broadinstitute.consent.http.models.DataAccessRequest;
+import org.broadinstitute.consent.http.models.DataAccessRequestData;
+import org.broadinstitute.consent.http.models.DatasetDetailEntry;
 import org.broadinstitute.consent.http.models.Election;
-import org.broadinstitute.consent.http.util.DarConstants;
-import org.bson.Document;
 import org.junit.Test;
 
 import java.io.File;
@@ -11,6 +12,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.Iterator;
@@ -47,7 +49,7 @@ public class DataAccessReportsParserTest {
         File file = File.createTempFile("ApprovedDataAccessRequests.tsv", ".tsv");
         Date currentDate = new Date();
         Election election = createElection(currentDate);
-        Document dar = createDAR(currentDate);
+        DataAccessRequest dar = createDAR(currentDate);
         FileWriter darWriter = new FileWriter(file);
         parser.setApprovedDARHeader(darWriter);
         parser.addApprovedDARLine(darWriter, election, dar, REQUESTER, ORGANIZATION, CONSENT_NAME, sDUL);
@@ -94,7 +96,7 @@ public class DataAccessReportsParserTest {
         File file = File.createTempFile("ApprovedDataAccessRequests.tsv", ".tsv");
         Date currentDate = new Date();
         Election election = createElection(currentDate);
-        Document dar = createDAR(currentDate);
+        DataAccessRequest dar = createDAR(currentDate);
         FileWriter darWriter = new FileWriter(file);
         parser.setReviewedDARHeader(darWriter);
         parser.addReviewedDARLine(darWriter, election, dar, CONSENT_NAME, sDUL);
@@ -170,19 +172,21 @@ public class DataAccessReportsParserTest {
         return election;
     }
 
-    private Document createDAR(Date currentDate) {
-        Document dar = new Document();
-        Document datasetDetail = new Document();
-        datasetDetail.put(DarConstants.OBJECT_ID, SC_ID);
-        datasetDetail.put("name", NAME);
-        List<Document> detailsList = new ArrayList<>();
+    private DataAccessRequest createDAR(Date currentDate) {
+        DataAccessRequest dar = new DataAccessRequest();
+        DataAccessRequestData data = new DataAccessRequestData();
+        dar.setData(data);
+        DatasetDetailEntry datasetDetail = new DatasetDetailEntry();
+        datasetDetail.setObjectId(SC_ID);
+        datasetDetail.setName(NAME);
+        List<DatasetDetailEntry> detailsList = new ArrayList<>();
         detailsList.add(datasetDetail);
-        dar.put(DarConstants.DATASET_DETAIL, detailsList);
-        dar.put(DarConstants.DATASET_ID, new ArrayList<>());
-        dar.put(DarConstants.DAR_CODE, DAR_CODE);
-        dar.put(DarConstants.TRANSLATED_RESTRICTION, TRANSLATED_USE_RESTRICTION);
-        dar.put(DarConstants.NON_TECH_RUS, RUS_SUMMARY);
-        dar.put(DarConstants.SORT_DATE, currentDate.getTime());
+        dar.data.setDatasetDetail(detailsList);
+        dar.data.setDatasetIds(new ArrayList<>());
+        dar.data.setDarCode(DAR_CODE);
+        dar.data.setTranslatedUseRestriction(TRANSLATED_USE_RESTRICTION);
+        dar.data.setNonTechRus(RUS_SUMMARY);
+        dar.setSortDate(new Timestamp(currentDate.getTime()));
         return dar;
     }
 }

--- a/src/test/java/org/broadinstitute/consent/http/service/DataAccessReportsParserTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DataAccessReportsParserTest.java
@@ -175,17 +175,17 @@ public class DataAccessReportsParserTest {
     private DataAccessRequest createDAR(Date currentDate) {
         DataAccessRequest dar = new DataAccessRequest();
         DataAccessRequestData data = new DataAccessRequestData();
-        dar.setData(data);
         DatasetDetailEntry datasetDetail = new DatasetDetailEntry();
         datasetDetail.setObjectId(SC_ID);
         datasetDetail.setName(NAME);
         List<DatasetDetailEntry> detailsList = new ArrayList<>();
         detailsList.add(datasetDetail);
-        dar.data.setDatasetDetail(detailsList);
-        dar.data.setDatasetIds(new ArrayList<>());
-        dar.data.setDarCode(DAR_CODE);
-        dar.data.setTranslatedUseRestriction(TRANSLATED_USE_RESTRICTION);
-        dar.data.setNonTechRus(RUS_SUMMARY);
+        data.setDatasetDetail(detailsList);
+        data.setDatasetIds(new ArrayList<>());
+        data.setDarCode(DAR_CODE);
+        data.setTranslatedUseRestriction(TRANSLATED_USE_RESTRICTION);
+        data.setNonTechRus(RUS_SUMMARY);
+        dar.setData(data);
         dar.setSortDate(new Timestamp(currentDate.getTime()));
         return dar;
     }

--- a/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
@@ -513,7 +513,7 @@ public class DataAccessRequestServiceTest {
         when(dataAccessRequestDAO.findAllDataAccessRequests()).thenReturn(dars);
         when(dacService.filterDataAccessRequestsByDac(eq(dars), any())).thenReturn(dars);
         initService();
-        List<DataAccessRequest> foundDars = service.getDataAccessRequestsForUser(authUser);
+        List<DataAccessRequest> foundDars = service.getDataAccessRequestsByUserRole(authUser);
         assertEquals(foundDars.size(), 1);
     }
 

--- a/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
@@ -7,6 +7,7 @@ import org.mockito.ArgumentMatcher;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 
@@ -499,27 +500,73 @@ public class DataAccessRequestServiceTest {
     }
 
     @Test
-    public void findAllDataAccessRequests() {
+    public void testFindAllDraftDataAccessRequests() {
+        when(dataAccessRequestDAO.findAllDraftDataAccessRequests()).thenReturn(Arrays.asList(new DataAccessRequest()));
+        initService();
+        List<DataAccessRequest> drafts = service.findAllDraftDataAccessRequests();
+        assertEquals(drafts.size(), 1);
     }
 
     @Test
-    public void findAllDraftDataAccessRequests() {
+    public void testFindAllDraftDataAccessRequestsByUser() {
+        when(dataAccessRequestDAO.findAllDraftsByUserId(any())).thenReturn(Arrays.asList(new DataAccessRequest()));
+        initService();
+        List<DataAccessRequest> drafts = service.findAllDraftDataAccessRequestsByUser(1);
+        assertEquals(drafts.size(), 1);
     }
 
     @Test
-    public void findAllDraftDataAccessRequestsByUser() {
+    public void getDataAccessRequestsForUser() {
+        List<DataAccessRequest> dars = Arrays.asList(new DataAccessRequest());
+        when(dataAccessRequestDAO.findAllDataAccessRequests()).thenReturn(dars);
+        when(dacService.filterDataAccessRequestsByDac(eq(dars), any())).thenReturn(dars);
+        initService();
+        List<DataAccessRequest> foundDars = service.getDataAccessRequestsForUser(authUser);
+        assertEquals(foundDars.size(), 1);
     }
 
     @Test
-    public void getDataAccessRequestsByReferenceIds() {
-    }
-
-    @Test
-    public void getDataAccessRequests() {
+    public void getDraftDataAccessRequestManage_NullUserId() {
+        DataAccessRequest dar = new DataAccessRequest();
+        dar.setReferenceId("referenceId");
+        dar.setUserId(1);
+        DataAccessRequestData data = new DataAccessRequestData();
+        data.setDatasetIds(Arrays.asList(361));
+        dar.setData(data);
+        when(dataAccessRequestDAO.findAllDraftDataAccessRequests()).thenReturn(Arrays.asList(dar));
+        initService();
+        List<DataAccessRequestManage> darManages = service.getDraftDataAccessRequestManage(null);
+        assertEquals(1, darManages.size());
     }
 
     @Test
     public void getDraftDataAccessRequestManage() {
+        DataAccessRequest dar = new DataAccessRequest();
+        dar.setReferenceId("referenceId");
+        dar.setUserId(1);
+        DataAccessRequestData data = new DataAccessRequestData();
+        data.setDatasetIds(Arrays.asList(361));
+        dar.setData(data);
+        when(dataAccessRequestDAO.findAllDraftsByUserId(any())).thenReturn(Arrays.asList(dar));
+        initService();
+        List<DataAccessRequestManage> darManages = service.getDraftDataAccessRequestManage(1);
+        assertEquals(1, darManages.size());
+    }
+
+    @Test
+    public void testFindByReferenceId() {
+        initService();
+        DataAccessRequest dar = new DataAccessRequest();
+        when(dataAccessRequestDAO.findByReferenceId(any())).thenReturn(dar);
+        DataAccessRequest foundDar = service.findByReferenceId("refId");
+        assertEquals(dar, foundDar);
+    }
+
+    @Test(expected = NotFoundException.class)
+    public void testFindByReferenceId_NotFound() {
+        initService();
+        when(dataAccessRequestDAO.findByReferenceId(any())).thenThrow(new NotFoundException());
+        service.findByReferenceId("referenceId");
     }
 
     private class LongerThanTwo implements ArgumentMatcher<String> {

--- a/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
@@ -498,6 +498,30 @@ public class DataAccessRequestServiceTest {
         return RandomStringUtils.random(10, true, false);
     }
 
+    @Test
+    public void findAllDataAccessRequests() {
+    }
+
+    @Test
+    public void findAllDraftDataAccessRequests() {
+    }
+
+    @Test
+    public void findAllDraftDataAccessRequestsByUser() {
+    }
+
+    @Test
+    public void getDataAccessRequestsByReferenceIds() {
+    }
+
+    @Test
+    public void getDataAccessRequests() {
+    }
+
+    @Test
+    public void getDraftDataAccessRequestManage() {
+    }
+
     private class LongerThanTwo implements ArgumentMatcher<String> {
 
         @Override

--- a/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
@@ -375,7 +375,6 @@ public class DataAccessRequestServiceTest {
     @Test
     public void testDARModalDetailsDTOBuilder() {
         DataAccessRequest dar = generateDataAccessRequest();
-        Document doc = generateDarDocument(dar);
 
         when(dataAccessRequestDAO.findByReferenceId(dar.getReferenceId()))
                 .thenReturn(dar);
@@ -393,7 +392,7 @@ public class DataAccessRequestServiceTest {
                 .thenReturn(Collections.emptyList());
         initService();
 
-        DARModalDetailsDTO darModalDetailsDTO = service.DARModalDetailsDTOBuilder(doc, user, electionService);
+        DARModalDetailsDTO darModalDetailsDTO = service.DARModalDetailsDTOBuilder(dar, user, electionService);
         assertNotNull(darModalDetailsDTO);
         assertEquals(dar.data.getInstitution(), darModalDetailsDTO.getInstitutionName());
     }
@@ -445,15 +444,6 @@ public class DataAccessRequestServiceTest {
         return dar;
     }
 
-    private Document generateDarDocument(DataAccessRequest dar) {
-        Document document = Document.parse(gson.toJson(dar.getData()));
-        document.put(DarConstants.DATA_ACCESS_REQUEST_ID, dar.getId());
-        document.put(DarConstants.REFERENCE_ID, dar.getReferenceId());
-        document.put(DarConstants.CREATE_DATE, dar.getCreateDate());
-        document.put(DarConstants.SORT_DATE, dar.getSortDate());
-        return document;
-    }
-
     private Election generateElection(Integer dataSetId) {
         String refId = UUID.randomUUID().toString();
         Election election = new Election();
@@ -461,26 +451,6 @@ public class DataAccessRequestServiceTest {
         election.setReferenceId(refId);
 
         return election;
-    }
-
-    private Document getDocument(String linkedIn, String orcid, String researcherGate) {
-        Document dar = new Document();
-        dar.put(UserFields.LINKEDIN_PROFILE.getValue(), linkedIn);
-        dar.put(UserFields.ORCID.getValue(), orcid);
-        dar.put(UserFields.RESEARCHER_GATE.getValue(), researcherGate);
-        dar.put(DarConstants.INVESTIGATOR, randomString());
-        dar.put(DarConstants.PI_EMAIL, randomString());
-        dar.put(DarConstants.PROJECT_TITLE, randomString());
-        dar.put(DarConstants.DATASET_DETAIL, new ArrayList<Document>());
-        dar.put(DarConstants.RUS, randomString());
-        dar.put(DarConstants.NON_TECH_RUS, randomString());
-        dar.put(DarConstants.METHODS, true);
-        dar.put(DarConstants.CONTROLS, true);
-        dar.put(DarConstants.OTHER, true);
-        dar.put(DarConstants.POA, true);
-        dar.put(DarConstants.HMB, true);
-        dar.put(DarConstants.OTHER_TEXT, randomString());
-        return dar;
     }
 
     private Map<String, String> getResearcherProperties() {

--- a/src/test/java/org/broadinstitute/consent/http/service/MetricsServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/MetricsServiceTest.java
@@ -91,7 +91,7 @@ public class MetricsServiceTest {
     Set<DatasetDTO> dataset = new HashSet<>(generateDatasetDTO(1));
 
     when(dataSetDAO.findDatasetDTOWithPropertiesByDatasetId(any())).thenReturn(dataset);
-    when(darDAO.findAllDataAccessRequestsForDatasetMetrics(any())).thenReturn(dars);
+    when(darDAO.findAllDataAccessRequestsByDatasetId(any())).thenReturn(dars);
     when(electionDAO.findLastElectionsByReferenceIdsAndType(any(), eq("DataAccess"))).thenReturn(election);
 
     initService();


### PR DESCRIPTION

SCOPE:
Resource: deprecate APIs in DataAccessRequestResource that use Documents and create replacement APIs in DataAccessRequestVersion2Resource
Resource test: add missing tests and refactor tests
Service: deprecate service class methods that use Documents and create replacement service class methods
Service test: add missing tests and refactor tests
DarModalDetailsDTO and test: refactor from doc from dar
DataAccessRequestParser and test: refactor from doc from dar
MetricsService and darUtil: move findPi from metrics service to darUtil
EmailNotifierService: commented out unused code, I didn't delete it because I wasn't sure if it was out of scope but it is unused and would need to be refactored

ADDRESSES:
https://broadworkbench.atlassian.net/browse/DUOS-1313

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
