### PR TITLE
DUOS-1093[risk=no]Update DAR to use Researcher's SO

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/UserDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/UserDAO.java
@@ -179,7 +179,7 @@ public interface UserDAO extends Transactional<UserDAO> {
     @SqlQuery("SELECT u.* FROM dacuser u "
       + " LEFT JOIN user_role ur ON ur.user_id = u.dacuserid "
       + " LEFT JOIN roles r ON r.roleid = ur.role_id "
-      + " WHERE r.name = 'SigningOfficial' "
+      + " WHERE LOWER(r.name) = 'signingofficial' "
       + " AND u.institution_id = :institutionId")
     List<User> getSOsByInstitution(@Bind("institutionId") Integer institutionId);
 

--- a/src/main/java/org/broadinstitute/consent/http/db/UserDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/UserDAO.java
@@ -175,4 +175,12 @@ public interface UserDAO extends Transactional<UserDAO> {
             @BindList("datasetIds") List<Integer> datasetIds,
             @BindList("roleNames") List<String> roleNames);
 
+    @RegisterBeanMapper(value = User.class)
+    @SqlQuery("SELECT u.* FROM dacuser u "
+      + " LEFT JOIN user_role ur ON ur.user_id = u.dacuserid "
+      + " LEFT JOIN roles r ON r.roleid = ur.role_id "
+      + " WHERE r.name = 'SigningOfficial' "
+      + " AND u.institution_id = :institutionId")
+    List<User> getSOsByInstitution(@Bind("institutionId") Integer institutionId);
+
 }

--- a/src/main/java/org/broadinstitute/consent/http/db/UserDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/UserDAO.java
@@ -176,7 +176,7 @@ public interface UserDAO extends Transactional<UserDAO> {
             @BindList("roleNames") List<String> roleNames);
 
     @RegisterBeanMapper(value = User.class)
-    @SqlQuery("SELECT u.* FROM dacuser u "
+    @SqlQuery("SELECT u.dacuserid, u.displayname FROM dacuser u "
       + " LEFT JOIN user_role ur ON ur.user_id = u.dacuserid "
       + " LEFT JOIN roles r ON r.roleid = ur.role_id "
       + " WHERE LOWER(r.name) = 'signingofficial' "

--- a/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
@@ -165,7 +165,7 @@ public class UserResource extends Resource {
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @Path("/SigningOfficials")
-    @PermitAll
+    @RolesAllowed(RESEARCHER)
     public Response getSOsForInstitution(@Auth AuthUser authUser) {
         try {
             User user = userService.findUserByEmail(authUser.getName());

--- a/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
@@ -162,6 +162,20 @@ public class UserResource extends Resource {
         return Response.ok().build();
     }
 
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Path("/SigningOfficials")
+    @PermitAll
+    public Response getSOsForInstitution(@Auth AuthUser authUser) {
+        try {
+            User user = userService.findUserByEmail(authUser.getName());
+            List<User> signingOfficials = userService.findSOsByInstitutionId(user.getInstitutionId());
+            return Response.ok().entity(signingOfficials).build();
+        } catch (Exception e) {
+            return createExceptionResponse(e);
+        }
+    }
+
     /**
      * Convenience method for a generic user object with custom properties added
      * @param user The User

--- a/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
@@ -39,6 +39,7 @@ import org.broadinstitute.consent.http.models.UserRole;
 import org.broadinstitute.consent.http.models.dto.Error;
 import org.broadinstitute.consent.http.service.LibraryCardService;
 import org.broadinstitute.consent.http.service.UserService;
+import org.broadinstitute.consent.http.service.UserService.SimplifiedUser;
 
 @Path("{api : (api/)?}user")
 public class UserResource extends Resource {
@@ -173,7 +174,7 @@ public class UserResource extends Resource {
             if (Objects.isNull(user.getInstitutionId())) {
                 throw new NotFoundException("Current user, " + user.getDisplayName() + ", does not have an institution.");
             }
-            List<User> signingOfficials = userService.findSOsByInstitutionId(user.getInstitutionId());
+            List<SimplifiedUser> signingOfficials = userService.findSOsByInstitutionId(user.getInstitutionId());
             return Response.ok().entity(signingOfficials).build();
         } catch (Exception e) {
             return createExceptionResponse(e);

--- a/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
@@ -165,7 +165,7 @@ public class UserResource extends Resource {
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    @Path("/SigningOfficials")
+    @Path("/signing-officials")
     @RolesAllowed(RESEARCHER)
     public Response getSOsForInstitution(@Auth AuthUser authUser) {
         try {

--- a/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import java.util.Objects;
 import javax.annotation.security.PermitAll;
 import javax.annotation.security.RolesAllowed;
 import javax.ws.rs.Consumes;
@@ -169,6 +170,9 @@ public class UserResource extends Resource {
     public Response getSOsForInstitution(@Auth AuthUser authUser) {
         try {
             User user = userService.findUserByEmail(authUser.getName());
+            if (Objects.isNull(user.getInstitutionId())) {
+                throw new NotFoundException("Current user, " + user.getDisplayName() + " does not have an institution.");
+            }
             List<User> signingOfficials = userService.findSOsByInstitutionId(user.getInstitutionId());
             return Response.ok().entity(signingOfficials).build();
         } catch (Exception e) {

--- a/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
@@ -171,7 +171,7 @@ public class UserResource extends Resource {
         try {
             User user = userService.findUserByEmail(authUser.getName());
             if (Objects.isNull(user.getInstitutionId())) {
-                throw new NotFoundException("Current user, " + user.getDisplayName() + " does not have an institution.");
+                throw new NotFoundException("Current user, " + user.getDisplayName() + ", does not have an institution.");
             }
             List<User> signingOfficials = userService.findSOsByInstitutionId(user.getInstitutionId());
             return Response.ok().entity(signingOfficials).build();

--- a/src/main/java/org/broadinstitute/consent/http/service/UserService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/UserService.java
@@ -50,6 +50,16 @@ public class UserService {
         this.libraryCardDAO = libraryCardDAO;
     }
 
+    public class SimplifiedUser {
+        public final String displayName;
+        public final Integer userId;
+
+        public SimplifiedUser(User user) {
+            this.displayName = user.getDisplayName();
+            this.userId = user.getDacUserId();
+        };
+    }
+
     public User createUser(User user) {
         // Default role is researcher.
         if (Objects.isNull(user.getRoles()) || CollectionUtils.isEmpty(user.getRoles())) {
@@ -168,11 +178,13 @@ public class UserService {
         userDAO.updateEmailPreference(preference, userId);
     }
 
-    public List<User> findSOsByInstitutionId(Integer institutionId) {
+    public List<SimplifiedUser> findSOsByInstitutionId(Integer institutionId) {
         if (Objects.isNull(institutionId)) {
             return Collections.emptyList();
         }
-       return userDAO.getSOsByInstitution(institutionId);
+
+        List<User> users = userDAO.getSOsByInstitution(institutionId);
+        return users.stream().map(u -> new SimplifiedUser(u)).collect(Collectors.toList());
     }
 
     private void validateRequiredFields(User user) {

--- a/src/main/java/org/broadinstitute/consent/http/service/UserService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/UserService.java
@@ -168,6 +168,13 @@ public class UserService {
         userDAO.updateEmailPreference(preference, userId);
     }
 
+    public List<User> findSOsByInstitutionId(Integer institutionId) {
+        if (Objects.isNull(institutionId)) {
+            return Collections.emptyList();
+        }
+       return userDAO.getSOsByInstitution(institutionId);
+    }
+
     private void validateRequiredFields(User user) {
         if (Objects.isNull(user.getDisplayName()) || StringUtils.isEmpty(user.getDisplayName())) {
             throw new BadRequestException("Display Name cannot be empty");

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -3413,7 +3413,7 @@ paths:
           description: User not found
         500:
           description: Server error.
-  /api/user/SigningOfficials:
+  /api/user/signing-officials:
     get:
       summary: Find SOs for currently authenticated user's institution
       description: Return list of SOs belonging to the same institution as currently authenticated user

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -3413,6 +3413,25 @@ paths:
           description: User not found
         500:
           description: Server error.
+  /api/user/SigningOfficials:
+    get:
+      summary: Find SOs for currently authenticated user's institution
+      description: Return list of SOs belonging to the same institution as currently authenticated user
+      tags:
+        - User
+      responses:
+        200:
+          description: The users with the same institutionId and SO Role
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/User'
+        404:
+          description: User not found
+        500:
+          description: Server error.
   /api/user/{id}:
     get:
       summary: Find user by id

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -3427,7 +3427,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/User'
+                  $ref: '#/components/schemas/SimplifiedUser'
         404:
           description: User not found
         500:

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -4868,6 +4868,15 @@ components:
         name:
           type: string
           description: Name of the role
+    SimplifiedUser:
+      type: object
+      properties:
+        dacUserId:
+          type: integer
+          description: ID of the user
+        displayName:
+          type: string
+          description: Name of the user
     ErrorResponse:
       properties:
         message:

--- a/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
@@ -337,6 +337,8 @@ public class DAOTestHelper {
         Integer userId = userDAO.insertUser(email, "display name", new Date());
         Integer institutionId = institutionDAO.insertInstitution("name", "itdirectorName", "itDirectorEmail", userId, new Date());
         userDAO.updateUser("display name", userId, email, institutionId);
+        addUserRole(7, userId);
+        createdInstitutionIds.add(institutionId);
         createdUserIds.add(userId);
         return userDAO.findUserById(userId);
     }

--- a/src/test/java/org/broadinstitute/consent/http/db/UserDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/UserDAOTest.java
@@ -343,6 +343,20 @@ public class UserDAOTest extends DAOTestHelper {
         assertTrue(users.isEmpty());
     }
 
+    @Test
+    public void testDescribeUsersByRoleAndInstitution() {
+        //user with institutionId and SO role
+        User user = createUserWithInstitution();
+        Integer institutionId = user.getInstitutionId();
+        String displayName = user.getDisplayName();
+        List<User> users = userDAO.getSOsByInstitution( institutionId);
+        assertEquals(1, users.size());
+        assertEquals(displayName, users.get(0).getDisplayName());
+
+        List<User> differentInstitutionUsers = userDAO.getSOsByInstitution( institutionId + 1);
+        assertEquals(0, differentInstitutionUsers.size());
+    }
+
     private String getRandomEmailAddress() {
         String user = RandomStringUtils.randomAlphanumeric(20);
         String domain = RandomStringUtils.randomAlphanumeric(10);

--- a/src/test/java/org/broadinstitute/consent/http/db/UserDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/UserDAOTest.java
@@ -344,7 +344,7 @@ public class UserDAOTest extends DAOTestHelper {
     }
 
     @Test
-    public void testDescribeUsersByRoleAndInstitution() {
+    public void testGetSOsByInstitution() {
         //user with institutionId and SO role
         User user = createUserWithInstitution();
         Integer institutionId = user.getInstitutionId();

--- a/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.consent.http.resources;
 
+import com.google.api.client.http.HttpStatusCodes;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -203,6 +204,25 @@ public class UserResourceTest {
     assertEquals(400, response.getStatus());
   }
 
+  @Test
+  public void testGetSOsForInstitution() {
+    User user = createUserWithInstitution();
+    User so = createUserWithRole();
+    when(userService.findUserByEmail(any())).thenReturn(user);
+    when(userService.findSOsByInstitutionId(any())).thenReturn(Arrays.asList(so, so, so));
+    initResource();
+    Response response = userResource.getSOsForInstitution(authUser);
+    assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+  }
+
+  @Test
+  public void testGetSOsForInstitution_UserNotFound() {
+    when(userService.findUserByEmail(any())).thenThrow(new NotFoundException());
+    initResource();
+    Response response = userResource.getSOsForInstitution(authUser);
+    assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
+  }
+
   private User createUserWithRole() {
     User user = new User();
     user.setDacUserId(1);
@@ -214,6 +234,15 @@ public class UserResourceTest {
     researcher.setRoleId(UserRoles.RESEARCHER.getRoleId());
     roles.add(researcher);
     user.setRoles(roles);
+    return user;
+  }
+
+  private User createUserWithInstitution() {
+    User user = new User();
+    user.setDacUserId(1);
+    user.setDisplayName("Test Name");
+    user.setEmail("Test Email");
+    user.setInstitutionId(1);
     return user;
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
@@ -209,7 +209,7 @@ public class UserResourceTest {
     User user = createUserWithInstitution();
     User so = createUserWithRole();
     when(userService.findUserByEmail(any())).thenReturn(user);
-    when(userService.findSOsByInstitutionId(any())).thenReturn(Arrays.asList(so, so, so));
+    when(userService.findSOsByInstitutionId(any())).thenReturn(Arrays.asList(userService.new SimplifiedUser(so), userService.new SimplifiedUser(so)));
     initResource();
     Response response = userResource.getSOsForInstitution(authUser);
     assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
@@ -220,7 +220,7 @@ public class UserResourceTest {
     User user = createUserWithRole();
     User so = createUserWithRole();
     when(userService.findUserByEmail(any())).thenReturn(user);
-    when(userService.findSOsByInstitutionId(any())).thenReturn(Arrays.asList(so, so, so));
+    when(userService.findSOsByInstitutionId(any())).thenReturn(Arrays.asList(userService.new SimplifiedUser(so), userService.new SimplifiedUser(so)));
     initResource();
     Response response = userResource.getSOsForInstitution(authUser);
     assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());

--- a/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
@@ -216,6 +216,17 @@ public class UserResourceTest {
   }
 
   @Test
+  public void testGetSOsForInstitution_NoInstitution() {
+    User user = createUserWithRole();
+    User so = createUserWithRole();
+    when(userService.findUserByEmail(any())).thenReturn(user);
+    when(userService.findSOsByInstitutionId(any())).thenReturn(Arrays.asList(so, so, so));
+    initResource();
+    Response response = userResource.getSOsForInstitution(authUser);
+    assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
+  }
+
+  @Test
   public void testGetSOsForInstitution_UserNotFound() {
     when(userService.findUserByEmail(any())).thenThrow(new NotFoundException());
     initResource();

--- a/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
@@ -28,6 +28,7 @@ import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.LibraryCard;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.UserRole;
+import org.broadinstitute.consent.http.service.UserService.SimplifiedUser;
 import org.broadinstitute.consent.http.service.users.handler.UserRolesHandler;
 import org.junit.Before;
 import org.junit.Test;
@@ -317,14 +318,15 @@ public class UserServiceTest {
         Integer institutionId = u.getInstitutionId();
         when(userDAO.getSOsByInstitution(any())).thenReturn(Arrays.asList(u, u, u));
         initService();
-        List<User> users = service.findSOsByInstitutionId(institutionId);
+        List<SimplifiedUser> users = service.findSOsByInstitutionId(institutionId);
         assertEquals(3, users.size());
+        assertEquals(u.getDisplayName(), users.get(0).displayName);
     }
 
     @Test
     public void testFindSOsByInstitutionId_NullId() {
         initService();
-        List<User> users = service.findSOsByInstitutionId(null);
+        List<SimplifiedUser> users = service.findSOsByInstitutionId(null);
         assertEquals(0, users.size());
     }
 

--- a/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
@@ -311,6 +311,23 @@ public class UserServiceTest {
         User user = service.updateDACUserById(dacUsers, u.getDacUserId());
     }
 
+    @Test
+    public void testFindSOsByInstitutionId() {
+        User u = generateUser();
+        Integer institutionId = u.getInstitutionId();
+        when(userDAO.getSOsByInstitution(any())).thenReturn(Arrays.asList(u, u, u));
+        initService();
+        List<User> users = service.findSOsByInstitutionId(institutionId);
+        assertEquals(3, users.size());
+    }
+
+    @Test
+    public void testFindSOsByInstitutionId_NullId() {
+        initService();
+        List<User> users = service.findSOsByInstitutionId(null);
+        assertEquals(0, users.size());
+    }
+
     private User generateUser() {
         User u = new User();
         int i1 = RandomUtils.nextInt(5, 10);


### PR DESCRIPTION
SCOPE:
This is the back end component of a UI update which aims to have a drop down for Researchers to pick their SO from a list of SOs belonging to their institution (or if their SO is not on that list they can enter a free text name). We did not have any API that was appropriate for this use (besides getting all users and filtering through them) so I made a new API for researchers only since the UI update is on the dar application page which is for researchers only. 
- New API getSOsByInstitution, two resource tests, add documentation API docs
- New Service class method, two service tests
- New DAO call, one new DAO test

ADDRESSES:
https://broadworkbench.atlassian.net/browse/DUOS-1093

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
