### PR TITLE
[DUOS-1597] consent-populate-user-properties-for-dar-collection-queries

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
@@ -202,17 +202,20 @@ public interface DarCollectionDAO {
   @RegisterBeanMapper(value = Institution.class, prefix = "i")
   @RegisterBeanMapper(value = DarCollection.class)
   @RegisterBeanMapper(value = DataAccessRequest.class, prefix = "dar")
+  @RegisterBeanMapper(value = UserProperty.class, prefix = "up")
   @UseRowReducer(DarCollectionReducer.class)
   @SqlQuery(
     "SELECT c.*, " +
       User.QUERY_FIELDS_WITH_U_PREFIX + QUERY_FIELD_SEPARATOR +
       Institution.QUERY_FIELDS_WITH_I_PREFIX + QUERY_FIELD_SEPARATOR +
+      UserProperty.QUERY_FIELDS_WITH_UP_PREFIX + QUERY_FIELD_SEPARATOR +
       "dar.id AS dar_id, dar.reference_id AS dar_reference_id, dar.collection_id AS dar_collection_id, " +
       "dar.draft AS dar_draft, dar.user_id AS dar_userId, dar.create_date AS dar_create_date, " +
       "dar.sort_date AS dar_sort_date, dar.submission_date AS dar_submission_date, " +
       "dar.update_date AS dar_update_date, (dar.data #>> '{}')::jsonb AS data " +
     "FROM dar_collection c " +
     "INNER JOIN dacuser u ON c.create_user_id = u.dacuserid " +
+    "LEFT JOIN user_property up ON u.dacuserid = up.userid " +
     "LEFT JOIN institution i ON i.institution_id = u.institution_id " +
     "INNER JOIN data_access_request dar ON c.collection_id = dar.collection_id " +
     "WHERE c.collection_id = (SELECT collection_id FROM data_access_request WHERE reference_id = :referenceId)")

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DarCollectionReducer.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DarCollectionReducer.java
@@ -6,6 +6,7 @@ import org.broadinstitute.consent.http.models.DataAccessRequestData;
 import org.broadinstitute.consent.http.models.Election;
 import org.broadinstitute.consent.http.models.Institution;
 import org.broadinstitute.consent.http.models.User;
+import org.broadinstitute.consent.http.models.UserProperty;
 import org.broadinstitute.consent.http.models.Vote;
 import org.jdbi.v3.core.mapper.MappingException;
 import org.jdbi.v3.core.result.LinkedHashMapRowReducer;
@@ -23,13 +24,20 @@ public class DarCollectionReducer
     Election election = null;
     Vote vote = null;
     User user = null;
+    UserProperty userProperty = null;
     Institution institution = null;
     DarCollection collection =
         map.computeIfAbsent(
             rowView.getColumn("collection_id", Integer.class),
             id -> rowView.getRow(DarCollection.class));
+    if (Objects.nonNull(collection) && Objects.nonNull(collection.getCreateUser())) {
+      user = collection.getCreateUser();
+    }
     try {
-      if (Objects.nonNull(rowView.getColumn("u_dacuserid", Integer.class))) {
+      if (Objects.nonNull(rowView.getColumn("up_property_id", Integer.class))) {
+        userProperty = rowView.getRow(UserProperty.class);
+      }
+      if (Objects.isNull(user) && Objects.nonNull(rowView.getColumn("u_dacuserid", Integer.class))) {
         user = rowView.getRow(User.class);
       }
       if (Objects.nonNull(rowView.getColumn("i_id", Integer.class))) {
@@ -77,6 +85,9 @@ public class DarCollectionReducer
     if (Objects.nonNull(user)) {
       if (Objects.nonNull(institution)) {
         user.setInstitution(institution);
+      }
+      if (Objects.nonNull(userProperty)) {
+        user.addProperty(userProperty);
       }
       collection.setCreateUser(user);
     }

--- a/src/main/java/org/broadinstitute/consent/http/models/UserProperty.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/UserProperty.java
@@ -6,6 +6,12 @@ import com.google.common.base.Objects;
 
 public class UserProperty {
 
+    public static final String QUERY_FIELDS_WITH_UP_PREFIX =
+                    " up.propertyid AS up_property_id, " +
+                    " up.userid AS up_user_id, " +
+                    " up.propertykey AS up_property_key, " +
+                    " up.propertyvalue AS up_property_value ";
+
     @JsonProperty
     private Integer propertyId;
 

--- a/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
@@ -377,6 +377,15 @@ public class DAOTestHelper {
         return userDAO.findUserById(userId);
     }
 
+    protected User createUserMultipleProperties() {
+        User user = createUser();
+        Integer userId = user.getDacUserId();
+        createUserProperty(userId, UserFields.PI_NAME.getValue());
+        createUserProperty(userId, UserFields.PI_EMAIL.getValue());
+        createUserProperty(userId, UserFields.DEPARTMENT.getValue());
+        return userDAO.findUserById(userId);
+    }
+
     protected void createUserProperty(Integer userId, String field) {
         UserProperty property = new UserProperty();
         property.setPropertyKey(field);
@@ -637,6 +646,23 @@ public class DAOTestHelper {
         createdDarCollections.add(collection_id);
         return darCollectionDAO.findDARCollectionByCollectionId(collection_id);
     }
+
+    protected DarCollection createDarCollectionMultipleUserProperties() {
+        User user = createUserMultipleProperties();
+        String darCode = "DAR-" + RandomUtils.nextInt(100, 1000);
+        Integer collection_id = darCollectionDAO.insertDarCollection(darCode, user.getDacUserId(), new Date());
+        DataSet dataset = createDataset();
+        DataAccessRequest dar = insertDAR(user.getDacUserId(), collection_id, darCode);
+        Election cancelled = createCancelledAccessElection(dar.getReferenceId(), dataset.getDataSetId());
+        Election access = createAccessElection(dar.getReferenceId(), dataset.getDataSetId());
+        createFinalVote(user.getDacUserId(), cancelled.getElectionId());
+        createFinalVote(user.getDacUserId(), access.getElectionId());
+        insertDAR(user.getDacUserId(), collection_id, darCode);
+        insertDAR(user.getDacUserId(), collection_id, darCode);
+        createdDarCollections.add(collection_id);
+        return darCollectionDAO.findDARCollectionByCollectionId(collection_id);
+    }
+
 
     protected DarCollection createDarCollectionWithSingleDataAccessRequest() {
         Date now = new Date();


### PR DESCRIPTION
[Link to Jira ticket](https://broadworkbench.atlassian.net/jira/software/c/projects/DUOS/boards/123?modal=detail&selectedIssue=DUOS-1597)
Summary of changes: 

- Add user properties to user for dar collection by role queries
- Update tests to check for single and multiple user properties for dar collection queries

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
