### PR TITLE
DUOS-1524[risk=no] Consolidate get/set calls for Election.lastUpdate

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/models/DarDecisionMetrics.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DarDecisionMetrics.java
@@ -6,7 +6,6 @@ import java.time.Duration;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.Objects;
-import org.apache.commons.collections4.CollectionUtils;
 
 /**
  * Generate a row of dar decision data in the form of:
@@ -163,7 +162,7 @@ public class DarDecisionMetrics implements DecisionMetrics {
       if (Objects.nonNull(election.getFinalVoteDate())) {
         this.dateApproved = election.getFinalVoteDate();
       } else {
-        this.dateApproved = election.getLastUpdateDate();
+        this.dateApproved = election.getLastUpdate();
       }
     }
   }
@@ -184,7 +183,7 @@ public class DarDecisionMetrics implements DecisionMetrics {
       if (Objects.nonNull(election.getFinalVoteDate())) {
         this.dateDenied = election.getFinalVoteDate();
       } else {
-        this.dateDenied = election.getLastUpdateDate();
+        this.dateDenied = election.getLastUpdate();
       }
     }
   }
@@ -205,7 +204,7 @@ public class DarDecisionMetrics implements DecisionMetrics {
       Date finalVoteDate =
         Objects.nonNull(election.getFinalVoteDate())
           ? election.getFinalVoteDate()
-          : election.getLastUpdateDate();
+          : election.getLastUpdate();
       if (Objects.nonNull(finalVoteDate)) {
         Calendar submittedDate = Calendar.getInstance();
         Calendar finalDate = Calendar.getInstance();

--- a/src/main/java/org/broadinstitute/consent/http/models/Election.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/Election.java
@@ -128,14 +128,6 @@ public class Election {
         this.status = status;
     }
 
-    public Date getLastUpdateDate() {
-        return lastUpdate;
-    }
-
-    public void setLastUpdateDate(Date lastUpdate) {
-        this.lastUpdate = lastUpdate;
-    }
-
     public Date getCreateDate() {
         return createDate;
     }

--- a/src/test/java/org/broadinstitute/consent/http/service/MetricsServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/MetricsServiceTest.java
@@ -5,7 +5,6 @@ import org.broadinstitute.consent.http.db.DataAccessRequestDAO;
 import org.broadinstitute.consent.http.db.DatasetDAO;
 import org.broadinstitute.consent.http.db.ElectionDAO;
 import org.broadinstitute.consent.http.db.MatchDAO;
-import org.broadinstitute.consent.http.db.UserDAO;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.Dac;
 import org.broadinstitute.consent.http.models.DecisionMetrics;
@@ -23,7 +22,6 @@ import org.broadinstitute.consent.http.models.DataAccessRequestData;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 
 import java.util.*;
 import java.util.stream.Collectors;


### PR DESCRIPTION
Addresses [DUOS-1524](https://broadworkbench.atlassian.net/browse/DUOS-1524)

PR removes duplicate logic provided by `get/setLastUpdateDate` and replaces said method calls with the already existing `get/setLastUpdate`. 

PR also removes unused imports on associated files.
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
