### PR TITLE
[DUOS-1362][risk=no] Return empty list if no institution for user

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
@@ -199,11 +199,11 @@ public class UserResource extends Resource {
     public Response getSOsForInstitution(@Auth AuthUser authUser) {
         try {
             User user = userService.findUserByEmail(authUser.getName());
-            if (Objects.isNull(user.getInstitutionId())) {
-                throw new NotFoundException("Current user, " + user.getDisplayName() + ", does not have an institution.");
+            if (Objects.nonNull(user.getInstitutionId())) {
+                List<SimplifiedUser> signingOfficials = userService.findSOsByInstitutionId(user.getInstitutionId());
+                return Response.ok().entity(signingOfficials).build();
             }
-            List<SimplifiedUser> signingOfficials = userService.findSOsByInstitutionId(user.getInstitutionId());
-            return Response.ok().entity(signingOfficials).build();
+            return Response.ok().entity(Collections.emptyList()).build();
         } catch (Exception e) {
             return createExceptionResponse(e);
         }

--- a/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
@@ -2,6 +2,8 @@ package org.broadinstitute.consent.http.resources;
 
 import com.google.api.client.http.HttpStatusCodes;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
@@ -277,6 +279,7 @@ public class UserResourceTest {
     assertEquals(400, response.getStatus());
   }
 
+  @SuppressWarnings({"unchecked"})
   @Test
   public void testGetSOsForInstitution() {
     User user = createUserWithInstitution();
@@ -286,17 +289,22 @@ public class UserResourceTest {
     initResource();
     Response response = userResource.getSOsForInstitution(authUser);
     assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+    var body = (List<UserService.SimplifiedUser>) response.getEntity();
+    assertFalse(body.isEmpty());
+    assertEquals(so.getDisplayName(), body.get(0).displayName);
   }
 
+  @SuppressWarnings("rawtypes")
   @Test
   public void testGetSOsForInstitution_NoInstitution() {
     User user = createUserWithRole();
-    User so = createUserWithRole();
     when(userService.findUserByEmail(any())).thenReturn(user);
-    when(userService.findSOsByInstitutionId(any())).thenReturn(Arrays.asList(new UserService.SimplifiedUser(so), new UserService.SimplifiedUser(so)));
+    when(userService.findSOsByInstitutionId(any())).thenReturn(Collections.emptyList());
     initResource();
     Response response = userResource.getSOsForInstitution(authUser);
-    assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
+    assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+    var body = (List) response.getEntity();
+    assertTrue(body.isEmpty());
   }
 
   @Test


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-1362

Tested locally with the UI and this avoids unnecessary 404 reporting

## Changes
Minor update to return an empty list if there is no institution for the user.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
