### PR TITLE
DUOS-1322[risk=no] Added Institution object to return on UserDAO.findUserById

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/UserDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/UserDAO.java
@@ -7,6 +7,7 @@ import java.util.Set;
 import org.broadinstitute.consent.http.db.mapper.UserWithRolesReducer;
 import org.broadinstitute.consent.http.db.mapper.UserWithPropertiesReducer;
 import org.broadinstitute.consent.http.db.mapper.UserWithRolesMapper;
+import org.broadinstitute.consent.http.models.Institution;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.UserProperty;
 import org.broadinstitute.consent.http.models.UserRole;
@@ -25,14 +26,19 @@ public interface UserDAO extends Transactional<UserDAO> {
 
     @RegisterBeanMapper(value = User.class)
     @RegisterBeanMapper(value = UserRole.class)
+    @RegisterBeanMapper(value = Institution.class, prefix = "i")
     @UseRowReducer(UserWithRolesReducer.class)
     @SqlQuery("SELECT "
         + "     u.dacuserid, u.email, u.displayname, u.createdate, u.additional_email, "
         + "     u.email_preference, u.status, u.rationale, u.institution_id, "
-        + "     ur.user_role_id, ur.user_id, ur.role_id, ur.dac_id, r.name "
+        + "     i.institution_id as i_id, i.institution_name as i_name, " 
+        + "     i.it_director_name as i_it_director_name, i.it_director_email as i_it_director_email, "
+        + "     i.create_date as i_create_date, i.update_date as i_update_date, "
+        + "     ur.user_role_id, ur.user_id, ur.role_id, ur.dac_id, r.name  "
         + " FROM dacuser u "
         + " LEFT JOIN user_role ur ON ur.user_id = u.dacuserid "
         + " LEFT JOIN roles r ON r.roleid = ur.role_id "
+        + " LEFT JOIN institution i ON u.institution_id = i.institution_id"
         + " WHERE u.dacuserid = :dacUserId")
     User findUserById(@Bind("dacUserId") Integer dacUserId);
 

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/UserWithRolesReducer.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/UserWithRolesReducer.java
@@ -3,6 +3,7 @@ package org.broadinstitute.consent.http.db.mapper;
 import java.util.Map;
 import java.util.Objects;
 import org.broadinstitute.consent.http.enumeration.RoleStatus;
+import org.broadinstitute.consent.http.models.Institution;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.UserRole;
 import org.jdbi.v3.core.mapper.MappingException;
@@ -34,6 +35,14 @@ public class UserWithRolesReducer implements LinkedHashMapRowReducer<Integer, Us
       }
     } catch (MappingException e) {
       // Ignore any attempt to map a column that doesn't exist
+    }
+    try {
+      if(Objects.nonNull(rowView.getColumn("i_id", Integer.class))) {
+        Institution institution = rowView.getRow(Institution.class);
+        user.setInstitution(institution);
+      }
+    } catch(MappingException e) {
+      //Ignore institution mapping errors, possible for new users to not have an institution
     }
   }
 

--- a/src/main/java/org/broadinstitute/consent/http/models/User.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/User.java
@@ -55,6 +55,8 @@ public class User {
     @JsonProperty
     private Integer institutionId;
 
+    private Institution institution;
+
     public User() {
     }
 
@@ -132,6 +134,7 @@ public class User {
         setStatus(u);
         setRationale(u);
         setInstitutionId(u);
+        setInstitution(u);
     }
 
     private void setUserId(User u) {
@@ -281,6 +284,20 @@ public class User {
     }
 
     public void setInstitutionId(Integer institutionId) { this.institutionId = institutionId; }
+
+    public void setInstitution(Institution institution) {
+        this.institution = institution;
+    }
+
+    public void setInstitution(User user) {
+        if (Objects.nonNull(user.getInstitution())) {
+            this.institution = user.institution;
+        }
+    }
+
+    public Institution getInstitution() {
+        return institution;
+    }
 
     public void addRole(UserRole userRole) {
         if (Objects.isNull(this.getRoles())) {

--- a/src/main/resources/changelog-master.xml
+++ b/src/main/resources/changelog-master.xml
@@ -72,4 +72,5 @@
     <include file="changesets/changelog-consent-67.0.xml" relativeToChangelogFile="true"/>
     <include file="changesets/changelog-consent-68.0.xml" relativeToChangelogFile="true"/>
     <include file="changesets/changelog-consent-69.0.xml" relativeToChangelogFile="true" />
+    <include file="changesets/changelog-consent-70.0.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/src/main/resources/changesets/changelog-consent-70.0.xml
+++ b/src/main/resources/changesets/changelog-consent-70.0.xml
@@ -1,0 +1,16 @@
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd
+    http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd">
+  <changeSet id="69.0" author="JVThomas">
+    <addForeignKeyConstraint baseColumnNames="institution_id"
+        baseTableName="dacuser"
+        constraintName="FK_institution_dacuser"
+        onDelete="SET NULL"
+        onUpdate="CASCADE"
+        referencedColumnNames="institution_id"
+        referencedTableName="institution"/>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/changesets/changelog-consent-70.0.xml
+++ b/src/main/resources/changesets/changelog-consent-70.0.xml
@@ -4,7 +4,7 @@
     xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
     xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd
     http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd">
-  <changeSet id="69.0" author="JVThomas">
+  <changeSet id="70.0" author="JVThomas">
     <addForeignKeyConstraint baseColumnNames="institution_id"
         baseTableName="dacuser"
         constraintName="FK_institution_dacuser"

--- a/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
@@ -166,8 +166,8 @@ public class DAOTestHelper {
         });
         createdUserIds.forEach(id -> {
             userPropertyDAO.deleteAllPropertiesByUser(id);
-            userRoleDAO.findRolesByUserId(id).
-                    forEach(ur -> userRoleDAO.removeSingleUserRole(ur.getUserId(), ur.getRoleId()));
+            userRoleDAO.findRolesByUserId(id)
+                    .forEach(ur -> userRoleDAO.removeSingleUserRole(ur.getUserId(), ur.getRoleId()));
             userDAO.deleteUserById(id);
         });
         createdDataAccessRequestReferenceIds.forEach(d -> {

--- a/src/test/java/org/broadinstitute/consent/http/db/UserDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/UserDAOTest.java
@@ -190,6 +190,7 @@ public class UserDAOTest extends DAOTestHelper {
                 );
         User user2 = userDAO.findUserById(user.getDacUserId());
         assertEquals(user2.getAdditionalEmail(), newEmail);
+        assertEquals(user2.getInstitution().getId(), firstInstitute.getId());
     }
 
     @Test

--- a/src/test/java/org/broadinstitute/consent/http/db/UserDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/UserDAOTest.java
@@ -38,7 +38,7 @@ public class UserDAOTest extends DAOTestHelper {
         addUserRole(UserRoles.ADMIN.getRoleId(), user.getDacUserId());
         addUserRole(UserRoles.RESEARCHER.getRoleId(), user.getDacUserId());
         addUserRole(UserRoles.DATAOWNER.getRoleId(), user.getDacUserId());
-
+        
         User user2 = userDAO.findUserById(user.getDacUserId());
         assertNotNull(user2);
         assertEquals(user.getEmail(), user2.getEmail());
@@ -52,6 +52,13 @@ public class UserDAOTest extends DAOTestHelper {
             .anyMatch(r -> r.getRoleId().equals(UserRoles.RESEARCHER.getRoleId())));
         assertTrue(user2.getRoles().stream()
             .anyMatch(r -> r.getRoleId().equals(UserRoles.DATAOWNER.getRoleId())));
+        
+        //assert institution base data is present if available
+        User user3 = createUserWithInstitution();
+        User queriedUser3 = userDAO.findUserById(user3.getDacUserId());
+        assert(queriedUser3.getDacUserId()).equals(user3.getDacUserId());
+        assertNotNull(queriedUser3.getInstitutionId());
+        assert(queriedUser3.getInstitution().getId()).equals(user3.getInstitution().getId());
     }
 
     @Test

--- a/src/test/java/org/broadinstitute/consent/http/db/UserDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/UserDAOTest.java
@@ -14,7 +14,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import org.apache.commons.lang3.RandomStringUtils;
-import org.apache.commons.lang3.RandomUtils;
 import org.broadinstitute.consent.http.enumeration.UserFields;
 import org.broadinstitute.consent.http.enumeration.RoleStatus;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
@@ -22,6 +21,7 @@ import org.broadinstitute.consent.http.models.Consent;
 import org.broadinstitute.consent.http.models.Dac;
 import org.broadinstitute.consent.http.models.DataSet;
 import org.broadinstitute.consent.http.models.Election;
+import org.broadinstitute.consent.http.models.Institution;
 import org.broadinstitute.consent.http.models.UserProperty;
 import org.broadinstitute.consent.http.models.User;
 import org.junit.Assert;
@@ -180,13 +180,13 @@ public class UserDAOTest extends DAOTestHelper {
     @Test
     public void testUpdateDACUser_case1() {
         User user = createUser();
+        Institution firstInstitute = createInstitution();
         String newEmail = getRandomEmailAddress();
-        Integer institutionId = getRandomInstitutionId();
         userDAO.updateUser(
                 "Dac User Test",
                 user.getDacUserId(),
                 newEmail,
-                institutionId
+                firstInstitute.getId()
                 );
         User user2 = userDAO.findUserById(user.getDacUserId());
         assertEquals(user2.getAdditionalEmail(), newEmail);
@@ -380,10 +380,5 @@ public class UserDAOTest extends DAOTestHelper {
         String user = RandomStringUtils.randomAlphanumeric(20);
         String domain = RandomStringUtils.randomAlphanumeric(10);
         return user + "@" + domain + ".org";
-    }
-
-    private Integer getRandomInstitutionId() {
-        Integer institutionId = RandomUtils.nextInt(1, 10);
-        return institutionId;
     }
 }


### PR DESCRIPTION
Addresses [DUOS-1322](https://broadworkbench.atlassian.net/browse/DUOS-1322)

PR adds Institution (if available) to the user response of `UserDAO.findUserById()`. PR includes updates to query, `UserWithRolesReducer`, associated tests, as well as add a foreign key restraint for `dacuser.institution_id` (needed for test teardown scripts, but it should be present regardless).

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
