### PR TITLE
[DUOS-1483][risk=medium] Allow any role to set their era commons account

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/resources/NihAccountResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/NihAccountResource.java
@@ -2,21 +2,19 @@ package org.broadinstitute.consent.http.resources;
 
 import com.google.inject.Inject;
 import io.dropwizard.auth.Auth;
-import org.broadinstitute.consent.http.models.AuthUser;
-import org.broadinstitute.consent.http.models.User;
-import org.broadinstitute.consent.http.models.UserProperty;
-import org.broadinstitute.consent.http.models.NIHUserAccount;
-import org.broadinstitute.consent.http.service.NihService;
-import org.broadinstitute.consent.http.service.UserService;
-
 import java.util.List;
-
-import javax.annotation.security.RolesAllowed;
+import javax.annotation.security.PermitAll;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.Response;
+import org.broadinstitute.consent.http.models.AuthUser;
+import org.broadinstitute.consent.http.models.NIHUserAccount;
+import org.broadinstitute.consent.http.models.User;
+import org.broadinstitute.consent.http.models.UserProperty;
+import org.broadinstitute.consent.http.service.NihService;
+import org.broadinstitute.consent.http.service.UserService;
 
 @Path("api/nih")
 public class NihAccountResource extends Resource {
@@ -32,7 +30,7 @@ public class NihAccountResource extends Resource {
 
     @POST
     @Produces("application/json")
-    @RolesAllowed(RESEARCHER)
+    @PermitAll
     public Response registerResearcher(NIHUserAccount nihAccount, @Auth AuthUser authUser) {
         try {
             User user = userService.findUserByEmail(authUser.getEmail());
@@ -45,7 +43,7 @@ public class NihAccountResource extends Resource {
 
     @DELETE
     @Produces("application/json")
-    @RolesAllowed(RESEARCHER)
+    @PermitAll
     public Response deleteNihAccount(@Auth AuthUser user) {
         try {
             User dacUser = userService.findUserByEmail(user.getEmail());


### PR DESCRIPTION
## Addresses
Partially fixes https://broadworkbench.atlassian.net/browse/DUOS-1483

Anyone should be able to set their era account, not just researchers

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
