### PR TITLE
[DUOS-1435][risk=no] Delay dependabot PRs when running automated tests

### DIFF
--- a/.github/workflows/automation.yaml
+++ b/.github/workflows/automation.yaml
@@ -11,12 +11,15 @@ jobs:
         run: echo "${{ github.actor }}"
 
       - name: Log ENV
+        if: github.actor == 'rushtong'
         run: |
           echo "GITHUB_RUN_NUMBER: $GITHUB_RUN_NUMBER"
+          echo $GITHUB_RUN_NUMBER % 2
           echo "GITHUB_JOB: $GITHUB_JOB"
           echo "GITHUB_RUN_ID: $GITHUB_RUN_ID"
 
       - name: Sleep if Dependabot
+        if: github.actor == 'rushtong'
         uses: whatnick/wait-action@master
         with:
           time: '1s'

--- a/.github/workflows/automation.yaml
+++ b/.github/workflows/automation.yaml
@@ -12,13 +12,13 @@ jobs:
 
       - name: Log ENV
         run: |
-          echo "GITHUB_RUN_NUMBER: ${{ github.GITHUB_RUN_NUMBER }}"
-          echo "GITHUB_JOB: ${{ github.GITHUB_JOB }}"
-          echo "GITHUB_RUN_ID: ${{ github.GITHUB_RUN_ID }}"
+          echo "GITHUB_RUN_NUMBER: ${{ GITHUB_RUN_NUMBER }}"
+          echo "GITHUB_JOB: ${{ GITHUB_JOB }}"
+          echo "GITHUB_RUN_ID: ${{ GITHUB_RUN_ID }}"
 
       - name: Sleep if Dependabot
-#        if: github.actor == 'dependabot[bot]'
-#       TODO: Change this to dependabot when functional
+        # TODO: Change this to dependabot when functional
+        # if: github.actor == 'dependabot[bot]'
         uses: whatnick/wait-action@master
         with:
           time: '1s'

--- a/.github/workflows/automation.yaml
+++ b/.github/workflows/automation.yaml
@@ -19,45 +19,46 @@ jobs:
           echo "GITHUB_JOB: $GITHUB_JOB"
           echo "GITHUB_RUN_ID: $GITHUB_RUN_ID"
           bash -c 'echo $(($GITHUB_RUN_NUMBER % 10))'
-          echo "::set-output name=sleep::bash -c 'echo $(($GITHUB_RUN_NUMBER % 10))'"
-          echo "sleep var is: ${{ steps.sleep-calculation.outputs.sleep }}"
+          echo $(($GITHUB_RUN_NUMBER % 10))
+          echo "::set-output name=sleep::$(($GITHUB_RUN_NUMBER % 10))"
 
       - name: Sleep if Dependabot
         if: github.actor == 'rushtong'
         uses: whatnick/wait-action@master
         with:
-          time: '1s'
+          time: '${{ steps.sleep-calculation.outputs.sleep }}m'
 
-      - name: Checkout
-        uses: actions/checkout@v1
-
-      - name: Setup paths
-        run: |
-          mkdir -p automation/src/test/resources/accounts
-          mkdir -p automation/target
-
-      - name: Render configs
-        env:
-          ADMIN: ${{ secrets.DUOS_AUTOMATION_ADMIN }}
-          CHAIR: ${{ secrets.DUOS_AUTOMATION_CHAIR }}
-          MEMBER: ${{ secrets.DUOS_AUTOMATION_MEMBER }}
-          RESEARCHER: ${{ secrets.DUOS_AUTOMATION_RESEARCHER }}
-          SIGNING_OFFICIAL: ${{ secrets.DUOS_AUTOMATION_SIGNING_OFFICIAL }}
-        run: |
-          echo "$ADMIN" >> ./automation/src/test/resources/accounts/duos-automation-admin.json
-          echo "$CHAIR" >> ./automation/src/test/resources/accounts/duos-automation-chair.json
-          echo "$MEMBER" >> ./automation/src/test/resources/accounts/duos-automation-member.json
-          echo "$RESEARCHER" >> ./automation/src/test/resources/accounts/duos-automation-researcher.json
-          echo "$SIGNING_OFFICIAL" >> ./automation/src/test/resources/accounts/duos-automation-signing-official.json
-          ls -al ./automation/src/test/resources/accounts
-
-      - name: Run automation tests
-        run: |
-          cd ./automation
-          docker-compose up --abort-on-container-exit --exit-code-from automation-tests
-
-      - name: Stop containers
-        if: always()
-        run: |
-          cd ./automation
-          docker-compose -f docker-compose.yml down
+# TODO: Renable
+#      - name: Checkout
+#        uses: actions/checkout@v1
+#
+#      - name: Setup paths
+#        run: |
+#          mkdir -p automation/src/test/resources/accounts
+#          mkdir -p automation/target
+#
+#      - name: Render configs
+#        env:
+#          ADMIN: ${{ secrets.DUOS_AUTOMATION_ADMIN }}
+#          CHAIR: ${{ secrets.DUOS_AUTOMATION_CHAIR }}
+#          MEMBER: ${{ secrets.DUOS_AUTOMATION_MEMBER }}
+#          RESEARCHER: ${{ secrets.DUOS_AUTOMATION_RESEARCHER }}
+#          SIGNING_OFFICIAL: ${{ secrets.DUOS_AUTOMATION_SIGNING_OFFICIAL }}
+#        run: |
+#          echo "$ADMIN" >> ./automation/src/test/resources/accounts/duos-automation-admin.json
+#          echo "$CHAIR" >> ./automation/src/test/resources/accounts/duos-automation-chair.json
+#          echo "$MEMBER" >> ./automation/src/test/resources/accounts/duos-automation-member.json
+#          echo "$RESEARCHER" >> ./automation/src/test/resources/accounts/duos-automation-researcher.json
+#          echo "$SIGNING_OFFICIAL" >> ./automation/src/test/resources/accounts/duos-automation-signing-official.json
+#          ls -al ./automation/src/test/resources/accounts
+#
+#      - name: Run automation tests
+#        run: |
+#          cd ./automation
+#          docker-compose up --abort-on-container-exit --exit-code-from automation-tests
+#
+#      - name: Stop containers
+#        if: always()
+#        run: |
+#          cd ./automation
+#          docker-compose -f docker-compose.yml down

--- a/.github/workflows/automation.yaml
+++ b/.github/workflows/automation.yaml
@@ -10,14 +10,15 @@ jobs:
       - name: Log Actor
         run: echo "${{ github.actor }}"
 
-      - name: Sleep if Dependabot
-#        if: github.actor == 'dependabot[bot]'
-#       TODO: Change this to dependabot when functional
-        if: github.actor == 'rushtong'
+      - name: Log ENV
         run: |
           echo "GITHUB_RUN_NUMBER: ${{ github.GITHUB_RUN_NUMBER }}"
           echo "GITHUB_JOB: ${{ github.GITHUB_JOB }}"
           echo "GITHUB_RUN_ID: ${{ github.GITHUB_RUN_ID }}"
+
+      - name: Sleep if Dependabot
+#        if: github.actor == 'dependabot[bot]'
+#       TODO: Change this to dependabot when functional
         uses: whatnick/wait-action@master
         with:
           time: '1s'

--- a/.github/workflows/automation.yaml
+++ b/.github/workflows/automation.yaml
@@ -11,18 +11,17 @@ jobs:
         run: echo "${{ github.actor }}"
 
       # For all dependabot PRs, add a sleep time from 0-9 minutes to reduce
-      # the contention on secrets from multiple, simultaneous dependabot PRs
-      - name: Calculate Sleep
+      # the contention on pulling repo secrets from multiple, simultaneous PRs
+      - name: Calculate Sleep if Dependabot
         id: sleep
-        if: github.actor == 'rushtong'
+        if: github.actor == 'dependabot[bot]'
         shell: bash
-        run: echo "::set-output name=sleep::$(($GITHUB_RUN_NUMBER % 10))"
-
+        run: echo "::set-output name=minutes::$(($GITHUB_RUN_NUMBER % 10))"
       - name: Sleep if Dependabot
-        if: github.actor == 'rushtong'
+        if: github.actor == 'dependabot[bot]'
         uses: whatnick/wait-action@master
         with:
-          time: '${{ steps.sleep.outputs.sleep }}m'
+          time: '${{ steps.sleep.outputs.minutes }}m'
 
       - name: Checkout
         uses: actions/checkout@v1

--- a/.github/workflows/automation.yaml
+++ b/.github/workflows/automation.yaml
@@ -11,12 +11,16 @@ jobs:
         run: echo "${{ github.actor }}"
 
       - name: Log ENV
+        id: sleep-calculation
         if: github.actor == 'rushtong'
+        shell: bash
         run: |
           echo "GITHUB_RUN_NUMBER: $GITHUB_RUN_NUMBER"
-          echo $GITHUB_RUN_NUMBER % 2
           echo "GITHUB_JOB: $GITHUB_JOB"
           echo "GITHUB_RUN_ID: $GITHUB_RUN_ID"
+          bash -c 'echo $(($GITHUB_RUN_NUMBER % 10))'
+          echo "::set-output name=sleep::bash -c 'echo $(($GITHUB_RUN_NUMBER % 10))'"
+          echo "sleep var is: ${{ steps.sleep-calculation.outputs.sleep }}"
 
       - name: Sleep if Dependabot
         if: github.actor == 'rushtong'

--- a/.github/workflows/automation.yaml
+++ b/.github/workflows/automation.yaml
@@ -10,6 +10,18 @@ jobs:
       - name: Log Actor
         run: echo "${{ github.actor }}"
 
+      - name: Sleep if Dependabot
+#        if: github.actor == 'dependabot[bot]'
+#       TODO: Change this to dependabot when functional
+        if: github.actor == 'rushtong'
+        run: |
+          echo "GITHUB_RUN_NUMBER: ${{ github.GITHUB_RUN_NUMBER }}"
+          echo "GITHUB_JOB: ${{ github.GITHUB_JOB }}"
+          echo "GITHUB_RUN_ID: ${{ github.GITHUB_RUN_ID }}"
+        uses: whatnick/wait-action@master
+        with:
+          time: '1s'
+
       - name: Checkout
         uses: actions/checkout@v1
 

--- a/.github/workflows/automation.yaml
+++ b/.github/workflows/automation.yaml
@@ -10,55 +10,50 @@ jobs:
       - name: Log Actor
         run: echo "${{ github.actor }}"
 
-      - name: Log ENV
-        id: sleep-calculation
+      # For all dependabot PRs, add a sleep time from 0-9 minutes to reduce
+      # the contention on secrets from multiple, simultaneous dependabot PRs
+      - name: Calculate Sleep
+        id: sleep
         if: github.actor == 'rushtong'
         shell: bash
-        run: |
-          echo "GITHUB_RUN_NUMBER: $GITHUB_RUN_NUMBER"
-          echo "GITHUB_JOB: $GITHUB_JOB"
-          echo "GITHUB_RUN_ID: $GITHUB_RUN_ID"
-          bash -c 'echo $(($GITHUB_RUN_NUMBER % 10))'
-          echo $(($GITHUB_RUN_NUMBER % 10))
-          echo "::set-output name=sleep::$(($GITHUB_RUN_NUMBER % 10))"
+        run: echo "::set-output name=sleep::$(($GITHUB_RUN_NUMBER % 10))"
 
       - name: Sleep if Dependabot
         if: github.actor == 'rushtong'
         uses: whatnick/wait-action@master
         with:
-          time: '${{ steps.sleep-calculation.outputs.sleep }}m'
+          time: '${{ steps.sleep.outputs.sleep }}m'
 
-# TODO: Renable
-#      - name: Checkout
-#        uses: actions/checkout@v1
-#
-#      - name: Setup paths
-#        run: |
-#          mkdir -p automation/src/test/resources/accounts
-#          mkdir -p automation/target
-#
-#      - name: Render configs
-#        env:
-#          ADMIN: ${{ secrets.DUOS_AUTOMATION_ADMIN }}
-#          CHAIR: ${{ secrets.DUOS_AUTOMATION_CHAIR }}
-#          MEMBER: ${{ secrets.DUOS_AUTOMATION_MEMBER }}
-#          RESEARCHER: ${{ secrets.DUOS_AUTOMATION_RESEARCHER }}
-#          SIGNING_OFFICIAL: ${{ secrets.DUOS_AUTOMATION_SIGNING_OFFICIAL }}
-#        run: |
-#          echo "$ADMIN" >> ./automation/src/test/resources/accounts/duos-automation-admin.json
-#          echo "$CHAIR" >> ./automation/src/test/resources/accounts/duos-automation-chair.json
-#          echo "$MEMBER" >> ./automation/src/test/resources/accounts/duos-automation-member.json
-#          echo "$RESEARCHER" >> ./automation/src/test/resources/accounts/duos-automation-researcher.json
-#          echo "$SIGNING_OFFICIAL" >> ./automation/src/test/resources/accounts/duos-automation-signing-official.json
-#          ls -al ./automation/src/test/resources/accounts
-#
-#      - name: Run automation tests
-#        run: |
-#          cd ./automation
-#          docker-compose up --abort-on-container-exit --exit-code-from automation-tests
-#
-#      - name: Stop containers
-#        if: always()
-#        run: |
-#          cd ./automation
-#          docker-compose -f docker-compose.yml down
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Setup paths
+        run: |
+          mkdir -p automation/src/test/resources/accounts
+          mkdir -p automation/target
+
+      - name: Render configs
+        env:
+          ADMIN: ${{ secrets.DUOS_AUTOMATION_ADMIN }}
+          CHAIR: ${{ secrets.DUOS_AUTOMATION_CHAIR }}
+          MEMBER: ${{ secrets.DUOS_AUTOMATION_MEMBER }}
+          RESEARCHER: ${{ secrets.DUOS_AUTOMATION_RESEARCHER }}
+          SIGNING_OFFICIAL: ${{ secrets.DUOS_AUTOMATION_SIGNING_OFFICIAL }}
+        run: |
+          echo "$ADMIN" >> ./automation/src/test/resources/accounts/duos-automation-admin.json
+          echo "$CHAIR" >> ./automation/src/test/resources/accounts/duos-automation-chair.json
+          echo "$MEMBER" >> ./automation/src/test/resources/accounts/duos-automation-member.json
+          echo "$RESEARCHER" >> ./automation/src/test/resources/accounts/duos-automation-researcher.json
+          echo "$SIGNING_OFFICIAL" >> ./automation/src/test/resources/accounts/duos-automation-signing-official.json
+          ls -al ./automation/src/test/resources/accounts
+
+      - name: Run automation tests
+        run: |
+          cd ./automation
+          docker-compose up --abort-on-container-exit --exit-code-from automation-tests
+
+      - name: Stop containers
+        if: always()
+        run: |
+          cd ./automation
+          docker-compose -f docker-compose.yml down

--- a/.github/workflows/automation.yaml
+++ b/.github/workflows/automation.yaml
@@ -12,13 +12,11 @@ jobs:
 
       - name: Log ENV
         run: |
-          echo "GITHUB_RUN_NUMBER: ${{ GITHUB_RUN_NUMBER }}"
-          echo "GITHUB_JOB: ${{ GITHUB_JOB }}"
-          echo "GITHUB_RUN_ID: ${{ GITHUB_RUN_ID }}"
+          echo "GITHUB_RUN_NUMBER: $GITHUB_RUN_NUMBER"
+          echo "GITHUB_JOB: $GITHUB_JOB"
+          echo "GITHUB_RUN_ID: $GITHUB_RUN_ID"
 
       - name: Sleep if Dependabot
-        # TODO: Change this to dependabot when functional
-        # if: github.actor == 'dependabot[bot]'
         uses: whatnick/wait-action@master
         with:
           time: '1s'

--- a/automation/project/Settings.scala
+++ b/automation/project/Settings.scala
@@ -27,7 +27,7 @@ object Settings {
     )
 
   lazy val rootSettings: Seq[Def.Setting[_]] = commonSettings ++ List(
-    name := "consent",
+    name := "consent-automation",
     libraryDependencies ++= rootDependencies
   )
 

--- a/automation/render-local-env.sh
+++ b/automation/render-local-env.sh
@@ -3,6 +3,10 @@ set -e
 
 ## Run from automation/
 ## Pulls templatized configs and renders them to src/test/resources
+## Log into vault first:
+##    vault login -method=github token=$(cat ~/.github-token)
+## Requires jq:
+##    brew install jq
 
 # Defaults
 WORKING_DIR=$PWD
@@ -35,7 +39,10 @@ fi
 listOfRoles="admin
 chair
 member
-researcher"
+researcher
+signing-official"
+
+mkdir -p src/test/resources/accounts
 
 for role in $listOfRoles; do
   echo "Writing $role file from $secretPath/duos-automation-$role.json"


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-1435

Add a sleep to the automation tests for Dependabot PRs so they don't fail when pulling secrets.
Also added a couple of minor updates to automation.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
