### PR TITLE
[DUOS-302][risk=no] Fix some shade warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -192,7 +192,6 @@
         <artifactId>maven-shade-plugin</artifactId>
         <version>3.2.4</version>
         <configuration>
-          <minimizeJar>true</minimizeJar>
           <finalName>consent</finalName>
           <createDependencyReducedPom>true</createDependencyReducedPom>
           <filters>

--- a/pom.xml
+++ b/pom.xml
@@ -198,11 +198,17 @@
             <filter>
               <artifact>*:*</artifact>
               <excludes>
+                <exclude>module-info.class</exclude>
+                <exclude>about.html</exclude>
+                <exclude>LICENSE</exclude>
+                <exclude>META-INF/DEPENDENCIES</exclude>
+                <exclude>META-INF/license</exclude>
+                <exclude>META-INF/LICENSE*</exclude>
+                <exclude>META-INF/MANIFEST*</exclude>
+                <exclude>META-INF/NOTICE*</exclude>
                 <exclude>META-INF/*.SF</exclude>
                 <exclude>META-INF/*.DSA</exclude>
                 <exclude>META-INF/*.RSA</exclude>
-                <exclude>META-INF/LICENSE</exclude>
-                <exclude>META-INF/license</exclude>
               </excludes>
             </filter>
           </filters>

--- a/pom.xml
+++ b/pom.xml
@@ -198,7 +198,7 @@
             <filter>
               <artifact>*:*</artifact>
               <excludes>
-                <exclude>**/*.html</exclude>
+                <exclude>about.html</exclude>
                 <exclude>**/LICENSE*</exclude>
                 <exclude>**/pom.properties</exclude>
                 <exclude>**/pom.xml</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -192,18 +192,20 @@
         <artifactId>maven-shade-plugin</artifactId>
         <version>3.2.4</version>
         <configuration>
+          <minimizeJar>true</minimizeJar>
           <finalName>consent</finalName>
           <createDependencyReducedPom>true</createDependencyReducedPom>
           <filters>
             <filter>
               <artifact>*:*</artifact>
               <excludes>
-                <exclude>module-info.class</exclude>
-                <exclude>about.html</exclude>
-                <exclude>LICENSE</exclude>
+                <exclude>**/*.html</exclude>
+                <exclude>**/LICENSE*</exclude>
+                <exclude>**/pom.properties</exclude>
+                <exclude>**/pom.xml</exclude>
+                <exclude>**/module-info.class</exclude>
                 <exclude>META-INF/DEPENDENCIES</exclude>
                 <exclude>META-INF/license</exclude>
-                <exclude>META-INF/LICENSE*</exclude>
                 <exclude>META-INF/MANIFEST*</exclude>
                 <exclude>META-INF/NOTICE*</exclude>
                 <exclude>META-INF/*.SF</exclude>


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-302

This removes some of the benign shade warnings by filtering out non-relevant files from the assembled jar

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
