### PR TITLE
DUOS-1256[risk=no] Correction to DAR Status processing in cancelDarCollection (DarCollectionService)

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequest.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequest.java
@@ -44,6 +44,11 @@ public class DataAccessRequest {
 
   @JsonProperty public Timestamp updateDate;
 
+  public static boolean isNotCanceled(DataAccessRequest dar) {
+    String status = dar.getData().getStatus();
+    return Objects.isNull(status) || status.toLowerCase() != "canceled";
+  }
+
   public Integer getId() {
     return id;
   }

--- a/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
@@ -189,7 +189,7 @@ public class DarCollectionService {
     List<String> nonCanceledIds = dars.stream()
       .filter(d -> {
         String status = d.getData().getStatus();
-        return Objects.nonNull(status) && status.toLowerCase() != "canceled";
+        return Objects.isNull(status) || status.toLowerCase() != "canceled";
       })
       .map(d -> d.getReferenceId())
       .collect(Collectors.toList());

--- a/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
@@ -187,10 +187,7 @@ public class DarCollectionService {
       throw new BadRequestException("Elections present on DARs; cannot cancel collection");
     }
     List<String> nonCanceledIds = dars.stream()
-      .filter(d -> {
-        String status = d.getData().getStatus();
-        return Objects.isNull(status) || status.toLowerCase() != "canceled";
-      })
+      .filter(DataAccessRequest::isNotCanceled)
       .map(d -> d.getReferenceId())
       .collect(Collectors.toList());
     


### PR DESCRIPTION
Back-end correction needed for [DUOS-1256](https://broadworkbench.atlassian.net/browse/DUOS-1256), adjustment correctly evaluates DAR with `status:null` as a non-cancelled DAR

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
