### PR TITLE
[DUOS-1643][risk=no] consent rp votes modifiable after election is closed

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/service/VoteService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/VoteService.java
@@ -118,10 +118,14 @@ public class VoteService {
     * @param voteValue Value to update the votes to
     * @param rationale Value to update the rationales to. Only update if non-null.
     * @return The updated Vote
-    * @throws IllegalArgumentException when there are non-open elections on any of the votes
+    * @throws IllegalArgumentException when there are non-open, non-rp elections on any of the votes
     */
     public List<Vote> updateVotesWithValue(List<Vote> votes, boolean voteValue, String rationale) throws IllegalArgumentException, SQLException {
-        return voteServiceDAO.updateVotesWithValue(votes, voteValue, rationale);
+        try {
+            return voteServiceDAO.updateVotesWithValue(votes, voteValue, rationale);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Unable to update election votes.");
+        }
     }
 
     public Vote updateVoteById(Vote rec,  Integer voteId) throws IllegalArgumentException {

--- a/src/main/java/org/broadinstitute/consent/http/service/dao/VoteServiceDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/dao/VoteServiceDAO.java
@@ -49,13 +49,7 @@ public class VoteServiceDAO {
     if (votes.isEmpty()) {
       return Collections.emptyList();
     }
-    // Validate that the elections are all in OPEN state
-    List<Election> elections =
-        electionDAO.findElectionsByIds(
-            votes.stream().map(Vote::getElectionId).collect(Collectors.toList()));
-    if (!allOpenOrRp(elections)) {
-      throw new IllegalArgumentException("Not all elections for votes are in OPEN state or for Research Purposes");
-    }
+    validateElectionsCanUpdateVotes(votes);
     // Update all votes in an atomic transaction, rollback on all if any fail
     jdbi.useHandle(
         handle -> {
@@ -94,7 +88,6 @@ public class VoteServiceDAO {
         });
     return voteDAO.findVotesByIds(votes.stream().map(Vote::getVoteId).collect(Collectors.toList()));
   }
-
 
   private void validateElectionsCanUpdateVotes(List<Vote> votes) {
       List<Election> elections = electionDAO.findElectionsByIds(votes.stream()

--- a/src/main/java/org/broadinstitute/consent/http/service/dao/VoteServiceDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/dao/VoteServiceDAO.java
@@ -54,7 +54,7 @@ public class VoteServiceDAO {
         electionDAO.findElectionsByIds(
             votes.stream().map(Vote::getElectionId).collect(Collectors.toList()));
     if (!canUpdateAllElections(elections)) {
-      throw new IllegalArgumentException("Not all elections for votes are in OPEN state");
+      throw new IllegalArgumentException("Not all elections for votes are in OPEN state or for Research Purposes");
     }
     // Update all votes in an atomic transaction, rollback on all if any fail
     jdbi.useHandle(

--- a/src/main/java/org/broadinstitute/consent/http/service/dao/VoteServiceDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/dao/VoteServiceDAO.java
@@ -4,6 +4,7 @@ import com.google.inject.Inject;
 import org.broadinstitute.consent.http.db.ElectionDAO;
 import org.broadinstitute.consent.http.db.VoteDAO;
 import org.broadinstitute.consent.http.enumeration.ElectionStatus;
+import org.broadinstitute.consent.http.enumeration.ElectionType;
 import org.broadinstitute.consent.http.enumeration.VoteType;
 import org.broadinstitute.consent.http.models.Election;
 import org.broadinstitute.consent.http.models.Vote;
@@ -19,7 +20,7 @@ import java.util.stream.Collectors;
 
 /**
  * Handle transactional, multi-table queries for vote operations.
- */ 
+ */
 public class VoteServiceDAO {
 
   private final ElectionDAO electionDAO;
@@ -55,7 +56,8 @@ public class VoteServiceDAO {
     boolean allOpen =
         !elections.isEmpty()
             && elections.stream()
-                .allMatch(e -> e.getStatus().equalsIgnoreCase(ElectionStatus.OPEN.getValue()));
+                .allMatch(e -> {return e.getStatus().equalsIgnoreCase(ElectionStatus.OPEN.getValue()) ||
+                e.getElectionType().equalsIgnoreCase(ElectionType.RP.getValue());});
     if (!allOpen) {
       throw new IllegalArgumentException("Not all elections for votes are in OPEN state");
     }

--- a/src/main/java/org/broadinstitute/consent/http/service/dao/VoteServiceDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/dao/VoteServiceDAO.java
@@ -53,12 +53,7 @@ public class VoteServiceDAO {
     List<Election> elections =
         electionDAO.findElectionsByIds(
             votes.stream().map(Vote::getElectionId).collect(Collectors.toList()));
-    boolean allOpen =
-        !elections.isEmpty()
-            && elections.stream()
-                .allMatch(e -> {return e.getStatus().equalsIgnoreCase(ElectionStatus.OPEN.getValue()) ||
-                e.getElectionType().equalsIgnoreCase(ElectionType.RP.getValue());});
-    if (!allOpen) {
+    if (!canUpdateAllElections(elections)) {
       throw new IllegalArgumentException("Not all elections for votes are in OPEN state");
     }
     // Update all votes in an atomic transaction, rollback on all if any fail
@@ -98,5 +93,14 @@ public class VoteServiceDAO {
               });
         });
     return voteDAO.findVotesByIds(votes.stream().map(Vote::getVoteId).collect(Collectors.toList()));
+  }
+
+  private boolean canUpdateAllElections(List<Election> elections) {
+      return !elections.isEmpty()
+              && elections.stream()
+                      .allMatch(e -> {
+                          return e.getStatus().equalsIgnoreCase(ElectionStatus.OPEN.getValue())
+                                  || e.getElectionType().equalsIgnoreCase(ElectionType.RP.getValue());
+                      });
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/service/dao/VoteServiceDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/dao/VoteServiceDAO.java
@@ -50,6 +50,7 @@ public class VoteServiceDAO {
       return Collections.emptyList();
     }
     validateElectionsCanUpdateVotes(votes);
+
     // Update all votes in an atomic transaction, rollback on all if any fail
     jdbi.useHandle(
         handle -> {
@@ -89,7 +90,7 @@ public class VoteServiceDAO {
     return voteDAO.findVotesByIds(votes.stream().map(Vote::getVoteId).collect(Collectors.toList()));
   }
 
-  private void validateElectionsCanUpdateVotes(List<Vote> votes) {
+  private void validateElectionsCanUpdateVotes(List<Vote> votes) throws IllegalArgumentException{
       List<Election> elections = electionDAO.findElectionsByIds(votes.stream()
                               .map(Vote::getElectionId)
                               .collect(Collectors.toList()));
@@ -102,9 +103,7 @@ public class VoteServiceDAO {
   private boolean allOpenOrRp(List<Election> elections) {
       return !elections.isEmpty()
               && elections.stream()
-              .allMatch(e -> {
-                  return e.getStatus().equalsIgnoreCase(ElectionStatus.OPEN.getValue())
-                          || e.getElectionType().equalsIgnoreCase(ElectionType.RP.getValue());
-              });
+              .allMatch(e -> e.getStatus().equalsIgnoreCase(ElectionStatus.OPEN.getValue())
+                      || e.getElectionType().equalsIgnoreCase(ElectionType.RP.getValue()));
   }
 }

--- a/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
@@ -290,9 +290,13 @@ public class DAOTestHelper {
     }
 
     protected void closeElection(Election election) {
+        changeElectionStatus(election, ElectionStatus.CLOSED);
+    }
+
+    protected void changeElectionStatus(Election election, ElectionStatus status) {
         electionDAO.updateElectionById(
                 election.getElectionId(),
-                ElectionStatus.CLOSED.getValue(),
+                status.getValue(),
                 new Date());
     }
 
@@ -349,7 +353,7 @@ public class DAOTestHelper {
         createdConsentIds.add(consentId);
         return consentDAO.findConsentById(consentId);
     }
-    
+
 
     protected Match createMatch() {
         DataAccessRequest dar = createDataAccessRequestV3();

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/VoteServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/VoteServiceDAOTest.java
@@ -2,7 +2,6 @@ package org.broadinstitute.consent.http.service.dao;
 
 import org.broadinstitute.consent.http.db.DAOTestHelper;
 import org.broadinstitute.consent.http.enumeration.ElectionStatus;
-import org.broadinstitute.consent.http.enumeration.ElectionType;
 import org.broadinstitute.consent.http.models.DataAccessRequest;
 import org.broadinstitute.consent.http.models.DataSet;
 import org.broadinstitute.consent.http.models.Election;

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/VoteServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/VoteServiceDAOTest.java
@@ -112,6 +112,23 @@ public class VoteServiceDAOTest extends DAOTestHelper {
     User user = createUser();
     DataAccessRequest dar = createDataAccessRequestV3();
     DataSet dataset = createDataset();
+    Election election = createAccessElection(dar.getReferenceId(), dataset.getDataSetId());
+    closeElection(election);
+    Vote vote = createDacVote(user.getDacUserId(), election.getElectionId());
+    initService();
+
+    List<Vote> votes = serviceDAO.updateVotesWithValue(List.of(vote), true, "rationale");
+    assertNotNull(votes);
+    assertFalse(votes.isEmpty());
+    assertTrue(votes.get(0).getVote());
+    assertEquals("rationale", votes.get(0).getRationale());
+  }
+
+  @Test
+  public void testUpdateVotesWithValue_cancelledElection() throws Exception {
+    User user = createUser();
+    DataAccessRequest dar = createDataAccessRequestV3();
+    DataSet dataset = createDataset();
     Election election = createCancelledAccessElection(dar.getReferenceId(), dataset.getDataSetId());
     Vote vote = createDacVote(user.getDacUserId(), election.getElectionId());
     initService();

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/VoteServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/VoteServiceDAOTest.java
@@ -10,6 +10,8 @@ import org.broadinstitute.consent.http.models.Vote;
 import org.junit.Test;
 
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -43,6 +45,7 @@ public class VoteServiceDAOTest extends DAOTestHelper {
     assertEquals(rationale, votes.get(0).getRationale());
     Election foundElection = electionDAO.findElectionById(vote.getElectionId());
     assertEquals(ElectionStatus.CLOSED.getValue(), foundElection.getStatus());
+    assertEquals(vote.getVoteId(), votes.get(0).getVoteId());
   }
 
   @Test
@@ -59,6 +62,7 @@ public class VoteServiceDAOTest extends DAOTestHelper {
     assertFalse(votes.isEmpty());
     assertTrue(votes.get(0).getVote());
     assertNull(votes.get(0).getRationale());
+    assertEquals(vote.getVoteId(), votes.get(0).getVoteId());
   }
 
   @Test
@@ -78,6 +82,7 @@ public class VoteServiceDAOTest extends DAOTestHelper {
     assertEquals(rationale, votes.get(0).getRationale());
     Election foundElection = electionDAO.findElectionById(vote.getElectionId());
     assertNotEquals(ElectionStatus.CLOSED.getValue(), foundElection.getStatus());
+    assertEquals(vote.getVoteId(), votes.get(0).getVoteId());
   }
 
   @Test
@@ -93,11 +98,16 @@ public class VoteServiceDAOTest extends DAOTestHelper {
     initService();
 
     List<Vote> votes = serviceDAO.updateVotesWithValue(List.of(vote1, vote2, vote3), true, rationale);
+
     assertNotNull(votes);
     assertFalse(votes.isEmpty());
+    List<Integer> requestVoteIds = Stream.of(vote1, vote2, vote3)
+            .map(Vote::getVoteId)
+            .collect(Collectors.toList());
     votes.forEach(v -> {
       assertTrue(v.getVote());
       assertEquals(rationale, v.getRationale());
+      assertTrue(requestVoteIds.contains(v.getVoteId()));
     });
   }
 
@@ -191,11 +201,16 @@ public class VoteServiceDAOTest extends DAOTestHelper {
     initService();
 
     List<Vote> votes = serviceDAO.updateVotesWithValue(List.of(vote1, vote2, vote3), true, rationale);
+
     assertNotNull(votes);
     assertFalse(votes.isEmpty());
+    List<Integer> requestVoteIds = Stream.of(vote1, vote2, vote3)
+            .map(Vote::getVoteId)
+            .collect(Collectors.toList());
     votes.forEach(v -> {
       assertTrue(v.getVote());
       assertEquals(rationale, v.getRationale());
+      assertTrue(requestVoteIds.contains(v.getVoteId()));
     });
   }
 
@@ -215,11 +230,16 @@ public class VoteServiceDAOTest extends DAOTestHelper {
     initService();
 
     List<Vote> votes = serviceDAO.updateVotesWithValue(List.of(vote1, vote2, vote3), true, rationale);
+
     assertNotNull(votes);
     assertFalse(votes.isEmpty());
+    List<Integer> requestVoteIds = Stream.of(vote1, vote2, vote3)
+            .map(Vote::getVoteId)
+            .collect(Collectors.toList());
     votes.forEach(v -> {
       assertTrue(v.getVote());
       assertEquals(rationale, v.getRationale());
+      assertTrue(requestVoteIds.contains(v.getVoteId()));
     });
   }
 
@@ -238,5 +258,6 @@ public class VoteServiceDAOTest extends DAOTestHelper {
     assertFalse(votes.isEmpty());
     assertTrue(votes.get(0).getVote());
     assertEquals(rationale, votes.get(0).getRationale());
+    assertEquals(vote.getVoteId(), votes.get(0).getVoteId());
   }
 }

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/VoteServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/VoteServiceDAOTest.java
@@ -95,8 +95,10 @@ public class VoteServiceDAOTest extends DAOTestHelper {
     List<Vote> votes = serviceDAO.updateVotesWithValue(List.of(vote1, vote2, vote3), true, rationale);
     assertNotNull(votes);
     assertFalse(votes.isEmpty());
-    votes.forEach(v -> assertTrue(v.getVote()));
-    votes.forEach(v -> assertEquals(rationale, v.getRationale()));
+    votes.forEach(v -> {
+      assertTrue(v.getVote());
+      assertEquals(rationale, v.getRationale());
+    });
   }
 
   @Test
@@ -191,8 +193,10 @@ public class VoteServiceDAOTest extends DAOTestHelper {
     List<Vote> votes = serviceDAO.updateVotesWithValue(List.of(vote1, vote2, vote3), true, rationale);
     assertNotNull(votes);
     assertFalse(votes.isEmpty());
-    votes.forEach(v -> assertTrue(v.getVote()));
-    votes.forEach(v -> assertEquals(rationale, v.getRationale()));
+    votes.forEach(v -> {
+      assertTrue(v.getVote());
+      assertEquals(rationale, v.getRationale());
+    });
   }
 
   @Test
@@ -213,8 +217,10 @@ public class VoteServiceDAOTest extends DAOTestHelper {
     List<Vote> votes = serviceDAO.updateVotesWithValue(List.of(vote1, vote2, vote3), true, rationale);
     assertNotNull(votes);
     assertFalse(votes.isEmpty());
-    votes.forEach(v -> assertTrue(v.getVote()));
-    votes.forEach(v -> assertEquals(rationale, v.getRationale()));
+    votes.forEach(v -> {
+      assertTrue(v.getVote());
+      assertEquals(rationale, v.getRationale());
+    });
   }
 
   private void testUpdateVotesWithValue_RPElectionWithStatus(ElectionStatus status) throws Exception {

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/VoteServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/VoteServiceDAOTest.java
@@ -81,7 +81,7 @@ public class VoteServiceDAOTest extends DAOTestHelper {
   }
 
   @Test
-  public void testUpdateVotesWithValue_MultipleVotesOpenElections() throws Exception {
+  public void testUpdateVotesWithValue_MultipleVotes() throws Exception {
     User user = createUser();
     DataAccessRequest dar = createDataAccessRequestV3();
     DataSet dataset = createDataset();
@@ -108,7 +108,7 @@ public class VoteServiceDAOTest extends DAOTestHelper {
   }
 
   @Test
-  public void testUpdateVotesWithValue_closedElection() throws Exception {
+  public void testUpdateVotesWithValue_ClosedElection() throws Exception {
     User user = createUser();
     DataAccessRequest dar = createDataAccessRequestV3();
     DataSet dataset = createDataset();
@@ -125,18 +125,41 @@ public class VoteServiceDAOTest extends DAOTestHelper {
   }
 
   @Test
-  public void testUpdateVotesWithValue_cancelledElection() throws Exception {
+  public void testUpdateVotesWithValue_CancelledElection() throws Exception {
     User user = createUser();
     DataAccessRequest dar = createDataAccessRequestV3();
     DataSet dataset = createDataset();
     Election election = createCancelledAccessElection(dar.getReferenceId(), dataset.getDataSetId());
     Vote vote = createDacVote(user.getDacUserId(), election.getElectionId());
+    String rationale = "rationale";
     initService();
 
-    List<Vote> votes = serviceDAO.updateVotesWithValue(List.of(vote), true, "rationale");
+    List<Vote> votes = serviceDAO.updateVotesWithValue(List.of(vote), true, rationale);
     assertNotNull(votes);
     assertFalse(votes.isEmpty());
     assertTrue(votes.get(0).getVote());
-    assertEquals("rationale", votes.get(0).getRationale());
+    assertEquals(rationale, votes.get(0).getRationale());
+  }
+
+  @Test
+  public void testUpdateVotesWithValue_MultipleElectionsDifferentStatuses() throws Exception {
+    User user = createUser();
+    DataAccessRequest dar = createDataAccessRequestV3();
+    DataSet dataset = createDataset();
+    Election election1 = createAccessElection(dar.getReferenceId(), dataset.getDataSetId());
+    Election election2 = createCancelledAccessElection(dar.getReferenceId(), dataset.getDataSetId());
+    Election election3 = createAccessElection(dar.getReferenceId(), dataset.getDataSetId());
+    closeElection(election3);
+    Vote vote1 = createDacVote(user.getDacUserId(), election1.getElectionId());
+    Vote vote2 = createDacVote(user.getDacUserId(), election2.getElectionId());
+    Vote vote3 = createDacVote(user.getDacUserId(), election3.getElectionId());
+    String rationale = "rationale";
+    initService();
+
+    List<Vote> votes = serviceDAO.updateVotesWithValue(List.of(vote1, vote2, vote3), true, rationale);
+    assertNotNull(votes);
+    assertFalse(votes.isEmpty());
+    votes.forEach(v -> assertTrue(v.getVote()));
+    votes.forEach(v -> assertEquals(rationale, v.getRationale()));
   }
 }

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/VoteServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/VoteServiceDAOTest.java
@@ -113,7 +113,7 @@ public class VoteServiceDAOTest extends DAOTestHelper {
     DataAccessRequest dar = createDataAccessRequestV3();
     DataSet dataset = createDataset();
     Election election = createAccessElection(dar.getReferenceId(), dataset.getDataSetId());
-    closeElection(election);
+    changeElectionStatus(election, ElectionStatus.CLOSED);
     Vote vote = createDacVote(user.getDacUserId(), election.getElectionId());
     initService();
 
@@ -137,16 +137,14 @@ public class VoteServiceDAOTest extends DAOTestHelper {
     User user = createUser();
     DataAccessRequest dar = createDataAccessRequestV3();
     DataSet dataset = createDataset();
-    Election election1 = createAccessElection(dar.getReferenceId(), dataset.getDataSetId());
-    Election election2 = createCancelledAccessElection(dar.getReferenceId(), dataset.getDataSetId());
-    Election election3 = createAccessElection(dar.getReferenceId(), dataset.getDataSetId());
-    Vote vote1 = createDacVote(user.getDacUserId(), election1.getElectionId());
-    Vote vote2 = createDacVote(user.getDacUserId(), election2.getElectionId());
-    Vote vote3 = createDacVote(user.getDacUserId(), election3.getElectionId());
+    Election openElection = createAccessElection(dar.getReferenceId(), dataset.getDataSetId());
+    Election canceledElection = createCancelledAccessElection(dar.getReferenceId(), dataset.getDataSetId());
+    Vote vote1 = createDacVote(user.getDacUserId(), openElection.getElectionId());
+    Vote vote2 = createDacVote(user.getDacUserId(), canceledElection.getElectionId());
     String rationale = "rationale";
     initService();
 
-    serviceDAO.updateVotesWithValue(List.of(vote1, vote2, vote3), true, rationale);
+    serviceDAO.updateVotesWithValue(List.of(vote1, vote2), true, rationale);
   }
 
   @Test
@@ -170,6 +168,11 @@ public class VoteServiceDAOTest extends DAOTestHelper {
   }
 
   @Test
+  public void testUpdateVotesWithValue_PendingApprovalRPElection() throws Exception {
+    testUpdateVotesWithValue_RPElectionWithStatus(ElectionStatus.PENDING_APPROVAL);
+  }
+
+  @Test
   public void testUpdateVotesWithValue_MultipleRPElections() throws Exception {
     User user = createUser();
     DataAccessRequest dar = createDataAccessRequestV3();
@@ -178,7 +181,7 @@ public class VoteServiceDAOTest extends DAOTestHelper {
     Election election2 = createRPElection(dar.getReferenceId(), dataset.getDataSetId());
     Election election3 = createRPElection(dar.getReferenceId(), dataset.getDataSetId());
     changeElectionStatus(election2, ElectionStatus.CANCELED);
-    closeElection(election3);
+    changeElectionStatus(election3, ElectionStatus.CLOSED);
     Vote vote1 = createDacVote(user.getDacUserId(), election1.getElectionId());
     Vote vote2 = createDacVote(user.getDacUserId(), election2.getElectionId());
     Vote vote3 = createDacVote(user.getDacUserId(), election3.getElectionId());
@@ -200,7 +203,7 @@ public class VoteServiceDAOTest extends DAOTestHelper {
     Election rpElection1 = createRPElection(dar.getReferenceId(), dataset.getDataSetId());
     Election rpElection2 = createRPElection(dar.getReferenceId(), dataset.getDataSetId());
     Election accessElection = createAccessElection(dar.getReferenceId(), dataset.getDataSetId());
-    closeElection(rpElection1);
+    changeElectionStatus(rpElection1, ElectionStatus.CLOSED);
     Vote vote1 = createDacVote(user.getDacUserId(), rpElection1.getElectionId());
     Vote vote2 = createDacVote(user.getDacUserId(), rpElection2.getElectionId());
     Vote vote3 = createDacVote(user.getDacUserId(), accessElection.getElectionId());

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/VoteServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/VoteServiceDAOTest.java
@@ -81,7 +81,7 @@ public class VoteServiceDAOTest extends DAOTestHelper {
   }
 
   @Test
-  public void testUpdateVotesWithValue_MultipleVotes() throws Exception {
+  public void testUpdateVotesWithValue_MultipleVotesOpenElections() throws Exception {
     User user = createUser();
     DataAccessRequest dar = createDataAccessRequestV3();
     DataSet dataset = createDataset();
@@ -107,7 +107,7 @@ public class VoteServiceDAOTest extends DAOTestHelper {
     assertTrue(votes.isEmpty());
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testUpdateVotesWithValue_closedElection() throws Exception {
     User user = createUser();
     DataAccessRequest dar = createDataAccessRequestV3();
@@ -116,6 +116,10 @@ public class VoteServiceDAOTest extends DAOTestHelper {
     Vote vote = createDacVote(user.getDacUserId(), election.getElectionId());
     initService();
 
-    serviceDAO.updateVotesWithValue(List.of(vote), true, "rationale");
+    List<Vote> votes = serviceDAO.updateVotesWithValue(List.of(vote), true, "rationale");
+    assertNotNull(votes);
+    assertFalse(votes.isEmpty());
+    assertTrue(votes.get(0).getVote());
+    assertEquals("rationale", votes.get(0).getRationale());
   }
 }


### PR DESCRIPTION
[Link to Jira ticket](https://broadworkbench.atlassian.net/browse/DUOS-1643)
Summary of changes:
- Check for Open or RP elections when validating if votes can be updated in VoteServiceDAO.updateVotesWithValue
- Add unit tests to VoteServiceDAOTest for rp elections 
- Add method to DAOTestHelper to change election status 
- Minor refactoring of updateVotesWithValue

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
