### PR TITLE
DUOS-1469[risk=no] Add Elections to DARCollection and findDarCollectionsCreatedByUserID 

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
@@ -3,6 +3,7 @@ package org.broadinstitute.consent.http.db;
 import org.broadinstitute.consent.http.db.mapper.DarCollectionReducer;
 import org.broadinstitute.consent.http.models.DarCollection;
 import org.broadinstitute.consent.http.models.DataAccessRequest;
+import org.broadinstitute.consent.http.models.Election;
 import org.jdbi.v3.sqlobject.config.RegisterBeanMapper;
 import org.jdbi.v3.sqlobject.customizer.Bind;
 import org.jdbi.v3.sqlobject.customizer.BindList;
@@ -103,14 +104,19 @@ public interface DarCollectionDAO {
 
   @RegisterBeanMapper(value = DarCollection.class)
   @RegisterBeanMapper(value = DataAccessRequest.class, prefix = "dar")
+  @RegisterBeanMapper(value = Election.class, prefix = "e")
   @UseRowReducer(DarCollectionReducer.class)
   @SqlQuery(" SELECT c.*, dar.id AS dar_id, dar.reference_id AS dar_reference_id, dar.collection_id AS dar_collection_id, "
       + "dar.draft AS dar_draft, dar.user_id AS dar_userId, dar.create_date AS dar_create_date, "
       + "dar.sort_date AS dar_sort_date, dar.submission_date AS dar_submission_date, "
-      + "dar.update_date AS dar_update_date, (dar.data #>> '{}')::jsonb AS data "
+      + "dar.update_date AS dar_update_date, (dar.data #>> '{}')::jsonb AS data, "
+      + "e.electionid AS e_election_id, e.referenceid AS e_reference_id, e.status AS e_status, e.createdate AS e_create_date, "
+      + "e.lastupdate AS e_last_update, e.datasetid AS e_dataset_id, e.electiontype AS e_election_type "
       + "FROM dar_collection c "
       + "INNER JOIN data_access_request dar ON c.collection_id = dar.collection_id "
-      + "AND c.create_user_id = :userId")
+      + "AND c.create_user_id = :userId "
+      + "LEFT JOIN election e ON e.referenceid = dar.reference_id "
+  )
   List<DarCollection> findDARCollectionsCreatedByUserId(@Bind("userId") Integer researcherId);
 
   /**
@@ -119,7 +125,7 @@ public interface DarCollectionDAO {
    * @return DarCollection
    */
   @RegisterBeanMapper(value = DarCollection.class)
-  @RegisterBeanMapper(value = DataAccessRequest.class,  prefix = "dar")
+  @RegisterBeanMapper(value = DataAccessRequest.class, prefix = "dar")
   @UseRowReducer(DarCollectionReducer.class)
   @SqlQuery(
     "SELECT " +

--- a/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
@@ -106,16 +106,20 @@ public interface DarCollectionDAO {
   @RegisterBeanMapper(value = DataAccessRequest.class, prefix = "dar")
   @RegisterBeanMapper(value = Election.class, prefix = "e")
   @UseRowReducer(DarCollectionReducer.class)
-  @SqlQuery(" SELECT c.*, dar.id AS dar_id, dar.reference_id AS dar_reference_id, dar.collection_id AS dar_collection_id, "
+  @SqlQuery("SELECT c.*, dar.id AS dar_id, dar.reference_id AS dar_reference_id, dar.collection_id AS dar_collection_id, "
       + "dar.draft AS dar_draft, dar.user_id AS dar_userId, dar.create_date AS dar_create_date, "
       + "dar.sort_date AS dar_sort_date, dar.submission_date AS dar_submission_date, "
       + "dar.update_date AS dar_update_date, (dar.data #>> '{}')::jsonb AS data, "
       + "e.electionid AS e_election_id, e.referenceid AS e_reference_id, e.status AS e_status, e.createdate AS e_create_date, "
-      + "e.lastupdate AS e_last_update, e.datasetid AS e_dataset_id, e.electiontype AS e_election_type "
+      + "e.lastupdate AS e_last_update, e.datasetid AS e_dataset_id, e.electiontype AS e_election_type, e.latest "
       + "FROM dar_collection c "
       + "INNER JOIN data_access_request dar ON c.collection_id = dar.collection_id "
       + "AND c.create_user_id = :userId "
-      + "LEFT JOIN election e ON e.referenceid = dar.reference_id "
+      + "LEFT JOIN ("
+          + "SELECT election.*, MAX(election.electionid) OVER (PARTITION BY election.referenceid, election.electiontype) AS latest "
+          + "FROM election"
+      + ") AS e "
+      + "ON dar.reference_id = e.referenceid AND (e.latest = e.electionid OR e.latest IS NULL)"
   )
   List<DarCollection> findDARCollectionsCreatedByUserId(@Bind("userId") Integer researcherId);
 

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DarCollectionReducer.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DarCollectionReducer.java
@@ -3,6 +3,7 @@ package org.broadinstitute.consent.http.db.mapper;
 import org.broadinstitute.consent.http.models.DarCollection;
 import org.broadinstitute.consent.http.models.DataAccessRequest;
 import org.broadinstitute.consent.http.models.DataAccessRequestData;
+import org.broadinstitute.consent.http.models.Election;
 import org.jdbi.v3.core.mapper.MappingException;
 import org.jdbi.v3.core.result.LinkedHashMapRowReducer;
 import org.jdbi.v3.core.result.RowView;
@@ -15,15 +16,20 @@ public class DarCollectionReducer implements LinkedHashMapRowReducer<Integer, Da
     @Override
     public void accumulate(Map<Integer, DarCollection> map, RowView rowView) {
       DataAccessRequest dar = null;
+      Election election = null;
       DarCollection collection = map.computeIfAbsent(
         rowView.getColumn("collection_id", Integer.class),
         id -> rowView.getRow(DarCollection.class));
-
-      try{
-        if(Objects.nonNull(collection) && Objects.nonNull(rowView.getColumn("dar_id", Integer.class))) {
-          dar = rowView.getRow(DataAccessRequest.class);
-          DataAccessRequestData data = translate(rowView.getColumn("data", String.class));
-          dar.setData(data);
+      try {
+        if(Objects.nonNull(collection)) {
+          if(Objects.nonNull(rowView.getColumn("dar_id", Integer.class))) {
+            dar = rowView.getRow(DataAccessRequest.class);
+            DataAccessRequestData data = translate(rowView.getColumn("data", String.class));
+            dar.setData(data);
+          }
+          if(Objects.nonNull(rowView.getColumn("e_election_id", Integer.class))) {
+            election = rowView.getRow(Election.class);
+          }
         }
       } catch(MappingException e) {
         //ignore any exceptions
@@ -32,6 +38,8 @@ public class DarCollectionReducer implements LinkedHashMapRowReducer<Integer, Da
       if(Objects.nonNull(dar)) {
         collection.addDar(dar);
       }
+      if(Objects.nonNull(election)) {
+        collection.addElection(election);
+      }
     }
-
 }

--- a/src/main/java/org/broadinstitute/consent/http/models/DarCollection.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DarCollection.java
@@ -6,6 +6,7 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
 
 import java.sql.Timestamp;
 import java.util.HashSet;
+import java.util.HashMap;
 import java.util.Set;
 import java.util.ArrayList;
 import java.util.Date;
@@ -50,11 +51,12 @@ public class DarCollection {
   private Set<DataSet> datasets;
 
   @JsonProperty
-  private List<Election> elections;
+  private Map<String, List<Election>> electionMap;
 
   public DarCollection() {
     this.createDate = new Timestamp(System.currentTimeMillis());
     this.datasets = new HashSet<>();
+    this.electionMap = new HashMap<>();
   }
 
   public DarCollection deepCopy() {
@@ -141,19 +143,20 @@ public class DarCollection {
     return datasets;
   }
 
-  public void setElections(List<Election> elections) {
-    this.elections = elections;
+  public void setElectionMap(Map<String, List<Election>> electionMap) {
+    this.electionMap = electionMap;
   }
 
-  public List<Election> getElections() {
-    return elections;
+  public Map<String, List<Election>> getElectionMap() {
+    return electionMap;
   }
 
   public void addElection(Election election) {
-    if(Objects.isNull(this.elections)) {
-      this.elections = new ArrayList<>();
+    String referenceId = election.getReferenceId();
+    if(!electionMap.containsKey(referenceId)){
+      electionMap.put(referenceId, new ArrayList<>());
     }
-    elections.add(election);
+    electionMap.get(referenceId).add(election);
   }
 
   @Override

--- a/src/main/java/org/broadinstitute/consent/http/models/DarCollection.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DarCollection.java
@@ -49,6 +49,9 @@ public class DarCollection {
   @JsonProperty
   private Set<DataSet> datasets;
 
+  @JsonProperty
+  private List<Election> elections;
+
   public DarCollection() {
     this.createDate = new Timestamp(System.currentTimeMillis());
     this.datasets = new HashSet<>();
@@ -136,6 +139,21 @@ public class DarCollection {
 
   public Set<DataSet> getDatasets() {
     return datasets;
+  }
+
+  public void setElections(List<Election> elections) {
+    this.elections = elections;
+  }
+
+  public List<Election> getElections() {
+    return elections;
+  }
+
+  public void addElection(Election election) {
+    if(Objects.isNull(this.elections)) {
+      this.elections = new ArrayList<>();
+    }
+    elections.add(election);
   }
 
   @Override

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -4101,58 +4101,7 @@ components:
           format: int32
           description: Describes the number of cases that are opened and have to be reviewed.
     Election:
-      type: object
-      properties:
-        electionId:
-          type: integer
-          format: int32
-          description: Describes the id of the election.
-        electionType:
-          type: string
-          description: Describes the type of the election.
-        finalVote:
-          type: boolean
-          description: Describes the chairperson final vote, if the election is closed.
-        status:
-          type: string
-          description: Describes the status of the election. Open, Closed or Cancelled.
-        createDate:
-          type: string
-          format: date
-          description: Describes the date the election was created.
-        lastUpdate:
-          type: string
-          format: date
-          description: Describes the date the election was last modified.
-        finalVoteDate:
-          type: string
-          format: date
-          description: Describes the date the chaiperson made the final vote.
-        referenceId:
-          type: string
-          description: Describes the id of the consent/data access request the election is related to.
-        finalRationale:
-          type: string
-          description: If the final vote is NO, the chairperson can specify why in this field.
-        finalAccessVote:
-          type: boolean
-          description: For Data Access Request only. Final vote that determines if the request is approved or denied.
-        dataSetId:
-          type: integer
-          description: The dataSetId related to the election.
-        displayId:
-          type: string
-          description: The ID for display.
-        dulName:
-          type: string
-          description: Contains the correspondant Dul name for the given election.
-        version:
-          type: integer
-          format: int32
-          description: Indicates the version number of the given election.
-        archived:
-          type: boolean
-          description: Determines if the election is archived.
+      $ref: "./schemas/Election.yaml"
     ConsentManage:
       type: object
       properties:

--- a/src/main/resources/assets/schemas/DarCollection.yaml
+++ b/src/main/resources/assets/schemas/DarCollection.yaml
@@ -30,3 +30,8 @@ properties:
     description: List of all datasets referenced across all DARs within the collection
     items:
       $ref: './Dataset.yaml'
+  elections:
+    type: array
+    description: List of all elections associated with collection's DARs
+    items:
+      $ref: './Election.yaml'

--- a/src/main/resources/assets/schemas/DarCollection.yaml
+++ b/src/main/resources/assets/schemas/DarCollection.yaml
@@ -30,8 +30,11 @@ properties:
     description: List of all datasets referenced across all DARs within the collection
     items:
       $ref: './Dataset.yaml'
-  elections:
-    type: array
-    description: List of all elections associated with collection's DARs
-    items:
-      $ref: './Election.yaml'
+  electionMap:
+    type: object
+    description: Map of referenceIds to their associated elections
+    additionalProperties: 
+      type: array
+      description: List of elections associated to referenceId key
+      item:
+        $ref: './Election.yaml'

--- a/src/main/resources/assets/schemas/Election.yaml
+++ b/src/main/resources/assets/schemas/Election.yaml
@@ -1,0 +1,52 @@
+type: object
+properties:
+  electionId:
+    type: integer
+    format: int32
+    description: Describes the id of the election.
+  electionType:
+    type: string
+    description: Describes the type of the election.
+  finalVote:
+    type: boolean
+    description: Describes the chairperson final vote, if the election is closed.
+  status:
+    type: string
+    description: Describes the status of the election. Open, Closed or Cancelled.
+  createDate:
+    type: string
+    format: date
+    description: Describes the date the election was created.
+  lastUpdate:
+    type: string
+    format: date
+    description: Describes the date the election was last modified.
+  finalVoteDate:
+    type: string
+    format: date
+    description: Describes the date the chaiperson made the final vote.
+  referenceId:
+    type: string
+    description: Describes the id of the consent/data access request the election is related to.
+  finalRationale:
+    type: string
+    description: If the final vote is NO, the chairperson can specify why in this field.
+  finalAccessVote:
+    type: boolean
+    description: For Data Access Request only. Final vote that determines if the request is approved or denied.
+  dataSetId:
+    type: integer
+    description: The dataSetId related to the election.
+  displayId:
+    type: string
+    description: The ID for display.
+  dulName:
+    type: string
+    description: Contains the correspondant Dul name for the given election.
+  version:
+    type: integer
+    format: int32
+    description: Indicates the version number of the given election.
+  archived:
+    type: boolean
+    description: Determines if the election is archived.

--- a/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
@@ -200,6 +200,17 @@ public class DAOTestHelper {
         return electionDAO.findElectionById(electionId);
     }
 
+    protected Election createCancelledAccessElection(String referenceId, Integer datasetId) {
+        Integer electionId = electionDAO.insertElection(
+                ElectionType.DATA_ACCESS.getValue(),
+                ElectionStatus.CANCELED.getValue(),
+                new Date(),
+                referenceId,
+                datasetId
+        );
+        createdElectionIds.add(electionId);
+        return electionDAO.findElectionById(electionId);
+    }
     protected Election createExtendedElection(String referenceId, Integer datasetId) {
         Integer electionId = electionDAO.insertElection(
                 ElectionType.DATA_ACCESS.getValue(),
@@ -579,6 +590,7 @@ public class DAOTestHelper {
         Integer collection_id = darCollectionDAO.insertDarCollection(darCode, user.getDacUserId(), new Date());
         DataSet dataset = createDataset();
         DataAccessRequest dar = insertDAR(user.getDacUserId(), collection_id, darCode);
+        createCancelledAccessElection(dar.getReferenceId(), dataset.getDataSetId());
         createAccessElection(dar.getReferenceId(), dataset.getDataSetId());
         insertDAR(user.getDacUserId(), collection_id, darCode);
         insertDAR(user.getDacUserId(), collection_id, darCode);

--- a/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
@@ -577,7 +577,9 @@ public class DAOTestHelper {
         User user = createUser();
         String darCode = "DAR-" + RandomUtils.nextInt(100, 1000);
         Integer collection_id = darCollectionDAO.insertDarCollection(darCode, user.getDacUserId(), new Date());
-        insertDAR(user.getDacUserId(), collection_id, darCode);
+        DataSet dataset = createDataset();
+        DataAccessRequest dar = insertDAR(user.getDacUserId(), collection_id, darCode); //use reference id to make some elections
+        createAccessElection(dar.getReferenceId(), dataset.getDataSetId()); //create elections for fetch and return (some endpoints)
         insertDAR(user.getDacUserId(), collection_id, darCode);
         insertDAR(user.getDacUserId(), collection_id, darCode);
         createdDarCollections.add(collection_id);

--- a/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
@@ -578,8 +578,8 @@ public class DAOTestHelper {
         String darCode = "DAR-" + RandomUtils.nextInt(100, 1000);
         Integer collection_id = darCollectionDAO.insertDarCollection(darCode, user.getDacUserId(), new Date());
         DataSet dataset = createDataset();
-        DataAccessRequest dar = insertDAR(user.getDacUserId(), collection_id, darCode); //use reference id to make some elections
-        createAccessElection(dar.getReferenceId(), dataset.getDataSetId()); //create elections for fetch and return (some endpoints)
+        DataAccessRequest dar = insertDAR(user.getDacUserId(), collection_id, darCode);
+        createAccessElection(dar.getReferenceId(), dataset.getDataSetId());
         insertDAR(user.getDacUserId(), collection_id, darCode);
         insertDAR(user.getDacUserId(), collection_id, darCode);
         createdDarCollections.add(collection_id);

--- a/src/test/java/org/broadinstitute/consent/http/db/DarCollectionDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DarCollectionDAOTest.java
@@ -5,6 +5,7 @@ import org.apache.commons.lang3.RandomUtils;
 import org.broadinstitute.consent.http.models.DarCollection;
 import org.broadinstitute.consent.http.models.DataAccessRequest;
 import org.broadinstitute.consent.http.models.DataAccessRequestData;
+import org.broadinstitute.consent.http.models.Election;
 import org.broadinstitute.consent.http.models.Institution;
 import org.broadinstitute.consent.http.models.User;
 import static org.junit.Assert.assertEquals;
@@ -311,6 +312,8 @@ public void testFindAllDARCollectionsWithFilters_InstitutionTerm() {
     List<DarCollection> collectionResult = darCollectionDAO.findDARCollectionsCreatedByUserId(userId);
     assertEquals(1, collectionResult.size());
     assertEquals(userId, collectionResult.get(0).getCreateUserId());
+    List<Election> elections = collectionResult.get(0).getElections();
+    assertEquals(elections.size(), 1);
 
     List<DataAccessRequest> darsResult = collectionResult.get(0).getDars();
     assertEquals(dars.size(), darsResult.size());

--- a/src/test/java/org/broadinstitute/consent/http/db/DarCollectionDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DarCollectionDAOTest.java
@@ -19,6 +19,7 @@ import org.postgresql.util.PSQLState;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 
@@ -312,8 +313,10 @@ public void testFindAllDARCollectionsWithFilters_InstitutionTerm() {
     List<DarCollection> collectionResult = darCollectionDAO.findDARCollectionsCreatedByUserId(userId);
     assertEquals(1, collectionResult.size());
     assertEquals(userId, collectionResult.get(0).getCreateUserId());
-    List<Election> elections = collectionResult.get(0).getElections();
-    assertEquals(elections.size(), 1);
+    Map<String, List<Election>> electionMap = collectionResult.get(0).getElectionMap();
+    assertEquals(1, electionMap.size());
+    String referenceId = collectionResult.get(0).getDars().get(0).getReferenceId();
+    assertEquals(1, electionMap.get(referenceId).size());
 
     List<DataAccessRequest> darsResult = collectionResult.get(0).getDars();
     assertEquals(dars.size(), darsResult.size());


### PR DESCRIPTION
Addresses [DUOS-1469](https://broadworkbench.atlassian.net/browse/DUOS-1469)

PR adds elections to the Collection, populated by the `findDarCollectionsCreatedByUserID` query. This will provide details needed in [DUOS-1256](https://broadworkbench.atlassian.net/browse/DUOS-1256) to enable/disable Collection cancellation buttons on the UI (visually).

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
