### PR TITLE
[DUOS-1521][risk=no] Populate election's final vote

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/SimpleElectionMapper.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/SimpleElectionMapper.java
@@ -11,7 +11,7 @@ public class SimpleElectionMapper implements RowMapper<Election>, RowMapperHelpe
 
   @Override
   public Election map(ResultSet r, StatementContext ctx) throws SQLException {
-    return new Election(
+    Election e = new Election(
         r.getInt(ElectionFields.ID.getValue()),
         r.getString(ElectionFields.TYPE.getValue()),
         r.getString(ElectionFields.STATUS.getValue()),
@@ -25,5 +25,11 @@ public class SimpleElectionMapper implements RowMapper<Election>, RowMapperHelpe
         r.getBoolean(ElectionFields.ARCHIVED.getValue()),
         r.getString(ElectionFields.DUL_NAME.getValue()),
         r.getString(ElectionFields.DATA_USE_LETTER.getValue()));
+    if (hasColumn(r, ElectionFields.FINAL_VOTE.getValue())) {
+      if (r.getString(ElectionFields.FINAL_VOTE.getValue()) != null) {
+        e.setFinalVote(r.getBoolean(ElectionFields.FINAL_VOTE.getValue()));
+      }
+    }
+    return e;
   }
 }


### PR DESCRIPTION
## Addresses
Partially addresses https://broadworkbench.atlassian.net/browse/DUOS-1521

Map the final vote value if we have one.
See also: https://github.com/DataBiosphere/duos-ui/pull/1361 where we handle the error case more explicitly.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
