### PR TITLE
DUOS-1304[risk=no]Remove unused DacUserResource methods once DUOS-1260 & DUOS-1328 are complete

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/resources/DACUserResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DACUserResource.java
@@ -31,7 +31,6 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 import java.net.URI;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -65,13 +64,6 @@ public class DACUserResource extends Resource {
         } catch (Exception e) {
             return Response.status(Response.Status.BAD_REQUEST).entity(new Error(e.getMessage(), Response.Status.BAD_REQUEST.getStatusCode())).build();
         }
-    }
-
-    @GET
-    @Produces("application/json")
-    @RolesAllowed(ADMIN)
-    public Collection<User> describeAllUsers() {
-        return userService.describeUsers();
     }
 
     @GET

--- a/src/main/java/org/broadinstitute/consent/http/service/UserService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/UserService.java
@@ -2,8 +2,6 @@ package org.broadinstitute.consent.http.service;
 
 import com.google.inject.Inject;
 
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -81,10 +79,6 @@ public class UserService {
             throw new NotFoundException("Unable to find user with email: " + email);
         }
         return user;
-    }
-
-    public Collection<User> describeUsers() {
-        return userDAO.findUsers();
     }
 
     public void deleteUserByEmail(String email) {

--- a/src/main/java/org/broadinstitute/consent/http/service/UserService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/UserService.java
@@ -2,6 +2,7 @@ package org.broadinstitute.consent.http.service;
 
 import com.google.inject.Inject;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -1160,20 +1160,6 @@ paths:
                 $ref: '#/components/schemas/User'
         400:
           description: Malformed user entity.
-    get:
-      summary: describeAllUsers
-      description: Returns all the users
-      tags:
-        - User
-      responses:
-        200:
-          description: Returns the collection of all the users and their permissions.
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/User'
   /api/dacuser/{email}:
     get:
       summary: describe


### PR DESCRIPTION
SCOPE:
- Delete unused DacUserResource API, no tests to delete
- Delete unused UserService method, no tests to delete
DUOS-1260(Consent) and DUOS-1328(UI) need to be merged in prior to this.

ADDRESSES:
https://broadworkbench.atlassian.net/browse/DUOS-1304

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
