### PR TITLE
DUOS-1255 [risk=no] Create DAR Collection on DAR submission

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
@@ -354,6 +354,7 @@ public class DataAccessRequestService {
         List<Integer> datasets = dataAccessRequest.getData().getDatasetIds();
         if (CollectionUtils.isNotEmpty(datasets)) {
             String darCodeSequence = "DAR-" + counterService.getNextDarSequence();
+            Integer collectionId = darCollectionDAO.insertDarCollection(darCodeSequence, user.getDacUserId(), now);
             for (int idx = 0; idx < datasets.size(); idx++) {
                 String darCode = (datasets.size() == 1) ? darCodeSequence: darCodeSequence + SUFFIX + idx ;
                 darData.setDatasetIds(Collections.singletonList(datasets.get(idx)));
@@ -372,12 +373,12 @@ public class DataAccessRequestService {
                         newDARList.add(findByReferenceId(dataAccessRequest.getReferenceId()));
                     } else {
                         String referenceId = UUID.randomUUID().toString();
-                        DataAccessRequest createdDar = insertSubmittedDataAccessRequest(user, referenceId, darData);
+                        DataAccessRequest createdDar = insertSubmittedDataAccessRequest(user, referenceId, darData, collectionId, now);
                         newDARList.add(createdDar);
                     }
                 } else {
                     String referenceId = UUID.randomUUID().toString();
-                    DataAccessRequest createdDar = insertSubmittedDataAccessRequest(user, referenceId, darData);
+                    DataAccessRequest createdDar = insertSubmittedDataAccessRequest(user, referenceId, darData, collectionId, now);
                     newDARList.add(createdDar);
                 }
             }
@@ -385,9 +386,9 @@ public class DataAccessRequestService {
         return newDARList;
     }
 
-    public DataAccessRequest insertSubmittedDataAccessRequest(User user, String referencedId, DataAccessRequestData darData) {
-        Date now = new Date();
-        dataAccessRequestDAO.insertVersion2(
+    public DataAccessRequest insertSubmittedDataAccessRequest(User user, String referencedId, DataAccessRequestData darData, Integer collectionId, Date now) {
+        dataAccessRequestDAO.insertVersion3(
+            collectionId,
             referencedId,
             user.getDacUserId(),
             new Date(darData.getCreateDate()),

--- a/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import org.mockito.ArgumentMatcher;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
@@ -197,10 +198,15 @@ public class DataAccessRequestServiceTest {
         when(counterService.getNextDarSequence()).thenReturn(1);
         when(dataAccessRequestDAO.findByReferenceId("id")).thenReturn(null);
         when(dataAccessRequestDAO.findByReferenceId(argThat(new LongerThanTwo()))).thenReturn(dar);
-        doNothing().when(dataAccessRequestDAO).insertVersion2(any(), any(), any(), any(), any(), any(), any());
+        when(darCollectionDAO.insertDarCollection(anyString(), anyInt(), any(Date.class))).thenReturn(RandomUtils.nextInt(1,100));
+        doNothing().when(dataAccessRequestDAO).insertVersion3(anyInt(), anyString(), anyInt(), any(Date.class), any(Date.class), any(Date.class), any(Date.class), any(DataAccessRequestData.class));
         initService();
         List<DataAccessRequest> newDars = service.createDataAccessRequest(user, dar);
         assertEquals(3, newDars.size());
+        Integer collectionId = newDars.get(0).getCollectionId();
+        for(DataAccessRequest darElement: newDars) {
+            assertEquals(collectionId, darElement.getCollectionId());
+        }   
     }
 
     @Test


### PR DESCRIPTION
Addresses [DUOS-1255](https://broadworkbench.atlassian.net/browse/DUOS-1255)

PR updates DAR create logic on the service method so that it creates a DAR Collection first for collection_id assignment on the new DAR.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
