### PR TITLE
DUOS-1329[risk=no]Consent: Update User include updates to status and rationale

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/UserDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/UserDAO.java
@@ -100,11 +100,19 @@ public interface UserDAO extends Transactional<UserDAO> {
                           @Bind("displayName") String displayName,
                           @Bind("createDate") Date createDate);
 
-    @SqlUpdate("UPDATE dacuser SET displayname=:displayName, additional_email=:additionalEmail, institution_id=:institutionId WHERE dacuserid=:id")
+    @SqlUpdate("UPDATE dacuser SET " 
+    + " displayname = :displayName, " 
+    + " additional_email = :additionalEmail, "
+    + " institution_id = :institutionId, "
+    + " status = :statusId, "
+    + " rationale = :rationale "
+    + " WHERE dacuserid = :id")
     void updateUser(@Bind("displayName") String displayName,
                        @Bind("id") Integer id,
                        @Bind("additionalEmail") String additionalEmail,
-                       @Bind("institutionId") Integer institutionId);
+                       @Bind("institutionId") Integer institutionId,
+                       @Bind("statusId") Integer statusId,
+                       @Bind("rationale") String rationale);
 
     @Deprecated // Use deleteUserById instead
     @SqlUpdate("DELETE FROM dacuser WHERE LOWER(email) = LOWER(:email)")
@@ -132,9 +140,11 @@ public interface UserDAO extends Transactional<UserDAO> {
     @SqlUpdate("update dacuser set email_preference = :emailPreference where dacUserId = :userId")
     void updateEmailPreference(@Bind("emailPreference") Boolean emailPreference, @Bind("userId") Integer userId);
 
+    @Deprecated
     @SqlUpdate("update dacuser set status = :status where dacUserId = :userId")
     void updateUserStatus(@Bind("status") Integer status, @Bind("userId") Integer userId);
 
+    @Deprecated
     @SqlUpdate("update dacuser set rationale = :rationale where dacUserId = :userId")
     void updateUserRationale(@Bind("rationale") String rationale, @Bind("userId") Integer userId);
 

--- a/src/main/java/org/broadinstitute/consent/http/service/UserService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/UserService.java
@@ -1,8 +1,6 @@
 package org.broadinstitute.consent.http.service;
 
 import com.google.inject.Inject;
-
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
@@ -117,6 +115,7 @@ public class UserService {
         return userDAO.describeUsersByRoleAndEmailPreference(UserRoles.ADMIN.getRoleName(), true);
     }
 
+    @Deprecated
     public User updateUserStatus(String status, Integer userId) {
         Integer statusId = RoleStatus.getValueByStatus(status);
         validateExistentUserById(userId);
@@ -127,6 +126,7 @@ public class UserService {
         return userDAO.findUserById(userId);
     }
 
+    @Deprecated
     public User updateUserRationale(String rationale, Integer userId) {
         validateExistentUserById(userId);
         if (rationale == null) {
@@ -156,8 +156,19 @@ public class UserService {
             throw new BadRequestException("Institution with the given id does not exist");
         }
 
+        if (Objects.isNull(updatedUser.getStatus())) {
+            updatedUser.setStatus(existingUser.getStatus());
+        }
+
+        Integer statusId = RoleStatus.getValueByStatus(updatedUser.getStatus());
+
+        if (Objects.isNull(updatedUser.getRationale())) {
+            updatedUser.setRationale(existingUser.getRationale());
+        }
+
         try {
-            userDAO.updateUser(updatedUser.getDisplayName(), id, updatedUser.getAdditionalEmail(), updatedUser.getInstitutionId());
+            userDAO.updateUser(updatedUser.getDisplayName(), id, updatedUser.getAdditionalEmail(), updatedUser.getInstitutionId(),
+              statusId,  updatedUser.getRationale());
         } catch (UnableToExecuteStatementException e) {
             throw new IllegalArgumentException("Email shoud be unique.");
         }
@@ -226,8 +237,9 @@ public class UserService {
                             user.getDacUserId(),
                             new Date());
                 });
-
-        userDAO.updateUser(user.getDisplayName(), user.getDacUserId(), user.getAdditionalEmail(), user.getInstitutionId());
+                
+        Integer statusId = RoleStatus.getValueByStatus(user.getStatus());
+        userDAO.updateUser(user.getDisplayName(), user.getDacUserId(), user.getAdditionalEmail(), user.getInstitutionId(), statusId, user.getRationale());
     }
 
     private Boolean checkForValidInstitution(Integer institutionId) {

--- a/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
@@ -336,7 +336,7 @@ public class DAOTestHelper {
         String email = RandomStringUtils.randomAlphabetic(i1);
         Integer userId = userDAO.insertUser(email, "display name", new Date());
         Integer institutionId = institutionDAO.insertInstitution("name", "itdirectorName", "itDirectorEmail", userId, new Date());
-        userDAO.updateUser("display name", userId, email, institutionId);
+        userDAO.updateUser("display name", userId, email, institutionId, 0, "");
         createdUserIds.add(userId);
         return userDAO.findUserById(userId);
     }

--- a/src/test/java/org/broadinstitute/consent/http/db/UserDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/UserDAOTest.java
@@ -179,10 +179,13 @@ public class UserDAOTest extends DAOTestHelper {
                 "Dac User Test",
                 user.getDacUserId(),
                 newEmail,
-                institutionId
-                );
+                institutionId,
+                0,
+                "rationale");
         User user2 = userDAO.findUserById(user.getDacUserId());
         assertEquals(user2.getAdditionalEmail(), newEmail);
+        assertEquals(RoleStatus.getStatusByValue(0), user2.getStatus());
+        assertEquals("rationale", user2.getRationale());
     }
 
     @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
@@ -292,7 +292,7 @@ public class UserServiceTest {
                 .thenReturn(u);
         when(institutionDAO.checkForExistingInstitution(any()))
                 .thenReturn(u.getInstitutionId());
-        doNothing().when(userDAO).updateUser(any(), any(), any(), any());
+        doNothing().when(userDAO).updateUser(any(), any(), any(), any(), any(), any());
         initService();
         Map<String, User> dacUsers = Map.of(UserRolesHandler.UPDATED_USER_KEY, u);
         User user = service.updateDACUserById(dacUsers, u.getDacUserId());
@@ -305,7 +305,7 @@ public class UserServiceTest {
         User u = generateUser();
         when(userDAO.findUserById(u.getDacUserId()))
                 .thenReturn(null);
-        doNothing().when(userDAO).updateUser(any(), any(), any(), any());
+        doNothing().when(userDAO).updateUser(any(), any(), any(), any(), any(), any());
         initService();
         Map<String, User> dacUsers = Map.of(UserRolesHandler.UPDATED_USER_KEY, u);
         User user = service.updateDACUserById(dacUsers, u.getDacUserId());


### PR DESCRIPTION
SCOPE:
- check for updates to status and rationale in user service method
- include status and rationale as arguments in updateUser dao call
- deprecate updateStatus and updateRationale methods in user service and user dao
- update tests for changes and add checks for updated status and rationale to userDAO test

This PR allows the UI to use the DACUser.update method exclusively (accomplished in DUOS-1314) and allows for the now unused code paths to be deleted (accomplished in DUOS-1315) thus this PR must be merged prior to those two PRs.

ADDRESSES:
https://broadworkbench.atlassian.net/browse/DUOS-1329

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
