### PR TITLE
Revert "Revert "[DUOS-1411][risk=no] Add Sam Status""

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
@@ -28,12 +28,13 @@ import org.broadinstitute.consent.http.authentication.DefaultAuthFilter;
 import org.broadinstitute.consent.http.authentication.DefaultAuthenticator;
 import org.broadinstitute.consent.http.authentication.OAuthAuthenticator;
 import org.broadinstitute.consent.http.authentication.OAuthCustomAuthFilter;
-import org.broadinstitute.consent.http.cloudstore.GCSHealthCheck;
+import org.broadinstitute.consent.http.health.GCSHealthCheck;
 import org.broadinstitute.consent.http.cloudstore.GCSService;
 import org.broadinstitute.consent.http.cloudstore.GCSStore;
 import org.broadinstitute.consent.http.configurations.ConsentConfiguration;
 import org.broadinstitute.consent.http.db.UserRoleDAO;
 import org.broadinstitute.consent.http.filters.ResponseServerFilter;
+import org.broadinstitute.consent.http.health.SamHealthCheck;
 import org.broadinstitute.consent.http.models.AuthUser;
 import org.broadinstitute.consent.http.resources.ApprovalExpirationTimeResource;
 import org.broadinstitute.consent.http.resources.ConsentAssociationResource;
@@ -90,11 +91,11 @@ import org.broadinstitute.consent.http.service.SummaryService;
 import org.broadinstitute.consent.http.service.UseRestrictionValidator;
 import org.broadinstitute.consent.http.service.UserService;
 import org.broadinstitute.consent.http.service.VoteService;
-import org.broadinstitute.consent.http.service.ontology.ElasticSearchHealthCheck;
+import org.broadinstitute.consent.http.health.ElasticSearchHealthCheck;
 import org.broadinstitute.consent.http.service.ontology.IndexOntologyService;
 import org.broadinstitute.consent.http.service.ontology.IndexerService;
 import org.broadinstitute.consent.http.service.ontology.IndexerServiceImpl;
-import org.broadinstitute.consent.http.service.ontology.OntologyHealthCheck;
+import org.broadinstitute.consent.http.health.OntologyHealthCheck;
 import org.broadinstitute.consent.http.service.ontology.StoreOntologyService;
 import org.broadinstitute.consent.http.service.sam.SamService;
 import org.broadinstitute.consent.http.util.HttpClientUtil;
@@ -124,6 +125,11 @@ import java.util.Objects;
 public class ConsentApplication extends Application<ConsentConfiguration> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger("ConsentApplication");
+
+    public static final String GCS_CHECK = "google-cloud-storage";
+    public static final String ES_CHECK = "elastic-search";
+    public static final String ONTOLOGY_CHECK = "ontology";
+    public static final String SAM_CHECK = "sam";
 
     public static void main(String[] args) throws Exception {
         LOGGER.info("Starting Consent Application");
@@ -187,9 +193,10 @@ public class ConsentApplication extends Application<ConsentConfiguration> {
         configureCors(env);
 
         // Health Checks
-        env.healthChecks().register("google-cloud-storage", new GCSHealthCheck(gcsService));
-        env.healthChecks().register("elastic-search", new ElasticSearchHealthCheck(config.getElasticSearchConfiguration()));
-        env.healthChecks().register("ontology", new OntologyHealthCheck(clientUtil, config.getServicesConfiguration()));
+        env.healthChecks().register(GCS_CHECK, new GCSHealthCheck(gcsService));
+        env.healthChecks().register(ES_CHECK, new ElasticSearchHealthCheck(config.getElasticSearchConfiguration()));
+        env.healthChecks().register(ONTOLOGY_CHECK, new OntologyHealthCheck(clientUtil, config.getServicesConfiguration()));
+        env.healthChecks().register(SAM_CHECK, new SamHealthCheck(clientUtil, config.getServicesConfiguration()));
 
         final StoreOntologyService storeOntologyService = new StoreOntologyService(
                 googleStore,

--- a/src/main/java/org/broadinstitute/consent/http/health/ElasticSearchHealthCheck.java
+++ b/src/main/java/org/broadinstitute/consent/http/health/ElasticSearchHealthCheck.java
@@ -1,4 +1,4 @@
-package org.broadinstitute.consent.http.service.ontology;
+package org.broadinstitute.consent.http.health;
 
 import static org.broadinstitute.consent.http.service.ontology.ElasticSearchSupport.jsonHeader;
 
@@ -9,6 +9,7 @@ import io.dropwizard.lifecycle.Managed;
 import java.nio.charset.Charset;
 import org.apache.commons.io.IOUtils;
 import org.broadinstitute.consent.http.configurations.ElasticSearchConfiguration;
+import org.broadinstitute.consent.http.service.ontology.ElasticSearchSupport;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.Response;

--- a/src/main/java/org/broadinstitute/consent/http/health/GCSHealthCheck.java
+++ b/src/main/java/org/broadinstitute/consent/http/health/GCSHealthCheck.java
@@ -1,7 +1,8 @@
-package org.broadinstitute.consent.http.cloudstore;
+package org.broadinstitute.consent.http.health;
 
 import com.codahale.metrics.health.HealthCheck;
 import com.google.cloud.storage.Bucket;
+import org.broadinstitute.consent.http.cloudstore.GCSService;
 
 public class GCSHealthCheck extends HealthCheck {
 

--- a/src/main/java/org/broadinstitute/consent/http/health/OntologyHealthCheck.java
+++ b/src/main/java/org/broadinstitute/consent/http/health/OntologyHealthCheck.java
@@ -1,12 +1,17 @@
-package org.broadinstitute.consent.http.service.ontology;
+package org.broadinstitute.consent.http.health;
 
 import com.codahale.metrics.health.HealthCheck;
 import com.google.api.client.http.HttpStatusCodes;
+import com.google.gson.Gson;
 import io.dropwizard.lifecycle.Managed;
+import org.apache.commons.io.IOUtils;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.broadinstitute.consent.http.configurations.ServicesConfiguration;
 import org.broadinstitute.consent.http.util.HttpClientUtil;
+
+import java.nio.charset.Charset;
+import java.util.LinkedHashMap;
 
 public class OntologyHealthCheck extends HealthCheck implements Managed {
 
@@ -24,8 +29,14 @@ public class OntologyHealthCheck extends HealthCheck implements Managed {
       String statusUrl = servicesConfiguration.getOntologyURL() + "status";
       HttpGet httpGet = new HttpGet(statusUrl);
       try (CloseableHttpResponse response = clientUtil.getHttpResponse(httpGet)) {
+        String content = IOUtils.toString(response.getEntity().getContent(), Charset.defaultCharset());
+        Object ontologyStatus = new Gson().fromJson(content, Object.class);
         if (response.getStatusLine().getStatusCode() == HttpStatusCodes.STATUS_CODE_OK) {
-          return Result.healthy();
+          return Result.builder()
+                  .withDetail("ok", true)
+                  .withDetail("systems", ontologyStatus)
+                  .healthy()
+                  .build();
         } else {
           return Result.unhealthy("Ontology status is unhealthy: " + response.getStatusLine());
         }

--- a/src/main/java/org/broadinstitute/consent/http/health/OntologyHealthCheck.java
+++ b/src/main/java/org/broadinstitute/consent/http/health/OntologyHealthCheck.java
@@ -8,17 +8,18 @@ import org.apache.commons.io.IOUtils;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.broadinstitute.consent.http.configurations.ServicesConfiguration;
+import org.broadinstitute.consent.http.resources.StatusResource;
 import org.broadinstitute.consent.http.util.HttpClientUtil;
 
 import java.nio.charset.Charset;
-import java.util.LinkedHashMap;
 
 public class OntologyHealthCheck extends HealthCheck implements Managed {
 
   private final HttpClientUtil clientUtil;
   private final ServicesConfiguration servicesConfiguration;
 
-  public OntologyHealthCheck(HttpClientUtil clientUtil, ServicesConfiguration servicesConfiguration) {
+  public OntologyHealthCheck(
+      HttpClientUtil clientUtil, ServicesConfiguration servicesConfiguration) {
     this.clientUtil = clientUtil;
     this.servicesConfiguration = servicesConfiguration;
   }
@@ -29,14 +30,15 @@ public class OntologyHealthCheck extends HealthCheck implements Managed {
       String statusUrl = servicesConfiguration.getOntologyURL() + "status";
       HttpGet httpGet = new HttpGet(statusUrl);
       try (CloseableHttpResponse response = clientUtil.getHttpResponse(httpGet)) {
-        String content = IOUtils.toString(response.getEntity().getContent(), Charset.defaultCharset());
-        Object ontologyStatus = new Gson().fromJson(content, Object.class);
         if (response.getStatusLine().getStatusCode() == HttpStatusCodes.STATUS_CODE_OK) {
+          String content =
+              IOUtils.toString(response.getEntity().getContent(), Charset.defaultCharset());
+          Object ontologyStatus = new Gson().fromJson(content, Object.class);
           return Result.builder()
-                  .withDetail("ok", true)
-                  .withDetail("systems", ontologyStatus)
-                  .healthy()
-                  .build();
+              .withDetail(StatusResource.OK, true)
+              .withDetail(StatusResource.SYSTEMS, ontologyStatus)
+              .healthy()
+              .build();
         } else {
           return Result.unhealthy("Ontology status is unhealthy: " + response.getStatusLine());
         }
@@ -50,11 +52,9 @@ public class OntologyHealthCheck extends HealthCheck implements Managed {
 
   @Override
   public void start() {
-    // no-op
   }
 
   @Override
   public void stop() {
-    // no-op
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/health/SamHealthCheck.java
+++ b/src/main/java/org/broadinstitute/consent/http/health/SamHealthCheck.java
@@ -8,57 +8,55 @@ import org.apache.commons.io.IOUtils;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.broadinstitute.consent.http.configurations.ServicesConfiguration;
+import org.broadinstitute.consent.http.resources.StatusResource;
 import org.broadinstitute.consent.http.util.HttpClientUtil;
 
 import java.nio.charset.Charset;
 
 public class SamHealthCheck extends HealthCheck implements Managed {
 
-    private final HttpClientUtil clientUtil;
-    private final ServicesConfiguration configuration;
+  private final HttpClientUtil clientUtil;
+  private final ServicesConfiguration configuration;
 
-    public SamHealthCheck(HttpClientUtil clientUtil, ServicesConfiguration configuration) {
-        this.clientUtil = clientUtil;
-        this.configuration = configuration;
-    }
+  public SamHealthCheck(HttpClientUtil clientUtil, ServicesConfiguration configuration) {
+    this.clientUtil = clientUtil;
+    this.configuration = configuration;
+  }
 
-    @Override
-    protected Result check() throws Exception {
-        try {
-            String statusUrl = configuration.getSamUrl() + "status";
-            HttpGet httpGet = new HttpGet(statusUrl);
-            try (CloseableHttpResponse response = clientUtil.getHttpResponse(httpGet)) {
-                String content = IOUtils.toString(response.getEntity().getContent(), Charset.defaultCharset());
-                SamStatus samStatus = new Gson().fromJson(content, SamStatus.class);
-                if (response.getStatusLine().getStatusCode() == HttpStatusCodes.STATUS_CODE_OK) {
-                    return Result.builder()
-                            .withDetail("ok", samStatus.ok)
-                            .withDetail("systems", samStatus.systems)
-                            .healthy()
-                            .build();
-                } else {
-                    return Result.unhealthy("Sam status is unhealthy: " + response.getStatusLine());
-                }
-            } catch (Exception e) {
-                return Result.unhealthy(e);
-            }
-        } catch (Exception e) {
-            return Result.unhealthy(e);
+  @Override
+  protected Result check() throws Exception {
+    try {
+      String statusUrl = configuration.getSamUrl() + "status";
+      HttpGet httpGet = new HttpGet(statusUrl);
+      try (CloseableHttpResponse response = clientUtil.getHttpResponse(httpGet)) {
+        if (response.getStatusLine().getStatusCode() == HttpStatusCodes.STATUS_CODE_OK) {
+          String content =
+              IOUtils.toString(response.getEntity().getContent(), Charset.defaultCharset());
+          SamStatus samStatus = new Gson().fromJson(content, SamStatus.class);
+          return Result.builder()
+              .withDetail(StatusResource.OK, samStatus.ok)
+              .withDetail(StatusResource.SYSTEMS, samStatus.systems)
+              .healthy()
+              .build();
+        } else {
+          return Result.unhealthy("Sam status is unhealthy: " + response.getStatusLine());
         }
+      } catch (Exception e) {
+        return Result.unhealthy(e);
+      }
+    } catch (Exception e) {
+      return Result.unhealthy(e);
     }
+  }
 
-    @Override
-    public void start() throws Exception {
+  @Override
+  public void start() throws Exception {}
 
-    }
+  @Override
+  public void stop() throws Exception {}
 
-    @Override
-    public void stop() throws Exception {
-
-    }
-
-    private static class SamStatus {
-        boolean ok;
-        Object systems;
-    }
+  private static class SamStatus {
+    boolean ok;
+    Object systems;
+  }
 }

--- a/src/main/java/org/broadinstitute/consent/http/health/SamHealthCheck.java
+++ b/src/main/java/org/broadinstitute/consent/http/health/SamHealthCheck.java
@@ -1,0 +1,64 @@
+package org.broadinstitute.consent.http.health;
+
+import com.codahale.metrics.health.HealthCheck;
+import com.google.api.client.http.HttpStatusCodes;
+import com.google.gson.Gson;
+import io.dropwizard.lifecycle.Managed;
+import org.apache.commons.io.IOUtils;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.broadinstitute.consent.http.configurations.ServicesConfiguration;
+import org.broadinstitute.consent.http.util.HttpClientUtil;
+
+import java.nio.charset.Charset;
+
+public class SamHealthCheck extends HealthCheck implements Managed {
+
+    private final HttpClientUtil clientUtil;
+    private final ServicesConfiguration configuration;
+
+    public SamHealthCheck(HttpClientUtil clientUtil, ServicesConfiguration configuration) {
+        this.clientUtil = clientUtil;
+        this.configuration = configuration;
+    }
+
+    @Override
+    protected Result check() throws Exception {
+        try {
+            String statusUrl = configuration.getSamUrl() + "status";
+            HttpGet httpGet = new HttpGet(statusUrl);
+            try (CloseableHttpResponse response = clientUtil.getHttpResponse(httpGet)) {
+                String content = IOUtils.toString(response.getEntity().getContent(), Charset.defaultCharset());
+                SamStatus samStatus = new Gson().fromJson(content, SamStatus.class);
+                if (response.getStatusLine().getStatusCode() == HttpStatusCodes.STATUS_CODE_OK) {
+                    return Result.builder()
+                            .withDetail("ok", samStatus.ok)
+                            .withDetail("systems", samStatus.systems)
+                            .healthy()
+                            .build();
+                } else {
+                    return Result.unhealthy("Sam status is unhealthy: " + response.getStatusLine());
+                }
+            } catch (Exception e) {
+                return Result.unhealthy(e);
+            }
+        } catch (Exception e) {
+            return Result.unhealthy(e);
+        }
+    }
+
+    @Override
+    public void start() throws Exception {
+
+    }
+
+    @Override
+    public void stop() throws Exception {
+
+    }
+
+    private static class SamStatus {
+        boolean ok;
+        Object systems;
+    }
+}

--- a/src/main/java/org/broadinstitute/consent/http/resources/StatusResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/StatusResource.java
@@ -20,6 +20,7 @@ public class StatusResource {
 
     public static final String OK = "ok";
     public static final String DEGRADED = "degraded";
+    public static final String SYSTEMS = "systems";
 
     private Logger logger() {
         return LoggerFactory.getLogger(this.getClass());
@@ -66,7 +67,7 @@ public class StatusResource {
                 || !ontology.isHealthy()
                 || !sam.isHealthy());
         formattedResults.put(DEGRADED, degraded);
-        formattedResults.putAll(results);
+        formattedResults.put(SYSTEMS, results);
         return formattedResults;
     }
 

--- a/src/main/java/org/broadinstitute/consent/http/resources/StatusResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/StatusResource.java
@@ -2,6 +2,7 @@ package org.broadinstitute.consent.http.resources;
 
 import com.codahale.metrics.health.HealthCheck;
 import com.codahale.metrics.health.HealthCheckRegistry;
+import org.broadinstitute.consent.http.ConsentApplication;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -9,12 +10,16 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.Response;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static org.broadinstitute.consent.http.ConsentModule.DB_ENV;
 
 @Path("status")
 public class StatusResource {
+
+    public static final String OK = "ok";
+    public static final String DEGRADED = "degraded";
 
     private Logger logger() {
         return LoggerFactory.getLogger(this.getClass());
@@ -32,14 +37,37 @@ public class StatusResource {
         Map<String, HealthCheck.Result> results = healthChecks.runHealthChecks();
         HealthCheck.Result postgresql = results.getOrDefault(DB_ENV, HealthCheck.Result.unhealthy("Unable to access postgresql database"));
         if (postgresql.isHealthy()) {
-            return Response.ok(results).build();
+            return Response.ok(formatResults(results)).build();
         } else {
             results.entrySet().
                     stream().
                     filter(e -> !e.getValue().isHealthy()).
                     forEach(e -> logger().error("Error in service " + e.getKey() + ": " + formatResultError(e.getValue())));
-            return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(results).build();
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(formatResults(results)).build();
         }
+    }
+
+    private Map<String, Object> formatResults(Map<String, HealthCheck.Result> results) {
+        // Order is important so we put Ok and Degraded states at the beginning of the map and
+        // add all other entries after that.
+        Map<String, Object> formattedResults = new LinkedHashMap<>();
+        boolean healthy = false;
+        HealthCheck.Result postgresql = results.getOrDefault(DB_ENV, HealthCheck.Result.unhealthy("Unable to access postgresql database"));
+        if (postgresql.isHealthy()) {
+            healthy = true;
+        }
+        formattedResults.put(OK, healthy);
+        HealthCheck.Result gcs = results.getOrDefault(ConsentApplication.GCS_CHECK, HealthCheck.Result.unhealthy("Unable to access Sam"));
+        HealthCheck.Result elasticSearch = results.getOrDefault(ConsentApplication.ES_CHECK, HealthCheck.Result.unhealthy("Unable to access Sam"));
+        HealthCheck.Result ontology = results.getOrDefault(ConsentApplication.ONTOLOGY_CHECK, HealthCheck.Result.unhealthy("Unable to access Sam"));
+        HealthCheck.Result sam = results.getOrDefault(ConsentApplication.SAM_CHECK, HealthCheck.Result.unhealthy("Unable to access Sam"));
+        boolean degraded = (!gcs.isHealthy()
+                || !elasticSearch.isHealthy()
+                || !ontology.isHealthy()
+                || !sam.isHealthy());
+        formattedResults.put(DEGRADED, degraded);
+        formattedResults.putAll(results);
+        return formattedResults;
     }
 
     private String formatResultError(HealthCheck.Result result) {

--- a/src/main/java/org/broadinstitute/consent/http/service/sam/SamService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/sam/SamService.java
@@ -67,6 +67,6 @@ public class SamService {
   }
 
   private String getV1ResourceTypesUrl() {
-    return configuration.getSamUrl() + "/api/config/v1/resourceTypes";
+    return configuration.getSamUrl() + "api/config/v1/resourceTypes";
   }
 }

--- a/src/test/java/org/broadinstitute/consent/http/health/GCSHealthCheckTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/health/GCSHealthCheckTest.java
@@ -1,15 +1,16 @@
-package org.broadinstitute.consent.http.cloudstore;
-
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.when;
+package org.broadinstitute.consent.http.health;
 
 import com.codahale.metrics.health.HealthCheck;
 import com.google.cloud.storage.Bucket;
+import org.broadinstitute.consent.http.cloudstore.GCSService;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
 
 public class GCSHealthCheckTest {
 
@@ -23,7 +24,7 @@ public class GCSHealthCheckTest {
 
     @Before
     public void setUpClass() {
-        MockitoAnnotations.initMocks(this);
+        MockitoAnnotations.openMocks(this);
         healthCheck = new GCSHealthCheck(store);
     }
 

--- a/src/test/java/org/broadinstitute/consent/http/health/OntologyHealthCheckTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/health/OntologyHealthCheckTest.java
@@ -1,0 +1,78 @@
+package org.broadinstitute.consent.http.health;
+
+import com.codahale.metrics.health.HealthCheck;
+import com.google.api.client.http.HttpStatusCodes;
+import org.apache.http.StatusLine;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.entity.StringEntity;
+import org.broadinstitute.consent.http.configurations.ServicesConfiguration;
+import org.broadinstitute.consent.http.util.HttpClientUtil;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+
+public class OntologyHealthCheckTest {
+
+  @Mock private HttpClientUtil clientUtil;
+
+  @Mock private CloseableHttpResponse response;
+
+  @Mock private StatusLine statusLine;
+
+  @Mock private ServicesConfiguration servicesConfiguration;
+
+  private OntologyHealthCheck healthCheck;
+
+  @Before
+  public void setUp() {
+    MockitoAnnotations.openMocks(this);
+  }
+
+  private void initHealthCheck() {
+    try {
+      when(response.getEntity()).thenReturn(new StringEntity("{}"));
+      when(clientUtil.getHttpResponse(any())).thenReturn(response);
+      when(servicesConfiguration.getOntologyURL()).thenReturn("http://localhost:8000/");
+      healthCheck = new OntologyHealthCheck(clientUtil, servicesConfiguration);
+    } catch (Exception e) {
+      fail(e.getMessage());
+    }
+  }
+
+  @Test
+  public void testCheckSuccess() {
+    when(statusLine.getStatusCode()).thenReturn(HttpStatusCodes.STATUS_CODE_OK);
+    when(response.getStatusLine()).thenReturn(statusLine);
+    initHealthCheck();
+
+    HealthCheck.Result result = healthCheck.check();
+    assertTrue(result.isHealthy());
+  }
+
+  @Test
+  public void testCheckFailure() {
+    when(statusLine.getStatusCode()).thenReturn(HttpStatusCodes.STATUS_CODE_SERVER_ERROR);
+    when(response.getStatusLine()).thenReturn(statusLine);
+    initHealthCheck();
+
+    HealthCheck.Result result = healthCheck.check();
+    assertFalse(result.isHealthy());
+  }
+
+  @Test
+  public void testCheckException() {
+    doThrow(new RuntimeException()).when(response).getStatusLine();
+    initHealthCheck();
+
+    HealthCheck.Result result = healthCheck.check();
+    assertFalse(result.isHealthy());
+  }
+}

--- a/src/test/java/org/broadinstitute/consent/http/resources/StatusResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/StatusResourceTest.java
@@ -2,74 +2,104 @@ package org.broadinstitute.consent.http.resources;
 
 import com.codahale.metrics.health.HealthCheck.Result;
 import com.codahale.metrics.health.HealthCheckRegistry;
-import org.junit.Assert;
+import org.broadinstitute.consent.http.ConsentApplication;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import javax.ws.rs.core.Response;
+import java.util.LinkedHashMap;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
 import static org.broadinstitute.consent.http.ConsentModule.DB_ENV;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.when;
 
 public class StatusResourceTest {
 
-    private Result postgresql;
-    private Result ontology;
-    private final static String ONT_ENV = "ontology";
+  @Mock private HealthCheckRegistry healthChecks;
 
-    @Mock
-    private HealthCheckRegistry healthChecks;
+  @Before
+  public void setUp() {
+    MockitoAnnotations.openMocks(this);
+  }
 
-    @Before
-    public void setUp() {
-        postgresql = Result.healthy();
-        ontology = Result.healthy();
-    }
+  private StatusResource initStatusResource(SortedMap<String, Result> checks) {
+    when(healthChecks.runHealthChecks()).thenReturn(checks);
+    return new StatusResource(healthChecks);
+  }
 
-    private StatusResource initStatusResource(SortedMap<String, Result> checks) {
-        MockitoAnnotations.initMocks(this);
-        when(healthChecks.runHealthChecks()).thenReturn(checks);
-        return new StatusResource(healthChecks);
-    }
+  @Test
+  public void testHealthy() {
+    SortedMap<String, Result> checks = new TreeMap<>();
+    checks.put(DB_ENV, Result.healthy());
+    checks.put(ConsentApplication.ONTOLOGY_CHECK, Result.healthy());
+    StatusResource statusResource = initStatusResource(checks);
 
-    @Test
-    public void testHealthy() {
-        SortedMap<String, Result> checks = new TreeMap<>();
-        checks.put(DB_ENV, postgresql);
-        checks.put(ONT_ENV, ontology);
-        StatusResource statusResource = initStatusResource(checks);
+    Response response = statusResource.getStatus();
+    assertEquals(200, response.getStatus());
+  }
 
-        Response response = statusResource.getStatus();
-        Assert.assertEquals(200, response.getStatus());
-    }
+  @Test
+  public void testUnhealthyDatabase() {
+    Result postgresql = Result.unhealthy(new Exception("Cannot connect to the postgresql database"));
+    SortedMap<String, Result> checks = new TreeMap<>();
+    checks.put(DB_ENV, postgresql);
+    checks.put(ConsentApplication.ONTOLOGY_CHECK, Result.healthy());
+    StatusResource statusResource = initStatusResource(checks);
 
-    @Test
-    public void testUnhealthyDatabase() {
-        postgresql = Result.unhealthy(new Exception("Cannot connect to the postgresql database"));
-        SortedMap<String, Result> checks = new TreeMap<>();
-        checks.put(DB_ENV, postgresql);
-        checks.put(ONT_ENV, ontology);
-        StatusResource statusResource = initStatusResource(checks);
+    Response response = statusResource.getStatus();
+    assertEquals(500, response.getStatus());
+  }
 
-        Response response = statusResource.getStatus();
-        Assert.assertEquals(500, response.getStatus());
-    }
+  @Test
+  public void testUnhealthyOntology() {
+    Result ontology = Result.unhealthy("Ontology is down");
+    SortedMap<String, Result> checks = new TreeMap<>();
+    checks.put(DB_ENV, Result.healthy());
+    checks.put(ConsentApplication.ONTOLOGY_CHECK, ontology);
+    StatusResource statusResource = initStatusResource(checks);
 
-    @Test
-    public void testUnhealthyOntology() {
-        ontology = Result.unhealthy("Ontology is down");
-        SortedMap<String, Result> checks = new TreeMap<>();
-        checks.put(DB_ENV, postgresql);
-        checks.put(ONT_ENV, ontology);
-        StatusResource statusResource = initStatusResource(checks);
+    Response response = statusResource.getStatus();
+    // A failing ontology check should not fail the status
+    assertEquals(200, response.getStatus());
+  }
 
-        Response response = statusResource.getStatus();
-        // A failing ontology check should not fail the status
-        Assert.assertEquals(200, response.getStatus());
-    }
+  @Test
+  public void testNotDegraded() {
+    SortedMap<String, Result> checks = new TreeMap<>();
+    checks.put(DB_ENV, Result.healthy());
+    checks.put(ConsentApplication.ONTOLOGY_CHECK, Result.healthy());
+    checks.put(ConsentApplication.ES_CHECK, Result.healthy());
+    checks.put(ConsentApplication.GCS_CHECK, Result.healthy());
+    checks.put(ConsentApplication.SAM_CHECK, Result.healthy());
+    StatusResource statusResource = initStatusResource(checks);
 
+    Response response = statusResource.getStatus();
+    assertEquals(200, response.getStatus());
+    @SuppressWarnings("rawtypes")
+    LinkedHashMap content = (LinkedHashMap) response.getEntity();
+    assertEquals(Boolean.FALSE, content.get(StatusResource.DEGRADED));
+  }
+
+  @Test
+  public void testDegraded() {
+    SortedMap<String, Result> checks = new TreeMap<>();
+    checks.put(DB_ENV, Result.healthy());
+    checks.put(ConsentApplication.ONTOLOGY_CHECK, Result.healthy());
+    checks.put(ConsentApplication.ES_CHECK, Result.healthy());
+    checks.put(ConsentApplication.GCS_CHECK, Result.healthy());
+    checks.put(ConsentApplication.SAM_CHECK, Result.unhealthy("Sam is Down"));
+    StatusResource statusResource = initStatusResource(checks);
+
+    Response response = statusResource.getStatus();
+    // A failing sam check should not fail the status
+    assertEquals(200, response.getStatus());
+    // A failing sam check should mark the system as degraded
+    @SuppressWarnings("rawtypes")
+    LinkedHashMap content = (LinkedHashMap) response.getEntity();
+    assertEquals(Boolean.TRUE, content.get(StatusResource.DEGRADED));
+  }
 }

--- a/src/test/java/org/broadinstitute/consent/http/service/SamServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/SamServiceTest.java
@@ -40,7 +40,7 @@ public class SamServiceTest implements WithMockServer {
     MockitoAnnotations.openMocks(this);
     mockServerClient = new MockServerClient(container.getHost(), container.getServerPort());
     ServicesConfiguration config = new ServicesConfiguration();
-    config.setSamUrl("http://" + container.getHost() + ":" + container.getServerPort());
+    config.setSamUrl("http://" + container.getHost() + ":" + container.getServerPort() + "/");
     service = new SamService(config);
   }
 


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-1411

Reverts DataBiosphere/consent#1234

This re-introduces https://github.com/DataBiosphere/consent/pull/1232 which was reverted in #1234.

Depends on:
* ~https://github.com/broadinstitute/firecloud-orchestration/pull/874~ (merged)
* ~https://github.com/broadinstitute/firecloud-develop/pull/2635~ (merged)
* ~https://github.com/broadinstitute/firecloud-develop/pull/2636~ (merged)

Manually verified that both orchestration and fiab-start work with the new consent status [here](https://fc-jenkins.dsp-techops.broadinstitute.org/view/FIAB/job/fiab-start/61710/).

