### PR TITLE
DUOS-1437[risk=med] Added DAR Collection initial filter query endpoint

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
@@ -66,7 +66,10 @@ public interface DarCollectionDAO {
   @RegisterBeanMapper(value = DarCollection.class)
   @RegisterBeanMapper(value = DataAccessRequest.class, prefix = "dar")
   @UseRowReducer(DarCollectionReducer.class)
-  @SqlQuery(getCollectionAndDars + " WHERE c.collection_id in (<collectionIds>)")
+  @SqlQuery(
+    getCollectionAndDars 
+    + " WHERE c.collection_id in (<collectionIds>)"
+    +  " ORDER BY <sortField> <sortOrder>")
   List<DarCollection> findDARCollectionByCollectionIds(
           @BindList("collectionIds") List<Integer> collectionIds,
           @Define("sortField") String sortField,

--- a/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
@@ -33,9 +33,6 @@ public interface DarCollectionDAO {
       " AND (" +
         "COALESCE(i.institution_name, '') ~* :filterTerm " +
         " OR (dar.data #>> '{}')::jsonb ->> 'projectTitle' ~* :filterTerm " +
-        //NOTE: since users can change their name, however the dar researcher attribute will not be updated
-        //Search on both dar.data and user displayname for proper name matching
-        " OR (dar.data #>> '{}')::jsonb ->> 'researcher' ~* :filterTerm " +
         " OR u.displayname ~* :filterTerm " +
         " OR c.dar_code ~* :filterTerm " +
         " OR EXISTS " +

--- a/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
@@ -67,10 +67,18 @@ public interface DarCollectionDAO {
   @RegisterBeanMapper(value = DataAccessRequest.class, prefix = "dar")
   @UseRowReducer(DarCollectionReducer.class)
   @SqlQuery(
+    getCollectionAndDars + " WHERE c.collection_id in (<collectionIds>)")
+  List<DarCollection> findDARCollectionByCollectionIds(
+          @BindList("collectionIds") List<Integer> collectionIds);
+
+  @RegisterBeanMapper(value = DarCollection.class)
+  @RegisterBeanMapper(value = DataAccessRequest.class, prefix = "dar")
+  @UseRowReducer(DarCollectionReducer.class)
+  @SqlQuery(
     getCollectionAndDars 
     + " WHERE c.collection_id in (<collectionIds>)"
     +  " ORDER BY <sortField> <sortOrder>")
-  List<DarCollection> findDARCollectionByCollectionIds(
+  List<DarCollection> findDARCollectionByCollectionIdsWithOrder(
           @BindList("collectionIds") List<Integer> collectionIds,
           @Define("sortField") String sortField,
           @Define("sortOrder") String sortOrder);

--- a/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
@@ -63,7 +63,9 @@ public interface DarCollectionDAO {
           @Define("sortField") String sortField,
           @Define("sortOrder") String sortOrder);
 
-
+  @RegisterBeanMapper(value = DarCollection.class)
+  @RegisterBeanMapper(value = DataAccessRequest.class, prefix = "dar")
+  @UseRowReducer(DarCollectionReducer.class)
   @SqlQuery(getCollectionAndDars + " WHERE c.collection_id in (<collectionIds>)")
   List<DarCollection> findDARCollectionByCollectionIds(
           @BindList("collectionIds") List<Integer> collectionIds,

--- a/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
@@ -33,6 +33,9 @@ public interface DarCollectionDAO {
       " AND (" +
         "COALESCE(i.institution_name, '') ~* :filterTerm " +
         " OR (dar.data #>> '{}')::jsonb ->> 'projectTitle' ~* :filterTerm " +
+        //NOTE: since users can change their name, however the dar researcher attribute will not be updated
+        //Search on both dar.data and user displayname for proper name matching
+        " OR (dar.data #>> '{}')::jsonb ->> 'researcher' ~* :filterTerm " +
         " OR u.displayname ~* :filterTerm " +
         " OR c.dar_code ~* :filterTerm " +
         " OR EXISTS " +

--- a/src/main/java/org/broadinstitute/consent/http/models/DarCollection.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DarCollection.java
@@ -23,7 +23,7 @@ public class DarCollection {
       "institution", "institution_name"
   );
 
-  public static String defaultSortField = "dar_code";
+  public static String defaultTokenSortField = "darCode";
 
   @JsonProperty
   private Integer darCollectionId;

--- a/src/main/java/org/broadinstitute/consent/http/models/DarCollection.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DarCollection.java
@@ -23,6 +23,8 @@ public class DarCollection {
       "institution", "institution_name"
   );
 
+  public static String defaultSortField = "dar_code";
+
   @JsonProperty
   private Integer darCollectionId;
 

--- a/src/main/java/org/broadinstitute/consent/http/models/DarCollection.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DarCollection.java
@@ -11,9 +11,17 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Objects;
+import java.util.Map;
 
 //represents a multi-dataset access request
 public class DarCollection {
+
+  public static Map<String, String> acceptableSortFields = Map.of(
+      "projectTitle", "projectTitle",
+      "researcher", "researcher",
+      "darCode", "dar_code",
+      "institution", "institution_name"
+  );
 
   @JsonProperty
   private Integer darCollectionId;

--- a/src/main/java/org/broadinstitute/consent/http/models/PaginationToken.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/PaginationToken.java
@@ -50,9 +50,9 @@ public class PaginationToken {
     checkSortField(sortField);
     checkSortDirection(sortDirection);
     this.page = page;
-    this.pageSize = pageSize;
-    this.sortField =  Objects.nonNull(sortField) ? sortField : "darCode";
-    this.sortDirection = Objects.nonNull(sortDirection) ? sortDirection : "DESC";
+    this.pageSize = Objects.nonNull(pageSize) ? pageSize : 10;
+    this.sortField = sortField;
+    this.sortDirection = sortDirection;
     this.filterTerm = filterTerm;
     checkForValidNumbers();
   }
@@ -65,8 +65,8 @@ public class PaginationToken {
     checkSortDirection(sortDirection);
     this.page = page;
     this.pageSize = pageSize;
-    this.sortField = Objects.nonNull(sortField) ? sortField : "darCode";
-    this.sortDirection = Objects.nonNull(sortDirection) ? sortDirection : "DESC";
+    this.sortField = sortField;
+    this.sortDirection = sortDirection;
     this.filterTerm = filterTerm;
     this.filteredCount = filteredCount;
     this.filteredPageCount = filteredPageCount;

--- a/src/main/java/org/broadinstitute/consent/http/models/PaginationToken.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/PaginationToken.java
@@ -51,7 +51,7 @@ public class PaginationToken {
     checkSortDirection(sortDirection);
     this.page = page;
     this.pageSize = pageSize;
-    this.sortField = sortField;
+    this.sortField = this.acceptableSortFields.get(sortField);
     this.sortDirection = sortDirection;
     this.filterTerm = filterTerm;
     checkForValidNumbers();
@@ -65,7 +65,7 @@ public class PaginationToken {
     checkSortDirection(sortDirection);
     this.page = page;
     this.pageSize = pageSize;
-    this.sortField = sortField;
+    this.sortField = this.acceptableSortFields.get(sortField);
     this.sortDirection = sortDirection;
     this.filterTerm = filterTerm;
     this.filteredCount = filteredCount;

--- a/src/main/java/org/broadinstitute/consent/http/models/PaginationToken.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/PaginationToken.java
@@ -7,8 +7,8 @@ import javax.ws.rs.BadRequestException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
-import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -16,7 +16,7 @@ import java.util.stream.IntStream;
 public class PaginationToken {
 
   private static final Charset UTF_8 = StandardCharsets.UTF_8;
-  private static final List<String> acceptableSortFields = Collections.emptyList();
+  // private static final Map<String> acceptableSortFields = Collections.emptyLi();
 
   @JsonProperty
   private Integer page;
@@ -42,8 +42,11 @@ public class PaginationToken {
   @JsonProperty
   private Integer unfilteredCount;
 
+  private Map<String, String> acceptableSortFields;
+
   //constructor for request tokens
-  public PaginationToken(Integer page, Integer pageSize, String sortField, String sortDirection, String filterTerm) {
+  public PaginationToken(Integer page, Integer pageSize, String sortField, String sortDirection, String filterTerm, Map<String, String> acceptableSortFields) {
+    this.acceptableSortFields = acceptableSortFields;
     checkSortField(sortField);
     checkSortDirection(sortDirection);
     this.page = page;
@@ -56,7 +59,8 @@ public class PaginationToken {
 
   //constructor for response tokens
   public PaginationToken(Integer page, Integer pageSize, String sortField, String sortDirection, String filterTerm,
-                         Integer filteredCount, Integer filteredPageCount, Integer unfilteredCount) {
+                         Integer filteredCount, Integer filteredPageCount, Integer unfilteredCount, Map<String, String> acceptableSortFields) {
+    this.acceptableSortFields = acceptableSortFields;
     checkSortField(sortField);
     checkSortDirection(sortDirection);
     this.page = page;
@@ -67,6 +71,7 @@ public class PaginationToken {
     this.filteredCount = filteredCount;
     this.filteredPageCount = filteredPageCount;
     this.unfilteredCount = unfilteredCount;
+    this.acceptableSortFields = acceptableSortFields;
     checkForValidNumbers();
   }
 
@@ -131,9 +136,17 @@ public class PaginationToken {
     return Base64.getEncoder().encodeToString(new Gson().toJson(this).getBytes(UTF_8));
   }
 
+  public void setAcceptableSortField(Map<String, String> acceptableSortFields) {
+    this.acceptableSortFields = acceptableSortFields;
+  }
+
+  public Map<String, String> getAcceptableSortFields() {
+    return acceptableSortFields;
+  }
+
   private void checkSortField(String sortField) {
     if (Objects.nonNull(sortField)) {
-      if (!acceptableSortFields.contains(sortField)) {
+      if (Objects.isNull(acceptableSortFields.get(sortField))) {
         throw new BadRequestException("Cannot sort on given field: " + sortField);
       }
     }
@@ -141,7 +154,7 @@ public class PaginationToken {
 
   private void checkSortDirection(String sortDirection) {
     if (Objects.nonNull(sortDirection)) {
-      if (!sortDirection.equals("asc") && !sortDirection.equals("desc")) {
+      if (!sortDirection.toLowerCase().equals("asc") && !sortDirection.toLowerCase().equals("desc")) {
         throw new BadRequestException("Sort direction must be either 'asc' or 'desc");
       }
     }
@@ -177,7 +190,8 @@ public class PaginationToken {
                 this.getFilterTerm(),
                 this.getFilteredCount(),
                 this.getFilteredPageCount(),
-                this.getUnfilteredCount()))
+                this.getUnfilteredCount(),
+                this.getAcceptableSortFields()))
         .collect(Collectors.toList());
   }
 

--- a/src/main/java/org/broadinstitute/consent/http/models/PaginationToken.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/PaginationToken.java
@@ -51,8 +51,8 @@ public class PaginationToken {
     checkSortDirection(sortDirection);
     this.page = page;
     this.pageSize = pageSize;
-    this.sortField = this.acceptableSortFields.get(sortField);
-    this.sortDirection = sortDirection;
+    this.sortField =  Objects.nonNull(sortField) ? sortField : "darCode";
+    this.sortDirection = Objects.nonNull(sortDirection) ? sortDirection : "DESC";
     this.filterTerm = filterTerm;
     checkForValidNumbers();
   }
@@ -65,13 +65,12 @@ public class PaginationToken {
     checkSortDirection(sortDirection);
     this.page = page;
     this.pageSize = pageSize;
-    this.sortField = this.acceptableSortFields.get(sortField);
-    this.sortDirection = sortDirection;
+    this.sortField = Objects.nonNull(sortField) ? sortField : "darCode";
+    this.sortDirection = Objects.nonNull(sortDirection) ? sortDirection : "DESC";
     this.filterTerm = filterTerm;
     this.filteredCount = filteredCount;
     this.filteredPageCount = filteredPageCount;
     this.unfilteredCount = unfilteredCount;
-    this.acceptableSortFields = acceptableSortFields;
     checkForValidNumbers();
   }
 

--- a/src/main/java/org/broadinstitute/consent/http/models/PaginationToken.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/PaginationToken.java
@@ -16,7 +16,6 @@ import java.util.stream.IntStream;
 public class PaginationToken {
 
   private static final Charset UTF_8 = StandardCharsets.UTF_8;
-  // private static final Map<String> acceptableSortFields = Collections.emptyLi();
 
   @JsonProperty
   private Integer page;
@@ -47,12 +46,10 @@ public class PaginationToken {
   //constructor for request tokens
   public PaginationToken(Integer page, Integer pageSize, String sortField, String sortDirection, String filterTerm, Map<String, String> acceptableSortFields) {
     this.acceptableSortFields = acceptableSortFields;
-    checkSortField(sortField);
-    checkSortDirection(sortDirection);
     this.page = page;
     this.pageSize = Objects.nonNull(pageSize) ? pageSize : 10;
-    this.sortField = sortField;
-    this.sortDirection = sortDirection;
+    this.sortField = validateSortField(sortField);
+    this.sortDirection = validateSortDirection(sortDirection);
     this.filterTerm = filterTerm;
     checkForValidNumbers();
   }
@@ -61,8 +58,6 @@ public class PaginationToken {
   public PaginationToken(Integer page, Integer pageSize, String sortField, String sortDirection, String filterTerm,
                          Integer filteredCount, Integer filteredPageCount, Integer unfilteredCount, Map<String, String> acceptableSortFields) {
     this.acceptableSortFields = acceptableSortFields;
-    checkSortField(sortField);
-    checkSortDirection(sortDirection);
     this.page = page;
     this.pageSize = pageSize;
     this.sortField = sortField;
@@ -143,20 +138,22 @@ public class PaginationToken {
     return acceptableSortFields;
   }
 
-  private void checkSortField(String sortField) {
-    if (Objects.nonNull(sortField)) {
-      if (Objects.isNull(acceptableSortFields.get(sortField))) {
-        throw new BadRequestException("Cannot sort on given field: " + sortField);
-      }
+  private String validateSortField(String sortField) {
+    if(Objects.isNull(sortField) || Objects.isNull(acceptableSortFields.get(sortField))) {
+      return "dar_code";
     }
+    return acceptableSortFields.get(sortField);
   }
 
-  private void checkSortDirection(String sortDirection) {
-    if (Objects.nonNull(sortDirection)) {
-      if (!sortDirection.toLowerCase().equals("asc") && !sortDirection.toLowerCase().equals("desc")) {
-        throw new BadRequestException("Sort direction must be either 'asc' or 'desc");
-      }
+  private String validateSortDirection(String sortDirection) {
+    if (
+      Objects.isNull(sortDirection) || 
+      !sortDirection.toLowerCase().equals("asc") && !sortDirection.toLowerCase().equals("desc")
+    ) {
+      return "DESC";
     }
+
+    return sortDirection;
   }
 
   private void checkForValidNumbers() {

--- a/src/main/java/org/broadinstitute/consent/http/models/PaginationToken.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/PaginationToken.java
@@ -44,12 +44,12 @@ public class PaginationToken {
   private Map<String, String> acceptableSortFields;
 
   //constructor for request tokens
-  public PaginationToken(Integer page, Integer pageSize, String sortField, String sortDirection, String filterTerm, Map<String, String> acceptableSortFields) {
+  public PaginationToken(Integer page, Integer pageSize, String sortField, String sortDirection, String filterTerm, Map<String, String> acceptableSortFields, String defaultField) {
     this.acceptableSortFields = acceptableSortFields;
     this.page = page;
     this.pageSize = Objects.nonNull(pageSize) ? pageSize : 10;
-    this.sortField = validateSortField(sortField);
-    this.sortDirection = validateSortDirection(sortDirection);
+    this.sortField = Objects.isNull(sortField) ? acceptableSortFields.get(defaultField) : validateSortField(sortField);
+    this.sortDirection = Objects.isNull(sortDirection) ? "DESC" : validateSortDirection(sortDirection);
     this.filterTerm = filterTerm;
     checkForValidNumbers();
   }
@@ -139,20 +139,18 @@ public class PaginationToken {
   }
 
   private String validateSortField(String sortField) {
-    if(Objects.isNull(sortField) || Objects.isNull(acceptableSortFields.get(sortField))) {
-      return "dar_code";
+    if(Objects.isNull(acceptableSortFields.get(sortField))) {
+      throw new BadRequestException("Invalid sortField");
     }
     return acceptableSortFields.get(sortField);
   }
 
   private String validateSortDirection(String sortDirection) {
     if (
-      Objects.isNull(sortDirection) || 
       !sortDirection.toLowerCase().equals("asc") && !sortDirection.toLowerCase().equals("desc")
     ) {
-      return "DESC";
+      throw new BadRequestException("Invalid sortDirection");
     }
-
     return sortDirection;
   }
 

--- a/src/main/java/org/broadinstitute/consent/http/resources/DarCollectionResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DarCollectionResource.java
@@ -4,11 +4,8 @@ import com.google.inject.Inject;
 import io.dropwizard.auth.Auth;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
-import java.util.Objects;
 import javax.annotation.security.PermitAll;
 import javax.annotation.security.RolesAllowed;
-import javax.ws.rs.BadRequestException;
 import javax.ws.rs.ForbiddenException;
 import javax.ws.rs.GET;
 import javax.ws.rs.NotFoundException;
@@ -96,8 +93,7 @@ public class DarCollectionResource extends Resource {
   ) {
     try {
       User user = userService.findUserByEmail(authUser.getEmail());
-      checkIfSortFieldAndSortOrderIsPresent(sortField, sortOrder);
-      PaginationToken token = new PaginationToken(1, pageSize, sortField, sortOrder, filterTerm, defineAcceptableSortFields());
+      PaginationToken token = new PaginationToken(1, pageSize, sortField, sortOrder, filterTerm, DarCollection.acceptableSortFields);
       PaginationResponse<DarCollection> paginationResponse = darCollectionService.getCollectionsWithFilters(token, user);
       return Response.ok().entity(paginationResponse).build();
     } catch(Exception e) {
@@ -113,21 +109,6 @@ public class DarCollectionResource extends Resource {
       validateAuthedRoleUser(Collections.emptyList(), user, collection.getCreateUserId());
     } catch (ForbiddenException e) {
       throw new NotFoundException();
-    }
-  }
-
-  private Map<String, String> defineAcceptableSortFields() {
-    return Map.of(
-      "projectTitle", "projectTitle",
-      "researcher", "researcher",
-      "darCode", "dar_code",
-      "institution", "institution_name"
-    );
-  }
-
-  private void checkIfSortFieldAndSortOrderIsPresent(String sortField, String sortOrder) {
-    if (Objects.isNull(sortOrder) || Objects.isNull(sortOrder)) {
-      throw new BadRequestException("sortOrder and sortField are required");
     }
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/resources/DarCollectionResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DarCollectionResource.java
@@ -93,7 +93,7 @@ public class DarCollectionResource extends Resource {
   ) {
     try {
       User user = userService.findUserByEmail(authUser.getEmail());
-      PaginationToken token = new PaginationToken(1, pageSize, sortField, sortOrder, filterTerm, DarCollection.acceptableSortFields);
+      PaginationToken token = new PaginationToken(1, pageSize, sortField, sortOrder, filterTerm, DarCollection.acceptableSortFields, DarCollection.defaultSortField);
       PaginationResponse<DarCollection> paginationResponse = darCollectionService.getCollectionsWithFilters(token, user);
       return Response.ok().entity(paginationResponse).build();
     } catch(Exception e) {

--- a/src/main/java/org/broadinstitute/consent/http/resources/DarCollectionResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DarCollectionResource.java
@@ -5,8 +5,10 @@ import io.dropwizard.auth.Auth;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import javax.annotation.security.PermitAll;
 import javax.annotation.security.RolesAllowed;
+import javax.ws.rs.BadRequestException;
 import javax.ws.rs.ForbiddenException;
 import javax.ws.rs.GET;
 import javax.ws.rs.NotFoundException;
@@ -94,6 +96,7 @@ public class DarCollectionResource extends Resource {
   ) {
     try {
       User user = userService.findUserByEmail(authUser.getEmail());
+      checkIfSortFieldAndSortOrderIsPresent(sortField, sortOrder);
       PaginationToken token = new PaginationToken(1, pageSize, sortField, sortOrder, filterTerm, defineAcceptableSortFields());
       PaginationResponse<DarCollection> paginationResponse = darCollectionService.getCollectionsWithFilters(token, user);
       return Response.ok().entity(paginationResponse).build();
@@ -120,5 +123,11 @@ public class DarCollectionResource extends Resource {
       "darCode", "dar_code",
       "institution", "institution_name"
     );
+  }
+
+  private void checkIfSortFieldAndSortOrderIsPresent(String sortField, String sortOrder) {
+    if (Objects.isNull(sortOrder) || Objects.isNull(sortOrder)) {
+      throw new BadRequestException("sortOrder and sortField are required");
+    }
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
@@ -57,7 +57,6 @@ public class DarCollectionService {
    * @return A PaginationResponse object
    */
   public PaginationResponse<DarCollection> getCollectionsWithFilters(PaginationToken token, User user) {
-
     List<DarCollection> unfilteredDars = darCollectionDAO.findDARCollectionsCreatedByUserId(user.getDacUserId());
     token.setUnfilteredCount(unfilteredDars.size());
 
@@ -143,5 +142,4 @@ public class DarCollectionService {
     // There were no datasets to add, so we return the original list
     return collections;
   }
-
 }

--- a/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
@@ -61,7 +61,6 @@ public class DarCollectionService {
     if(unfilteredDars.isEmpty()) {
       return createEmptyPaginationResponse(0);
     }
-    Map<String,String> acceptableSortFields = token.getAcceptableSortFields();
     token.setUnfilteredCount(unfilteredDars.size());
 
     String filterTerm = Objects.isNull(token.getFilterTerm()) ? "" : token.getFilterTerm();
@@ -78,7 +77,7 @@ public class DarCollectionService {
     } else {
       logger.warn(String.format("Invalid pagination state: startIndex: %s endIndex: %s", token.getStartIndex(), token.getEndIndex()));
     }
-    List<DarCollection> slicedCollections = darCollectionDAO.findDARCollectionByCollectionIdsWithOrder(slice, acceptableSortFields.get(token.getSortField()), token.getSortDirection());
+    List<DarCollection> slicedCollections = darCollectionDAO.findDARCollectionByCollectionIdsWithOrder(slice, token.getSortField(), token.getSortDirection());
     List<PaginationToken> orderedTokens = token.createListOfPaginationTokensFromSelf();
     List<String> orderedTokenStrings = orderedTokens.stream().map(PaginationToken::toBase64).collect(Collectors.toList());
     return new PaginationResponse<DarCollection>()

--- a/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
@@ -64,6 +64,14 @@ public class DarCollectionService {
     String filterTerm = Objects.isNull(token.getFilterTerm()) ? "" : token.getFilterTerm();
     List<DarCollection> filteredDars = darCollectionDAO.findAllDARCollectionsWithFiltersByUser(filterTerm, user.getDacUserId(), token.getSortField(), token.getSortDirection());
     token.setFilteredCount(filteredDars.size());
+    if(filteredDars.isEmpty()) {
+      return new PaginationResponse<DarCollection>()
+          .setUnfilteredCount(token.getUnfilteredCount())
+          .setFilteredCount(0)
+          .setFilteredPageCount(0) //should this be 0 or 1?
+          .setResults(Collections.emptyList())
+          .setPaginationTokens(Collections.emptyList());
+    }
 
     List<Integer> collectionIds = filteredDars.stream().map(DarCollection::getDarCollectionId).collect(Collectors.toList());
     List<Integer> slice = new ArrayList<>();

--- a/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
@@ -58,6 +58,9 @@ public class DarCollectionService {
    */
   public PaginationResponse<DarCollection> getCollectionsWithFilters(PaginationToken token, User user) {
     List<DarCollection> unfilteredDars = darCollectionDAO.findDARCollectionsCreatedByUserId(user.getDacUserId());
+    if(unfilteredDars.isEmpty()) {
+      return createEmptyPaginationResponse(0);
+    }
     Map<String,String> acceptableSortFields = token.getAcceptableSortFields();
     token.setUnfilteredCount(unfilteredDars.size());
 
@@ -65,12 +68,7 @@ public class DarCollectionService {
     List<DarCollection> filteredDars = darCollectionDAO.findAllDARCollectionsWithFiltersByUser(filterTerm, user.getDacUserId(), token.getSortField(), token.getSortDirection());
     token.setFilteredCount(filteredDars.size());
     if(filteredDars.isEmpty()) {
-      return new PaginationResponse<DarCollection>()
-          .setUnfilteredCount(token.getUnfilteredCount())
-          .setFilteredCount(0)
-          .setFilteredPageCount(0) //should this be 0 or 1?
-          .setResults(Collections.emptyList())
-          .setPaginationTokens(Collections.emptyList());
+      return createEmptyPaginationResponse(token.getUnfilteredCount());
     }
 
     List<Integer> collectionIds = filteredDars.stream().map(DarCollection::getDarCollectionId).collect(Collectors.toList());
@@ -150,5 +148,14 @@ public class DarCollectionService {
     }
     // There were no datasets to add, so we return the original list
     return collections;
+  }
+
+  private PaginationResponse<DarCollection> createEmptyPaginationResponse(Integer unfilteredCount) {
+    return new PaginationResponse<DarCollection>()
+          .setUnfilteredCount(unfilteredCount)
+          .setFilteredCount(0)
+          .setFilteredPageCount(0) //should this be 0 or 1?
+          .setResults(Collections.emptyList())
+          .setPaginationTokens(Collections.emptyList());
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
@@ -154,7 +154,7 @@ public class DarCollectionService {
     return new PaginationResponse<DarCollection>()
           .setUnfilteredCount(unfilteredCount)
           .setFilteredCount(0)
-          .setFilteredPageCount(0) //should this be 0 or 1?
+          .setFilteredPageCount(1) //should this be 0 or 1?
           .setResults(Collections.emptyList())
           .setPaginationTokens(Collections.emptyList());
   }

--- a/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
@@ -58,7 +58,7 @@ public class DarCollectionService {
    */
   public PaginationResponse<DarCollection> getCollectionsWithFilters(PaginationToken token, User user) {
     List<DarCollection> unfilteredDars = darCollectionDAO.findDARCollectionsCreatedByUserId(user.getDacUserId());
-    if(unfilteredDars.isEmpty()) {
+    if (unfilteredDars.isEmpty()) {
       return createEmptyPaginationResponse(0);
     }
     token.setUnfilteredCount(unfilteredDars.size());

--- a/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
@@ -58,6 +58,7 @@ public class DarCollectionService {
    */
   public PaginationResponse<DarCollection> getCollectionsWithFilters(PaginationToken token, User user) {
     List<DarCollection> unfilteredDars = darCollectionDAO.findDARCollectionsCreatedByUserId(user.getDacUserId());
+    Map<String,String> acceptableSortFields = token.getAcceptableSortFields();
     token.setUnfilteredCount(unfilteredDars.size());
 
     String filterTerm = Objects.isNull(token.getFilterTerm()) ? "" : token.getFilterTerm();
@@ -71,7 +72,7 @@ public class DarCollectionService {
     } else {
       logger.warn(String.format("Invalid pagination state: startIndex: %s endIndex: %s", token.getStartIndex(), token.getEndIndex()));
     }
-    List<DarCollection> slicedCollections = darCollectionDAO.findDARCollectionByCollectionIdsWithOrder(slice, token.getSortField(), token.getSortDirection());
+    List<DarCollection> slicedCollections = darCollectionDAO.findDARCollectionByCollectionIdsWithOrder(slice, acceptableSortFields.get(token.getSortField()), token.getSortDirection());
     List<PaginationToken> orderedTokens = token.createListOfPaginationTokensFromSelf();
     List<String> orderedTokenStrings = orderedTokens.stream().map(PaginationToken::toBase64).collect(Collectors.toList());
     return new PaginationResponse<DarCollection>()

--- a/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
@@ -71,7 +71,7 @@ public class DarCollectionService {
     } else {
       logger.warn(String.format("Invalid pagination state: startIndex: %s endIndex: %s", token.getStartIndex(), token.getEndIndex()));
     }
-    List<DarCollection> slicedCollections = darCollectionDAO.findDARCollectionByCollectionIds(slice, token.getSortField(), token.getSortDirection());
+    List<DarCollection> slicedCollections = darCollectionDAO.findDARCollectionByCollectionIdsWithOrder(slice, token.getSortField(), token.getSortDirection());
     List<PaginationToken> orderedTokens = token.createListOfPaginationTokensFromSelf();
     List<String> orderedTokenStrings = orderedTokens.stream().map(PaginationToken::toBase64).collect(Collectors.toList());
     return new PaginationResponse<DarCollection>()

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -124,6 +124,8 @@ paths:
     $ref: './paths/collection.yaml'
   /api/collections/dar/{referenceId}:
     $ref: './paths/collectionByReferenceId.yaml'
+  /api/collections/query:
+    $ref: './paths/collectionsByQuery.yaml'
   /api/ontology:
     get:
       summary: List Ontology Files

--- a/src/main/resources/assets/paths/collectionsByQuery.yaml
+++ b/src/main/resources/assets/paths/collectionsByQuery.yaml
@@ -12,15 +12,15 @@ get:
     - name: sortField
       in: query
       description: String value that represents field to order by
-      required: true
       schema:
         type: string
+      default: "darCode"
     - name: sortOrder
       in: query
       description: String value that represents direction of ordering
-      required: true
       schema:
         type: string
+      default: "DESC"
     - name: pageSize
       in: query
       description: Integer value that represents number of records returned on each page
@@ -34,10 +34,6 @@ get:
         application/json:
           schema:
             $ref: '../schemas/DarCollection.yaml'
-    400:
-      description: Bad Request
-    401:
-      description: Unauthorized
     404:
       description: Not Found
     500:

--- a/src/main/resources/assets/paths/collectionsByQuery.yaml
+++ b/src/main/resources/assets/paths/collectionsByQuery.yaml
@@ -12,11 +12,13 @@ get:
     - name: sortField
       in: query
       description: String value that represents field to order by
+      required: true
       schema:
         type: string
     - name: sortOrder
       in: query
       description: String value that represents direction of ordering
+      required: true
       schema:
         type: string
     - name: pageSize
@@ -32,5 +34,12 @@ get:
         application/json:
           schema:
             $ref: '../schemas/DarCollection.yaml'
+    400:
+      description: Bad Request
+    401:
+      description: Unauthorized
     404:
       description: Not Found
+    500:
+      description: Internal Server Error
+      

--- a/src/main/resources/assets/paths/collectionsByQuery.yaml
+++ b/src/main/resources/assets/paths/collectionsByQuery.yaml
@@ -1,0 +1,36 @@
+get:
+  summary: Get DAR Collection By Query
+  description: Returns DAR collections that meet query criteria
+  tags:
+    - DAR Collection
+  parameters:
+    - name: filterTerm
+      in: query
+      description: String value that represents term(s) to search upon
+      schema:
+        type: string
+    - name: sortField
+      in: query
+      description: String value that represents field to order by
+      schema:
+        type: string
+    - name: sortOrder
+      in: query
+      description: String value that represents direction of ordering
+      schema:
+        type: string
+    - name: pageSize
+      in: query
+      description: Integer value that represents number of records returned on each page
+      schema:
+        type: integer
+      default: 10
+  responses:
+    200:
+      description: Returns a single DAR Collection
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/DarCollection.yaml'
+    404:
+      description: Not Found

--- a/src/test/java/org/broadinstitute/consent/http/db/DarCollectionDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DarCollectionDAOTest.java
@@ -65,6 +65,36 @@ public class DarCollectionDAOTest extends DAOTestHelper  {
   }
 
   @Test
+  public void testFindDARCollectionByCollectionIdWithOrder_ASC() {
+    DarCollection collectionOne = createDarCollection();
+    DarCollection collectionTwo = createDarCollection();
+    List<Integer> collectionIds = List.of(
+      collectionOne.getDarCollectionId(),
+      collectionTwo.getDarCollectionId()
+    );
+    List<DarCollection> returnedCollections = darCollectionDAO.findDARCollectionByCollectionIdsWithOrder(collectionIds, "dar_code", "ASC");
+    for(int i = 0; i < returnedCollections.size() - 1; i++) {
+      String firstCode = returnedCollections.get(i).getDarCode();
+      String secondCode = returnedCollections.get(i+1).getDarCode();
+      assertTrue(firstCode.compareTo(secondCode) < 0);
+    }
+  }
+
+  @Test
+  public void testFindDARCollectionByCollectionIdWithOrder_DESC() {
+    DarCollection collectionOne = createDarCollection();
+    DarCollection collectionTwo = createDarCollection();
+    List<Integer> collectionIds = List.of(collectionOne.getDarCollectionId(), collectionTwo.getDarCollectionId());
+    List<DarCollection> returnedCollections = darCollectionDAO.findDARCollectionByCollectionIdsWithOrder(collectionIds,
+        "dar_code", "DESC");
+    for (int i = 0; i < returnedCollections.size() - 1; i++) {
+      String firstCode = returnedCollections.get(i).getDarCode();
+      String secondCode = returnedCollections.get(i + 1).getDarCode();
+      assertTrue(firstCode.compareTo(secondCode) > 0);
+    }
+  }
+
+  @Test
   public void testInsertDARCollection() {
     List<DarCollection> allBefore = darCollectionDAO.findAllDARCollections();
     assertTrue(allBefore.isEmpty());

--- a/src/test/java/org/broadinstitute/consent/http/resources/DarCollectionResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DarCollectionResourceTest.java
@@ -162,7 +162,10 @@ public class DarCollectionResourceTest {
     initResource();
 
     Response response = resource.getCollectionsByInitialQuery(authUser, "filterTerm", "projectTitle", "badSortOrder", 10);
+    assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
   }
+
+  @Test
   public void testCancelDarCollection_OKStatus() {
     DarCollection collection = mockDarCollection();
     collection.setCreateUserId(researcher.getDacUserId());
@@ -210,7 +213,7 @@ public class DarCollectionResourceTest {
     Response response = resource.getCollectionsByInitialQuery(authUser, "filterTerm", "projectTitle", "asc", 10);
     assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
   }
-  
+
   public void testCancelDarCollection_InternalErrorStatus() {
     DarCollection collection = mockDarCollection();
     collection.setCreateUserId(researcher.getDacUserId());

--- a/src/test/java/org/broadinstitute/consent/http/resources/DarCollectionResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DarCollectionResourceTest.java
@@ -150,7 +150,7 @@ public class DarCollectionResourceTest {
     initResource();
 
     Response response = resource.getCollectionsByInitialQuery(authUser, "filterTerm", "badSortFieldName", "ASC", 10);
-    assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
+    assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
   }
 
   @Test
@@ -159,7 +159,7 @@ public class DarCollectionResourceTest {
     initResource();
 
     Response response = resource.getCollectionsByInitialQuery(authUser, "filterTerm", "projectTitle", "badSortOrder", 10);
-    assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
+    assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/resources/DarCollectionResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DarCollectionResourceTest.java
@@ -150,7 +150,7 @@ public class DarCollectionResourceTest {
     initResource();
 
     Response response = resource.getCollectionsByInitialQuery(authUser, "filterTerm", "badSortFieldName", "ASC", 10);
-    assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+    assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
   }
 
   @Test
@@ -159,7 +159,7 @@ public class DarCollectionResourceTest {
     initResource();
 
     Response response = resource.getCollectionsByInitialQuery(authUser, "filterTerm", "projectTitle", "badSortOrder", 10);
-    assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+    assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/resources/DarCollectionResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DarCollectionResourceTest.java
@@ -14,7 +14,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import javax.ws.rs.BadRequestException;
 import javax.ws.rs.core.Response;
 import org.apache.commons.lang3.RandomUtils;
 import org.broadinstitute.consent.http.enumeration.UserRoles;

--- a/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
@@ -53,7 +53,7 @@ public class DarCollectionServiceTest {
             page -> {
               int filteredCount = 75;
               int unfilteredCount = 100;
-              PaginationToken token = new PaginationToken(page, 10, null, null, null, defineAcceptableSortFields());
+              PaginationToken token = new PaginationToken(page, 10, "darCode", "DESC", null, defineAcceptableSortFields());
               initWithPaginationToken(token, unfilteredCount, filteredCount);
               PaginationResponse<DarCollection> response = service.getCollectionsWithFilters(token, user);
               /*
@@ -80,7 +80,7 @@ public class DarCollectionServiceTest {
 
   @Test
   public void testGetCollectionsWithFilters_EmptyUnfiltered() {
-    PaginationToken token = new PaginationToken(1, 10, null, null, null, defineAcceptableSortFields());
+    PaginationToken token = new PaginationToken(1, 10, "darCode", "DESC", null, defineAcceptableSortFields());
     when(darCollectionDAO.findDARCollectionsCreatedByUserId(anyInt())).thenReturn(Collections.emptyList());
     service = new DarCollectionService(darCollectionDAO, datasetDAO);
 
@@ -93,12 +93,12 @@ public class DarCollectionServiceTest {
 
   @Test
   public void testGetCollectionsWithFilters_EmptyFiltered() {
-    PaginationToken token = new PaginationToken(1, 10, null, null, null, defineAcceptableSortFields());
+    PaginationToken token = new PaginationToken(1, 10, "darCode", "DESC", null, defineAcceptableSortFields());
     List<DarCollection> collections = createMockCollections(3);
     when(darCollectionDAO.findDARCollectionsCreatedByUserId(anyInt())).thenReturn(collections);
     when(darCollectionDAO.findAllDARCollectionsWithFiltersByUser(anyString(), anyInt(), anyString(), anyString())).thenReturn(Collections.emptyList());
     service = new DarCollectionService(darCollectionDAO, datasetDAO);
-    
+
     PaginationResponse<DarCollection> response = service.getCollectionsWithFilters(token, user);
 
     assertEquals(1, response.getFilteredPageCount().intValue());
@@ -110,7 +110,7 @@ public class DarCollectionServiceTest {
   public void testGetCollectionsWithFiltersByPageLessThanPageSize() {
       int filteredCount = 3;
       int unfilteredCount = 5;
-      PaginationToken token = new PaginationToken(1, 10, null, null, null, defineAcceptableSortFields());
+      PaginationToken token = new PaginationToken(1, 10, "darCode", "DESC", null, defineAcceptableSortFields());
       initWithPaginationToken(token, unfilteredCount, filteredCount);
       PaginationResponse<DarCollection> response = service.getCollectionsWithFilters(token, user);
 
@@ -123,7 +123,7 @@ public class DarCollectionServiceTest {
   public void testInitWithInvalidTokenValues() {
       int filteredCount = 5;
       int unfilteredCount = 20;
-      PaginationToken token = new PaginationToken(2, 10, null, null, null, defineAcceptableSortFields());
+      PaginationToken token = new PaginationToken(2, 10, "darCode", "DESC", null, defineAcceptableSortFields());
       initWithPaginationToken(token, unfilteredCount, filteredCount);
 
       // Start index will be > end index in this case since we're trying to get results 11-20 when

--- a/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
@@ -52,7 +52,7 @@ public class DarCollectionServiceTest {
             page -> {
               int filteredCount = 75;
               int unfilteredCount = 100;
-              PaginationToken token = new PaginationToken(page, 10, "darCode", "DESC", null, DarCollection.acceptableSortFields);
+              PaginationToken token = new PaginationToken(page, 10, "darCode", "DESC", null, DarCollection.acceptableSortFields, DarCollection.defaultSortField);
               initWithPaginationToken(token, unfilteredCount, filteredCount);
               PaginationResponse<DarCollection> response = service.getCollectionsWithFilters(token, user);
               /*
@@ -79,7 +79,7 @@ public class DarCollectionServiceTest {
 
   @Test
   public void testGetCollectionsWithFilters_EmptyUnfiltered() {
-    PaginationToken token = new PaginationToken(1, 10, "darCode", "DESC", null, DarCollection.acceptableSortFields);
+    PaginationToken token = new PaginationToken(1, 10, "darCode", "DESC", null, DarCollection.acceptableSortFields, DarCollection.defaultSortField);
     when(darCollectionDAO.findDARCollectionsCreatedByUserId(anyInt())).thenReturn(Collections.emptyList());
     service = new DarCollectionService(darCollectionDAO, datasetDAO);
 
@@ -92,7 +92,7 @@ public class DarCollectionServiceTest {
 
   @Test
   public void testGetCollectionsWithFilters_EmptyFiltered() {
-    PaginationToken token = new PaginationToken(1, 10, "darCode", "DESC", null, DarCollection.acceptableSortFields);
+    PaginationToken token = new PaginationToken(1, 10, "darCode", "DESC", null, DarCollection.acceptableSortFields, DarCollection.defaultSortField);
     List<DarCollection> collections = createMockCollections(3);
     when(darCollectionDAO.findDARCollectionsCreatedByUserId(anyInt())).thenReturn(collections);
     when(darCollectionDAO.findAllDARCollectionsWithFiltersByUser(anyString(), anyInt(), anyString(), anyString())).thenReturn(Collections.emptyList());
@@ -109,7 +109,7 @@ public class DarCollectionServiceTest {
   public void testGetCollectionsWithFiltersByPageLessThanPageSize() {
       int filteredCount = 3;
       int unfilteredCount = 5;
-      PaginationToken token = new PaginationToken(1, 10, "darCode", "DESC", null, DarCollection.acceptableSortFields);
+      PaginationToken token = new PaginationToken(1, 10, "darCode", "DESC", null, DarCollection.acceptableSortFields, DarCollection.defaultSortField);
       initWithPaginationToken(token, unfilteredCount, filteredCount);
       PaginationResponse<DarCollection> response = service.getCollectionsWithFilters(token, user);
 
@@ -122,7 +122,7 @@ public class DarCollectionServiceTest {
   public void testInitWithInvalidTokenValues() {
       int filteredCount = 5;
       int unfilteredCount = 20;
-      PaginationToken token = new PaginationToken(2, 10, "darCode", "DESC", null, DarCollection.acceptableSortFields);
+      PaginationToken token = new PaginationToken(2, 10, "darCode", "DESC", null, DarCollection.acceptableSortFields, DarCollection.defaultSortField);
       initWithPaginationToken(token, unfilteredCount, filteredCount);
 
       // Start index will be > end index in this case since we're trying to get results 11-20 when

--- a/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
@@ -13,7 +13,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -53,7 +52,7 @@ public class DarCollectionServiceTest {
             page -> {
               int filteredCount = 75;
               int unfilteredCount = 100;
-              PaginationToken token = new PaginationToken(page, 10, "darCode", "DESC", null, defineAcceptableSortFields());
+              PaginationToken token = new PaginationToken(page, 10, "darCode", "DESC", null, DarCollection.acceptableSortFields);
               initWithPaginationToken(token, unfilteredCount, filteredCount);
               PaginationResponse<DarCollection> response = service.getCollectionsWithFilters(token, user);
               /*
@@ -80,7 +79,7 @@ public class DarCollectionServiceTest {
 
   @Test
   public void testGetCollectionsWithFilters_EmptyUnfiltered() {
-    PaginationToken token = new PaginationToken(1, 10, "darCode", "DESC", null, defineAcceptableSortFields());
+    PaginationToken token = new PaginationToken(1, 10, "darCode", "DESC", null, DarCollection.acceptableSortFields);
     when(darCollectionDAO.findDARCollectionsCreatedByUserId(anyInt())).thenReturn(Collections.emptyList());
     service = new DarCollectionService(darCollectionDAO, datasetDAO);
 
@@ -93,7 +92,7 @@ public class DarCollectionServiceTest {
 
   @Test
   public void testGetCollectionsWithFilters_EmptyFiltered() {
-    PaginationToken token = new PaginationToken(1, 10, "darCode", "DESC", null, defineAcceptableSortFields());
+    PaginationToken token = new PaginationToken(1, 10, "darCode", "DESC", null, DarCollection.acceptableSortFields);
     List<DarCollection> collections = createMockCollections(3);
     when(darCollectionDAO.findDARCollectionsCreatedByUserId(anyInt())).thenReturn(collections);
     when(darCollectionDAO.findAllDARCollectionsWithFiltersByUser(anyString(), anyInt(), anyString(), anyString())).thenReturn(Collections.emptyList());
@@ -110,7 +109,7 @@ public class DarCollectionServiceTest {
   public void testGetCollectionsWithFiltersByPageLessThanPageSize() {
       int filteredCount = 3;
       int unfilteredCount = 5;
-      PaginationToken token = new PaginationToken(1, 10, "darCode", "DESC", null, defineAcceptableSortFields());
+      PaginationToken token = new PaginationToken(1, 10, "darCode", "DESC", null, DarCollection.acceptableSortFields);
       initWithPaginationToken(token, unfilteredCount, filteredCount);
       PaginationResponse<DarCollection> response = service.getCollectionsWithFilters(token, user);
 
@@ -123,7 +122,7 @@ public class DarCollectionServiceTest {
   public void testInitWithInvalidTokenValues() {
       int filteredCount = 5;
       int unfilteredCount = 20;
-      PaginationToken token = new PaginationToken(2, 10, "darCode", "DESC", null, defineAcceptableSortFields());
+      PaginationToken token = new PaginationToken(2, 10, "darCode", "DESC", null, DarCollection.acceptableSortFields);
       initWithPaginationToken(token, unfilteredCount, filteredCount);
 
       // Start index will be > end index in this case since we're trying to get results 11-20 when
@@ -217,14 +216,5 @@ public class DarCollectionServiceTest {
               return collection;
             })
         .collect(Collectors.toList());
-  }
-
-  private Map<String, String> defineAcceptableSortFields() {
-    return Map.of(
-      "projectTitle", "projectTitle",
-      "researcher", "researcher",
-      "darCode", "dar_code",
-      "institution", "institution_name"
-    );
   }
 }

--- a/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
@@ -172,7 +172,7 @@ public class DarCollectionServiceTest {
     }
     when(darCollectionDAO.findDARCollectionsCreatedByUserId(any())).thenReturn(unfilteredDars);
     when(darCollectionDAO.findAllDARCollectionsWithFiltersByUser(any(), any(), any(), any())).thenReturn(filteredDars);
-    when(darCollectionDAO.findDARCollectionByCollectionIds(any(), any(), any())).thenReturn(collectionIdDars);
+    when(darCollectionDAO.findDARCollectionByCollectionIdsWithOrder(any(), any(), any())).thenReturn(collectionIdDars);
     service = new DarCollectionService(darCollectionDAO, datasetDAO);
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -50,7 +51,7 @@ public class DarCollectionServiceTest {
             page -> {
               int filteredCount = 75;
               int unfilteredCount = 100;
-              PaginationToken token = new PaginationToken(page, 10, null, null, null);
+              PaginationToken token = new PaginationToken(page, 10, null, null, null, defineAcceptableSortFields());
               initWithPaginationToken(token, unfilteredCount, filteredCount);
               PaginationResponse<DarCollection> response = service.getCollectionsWithFilters(token, user);
               /*
@@ -79,7 +80,7 @@ public class DarCollectionServiceTest {
   public void testGetCollectionsWithFiltersByPageLessThanPageSize() {
       int filteredCount = 3;
       int unfilteredCount = 5;
-      PaginationToken token = new PaginationToken(1, 10, null, null, null);
+      PaginationToken token = new PaginationToken(1, 10, null, null, null, defineAcceptableSortFields());
       initWithPaginationToken(token, unfilteredCount, filteredCount);
       PaginationResponse<DarCollection> response = service.getCollectionsWithFilters(token, user);
 
@@ -92,7 +93,7 @@ public class DarCollectionServiceTest {
   public void testInitWithInvalidTokenValues() {
       int filteredCount = 5;
       int unfilteredCount = 20;
-      PaginationToken token = new PaginationToken(2, 10, null, null, null);
+      PaginationToken token = new PaginationToken(2, 10, null, null, null, defineAcceptableSortFields());
       initWithPaginationToken(token, unfilteredCount, filteredCount);
 
       // Start index will be > end index in this case since we're trying to get results 11-20 when
@@ -186,5 +187,14 @@ public class DarCollectionServiceTest {
               return collection;
             })
         .collect(Collectors.toList());
+  }
+
+  private Map<String, String> defineAcceptableSortFields() {
+    return Map.of(
+      "projectTitle", "projectTitle",
+      "researcher", "researcher",
+      "darCode", "dar_code",
+      "institution", "institution_name"
+    );
   }
 }


### PR DESCRIPTION
Addresses [DUOS-1437](https://broadworkbench.atlassian.net/browse/DUOS-1437)

PR adds a initialQuery endpoint that executes the initial query for a new filtered Collections GET request alongside tests for endpoint responses. PR also adds adjustments to the model, service and DAO classes with associated updates to their respective tests. 

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
