### PR TITLE
[DUOS-1644][risk=no] Update User by ID improvements

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/models/User.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/User.java
@@ -354,6 +354,9 @@ public class User {
 
     @Transient
     public List<Integer> getUserRoleIdsFromUser() {
+        if (Objects.isNull(this.getRoles())) {
+            return List.of();
+        }
         return this.getRoles()
           .stream()
           .map(UserRole::getRoleId)

--- a/src/main/java/org/broadinstitute/consent/http/resources/DACUserResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DACUserResource.java
@@ -103,6 +103,10 @@ public class DACUserResource extends Resource {
             }
             validateAuthedRoleUser(Collections.singletonList(UserRoles.ADMIN), findByAuthUser(authUser), userId);
             URI uri = info.getRequestUriBuilder().path("{id}").build(userId);
+            // The `updateDACUserById` method only updates the following fields:
+            // * Display Name
+            // * Additional Email
+            // * Institution
             User user = userService.updateDACUserById(userMap, userId);
             // Update email preference
             JsonObject jsonObject = JsonParser.parseString(json).getAsJsonObject();

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -984,48 +984,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/User'
   /api/dacuser/{id}:
-    put:
-      summary: update
-      description: |
-        Updates the user identified by the ID. Requires the authenticated user to have the same id
-        as that of the user being updated except in the admin case - admins can update information
-        for other users. A user's email cannot be updated. Role changes are not allowed for Chairperson
-        and Member roles using this endpoint. All Chairperson and Member changes (additions or removals)
-        are ignored. See [DAC](/#!/DAC) endpoints for **POST/DELETE** endpoints for
-        **/api/dac/{dacId}/chair/{userId}** and **/api/dac/{dacId}/member/{userId}** calls.
-        Users with the "Signing Official" are not permitted to change their institution. Such calls
-        will result in a "Bad Request". "Signing Official" users are, however, allowed to save their
-        institution if it is not already set.
-      parameters:
-        - name: id
-          in: path
-          description: The id of the updated user
-          required: true
-          schema:
-            type: string
-        - name: user
-          in: body
-          description: The updated user information
-          required: true
-          schema:
-            type: object
-            properties:
-              updatedUser:
-                $ref: '#/components/schemas/User'
-      tags:
-        - User
-      responses:
-        200:
-          description: Returns the updated user.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/User'
-        400:
-          description: Malformed user entity or improper institution update
-        403:
-          description: User must have appropriate roles to update different users' information.
-
+    $ref: './paths/userById.yaml'
   /api/dar/v2:
     post:
       summary: Create Data Access Request, version 2

--- a/src/main/resources/assets/paths/userById.yaml
+++ b/src/main/resources/assets/paths/userById.yaml
@@ -1,0 +1,41 @@
+put:
+  summary: update
+  description: |
+    Updates the user identified by the ID. Requires the authenticated user to have the same id as that of the user being updated except in the admin case - admins can update information for other users. A user's email cannot be updated. 
+    * The following fields can be updated via this endpoint
+      * Display Name
+      * Additional Email
+      * Institution Id
+      * Email Preference
+    * Users with the "Signing Official" are not permitted to change their institution. Such calls will result in a "Bad Request". "Signing Official" users are, however, allowed to save their
+        institution if it is not already set.
+  parameters:
+    - name: id
+      in: path
+      description: The id of the updated user
+      required: true
+      schema:
+        type: string
+  requestBody:
+    description: The updated user information in JSON format
+    required: true
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            updatedUser:
+              $ref: '../schemas/User.yaml'
+  tags:
+    - User
+  responses:
+    200:
+      description: Returns the updated user.
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/User.yaml'
+    400:
+      description: Malformed user entity or improper institution update
+    403:
+      description: User must have appropriate roles to update different users' information.


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-1644

Minor updates to `PUT /api/dacuser/{id}`
* API docs revamped for function and clarity
* Added comments for clarity
* Handle NPE for null user roles

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
