### PR TITLE
DUOS-1335[risk=no]Add Library Cards to findUserById response

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/models/User.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/User.java
@@ -57,6 +57,8 @@ public class User {
 
     private Institution institution;
 
+    private List<LibraryCard> libraryCards;
+
     public User() {
     }
 
@@ -297,6 +299,14 @@ public class User {
 
     public Institution getInstitution() {
         return institution;
+    }
+
+    public void setLibraryCards(List<LibraryCard> cards) {
+        this.libraryCards = cards;
+    }
+    
+    public List<LibraryCard> getLibraryCards() {
+        return this.libraryCards;
     }
 
     public void addRole(UserRole userRole) {

--- a/src/main/java/org/broadinstitute/consent/http/service/UserService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/UserService.java
@@ -84,6 +84,8 @@ public class UserService {
         if (user == null) {
             throw new NotFoundException("Unable to find user with id: " + id);
         }
+        List<LibraryCard> cards = libraryCardDAO.findLibraryCardsByUserId(user.getDacUserId());
+        user.setLibraryCards(cards);
         return user;
     }
 

--- a/src/test/java/org/broadinstitute/consent/http/db/LibraryCardDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/LibraryCardDAOTest.java
@@ -142,6 +142,19 @@ public class LibraryCardDAOTest extends DAOTestHelper {
     assertNotNull(libraryCards);
     assertEquals(1, libraryCards.size());
     assertEquals(user.getEmail(), libraryCards.get(0).getUserEmail());
+    assertEquals(libraryCard.getId(), libraryCards.get(0).getId());
+  }
+
+  @Test
+  public void testFindAllLibraryCardsByUserId() {
+    User user = createUser();
+    LibraryCard one = createLibraryCard(user);
+    LibraryCard two = createLibraryCard(user);
+    List<LibraryCard> libraryCards = libraryCardDAO.findLibraryCardsByUserId(user.getDacUserId());
+    assertNotNull(libraryCards);
+    assertEquals(2, libraryCards.size());
+    assertEquals(one.getId(), libraryCards.get(0).getId());
+    assertEquals(two.getId(), libraryCards.get(1).getId());
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
@@ -163,6 +163,24 @@ public class UserServiceTest {
     }
 
     @Test
+    public void testFindUserById_HasLibraryCards() {
+        User u = generateUser();
+        LibraryCard one = generateLibraryCard(u);
+        LibraryCard two = generateLibraryCard(u);
+        List<LibraryCard> cards = Arrays.asList(one, two);
+        when(userDAO.findUserById(any())).thenReturn(u);
+        when(libraryCardDAO.findLibraryCardsByUserId(any())).thenReturn(cards);
+        initService();
+
+        User user = service.findUserById(u.getDacUserId());
+        assertNotNull(user);
+        assertNotNull(user.getLibraryCards());
+        assertEquals(user.getLibraryCards().size(), 2);
+        assertEquals(user.getLibraryCards().get(0).getId(), one.getId());
+        assertEquals(user.getLibraryCards().get(1).getId(), two.getId());
+    }
+
+    @Test
     public void testFindUserByIdNoRoles() {
         User u = generateUser();
         when(userDAO.findUserById(any())).thenReturn(u);
@@ -388,6 +406,14 @@ public class UserServiceTest {
         libraryCard.setInstitutionId(RandomUtils.nextInt(1, 10));
         libraryCard.setUserEmail(email);
         libraryCard.setUserName(RandomStringUtils.randomAlphabetic(RandomUtils.nextInt(1, 10)));
+        return libraryCard;
+    }
+
+    private LibraryCard generateLibraryCard(User user) {
+        LibraryCard libraryCard = new LibraryCard();
+        libraryCard.setId(RandomUtils.nextInt(1, 10));
+        libraryCard.setUserId(user.getDacUserId());
+        libraryCard.setInstitutionId(RandomUtils.nextInt(1,10));
         return libraryCard;
     }
 


### PR DESCRIPTION
Addresses [DUOS-1335](https://broadworkbench.atlassian.net/browse/DUOS-1335) (back-end component of the ticket)

PR adds library cards to the User object within the `findUserById` method for the front-end response. PR also includes updates to the User class and associated tests.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
