### PR TITLE
[DUOS-1415][risk=no] Fetch/display Sam user status info

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
@@ -175,7 +175,7 @@ public class ConsentModule extends AbstractModule {
 
     @Provides
     OAuthAuthenticator providesOAuthAuthenticator() {
-        return new OAuthAuthenticator(providesClient());
+        return new OAuthAuthenticator(providesClient(), providesSamService());
     }
 
     @Provides

--- a/src/main/java/org/broadinstitute/consent/http/models/AuthUser.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/AuthUser.java
@@ -1,6 +1,8 @@
 package org.broadinstitute.consent.http.models;
 
+import com.google.gson.Gson;
 import org.broadinstitute.consent.http.authentication.GoogleUser;
+import org.broadinstitute.consent.http.models.sam.UserStatusInfo;
 
 import java.security.Principal;
 
@@ -10,11 +12,17 @@ public class AuthUser implements Principal {
   private String email;
   private GoogleUser googleUser;
   private String name;
+  private UserStatusInfo userStatusInfo;
 
   public AuthUser() {}
 
   public AuthUser(String email) {
     this.email = email;
+  }
+
+  public AuthUser deepCopy() {
+    Gson gson = new Gson();
+    return gson.fromJson(gson.toJson(this), AuthUser.class);
   }
 
   public AuthUser(GoogleUser googleUser) {
@@ -57,6 +65,15 @@ public class AuthUser implements Principal {
 
   public AuthUser setName(String name) {
     this.name = name;
+    return this;
+  }
+
+  public UserStatusInfo getUserStatusInfo() {
+    return userStatusInfo;
+  }
+
+  public AuthUser setUserStatusInfo(UserStatusInfo userStatusInfo) {
+    this.userStatusInfo = userStatusInfo;
     return this;
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
@@ -93,7 +93,7 @@ public class UserResource extends Resource {
     public Response getUser(@Auth AuthUser authUser) {
         try {
             User user = userService.findUserByEmail(authUser.getEmail());
-            JsonObject userJson = constructUserJsonObject(user);
+            JsonObject userJson = constructUserJsonObject(authUser, user);
             return Response.ok(gson.toJson(userJson)).build();
         } catch (Exception e) {
             return createExceptionResponse(e);
@@ -107,7 +107,7 @@ public class UserResource extends Resource {
     public Response getUserById(@Auth AuthUser authUser, @PathParam("userId") Integer userId) {
         try {
             User user = userService.findUserById(userId);
-            JsonObject userJson = constructUserJsonObject(user);
+            JsonObject userJson = constructUserJsonObject(authUser, user);
             return Response.ok(gson.toJson(userJson)).build();
         } catch (Exception e) {
             return createExceptionResponse(e);
@@ -140,7 +140,7 @@ public class UserResource extends Resource {
                     UserRole role = new UserRole(roleId, UserRoles.getUserRoleFromId(roleId).getRoleName());
                     userService.insertUserRoles(Collections.singletonList(role), user.getDacUserId());
                     user = userService.findUserById(userId);
-                    JsonObject userJson = constructUserJsonObject(user);
+                    JsonObject userJson = constructUserJsonObject(authUser, user);
                     return Response.ok().entity(gson.toJson(userJson)).build();
                 } else {
                     return Response.notModified().build();
@@ -165,13 +165,13 @@ public class UserResource extends Resource {
             }
             List<Integer> currentUserRoleIds = user.getUserRoleIdsFromUser();
             if (!currentUserRoleIds.contains(roleId)) {
-                JsonObject userJson = constructUserJsonObject(user);
+                JsonObject userJson = constructUserJsonObject(authUser, user);
                 return Response.ok().entity(gson.toJson(userJson)).build();
             }
             User auth = userService.findUserByEmail(authUser.getEmail());
             userService.deleteUserRole(auth, userId, roleId);
             user = userService.findUserById(userId);
-            JsonObject userJson = constructUserJsonObject(user);
+            JsonObject userJson = constructUserJsonObject(authUser, user);
             return Response.ok().entity(gson.toJson(userJson)).build();
         } catch (Exception e) {
             return createExceptionResponse(e);
@@ -248,7 +248,7 @@ public class UserResource extends Resource {
             User user = userService.findUserByEmail(authUser.getEmail());
             researcherService.setProperties(userPropertiesMap, authUser);
             User updatedUser = userService.findUserById(user.getDacUserId());
-            JsonObject userJson = constructUserJsonObject(updatedUser);
+            JsonObject userJson = constructUserJsonObject(authUser, updatedUser);
             return Response.created(info.getRequestUriBuilder().build()).entity(gson.toJson(userJson)).build();
         } catch (Exception e) {
             return createExceptionResponse(e);
@@ -264,7 +264,7 @@ public class UserResource extends Resource {
             User user = userService.findUserByEmail(authUser.getEmail());
             researcherService.updateProperties(userProperties, authUser, validate);
             User updatedUser = userService.findUserById(user.getDacUserId());
-            JsonObject userJson = constructUserJsonObject(updatedUser);
+            JsonObject userJson = constructUserJsonObject(authUser, updatedUser);
             return Response.ok().entity(gson.toJson(userJson)).build();
         } catch (Exception e) {
             return createExceptionResponse(e);
@@ -276,14 +276,16 @@ public class UserResource extends Resource {
      * @param user The User
      * @return JsonObject version of the user with researcher properties and library card entries
      */
-    private JsonObject constructUserJsonObject(User user) {
+    private JsonObject constructUserJsonObject(AuthUser authUser, User user) {
         List<UserProperty> props = userService.findAllUserProperties(user.getDacUserId());
         List<LibraryCard> entries = libraryCardService.findLibraryCardsByUserId(user.getDacUserId());
         JsonObject userJson = gson.toJsonTree(user).getAsJsonObject();
         JsonArray propsJson = gson.toJsonTree(props).getAsJsonArray();
         JsonArray entriesJson = gson.toJsonTree(entries).getAsJsonArray();
+        JsonObject userInfoStatusJson = gson.toJsonTree(authUser.getUserStatusInfo()).getAsJsonObject();
         userJson.add("researcherProperties", propsJson);
         userJson.add("libraryCards", entriesJson);
+        userJson.add("userInfoStatus", userInfoStatusJson);
         return userJson;
     }
 

--- a/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
@@ -285,8 +285,8 @@ public class UserResource extends Resource {
         userJson.add("researcherProperties", propsJson);
         userJson.add("libraryCards", entriesJson);
         if (Objects.nonNull(authUser.getUserStatusInfo())) {
-            JsonObject userInfoStatusJson = gson.toJsonTree(authUser.getUserStatusInfo()).getAsJsonObject();
-            userJson.add("userInfoStatus", userInfoStatusJson);
+            JsonObject userStatusInfoJson = gson.toJsonTree(authUser.getUserStatusInfo()).getAsJsonObject();
+            userJson.add("userStatusInfo", userStatusInfoJson);
         }
         return userJson;
     }

--- a/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
@@ -282,10 +282,12 @@ public class UserResource extends Resource {
         JsonObject userJson = gson.toJsonTree(user).getAsJsonObject();
         JsonArray propsJson = gson.toJsonTree(props).getAsJsonArray();
         JsonArray entriesJson = gson.toJsonTree(entries).getAsJsonArray();
-        JsonObject userInfoStatusJson = gson.toJsonTree(authUser.getUserStatusInfo()).getAsJsonObject();
         userJson.add("researcherProperties", propsJson);
         userJson.add("libraryCards", entriesJson);
-        userJson.add("userInfoStatus", userInfoStatusJson);
+        if (Objects.nonNull(authUser.getUserStatusInfo())) {
+            JsonObject userInfoStatusJson = gson.toJsonTree(authUser.getUserStatusInfo()).getAsJsonObject();
+            userJson.add("userInfoStatus", userInfoStatusJson);
+        }
         return userJson;
     }
 

--- a/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
@@ -10,6 +10,7 @@ import org.broadinstitute.consent.http.models.LibraryCard;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.UserProperty;
 import org.broadinstitute.consent.http.models.UserRole;
+import org.broadinstitute.consent.http.models.sam.UserStatusInfo;
 import org.broadinstitute.consent.http.service.LibraryCardService;
 import org.broadinstitute.consent.http.service.ResearcherService;
 import org.broadinstitute.consent.http.service.UserService;
@@ -43,6 +44,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 public class UserResourceTest {
 
@@ -58,6 +60,8 @@ public class UserResourceTest {
 
   @Mock private UriBuilder uriBuilder;
 
+  @Mock private UserStatusInfo userStatusInfo;
+
   private final String TEST_EMAIL = "test@gmail.com";
 
   private AuthUser authUser;
@@ -67,8 +71,10 @@ public class UserResourceTest {
     GoogleUser googleUser = new GoogleUser();
     googleUser.setName("Test User");
     googleUser.setEmail(TEST_EMAIL);
-    authUser = new AuthUser(googleUser);
-    MockitoAnnotations.initMocks(this);
+    authUser = new AuthUser(googleUser)
+            .setAuthToken("auth-token")
+            .setUserStatusInfo(userStatusInfo);
+    openMocks(this);
     when(uriInfo.getRequestUriBuilder()).thenReturn(uriBuilder);
     when(uriBuilder.path(anyString())).thenReturn(uriBuilder);
     when(uriBuilder.build(anyString())).thenReturn(new URI("http://localhost:8180/dacuser/api"));


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-1415

## Changes
* Fetch Sam user registration status for all authenticated requests
* Show that info on the user object when available
* Log any errors we get but do not block the user on failure

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
