### PR TITLE
[DUOS-1410][risk=no] Add SO token for jenkins tests

### DIFF
--- a/jenkins/jenkins-render-configs.sh
+++ b/jenkins/jenkins-render-configs.sh
@@ -24,7 +24,8 @@ secretPath="/secret/dsde/firecloud/${ENV}/consent/automation"
 listOfRoles="admin
 chair
 member
-researcher"
+researcher
+signing-official"
 
 for role in $listOfRoles; do
   echo "Writing $role file from $secretPath/duos-automation-$role.json"


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-1410

The SO credentials exist in vault but aren't used in any tests yet. Add it to the rendering script for the time when we do have SO specific integration tests.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
