### PR TITLE
[DUOS-1636][risk=no] Improve DAR Collections By Role Performance

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
@@ -37,7 +37,7 @@ public interface DarCollectionDAO {
           "(dar.data #>> '{}')::jsonb ->> 'projectTitle' as projectTitle " +
       " FROM dar_collection c " +
       " INNER JOIN dacuser u ON u.dacuserid = c.create_user_id " +
-      " LEFT JOIN user_property up ON u.dacuserid = up.userid " +
+      " LEFT JOIN user_property up ON u.dacuserid = up.userid AND up.propertykey in ('isThePI', 'piName', 'havePI', 'piERACommonsID') " +
       " LEFT JOIN institution i ON i.institution_id = u.institution_id " +
       " INNER JOIN data_access_request dar ON c.collection_id = dar.collection_id " +
       " LEFT JOIN (SELECT election.*, MAX(election.electionid) OVER (PARTITION BY election.referenceid, election.electiontype) AS latest FROM election) AS e " +

--- a/src/main/resources/changelog-master.xml
+++ b/src/main/resources/changelog-master.xml
@@ -78,7 +78,8 @@
     <include file="changesets/changelog-consent-73.0.xml" relativeToChangelogFile="true"/>
     <include file="changesets/changelog-consent-74.0.xml" relativeToChangelogFile="true"/>
     <include file="changesets/changelog-consent-75.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-76.0.xml" relativeToChangelogFile="true" />
-    <include file="changesets/changelog-consent-77.0.xml" relativeToChangelogFile="true" />
-    <include file="changesets/changelog-consent-78.0.xml" relativeToChangelogFile="true" />
+    <include file="changesets/changelog-consent-76.0.xml" relativeToChangelogFile="true"/>
+    <include file="changesets/changelog-consent-77.0.xml" relativeToChangelogFile="true"/>
+    <include file="changesets/changelog-consent-78.0.xml" relativeToChangelogFile="true"/>
+    <include file="changesets/changelog-consent-79.0.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/changesets/changelog-consent-79.0.xml
+++ b/src/main/resources/changesets/changelog-consent-79.0.xml
@@ -2,12 +2,17 @@
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
          http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
-  <changeSet id="79.0" author="grushton">
+    <changeSet id="79.0" author="grushton">
         <createIndex tableName="data_access_request" indexName="data_access_request_collection_id_index">
-          <column name="collection_id"/>
+            <column name="collection_id"/>
         </createIndex>
         <createIndex tableName="election" indexName="election_referenceid_index">
-          <column name="referenceid"/>
+            <column name="referenceid"/>
         </createIndex>
-  </changeSet>
+
+        <rollback>
+            <dropIndex tableName="data_access_request" indexName="data_access_request_collection_id_index"/>
+            <dropIndex tableName="election" indexName="election_referenceid_index"/>
+        </rollback>
+    </changeSet>
 </databaseChangeLog>

--- a/src/main/resources/changesets/changelog-consent-79.0.xml
+++ b/src/main/resources/changesets/changelog-consent-79.0.xml
@@ -6,5 +6,8 @@
         <createIndex tableName="data_access_request" indexName="data_access_request_collection_id_index">
           <column name="collection_id"/>
         </createIndex>
+        <createIndex tableName="election" indexName="election_referenceid_index">
+          <column name="referenceid"/>
+        </createIndex>
   </changeSet>
 </databaseChangeLog>

--- a/src/main/resources/changesets/changelog-consent-79.0.xml
+++ b/src/main/resources/changesets/changelog-consent-79.0.xml
@@ -1,0 +1,10 @@
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+  <changeSet id="79.0" author="grushton">
+        <createIndex tableName="data_access_request" indexName="data_access_request_collection_id_index">
+          <column name="collection_id"/>
+        </createIndex>
+  </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-1636

This PR makes a few small adjustments to help improve performance somewhat. There is likely more work to do here, but this is a start.
* Filter the user properties down to those specifically necessary for the user console UIs
* Add a couple of indexes to help improve lookups.

Empirically, testing as a chairperson, I was able to get the following results:
* Payload reduced from 1.98 MB to 1.59 MB (24% improvement)
* TTFB reduced from 19.13 seconds to 3.35 seconds (5.7x improvement)

Additionally, I tested the approach of simplifying the partition query of the elections into a simple join and then post-processing the older elections out of the response objects in the reducer. That actually increased response times so that is not part of this PR.

### Pre-optimization
<img width="1572" alt="Pre-optimization" src="https://user-images.githubusercontent.com/116679/154532446-10fedf28-42ab-4def-a2c6-1d444906bff4.png">

### Post-optimization
<img width="1572" alt="Reference id Index" src="https://user-images.githubusercontent.com/116679/154532483-856c1e4e-a57f-4b18-88fd-a83780b99b45.png">

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
