### PR TITLE
[DUOS-1427][risk=no] Auto-register unregistered users in Sam

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
@@ -243,7 +243,7 @@ public class ConsentApplication extends Application<ConsentConfiguration> {
         env.jersey().register(new ApprovalExpirationTimeResource(approvalExpirationTimeService, userService));
         env.jersey().register(new MatchResource(matchService));
         env.jersey().register(new MetricsResource(metricsService));
-        env.jersey().register(new UserResource(researcherService, userService, libraryCardService));
+        env.jersey().register(new UserResource(libraryCardService, researcherService, samService, userService));
         env.jersey().register(new ResearcherResource(researcherService, userService, libraryCardService));
         env.jersey().register(new SamResource(samService));
         env.jersey().register(new SwaggerResource(config.getGoogleAuthentication()));

--- a/src/main/java/org/broadinstitute/consent/http/authentication/OAuthAuthenticator.java
+++ b/src/main/java/org/broadinstitute/consent/http/authentication/OAuthAuthenticator.java
@@ -86,7 +86,7 @@ public class OAuthAuthenticator implements Authenticator<String, AuthUser> {
                     request(MediaType.APPLICATION_JSON_TYPE).
                     get(Response.class);
             String result = response.readEntity(String.class);
-            tokenInfo = new ObjectMapper().readValue(result, new TypeReference<HashMap<String, Object>>() {});
+            tokenInfo = new ObjectMapper().readValue(result, new TypeReference<>() {});
         } catch (Exception e) {
             logger.error("Error validating access token: " + e.getMessage());
             unauthorized(accessToken);

--- a/src/main/java/org/broadinstitute/consent/http/authentication/OAuthAuthenticator.java
+++ b/src/main/java/org/broadinstitute/consent/http/authentication/OAuthAuthenticator.java
@@ -11,6 +11,7 @@ import org.broadinstitute.consent.http.service.sam.SamService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.ws.rs.NotFoundException;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -56,6 +57,8 @@ public class OAuthAuthenticator implements Authenticator<String, AuthUser> {
         try {
             UserStatusInfo userStatusInfo = samService.getRegistrationInfo(authUser);
             return authUser.deepCopy().setUserStatusInfo(userStatusInfo);
+        } catch (NotFoundException e) {
+            logger.warn("User not found: '" + authUser.getEmail());
         } catch (Throwable e) {
             logger.error("Exception retrieving Sam user info for '" + authUser.getEmail() + "': " + e.getMessage());
         }

--- a/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
@@ -47,6 +47,10 @@ import java.util.Objects;
 @Path("api/user")
 public class UserResource extends Resource {
 
+    public static final String LIBRARY_CARDS_FIELD = "libraryCards";
+    public static final String RESEARCHER_PROPERTIES_FIELD = "researcherProperties";
+    private final static String USER_STATUS_INFO_FIELD = "userStatusInfo";
+
     private final LibraryCardService libraryCardService;
     private final UserService userService;
     private final ResearcherService researcherService;
@@ -97,6 +101,9 @@ public class UserResource extends Resource {
         try {
             User user = userService.findUserByEmail(authUser.getEmail());
             JsonObject userJson = constructUserJsonObject(authUser, user);
+            if (!userJson.has(USER_STATUS_INFO_FIELD)) {
+                samService.asyncPostRegistrationInfo(authUser);
+            }
             return Response.ok(gson.toJson(userJson)).build();
         } catch (Exception e) {
             return createExceptionResponse(e);
@@ -285,11 +292,11 @@ public class UserResource extends Resource {
         JsonObject userJson = gson.toJsonTree(user).getAsJsonObject();
         JsonArray propsJson = gson.toJsonTree(props).getAsJsonArray();
         JsonArray entriesJson = gson.toJsonTree(entries).getAsJsonArray();
-        userJson.add("researcherProperties", propsJson);
-        userJson.add("libraryCards", entriesJson);
+        userJson.add(RESEARCHER_PROPERTIES_FIELD, propsJson);
+        userJson.add(LIBRARY_CARDS_FIELD, entriesJson);
         if (Objects.nonNull(authUser.getUserStatusInfo())) {
             JsonObject userStatusInfoJson = gson.toJsonTree(authUser.getUserStatusInfo()).getAsJsonObject();
-            userJson.add("userStatusInfo", userStatusInfoJson);
+            userJson.add(USER_STATUS_INFO_FIELD, userStatusInfoJson);
         }
         return userJson;
     }

--- a/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
@@ -19,6 +19,7 @@ import org.broadinstitute.consent.http.service.LibraryCardService;
 import org.broadinstitute.consent.http.service.ResearcherService;
 import org.broadinstitute.consent.http.service.UserService;
 import org.broadinstitute.consent.http.service.UserService.SimplifiedUser;
+import org.broadinstitute.consent.http.service.sam.SamService;
 
 import javax.annotation.security.PermitAll;
 import javax.annotation.security.RolesAllowed;
@@ -46,17 +47,19 @@ import java.util.Objects;
 @Path("api/user")
 public class UserResource extends Resource {
 
+    private final LibraryCardService libraryCardService;
     private final UserService userService;
     private final ResearcherService researcherService;
-    private final LibraryCardService libraryCardService;
-    private final Gson gson;
+    private final Gson gson = new Gson();
+    private final SamService samService;
 
     @Inject
-    public UserResource(ResearcherService researcherService, UserService userService, LibraryCardService libraryCardService) {
-        this.researcherService = researcherService;
-        this.userService = userService;
+    public UserResource(LibraryCardService libraryCardService, ResearcherService researcherService,
+                        SamService samService, UserService userService) {
         this.libraryCardService = libraryCardService;
-        this.gson = new Gson();
+        this.researcherService = researcherService;
+        this.samService = samService;
+        this.userService = userService;
     }
 
     @GET

--- a/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
@@ -47,8 +47,8 @@ import java.util.Objects;
 @Path("api/user")
 public class UserResource extends Resource {
 
-    public static final String LIBRARY_CARDS_FIELD = "libraryCards";
-    public static final String RESEARCHER_PROPERTIES_FIELD = "researcherProperties";
+    private final static String LIBRARY_CARDS_FIELD = "libraryCards";
+    private final static String RESEARCHER_PROPERTIES_FIELD = "researcherProperties";
     private final static String USER_STATUS_INFO_FIELD = "userStatusInfo";
 
     private final LibraryCardService libraryCardService;

--- a/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
@@ -100,10 +100,10 @@ public class UserResource extends Resource {
     public Response getUser(@Auth AuthUser authUser) {
         try {
             User user = userService.findUserByEmail(authUser.getEmail());
-            JsonObject userJson = constructUserJsonObject(authUser, user);
-            if (!userJson.has(USER_STATUS_INFO_FIELD)) {
+            if (Objects.isNull(authUser.getUserStatusInfo())) {
                 samService.asyncPostRegistrationInfo(authUser);
             }
+            JsonObject userJson = constructUserJsonObject(authUser, user);
             return Response.ok(gson.toJson(userJson)).build();
         } catch (Exception e) {
             return createExceptionResponse(e);

--- a/src/main/java/org/broadinstitute/consent/http/service/sam/SamService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/sam/SamService.java
@@ -62,4 +62,9 @@ public class SamService {
     String body = response.parseAsString();
     return new Gson().fromJson(body, UserStatus.class);
   }
+
+  public void asyncPostRegistrationInfo(AuthUser authUser) throws Exception {
+
+  }
+
 }

--- a/src/main/java/org/broadinstitute/consent/http/service/sam/SamService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/sam/SamService.java
@@ -80,11 +80,7 @@ public class SamService {
   public void asyncPostRegistrationInfo(AuthUser authUser) {
     ListeningExecutorService listeningExecutorService = MoreExecutors.listeningDecorator(executorService);
     ListenableFuture<UserStatus> userStatusFuture =
-        listeningExecutorService.submit(() -> {
-          UserStatus userStatus = postRegistrationInfo(authUser);
-          Thread.sleep(10000);
-          return userStatus;
-        });
+        listeningExecutorService.submit(() -> postRegistrationInfo(authUser));
     Futures.addCallback(
         userStatusFuture,
         new FutureCallback<>() {

--- a/src/main/java/org/broadinstitute/consent/http/util/HttpClientUtil.java
+++ b/src/main/java/org/broadinstitute/consent/http/util/HttpClientUtil.java
@@ -44,23 +44,28 @@ public class HttpClientUtil {
     return request;
   }
 
-  public HttpResponse handleHttpRequest(HttpRequest request) throws Exception {
-    HttpResponse response = request.setThrowExceptionOnExecuteError(false).execute();
-    if (Objects.nonNull(response)) {
-      switch (response.getStatusCode()) {
-        case HttpStatusCodes.STATUS_CODE_BAD_REQUEST:
-          throw new BadRequestException(response.getStatusMessage());
-        case HttpStatusCodes.STATUS_CODE_UNAUTHORIZED:
-          throw new NotAuthorizedException(response.getStatusMessage());
-        case HttpStatusCodes.STATUS_CODE_FORBIDDEN:
-          throw new ForbiddenException(response.getStatusMessage());
-        case HttpStatusCodes.STATUS_CODE_NOT_FOUND:
-          throw new NotFoundException(response.getStatusMessage());
-        case HttpStatusCodes.STATUS_CODE_CONFLICT:
-          throw new ConsentConflictException(response.getStatusMessage());
-        default:
-          return response;
+  public HttpResponse handleHttpRequest(HttpRequest request) {
+    try {
+      request.setThrowExceptionOnExecuteError(false);
+      HttpResponse response = request.execute();
+      if (Objects.nonNull(response)) {
+        switch (response.getStatusCode()) {
+          case HttpStatusCodes.STATUS_CODE_BAD_REQUEST:
+            throw new BadRequestException(response.getStatusMessage());
+          case HttpStatusCodes.STATUS_CODE_UNAUTHORIZED:
+            throw new NotAuthorizedException(response.getStatusMessage());
+          case HttpStatusCodes.STATUS_CODE_FORBIDDEN:
+            throw new ForbiddenException(response.getStatusMessage());
+          case HttpStatusCodes.STATUS_CODE_NOT_FOUND:
+            throw new NotFoundException(response.getStatusMessage());
+          case HttpStatusCodes.STATUS_CODE_CONFLICT:
+            throw new ConsentConflictException(response.getStatusMessage());
+          default:
+            return response;
+        }
       }
+    } catch (IOException e) {
+      throw new ServerErrorException("Server Error", HttpStatusCodes.STATUS_CODE_SERVER_ERROR);
     }
     throw new ServerErrorException("Server Error", HttpStatusCodes.STATUS_CODE_SERVER_ERROR);
   }

--- a/src/test/java/org/broadinstitute/consent/http/WithMockServer.java
+++ b/src/test/java/org/broadinstitute/consent/http/WithMockServer.java
@@ -1,9 +1,16 @@
 package org.broadinstitute.consent.http;
 
+import org.mockserver.configuration.ConfigurationProperties;
 import org.testcontainers.containers.MockServerContainer;
 import org.testcontainers.utility.DockerImageName;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.util.Objects;
+import java.util.logging.LogManager;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.mockserver.configuration.ConfigurationProperties.javaLoggerLogLevel;
 
 public interface WithMockServer {
 
@@ -17,5 +24,21 @@ public interface WithMockServer {
 
   default String getRootUrl(MockServerContainer container) {
     return container.getEndpoint() + "/";
+  }
+
+  default void setDebugLogging() {
+    try {
+      ConfigurationProperties.logLevel("DEBUG");
+      String loggingConfiguration = "" +
+              "handlers=org.mockserver.logging.StandardOutConsoleHandler\n" +
+              "org.mockserver.logging.StandardOutConsoleHandler.level=ALL\n" +
+              "org.mockserver.logging.StandardOutConsoleHandler.formatter=java.util.logging.SimpleFormatter\n" +
+              "java.util.logging.SimpleFormatter.format=%1$tF %1$tT  %3$s  %4$s  %5$s %6$s%n\n" +
+              ".level=" + javaLoggerLogLevel() + "\n" +
+              "io.netty.handler.ssl.SslHandler.level=WARNING";
+      LogManager.getLogManager().readConfiguration(new ByteArrayInputStream(loggingConfiguration.getBytes(UTF_8)));
+    } catch (IOException ignore) {
+      //
+    }
   }
 }

--- a/src/test/java/org/broadinstitute/consent/http/WithMockServer.java
+++ b/src/test/java/org/broadinstitute/consent/http/WithMockServer.java
@@ -1,6 +1,7 @@
 package org.broadinstitute.consent.http;
 
 import org.mockserver.configuration.ConfigurationProperties;
+import org.slf4j.event.Level;
 import org.testcontainers.containers.MockServerContainer;
 import org.testcontainers.utility.DockerImageName;
 
@@ -26,9 +27,14 @@ public interface WithMockServer {
     return container.getEndpoint() + "/";
   }
 
+  /**
+   * Call this method to log requests/responses. It adds a good amount of non-mock-server related
+   * logging which can be ignored.
+   */
+  @SuppressWarnings("unused")
   default void setDebugLogging() {
     try {
-      ConfigurationProperties.logLevel("DEBUG");
+      ConfigurationProperties.logLevel(Level.DEBUG.name());
       String loggingConfiguration = "" +
               "handlers=org.mockserver.logging.StandardOutConsoleHandler\n" +
               "org.mockserver.logging.StandardOutConsoleHandler.level=ALL\n" +

--- a/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
@@ -14,11 +14,11 @@ import org.broadinstitute.consent.http.models.sam.UserStatusInfo;
 import org.broadinstitute.consent.http.service.LibraryCardService;
 import org.broadinstitute.consent.http.service.ResearcherService;
 import org.broadinstitute.consent.http.service.UserService;
+import org.broadinstitute.consent.http.service.sam.SamService;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 
 import javax.ws.rs.NotFoundException;
 import javax.ws.rs.core.Response;
@@ -54,6 +54,8 @@ public class UserResourceTest {
 
   @Mock private ResearcherService researcherService;
 
+  @Mock private SamService samService;
+
   private UserResource userResource;
 
   @Mock private UriInfo uriInfo;
@@ -81,7 +83,7 @@ public class UserResourceTest {
   }
 
   private void initResource() {
-    userResource = new UserResource(researcherService, userService, libraryCardService);
+    userResource = new UserResource(libraryCardService, researcherService, samService, userService);
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/SamServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/SamServiceTest.java
@@ -32,6 +32,7 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
 
@@ -160,6 +161,7 @@ public class SamServiceTest implements WithMockServer {
    * This test doesn't technically work due to some sort of async issue.
    * The response is terminated before the http request can finish executing.
    * The response completes as expected in the non-async case (see #testPostRegistrationInfo()).
+   * In practice, the async calls work as expected.
    */
   @Test
   public void testAsyncPostRegistrationInfo() {
@@ -168,6 +170,10 @@ public class SamServiceTest implements WithMockServer {
     UserStatus status = new UserStatus().setUserInfo(info).setEnabled(enabled);
     mockServerClient.when(request()).respond(response().withHeader(Header.header("Content-Type", "application/json")).withStatusCode(200).withBody(status.toString()));
 
-    service.asyncPostRegistrationInfo(authUser);
+    try {
+      service.asyncPostRegistrationInfo(authUser);
+    } catch (Exception e) {
+      fail(e.getMessage());
+    }
   }
 }

--- a/src/test/java/org/broadinstitute/consent/http/service/SamServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/SamServiceTest.java
@@ -18,6 +18,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockserver.client.MockServerClient;
 import org.mockserver.model.Header;
+import org.mockserver.model.HttpResponse;
 import org.testcontainers.containers.MockServerContainer;
 
 import java.util.Collections;
@@ -103,5 +104,20 @@ public class SamServiceTest implements WithMockServer {
 
     UserStatus userStatus = service.postRegistrationInfo(authUser);
     assertNotNull(userStatus);
+  }
+
+  /**
+   * This test doesn't technically work due to some sort of async issue.
+   * The response is terminated before the http request can finish executing.
+   * The response completes as expected in the non-async case (see #testPostRegistrationInfo()).
+   */
+  @Test
+  public void testAsyncPostRegistrationInfo() {
+    UserStatus.UserInfo info = new UserStatus.UserInfo().setUserEmail("test@test.org").setUserSubjectId("subjectId");
+    UserStatus.Enabled enabled = new UserStatus.Enabled().setAllUsersGroup(true).setGoogle(true).setLdap(true);
+    UserStatus status = new UserStatus().setUserInfo(info).setEnabled(enabled);
+    mockServerClient.when(request()).respond(response().withHeader(Header.header("Content-Type", "application/json")).withStatusCode(200).withBody(status.toString()));
+
+    service.asyncPostRegistrationInfo(authUser);
   }
 }


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-1427

## Changes
* New async call to register a user in Sam
* Check in `/me` on registration status and register if none found
* Minor cleanup in `OAuthAuthenticator` and `HttpClientUtil`
* More tests for `SamService`
* Minor mock server utility update

## Testing
To test locally:
* Set up a new gmail account that does not exist in Sam
* Go to [Sam Dev](https://sam.dsde-dev.broadinstitute.org/#/Users/getUserStatus), auth with that account, and try the endpoint. You should get a 404.
* On your local instance of consent, auth with that same account
* Go to go `/api/me` in swagger
* You should now see in the logs a successful registration message, i.e. `consent  | INFO  [2021-08-31 15:47:55,843] org.broadinstitute.consent.http.service.sam.SamService: Successfully registered user in Sam: grushton.dev20@gmail.com`
* Go back to the Sam swagger and retry your get user registration status - it should find your user.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
