### PR TITLE
DUOS-1122[risk=no]DataAccessRequestData: Refactor usages of profile name

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequestData.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequestData.java
@@ -50,7 +50,6 @@ public class DataAccessRequestData {
     private String isThePi;
     private String havePi;
     private String piEmail;
-    private String profileName;
     private String pubmedId;
     private String scientificUrl;
     private Boolean eraExpiration;
@@ -280,14 +279,6 @@ public class DataAccessRequestData {
 
     public void setPiEmail(String piEmail) {
         this.piEmail = piEmail;
-    }
-
-    public String getProfileName() {
-        return profileName;
-    }
-
-    public void setProfileName(String profileName) {
-        this.profileName = profileName;
     }
 
     public String getPubmedId() {

--- a/src/main/java/org/broadinstitute/consent/http/util/DarConstants.java
+++ b/src/main/java/org/broadinstitute/consent/http/util/DarConstants.java
@@ -37,8 +37,6 @@ public class DarConstants {
 
     public static final String SORT_DATE = "sortDate";
 
-    public static final String PROFILE_NAME = "profileName";
-
     public static final String ACADEMIC_BUSINESS_EMAIL = "academicEmail";
 
     public static final String DEPARTMENT = "department";

--- a/src/test/java/org/broadinstitute/consent/http/models/darsummary/DARModalDetailsDTOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/darsummary/DARModalDetailsDTOTest.java
@@ -42,7 +42,6 @@ public class DARModalDetailsDTOTest {
         Integer userId = userDAO.insertUser("email", "name", new Date());
         User user = userDAO.findUserById(userId);
         dar.setUserId(userId);
-        data.setProfileName("name");
         data.setInstitution("");
         data.setDarCode(DAR_CODE);
         data.setProjectTitle(TITLE);


### PR DESCRIPTION
SCOPE: 
Remove profile name from data access request data and dar constants now that it is unused after the refactoring job in DUOS-1311

ADDRESSES:
https://broadworkbench.atlassian.net/browse/DUOS-1122

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
