### PR TITLE
[DUOS-1511][risk=no] Test coverage for resource classes (Part 1)

### DIFF
--- a/src/test/java/org/broadinstitute/consent/http/resources/DataRequestReportsResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DataRequestReportsResourceTest.java
@@ -1,0 +1,51 @@
+package org.broadinstitute.consent.http.resources;
+
+import org.broadinstitute.consent.http.service.DataAccessRequestService;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import javax.ws.rs.core.Response;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.MockitoAnnotations.openMocks;
+
+public class DataRequestReportsResourceTest {
+    @Mock
+    private DataAccessRequestService darService;
+
+    private DataRequestReportsResource resource;
+
+    @Before
+    public void setUp() {
+        openMocks(this);
+        resource = new DataRequestReportsResource(darService);
+    }
+
+    @Test
+    public void testDownloadApprovedDARsSuccess() throws Exception {
+        Response response = resource.downloadApprovedDARs();
+        assertEquals(200, response.getStatus());
+    }
+
+    @Test
+    public void testDownloadApprovedDARsError() throws Exception {
+        doThrow(new RuntimeException()).when(darService).createApprovedDARDocument();
+        Response response = resource.downloadApprovedDARs();
+        assertEquals(500, response.getStatus());
+    }
+
+    @Test
+    public void testDownloadReviewedDARsSuccess() throws Exception {
+        Response response = resource.downloadReviewedDARs();
+        assertEquals(200, response.getStatus());
+    }
+
+    @Test
+    public void testDownloadReviewedDARsError() throws Exception {
+        doThrow(new RuntimeException()).when(darService).createReviewedDARDocument();
+        Response response = resource.downloadReviewedDARs();
+        assertEquals(500, response.getStatus());
+    }
+}

--- a/src/test/java/org/broadinstitute/consent/http/resources/DataRequestVoteResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DataRequestVoteResourceTest.java
@@ -1,0 +1,47 @@
+package org.broadinstitute.consent.http.resources;
+
+import org.broadinstitute.consent.http.service.DataAccessRequestService;
+import org.broadinstitute.consent.http.service.DatasetAssociationService;
+import org.broadinstitute.consent.http.service.DatasetService;
+import org.broadinstitute.consent.http.service.ElectionService;
+import org.broadinstitute.consent.http.service.EmailNotifierService;
+import org.broadinstitute.consent.http.service.UserService;
+import org.broadinstitute.consent.http.service.VoteService;
+import org.junit.Before;
+import org.mockito.Mock;
+
+import static org.mockito.MockitoAnnotations.openMocks;
+
+public class DataRequestVoteResourceTest {
+    @Mock
+    private EmailNotifierService emailNotifierService;
+    @Mock
+    private UserService userService;
+    @Mock
+    private DatasetService datasetService;
+    @Mock
+    private DataAccessRequestService dataAccessRequestService;
+    @Mock
+    private DatasetAssociationService datasetAssociationService;
+    @Mock
+    private ElectionService electionService;
+    @Mock
+    private VoteService voteService;
+
+    private DataRequestVoteResource resource;
+
+    @Before
+    public void setUp() {
+        openMocks(this);
+    }
+
+    private void initResource() {
+        resource = new DataRequestVoteResource(
+                dataAccessRequestService, datasetAssociationService,
+                emailNotifierService, voteService,
+                datasetService, electionService, userService
+        );
+    }
+
+    // This test will be written in a future PR.
+}

--- a/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
@@ -100,6 +100,17 @@ public class DatasetResourceTest {
         assertEquals(201,response.getStatus());
     }
 
+    // Testing if Coveralls recognizes this test
+    @Test(expected = BadRequestException.class)
+    public void testCreateDatasetNoPropertiesError() {
+        DataSet inUse = new DataSet();
+        when(datasetService.getDatasetByName("test")).thenReturn(inUse);
+
+        initResource();
+        Response responseNoProperties = resource.createDataset(authUser, uriInfo, "{\"properties\":[]}");
+        assertEquals(400, responseNoProperties.getStatus());
+    }
+
     @Test(expected = BadRequestException.class)
     public void testCreateDatasetErrors() {
         DataSet inUse = new DataSet();

--- a/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
@@ -218,11 +218,14 @@ public class DatasetResourceTest {
         assertEquals(404, response.getStatus());
     }
 
+    @Test
     public void testUpdateDatasetInvalidProperty() {
         List<DataSetPropertyDTO> invalidProperties = new ArrayList<>();
         invalidProperties.add(new DataSetPropertyDTO("Invalid Property", "test"));
         when(datasetService.findInvalidProperties(any())).thenReturn(invalidProperties);
 
+        DataSet preexistingDataset = new DataSet();
+        when(datasetService.findDatasetById(anyInt())).thenReturn(preexistingDataset);
         String json = createPropertiesJson(invalidProperties);
 
         initResource();
@@ -230,13 +233,15 @@ public class DatasetResourceTest {
         assertEquals(400, response.getStatus());
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test
     public void testUpdateDatasetDuplicateProperties() {
         List<DataSetPropertyDTO> duplicateProperties = new ArrayList<>();
         duplicateProperties.add(new DataSetPropertyDTO("Dataset Name", "test"));
         duplicateProperties.add(new DataSetPropertyDTO("Dataset Name", "test"));
         when(datasetService.findDuplicateProperties(any())).thenReturn(duplicateProperties);
 
+        DataSet preexistingDataset = new DataSet();
+        when(datasetService.findDatasetById(anyInt())).thenReturn(preexistingDataset);
         String json = createPropertiesJson(duplicateProperties);
 
         initResource();

--- a/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
@@ -1,7 +1,6 @@
 package org.broadinstitute.consent.http.resources;
 
 import com.google.gson.Gson;
-import liquibase.pro.packaged.D;
 import org.broadinstitute.consent.http.authentication.GoogleUser;
 import org.broadinstitute.consent.http.models.AuthUser;
 import org.broadinstitute.consent.http.models.Consent;
@@ -116,25 +115,39 @@ public class DatasetResourceTest {
     @Test(expected = BadRequestException.class)
     public void testCreateDatasetNoJson() {
         initResource();
-        Response response = resource.createDataset(authUser, uriInfo, "");
-        assertEquals(400, response.getStatus());
+        resource.createDataset(authUser, uriInfo, "");
     }
 
     @Test(expected = BadRequestException.class)
     public void testCreateDatasetNoProperties() {
         initResource();
-        Response response = resource.createDataset(authUser, uriInfo, "{\"properties\":[]}");
-        assertEquals(400, response.getStatus());
+        resource.createDataset(authUser, uriInfo, "{\"properties\":[]}");
     }
 
     @Test(expected = BadRequestException.class)
-    public void testCreateDatasetMissingName() {
+    public void testCreateDatasetNullName() {
         String json = createPropertiesJson("Dataset Name", null);
-        // TODO: Rewrite createDataset to handle empty name strings and entirely missing name properties
 
         initResource();
-        Response response = resource.createDataset(authUser, uriInfo, json);
-        assertEquals(400, response.getStatus());
+        resource.createDataset(authUser, uriInfo, json);
+    }
+
+    @Test(expected = NullPointerException.class)
+    // TODO: Recode createDataset to return a BadRequestException with this test
+    public void testCreateDatasetEmptyName() {
+        String json = createPropertiesJson("Dataset Name", "");
+
+        initResource();
+        resource.createDataset(authUser, uriInfo, json);
+    }
+
+    @Test(expected = IndexOutOfBoundsException.class)
+    // TODO: Recode createDataset to return a BadRequestException with this test
+    public void testCreateDatasetMissingName() {
+        String json = createPropertiesJson("Property", "test");
+
+        initResource();
+        resource.createDataset(authUser, uriInfo, json);
     }
 
     @Test(expected = BadRequestException.class)
@@ -146,8 +159,7 @@ public class DatasetResourceTest {
         String json = createPropertiesJson(invalidProperties);
 
         initResource();
-        Response response = resource.createDataset(authUser, uriInfo, json);
-        assertEquals(400, response.getStatus());
+        resource.createDataset(authUser, uriInfo, json);
     }
 
     @Test(expected = BadRequestException.class)
@@ -160,8 +172,7 @@ public class DatasetResourceTest {
         String json = createPropertiesJson(duplicateProperties);
 
         initResource();
-        Response response = resource.createDataset(authUser, uriInfo, json);
-        assertEquals(400, response.getStatus());
+        resource.createDataset(authUser, uriInfo, json);
     }
 
     @Test(expected = ClientErrorException.class)
@@ -172,8 +183,7 @@ public class DatasetResourceTest {
         String json = createPropertiesJson("Dataset Name", "test");
 
         initResource();
-        Response response = resource.createDataset(authUser, uriInfo, json);
-        assertEquals(409, response.getStatus());
+        resource.createDataset(authUser, uriInfo, json);
     }
 
     @Test
@@ -313,8 +323,7 @@ public class DatasetResourceTest {
     @Test(expected = NotFoundException.class)
     public void testValidateDatasetNameNotFound() {
         initResource();
-        Response response = resource.validateDatasetName("test");
-        assertEquals(404, response.getStatus());
+        resource.validateDatasetName("test");
     }
 
 }

--- a/src/test/java/org/broadinstitute/consent/http/resources/NihAccountResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/NihAccountResourceTest.java
@@ -1,0 +1,92 @@
+package org.broadinstitute.consent.http.resources;
+
+import org.broadinstitute.consent.http.models.AuthUser;
+import org.broadinstitute.consent.http.models.NIHUserAccount;
+import org.broadinstitute.consent.http.models.User;
+import org.broadinstitute.consent.http.service.NihService;
+import org.broadinstitute.consent.http.service.UserService;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import javax.ws.rs.core.Response;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.openMocks;
+
+public class NihAccountResourceTest {
+    @Mock
+    private NihService nihService;
+
+    @Mock
+    private UserService userService;
+
+    @Mock
+    private NIHUserAccount nihAccount;
+
+    @Mock
+    private User user;
+
+    @Mock
+    private AuthUser authUser;
+
+    private NihAccountResource resource;
+
+    @Before
+    public void setUp() {
+        openMocks(this);
+    }
+
+    @Test
+    public void testRegisterResearcherSuccess() {
+        when(userService.findUserByEmail(any())).thenReturn(user);
+        resource = new NihAccountResource(nihService, userService);
+        Response response = resource.registerResearcher(nihAccount, authUser);
+        assertEquals(200, response.getStatus());
+    }
+
+    @Test
+    public void testRegisterResearcherNoAuth() {
+        when(userService.findUserByEmail(any())).thenReturn(null);
+        resource = new NihAccountResource(nihService, userService);
+        Response response = resource.registerResearcher(nihAccount, authUser);
+        assertEquals(500, response.getStatus());
+    }
+
+    @Test
+    public void testRegisterResearcherError() {
+        when(userService.findUserByEmail(any())).thenReturn(user);
+        doThrow(new RuntimeException()).when(nihService).authenticateNih(any(), any(), any());
+        resource = new NihAccountResource(nihService, userService);
+        Response response = resource.registerResearcher(nihAccount, authUser);
+        assertEquals(500, response.getStatus());
+    }
+
+    @Test
+    public void testDeleteNihAccountSuccess() {
+        when(userService.findUserByEmail(any())).thenReturn(user);
+        resource = new NihAccountResource(nihService, userService);
+        Response response = resource.deleteNihAccount(authUser);
+        assertEquals(200, response.getStatus());
+    }
+
+    @Test
+    public void testDeleteNihAccountNoAuth() {
+        when(userService.findUserByEmail(any())).thenReturn(null);
+        resource = new NihAccountResource(nihService, userService);
+        Response response = resource.deleteNihAccount(authUser);
+        assertEquals(500, response.getStatus());
+    }
+
+    @Test
+    public void testDeleteNihAccountError() {
+        when(userService.findUserByEmail(any())).thenReturn(user);
+        doThrow(new RuntimeException()).when(nihService).deleteNihAccountById(any());
+        resource = new NihAccountResource(nihService, userService);
+        Response response = resource.deleteNihAccount(authUser);
+        assertEquals(500, response.getStatus());
+    }
+}


### PR DESCRIPTION
- All new tests for DataRequestReportsResource and NihAccountResource
- Recoded existing tests for ConsentVotesResource and DatasetResource

Not included:
- New tests for DatasetResource
- New tests for DataRequestVoteResource

Issue: https://broadworkbench.atlassian.net/browse/DUOS-1511

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
