### PR TITLE
DUOS-1478[risk=no] DAR Collection ID Assignment - Bugfix and Backfill

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/DataAccessRequestDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DataAccessRequestDAO.java
@@ -236,6 +236,9 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
   @SqlUpdate("UPDATE data_access_request SET draft = :draft WHERE reference_id = :referenceId ")
   void updateDraftByReferenceId(@Bind("referenceId") String referenceId, @Bind("draft") Boolean draft);
 
+  @SqlUpdate("UPDATE data_access_request SET draft = false, collection_id = :collectionId WHERE reference_id = :referenceId")
+  void updateDraftForCollection(@Bind("collectionId") Integer collectionId, @Bind("referenceId") String referenceId);
+
   @RegisterRowMapper(DataAccessRequestDataMapper.class)
   @SqlQuery(" SELECT (data #>> '{}')::jsonb AS data FROM data_access_request ")
   List<DataAccessRequestData> findAllDataAccessRequestDatas();

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
@@ -362,7 +362,7 @@ public class DataAccessRequestService {
                 if (idx == 0) {
                     DataAccessRequest alreadyExists = dataAccessRequestDAO.findByReferenceId(dataAccessRequest.getReferenceId());
                     if (Objects.nonNull(alreadyExists)) {
-                        dataAccessRequestDAO.updateDraftByReferenceId(dataAccessRequest.getReferenceId(), false);
+                        dataAccessRequestDAO.updateDraftForCollection(collectionId, dataAccessRequest.getReferenceId());
                         dataAccessRequestDAO.updateDataByReferenceIdVersion2(
                             dataAccessRequest.getReferenceId(),
                             user.getDacUserId(),

--- a/src/main/resources/changelog-master.xml
+++ b/src/main/resources/changelog-master.xml
@@ -78,4 +78,5 @@
     <include file="changesets/changelog-consent-73.0.xml" relativeToChangelogFile="true"/>
     <include file="changesets/changelog-consent-74.0.xml" relativeToChangelogFile="true"/>
     <include file="changesets/changelog-consent-75.0.xml" relativeToChangelogFile="true"/>
+    <include file="changesets/changelog-consent-76.0.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/src/main/resources/changesets/changelog-consent-76.0.xml
+++ b/src/main/resources/changesets/changelog-consent-76.0.xml
@@ -1,0 +1,20 @@
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+  <changeSet id="76.0" author="JVThomas">
+    <validCheckSum>ANY</validCheckSum>
+
+    <sql>
+      UPDATE data_access_request AS dar 
+      SET collection_id = c.collection_id
+      FROM dar_collection c
+      WHERE (
+        CONCAT((dar.data #>> '{}')::jsonb ->> 'darCode', '-') ~* c.dar_code
+        OR (dar.data #>> '{}')::jsonb ->> 'darCode' = c.dar_code
+      ) 
+      AND dar.collection_id IS NULL
+      AND dar.draft = false;
+    </sql>
+
+  </changeSet>
+</databaseChangeLog>

--- a/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
@@ -2,6 +2,7 @@ package org.broadinstitute.consent.http.db;
 
 import static junit.framework.TestCase.assertNull;
 import org.apache.commons.lang3.RandomStringUtils;
+import org.broadinstitute.consent.http.models.DarCollection;
 import org.broadinstitute.consent.http.models.DataAccessRequest;
 import org.broadinstitute.consent.http.models.User;
 import org.junit.Test;
@@ -231,4 +232,15 @@ public class DataAccessRequestDAOTest extends DAOTestHelper {
         assertEquals(dar2.getData().getAddress1(), updatedDar2.getData().getAddress1());
     }
 
+    @Test
+    public void testUpdateDraftForCollection() {
+        DarCollection collection = createDarCollection();
+        DataAccessRequest draft = createDraftDataAccessRequest();
+        String referenceId = draft.getReferenceId();
+        Integer collectionId = collection.getDarCollectionId();
+        dataAccessRequestDAO.updateDraftForCollection(collectionId, referenceId);
+        DataAccessRequest updatedDraft = dataAccessRequestDAO.findByReferenceId(referenceId);
+        assertEquals(false, updatedDraft.getDraft());
+        assertEquals(collectionId, updatedDraft.getCollectionId());
+    }
 }


### PR DESCRIPTION
Addresses [DUOS-1478](https://broadworkbench.atlassian.net/browse/DUOS-1478)

PR corrects collection ID assignment on DAR drafts when they are submitted review. PR also backfills missing collection IDs on DARs that 

- Have the `darCode` key saved in the `data` column
- Have `collection_id = NULL`
- Have `draft = false`

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
