### PR TITLE
[DUOS-1398][risk=no] Update version to 12 character hash

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/resources/VersionResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/VersionResource.java
@@ -37,7 +37,7 @@ public class VersionResource {
         return null;
     }
 
-    private class Version {
+    private static class Version {
         String hash;
         String version;
 

--- a/src/main/java/org/broadinstitute/consent/http/resources/VersionResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/VersionResource.java
@@ -47,10 +47,11 @@ public class VersionResource {
                 this.version = "error";
             } else {
                 JsonObject jsonObject = new Gson().fromJson(props, JsonObject.class);
-                String shortHash = Optional
+                String longHash = Optional
                         .ofNullable(jsonObject.get("git.commit.id"))
                         .orElse(new JsonPrimitive("error"))
-                        .getAsString().substring(0, 12);
+                        .getAsString();
+                String shortHash = longHash.substring(0, Math.min(longHash.length(), 12));
                 JsonElement buildVersion = jsonObject.get("git.build.version");
                 if (Objects.nonNull(buildVersion)) {
                     this.hash = shortHash;

--- a/src/main/java/org/broadinstitute/consent/http/resources/VersionResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/VersionResource.java
@@ -3,7 +3,7 @@ package org.broadinstitute.consent.http.resources;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import java.util.Objects;
+import com.google.gson.JsonPrimitive;
 import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -13,6 +13,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.Response;
 import java.nio.charset.Charset;
+import java.util.Objects;
 import java.util.Optional;
 
 @Path("/version")
@@ -46,10 +47,13 @@ public class VersionResource {
                 this.version = "error";
             } else {
                 JsonObject jsonObject = new Gson().fromJson(props, JsonObject.class);
-                JsonElement shortHash = jsonObject.get("git.commit.id.abbrev");
+                String shortHash = Optional
+                        .ofNullable(jsonObject.get("git.commit.id"))
+                        .orElse(new JsonPrimitive("error"))
+                        .getAsString().substring(0, 12);
                 JsonElement buildVersion = jsonObject.get("git.build.version");
-                if (Objects.nonNull(shortHash) && Objects.nonNull(buildVersion)) {
-                    this.hash = Optional.ofNullable(shortHash.getAsString()).orElse("error");
+                if (Objects.nonNull(buildVersion)) {
+                    this.hash = shortHash;
                     this.version = Optional.ofNullable(buildVersion.getAsString()).orElse("error");
                 }
             }

--- a/src/test/java/org/broadinstitute/consent/http/resources/VersionResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/VersionResourceTest.java
@@ -18,7 +18,7 @@ public class VersionResourceTest {
     @Test
     public void testGetVersion() {
         Response response = resources.target("/version").request().get();
-        Assert.assertEquals(response.getStatus(), 200);
+        Assert.assertEquals(200, response.getStatus());
     }
 
 }


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-1398

Since we use 12 character hashes everywhere, it makes more sense to show that value in the version endpoint.
See also: https://github.com/DataBiosphere/consent-ontology/pull/484

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
