### PR TITLE
DUOS-1324[risk=no] Remove investigator name from dataset metrics API and display

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/service/MetricsService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/MetricsService.java
@@ -60,7 +60,6 @@ public class MetricsService {
     @JsonProperty final String projectTitle;
     @JsonProperty final String darCode;
     @JsonProperty final String nonTechRus;
-    @JsonProperty final String investigator;
     @JsonProperty final String referenceId;
 
     public DarMetricsSummary(DataAccessRequest dar) {
@@ -69,14 +68,12 @@ public class MetricsService {
         this.projectTitle = dar.data.getProjectTitle();
         this.darCode =  dar.data.getDarCode();
         this.nonTechRus =  dar.data.getNonTechRus();
-        this.investigator = DarUtil.findPI(userDAO.findUserById(dar.userId));
         this.referenceId = dar.getReferenceId();
       } else {
         this.updateDate = null;
         this.projectTitle = null;
         this.darCode =  null;
         this.nonTechRus =  null;
-        this.investigator = null;
         this.referenceId = null;
       }
     }


### PR DESCRIPTION
SCOPE:
- remove investigator from dataset metrics summary object

ADDRESSES:
https://broadworkbench.atlassian.net/browse/DUOS-1324
----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
