### PR TITLE
DUOS-1633[risk=no] Add missing UserProperties Mappers to Role Based Queries

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
@@ -314,6 +314,7 @@ public interface DarCollectionDAO {
   @RegisterBeanMapper(value = DataAccessRequest.class, prefix = "dar")
   @RegisterBeanMapper(value = Election.class, prefix = "e")
   @RegisterBeanMapper(value = Vote.class, prefix = "v")
+  @RegisterBeanMapper(value = UserProperty.class, prefix = "up")
   @UseRowReducer(DarCollectionReducer.class)
   @SqlQuery(getCollectionAndDars
           + " WHERE (" + DarCollection.FILTER_TERMS_QUERY + ") " + orderStatement)
@@ -329,6 +330,7 @@ public interface DarCollectionDAO {
   @RegisterBeanMapper(value = DataAccessRequest.class, prefix = "dar")
   @RegisterBeanMapper(value = Election.class, prefix = "e")
   @RegisterBeanMapper(value = Vote.class, prefix = "v")
+  @RegisterBeanMapper(value = UserProperty.class, prefix = "up")
   @UseRowReducer(DarCollectionReducer.class)
   @SqlQuery(getCollectionAndDars
       + " WHERE u.institution_id = :institutionId AND ("
@@ -345,6 +347,7 @@ public interface DarCollectionDAO {
   @RegisterBeanMapper(value = DataAccessRequest.class, prefix = "dar")
   @RegisterBeanMapper(value = Election.class, prefix = "e")
   @RegisterBeanMapper(value = Vote.class, prefix = "v")
+  @RegisterBeanMapper(value = UserProperty.class, prefix = "up")
   @UseRowReducer(DarCollectionReducer.class)
   @SqlQuery(getCollectionAndDars
       + " WHERE c.create_user_id = :userId AND ("

--- a/src/main/resources/assets/paths/collectionsByQuery.yaml
+++ b/src/main/resources/assets/paths/collectionsByQuery.yaml
@@ -27,7 +27,12 @@ get:
       description: String value that represents field to order by
       schema:
         type: string
-      default: "darCode"
+        default: "darCode"
+        enum:
+          - researcher
+          - darCode
+          - projectTitle
+          - institution
     - name: sortOrder
       in: query
       description: String value that represents direction of ordering


### PR DESCRIPTION
Addresses [DUOS-1633](https://broadworkbench.atlassian.net/browse/DUOS-1633)

PR updates role based filter queries to use `UserPropertiesMapper` to account for the addition of `UserProperties` in Collection queries. 

PR also includes a minor update to Swagger UI (sets `sortField` as a dropdown instead of a text field).

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
