### PR TITLE
[DUOS-1503][risk=no] Update builder to a non-deprecated image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Builder
-FROM adoptopenjdk/maven-openjdk11:latest AS build
+FROM maven:3.8.3-eclipse-temurin-11 AS build
 
-RUN mkdir /usr/src/app
+RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
 COPY .git /usr/src/app/.git

--- a/automation/README.md
+++ b/automation/README.md
@@ -46,7 +46,10 @@ sbt clean gatling:testOnly *.StatusScenarios
 ```
 
 ### Run all tests with the standalone docker stack:
+Note that postgres will cache its local db so subsequent runs can result
+in duplicate exceptions if the image cache isn't cleared out
 ```
+docker rmi -f $(docker images --filter=reference="postgres:11.6-alpine" -q)
 docker-compose build --no-cache
 docker-compose up --quiet-pull --abort-on-container-exit --exit-code-from automation-tests
 ```


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-1503

The existing build image is deprecated: https://hub.docker.com/_/adoptopenjdk
Also figured out why local automation test reruns would hit a 409 duplicate error on dar submission

See also: https://github.com/broadinstitute/dsp-appsec-blessed-images/pull/21
See also: https://github.com/DataBiosphere/consent-ontology/pull/524

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
