### PR TITLE
[DUOS-1388][risk=no] Fix find all users so it includes properties

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/DacDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DacDAO.java
@@ -63,7 +63,7 @@ public interface DacDAO extends Transactional<DacDAO> {
               " where lower(du.displayName) like concat('%', lower(:term), '%') " +
               " or lower(du.email) like concat('%', lower(:term), '%') " +
               " or lower(du.additional_email) like concat('%', lower(:term), '%') ")
-    List<User> findAllDACUsersBySearchString(@Bind("term") String term);
+    Set<User> findAllDACUsersBySearchString(@Bind("term") String term);
 
     @SqlQuery("select * from dac where dac_id = :dacId")
     Dac findById(@Bind("dacId") Integer dacId);

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/UserWithRolesReducer.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/UserWithRolesReducer.java
@@ -1,9 +1,11 @@
 package org.broadinstitute.consent.http.db.mapper;
 
 import org.broadinstitute.consent.http.enumeration.RoleStatus;
+import org.broadinstitute.consent.http.enumeration.UserFields;
 import org.broadinstitute.consent.http.models.Institution;
 import org.broadinstitute.consent.http.models.LibraryCard;
 import org.broadinstitute.consent.http.models.User;
+import org.broadinstitute.consent.http.models.UserProperty;
 import org.broadinstitute.consent.http.models.UserRole;
 import org.jdbi.v3.core.mapper.MappingException;
 import org.jdbi.v3.core.result.LinkedHashMapRowReducer;
@@ -72,6 +74,18 @@ public class UserWithRolesReducer implements LinkedHashMapRowReducer<Integer, Us
       }
     } catch(MappingException e) {
       //Ignore exceptions here, user may not have a library card issued under this instiution
+    }
+    try {
+      if (Objects.nonNull(rowView.getColumn("up_property_id", Integer.class))) {
+        UserProperty p = rowView.getRow(UserProperty.class);
+        user.addProperty(p);
+        // Note that the completed field is deprecated and will be removed in a future PR. 
+        if (p.getPropertyKey().equalsIgnoreCase(UserFields.COMPLETED.getValue())) {
+          user.setProfileCompleted(Boolean.valueOf(p.getPropertyValue()));
+        }
+      }
+    } catch (MappingException e) {
+      // Ignore any attempt to map a column that doesn't exist
     }
   }
 

--- a/src/main/java/org/broadinstitute/consent/http/models/User.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/User.java
@@ -324,21 +324,27 @@ public class User {
         if (Objects.isNull(this.getRoles())) {
             this.setRoles(new ArrayList<>());
         }
-        this.getRoles().add(userRole);
+        if (!this.getRoles().contains(userRole)) {
+            this.getRoles().add(userRole);
+        }
     }
 
     public void addProperty(UserProperty userProp) {
         if (Objects.isNull(this.getProperties())) {
             this.setProperties(new ArrayList<>());
         }
-        this.getProperties().add(userProp);
+        if (!this.getProperties().contains(userProp)) {
+            this.getProperties().add(userProp);
+        }
     }
 
     public void addLibraryCard(LibraryCard card) {
         if(Objects.isNull(this.getLibraryCards())) {
-            this.setLibraryCards(new ArrayList<LibraryCard>());
+            this.setLibraryCards(new ArrayList<>());
         }
-        this.getLibraryCards().add(card);
+        if (!this.getLibraryCards().contains(card)) {
+            this.getLibraryCards().add(card);
+        }
     }
 
     @Override

--- a/src/main/java/org/broadinstitute/consent/http/models/UserProperty.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/UserProperty.java
@@ -2,6 +2,7 @@ package org.broadinstitute.consent.http.models;
 
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Objects;
 
 public class UserProperty {
 
@@ -69,5 +70,18 @@ public class UserProperty {
 
     public void setUserId(Integer userId) {
         this.userId = userId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        UserProperty property = (UserProperty) o;
+        return Objects.equal(propertyId, property.propertyId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(propertyId);
     }
 }

--- a/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
@@ -24,6 +24,8 @@ import org.broadinstitute.consent.http.ConsentApplication;
 import org.broadinstitute.consent.http.configurations.ConsentConfiguration;
 import org.broadinstitute.consent.http.enumeration.ElectionStatus;
 import org.broadinstitute.consent.http.enumeration.ElectionType;
+import org.broadinstitute.consent.http.enumeration.UserFields;
+import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.enumeration.VoteType;
 import org.broadinstitute.consent.http.models.ApprovalExpirationTime;
 import org.broadinstitute.consent.http.models.Consent;
@@ -37,6 +39,7 @@ import org.broadinstitute.consent.http.models.Institution;
 import org.broadinstitute.consent.http.models.LibraryCard;
 import org.broadinstitute.consent.http.models.Match;
 import org.broadinstitute.consent.http.models.User;
+import org.broadinstitute.consent.http.models.UserProperty;
 import org.broadinstitute.consent.http.models.Vote;
 import org.broadinstitute.consent.http.models.DarCollection;
 import org.jdbi.v3.core.Jdbi;
@@ -353,8 +356,18 @@ public class DAOTestHelper {
                 "." +
                 RandomStringUtils.randomAlphabetic(i3);
         Integer userId = userDAO.insertUser(email, "display name", new Date());
+        createUserProperty(userId, UserFields.ORCID.getValue());
+        addUserRole(UserRoles.RESEARCHER.getRoleId(), userId);
         createdUserIds.add(userId);
         return userDAO.findUserById(userId);
+    }
+    
+    protected void createUserProperty(Integer userId, String field) {
+        UserProperty property = new UserProperty();
+        property.setPropertyKey(field);
+        property.setPropertyValue(UUID.randomUUID().toString());
+        property.setUserId(userId);
+        userPropertyDAO.insertAll(List.of(property));
     }
 
     protected User createUserWithInstitution() {

--- a/src/test/java/org/broadinstitute/consent/http/db/DacDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DacDAOTest.java
@@ -8,6 +8,8 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
+
 import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.Consent;
 import org.broadinstitute.consent.http.models.Dac;
@@ -63,17 +65,17 @@ public class DacDAOTest extends DAOTestHelper {
     @Test
     public void testFindAllDACUsersBySearchString_case1() {
         Dac dac = createDac();
-        User chair = createUser();
+        User chair = createUser(); // Creates a user with researcher role
         dacDAO.addDacMember(UserRoles.CHAIRPERSON.getRoleId(), chair.getDacUserId(), dac.getDacId());
 
-        List<User> users = dacDAO.findAllDACUsersBySearchString(chair.getEmail());
+        Set<User> users = dacDAO.findAllDACUsersBySearchString(chair.getEmail());
         assertFalse(users.isEmpty());
         Assert.assertEquals(1, users.size());
     }
 
     @Test
     public void testFindAllDACUsersBySearchString_case2() {
-        List<User> users = dacDAO.findAllDACUsersBySearchString("random");
+        Set<User> users = dacDAO.findAllDACUsersBySearchString("random");
         Assert.assertTrue(users.isEmpty());
     }
 
@@ -174,13 +176,13 @@ public class DacDAOTest extends DAOTestHelper {
     @Test
     public void testFindUserRolesForUsers() {
         Dac dac = createDac();
-        User chair = createUser();
-        User member = createUser();
+        User chair = createUser(); // Creates a user with researcher role
+        User member = createUser(); // Creates a user with researcher role
         dacDAO.addDacMember(UserRoles.CHAIRPERSON.getRoleId(), chair.getDacUserId(), dac.getDacId());
         dacDAO.addDacMember(UserRoles.MEMBER.getRoleId(), member.getDacUserId(), dac.getDacId());
         List<Integer> userIds = Arrays.asList(chair.getDacUserId(), member.getDacUserId());
-        List<UserRole> userRoles = dacDAO.findUserRolesForUsers(userIds);
-        Assert.assertEquals(userRoles.size(), 2);
+        List<UserRole> userRoles = dacDAO.findUserRolesForUsers(userIds).stream().distinct().collect(Collectors.toList());
+        Assert.assertEquals(userRoles.size(), 3);
     }
 
     @Test

--- a/src/test/java/org/broadinstitute/consent/http/db/UserDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/UserDAOTest.java
@@ -1,19 +1,5 @@
 package org.broadinstitute.consent.http.db;
 
-import static org.broadinstitute.consent.http.enumeration.RoleStatus.getStatusByValue;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-
 import org.apache.commons.lang3.RandomStringUtils;
 import org.broadinstitute.consent.http.enumeration.RoleStatus;
 import org.broadinstitute.consent.http.enumeration.UserFields;
@@ -24,10 +10,24 @@ import org.broadinstitute.consent.http.models.DataSet;
 import org.broadinstitute.consent.http.models.Election;
 import org.broadinstitute.consent.http.models.Institution;
 import org.broadinstitute.consent.http.models.LibraryCard;
-import org.broadinstitute.consent.http.models.UserProperty;
 import org.broadinstitute.consent.http.models.User;
+import org.broadinstitute.consent.http.models.UserProperty;
 import org.junit.Assert;
 import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.broadinstitute.consent.http.enumeration.RoleStatus.getStatusByValue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 public class UserDAOTest extends DAOTestHelper {
 
@@ -203,9 +203,11 @@ public class UserDAOTest extends DAOTestHelper {
     @Test
     public void testFindUsers_noArgs() {
         createUser();
-        Collection<User> users = userDAO.findUsers();
+        List<User> users = new ArrayList<>(userDAO.findUsers());
         assertNotNull(users);
         assertFalse(users.isEmpty());
+        assertFalse(users.get(0).getProperties().isEmpty());
+        assertFalse(users.get(0).getRoles().isEmpty());
     }
 
     @Test

--- a/src/test/java/org/broadinstitute/consent/http/db/UserDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/UserDAOTest.java
@@ -143,14 +143,6 @@ public class UserDAOTest extends DAOTestHelper {
     }
 
     @Test
-    public void testFindUsersWithNoRoles() {
-        User user = createUser();
-        Collection<Integer> userIds = Collections.singletonList(user.getDacUserId());
-        Collection<User> users = userDAO.findUsersWithRoles(userIds);
-        users.forEach(u -> assertTrue("User: " + u.getDacUserId() + " has roles", u.getRoles().isEmpty()));
-    }
-
-    @Test
     public void testFindDACUserByEmail() {
         User user = createUser();
         addUserRole(UserRoles.ALUMNI.getRoleId(), user.getDacUserId());


### PR DESCRIPTION
## Addresses
Partially addresses https://broadworkbench.atlassian.net/browse/DUOS-1388
Necessary to support the admin UI calculations for profile completion state.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
