### PR TITLE
DUOS-1345[risk=no]Refactor getDatasetIds() and other getters for list fields on darData

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/models/DarDecisionMetrics.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DarDecisionMetrics.java
@@ -124,8 +124,8 @@ public class DarDecisionMetrics implements DecisionMetrics {
       (Objects.nonNull(dar.getData())) ?
         (int) Streams
           .concat(
-            CollectionUtils.emptyIfNull(dar.getData().getLabCollaborators()).stream(),
-            CollectionUtils.emptyIfNull(dar.getData().getInternalCollaborators()).stream())
+            dar.getData().getLabCollaborators().stream(),
+            dar.getData().getInternalCollaborators().stream())
           .filter(Objects::nonNull)
           .map(Collaborator::getEmail)
           .filter(Objects::nonNull)

--- a/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequestData.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequestData.java
@@ -386,6 +386,9 @@ public class DataAccessRequestData {
     }
 
     public List<OntologyEntry> getOntologies() {
+        if (Objects.isNull(ontologies)) {
+            return Collections.emptyList();
+        }
         return ontologies;
     }
 
@@ -498,6 +501,9 @@ public class DataAccessRequestData {
     }
 
     public List<DatasetEntry> getDatasets() {
+        if (Objects.isNull(datasets)) {
+            return Collections.emptyList();
+        }
         return datasets;
     }
 
@@ -562,6 +568,9 @@ public class DataAccessRequestData {
     }
 
     public List<Integer> getDatasetIds() {
+        if (Objects.isNull(datasetIds)) {
+            return Collections.emptyList();
+        }
         return datasetIds;
     }
 
@@ -570,6 +579,9 @@ public class DataAccessRequestData {
     }
 
     public List<DatasetDetailEntry> getDatasetDetail() {
+        if (Objects.isNull(datasetDetail)) {
+            return Collections.emptyList();
+        }
         return datasetDetail;
     }
 
@@ -746,6 +758,9 @@ public class DataAccessRequestData {
     }
 
     public List<Collaborator> getLabCollaborators() {
+        if (Objects.isNull(labCollaborators)) {
+            return Collections.emptyList();
+        }
         return labCollaborators;
     }
 
@@ -755,6 +770,9 @@ public class DataAccessRequestData {
     }
 
     public List<Collaborator> getInternalCollaborators() {
+        if (Objects.isNull(internalCollaborators)) {
+            return Collections.emptyList();
+        }
         return internalCollaborators;
     }
 
@@ -764,6 +782,9 @@ public class DataAccessRequestData {
     }
 
     public List<Collaborator> getExternalCollaborators() {
+        if (Objects.isNull(externalCollaborators)) {
+            return Collections.emptyList();
+        }
         return externalCollaborators;
     }
 
@@ -830,8 +851,7 @@ public class DataAccessRequestData {
 
     // Validate all ontology entries
     private static void validateOntologyEntries(DataAccessRequestData data) {
-        if (Objects.nonNull(data) &&
-            Objects.nonNull(data.getOntologies())
+        if (Objects.nonNull(data)
             && !data.getOntologies().isEmpty()) {
             List<OntologyEntry> filteredEntries =
                 data.getOntologies().stream()

--- a/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
@@ -175,7 +175,7 @@ public class DataAccessRequestResource extends Resource {
      */
     private Optional<Integer> getDatasetIdForDarId(String id) {
         DataAccessRequest dar = dataAccessRequestService.findByReferenceId(id);
-        List<Integer> datasetIdList = (Objects.nonNull(dar.getData()) && Objects.nonNull(dar.getData().getDatasetIds())) ?
+        List<Integer> datasetIdList = (Objects.nonNull(dar.getData())) ?
                 dar.getData().getDatasetIds() :
                 Collections.emptyList();
         if (datasetIdList == null || datasetIdList.isEmpty()) {

--- a/src/main/java/org/broadinstitute/consent/http/resources/ElectionReviewResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/ElectionReviewResource.java
@@ -71,7 +71,7 @@ public class ElectionReviewResource extends Resource {
         Election consentElection = electionService.getConsentElectionByDARElectionId(election.getElectionId());
         DataAccessRequest dar = darService.findByReferenceId(election.getReferenceId());
         List<Integer> dataSetId = new ArrayList<>();
-        if (Objects.nonNull(dar) && Objects.nonNull(dar.getData()) && Objects.nonNull(dar.getData().getDatasetIds())) {
+        if (Objects.nonNull(dar) && Objects.nonNull(dar.getData())) {
             dataSetId.addAll(dar.getData().getDatasetIds());
         }
         Consent consent = consentService.getConsentFromDatasetID(dataSetId.get(0));

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessReportsParser.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessReportsParser.java
@@ -12,7 +12,6 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Calendar;
-import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Objects;
@@ -107,7 +106,7 @@ public class DataAccessReportsParser {
         List<Integer> dataSetIds = new ArrayList<>();
         List<String> dataSetUUIds = new ArrayList<>();
         if (Objects.nonNull(dar) && Objects.nonNull(dar.getData())) {
-            List<DatasetDetailEntry> dataSetDetails = Objects.nonNull(dar.getData().getDatasetDetail()) ? dar.getData().getDatasetDetail() : Collections.emptyList();
+            List<DatasetDetailEntry> dataSetDetails = dar.getData().getDatasetDetail();
             for (DatasetDetailEntry detail : dataSetDetails) {
                 try {
                     Integer id = Integer.parseInt(detail.getDatasetId());

--- a/src/main/java/org/broadinstitute/consent/http/service/UseRestrictionConverter.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/UseRestrictionConverter.java
@@ -135,12 +135,11 @@ public class UseRestrictionConverter {
             //
             //    Diseases related entries
             //
-            if (Objects.nonNull(dar.getData().getOntologies())) {
-                List<String> ontologies = dar.getData().getOntologies()
-                    .stream().map(OntologyEntry::getId).collect(Collectors.toList());
-                if (CollectionUtils.isNotEmpty(ontologies)) {
-                    dataUse.setDiseaseRestrictions(ontologies);
-                }
+        
+            List<String> ontologies = dar.getData().getOntologies()
+                .stream().map(OntologyEntry::getId).collect(Collectors.toList());
+            if (CollectionUtils.isNotEmpty(ontologies)) {
+                dataUse.setDiseaseRestrictions(ontologies);
             }
 
             //


### PR DESCRIPTION
SCOPE:
- Add null checks to fields that are lists and return empty list
- Remove null checks where no longer necessary

ADDRESS: 
- https://broadworkbench.atlassian.net/browse/DUOS-1345

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
