### PR TITLE
DUOS-1339[risk=no] Added email to getSOByInstitution response

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/UserDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/UserDAO.java
@@ -192,7 +192,7 @@ public interface UserDAO extends Transactional<UserDAO> {
     List<User> findUsersByInstitution(@Bind("institutionId") Integer institutionId);
 
     @RegisterBeanMapper(value = User.class)
-    @SqlQuery("SELECT u.dacuserid, u.displayname FROM dacuser u "
+    @SqlQuery("SELECT u.dacuserid, u.displayname, u.email FROM dacuser u "
       + " LEFT JOIN user_role ur ON ur.user_id = u.dacuserid "
       + " LEFT JOIN roles r ON r.roleid = ur.role_id "
       + " WHERE LOWER(r.name) = 'signingofficial' "

--- a/src/main/java/org/broadinstitute/consent/http/service/UserService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/UserService.java
@@ -53,10 +53,12 @@ public class UserService {
     public class SimplifiedUser {
         public final String displayName;
         public final Integer userId;
+        public final String email;
 
         public SimplifiedUser(User user) {
             this.displayName = user.getDisplayName();
             this.userId = user.getDacUserId();
+            this.email = user.getEmail();
         };
     }
 

--- a/src/test/java/org/broadinstitute/consent/http/db/UserDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/UserDAOTest.java
@@ -369,9 +369,11 @@ public class UserDAOTest extends DAOTestHelper {
         User user = createUserWithInstitution();
         Integer institutionId = user.getInstitutionId();
         String displayName = user.getDisplayName();
+        String email = user.getEmail();
         List<User> users = userDAO.getSOsByInstitution( institutionId);
         assertEquals(1, users.size());
         assertEquals(displayName, users.get(0).getDisplayName());
+        assertEquals(email, users.get(0).getEmail());
 
         List<User> differentInstitutionUsers = userDAO.getSOsByInstitution( institutionId + 1);
         assertEquals(0, differentInstitutionUsers.size());

--- a/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
@@ -322,6 +322,7 @@ public class UserServiceTest {
         List<SimplifiedUser> users = service.findSOsByInstitutionId(institutionId);
         assertEquals(3, users.size());
         assertEquals(u.getDisplayName(), users.get(0).displayName);
+        assertEquals(u.getEmail(), users.get(0).email);
     }
 
     @Test


### PR DESCRIPTION
Addresses [DUOS-1339](https://broadworkbench.atlassian.net/browse/DUOS-1339)

Back-end portion of DUOS-1339, this PR adds email to the `getSOByInstitution()` query, which is needed in the front end for the UI to distinguish between users on a dropdown list that share the same name.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
