### PR TITLE
DUOS-1323[risk=low] Admins can create Library cards for unregistered users

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/exceptions/ConsentConflictException.java
+++ b/src/main/java/org/broadinstitute/consent/http/exceptions/ConsentConflictException.java
@@ -1,0 +1,23 @@
+package org.broadinstitute.consent.http.exceptions;
+
+public class ConsentConflictException extends Exception{
+  public ConsentConflictException() {
+    super();
+  }
+
+  public ConsentConflictException(String message) {
+    super(message);
+  }
+
+  public ConsentConflictException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public ConsentConflictException(Throwable cause) {
+    super(cause);
+  }
+
+  public ConsentConflictException(String message, Throwable cause, boolean enableSuppresion, boolean writableStackTrace) {
+    super(message, cause, enableSuppresion, writableStackTrace);
+  }
+}

--- a/src/main/java/org/broadinstitute/consent/http/exceptions/ConsentConflictException.java
+++ b/src/main/java/org/broadinstitute/consent/http/exceptions/ConsentConflictException.java
@@ -1,23 +1,10 @@
 package org.broadinstitute.consent.http.exceptions;
 
-public class ConsentConflictException extends Exception{
-  public ConsentConflictException() {
-    super();
-  }
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ClientErrorException;
 
-  public ConsentConflictException(String message) {
-    super(message);
-  }
-
-  public ConsentConflictException(String message, Throwable cause) {
-    super(message, cause);
-  }
-
-  public ConsentConflictException(Throwable cause) {
-    super(cause);
-  }
-
-  public ConsentConflictException(String message, Throwable cause, boolean enableSuppresion, boolean writableStackTrace) {
-    super(message, cause, enableSuppresion, writableStackTrace);
-  }
+public class ConsentConflictException extends ClientErrorException {
+ public ConsentConflictException() {
+   super(Response.Status.CONFLICT);
+ }
 }

--- a/src/main/java/org/broadinstitute/consent/http/resources/LibraryCardResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/LibraryCardResource.java
@@ -5,9 +5,7 @@ import com.google.gson.Gson;
 import com.google.inject.Inject;
 import io.dropwizard.auth.Auth;
 import java.util.List;
-import java.util.Objects;
 import javax.annotation.security.RolesAllowed;
-import javax.ws.rs.BadRequestException;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
@@ -81,12 +79,10 @@ public class LibraryCardResource extends Resource{
   @RolesAllowed(ADMIN)
   public Response createLibraryCard(@Auth AuthUser authUser, String libraryCard) {
     try{
-      User user = userService.findUserByEmail(authUser.getName());
+      User admin = userService.findUserByEmail(authUser.getName());
       LibraryCard payload = new Gson().fromJson(libraryCard, LibraryCard.class);
-      User lcUser = userService.findUserByEmail(payload.getUserEmail());
-
-      payload.setUserId(lcUser.getDacUserId());
-      LibraryCard newLibraryCard = libraryCardService.createLibraryCard(payload, user.getDacUserId());
+      payload.setCreateUserId(admin.getDacUserId());
+      LibraryCard newLibraryCard = libraryCardService.createLibraryCard(payload);
       return Response.status(HttpStatusCodes.STATUS_CODE_CREATED).entity(newLibraryCard).build();
     } catch(Exception e) {
       return createExceptionResponse(e);

--- a/src/main/java/org/broadinstitute/consent/http/resources/Resource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/Resource.java
@@ -19,6 +19,7 @@ import javax.ws.rs.core.StreamingOutput;
 
 import org.apache.commons.io.IOUtils;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
+import org.broadinstitute.consent.http.exceptions.ConsentConflictException;
 import org.broadinstitute.consent.http.exceptions.UpdateConsentException;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.dto.Error;
@@ -47,6 +48,7 @@ abstract public class Resource {
     public final static String DATAOWNER = "DataOwner";
     public final static String MEMBER = "Member";
     public final static String RESEARCHER = "Researcher";
+    public final static String SIGNINGOFFICIAL = "SigningOfficial";
 
     // NOTE: implement more Postgres vendor codes as we encounter them
     private final static Map<String, Integer> vendorCodeStatusMap = Map.ofEntries(
@@ -103,6 +105,8 @@ abstract public class Resource {
     private static final Map<Class<? extends Throwable>, ExceptionHandler> dispatch = new HashMap<>();
 
     static {
+        dispatch.put(ConsentConflictException.class, e-> 
+            Response.status(Response.Status.CONFLICT).type(MediaType.APPLICATION_JSON).entity(new Error(e.getMessage(), Response.Status.CONFLICT.getStatusCode())).build());
         dispatch.put(UserRoleHandlerException.class, e ->
                 Response.status(Response.Status.CONFLICT).type(MediaType.APPLICATION_JSON).entity(new Error(e.getMessage(), Response.Status.CONFLICT.getStatusCode())).build());
         dispatch.put(UnsupportedOperationException.class, e ->

--- a/src/main/java/org/broadinstitute/consent/http/service/LibraryCardService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/LibraryCardService.java
@@ -3,12 +3,12 @@ package org.broadinstitute.consent.http.service;
 import org.broadinstitute.consent.http.db.InstitutionDAO;
 import org.broadinstitute.consent.http.db.LibraryCardDAO;
 import org.broadinstitute.consent.http.db.UserDAO;
+import org.broadinstitute.consent.http.exceptions.ConsentConflictException;
 import org.broadinstitute.consent.http.models.Institution;
 import org.broadinstitute.consent.http.models.LibraryCard;
 import org.broadinstitute.consent.http.models.User;
 
 import javax.ws.rs.BadRequestException;
-import javax.ws.rs.InternalServerErrorException;
 import javax.ws.rs.NotFoundException;
 
 import java.util.Date;
@@ -28,7 +28,7 @@ public class LibraryCardService {
         this.userDAO = userDAO;
     }
 
-    public LibraryCard createLibraryCard(LibraryCard libraryCard) {
+    public LibraryCard createLibraryCard(LibraryCard libraryCard) throws Exception {
         throwIfNull(libraryCard);
         checkForValidInstitution(libraryCard.getInstitutionId());
         checkIfCardExists(libraryCard);
@@ -130,7 +130,7 @@ public class LibraryCardService {
     }
 
     //helper method for create method, checks to see if card already exists
-    private void checkIfCardExists(LibraryCard payload) {
+    private void checkIfCardExists(LibraryCard payload) throws Exception {
         Integer userId = payload.getUserId();
         String email = payload.getUserEmail();
         Integer institutionId = payload.getInstitutionId();
@@ -154,7 +154,7 @@ public class LibraryCardService {
 
         if(foundCard.isPresent()) {
             //This exception is a placeholder, what's an exception that can be translated as "CONFLICT"
-            throw new InternalServerErrorException();
+            throw new ConsentConflictException();
         } 
     }
 

--- a/src/main/java/org/broadinstitute/consent/http/service/LibraryCardService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/LibraryCardService.java
@@ -152,7 +152,6 @@ public class LibraryCardService {
         }).findFirst();
 
         if(foundCard.isPresent()) {
-            //This exception is a placeholder, what's an exception that can be translated as "CONFLICT"
             throw new ConsentConflictException();
         } 
     }
@@ -174,6 +173,9 @@ public class LibraryCardService {
         } else {
             //check if userId exists
             User user = userDAO.findUserById(card.getUserId());
+            if(Objects.isNull(user)) {
+                throw new NotFoundException();
+            }
             if(Objects.nonNull(user.getEmail()) && !(user.getEmail().equalsIgnoreCase(card.getUserEmail()))) {
                 //throw error here, user is trying to associate incorrect userId with email
                 throw new ConsentConflictException();

--- a/src/main/java/org/broadinstitute/consent/http/service/LibraryCardService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/LibraryCardService.java
@@ -7,10 +7,14 @@ import org.broadinstitute.consent.http.models.Institution;
 import org.broadinstitute.consent.http.models.LibraryCard;
 import org.broadinstitute.consent.http.models.User;
 
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.InternalServerErrorException;
 import javax.ws.rs.NotFoundException;
+
 import java.util.Date;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 public class LibraryCardService {
 
@@ -24,19 +28,19 @@ public class LibraryCardService {
         this.userDAO = userDAO;
     }
 
-    public LibraryCard createLibraryCard(LibraryCard libraryCard, Integer userId) {
-        checkUserId(userId);
-        checkForValidUser(libraryCard.getUserId());
+    public LibraryCard createLibraryCard(LibraryCard libraryCard) {
+        throwIfNull(libraryCard);
         checkForValidInstitution(libraryCard.getInstitutionId());
-
+        checkIfCardExists(libraryCard);
+        LibraryCard processedCard = processUserOnNewLC(libraryCard);
         Date createDate = new Date();
         Integer id = this.libraryCardDAO.insertLibraryCard(
-                libraryCard.getUserId(),
-                libraryCard.getInstitutionId(),
-                libraryCard.getEraCommonsId(),
-                libraryCard.getUserName(),
-                libraryCard.getUserEmail(),
-                userId,
+                processedCard.getUserId(),
+                processedCard.getInstitutionId(),
+                processedCard.getEraCommonsId(),
+                processedCard.getUserName(),
+                processedCard.getUserEmail(),
+                processedCard.getCreateUserId(),
                 createDate
         );
         return this.libraryCardDAO.findLibraryCardById(id);
@@ -123,5 +127,63 @@ public class LibraryCardService {
         if (Objects.isNull(libraryCard)) {
             throw new NotFoundException("LibraryCard not found.");
         }
+    }
+
+    //helper method for create method, checks to see if card already exists
+    private void checkIfCardExists(LibraryCard payload) {
+        Integer userId = payload.getUserId();
+        String email = payload.getUserEmail();
+        Integer institutionId = payload.getInstitutionId();
+        Optional<LibraryCard> foundCard;
+        List<LibraryCard> results;
+
+        if(Objects.nonNull(payload.getUserId())) {
+            results = libraryCardDAO.findLibraryCardsByUserId(userId);
+        } else if(Objects.nonNull(email)) {
+            results = libraryCardDAO.findAllLibraryCardsByUserEmail(email);
+        }
+        else {
+            throw new BadRequestException();
+        }
+        foundCard = results.stream().filter(card -> {
+            Boolean sameUserId = Objects.nonNull(userId) && card.getUserId().equals(userId);
+            Boolean sameUserEmail = Objects.nonNull(email) && card.getUserEmail().equalsIgnoreCase(email);
+            Boolean sameInstitution = card.getInstitutionId().equals(institutionId);
+            return (sameUserId || sameUserEmail) && sameInstitution;
+        }).findFirst();
+
+        if(foundCard.isPresent()) {
+            //This exception is a placeholder, what's an exception that can be translated as "CONFLICT"
+            throw new InternalServerErrorException();
+        } 
+    }
+
+    //Helper method to process user data on create LC payload
+    //Needed since CREATE has a unique situation where admins can create LCs without an active user (save with userEmail instead)
+    private LibraryCard processUserOnNewLC(LibraryCard card) {
+        if (Objects.isNull(card.getUserId())) {
+            if (Objects.isNull(card.getUserEmail())) {
+                throw new BadRequestException();
+            } else {
+                try{
+                    //If a user is found, update the card to have the correct userId associated
+                    User user = userDAO.findUserByEmail(card.getUserEmail());
+                    Integer userId = user.getDacUserId();
+                    card.setUserId(userId);
+                } catch(Exception e) {
+                    //Exception here means the email has not been used
+                    //Does not mean card is invalid, it just means it will only have user email provided
+                    //As such card can move forward as is
+                }
+            }
+        } else {
+            //check if userId exists
+            User user = userDAO.findUserById(card.getUserId());
+            if(Objects.nonNull(user.getEmail()) && !(user.getEmail().equalsIgnoreCase(card.getUserEmail()))) {
+                //throw error here, user is trying to associate incorrect userId with email
+                throw new BadRequestException();
+            }
+        }
+        return card;
     }
 }

--- a/src/main/resources/changelog-master.xml
+++ b/src/main/resources/changelog-master.xml
@@ -70,4 +70,5 @@
     <include file="changesets/changelog-consent-65.0.xml" relativeToChangelogFile="true"/>
     <include file="changesets/changelog-consent-66.0.xml" relativeToChangelogFile="true"/>
     <include file="changesets/changelog-consent-67.0.xml" relativeToChangelogFile="true"/>
+    <include file="changesets/changelog-consent-68.0.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/src/main/resources/changesets/changelog-consent-68.0.xml
+++ b/src/main/resources/changesets/changelog-consent-68.0.xml
@@ -1,0 +1,13 @@
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd
+    http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd">
+   <changeSet id="68.0" author="JVThomas">
+      <dropNotNullConstraint
+          columnName="user_name"
+          columnDataType="varchar(255)"
+          tableName="library_card"/>
+   </changeSet>
+</databaseChangeLog>

--- a/src/test/java/org/broadinstitute/consent/http/resources/LibraryCardResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/LibraryCardResourceTest.java
@@ -11,11 +11,10 @@ import static org.mockito.Mockito.when;
 import com.google.api.client.http.HttpStatusCodes;
 import com.google.gson.Gson;
 
-import java.util.Arrays;
 import java.util.Collections;
-import javax.ws.rs.BadRequestException;
 import javax.ws.rs.core.UriInfo;
 import javax.ws.rs.core.UriBuilder;
+import javax.ws.rs.BadRequestException;
 import javax.ws.rs.NotFoundException;
 import javax.ws.rs.core.Response;
 import java.util.List;
@@ -127,11 +126,9 @@ public class LibraryCardResourceTest {
   @Test
   public void testCreateLibraryCard() {
     LibraryCard mockCard = mockLibraryCardSetup();
-    mockCard.setUserEmail(lcUser.getEmail());
     String payload = new Gson().toJson(mockCard);
     when(userService.findUserByEmail(authUser.getName())).thenReturn(user);
-    when(userService.findUserByEmail(mockCard.getUserEmail())).thenReturn(lcUser);
-    when(libraryCardService.createLibraryCard(any(LibraryCard.class), anyInt())).thenReturn(mockCard);
+    when(libraryCardService.createLibraryCard(any(LibraryCard.class))).thenReturn(mockCard);
     initResource();
     Response response = resource.createLibraryCard(authUser, payload);
     String json = response.getEntity().toString();
@@ -139,25 +136,25 @@ public class LibraryCardResourceTest {
     assertNotNull(json);
   }
 
-  @Test
-  public void testCreateLibraryCardInvalidEmail() {
-    LibraryCard mockCard = mockLibraryCardSetup();
-    mockCard.setUserEmail("wrongemail@gmail.com");
-    String payload = new Gson().toJson(mockCard);
-    when(userService.findUserByEmail(authUser.getName())).thenReturn(user);
-    when(userService.findUserByEmail(lcUser.getEmail())).thenReturn(lcUser);
-    when(libraryCardService.createLibraryCard(any(LibraryCard.class), anyInt())).thenReturn(mockCard);
-    initResource();
-    Response response = resource.createLibraryCard(authUser, payload);
-    assertEquals(HttpStatusCodes.STATUS_CODE_SERVER_ERROR, response.getStatus());
-  }
+  // Email validation now occurs in service, commenting out for review with plans for deletion if approved
+  // @Test
+  // public void testCreateLibraryCardInvalidEmail() {
+  //   LibraryCard mockCard = mockLibraryCardSetup();
+  //   mockCard.setUserEmail("wrongemail@gmail.com");
+  //   String payload = new Gson().toJson(mockCard);
+  //   when(userService.findUserByEmail(authUser.getName())).thenReturn(user);
+  //   when(libraryCardService.createLibraryCard(any(LibraryCard.class))).thenReturn(mockCard);
+  //   initResource();
+  //   Response response = resource.createLibraryCard(authUser, payload);
+  //   assertEquals(HttpStatusCodes.STATUS_CODE_SERVER_ERROR, response.getStatus());
+  // }
 
   @Test
   public void testCreateLibraryCardThrowsIllegalArgumentException() {
     LibraryCard mockCard = mockLibraryCardSetup();
     String payload = new Gson().toJson(mockCard);
     when(userService.findUserByEmail(anyString())).thenReturn(user);
-    when(libraryCardService.createLibraryCard(any(LibraryCard.class), anyInt())).thenThrow(new IllegalArgumentException());
+    when(libraryCardService.createLibraryCard(any(LibraryCard.class))).thenThrow(new IllegalArgumentException());
     initResource();
     Response response = resource.createLibraryCard(authUser, payload);
     assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
@@ -168,10 +165,32 @@ public class LibraryCardResourceTest {
     UnableToExecuteStatementException exception = generateUniqueViolationException();
     String json = new Gson().toJson(mockLibraryCardSetup());
     when(userService.findUserByEmail(anyString())).thenReturn(user);
-    when(libraryCardService.createLibraryCard(any(LibraryCard.class), anyInt())).thenThrow(exception);
+    when(libraryCardService.createLibraryCard(any(LibraryCard.class))).thenThrow(exception);
     initResource();
     Response response = resource.createLibraryCard(authUser, json);
     assertEquals(HttpStatusCodes.STATUS_CODE_CONFLICT, response.getStatus());
+  }
+
+  @Test
+  public void testCreateLibraryCardThrowsBadRequestException() {
+    BadRequestException exception = new BadRequestException();
+    String json = new Gson().toJson(mockLibraryCardSetup());
+    when(userService.findUserByEmail(anyString())).thenReturn(user);
+    when(libraryCardService.createLibraryCard(any(LibraryCard.class))).thenThrow(exception);
+    initResource();
+    Response response = resource.createLibraryCard(authUser, json);
+    assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
+  }
+
+  @Test
+  public void testCreateLibraruCardThrowsNotFoundException() {
+    NotFoundException exception = new NotFoundException();
+    String json = new Gson().toJson(mockLibraryCardSetup());
+    when(userService.findUserByEmail(anyString())).thenReturn(user);
+    when(libraryCardService.createLibraryCard(any(LibraryCard.class))).thenThrow(exception);
+    initResource();
+    Response response = resource.createLibraryCard(authUser, json);
+    assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/resources/LibraryCardResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/LibraryCardResourceTest.java
@@ -124,7 +124,7 @@ public class LibraryCardResourceTest {
   }
 
   @Test
-  public void testCreateLibraryCard() {
+  public void testCreateLibraryCard() throws Exception {
     LibraryCard mockCard = mockLibraryCardSetup();
     String payload = new Gson().toJson(mockCard);
     when(userService.findUserByEmail(authUser.getName())).thenReturn(user);
@@ -150,7 +150,7 @@ public class LibraryCardResourceTest {
   // }
 
   @Test
-  public void testCreateLibraryCardThrowsIllegalArgumentException() {
+  public void testCreateLibraryCardThrowsIllegalArgumentException() throws Exception {
     LibraryCard mockCard = mockLibraryCardSetup();
     String payload = new Gson().toJson(mockCard);
     when(userService.findUserByEmail(anyString())).thenReturn(user);
@@ -161,7 +161,7 @@ public class LibraryCardResourceTest {
   }
 
   @Test
-  public void testCreateLibraryCardThrowsConflictException() {
+  public void testCreateLibraryCardThrowsConflictException() throws Exception {
     UnableToExecuteStatementException exception = generateUniqueViolationException();
     String json = new Gson().toJson(mockLibraryCardSetup());
     when(userService.findUserByEmail(anyString())).thenReturn(user);
@@ -172,7 +172,7 @@ public class LibraryCardResourceTest {
   }
 
   @Test
-  public void testCreateLibraryCardThrowsBadRequestException() {
+  public void testCreateLibraryCardThrowsBadRequestException() throws Exception {
     BadRequestException exception = new BadRequestException();
     String json = new Gson().toJson(mockLibraryCardSetup());
     when(userService.findUserByEmail(anyString())).thenReturn(user);
@@ -183,7 +183,7 @@ public class LibraryCardResourceTest {
   }
 
   @Test
-  public void testCreateLibraruCardThrowsNotFoundException() {
+  public void testCreateLibraruCardThrowsNotFoundException() throws Exception {
     NotFoundException exception = new NotFoundException();
     String json = new Gson().toJson(mockLibraryCardSetup());
     when(userService.findUserByEmail(anyString())).thenReturn(user);

--- a/src/test/java/org/broadinstitute/consent/http/resources/LibraryCardResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/LibraryCardResourceTest.java
@@ -136,19 +136,6 @@ public class LibraryCardResourceTest {
     assertNotNull(json);
   }
 
-  // Email validation now occurs in service, commenting out for review with plans for deletion if approved
-  // @Test
-  // public void testCreateLibraryCardInvalidEmail() {
-  //   LibraryCard mockCard = mockLibraryCardSetup();
-  //   mockCard.setUserEmail("wrongemail@gmail.com");
-  //   String payload = new Gson().toJson(mockCard);
-  //   when(userService.findUserByEmail(authUser.getName())).thenReturn(user);
-  //   when(libraryCardService.createLibraryCard(any(LibraryCard.class))).thenReturn(mockCard);
-  //   initResource();
-  //   Response response = resource.createLibraryCard(authUser, payload);
-  //   assertEquals(HttpStatusCodes.STATUS_CODE_SERVER_ERROR, response.getStatus());
-  // }
-
   @Test
   public void testCreateLibraryCardThrowsIllegalArgumentException() throws Exception {
     LibraryCard mockCard = mockLibraryCardSetup();

--- a/src/test/java/org/broadinstitute/consent/http/service/LibraryCardServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/LibraryCardServiceTest.java
@@ -109,7 +109,7 @@ public class LibraryCardServiceTest {
         service.createLibraryCard(payload);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expected = ConsentConflictException.class)
     //Negative test, checks if error is thrown if payload email and userId don't match up to those on user record
     public void testCreateLibraryCardIncorrectUserIdAndEmail() throws Exception {
         initService();

--- a/src/test/java/org/broadinstitute/consent/http/service/LibraryCardServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/LibraryCardServiceTest.java
@@ -4,6 +4,7 @@ import org.apache.commons.lang3.RandomUtils;
 import org.broadinstitute.consent.http.db.InstitutionDAO;
 import org.broadinstitute.consent.http.db.LibraryCardDAO;
 import org.broadinstitute.consent.http.db.UserDAO;
+import org.broadinstitute.consent.http.exceptions.ConsentConflictException;
 import org.broadinstitute.consent.http.models.Institution;
 import org.broadinstitute.consent.http.models.LibraryCard;
 import org.broadinstitute.consent.http.models.User;
@@ -22,7 +23,6 @@ import static org.mockito.Mockito.when;
 import java.util.Collections;
 
 import javax.ws.rs.BadRequestException;
-import javax.ws.rs.InternalServerErrorException;
 import javax.ws.rs.NotFoundException;
 
 public class LibraryCardServiceTest {
@@ -47,7 +47,7 @@ public class LibraryCardServiceTest {
 
     @Test
     // Test LC create with userId and email
-    public void testCreateLibraryCardFullUserDetails() {
+    public void testCreateLibraryCardFullUserDetails() throws Exception {
         initService();
         Institution institution = testInstitution();
         User user = testUser(institution.getId());
@@ -67,7 +67,7 @@ public class LibraryCardServiceTest {
 
     @Test
     //Test LC create with only user email (no userId)
-    public void testCreateLibraryCardPartialUserDetailsEmail() {
+    public void testCreateLibraryCardPartialUserDetailsEmail() throws Exception {
         initService();
         Institution institution = testInstitution();
         User user = testUser(institution.getId());
@@ -90,7 +90,7 @@ public class LibraryCardServiceTest {
 
     @Test
     //Test LC create with only user id (no email)
-    public void testCreateLibraryCardPartialUserDetailsId() {
+    public void testCreateLibraryCardPartialUserDetailsId() throws Exception {
         initService();
         Institution institution = testInstitution();
         User user = testUser(institution.getId());
@@ -111,7 +111,7 @@ public class LibraryCardServiceTest {
 
     @Test(expected = BadRequestException.class)
     //Negative test, checks if error is thrown if payload email and userId don't match up to those on user record
-    public void testCreateLibraryCardIncorrectUserIdAndEmail() {
+    public void testCreateLibraryCardIncorrectUserIdAndEmail() throws Exception {
         initService();
         Institution institution = testInstitution();
         User user = testUser(institution.getId());
@@ -131,9 +131,9 @@ public class LibraryCardServiceTest {
         service.createLibraryCard(payload);
     }
 
-    @Test(expected = InternalServerErrorException.class)
+    @Test(expected = ConsentConflictException.class)
     //Negative test, checks to see if error thrown if card already exists on user id and institution id
-    public void testCreateLibraryCardAlreadyExistsOnUserId(){
+    public void testCreateLibraryCardAlreadyExistsOnUserId() throws Exception{
         initService();
         Institution institution = testInstitution();
         User user = testUser(institution.getId());
@@ -145,9 +145,9 @@ public class LibraryCardServiceTest {
         service.createLibraryCard(payload);
     }
 
-    @Test(expected = InternalServerErrorException.class)
+    @Test(expected = ConsentConflictException.class)
     // Negative test, checks to see if error thrown if card already exists on user email and institution id
-    public void testCreateLibraryCardAlreadyExistsOnUserEmail() {
+    public void testCreateLibraryCardAlreadyExistsOnUserEmail() throws Exception {
         initService();
         Institution institution = testInstitution();
         User user = testUser(institution.getId());
@@ -164,7 +164,7 @@ public class LibraryCardServiceTest {
 
     @Test(expected = BadRequestException.class)
     //Negative test, checks to see if error is thrown if email and userId are not provided
-    public void testCreateLibraryCardNoUserDetails() {
+    public void testCreateLibraryCardNoUserDetails() throws Exception {
         initService();
         Institution institution = testInstitution();
         LibraryCard payload = testLibraryCard(institution.getId(), null);
@@ -175,7 +175,7 @@ public class LibraryCardServiceTest {
 
     @Test(expected = IllegalArgumentException.class)
     //Negative test, checks if error is thrown on null institutionId
-    public void testCreateLibraryCard_InvalidInstitution() {
+    public void testCreateLibraryCard_InvalidInstitution() throws Exception {
         User user = testUser(1);
         LibraryCard libraryCard = testLibraryCard(1, user.getDacUserId());
 
@@ -192,7 +192,7 @@ public class LibraryCardServiceTest {
 
     @Test(expected = NotFoundException.class)
     //Negative test, checks to see if error is thrown on null payload
-    public void testCreateLibraryCardNullPayload() {
+    public void testCreateLibraryCardNullPayload() throws Exception {
         initService();
         service.createLibraryCard(null);
     }


### PR DESCRIPTION
Addresses [DUOS-1323](https://broadworkbench.atlassian.net/browse/DUOS-1323)

Per requirement on [DUOS-1068](https://broadworkbench.atlassian.net/browse/DUOS-1068), admins should be able to create Library Cards for unregistered emails by providing an email. In addition, create flow should have validation steps to ensure that duplicate cards are not created if a card already exists. This PR modifies LC Resource, LC Service, and associated tests to account for changes in user and payload validation.

NOTE: May need to introduce further adjustments later on when service class methods are utilized by other roles (Signing Official comes to mind).

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
