### PR TITLE
[DUOS-302][risk=no] Add failure config for owasp checks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -238,6 +238,11 @@
         <groupId>org.owasp</groupId>
         <artifactId>dependency-check-maven</artifactId>
         <version>6.3.2</version>
+        <configuration>
+          <skipProvidedScope>true</skipProvidedScope>
+          <skipRuntimeScope>true</skipRuntimeScope>
+          <failBuildOnCVSS>1</failBuildOnCVSS>
+        </configuration>
         <executions>
           <execution>
             <goals>


### PR DESCRIPTION
Adds a simple count check so we can know if a nightly run is failing.
See also: https://github.com/DataBiosphere/consent-ontology/pull/508

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
