### PR TITLE
[DUOS-511][risk=no] Refactor DataAccessRequest Summary Details

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/ElectionDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/ElectionDAO.java
@@ -225,10 +225,6 @@ public interface ElectionDAO extends Transactional<ElectionDAO> {
             "left join vote v on v.electionId = e.electionId and lower(v.type) = 'chairperson' ")
      List<Election> findLastElectionsWithFinalVoteByReferenceIdsTypeAndStatus(@BindList("referenceIds") List<String> referenceIds, @Bind("status") String status);
 
-     @RegisterRowMapper(AccessRPMapper.class)
-     @SqlQuery("select * from access_rp where electionAccessId in (<electionAccessIds>) ")
-     List<AccessRP> findAccessRPbyElectionAccessId(@BindList("electionAccessIds") List<Integer> electionAccessIds); 
-
     @SqlQuery("select * from election e inner join (select referenceId, MAX(createDate) maxDate from election e where lower(e.electionType) = lower(:type) group by referenceId) " +
             "electionView ON electionView.maxDate = e.createDate AND electionView.referenceId = e.referenceId  " +
             "AND e.referenceId = :referenceId ")

--- a/src/main/java/org/broadinstitute/consent/http/db/ElectionDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/ElectionDAO.java
@@ -1,13 +1,13 @@
 package org.broadinstitute.consent.http.db;
 
+import java.util.Date;
+import java.util.List;
 import org.apache.commons.lang3.tuple.Pair;
-import org.broadinstitute.consent.http.db.mapper.AccessRPMapper;
 import org.broadinstitute.consent.http.db.mapper.DacMapper;
 import org.broadinstitute.consent.http.db.mapper.DateMapper;
+import org.broadinstitute.consent.http.db.mapper.ElectionMapper;
 import org.broadinstitute.consent.http.db.mapper.ImmutablePairOfIntsMapper;
 import org.broadinstitute.consent.http.db.mapper.SimpleElectionMapper;
-import org.broadinstitute.consent.http.db.mapper.ElectionMapper;
-import org.broadinstitute.consent.http.models.AccessRP;
 import org.broadinstitute.consent.http.models.Dac;
 import org.broadinstitute.consent.http.models.Election;
 import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
@@ -18,9 +18,6 @@ import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 import org.jdbi.v3.sqlobject.statement.UseRowMapper;
 import org.jdbi.v3.sqlobject.transaction.Transactional;
-
-import java.util.Date;
-import java.util.List;
 
 @RegisterRowMapper(ElectionMapper.class)
 public interface ElectionDAO extends Transactional<ElectionDAO> {
@@ -100,6 +97,11 @@ public interface ElectionDAO extends Transactional<ElectionDAO> {
     @UseRowMapper(SimpleElectionMapper.class)
     Election findElectionByVoteId(@Bind("voteId") Integer voteId);
 
+    // TODO: This can return multiple rows per election id, e.g. ID 578 on staging.
+    // The root of the duplicate rows is in the vote inner join. When there are multiple chairperson
+    // votes, v.rationale and v.createDate can be different between the chairperson votes, leading 
+    // to duplicate rows.
+    // See https://broadworkbench.atlassian.net/browse/DUOS-1526
     @SqlQuery("select distinct e.electionId,  e.datasetId, v.vote finalVote, e.status, e.createDate, e.referenceId, v.rationale finalRationale, v.createDate finalVoteDate, "
             + "e.lastUpdate, e.finalAccessVote, e.electionType,  e.dataUseLetter, e.dulName, e.archived, e.version from election e "
             + "inner join vote v on v.electionId = e.electionId and lower(v.type) = 'chairperson' "

--- a/src/main/java/org/broadinstitute/consent/http/models/ConsentSummaryDetail.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/ConsentSummaryDetail.java
@@ -2,6 +2,7 @@ package org.broadinstitute.consent.http.models;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.IntStream;
 import org.broadinstitute.consent.http.enumeration.HeaderSummary;
@@ -80,15 +81,32 @@ public class ConsentSummaryDetail implements SummaryDetail {
   @Override
   public String toString() {
     StringBuilder builder = new StringBuilder();
-    builder.append(delimiterCheck(getConsent().getName())).append(TAB);
-    builder.append(getElection().getVersion()).append(TAB);
-    builder.append(getElection().getStatus()).append(TAB);
-    builder.append(booleanToString(getElection().getArchived())).append(TAB);
-    builder.append(delimiterCheck(getConsent().getTranslatedUseRestriction())).append(TAB);
-    builder.append(formatLongToDate(getConsent().getCreateDate().getTime())).append(TAB);
-    builder.append(getChairPerson().getDisplayName()).append(TAB);
-    builder.append(booleanToString(getChairPersonVote().getVote())).append(TAB);
-    builder.append(nullToString(getChairPersonVote().getRationale())).append(TAB);
+    if (Objects.nonNull(getConsent())) {
+      builder.append(delimiterCheck(getConsent().getName()));
+    }
+    builder.append(TAB);
+    builder.append(getElection().getVersion());
+    builder.append(TAB);
+    builder.append(getElection().getStatus());
+    builder.append(TAB);
+    builder.append(booleanToString(getElection().getArchived()));
+    builder.append(TAB);
+    builder.append(delimiterCheck(getConsent().getTranslatedUseRestriction()));
+    builder.append(TAB);
+    builder.append(formatLongToDate(getConsent().getCreateDate().getTime()));
+    builder.append(TAB);
+    if (Objects.nonNull(getChairPerson())) {
+      builder.append(nullToString(getChairPerson().getDisplayName()));
+    }
+    builder.append(TAB);
+    if (Objects.nonNull(getChairPersonVote())) {
+      builder.append(booleanToString(getChairPersonVote().getVote()));
+    }
+    builder.append(TAB);
+    if (Objects.nonNull(getChairPersonVote())) {
+      builder.append(nullToString(getChairPersonVote().getRationale()));
+    }
+    builder.append(TAB);
     getElectionVotes().stream()
         .filter(ev -> ev.getType().equals(VoteType.DAC.getValue()))
         .forEach(
@@ -97,13 +115,12 @@ public class ConsentSummaryDetail implements SummaryDetail {
                   getElectionUsers().stream()
                       .filter(u -> v.getDacUserId().equals(u.getDacUserId()))
                       .findFirst();
-              if (user.isPresent()) {
-                builder.append(user.get().getDisplayName()).append(TAB);
-              } else {
-                builder.append(TAB);
-              }
-              builder.append(booleanToString(v.getVote())).append(TAB);
-              builder.append(nullToString(v.getRationale())).append(TAB);
+              user.ifPresent(value -> builder.append(value.getDisplayName()));
+              builder.append(TAB);
+              builder.append(booleanToString(v.getVote()));
+              builder.append(TAB);
+              builder.append(nullToString(v.getRationale()));
+              builder.append(TAB);
               // Append extra tabs for the case where there are more election users in other rows
               // than there are election users for this row.
               builder.append(

--- a/src/main/java/org/broadinstitute/consent/http/models/ConsentSummaryDetail.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/ConsentSummaryDetail.java
@@ -104,7 +104,7 @@ public class ConsentSummaryDetail implements SummaryDetail {
     }
     builder.append(TAB);
     if (Objects.nonNull(getChairPersonVote())) {
-      builder.append(nullToString(getChairPersonVote().getRationale()));
+      builder.append(unwrapLines(nullToString(getChairPersonVote().getRationale())));
     }
     builder.append(TAB);
     getElectionVotes().stream()
@@ -119,7 +119,7 @@ public class ConsentSummaryDetail implements SummaryDetail {
               builder.append(TAB);
               builder.append(booleanToString(v.getVote()));
               builder.append(TAB);
-              builder.append(nullToString(v.getRationale()));
+              builder.append(unwrapLines(nullToString(v.getRationale())));
               builder.append(TAB);
               // Append extra tabs for the case where there are more election users in other rows
               // than there are election users for this row.

--- a/src/main/java/org/broadinstitute/consent/http/models/ConsentSummaryDetail.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/ConsentSummaryDetail.java
@@ -1,0 +1,171 @@
+package org.broadinstitute.consent.http.models;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.IntStream;
+import org.broadinstitute.consent.http.enumeration.HeaderSummary;
+import org.broadinstitute.consent.http.enumeration.VoteType;
+
+public class ConsentSummaryDetail implements SummaryDetail {
+
+  private Election election;
+  private Consent consent;
+  private List<Vote> electionVotes;
+  private Collection<User> electionUsers;
+  private Vote chairPersonVote;
+  private User chairPerson;
+  private Integer maxNumberOfElectionUsers;
+
+  public ConsentSummaryDetail(
+      Election election,
+      Consent consent,
+      List<Vote> electionVotes,
+      Collection<User> electionUsers,
+      Vote chairPersonVote,
+      User chairPerson,
+      Integer maxNumberOfElectionUsers) {
+    setElection(election);
+    setConsent(consent);
+    setElectionVotes(electionVotes);
+    setElectionUsers(electionUsers);
+    setChairPersonVote(chairPersonVote);
+    setChairPerson(chairPerson);
+    setMaxNumberOfElectionUsers(maxNumberOfElectionUsers);
+  }
+
+  private static final String TAB = "\t";
+
+  public String headers() {
+    StringBuilder builder = new StringBuilder();
+    builder
+        .append(HeaderSummary.CONSENT.getValue())
+        .append(TAB)
+        .append(HeaderSummary.VERSION.getValue())
+        .append(TAB)
+        .append(HeaderSummary.STATUS.getValue())
+        .append(TAB)
+        .append(HeaderSummary.ARCHIVED.getValue())
+        .append(TAB)
+        .append(HeaderSummary.STRUCT_LIMITATIONS.getValue())
+        .append(TAB)
+        .append(HeaderSummary.DATE.getValue())
+        .append(TAB)
+        .append(HeaderSummary.CHAIRPERSON.getValue())
+        .append(TAB)
+        .append(HeaderSummary.FINAL_DECISION.getValue())
+        .append(TAB)
+        .append(HeaderSummary.FINAL_DECISION_RATIONALE.getValue())
+        .append(TAB);
+    IntStream.rangeClosed(1, getMaxNumberOfElectionUsers())
+        .forEach(
+            i ->
+                builder
+                    .append(HeaderSummary.USER.getValue())
+                    .append(TAB)
+                    .append(HeaderSummary.VOTE.getValue())
+                    .append(TAB)
+                    .append(HeaderSummary.RATIONALE.getValue())
+                    .append(TAB));
+    builder
+        .append(HeaderSummary.USER.getValue())
+        .append(TAB)
+        .append(HeaderSummary.VOTE.getValue())
+        .append(TAB)
+        .append(HeaderSummary.RATIONALE.getValue())
+        .append(System.lineSeparator());
+    return builder.toString();
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder builder = new StringBuilder();
+    builder.append(delimiterCheck(getConsent().getName())).append(TAB);
+    builder.append(getElection().getVersion()).append(TAB);
+    builder.append(getElection().getStatus()).append(TAB);
+    builder.append(booleanToString(getElection().getArchived())).append(TAB);
+    builder.append(delimiterCheck(getConsent().getTranslatedUseRestriction())).append(TAB);
+    builder.append(formatLongToDate(getConsent().getCreateDate().getTime())).append(TAB);
+    builder.append(getChairPerson().getDisplayName()).append(TAB);
+    builder.append(booleanToString(getChairPersonVote().getVote())).append(TAB);
+    builder.append(nullToString(getChairPersonVote().getRationale())).append(TAB);
+    getElectionVotes().stream()
+        .filter(ev -> ev.getType().equals(VoteType.DAC.getValue()))
+        .forEach(
+            v -> {
+              Optional<User> user =
+                  getElectionUsers().stream()
+                      .filter(u -> v.getDacUserId().equals(u.getDacUserId()))
+                      .findFirst();
+              if (user.isPresent()) {
+                builder.append(user.get().getDisplayName()).append(TAB);
+              } else {
+                builder.append(TAB);
+              }
+              builder.append(booleanToString(v.getVote())).append(TAB);
+              builder.append(nullToString(v.getRationale())).append(TAB);
+              // Append extra tabs for the case where there are more election users in other rows
+              // than there are election users for this row.
+              builder.append(
+                  TAB.repeat(
+                      Math.max(0, (getMaxNumberOfElectionUsers() - getElectionUsers().size()))));
+            });
+    return builder.toString();
+  }
+
+  private Election getElection() {
+    return election;
+  }
+
+  private void setElection(Election election) {
+    this.election = election;
+  }
+
+  private Consent getConsent() {
+    return consent;
+  }
+
+  private void setConsent(Consent consent) {
+    this.consent = consent;
+  }
+
+  private List<Vote> getElectionVotes() {
+    return electionVotes;
+  }
+
+  private void setElectionVotes(List<Vote> electionVotes) {
+    this.electionVotes = electionVotes;
+  }
+
+  private Collection<User> getElectionUsers() {
+    return electionUsers;
+  }
+
+  private void setElectionUsers(Collection<User> electionUsers) {
+    this.electionUsers = electionUsers;
+  }
+
+  private Vote getChairPersonVote() {
+    return chairPersonVote;
+  }
+
+  private void setChairPersonVote(Vote chairPersonVote) {
+    this.chairPersonVote = chairPersonVote;
+  }
+
+  private User getChairPerson() {
+    return chairPerson;
+  }
+
+  private void setChairPerson(User chairPerson) {
+    this.chairPerson = chairPerson;
+  }
+
+  private Integer getMaxNumberOfElectionUsers() {
+    return maxNumberOfElectionUsers;
+  }
+
+  private void setMaxNumberOfElectionUsers(Integer maxNumberOfElectionUsers) {
+    this.maxNumberOfElectionUsers = maxNumberOfElectionUsers;
+  }
+}

--- a/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequestSummaryDetail.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequestSummaryDetail.java
@@ -1,0 +1,275 @@
+package org.broadinstitute.consent.http.models;
+
+import java.util.Calendar;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.apache.commons.lang3.StringUtils;
+import org.broadinstitute.consent.http.enumeration.HeaderSummary;
+import org.broadinstitute.consent.http.enumeration.VoteType;
+
+public class DataAccessRequestSummaryDetail {
+
+  private DataAccessRequest dar;
+  private Election accessElection;
+  private List<Vote> accessVotes;
+  private List<Vote> rpVotes;
+  private List<Vote> consentVotes;
+  private Match matchObject;
+  private List<User> dacMembers;
+  private User darUser;
+  private Integer maxNumberOfDACMembers;
+
+  public DataAccessRequestSummaryDetail(
+      DataAccessRequest dar,
+      Election accessElection,
+      List<Vote> accessVotes,
+      List<Vote> rpVotes,
+      List<Vote> consentVotes,
+      Match matchObject,
+      List<User> electionUsers,
+      User darUser,
+      Integer maxNumberOfDACMembers) {
+
+    setDar(dar);
+    setAccessElection(accessElection);
+    setAccessVotes(accessVotes);
+    setRpVotes(rpVotes);
+    setConsentVotes(consentVotes);
+    setMatchObject(matchObject);
+    setDacMembers(electionUsers);
+    setDarUser(darUser);
+    setMaxNumberOfDACMembers(maxNumberOfDACMembers);
+  }
+
+  private static final String TAB = "\t";
+  private static final String MANUAL_REVIEW = "Manual Review";
+
+  public String headers() {
+    StringBuilder builder = new StringBuilder();
+    builder
+        .append(HeaderSummary.DATA_REQUEST_ID.getValue())
+        .append(TAB)
+        .append(HeaderSummary.DATE.getValue())
+        .append(TAB)
+        .append(HeaderSummary.CHAIRPERSON.getValue())
+        .append(TAB)
+        .append(HeaderSummary.FINAL_DECISION.getValue())
+        .append(TAB)
+        .append(HeaderSummary.FINAL_DECISION_RATIONALE.getValue())
+        .append(TAB)
+        .append(HeaderSummary.VAULT_DECISION.getValue())
+        .append(TAB)
+        .append(HeaderSummary.VAULT_VS_DAC_AGREEMENT.getValue())
+        .append(TAB)
+        .append(HeaderSummary.CHAIRPERSON_FEEDBACK.getValue())
+        .append(TAB)
+        .append(HeaderSummary.RESEARCHER.getValue())
+        .append(TAB)
+        .append(HeaderSummary.PROJECT_TITLE.getValue())
+        .append(TAB)
+        .append(HeaderSummary.DATASET_ID.getValue())
+        .append(TAB)
+        .append(HeaderSummary.DATA_ACCESS_SUBM_DATE.getValue())
+        .append(TAB);
+    IntStream.rangeClosed(1, getMaxNumberOfDACMembers()).forEach(i -> builder.append(HeaderSummary.DAC_MEMBERS.getValue()).append(TAB));
+    builder
+        .append(HeaderSummary.REQUIRE_MANUAL_REVIEW.getValue())
+        .append(TAB)
+        .append(HeaderSummary.FINAL_DECISION_DAR.getValue())
+        .append(TAB)
+        .append(HeaderSummary.FINAL_RATIONALE_DAR.getValue())
+        .append(TAB)
+        .append(HeaderSummary.FINAL_DECISION_RP.getValue())
+        .append(TAB)
+        .append(HeaderSummary.FINAL_RATIONALE_RP.getValue())
+        .append(TAB)
+        .append(HeaderSummary.FINAL_DECISION_DUL.getValue())
+        .append(TAB)
+        .append(HeaderSummary.FINAL_RATIONALE_DUL.getValue());
+    return builder.toString();
+  }
+
+  @Override
+  public String toString() {
+    List<String> dataSetUUIds =
+        getDar().getData().getDatasetIds().stream()
+            .map(DataSet::parseAliasToIdentifier)
+            .collect(Collectors.toUnmodifiableList());
+    Optional<Vote> chairPersonRPVote =
+        getRpVotes().stream()
+            .filter(v -> v.getType().equalsIgnoreCase(VoteType.CHAIRPERSON.getValue()))
+            .filter(v -> Objects.nonNull(v.getVote()))
+            .findFirst();
+    Optional<Vote> chairPersonAccessVote =
+        getAccessVotes().stream()
+            .filter(v -> v.getType().equalsIgnoreCase(VoteType.CHAIRPERSON.getValue()))
+            .filter(v -> Objects.nonNull(v.getVote()))
+            .findFirst();
+    Optional<Vote> chairPersonConsentVote =
+        getConsentVotes().stream()
+            .filter(v -> v.getType().equalsIgnoreCase(VoteType.CHAIRPERSON.getValue()))
+            .filter(v -> Objects.nonNull(v.getVote()))
+            .findFirst();
+    Optional<Vote> finalVote =
+        getAccessVotes().stream()
+            .filter(v -> v.getType().equalsIgnoreCase(VoteType.FINAL.getValue()))
+            .filter(v -> Objects.nonNull(v.getVote()))
+            .findFirst();
+    Optional<User> chairpersonUser =
+        finalVote.flatMap(
+            vote ->
+                getDacMembers().stream()
+                    .filter(u -> u.getDacUserId().equals(vote.getDacUserId()))
+                    .findFirst());
+    Boolean agreement =
+        (finalVote.isPresent() && Objects.nonNull(getMatchObject()))
+            ? finalVote.get().getVote().equals(getMatchObject().getMatch())
+            : null;
+
+    StringBuilder builder = new StringBuilder();
+    builder.append(getDar().getData().getDarCode()).append(TAB);
+    builder
+        .append(formatLongToDate(getAccessElection().getCreateDate().getTime()))
+        .append(TAB);
+    if (chairpersonUser.isPresent()) {
+      builder.append(chairpersonUser.get().getDisplayName()).append(TAB);
+    } else {
+      builder.append(nullToString(null)).append(TAB);
+    }
+    appendVoteDetails(finalVote, builder);
+    if (Objects.nonNull(getMatchObject())) {
+      builder.append(booleanToString(getMatchObject().getMatch())).append(TAB);
+    } else {
+      builder.append(MANUAL_REVIEW + TAB);
+    }
+    Vote agreementVote = new Vote();
+    agreementVote.setVote(agreement);
+    agreementVote.setRationale("");
+    appendVoteDetails(Optional.of(agreementVote), builder);
+    builder.append(getDarUser().getDisplayName()).append(TAB);
+    builder.append(getDar().getData().getProjectTitle()).append(TAB);
+    builder.append(StringUtils.join(dataSetUUIds, ",")).append(TAB);
+    builder.append(formatLongToDate(getDar().getSortDate().getTime())).append(TAB);
+    for (User user : getDacMembers()) {
+      builder.append(user.getDisplayName()).append(TAB);
+    }
+    // Append extra tabs for the case where there are more DAC members in other rows
+    // than there are DAC members for this row.
+    builder.append(
+        TAB.repeat(Math.max(0, (getMaxNumberOfDACMembers() - getDacMembers().size()))));
+    builder
+        .append(booleanToString(Objects.isNull(getDar().getData().getRestriction())))
+        .append(TAB);
+
+    appendVoteDetails(chairPersonAccessVote, builder);
+    appendVoteDetails(chairPersonRPVote, builder);
+    appendVoteDetails(chairPersonConsentVote, builder);
+    return builder.toString();
+  }
+
+  @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+  private void appendVoteDetails(Optional<Vote> vote, StringBuilder builder) {
+    if (vote.isPresent()) {
+      builder.append(booleanToString(vote.get().getVote())).append(TAB);
+      builder.append(nullToString(vote.get().getRationale())).append(TAB);
+    } else {
+      builder.append(nullToString(null)).append(TAB);
+      builder.append(nullToString(null)).append(TAB);
+    }
+  }
+
+  public DataAccessRequest getDar() {
+    return dar;
+  }
+
+  public void setDar(DataAccessRequest dar) {
+    this.dar = dar;
+  }
+
+  public Election getAccessElection() {
+    return accessElection;
+  }
+
+  public void setAccessElection(Election accessElection) {
+    this.accessElection = accessElection;
+  }
+
+  public List<Vote> getAccessVotes() {
+    return accessVotes;
+  }
+
+  public void setAccessVotes(List<Vote> accessVotes) {
+    this.accessVotes = accessVotes;
+  }
+
+  public List<Vote> getRpVotes() {
+    return rpVotes;
+  }
+
+  public void setRpVotes(List<Vote> rpVotes) {
+    this.rpVotes = rpVotes;
+  }
+
+  public List<Vote> getConsentVotes() {
+    return consentVotes;
+  }
+
+  public void setConsentVotes(List<Vote> consentVotes) {
+    this.consentVotes = consentVotes;
+  }
+
+  public List<User> getDacMembers() {
+    return dacMembers;
+  }
+
+  public void setDacMembers(List<User> dacMembers) {
+    this.dacMembers = dacMembers;
+  }
+
+  public User getDarUser() {
+    return darUser;
+  }
+
+  public void setDarUser(User darUser) {
+    this.darUser = darUser;
+  }
+
+  public Match getMatchObject() {
+    return matchObject;
+  }
+
+  public void setMatchObject(Match matchObject) {
+    this.matchObject = matchObject;
+  }
+
+  public Integer getMaxNumberOfDACMembers() {
+    return maxNumberOfDACMembers;
+  }
+
+  public void setMaxNumberOfDACMembers(Integer maxNumberOfDACMembers) {
+    this.maxNumberOfDACMembers = maxNumberOfDACMembers;
+  }
+
+  private String formatLongToDate(long time) {
+    Calendar cal = Calendar.getInstance();
+    cal.setTimeInMillis(time);
+    int day = cal.get(Calendar.DAY_OF_MONTH);
+    int month = cal.get(Calendar.MONTH) + 1;
+    int year = cal.get(Calendar.YEAR);
+    return String.format("%d/%d/%d", month, day, year);
+  }
+
+  private String booleanToString(Boolean b) {
+    if (b != null) {
+      return b ? "YES" : "NO";
+    }
+    return "-";
+  }
+
+  private String nullToString(String b) {
+    return b != null && !b.isEmpty() ? b : "-";
+  }
+}

--- a/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequestSummaryDetail.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequestSummaryDetail.java
@@ -29,7 +29,7 @@ public class DataAccessRequestSummaryDetail {
       List<Vote> rpVotes,
       List<Vote> consentVotes,
       Match matchObject,
-      List<User> electionUsers,
+      List<User> dacMembers,
       User darUser,
       Integer maxNumberOfDACMembers) {
 
@@ -39,7 +39,7 @@ public class DataAccessRequestSummaryDetail {
     setRpVotes(rpVotes);
     setConsentVotes(consentVotes);
     setMatchObject(matchObject);
-    setDacMembers(electionUsers);
+    setDacMembers(dacMembers);
     setDarUser(darUser);
     setMaxNumberOfDACMembers(maxNumberOfDACMembers);
   }

--- a/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequestSummaryDetail.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequestSummaryDetail.java
@@ -158,7 +158,6 @@ public class DataAccessRequestSummaryDetail {
     // Append extra tabs for the case where there are more DAC members in other rows
     // than there are DAC members for this row.
     builder.append(TAB.repeat(Math.max(0, (getMaxNumberOfDACMembers() - getDacMembers().size()))));
-    // TODO: Need to get the real restriction, not the thing on the data
     builder
         .append(booleanToString(Objects.isNull(getDar().getData().getRestriction())))
         .append(TAB);

--- a/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequestSummaryDetail.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequestSummaryDetail.java
@@ -171,7 +171,7 @@ public class DataAccessRequestSummaryDetail implements SummaryDetail {
   private void appendVoteDetails(Optional<Vote> vote, StringBuilder builder) {
     if (vote.isPresent()) {
       builder.append(booleanToString(vote.get().getVote())).append(TAB);
-      builder.append(nullToString(vote.get().getRationale())).append(TAB);
+      builder.append(unwrapLines(nullToString(vote.get().getRationale()))).append(TAB);
     } else {
       builder.append(nullToString(null)).append(TAB);
       builder.append(nullToString(null)).append(TAB);

--- a/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequestSummaryDetail.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequestSummaryDetail.java
@@ -1,6 +1,5 @@
 package org.broadinstitute.consent.http.models;
 
-import java.util.Calendar;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -10,7 +9,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.consent.http.enumeration.HeaderSummary;
 import org.broadinstitute.consent.http.enumeration.VoteType;
 
-public class DataAccessRequestSummaryDetail {
+public class DataAccessRequestSummaryDetail implements SummaryDetail {
 
   private DataAccessRequest dar;
   private Election accessElection;
@@ -249,25 +248,5 @@ public class DataAccessRequestSummaryDetail {
 
   private void setMaxNumberOfDACMembers(Integer maxNumberOfDACMembers) {
     this.maxNumberOfDACMembers = maxNumberOfDACMembers;
-  }
-
-  private String formatLongToDate(long time) {
-    Calendar cal = Calendar.getInstance();
-    cal.setTimeInMillis(time);
-    int day = cal.get(Calendar.DAY_OF_MONTH);
-    int month = cal.get(Calendar.MONTH) + 1;
-    int year = cal.get(Calendar.YEAR);
-    return String.format("%d/%d/%d", month, day, year);
-  }
-
-  private String booleanToString(Boolean b) {
-    if (Objects.nonNull(b)) {
-      return b ? "YES" : "NO";
-    }
-    return "-";
-  }
-
-  private String nullToString(String b) {
-    return (Objects.nonNull(b) && !b.isBlank()) ? b : "-";
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequestSummaryDetail.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequestSummaryDetail.java
@@ -74,7 +74,8 @@ public class DataAccessRequestSummaryDetail {
         .append(TAB)
         .append(HeaderSummary.DATA_ACCESS_SUBM_DATE.getValue())
         .append(TAB);
-    IntStream.rangeClosed(1, getMaxNumberOfDACMembers()).forEach(i -> builder.append(HeaderSummary.DAC_MEMBERS.getValue()).append(TAB));
+    IntStream.rangeClosed(1, getMaxNumberOfDACMembers())
+        .forEach(i -> builder.append(HeaderSummary.DAC_MEMBERS.getValue()).append(TAB));
     builder
         .append(HeaderSummary.REQUIRE_MANUAL_REVIEW.getValue())
         .append(TAB)
@@ -131,9 +132,7 @@ public class DataAccessRequestSummaryDetail {
 
     StringBuilder builder = new StringBuilder();
     builder.append(getDar().getData().getDarCode()).append(TAB);
-    builder
-        .append(formatLongToDate(getAccessElection().getCreateDate().getTime()))
-        .append(TAB);
+    builder.append(formatLongToDate(getAccessElection().getCreateDate().getTime())).append(TAB);
     if (chairpersonUser.isPresent()) {
       builder.append(chairpersonUser.get().getDisplayName()).append(TAB);
     } else {
@@ -158,8 +157,7 @@ public class DataAccessRequestSummaryDetail {
     }
     // Append extra tabs for the case where there are more DAC members in other rows
     // than there are DAC members for this row.
-    builder.append(
-        TAB.repeat(Math.max(0, (getMaxNumberOfDACMembers() - getDacMembers().size()))));
+    builder.append(TAB.repeat(Math.max(0, (getMaxNumberOfDACMembers() - getDacMembers().size()))));
     builder
         .append(booleanToString(Objects.isNull(getDar().getData().getRestriction())))
         .append(TAB);
@@ -181,75 +179,75 @@ public class DataAccessRequestSummaryDetail {
     }
   }
 
-  public DataAccessRequest getDar() {
+  private DataAccessRequest getDar() {
     return dar;
   }
 
-  public void setDar(DataAccessRequest dar) {
+  private void setDar(DataAccessRequest dar) {
     this.dar = dar;
   }
 
-  public Election getAccessElection() {
+  private Election getAccessElection() {
     return accessElection;
   }
 
-  public void setAccessElection(Election accessElection) {
+  private void setAccessElection(Election accessElection) {
     this.accessElection = accessElection;
   }
 
-  public List<Vote> getAccessVotes() {
+  private List<Vote> getAccessVotes() {
     return accessVotes;
   }
 
-  public void setAccessVotes(List<Vote> accessVotes) {
+  private void setAccessVotes(List<Vote> accessVotes) {
     this.accessVotes = accessVotes;
   }
 
-  public List<Vote> getRpVotes() {
+  private List<Vote> getRpVotes() {
     return rpVotes;
   }
 
-  public void setRpVotes(List<Vote> rpVotes) {
+  private void setRpVotes(List<Vote> rpVotes) {
     this.rpVotes = rpVotes;
   }
 
-  public List<Vote> getConsentVotes() {
+  private List<Vote> getConsentVotes() {
     return consentVotes;
   }
 
-  public void setConsentVotes(List<Vote> consentVotes) {
+  private void setConsentVotes(List<Vote> consentVotes) {
     this.consentVotes = consentVotes;
   }
 
-  public List<User> getDacMembers() {
+  private List<User> getDacMembers() {
     return dacMembers;
   }
 
-  public void setDacMembers(List<User> dacMembers) {
+  private void setDacMembers(List<User> dacMembers) {
     this.dacMembers = dacMembers;
   }
 
-  public User getDarUser() {
+  private User getDarUser() {
     return darUser;
   }
 
-  public void setDarUser(User darUser) {
+  private void setDarUser(User darUser) {
     this.darUser = darUser;
   }
 
-  public Match getMatchObject() {
+  private Match getMatchObject() {
     return matchObject;
   }
 
-  public void setMatchObject(Match matchObject) {
+  private void setMatchObject(Match matchObject) {
     this.matchObject = matchObject;
   }
 
-  public Integer getMaxNumberOfDACMembers() {
+  private Integer getMaxNumberOfDACMembers() {
     return maxNumberOfDACMembers;
   }
 
-  public void setMaxNumberOfDACMembers(Integer maxNumberOfDACMembers) {
+  private void setMaxNumberOfDACMembers(Integer maxNumberOfDACMembers) {
     this.maxNumberOfDACMembers = maxNumberOfDACMembers;
   }
 

--- a/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequestSummaryDetail.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequestSummaryDetail.java
@@ -158,6 +158,7 @@ public class DataAccessRequestSummaryDetail {
     // Append extra tabs for the case where there are more DAC members in other rows
     // than there are DAC members for this row.
     builder.append(TAB.repeat(Math.max(0, (getMaxNumberOfDACMembers() - getDacMembers().size()))));
+    // TODO: Need to get the real restriction, not the thing on the data
     builder
         .append(booleanToString(Objects.isNull(getDar().getData().getRestriction())))
         .append(TAB);
@@ -261,13 +262,13 @@ public class DataAccessRequestSummaryDetail {
   }
 
   private String booleanToString(Boolean b) {
-    if (b != null) {
+    if (Objects.nonNull(b)) {
       return b ? "YES" : "NO";
     }
     return "-";
   }
 
   private String nullToString(String b) {
-    return b != null && !b.isEmpty() ? b : "-";
+    return (Objects.nonNull(b) && !b.isBlank()) ? b : "-";
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/models/SummaryDetail.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/SummaryDetail.java
@@ -7,6 +7,11 @@ import java.util.Calendar;
  */
 public interface SummaryDetail {
 
+  String headers();
+  
+  @Override
+  String toString();
+
   default String delimiterCheck(String delimitedString) {
     String textDelimiter = "\"";
     if (!delimitedString.isBlank()) {

--- a/src/main/java/org/broadinstitute/consent/http/models/SummaryDetail.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/SummaryDetail.java
@@ -41,4 +41,8 @@ public interface SummaryDetail {
   default String nullToString(String b) {
     return Objects.nonNull(b) && !b.isEmpty() ? b : "-";
   }
+  
+  default String unwrapLines(String b) {
+    return b.replaceAll("\\t", " ").replaceAll("\\n", " ");
+  }
 }

--- a/src/main/java/org/broadinstitute/consent/http/models/SummaryDetail.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/SummaryDetail.java
@@ -1,6 +1,7 @@
 package org.broadinstitute.consent.http.models;
 
 import java.util.Calendar;
+import java.util.Objects;
 
 /**
  * Utility Interface Trait for writing out Summary Details 
@@ -22,7 +23,7 @@ public interface SummaryDetail {
   }
 
   default String booleanToString(Boolean b) {
-    if (b != null) {
+    if (Objects.nonNull(b)) {
       return b ? "YES" : "NO";
     }
     return "-";
@@ -38,6 +39,6 @@ public interface SummaryDetail {
   }
 
   default String nullToString(String b) {
-    return b != null && !b.isEmpty() ? b : "-";
+    return Objects.nonNull(b) && !b.isEmpty() ? b : "-";
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/models/SummaryDetail.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/SummaryDetail.java
@@ -1,0 +1,38 @@
+package org.broadinstitute.consent.http.models;
+
+import java.util.Calendar;
+
+/**
+ * Utility Interface Trait for writing out Summary Details 
+ */
+public interface SummaryDetail {
+
+  default String delimiterCheck(String delimitedString) {
+    String textDelimiter = "\"";
+    if (!delimitedString.isBlank()) {
+      return textDelimiter + delimitedString.replaceAll(textDelimiter, "'") + textDelimiter;
+    } else {
+      return "";
+    }
+  }
+
+  default String booleanToString(Boolean b) {
+    if (b != null) {
+      return b ? "YES" : "NO";
+    }
+    return "-";
+  }
+
+  default String formatLongToDate(long time) {
+    Calendar cal = Calendar.getInstance();
+    cal.setTimeInMillis(time);
+    int day = cal.get(Calendar.DAY_OF_MONTH);
+    int month = cal.get(Calendar.MONTH) + 1;
+    int year = cal.get(Calendar.YEAR);
+    return String.format("%d/%d/%d", month, day, year);
+  }
+
+  default String nullToString(String b) {
+    return b != null && !b.isEmpty() ? b : "-";
+  }
+}

--- a/src/main/java/org/broadinstitute/consent/http/resources/ConsentCasesResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/ConsentCasesResource.java
@@ -4,7 +4,6 @@ import com.google.inject.Inject;
 import io.dropwizard.auth.Auth;
 import java.io.File;
 import java.util.List;
-import java.util.Objects;
 import javax.annotation.security.PermitAll;
 import javax.annotation.security.RolesAllowed;
 import javax.ws.rs.GET;
@@ -59,15 +58,13 @@ public class ConsentCasesResource extends Resource {
     @PermitAll
     public Response getConsentSummaryDetailFile(@QueryParam("fileType") String fileType, @Auth AuthUser authUser) {
         try {
-            File fileToSend = null;
-            List<DataAccessRequestSummaryDetail> details = null;
-            StringBuilder summaryDetails = new StringBuilder();
             if (fileType.equals(ElectionType.TRANSLATE_DUL.getValue())) {
-                fileToSend = summaryService.describeConsentSummaryDetail();
+                File fileToSend = summaryService.describeConsentSummaryDetail();
                 return Response.ok(fileToSend).build();
             } else if (fileType.equals(ElectionType.DATA_ACCESS.getValue())) {
-                details = summaryService.listDataAccessRequestSummaryDetails();
+                List<DataAccessRequestSummaryDetail> details = summaryService.listDataAccessRequestSummaryDetails();
                 if (!details.isEmpty()) {
+                    StringBuilder summaryDetails = new StringBuilder();
                     summaryDetails.append(details.get(0).headers()).append(System.lineSeparator());
                     details.forEach(d -> summaryDetails.append(d.toString()).append(System.lineSeparator()));
                     return Response.ok(summaryDetails.toString()).build();

--- a/src/main/java/org/broadinstitute/consent/http/resources/ConsentCasesResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/ConsentCasesResource.java
@@ -64,20 +64,16 @@ public class ConsentCasesResource extends Resource {
             StringBuilder summaryDetails = new StringBuilder();
             if (fileType.equals(ElectionType.TRANSLATE_DUL.getValue())) {
                 fileToSend = summaryService.describeConsentSummaryDetail();
+                return Response.ok(fileToSend).build();
             } else if (fileType.equals(ElectionType.DATA_ACCESS.getValue())) {
                 details = summaryService.listDataAccessRequestSummaryDetails();
                 if (!details.isEmpty()) {
                     summaryDetails.append(details.get(0).headers()).append(System.lineSeparator());
                     details.forEach(d -> summaryDetails.append(d.toString()).append(System.lineSeparator()));
+                    return Response.ok(summaryDetails.toString()).build();
                 }
             }
-            if ((fileToSend != null)) {
-                return Response.ok(fileToSend).build();
-            } else if (Objects.nonNull(details) && (!details.isEmpty())) {
-                return Response.ok(summaryDetails.toString()).build();
-            } else {
-                return Response.ok().build();
-            }
+            return Response.ok().build();
         } catch (Exception e) {
             return createExceptionResponse(e);
         }

--- a/src/main/java/org/broadinstitute/consent/http/resources/ConsentCasesResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/ConsentCasesResource.java
@@ -4,6 +4,7 @@ import com.google.inject.Inject;
 import io.dropwizard.auth.Auth;
 import java.io.File;
 import java.util.List;
+import java.util.Objects;
 import javax.annotation.security.PermitAll;
 import javax.annotation.security.RolesAllowed;
 import javax.ws.rs.GET;
@@ -58,6 +59,9 @@ public class ConsentCasesResource extends Resource {
     @PermitAll
     public Response getConsentSummaryDetailFile(@QueryParam("fileType") String fileType, @Auth AuthUser authUser) {
         try {
+            if (Objects.isNull(fileType)) {
+                fileType = ElectionType.DATA_ACCESS.getValue();
+            }
             if (fileType.equals(ElectionType.TRANSLATE_DUL.getValue())) {
                 File fileToSend = summaryService.describeConsentSummaryDetail();
                 return Response.ok(fileToSend).build();

--- a/src/main/java/org/broadinstitute/consent/http/resources/ConsentCasesResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/ConsentCasesResource.java
@@ -15,6 +15,7 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Response;
 import org.broadinstitute.consent.http.enumeration.ElectionType;
 import org.broadinstitute.consent.http.models.AuthUser;
+import org.broadinstitute.consent.http.models.ConsentSummaryDetail;
 import org.broadinstitute.consent.http.models.DataAccessRequestSummaryDetail;
 import org.broadinstitute.consent.http.models.Election;
 import org.broadinstitute.consent.http.models.PendingCase;
@@ -57,15 +58,20 @@ public class ConsentCasesResource extends Resource {
     @Path("/summary/file")
     @Produces("text/plain")
     @PermitAll
-    public Response getConsentSummaryDetailFile(@QueryParam("fileType") String fileType, @Auth AuthUser authUser) {
+    public Response getConsentSummaryDetailFile(@QueryParam("type") String type, @Auth AuthUser authUser) {
         try {
-            if (Objects.isNull(fileType)) {
-                fileType = ElectionType.DATA_ACCESS.getValue();
+            if (Objects.isNull(type)) {
+                type = ElectionType.DATA_ACCESS.getValue();
             }
-            if (fileType.equals(ElectionType.TRANSLATE_DUL.getValue())) {
-                File fileToSend = summaryService.describeConsentSummaryDetail();
-                return Response.ok(fileToSend).build();
-            } else if (fileType.equals(ElectionType.DATA_ACCESS.getValue())) {
+            if (type.equals(ElectionType.TRANSLATE_DUL.getValue())) {
+                List<ConsentSummaryDetail> details = summaryService.describeConsentSummaryDetail();
+                if (!details.isEmpty()) {
+                    StringBuilder summaryDetails = new StringBuilder();
+                    summaryDetails.append(details.get(0).headers()).append(System.lineSeparator());
+                    details.forEach(d -> summaryDetails.append(d.toString()).append(System.lineSeparator()));
+                    return Response.ok(summaryDetails.toString()).build();
+                }
+            } else if (type.equals(ElectionType.DATA_ACCESS.getValue())) {
                 List<DataAccessRequestSummaryDetail> details = summaryService.listDataAccessRequestSummaryDetails();
                 if (!details.isEmpty()) {
                     StringBuilder summaryDetails = new StringBuilder();

--- a/src/main/java/org/broadinstitute/consent/http/resources/ConsentCasesResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/ConsentCasesResource.java
@@ -2,9 +2,9 @@ package org.broadinstitute.consent.http.resources;
 
 import com.google.inject.Inject;
 import io.dropwizard.auth.Auth;
-
 import java.io.File;
 import java.util.List;
+import java.util.Objects;
 import javax.annotation.security.PermitAll;
 import javax.annotation.security.RolesAllowed;
 import javax.ws.rs.GET;
@@ -13,10 +13,9 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.ResponseBuilder;
-
 import org.broadinstitute.consent.http.enumeration.ElectionType;
 import org.broadinstitute.consent.http.models.AuthUser;
+import org.broadinstitute.consent.http.models.DataAccessRequestSummaryDetail;
 import org.broadinstitute.consent.http.models.Election;
 import org.broadinstitute.consent.http.models.PendingCase;
 import org.broadinstitute.consent.http.models.Summary;
@@ -59,19 +58,27 @@ public class ConsentCasesResource extends Resource {
     @Produces("text/plain")
     @PermitAll
     public Response getConsentSummaryDetailFile(@QueryParam("fileType") String fileType, @Auth AuthUser authUser) {
-        ResponseBuilder response;
-        File fileToSend = null;
-        if (fileType.equals(ElectionType.TRANSLATE_DUL.getValue())) {
-            fileToSend = summaryService.describeConsentSummaryDetail();
-        } else if (fileType.equals(ElectionType.DATA_ACCESS.getValue())) {
-            fileToSend = summaryService.describeDataAccessRequestSummaryDetail();
+        try {
+            File fileToSend = null;
+            List<DataAccessRequestSummaryDetail> details = null;
+            StringBuilder summaryDetails = new StringBuilder();
+            if (fileType.equals(ElectionType.TRANSLATE_DUL.getValue())) {
+                fileToSend = summaryService.describeConsentSummaryDetail();
+            } else if (fileType.equals(ElectionType.DATA_ACCESS.getValue())) {
+                details = summaryService.listDataAccessRequestSummaryDetails();
+                summaryDetails.append(details.get(0).headers()).append(System.lineSeparator());
+                details.forEach(d -> summaryDetails.append(d.toString()).append(System.lineSeparator()));
+            }
+            if ((fileToSend != null)) {
+                return Response.ok(fileToSend).build();
+            } else if (Objects.nonNull(details)) {
+                return Response.ok(summaryDetails.toString()).build();
+            } else {
+                return Response.ok().build();
+            }
+        } catch (Exception e) {
+            return createExceptionResponse(e);
         }
-        if ((fileToSend != null)) {
-            response = Response.ok(fileToSend);
-        } else {
-            response = Response.ok();
-        }
-        return response.build();
     }
 
 

--- a/src/main/java/org/broadinstitute/consent/http/resources/ConsentCasesResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/ConsentCasesResource.java
@@ -66,12 +66,14 @@ public class ConsentCasesResource extends Resource {
                 fileToSend = summaryService.describeConsentSummaryDetail();
             } else if (fileType.equals(ElectionType.DATA_ACCESS.getValue())) {
                 details = summaryService.listDataAccessRequestSummaryDetails();
-                summaryDetails.append(details.get(0).headers()).append(System.lineSeparator());
-                details.forEach(d -> summaryDetails.append(d.toString()).append(System.lineSeparator()));
+                if (!details.isEmpty()) {
+                    summaryDetails.append(details.get(0).headers()).append(System.lineSeparator());
+                    details.forEach(d -> summaryDetails.append(d.toString()).append(System.lineSeparator()));
+                }
             }
             if ((fileToSend != null)) {
                 return Response.ok(fileToSend).build();
-            } else if (Objects.nonNull(details)) {
+            } else if (Objects.nonNull(details) && (!details.isEmpty())) {
                 return Response.ok(summaryDetails.toString()).build();
             } else {
                 return Response.ok().build();

--- a/src/main/java/org/broadinstitute/consent/http/resources/ConsentCasesResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/ConsentCasesResource.java
@@ -2,7 +2,6 @@ package org.broadinstitute.consent.http.resources;
 
 import com.google.inject.Inject;
 import io.dropwizard.auth.Auth;
-import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -16,8 +15,6 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Response;
 import org.broadinstitute.consent.http.enumeration.ElectionType;
 import org.broadinstitute.consent.http.models.AuthUser;
-import org.broadinstitute.consent.http.models.ConsentSummaryDetail;
-import org.broadinstitute.consent.http.models.DataAccessRequestSummaryDetail;
 import org.broadinstitute.consent.http.models.Election;
 import org.broadinstitute.consent.http.models.PendingCase;
 import org.broadinstitute.consent.http.models.Summary;

--- a/src/main/java/org/broadinstitute/consent/http/resources/ConsentCasesResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/ConsentCasesResource.java
@@ -3,6 +3,7 @@ package org.broadinstitute.consent.http.resources;
 import com.google.inject.Inject;
 import io.dropwizard.auth.Auth;
 import java.io.File;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import javax.annotation.security.PermitAll;
@@ -20,6 +21,7 @@ import org.broadinstitute.consent.http.models.DataAccessRequestSummaryDetail;
 import org.broadinstitute.consent.http.models.Election;
 import org.broadinstitute.consent.http.models.PendingCase;
 import org.broadinstitute.consent.http.models.Summary;
+import org.broadinstitute.consent.http.models.SummaryDetail;
 import org.broadinstitute.consent.http.service.ElectionService;
 import org.broadinstitute.consent.http.service.PendingCaseService;
 import org.broadinstitute.consent.http.service.SummaryService;
@@ -63,22 +65,17 @@ public class ConsentCasesResource extends Resource {
             if (Objects.isNull(type)) {
                 type = ElectionType.DATA_ACCESS.getValue();
             }
+            List<? extends SummaryDetail> details = new ArrayList<>();
             if (type.equals(ElectionType.TRANSLATE_DUL.getValue())) {
-                List<ConsentSummaryDetail> details = summaryService.describeConsentSummaryDetail();
-                if (!details.isEmpty()) {
-                    StringBuilder summaryDetails = new StringBuilder();
-                    summaryDetails.append(details.get(0).headers()).append(System.lineSeparator());
-                    details.forEach(d -> summaryDetails.append(d.toString()).append(System.lineSeparator()));
-                    return Response.ok(summaryDetails.toString()).build();
-                }
+                details = summaryService.describeConsentSummaryDetail();
             } else if (type.equals(ElectionType.DATA_ACCESS.getValue())) {
-                List<DataAccessRequestSummaryDetail> details = summaryService.listDataAccessRequestSummaryDetails();
-                if (!details.isEmpty()) {
-                    StringBuilder summaryDetails = new StringBuilder();
-                    summaryDetails.append(details.get(0).headers()).append(System.lineSeparator());
-                    details.forEach(d -> summaryDetails.append(d.toString()).append(System.lineSeparator()));
-                    return Response.ok(summaryDetails.toString()).build();
-                }
+                details = summaryService.listDataAccessRequestSummaryDetails();
+            }
+            if (!details.isEmpty()) {
+                StringBuilder detailsBuilder = new StringBuilder();
+                detailsBuilder.append(details.get(0).headers()).append(System.lineSeparator());
+                details.forEach(d -> detailsBuilder.append(d.toString()).append(System.lineSeparator()));
+                return Response.ok(detailsBuilder.toString()).build();
             }
             return Response.ok().build();
         } catch (Exception e) {

--- a/src/main/java/org/broadinstitute/consent/http/service/SummaryService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/SummaryService.java
@@ -161,7 +161,7 @@ public class SummaryService {
             Stream.of(ElectionStatus.CLOSED.getValue(), ElectionStatus.CANCELED.getValue())
                 .map(String::toLowerCase)
                 .collect(Collectors.toList());
-        List<Election> reviewedElections = electionDAO.findElectionsWithFinalVoteByTypeAndStatus(ElectionType.TRANSLATE_DUL.getValue(), statuses).stream().distinct().collect(Collectors.toUnmodifiableList());
+        List<Election> reviewedElections = electionDAO.findElectionsWithFinalVoteByTypeAndStatus(ElectionType.TRANSLATE_DUL.getValue(), statuses).stream().filter(e -> Objects.nonNull(e.getFinalVote())).distinct().collect(Collectors.toUnmodifiableList());
         if (!CollectionUtils.isEmpty(reviewedElections)) {
           List<String> consentIds =
               reviewedElections.stream().map(Election::getReferenceId).collect(Collectors.toList());
@@ -223,8 +223,8 @@ public class SummaryService {
    */
   public List<DataAccessRequestSummaryDetail> listDataAccessRequestSummaryDetails() {
     List<DataAccessRequestSummaryDetail> details = new ArrayList<>();
-    List<Election> accessElections = electionDAO.findElectionsWithFinalVoteByTypeAndStatus(ElectionType.DATA_ACCESS.getValue(), ElectionStatus.CLOSED.getValue()).stream().distinct().collect(Collectors.toUnmodifiableList());
-    List<Election> rpElections = electionDAO.findElectionsWithFinalVoteByTypeAndStatus(ElectionType.RP.getValue(), ElectionStatus.CLOSED.getValue()).stream().distinct().collect(Collectors.toUnmodifiableList());
+    List<Election> accessElections = electionDAO.findElectionsWithFinalVoteByTypeAndStatus(ElectionType.DATA_ACCESS.getValue(), ElectionStatus.CLOSED.getValue()).stream().filter(e -> Objects.nonNull(e.getFinalVote())).distinct().collect(Collectors.toUnmodifiableList());
+    List<Election> rpElections = electionDAO.findElectionsWithFinalVoteByTypeAndStatus(ElectionType.RP.getValue(), ElectionStatus.CLOSED.getValue()).stream().filter(e -> Objects.nonNull(e.getFinalVote())).distinct().collect(Collectors.toUnmodifiableList());
     if (!accessElections.isEmpty()) {
       List<String> referenceIds = accessElections.stream().map(Election::getReferenceId).collect(Collectors.toList());
       List<DataAccessRequest> dataAccessRequests = referenceIds.isEmpty() ? Collections.emptyList() : dataAccessRequestService.getDataAccessRequestsByReferenceIds(referenceIds);

--- a/src/main/java/org/broadinstitute/consent/http/service/SummaryService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/SummaryService.java
@@ -7,7 +7,6 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Calendar;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -15,11 +14,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.stream.Collector;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.consent.http.db.ConsentDAO;
 import org.broadinstitute.consent.http.db.DatasetDAO;
 import org.broadinstitute.consent.http.db.ElectionDAO;
@@ -55,7 +52,6 @@ public class SummaryService {
     private final MatchDAO matchDAO;
     private final DataAccessRequestService dataAccessRequestService;
     private static final String SEPARATOR = "\t";
-    private static final String TEXT_DELIMITER = "\"";
     private static final String END_OF_LINE = System.lineSeparator();
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
 

--- a/src/main/java/org/broadinstitute/consent/http/service/SummaryService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/SummaryService.java
@@ -1,7 +1,7 @@
 package org.broadinstitute.consent.http.service;
 
-import org.broadinstitute.consent.http.models.DataAccessRequest;
 import static org.broadinstitute.consent.http.resources.Resource.CHAIRPERSON;
+
 import com.google.inject.Inject;
 import java.io.File;
 import java.io.FileWriter;
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -29,9 +30,11 @@ import org.broadinstitute.consent.http.enumeration.ElectionStatus;
 import org.broadinstitute.consent.http.enumeration.ElectionType;
 import org.broadinstitute.consent.http.enumeration.HeaderSummary;
 import org.broadinstitute.consent.http.enumeration.VoteType;
-import org.broadinstitute.consent.http.models.AccessRP;
 import org.broadinstitute.consent.http.models.Association;
 import org.broadinstitute.consent.http.models.Consent;
+import org.broadinstitute.consent.http.models.DataAccessRequest;
+import org.broadinstitute.consent.http.models.DataAccessRequestData;
+import org.broadinstitute.consent.http.models.DataAccessRequestSummaryDetail;
 import org.broadinstitute.consent.http.models.DataSet;
 import org.broadinstitute.consent.http.models.Election;
 import org.broadinstitute.consent.http.models.Match;
@@ -53,7 +56,6 @@ public class SummaryService {
     private static final String SEPARATOR = "\t";
     private static final String TEXT_DELIMITER = "\"";
     private static final String END_OF_LINE = System.lineSeparator();
-    private static final String MANUAL_REVIEW = "Manual Review";
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
     @Inject
@@ -209,144 +211,99 @@ public class SummaryService {
         return file;
     }
 
-    public File describeDataAccessRequestSummaryDetail() {
-        File file = null;
-        try {
-            file = File.createTempFile("DAR_summary", ".txt");
-            try (FileWriter summaryWriter = new FileWriter(file)) {
-                List<Election> reviewedElections = electionDAO.findElectionsWithFinalVoteByTypeAndStatus(ElectionType.DATA_ACCESS.getValue(), ElectionStatus.CLOSED.getValue());
-                List<Election> reviewedRPElections = electionDAO.findElectionsWithFinalVoteByTypeAndStatus(ElectionType.RP.getValue(), ElectionStatus.CLOSED.getValue());
-                if (!CollectionUtils.isEmpty(reviewedElections)) {
-                    List<String> referenceIds = reviewedElections.stream().map(Election::getReferenceId).collect(Collectors.toList());
-                    List<DataAccessRequest> dataAccessRequests = dataAccessRequestService.getDataAccessRequestsByReferenceIds(referenceIds);
-                    List<Integer> datasetIds = dataAccessRequests.stream().
-                            map(dar -> Objects.nonNull(dar) && Objects.nonNull(dar.getData()) ? dar.getData().getDatasetIds() : new ArrayList<Integer>()).
-                            flatMap(List::stream).
-                            collect(Collectors.toList());
-                    List<Association> associations = datasetDAO.getAssociationsForDataSetIdList(new ArrayList<>(datasetIds));
-                    List<String> associatedConsentIds =   associations.stream().map(Association::getConsentId).collect(Collectors.toList());
-                    List<Election> reviewedConsentElections = electionDAO.findLastElectionsWithFinalVoteByReferenceIdsTypeAndStatus(associatedConsentIds, ElectionStatus.CLOSED.getValue());
-                    List<Integer> darElectionIds = reviewedElections.stream().map(Election::getElectionId).collect(Collectors.toList());
-                    List<Integer> consentElectionIds = reviewedConsentElections.stream().map(Election::getElectionId).collect(Collectors.toList());
-                    List<AccessRP> accessRPList = electionDAO.findAccessRPbyElectionAccessId(darElectionIds);
-                    List<Vote> votes = voteDAO.findVotesByElectionIds(darElectionIds);
-                    List<Integer> rpElectionIds = reviewedRPElections.stream().map(Election::getElectionId).collect(Collectors.toList());
-                    List<Vote> rpVotes;
-                    if (CollectionUtils.isNotEmpty(rpElectionIds)) {
-                        rpVotes = voteDAO.findVotesByElectionIds(rpElectionIds);
-                    } else rpVotes = null;
-                    List<Vote> consentVotes = voteDAO.findVotesByElectionIds(consentElectionIds);
-                    List<Match> matchList = matchDAO.findMatchesForPurposeIds(referenceIds);
-                    Collection<Integer> dacUserIds = votes.stream().map(Vote::getDacUserId).collect(Collectors.toSet());
-                    Collection<User> users = userDAO.findUsers(dacUserIds);
-                    Integer maxNumberOfDACMembers = voteDAO.findMaxNumberOfDACMembers(darElectionIds);
-                    setSummaryHeaderDataAccessRequest(summaryWriter, maxNumberOfDACMembers);
-                    for (Election election : reviewedElections) {
+  /**
+   * Generate a list of Summary Details for all reviewed Data Access Requests
+   * @return List<DataAccessRequestSummaryDetail>
+   */
+  public List<DataAccessRequestSummaryDetail> listDataAccessRequestSummaryDetails() {
+    List<DataAccessRequestSummaryDetail> details = new ArrayList<>();
+    List<Election> accessElections = electionDAO.findElectionsWithFinalVoteByTypeAndStatus(ElectionType.DATA_ACCESS.getValue(), ElectionStatus.CLOSED.getValue());
+    List<Election> rpElections = electionDAO.findElectionsWithFinalVoteByTypeAndStatus(ElectionType.RP.getValue(), ElectionStatus.CLOSED.getValue());
+    if (!CollectionUtils.isEmpty(accessElections)) {
+      List<String> referenceIds = accessElections.stream().map(Election::getReferenceId).collect(Collectors.toList());
+      List<DataAccessRequest> dataAccessRequests = dataAccessRequestService.getDataAccessRequestsByReferenceIds(referenceIds);
+      List<Integer> datasetIds =
+          dataAccessRequests.stream()
+            .filter(Objects::nonNull)
+            .map(DataAccessRequest::getData)
+            .filter(Objects::nonNull)
+            .map(DataAccessRequestData::getDatasetIds)
+            .flatMap(List::stream)
+            .filter(Objects::nonNull)
+            .collect(Collectors.toList());
+      List<Association> associations = datasetDAO.getAssociationsForDataSetIdList(new ArrayList<>(datasetIds));
+      List<String> associatedConsentIds = associations.stream().map(Association::getConsentId).collect(Collectors.toList());
+      List<Election> reviewedConsentElections = electionDAO.findLastElectionsWithFinalVoteByReferenceIdsTypeAndStatus(associatedConsentIds, ElectionStatus.CLOSED.getValue());
+      List<Integer> accessElectionIds = accessElections.stream().map(Election::getElectionId).collect(Collectors.toList());
+      List<Integer> rpElectionIds = rpElections.stream().map(Election::getElectionId).collect(Collectors.toList());
+      List<Integer> consentElectionIds = reviewedConsentElections.stream().map(Election::getElectionId).collect(Collectors.toList());
+      List<Vote> accessVotes = voteDAO.findVotesByElectionIds(accessElectionIds);
+      List<Vote> rpVotes = voteDAO.findVotesByElectionIds(rpElectionIds);
+      List<Vote> consentVotes = voteDAO.findVotesByElectionIds(consentElectionIds);
+      List<Match> matchList = matchDAO.findMatchesForPurposeIds(referenceIds);
+      Collection<Integer> voteUserIds = accessVotes.stream().map(Vote::getDacUserId).collect(Collectors.toSet());
+      List<User> voteUsers = userDAO.findUsers(voteUserIds).stream().collect(Collectors.toUnmodifiableList());
+      List<Integer> darUserIds = dataAccessRequests.stream().map(DataAccessRequest::getUserId).collect(Collectors.toList());
+      List<User> darUsers = darUserIds.isEmpty() ? Collections.emptyList() : userDAO.findUsers(darUserIds).stream().collect(Collectors.toUnmodifiableList());
 
-                        List<Vote> electionVotes = votes.stream().filter(ev -> ev.getElectionId().equals(election.getElectionId())).collect(Collectors.toList());
-                        List<Integer> electionVotesUserIds = electionVotes.stream().filter(v -> v.getType().equalsIgnoreCase(VoteType.DAC.getValue())).map(Vote::getDacUserId).collect(Collectors.toList());
-                        Collection<User> electionUsers = users.stream().filter(du -> electionVotesUserIds.contains(du.getDacUserId())).collect(Collectors.toSet());
+      // This represents the maximum possible number of DAC members. We need to pre-calculate this
+      // across all elections so each row can know the correct max # of DAC members.
+      int maxNumberOfDACMembers = 0;
+      for (Election accessElection : accessElections) {
+        List<Vote> accessElectionVotes = Objects.nonNull(accessElection) ? accessVotes
+            .stream()
+            .filter(ev -> ev.getElectionId().equals(accessElection.getElectionId()))
+            .collect(Collectors.toList()) :
+            Collections.emptyList();
+        List<Integer> dacUserIds = accessElectionVotes.stream().map(Vote::getDacUserId).distinct().collect(Collectors.toUnmodifiableList());
+        maxNumberOfDACMembers = Math.max(maxNumberOfDACMembers, dacUserIds.size());
+      }
 
-                        Vote finalVote =  electionVotes.stream().filter(v -> v.getType().equalsIgnoreCase(VoteType.FINAL.getValue())).collect(singletonCollector());
-                        Vote chairPersonVote =  electionVotes.stream().filter(v -> v.getType().equalsIgnoreCase(VoteType.CHAIRPERSON.getValue())).collect(singletonCollector());
-                        Vote  chairPersonRPVote = null;
-                        Vote agreementVote = null;
-                        if (CollectionUtils.isNotEmpty(reviewedRPElections) && CollectionUtils.isNotEmpty(accessRPList)) {
-                            agreementVote =  electionVotes.stream().filter(v -> v.getType().equalsIgnoreCase(VoteType.AGREEMENT.getValue())).collect(singletonCollector());
-                            AccessRP accessRP =  accessRPList.stream().filter(arp -> arp.getElectionAccessId().equals(election.getElectionId())).collect(singletonCollector());
-                            if (Objects.nonNull(accessRP) && Objects.nonNull(rpVotes)) {
-                                chairPersonRPVote = rpVotes.stream()
-                                    .filter(v -> v.getElectionId().equals(accessRP.getElectionRPId()))
-                                    .filter(v -> v.getType().equalsIgnoreCase(VoteType.CHAIRPERSON.getValue()))
-                                    .collect(singletonCollector());
-                            }
-                        }
-                        User chairPerson =  users.stream().filter(du -> du.getDacUserId().equals(finalVote.getDacUserId())).collect(singletonCollector());
-                        Match match;
-                        try {
-                            match = matchList.stream().filter(m -> m.getPurpose().equals(election.getReferenceId())).collect(singletonCollector());
-                        } catch (IllegalStateException e){
-                            match = null;
-                        }
-                        DataAccessRequest dar = findAssociatedDAR(dataAccessRequests, election.getReferenceId());
-                        if (Objects.nonNull(dar) && Objects.nonNull(dar.getData())) {
-                            List<Integer> datasetId = dar.getData().getDatasetIds();
-                            if (CollectionUtils.isNotEmpty(datasetId)) {
-                                Association association = associations.stream().filter((as) -> as.getDataSetId().equals(datasetId.get(0))).collect(singletonCollector());
-                                Election consentElection = reviewedConsentElections.stream().filter(re -> re.getReferenceId().equals(association.getConsentId())).collect(singletonCollector());
-                                List<Vote> electionConsentVotes = consentVotes.stream().filter(cv -> cv.getElectionId().equals(consentElection.getElectionId())).collect(Collectors.toList());
-                                Vote chairPersonConsentVote =  electionConsentVotes.stream().filter(v -> v.getType().equalsIgnoreCase(VoteType.CHAIRPERSON.getValue())).collect(singletonCollector());
-                                summaryWriter.write(dar.getData().getDarCode() + SEPARATOR);
-                                summaryWriter.write(formatLongToDate(election.getCreateDate().getTime()) + SEPARATOR);
-                                summaryWriter.write(chairPerson.getDisplayName() + SEPARATOR);
-                                summaryWriter.write( booleanToString(finalVote.getVote()) + SEPARATOR);
-                                summaryWriter.write( nullToString(finalVote.getRationale()) + SEPARATOR);
-                                if (match != null) {
-                                    summaryWriter.write(booleanToString(match.getMatch()) + SEPARATOR);
-                                } else {
-                                    summaryWriter.write(MANUAL_REVIEW + SEPARATOR);
-                                }
-                                if (agreementVote != null) {
-                                    summaryWriter.write(booleanToString(agreementVote.getVote()) + SEPARATOR);
-                                    summaryWriter.write(nullToString(agreementVote.getRationale()) + SEPARATOR);
-                                } else {
-                                    summaryWriter.write("-" + SEPARATOR);
-                                    summaryWriter.write("-" + SEPARATOR);
-                                }
-                                User u = userDAO.findUserById(dar.getUserId());
-                                summaryWriter.write( u.getDisplayName()  + SEPARATOR);
-                                summaryWriter.write( dar.getData().getProjectTitle() + SEPARATOR);
-                                List<String> dataSetUUIds = new ArrayList<>();
-                                for (Integer id : datasetId) {
-                                    dataSetUUIds.add(DataSet.parseAliasToIdentifier(id));
-                                }
-                                summaryWriter.write( StringUtils.join(dataSetUUIds, ",")  + SEPARATOR);
-                                summaryWriter.write( formatLongToDate(dar.getSortDate().getTime())  + SEPARATOR);
-                                for (User user : electionUsers){
-                                    summaryWriter.write( user.getDisplayName() + SEPARATOR);
-                                }
-                                for (int i = 0; i < (maxNumberOfDACMembers - electionUsers.size()); i++) {
-                                    summaryWriter.write(
-                                            SEPARATOR);
-                                }
-                                summaryWriter.write( booleanToString(Objects.isNull(dar.getData().getRestriction()))+ SEPARATOR);
+      for (Election accessElection : accessElections) {
+        List<Vote> accessElectionVotes = Objects.nonNull(accessElection) ? accessVotes
+            .stream()
+            .filter(ev -> ev.getElectionId().equals(accessElection.getElectionId()))
+            .collect(Collectors.toList()) :
+            Collections.emptyList();
+        Optional<Election> rpElection = rpElections
+            .stream()
+            .filter(e -> e.getReferenceId().equalsIgnoreCase(accessElection.getReferenceId()))
+            .findFirst();
+        List<Vote> rpElectionVotes = rpElection
+            .map(election -> rpVotes
+            .stream()
+            .filter(ev -> ev.getElectionId().equals(election.getElectionId()))
+            .collect(Collectors.toList())).orElse(Collections.emptyList());
+        Optional<Match> matchOption = matchList.stream().filter(m -> m.getPurpose().equals(accessElection.getReferenceId())).findFirst(); 
+        Optional<DataAccessRequest> darOption = dataAccessRequests.stream()
+            .filter(Objects::nonNull)
+            .filter(d -> d.getReferenceId().equalsIgnoreCase(accessElection.getReferenceId()))
+            .findFirst();
+        DataAccessRequest dar = darOption.orElse(null);
+        List<Integer> dacUserIds = accessElectionVotes.stream().map(Vote::getDacUserId).distinct().collect(Collectors.toUnmodifiableList());
+        List<User> dacMembers = voteUsers.stream().filter(v -> dacUserIds.contains(v.getDacUserId())).collect(Collectors.toUnmodifiableList());
 
-                                if (Objects.nonNull(chairPersonVote)) {
-                                    summaryWriter.write(booleanToString(chairPersonVote.getVote()) + SEPARATOR);
-                                    summaryWriter.write(nullToString(chairPersonVote.getRationale()) + SEPARATOR);
-                                } else {
-                                    summaryWriter.write(nullToString(null) + SEPARATOR);
-                                    summaryWriter.write(nullToString(null) + SEPARATOR);
-                                }
-
-                                if (Objects.nonNull(chairPersonRPVote)) {
-                                    summaryWriter.write(booleanToString(chairPersonRPVote.getVote()) + SEPARATOR);
-                                    summaryWriter.write(nullToString(chairPersonRPVote.getRationale()) + SEPARATOR);
-                                } else {
-                                    summaryWriter.write(nullToString(null) + SEPARATOR);
-                                    summaryWriter.write(nullToString(null) + SEPARATOR);
-                                }
-
-                                if (Objects.nonNull(chairPersonConsentVote)) {
-                                    summaryWriter.write(booleanToString(chairPersonConsentVote.getVote()) + SEPARATOR);
-                                    summaryWriter.write(nullToString(chairPersonConsentVote.getRationale()) + SEPARATOR);
-                                } else {
-                                    summaryWriter.write(nullToString(null) + SEPARATOR);
-                                    summaryWriter.write(nullToString(null) + SEPARATOR);
-                                }
-                            }
-                        }
-                        summaryWriter.write(END_OF_LINE);
-                    }
-                }else file = null;
-                summaryWriter.flush();
-            }
-            return file;
-        } catch (Exception e) {
-            logger.error(e.getMessage());
+        if (Objects.nonNull(dar) && Objects.nonNull(dar.getData())) {
+          List<Integer> datasetId = dar.getData().getDatasetIds();
+          if (CollectionUtils.isNotEmpty(datasetId)) {
+            Optional<User> darUser = darUsers.stream().filter(u -> u.getDacUserId().equals(dar.getUserId())).findFirst();
+            details.add(new DataAccessRequestSummaryDetail(
+                dar,
+                accessElection,
+                accessElectionVotes,
+                rpElectionVotes,
+                consentVotes,
+                matchOption.orElse(null),
+                dacMembers,
+                darUser.orElse(null),
+                maxNumberOfDACMembers
+            ));
+          }
         }
-        return file;
+      }
     }
+    return details;
+  }
 
     public File describeDataSetElectionsVotesForDar(String referenceId) {
         File file = null;
@@ -465,34 +422,6 @@ public class SummaryService {
         summaryWriter.write(END_OF_LINE);
     }
 
-    private void setSummaryHeaderDataAccessRequest(FileWriter summaryWriter , Integer maxNumberOfDACMembers) throws IOException {
-        summaryWriter.write(
-                HeaderSummary.DATA_REQUEST_ID.getValue() + SEPARATOR +
-                        HeaderSummary.DATE.getValue() + SEPARATOR +
-                        HeaderSummary.CHAIRPERSON.getValue() + SEPARATOR +
-                        HeaderSummary.FINAL_DECISION.getValue() + SEPARATOR +
-                        HeaderSummary.FINAL_DECISION_RATIONALE.getValue() + SEPARATOR +
-                        HeaderSummary.VAULT_DECISION.getValue() + SEPARATOR +
-                        HeaderSummary.VAULT_VS_DAC_AGREEMENT.getValue() + SEPARATOR +
-                        HeaderSummary.CHAIRPERSON_FEEDBACK.getValue() + SEPARATOR +
-                        HeaderSummary.RESEARCHER.getValue() + SEPARATOR +
-                        HeaderSummary.PROJECT_TITLE.getValue() + SEPARATOR +
-                        HeaderSummary.DATASET_ID.getValue() + SEPARATOR +
-                        HeaderSummary.DATA_ACCESS_SUBM_DATE.getValue() + SEPARATOR);
-        for (int i = 1; i <= maxNumberOfDACMembers; i++) {
-            summaryWriter.write(
-                    HeaderSummary.DAC_MEMBERS.getValue() + SEPARATOR);
-        }
-        summaryWriter.write(
-                HeaderSummary.REQUIRE_MANUAL_REVIEW.getValue() + SEPARATOR +
-                        HeaderSummary.FINAL_DECISION_DAR.getValue() + SEPARATOR +
-                        HeaderSummary.FINAL_RATIONALE_DAR.getValue() + SEPARATOR +
-                        HeaderSummary.FINAL_DECISION_RP.getValue() + SEPARATOR +
-                        HeaderSummary.FINAL_RATIONALE_RP.getValue() + SEPARATOR +
-                        HeaderSummary.FINAL_DECISION_DUL.getValue() + SEPARATOR +
-                        HeaderSummary.FINAL_RATIONALE_DUL.getValue() + END_OF_LINE);
-    }
-
     public static <T> Collector<T, ?, T> singletonCollector() {
         return Collectors.collectingAndThen(
                 Collectors.toList(),
@@ -508,13 +437,6 @@ public class SummaryService {
         );
     }
 
-    private DataAccessRequest findAssociatedDAR(List<DataAccessRequest> dataAccessRequests, String referenceId) {
-        Optional<DataAccessRequest> darOption = dataAccessRequests.stream().
-                filter(d -> Objects.nonNull(d) ? d.getReferenceId().equalsIgnoreCase(referenceId) : false).
-                findFirst();
-        return darOption.orElse(null);
-    }
-
     private String booleanToString(Boolean b) {
         if(b != null) {
             return b ? "YES" : "NO";
@@ -525,7 +447,6 @@ public class SummaryService {
     private String nullToString(String b) {
         return b != null && !b.isEmpty()  ? b : "-";
     }
-
 
     public String formatLongToDate(long time) {
         Calendar cal = Calendar.getInstance();

--- a/src/main/java/org/broadinstitute/consent/http/service/SummaryService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/SummaryService.java
@@ -223,7 +223,7 @@ public class SummaryService {
     List<DataAccessRequestSummaryDetail> details = new ArrayList<>();
     List<Election> accessElections = electionDAO.findElectionsWithFinalVoteByTypeAndStatus(ElectionType.DATA_ACCESS.getValue(), ElectionStatus.CLOSED.getValue());
     List<Election> rpElections = electionDAO.findElectionsWithFinalVoteByTypeAndStatus(ElectionType.RP.getValue(), ElectionStatus.CLOSED.getValue());
-    if (!CollectionUtils.isEmpty(accessElections)) {
+    if (!accessElections.isEmpty()) {
       List<String> referenceIds = accessElections.stream().map(Election::getReferenceId).collect(Collectors.toList());
       List<DataAccessRequest> dataAccessRequests = referenceIds.isEmpty() ? Collections.emptyList() : dataAccessRequestService.getDataAccessRequestsByReferenceIds(referenceIds);
       List<Integer> datasetIds =

--- a/src/main/java/org/broadinstitute/consent/http/service/SummaryService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/SummaryService.java
@@ -245,10 +245,10 @@ public class SummaryService {
       List<Vote> rpVotes = rpElectionIds.isEmpty() ? Collections.emptyList() : voteDAO.findVotesByElectionIds(rpElectionIds);
       List<Vote> consentVotes = consentElectionIds.isEmpty() ? Collections.emptyList() : voteDAO.findVotesByElectionIds(consentElectionIds);
       List<Match> matchList = referenceIds.isEmpty() ? Collections.emptyList() : matchDAO.findMatchesForPurposeIds(referenceIds);
-      Collection<Integer> voteUserIds = accessVotes.stream().map(Vote::getDacUserId).collect(Collectors.toSet());
-      List<User> voteUsers = voteUserIds.isEmpty() ? Collections.emptyList() : userDAO.findUsers(voteUserIds).stream().collect(Collectors.toUnmodifiableList());
+      List<Integer> voteUserIds = accessVotes.stream().map(Vote::getDacUserId).distinct().collect(Collectors.toList());
+      List<User> voteUsers = voteUserIds.isEmpty() ? Collections.emptyList() : new ArrayList<>(userDAO.findUsers(voteUserIds));
       List<Integer> darUserIds = dataAccessRequests.stream().map(DataAccessRequest::getUserId).collect(Collectors.toList());
-      List<User> darUsers = darUserIds.isEmpty() ? Collections.emptyList() : userDAO.findUsers(darUserIds).stream().collect(Collectors.toUnmodifiableList());
+      List<User> darUsers = darUserIds.isEmpty() ? Collections.emptyList() : new ArrayList<>(userDAO.findUsers(darUserIds));
 
       // This represents the maximum possible number of DAC members across all elections. We need to
       // pre-calculate this so each row can know the correct max # of DAC members for header

--- a/src/main/java/org/broadinstitute/consent/http/service/SummaryService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/SummaryService.java
@@ -154,72 +154,64 @@ public class SummaryService {
     }
 
     public List<ConsentSummaryDetail> describeConsentSummaryDetail() {
-        List<ConsentSummaryDetail> details = new ArrayList<>();
-//        File file = null;
-        try {
-//            file = File.createTempFile("summary", ".txt");
-//            try (FileWriter summaryWriter = new FileWriter(file)) {
-//            try {
-                List<String> statuses = Stream.of(ElectionStatus.CLOSED.getValue(), ElectionStatus.CANCELED.getValue()).
-                        map(String::toLowerCase).
-                        collect(Collectors.toList());
-                List<Election> reviewedElections = electionDAO.findElectionsWithFinalVoteByTypeAndStatus(ElectionType.TRANSLATE_DUL.getValue(), statuses);
-                if (!CollectionUtils.isEmpty(reviewedElections)) {
-                    List<String> consentIds = reviewedElections.stream().map(Election::getReferenceId).collect(Collectors.toList());
-                    List<Integer> electionIds = reviewedElections.stream().map(Election::getElectionId).collect(Collectors.toList());
-                    Integer maxNumberOfDACMembers = voteDAO.findMaxNumberOfDACMembers(electionIds);
-//                    setSummaryHeader(summaryWriter, maxNumberOfDACMembers);
-                    Collection<Consent> consents = consentDAO.findConsentsFromConsentsIDs(consentIds);
-                    List<Vote> votes = voteDAO.findVotesByElectionIds(electionIds);
-                    Collection<Integer> dacUserIds = votes.stream().map(Vote::getDacUserId).collect(Collectors.toSet());
-                    Collection<User> users = userDAO.findUsers(dacUserIds);
-                    for (Election election : reviewedElections) {
-                        Consent electionConsent = consents.stream().filter(c -> c.getConsentId().equals(election.getReferenceId())).collect(singletonCollector());
-                        List<Vote> electionVotes = votes.stream().filter(ev -> ev.getElectionId().equals(election.getElectionId())).collect(Collectors.toList());
-                        List<Integer> electionVotesUserIds = electionVotes.stream().map(Vote::getDacUserId).collect(Collectors.toList());
-                        Collection<User> electionUsers = users.stream().filter(du -> electionVotesUserIds.contains(du.getDacUserId())).collect(Collectors.toSet());
-//                        List<Vote> electionDACVotes = electionVotes.stream().filter(ev -> ev.getType().equals("DAC")).collect(Collectors.toList());
-                        Vote chairPersonVote =  electionVotes.stream().filter(ev -> ev.getType().equals(CHAIRPERSON)).collect(singletonCollector());
-                        User chairPerson =  users.stream().filter(du -> du.getDacUserId().equals(chairPersonVote.getDacUserId())).collect(singletonCollector());
-                        details.add(new ConsentSummaryDetail(
-                          election,
-                          electionConsent,
-                          electionVotes,
-                          electionUsers,
-                          chairPersonVote,
-                          chairPerson,
-                          maxNumberOfDACMembers
-                        ));
-//                        summaryWriter.write(delimiterCheck(electionConsent.getName()) + SEPARATOR);
-//                        summaryWriter.write(election.getVersion() + SEPARATOR);
-//                        summaryWriter.write(election.getStatus() + SEPARATOR);
-//                        summaryWriter.write(booleanToString(election.getArchived()) + SEPARATOR);
-//                        summaryWriter.write(delimiterCheck(electionConsent.getTranslatedUseRestriction())+ SEPARATOR);
-//                        summaryWriter.write(formatLongToDate(electionConsent.getCreateDate().getTime()) + SEPARATOR);
-//                        summaryWriter.write( chairPerson.getDisplayName() + SEPARATOR);
-//                        summaryWriter.write( booleanToString(chairPersonVote.getVote()) + SEPARATOR);
-//                        summaryWriter.write( nullToString(chairPersonVote.getRationale()) + SEPARATOR);
-//                        if (CollectionUtils.isNotEmpty(electionDACVotes)) {
-//                            for (Vote vote : electionDACVotes) {
-//                                List<User> user = electionUsers.stream().filter(du -> du.getDacUserId().equals(vote.getDacUserId())).collect(Collectors.toList());
-//                                summaryWriter.write( user.get(0).getDisplayName() + SEPARATOR);
-//                                summaryWriter.write( booleanToString(vote.getVote()) + SEPARATOR);
-//                                summaryWriter.write( nullToString(vote.getRationale())+ SEPARATOR);
-//                            }
-//                            for (int i = 0; i < (maxNumberOfDACMembers - electionVotes.size()); i++) {
-//                                summaryWriter.write(
-//                                        SEPARATOR);
-//                            }
-//                        }
-//                        summaryWriter.write(END_OF_LINE);
-                    }
-                } //else file = null;
-//                summaryWriter.flush();
-//            }
-        } catch (Exception e) {
-            logger.error("There is an error trying to create statistics file, error: "+ e.getMessage());
+      List<ConsentSummaryDetail> details = new ArrayList<>();
+      try {
+        List<String> statuses =
+            Stream.of(ElectionStatus.CLOSED.getValue(), ElectionStatus.CANCELED.getValue())
+                .map(String::toLowerCase)
+                .collect(Collectors.toList());
+        List<Election> reviewedElections =
+            electionDAO.findElectionsWithFinalVoteByTypeAndStatus(
+                ElectionType.TRANSLATE_DUL.getValue(), statuses);
+        if (!CollectionUtils.isEmpty(reviewedElections)) {
+          List<String> consentIds =
+              reviewedElections.stream().map(Election::getReferenceId).collect(Collectors.toList());
+          List<Integer> electionIds =
+              reviewedElections.stream().map(Election::getElectionId).collect(Collectors.toList());
+          Integer maxNumberOfDACMembers = voteDAO.findMaxNumberOfDACMembers(electionIds);
+          Collection<Consent> consents = consentDAO.findConsentsFromConsentsIDs(consentIds);
+          List<Vote> votes = voteDAO.findVotesByElectionIds(electionIds);
+          Collection<Integer> dacUserIds =
+              votes.stream().map(Vote::getDacUserId).collect(Collectors.toSet());
+          Collection<User> users = userDAO.findUsers(dacUserIds);
+          for (Election election : reviewedElections) {
+            Consent electionConsent =
+                consents.stream()
+                    .filter(c -> c.getConsentId().equals(election.getReferenceId()))
+                    .collect(singletonCollector());
+            List<Vote> electionVotes =
+                votes.stream()
+                    .filter(ev -> ev.getElectionId().equals(election.getElectionId()))
+                    .collect(Collectors.toList());
+            List<Integer> electionVotesUserIds =
+                electionVotes.stream().map(Vote::getDacUserId).collect(Collectors.toList());
+            Collection<User> electionUsers =
+                users.stream()
+                    .filter(du -> electionVotesUserIds.contains(du.getDacUserId()))
+                    .collect(Collectors.toSet());
+            Vote chairPersonVote =
+                electionVotes.stream()
+                    .filter(ev -> ev.getType().equals(CHAIRPERSON))
+                    .collect(singletonCollector());
+            User chairPerson =
+                users.stream()
+                    .filter(du -> du.getDacUserId().equals(chairPersonVote.getDacUserId()))
+                    .collect(singletonCollector());
+            details.add(
+                new ConsentSummaryDetail(
+                    election,
+                    electionConsent,
+                    electionVotes,
+                    electionUsers,
+                    chairPersonVote,
+                    chairPerson,
+                    maxNumberOfDACMembers));
+          }
         }
-        return details;
+      } catch (Exception e) {
+        logger.error("There is an error trying to create statistics file, error: " + e.getMessage());
+      }
+      return details;
     }
 
   /**
@@ -398,29 +390,6 @@ public class SummaryService {
         }
     }
 
-    private void setSummaryHeader(FileWriter summaryWriter , Integer maxNumberOfDACMembers) throws IOException {
-        summaryWriter.write(
-                HeaderSummary.CONSENT.getValue() + SEPARATOR +
-                        HeaderSummary.VERSION.getValue() + SEPARATOR +
-                        HeaderSummary.STATUS.getValue() + SEPARATOR +
-                        HeaderSummary.ARCHIVED.getValue() + SEPARATOR +
-                        HeaderSummary.STRUCT_LIMITATIONS.getValue() + SEPARATOR +
-                        HeaderSummary.DATE.getValue() + SEPARATOR +
-                        HeaderSummary.CHAIRPERSON.getValue() + SEPARATOR +
-                        HeaderSummary.FINAL_DECISION.getValue() + SEPARATOR +
-                        HeaderSummary.FINAL_DECISION_RATIONALE.getValue() + SEPARATOR);
-        for (int i = 1; i < maxNumberOfDACMembers; i++) {
-            summaryWriter.write(
-                    HeaderSummary.USER.getValue() + SEPARATOR +
-                    HeaderSummary.VOTE.getValue() + SEPARATOR +
-                    HeaderSummary.RATIONALE.getValue() + SEPARATOR);
-        }
-        summaryWriter.write(
-                HeaderSummary.USER.getValue() + SEPARATOR +
-                HeaderSummary.VOTE.getValue() + SEPARATOR +
-                HeaderSummary.RATIONALE.getValue()+ END_OF_LINE);
-    }
-
     private void setDatasetElectionsHeader(FileWriter summaryWriter , Integer maxNumberOfVotes) throws IOException {
         summaryWriter.write(
                 HeaderSummary.DATA_REQUEST_ID.getValue() + SEPARATOR +
@@ -451,17 +420,6 @@ public class SummaryService {
                     return list.get(0);
                 }
         );
-    }
-
-    private String booleanToString(Boolean b) {
-        if(b != null) {
-            return b ? "YES" : "NO";
-        }
-        return "-";
-    }
-
-    private String nullToString(String b) {
-        return b != null && !b.isEmpty()  ? b : "-";
     }
 
     public String formatLongToDate(long time) {

--- a/src/main/java/org/broadinstitute/consent/http/service/SummaryService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/SummaryService.java
@@ -153,6 +153,11 @@ public class SummaryService {
         return summary;
     }
 
+    /**
+     * Generate a list of Summary Details for all reviewed Consent elections.
+     *
+     * @return List<ConsentSummaryDetail>
+     */
     public List<ConsentSummaryDetail> describeConsentSummaryDetail() {
       List<ConsentSummaryDetail> details = new ArrayList<>();
       try {

--- a/src/main/java/org/broadinstitute/consent/http/service/SummaryService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/SummaryService.java
@@ -161,9 +161,7 @@ public class SummaryService {
             Stream.of(ElectionStatus.CLOSED.getValue(), ElectionStatus.CANCELED.getValue())
                 .map(String::toLowerCase)
                 .collect(Collectors.toList());
-        List<Election> reviewedElections =
-            electionDAO.findElectionsWithFinalVoteByTypeAndStatus(
-                ElectionType.TRANSLATE_DUL.getValue(), statuses);
+        List<Election> reviewedElections = electionDAO.findElectionsWithFinalVoteByTypeAndStatus(ElectionType.TRANSLATE_DUL.getValue(), statuses).stream().distinct().collect(Collectors.toUnmodifiableList());
         if (!CollectionUtils.isEmpty(reviewedElections)) {
           List<String> consentIds =
               reviewedElections.stream().map(Election::getReferenceId).collect(Collectors.toList());
@@ -225,8 +223,8 @@ public class SummaryService {
    */
   public List<DataAccessRequestSummaryDetail> listDataAccessRequestSummaryDetails() {
     List<DataAccessRequestSummaryDetail> details = new ArrayList<>();
-    List<Election> accessElections = electionDAO.findElectionsWithFinalVoteByTypeAndStatus(ElectionType.DATA_ACCESS.getValue(), ElectionStatus.CLOSED.getValue());
-    List<Election> rpElections = electionDAO.findElectionsWithFinalVoteByTypeAndStatus(ElectionType.RP.getValue(), ElectionStatus.CLOSED.getValue());
+    List<Election> accessElections = electionDAO.findElectionsWithFinalVoteByTypeAndStatus(ElectionType.DATA_ACCESS.getValue(), ElectionStatus.CLOSED.getValue()).stream().distinct().collect(Collectors.toUnmodifiableList());
+    List<Election> rpElections = electionDAO.findElectionsWithFinalVoteByTypeAndStatus(ElectionType.RP.getValue(), ElectionStatus.CLOSED.getValue()).stream().distinct().collect(Collectors.toUnmodifiableList());
     if (!accessElections.isEmpty()) {
       List<String> referenceIds = accessElections.stream().map(Election::getReferenceId).collect(Collectors.toList());
       List<DataAccessRequest> dataAccessRequests = referenceIds.isEmpty() ? Collections.emptyList() : dataAccessRequestService.getDataAccessRequestsByReferenceIds(referenceIds);

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -255,25 +255,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Summary'
   /api/consent/cases/summary/file:
-      get:
-        summary: Get Consent Summary Detail File
-        description: Returns a file with the detail of the reviewed cases whose type will be specified by fileType param.
-        parameters:
-         - name: fileType
-           in: query
-           description: DataAccess / TranslateDUL , defines the type of the reviewed cases info required.
-           required: true
-           schema:
-             type: string
-        tags:
-          - Summary File
-        responses:
-          200:
-            description: Export data to a txt file.
-            content:
-              text/plain:
-                schema:
-                  type: string
+    $ref: './paths/consentCasesSummaryFile.yaml'
   /api/consent/cases/closed:
     get:
       summary: Describe Closed Elections

--- a/src/main/resources/assets/paths/consentCasesSummaryFile.yaml
+++ b/src/main/resources/assets/paths/consentCasesSummaryFile.yaml
@@ -1,18 +1,22 @@
 get:
-  summary: Get Consent Summary Details
-  description: Returns the details of the reviewed cases whose type will be specified by fileType param.
+  summary: Get Data Access Request or Consent Election Summary Details
+  description: | 
+    Returns the details of the reviewed cases by type 
+      * `DataAccess` (default option when none specified) returns Data Access Request Election details
+      * `TranslateDUL` returns Consent Election details
   tags:
-    - Summary File
+    - Summary
   parameters:
-    - name: fileType
+    - name: type
       in: query
-      description: DataAccess / TranslateDUL , defines the type of the reviewed cases info required.
+      description: |
+        `DataAccess` (default option) or `TranslateDUL` define the type of the reviewed cases returned
       schema:
-        type: String
+        type: string
         enum: [DataAccess, TranslateDUL]
   responses:
     200:
-      description: Export data to a txt file.
+      description: Summary data as plain text
       content:
         text/plain:
           schema:

--- a/src/main/resources/assets/paths/consentCasesSummaryFile.yaml
+++ b/src/main/resources/assets/paths/consentCasesSummaryFile.yaml
@@ -1,0 +1,19 @@
+get:
+  summary: Get Consent Summary Details
+  description: Returns the details of the reviewed cases whose type will be specified by fileType param.
+  tags:
+    - Summary File
+  parameters:
+    - name: fileType
+      in: query
+      description: DataAccess / TranslateDUL , defines the type of the reviewed cases info required.
+      schema:
+        type: String
+        enum: [DataAccess, TranslateDUL]
+  responses:
+    200:
+      description: Export data to a txt file.
+      content:
+        text/plain:
+          schema:
+            type: string

--- a/src/test/java/org/broadinstitute/consent/http/resources/ConsentCasesResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/ConsentCasesResourceTest.java
@@ -1,9 +1,11 @@
 package org.broadinstitute.consent.http.resources;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.notNull;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.notNull;
 import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.openMocks;
+
 import java.io.File;
 import java.util.Collections;
 import java.util.List;
@@ -18,7 +20,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 
 public class ConsentCasesResourceTest {
 
@@ -35,7 +36,7 @@ public class ConsentCasesResourceTest {
 
     @Before
     public void setUp() {
-        MockitoAnnotations.initMocks(this);
+        openMocks(this);
     }
 
     @Test
@@ -78,16 +79,6 @@ public class ConsentCasesResourceTest {
         Assert.assertNotNull(summaryFile);
     }
 
-    @Test
-    public void testGetConsentSummaryDetailFileDataAccess() throws Exception {
-        File file = File.createTempFile("temp", ".txt");
-        when(summaryService.describeDataAccessRequestSummaryDetail()).thenReturn(file);
-        initResource();
-        Response response = resource.getConsentSummaryDetailFile(ElectionType.DATA_ACCESS.getValue(), null);
-        Assert.assertEquals(200, response.getStatus());
-        Object summaryFile = response.getEntity();
-        Assert.assertNotNull(summaryFile);
-    }
     @Test
     public void testDescribeClosedElections() {
         when(electionService.describeClosedElectionsByType(anyString(), notNull())).thenReturn(Collections.emptyList());

--- a/src/test/java/org/broadinstitute/consent/http/resources/ConsentCasesResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/ConsentCasesResourceTest.java
@@ -1,5 +1,7 @@
 package org.broadinstitute.consent.http.resources;
 
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.notNull;
@@ -7,11 +9,13 @@ import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import javax.ws.rs.core.Response;
 import org.broadinstitute.consent.http.enumeration.ElectionType;
+import org.broadinstitute.consent.http.models.DataAccessRequestSummaryDetail;
 import org.broadinstitute.consent.http.models.Summary;
 import org.broadinstitute.consent.http.service.ElectionService;
 import org.broadinstitute.consent.http.service.PendingCaseService;
@@ -56,7 +60,7 @@ public class ConsentCasesResourceTest {
         Response response = resource.getConsentSummaryCases(null);
         Assert.assertEquals(200, response.getStatus());
         Object summary = response.getEntity();
-        Assert.assertNotNull(summary);
+        assertNotNull(summary);
     }
 
     @Test
@@ -76,7 +80,18 @@ public class ConsentCasesResourceTest {
         Response response = resource.getConsentSummaryDetailFile(ElectionType.TRANSLATE_DUL.getValue(), null);
         Assert.assertEquals(200, response.getStatus());
         Object summaryFile = response.getEntity();
-        Assert.assertNotNull(summaryFile);
+        assertNotNull(summaryFile);
+    }
+
+    @Test
+    public void testGetConsentSummaryDetailFileDataAccess() throws Exception {
+        List<DataAccessRequestSummaryDetail> details = Collections.emptyList();
+        when(summaryService.listDataAccessRequestSummaryDetails()).thenReturn(details);
+        initResource();
+        Response response = resource.getConsentSummaryDetailFile(ElectionType.DATA_ACCESS.getValue(), null);
+        Assert.assertEquals(200, response.getStatus());
+        Object summaryDetails = response.getEntity();
+        assertNull(summaryDetails);
     }
 
     @Test

--- a/src/test/java/org/broadinstitute/consent/http/resources/ConsentCasesResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/ConsentCasesResourceTest.java
@@ -9,7 +9,6 @@ import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.io.File;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
@@ -84,11 +83,22 @@ public class ConsentCasesResourceTest {
     }
 
     @Test
-    public void testGetConsentSummaryDetailFileDataAccess() throws Exception {
+    public void testGetConsentSummaryDetailFileDataAccess() {
         List<DataAccessRequestSummaryDetail> details = Collections.emptyList();
         when(summaryService.listDataAccessRequestSummaryDetails()).thenReturn(details);
         initResource();
         Response response = resource.getConsentSummaryDetailFile(ElectionType.DATA_ACCESS.getValue(), null);
+        Assert.assertEquals(200, response.getStatus());
+        Object summaryDetails = response.getEntity();
+        assertNull(summaryDetails);
+    }
+
+    @Test
+    public void testGetConsentSummaryDetailFileNoSelection() {
+        List<DataAccessRequestSummaryDetail> details = Collections.emptyList();
+        when(summaryService.listDataAccessRequestSummaryDetails()).thenReturn(details);
+        initResource();
+        Response response = resource.getConsentSummaryDetailFile(null, null);
         Assert.assertEquals(200, response.getStatus());
         Object summaryDetails = response.getEntity();
         assertNull(summaryDetails);

--- a/src/test/java/org/broadinstitute/consent/http/resources/ConsentCasesResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/ConsentCasesResourceTest.java
@@ -9,11 +9,13 @@ import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import javax.ws.rs.core.Response;
 import org.broadinstitute.consent.http.enumeration.ElectionType;
+import org.broadinstitute.consent.http.models.ConsentSummaryDetail;
 import org.broadinstitute.consent.http.models.DataAccessRequestSummaryDetail;
 import org.broadinstitute.consent.http.models.Summary;
 import org.broadinstitute.consent.http.service.ElectionService;
@@ -72,14 +74,14 @@ public class ConsentCasesResourceTest {
     }
 
     @Test
-    public void testGetConsentSummaryDetailFileDUL() throws Exception {
-        File file = File.createTempFile("temp", ".txt");
-        when(summaryService.describeConsentSummaryDetail()).thenReturn(file);
+    public void testGetConsentSummaryDetailFileDUL() {
+        List<ConsentSummaryDetail> details = Collections.emptyList();
+        when(summaryService.describeConsentSummaryDetail()).thenReturn(details);
         initResource();
         Response response = resource.getConsentSummaryDetailFile(ElectionType.TRANSLATE_DUL.getValue(), null);
         Assert.assertEquals(200, response.getStatus());
-        Object summaryFile = response.getEntity();
-        assertNotNull(summaryFile);
+        Object summaryDetails = response.getEntity();
+        assertNull(summaryDetails);
     }
 
     @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/SummaryServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/SummaryServiceTest.java
@@ -1,8 +1,6 @@
 package org.broadinstitute.consent.http.service;
 
-import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.anyList;
@@ -11,18 +9,13 @@ import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.sql.Timestamp;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Calendar;
 import java.util.Date;
-import java.util.GregorianCalendar;
 import java.util.List;
-import java.util.Objects;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import org.apache.commons.collections.ListUtils;
 import org.apache.commons.lang3.RandomUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.consent.http.db.ConsentDAO;
 import org.broadinstitute.consent.http.db.DatasetDAO;
 import org.broadinstitute.consent.http.db.ElectionDAO;
@@ -239,6 +232,9 @@ public class SummaryServiceTest {
         e.setElectionId(type.ordinal());
         e.setCreateDate(new Date());
         e.setLastUpdate(new Date());
+        e.setFinalVote(true);
+        e.setFinalVoteDate(new Date());
+        e.setFinalAccessVote(true);
         return e;
     }
 

--- a/src/test/java/org/broadinstitute/consent/http/service/SummaryServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/SummaryServiceTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.notNull;
 import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -30,7 +31,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
 
 public class SummaryServiceTest {
 
@@ -53,7 +53,7 @@ public class SummaryServiceTest {
 
     @Before
     public void setUp() throws Exception {
-        MockitoAnnotations.initMocks(this);
+        openMocks(this);
         summaryService = Mockito.spy(new SummaryService(dataAccessRequestService, voteDAO, electionDAO, userDAO, consentDAO, dataSetDAO, matchDAO));
     }
 

--- a/src/test/java/org/broadinstitute/consent/http/service/SummaryServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/SummaryServiceTest.java
@@ -180,39 +180,6 @@ public class SummaryServiceTest {
         assertTrue("The list for closed negative cases should be three: ", matchSummaryList.get(1).getReviewedNegativeCases().equals(3));
     }
 
-    @Test(expected = IllegalStateException.class )
-    public void testSingletonCollectorException() throws Exception {
-        List<String> strings = Arrays.asList("One item", "Another item");
-        strings.stream().filter(s -> s.length() > 0).collect(SummaryService.singletonCollector());
-    }
-
-    @Test
-    public void testSingletonCollector() throws Exception {
-        List<String> strings = Arrays.asList("One item");
-        String string = strings.stream().filter(s -> s.length() > 0).collect(SummaryService.singletonCollector());
-        assertTrue("The returned element equals the only element in the list ", string.equals("One item"));
-
-        strings = new ArrayList<>();
-        string = strings.stream().filter(s -> s.length() > 0).collect(SummaryService.singletonCollector());
-        assertTrue("There are no elements, so the returned string should be null ", Objects.isNull(string));
-    }
-
-    @Test
-    public void testFormatTimeToDate() throws Exception {
-        Calendar myCalendar = new GregorianCalendar(2016, 2, 11);
-        String getAsString = summaryService.formatLongToDate(myCalendar.getTimeInMillis());
-        assertTrue(getAsString + " is the same date string for March 3, 2016 ", getAsString.equals("3/11/2016"));
-    }
-
-    @Test
-    public void testDelimiterCheck(){
-        String testString = "\"Samples\" Restricted for use with \"cancer\" [DOID_162(CC)]\bFuture use \"\"\\\" for methods" +
-                " research (analytic/software/technology development) is prohibited [NMDS]\bNotes:\bFuture use as a" +
-                " control set for\"' diseases other\' than\" those specified is not prohibited\n\"";
-        int count = StringUtils.countMatches(summaryService.delimiterCheck(testString), "\"");
-        assertThat(count, is(2));
-    }
-
     /** Private methods for mocking **/
 
     private List<Election> electionsList(String electionType, String status){

--- a/src/test/java/org/broadinstitute/consent/http/service/SummaryServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/SummaryServiceTest.java
@@ -24,6 +24,7 @@ import org.broadinstitute.consent.http.db.UserDAO;
 import org.broadinstitute.consent.http.db.VoteDAO;
 import org.broadinstitute.consent.http.enumeration.ElectionType;
 import org.broadinstitute.consent.http.enumeration.VoteType;
+import org.broadinstitute.consent.http.models.DataAccessRequestSummaryDetail;
 import org.broadinstitute.consent.http.models.Election;
 import org.broadinstitute.consent.http.models.Summary;
 import org.broadinstitute.consent.http.models.Vote;
@@ -55,6 +56,17 @@ public class SummaryServiceTest {
     public void setUp() throws Exception {
         openMocks(this);
         summaryService = Mockito.spy(new SummaryService(dataAccessRequestService, voteDAO, electionDAO, userDAO, consentDAO, dataSetDAO, matchDAO));
+    }
+    
+    private void initService() {
+        summaryService = new SummaryService(dataAccessRequestService, voteDAO, electionDAO, userDAO, consentDAO, dataSetDAO, matchDAO);
+    }
+    
+    @Test
+    public void testListDataAccessRequestSummaryDetails() {
+        initService();
+        List<DataAccessRequestSummaryDetail> details = summaryService.listDataAccessRequestSummaryDetails();
+        assertTrue(details.isEmpty());
     }
 
     // In this tests we won't validate the resulting file, we will just validate the methods being called for each response given by the mocks is accurate.

--- a/src/test/java/org/broadinstitute/consent/http/service/SummaryServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/SummaryServiceTest.java
@@ -1,12 +1,16 @@
 package org.broadinstitute.consent.http.service;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.notNull;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.openMocks;
 
+import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
@@ -14,7 +18,10 @@ import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.List;
 import java.util.Objects;
+import java.util.UUID;
+import java.util.stream.Collectors;
 import org.apache.commons.collections.ListUtils;
+import org.apache.commons.lang3.RandomUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.consent.http.db.ConsentDAO;
 import org.broadinstitute.consent.http.db.DatasetDAO;
@@ -22,11 +29,18 @@ import org.broadinstitute.consent.http.db.ElectionDAO;
 import org.broadinstitute.consent.http.db.MatchDAO;
 import org.broadinstitute.consent.http.db.UserDAO;
 import org.broadinstitute.consent.http.db.VoteDAO;
+import org.broadinstitute.consent.http.enumeration.AssociationType;
+import org.broadinstitute.consent.http.enumeration.ElectionStatus;
 import org.broadinstitute.consent.http.enumeration.ElectionType;
 import org.broadinstitute.consent.http.enumeration.VoteType;
+import org.broadinstitute.consent.http.models.Association;
+import org.broadinstitute.consent.http.models.DataAccessRequest;
+import org.broadinstitute.consent.http.models.DataAccessRequestData;
 import org.broadinstitute.consent.http.models.DataAccessRequestSummaryDetail;
 import org.broadinstitute.consent.http.models.Election;
+import org.broadinstitute.consent.http.models.Match;
 import org.broadinstitute.consent.http.models.Summary;
+import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.Vote;
 import org.junit.Before;
 import org.junit.Test;
@@ -44,7 +58,7 @@ public class SummaryServiceTest {
     @Mock
     private ConsentDAO consentDAO;
     @Mock
-    private DatasetDAO dataSetDAO;
+    private DatasetDAO datasetDAO;
     @Mock
     private MatchDAO matchDAO;
     @Mock
@@ -55,18 +69,73 @@ public class SummaryServiceTest {
     @Before
     public void setUp() throws Exception {
         openMocks(this);
-        summaryService = Mockito.spy(new SummaryService(dataAccessRequestService, voteDAO, electionDAO, userDAO, consentDAO, dataSetDAO, matchDAO));
+        summaryService = Mockito.spy(new SummaryService(dataAccessRequestService, voteDAO, electionDAO, userDAO, consentDAO,
+            datasetDAO, matchDAO));
     }
     
     private void initService() {
-        summaryService = new SummaryService(dataAccessRequestService, voteDAO, electionDAO, userDAO, consentDAO, dataSetDAO, matchDAO);
+        summaryService = new SummaryService(dataAccessRequestService, voteDAO, electionDAO, userDAO, consentDAO,
+            datasetDAO, matchDAO);
     }
     
+    // Test that empty data will not throw errors
     @Test
-    public void testListDataAccessRequestSummaryDetails() {
+    public void testListDataAccessRequestSummaryDetails_case1() {
         initService();
         List<DataAccessRequestSummaryDetail> details = summaryService.listDataAccessRequestSummaryDetails();
         assertTrue(details.isEmpty());
+    }
+
+    // Test that minimal data will produce minimal results.
+    // This unfortunately requires quite a bit of setup.
+    @Test
+    public void testListDataAccessRequestSummaryDetails_case2() {
+        User voteUser = new User();
+        voteUser.setDacUserId(5);
+        voteUser.setDisplayName("Vote User Name");
+        User darUser = new User();
+        darUser.setDacUserId(10);
+        darUser.setDisplayName("DAR User Name");
+        List<Election> accessElections = List.of(createElection(ElectionType.DATA_ACCESS.getValue()));
+        List<Election> rpElections = List.of(createElectionWithReferenceId(ElectionType.RP.getValue(), accessElections.get(0).getReferenceId()));
+        List<Election> consentElections = List.of(createElection(ElectionType.TRANSLATE_DUL.getValue()));
+        List<Integer> accessElectionIds = accessElections.stream().map(Election::getElectionId).collect(Collectors.toList());
+        List<Integer> rpElectionIds = rpElections.stream().map(Election::getElectionId).collect(Collectors.toList());
+        List<Integer> consentElectionIds = consentElections.stream().map(Election::getElectionId).collect(Collectors.toList());
+        List<DataAccessRequest> dars = List.of(createDAR(accessElections.get(0).getReferenceId(), darUser.getDacUserId()));
+        List<Association> associations = List.of(createAssociation(dars.get(0).getData().getDatasetIds().get(0), consentElections.get(0).getReferenceId()));
+        List<String> associatedConsentIds = List.of(consentElections.get(0).getReferenceId());
+        List<Vote> accessVotes = createVotes(accessElections.get(0).getElectionId(), voteUser.getDacUserId());
+        List<Vote> rpVotes = createVotes(rpElections.get(0).getElectionId(), voteUser.getDacUserId());
+        List<Vote> consentVotes = createVotes(consentElections.get(0).getElectionId(), voteUser.getDacUserId());
+        List<Match> matchList = List.of(createMatch(associatedConsentIds.get(0), dars.get(0).getReferenceId()));
+        List<String> referenceIds = List.of(accessElections.get(0).getReferenceId());
+        List<Integer> datasetIds = dars.get(0).getData().getDatasetIds();
+
+        when(electionDAO.findElectionsWithFinalVoteByTypeAndStatus(ElectionType.DATA_ACCESS.getValue(), ElectionStatus.CLOSED.getValue())).thenReturn(accessElections);
+        when(electionDAO.findElectionsWithFinalVoteByTypeAndStatus(ElectionType.RP.getValue(), ElectionStatus.CLOSED.getValue())).thenReturn(rpElections);
+        when(dataAccessRequestService.getDataAccessRequestsByReferenceIds(anyList())).thenReturn(dars);
+        when(datasetDAO.getAssociationsForDataSetIdList(datasetIds)).thenReturn(associations);
+        when(electionDAO.findLastElectionsWithFinalVoteByReferenceIdsTypeAndStatus(associatedConsentIds, ElectionStatus.CLOSED.getValue())).thenReturn(consentElections);
+        when(voteDAO.findVotesByElectionIds(accessElectionIds)).thenReturn(accessVotes);
+        when(voteDAO.findVotesByElectionIds(rpElectionIds)).thenReturn(rpVotes);
+        when(voteDAO.findVotesByElectionIds(consentElectionIds)).thenReturn(consentVotes);
+        when(matchDAO.findMatchesForPurposeIds(referenceIds)).thenReturn(matchList);
+        when(userDAO.findUsers(List.of(voteUser.getDacUserId()))).thenReturn(List.of(voteUser));
+        when(userDAO.findUsers(List.of(darUser.getDacUserId()))).thenReturn(List.of(darUser));
+
+        initService();
+        List<DataAccessRequestSummaryDetail> details = summaryService.listDataAccessRequestSummaryDetails();
+        assertFalse(details.isEmpty());
+        // Should be able to print without errors.
+        try {
+            String headers = details.get(0).headers();
+            assertFalse(headers.isBlank());
+            String val = details.get(0).toString();
+            assertFalse(val.isBlank());
+        } catch (Exception e) {
+            fail(e.getMessage());
+        }
     }
 
     // In this tests we won't validate the resulting file, we will just validate the methods being called for each response given by the mocks is accurate.
@@ -162,6 +231,68 @@ public class SummaryServiceTest {
         Vote v5 = new Vote(5, true, dacUserId, new Date(), new Date(), 5, "", voteType, false, false);
         Vote nul = new Vote(6, null, dacUserId, new Date(), new Date(), 6, "", voteType, false, false);
         return Arrays.asList(v1, v2, v3, v4, v5, nul);
+    }
+
+    private Match createMatch(String consentId, String referenceId) {
+        Match m = new Match();
+        m.setConsent(consentId);
+        m.setPurpose(referenceId);
+        m.setMatch(true);
+        return m;
+    }
+    
+    private Association createAssociation(Integer datasetId, String consentId) {
+        Association a = new Association();
+        a.setAssociationId(RandomUtils.nextInt(1, 100));
+        a.setAssociationType(AssociationType.SAMPLE_SET.getValue());
+        a.setDataSetId(datasetId);
+        a.setConsentId(consentId);
+        return a;
+    }
+
+    private DataAccessRequest createDAR(String referenceId, Integer userId) {
+        DataAccessRequestData data = new DataAccessRequestData();
+        data.setDatasetIds(List.of(1));
+        data.setReferenceId(referenceId);
+        data.setDarCode("DAR-" + RandomUtils.nextInt(100, 200));
+        data.setProjectTitle("Project-TEST");
+        DataAccessRequest dar = new DataAccessRequest();
+        dar.setReferenceId(referenceId);
+        dar.setUserId(userId);
+        dar.setData(data);
+        dar.setSortDate(new Timestamp(new Date().getTime()));
+        return dar;
+    }
+
+    private Election createElection(String electionType) {
+        ElectionType type = ElectionType.getFromValue(electionType);
+        Election e = new Election();
+        e.setReferenceId(UUID.randomUUID().toString());
+        e.setElectionType(type.getValue());
+        e.setElectionId(type.ordinal());
+        e.setCreateDate(new Date());
+        e.setLastUpdate(new Date());
+        return e;
+    }
+
+    private Election createElectionWithReferenceId(String electionType, String referenceId) {
+        Election e = createElection(electionType);
+        e.setReferenceId(referenceId);
+        return e;
+    }
+    
+    private List<Vote> createVotes(Integer electionId, Integer userId) {
+        return Arrays.stream(VoteType.values()).map(t -> {
+                Vote v = new Vote();
+                v.setVote(true);
+                v.setType(t.getValue());
+                v.setElectionId(electionId);
+                v.setCreateDate(new Date());
+                v.setUpdateDate(new Date());
+                v.setDacUserId(userId);
+                return v;
+            }
+        ).collect(Collectors.toUnmodifiableList());
     }
 
 }


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-511
See also: https://github.com/DataBiosphere/duos-ui/pull/1365

Discovered an underlying bug in the election dao that returns duplicate election rows: https://broadworkbench.atlassian.net/browse/DUOS-1526

## Changes
* Extract `DataAccessRequestSummaryDetail` and `ConsentSummaryDetail` into value objects for easier construction and printing
* Handle the case of `N` DAC members flexibly
* Minor updates to api docs
* Updated tests
* Updated the resource class with a default selection and simplification

Before this update, dev returned only a small fraction of DARs and 0 Consents. After this update, all reviewed DARs and consent summaries are returned. We add extra columns for additional DAC Members when it is necessary. All rows need to know the max number of DAC Members so they can write out the correct number of columns. This was not handled correctly in the original code, but is in this version. This PR also fixes a number of missing `Agreement` votes. We don't need to look at the actual database value of votes of `Agreement` type, we can simply compare the match value to the chairperson final vote value to determine agreement.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
