### PR TITLE
[DUOS-1364][risk=no] Fix thread safety

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/CounterDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/CounterDAO.java
@@ -11,11 +11,8 @@ import org.jdbi.v3.sqlobject.transaction.Transactional;
 @RegisterRowMapper(CounterMapper.class)
 public interface CounterDAO extends Transactional<CounterDAO> {
 
-    @SqlUpdate("INSERT INTO counter (name, count) VALUES (:name, :count) ")
-    void addCounter(@Bind("name") String name, @Bind("count") Integer count);
-
-    @SqlQuery("SELECT MAX(count) FROM counter c WHERE name = :name ")
-    Integer getMaxCountByName(@Bind("name") String name);
+  @SqlUpdate("INSERT INTO counter (name, count) VALUES (:name, :count) ")
+  void addCounter(@Bind("name") String name, @Bind("count") Integer count);
 
   @SqlQuery(
       " WITH m AS ( "
@@ -27,7 +24,6 @@ public interface CounterDAO extends Transactional<CounterDAO> {
           + " SELECT MAX(count) FROM m WHERE name = :name ")
   Integer incrementCountByName(@Bind("name") String name);
 
-    @SqlUpdate("DELETE FROM counter")
-    void deleteAll();
-
+  @SqlUpdate("DELETE FROM counter")
+  void deleteAll();
 }

--- a/src/main/java/org/broadinstitute/consent/http/db/CounterDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/CounterDAO.java
@@ -1,6 +1,5 @@
 package org.broadinstitute.consent.http.db;
 
-import java.util.List;
 import org.broadinstitute.consent.http.db.mapper.CounterMapper;
 import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
 import org.jdbi.v3.sqlobject.customizer.Bind;
@@ -18,11 +17,15 @@ public interface CounterDAO extends Transactional<CounterDAO> {
     @SqlQuery("SELECT MAX(count) FROM counter c WHERE name = :name ")
     Integer getMaxCountByName(@Bind("name") String name);
 
-    @SqlUpdate("UPDATE counter " +
-            "   SET count = subquery.max_count + 1 " +
-            "   FROM (SELECT MAX(count) as max_count FROM counter WHERE name = :name) AS subquery " +
-            "   WHERE name = :name")
-    void incrementCountByName(@Bind("name") String name);
+  @SqlQuery(
+      " WITH m AS ( "
+          + "    UPDATE counter SET count = subquery.max_count + 1 "
+          + "    FROM (SELECT MAX(count) as max_count FROM counter WHERE name = :name) AS subquery "
+          + "    WHERE name = :name "
+          + "    RETURNING * "
+          + " ) "
+          + " SELECT MAX(count) FROM m WHERE name = :name ")
+  Integer incrementCountByName(@Bind("name") String name);
 
     @SqlUpdate("DELETE FROM counter")
     void deleteAll();

--- a/src/main/java/org/broadinstitute/consent/http/service/CounterService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/CounterService.java
@@ -1,9 +1,6 @@
 package org.broadinstitute.consent.http.service;
 
 import com.google.inject.Inject;
-import java.util.List;
-import java.util.Objects;
-import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.consent.http.db.CounterDAO;
 
 public class CounterService {
@@ -17,8 +14,7 @@ public class CounterService {
     }
 
     public Integer getNextDarSequence() {
-        counterDAO.incrementCountByName(DAR_COUNTER);
-        return counterDAO.getMaxCountByName(DAR_COUNTER);
+        return counterDAO.incrementCountByName(DAR_COUNTER);
     }
 
 }

--- a/src/test/java/org/broadinstitute/consent/http/db/CounterDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/CounterDAOTest.java
@@ -1,40 +1,39 @@
 package org.broadinstitute.consent.http.db;
 
-import static org.junit.Assert.assertEquals;
-
 import org.apache.commons.lang3.RandomStringUtils;
 import org.broadinstitute.consent.http.service.CounterService;
 import org.junit.After;
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
+
 public class CounterDAOTest extends DAOTestHelper {
 
-    @After
-    public void tearDown() {
-        counterDAO.deleteAll();
-    }
+  @After
+  public void tearDown() {
+    counterDAO.deleteAll();
+  }
 
-    @Test
-    public void testIncrementDarCounter() {
-        counterDAO.addCounter(CounterService.DAR_COUNTER, 0);
-        int count = 5;
-        for (int i = 0; i < count; i++) {
-            counterDAO.incrementCountByName(CounterService.DAR_COUNTER);
-        }
-        Integer lastCount = counterDAO.getMaxCountByName(CounterService.DAR_COUNTER);
-        assertEquals(Integer.valueOf(count), lastCount);
+  @Test
+  public void testIncrementDarCounter() {
+    counterDAO.addCounter(CounterService.DAR_COUNTER, 0);
+    int count = 5;
+    Integer lastCount = 0;
+    for (int i = 0; i < count; i++) {
+      lastCount = counterDAO.incrementCountByName(CounterService.DAR_COUNTER);
     }
+    assertEquals(Integer.valueOf(count), lastCount);
+  }
 
-    @Test
-    public void testIncrementRandomCounter() {
-        String name = RandomStringUtils.random(10, true, false);
-        counterDAO.addCounter(name, 0);
-        int count = 5;
-        for (int i = 0; i < count; i++) {
-            counterDAO.incrementCountByName(name);
-        }
-        Integer maxCount = counterDAO.getMaxCountByName(name);
-        assertEquals(count, maxCount.intValue());
+  @Test
+  public void testIncrementRandomCounter() {
+    String name = RandomStringUtils.random(10, true, false);
+    counterDAO.addCounter(name, 0);
+    int count = 5;
+    Integer maxCount = 0;
+    for (int i = 0; i < count; i++) {
+      maxCount = counterDAO.incrementCountByName(name);
     }
-
+    assertEquals(count, maxCount.intValue());
+  }
 }

--- a/src/test/java/org/broadinstitute/consent/http/service/CounterServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/CounterServiceTest.java
@@ -1,15 +1,14 @@
 package org.broadinstitute.consent.http.service;
 
-import static org.junit.Assert.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.when;
-
 import org.broadinstitute.consent.http.db.CounterDAO;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 
 public class CounterServiceTest {
 
@@ -20,7 +19,7 @@ public class CounterServiceTest {
 
     @Before
     public void setUp() {
-        MockitoAnnotations.initMocks(this);
+        MockitoAnnotations.openMocks(this);
     }
 
     private void initService() {
@@ -30,8 +29,7 @@ public class CounterServiceTest {
     @Test
     public void testGetNextDarSequence() {
         int count = 10;
-        doNothing().when(counterDAO).incrementCountByName(any());
-        when(counterDAO.getMaxCountByName(any())).thenReturn(count);
+        when(counterDAO.incrementCountByName(any())).thenReturn(count);
         initService();
 
         Integer seq = service.getNextDarSequence();

--- a/src/test/java/org/broadinstitute/consent/http/service/CounterServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/CounterServiceTest.java
@@ -12,28 +12,26 @@ import static org.mockito.Mockito.when;
 
 public class CounterServiceTest {
 
-    @Mock
-    private CounterDAO counterDAO;
+  @Mock private CounterDAO counterDAO;
 
-    private CounterService service;
+  private CounterService service;
 
-    @Before
-    public void setUp() {
-        MockitoAnnotations.openMocks(this);
-    }
+  @Before
+  public void setUp() {
+    MockitoAnnotations.openMocks(this);
+  }
 
-    private void initService() {
-        service = new CounterService(counterDAO);
-    }
+  private void initService() {
+    service = new CounterService(counterDAO);
+  }
 
-    @Test
-    public void testGetNextDarSequence() {
-        int count = 10;
-        when(counterDAO.incrementCountByName(any())).thenReturn(count);
-        initService();
+  @Test
+  public void testGetNextDarSequence() {
+    int count = 10;
+    when(counterDAO.incrementCountByName(any())).thenReturn(count);
+    initService();
 
-        Integer seq = service.getNextDarSequence();
-        assertEquals(count, seq.intValue());
-    }
-
+    Integer seq = service.getNextDarSequence();
+    assertEquals(count, seq.intValue());
+  }
 }


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-1364

Note to reviewers, it is recommended to hide whitespace changes.

## Changes
Update the query to update + select the max value so we don't have to run two queries to get the max count. Integrating them into a single query makes it a single transaction and protects against simultaneous calls making out-of-order updates+selects.

See also: https://www.postgresql.org/docs/9.3/queries-with.html#QUERIES-WITH-MODIFYING

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
