### PR TITLE
DUOS-1252[risk=no]DarCollection DAO classes

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
@@ -19,6 +19,7 @@ import org.broadinstitute.consent.http.db.ConsentDAO;
 import org.broadinstitute.consent.http.db.CounterDAO;
 import org.broadinstitute.consent.http.db.DAOContainer;
 import org.broadinstitute.consent.http.db.DacDAO;
+import org.broadinstitute.consent.http.db.DarCollectionDAO;
 import org.broadinstitute.consent.http.db.DataAccessRequestDAO;
 import org.broadinstitute.consent.http.db.DatasetDAO;
 import org.broadinstitute.consent.http.db.DatasetAssociationDAO;
@@ -89,6 +90,7 @@ public class ConsentModule extends AbstractModule {
     private final WorkspaceAuditDAO workspaceAuditDAO;
     private final AssociationDAO associationDAO;
     private final DataAccessRequestDAO dataAccessRequestDAO;
+    private final DarCollectionDAO darCollectionDAO;
     private final InstitutionDAO institutionDAO;
     private final LibraryCardDAO libraryCardDAO;
 
@@ -123,6 +125,7 @@ public class ConsentModule extends AbstractModule {
         this.workspaceAuditDAO = this.jdbi.onDemand(WorkspaceAuditDAO.class);
         this.associationDAO = this.jdbi.onDemand(AssociationDAO.class);
         this.dataAccessRequestDAO = this.jdbi.onDemand(DataAccessRequestDAO.class);
+        this.darCollectionDAO = this.jdbi.onDemand(DarCollectionDAO.class);
         this.institutionDAO = this.jdbi.onDemand((InstitutionDAO.class));
         this.libraryCardDAO = this.jdbi.onDemand((LibraryCardDAO.class));
     }
@@ -142,6 +145,7 @@ public class ConsentModule extends AbstractModule {
         container.setCounterDAO(providesCounterDAO());
         container.setDacDAO(providesDacDAO());
         container.setDataAccessRequestDAO(providesDataAccessRequestDAO());
+        container.setDarCollectionDAO(providesDARCollectionDAO());
         container.setDatasetAssociationDAO(providesDatasetAssociationDAO());
         container.setDatasetDAO(providesDataSetDAO());
         container.setElectionDAO(providesElectionDAO());
@@ -325,6 +329,11 @@ public class ConsentModule extends AbstractModule {
     @Provides
     DataAccessRequestDAO providesDataAccessRequestDAO() {
         return dataAccessRequestDAO;
+    }
+
+    @Provides
+    DarCollectionDAO providesDARCollectionDAO() {
+        return darCollectionDAO;
     }
 
     @Provides

--- a/src/main/java/org/broadinstitute/consent/http/db/DAOContainer.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DAOContainer.java
@@ -13,6 +13,7 @@ public class DAOContainer {
   private CounterDAO counterDAO;
   private DacDAO dacDAO;
   private DataAccessRequestDAO dataAccessRequestDAO;
+  private DarCollectionDAO darCollectionDAO;
   private DatasetAssociationDAO datasetAssociationDAO;
   private DatasetDAO datasetDAO;
   private ElectionDAO electionDAO;
@@ -74,6 +75,15 @@ public class DAOContainer {
   public void setDataAccessRequestDAO(
       DataAccessRequestDAO dataAccessRequestDAO) {
     this.dataAccessRequestDAO = dataAccessRequestDAO;
+  }
+
+  public DarCollectionDAO getDarCollectionDAO() {
+    return darCollectionDAO;
+  }
+
+  public void setDarCollectionDAO(
+    DarCollectionDAO darCollectionDAO) {
+    this.darCollectionDAO = darCollectionDAO;
   }
 
   public DatasetAssociationDAO getDatasetAssociationDAO() {

--- a/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
@@ -17,20 +17,20 @@ import java.util.List;
 public interface DarCollectionDAO {
 
   final String getCollectionAndDars =
-      "SELECT c.*, dar.id AS dar_id, dar.reference_id AS dar_reference_id, dar.collection_id AS dar_collection_id, " +
+      "SELECT c.*, i.institution_name, u.displayname AS researcher, dar.id AS dar_id, dar.reference_id AS dar_reference_id, dar.collection_id AS dar_collection_id, " +
           "dar.draft AS dar_draft, dar.user_id AS dar_userId, dar.create_date AS dar_create_date, " +
           "dar.sort_date AS dar_sort_date, dar.submission_date AS dar_submission_date, " +
           "dar.update_date AS dar_update_date, (dar.data #>> '{}')::jsonb AS data, " +
-          "(dar.data #>> '{}')::jsonb ->> 'institution' as institution, " + 
-          "(dar.data #>> '{}')::jsonb ->> 'researcher' as researcher, " +
           "(dar.data #>> '{}')::jsonb ->> 'projectTitle' as projectTitle " +
       "FROM dar_collection c " + 
+      "INNER JOIN dacuser u ON u.dacuserid = c.create_user " +
+      "LEFT JOIN institution i ON i.institution_id = u.institution_id " +
       "INNER JOIN data_access_request dar ON c.collection_id = dar.collection_id ";
   
   final String filterQuery = 
-    "WHERE (dar.data #>> '{}')::jsonb ->> 'institution' ~* :institutionSearchTerm " +
+    "WHERE COALESCE(i.institution_name, '') ~* :institutionSearchTerm " +
     "AND (dar.data #>> '{}')::jsonb ->> 'projectTitle' ~* :projectSearchTerm " +
-    "AND (dar.data #>> '{}')::jsonb ->> 'researcher' ~* :researcherSearchTerm " +
+    "AND u.displayname ~* :researcherSearchTerm " +
     "AND c.dar_code ~* :darCodeSearchTerm " + 
     "AND EXISTS " +
         "(SELECT FROM jsonb_array_elements((dar.data #>> '{}')::jsonb -> 'datasets') dataset " +

--- a/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
@@ -3,6 +3,7 @@ package org.broadinstitute.consent.http.db;
 import org.broadinstitute.consent.http.db.mapper.DarCollectionReducer;
 import org.broadinstitute.consent.http.db.mapper.DataAccessRequestMapper;
 import org.broadinstitute.consent.http.models.DarCollection;
+import org.broadinstitute.consent.http.models.DataAccessRequest;
 import org.jdbi.v3.sqlobject.config.RegisterBeanMapper;
 import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
 import org.jdbi.v3.sqlobject.customizer.Bind;
@@ -20,8 +21,8 @@ public interface DarCollectionDAO {
    *
    * @return List<DarCollection>
    */
-  @RegisterBeanMapper(DarCollection.class)
-  @RegisterRowMapper(DataAccessRequestMapper.class)
+  @RegisterBeanMapper(value = DarCollection.class)
+  @RegisterBeanMapper(value = DataAccessRequest.class)
   @UseRowReducer(DarCollectionReducer.class)
   @SqlQuery(
     "SELECT * FROM dar_collection c "
@@ -48,7 +49,7 @@ public interface DarCollectionDAO {
       + "            submission_date, update_date AS dar_update_date, (data #>> '{}')::jsonb AS data "
       + "    FROM data_access_request) dar "
       + " ON c.collection_id = dar.dar_collection_id ")
-  List<DarCollection> findAllDARCollectionsWithFilters();
+  List<DarCollection> findAllDARCollectionsWithFilters(String sortField, String sortDirection, List<String> filterTerms);
   /**
    * Find the DARCollection and all of its Data Access Requests that contains the DAR with the given referenceId
    *
@@ -99,7 +100,15 @@ public interface DarCollectionDAO {
                             @Bind("createDate") Date createDate);
 
   /**
-   * Delete the DAR Collection with the given colelction ID
+   * Update the update user and update date of the DAR Collection with the given collection ID
+   */
+  @SqlUpdate("UPDATE dar_collection SET update_user = :updateUserId, update_date = :updateDate WHERE collection_id = :collectionId")
+  void updateDarCollection(@Bind("collectionId") Integer collectionId,
+                           @Bind("updateUserId") Integer updateUserId,
+                           @Bind("updateDate") Date updateDate);
+
+  /**
+   * Delete the DAR Collection with the given collection ID
    */
   @SqlUpdate("DELETE FROM dar_collection WHERE collection_id = :collectionId")
   void deleteByCollectionId(@Bind("collectionId") Integer collectionId);

--- a/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
@@ -5,6 +5,7 @@ import org.broadinstitute.consent.http.models.DarCollection;
 import org.broadinstitute.consent.http.models.DataAccessRequest;
 import org.jdbi.v3.sqlobject.config.RegisterBeanMapper;
 import org.jdbi.v3.sqlobject.customizer.Bind;
+import org.jdbi.v3.sqlobject.customizer.Define;
 import org.jdbi.v3.sqlobject.statement.GetGeneratedKeys;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
@@ -37,7 +38,7 @@ public interface DarCollectionDAO {
 
   final String projectSortFilterQuery = 
     getCollectionAndDars + filterQuery + 
-    "ORDER BY projectTitle DESC " +
+    "ORDER BY <sortField> <sortOrder> " +
     "LIMIT :limit OFFSET :offset";
   
   /**
@@ -80,7 +81,9 @@ public interface DarCollectionDAO {
                                                     @Bind("darCodeSearchTerm") String darCodeSearchTerm,
                                                     @Bind("datasetSearchTerm") String datasetSearchTerm,
                                                     @Bind("offset") Integer offset,
-                                                    @Bind("limit") Integer limit);
+                                                    @Bind("limit") Integer limit,
+                                                    @Define("sortField") String sortField,
+                                                    @Define("sortOrder") String sortOrder);
 
   /**
    * Find the DARCollection and all of its Data Access Requests that contains the DAR with the given referenceId

--- a/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
@@ -23,7 +23,7 @@ public interface DarCollectionDAO {
           "dar.update_date AS dar_update_date, (dar.data #>> '{}')::jsonb AS data, " +
           "(dar.data #>> '{}')::jsonb ->> 'projectTitle' as projectTitle " +
       "FROM dar_collection c " + 
-      "INNER JOIN dacuser u ON u.dacuserid = c.create_user " +
+      "INNER JOIN dacuser u ON u.dacuserid = c.create_user_id " +
       "LEFT JOIN institution i ON i.institution_id = u.institution_id " +
       "INNER JOIN data_access_request dar ON c.collection_id = dar.collection_id ";
   
@@ -68,7 +68,7 @@ public interface DarCollectionDAO {
       + "dar.update_date AS dar_update_date, (dar.data #>> '{}')::jsonb AS data "
       + "FROM dar_collection c, data_access_request dar " 
       + "WHERE c.collection_id = dar.collection_id "
-      + "AND c.create_user = :userId")
+      + "AND c.create_user_id = :userId")
   List<DarCollection> findDARCollectionsCreatedByUserId(@Bind("userId") Integer researcherId);
 
   /**
@@ -133,7 +133,7 @@ public interface DarCollectionDAO {
    * @return Integer, ID of newly created DarCollection
    */
   @SqlUpdate("INSERT INTO dar_collection " +
-    " (dar_code, create_user, create_date) " +
+    " (dar_code, create_user_id, create_date) " +
     " VALUES (:darCode, :createUserId, :createDate)")
   @GetGeneratedKeys
   Integer insertDarCollection(@Bind("darCode") String darCode,

--- a/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
@@ -1,34 +1,45 @@
 package org.broadinstitute.consent.http.db;
 
 import org.broadinstitute.consent.http.db.mapper.DarCollectionReducer;
-import org.broadinstitute.consent.http.db.mapper.DataAccessRequestMapper;
 import org.broadinstitute.consent.http.models.DarCollection;
 import org.broadinstitute.consent.http.models.DataAccessRequest;
 import org.jdbi.v3.sqlobject.config.RegisterBeanMapper;
-import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
 import org.jdbi.v3.sqlobject.customizer.Bind;
 import org.jdbi.v3.sqlobject.statement.GetGeneratedKeys;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 import org.jdbi.v3.sqlobject.statement.UseRowReducer;
-import org.jdbi.v3.core.Handle;
 
 import java.util.Date;
 import java.util.List;
 
 public interface DarCollectionDAO {
 
-  String getCollectionAndDars =
-      " SELECT c.*, dar.id AS dar_id, dar.reference_id AS dar_reference_id, dar.collection_id AS dar_collection_id, " +
-      "        dar.draft AS dar_draft, dar.user_id AS dar_userId, dar.create_date AS dar_create_date, " +
-      "        dar.sort_date AS dar_sort_date, dar.submission_date AS dar_submission_date, " +
-      "        dar.update_date AS dar_update_date, (dar.data #>> '{}')::jsonb AS data, " +
-      "(dar.data #>> '{}')::jsonb ->> 'institution' as institution, " + 
-      "(dar.data #>> '{}')::jsonb ->> 'researcher' as researcher, " +
-      "(dar.data #>> '{}')::jsonb ->> 'projectTitle' as projectTitle " +
-      " FROM dar_collection c " + 
-      " INNER JOIN data_access_request dar ON c.collection_id = dar.collection_id ";
+  final String getCollectionAndDars =
+      "SELECT c.*, dar.id AS dar_id, dar.reference_id AS dar_reference_id, dar.collection_id AS dar_collection_id, " +
+          "dar.draft AS dar_draft, dar.user_id AS dar_userId, dar.create_date AS dar_create_date, " +
+          "dar.sort_date AS dar_sort_date, dar.submission_date AS dar_submission_date, " +
+          "dar.update_date AS dar_update_date, (dar.data #>> '{}')::jsonb AS data, " +
+          "(dar.data #>> '{}')::jsonb ->> 'institution' as institution, " + 
+          "(dar.data #>> '{}')::jsonb ->> 'researcher' as researcher, " +
+          "(dar.data #>> '{}')::jsonb ->> 'projectTitle' as projectTitle " +
+      "FROM dar_collection c " + 
+      "INNER JOIN data_access_request dar ON c.collection_id = dar.collection_id ";
+  
+  final String filterQuery = 
+    "WHERE (dar.data #>> '{}')::jsonb ->> 'institution' ~* :institutionSearchTerm " +
+    "AND (dar.data #>> '{}')::jsonb ->> 'projectTitle' ~* :projectSearchTerm " +
+    "AND (dar.data #>> '{}')::jsonb ->> 'researcher' ~* :researcherSearchTerm " +
+    "AND c.dar_code ~* :darCodeSearchTerm " + 
+    "AND EXISTS " +
+        "(SELECT FROM jsonb_array_elements((dar.data #>> '{}')::jsonb -> 'datasets') dataset " +
+        "WHERE dataset ->> 'label' ~* :datasetSearchTerm)";
 
+  final String projectSortFilterQuery = 
+    getCollectionAndDars + filterQuery + 
+    "ORDER BY projectTitle DESC " +
+    "LIMIT :limit OFFSET :offset";
+  
   /**
    * Find all DARCollections with their DataAccessRequests
    *
@@ -58,33 +69,16 @@ public interface DarCollectionDAO {
    * @return List<DarCollection>
    */
 
-  //this is merely a rough draft, an idea, it does not work (CONTAINS can be replaced with @>)
-  //look at changeSet 73, could do something like that: WHEN POSITION(filterTerm in  (data #>> '{}')::jsonb->>'dar_code') > 0
-  // for ANY filterTerm in filterTerms
-
- @RegisterBeanMapper(DarCollection.class)
+ @RegisterBeanMapper(value = DarCollection.class)
  @RegisterBeanMapper(value = DataAccessRequest.class, prefix = "dar")
  @UseRowReducer(DarCollectionReducer.class)
- @SqlQuery(
-    getCollectionAndDars + 
-    "WHERE (dar.data #>> '{}')::jsonb ->> 'institution' ~* :institutionSearchTerm " +
-    "AND (dar.data #>> '{}')::jsonb ->> 'projectTitle' ~* :projectSearchTerm " +
-    "AND (dar.data #>> '{}')::jsonb ->> 'researcher' ~* :researcherSearchTerm " +
-    "AND c.dar_code ~* :darCodeSearchTerm " +
-    "AND EXISTS " +
-    "   (SELECT FROM jsonb_array_elements((dar.data #>> '{}')::jsonb -> 'datasets') dataset " +
-    "    WHERE dataset ->> 'label' ~* :datasetSearchTerm) " +
-    "ORDER BY :sortField :sortDirection " +
-    "OFFSET :offset LIMIT :limit"
- )
- List<DarCollection> findAllDARCollectionsWithFilters(
-                                                    @Bind("institutionSearchTerm") String institutionTerm,
-                                                    @Bind("projectSearchTerm") String projectTerm,
-                                                    @Bind("researcherSearchTerm") String researcherName,
-                                                    @Bind("darCodeSearchTerm") String darCode,
-                                                    @Bind("datasetSearchTerm") String datasetName,
-                                                    @Bind("sortField") String sortField, 
-                                                    @Bind("sortDirection") String sortDirection,
+ @SqlQuery(projectSortFilterQuery)
+ List<DarCollection> findAllDARCollectionsWithFiltersAndProjectTitleSort(
+                                                    @Bind("institutionSearchTerm") String institutionSearchTerm,
+                                                    @Bind("projectSearchTerm") String projectSearchTerm,
+                                                    @Bind("researcherSearchTerm") String researcherSearchTerm,
+                                                    @Bind("darCodeSearchTerm") String darCodeSearchTerm,
+                                                    @Bind("datasetSearchTerm") String datasetSearchTerm,
                                                     @Bind("offset") Integer offset,
                                                     @Bind("limit") Integer limit);
 

--- a/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
@@ -61,15 +61,17 @@ public interface DarCollectionDAO {
       + "    FROM data_access_request) dar "
       + " ON c.collection_id = dar.collection_id "
       + " WHERE c.collection_id = :collectionId ")
-  DarCollection findDARCollectionByCollectionId(@Bind("collectionId") String collectionId);
+  DarCollection findDARCollectionByCollectionId(@Bind("collectionId") Integer collectionId);
 
   @SqlUpdate("INSERT INTO dar_collection " +
-    " (collection_id, dar_code, create_user, create_date) " +
-    " VALUES (:collectionId, :darCode, :createUserId, :createDate)")
+    " (dar_code, create_user, create_date) " +
+    " VALUES (:darCode, :createUserId, :createDate)")
   @GetGeneratedKeys
-  Integer insertDarCollection(@Bind("collectionId") Integer collectionId,
-                            @Bind("darCode") String darCode,
+  Integer insertDarCollection(@Bind("darCode") String darCode,
                             @Bind("createUserId") Integer createUserId,
                             @Bind("createDate") Date createDate);
+
+  @SqlUpdate("DELETE * FROM dar_collection WHERE collection_id = :collectionId")
+  void deleteByCollectionId(@Bind("collectionId") Integer collectionId);
 }
 

--- a/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
@@ -4,9 +4,12 @@ import org.broadinstitute.consent.http.db.mapper.DarCollectionReducer;
 import org.broadinstitute.consent.http.models.DarCollection;
 import org.jdbi.v3.sqlobject.config.RegisterBeanMapper;
 import org.jdbi.v3.sqlobject.customizer.Bind;
+import org.jdbi.v3.sqlobject.statement.GetGeneratedKeys;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
+import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 import org.jdbi.v3.sqlobject.statement.UseRowReducer;
 
+import java.util.Date;
 import java.util.List;
 
 public interface DarCollectionDAO {
@@ -27,10 +30,12 @@ public interface DarCollectionDAO {
   List<DarCollection> findAllDARCollections();
 
   /**
-   * Find all DARCollections with their DataAccessRequests
+   * Find the DARCollection and all of its Data Access Requests that contains the DAR with the given referenceId
    *
    * @return List<DataAccessRequest>
    */
+  @RegisterBeanMapper(DarCollection.class)
+  @UseRowReducer(DarCollectionReducer.class)
   @SqlQuery(
     "SELECT * FROM dar_collection c "
       + " INNER JOIN "
@@ -42,10 +47,12 @@ public interface DarCollectionDAO {
   DarCollection findDARCollectionByReferenceId(@Bind("referenceId") String referenceId);
 
   /**
-   * Find all DARCollections with their DataAccessRequests
+   * Find the DARCollection and all of its Data Access Requests that has the given collectionId
    *
    * @return List<DataAccessRequest>
    */
+  @RegisterBeanMapper(DarCollection.class)
+  @UseRowReducer(DarCollectionReducer.class)
   @SqlQuery(
     "SELECT * FROM dar_collection c "
       + " LEFT JOIN "
@@ -56,5 +63,13 @@ public interface DarCollectionDAO {
       + " WHERE c.collection_id = :collectionId ")
   DarCollection findDARCollectionByCollectionId(@Bind("collectionId") String collectionId);
 
+  @SqlUpdate("INSERT INTO dar_collection " +
+    " (collection_id, dar_code, create_user, create_date) " +
+    " VALUES (:collectionId, :darCode, :createUserId, :createDate)")
+  @GetGeneratedKeys
+  Integer insertDarCollection(@Bind("collectionId") Integer collectionId,
+                            @Bind("darCode") String darCode,
+                            @Bind("createUserId") Integer createUserId,
+                            @Bind("createDate") Date createDate);
 }
 

--- a/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
@@ -1,0 +1,53 @@
+package org.broadinstitute.consent.http.db;
+
+import org.broadinstitute.consent.http.models.DarCollection;
+import org.broadinstitute.consent.http.models.DataAccessRequest;
+import org.jdbi.v3.sqlobject.customizer.Bind;
+import org.jdbi.v3.sqlobject.statement.SqlQuery;
+
+import java.util.List;
+
+public interface DarCollectionDAO {
+  /**
+   * Find all DARCollections with their DataAccessRequests
+   *
+   * @return List<DataAccessRequest>
+   */
+  @SqlQuery(
+    "SELECT * FROM dar_collection c "
+     + " LEFT JOIN "
+     + "    (SELECT id, reference_id, collection_id, draft, user_id, create_date, sort_date, submission_date, "
+     + "            update_date, (data #>> '{}')::jsonb AS data FROM data_access_request) dar "
+     + " ON c.collection_id = dar.collection_id ")
+  List<DarCollection> findAllDARCollections();
+
+  /**
+   * Find all DARCollections with their DataAccessRequests
+   *
+   * @return List<DataAccessRequest>
+   */
+  @SqlQuery(
+    "SELECT * FROM dar_collection c "
+      + " INNER JOIN "
+      + "    (SELECT id, reference_id, collection_id, draft, user_id, create_date, sort_date, submission_date, "
+      + "            update_date, (data #>> '{}')::jsonb AS data FROM data_access_request" +
+      "      WHERE reference_id = :referenceId) dar "
+      + " ON c.collection_id = dar.collection_id ")
+  DarCollection findDARCollectionByReferenceId(@Bind("referenceId") String referenceId);
+
+  /**
+   * Find all DARCollections with their DataAccessRequests
+   *
+   * @return List<DataAccessRequest>
+   */
+  @SqlQuery(
+    "SELECT * FROM dar_collection c "
+      + " LEFT JOIN "
+      + "    (SELECT id, reference_id, collection_id, draft, user_id, create_date, sort_date, submission_date, "
+      + "            update_date, (data #>> '{}')::jsonb AS data FROM data_access_request) dar "
+      + " ON c.collection_id = dar.collection_id "
+      + " WHERE c.collection_id = :collectionId ")
+  DarCollection findDARCollectionByCollectionId(@Bind("collectionId") String collectionId);
+
+}
+

--- a/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
@@ -26,7 +26,7 @@ public interface DarCollectionDAO {
      + "    (SELECT id, reference_id, collection_id AS dar_collection_id, draft, user_id, create_date AS dar_create_date, "
      + "            submission_date, update_date AS dar_update_date, (data #>> '{}')::jsonb AS data "
      + "    FROM data_access_request) dar "
-     + " ON c.collection_id = dar.collection_id ")
+     + " ON c.collection_id = dar.dar_collection_id ")
   List<DarCollection> findAllDARCollections();
 
   /**
@@ -43,7 +43,7 @@ public interface DarCollectionDAO {
       + "            submission_date, update_date AS dar_update_date, (data #>> '{}')::jsonb AS data "
       + "    FROM data_access_request"
       + "    WHERE reference_id = :referenceId) dar "
-      + " ON c.collection_id = dar.collection_id ")
+      + " ON c.collection_id = dar.dar_collection_id ")
   DarCollection findDARCollectionByReferenceId(@Bind("referenceId") String referenceId);
 
   /**
@@ -59,7 +59,7 @@ public interface DarCollectionDAO {
       + "    (SELECT id, reference_id, collection_id AS dar_collection_id, draft, user_id, create_date AS dar_create_date, "
       + "            submission_date, update_date AS dar_update_date, (data #>> '{}')::jsonb AS data "
       + "    FROM data_access_request) dar "
-      + " ON c.collection_id = dar.collection_id "
+      + " ON c.collection_id = dar.dar_collection_id "
       + " WHERE c.collection_id = :collectionId ")
   DarCollection findDARCollectionByCollectionId(@Bind("collectionId") Integer collectionId);
 

--- a/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
@@ -143,7 +143,7 @@ public interface DarCollectionDAO {
   /**
    * Update the update user and update date of the DAR Collection with the given collection ID
    */
-  @SqlUpdate("UPDATE dar_collection SET update_user = :updateUserId, update_date = :updateDate WHERE collection_id = :collectionId")
+  @SqlUpdate("UPDATE dar_collection SET update_user_id = :updateUserId, update_date = :updateDate WHERE collection_id = :collectionId")
   void updateDarCollection(@Bind("collectionId") Integer collectionId,
                            @Bind("updateUserId") Integer updateUserId,
                            @Bind("updateDate") Date updateDate);

--- a/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
@@ -59,6 +59,17 @@ public interface DarCollectionDAO {
   )
   List<DarCollection> findAllDARCollections();
 
+  @RegisterBeanMapper(value = DarCollection.class)
+  @RegisterBeanMapper(value = DataAccessRequest.class, prefix = "dar")
+  @UseRowReducer(DarCollectionReducer.class)
+  @SqlQuery(" SELECT c.*, dar.id AS dar_id, dar.reference_id AS dar_reference_id, dar.collection_id AS dar_collection_id, "
+      + "dar.draft AS dar_draft, dar.user_id AS dar_userId, dar.create_date AS dar_create_date, "
+      + "dar.sort_date AS dar_sort_date, dar.submission_date AS dar_submission_date, "
+      + "dar.update_date AS dar_update_date, (dar.data #>> '{}')::jsonb AS data "
+      + "FROM dar_collection c, data_access_request dar " 
+      + "WHERE c.collection_id = dar.collection_id "
+      + "AND c.create_user = :userId")
+  List<DarCollection> findDARCollectionsCreatedByUserId(@Bind("userId") Integer researcherId);
 
   /**
    * Find all DARCollections with their DataAccessRequests that match the given filters

--- a/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
@@ -124,7 +124,7 @@ public interface DarCollectionDAO {
   @RegisterBeanMapper(value = DataAccessRequest.class, prefix = "dar")
   @UseRowReducer(DarCollectionReducer.class)
   @SqlQuery(
-      getCollectionAndDars +  " WHERE c.collection_id = dar.collection_id AND c.collection_id = :collectionId ")
+      getCollectionAndDars +  " WHERE c.collection_id = :collectionId ")
   DarCollection findDARCollectionByCollectionId(@Bind("collectionId") Integer collectionId);
 
   /**

--- a/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
@@ -54,8 +54,8 @@ public interface DarCollectionDAO {
         "dar.draft AS dar_draft, dar.user_id AS dar_userId, dar.create_date AS dar_create_date, " +
         "dar.sort_date AS dar_sort_date, dar.submission_date AS dar_submission_date, " +
         "dar.update_date AS dar_update_date, (dar.data #>> '{}')::jsonb AS data " +
-        "FROM dar_collection c, data_access_request dar " +
-    " WHERE c.collection_id = dar.collection_id"
+        "FROM dar_collection c " +
+        "INNER JOIN data_access_request dar on c.collection_id = dar.collection_id;"
   )
   List<DarCollection> findAllDARCollections();
 
@@ -66,8 +66,8 @@ public interface DarCollectionDAO {
       + "dar.draft AS dar_draft, dar.user_id AS dar_userId, dar.create_date AS dar_create_date, "
       + "dar.sort_date AS dar_sort_date, dar.submission_date AS dar_submission_date, "
       + "dar.update_date AS dar_update_date, (dar.data #>> '{}')::jsonb AS data "
-      + "FROM dar_collection c, data_access_request dar " 
-      + "WHERE c.collection_id = dar.collection_id "
+      + "FROM dar_collection c " 
+      + "INNER JOIN data_access_request dar ON c.collection_id = dar.collection_id "
       + "AND c.create_user_id = :userId")
   List<DarCollection> findDARCollectionsCreatedByUserId(@Bind("userId") Integer researcherId);
 

--- a/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
@@ -74,7 +74,7 @@ public interface DarCollectionDAO {
  @RegisterBeanMapper(value = DataAccessRequest.class, prefix = "dar")
  @UseRowReducer(DarCollectionReducer.class)
  @SqlQuery(projectSortFilterQuery)
- List<DarCollection> findAllDARCollectionsWithFiltersAndProjectTitleSort(
+ List<DarCollection> findAllDARCollectionsWithFilters(
                                                     @Bind("institutionSearchTerm") String institutionSearchTerm,
                                                     @Bind("projectSearchTerm") String projectSearchTerm,
                                                     @Bind("researcherSearchTerm") String researcherSearchTerm,

--- a/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
@@ -1,9 +1,11 @@
 package org.broadinstitute.consent.http.db;
 
+import org.broadinstitute.consent.http.db.mapper.DarCollectionReducer;
 import org.broadinstitute.consent.http.models.DarCollection;
-import org.broadinstitute.consent.http.models.DataAccessRequest;
+import org.jdbi.v3.sqlobject.config.RegisterBeanMapper;
 import org.jdbi.v3.sqlobject.customizer.Bind;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
+import org.jdbi.v3.sqlobject.statement.UseRowReducer;
 
 import java.util.List;
 
@@ -13,11 +15,14 @@ public interface DarCollectionDAO {
    *
    * @return List<DataAccessRequest>
    */
+  @RegisterBeanMapper(DarCollection.class)
+  @UseRowReducer(DarCollectionReducer.class)
   @SqlQuery(
     "SELECT * FROM dar_collection c "
      + " LEFT JOIN "
-     + "    (SELECT id, reference_id, collection_id, draft, user_id, create_date, sort_date, submission_date, "
-     + "            update_date, (data #>> '{}')::jsonb AS data FROM data_access_request) dar "
+     + "    (SELECT id, reference_id, collection_id AS dar_collection_id, draft, user_id, create_date AS dar_create_date, "
+     + "            submission_date, update_date AS dar_update_date, (data #>> '{}')::jsonb AS data "
+     + "    FROM data_access_request) dar "
      + " ON c.collection_id = dar.collection_id ")
   List<DarCollection> findAllDARCollections();
 
@@ -29,9 +34,10 @@ public interface DarCollectionDAO {
   @SqlQuery(
     "SELECT * FROM dar_collection c "
       + " INNER JOIN "
-      + "    (SELECT id, reference_id, collection_id, draft, user_id, create_date, sort_date, submission_date, "
-      + "            update_date, (data #>> '{}')::jsonb AS data FROM data_access_request" +
-      "      WHERE reference_id = :referenceId) dar "
+      + "    (SELECT id, reference_id, collection_id AS dar_collection_id, draft, user_id, create_date AS dar_create_date, "
+      + "            submission_date, update_date AS dar_update_date, (data #>> '{}')::jsonb AS data "
+      + "    FROM data_access_request"
+      + "    WHERE reference_id = :referenceId) dar "
       + " ON c.collection_id = dar.collection_id ")
   DarCollection findDARCollectionByReferenceId(@Bind("referenceId") String referenceId);
 
@@ -43,8 +49,9 @@ public interface DarCollectionDAO {
   @SqlQuery(
     "SELECT * FROM dar_collection c "
       + " LEFT JOIN "
-      + "    (SELECT id, reference_id, collection_id, draft, user_id, create_date, sort_date, submission_date, "
-      + "            update_date, (data #>> '{}')::jsonb AS data FROM data_access_request) dar "
+      + "    (SELECT id, reference_id, collection_id AS dar_collection_id, draft, user_id, create_date AS dar_create_date, "
+      + "            submission_date, update_date AS dar_update_date, (data #>> '{}')::jsonb AS data "
+      + "    FROM data_access_request) dar "
       + " ON c.collection_id = dar.collection_id "
       + " WHERE c.collection_id = :collectionId ")
   DarCollection findDARCollectionByCollectionId(@Bind("collectionId") String collectionId);

--- a/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
@@ -79,13 +79,14 @@ public interface DarCollectionDAO {
 //                                                      @Bind("filterterms) List<String> filterTerms,
 //                                                      @Bind("offset") Integer offset,
 //                                                      @Bind("limit") Integer limit);
+
   /**
    * Find the DARCollection and all of its Data Access Requests that contains the DAR with the given referenceId
    *
    * @return DarCollection
    */
   @RegisterBeanMapper(DarCollection.class)
-  @RegisterRowMapper(DataAccessRequestMapper.class)
+  @RegisterBeanMapper(DataAccessRequest.class)
   @UseRowReducer(DarCollectionReducer.class)
   @SqlQuery(
     "SELECT * FROM dar_collection c "
@@ -103,7 +104,7 @@ public interface DarCollectionDAO {
    * @return DarCollection
    */
   @RegisterBeanMapper(DarCollection.class)
-  @RegisterRowMapper(DataAccessRequestMapper.class)
+  @RegisterBeanMapper(DataAccessRequest.class)
   @UseRowReducer(DarCollectionReducer.class)
   @SqlQuery(
     "SELECT * FROM dar_collection c "

--- a/src/main/java/org/broadinstitute/consent/http/db/DataAccessRequestDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DataAccessRequestDAO.java
@@ -152,6 +152,14 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
   void deleteByReferenceId(@Bind("referenceId") String referenceId);
 
   /**
+   * Delete all DataAccessRequests with the given collection id
+   *
+   * @param collectionId Integer
+   */
+  @SqlUpdate("DELETE FROM data_access_request WHERE collection_id = :collectionId")
+  void deleteByCollectionId(@Bind("collectionId") Integer collectionId);
+
+  /**
    * Create new DataAccessRequest.
    * This version supercedes `insert`
    *

--- a/src/main/java/org/broadinstitute/consent/http/db/DataAccessRequestDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DataAccessRequestDAO.java
@@ -176,6 +176,32 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
       @Bind("data") @Json DataAccessRequestData data);
 
   /**
+   * Create new DataAccessRequest.
+   * This version supercedes `insertV2`
+   *
+   * @param collectionId Integer DarCollection
+   * @param referenceId String
+   * @param userId Integer User
+   * @param createDate Date Creation Date
+   * @param sortDate Date Sorting Date
+   * @param submissionDate Date Submission Date
+   * @param updateDate Date Update Date
+   * @param data DataAccessRequestData DAR Properties
+   */
+  @RegisterArgumentFactory(JsonArgumentFactory.class)
+  @SqlUpdate(
+    "INSERT INTO data_access_request (collection_id, reference_id, user_id, create_date, sort_date, submission_date, update_date, data) VALUES (:collectionId, :referenceId, :userId, :createDate, :sortDate, :submissionDate, :updateDate, to_jsonb(:data)) ")
+  void insertVersion3(
+    @Bind("collectionId") Integer collectionId,
+    @Bind("referenceId") String referenceId,
+    @Bind("userId") Integer userId,
+    @Bind("createDate") Date createDate,
+    @Bind("sortDate") Date sortDate,
+    @Bind("submissionDate") Date submissionDate,
+    @Bind("updateDate") Date updateDate,
+    @Bind("data") @Json DataAccessRequestData data);
+
+  /**
    * Insert DataAccessRequest by reference id and provided DataAccessRequestData
    *
    * @param referenceId String

--- a/src/main/java/org/broadinstitute/consent/http/db/DataAccessRequestDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DataAccessRequestDAO.java
@@ -171,6 +171,7 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
    * @param updateDate Date Update Date
    * @param data DataAccessRequestData DAR Properties
    */
+  @Deprecated
   @RegisterArgumentFactory(JsonArgumentFactory.class)
   @SqlUpdate(
       "INSERT INTO data_access_request (reference_id, user_id, create_date, sort_date, submission_date, update_date, data) VALUES (:referenceId, :userId, :createDate, :sortDate, :submissionDate, :updateDate, to_jsonb(:data)) ")

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DarCollectionReducer.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DarCollectionReducer.java
@@ -1,11 +1,15 @@
 package org.broadinstitute.consent.http.db.mapper;
 
+import com.google.gson.JsonSyntaxException;
 import org.broadinstitute.consent.http.models.DarCollection;
 import org.broadinstitute.consent.http.models.DataAccessRequest;
+import org.broadinstitute.consent.http.models.DataAccessRequestData;
 import org.jdbi.v3.core.mapper.MappingException;
 import org.jdbi.v3.core.result.LinkedHashMapRowReducer;
 import org.jdbi.v3.core.result.RowView;
+import org.postgresql.util.PGobject;
 
+import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.util.Map;
 import java.util.Objects;
@@ -22,6 +26,23 @@ public class DarCollectionReducer implements LinkedHashMapRowReducer<Integer, Da
       try{
         if(Objects.nonNull(collection) && Objects.nonNull(rowView.getColumn("id", Integer.class))) {
           dar = rowView.getRow(DataAccessRequest.class);
+
+//          String darDataString = resultSet.getObject("data", PGobject.class).getValue();
+//          if (Objects.nonNull(darDataString)) {
+//            // Handle nested quotes
+//            String quoteFixedDataString = darDataString.replaceAll("\\\\\"", "'");
+//            // Inserted json data ends up double-escaped via standard jdbi insert.
+//            String escapedDataString = unescapeJava(quoteFixedDataString);
+//            try {
+//              DataAccessRequestData data = DataAccessRequestData.fromString(escapedDataString);
+//              data.setReferenceId(dar.getReferenceId());
+//              dar.setData(data);
+//            } catch (JsonSyntaxException | NullPointerException e) {
+//              String message = "Unable to parse Data Access Request, reference id: " + dar.getReferenceId() + "; error: " + e.getMessage();
+//              logger.error(message);
+//              throw new SQLException(message);
+//            }
+//          }
           //aliased fields must be set directly
           dar.setCollectionId(rowView.getColumn("dar_collection_id", Integer.class));
           dar.setCreateDate(rowView.getColumn("dar_create_date", Timestamp.class));

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DarCollectionReducer.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DarCollectionReducer.java
@@ -24,7 +24,7 @@ public class DarCollectionReducer implements LinkedHashMapRowReducer<Integer, Da
         id -> rowView.getRow(DarCollection.class));
 
       try{
-        if(Objects.nonNull(collection) && Objects.nonNull(rowView.getColumn("id", Integer.class))) {
+        if(Objects.nonNull(collection) && Objects.nonNull(rowView.getColumn("dar_id", Integer.class))) {
           dar = rowView.getRow(DataAccessRequest.class);
 
 //          String darDataString = resultSet.getObject("data", PGobject.class).getValue();
@@ -43,10 +43,7 @@ public class DarCollectionReducer implements LinkedHashMapRowReducer<Integer, Da
 //              throw new SQLException(message);
 //            }
 //          }
-          //aliased fields must be set directly
-          dar.setCollectionId(rowView.getColumn("dar_collection_id", Integer.class));
-          dar.setCreateDate(rowView.getColumn("dar_create_date", Timestamp.class));
-          dar.setUpdateDate(rowView.getColumn("dar_update_date", Timestamp.class));
+
         }
       } catch(MappingException e) {
         //ignore any exceptions

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DarCollectionReducer.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DarCollectionReducer.java
@@ -10,7 +10,7 @@ import org.jdbi.v3.core.result.RowView;
 import java.util.Map;
 import java.util.Objects;
 
-public class DarCollectionReducer implements LinkedHashMapRowReducer<Integer, DarCollection> {
+public class DarCollectionReducer implements LinkedHashMapRowReducer<Integer, DarCollection>, RowMapperHelper {
 
     @Override
     public void accumulate(Map<Integer, DarCollection> map, RowView rowView) {
@@ -22,7 +22,7 @@ public class DarCollectionReducer implements LinkedHashMapRowReducer<Integer, Da
       try{
         if(Objects.nonNull(collection) && Objects.nonNull(rowView.getColumn("dar_id", Integer.class))) {
           dar = rowView.getRow(DataAccessRequest.class);
-          DataAccessRequestData data = RowMapperHelper.translate(rowView.getColumn("data", String.class));
+          DataAccessRequestData data = translate(rowView.getColumn("data", String.class));
           dar.setData(data);
         }
       } catch(MappingException e) {

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DarCollectionReducer.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DarCollectionReducer.java
@@ -1,0 +1,39 @@
+package org.broadinstitute.consent.http.db.mapper;
+
+import org.broadinstitute.consent.http.models.DarCollection;
+import org.broadinstitute.consent.http.models.DataAccessRequest;
+import org.jdbi.v3.core.mapper.MappingException;
+import org.jdbi.v3.core.result.LinkedHashMapRowReducer;
+import org.jdbi.v3.core.result.RowView;
+
+import java.sql.Timestamp;
+import java.util.Map;
+import java.util.Objects;
+
+public class DarCollectionReducer implements LinkedHashMapRowReducer<Integer, DarCollection> {
+
+    @Override
+    public void accumulate(Map<Integer, DarCollection> map, RowView rowView) {
+      DataAccessRequest dar = null;
+      DarCollection collection = map.computeIfAbsent(
+        rowView.getColumn("collection_id", Integer.class),
+        id -> rowView.getRow(DarCollection.class));
+
+      try{
+        if(Objects.nonNull(collection) && Objects.nonNull(rowView.getColumn("id", Integer.class))) {
+          dar = rowView.getRow(DataAccessRequest.class);
+          //aliased fields must be set directly
+          dar.setCollectionId(rowView.getColumn("dar_collection_id", Integer.class));
+          dar.setCreateDate(rowView.getColumn("dar_create_date", Timestamp.class));
+          dar.setUpdateDate(rowView.getColumn("dar_update_date", Timestamp.class));
+        }
+      } catch(MappingException e) {
+        //ignore any exceptions
+      }
+
+      if(Objects.nonNull(dar)) {
+        collection.addDar(dar);
+      }
+    }
+
+}

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DarCollectionReducer.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DarCollectionReducer.java
@@ -1,16 +1,12 @@
 package org.broadinstitute.consent.http.db.mapper;
 
-import com.google.gson.JsonSyntaxException;
 import org.broadinstitute.consent.http.models.DarCollection;
 import org.broadinstitute.consent.http.models.DataAccessRequest;
 import org.broadinstitute.consent.http.models.DataAccessRequestData;
 import org.jdbi.v3.core.mapper.MappingException;
 import org.jdbi.v3.core.result.LinkedHashMapRowReducer;
 import org.jdbi.v3.core.result.RowView;
-import org.postgresql.util.PGobject;
 
-import java.sql.SQLException;
-import java.sql.Timestamp;
 import java.util.Map;
 import java.util.Objects;
 
@@ -26,24 +22,8 @@ public class DarCollectionReducer implements LinkedHashMapRowReducer<Integer, Da
       try{
         if(Objects.nonNull(collection) && Objects.nonNull(rowView.getColumn("dar_id", Integer.class))) {
           dar = rowView.getRow(DataAccessRequest.class);
-
-//          String darDataString = resultSet.getObject("data", PGobject.class).getValue();
-//          if (Objects.nonNull(darDataString)) {
-//            // Handle nested quotes
-//            String quoteFixedDataString = darDataString.replaceAll("\\\\\"", "'");
-//            // Inserted json data ends up double-escaped via standard jdbi insert.
-//            String escapedDataString = unescapeJava(quoteFixedDataString);
-//            try {
-//              DataAccessRequestData data = DataAccessRequestData.fromString(escapedDataString);
-//              data.setReferenceId(dar.getReferenceId());
-//              dar.setData(data);
-//            } catch (JsonSyntaxException | NullPointerException e) {
-//              String message = "Unable to parse Data Access Request, reference id: " + dar.getReferenceId() + "; error: " + e.getMessage();
-//              logger.error(message);
-//              throw new SQLException(message);
-//            }
-//          }
-
+          DataAccessRequestData data = RowMapperHelper.translate(rowView.getColumn("data", String.class));
+          dar.setData(data);
         }
       } catch(MappingException e) {
         //ignore any exceptions

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DataAccessRequestDataMapper.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DataAccessRequestDataMapper.java
@@ -14,7 +14,7 @@ public class DataAccessRequestDataMapper implements RowMapper<DataAccessRequestD
     @Override
     public DataAccessRequestData map(ResultSet resultSet, StatementContext statementContext) throws SQLException {
         String darDataString = resultSet.getObject("data", PGobject.class).getValue();
-        DataAccessRequestData data = RowMapperHelper.translate(darDataString);
+        DataAccessRequestData data = translate(darDataString);
         return data;
     }
 

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DataAccessRequestDataMapper.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DataAccessRequestDataMapper.java
@@ -1,38 +1,20 @@
 package org.broadinstitute.consent.http.db.mapper;
 
-import com.google.gson.JsonSyntaxException;
 import org.broadinstitute.consent.http.models.DataAccessRequestData;
 import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.core.statement.StatementContext;
 import org.postgresql.util.PGobject;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.Objects;
 
 public class DataAccessRequestDataMapper implements RowMapper<DataAccessRequestData>, RowMapperHelper {
 
-    private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
     @Override
     public DataAccessRequestData map(ResultSet resultSet, StatementContext statementContext) throws SQLException {
-        DataAccessRequestData data = null;
         String darDataString = resultSet.getObject("data", PGobject.class).getValue();
-        if (Objects.nonNull(darDataString)) {
-            // Handle nested quotes
-            String quoteFixedDataString = darDataString.replaceAll("\\\\\"", "'");
-            // Inserted json data ends up double-escaped via standard jdbi insert.
-            String escapedDataString = unescapeJava(quoteFixedDataString);
-            try {
-                data = DataAccessRequestData.fromString(escapedDataString);
-            } catch (JsonSyntaxException | NullPointerException e) {
-                String message = "Unable to parse Data Access Request; error: " + e.getMessage();
-                logger.error(message);
-                throw new SQLException(message);
-            }
-        }
+        DataAccessRequestData data = RowMapperHelper.translate(darDataString);
         return data;
     }
 

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DataAccessRequestMapper.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DataAccessRequestMapper.java
@@ -1,20 +1,14 @@
 package org.broadinstitute.consent.http.db.mapper;
 
-import com.google.gson.JsonSyntaxException;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.Objects;
 import org.broadinstitute.consent.http.models.DataAccessRequest;
 import org.broadinstitute.consent.http.models.DataAccessRequestData;
 import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.core.statement.StatementContext;
 import org.postgresql.util.PGobject;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class DataAccessRequestMapper implements RowMapper<DataAccessRequest>, RowMapperHelper {
-
-    private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
     @Override
     public DataAccessRequest map(ResultSet resultSet, StatementContext statementContext) throws SQLException {
@@ -31,21 +25,8 @@ public class DataAccessRequestMapper implements RowMapper<DataAccessRequest>, Ro
         dar.setSubmissionDate(resultSet.getTimestamp("submission_date"));
         dar.setUpdateDate(resultSet.getTimestamp("update_date"));
         String darDataString = resultSet.getObject("data", PGobject.class).getValue();
-        if (Objects.nonNull(darDataString)) {
-            // Handle nested quotes
-            String quoteFixedDataString = darDataString.replaceAll("\\\\\"", "'");
-            // Inserted json data ends up double-escaped via standard jdbi insert.
-            String escapedDataString = unescapeJava(quoteFixedDataString);
-            try {
-                DataAccessRequestData data = DataAccessRequestData.fromString(escapedDataString);
-                data.setReferenceId(dar.getReferenceId());
-                dar.setData(data);
-            } catch (JsonSyntaxException | NullPointerException e) {
-                String message = "Unable to parse Data Access Request, reference id: " + dar.getReferenceId() + "; error: " + e.getMessage();
-                logger.error(message);
-                throw new SQLException(message);
-            }
-        }
+        DataAccessRequestData data = RowMapperHelper.translate(darDataString);
+        dar.setData(data);
         return dar;
     }
 

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DataAccessRequestMapper.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DataAccessRequestMapper.java
@@ -25,7 +25,7 @@ public class DataAccessRequestMapper implements RowMapper<DataAccessRequest>, Ro
         dar.setSubmissionDate(resultSet.getTimestamp("submission_date"));
         dar.setUpdateDate(resultSet.getTimestamp("update_date"));
         String darDataString = resultSet.getObject("data", PGobject.class).getValue();
-        DataAccessRequestData data = translate(darDataString);
+        DataAccessRequestData data = RowMapperHelper.translate(darDataString);
         dar.setData(data);
         return dar;
     }

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DataAccessRequestMapper.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DataAccessRequestMapper.java
@@ -25,7 +25,7 @@ public class DataAccessRequestMapper implements RowMapper<DataAccessRequest>, Ro
         dar.setSubmissionDate(resultSet.getTimestamp("submission_date"));
         dar.setUpdateDate(resultSet.getTimestamp("update_date"));
         String darDataString = resultSet.getObject("data", PGobject.class).getValue();
-        DataAccessRequestData data = RowMapperHelper.translate(darDataString);
+        DataAccessRequestData data = translate(darDataString);
         dar.setData(data);
         return dar;
     }

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DataAccessRequestMapper.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DataAccessRequestMapper.java
@@ -2,6 +2,7 @@ package org.broadinstitute.consent.http.db.mapper;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+
 import org.broadinstitute.consent.http.models.DataAccessRequest;
 import org.broadinstitute.consent.http.models.DataAccessRequestData;
 import org.jdbi.v3.core.mapper.RowMapper;
@@ -16,7 +17,10 @@ public class DataAccessRequestMapper implements RowMapper<DataAccessRequest>, Ro
         dar.setId(resultSet.getInt("id"));
         dar.setReferenceId(resultSet.getString("reference_id"));
         if (hasColumn(resultSet, "collection_id")) {
-            dar.setCollectionId(resultSet.getInt("collection_id"));
+            int collectionId = resultSet.getInt("collection_id");
+            if(!resultSet.wasNull()) {
+                dar.setCollectionId(collectionId);
+            }
         }
         dar.setDraft(resultSet.getBoolean("draft"));
         dar.setUserId(resultSet.getInt("user_id"));

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/RowMapperHelper.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/RowMapperHelper.java
@@ -39,7 +39,7 @@ public interface RowMapperHelper {
     return StringEscapeUtils.unescapeJava(StringEscapeUtils.unescapeJava(value));
   }
 
-  static DataAccessRequestData translate(String darDataString) {
+  default DataAccessRequestData translate(String darDataString) {
     DataAccessRequestData data = null;
     if (Objects.nonNull(darDataString)) {
       // Handle nested quotes

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/RowMapperHelper.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/RowMapperHelper.java
@@ -39,7 +39,7 @@ public interface RowMapperHelper {
     return StringEscapeUtils.unescapeJava(StringEscapeUtils.unescapeJava(value));
   }
 
-  default DataAccessRequestData translate(String darDataString) {
+  static DataAccessRequestData translate(String darDataString) {
     DataAccessRequestData data = null;
     if (Objects.nonNull(darDataString)) {
       // Handle nested quotes

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/RowMapperHelper.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/RowMapperHelper.java
@@ -3,9 +3,17 @@ package org.broadinstitute.consent.http.db.mapper;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
+import java.util.Objects;
+
+import com.google.gson.JsonSyntaxException;
 import org.apache.commons.text.StringEscapeUtils;
+import org.broadinstitute.consent.http.models.DataAccessRequestData;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public interface RowMapperHelper {
+
+  Logger log = LoggerFactory.getLogger(RowMapperHelper.class);
 
   /**
    * Utility method to check if a column exists in the result set or not.
@@ -27,7 +35,26 @@ public interface RowMapperHelper {
     return false;
   }
 
-  default String unescapeJava(String value) {
+  static String unescapeJava(String value) {
     return StringEscapeUtils.unescapeJava(StringEscapeUtils.unescapeJava(value));
   }
+
+  static DataAccessRequestData translate(String darDataString) {
+    DataAccessRequestData data = null;
+    if (Objects.nonNull(darDataString)) {
+      // Handle nested quotes
+      String quoteFixedDataString = darDataString.replaceAll("\\\\\"", "'");
+      // Inserted json data ends up double-escaped via standard jdbi insert.
+      String escapedDataString = unescapeJava(quoteFixedDataString);
+      try {
+        data = DataAccessRequestData.fromString(escapedDataString);
+      } catch (JsonSyntaxException | NullPointerException e) {
+        String message = "Unable to parse Data Access Request; error: " + e.getMessage();
+        log.error(message);
+        throw e;
+      }
+    }
+    return data;
+  }
+
 }

--- a/src/main/java/org/broadinstitute/consent/http/models/DarCollection.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DarCollection.java
@@ -22,7 +22,7 @@ public class DarCollection {
   Timestamp createDate;
 
   @JsonProperty
-  Integer createUser;
+  Integer createUserId;
 
   @JsonProperty
   Timestamp updateDate;
@@ -59,12 +59,12 @@ public class DarCollection {
     this.createDate = createDate;
   }
 
-  public Integer getCreateUser() {
-    return createUser;
+  public Integer getCreateUserId() {
+    return createUserId;
   }
 
-  public void setCreateUser(Integer createUser) {
-    this.createUser = createUser;
+  public void setCreateUserId(Integer createUserId) {
+    this.createUserId = createUserId;
   }
 
   public Date getUpdateDate() {

--- a/src/main/java/org/broadinstitute/consent/http/models/DarCollection.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DarCollection.java
@@ -1,7 +1,12 @@
 package org.broadinstitute.consent.http.models;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.jdbi.v3.json.Json;
+
 import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
 
 //represents a multi-dataset access request
 public class DarCollection {
@@ -23,6 +28,9 @@ public class DarCollection {
 
   @JsonProperty
   User updateUser;
+
+  @JsonProperty
+  List<DataAccessRequest> dars;
 
   public DarCollection() {this.createDate = new Timestamp(System.currentTimeMillis()); }
 
@@ -72,6 +80,18 @@ public class DarCollection {
 
   public void setUpdateUser(User updateUser) {
     this.updateUser = updateUser;
+  }
+
+  public List<DataAccessRequest> getDars() { return dars; }
+
+  public void setDars(List<DataAccessRequest> dars) { this.dars = dars; }
+
+  public void addDar(DataAccessRequest dar) {
+    if (Objects.isNull(dars)) {
+      this.setDars(new ArrayList<>());
+    }
+    dars.add(dar);
+
   }
 
 }

--- a/src/main/java/org/broadinstitute/consent/http/models/DarCollection.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DarCollection.java
@@ -1,6 +1,7 @@
 package org.broadinstitute.consent.http.models;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.commons.lang3.builder.EqualsBuilder;
 
 import java.sql.Timestamp;
 import java.util.ArrayList;
@@ -82,7 +83,12 @@ public class DarCollection {
     this.updateUser = updateUser;
   }
 
-  public List<DataAccessRequest> getDars() { return dars; }
+  public List<DataAccessRequest> getDars() {
+    if (Objects.isNull(dars)) {
+      return new ArrayList<>();
+    }
+    return dars;
+  }
 
   public void setDars(List<DataAccessRequest> dars) { this.dars = dars; }
 
@@ -91,7 +97,23 @@ public class DarCollection {
       this.setDars(new ArrayList<>());
     }
     dars.add(dar);
-
   }
+
+  @Override
+  public boolean equals(Object obj){
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+
+    DarCollection other = (DarCollection) obj;
+    return new EqualsBuilder()
+      .append(this.getDarCollectionId(), other.getDarCollectionId())
+      .append(this.getDarCode(), other.getDarCode())
+      .isEquals();
+  }
+
 
 }

--- a/src/main/java/org/broadinstitute/consent/http/models/DarCollection.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DarCollection.java
@@ -28,7 +28,7 @@ public class DarCollection {
   Timestamp updateDate;
 
   @JsonProperty
-  Integer updateUser;
+  Integer updateUserId;
 
   @JsonProperty
   List<DataAccessRequest> dars;
@@ -75,12 +75,12 @@ public class DarCollection {
     this.updateDate = updateDate;
   }
 
-  public Integer getUpdateUser() {
-    return updateUser;
+  public Integer getUpdateUserId() {
+    return updateUserId;
   }
 
-  public void setUpdateUser(Integer updateUser) {
-    this.updateUser = updateUser;
+  public void setUpdateUserId(Integer updateUserId) {
+    this.updateUserId = updateUserId;
   }
 
   public List<DataAccessRequest> getDars() {

--- a/src/main/java/org/broadinstitute/consent/http/models/DarCollection.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DarCollection.java
@@ -1,10 +1,10 @@
 package org.broadinstitute.consent.http.models;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.jdbi.v3.json.Json;
 
 import java.sql.Timestamp;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 
@@ -21,13 +21,13 @@ public class DarCollection {
   Timestamp createDate;
 
   @JsonProperty
-  User createUser;
+  Integer createUser;
 
   @JsonProperty
   Timestamp updateDate;
 
   @JsonProperty
-  User updateUser;
+  Integer updateUser;
 
   @JsonProperty
   List<DataAccessRequest> dars;
@@ -58,15 +58,15 @@ public class DarCollection {
     this.createDate = createDate;
   }
 
-  public User getCreateUser() {
+  public Integer getCreateUser() {
     return createUser;
   }
 
-  public void setCreateUser(User createUser) {
+  public void setCreateUser(Integer createUser) {
     this.createUser = createUser;
   }
 
-  public Timestamp getUpdateDate() {
+  public Date getUpdateDate() {
     return updateDate;
   }
 
@@ -74,11 +74,11 @@ public class DarCollection {
     this.updateDate = updateDate;
   }
 
-  public User getUpdateUser() {
+  public Integer getUpdateUser() {
     return updateUser;
   }
 
-  public void setUpdateUser(User updateUser) {
+  public void setUpdateUser(Integer updateUser) {
     this.updateUser = updateUser;
   }
 

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
@@ -27,6 +27,7 @@ import org.apache.commons.collections.CollectionUtils;
 import org.broadinstitute.consent.http.db.ConsentDAO;
 import org.broadinstitute.consent.http.db.DAOContainer;
 import org.broadinstitute.consent.http.db.DacDAO;
+import org.broadinstitute.consent.http.db.DarCollectionDAO;
 import org.broadinstitute.consent.http.db.DataAccessRequestDAO;
 import org.broadinstitute.consent.http.db.DatasetDAO;
 import org.broadinstitute.consent.http.db.ElectionDAO;
@@ -64,6 +65,7 @@ public class DataAccessRequestService {
     private final DacDAO dacDAO;
     private final DatasetDAO dataSetDAO;
     private final DataAccessRequestDAO dataAccessRequestDAO;
+    private final DarCollectionDAO darCollectionDAO;
     private final ElectionDAO electionDAO;
     private final MatchDAO matchDAO;
     private final UserDAO userDAO;
@@ -81,6 +83,7 @@ public class DataAccessRequestService {
         this.counterService = counterService;
         this.dacDAO = container.getDacDAO();
         this.dataAccessRequestDAO = container.getDataAccessRequestDAO();
+        this.darCollectionDAO = container.getDarCollectionDAO();
         this.dataSetDAO = container.getDatasetDAO();
         this.electionDAO = container.getElectionDAO();
         this.matchDAO = container.getMatchDAO();
@@ -410,6 +413,9 @@ public class DataAccessRequestService {
             dar.getSubmissionDate(),
             now,
             dar.getData());
+        if (Objects.nonNull(dar.getCollectionId())) {
+            darCollectionDAO.updateDarCollection(dar.getCollectionId(), user.getDacUserId(), now);
+        }
         return findByReferenceId(dar.getReferenceId());
     }
 

--- a/src/main/resources/changelog-master.xml
+++ b/src/main/resources/changelog-master.xml
@@ -76,4 +76,5 @@
     <include file="changesets/changelog-consent-71.0.xml" relativeToChangelogFile="true" />
     <include file="changesets/changelog-consent-72.0.xml" relativeToChangelogFile="true" />
     <include file="changesets/changelog-consent-73.0.xml" relativeToChangelogFile="true"/>
+    <include file="changesets/changelog-consent-74.0.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/changesets/changelog-consent-74.0.xml
+++ b/src/main/resources/changesets/changelog-consent-74.0.xml
@@ -12,7 +12,7 @@
         <dropColumn tableName="dar_collection" columnName="update_user"/>
         <dropColumn tableName="dar_collection" columnName="update_date"/>
         <addColumn tableName="dar_collection">
-            <column name="update_user" type="bigint"/>
+            <column name="update_user_id" type="bigint"/>
         </addColumn>
         <addColumn tableName="dar_collection">
             <column name="update_date" type="timestamp"/>

--- a/src/main/resources/changesets/changelog-consent-74.0.xml
+++ b/src/main/resources/changesets/changelog-consent-74.0.xml
@@ -1,0 +1,22 @@
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet id="74.0" author="raejohanek">
+        <validCheckSum>ANY</validCheckSum>
+
+        <!-- fix mistake made in changeSet 72.0
+        column types cannot be cast to new type so must be dropped and re-added -->
+        <dropColumn tableName="dar_collection" columnName="update_user"/>
+        <dropColumn tableName="dar_collection" columnName="update_date"/>
+        <addColumn tableName="dar_collection">
+            <column name="update_user" type="bigint"/>
+        </addColumn>
+        <addColumn tableName="dar_collection">
+            <column name="update_date" type="timestamp"/>
+        </addColumn>
+
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/changesets/changelog-consent-74.0.xml
+++ b/src/main/resources/changesets/changelog-consent-74.0.xml
@@ -17,6 +17,6 @@
         <addColumn tableName="dar_collection">
             <column name="update_date" type="timestamp"/>
         </addColumn>
-
+        <renameColumn tableName="dar_collection" oldColumnName="create_user" newColumnName="create_user_id" />
     </changeSet>
 </databaseChangeLog>

--- a/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
@@ -341,9 +341,10 @@ public class DAOTestHelper {
     protected User createUserWithInstitution() {
         int i1 = RandomUtils.nextInt(5, 10);
         String email = RandomStringUtils.randomAlphabetic(i1);
-        Integer userId = userDAO.insertUser(email, "display name", new Date());
-        Integer institutionId = institutionDAO.insertInstitution("name", "itdirectorName", "itDirectorEmail", userId, new Date());
-        userDAO.updateUser("display name", userId, email, institutionId);
+        String name = RandomStringUtils.randomAlphabetic(10);
+        Integer userId = userDAO.insertUser(email, name, new Date());
+        Integer institutionId = institutionDAO.insertInstitution(RandomStringUtils.randomAlphanumeric(10), "itdirectorName", "itDirectorEmail", userId, new Date());
+        userDAO.updateUser(name, userId, email, institutionId);
         addUserRole(7, userId);
         createdInstitutionIds.add(institutionId);
         createdUserIds.add(userId);
@@ -470,7 +471,7 @@ public class DAOTestHelper {
     }
 
     protected DataAccessRequest createDataAccessRequestV3() {
-        User user = createUser();
+        User user = createUserWithInstitution();
         String darCode = "DAR-" + RandomUtils.nextInt(100, 1000);
         Integer collection_id = darCollectionDAO.insertDarCollection(darCode, user.getDacUserId(), new Date());
         createdDarCollections.add(collection_id);

--- a/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
@@ -466,23 +466,24 @@ public class DAOTestHelper {
 
     protected DataAccessRequest createDataAccessRequestV2() {
         Integer userId = createUser().getDacUserId();
-        return insertDAR(userId, 0);
+        return insertDAR(userId, 0, "");
     }
 
     protected DataAccessRequest createDataAccessRequestV3() {
         User user = createUser();
-        Integer collection_id = darCollectionDAO.insertDarCollection("DAR-" + RandomUtils.nextInt(100, 1000), user.getDacUserId(), new Date());
+        String darCode = "DAR-" + RandomUtils.nextInt(100, 1000);
+        Integer collection_id = darCollectionDAO.insertDarCollection(darCode, user.getDacUserId(), new Date());
         createdDarCollections.add(collection_id);
-        return insertDAR(user.getDacUserId(), collection_id);
+        return insertDAR(user.getDacUserId(), collection_id, darCode);
     }
 
     protected Integer createDataAccessRequestUserWithInstitute() {
         User user = createUserWithInstitution();
-        insertDAR(user.getDacUserId(), 0);
+        insertDAR(user.getDacUserId(), 0, "");
         return user.getInstitutionId();
     }
 
-    private DataAccessRequest insertDAR(Integer userId, Integer collectionId) {
+    private DataAccessRequest insertDAR(Integer userId, Integer collectionId, String darCode) {
         DataAccessRequestData data;
         Date now = new Date();
         try {
@@ -490,6 +491,7 @@ public class DAOTestHelper {
               new File(ResourceHelpers.resourceFilePath("dataset/dar.json")),
               Charset.defaultCharset());
             data = DataAccessRequestData.fromString(darDataString);
+            data.setDarCode(darCode);
             String referenceId = UUID.randomUUID().toString();
             if (collectionId == 0) {
                 dataAccessRequestDAO.insertVersion2(referenceId, userId, now, now, now, now, data);
@@ -535,10 +537,11 @@ public class DAOTestHelper {
 
     protected DarCollection createDarCollection() {
         User user = createUser();
-        Integer collection_id = darCollectionDAO.insertDarCollection("DAR-" + RandomUtils.nextInt(0, 1000), user.getDacUserId(), new Date());
-        insertDAR(user.getDacUserId(), collection_id);
-        insertDAR(user.getDacUserId(), collection_id);
-        insertDAR(user.getDacUserId(), collection_id);
+        String darCode = "DAR-" + RandomUtils.nextInt(100, 1000);
+        Integer collection_id = darCollectionDAO.insertDarCollection(darCode, user.getDacUserId(), new Date());
+        insertDAR(user.getDacUserId(), collection_id, darCode);
+        insertDAR(user.getDacUserId(), collection_id, darCode);
+        insertDAR(user.getDacUserId(), collection_id, darCode);
         createdDarCollections.add(collection_id);
         return darCollectionDAO.findDARCollectionByCollectionId(collection_id);
     }

--- a/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
@@ -471,7 +471,7 @@ public class DAOTestHelper {
 
     protected DataAccessRequest createDataAccessRequestV3() {
         User user = createUser();
-        Integer collection_id = darCollectionDAO.insertDarCollection("DAR-CODE", user.getDacUserId(), new Date());
+        Integer collection_id = darCollectionDAO.insertDarCollection("DAR-" + RandomUtils.nextInt(3, 5), user.getDacUserId(), new Date());
         return insertDAR(user.getDacUserId(), collection_id);
     }
 
@@ -534,7 +534,7 @@ public class DAOTestHelper {
 
     protected DarCollection createDarCollection() {
         User user = createUser();
-        Integer collection_id = darCollectionDAO.insertDarCollection("DAR-CODE", user.getDacUserId(), new Date());
+        Integer collection_id = darCollectionDAO.insertDarCollection("DAR-" + RandomUtils.nextInt(3, 5), user.getDacUserId(), new Date());
         insertDAR(user.getDacUserId(), collection_id);
         insertDAR(user.getDacUserId(), collection_id);
         insertDAR(user.getDacUserId(), collection_id);

--- a/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
@@ -471,7 +471,8 @@ public class DAOTestHelper {
 
     protected DataAccessRequest createDataAccessRequestV3() {
         User user = createUser();
-        Integer collection_id = darCollectionDAO.insertDarCollection("DAR-" + RandomUtils.nextInt(3, 5), user.getDacUserId(), new Date());
+        Integer collection_id = darCollectionDAO.insertDarCollection("DAR-" + RandomUtils.nextInt(100, 1000), user.getDacUserId(), new Date());
+        createdDarCollections.add(collection_id);
         return insertDAR(user.getDacUserId(), collection_id);
     }
 

--- a/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
@@ -475,6 +475,9 @@ public class DAOTestHelper {
         String darCode = "DAR-" + RandomUtils.nextInt(100, 1000);
         Integer collection_id = darCollectionDAO.insertDarCollection(darCode, user.getDacUserId(), new Date());
         createdDarCollections.add(collection_id);
+        for(int i = 0; i < 4; i++) {
+            insertDAR(user.getDacUserId(), collection_id, darCode);
+        }
         return insertDAR(user.getDacUserId(), collection_id, darCode);
     }
 

--- a/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
@@ -534,7 +534,7 @@ public class DAOTestHelper {
 
     protected DarCollection createDarCollection() {
         User user = createUser();
-        Integer collection_id = darCollectionDAO.insertDarCollection("DAR-" + RandomUtils.nextInt(3, 5), user.getDacUserId(), new Date());
+        Integer collection_id = darCollectionDAO.insertDarCollection("DAR-" + RandomUtils.nextInt(0, 1000), user.getDacUserId(), new Date());
         insertDAR(user.getDacUserId(), collection_id);
         insertDAR(user.getDacUserId(), collection_id);
         insertDAR(user.getDacUserId(), collection_id);

--- a/src/test/java/org/broadinstitute/consent/http/db/DarCollectionDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DarCollectionDAOTest.java
@@ -314,6 +314,27 @@ public void testFindAllDARCollectionsWithFilters_InstitutionTerm() {
     assertEquals(expectedDar.getId(), darResult.getId());
   }
 
+  @Test
+  public void testFindAllDARCollectionsCreatedByUserId(){
+    DarCollection collection = createDarCollection();
+    List<DataAccessRequest> dars = collection.getDars();
+    createDarCollection(); //create new collection associated with different user
+    Integer userId = collection.getCreateUser();
+    List<DarCollection> collectionResult = darCollectionDAO.findDARCollectionsCreatedByUserId(userId);
+    assertEquals(1, collectionResult.size());
+    assertEquals(userId, collectionResult.get(0).getCreateUser());
+
+    List<DataAccessRequest> darsResult = collectionResult.get(0).getDars();
+    assertEquals(dars.size(), darsResult.size());
+
+    for (int i = 0; i < dars.size(); i++) {
+      DataAccessRequest darOriginal = dars.get(i);
+      DataAccessRequest darResults = darsResult.get(i);
+      assertEquals(darOriginal.getId(), darResults.getId());
+      assertEquals(collection.getDarCode(), darResults.getData().getDarCode());
+    }
+  }
+
   private final String generateTestTerm(String targetString) {
     return "(?=.*" + targetString.substring(0, 4) + ")";
   }

--- a/src/test/java/org/broadinstitute/consent/http/db/DarCollectionDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DarCollectionDAOTest.java
@@ -55,7 +55,7 @@ public class DarCollectionDAOTest extends DAOTestHelper  {
     DarCollection returned = darCollectionDAO.findDARCollectionByCollectionId(collection.getDarCollectionId());
     assertNotNull(returned);
     assertEquals(collection.getDarCode(), returned.getDarCode());
-    assertEquals(collection.getCreateUser(), returned.getCreateUser());
+    assertEquals(collection.getCreateUserId(), returned.getCreateUserId());
   }
 
   @Test
@@ -320,10 +320,10 @@ public void testFindAllDARCollectionsWithFilters_InstitutionTerm() {
     DarCollection collection = createDarCollection();
     List<DataAccessRequest> dars = collection.getDars();
     createDarCollection(); //create new collection associated with different user
-    Integer userId = collection.getCreateUser();
+    Integer userId = collection.getCreateUserId();
     List<DarCollection> collectionResult = darCollectionDAO.findDARCollectionsCreatedByUserId(userId);
     assertEquals(1, collectionResult.size());
-    assertEquals(userId, collectionResult.get(0).getCreateUser());
+    assertEquals(userId, collectionResult.get(0).getCreateUserId());
 
     List<DataAccessRequest> darsResult = collectionResult.get(0).getDars();
     assertEquals(dars.size(), darsResult.size());

--- a/src/test/java/org/broadinstitute/consent/http/db/DarCollectionDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DarCollectionDAOTest.java
@@ -1,0 +1,100 @@
+package org.broadinstitute.consent.http.db;
+
+
+import org.apache.commons.lang3.RandomUtils;
+import org.broadinstitute.consent.http.models.DarCollection;
+import org.broadinstitute.consent.http.models.DataAccessRequest;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+import org.postgresql.util.PSQLException;
+import org.postgresql.util.PSQLState;
+
+import java.util.Date;
+import java.util.List;
+
+public class DarCollectionDAOTest extends DAOTestHelper  {
+
+  @Test
+  public void testFindAllDARCollections() {
+    DarCollection collection = createDarCollection();
+    List<DarCollection> allAfter = darCollectionDAO.findAllDARCollections();
+    assertTrue(allAfter.contains(collection));
+    assertEquals(1, allAfter.size());
+  }
+
+  @Test
+  public void testFindDARCollectionByReferenceId() {
+    DataAccessRequest dar = createDataAccessRequestV3();
+    DarCollection collection = darCollectionDAO.findDARCollectionByReferenceId(dar.getReferenceId());
+    assertNotNull(collection);
+    assertEquals(dar.getCollectionId(), collection.getDarCollectionId());
+    assertTrue(collection.getDars().contains(dar));
+  }
+
+  @Test
+  public void testFindDARCollectionByReferenceIdNegative() {
+    //dar without a collection ID
+    DataAccessRequest dar = createDataAccessRequestV2();
+    DarCollection collection = darCollectionDAO.findDARCollectionByReferenceId(dar.getReferenceId());
+    assertNull(collection);
+  }
+
+  @Test
+  public void testFindDARCollectionByCollectionId() {
+    DarCollection collection = createDarCollection();
+    DarCollection returned = darCollectionDAO.findDARCollectionByCollectionId(collection.getDarCollectionId());
+    assertNotNull(returned);
+    assertEquals(collection.getDarCode(), returned.getDarCode());
+    assertEquals(collection.getCreateUser(), returned.getCreateUser());
+  }
+
+  @Test
+  public void testFindDARCollectionByCollectionIdNegative() {
+    DarCollection returned = darCollectionDAO.findDARCollectionByCollectionId(RandomUtils.nextInt(1000, 2000));
+    assertNull(returned);
+  }
+
+  @Test
+  public void testInsertDARCollection() {
+    List<DarCollection> allBefore = darCollectionDAO.findAllDARCollections();
+    assertTrue(allBefore.isEmpty());
+    DarCollection collection = createDarCollection();
+    assertNotNull(collection);
+  }
+
+  @Test
+  public void testInsertDarCollectionNegative() {
+    Integer userId = createUser().getDacUserId();
+    try {
+      darCollectionDAO.insertDarCollection("darCode", 0, new Date());
+    } catch (Exception e) {
+      assertEquals(PSQLState.FOREIGN_KEY_VIOLATION.getState(), ((PSQLException)e.getCause()).getSQLState());
+    }
+    try {
+      darCollectionDAO.insertDarCollection("darCode", userId, new Date());
+      darCollectionDAO.insertDarCollection("darCode", userId, new Date());
+    } catch (Exception e) {
+      assertEquals(PSQLState.UNIQUE_VIOLATION.getState(), ((PSQLException)e.getCause()).getSQLState());
+    }
+  }
+
+  @Test
+  public void testDeleteByCollectionId() {
+    DarCollection collection = createDarCollection();
+    dataAccessRequestDAO.deleteByCollectionId(collection.getDarCollectionId());
+    darCollectionDAO.deleteByCollectionId(collection.getDarCollectionId());
+    assertNull(darCollectionDAO.findDARCollectionByCollectionId(collection.getDarCollectionId()));
+  }
+
+  @Test
+  public void testDeleteByCollectionIdNegative() {
+    try{
+      darCollectionDAO.deleteByCollectionId(RandomUtils.nextInt(100, 1000));
+    } catch (Exception e) {
+      assertEquals(PSQLState.UNIQUE_VIOLATION.getState(), ((PSQLException)e.getCause()).getSQLState());
+    }
+  }
+}

--- a/src/test/java/org/broadinstitute/consent/http/db/DarCollectionDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DarCollectionDAOTest.java
@@ -158,7 +158,7 @@ public class DarCollectionDAOTest extends DAOTestHelper  {
     DataAccessRequestData data = dar.getData();
     String projectTitle = data.getProjectTitle();
 
-    List<DarCollection> collections = darCollectionDAO.findAllDARCollectionsWithFiltersAndProjectTitleSort("", projectTitle.substring(0,5), "", "", "", 0, 10);
+    List<DarCollection> collections = darCollectionDAO.findAllDARCollectionsWithFiltersAndProjectTitleSort("", projectTitle.substring(0,5), "", "", "", 0, 10, "projectTitle", "ASC");
     assertEquals(1, collections.size());
     DarCollection targetCollection = collections.get(0);
     assertEquals(1, targetCollection.getDars().size());

--- a/src/test/java/org/broadinstitute/consent/http/db/DarCollectionDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DarCollectionDAOTest.java
@@ -4,6 +4,7 @@ package org.broadinstitute.consent.http.db;
 import org.apache.commons.lang3.RandomUtils;
 import org.broadinstitute.consent.http.models.DarCollection;
 import org.broadinstitute.consent.http.models.DataAccessRequest;
+import org.broadinstitute.consent.http.models.User;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -19,6 +20,39 @@ public class DarCollectionDAOTest extends DAOTestHelper  {
 
   @Test
   public void testFindAllDARCollections() {
+    DarCollection collection = createDarCollection();
+    List<DarCollection> allAfter = darCollectionDAO.findAllDARCollections();
+    assertTrue(allAfter.contains(collection));
+    assertEquals(1, allAfter.size());
+    assertEquals(3, collection.getDars().size());
+  }
+
+
+  public void testFindAllDARCollectionsWithFilters_None() {
+    DarCollection collection = createDarCollection();
+    List<DarCollection> allAfter = darCollectionDAO.findAllDARCollections();
+    assertTrue(allAfter.contains(collection));
+    assertEquals(1, allAfter.size());
+  }
+
+  //sort field and sort direction are populated, no filter terms present
+  public void testFindAllDARCollectionsWithFilters_SortField() {
+    DarCollection collection = createDarCollection();
+    List<DarCollection> allAfter = darCollectionDAO.findAllDARCollections();
+    assertTrue(allAfter.contains(collection));
+    assertEquals(1, allAfter.size());
+  }
+
+  //sort field and sort direction are not populated, and filter terms are present
+  public void testFindAllDARCollectionsWithFilters_Filter() {
+    DarCollection collection = createDarCollection();
+    List<DarCollection> allAfter = darCollectionDAO.findAllDARCollections();
+    assertTrue(allAfter.contains(collection));
+    assertEquals(1, allAfter.size());
+  }
+
+  //sort field and sort direction are populated, and filter terms are present
+  public void testFindAllDARCollectionsWithFilters_Both() {
     DarCollection collection = createDarCollection();
     List<DarCollection> allAfter = darCollectionDAO.findAllDARCollections();
     assertTrue(allAfter.contains(collection));
@@ -63,6 +97,8 @@ public class DarCollectionDAOTest extends DAOTestHelper  {
     assertTrue(allBefore.isEmpty());
     DarCollection collection = createDarCollection();
     assertNotNull(collection);
+    List<DarCollection> allAfter = darCollectionDAO.findAllDARCollections();
+    assertTrue(allAfter.contains(collection));
   }
 
   @Test
@@ -78,6 +114,36 @@ public class DarCollectionDAOTest extends DAOTestHelper  {
       darCollectionDAO.insertDarCollection("darCode", userId, new Date());
     } catch (Exception e) {
       assertEquals(PSQLState.UNIQUE_VIOLATION.getState(), ((PSQLException)e.getCause()).getSQLState());
+    }
+  }
+
+  @Test
+  public void testUpdateDARCollection() {
+    DarCollection collection = createDarCollection();
+    assertNotNull(collection);
+    assertNull(collection.getUpdateDate());
+    assertNull(collection.getUpdateUser());
+    User user = createUser();
+    Date date = new Date();
+    darCollectionDAO.updateDarCollection(collection.getDarCollectionId(), user.getDacUserId(), date);
+    DarCollection updated = darCollectionDAO.findDARCollectionByCollectionId(collection.getDarCollectionId());
+    assertEquals(user.getDacUserId(), updated.getUpdateUser());
+    assertEquals(date, updated.getUpdateDate());
+  }
+
+  @Test
+  public void testUpdateDarCollectionNegative() {
+    Integer userId = createUser().getDacUserId();
+    try {
+      darCollectionDAO.updateDarCollection(0, userId, new Date());
+    } catch (Exception e) {
+      assertEquals(PSQLState.FOREIGN_KEY_VIOLATION.getState(), ((PSQLException)e.getCause()).getSQLState());
+    }
+    try {
+      DarCollection collection = createDarCollection();
+      darCollectionDAO.updateDarCollection(collection.getDarCollectionId(), 0, new Date());
+    } catch (Exception e) {
+      assertEquals(PSQLState.FOREIGN_KEY_VIOLATION.getState(), ((PSQLException)e.getCause()).getSQLState());
     }
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/db/DarCollectionDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DarCollectionDAOTest.java
@@ -95,12 +95,12 @@ public class DarCollectionDAOTest extends DAOTestHelper  {
     DarCollection collection = createDarCollection();
     assertNotNull(collection);
     assertNull(collection.getUpdateDate());
-    assertNull(collection.getUpdateUser());
+    assertNull(collection.getUpdateUserId());
     User user = createUser();
     Date date = new Date();
     darCollectionDAO.updateDarCollection(collection.getDarCollectionId(), user.getDacUserId(), date);
     DarCollection updated = darCollectionDAO.findDARCollectionByCollectionId(collection.getDarCollectionId());
-    assertEquals(user.getDacUserId(), updated.getUpdateUser());
+    assertEquals(user.getDacUserId(), updated.getUpdateUserId());
     assertEquals(date, updated.getUpdateDate());
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/db/DarCollectionDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DarCollectionDAOTest.java
@@ -5,6 +5,7 @@ import org.apache.commons.lang3.RandomUtils;
 import org.broadinstitute.consent.http.models.DarCollection;
 import org.broadinstitute.consent.http.models.DataAccessRequest;
 import org.broadinstitute.consent.http.models.DataAccessRequestData;
+import org.broadinstitute.consent.http.models.Institution;
 import org.broadinstitute.consent.http.models.User;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -171,9 +172,9 @@ public class DarCollectionDAOTest extends DAOTestHelper  {
 public void testFindAllDARCollectionsWithFilters_InstitutionTerm() {
 
     DataAccessRequest dar = createDataAccessRequestV3();
-    DataAccessRequestData data = dar.getData();
-    String institution = data.getInstitution();
-    String testTerm = generateTestTerm(institution);
+    User user = userDAO.findUserById(dar.getUserId());
+    Institution institution = institutionDAO.findInstitutionById(user.getInstitutionId());
+    String testTerm = generateTestTerm(institution.getName());
 
     List<DarCollection> collections = darCollectionDAO.findAllDARCollectionsWithFilters(testTerm, "", "", "", "", 0, 10, "dar_code", "ASC");
     assertEquals(1, collections.size());
@@ -218,8 +219,8 @@ public void testFindAllDARCollectionsWithFilters_InstitutionTerm() {
   @Test
   public void testFindAllDARCollectionssWithFilters_ResearcherTerm() {
     DataAccessRequest dar = createDataAccessRequestV3();
-    DataAccessRequestData data = dar.getData();
-    String researcherTerm = data.getResearcher().substring(0, 5);
+    User user = userDAO.findUserById(dar.getUserId());
+    String researcherTerm = user.getDisplayName();
     String testTerm = generateTestTerm(researcherTerm);
 
     List<DarCollection> collections = darCollectionDAO.findAllDARCollectionsWithFilters("", "", testTerm,

--- a/src/test/java/org/broadinstitute/consent/http/db/DarCollectionDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DarCollectionDAOTest.java
@@ -14,13 +14,10 @@ import org.junit.Test;
 import org.postgresql.util.PSQLException;
 import org.postgresql.util.PSQLState;
 
-import java.util.Collections;
 import java.util.Date;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import javax.validation.constraints.AssertTrue;
 
 public class DarCollectionDAOTest extends DAOTestHelper  {
 

--- a/src/test/java/org/broadinstitute/consent/http/db/DarCollectionDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DarCollectionDAOTest.java
@@ -15,6 +15,7 @@ import org.postgresql.util.PSQLState;
 
 import java.util.Date;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class DarCollectionDAOTest extends DAOTestHelper  {
 
@@ -49,7 +50,8 @@ public class DarCollectionDAOTest extends DAOTestHelper  {
     DarCollection collection = darCollectionDAO.findDARCollectionByReferenceId(dar.getReferenceId());
     assertNotNull(collection);
     assertEquals(dar.getCollectionId(), collection.getDarCollectionId());
-    //assertTrue(collection.getDars().contains(dar));
+    List<String> ids = collection.getDars().stream().map(d -> d.getReferenceId()).collect(Collectors.toList());
+    assertTrue(ids.contains(dar.getReferenceId()));
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/db/DarCollectionDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DarCollectionDAOTest.java
@@ -15,6 +15,7 @@ import org.junit.Test;
 import org.postgresql.util.PSQLException;
 import org.postgresql.util.PSQLState;
 
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -28,7 +29,6 @@ public class DarCollectionDAOTest extends DAOTestHelper  {
     List<DarCollection> allAfter = darCollectionDAO.findAllDARCollections();
     assertTrue(allAfter.contains(collection));
     assertEquals(1, allAfter.size());
-    assertEquals(3, collection.getDars().size());
   }
 
   @Test
@@ -142,7 +142,7 @@ public class DarCollectionDAOTest extends DAOTestHelper  {
     createDataAccessRequestV3(); // create second collection w DAR
 
     List<DarCollection> collectionsResult = darCollectionDAO.findAllDARCollectionsWithFilters("", "",
-        "", "", "", 0, 10, "dar_code", "ASC");
+        "", "", "", "dar_code", "ASC");
 
     assertEquals(2, collectionsResult.size());
     
@@ -160,12 +160,12 @@ public class DarCollectionDAOTest extends DAOTestHelper  {
     String projectTitle = data.getProjectTitle();
     String testTerm = generateTestTerm(projectTitle);
 
-    List<DarCollection> collections = darCollectionDAO.findAllDARCollectionsWithFilters("", testTerm, "", "", "", 0, 10, "dar_code", "ASC");
+    List<DarCollection> collections = darCollectionDAO.findAllDARCollectionsWithFilters("", testTerm, "", "", "", "dar_code", "ASC");
     assertEquals(1, collections.size());
     DarCollection targetCollection = collections.get(0);
-    assertEquals(1, targetCollection.getDars().size());
+    assertEquals(5, targetCollection.getDars().size());
     DataAccessRequest targetDar = targetCollection.getDars().get(0);
-    assertEquals(dar.getId(), targetDar.getId());
+    assertEquals(targetDar.getData().getDarCode(), targetCollection.getDarCode());
   }
 
 @Test
@@ -176,12 +176,12 @@ public void testFindAllDARCollectionsWithFilters_InstitutionTerm() {
     Institution institution = institutionDAO.findInstitutionById(user.getInstitutionId());
     String testTerm = generateTestTerm(institution.getName());
 
-    List<DarCollection> collections = darCollectionDAO.findAllDARCollectionsWithFilters(testTerm, "", "", "", "", 0, 10, "dar_code", "ASC");
+    List<DarCollection> collections = darCollectionDAO.findAllDARCollectionsWithFilters(testTerm, "", "", "", "", "dar_code", "ASC");
     assertEquals(1, collections.size());
     DarCollection targetCollection = collections.get(0);
-    assertEquals(1, targetCollection.getDars().size());
+    assertEquals(5, targetCollection.getDars().size());
     DataAccessRequest targetDar = targetCollection.getDars().get(0);
-    assertEquals(dar.getId(), targetDar.getId());
+    assertEquals(targetCollection.getDarCode(), targetDar.getData().getDarCode());
   }
 
   @Test
@@ -192,12 +192,12 @@ public void testFindAllDARCollectionsWithFilters_InstitutionTerm() {
     String datasetLabel = data.getDatasets().get(0).getLabel();
     String testTerm = generateTestTerm(datasetLabel);
 
-    List<DarCollection> collections = darCollectionDAO.findAllDARCollectionsWithFilters("", "", "", "", testTerm, 0, 10, "dar_code", "ASC");
+    List<DarCollection> collections = darCollectionDAO.findAllDARCollectionsWithFilters("", "", "", "", testTerm, "dar_code", "ASC");
     assertEquals(1, collections.size());
     DarCollection targetCollection = collections.get(0);
-    assertEquals(1, targetCollection.getDars().size());
+    assertEquals(5, targetCollection.getDars().size());
     DataAccessRequest targetDar = targetCollection.getDars().get(0);
-    assertEquals(dar.getId(), targetDar.getId());
+    assertEquals(targetCollection.getDarCode(), targetDar.getData().getDarCode());
   }
 
   @Test
@@ -208,28 +208,28 @@ public void testFindAllDARCollectionsWithFilters_InstitutionTerm() {
     String darCode = data.getDarCode();
     String testTerm = generateTestTerm(darCode);
 
-    List<DarCollection> collections = darCollectionDAO.findAllDARCollectionsWithFilters("", "", "", testTerm, "", 0, 10, "dar_code", "ASC");
+    List<DarCollection> collections = darCollectionDAO.findAllDARCollectionsWithFilters("", "", "", testTerm, "", "dar_code", "ASC");
     assertEquals(1, collections.size());
     DarCollection targetCollection = collections.get(0);
-    assertEquals(1, targetCollection.getDars().size());
+    assertEquals(5, targetCollection.getDars().size());
     DataAccessRequest targetDar = targetCollection.getDars().get(0);
-    assertEquals(dar.getId(), targetDar.getId());
+    assertEquals(targetCollection.getDarCode(), targetDar.getData().getDarCode());
   }
 
   @Test
-  public void testFindAllDARCollectionssWithFilters_ResearcherTerm() {
+  public void testFindAllDARCollectionsWithFilters_ResearcherTerm() {
     DataAccessRequest dar = createDataAccessRequestV3();
     User user = userDAO.findUserById(dar.getUserId());
     String researcherTerm = user.getDisplayName();
     String testTerm = generateTestTerm(researcherTerm);
 
     List<DarCollection> collections = darCollectionDAO.findAllDARCollectionsWithFilters("", "", testTerm,
-        "", "", 0, 10, "dar_code", "ASC");
+        "", "", "dar_code", "ASC");
     assertEquals(1, collections.size());
     DarCollection targetCollection = collections.get(0);
-    assertEquals(1, targetCollection.getDars().size());
+    assertEquals(5, targetCollection.getDars().size());
     DataAccessRequest targetDar = targetCollection.getDars().get(0);
-    assertEquals(dar.getId(), targetDar.getId());
+    assertEquals(targetDar.getData().getDarCode(), targetCollection.getDarCode());
   }
 
   @Test
@@ -238,21 +238,19 @@ public void testFindAllDARCollectionsWithFilters_InstitutionTerm() {
     createDataAccessRequestV3(); //create second collection w DAR
 
     List<DarCollection> collections =  darCollectionDAO.findAllDARCollections();
-    collections.sort((a,b) -> -1 * (a.getDarCode().compareToIgnoreCase(b.getDarCode())));
+    collections.sort((a,b) -> (a.getDarCode().compareToIgnoreCase(b.getDarCode())));
+    Collections.reverse(collections);
 
     List<DarCollection> collectionsResult = darCollectionDAO.findAllDARCollectionsWithFilters("", "",
-        "", "", "", 0, 10, "dar_code", "DESC");
+        "", "", "", "dar_code", "DESC");
     
     assertEquals(2, collectionsResult.size());
-    assertEquals(collectionsResult.get(0).getDarCode(), collections.get(0).getDarCode());
+    assertEquals(collections.get(0).getDarCode(), collectionsResult.get(0).getDarCode());
 
     DataAccessRequest darResultOne = collectionsResult.get(0).getDars().get(0);
     DataAccessRequest darResultTwo = collectionsResult.get(1).getDars().get(0);
-    DataAccessRequest expectedDarOne = collections.get(0).getDars().get(0);
-    DataAccessRequest expectedDarTwo = collections.get(1).getDars().get(0);
-    assertEquals(expectedDarOne.getId(), darResultOne.getId());
-    assertEquals(expectedDarTwo.getId(), darResultTwo.getId());
-
+    assertEquals(collections.get(0).getDarCode(), darResultOne.getData().getDarCode());
+    assertEquals(collections.get(1).getDarCode(), darResultTwo.getData().getDarCode());
   }
 
   @Test
@@ -264,7 +262,7 @@ public void testFindAllDARCollectionsWithFilters_InstitutionTerm() {
     collections.sort((a, b) -> (a.getDarCode().compareToIgnoreCase(b.getDarCode())));
 
     List<DarCollection> collectionsResult = darCollectionDAO.findAllDARCollectionsWithFilters("", "",
-        "", "", "", 0, 10, "dar_code", "ASC");
+        "", "", "", "dar_code", "ASC");
 
     assertEquals(2, collectionsResult.size());
     assertEquals(collectionsResult.get(0).getDarCode(), collections.get(0).getDarCode());
@@ -273,46 +271,8 @@ public void testFindAllDARCollectionsWithFilters_InstitutionTerm() {
     DataAccessRequest darResultTwo = collectionsResult.get(1).getDars().get(0);
     DataAccessRequest expectedDarOne = collections.get(0).getDars().get(0);
     DataAccessRequest expectedDarTwo = collections.get(1).getDars().get(0);
-    assertEquals(expectedDarOne.getId(), darResultOne.getId());
-    assertEquals(expectedDarTwo.getId(), darResultTwo.getId());
-  }
-
-  @Test
-  public void testFindAllDarCollectionsWithFilters_Limit() {
-    createDataAccessRequestV3(); // create first collection w DAR
-    createDataAccessRequestV3(); // create second collection w DAR
-
-    List<DarCollection> collections = darCollectionDAO.findAllDARCollections();
-    collections.sort((a, b) -> (a.getDarCode().compareToIgnoreCase(b.getDarCode())));
-
-    List<DarCollection> collectionsResult = darCollectionDAO.findAllDARCollectionsWithFilters("", "",
-        "", "", "", 0, 1, "dar_code", "ASC");
-
-    assertEquals(1, collectionsResult.size());
-    assertEquals(collectionsResult.get(0).getDarCode(), collections.get(0).getDarCode());
-
-    DataAccessRequest darResult = collectionsResult.get(0).getDars().get(0);
-    DataAccessRequest expectedDar = collections.get(0).getDars().get(0);
-    assertEquals(expectedDar.getId(), darResult.getId());
-  }
-
-  @Test
-  public void testFindAllDarCollectionsWithFilters_Offset() {
-    createDataAccessRequestV3(); // create first collection w DAR
-    createDataAccessRequestV3(); // create second collection w DAR
-
-    List<DarCollection> collections = darCollectionDAO.findAllDARCollections();
-    collections.sort((a, b) -> (a.getDarCode().compareToIgnoreCase(b.getDarCode())));
-
-    List<DarCollection> collectionsResult = darCollectionDAO.findAllDARCollectionsWithFilters("", "",
-        "", "", "", 1, 1, "dar_code", "ASC");
-
-    assertEquals(1, collectionsResult.size());
-    assertEquals(collectionsResult.get(0).getDarCode(), collections.get(1).getDarCode());
-
-    DataAccessRequest darResult = collectionsResult.get(0).getDars().get(0);
-    DataAccessRequest expectedDar = collections.get(1).getDars().get(0);
-    assertEquals(expectedDar.getId(), darResult.getId());
+    assertEquals(expectedDarOne.getData().getDarCode(), darResultOne.getData().getDarCode());
+    assertEquals(expectedDarTwo.getData().getDarCode(), darResultTwo.getData().getDarCode());
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/db/DarCollectionDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DarCollectionDAOTest.java
@@ -4,6 +4,7 @@ package org.broadinstitute.consent.http.db;
 import org.apache.commons.lang3.RandomUtils;
 import org.broadinstitute.consent.http.models.DarCollection;
 import org.broadinstitute.consent.http.models.DataAccessRequest;
+import org.broadinstitute.consent.http.models.DataAccessRequestData;
 import org.broadinstitute.consent.http.models.User;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -149,4 +150,14 @@ public class DarCollectionDAOTest extends DAOTestHelper  {
       assertEquals(PSQLState.UNIQUE_VIOLATION.getState(), ((PSQLException)e.getCause()).getSQLState());
     }
   }
+
+  @Test
+  public void testFindAllDARCollectionsWithFilters_NonetionsWithFilters_ProjectTitleFilter() {
+    DataAccessRequest dar = createDataAccessRequestV3();
+    DataAccessRequestData data = dar.getData();
+
+    String projectTitle = data.getProjectTitle();
+    List<DarCollection> collection = darCollectionDAO.findAllDARCollectionsWithFilters("", projectTitle, "", "", "", "projectTitle", "DESC", 0, 10);
+    assertEquals(1, collection.size());
+  };
 }

--- a/src/test/java/org/broadinstitute/consent/http/db/DarCollectionDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DarCollectionDAOTest.java
@@ -27,36 +27,20 @@ public class DarCollectionDAOTest extends DAOTestHelper  {
     assertEquals(3, collection.getDars().size());
   }
 
-
+  //test stubs for uncompleted DAO call
   public void testFindAllDARCollectionsWithFilters_None() {
-    DarCollection collection = createDarCollection();
-    List<DarCollection> allAfter = darCollectionDAO.findAllDARCollections();
-    assertTrue(allAfter.contains(collection));
-    assertEquals(1, allAfter.size());
   }
 
   //sort field and sort direction are populated, no filter terms present
   public void testFindAllDARCollectionsWithFilters_SortField() {
-    DarCollection collection = createDarCollection();
-    List<DarCollection> allAfter = darCollectionDAO.findAllDARCollections();
-    assertTrue(allAfter.contains(collection));
-    assertEquals(1, allAfter.size());
   }
 
   //sort field and sort direction are not populated, and filter terms are present
   public void testFindAllDARCollectionsWithFilters_Filter() {
-    DarCollection collection = createDarCollection();
-    List<DarCollection> allAfter = darCollectionDAO.findAllDARCollections();
-    assertTrue(allAfter.contains(collection));
-    assertEquals(1, allAfter.size());
   }
 
   //sort field and sort direction are populated, and filter terms are present
   public void testFindAllDARCollectionsWithFilters_Both() {
-    DarCollection collection = createDarCollection();
-    List<DarCollection> allAfter = darCollectionDAO.findAllDARCollections();
-    assertTrue(allAfter.contains(collection));
-    assertEquals(1, allAfter.size());
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/db/DarCollectionDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DarCollectionDAOTest.java
@@ -140,7 +140,7 @@ public class DarCollectionDAOTest extends DAOTestHelper  {
     createDataAccessRequestV3(); // create first collection w DAR
     createDataAccessRequestV3(); // create second collection w DAR
 
-    List<DarCollection> collectionsResult = darCollectionDAO.findAllDARCollectionsWithFiltersAndProjectTitleSort("", "",
+    List<DarCollection> collectionsResult = darCollectionDAO.findAllDARCollectionsWithFilters("", "",
         "", "", "", 0, 10, "dar_code", "ASC");
 
     assertEquals(2, collectionsResult.size());
@@ -159,7 +159,7 @@ public class DarCollectionDAOTest extends DAOTestHelper  {
     String projectTitle = data.getProjectTitle();
     String testTerm = generateTestTerm(projectTitle);
 
-    List<DarCollection> collections = darCollectionDAO.findAllDARCollectionsWithFiltersAndProjectTitleSort("", testTerm, "", "", "", 0, 10, "dar_code", "ASC");
+    List<DarCollection> collections = darCollectionDAO.findAllDARCollectionsWithFilters("", testTerm, "", "", "", 0, 10, "dar_code", "ASC");
     assertEquals(1, collections.size());
     DarCollection targetCollection = collections.get(0);
     assertEquals(1, targetCollection.getDars().size());
@@ -175,7 +175,7 @@ public void testFindAllDARCollectionsWithFilters_InstitutionTerm() {
     String institution = data.getInstitution();
     String testTerm = generateTestTerm(institution);
 
-    List<DarCollection> collections = darCollectionDAO.findAllDARCollectionsWithFiltersAndProjectTitleSort(testTerm, "", "", "", "", 0, 10, "dar_code", "ASC");
+    List<DarCollection> collections = darCollectionDAO.findAllDARCollectionsWithFilters(testTerm, "", "", "", "", 0, 10, "dar_code", "ASC");
     assertEquals(1, collections.size());
     DarCollection targetCollection = collections.get(0);
     assertEquals(1, targetCollection.getDars().size());
@@ -191,7 +191,7 @@ public void testFindAllDARCollectionsWithFilters_InstitutionTerm() {
     String datasetLabel = data.getDatasets().get(0).getLabel();
     String testTerm = generateTestTerm(datasetLabel);
 
-    List<DarCollection> collections = darCollectionDAO.findAllDARCollectionsWithFiltersAndProjectTitleSort("", "", "", "", testTerm, 0, 10, "dar_code", "ASC");
+    List<DarCollection> collections = darCollectionDAO.findAllDARCollectionsWithFilters("", "", "", "", testTerm, 0, 10, "dar_code", "ASC");
     assertEquals(1, collections.size());
     DarCollection targetCollection = collections.get(0);
     assertEquals(1, targetCollection.getDars().size());
@@ -207,7 +207,7 @@ public void testFindAllDARCollectionsWithFilters_InstitutionTerm() {
     String darCode = data.getDarCode();
     String testTerm = generateTestTerm(darCode);
 
-    List<DarCollection> collections = darCollectionDAO.findAllDARCollectionsWithFiltersAndProjectTitleSort("", "", "", testTerm, "", 0, 10, "dar_code", "ASC");
+    List<DarCollection> collections = darCollectionDAO.findAllDARCollectionsWithFilters("", "", "", testTerm, "", 0, 10, "dar_code", "ASC");
     assertEquals(1, collections.size());
     DarCollection targetCollection = collections.get(0);
     assertEquals(1, targetCollection.getDars().size());
@@ -222,7 +222,7 @@ public void testFindAllDARCollectionsWithFilters_InstitutionTerm() {
     String researcherTerm = data.getResearcher().substring(0, 5);
     String testTerm = generateTestTerm(researcherTerm);
 
-    List<DarCollection> collections = darCollectionDAO.findAllDARCollectionsWithFiltersAndProjectTitleSort("", "", testTerm,
+    List<DarCollection> collections = darCollectionDAO.findAllDARCollectionsWithFilters("", "", testTerm,
         "", "", 0, 10, "dar_code", "ASC");
     assertEquals(1, collections.size());
     DarCollection targetCollection = collections.get(0);
@@ -239,7 +239,7 @@ public void testFindAllDARCollectionsWithFilters_InstitutionTerm() {
     List<DarCollection> collections =  darCollectionDAO.findAllDARCollections();
     collections.sort((a,b) -> -1 * (a.getDarCode().compareToIgnoreCase(b.getDarCode())));
 
-    List<DarCollection> collectionsResult = darCollectionDAO.findAllDARCollectionsWithFiltersAndProjectTitleSort("", "",
+    List<DarCollection> collectionsResult = darCollectionDAO.findAllDARCollectionsWithFilters("", "",
         "", "", "", 0, 10, "dar_code", "DESC");
     
     assertEquals(2, collectionsResult.size());
@@ -262,7 +262,7 @@ public void testFindAllDARCollectionsWithFilters_InstitutionTerm() {
     List<DarCollection> collections = darCollectionDAO.findAllDARCollections();
     collections.sort((a, b) -> (a.getDarCode().compareToIgnoreCase(b.getDarCode())));
 
-    List<DarCollection> collectionsResult = darCollectionDAO.findAllDARCollectionsWithFiltersAndProjectTitleSort("", "",
+    List<DarCollection> collectionsResult = darCollectionDAO.findAllDARCollectionsWithFilters("", "",
         "", "", "", 0, 10, "dar_code", "ASC");
 
     assertEquals(2, collectionsResult.size());
@@ -284,7 +284,7 @@ public void testFindAllDARCollectionsWithFilters_InstitutionTerm() {
     List<DarCollection> collections = darCollectionDAO.findAllDARCollections();
     collections.sort((a, b) -> (a.getDarCode().compareToIgnoreCase(b.getDarCode())));
 
-    List<DarCollection> collectionsResult = darCollectionDAO.findAllDARCollectionsWithFiltersAndProjectTitleSort("", "",
+    List<DarCollection> collectionsResult = darCollectionDAO.findAllDARCollectionsWithFilters("", "",
         "", "", "", 0, 1, "dar_code", "ASC");
 
     assertEquals(1, collectionsResult.size());
@@ -303,7 +303,7 @@ public void testFindAllDARCollectionsWithFilters_InstitutionTerm() {
     List<DarCollection> collections = darCollectionDAO.findAllDARCollections();
     collections.sort((a, b) -> (a.getDarCode().compareToIgnoreCase(b.getDarCode())));
 
-    List<DarCollection> collectionsResult = darCollectionDAO.findAllDARCollectionsWithFiltersAndProjectTitleSort("", "",
+    List<DarCollection> collectionsResult = darCollectionDAO.findAllDARCollectionsWithFilters("", "",
         "", "", "", 1, 1, "dar_code", "ASC");
 
     assertEquals(1, collectionsResult.size());

--- a/src/test/java/org/broadinstitute/consent/http/db/DarCollectionDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DarCollectionDAOTest.java
@@ -49,7 +49,7 @@ public class DarCollectionDAOTest extends DAOTestHelper  {
     DarCollection collection = darCollectionDAO.findDARCollectionByReferenceId(dar.getReferenceId());
     assertNotNull(collection);
     assertEquals(dar.getCollectionId(), collection.getDarCollectionId());
-    assertTrue(collection.getDars().contains(dar));
+    //assertTrue(collection.getDars().contains(dar));
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/db/DarCollectionDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DarCollectionDAOTest.java
@@ -153,11 +153,16 @@ public class DarCollectionDAOTest extends DAOTestHelper  {
 
   @Test
   public void testFindAllDARCollectionsWithFilters_NonetionsWithFilters_ProjectTitleFilter() {
+
     DataAccessRequest dar = createDataAccessRequestV3();
     DataAccessRequestData data = dar.getData();
-
     String projectTitle = data.getProjectTitle();
-    List<DarCollection> collection = darCollectionDAO.findAllDARCollectionsWithFilters("", projectTitle, "", "", "", "projectTitle", "DESC", 0, 10);
-    assertEquals(1, collection.size());
+
+    List<DarCollection> collections = darCollectionDAO.findAllDARCollectionsWithFiltersAndProjectTitleSort("", projectTitle.substring(0,5), "", "", "", 0, 10);
+    assertEquals(1, collections.size());
+    DarCollection targetCollection = collections.get(0);
+    assertEquals(1, targetCollection.getDars().size());
+    DataAccessRequest targetDar = targetCollection.getDars().get(0);
+    assertEquals(dar.getId(), targetDar.getId());
   };
 }

--- a/src/test/java/org/broadinstitute/consent/http/db/DarCollectionDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DarCollectionDAOTest.java
@@ -152,17 +152,38 @@ public class DarCollectionDAOTest extends DAOTestHelper  {
   }
 
   @Test
-  public void testFindAllDARCollectionsWithFilters_NonetionsWithFilters_ProjectTitleFilter() {
+  public void testFindAllDARCollectionsWithFilters_ProjectTitleFilter() {
 
     DataAccessRequest dar = createDataAccessRequestV3();
     DataAccessRequestData data = dar.getData();
     String projectTitle = data.getProjectTitle();
+    String testTerm = generateTestTerm(projectTitle);
 
-    List<DarCollection> collections = darCollectionDAO.findAllDARCollectionsWithFiltersAndProjectTitleSort("", projectTitle.substring(0,5), "", "", "", 0, 10, "projectTitle", "ASC");
+    List<DarCollection> collections = darCollectionDAO.findAllDARCollectionsWithFiltersAndProjectTitleSort("", testTerm, "", "", "", 0, 10, "projectTitle", "ASC");
     assertEquals(1, collections.size());
     DarCollection targetCollection = collections.get(0);
     assertEquals(1, targetCollection.getDars().size());
     DataAccessRequest targetDar = targetCollection.getDars().get(0);
     assertEquals(dar.getId(), targetDar.getId());
-  };
-}
+  }
+
+@Test
+public void testFindAllDARCollectionsWithFilters_InstitutionFilter() {
+
+    DataAccessRequest dar = createDataAccessRequestV3();
+    DataAccessRequestData data = dar.getData();
+    String institution = data.getInstitution();
+    String testTerm = generateTestTerm(institution);
+
+    List<DarCollection> collections = darCollectionDAO.findAllDARCollectionsWithFiltersAndProjectTitleSort(testTerm, "", "", "", "", 0, 10, "projectTitle", "ASC");
+    assertEquals(1, collections.size());
+    DarCollection targetCollection = collections.get(0);
+    assertEquals(1, targetCollection.getDars().size());
+    DataAccessRequest targetDar = targetCollection.getDars().get(0);
+    assertEquals(dar.getId(), targetDar.getId());
+  }
+
+  private final String generateTestTerm(String targetString) {
+    return "(?=.*" + targetString.substring(0, 5) + ")";
+  }
+};

--- a/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
@@ -145,6 +145,12 @@ public class DataAccessRequestDAOTest extends DAOTestHelper {
     }
 
     @Test
+    public void testInsertVersion3() {
+        DataAccessRequest dar = createDataAccessRequestV3();
+        assertNotNull(dar);
+    }
+
+    @Test
     public void testEscapedCharacters() {
         DataAccessRequest dar = createDataAccessRequestV2();
         DataAccessRequest foundDar = dataAccessRequestDAO.findByReferenceId(dar.getReferenceId());

--- a/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.consent.http.db;
 
+import static junit.framework.TestCase.assertNull;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.broadinstitute.consent.http.models.DataAccessRequest;
 import org.broadinstitute.consent.http.models.User;
@@ -177,6 +178,19 @@ public class DataAccessRequestDAOTest extends DAOTestHelper {
         List<DataAccessRequest> newDars = dataAccessRequestDAO.findAllDataAccessRequestsForInstitution(institutionId);
         assertFalse(newDars.isEmpty());
         assertEquals(1, newDars.size());
+
+    }
+
+    @Test
+    public void testDeleteByCollectionId() {
+        //creates a dar with a collection ID (also creates a DarCollection)
+        DataAccessRequest dar = createDataAccessRequestV3();
+        DataAccessRequest returned = dataAccessRequestDAO.findByReferenceId(dar.getReferenceId());
+        assertNotNull(returned);
+        assertEquals(dar.getId(), returned.getId());
+        dataAccessRequestDAO.deleteByCollectionId(dar.getCollectionId());
+        DataAccessRequest returnedAfter = dataAccessRequestDAO.findByReferenceId(dar.getReferenceId());
+        assertNull(returnedAfter);
 
     }
 

--- a/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
@@ -1,5 +1,7 @@
 package org.broadinstitute.consent.http.service;
 
+import org.apache.commons.lang3.RandomUtils;
+import org.broadinstitute.consent.http.db.DarCollectionDAO;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.AuthUser;
 import org.broadinstitute.consent.http.models.Consent;
@@ -64,6 +66,8 @@ public class DataAccessRequestServiceTest {
     @Mock
     private DataAccessRequestDAO dataAccessRequestDAO;
     @Mock
+    private DarCollectionDAO darCollectionDAO;
+    @Mock
     private DacDAO dacDAO;
     @Mock
     private UserDAO userDAO;
@@ -96,6 +100,7 @@ public class DataAccessRequestServiceTest {
         DAOContainer container = new DAOContainer();
         container.setConsentDAO(consentDAO);
         container.setDataAccessRequestDAO(dataAccessRequestDAO);
+        container.setDarCollectionDAO(darCollectionDAO);
         container.setInstitutionDAO(institutionDAO);
         container.setDacDAO(dacDAO);
         container.setUserDAO(userDAO);
@@ -201,10 +206,25 @@ public class DataAccessRequestServiceTest {
     @Test
     public void testUpdateByReferenceIdVersion2() {
         DataAccessRequest dar = generateDataAccessRequest();
+        dar.setCollectionId(RandomUtils.nextInt(0, 100));
         User user = new User(1, "email@test.org", "Display Name", new Date());
         dar.getData().setDatasetIds(Arrays.asList(1, 2, 3));
         doNothing().when(dataAccessRequestDAO).updateDataByReferenceIdVersion2(any(), any(),
             any(), any(), any(), any());
+        when(dataAccessRequestDAO.findByReferenceId(any())).thenReturn(dar);
+        initService();
+        DataAccessRequest newDar = service.updateByReferenceIdVersion2(user, dar);
+        assertNotNull(newDar);
+    }
+
+    @Test
+    public void testUpdateByReferenceIdVersion2_WithCollection() {
+        DataAccessRequest dar = generateDataAccessRequest();
+        User user = new User(1, "email@test.org", "Display Name", new Date());
+        dar.getData().setDatasetIds(Arrays.asList(1, 2, 3));
+        doNothing().when(dataAccessRequestDAO).updateDataByReferenceIdVersion2(any(), any(),
+          any(), any(), any(), any());
+        doNothing().when(darCollectionDAO).updateDarCollection(any(), any(), any());
         when(dataAccessRequestDAO.findByReferenceId(any())).thenReturn(dar);
         initService();
         DataAccessRequest newDar = service.updateByReferenceIdVersion2(user, dar);


### PR DESCRIPTION
SCOPE: 
- This adds findAll, findByCollectionId, findByReferenceId, Insert, Delete, and Update  in DarCollection DAO 
- - Adds tests
- This adds delete By CollectionId and Insert Dar with collectionId DataAccessRequestDAO
- - Adds tests
- This Modifies DataAccessRequestService to update the dar collection when the dar is updated 
- - Adds test
- Adds helper in RowMapperHelper and replaces repeated code in Dar Mapper and Dar Data Mapper
- Adds a changeset that fixes an error made in changeset 72

UPDATE:
- Adds `findDarCollectionsCreatedByUserId` with associated tests
- Adds `findAllDarCollectionsWithFilters` with associated tests

ADDRESSES:
https://broadworkbench.atlassian.net/browse/DUOS-1252

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
