### PR TITLE
DUOS-1253[risk=med] Added DAR Collection Resource Cancel endpoint

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
@@ -206,7 +206,9 @@ public class ConsentModule extends AbstractModule {
     DarCollectionService providesDarCollectionService() {
         return new DarCollectionService(
             providesDARCollectionDAO(),
-            providesDataSetDAO()
+            providesDataSetDAO(),
+            providesElectionDAO(),
+            providesDataAccessRequestDAO()
         );
     }
 

--- a/src/main/java/org/broadinstitute/consent/http/db/DataAccessRequestDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DataAccessRequestDAO.java
@@ -151,6 +151,12 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
   @SqlUpdate("DELETE FROM data_access_request WHERE reference_id = :referenceId")
   void deleteByReferenceId(@Bind("referenceId") String referenceId);
 
+  @SqlUpdate(
+      "UPDATE data_access_request dar SET data=jsonb_set((dar.data #>> '{}')::jsonb, '{status}', '\"Canceled\"')" +
+      "WHERE reference_id IN (<referenceIds>)"
+    )
+    void cancelByReferenceIds(@BindList("referenceIds") List<String> referenceIds);
+
   /**
    * Delete all DataAccessRequests with the given collection id
    *

--- a/src/main/java/org/broadinstitute/consent/http/db/ElectionDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/ElectionDAO.java
@@ -161,6 +161,10 @@ public interface ElectionDAO extends Transactional<ElectionDAO> {
     @SqlQuery("SELECT * FROM election WHERE referenceid = :referenceId")
     List<Election> findElectionsByReferenceId(@Bind("referenceId") String referenceId);
 
+    @UseRowMapper(SimpleElectionMapper.class)
+    @SqlQuery("SELECT * FROM election where referenceid IN (<referenceIds>) AND lower(electiontype) = 'dataaccess'")
+    List<Election> findElectionsByReferenceIds(@BindList("referenceIds") List<String> referenceIds);
+
     @SqlQuery(
       "SELECT * from ( "
         + "SELECT e.*, v.vote finalvote, "
@@ -358,7 +362,6 @@ public interface ElectionDAO extends Transactional<ElectionDAO> {
     @UseRowMapper(DacMapper.class)
     List<Dac> findAllDacsForElectionIds(@BindList("electionIds") List<Integer> electionIds);
   
-
     /**
      * Find the OPEN elections that belong to this Dac
      *

--- a/src/main/java/org/broadinstitute/consent/http/db/ElectionDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/ElectionDAO.java
@@ -161,10 +161,6 @@ public interface ElectionDAO extends Transactional<ElectionDAO> {
     @SqlQuery("SELECT * FROM election WHERE referenceid = :referenceId")
     List<Election> findElectionsByReferenceId(@Bind("referenceId") String referenceId);
 
-    @UseRowMapper(SimpleElectionMapper.class)
-    @SqlQuery("SELECT * FROM election where referenceid IN (<referenceIds>) AND lower(electiontype) = 'dataaccess'")
-    List<Election> findElectionsByReferenceIds(@BindList("referenceIds") List<String> referenceIds);
-
     @SqlQuery(
       "SELECT * from ( "
         + "SELECT e.*, v.vote finalvote, "

--- a/src/main/java/org/broadinstitute/consent/http/resources/DarCollectionResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DarCollectionResource.java
@@ -81,7 +81,7 @@ public class DarCollectionResource extends Resource {
   }
 
   @PUT
-  @Path("dar/{id}/cancel")
+  @Path("{id}/cancel")
   @Produces("application/json")
   @RolesAllowed(RESEARCHER)
   public Response cancelDarCollectionByCollectionId(@Auth AuthUser authUser, @PathParam("id") Integer collectionId) {

--- a/src/main/java/org/broadinstitute/consent/http/resources/DarCollectionResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DarCollectionResource.java
@@ -4,6 +4,8 @@ import com.google.inject.Inject;
 import io.dropwizard.auth.Auth;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
+
 import javax.annotation.security.PermitAll;
 import javax.annotation.security.RolesAllowed;
 import javax.ws.rs.ForbiddenException;
@@ -82,15 +84,22 @@ public class DarCollectionResource extends Resource {
   @Path("dar/{id}/cancel")
   @Produces("application/json")
   @RolesAllowed(RESEARCHER)
-  public Response cancelDarCollection(@Auth AuthUser authUser, @PathParam("id") Integer collectionId) {
+  public Response cancelDarCollectionByCollectionId(@Auth AuthUser authUser, @PathParam("id") Integer collectionId) {
     try {
       User user = userService.findUserByEmail(authUser.getEmail());
       DarCollection collection = darCollectionService.getByCollectionId(collectionId);
+      isCollectionPresent(collection);
       validateUserIsCreator(user, collection);
       DarCollection cancelledCollection = darCollectionService.cancelDarCollection(collection, user);
       return Response.ok().entity(cancelledCollection).build();
     } catch(Exception e) {
       return createExceptionResponse(e);
+    }
+  }
+
+  private void isCollectionPresent(DarCollection collection) {
+    if(Objects.isNull(collection)) {
+      throw new NotFoundException("Collection not found");
     }
   }
 

--- a/src/main/java/org/broadinstitute/consent/http/resources/DarCollectionResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DarCollectionResource.java
@@ -9,6 +9,7 @@ import javax.annotation.security.RolesAllowed;
 import javax.ws.rs.ForbiddenException;
 import javax.ws.rs.GET;
 import javax.ws.rs.NotFoundException;
+import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
@@ -73,6 +74,22 @@ public class DarCollectionResource extends Resource {
       validateUserIsCreator(user, collection);
       return Response.ok().entity(collection).build();
     } catch (Exception e) {
+      return createExceptionResponse(e);
+    }
+  }
+
+  @PUT
+  @Path("dar/{id}/cancel")
+  @Produces("application/json")
+  @RolesAllowed(RESEARCHER)
+  public Response cancelDarCollection(@Auth AuthUser authUser, @PathParam("id") Integer collectionId) {
+    try {
+      User user = userService.findUserByEmail(authUser.getEmail());
+      DarCollection collection = darCollectionService.getByCollectionId(collectionId);
+      validateUserIsCreator(user, collection);
+      DarCollection cancelledCollection = darCollectionService.cancelDarCollection(collection, user);
+      return Response.ok().entity(cancelledCollection).build();
+    } catch(Exception e) {
       return createExceptionResponse(e);
     }
   }

--- a/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
@@ -12,7 +12,6 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import java.lang.IllegalStateException;
 import javax.ws.rs.BadRequestException;
 
 import org.broadinstitute.consent.http.db.DarCollectionDAO;

--- a/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
@@ -18,6 +18,7 @@ import org.broadinstitute.consent.http.db.DarCollectionDAO;
 import org.broadinstitute.consent.http.db.DataAccessRequestDAO;
 import org.broadinstitute.consent.http.db.DatasetDAO;
 import org.broadinstitute.consent.http.db.ElectionDAO;
+import org.broadinstitute.consent.http.enumeration.ElectionType;
 import org.broadinstitute.consent.http.models.DarCollection;
 import org.broadinstitute.consent.http.models.DataAccessRequest;
 import org.broadinstitute.consent.http.models.DataAccessRequestData;
@@ -164,7 +165,7 @@ public class DarCollectionService {
       .map(d -> d.getReferenceId())
       .collect(Collectors.toList());
     
-    List<Election> elections = electionDAO.findElectionsByReferenceIds(referenceIds);
+    List<Election> elections = electionDAO.findLastElectionsByReferenceIdsAndType(referenceIds, ElectionType.DATA_ACCESS.getValue());
     if(!elections.isEmpty()) {
       throw new BadRequestException("Elections present on DARs; cannot cancel collection");
     }

--- a/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
@@ -11,12 +11,18 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+
+import javax.ws.rs.BadRequestException;
+
 import org.broadinstitute.consent.http.db.DarCollectionDAO;
+import org.broadinstitute.consent.http.db.DataAccessRequestDAO;
 import org.broadinstitute.consent.http.db.DatasetDAO;
+import org.broadinstitute.consent.http.db.ElectionDAO;
 import org.broadinstitute.consent.http.models.DarCollection;
 import org.broadinstitute.consent.http.models.DataAccessRequest;
 import org.broadinstitute.consent.http.models.DataAccessRequestData;
 import org.broadinstitute.consent.http.models.DataSet;
+import org.broadinstitute.consent.http.models.Election;
 import org.broadinstitute.consent.http.models.PaginationResponse;
 import org.broadinstitute.consent.http.models.PaginationToken;
 import org.broadinstitute.consent.http.models.User;
@@ -27,12 +33,16 @@ public class DarCollectionService {
 
   private final Logger logger = LoggerFactory.getLogger(this.getClass());
   private final DarCollectionDAO darCollectionDAO;
+  private final DataAccessRequestDAO dataAccessRequestDAO;
   private final DatasetDAO datasetDAO;
+  private final ElectionDAO electionDAO;
 
   @Inject
-  public DarCollectionService(DarCollectionDAO darCollectionDAO, DatasetDAO datasetDAO) {
+  public DarCollectionService(DarCollectionDAO darCollectionDAO, DatasetDAO datasetDAO, ElectionDAO electionDAO, DataAccessRequestDAO dataAccessRequestDAO) {
     this.darCollectionDAO = darCollectionDAO;
     this.datasetDAO = datasetDAO;
+    this.electionDAO = electionDAO;
+    this.dataAccessRequestDAO = dataAccessRequestDAO;
   }
 
   public List<DarCollection> getAllCollections() {
@@ -142,6 +152,32 @@ public class DarCollectionService {
     }
     // There were no datasets to add, so we return the original list
     return collections;
+  }
+
+  // fetch elections in bulk via dar reference ids
+  // if any election exists, throw a bad request
+  // else collect the dar reference ids where the status is NOT cancelled
+  // once collected, perform bulk update where status is updated with cancelled
+  public DarCollection cancelDarCollection(DarCollection collection, User user) {
+    List<DataAccessRequest> dars = collection.getDars();
+    List<String> referenceIds = dars.stream()
+      .map(d -> d.getReferenceId())
+      .collect(Collectors.toList());
+    
+    List<Election> elections = electionDAO.findElectionsByReferenceIds(referenceIds);
+    if(!elections.isEmpty()) {
+      throw new BadRequestException("Elections present on DARs; cannot cancel collection");
+    }
+    List<String> nonCanceledIds = dars.stream()
+      .filter(d -> {
+        String status = d.getData().getStatus();
+        return Objects.nonNull(status) && status.toLowerCase() != "canceled";
+      })
+      .map(d -> d.getReferenceId())
+      .collect(Collectors.toList());
+    
+    dataAccessRequestDAO.cancelByReferenceIds(nonCanceledIds);
+    return darCollectionDAO.findDARCollectionByCollectionId(collection.getDarCollectionId());
   }
 
 }

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -124,7 +124,7 @@ paths:
     $ref: './paths/collection.yaml'
   /api/collections/dar/{referenceId}:
     $ref: './paths/collectionByReferenceId.yaml'
-  /api/collections/cancel/{collectionId}:
+  /api/collections/{collectionId}/cancel:
     $ref: './paths/cancelCollectionByCollectionId.yaml'
   /api/ontology:
     get:

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -124,6 +124,8 @@ paths:
     $ref: './paths/collection.yaml'
   /api/collections/dar/{referenceId}:
     $ref: './paths/collectionByReferenceId.yaml'
+  /api/collections/cancel/{collectionId}:
+    $ref: './paths/cancelCollectionByCollectionId.yaml'
   /api/ontology:
     get:
       summary: List Ontology Files

--- a/src/main/resources/assets/paths/cancelCollectionByCollectionId.yaml
+++ b/src/main/resources/assets/paths/cancelCollectionByCollectionId.yaml
@@ -1,0 +1,25 @@
+put:
+  summary: Cancel DAR Collection By ID
+  description: Returns DAR Collection after canceling associated dars
+  tags:
+    - DAR Collection
+  parameters:
+    - name: collectionId
+      in: path
+      description: DAR Collection Id
+      required: true
+      schema:
+        type: integer
+  responses:
+    200:
+      description: Returns target dar collection with DARs canceled
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/DarCollection.yaml'
+    400: 
+      description: Bad Request (result of elections present on DARs)
+    404:
+      description: Not Found
+    500:
+      description: Internal Server Error

--- a/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
@@ -209,9 +209,12 @@ public class DataAccessRequestDAOTest extends DAOTestHelper {
         DataAccessRequest updatedDar1 = dataAccessRequestDAO.findByReferenceId(dar1.getReferenceId());
         DataAccessRequest updatedDar2 = dataAccessRequestDAO.findByReferenceId(dar2.getReferenceId());
 
+        assertEquals(dar1.getReferenceId(), updatedDar1.getReferenceId());
+        assertEquals(dar2.getReferenceId(), updatedDar2.getReferenceId());
+
         assertEquals("Canceled", updatedDar1.getData().getStatus());
         assertEquals("Canceled", updatedDar2.getData().getStatus());
-        
+
         assertNotNull(updatedDar1.getData().getHmb());
         assertNotNull(updatedDar2.getData().getHmb());
         assertEquals(dar1.getData().getHmb(), updatedDar1.getData().getHmb());

--- a/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
@@ -7,6 +7,7 @@ import org.broadinstitute.consent.http.models.User;
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
@@ -192,6 +193,39 @@ public class DataAccessRequestDAOTest extends DAOTestHelper {
         DataAccessRequest returnedAfter = dataAccessRequestDAO.findByReferenceId(dar.getReferenceId());
         assertNull(returnedAfter);
 
+    }
+
+    @Test
+    public void testCancelDeleteByCollectionIds() {
+        DataAccessRequest dar1 = createDataAccessRequestV3();
+        DataAccessRequest dar2 = createDataAccessRequestV3();
+
+        List<String> referenceIds = new ArrayList<>();
+        referenceIds.add(dar1.getReferenceId());
+        referenceIds.add(dar2.getReferenceId());
+
+        dataAccessRequestDAO.cancelByReferenceIds(referenceIds);
+
+        DataAccessRequest updatedDar1 = dataAccessRequestDAO.findByReferenceId(dar1.getReferenceId());
+        DataAccessRequest updatedDar2 = dataAccessRequestDAO.findByReferenceId(dar2.getReferenceId());
+
+        assertEquals("Canceled", updatedDar1.getData().getStatus());
+        assertEquals("Canceled", updatedDar2.getData().getStatus());
+        
+        assertNotNull(updatedDar1.getData().getHmb());
+        assertNotNull(updatedDar2.getData().getHmb());
+        assertEquals(dar1.getData().getHmb(), updatedDar1.getData().getHmb());
+        assertEquals(dar2.getData().getHmb(), updatedDar2.getData().getHmb());
+
+        assertNotNull(updatedDar1.getData().getMethods());
+        assertNotNull(updatedDar2.getData().getMethods());
+        assertEquals(dar1.getData().getMethods(), updatedDar1.getData().getMethods());
+        assertEquals(dar2.getData().getMethods(), updatedDar2.getData().getMethods());
+
+        assertNotNull(updatedDar1.getData().getAddress1());
+        assertNotNull(updatedDar2.getData().getAddress1());
+        assertEquals(dar1.getData().getAddress1(), updatedDar1.getData().getAddress1());
+        assertEquals(dar2.getData().getAddress1(), updatedDar2.getData().getAddress1());
     }
 
 }

--- a/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.openMocks;
 
@@ -14,14 +15,20 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+
+import javax.ws.rs.BadRequestException;
+
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.RandomUtils;
 import org.broadinstitute.consent.http.db.DarCollectionDAO;
 import org.broadinstitute.consent.http.db.DatasetDAO;
+import org.broadinstitute.consent.http.db.ElectionDAO;
+import org.broadinstitute.consent.http.db.DataAccessRequestDAO;
 import org.broadinstitute.consent.http.models.DarCollection;
 import org.broadinstitute.consent.http.models.DataAccessRequest;
 import org.broadinstitute.consent.http.models.DataAccessRequestData;
 import org.broadinstitute.consent.http.models.DataSet;
+import org.broadinstitute.consent.http.models.Election;
 import org.broadinstitute.consent.http.models.PaginationResponse;
 import org.broadinstitute.consent.http.models.PaginationToken;
 import org.broadinstitute.consent.http.models.User;
@@ -35,6 +42,8 @@ public class DarCollectionServiceTest {
 
   @Mock private DarCollectionDAO darCollectionDAO;
   @Mock private DatasetDAO datasetDAO;
+  @Mock private ElectionDAO electionDAO;
+  @Mock private DataAccessRequestDAO dataAccessRequestDAO;
 
   @Mock private User user;
 
@@ -128,6 +137,44 @@ public class DarCollectionServiceTest {
     assertEquals(datasetIds, collectionDatasetIds);
   }
 
+  @Test
+  public void testCancelDarCollection_noElections() { 
+    Set<DataSet> datasets = new HashSet<>();
+    DarCollection collection = generateMockDarCollection(datasets);
+    collection.getDars().forEach(d -> {
+      d.getData().setStatus("Canceled");
+    });
+    List<Election> elections = new ArrayList<>();
+    User user = new User();
+    user.setDacUserId(RandomUtils.nextInt(1,100));
+
+    when(electionDAO.findElectionsByReferenceIds(anyList())).thenReturn(elections);
+    doNothing().when(dataAccessRequestDAO).cancelByReferenceIds(anyList());
+    when(darCollectionDAO.findDARCollectionByCollectionId(any())).thenReturn(collection);
+    initService();
+
+    DarCollection canceledCollection = service.cancelDarCollection(collection, user);
+    for (DataAccessRequest collectionDar : canceledCollection.getDars()) {
+      assertEquals("canceled", collectionDar.getData().getStatus().toLowerCase());
+    }
+  }
+
+  @Test(expected = BadRequestException.class)
+  public void testCancelDarCollection_electionPresent() {
+    Set<DataSet> datasets = new HashSet<>();
+    DarCollection collection = generateMockDarCollection(datasets);
+    List<Election> elections = Collections.singletonList(new Election());
+    User user = new User();
+    user.setDacUserId(RandomUtils.nextInt(1, 100));
+
+    when(electionDAO.findElectionsByReferenceIds(anyList())).thenReturn(elections);
+    doNothing().when(dataAccessRequestDAO).cancelByReferenceIds(anyList());
+    when(darCollectionDAO.findDARCollectionByCollectionId(any())).thenReturn(collection);
+    initService();
+
+    service.cancelDarCollection(collection, user);
+  }
+
   private DarCollection generateMockDarCollection(Set<DataSet> datasets) {
     DarCollection collection = new DarCollection();
     List<DataAccessRequest> dars = new ArrayList<>();
@@ -155,7 +202,7 @@ public class DarCollectionServiceTest {
   }
 
   private void initService() {
-    service = new DarCollectionService(darCollectionDAO, datasetDAO);
+    service = new DarCollectionService(darCollectionDAO, datasetDAO, electionDAO, dataAccessRequestDAO);
   }
 
   private void initWithPaginationToken(PaginationToken token, int unfilteredCount, int filteredCount) {
@@ -172,7 +219,7 @@ public class DarCollectionServiceTest {
     when(darCollectionDAO.findDARCollectionsCreatedByUserId(any())).thenReturn(unfilteredDars);
     when(darCollectionDAO.findAllDARCollectionsWithFiltersByUser(any(), any(), any(), any())).thenReturn(filteredDars);
     when(darCollectionDAO.findDARCollectionByCollectionIds(any(), any(), any())).thenReturn(collectionIdDars);
-    service = new DarCollectionService(darCollectionDAO, datasetDAO);
+    service = new DarCollectionService(darCollectionDAO, datasetDAO, electionDAO, dataAccessRequestDAO);
   }
 
   private List<DarCollection> createMockDars(int count) {

--- a/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.openMocks;
@@ -148,7 +149,7 @@ public class DarCollectionServiceTest {
     User user = new User();
     user.setDacUserId(RandomUtils.nextInt(1,100));
 
-    when(electionDAO.findElectionsByReferenceIds(anyList())).thenReturn(elections);
+    when(electionDAO.findLastElectionsByReferenceIdsAndType(anyList(), anyString())).thenReturn(elections);
     doNothing().when(dataAccessRequestDAO).cancelByReferenceIds(anyList());
     when(darCollectionDAO.findDARCollectionByCollectionId(any())).thenReturn(collection);
     initService();
@@ -167,7 +168,7 @@ public class DarCollectionServiceTest {
     User user = new User();
     user.setDacUserId(RandomUtils.nextInt(1, 100));
 
-    when(electionDAO.findElectionsByReferenceIds(anyList())).thenReturn(elections);
+    when(electionDAO.findLastElectionsByReferenceIdsAndType(anyList(), anyString())).thenReturn(elections);
     doNothing().when(dataAccessRequestDAO).cancelByReferenceIds(anyList());
     when(darCollectionDAO.findDARCollectionByCollectionId(any())).thenReturn(collection);
     initService();


### PR DESCRIPTION
Addresses [DUOS-1253](https://broadworkbench.atlassian.net/browse/DUOS-1253)

PR creates cancel endpoint that allows researchers to cancel a DAR Collection with expected additions to DarCollectionService and DarCollectionDAO classes. PR also includes a new cancel DAO method to DataAccessRequestDAO to help facilitate cancel updates.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
