### PR TITLE
[DUOS-302][risk=no] Run coverage on pushes to develop

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -1,5 +1,11 @@
 name: Coverage
-on: [pull_request]
+on: 
+  push:
+    branches:
+    - develop
+  pull_request:
+    branches:
+    - develop
 jobs:
   package:
     name: Coverage


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-302

Run coverage on pushes to develop branch
See also: https://github.com/DataBiosphere/consent-ontology/pull/522

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
