### PR TITLE
[DUOS-1475][risk=no] Use TF secrets

### DIFF
--- a/.github/workflows/automation.yaml
+++ b/.github/workflows/automation.yaml
@@ -21,11 +21,11 @@ jobs:
 
       - name: Render configs
         env:
-          ADMIN: ${{ secrets.DUOS_AUTOMATION_ADMIN }}
-          CHAIR: ${{ secrets.DUOS_AUTOMATION_CHAIR }}
-          MEMBER: ${{ secrets.DUOS_AUTOMATION_MEMBER }}
-          RESEARCHER: ${{ secrets.DUOS_AUTOMATION_RESEARCHER }}
-          SIGNING_OFFICIAL: ${{ secrets.DUOS_AUTOMATION_SIGNING_OFFICIAL }}
+          ADMIN: ${{ secrets.DUOS_AUTOMATION_ADMIN_SA }}
+          CHAIR: ${{ secrets.DUOS_AUTOMATION_CHAIR_SA }}
+          MEMBER: ${{ secrets.DUOS_AUTOMATION_MEMBER_SA }}
+          RESEARCHER: ${{ secrets.DUOS_AUTOMATION_RESEARCHER_SA }}
+          SIGNING_OFFICIAL: ${{ secrets.DUOS_AUTOMATION_SIGNING_OFFICIAL_SA }}
         run: |
           echo "$ADMIN" >> ./automation/src/test/resources/accounts/duos-automation-admin.json
           echo "$CHAIR" >> ./automation/src/test/resources/accounts/duos-automation-chair.json


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-1475

Updates the secrets we use for automation to use the ones pushed via TF.
Depends on: https://github.com/broadinstitute/terraform-ap-deployments/pull/446

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
