### PR TITLE
DUOS-1531[risk=no] DAR Collection Model Updates

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
@@ -6,6 +6,7 @@ import org.broadinstitute.consent.http.db.mapper.DarCollectionReducer;
 import org.broadinstitute.consent.http.models.DarCollection;
 import org.broadinstitute.consent.http.models.DataAccessRequest;
 import org.broadinstitute.consent.http.models.Election;
+import org.broadinstitute.consent.http.models.Vote;
 import org.jdbi.v3.sqlobject.config.RegisterBeanMapper;
 import org.jdbi.v3.sqlobject.customizer.Bind;
 import org.jdbi.v3.sqlobject.customizer.BindList;
@@ -168,9 +169,31 @@ public interface DarCollectionDAO {
    */
   @RegisterBeanMapper(value = DarCollection.class)
   @RegisterBeanMapper(value = DataAccessRequest.class, prefix = "dar")
+  @RegisterBeanMapper(value = Election.class, prefix = "e")
+  @RegisterBeanMapper(value = Vote.class, prefix = "v")
   @UseRowReducer(DarCollectionReducer.class)
   @SqlQuery(
-      getCollectionAndDars +  " WHERE c.collection_id = :collectionId ")
+    "SELECT c.*, dar.id AS dar_id, dar.reference_id AS dar_reference_id, dar.collection_id AS dar_collection_id, "
+      + "dar.draft AS dar_draft, dar.user_id AS dar_userId, dar.create_date AS dar_create_date, "
+      + "dar.sort_date AS dar_sort_date, dar.submission_date AS dar_submission_date, "
+      + "dar.update_date AS dar_update_date, (dar.data #>> '{}')::jsonb AS data, "
+      + "e.electionid AS e_election_id, e.referenceid AS e_reference_id, e.status AS e_status, e.createdate AS e_create_date, "
+      + "e.lastupdate AS e_last_update, e.datasetid AS e_dataset_id, e.electiontype AS e_election_type, e.latest, "
+      + "v.voteid as v_vote_id, v.vote as v_vote, v.dacuserid as v_dac_user_id, v.rationale as v_rationale, v.electionid as v_election_id, "
+      + "v.createdate as v_create_date, v.updatedate as v_update_date, v.type as v_type, du.displayname as v_display_name "
+      + "FROM dar_collection c "
+      + "INNER JOIN data_access_request dar ON c.collection_id = dar.collection_id "
+      + "LEFT JOIN ("
+          + "SELECT election.*, MAX(election.electionid) OVER (PARTITION BY election.referenceid, election.electiontype) AS latest "
+          + "FROM election"
+      + ") AS e "
+      + "ON dar.reference_id = e.referenceid AND (e.latest = e.electionid OR e.latest IS NULL) "
+      + "LEFT JOIN vote v "
+      + "ON v.electionid = e.electionid "
+      + "INNER JOIN dacuser du "
+      + "ON du.dacuserid = v.dacuserid "
+      + "WHERE c.collection_id = :collectionId;"
+  )
   DarCollection findDARCollectionByCollectionId(@Bind("collectionId") Integer collectionId);
 
   /**

--- a/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
@@ -190,7 +190,7 @@ public interface DarCollectionDAO {
       + "ON dar.reference_id = e.referenceid AND (e.latest = e.electionid OR e.latest IS NULL) "
       + "LEFT JOIN vote v "
       + "ON v.electionid = e.electionid "
-      + "INNER JOIN dacuser du "
+      + "LEFT JOIN dacuser du "
       + "ON du.dacuserid = v.dacuserid "
       + "WHERE c.collection_id = :collectionId;"
   )

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DarCollectionReducer.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DarCollectionReducer.java
@@ -4,6 +4,7 @@ import org.broadinstitute.consent.http.models.DarCollection;
 import org.broadinstitute.consent.http.models.DataAccessRequest;
 import org.broadinstitute.consent.http.models.DataAccessRequestData;
 import org.broadinstitute.consent.http.models.Election;
+import org.broadinstitute.consent.http.models.Vote;
 import org.jdbi.v3.core.mapper.MappingException;
 import org.jdbi.v3.core.result.LinkedHashMapRowReducer;
 import org.jdbi.v3.core.result.RowView;
@@ -17,6 +18,7 @@ public class DarCollectionReducer implements LinkedHashMapRowReducer<Integer, Da
     public void accumulate(Map<Integer, DarCollection> map, RowView rowView) {
       DataAccessRequest dar = null;
       Election election = null;
+      Vote vote = null;
       DarCollection collection = map.computeIfAbsent(
         rowView.getColumn("collection_id", Integer.class),
         id -> rowView.getRow(DarCollection.class));
@@ -30,6 +32,9 @@ public class DarCollectionReducer implements LinkedHashMapRowReducer<Integer, Da
           if(Objects.nonNull(rowView.getColumn("e_election_id", Integer.class))) {
             election = rowView.getRow(Election.class);
           }
+          if (Objects.nonNull(rowView.getColumn("v_vote_id", Integer.class))) {
+            vote = rowView.getRow(Vote.class);
+          }
         }
       } catch(MappingException e) {
         //ignore any exceptions
@@ -41,5 +46,6 @@ public class DarCollectionReducer implements LinkedHashMapRowReducer<Integer, Da
       if(Objects.nonNull(election)) {
         collection.addElection(election);
       }
+      collection.addVote(vote);
     }
 }

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DarCollectionReducer.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DarCollectionReducer.java
@@ -26,11 +26,22 @@ public class DarCollectionReducer implements LinkedHashMapRowReducer<Integer, Da
         if(Objects.nonNull(collection)) {
           if(Objects.nonNull(rowView.getColumn("dar_id", Integer.class))) {
             dar = rowView.getRow(DataAccessRequest.class);
-            DataAccessRequestData data = translate(rowView.getColumn("data", String.class));
-            dar.setData(data);
+            String referenceId = dar.getReferenceId();
+            DataAccessRequest savedDar = collection.getDars().get(referenceId);
+            if(Objects.isNull(savedDar)) {
+              DataAccessRequestData data = translate(rowView.getColumn("data", String.class));
+              dar.setData(data);
+            } else {
+              dar = savedDar;
+            }
           }
           if(Objects.nonNull(rowView.getColumn("e_election_id", Integer.class))) {
             election = rowView.getRow(Election.class);
+            Integer electionId = election.getElectionId();
+            Election savedElection = dar.getElections().get(electionId);
+            if(Objects.nonNull(savedElection)) {
+              election = savedElection;
+            }
           }
           if (Objects.nonNull(rowView.getColumn("v_vote_id", Integer.class))) {
             vote = rowView.getRow(Vote.class);
@@ -39,13 +50,16 @@ public class DarCollectionReducer implements LinkedHashMapRowReducer<Integer, Da
       } catch(MappingException e) {
         //ignore any exceptions
       }
+      if(Objects.nonNull(vote)) {
+        election.addVote(vote);
+      }
+
+      if(Objects.nonNull(election)) {
+        dar.addElection(election);
+      }
 
       if(Objects.nonNull(dar)) {
         collection.addDar(dar);
       }
-      if(Objects.nonNull(election)) {
-        collection.addElection(election);
-      }
-      collection.addVote(vote);
     }
 }

--- a/src/main/java/org/broadinstitute/consent/http/models/DarCollection.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DarCollection.java
@@ -45,7 +45,7 @@ public class DarCollection {
   private Integer updateUserId;
 
   @JsonProperty
-  private List<DataAccessRequest> dars;
+  private Map<String, DataAccessRequest> dars;
 
   @JsonProperty
   private Set<DataSet> datasets;
@@ -117,22 +117,22 @@ public class DarCollection {
     this.updateUserId = updateUserId;
   }
 
-  public List<DataAccessRequest> getDars() {
+  public Map<String, DataAccessRequest> getDars() {
     if (Objects.isNull(dars)) {
-      return new ArrayList<>();
+      return new HashMap<>();
     }
     return dars;
   }
 
-  public void setDars(List<DataAccessRequest> dars) {
+  public void setDars(Map<String, DataAccessRequest> dars) {
     this.dars = dars;
   }
 
   public void addDar(DataAccessRequest dar) {
     if (Objects.isNull(dars)) {
-      this.setDars(new ArrayList<>());
+      this.setDars(new HashMap<>());
     }
-    dars.add(dar);
+    dars.put(dar.getReferenceId(), dar);
   }
 
   public void addDataset(DataSet dataset) {

--- a/src/main/java/org/broadinstitute/consent/http/models/DarCollection.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DarCollection.java
@@ -51,16 +51,16 @@ public class DarCollection {
   private Set<DataSet> datasets;
 
   @JsonProperty
-  private Map<String, Map<Integer, Election>> electionMap;
+  private Map<String, Map<Integer, Election>> darElectionMap;
 
   @JsonProperty
-  private Map<Integer, List<Vote>> votes;
+  private Map<Integer, List<Vote>> electionVoteMap;
 
   public DarCollection() {
     this.createDate = new Timestamp(System.currentTimeMillis());
     this.datasets = new HashSet<>();
-    this.electionMap = new HashMap<>();
-    this.votes = new HashMap<>();
+    this.darElectionMap = new HashMap<>();
+    this.electionVoteMap = new HashMap<>();
   }
 
   public DarCollection deepCopy() {
@@ -147,39 +147,39 @@ public class DarCollection {
     return datasets;
   }
 
-  public void setElectionMap(Map<String, Map<Integer, Election>> electionMap) {
-    this.electionMap = electionMap;
+  public void setDarElectionMap(Map<String, Map<Integer, Election>> darElectionMap) {
+    this.darElectionMap = darElectionMap;
   }
 
-  public Map<String, Map<Integer, Election>> getElectionMap() {
-    return electionMap;
+  public Map<String, Map<Integer, Election>> getDarElectionMap() {
+    return darElectionMap;
   }
 
   public void addElection(Election election) {
     if(Objects.nonNull(election.getReferenceId())) {
       String referenceId = election.getReferenceId();
-      if(!electionMap.containsKey(referenceId)) {
-        electionMap.put(referenceId, new HashMap<>());
+      if(!darElectionMap.containsKey(referenceId)) {
+        darElectionMap.put(referenceId, new HashMap<>());
       }
-      electionMap.get(referenceId).put(election.getElectionId(), election);
+      darElectionMap.get(referenceId).put(election.getElectionId(), election);
     }
   }
 
-  public Map<Integer, List<Vote>> getVotes() {
-    return votes;
+  public Map<Integer, List<Vote>> getElectionVoteMap() {
+    return electionVoteMap;
   }
 
-  public void setVotes(Map<Integer, List<Vote>> votes) {
-    this.votes = votes;
+  public void setVotes(Map<Integer, List<Vote>> electionVoteMap) {
+    this.electionVoteMap = electionVoteMap;
   }  
 
   public void addVote(Vote vote) {
     if(Objects.nonNull(vote) && Objects.nonNull(vote.getElectionId())){
       Integer electionId = vote.getElectionId();
-      if(!votes.containsKey(electionId)) {
-        votes.put(electionId, new ArrayList<>());
+      if(!electionVoteMap.containsKey(electionId)) {
+        electionVoteMap.put(electionId, new ArrayList<>());
       }
-      votes.get(electionId).add(vote);
+      electionVoteMap.get(electionId).add(vote);
     }
   }
 

--- a/src/main/java/org/broadinstitute/consent/http/models/DarCollection.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DarCollection.java
@@ -53,10 +53,14 @@ public class DarCollection {
   @JsonProperty
   private Map<String, List<Election>> electionMap;
 
+  @JsonProperty
+  private Map<Integer, Vote> votes;
+
   public DarCollection() {
     this.createDate = new Timestamp(System.currentTimeMillis());
     this.datasets = new HashSet<>();
     this.electionMap = new HashMap<>();
+    this.votes = new HashMap<>();
   }
 
   public DarCollection deepCopy() {
@@ -157,6 +161,20 @@ public class DarCollection {
       electionMap.put(referenceId, new ArrayList<>());
     }
     electionMap.get(referenceId).add(election);
+  }
+
+  public Map<Integer, Vote> getVotes() {
+    return votes;
+  }
+
+  public void setVotes(Map<Integer, Vote> votes) {
+    this.votes = votes;
+  }  
+
+  public void addVote(Vote vote) {
+    if(Objects.nonNull(vote)) {
+      votes.put(vote.getVoteId(), vote);
+    }
   }
 
   @Override

--- a/src/main/java/org/broadinstitute/consent/http/models/DarCollection.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DarCollection.java
@@ -8,9 +8,7 @@ import java.sql.Timestamp;
 import java.util.HashSet;
 import java.util.HashMap;
 import java.util.Set;
-import java.util.ArrayList;
 import java.util.Date;
-import java.util.List;
 import java.util.Objects;
 import java.util.Map;
 
@@ -50,17 +48,9 @@ public class DarCollection {
   @JsonProperty
   private Set<DataSet> datasets;
 
-  @JsonProperty
-  private Map<String, Map<Integer, Election>> darElectionMap;
-
-  @JsonProperty
-  private Map<Integer, List<Vote>> electionVoteMap;
-
   public DarCollection() {
     this.createDate = new Timestamp(System.currentTimeMillis());
     this.datasets = new HashSet<>();
-    this.darElectionMap = new HashMap<>();
-    this.electionVoteMap = new HashMap<>();
   }
 
   public DarCollection deepCopy() {
@@ -132,7 +122,13 @@ public class DarCollection {
     if (Objects.isNull(dars)) {
       this.setDars(new HashMap<>());
     }
-    dars.put(dar.getReferenceId(), dar);
+    if(Objects.nonNull(dar)) {
+      String referenceId = dar.getReferenceId();
+      DataAccessRequest savedDar = dars.get(referenceId);
+      if(Objects.isNull(savedDar)) {
+        dars.put(referenceId, dar);
+      }
+    }
   }
 
   public void addDataset(DataSet dataset) {
@@ -145,42 +141,6 @@ public class DarCollection {
 
   public Set<DataSet> getDatasets() {
     return datasets;
-  }
-
-  public void setDarElectionMap(Map<String, Map<Integer, Election>> darElectionMap) {
-    this.darElectionMap = darElectionMap;
-  }
-
-  public Map<String, Map<Integer, Election>> getDarElectionMap() {
-    return darElectionMap;
-  }
-
-  public void addElection(Election election) {
-    if(Objects.nonNull(election.getReferenceId())) {
-      String referenceId = election.getReferenceId();
-      if(!darElectionMap.containsKey(referenceId)) {
-        darElectionMap.put(referenceId, new HashMap<>());
-      }
-      darElectionMap.get(referenceId).put(election.getElectionId(), election);
-    }
-  }
-
-  public Map<Integer, List<Vote>> getElectionVoteMap() {
-    return electionVoteMap;
-  }
-
-  public void setVotes(Map<Integer, List<Vote>> electionVoteMap) {
-    this.electionVoteMap = electionVoteMap;
-  }  
-
-  public void addVote(Vote vote) {
-    if(Objects.nonNull(vote) && Objects.nonNull(vote.getElectionId())){
-      Integer electionId = vote.getElectionId();
-      if(!electionVoteMap.containsKey(electionId)) {
-        electionVoteMap.put(electionId, new ArrayList<>());
-      }
-      electionVoteMap.get(electionId).add(vote);
-    }
   }
 
   @Override

--- a/src/main/java/org/broadinstitute/consent/http/models/DarCollection.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DarCollection.java
@@ -51,10 +51,10 @@ public class DarCollection {
   private Set<DataSet> datasets;
 
   @JsonProperty
-  private Map<String, List<Election>> electionMap;
+  private Map<String, Map<Integer, Election>> electionMap;
 
   @JsonProperty
-  private Map<Integer, Vote> votes;
+  private Map<Integer, List<Vote>> votes;
 
   public DarCollection() {
     this.createDate = new Timestamp(System.currentTimeMillis());
@@ -147,33 +147,39 @@ public class DarCollection {
     return datasets;
   }
 
-  public void setElectionMap(Map<String, List<Election>> electionMap) {
+  public void setElectionMap(Map<String, Map<Integer, Election>> electionMap) {
     this.electionMap = electionMap;
   }
 
-  public Map<String, List<Election>> getElectionMap() {
+  public Map<String, Map<Integer, Election>> getElectionMap() {
     return electionMap;
   }
 
   public void addElection(Election election) {
-    String referenceId = election.getReferenceId();
-    if(!electionMap.containsKey(referenceId)){
-      electionMap.put(referenceId, new ArrayList<>());
+    if(Objects.nonNull(election.getReferenceId())) {
+      String referenceId = election.getReferenceId();
+      if(!electionMap.containsKey(referenceId)) {
+        electionMap.put(referenceId, new HashMap<>());
+      }
+      electionMap.get(referenceId).put(election.getElectionId(), election);
     }
-    electionMap.get(referenceId).add(election);
   }
 
-  public Map<Integer, Vote> getVotes() {
+  public Map<Integer, List<Vote>> getVotes() {
     return votes;
   }
 
-  public void setVotes(Map<Integer, Vote> votes) {
+  public void setVotes(Map<Integer, List<Vote>> votes) {
     this.votes = votes;
   }  
 
   public void addVote(Vote vote) {
-    if(Objects.nonNull(vote)) {
-      votes.put(vote.getVoteId(), vote);
+    if(Objects.nonNull(vote) && Objects.nonNull(vote.getElectionId())){
+      Integer electionId = vote.getElectionId();
+      if(!votes.containsKey(electionId)) {
+        votes.put(electionId, new ArrayList<>());
+      }
+      votes.get(electionId).add(vote);
     }
   }
 

--- a/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequest.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequest.java
@@ -10,6 +10,7 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
 import com.google.gson.JsonSerializer;
 import com.google.gson.reflect.TypeToken;
+
 import java.lang.reflect.Type;
 import java.sql.Timestamp;
 import java.util.Date;
@@ -43,6 +44,12 @@ public class DataAccessRequest {
   @JsonProperty public Timestamp submissionDate;
 
   @JsonProperty public Timestamp updateDate;
+
+  @JsonProperty private Map<Integer, Election> elections;
+
+  public DataAccessRequest() {
+    this.elections = new HashMap<>();
+  }
 
   public static boolean isNotCanceled(DataAccessRequest dar) {
     String status = dar.getData().getStatus();
@@ -123,6 +130,27 @@ public class DataAccessRequest {
 
   public void setUpdateDate(Timestamp updateDate) {
     this.updateDate = updateDate;
+  }
+
+  public void setElections(Map<Integer, Election> elections) {
+    this.elections = elections;
+  }
+
+  public Map<Integer, Election> getElections() {
+    return elections;
+  }
+
+  public void addElection(Election election) {
+    if(Objects.isNull(elections)) {
+      this.setElections(new HashMap<>());
+    }
+    if(Objects.nonNull(election)) {
+      Integer electionId = election.getElectionId();
+      Election savedRecord = elections.get(electionId);
+      if (Objects.isNull(savedRecord)) {
+        elections.put(electionId, election);
+      }
+    }
   }
 
   /**

--- a/src/main/java/org/broadinstitute/consent/http/models/Election.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/Election.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Objects;
 import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
 
 @JsonInclude(Include.NON_NULL)
 public class Election {
@@ -63,6 +65,9 @@ public class Election {
     @JsonProperty
     private String projectTitle;
 
+    @JsonProperty
+    private Map<Integer, Vote> votes;
+
     public Election() {
     }
 
@@ -77,6 +82,7 @@ public class Election {
         this.lastUpdate = lastUpdate;
         this.finalAccessVote = finalAccessVote;
         this.dataSetId = dataSetId;
+        this.votes = new HashMap<>();
     }
 
     public Election(Integer electionId, String electionType,
@@ -232,6 +238,27 @@ public class Election {
 
     public void setProjectTitle(String projectTitle) {
         this.projectTitle = projectTitle;
+    }
+
+    public Map<Integer, Vote> getVotes() {
+        return votes;
+    }
+
+    public void setVotes(Map<Integer, Vote> votes) {
+        this.votes = votes;
+    }
+
+    public void addVote(Vote vote) {
+        if(java.util.Objects.isNull(votes)) {
+            this.setVotes(new HashMap<>());
+        }
+        if(java.util.Objects.nonNull(vote)) {
+            Integer voteId = vote.getVoteId();
+            Vote savedVote = votes.get(voteId);
+            if(java.util.Objects.isNull(savedVote)) {
+                votes.put(voteId, vote);
+            }
+        }
     }
 
     @Override

--- a/src/main/java/org/broadinstitute/consent/http/models/Vote.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/Vote.java
@@ -40,6 +40,9 @@ public class Vote {
     @JsonProperty
     private Boolean hasConcerns;
 
+    @JsonProperty
+    private String displayName;
+
     public Vote() {
     }
 
@@ -135,6 +138,14 @@ public class Vote {
 
     public void setHasConcerns(Boolean hasConcerns) {
         this.hasConcerns = hasConcerns;
+    }
+
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public String getDisplayName() {
+        return displayName;
     }
 
     @Override

--- a/src/main/java/org/broadinstitute/consent/http/resources/DarCollectionResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DarCollectionResource.java
@@ -83,6 +83,9 @@ public class DarCollectionResource extends Resource {
       @PathParam("collectionId") Integer collectionId) {
     try {
       DarCollection collection = darCollectionService.getByCollectionId(collectionId);
+      // NOTE: restore this after front-end code is done, DO NOT MERGE UNTIL FRONT-END DESIGN IS DONE
+      User user = userService.findUserByEmail(authUser.getEmail());
+      // validateUserIsCreator(user, collection);
       return Response.ok().entity(collection).build();
     } catch (Exception e) {
       return createExceptionResponse(e);
@@ -184,7 +187,7 @@ public class DarCollectionResource extends Resource {
 
   private void validateCollectionIsCanceled(DarCollection collection) {
     boolean isCanceled =
-        collection.getDars().stream()
+        collection.getDars().values().stream()
             .anyMatch(
                 d -> d.getData().getStatus().equalsIgnoreCase(DarStatus.CANCELED.getValue()));
     if (!isCanceled) {

--- a/src/main/java/org/broadinstitute/consent/http/resources/DarCollectionResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DarCollectionResource.java
@@ -82,9 +82,7 @@ public class DarCollectionResource extends Resource {
       @Auth AuthUser authUser,
       @PathParam("collectionId") Integer collectionId) {
     try {
-      User user = userService.findUserByEmail(authUser.getEmail());
       DarCollection collection = darCollectionService.getByCollectionId(collectionId);
-      validateUserIsCreator(user, collection);
       return Response.ok().entity(collection).build();
     } catch (Exception e) {
       return createExceptionResponse(e);

--- a/src/main/java/org/broadinstitute/consent/http/resources/DarCollectionResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DarCollectionResource.java
@@ -83,9 +83,8 @@ public class DarCollectionResource extends Resource {
       @PathParam("collectionId") Integer collectionId) {
     try {
       DarCollection collection = darCollectionService.getByCollectionId(collectionId);
-      // NOTE: restore this after front-end code is done, DO NOT MERGE UNTIL FRONT-END DESIGN IS DONE
       User user = userService.findUserByEmail(authUser.getEmail());
-      // validateUserIsCreator(user, collection);
+      validateUserIsCreator(user, collection);
       return Response.ok().entity(collection).build();
     } catch (Exception e) {
       return createExceptionResponse(e);

--- a/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
@@ -16,13 +16,11 @@ import org.broadinstitute.consent.http.db.DarCollectionDAO;
 import org.broadinstitute.consent.http.db.DataAccessRequestDAO;
 import org.broadinstitute.consent.http.db.DatasetDAO;
 import org.broadinstitute.consent.http.db.ElectionDAO;
-import org.broadinstitute.consent.http.enumeration.ElectionType;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.DarCollection;
 import org.broadinstitute.consent.http.models.DataAccessRequest;
 import org.broadinstitute.consent.http.models.DataAccessRequestData;
 import org.broadinstitute.consent.http.models.DataSet;
-import org.broadinstitute.consent.http.models.Election;
 import org.broadinstitute.consent.http.models.PaginationResponse;
 import org.broadinstitute.consent.http.models.PaginationToken;
 import org.broadinstitute.consent.http.models.User;
@@ -184,7 +182,7 @@ public class DarCollectionService {
   public List<DarCollection> addDatasetsToCollections(List<DarCollection> collections) {
 
     List<Integer> datasetIds = collections.stream()
-      .map(DarCollection::getDars)
+      .map(d-> d.getDars().values())
       .flatMap(Collection::stream)
       .map(d -> d.getData().getDatasetIds())
       .flatMap(Collection::stream)
@@ -196,7 +194,7 @@ public class DarCollectionService {
           .collect(Collectors.toMap(DataSet::getDataSetId, Function.identity()));
 
       return collections.stream().map(c -> {
-        Set<DataSet> collectionDatasets = c.getDars().stream()
+        Set<DataSet> collectionDatasets = c.getDars().values().stream()
           .map(DataAccessRequest::getData)
           .map(DataAccessRequestData::getDatasetIds)
           .flatMap(Collection::stream)
@@ -222,7 +220,7 @@ public class DarCollectionService {
   // If an election exists for a DAR within the collection, that DAR cannot be cancelled by the researcher
   // Since it's now under DAC review, it's up to the DAC Chair (or admin) to ultimately decline or cancel via elections
   public DarCollection cancelDarCollection(DarCollection collection) {
-    List<DataAccessRequest> dars = collection.getDars();
+    Collection<DataAccessRequest> dars = collection.getDars().values();
     List<String> referenceIds = dars.stream()
       .map(DataAccessRequest::getReferenceId)
       .collect(Collectors.toList());

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
@@ -250,14 +250,14 @@ public class DataAccessRequestService {
         if (Objects.isNull(sourceCollection.getDars()) || sourceCollection.getDars().isEmpty()) {
             throw new IllegalArgumentException("Source Collection must contain at least a single DAR");
         }
-        DataAccessRequest sourceDar = sourceCollection.getDars().get(0);
+        DataAccessRequest sourceDar = new ArrayList<DataAccessRequest>(sourceCollection.getDars().values()).get(0);
         DataAccessRequestData sourceData = sourceDar.getData();
         if (Objects.isNull(sourceData)) {
             throw new IllegalArgumentException("Source Collection must contain at least a single DAR with a populated data");
         }
         // Find all dataset ids for canceled DARs in the collection
         List<Integer> datasetIds = sourceCollection
-            .getDars().stream()
+            .getDars().values().stream()
             .map(DataAccessRequest::getData)
             .filter(d -> d.getStatus().equalsIgnoreCase(DarStatus.CANCELED.getValue()))
             .map(DataAccessRequestData::getDatasetIds)
@@ -267,7 +267,7 @@ public class DataAccessRequestService {
             throw new IllegalArgumentException("Source Collection must contain references to at least a single canceled DAR's dataset");
         }
         List<String> canceledReferenceIds = sourceCollection
-            .getDars().stream()
+            .getDars().values().stream()
             .map(DataAccessRequest::getData)
             .filter(d -> d.getStatus().equalsIgnoreCase(DarStatus.CANCELED.getValue()))
             .map(DataAccessRequestData::getReferenceId)

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -3577,43 +3577,7 @@ components:
           type: string
           description: Contains the eRA account expiration date in miliseconds. This will be 30 days from the user's authentication.
     Vote:
-      type: object
-      properties:
-        voteId:
-          type: integer
-          format: int32
-          description: Describes the id of the vote.
-        vote:
-          type: boolean
-          description: Describe the Positive or negative value of the vote
-        dacUserId:
-          type: integer
-          format: int32
-          description: Describes the id of the voter.
-        createDate:
-          type: string
-          format: date
-          description: Describes the date the vote was created.
-        updateDate:
-          type: string
-          format: date
-          description: Describes the date the vote was last modified.
-        electionId:
-          type: integer
-          format: int32
-          description: Describes the id of the election the election at which the vote belongs.
-        rationale:
-          type: string
-          description: If the final vote is NO, the voter can specify why in this field.
-        type:
-          type: string
-          description: Specifies the type of the vote (DAC, CHAIRPERSON, AGREEMENT, FINAL)
-        isReminderSent:
-          type: boolean
-          description: Describes if the user recieved a reminder by the chairperson to log the vote on the case.
-        hasConcerns:
-          type: boolean
-          description: For Dataset elections, it is a flag for DataSet owners concerns.
+      $ref: './schemas/Vote.yaml'
     MatchResult:
       type: object
       properties:

--- a/src/main/resources/assets/schemas/DarCollection.yaml
+++ b/src/main/resources/assets/schemas/DarCollection.yaml
@@ -21,8 +21,8 @@ properties:
     type: integer
     description: ID of user that last updated the collection
   dars:
-    type: array
-    description: List of all DARs associated with the collection
+    type: Object
+    description: Map of all DARs associated with the collection (referenceId-dar)
     items:
       $ref: './DataAccessRequest.yaml'
   datasets:
@@ -30,19 +30,3 @@ properties:
     description: List of all datasets referenced across all DARs within the collection
     items:
       $ref: './Dataset.yaml'
-  darElectionMap:
-    type: object
-    description: Map of referenceIds to their associated elections
-    additionalProperties: 
-      type: Object
-      description: List of elections associated to referenceId key
-      item:
-        $ref: './Election.yaml'
-  electionVoteMap:
-    type: object
-    description: Map of electionIds to their associated votes
-    additionalProperties:
-      type: array
-      description: List of votes belonging to election
-      item:
-          $ref: './Vote.yaml'

--- a/src/main/resources/assets/schemas/DarCollection.yaml
+++ b/src/main/resources/assets/schemas/DarCollection.yaml
@@ -30,11 +30,19 @@ properties:
     description: List of all datasets referenced across all DARs within the collection
     items:
       $ref: './Dataset.yaml'
-  electionMap:
+  darElectionMap:
     type: object
     description: Map of referenceIds to their associated elections
     additionalProperties: 
-      type: array
+      type: Object
       description: List of elections associated to referenceId key
       item:
         $ref: './Election.yaml'
+  electionVoteMap:
+    type: object
+    description: Map of electionIds to their associated votes
+    additionalProperties:
+      type: array
+      description: List of votes belonging to election
+      item:
+          $ref: './Vote.yaml'

--- a/src/main/resources/assets/schemas/DataAccessRequest.yaml
+++ b/src/main/resources/assets/schemas/DataAccessRequest.yaml
@@ -25,6 +25,11 @@ properties:
   darCode:
     type: string
     description: Unique DAR Code
+  elections:
+    type: object
+    description: Map of elections tied to the DAR (electionid - election)
+    items:
+      $ref: './Election.yaml' 
   partialDarCode:
     type: string
     description: Unique Partial DAR Code

--- a/src/main/resources/assets/schemas/Election.yaml
+++ b/src/main/resources/assets/schemas/Election.yaml
@@ -50,3 +50,8 @@ properties:
   archived:
     type: boolean
     description: Determines if the election is archived.
+  votes:
+    type: object
+    description: Map of votes tied to this election (voteId - vote)
+    items:
+      $ref: './Vote.yaml'

--- a/src/main/resources/assets/schemas/Vote.yaml
+++ b/src/main/resources/assets/schemas/Vote.yaml
@@ -1,0 +1,37 @@
+type: object
+properties:
+  voteId:
+    type: integer
+    format: int32
+    description: Describes the id of the vote.
+  vote:
+    type: boolean
+    description: Describe the Positive or negative value of the vote
+  dacUserId:
+    type: integer
+    format: int32
+    description: Describes the id of the voter.
+  createDate:
+    type: string
+    format: date
+    description: Describes the date the vote was created.
+  updateDate:
+    type: string
+    format: date
+    description: Describes the date the vote was last modified.
+  electionId:
+    type: integer
+    format: int32
+    description: Describes the id of the election the election at which the vote belongs.
+  rationale:
+    type: string
+    description: If the final vote is NO, the voter can specify why in this field.
+  type:
+    type: string
+    description: Specifies the type of the vote (DAC, CHAIRPERSON, AGREEMENT, FINAL)
+  isReminderSent:
+    type: boolean
+    description: Describes if the user recieved a reminder by the chairperson to log the vote on the case.
+  hasConcerns:
+    type: boolean
+    description: For Dataset elections, it is a flag for DataSet owners concerns.

--- a/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
@@ -81,6 +81,7 @@ public class DAOTestHelper {
     private static final List<String> createdConsentIds = new ArrayList<>();
     private static final List<Integer> createdElectionIds = new ArrayList<>();
     private static final List<Integer> createdUserIds = new ArrayList<>();
+    private static final List<Integer> createdVoteIds = new ArrayList<>();
     private static final List<String> createdDataAccessRequestReferenceIds = new ArrayList<>();
     private static final List<Integer> createdInstitutionIds = new ArrayList<>();
     private static final List<Integer> createdLibraryCardIds = new ArrayList<>();
@@ -159,6 +160,7 @@ public class DAOTestHelper {
             consentDAO.deleteAllAssociationsForConsent(id);
             consentDAO.deleteConsent(id);
         });
+        createdVoteIds.forEach(id -> voteDAO.deleteVoteById(id));
         createdElectionIds.forEach(id -> electionDAO.deleteAccessRP(id));
         createdElectionIds.forEach(id -> electionDAO.deleteElectionById(id));
         dataSetDAO.deleteDataSetsProperties(createdDataSetIds);
@@ -281,6 +283,7 @@ public class DAOTestHelper {
 
     protected Vote createFinalVote(Integer userId, Integer electionId) {
         Integer voteId = voteDAO.insertVote(userId, electionId, VoteType.FINAL.getValue());
+        createdVoteIds.add(voteId);
         return voteDAO.findVoteById(voteId);
     }
 
@@ -597,8 +600,10 @@ public class DAOTestHelper {
         Integer collection_id = darCollectionDAO.insertDarCollection(darCode, user.getDacUserId(), new Date());
         DataSet dataset = createDataset();
         DataAccessRequest dar = insertDAR(user.getDacUserId(), collection_id, darCode);
-        createCancelledAccessElection(dar.getReferenceId(), dataset.getDataSetId());
-        createAccessElection(dar.getReferenceId(), dataset.getDataSetId());
+        Election cancelled = createCancelledAccessElection(dar.getReferenceId(), dataset.getDataSetId());
+        Election access = createAccessElection(dar.getReferenceId(), dataset.getDataSetId());
+        createFinalVote(user.getDacUserId(), cancelled.getElectionId());
+        createFinalVote(user.getDacUserId(), access.getElectionId());
         insertDAR(user.getDacUserId(), collection_id, darCode);
         insertDAR(user.getDacUserId(), collection_id, darCode);
         createdDarCollections.add(collection_id);

--- a/src/test/java/org/broadinstitute/consent/http/db/DarCollectionDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DarCollectionDAOTest.java
@@ -65,11 +65,12 @@ public class DarCollectionDAOTest extends DAOTestHelper  {
     assertNotNull(returned);
     assertEquals(collection.getDarCode(), returned.getDarCode());
     assertEquals(collection.getCreateUserId(), returned.getCreateUserId());
-    assertEquals(collection.getElectionMap().size(), 1);
-    assertEquals(collection.getVotes().size(), 1);
-    List<Election> electionList = collection.getElectionMap().values().stream().findFirst().orElse(null);
-    Election election = electionList.get(0);
-    Vote vote = collection.getVotes().values().stream().findFirst().orElse(null);
+    Map<Integer, Election> electionList = collection.getElectionMap().values().stream().findFirst().orElse(null);
+    Election election = electionList.values().stream().findFirst().orElse(null);
+    List<Vote> votes = collection.getVotes().get(election.getElectionId());
+    Vote vote = votes.get(0);
+    assertEquals(1, votes.size());
+    assertEquals(1, electionList.size());
     assertEquals("Open", election.getStatus());
     assertEquals(election.getElectionId(), vote.getElectionId());
   }
@@ -366,12 +367,15 @@ public void testFindAllDARCollectionsWithFilters_InstitutionTerm() {
     List<DarCollection> collectionResult = darCollectionDAO.findDARCollectionsCreatedByUserId(userId);
     assertEquals(1, collectionResult.size());
     assertEquals(userId, collectionResult.get(0).getCreateUserId());
-    Map<String, List<Election>> electionMap = collectionResult.get(0).getElectionMap();
+    Map<String, Map<Integer, Election>> electionMap = collectionResult.get(0).getElectionMap();
     assertEquals(1, electionMap.size());
     List<String> keyset = electionMap.keySet().stream().collect(Collectors.toList());
-    String key = keyset.get(0);
-    List<Election> elections = electionMap.get(key);
+    String darReferenceId = keyset.get(0);
+    Map<Integer, Election> elections = electionMap.get(darReferenceId);
     assertEquals(1, elections.size());
+    Integer electionId = elections.keySet().stream().findFirst().orElse(null);
+    Election election = elections.values().stream().findFirst().orElse(null);
+    assertEquals(electionId, election.getElectionId());
 
     Collection<DataAccessRequest> darsResult = collectionResult.get(0).getDars().values();
     assertEquals(dars.values().size(), darsResult.size());

--- a/src/test/java/org/broadinstitute/consent/http/db/DarCollectionDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DarCollectionDAOTest.java
@@ -12,6 +12,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.RandomUtils;
 import org.broadinstitute.consent.http.models.Consent;
@@ -23,6 +24,7 @@ import org.broadinstitute.consent.http.models.DataSet;
 import org.broadinstitute.consent.http.models.Election;
 import org.broadinstitute.consent.http.models.Institution;
 import org.broadinstitute.consent.http.models.User;
+import org.broadinstitute.consent.http.models.Vote;
 import org.junit.Test;
 import org.postgresql.util.PSQLException;
 import org.postgresql.util.PSQLState;
@@ -62,6 +64,13 @@ public class DarCollectionDAOTest extends DAOTestHelper  {
     assertNotNull(returned);
     assertEquals(collection.getDarCode(), returned.getDarCode());
     assertEquals(collection.getCreateUserId(), returned.getCreateUserId());
+    assertEquals(collection.getElectionMap().size(), 1);
+    assertEquals(collection.getVotes().size(), 1);
+    List<Election> electionList = collection.getElectionMap().values().stream().findFirst().orElse(null);
+    Election election = electionList.get(0);
+    Vote vote = collection.getVotes().values().stream().findFirst().orElse(null);
+    assertEquals("Open", election.getStatus());
+    assertEquals(election.getElectionId(), vote.getElectionId());
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/db/DarCollectionDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DarCollectionDAOTest.java
@@ -65,9 +65,9 @@ public class DarCollectionDAOTest extends DAOTestHelper  {
     assertNotNull(returned);
     assertEquals(collection.getDarCode(), returned.getDarCode());
     assertEquals(collection.getCreateUserId(), returned.getCreateUserId());
-    Map<Integer, Election> electionList = collection.getElectionMap().values().stream().findFirst().orElse(null);
+    Map<Integer, Election> electionList = collection.getDarElectionMap().values().stream().findFirst().orElse(null);
     Election election = electionList.values().stream().findFirst().orElse(null);
-    List<Vote> votes = collection.getVotes().get(election.getElectionId());
+    List<Vote> votes = collection.getElectionVoteMap().get(election.getElectionId());
     Vote vote = votes.get(0);
     assertEquals(1, votes.size());
     assertEquals(1, electionList.size());
@@ -367,7 +367,7 @@ public void testFindAllDARCollectionsWithFilters_InstitutionTerm() {
     List<DarCollection> collectionResult = darCollectionDAO.findDARCollectionsCreatedByUserId(userId);
     assertEquals(1, collectionResult.size());
     assertEquals(userId, collectionResult.get(0).getCreateUserId());
-    Map<String, Map<Integer, Election>> electionMap = collectionResult.get(0).getElectionMap();
+    Map<String, Map<Integer, Election>> electionMap = collectionResult.get(0).getDarElectionMap();
     assertEquals(1, electionMap.size());
     List<String> keyset = electionMap.keySet().stream().collect(Collectors.toList());
     String darReferenceId = keyset.get(0);

--- a/src/test/java/org/broadinstitute/consent/http/db/DarCollectionDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DarCollectionDAOTest.java
@@ -7,12 +7,13 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.RandomUtils;
 import org.broadinstitute.consent.http.models.Consent;
@@ -45,7 +46,7 @@ public class DarCollectionDAOTest extends DAOTestHelper  {
     DarCollection collection = darCollectionDAO.findDARCollectionByReferenceId(dar.getReferenceId());
     assertNotNull(collection);
     assertEquals(dar.getCollectionId(), collection.getDarCollectionId());
-    List<String> ids = collection.getDars().stream().map(DataAccessRequest::getReferenceId).collect(Collectors.toList());
+    List<String> ids = collection.getDars().values().stream().map(DataAccessRequest::getReferenceId).collect(Collectors.toList());
     assertTrue(ids.contains(dar.getReferenceId()));
   }
 
@@ -85,7 +86,7 @@ public class DarCollectionDAOTest extends DAOTestHelper  {
     // and DAC in such a way that all are connected via the dataset id.
     DataSet dataset = createDataset();
     DarCollection c = createDarCollection();
-    DataAccessRequest dar = c.getDars().get(0);
+    DataAccessRequest dar = new ArrayList<DataAccessRequest>(c.getDars().values()).get(0);
     if (Objects.isNull(dar)) {
       fail("DAR was not created in collection");
     }
@@ -104,7 +105,7 @@ public class DarCollectionDAOTest extends DAOTestHelper  {
   public void testFindDARCollectionIdsByInstitutionId() {
     // Set up a DAR Collection with a DAR, User, and Institution
     DarCollection c = createDarCollection();
-    DataAccessRequest dar = c.getDars().get(0);
+    DataAccessRequest dar = new ArrayList<DataAccessRequest>(c.getDars().values()).get(0);
     if (Objects.isNull(dar)) {
       fail("DAR was not created in collection");
     }
@@ -230,8 +231,8 @@ public class DarCollectionDAOTest extends DAOTestHelper  {
 
     assertEquals(2, collectionsResult.size());
 
-    DataAccessRequest darOne = collectionsResult.get(0).getDars().get(0);
-    DataAccessRequest darTwo = collectionsResult.get(1).getDars().get(0);
+    DataAccessRequest darOne = new ArrayList<DataAccessRequest>(collectionsResult.get(0).getDars().values()).get(0);
+    DataAccessRequest darTwo = new ArrayList<DataAccessRequest>(collectionsResult.get(1).getDars().values()).get(0);
     int comparatorValue = darOne.getData().getDarCode().compareTo(darTwo.getData().getDarCode());
     assertTrue(comparatorValue < 0);
   }
@@ -248,7 +249,7 @@ public class DarCollectionDAOTest extends DAOTestHelper  {
     assertEquals(1, collections.size());
     DarCollection targetCollection = collections.get(0);
     assertEquals(5, targetCollection.getDars().size());
-    DataAccessRequest targetDar = targetCollection.getDars().get(0);
+    DataAccessRequest targetDar = new ArrayList<DataAccessRequest>(targetCollection.getDars().values()).get(0);
     assertEquals(targetDar.getData().getDarCode(), targetCollection.getDarCode());
   }
 
@@ -264,7 +265,7 @@ public void testFindAllDARCollectionsWithFilters_InstitutionTerm() {
     assertEquals(1, collections.size());
     DarCollection targetCollection = collections.get(0);
     assertEquals(5, targetCollection.getDars().size());
-    DataAccessRequest targetDar = targetCollection.getDars().get(0);
+    DataAccessRequest targetDar = new ArrayList<DataAccessRequest>(targetCollection.getDars().values()).get(0);
     assertEquals(targetCollection.getDarCode(), targetDar.getData().getDarCode());
   }
 
@@ -280,7 +281,7 @@ public void testFindAllDARCollectionsWithFilters_InstitutionTerm() {
     assertEquals(1, collections.size());
     DarCollection targetCollection = collections.get(0);
     assertEquals(5, targetCollection.getDars().size());
-    DataAccessRequest targetDar = targetCollection.getDars().get(0);
+    DataAccessRequest targetDar = new ArrayList<DataAccessRequest>(targetCollection.getDars().values()).get(0);
     assertEquals(targetCollection.getDarCode(), targetDar.getData().getDarCode());
   }
 
@@ -296,7 +297,7 @@ public void testFindAllDARCollectionsWithFilters_InstitutionTerm() {
     assertEquals(1, collections.size());
     DarCollection targetCollection = collections.get(0);
     assertEquals(5, targetCollection.getDars().size());
-    DataAccessRequest targetDar = targetCollection.getDars().get(0);
+    DataAccessRequest targetDar = new ArrayList<DataAccessRequest>(targetCollection.getDars().values()).get(0);
     assertEquals(targetCollection.getDarCode(), targetDar.getData().getDarCode());
   }
 
@@ -311,7 +312,7 @@ public void testFindAllDARCollectionsWithFilters_InstitutionTerm() {
     assertEquals(1, collections.size());
     DarCollection targetCollection = collections.get(0);
     assertEquals(5, targetCollection.getDars().size());
-    DataAccessRequest targetDar = targetCollection.getDars().get(0);
+    DataAccessRequest targetDar = new ArrayList<DataAccessRequest>(targetCollection.getDars().values()).get(0);
     assertEquals(targetDar.getData().getDarCode(), targetCollection.getDarCode());
   }
 
@@ -329,8 +330,8 @@ public void testFindAllDARCollectionsWithFilters_InstitutionTerm() {
     assertEquals(2, collectionsResult.size());
     assertEquals(collections.get(0).getDarCode(), collectionsResult.get(0).getDarCode());
 
-    DataAccessRequest darResultOne = collectionsResult.get(0).getDars().get(0);
-    DataAccessRequest darResultTwo = collectionsResult.get(1).getDars().get(0);
+    DataAccessRequest darResultOne = new ArrayList<DataAccessRequest>(collectionsResult.get(0).getDars().values()).get(0);
+    DataAccessRequest darResultTwo = new ArrayList<DataAccessRequest>(collectionsResult.get(1).getDars().values()).get(0);
     assertEquals(collections.get(0).getDarCode(), darResultOne.getData().getDarCode());
     assertEquals(collections.get(1).getDarCode(), darResultTwo.getData().getDarCode());
   }
@@ -348,10 +349,10 @@ public void testFindAllDARCollectionsWithFilters_InstitutionTerm() {
     assertEquals(2, collectionsResult.size());
     assertEquals(collectionsResult.get(0).getDarCode(), collections.get(0).getDarCode());
 
-    DataAccessRequest darResultOne = collectionsResult.get(0).getDars().get(0);
-    DataAccessRequest darResultTwo = collectionsResult.get(1).getDars().get(0);
-    DataAccessRequest expectedDarOne = collections.get(0).getDars().get(0);
-    DataAccessRequest expectedDarTwo = collections.get(1).getDars().get(0);
+    DataAccessRequest darResultOne = new ArrayList<DataAccessRequest>(collectionsResult.get(0).getDars().values()).get(0);
+    DataAccessRequest darResultTwo = new ArrayList<DataAccessRequest>(collectionsResult.get(1).getDars().values()).get(0);
+    DataAccessRequest expectedDarOne = new ArrayList<DataAccessRequest>(collections.get(0).getDars().values()).get(0);
+    DataAccessRequest expectedDarTwo = new ArrayList<DataAccessRequest>(collections.get(1).getDars().values()).get(0);
     assertEquals(expectedDarOne.getData().getDarCode(), darResultOne.getData().getDarCode());
     assertEquals(expectedDarTwo.getData().getDarCode(), darResultTwo.getData().getDarCode());
   }
@@ -359,7 +360,7 @@ public void testFindAllDARCollectionsWithFilters_InstitutionTerm() {
   @Test
   public void testFindAllDARCollectionsCreatedByUserId(){
     DarCollection collection = createDarCollection();
-    List<DataAccessRequest> dars = collection.getDars();
+    Map<String, DataAccessRequest> dars = collection.getDars();
     createDarCollection(); //create new collection associated with different user
     Integer userId = collection.getCreateUserId();
     List<DarCollection> collectionResult = darCollectionDAO.findDARCollectionsCreatedByUserId(userId);
@@ -367,15 +368,20 @@ public void testFindAllDARCollectionsWithFilters_InstitutionTerm() {
     assertEquals(userId, collectionResult.get(0).getCreateUserId());
     Map<String, List<Election>> electionMap = collectionResult.get(0).getElectionMap();
     assertEquals(1, electionMap.size());
-    String referenceId = collectionResult.get(0).getDars().get(0).getReferenceId();
-    assertEquals(1, electionMap.get(referenceId).size());
+    List<String> keyset = electionMap.keySet().stream().collect(Collectors.toList());
+    String key = keyset.get(0);
+    List<Election> elections = electionMap.get(key);
+    assertEquals(1, elections.size());
 
-    List<DataAccessRequest> darsResult = collectionResult.get(0).getDars();
-    assertEquals(dars.size(), darsResult.size());
+    Collection<DataAccessRequest> darsResult = collectionResult.get(0).getDars().values();
+    assertEquals(dars.values().size(), darsResult.size());
 
+    List<DataAccessRequest> originalDars = new ArrayList<>(dars.values());
+    List<DataAccessRequest> resultDars = new ArrayList<>(dars.values());
+    
     for (int i = 0; i < dars.size(); i++) {
-      DataAccessRequest darOriginal = dars.get(i);
-      DataAccessRequest darResults = darsResult.get(i);
+      DataAccessRequest darOriginal = originalDars.get(i);
+      DataAccessRequest darResults = resultDars.get(i);
       assertEquals(darOriginal.getId(), darResults.getId());
       assertEquals(collection.getDarCode(), darResults.getData().getDarCode());
     }

--- a/src/test/java/org/broadinstitute/consent/http/resources/DarCollectionResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DarCollectionResourceTest.java
@@ -14,7 +14,10 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
+
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.InternalServerErrorException;
 import javax.ws.rs.core.Response;
@@ -66,9 +69,8 @@ public class DarCollectionResourceTest {
 
   private DarCollection mockDarCollection() {
     DarCollection collection = new DarCollection();
-    collection.setDars(new ArrayList<>());
     for(int i = 0; i < 3; i++) {
-      collection.getDars().add(mockDataAccessRequestWithDatasetIds());
+      collection.addDar(mockDataAccessRequestWithDatasetIds());
     }
     return collection;
   }
@@ -342,9 +344,12 @@ public class DarCollectionResourceTest {
     when(collection.getCreateUserId()).thenReturn(userId);
     DataAccessRequest dar = mock(DataAccessRequest.class);
     DataAccessRequestData data = mock(DataAccessRequestData.class);
+    String referenceId = UUID.randomUUID().toString();
     when(data.getStatus()).thenReturn("Not Canceled");
     when(dar.getData()).thenReturn(data);
-    when(collection.getDars()).thenReturn(List.of(dar));
+    when(dar.getReferenceId()).thenReturn(referenceId);
+    Map<String, DataAccessRequest> darMap = Map.of(dar.getReferenceId(), dar);
+    when(collection.getDars()).thenReturn(darMap);
     when(darCollectionService.getByCollectionId(any())).thenReturn(collection);
     initResource();
 
@@ -362,9 +367,12 @@ public class DarCollectionResourceTest {
     when(collection.getCreateUserId()).thenReturn(userId);
     DataAccessRequest dar = mock(DataAccessRequest.class);
     DataAccessRequestData data = mock(DataAccessRequestData.class);
+    String referenceId = UUID.randomUUID().toString();
     when(data.getStatus()).thenReturn(DarStatus.CANCELED.getValue());
     when(dar.getData()).thenReturn(data);
-    when(collection.getDars()).thenReturn(List.of(dar));
+    when(dar.getReferenceId()).thenReturn(referenceId);
+    Map<String, DataAccessRequest> darMap = Map.of(dar.getReferenceId(), dar);
+    when(collection.getDars()).thenReturn(darMap);
     when(darCollectionService.getByCollectionId(any())).thenReturn(collection);
     when(dataAccessRequestService.createDraftDarFromCanceledCollection(any(), any())).thenReturn(new DataAccessRequest());
     initResource();

--- a/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
@@ -12,9 +12,12 @@ import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import javax.ws.rs.BadRequestException;
@@ -264,7 +267,7 @@ public class DarCollectionServiceTest {
   public void testCancelDarCollection_noElections() {
     Set<DataSet> datasets = new HashSet<>();
     DarCollection collection = generateMockDarCollection(datasets);
-    collection.getDars().forEach(d -> d.getData().setStatus("Canceled"));
+    collection.getDars().values().forEach(d -> d.getData().setStatus("Canceled"));
     List<Election> elections = new ArrayList<>();
     when(electionDAO.findLastElectionsByReferenceIdsAndType(anyList(), anyString())).thenReturn(elections);
     doNothing().when(dataAccessRequestDAO).cancelByReferenceIds(anyList());
@@ -272,7 +275,7 @@ public class DarCollectionServiceTest {
     initService();
 
     DarCollection canceledCollection = service.cancelDarCollection(collection);
-    for (DataAccessRequest collectionDar : canceledCollection.getDars()) {
+    for (DataAccessRequest collectionDar : canceledCollection.getDars().values()) {
       assertEquals("canceled", collectionDar.getData().getStatus().toLowerCase());
     }
   }
@@ -292,9 +295,11 @@ public class DarCollectionServiceTest {
 
   private DarCollection generateMockDarCollection(Set<DataSet> datasets) {
     DarCollection collection = new DarCollection();
-    List<DataAccessRequest> dars = new ArrayList<>();
-    dars.add(generateMockDarWithDatasetId(datasets));
-    dars.add(generateMockDarWithDatasetId(datasets));
+    Map<String, DataAccessRequest> dars = new HashMap<>();
+    DataAccessRequest darOne = generateMockDarWithDatasetId(datasets);
+    DataAccessRequest darTwo = generateMockDarWithDatasetId(datasets);
+    dars.put(darOne.getReferenceId(), darOne);
+    dars.put(darTwo.getReferenceId(), darTwo);
     collection.setDars(dars);
     return collection;
   }
@@ -307,6 +312,7 @@ public class DarCollectionServiceTest {
     datasets.add(generateMockDatasetWithDataUse(datasetId));
     data.setDatasetIds(Collections.singletonList(datasetId));
     dar.setData(data);
+    dar.setReferenceId(UUID.randomUUID().toString());
     return dar;
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
@@ -662,7 +662,9 @@ public class DataAccessRequestServiceTest {
     public void testCreateDraftDarFromCanceledCollection_NoDarData() {
         User user = new User();
         DarCollection sourceCollection = new DarCollection();
-        sourceCollection.setDars(List.of(new DataAccessRequest()));
+        DataAccessRequest newDar = new DataAccessRequest();
+        newDar.setReferenceId(UUID.randomUUID().toString());
+        sourceCollection.addDar(newDar);
         initService();
         service.createDraftDarFromCanceledCollection(user, sourceCollection);
     }
@@ -673,9 +675,11 @@ public class DataAccessRequestServiceTest {
         DarCollection sourceCollection = new DarCollection();
         DataAccessRequest dar = new DataAccessRequest();
         DataAccessRequestData data = new DataAccessRequestData();
+        data.setReferenceId(UUID.randomUUID().toString());
         data.setStatus("Not Canceled");
         dar.setData(data);
-        sourceCollection.setDars(List.of(dar));
+        dar.setReferenceId(data.getReferenceId());
+        sourceCollection.addDar(dar);
         initService();
         service.createDraftDarFromCanceledCollection(user, sourceCollection);
     }
@@ -686,10 +690,12 @@ public class DataAccessRequestServiceTest {
         DarCollection sourceCollection = new DarCollection();
         DataAccessRequest dar = new DataAccessRequest();
         DataAccessRequestData data = new DataAccessRequestData();
+        data.setReferenceId(UUID.randomUUID().toString());
         data.setStatus(DarStatus.CANCELED.getValue());
         data.setDatasetIds(List.of());
         dar.setData(data);
-        sourceCollection.setDars(List.of(dar));
+        dar.setReferenceId(data.getReferenceId());
+        sourceCollection.addDar(dar);
         initService();
         service.createDraftDarFromCanceledCollection(user, sourceCollection);
     }
@@ -705,7 +711,7 @@ public class DataAccessRequestServiceTest {
         data.setReferenceId(UUID.randomUUID().toString());
         dar.setData(data);
         dar.setReferenceId(data.getReferenceId());
-        sourceCollection.setDars(List.of(dar));
+        sourceCollection.addDar(dar);
         when(electionDAO.getElectionIdsByReferenceIds(any())).thenReturn(List.of(1));
         initService();
         service.createDraftDarFromCanceledCollection(user, sourceCollection);
@@ -722,7 +728,7 @@ public class DataAccessRequestServiceTest {
         data.setReferenceId(UUID.randomUUID().toString());
         dar.setData(data);
         dar.setReferenceId(data.getReferenceId());
-        sourceCollection.setDars(List.of(dar));
+        sourceCollection.addDar(dar);
         when(electionDAO.getElectionIdsByReferenceIds(any())).thenReturn(List.of());
         doNothing().when(dataAccessRequestDAO).insertDraftDataAccessRequest(
             any(),


### PR DESCRIPTION
Addresses [DUOS-1531](https://broadworkbench.atlassian.net/browse/DUOS-1531)

PR updates Dar Collection to include elections and votes in payload. Elections are mapped to the reference id of the DAR they belong to, while votes are mapped to their election. PR also includes a query update for `findDARCollectionByCollectionId`, as well as updates to service, resource, and test methods.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
