### PR TITLE
[DUOS-1492][risk=no] Stop deleting ALL props, only delete the things that are changing

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/service/ResearcherService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ResearcherService.java
@@ -67,7 +67,6 @@ public class ResearcherService {
             saveProperties(properties);
             notifyAdmins(user.getDacUserId());
         } else if (hasUpdatedFields(user.getDacUserId(), validatedProperties, isUpdatedProfileCompleted)) {
-            deleteResearcherProperties(user.getDacUserId());
             saveProperties(properties);
             userService.updateUserStatus(RoleStatus.PENDING.toString(), user.getDacUserId());
         } else {


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-1492

Old code was deleting ALL props, even the ones that were not changing. Current code only drops the changed fields.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
