### PR TITLE
[DUOS-302][risk=no] Disable maven progress indicator

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -20,12 +20,12 @@ jobs:
         if: github.actor == 'dependabot[bot]'
         env:
           MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
-        run: mvn clean test
+        run: mvn clean test --no-transfer-progress
       - name: Test Report
         if: github.actor != 'dependabot[bot]'
         env:
           COVERALLS_TOKEN: ${{ secrets.COVERALLS_TOKEN }}
           MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
         run: |
-          mvn -v
-          mvn clean jacoco:prepare-agent test jacoco:report coveralls:report -DrepoToken=$COVERALLS_TOKEN
+          mvn -v --no-transfer-progress
+          mvn clean jacoco:prepare-agent test jacoco:report coveralls:report -DrepoToken=$COVERALLS_TOKEN --no-transfer-progress

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -27,5 +27,5 @@ jobs:
           COVERALLS_TOKEN: ${{ secrets.COVERALLS_TOKEN }}
           MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
         run: |
-          mvn -v --no-transfer-progress
+          mvn -v
           mvn clean jacoco:prepare-agent test jacoco:report coveralls:report -DrepoToken=$COVERALLS_TOKEN --no-transfer-progress

--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -20,5 +20,5 @@ jobs:
         env:
           MAVEN_OPTS: -Dmaven.test.skip=true -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
         run: |
-          mvn -v --no-transfer-progress
+          mvn -v
           mvn clean package --no-transfer-progress

--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -20,5 +20,5 @@ jobs:
         env:
           MAVEN_OPTS: -Dmaven.test.skip=true -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
         run: |
-          mvn -v
-          mvn clean package
+          mvn -v --no-transfer-progress
+          mvn clean package --no-transfer-progress

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY .git /usr/src/app/.git
 COPY pom.xml /usr/src/app/pom.xml
 COPY src /usr/src/app/src
 
-RUN mvn clean package -Dmaven.test.skip=true
+RUN mvn clean package -Dmaven.test.skip=true --no-transfer-progress
 
 # Published
 FROM us.gcr.io/broad-dsp-gcr-public/base/jre:11-alpine


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-302

These changes cut down the logs in the actions so they're easier to read. The automation tests alone are cut from 30K+ down to about 1500.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
