### PR TITLE
DUOS-1259[risk=no]Update manage/v2 endpoint with optional role name for SOs

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/DataAccessRequestDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DataAccessRequestDAO.java
@@ -185,4 +185,16 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
   @RegisterRowMapper(DataAccessRequestDataMapper.class)
   @SqlQuery(" SELECT (data #>> '{}')::jsonb AS data FROM data_access_request ")
   List<DataAccessRequestData> findAllDataAccessRequestDatas();
+
+  /**
+   * Find all non-draft/partial DataAccessRequests for users in the given institution
+   *
+   * @return List<DataAccessRequest>
+   */
+  @SqlQuery(
+    "SELECT id, reference_id, draft, user_id, create_date, sort_date, submission_date, update_date, (data #>> '{}')::jsonb AS data FROM data_access_request "
+        + " INNER JOIN dacuser d on d.dacuserid = user_id AND d.institution_id = :institutionId "
+        + " WHERE draft != true")
+  List<DataAccessRequest> findAllDataAccessRequestsForInstitution(@Bind("institutionId") Integer institutionId);
+
 }

--- a/src/main/java/org/broadinstitute/consent/http/models/User.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/User.java
@@ -319,11 +319,11 @@ public class User {
         return new Gson().toJson(this);
     }
 
-    public static boolean hasUserRole(User user, UserRoles role) {
-        if (Objects.isNull(user) || Objects.isNull(user.getRoles())) {
+    public boolean hasUserRole(UserRoles role) {
+        if (Objects.isNull(this.getRoles())) {
             return false;
         } else {
-            return user.getRoles().stream().anyMatch((r) -> r.getRoleId().equals(role.getRoleId()));
+            return this.getRoles().stream().anyMatch((r) -> r.getRoleId().equals(role.getRoleId()));
         }
     }
 

--- a/src/main/java/org/broadinstitute/consent/http/models/User.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/User.java
@@ -13,6 +13,7 @@ import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.broadinstitute.consent.http.authentication.GoogleUser;
+import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.slf4j.LoggerFactory;
 import net.gcardone.junidecode.Junidecode;
 
@@ -316,6 +317,14 @@ public class User {
     @Override
     public String toString() {
         return new Gson().toJson(this);
+    }
+
+    public static boolean hasUserRole(User user, UserRoles role) {
+        if (Objects.isNull(user) || Objects.isNull(user.getRoles())) {
+            return false;
+        } else {
+            return user.getRoles().stream().anyMatch((r) -> r.getRoleId().equals(role.getRoleId()));
+        }
     }
 
 }

--- a/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
@@ -160,12 +160,18 @@ public class DataAccessRequestResource extends Resource {
             User user = userService.findUserByEmail(authUser.getName());
             String roleNameValue = roleName.orElse(null);
             if (Objects.nonNull(roleNameValue)) {
+                if (roleNameValue.equalsIgnoreCase(UserRoles.MEMBER.getRoleName())
+                || roleNameValue.equalsIgnoreCase(UserRoles.CHAIRPERSON.getRoleName())
+                || roleNameValue.equalsIgnoreCase(UserRoles.DATAOWNER.getRoleName())
+                || roleNameValue.equalsIgnoreCase(UserRoles.RESEARCHER.getRoleName())
+                || roleNameValue.equalsIgnoreCase(UserRoles.ALUMNI.getRoleName())) {
+                    throw new BadRequestException("Signing Official Role is the only role supported at this time");
+                }
                 //if the roleName is SO and the user does not have that role throw an exception
-                if (roleNameValue.equals(UserRoles.SIGNINGOFFICIAL.getRoleName())) {
+                if (roleNameValue.equalsIgnoreCase(UserRoles.SIGNINGOFFICIAL.getRoleName())) {
                     if (!user.hasUserRole(UserRoles.SIGNINGOFFICIAL)) {
                         throw new NotFoundException("User: " + user.getDisplayName() + ", " + " does not have Signing Official role.");
                     }
-                //if there is a roleName but it is not SO then throw an exception
                 } else {
                     throw new BadRequestException("Invalid role name: " + roleNameValue);
                 }

--- a/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
@@ -156,8 +156,13 @@ public class DataAccessRequestResource extends Resource {
     @Path("/manage/v2")
     @RolesAllowed({ADMIN, CHAIRPERSON, MEMBER, SIGNINGOFFICIAL})
     public Response describeManageDataAccessRequestsV2(@Auth AuthUser authUser, @QueryParam("roleName") Optional<String> roleName) {
-        List<DataAccessRequestManage> dars = dataAccessRequestService.describeDataAccessRequestManageV2(authUser, roleName);
-        return Response.ok().entity(dars).build();
+        try {
+            User user = userService.findUserByEmail(authUser.getName());
+            List<DataAccessRequestManage> dars = dataAccessRequestService.describeDataAccessRequestManageV2(user, roleName);
+            return Response.ok().entity(dars).build();
+        } catch(Exception e) {
+            return createExceptionResponse(e);
+        }
     }
 
     @GET

--- a/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
@@ -154,9 +154,9 @@ public class DataAccessRequestResource extends Resource {
     @GET
     @Produces("application/json")
     @Path("/manage/v2")
-    @RolesAllowed({ADMIN, CHAIRPERSON, MEMBER})
-    public Response describeManageDataAccessRequestsV2(@Auth AuthUser authUser) {
-        List<DataAccessRequestManage> dars = dataAccessRequestService.describeDataAccessRequestManageV2(authUser);
+    @RolesAllowed({ADMIN, CHAIRPERSON, MEMBER, SIGNINGOFFICIAL})
+    public Response describeManageDataAccessRequestsV2(@Auth AuthUser authUser, @QueryParam("roleName") Optional<String> roleName) {
+        List<DataAccessRequestManage> dars = dataAccessRequestService.describeDataAccessRequestManageV2(authUser, roleName);
         return Response.ok().entity(dars).build();
     }
 

--- a/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
@@ -157,7 +157,8 @@ public class DataAccessRequestResource extends Resource {
     public Response describeManageDataAccessRequestsV2(@Auth AuthUser authUser, @QueryParam("roleName") Optional<String> roleName) {
         try {
             User user = userService.findUserByEmail(authUser.getName());
-            List<DataAccessRequestManage> dars = dataAccessRequestService.describeDataAccessRequestManageV2(user, roleName);
+            String roleNameValue = roleName.isPresent() ? roleName.get() : null;
+            List<DataAccessRequestManage> dars = dataAccessRequestService.describeDataAccessRequestManageV2(user, roleNameValue);
             return Response.ok().entity(dars).build();
         } catch(Exception e) {
             return createExceptionResponse(e);

--- a/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
@@ -13,6 +13,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.security.PermitAll;
 import javax.annotation.security.RolesAllowed;
+import javax.ws.rs.BadRequestException;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.ForbiddenException;
 import javax.ws.rs.GET;
@@ -158,9 +159,15 @@ public class DataAccessRequestResource extends Resource {
         try {
             User user = userService.findUserByEmail(authUser.getName());
             String roleNameValue = roleName.orElse(null);
-            if (Objects.nonNull(roleNameValue) && roleNameValue.equals(UserRoles.SIGNINGOFFICIAL.getRoleName())) {
-                if (!user.hasUserRole(UserRoles.SIGNINGOFFICIAL)) {
-                    throw new ForbiddenException("User: " + user.getDisplayName() + ", " + " does not have Signing Official role.");
+            if (Objects.nonNull(roleNameValue)) {
+                //if the roleName is SO and the user does not have that role throw an exception
+                if (roleNameValue.equals(UserRoles.SIGNINGOFFICIAL.getRoleName())) {
+                    if (!user.hasUserRole(UserRoles.SIGNINGOFFICIAL)) {
+                        throw new NotFoundException("User: " + user.getDisplayName() + ", " + " does not have Signing Official role.");
+                    }
+                //if there is a roleName but it is not SO then throw an exception
+                } else {
+                    throw new BadRequestException("Invalid role name: " + roleNameValue);
                 }
             }
             List<DataAccessRequestManage> dars = dataAccessRequestService.describeDataAccessRequestManageV2(user, roleNameValue);

--- a/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
@@ -158,6 +158,11 @@ public class DataAccessRequestResource extends Resource {
         try {
             User user = userService.findUserByEmail(authUser.getName());
             String roleNameValue = roleName.orElse(null);
+            if (Objects.nonNull(roleNameValue) && roleNameValue.equals(UserRoles.SIGNINGOFFICIAL.getRoleName())) {
+                if (!user.hasUserRole(UserRoles.SIGNINGOFFICIAL)) {
+                    throw new ForbiddenException("User: " + user.getDisplayName() + ", " + " does not have Signing Official role.");
+                }
+            }
             List<DataAccessRequestManage> dars = dataAccessRequestService.describeDataAccessRequestManageV2(user, roleNameValue);
             return Response.ok().entity(dars).build();
         } catch(Exception e) {

--- a/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
@@ -157,7 +157,7 @@ public class DataAccessRequestResource extends Resource {
     public Response describeManageDataAccessRequestsV2(@Auth AuthUser authUser, @QueryParam("roleName") Optional<String> roleName) {
         try {
             User user = userService.findUserByEmail(authUser.getName());
-            String roleNameValue = roleName.isPresent() ? roleName.get() : null;
+            String roleNameValue = roleName.orElse(null);
             List<DataAccessRequestManage> dars = dataAccessRequestService.describeDataAccessRequestManageV2(user, roleNameValue);
             return Response.ok().entity(dars).build();
         } catch(Exception e) {

--- a/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceVersion2.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceVersion2.java
@@ -76,7 +76,8 @@ public class DataAccessRequestResourceVersion2 extends Resource {
   @PermitAll
   public Response getDataAccessRequests(@Auth AuthUser authUser) {
     try {
-      List<DataAccessRequest> dars = dataAccessRequestService.getDataAccessRequestsByUserRole(authUser);
+      User user = userService.findUserByEmail(authUser.getName());
+      List<DataAccessRequest> dars = dataAccessRequestService.getDataAccessRequestsByUserRole(user);
       return Response.ok().entity(dars).build();
     } catch (Exception e) {
       return createExceptionResponse(e);

--- a/src/main/java/org/broadinstitute/consent/http/service/DacService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DacService.java
@@ -307,11 +307,11 @@ public class DacService {
      * Filter data access requests by the DAC they are associated with.
      */
     List<DataAccessRequest> filterDataAccessRequestsByDac(List<DataAccessRequest> documents, User user) {
-        if (DarUtil.hasUserRole(user, 4)) {
+        if (User.hasUserRole(user, UserRoles.ADMIN)) {
             return documents;
         }
         // Chair and Member users can see data access requests that they have DAC access to
-        if (DarUtil.hasUserRole(user, 1) || DarUtil.hasUserRole(user, 2)) {
+        if (User.hasUserRole(user, UserRoles.MEMBER) || User.hasUserRole(user, UserRoles.CHAIRPERSON)) {
             List<Integer> accessibleDatasetIds = dataSetDAO.findDataSetsByAuthUserEmail(user.getEmail()).
                     stream().
                     map(DataSet::getDataSetId).

--- a/src/main/java/org/broadinstitute/consent/http/service/DacService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DacService.java
@@ -306,13 +306,13 @@ public class DacService {
     /**
      * Filter data access requests by the DAC they are associated with.
      */
-    List<DataAccessRequest> filterDataAccessRequestsByDac(List<DataAccessRequest> documents, AuthUser authUser) {
-        if (isAuthUserAdmin(authUser)) {
+    List<DataAccessRequest> filterDataAccessRequestsByDac(List<DataAccessRequest> documents, User user) {
+        if (DarUtil.hasUserRole(user, 4)) {
             return documents;
         }
         // Chair and Member users can see data access requests that they have DAC access to
-        if (isAuthUserChairOrMember(authUser)) {
-            List<Integer> accessibleDatasetIds = dataSetDAO.findDataSetsByAuthUserEmail(authUser.getName()).
+        if (DarUtil.hasUserRole(user, 1) || DarUtil.hasUserRole(user, 2)) {
+            List<Integer> accessibleDatasetIds = dataSetDAO.findDataSetsByAuthUserEmail(user.getEmail()).
                     stream().
                     map(DataSet::getDataSetId).
                     collect(Collectors.toList());

--- a/src/main/java/org/broadinstitute/consent/http/service/DacService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DacService.java
@@ -307,23 +307,25 @@ public class DacService {
      * Filter data access requests by the DAC they are associated with.
      */
     List<DataAccessRequest> filterDataAccessRequestsByDac(List<DataAccessRequest> documents, User user) {
-        if (User.hasUserRole(user, UserRoles.ADMIN)) {
-            return documents;
-        }
-        // Chair and Member users can see data access requests that they have DAC access to
-        if (User.hasUserRole(user, UserRoles.MEMBER) || User.hasUserRole(user, UserRoles.CHAIRPERSON)) {
-            List<Integer> accessibleDatasetIds = dataSetDAO.findDataSetsByAuthUserEmail(user.getEmail()).
-                    stream().
-                    map(DataSet::getDataSetId).
-                    collect(Collectors.toList());
+        if (Objects.nonNull(user)) {
+            if (user.hasUserRole(UserRoles.ADMIN)) {
+                return documents;
+            }
+            // Chair and Member users can see data access requests that they have DAC access to
+            if (user.hasUserRole(UserRoles.MEMBER) || user.hasUserRole(UserRoles.CHAIRPERSON)) {
+                List<Integer> accessibleDatasetIds = dataSetDAO.findDataSetsByAuthUserEmail(user.getEmail()).
+                  stream().
+                  map(DataSet::getDataSetId).
+                  collect(Collectors.toList());
 
-            return documents.
-                    stream().
-                    filter(d -> {
-                        List<Integer> datasetIds = d.getData().getDatasetIds();
-                        return accessibleDatasetIds.stream().anyMatch(datasetIds::contains);
-                    }).
-                    collect(Collectors.toList());
+                return documents.
+                  stream().
+                  filter(d -> {
+                      List<Integer> datasetIds = d.getData().getDatasetIds();
+                      return accessibleDatasetIds.stream().anyMatch(datasetIds::contains);
+                  }).
+                  collect(Collectors.toList());
+            }
         }
         return Collections.emptyList();
     }

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
@@ -146,7 +146,7 @@ public class DataAccessRequestService {
     public List<DataAccessRequestManage> describeDataAccessRequestManageV2(AuthUser authUser, Optional<String> roleName) {
         if (roleName.isPresent()) {
             if (roleName.get().equalsIgnoreCase(UserRoles.SIGNINGOFFICIAL.getRoleName())) {
-                User user = userDAO.findUserByEmail(authUser.getName());
+                User user = userDAO.findUserByEmailAndRoleId(authUser.getName(), 7);
                 if (Objects.nonNull(user) && Objects.nonNull(user.getInstitutionId())) {
                     List<DataAccessRequest> dars = dataAccessRequestDAO.findAllDataAccessRequestsForInstitution(user.getInstitutionId());
                     List<DataAccessRequest> openDars = filterOutCanceledDars(dars);

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
@@ -146,7 +146,7 @@ public class DataAccessRequestService {
      */
     public List<DataAccessRequestManage> describeDataAccessRequestManageV2(User user, String roleName) {
         if (Objects.nonNull(roleName) && Objects.nonNull(user)) {
-            if (roleName.equalsIgnoreCase(UserRoles.SIGNINGOFFICIAL.getRoleName()) && user.hasUserRole( UserRoles.SIGNINGOFFICIAL)) {
+            if (roleName.equalsIgnoreCase(UserRoles.SIGNINGOFFICIAL.getRoleName())) {
                 if (Objects.nonNull(user.getInstitutionId())) {
                     List<DataAccessRequest> dars = dataAccessRequestDAO.findAllDataAccessRequestsForInstitution(user.getInstitutionId());
                     List<DataAccessRequest> openDars = filterOutCanceledDars(dars);
@@ -155,10 +155,9 @@ public class DataAccessRequestService {
                     throw new NotFoundException("Signing Official (user: " + user.getDisplayName() + ") "
                       + "is not associated with an Institution.");
                 }
-            } else {
-                throw new ForbiddenException("User: " + user.getDisplayName() + ", " + user.getDacUserId() + " does not have Signing Official role.");
             }
         }
+        //if there is no roleName then user is a member, chair, or admin
         List<DataAccessRequest> allDars = findAllDataAccessRequests();
         List<DataAccessRequest> filteredAccessList = dacService.filterDataAccessRequestsByDac(allDars, user);
         List<DataAccessRequest> openDarList = filterOutCanceledDars(filteredAccessList);

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
@@ -144,15 +144,15 @@ public class DataAccessRequestService {
      * @param user Filter on what DARs the user has access to.
      * @return List of DataAccessRequestManage objects
      */
-    public List<DataAccessRequestManage> describeDataAccessRequestManageV2(User user, Optional<String> roleName) {
-        if (roleName.isPresent()) {
-            if (roleName.get().equalsIgnoreCase(UserRoles.SIGNINGOFFICIAL.getRoleName()) && DarUtil.hasUserRole(user, 7)) {
+    public List<DataAccessRequestManage> describeDataAccessRequestManageV2(User user, String roleName) {
+        if (Objects.nonNull(roleName)) {
+            if (roleName.equalsIgnoreCase(UserRoles.SIGNINGOFFICIAL.getRoleName()) && User.hasUserRole(user, UserRoles.SIGNINGOFFICIAL)) {
                 if (Objects.nonNull(user.getInstitutionId())) {
                     List<DataAccessRequest> dars = dataAccessRequestDAO.findAllDataAccessRequestsForInstitution(user.getInstitutionId());
                     List<DataAccessRequest> openDars = filterOutCanceledDars(dars);
                     return createAccessRequestManageV2(openDars);
                 } else {
-                    throw new NotFoundException("Signing Official (user: " + user.getDisplayName() + ", " + user.getDacUserId() + ") "
+                    throw new NotFoundException("Signing Official (user: " + user.getDisplayName() + ") "
                       + "is not associated with an Institution.");
                 }
             } else {

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
@@ -145,8 +145,8 @@ public class DataAccessRequestService {
      * @return List of DataAccessRequestManage objects
      */
     public List<DataAccessRequestManage> describeDataAccessRequestManageV2(User user, String roleName) {
-        if (Objects.nonNull(roleName)) {
-            if (roleName.equalsIgnoreCase(UserRoles.SIGNINGOFFICIAL.getRoleName()) && User.hasUserRole(user, UserRoles.SIGNINGOFFICIAL)) {
+        if (Objects.nonNull(roleName) && Objects.nonNull(user)) {
+            if (roleName.equalsIgnoreCase(UserRoles.SIGNINGOFFICIAL.getRoleName()) && user.hasUserRole( UserRoles.SIGNINGOFFICIAL)) {
                 if (Objects.nonNull(user.getInstitutionId())) {
                     List<DataAccessRequest> dars = dataAccessRequestDAO.findAllDataAccessRequestsForInstitution(user.getInstitutionId());
                     List<DataAccessRequest> openDars = filterOutCanceledDars(dars);

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
@@ -43,6 +43,7 @@ import org.broadinstitute.consent.http.db.UserPropertyDAO;
 import org.broadinstitute.consent.http.db.VoteDAO;
 import org.broadinstitute.consent.http.enumeration.ElectionStatus;
 import org.broadinstitute.consent.http.enumeration.ElectionType;
+import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.enumeration.VoteType;
 import org.broadinstitute.consent.http.models.AuthUser;
 import org.broadinstitute.consent.http.models.Consent;
@@ -142,12 +143,22 @@ public class DataAccessRequestService {
      * @param authUser Filter on what DACs the auth user has access to.
      * @return List of DataAccessRequestManage objects
      */
-    public List<DataAccessRequestManage> describeDataAccessRequestManageV2(AuthUser authUser) {
+    public List<DataAccessRequestManage> describeDataAccessRequestManageV2(AuthUser authUser, Optional<String> roleName) {
+        if (roleName.isPresent()) {
+            if (roleName.get().equalsIgnoreCase(UserRoles.SIGNINGOFFICIAL.getRoleName())) {
+                User user = userDAO.findUserByEmail(authUser.getName());
+                if (Objects.nonNull(user) && Objects.nonNull(user.getInstitutionId())) {
+                    List<DataAccessRequest> dars = dataAccessRequestDAO.findAllDataAccessRequestsForInstitution(user.getInstitutionId());
+                    List<DataAccessRequest> openDars = filterOutCanceledDars(dars);
+                    return createAccessRequestManageV2(openDars);
+                } else {
+                    throw new NotFoundException("Signing Official user associated to an Institution cannot be found.");
+                }
+            }
+        }
         List<DataAccessRequest> allDars = findAllDataAccessRequests();
         List<DataAccessRequest> filteredAccessList = dacService.filterDataAccessRequestsByDac(allDars, authUser);
-        List<DataAccessRequest> openDarList = filteredAccessList.stream().filter(dar -> {
-            return !ElectionStatus.CANCELED.getValue().equals(dar.getData().getStatus());
-        }).collect(Collectors.toList());
+        List<DataAccessRequest> openDarList = filterOutCanceledDars(filteredAccessList);
         openDarList.sort(sortTimeComparator());
         if (CollectionUtils.isNotEmpty(openDarList)) {
             return createAccessRequestManageV2(openDarList);
@@ -420,6 +431,10 @@ public class DataAccessRequestService {
                 return darManage;
             })
             .collect(toList());
+    }
+
+    private List<DataAccessRequest> filterOutCanceledDars(List<DataAccessRequest> dars) {
+        return dars.stream().filter(dar -> !ElectionStatus.CANCELED.getValue().equals(dar.getData().getStatus())).collect(Collectors.toList());
     }
 
     @Deprecated // Use createAccessRequestManageV2 instead

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
@@ -378,12 +378,12 @@ public class DataAccessRequestService {
 
     /**
      *
-     * @param authUser AuthUser
+     * @param user User
      * @return List<DataAccessRequest>
      */
-    public List<DataAccessRequest> getDataAccessRequestsByUserRole(AuthUser authUser) {
+    public List<DataAccessRequest> getDataAccessRequestsByUserRole(User user) {
         List<DataAccessRequest> dars = dataAccessRequestDAO.findAllDataAccessRequests();
-        return dacService.filterDataAccessRequestsByDac(dars, authUser);
+        return dacService.filterDataAccessRequestsByDac(dars, user);
     }
 
     /**

--- a/src/main/java/org/broadinstitute/consent/http/util/DarUtil.java
+++ b/src/main/java/org/broadinstitute/consent/http/util/DarUtil.java
@@ -23,14 +23,6 @@ public class DarUtil {
         return Collections.emptyList();
     }
 
-    public static boolean hasUserRole(User user, Integer roleId) {
-        if (Objects.isNull(user) || Objects.isNull(user.getRoles())) {
-            return false;
-        } else {
-            return user.getRoles().stream().anyMatch((role) -> role.getRoleId().equals(roleId));
-        }
-    }
-
     public static String findPI(User user) {
         if (user != null && user.getProperties() != null) {
             Optional<UserProperty> isResearcher = user.getProperties().stream().filter(prop -> prop.getPropertyKey().equals("isThePI") && prop.getPropertyValue().equalsIgnoreCase("true")).findFirst();

--- a/src/main/java/org/broadinstitute/consent/http/util/DarUtil.java
+++ b/src/main/java/org/broadinstitute/consent/http/util/DarUtil.java
@@ -4,6 +4,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
+
+import org.broadinstitute.consent.http.models.User;
 import org.bson.Document;
 
 public class DarUtil {
@@ -17,6 +19,14 @@ public class DarUtil {
                 collect(Collectors.toList());
         }
         return Collections.emptyList();
+    }
+
+    public static boolean hasUserRole(User user, Integer roleId) {
+        if (Objects.isNull(user) || Objects.isNull(user.getRoles())) {
+            return false;
+        } else {
+            return user.getRoles().stream().anyMatch((role) -> role.getRoleId().equals(roleId));
+        }
     }
 
 }

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -1673,7 +1673,7 @@ paths:
       parameters:
         - name: roleName
           in: query
-          description: The optional roleName of the user making the request
+          description: An optional roleName that the user is making the request as. A user can have multiple roles, so adding this parameter will filter the list accordingly.
           required: false
           schema:
             type: String

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -1752,7 +1752,6 @@ paths:
             nullable: true
             enum:
               - SigningOfficial
-              - null
       tags:
         - Data Access Request
       responses:

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -1670,6 +1670,13 @@ paths:
       summary: Manage Data Access Requests V2
       description: |
         Returns all the elections created for Data Access Requests relevant to the current user.
+      parameters:
+        - name: roleName
+          in: query
+          description: The optional roleName of the user making the request
+          required: false
+          schema:
+            type: String
       tags:
         - Data Access Request
       responses:

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -1749,6 +1749,10 @@ paths:
           required: false
           schema:
             type: String
+            nullable: true
+            enum:
+              - SigningOfficial
+              - null
       tags:
         - Data Access Request
       responses:

--- a/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
@@ -331,6 +331,16 @@ public class DAOTestHelper {
         return userDAO.findUserById(userId);
     }
 
+    protected User createUserWithInstitution() {
+        int i1 = RandomUtils.nextInt(5, 10);
+        String email = RandomStringUtils.randomAlphabetic(i1);
+        Integer userId = userDAO.insertUser(email, "display name", new Date());
+        Integer institutionId = institutionDAO.insertInstitution("name", "itdirectorName", "itDirectorEmail", userId, new Date());
+        userDAO.updateUser("display name", userId, email, institutionId);
+        createdUserIds.add(userId);
+        return userDAO.findUserById(userId);
+    }
+
     protected User createUserWithRole(Integer roleId) {
         int i1 = RandomUtils.nextInt(5, 10);
         int i2 = RandomUtils.nextInt(5, 10);
@@ -445,13 +455,23 @@ public class DAOTestHelper {
     }
 
     protected DataAccessRequest createDataAccessRequestV2() {
+        Integer userId = createUser().getDacUserId();
+        return insertDAR(userId);
+    }
+
+    protected Integer createDataAccessRequestUserWithInstitute() {
+        User user = createUserWithInstitution();
+        insertDAR(user.getDacUserId());
+        return user.getInstitutionId();
+    }
+
+    private DataAccessRequest insertDAR(Integer userId) {
         DataAccessRequestData data;
         Date now = new Date();
-        Integer userId = createUser().getDacUserId();
         try {
             String darDataString = FileUtils.readFileToString(
-                    new File(ResourceHelpers.resourceFilePath("dataset/dar.json")),
-                    Charset.defaultCharset());
+              new File(ResourceHelpers.resourceFilePath("dataset/dar.json")),
+              Charset.defaultCharset());
             data = DataAccessRequestData.fromString(darDataString);
             String referenceId = UUID.randomUUID().toString();
             dataAccessRequestDAO.insertVersion2(referenceId, userId, now, now, now, now, data);

--- a/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
@@ -147,4 +147,19 @@ public class DataAccessRequestDAOTest extends DAOTestHelper {
         assertTrue(foundDar.getData().getTranslatedUseRestriction().contains(">"));
     }
 
+    @Test
+    public void  testFindAllDataAccessRequestsForInstitution() {
+        //should be included in result
+        Integer institutionId = createDataAccessRequestUserWithInstitute();
+
+        //should not be included in result
+        createDraftDataAccessRequest();
+        createDataAccessRequestV2();
+
+        List<DataAccessRequest> newDars = dataAccessRequestDAO.findAllDataAccessRequestsForInstitution(institutionId);
+        assertFalse(newDars.isEmpty());
+        assertEquals(1, newDars.size());
+
+    }
+
 }

--- a/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceTest.java
@@ -163,8 +163,20 @@ public class DataAccessRequestResourceTest {
           userService,
           consentService, electionService);
         Response response = resource.describeManageDataAccessRequestsV2(authUser, Optional.of("SigningOfficial"));
-        assertEquals(HttpStatusCodes.STATUS_CODE_FORBIDDEN, response.getStatus());
+        assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
     }
+
+    @Test
+    public void testDescribeManageDataAccessRequestsV2_InvalidRoleName() {
+        when(userService.findUserByEmail(any())).thenReturn(new User());
+        resource = new DataAccessRequestResource(
+          dataAccessRequestService,
+          userService,
+          consentService, electionService);
+        Response response = resource.describeManageDataAccessRequestsV2(authUser, Optional.of("BadRequest"));
+        assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
+    }
+
 
     private DataAccessRequest generateDataAccessRequest() {
         DataAccessRequest dar = new DataAccessRequest();

--- a/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.when;
 import com.google.api.client.http.HttpStatusCodes;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Optional;
 import java.util.UUID;
 import javax.ws.rs.ForbiddenException;
 import javax.ws.rs.NotFoundException;
@@ -133,14 +134,14 @@ public class DataAccessRequestResourceTest {
         DataAccessRequest dar = generateDataAccessRequest();
         DataAccessRequestManage manage = new DataAccessRequestManage();
         manage.setDar(dar);
-        when(dataAccessRequestService.describeDataAccessRequestManageV2(any()))
+        when(dataAccessRequestService.describeDataAccessRequestManageV2(any(), any()))
             .thenReturn(Collections.singletonList(manage));
         resource = new DataAccessRequestResource(
             dataAccessRequestService,
             emailNotifierService,
             userService,
             consentService, electionService);
-        Response response = resource.describeManageDataAccessRequestsV2(authUser);
+        Response response = resource.describeManageDataAccessRequestsV2(authUser, Optional.empty());
         assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
     }
 

--- a/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceTest.java
@@ -167,6 +167,17 @@ public class DataAccessRequestResourceTest {
     }
 
     @Test
+    public void testDescribeManageDataAccessRequestsV2_UnsupportedRoleName() {
+        when(userService.findUserByEmail(any())).thenReturn(new User());
+        resource = new DataAccessRequestResource(
+          dataAccessRequestService,
+          userService,
+          consentService, electionService);
+        Response response = resource.describeManageDataAccessRequestsV2(authUser, Optional.of("Member"));
+        assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
+    }
+
+    @Test
     public void testDescribeManageDataAccessRequestsV2_InvalidRoleName() {
         when(userService.findUserByEmail(any())).thenReturn(new User());
         resource = new DataAccessRequestResource(

--- a/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceTest.java
@@ -149,7 +149,6 @@ public class DataAccessRequestResourceTest {
         when(userService.findUserByEmail(any())).thenThrow(new NotFoundException());
         resource = new DataAccessRequestResource(
           dataAccessRequestService,
-          emailNotifierService,
           userService,
           consentService, electionService);
         Response response = resource.describeManageDataAccessRequestsV2(authUser, Optional.empty());

--- a/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceTest.java
@@ -145,6 +145,18 @@ public class DataAccessRequestResourceTest {
         assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
     }
 
+    @Test
+    public void testDescribeManageDataAccessRequestsV2_UserNotFound() {
+        when(userService.findUserByEmail(any())).thenThrow(new NotFoundException());
+        resource = new DataAccessRequestResource(
+          dataAccessRequestService,
+          emailNotifierService,
+          userService,
+          consentService, electionService);
+        Response response = resource.describeManageDataAccessRequestsV2(authUser, Optional.empty());
+        assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
+    }
+
     private DataAccessRequest generateDataAccessRequest() {
         DataAccessRequest dar = new DataAccessRequest();
         DataAccessRequestData data = new DataAccessRequestData();

--- a/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceTest.java
@@ -155,6 +155,17 @@ public class DataAccessRequestResourceTest {
         assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
     }
 
+    @Test
+    public void testDescribeManageDataAccessRequestsV2_UserMissingRole() {
+        when(userService.findUserByEmail(any())).thenReturn(new User());
+        resource = new DataAccessRequestResource(
+          dataAccessRequestService,
+          userService,
+          consentService, electionService);
+        Response response = resource.describeManageDataAccessRequestsV2(authUser, Optional.of("SigningOfficial"));
+        assertEquals(HttpStatusCodes.STATUS_CODE_FORBIDDEN, response.getStatus());
+    }
+
     private DataAccessRequest generateDataAccessRequest() {
         DataAccessRequest dar = new DataAccessRequest();
         DataAccessRequestData data = new DataAccessRequestData();

--- a/src/test/java/org/broadinstitute/consent/http/service/DacServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DacServiceTest.java
@@ -382,22 +382,22 @@ public class DacServiceTest {
 
     @Test
     public void testFilterDataAccessRequestsByDAC_adminCase() {
+        User user = new User();
+        user.setRoles(new ArrayList<>());
+        user.getRoles().add(new UserRole( UserRoles.ADMIN.getRoleId(), UserRoles.ADMIN.getRoleName()));
+
         // User is an admin user
-        when(userDAO.findUserByEmailAndRoleId(anyString(), anyInt())).thenReturn(getDacUsers().get(0));
         initService();
 
         List<DataAccessRequest> dars = getDataAccessRequests();
 
-        List<DataAccessRequest> filtered = service.filterDataAccessRequestsByDac(dars, getUser());
+        List<DataAccessRequest> filtered = service.filterDataAccessRequestsByDac(dars, user);
         // As an admin, all docs should be returned.
         Assert.assertEquals(dars.size(), filtered.size());
     }
 
     @Test
     public void testFilterDataAccessRequestsByDAC_memberCase_1() {
-        // Member is not an admin user
-        when(userDAO.findUserByEmailAndRoleId(getMember().getEmail(), UserRoles.MEMBER.getRoleId())).thenReturn(getMember());
-
         // Member has access to DataSet 1
         List<DataSet> memberDataSets = Collections.singletonList(getDatasets().get(0));
         when(dataSetDAO.findDataSetsByAuthUserEmail(getMember().getEmail())).thenReturn(memberDataSets);
@@ -408,7 +408,7 @@ public class DacServiceTest {
 
         List<DataAccessRequest> dars = getDataAccessRequests();
 
-        List<DataAccessRequest> filtered = service.filterDataAccessRequestsByDac(dars, getMemberAuthUser());
+        List<DataAccessRequest> filtered = service.filterDataAccessRequestsByDac(dars, getMember());
 
         // Filtered documents should only contain the ones the user has direct access to:
         Assert.assertEquals(memberDataSets.size(), filtered.size());
@@ -416,9 +416,6 @@ public class DacServiceTest {
 
     @Test
     public void testFilterDataAccessRequestsByDAC_memberCase_2() {
-        // Member is not an admin user
-        when(userDAO.findUserByEmailAndRoleId(getMember().getEmail(), UserRoles.MEMBER.getRoleId())).thenReturn(getMember());
-
         // Member has access to datasets
         List<DataSet> memberDataSets = Collections.singletonList(getDatasets().get(0));
         when(dataSetDAO.findDataSetsByAuthUserEmail(getMember().getEmail())).thenReturn(memberDataSets);
@@ -430,7 +427,7 @@ public class DacServiceTest {
 
         List<DataAccessRequest> dars = getDataAccessRequests();
 
-        List<DataAccessRequest> filtered = service.filterDataAccessRequestsByDac(dars, getMemberAuthUser());
+        List<DataAccessRequest> filtered = service.filterDataAccessRequestsByDac(dars, getMember());
 
         // Filtered documents should only contain the ones the user has direct access to
         Assert.assertEquals(memberDataSets.size(), filtered.size());
@@ -438,9 +435,6 @@ public class DacServiceTest {
 
     @Test
     public void testFilterDataAccessRequestsByDAC_memberCase_3() {
-        // Member is not an admin user
-        when(userDAO.findUserByEmailAndRoleId(getMember().getEmail(), UserRoles.MEMBER.getRoleId())).thenReturn(getMember());
-
         // Member no direct access to datasets
         List<DataSet> memberDataSets = Collections.emptyList();
         when(dataSetDAO.findDataSetsByAuthUserEmail(getMember().getEmail())).thenReturn(memberDataSets);
@@ -452,7 +446,7 @@ public class DacServiceTest {
 
         List<DataAccessRequest> dars = getDataAccessRequests();
 
-        List<DataAccessRequest> filtered = service.filterDataAccessRequestsByDac(dars, getMemberAuthUser());
+        List<DataAccessRequest> filtered = service.filterDataAccessRequestsByDac(dars, getMember());
 
         // Filtered documents should contain the ones the user has direct access to
         Assert.assertEquals(memberDataSets.size(), filtered.size());

--- a/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
@@ -331,13 +331,6 @@ public class DataAccessRequestServiceTest {
         service.describeDataAccessRequestManageV2(user, "SigningOfficial");
     }
 
-    @Test(expected = ForbiddenException.class)
-    public void testDescribeDataAccessRequestManageV2_SO_RoleMissing() {
-        User user = new User();
-        initService();
-        service.describeDataAccessRequestManageV2(user, "SigningOfficial");
-    }
-
     @Test
     public void testDescribeDataAccessRequestFieldsById() {
         DataAccessRequest dar = generateDataAccessRequest();

--- a/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
@@ -1,7 +1,18 @@
 package org.broadinstitute.consent.http.service;
 
 import org.broadinstitute.consent.http.enumeration.UserRoles;
-import org.broadinstitute.consent.http.models.*;
+import org.broadinstitute.consent.http.models.AuthUser;
+import org.broadinstitute.consent.http.models.Consent;
+import org.broadinstitute.consent.http.models.Dac;
+import org.broadinstitute.consent.http.models.DataAccessRequest;
+import org.broadinstitute.consent.http.models.DataAccessRequestData;
+import org.broadinstitute.consent.http.models.DataAccessRequestManage;
+import org.broadinstitute.consent.http.models.DataSet;
+import org.broadinstitute.consent.http.models.DatasetDetailEntry;
+import org.broadinstitute.consent.http.models.Election;
+import org.broadinstitute.consent.http.models.User;
+import org.broadinstitute.consent.http.models.UserRole;
+import org.broadinstitute.consent.http.models.Vote;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -23,7 +34,6 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.UUID;
 import javax.ws.rs.ForbiddenException;
 import javax.ws.rs.NotFoundException;
@@ -262,7 +272,7 @@ public class DataAccessRequestServiceTest {
         when(dacDAO.findDacsForDatasetIds(any())).thenReturn(Collections.singleton(d));
         initService();
 
-        List<DataAccessRequestManage> manages =  service.describeDataAccessRequestManageV2(user, Optional.empty());
+        List<DataAccessRequestManage> manages =  service.describeDataAccessRequestManageV2(user, null);
         assertNotNull(manages);
         assertFalse(manages.isEmpty());
         assertEquals(dar.getReferenceId(), manages.get(0).getDar().getReferenceId());
@@ -302,7 +312,7 @@ public class DataAccessRequestServiceTest {
         when(dacDAO.findDacsForDatasetIds(any())).thenReturn(Collections.singleton(d));
         initService();
 
-        List<DataAccessRequestManage> manages =  service.describeDataAccessRequestManageV2(user, Optional.of("SigningOfficial"));
+        List<DataAccessRequestManage> manages =  service.describeDataAccessRequestManageV2(user, "SigningOfficial");
         assertNotNull(manages);
         assertFalse(manages.isEmpty());
         assertEquals(dar.getReferenceId(), manages.get(0).getDar().getReferenceId());
@@ -318,14 +328,14 @@ public class DataAccessRequestServiceTest {
         user.setRoles(new ArrayList<>());
         user.getRoles().add(new UserRole(7, UserRoles.SIGNINGOFFICIAL.getRoleName()));
         initService();
-        service.describeDataAccessRequestManageV2(user, Optional.of("SigningOfficial"));
+        service.describeDataAccessRequestManageV2(user, "SigningOfficial");
     }
 
     @Test(expected = ForbiddenException.class)
     public void testDescribeDataAccessRequestManageV2_SO_RoleMissing() {
         User user = new User();
         initService();
-        service.describeDataAccessRequestManageV2(user, Optional.of("SigningOfficial"));
+        service.describeDataAccessRequestManageV2(user, "SigningOfficial");
     }
 
     @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
@@ -563,7 +563,7 @@ public class DataAccessRequestServiceTest {
         when(dataAccessRequestDAO.findAllDataAccessRequests()).thenReturn(dars);
         when(dacService.filterDataAccessRequestsByDac(eq(dars), any())).thenReturn(dars);
         initService();
-        List<DataAccessRequest> foundDars = service.getDataAccessRequestsByUserRole(authUser);
+        List<DataAccessRequest> foundDars = service.getDataAccessRequestsByUserRole(new User());
         assertEquals(foundDars.size(), 1);
     }
 

--- a/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
@@ -262,7 +262,7 @@ public class DataAccessRequestServiceTest {
     public void testDescribeDataAccessRequestManageV2_SO() {
         User user = new User();
         user.setInstitutionId(1);
-        when(userDAO.findUserByEmail(any())).thenReturn(user);
+        when(userDAO.findUserByEmailAndRoleId(any(), any())).thenReturn(user);
 
         Integer genericId = 1;
         DataAccessRequest dar = generateDataAccessRequest();


### PR DESCRIPTION
## SCOPE:
- RESOURCE: Add SO as allowed role, add optional role param to manage/v2 endpoint, and update resource test signatures to match
- - made new test for user not found case
- SERVICE: If the roleName is present and is Signing Official, then use the new DAO call to get just the dars belonging to the SO's institution, otherwise the pre-existing functionality is maintained, using the user object instead of authUser
- - made a helper for filtering out canceled dars since it is now used in two spots
- - made three new tests for roleName = SO functionality
- - service method calls helper filterDataAccessRequestsByDAC so that had to be slightly refactored to take user instead of authuser
- - made a helper DarUtils hasUserRole, used in DAR and DAC service classes
- DAO: made new query that gets DAR info if the users belong to the same institution as the SO
- API DOCS: add optional param documentation

## ADDRESSES:
https://broadworkbench.atlassian.net/browse/DUOS-1259

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
