### PR TITLE
[DUOS-1445][risk=no] Prevent SOs from changing their institution

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/resources/DACUserResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DACUserResource.java
@@ -5,19 +5,19 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.google.inject.Inject;
 import io.dropwizard.auth.Auth;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.broadinstitute.consent.http.authentication.GoogleUser;
-import org.broadinstitute.consent.http.enumeration.UserRoles;
-import org.broadinstitute.consent.http.models.AuthUser;
-import org.broadinstitute.consent.http.models.User;
-import org.broadinstitute.consent.http.models.dto.Error;
-import org.broadinstitute.consent.http.service.UserService;
-import org.broadinstitute.consent.http.service.users.handler.UserRolesHandler;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import javax.annotation.security.PermitAll;
 import javax.annotation.security.RolesAllowed;
+import javax.ws.rs.BadRequestException;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.NotFoundException;
@@ -29,14 +29,15 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
-import java.net.URI;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.stream.Collectors;
+import org.broadinstitute.consent.http.authentication.GoogleUser;
+import org.broadinstitute.consent.http.enumeration.UserRoles;
+import org.broadinstitute.consent.http.models.AuthUser;
+import org.broadinstitute.consent.http.models.User;
+import org.broadinstitute.consent.http.models.dto.Error;
+import org.broadinstitute.consent.http.service.UserService;
+import org.broadinstitute.consent.http.service.users.handler.UserRolesHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Path("api/dacuser")
 public class DACUserResource extends Resource {
@@ -88,6 +89,14 @@ public class DACUserResource extends Resource {
     public Response update(@Auth AuthUser authUser, @Context UriInfo info, String json, @PathParam("id") Integer userId) {
         Map<String, User> userMap = constructUserMapFromJson(json);
         try {
+            User userToUpdate = userMap.get(UserRolesHandler.UPDATED_USER_KEY);
+            User existingUser = userService.findUserById(userToUpdate.getDacUserId());
+            // Signing Officials are prohibited from updating their institution
+            if (existingUser.getUserRoleIdsFromUser().contains(UserRoles.SIGNINGOFFICIAL.getRoleId())) {
+                if (!Objects.equals(userToUpdate.getInstitutionId(), existingUser.getInstitutionId())) {
+                    throw new BadRequestException("Signing Officials are not permitted to update their institution. Please contact support.");
+                }
+            }
             validateAuthedRoleUser(Collections.singletonList(UserRoles.ADMIN), findByAuthUser(authUser), userId);
             URI uri = info.getRequestUriBuilder().path("{id}").build(userId);
             User user = userService.updateDACUserById(userMap, userId);

--- a/src/main/java/org/broadinstitute/consent/http/resources/DACUserResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DACUserResource.java
@@ -91,10 +91,14 @@ public class DACUserResource extends Resource {
         try {
             User userToUpdate = userMap.get(UserRolesHandler.UPDATED_USER_KEY);
             User existingUser = userService.findUserById(userToUpdate.getDacUserId());
-            // Signing Officials are prohibited from updating their institution
+            // Signing Officials are prohibited from changing their institution
             if (existingUser.getUserRoleIdsFromUser().contains(UserRoles.SIGNINGOFFICIAL.getRoleId())) {
-                if (!Objects.equals(userToUpdate.getInstitutionId(), existingUser.getInstitutionId())) {
-                    throw new BadRequestException("Signing Officials are not permitted to update their institution. Please contact support.");
+                // A SO should be able to update their institution if they don't have one
+                // If they do have one, it cannot be changed through this endpoint.
+                if (Objects.nonNull(existingUser.getInstitutionId())) {
+                    if (!Objects.equals(userToUpdate.getInstitutionId(), existingUser.getInstitutionId())) {
+                        throw new BadRequestException("Signing Officials are not permitted to update their institution. Please contact support.");
+                    }
                 }
             }
             validateAuthedRoleUser(Collections.singletonList(UserRoles.ADMIN), findByAuthUser(authUser), userId);

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -1179,6 +1179,8 @@ paths:
         and Member roles using this endpoint. All Chairperson and Member changes (additions or removals)
         are ignored. See [DAC](/#!/DAC) endpoints for **POST/DELETE** endpoints for
         **/api/dac/{dacId}/chair/{userId}** and **/api/dac/{dacId}/member/{userId}** calls.
+        Users with the "Signing Official" are not permitted to update their institution. Such calls
+        will result in a "Bad Request".
       parameters:
         - name: id
           in: path
@@ -1205,7 +1207,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/User'
         400:
-          description: Malformed user entity.
+          description: Malformed user entity or improper institution update
         403:
           description: User must have appropriate roles to update different users' information.
   /api/dacuser/status/{userId}:

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -1179,8 +1179,9 @@ paths:
         and Member roles using this endpoint. All Chairperson and Member changes (additions or removals)
         are ignored. See [DAC](/#!/DAC) endpoints for **POST/DELETE** endpoints for
         **/api/dac/{dacId}/chair/{userId}** and **/api/dac/{dacId}/member/{userId}** calls.
-        Users with the "Signing Official" are not permitted to update their institution. Such calls
-        will result in a "Bad Request".
+        Users with the "Signing Official" are not permitted to change their institution. Such calls
+        will result in a "Bad Request". "Signing Official" users are, however, allowed to save their
+        institution if it is not already set.
       parameters:
         - name: id
           in: path

--- a/src/test/java/org/broadinstitute/consent/http/resources/DACUserResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DACUserResourceTest.java
@@ -124,6 +124,27 @@ public class DACUserResourceTest {
     }
 
     @Test
+    public void testSetSOInstitutionOK() {
+        User user = createDacUser(UserRoles.SIGNINGOFFICIAL);
+        user.setInstitutionId(null);
+        user.setDacUserId(RandomUtils.nextInt(1, 10));
+        when(userService.findUserById(any())).thenReturn(user);
+        when(userService.findUserByEmail(any())).thenReturn(user);
+        when(userService.updateDACUserById(any(), anyInt())).thenReturn(user);
+        initResource();
+
+        // Update passed in user to have a different institution id to trigger SO error
+        Gson gson = new Gson();
+        User updateUser = gson.fromJson(gson.toJson(user), User.class);
+        updateUser.setInstitutionId(RandomUtils.nextInt(1, 10));
+
+        JsonObject json = makeUserMapJsonObject(updateUser);
+
+        Response response = resource.update(authUser, uriInfo, json.toString(), updateUser.getDacUserId());
+        assertEquals(200, response.getStatus());
+    }
+
+    @Test
     public void testUpdateSOInstitutionBadRequest() {
         User user = createDacUser(UserRoles.SIGNINGOFFICIAL);
         user.setDacUserId(RandomUtils.nextInt(1, 10));


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-1445

Signing officials are prohibited from updating their institution to prevent users from changing institutions just to issue library cards that might be outside of their normal institution. Signing Officials must go through customer support to accomplish this.

This PR does not complete DUOS-1445 as there will need to be a follow-on UI PR that helps user's navigate this edge case on their profile page.

## Changes
* When updating a user, and the user is a Signing Official, throw an error if the user is trying to change their institution. 

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
