### PR TITLE
[DUOS-1338][risk=no] Use DataUse for translation

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
@@ -217,7 +217,8 @@ public class ConsentModule extends AbstractModule {
                 providesAuditService(),
                 providesAssociationDAO(),
                 providesJdbi(),
-                providesDataSetDAO());
+                providesDataSetDAO(),
+                providesUseRestrictionConverter());
     }
 
     @Provides
@@ -277,7 +278,8 @@ public class ConsentModule extends AbstractModule {
                 providesMailMessageDAO(),
                 providesDacService(),
                 providesEmailNotifierService(),
-                providesDataAccessRequestService());
+                providesDataAccessRequestService(),
+                providesUseRestrictionConverter());
     }
 
     @Provides

--- a/src/main/java/org/broadinstitute/consent/http/db/ConsentDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/ConsentDAO.java
@@ -95,7 +95,7 @@ public interface ConsentDAO extends Transactional<ConsentDAO> {
                        @Bind("dacId") Integer dacId);
 
     @SqlUpdate(" UPDATE consents " +
-            " SET translateduserestriction = :translatedUseRestriction, " +
+            " SET translateduserestriction = :translatedUseRestriction " +
             " WHERE consentid = :consentId ")
     void updateConsentTranslatedUseRestriction(
             @Bind("consentId") String consentId,

--- a/src/main/java/org/broadinstitute/consent/http/db/ConsentDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/ConsentDAO.java
@@ -94,6 +94,13 @@ public interface ConsentDAO extends Transactional<ConsentDAO> {
                        @Bind("updated") Boolean updateStatus,
                        @Bind("dacId") Integer dacId);
 
+    @SqlUpdate(" update consents set " +
+            " translatedUseRestriction = :translatedUseRestriction, " +
+            " where consentId = :consentId ")
+    void updateConsentTranslatedUseRestriction(
+            @Bind("consentId") String consentId,
+            @Bind("translatedUseRestriction") String translatedUseRestriction);
+
     @SqlUpdate("update consents set sortDate = :sortDate " +
             "where consentId = :consentId and active = true")
     void updateConsentSortDate(@Bind("consentId") String consentId, @Bind("sortDate") Date sortDate);

--- a/src/main/java/org/broadinstitute/consent/http/db/ConsentDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/ConsentDAO.java
@@ -94,9 +94,9 @@ public interface ConsentDAO extends Transactional<ConsentDAO> {
                        @Bind("updated") Boolean updateStatus,
                        @Bind("dacId") Integer dacId);
 
-    @SqlUpdate(" update consents set " +
-            " translatedUseRestriction = :translatedUseRestriction, " +
-            " where consentId = :consentId ")
+    @SqlUpdate(" UPDATE consents " +
+            " SET translateduserestriction = :translatedUseRestriction, " +
+            " WHERE consentid = :consentId ")
     void updateConsentTranslatedUseRestriction(
             @Bind("consentId") String consentId,
             @Bind("translatedUseRestriction") String translatedUseRestriction);

--- a/src/main/java/org/broadinstitute/consent/http/db/VoteDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/VoteDAO.java
@@ -28,7 +28,7 @@ public interface VoteDAO extends Transactional<VoteDAO> {
     @UseRowMapper(ElectionReviewVoteMapper.class)
     List<ElectionReviewVote> findElectionReviewVotesByElectionId(@Bind("electionId") Integer electionId);
 
-    @SqlQuery("SELECT v.*, u.email, u.displayName FROM vote v " 
+    @SqlQuery("SELECT v.*, u.email, u.displayName FROM vote v "
             + " INNER JOIN election ON election.electionId = v.electionId "
             + " INNER JOIN dacuser u ON u.dacUserId = v.dacUserId "
             + " WHERE election.electionId = :electionId")
@@ -77,9 +77,6 @@ public interface VoteDAO extends Transactional<VoteDAO> {
     @SqlQuery("select * from vote v where v.electionId = :electionId and lower(v.type) = lower(:type)")
     @Deprecated // This query can return a list of votes and should be avoided
     Vote findVoteByElectionIdAndType(@Bind("electionId") Integer electionId, @Bind("type") String type);
-
-    @SqlQuery("SELECT * FROM vote v WHERE v.electionid = :electionId AND LOWER(v.type) = 'final'")
-    List<Vote> findFinalVotesByElectionId(@Bind("electionId") Integer electionId);
 
     @SqlQuery("select * from vote v where v.electionId = :electionId and v.dacUserId = :dacUserId and lower(v.type) = 'final'")
     Vote findChairPersonVoteByElectionIdAndDACUserId(@Bind("electionId") Integer electionId,

--- a/src/main/java/org/broadinstitute/consent/http/enumeration/DataUseTranslationType.java
+++ b/src/main/java/org/broadinstitute/consent/http/enumeration/DataUseTranslationType.java
@@ -1,0 +1,44 @@
+package org.broadinstitute.consent.http.enumeration;
+
+import java.util.List;
+
+public enum DataUseTranslationType {
+  DATASET("dataset"),
+  PURPOSE("purpose");
+  private final String value;
+
+  DataUseTranslationType(String value) {
+    this.value = value;
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+  public static String getValue(String value) {
+    for (DataUseTranslationType e : DataUseTranslationType.values()) {
+      if (e.getValue().equalsIgnoreCase(value)) {
+        return e.getValue();
+      }
+    }
+    return null;
+  }
+
+  public static boolean contains(List<String> valueList) {
+    for (String value : valueList) {
+      if (!contains(value)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  public static boolean contains(String value) {
+    for (DataUseTranslationType c : DataUseTranslationType.values()) {
+      if (c.name().equalsIgnoreCase(value)) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/src/main/java/org/broadinstitute/consent/http/enumeration/DataUseTranslationType.java
+++ b/src/main/java/org/broadinstitute/consent/http/enumeration/DataUseTranslationType.java
@@ -2,6 +2,11 @@ package org.broadinstitute.consent.http.enumeration;
 
 import java.util.List;
 
+/**
+ * Ontology's translation endpoint for a `DataUse` object has separate
+ * translations depending on the whether the use restrictions apply to
+ * a dataset (i.e. consent) or a purpose (i.e. DAR or research purpose).
+ */
 public enum DataUseTranslationType {
   DATASET("dataset"),
   PURPOSE("purpose");

--- a/src/main/java/org/broadinstitute/consent/http/service/ConsentService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ConsentService.java
@@ -107,7 +107,7 @@ public class ConsentService {
         Date createDate = new Date();
         if (Objects.isNull(rec.getTranslatedUseRestriction()) && Objects.nonNull(rec.getDataUse())) {
       String translatedUseRestriction =
-          useRestrictionConverter.translateDataUse(rec.getDataUse(), DataUseTranslationType.PURPOSE);
+          useRestrictionConverter.translateDataUse(rec.getDataUse(), DataUseTranslationType.DATASET);
             rec.setTranslatedUseRestriction(translatedUseRestriction);
         }
         consentDAO.insertConsent(id, rec.getRequiresManualReview(),
@@ -152,7 +152,7 @@ public class ConsentService {
             throw new NotFoundException();
         }
         if (Objects.isNull(rec.getTranslatedUseRestriction()) && Objects.nonNull(rec.getDataUse())) {
-            rec.setTranslatedUseRestriction(useRestrictionConverter.translateDataUse(rec.getDataUse(), DataUseTranslationType.PURPOSE));
+            rec.setTranslatedUseRestriction(useRestrictionConverter.translateDataUse(rec.getDataUse(), DataUseTranslationType.DATASET));
         }
         consentDAO.updateConsent(id, rec.getRequiresManualReview(),
                 rec.getUseRestriction().toString(), rec.getDataUse().toString(),

--- a/src/main/java/org/broadinstitute/consent/http/service/ConsentService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ConsentService.java
@@ -28,6 +28,7 @@ import org.broadinstitute.consent.http.enumeration.AssociationType;
 import org.broadinstitute.consent.http.enumeration.AuditTable;
 import org.broadinstitute.consent.http.enumeration.ElectionStatus;
 import org.broadinstitute.consent.http.enumeration.ElectionType;
+import org.broadinstitute.consent.http.enumeration.DataUseTranslationType;
 import org.broadinstitute.consent.http.models.AuthUser;
 import org.broadinstitute.consent.http.models.Consent;
 import org.broadinstitute.consent.http.models.ConsentAssociation;
@@ -105,7 +106,8 @@ public class ConsentService {
         }
         Date createDate = new Date();
         if (Objects.isNull(rec.getTranslatedUseRestriction()) && Objects.nonNull(rec.getDataUse())) {
-            String translatedUseRestriction = useRestrictionConverter.translateDataUse(rec.getDataUse());
+      String translatedUseRestriction =
+          useRestrictionConverter.translateDataUse(rec.getDataUse(), DataUseTranslationType.PURPOSE);
             rec.setTranslatedUseRestriction(translatedUseRestriction);
         }
         consentDAO.insertConsent(id, rec.getRequiresManualReview(),
@@ -150,7 +152,7 @@ public class ConsentService {
             throw new NotFoundException();
         }
         if (Objects.isNull(rec.getTranslatedUseRestriction()) && Objects.nonNull(rec.getDataUse())) {
-            rec.setTranslatedUseRestriction(useRestrictionConverter.translateDataUse(rec.getDataUse()));
+            rec.setTranslatedUseRestriction(useRestrictionConverter.translateDataUse(rec.getDataUse(), DataUseTranslationType.PURPOSE));
         }
         consentDAO.updateConsent(id, rec.getRequiresManualReview(),
                 rec.getUseRestriction().toString(), rec.getDataUse().toString(),

--- a/src/main/java/org/broadinstitute/consent/http/service/ConsentService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ConsentService.java
@@ -106,8 +106,7 @@ public class ConsentService {
         }
         Date createDate = new Date();
         if (Objects.isNull(rec.getTranslatedUseRestriction()) && Objects.nonNull(rec.getDataUse())) {
-      String translatedUseRestriction =
-          useRestrictionConverter.translateDataUse(rec.getDataUse(), DataUseTranslationType.DATASET);
+            String translatedUseRestriction = useRestrictionConverter.translateDataUse(rec.getDataUse(), DataUseTranslationType.DATASET);
             rec.setTranslatedUseRestriction(translatedUseRestriction);
         }
         consentDAO.insertConsent(id, rec.getRequiresManualReview(),

--- a/src/main/java/org/broadinstitute/consent/http/service/ConsentService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ConsentService.java
@@ -104,8 +104,7 @@ public class ConsentService {
             throw new IllegalArgumentException("Consent for the specified id already exist");
         }
         Date createDate = new Date();
-        if (Objects.isNull(rec.getTranslatedUseRestriction()) &&
-        Objects.nonNull(rec.getDataUse())) {
+        if (Objects.isNull(rec.getTranslatedUseRestriction()) && Objects.nonNull(rec.getDataUse())) {
             String translatedUseRestriction = useRestrictionConverter.translateDataUse(rec.getDataUse());
             rec.setTranslatedUseRestriction(translatedUseRestriction);
         }

--- a/src/main/java/org/broadinstitute/consent/http/service/ConsentService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ConsentService.java
@@ -149,7 +149,7 @@ public class ConsentService {
         if (StringUtils.isEmpty(consentDAO.checkConsentById(id))) {
             throw new NotFoundException();
         }
-        if (Objects.isNull(rec.getTranslatedUseRestriction())) {
+        if (Objects.isNull(rec.getTranslatedUseRestriction()) && Objects.nonNull(rec.getDataUse())) {
             rec.setTranslatedUseRestriction(useRestrictionConverter.translateDataUse(rec.getDataUse()));
         }
         consentDAO.updateConsent(id, rec.getRequiresManualReview(),

--- a/src/main/java/org/broadinstitute/consent/http/service/ConsentService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ConsentService.java
@@ -52,15 +52,18 @@ public class ConsentService {
     private final Logger logger;
     private final DatasetDAO dataSetDAO;
 
-    private ConsentDAO consentDAO;
-    private ElectionDAO electionDAO;
-    private VoteDAO voteDAO;
-    private DacService dacService;
-    private DataAccessRequestDAO dataAccessRequestDAO;
+    private final ConsentDAO consentDAO;
+    private final ElectionDAO electionDAO;
+    private final VoteDAO voteDAO;
+    private final DacService dacService;
+    private final DataAccessRequestDAO dataAccessRequestDAO;
+    private final UseRestrictionConverter useRestrictionConverter;
 
     @Inject
     public ConsentService(ConsentDAO consentDAO, ElectionDAO electionDAO, VoteDAO voteDAO, DacService dacService,
-                          DataAccessRequestDAO dataAccessRequestDAO, AuditService auditService, AssociationDAO associationDAO, Jdbi jdbi, DatasetDAO dataSetDAO) {
+                          DataAccessRequestDAO dataAccessRequestDAO, AuditService auditService,
+                          AssociationDAO associationDAO, Jdbi jdbi, DatasetDAO dataSetDAO,
+                          UseRestrictionConverter useRestrictionConverter) {
         this.consentDAO = consentDAO;
         this.electionDAO = electionDAO;
         this.voteDAO = voteDAO;
@@ -70,6 +73,7 @@ public class ConsentService {
         this.associationDAO = associationDAO;
         this.jdbi = jdbi;
         this.dataSetDAO = dataSetDAO;
+        this.useRestrictionConverter = useRestrictionConverter;
         this.logger = LoggerFactory.getLogger(this.getClass());
     }
 
@@ -100,6 +104,11 @@ public class ConsentService {
             throw new IllegalArgumentException("Consent for the specified id already exist");
         }
         Date createDate = new Date();
+        if (Objects.isNull(rec.getTranslatedUseRestriction()) &&
+        Objects.nonNull(rec.getDataUse())) {
+            String translatedUseRestriction = useRestrictionConverter.translateDataUse(rec.getDataUse());
+            rec.setTranslatedUseRestriction(translatedUseRestriction);
+        }
         consentDAO.insertConsent(id, rec.getRequiresManualReview(),
                 rec.getUseRestriction().toString(), rec.getDataUse().toString(),
                 rec.getDataUseLetter(), rec.getName(), rec.getDulName(), createDate, createDate,
@@ -140,6 +149,9 @@ public class ConsentService {
         rec = updateConsentDates(rec);
         if (StringUtils.isEmpty(consentDAO.checkConsentById(id))) {
             throw new NotFoundException();
+        }
+        if (Objects.isNull(rec.getTranslatedUseRestriction())) {
+            rec.setTranslatedUseRestriction(useRestrictionConverter.translateDataUse(rec.getDataUse()));
         }
         consentDAO.updateConsent(id, rec.getRequiresManualReview(),
                 rec.getUseRestriction().toString(), rec.getDataUse().toString(),

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -6,6 +6,7 @@ import org.broadinstitute.consent.http.db.DatasetDAO;
 import org.broadinstitute.consent.http.db.UserRoleDAO;
 import org.broadinstitute.consent.http.enumeration.Actions;
 import org.broadinstitute.consent.http.enumeration.AssociationType;
+import org.broadinstitute.consent.http.enumeration.DataUseTranslationType;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.Consent;
 import org.broadinstitute.consent.http.models.DataAccessRequestData;
@@ -120,7 +121,7 @@ public class DatasetService {
              * data user letter name
              */
             UseRestriction useRestriction = converter.parseUseRestriction(dataset.getDataUse());
-            String translatedUseRestriction = converter.translateDataUse(dataset.getDataUse());
+            String translatedUseRestriction = converter.translateDataUse(dataset.getDataUse(), DataUseTranslationType.PURPOSE);
             consentDAO.useTransaction(h -> {
                 try {
                     h.insertConsent(consentId, manualReview, useRestriction.toString(), dataset.getDataUse().toString(), null, name, null, createDate, createDate, translatedUseRestriction, groupName, dataset.getDacId());

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -116,15 +116,14 @@ public class DatasetService {
             boolean manualReview = isConsentDataUseManualReview(dataset.getDataUse());
             /*
              * Consents created for a dataset do not need the following properties:
-             * use restriction
              * data user letter
              * data user letter name
-             * translated use restriction
              */
             UseRestriction useRestriction = converter.parseUseRestriction(dataset.getDataUse());
+            String translatedUseRestriction = converter.translateDataUse(dataset.getDataUse());
             consentDAO.useTransaction(h -> {
                 try {
-                    h.insertConsent(consentId, manualReview, useRestriction.toString(), dataset.getDataUse().toString(), null, name, null, createDate, createDate, null, groupName, dataset.getDacId());
+                    h.insertConsent(consentId, manualReview, useRestriction.toString(), dataset.getDataUse().toString(), null, name, null, createDate, createDate, translatedUseRestriction, groupName, dataset.getDacId());
                     if (Objects.nonNull(dataset.getDacId())) {
                         h.updateConsentDac(consentId, dataset.getDacId());
                     }

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -121,7 +121,7 @@ public class DatasetService {
              * data user letter name
              */
             UseRestriction useRestriction = converter.parseUseRestriction(dataset.getDataUse());
-            String translatedUseRestriction = converter.translateDataUse(dataset.getDataUse(), DataUseTranslationType.PURPOSE);
+            String translatedUseRestriction = converter.translateDataUse(dataset.getDataUse(), DataUseTranslationType.DATASET);
             consentDAO.useTransaction(h -> {
                 try {
                     h.insertConsent(consentId, manualReview, useRestriction.toString(), dataset.getDataUse().toString(), null, name, null, createDate, createDate, translatedUseRestriction, groupName, dataset.getDacId());

--- a/src/main/java/org/broadinstitute/consent/http/service/ElectionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ElectionService.java
@@ -649,7 +649,7 @@ public class ElectionService {
             String translatedUseRestriction = consent.getTranslatedUseRestriction();
             if (Objects.isNull(translatedUseRestriction)) {
                 if (Objects.nonNull(consent.getDataUse())) {
-                    translatedUseRestriction = useRestrictionConverter.translateDataUse(consent.getDataUse(), DataUseTranslationType.PURPOSE);
+                    translatedUseRestriction = useRestrictionConverter.translateDataUse(consent.getDataUse(), DataUseTranslationType.DATASET);
                     // update so we don't have to make this check again
                     consentDAO.updateConsentTranslatedUseRestriction(consent.getConsentId(), translatedUseRestriction);
                 } else {

--- a/src/main/java/org/broadinstitute/consent/http/service/ElectionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ElectionService.java
@@ -643,13 +643,12 @@ public class ElectionService {
                     datasetsDetail.add(new DatasetMailDTO(ds.getName(), ds.getDatasetIdentifier()))
             );
             Consent consent = consentDAO.findConsentFromDatasetID(dataSets.get(0).getDataSetId());
-            DataUse dataUse = consent.getDataUse();
             // Legacy behavior was to populate the plain language translation we received from ORSP
             // If we don't have that and have a valid data use, use that instead as it is more up to date.
             String translatedUseRestriction = consent.getTranslatedUseRestriction();
             if (Objects.isNull(translatedUseRestriction)) {
-                if (Objects.nonNull(dataUse)) {
-                    translatedUseRestriction = useRestrictionConverter.translateDataUse(dataUse);
+                if (Objects.nonNull(consent.getDataUse())) {
+                    translatedUseRestriction = useRestrictionConverter.translateDataUse(consent.getDataUse());
                     // update so we don't have to make this check again
                     consentDAO.updateConsentTranslatedUseRestriction(consent.getConsentId(), translatedUseRestriction);
                 } else {

--- a/src/main/java/org/broadinstitute/consent/http/service/ElectionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ElectionService.java
@@ -13,6 +13,7 @@ import org.broadinstitute.consent.http.db.MailMessageDAO;
 import org.broadinstitute.consent.http.db.UserDAO;
 import org.broadinstitute.consent.http.db.VoteDAO;
 import org.broadinstitute.consent.http.enumeration.DataSetElectionStatus;
+import org.broadinstitute.consent.http.enumeration.DataUseTranslationType;
 import org.broadinstitute.consent.http.enumeration.ElectionStatus;
 import org.broadinstitute.consent.http.enumeration.ElectionType;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
@@ -648,7 +649,7 @@ public class ElectionService {
             String translatedUseRestriction = consent.getTranslatedUseRestriction();
             if (Objects.isNull(translatedUseRestriction)) {
                 if (Objects.nonNull(consent.getDataUse())) {
-                    translatedUseRestriction = useRestrictionConverter.translateDataUse(consent.getDataUse());
+                    translatedUseRestriction = useRestrictionConverter.translateDataUse(consent.getDataUse(), DataUseTranslationType.PURPOSE);
                     // update so we don't have to make this check again
                     consentDAO.updateConsentTranslatedUseRestriction(consent.getConsentId(), translatedUseRestriction);
                 } else {

--- a/src/main/java/org/broadinstitute/consent/http/service/UseRestrictionConverter.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/UseRestrictionConverter.java
@@ -195,6 +195,20 @@ public class UseRestrictionConverter {
         return null;
     }
 
+    public String translateDataUse(DataUse dataUse) {
+        WebTarget target = client.target(servicesConfiguration.getOntologyURL() + "translate");
+        Response response = target.request(MediaType.APPLICATION_JSON).post(Entity.json(dataUse.toString()));
+        if (response.getStatus() == 200) {
+            try {
+                return response.readEntity(String.class);
+            } catch (Exception e) {
+                LOGGER.error("Error parsing response from Ontology service: " + e);
+            }
+        }
+        LOGGER.error("Error response from Ontology service: " + response.readEntity(String.class));
+        return null;
+    }
+
     public Map<String, Object> parseAsMap(String str) {
         ObjectReader reader = mapper.readerFor(Map.class);
         try {

--- a/src/main/java/org/broadinstitute/consent/http/service/UseRestrictionConverter.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/UseRestrictionConverter.java
@@ -16,6 +16,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import org.apache.commons.collections.CollectionUtils;
 import org.broadinstitute.consent.http.configurations.ServicesConfiguration;
+import org.broadinstitute.consent.http.enumeration.DataUseTranslationType;
 import org.broadinstitute.consent.http.models.DataAccessRequest;
 import org.broadinstitute.consent.http.models.DataUse;
 import org.broadinstitute.consent.http.models.OntologyEntry;
@@ -195,8 +196,8 @@ public class UseRestrictionConverter {
         return null;
     }
 
-    public String translateDataUse(DataUse dataUse) {
-        WebTarget target = client.target(servicesConfiguration.getOntologyURL() + "translate");
+    public String translateDataUse(DataUse dataUse, DataUseTranslationType type) {
+        WebTarget target = client.target(servicesConfiguration.getOntologyURL() + "translate?for=" + type.getValue());
         Response response = target.request(MediaType.APPLICATION_JSON).post(Entity.json(dataUse.toString()));
         if (response.getStatus() == 200) {
             try {

--- a/src/test/java/org/broadinstitute/consent/http/db/ConsentDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/ConsentDAOTest.java
@@ -12,6 +12,8 @@ import java.util.Date;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import org.apache.commons.lang3.RandomStringUtils;
 import org.broadinstitute.consent.http.models.Consent;
 import org.broadinstitute.consent.http.models.ConsentManage;
 import org.broadinstitute.consent.http.models.Dac;
@@ -143,6 +145,16 @@ public class ConsentDAOTest extends DAOTestHelper {
         Consent foundConsent = consentDAO.findConsentById(consent.getConsentId());
         assertNotNull(foundConsent.getDacId());
         assertEquals(dac.getDacId(), foundConsent.getDacId());
+    }
+
+    @Test
+    public void testUpdateConsentTranslatedUseRestriction() {
+        String randomString = RandomStringUtils.random(10);
+        Consent consent = createConsent(null);
+
+        consentDAO.updateConsentTranslatedUseRestriction(consent.getConsentId(), randomString);
+        Consent foundConsent = consentDAO.findConsentById(consent.getConsentId());
+        assertEquals(randomString, foundConsent.getTranslatedUseRestriction());
     }
 
     @Test

--- a/src/test/java/org/broadinstitute/consent/http/db/ConsentDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/ConsentDAOTest.java
@@ -2,6 +2,7 @@ package org.broadinstitute.consent.http.db;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -149,12 +150,13 @@ public class ConsentDAOTest extends DAOTestHelper {
 
     @Test
     public void testUpdateConsentTranslatedUseRestriction() {
-        String randomString = RandomStringUtils.random(10);
         Consent consent = createConsent(null);
 
+        String randomString = RandomStringUtils.random(10);
         consentDAO.updateConsentTranslatedUseRestriction(consent.getConsentId(), randomString);
         Consent foundConsent = consentDAO.findConsentById(consent.getConsentId());
         assertEquals(randomString, foundConsent.getTranslatedUseRestriction());
+        assertNotEquals(consent.getTranslatedUseRestriction(), foundConsent.getTranslatedUseRestriction());
     }
 
     @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/ConsentServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/ConsentServiceTest.java
@@ -76,13 +76,16 @@ public class ConsentServiceTest {
     @Mock
     Jdbi jdbi;
 
+    @Mock
+    UseRestrictionConverter useRestrictionConverter;
+
     @Before
     public void setUp() {
         MockitoAnnotations.initMocks(this);
     }
 
     private void initService() {
-        service = new ConsentService(consentDAO, electionDAO, voteDAO, dacService, dataAccessRequestDAO, auditService, associationDAO, jdbi, dataSetDAO);
+        service = new ConsentService(consentDAO, electionDAO, voteDAO, dacService, dataAccessRequestDAO, auditService, associationDAO, jdbi, dataSetDAO, useRestrictionConverter);
     }
 
     @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/ElectionServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/ElectionServiceTest.java
@@ -295,8 +295,6 @@ public class ElectionServiceTest {
     }
 
     private void voteStubs() {
-        when(voteDAO.findFinalVotesByElectionId(sampleElection1.getElectionId()))
-                .thenReturn(Arrays.asList(sampleVoteMember, sampleVoteChairpersonApproval));
         when(voteDAO.findPendingVotesByElectionId(sampleElection1.getElectionId()))
                 .thenReturn(Arrays.asList(sampleVoteMember, sampleVoteChairpersonApproval));
         when(voteDAO.findPendingVotesByElectionId(sampleElection2.getElectionId()))
@@ -372,7 +370,6 @@ public class ElectionServiceTest {
     public void testSubmitFinalAccessVoteDataRequestElection_noLibraryCard_DataAccessRejection() {
         initService();
         when(libraryCardDAO.findLibraryCardsByUserId(any())).thenReturn(List.of());
-        when(voteDAO.findFinalVotesByElectionId(anyInt())).thenReturn(Collections.singletonList(sampleVoteChairpersonReject));
         try{
             Election election = service.submitFinalAccessVoteDataRequestElection(sampleElection1.getElectionId(), false);
             assertNotNull(election);

--- a/src/test/java/org/broadinstitute/consent/http/service/ElectionServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/ElectionServiceTest.java
@@ -85,6 +85,9 @@ public class ElectionServiceTest {
     private DataAccessRequestDAO dataAccessRequestDAO;
     @Mock
     private EmailNotifierService emailNotifierService;
+    @Mock
+    private UseRestrictionConverter useRestrictionConverter;
+
     private static final Gson gson = new GsonBuilder().setDateFormat("MMM d, yyyy").create();
 
     private static Election sampleElection1;
@@ -307,7 +310,7 @@ public class ElectionServiceTest {
     }
 
     private void initService() {
-        service = new ElectionService(consentDAO, electionDAO, voteDAO, userDAO, dataSetDAO, libraryCardDAO, datasetAssociationDAO, mailMessageDAO, dacService, emailNotifierService, dataAccessRequestService);
+        service = new ElectionService(consentDAO, electionDAO, voteDAO, userDAO, dataSetDAO, libraryCardDAO, datasetAssociationDAO, mailMessageDAO, dacService, emailNotifierService, dataAccessRequestService, useRestrictionConverter);
     }
 
     @Test
@@ -377,7 +380,7 @@ public class ElectionServiceTest {
         //function throws exception, need to have a catch block to handle it
         } catch(Exception e) {
             Assert.fail("Vote should not have failed");
-        } 
+        }
     }
 
     @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/UseRestrictionConverterTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/UseRestrictionConverterTest.java
@@ -3,6 +3,7 @@ package org.broadinstitute.consent.http.service;
 import org.broadinstitute.consent.http.WithMockServer;
 import org.broadinstitute.consent.http.configurations.ServicesConfiguration;
 import org.broadinstitute.consent.http.models.DataUse;
+import org.broadinstitute.consent.http.models.DataUseBuilder;
 import org.broadinstitute.consent.http.models.grammar.Everything;
 import org.broadinstitute.consent.http.models.grammar.UseRestriction;
 import org.junit.After;
@@ -41,7 +42,36 @@ public class UseRestrictionConverterTest implements WithMockServer {
         stop(container);
     }
 
-    private void mockSuccess() {
+    private void mockDataUseTranslateSuccess() {
+        client.reset();
+        client
+            .when(request().withMethod("POST").withPath("/translate"))
+            .respond(
+                response()
+                    .withStatusCode(200)
+                    .withHeaders(new Header("Content-Type", MediaType.APPLICATION_JSON))
+                    .withBody(
+                        "Samples are restricted for use under the following conditions:\n"
+                            + "Data is limited for health/medical/biomedical research. [HMB]\n"
+                            + "Commercial use is not prohibited.\n"
+                            + "Data use for methods development research irrespective of the specified data use limitations is not prohibited.\n"
+                            + "Restrictions for use as a control set for diseases other than those defined were not specified."));
+    }
+
+    private void mockDataUseTranslateFailure() {
+        client.reset();
+        client
+            .when(request().withMethod("POST").withPath("/translate"))
+            .respond(
+                response()
+                        .withStatusCode(500)
+                        .withHeaders(new Header("Content-Type", MediaType.APPLICATION_JSON))
+                        .withBody("Exception")
+            );
+    }
+
+
+    private void mockDarTranslateSuccess() {
         client.reset();
         client.when(
             request()
@@ -55,7 +85,7 @@ public class UseRestrictionConverterTest implements WithMockServer {
         );
     }
 
-    private void mockFailure() {
+    private void mockDarTranslateFailure() {
         client.reset();
         client.when(
             request()
@@ -81,7 +111,7 @@ public class UseRestrictionConverterTest implements WithMockServer {
      */
     @Test
     public void testUseRestrictionConverterConnection() {
-        mockSuccess();
+        mockDarTranslateSuccess();
 
         Client client = ClientBuilder.newClient();
         UseRestrictionConverter converter = new UseRestrictionConverter(client, config());
@@ -96,13 +126,40 @@ public class UseRestrictionConverterTest implements WithMockServer {
      */
     @Test
     public void testFailedUseRestrictionConverterConnection() {
-        mockFailure();
+        mockDarTranslateFailure();
 
         Client client = ClientBuilder.newClient();
         UseRestrictionConverter converter = new UseRestrictionConverter(client, config());
         DataUse dataUse = converter.parseDataUsePurpose("{  }");
         UseRestriction restriction = converter.parseUseRestriction(dataUse);
         assertNull(restriction);
+    }
+
+    /*
+     * Test that the UseRestrictionConverter makes a call to the ontology service and gets back a valid translation
+     */
+    @Test
+    public void testTranslateDataUse() {
+        mockDataUseTranslateSuccess();
+        Client client = ClientBuilder.newClient();
+        UseRestrictionConverter converter = new UseRestrictionConverter(client, config());
+        DataUse dataUse = new DataUseBuilder().setHmbResearch(true).build();
+        String translation = converter.translateDataUse(dataUse);
+        assertNotNull(translation);
+    }
+
+    /*
+     * Test that when the UseRestrictionConverter makes a failed call to the ontology service, a null is returned.
+     */
+    @Test
+    public void testFailedDataUseTranslateConverterConnection() {
+        mockDataUseTranslateFailure();
+
+        Client client = ClientBuilder.newClient();
+        UseRestrictionConverter converter = new UseRestrictionConverter(client, config());
+        DataUse dataUse = new DataUseBuilder().setHmbResearch(true).build();
+        String translation = converter.translateDataUse(dataUse);
+        assertNull(translation);
     }
 
     /*

--- a/src/test/java/org/broadinstitute/consent/http/service/UseRestrictionConverterTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/UseRestrictionConverterTest.java
@@ -2,6 +2,7 @@ package org.broadinstitute.consent.http.service;
 
 import org.broadinstitute.consent.http.WithMockServer;
 import org.broadinstitute.consent.http.configurations.ServicesConfiguration;
+import org.broadinstitute.consent.http.enumeration.DataUseTranslationType;
 import org.broadinstitute.consent.http.models.DataUse;
 import org.broadinstitute.consent.http.models.DataUseBuilder;
 import org.broadinstitute.consent.http.models.grammar.Everything;
@@ -139,12 +140,25 @@ public class UseRestrictionConverterTest implements WithMockServer {
      * Test that the UseRestrictionConverter makes a call to the ontology service and gets back a valid translation
      */
     @Test
-    public void testTranslateDataUse() {
+    public void testTranslateDataUsePurpose() {
         mockDataUseTranslateSuccess();
         Client client = ClientBuilder.newClient();
         UseRestrictionConverter converter = new UseRestrictionConverter(client, config());
         DataUse dataUse = new DataUseBuilder().setHmbResearch(true).build();
-        String translation = converter.translateDataUse(dataUse);
+        String translation = converter.translateDataUse(dataUse, DataUseTranslationType.PURPOSE);
+        assertNotNull(translation);
+    }
+
+    /*
+     * Test that the UseRestrictionConverter makes a call to the ontology service and gets back a valid translation
+     */
+    @Test
+    public void testTranslateDataUseDataset() {
+        mockDataUseTranslateSuccess();
+        Client client = ClientBuilder.newClient();
+        UseRestrictionConverter converter = new UseRestrictionConverter(client, config());
+        DataUse dataUse = new DataUseBuilder().setHmbResearch(true).build();
+        String translation = converter.translateDataUse(dataUse, DataUseTranslationType.DATASET);
         assertNotNull(translation);
     }
 
@@ -158,7 +172,7 @@ public class UseRestrictionConverterTest implements WithMockServer {
         Client client = ClientBuilder.newClient();
         UseRestrictionConverter converter = new UseRestrictionConverter(client, config());
         DataUse dataUse = new DataUseBuilder().setHmbResearch(true).build();
-        String translation = converter.translateDataUse(dataUse);
+        String translation = converter.translateDataUse(dataUse, DataUseTranslationType.PURPOSE);
         assertNull(translation);
     }
 


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-1338

## Changes
* New ontology call to get the plain language translation of a `DataUse`
* Use data use for the consent's translated use restriction when possible
* Handle NPE cases
* Make updates to the translation when possible
* Fixed bug in `ElectionService.submitFinalAccessVoteDataRequestElection` where we were not honoring the vote that was being passed in.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
