### PR TITLE
[DUOS-1514][risk=no] Remove Elastic Search health check exceptions

### DIFF
--- a/src/test/java/org/broadinstitute/consent/http/health/ElasticSearchHealthCheckTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/health/ElasticSearchHealthCheckTest.java
@@ -11,7 +11,6 @@ import org.junit.Test;
 import org.mockserver.client.MockServerClient;
 import org.testcontainers.containers.MockServerContainer;
 
-import javax.ws.rs.InternalServerErrorException;
 import java.util.Collections;
 
 import static org.junit.Assert.assertFalse;
@@ -82,9 +81,11 @@ public class ElasticSearchHealthCheckTest implements WithMockServer {
         assertFalse(result.isHealthy());
     }
 
-    @Test (expected = InternalServerErrorException.class)
+    @Test
     public void testCheckServerFailure() throws Exception {
         initHealthCheck("green", HttpStatusCodes.STATUS_CODE_SERVER_ERROR);
-        healthCheck.check();
+
+        HealthCheck.Result result = healthCheck.check();
+        assertFalse(result.isHealthy());
     }
 }


### PR DESCRIPTION
Rewriting thrown exceptions in Elastic Search health check as unhealthy results, editing tests to reflect changes

Issue: https://broadworkbench.atlassian.net/browse/DUOS-1514

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
