### PR TITLE
[DUOS-1350][risk=no] Omit the user's create date on update

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/models/User.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/User.java
@@ -98,36 +98,14 @@ public class User {
     public User(String json) {
         Gson gson = new Gson();
         JsonObject userJsonObject = gson.fromJson(json, JsonObject.class);
-        // Create Date can come in differently, either as a long or a string.
-        // Handle known cases here.
-        String createDateFieldName = "createDate";
-        Date createDate = null;
-        if (userJsonObject.has(createDateFieldName)) {
-            JsonElement createDateElement = userJsonObject.get(createDateFieldName);
-            try {
-                createDate = new Date(createDateElement.getAsLong());
-            } catch (NumberFormatException nfe) {
-                // Known date formats createDate could be in:
-                //   * "Oct 28, 2020"
-                SimpleDateFormat sdf = new SimpleDateFormat("MMM dd, yyyy");
-                try {
-                    createDate = sdf.parse(createDateElement.getAsString());
-                } catch (Exception e) {
-                    LoggerFactory
-                        .getLogger(this.getClass())
-                        .error("Unable to parse create date: " + e.getMessage());
-                }
-            }
-            // Remove this from the JSON so we don't re-process it in `gson.fromJson(String, User)`
-            userJsonObject.remove(createDateFieldName);
+        // There are no cases where we want to pull the create date from user-provided data.
+        if (userJsonObject.has("createDate")) {
+            userJsonObject.remove("createDate");
         }
         User u = gson.fromJson(userJsonObject.toString(), User.class);
         setUserId(u);
         setEmail(u);
         setDisplayName(u);
-        if (Objects.nonNull(createDate)) {
-            setCreateDate(createDate);
-        }
         setAdditionalEmail(u);
         setEmailPreference(u);
         setRoles(u);
@@ -199,7 +177,7 @@ public class User {
         this.dacUserId = dacUserId;
     }
 
-    public String getEmail() { 
+    public String getEmail() {
         return email;
     }
 

--- a/src/main/java/org/broadinstitute/consent/http/models/User.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/User.java
@@ -104,8 +104,8 @@ public class User {
         JsonObject userJsonObject = gson.fromJson(json, JsonObject.class);
         // There are no cases where we want to pull the create date/update date from user-provided data.
         // Nor do we need to retrieve the full institution object from user-provided data.
-        userJsonObject = filterFields(userJsonObject, Arrays.asList("createDate", "institution"));
-        User u = gson.fromJson(userJsonObject.toString(), User.class);
+        JsonObject filteredUserJsonObject = filterFields(userJsonObject, Arrays.asList("createDate", "institution"));
+        User u = gson.fromJson(filteredUserJsonObject.toString(), User.class);
         setUserId(u);
         setEmail(u);
         setDisplayName(u);

--- a/src/main/java/org/broadinstitute/consent/http/models/User.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/User.java
@@ -95,7 +95,7 @@ public class User {
      * This method is intended to reconstruct a User object from a supplied JSON string
      * for primary fields and roles. Other associated objects are not intended to be parsed
      * using this method since it comes from user-supplied data and may conflict with what
-     * system knows about those associations.
+     * the system knows about those associations.
      *
      * @param json A json string that may or may not be correctly structured as a DACUser
      */

--- a/src/main/java/org/broadinstitute/consent/http/models/User.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/User.java
@@ -92,6 +92,10 @@ public class User {
 
     /**
      * Convenience method for backwards compatibility support for older clients.
+     * This method is intended to reconstruct a User object from a supplied JSON string
+     * for primary fields and roles. Other associated objects are not intended to be parsed
+     * using this method since it comes from user-supplied data and may conflict with what
+     * system knows about those associations.
      *
      * @param json A json string that may or may not be correctly structured as a DACUser
      */
@@ -99,13 +103,8 @@ public class User {
         Gson gson = new Gson();
         JsonObject userJsonObject = gson.fromJson(json, JsonObject.class);
         // There are no cases where we want to pull the create date/update date from user-provided data.
-        userJsonObject = filterFields(userJsonObject, Collections.singletonList("createDate"));
-        if (userJsonObject.has("institution")) {
-            JsonObject institutionJsonObject = userJsonObject.get("institution").getAsJsonObject();
-            userJsonObject.remove("institution");
-            JsonObject filteredInstitution = filterFields(institutionJsonObject, Arrays.asList("createDate", "updateDate"));
-            userJsonObject.add("institution", filteredInstitution);
-        }
+        // Nor do we need to retrieve the full institution object from user-provided data.
+        userJsonObject = filterFields(userJsonObject, Arrays.asList("createDate", "institution"));
         User u = gson.fromJson(userJsonObject.toString(), User.class);
         setUserId(u);
         setEmail(u);
@@ -116,7 +115,6 @@ public class User {
         setStatus(u);
         setRationale(u);
         setInstitutionId(u);
-        setInstitution(u);
     }
 
     /**

--- a/src/main/java/org/broadinstitute/consent/http/models/User.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/User.java
@@ -12,7 +12,6 @@ import org.broadinstitute.consent.http.enumeration.UserRoles;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Objects;
@@ -104,7 +103,9 @@ public class User {
         JsonObject userJsonObject = gson.fromJson(json, JsonObject.class);
         // There are no cases where we want to pull the create date/update date from user-provided data.
         // Nor do we need to retrieve the full institution object from user-provided data.
-        JsonObject filteredUserJsonObject = filterFields(userJsonObject, Arrays.asList("createDate", "institution"));
+        JsonObject filteredUserJsonObject = filterFields(
+                userJsonObject,
+                Arrays.asList("createDate", "institution", "libraryCards"));
         User u = gson.fromJson(filteredUserJsonObject.toString(), User.class);
         setUserId(u);
         setEmail(u);

--- a/src/test/java/org/broadinstitute/consent/http/resources/DACUserResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DACUserResourceTest.java
@@ -159,35 +159,18 @@ public class DACUserResourceTest {
     }
 
     @Test
-    public void testConvertJsonToDACUserNumericDateCase() {
-        String jsonRole = "[{\"roleId\": 1, \"name\":\"name\", \"what\": \"Huh?\", \"rationale\": \"rationale\", \"status\": \"pending\"}]";
-        String json = "{\"dacUserId\": 1, \"email\":\"email\", \"what\": \"Huh?\", \"createDate\": 1302828677828, \"additionalEmail\": \"additionalEmail\", \"emailPreference\": false, \"roles\": " + jsonRole + "}";
-        User user = new User(json);
-        Assert.assertNotNull(user);
-        Assert.assertNotNull(user.getCreateDate());
-        Assert.assertEquals(user.getDacUserId().intValue(), 1);
-        Assert.assertEquals(user.getEmail(), "email");
-        Assert.assertEquals(user.getAdditionalEmail(), "additionalEmail");
-        Assert.assertEquals(user.getEmailPreference(), false);
-        Assert.assertFalse(user.getRoles().isEmpty());
-        Assert.assertEquals(user.getRoles().get(0).getRoleId().intValue(), 1);
-        System.out.println(user.toString());
-    }
-
-    @Test
-    public void testConvertJsonToDACUserStringDateCase() {
+    public void testConvertJsonToDACUserDateIgnoredCase() {
         String jsonRole = "[{\"roleId\": 1, \"name\":\"name\", \"what\": \"Huh?\", \"rationale\": \"rationale\", \"status\": \"pending\"}]";
         String json = "{\"dacUserId\": 1, \"email\":\"email\", \"what\": \"Huh?\", \"createDate\": \"Oct 28, 2020\", \"additionalEmail\": \"additionalEmail\", \"emailPreference\": false, \"roles\": " + jsonRole + "}";
         User user = new User(json);
         Assert.assertNotNull(user);
-        Assert.assertNotNull(user.getCreateDate());
+        Assert.assertNull(user.getCreateDate());
         Assert.assertEquals(user.getDacUserId().intValue(), 1);
         Assert.assertEquals(user.getEmail(), "email");
         Assert.assertEquals(user.getAdditionalEmail(), "additionalEmail");
         Assert.assertEquals(user.getEmailPreference(), false);
         Assert.assertFalse(user.getRoles().isEmpty());
         Assert.assertEquals(user.getRoles().get(0).getRoleId().intValue(), 1);
-        System.out.println(user.toString());
     }
 
     @Test
@@ -203,7 +186,6 @@ public class DACUserResourceTest {
         Assert.assertEquals(user.getEmailPreference(), false);
         Assert.assertFalse(user.getRoles().isEmpty());
         Assert.assertEquals(user.getRoles().get(0).getRoleId().intValue(), 1);
-        System.out.println(user.toString());
     }
 
     private User createDacUser(UserRoles roles) {


### PR DESCRIPTION
## Addresses
Consent side of https://broadworkbench.atlassian.net/browse/DUOS-1350

See also: https://github.com/DataBiosphere/duos-ui/pull/1183

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
