### PR TITLE
[DUOS-1307][risk=low] Allow for Admins, Chairs, to cancel DAR Collection & Associated Elections

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
@@ -238,7 +238,7 @@ public class ConsentApplication extends Application<ConsentConfiguration> {
         env.jersey().register(new ConsentCasesResource(electionService, pendingCaseService, summaryService));
         env.jersey().register(new DacResource(dacService, userService));
         env.jersey().register(new DACUserResource(userService));
-        env.jersey().register(new DarCollectionResource(userService, darCollectionService, dataAccessRequestService));
+        env.jersey().register(new DarCollectionResource(dataAccessRequestService, darCollectionService, userService));
         env.jersey().register(new DataRequestElectionResource(dataAccessRequestService, emailNotifierService, summaryService, voteService, electionService));
         env.jersey().register(new DataRequestVoteResource(dataAccessRequestService, datasetAssociationService, emailNotifierService, voteService, datasetService, electionService, userService));
         env.jersey().register(new DataRequestCasesResource(electionService, pendingCaseService, summaryService));

--- a/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
@@ -242,7 +242,7 @@ public class ConsentApplication extends Application<ConsentConfiguration> {
         env.jersey().register(new DataRequestReportsResource(dataAccessRequestService));
         env.jersey().register(new DacResource(dacService, userService));
         env.jersey().register(new DACUserResource(userService));
-        env.jersey().register(new DarCollectionResource(userService, darCollectionService, dataAccessRequestService));
+        env.jersey().register(new DarCollectionResource(dataAccessRequestService, darCollectionService, userService));
         env.jersey().register(new ElectionReviewResource(dataAccessRequestService, consentService, electionService, reviewResultsService));
         env.jersey().register(new ElectionResource(voteService, electionService));
         env.jersey().register(new EmailNotifierResource(emailNotifierService));

--- a/src/main/java/org/broadinstitute/consent/http/db/ElectionDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/ElectionDAO.java
@@ -99,7 +99,7 @@ public interface ElectionDAO extends Transactional<ElectionDAO> {
 
     // TODO: This can return multiple rows per election id, e.g. ID 578 on staging.
     // The root of the duplicate rows is in the vote inner join. When there are multiple chairperson
-    // votes, v.rationale and v.createDate can be different between the chairperson votes, leading 
+    // votes, v.rationale and v.createDate can be different between the chairperson votes, leading
     // to duplicate rows.
     // See https://broadworkbench.atlassian.net/browse/DUOS-1526
     @SqlQuery("select distinct e.electionId,  e.datasetId, v.vote finalVote, e.status, e.createDate, e.referenceId, v.rationale finalRationale, v.createDate finalVoteDate, "
@@ -164,27 +164,27 @@ public interface ElectionDAO extends Transactional<ElectionDAO> {
     @SqlQuery(
       "SELECT * from ( "
         + "SELECT e.*, v.vote finalvote, "
-        + "CASE "
-        + "WHEN v.updatedate IS NULL THEN v.createdate "
-        + "ELSE v.updatedate "
-        + "END as finalvotedate, "
-        + "v.rationale finalrationale, MAX(e.electionid) "
-        + "OVER (PARTITION BY e.referenceid, e.electiontype) AS latest "
-        + "FROM election e "
-        + "LEFT JOIN vote v ON e.electionid = v.electionid AND "
-        + "CASE "
-        + "WHEN LOWER(e.electiontype) = 'dataaccess' THEN 'final'"
-        + "WHEN LOWER(e.electiontype) = 'dataset' THEN 'data_owner' "
-        + "ELSE 'chairperson' "
-        + "END = LOWER(v.type) "
-        + "WHERE e.referenceid in(<referenceIds>) "
+        + "     CASE "
+        + "     WHEN v.updatedate IS NULL THEN v.createdate "
+        + "     ELSE v.updatedate "
+        + "     END as finalvotedate, "
+        + " v.rationale finalrationale, MAX(e.electionid) "
+        + " OVER (PARTITION BY e.referenceid, e.electiontype) AS latest "
+        + " FROM election e "
+        + " LEFT JOIN vote v ON e.electionid = v.electionid AND "
+        + "     CASE "
+        + "     WHEN LOWER(e.electiontype) = 'dataaccess' THEN 'final'"
+        + "     WHEN LOWER(e.electiontype) = 'dataset' THEN 'data_owner' "
+        + "     ELSE 'chairperson' "
+        + "     END = LOWER(v.type) "
+        + " WHERE e.referenceid IN (<referenceIds>) "
         + ") AS results "
-        + "WHERE results.latest = results.electionid "
-        + "ORDER BY results.electionid DESC, "
-        + "CASE "
-        + "WHEN results.finalvotedate IS NULL THEN results.lastupdate "
-        + "ELSE results.finalvotedate "
-        + "END DESC"
+        + " WHERE results.latest = results.electionid "
+        + " ORDER BY results.electionid DESC, "
+        + "     CASE "
+        + "     WHEN results.finalvotedate IS NULL THEN results.lastupdate "
+        + "     ELSE results.finalvotedate "
+        + "     END DESC"
     )
     @UseRowMapper(ElectionMapper.class)
     List<Election> findLastElectionsByReferenceIds(
@@ -329,21 +329,21 @@ public interface ElectionDAO extends Transactional<ElectionDAO> {
         + "INNER JOIN dac d on d.dac_id = c.dac_id "
         + "WHERE e.electionId IN (<electionIds>) "
         + "UNION "
-        + "SELECT d.*, e.electionid " 
-        + "FROM dac d " 
+        + "SELECT d.*, e.electionid "
+        + "FROM dac d "
         + "INNER JOIN consents "
-        + "ON d.dac_id = consents.dac_id " 
+        + "ON d.dac_id = consents.dac_id "
         + "INNER JOIN consentassociations ca "
-        + "ON ca.consentid = consents.consentid " 
+        + "ON ca.consentid = consents.consentid "
         + "INNER JOIN dataset data "
-        + "ON data.datasetid = ca.datasetid " 
+        + "ON data.datasetid = ca.datasetid "
         + "INNER JOIN election e "
         + "ON e.datasetid = data.datasetid "
         + "WHERE e.electionId IN (<electionIds>)"
     )
     @UseRowMapper(DacMapper.class)
     List<Dac> findAllDacsForElectionIds(@BindList("electionIds") List<Integer> electionIds);
-  
+
     /**
      * Find the OPEN elections that belong to this Dac
      *

--- a/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequest.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequest.java
@@ -51,9 +51,12 @@ public class DataAccessRequest {
     this.elections = new HashMap<>();
   }
 
-  public static boolean isNotCanceled(DataAccessRequest dar) {
-    String status = dar.getData().getStatus();
-    return Objects.isNull(status) || !status.equalsIgnoreCase("canceled");
+  public static boolean isCanceled(DataAccessRequest dar) {
+    return
+      Objects.nonNull(dar) &&
+      Objects.nonNull(dar.getData()) &&
+      Objects.nonNull(dar.getData().getStatus()) &&
+      dar.getData().getStatus().equalsIgnoreCase("canceled");
   }
 
   public Integer getId() {

--- a/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequest.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequest.java
@@ -53,7 +53,7 @@ public class DataAccessRequest {
 
   public static boolean isNotCanceled(DataAccessRequest dar) {
     String status = dar.getData().getStatus();
-    return Objects.isNull(status) || status.toLowerCase() != "canceled";
+    return Objects.isNull(status) || !status.equalsIgnoreCase("canceled");
   }
 
   public Integer getId() {

--- a/src/main/java/org/broadinstitute/consent/http/resources/DarCollectionResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DarCollectionResource.java
@@ -11,7 +11,6 @@ import org.broadinstitute.consent.http.models.DataAccessRequest;
 import org.broadinstitute.consent.http.models.PaginationResponse;
 import org.broadinstitute.consent.http.models.PaginationToken;
 import org.broadinstitute.consent.http.models.User;
-import org.broadinstitute.consent.http.models.UserRole;
 import org.broadinstitute.consent.http.service.DarCollectionService;
 import org.broadinstitute.consent.http.service.DataAccessRequestService;
 import org.broadinstitute.consent.http.service.UserService;

--- a/src/main/java/org/broadinstitute/consent/http/resources/DarCollectionResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DarCollectionResource.java
@@ -3,11 +3,18 @@ package org.broadinstitute.consent.http.resources;
 import com.google.gson.Gson;
 import com.google.inject.Inject;
 import io.dropwizard.auth.Auth;
-import java.nio.charset.StandardCharsets;
-import java.util.Base64;
-import java.util.Collections;
-import java.util.List;
-import java.util.Objects;
+import org.broadinstitute.consent.http.enumeration.DarStatus;
+import org.broadinstitute.consent.http.enumeration.UserRoles;
+import org.broadinstitute.consent.http.models.AuthUser;
+import org.broadinstitute.consent.http.models.DarCollection;
+import org.broadinstitute.consent.http.models.DataAccessRequest;
+import org.broadinstitute.consent.http.models.PaginationResponse;
+import org.broadinstitute.consent.http.models.PaginationToken;
+import org.broadinstitute.consent.http.models.User;
+import org.broadinstitute.consent.http.service.DarCollectionService;
+import org.broadinstitute.consent.http.service.DataAccessRequestService;
+import org.broadinstitute.consent.http.service.UserService;
+
 import javax.annotation.security.PermitAll;
 import javax.annotation.security.RolesAllowed;
 import javax.ws.rs.BadRequestException;
@@ -20,30 +27,25 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Response;
-import org.broadinstitute.consent.http.enumeration.DarStatus;
-import org.broadinstitute.consent.http.models.AuthUser;
-import org.broadinstitute.consent.http.models.DarCollection;
-import org.broadinstitute.consent.http.models.DataAccessRequest;
-import org.broadinstitute.consent.http.models.PaginationResponse;
-import org.broadinstitute.consent.http.models.PaginationToken;
-import org.broadinstitute.consent.http.models.User;
-import org.broadinstitute.consent.http.service.DarCollectionService;
-import org.broadinstitute.consent.http.service.DataAccessRequestService;
-import org.broadinstitute.consent.http.service.UserService;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
 
 @Path("api/collections")
 public class DarCollectionResource extends Resource {
 
-  private final UserService userService;
-  private final DarCollectionService darCollectionService;
   private final DataAccessRequestService dataAccessRequestService;
+  private final DarCollectionService darCollectionService;
+  private final UserService userService;
 
   @Inject
-  public DarCollectionResource(UserService userService, DarCollectionService darCollectionService, 
-    DataAccessRequestService dataAccessRequestService) {
-    this.userService = userService;
-    this.darCollectionService = darCollectionService;
+  public DarCollectionResource(DataAccessRequestService dataAccessRequestService,
+    DarCollectionService darCollectionService, UserService userService) {
     this.dataAccessRequestService = dataAccessRequestService;
+    this.darCollectionService = darCollectionService;
+    this.userService = userService;
   }
 
   @GET
@@ -148,18 +150,47 @@ public class DarCollectionResource extends Resource {
     }
   }
 
-
   @PUT
   @Path("{id}/cancel")
   @Produces("application/json")
-  @RolesAllowed(RESEARCHER)
-  public Response cancelDarCollectionByCollectionId(@Auth AuthUser authUser, @PathParam("id") Integer collectionId) {
+  @RolesAllowed({ADMIN, CHAIRPERSON, RESEARCHER})
+  public Response cancelDarCollectionByCollectionId(
+    @Auth AuthUser authUser,
+    @PathParam("id") Integer collectionId,
+    @QueryParam("roleName") String roleName) {
     try {
       User user = userService.findUserByEmail(authUser.getEmail());
       DarCollection collection = darCollectionService.getByCollectionId(collectionId);
       isCollectionPresent(collection);
-      validateUserIsCreator(user, collection);
-      DarCollection cancelledCollection = darCollectionService.cancelDarCollection(collection);
+
+      UserRoles actingRole;
+      if (Objects.nonNull(roleName)) {
+        validateUserHasRoleName(user, roleName);
+        actingRole = UserRoles.getUserRoleFromName(roleName);
+      } else {
+        if (user.hasUserRole(UserRoles.ADMIN)) {
+          actingRole = UserRoles.ADMIN;
+        } else if (user.hasUserRole(UserRoles.CHAIRPERSON)) {
+          actingRole = UserRoles.CHAIRPERSON;
+        } else {
+          actingRole = UserRoles.RESEARCHER;
+        }
+      }
+
+      DarCollection cancelledCollection;
+      switch (Objects.requireNonNull(actingRole)) {
+        case ADMIN:
+          cancelledCollection = darCollectionService.cancelDarCollectionAsAdmin(collection);
+          break;
+        case CHAIRPERSON:
+          cancelledCollection = darCollectionService.cancelDarCollectionAsChair(collection, user);
+          break;
+        default:
+          validateUserIsCreator(user, collection);
+          cancelledCollection = darCollectionService.cancelDarCollectionAsResearcher(collection);
+          break;
+      }
+
       return Response.ok().entity(cancelledCollection).build();
     } catch(Exception e) {
       return createExceptionResponse(e);

--- a/src/main/java/org/broadinstitute/consent/http/resources/DarCollectionResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DarCollectionResource.java
@@ -163,18 +163,11 @@ public class DarCollectionResource extends Resource {
       DarCollection collection = darCollectionService.getByCollectionId(collectionId);
       isCollectionPresent(collection);
 
-      UserRoles actingRole;
+      // Default to the least impactful role if none provided.
+      UserRoles actingRole = UserRoles.RESEARCHER;
       if (Objects.nonNull(roleName)) {
         validateUserHasRoleName(user, roleName);
         actingRole = UserRoles.getUserRoleFromName(roleName);
-      } else {
-        if (user.hasUserRole(UserRoles.ADMIN)) {
-          actingRole = UserRoles.ADMIN;
-        } else if (user.hasUserRole(UserRoles.CHAIRPERSON)) {
-          actingRole = UserRoles.CHAIRPERSON;
-        } else {
-          actingRole = UserRoles.RESEARCHER;
-        }
       }
 
       DarCollection cancelledCollection;

--- a/src/main/java/org/broadinstitute/consent/http/resources/DarCollectionResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DarCollectionResource.java
@@ -11,6 +11,7 @@ import org.broadinstitute.consent.http.models.DataAccessRequest;
 import org.broadinstitute.consent.http.models.PaginationResponse;
 import org.broadinstitute.consent.http.models.PaginationToken;
 import org.broadinstitute.consent.http.models.User;
+import org.broadinstitute.consent.http.models.UserRole;
 import org.broadinstitute.consent.http.service.DarCollectionService;
 import org.broadinstitute.consent.http.service.DataAccessRequestService;
 import org.broadinstitute.consent.http.service.UserService;
@@ -167,11 +168,14 @@ public class DarCollectionResource extends Resource {
       UserRoles actingRole = UserRoles.RESEARCHER;
       if (Objects.nonNull(roleName)) {
         validateUserHasRoleName(user, roleName);
-        actingRole = UserRoles.getUserRoleFromName(roleName);
+        UserRoles requestedRole = UserRoles.getUserRoleFromName(roleName);
+        if (Objects.nonNull(requestedRole)) {
+          actingRole = requestedRole;
+        }
       }
 
       DarCollection cancelledCollection;
-      switch (Objects.requireNonNull(actingRole)) {
+      switch (actingRole) {
         case ADMIN:
           cancelledCollection = darCollectionService.cancelDarCollectionElectionsAsAdmin(collection);
           break;

--- a/src/main/java/org/broadinstitute/consent/http/resources/DarCollectionResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DarCollectionResource.java
@@ -173,10 +173,10 @@ public class DarCollectionResource extends Resource {
       DarCollection cancelledCollection;
       switch (Objects.requireNonNull(actingRole)) {
         case ADMIN:
-          cancelledCollection = darCollectionService.cancelDarCollectionAsAdmin(collection);
+          cancelledCollection = darCollectionService.cancelDarCollectionElectionsAsAdmin(collection);
           break;
         case CHAIRPERSON:
-          cancelledCollection = darCollectionService.cancelDarCollectionAsChair(collection, user);
+          cancelledCollection = darCollectionService.cancelDarCollectionElectionsAsChair(collection, user);
           break;
         default:
           validateUserIsCreator(user, collection);

--- a/src/main/java/org/broadinstitute/consent/http/resources/DataRequestElectionResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataRequestElectionResource.java
@@ -97,6 +97,7 @@ public class DataRequestElectionResource extends Resource {
         }
     }
 
+    @Deprecated
     @DELETE
     @Produces(MediaType.APPLICATION_JSON)
     @Path("/{id}")

--- a/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
@@ -326,7 +326,7 @@ public class DarCollectionService {
       .filter(DataAccessRequest::isNotCanceled)
       .map(DataAccessRequest::getReferenceId)
       .collect(Collectors.toList());
-    if(!activeDarIds.isEmpty()) {
+    if (!activeDarIds.isEmpty()) {
       dataAccessRequestDAO.cancelByReferenceIds(activeDarIds);
     }
 }

--- a/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
@@ -227,7 +227,7 @@ public class DarCollectionService {
    *
    * If an election exists for a DAR within the collection, that DAR cannot be cancelled by the
    * researcher. Since it's now under DAC review, it's up to the DAC Chair (or admin) to
-   * ultimately decline or cancel the collection.
+   * ultimately decline or cancel the elections for the collection.
    *
    * @param collection The DarCollection
    * @return The canceled DarCollection

--- a/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
@@ -291,7 +291,7 @@ public class DarCollectionService {
    * @return The canceled DarCollection
    */
   public DarCollection cancelDarCollectionAsChair(DarCollection collection, User user) {
-    // Find DARs for which the chairperson has access to:
+    // Find dataset ids the chairperson has access to:
     List<Integer> datasetIds = datasetDAO.findDataSetsByAuthUserEmail(user.getEmail())
       .stream()
       .map(DataSet::getDataSetId)

--- a/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
@@ -226,8 +226,8 @@ public class DarCollectionService {
    * Cancel a DarCollection as a researcher.
    *
    * If an election exists for a DAR within the collection, that DAR cannot be cancelled by the
-   * researcher // Since it's now under DAC review, it's up to the DAC Chair (or admin) to
-   * ultimately decline or cancel via elections
+   * researcher. Since it's now under DAC review, it's up to the DAC Chair (or admin) to
+   * ultimately decline or cancel the collection.
    *
    * @param collection The DarCollection
    * @return The canceled DarCollection
@@ -257,7 +257,7 @@ public class DarCollectionService {
   /**
    * Cancel a DarCollection as an admin.
    *
-   * Admins can cancel all DARs in a DarCollection without any
+   * Admins can cancel all DARs + elections in a DarCollection
    *
    * @param collection The DarCollection
    * @return The canceled DarCollection
@@ -322,12 +322,10 @@ public class DarCollectionService {
 
   // Private helper method to mark DataAccessRequests as 'Canceled'
   private void markDarsAsCancelled(Collection<DataAccessRequest> dars) {
-      List<String> activeDarIds = dars.stream()
+    List<String> activeDarIds = dars.stream()
       .filter(DataAccessRequest::isNotCanceled)
       .map(DataAccessRequest::getReferenceId)
       .collect(Collectors.toList());
-
-    // Cancel active dars that we can work on
     if(!activeDarIds.isEmpty()) {
       dataAccessRequestDAO.cancelByReferenceIds(activeDarIds);
     }

--- a/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
@@ -250,7 +250,7 @@ public class DarCollectionService {
 
     // Cancel active dars for the researcher
     List<String> activeDarIds = dars.stream()
-      .filter(DataAccessRequest::isNotCanceled)
+      .filter(d -> !DataAccessRequest.isCanceled(d))
       .map(DataAccessRequest::getReferenceId)
       .collect(Collectors.toList());
     if (!activeDarIds.isEmpty()) {

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -1687,6 +1687,7 @@ paths:
           description: The DAR couldn't be found.
   /api/dataRequest/{requestId}/election/{id}:
     delete:
+      deprecated: true
       summary: deleteElection
       description: Deletes the election identified by the id.
       parameters:

--- a/src/main/resources/assets/paths/cancelCollectionByCollectionId.yaml
+++ b/src/main/resources/assets/paths/cancelCollectionByCollectionId.yaml
@@ -15,7 +15,7 @@ put:
       description: | 
         String value that represents the role name to act as. If not provided,
         the system will cancel the collection and associated elections as the 
-        highest permissioned role the user has.
+        least permissioned role the user has (researcher) for safety.
       required: false
       schema:
         type: string

--- a/src/main/resources/assets/paths/cancelCollectionByCollectionId.yaml
+++ b/src/main/resources/assets/paths/cancelCollectionByCollectionId.yaml
@@ -10,6 +10,16 @@ put:
       required: true
       schema:
         type: integer
+    - name: roleName
+      in: query
+      description: | 
+        String value that represents the role name to act as. If not provided,
+        the system will cancel the collection and associated elections as the 
+        highest permissioned role the user has.
+      required: false
+      schema:
+        type: string
+        enum: [Admin, Chairperson, Researcher]
   responses:
     200:
       description: Returns target dar collection with DARs canceled
@@ -17,8 +27,8 @@ put:
         application/json:
           schema:
             $ref: '../schemas/DarCollection.yaml'
-    400: 
-      description: Bad Request (result of elections present on DARs)
+    400:
+      description: Bad Request (result of elections present on DARs or the user not having the provided role name)
     404:
       description: Not Found
     500:

--- a/src/test/java/org/broadinstitute/consent/http/resources/DarCollectionResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DarCollectionResourceTest.java
@@ -279,6 +279,75 @@ public class DarCollectionResourceTest {
   }
 
   @Test
+  public void testCancelDarCollection_asAdmin() {
+    List<UserRole> adminRole = List.of(new UserRole(UserRoles.ADMIN.getRoleId(), UserRoles.ADMIN.getRoleName()));
+    User admin = new User(1, authUser.getEmail(), "Display Name", new Date(), adminRole, authUser.getEmail());
+
+    DarCollection collection = mockDarCollection();
+    collection.setCreateUserId(admin.getDacUserId());
+    when(userService.findUserByEmail(anyString())).thenReturn(admin);
+    when(darCollectionService.getByCollectionId(anyInt())).thenReturn(collection);
+    initResource();
+
+    Response response = resource.cancelDarCollectionByCollectionId(authUser, 1, Resource.ADMIN);
+    assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+  }
+
+  @Test
+  public void testCancelDarCollection_asChair() {
+    List<UserRole> chairRole = List.of(new UserRole(UserRoles.CHAIRPERSON.getRoleId(), UserRoles.CHAIRPERSON.getRoleName()));
+    User chair = new User(1, authUser.getEmail(), "Display Name", new Date(), chairRole, authUser.getEmail());
+
+    DarCollection collection = mockDarCollection();
+    collection.setCreateUserId(chair.getDacUserId());
+    when(userService.findUserByEmail(anyString())).thenReturn(chair);
+    when(darCollectionService.getByCollectionId(anyInt())).thenReturn(collection);
+    initResource();
+
+    Response response = resource.cancelDarCollectionByCollectionId(authUser, 1, Resource.CHAIRPERSON);
+    assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+  }
+
+  @Test
+  public void testCancelDarCollection_asChairAsAdmin() {
+    List<UserRole> chairRole = List.of(new UserRole(UserRoles.CHAIRPERSON.getRoleId(), UserRoles.CHAIRPERSON.getRoleName()));
+    User chair = new User(1, authUser.getEmail(), "Display Name", new Date(), chairRole, authUser.getEmail());
+
+    DarCollection collection = mockDarCollection();
+    collection.setCreateUserId(chair.getDacUserId());
+    when(userService.findUserByEmail(anyString())).thenReturn(chair);
+    when(darCollectionService.getByCollectionId(anyInt())).thenReturn(collection);
+    initResource();
+
+    Response response = resource.cancelDarCollectionByCollectionId(authUser, 1, Resource.ADMIN);
+    assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
+  }
+
+  @Test
+  public void testCancelDarCollection_asResearcher() {
+    DarCollection collection = mockDarCollection();
+    collection.setCreateUserId(researcher.getDacUserId());
+    when(userService.findUserByEmail(anyString())).thenReturn(researcher);
+    when(darCollectionService.getByCollectionId(anyInt())).thenReturn(collection);
+    initResource();
+
+    Response response = resource.cancelDarCollectionByCollectionId(authUser, 1, Resource.RESEARCHER);
+    assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+  }
+
+  @Test
+  public void testCancelDarCollection_asResearcherAsAdmin() {
+    DarCollection collection = mockDarCollection();
+    collection.setCreateUserId(researcher.getDacUserId());
+    when(userService.findUserByEmail(anyString())).thenReturn(researcher);
+    when(darCollectionService.getByCollectionId(anyInt())).thenReturn(collection);
+    initResource();
+
+    Response response = resource.cancelDarCollectionByCollectionId(authUser, 1, Resource.ADMIN);
+    assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
+  }
+
+  @Test
   public void testGetCollectionsByToken_InvalidToken() {
     initResource();
     Response response = resource.getCollectionsByToken(authUser, "badTokenString");

--- a/src/test/java/org/broadinstitute/consent/http/resources/DataRequestElectionResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DataRequestElectionResourceTest.java
@@ -134,6 +134,7 @@ public class DataRequestElectionResourceTest {
         Assert.assertEquals(BAD_REQUEST.getStatusCode(), response.getStatus());
     }
 
+    @Deprecated
     @Test
     public void testDeleteElection() {
         doNothing().when(electionService).deleteElection(any());
@@ -146,6 +147,7 @@ public class DataRequestElectionResourceTest {
         Assert.assertEquals(OK.getStatusCode(), response.getStatus());
     }
 
+    @Deprecated
     @Test
     public void testDeleteElectionNotFound() {
         doThrow(new NotFoundException()).when(electionService).deleteElection(any());
@@ -158,6 +160,7 @@ public class DataRequestElectionResourceTest {
         Assert.assertEquals(NOT_FOUND.getStatusCode(), response.getStatus());
     }
 
+    @Deprecated
     @Test
     public void testDeleteElectionBadRequest() {
         doThrow(new IllegalArgumentException()).when(electionService).deleteElection(any());

--- a/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
@@ -324,8 +324,68 @@ public class DarCollectionServiceTest {
   }
 
   @Test
-  public void testCancelDarCollectionAsChair() {
+  public void testCancelDarCollectionAsChair_ChairHasDatasets() {
+    User user = new User();
+    user.setEmail("email");
+    DataSet dataset = new DataSet();
+    dataset.setDataSetId(1);
+    DataAccessRequest dar = new DataAccessRequest();
+    dar.setReferenceId(UUID.randomUUID().toString());
+    DataAccessRequestData data = new DataAccessRequestData();
+    data.setDatasetIds(List.of(dataset.getDataSetId()));
+    dar.setData(data);
+    DarCollection collection = createMockCollections(1).get(0);
+    collection.setDars(Map.of(dar.getReferenceId(), dar));
+    Election election = createMockElection();
+    election.setReferenceId(dar.getReferenceId());
+    election.setStatus(ElectionStatus.OPEN.getValue());
+    election.setElectionId(1);
+    when(datasetDAO.findDataSetsByAuthUserEmail(anyString())).thenReturn(List.of(dataset));
+    when(electionDAO.findLastElectionsByReferenceIds(anyList())).thenReturn(List.of(election));
+    spy(datasetDAO);
+    spy(electionDAO);
+    spy(dataAccessRequestDAO);
+    spy(darCollectionDAO);
+    initService();
 
+    service.cancelDarCollectionAsChair(collection, user);
+    verify(datasetDAO, times(1)).findDataSetsByAuthUserEmail(anyString());
+    verify(electionDAO, times(1)).findLastElectionsByReferenceIds(anyList());
+    verify(electionDAO, times(1)).updateElectionById(anyInt(), anyString(), any());
+    verify(dataAccessRequestDAO, times(1)).cancelByReferenceIds(anyList());
+    verify(darCollectionDAO, times(1)).findDARCollectionByCollectionId(anyInt());
+  }
+
+  @Test
+  public void testCancelDarCollectionAsChair_ChairHasNoDatasets() {
+    User user = new User();
+    user.setEmail("email");
+    DataSet dataset = new DataSet();
+    dataset.setDataSetId(1);
+    DataAccessRequest dar = new DataAccessRequest();
+    dar.setReferenceId(UUID.randomUUID().toString());
+    DataAccessRequestData data = new DataAccessRequestData();
+    data.setDatasetIds(List.of(dataset.getDataSetId()));
+    dar.setData(data);
+    DarCollection collection = createMockCollections(1).get(0);
+    collection.setDars(Map.of(dar.getReferenceId(), dar));
+    Election election = createMockElection();
+    election.setReferenceId(dar.getReferenceId());
+    election.setStatus(ElectionStatus.OPEN.getValue());
+    election.setElectionId(1);
+    when(datasetDAO.findDataSetsByAuthUserEmail(anyString())).thenReturn(List.of());
+    spy(datasetDAO);
+    spy(electionDAO);
+    spy(dataAccessRequestDAO);
+    spy(darCollectionDAO);
+    initService();
+
+    service.cancelDarCollectionAsChair(collection, user);
+    verify(datasetDAO, times(1)).findDataSetsByAuthUserEmail(anyString());
+    verify(electionDAO, times(0)).findLastElectionsByReferenceIds(anyList());
+    verify(electionDAO, times(0)).updateElectionById(anyInt(), anyString(), any());
+    verify(dataAccessRequestDAO, times(0)).cancelByReferenceIds(anyList());
+    verify(darCollectionDAO, times(0)).findDARCollectionByCollectionId(anyInt());
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
@@ -355,10 +355,10 @@ public class DarCollectionServiceTest {
     spy(darCollectionDAO);
     initService();
 
-    service.cancelDarCollectionAsAdmin(collection);
+    service.cancelDarCollectionElectionsAsAdmin(collection);
     verify(electionDAO, times(1)).findLastElectionsByReferenceIds(anyList());
     verify(electionDAO, times(1)).updateElectionById(anyInt(), anyString(), any());
-    verify(dataAccessRequestDAO, times(1)).cancelByReferenceIds(anyList());
+    verify(dataAccessRequestDAO, times(0)).cancelByReferenceIds(anyList());
     verify(darCollectionDAO, times(1)).findDARCollectionByCollectionId(anyInt());
   }
 
@@ -387,11 +387,11 @@ public class DarCollectionServiceTest {
     spy(darCollectionDAO);
     initService();
 
-    service.cancelDarCollectionAsChair(collection, user);
+    service.cancelDarCollectionElectionsAsChair(collection, user);
     verify(datasetDAO, times(1)).findDataSetsByAuthUserEmail(anyString());
     verify(electionDAO, times(1)).findLastElectionsByReferenceIds(anyList());
     verify(electionDAO, times(1)).updateElectionById(anyInt(), anyString(), any());
-    verify(dataAccessRequestDAO, times(1)).cancelByReferenceIds(anyList());
+    verify(dataAccessRequestDAO, times(0)).cancelByReferenceIds(anyList());
     verify(darCollectionDAO, times(1)).findDARCollectionByCollectionId(anyInt());
   }
 
@@ -419,7 +419,7 @@ public class DarCollectionServiceTest {
     spy(darCollectionDAO);
     initService();
 
-    service.cancelDarCollectionAsChair(collection, user);
+    service.cancelDarCollectionElectionsAsChair(collection, user);
     verify(datasetDAO, times(1)).findDataSetsByAuthUserEmail(anyString());
     verify(electionDAO, times(0)).findLastElectionsByReferenceIds(anyList());
     verify(electionDAO, times(0)).updateElectionById(anyInt(), anyString(), any());

--- a/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
@@ -274,7 +274,7 @@ public class DarCollectionServiceTest {
     when(darCollectionDAO.findDARCollectionByCollectionId(any())).thenReturn(collection);
     initService();
 
-    DarCollection canceledCollection = service.cancelDarCollection(collection);
+    DarCollection canceledCollection = service.cancelDarCollectionAsResearcher(collection);
     for (DataAccessRequest collectionDar : canceledCollection.getDars().values()) {
       assertEquals("canceled", collectionDar.getData().getStatus().toLowerCase());
     }
@@ -285,12 +285,12 @@ public class DarCollectionServiceTest {
     Set<DataSet> datasets = new HashSet<>();
     DarCollection collection = generateMockDarCollection(datasets);
 
-    when(electionDAO.getElectionIdsByReferenceIds(anyList())).thenReturn(List.of(1));
+    when(electionDAO.findLastElectionsByReferenceIds(anyList())).thenReturn(List.of(new Election()));
     doNothing().when(dataAccessRequestDAO).cancelByReferenceIds(anyList());
     when(darCollectionDAO.findDARCollectionByCollectionId(any())).thenReturn(collection);
     initService();
 
-    service.cancelDarCollection(collection);
+    service.cancelDarCollectionAsResearcher(collection);
   }
 
   private DarCollection generateMockDarCollection(Set<DataSet> datasets) {


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-1307

## Changes
* Updated existing researcher only endpoint to be accessible to Admins, Chairs
* Added optional role name param so Admins can cancel as a Chair, or as a Researcher
* Split service logic into three methods since they have very different effects
  * Researchers can only cancel DARs when there are no elections
  * Chairs can only cancel DARs+elections that are against datasets in their DACs
  * Admins can cancel all of the above.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
