### PR TITLE
DUOS-1526[risk=no] findElectionsWithFinalVoteByTypeAndStatus only pulls Chairperson vote where vote != null

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/ElectionDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/ElectionDAO.java
@@ -105,7 +105,8 @@ public interface ElectionDAO extends Transactional<ElectionDAO> {
     @SqlQuery("select distinct e.electionId,  e.datasetId, v.vote finalVote, e.status, e.createDate, e.referenceId, v.rationale finalRationale, v.createDate finalVoteDate, "
             + "e.lastUpdate, e.finalAccessVote, e.electionType,  e.dataUseLetter, e.dulName, e.archived, e.version from election e "
             + "inner join vote v on v.electionId = e.electionId and lower(v.type) = 'chairperson' "
-            + "where lower(e.electionType) = lower(:type) and lower(e.status) = lower(:status) order by createDate asc")
+            + "where lower(e.electionType) = lower(:type) and lower(e.status) = lower(:status) and v.vote is not null "
+            + "order by createDate asc")
     List<Election> findElectionsWithFinalVoteByTypeAndStatus(@Bind("type") String type, @Bind("status") String status);
 
     @SqlQuery("select distinct e.electionId,  e.datasetId, v.vote finalVote, e.status, e.createDate, e.referenceId, v.rationale finalRationale, v.createDate finalVoteDate, "


### PR DESCRIPTION
Addresses [DUOS-1526](https://broadworkbench.atlassian.net/browse/DUOS-1526)

PR addresses overlapping Chairperson votes on query by only pulling in Chairperson votes where the vote is recorded. Since the election closes on the submission of a (first) chairperson vote, the remaining chairperson votes will remain null.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
