### PR TITLE
[DUOS-1645][risk=no] Update create election logic for Chairs

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
@@ -345,6 +345,8 @@ public class ConsentModule extends AbstractModule {
     @Provides
     DarCollectionServiceDAO providesDarCollectionServiceDAO() {
         return new DarCollectionServiceDAO(
+            providesDataSetDAO(),
+            providesElectionDAO(),
             providesJdbi(),
             providesUserDAO());
     }

--- a/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
@@ -197,7 +197,7 @@ public class DarCollectionService {
       default:
         collections = darCollectionDAO.getFilteredListForResearcher(sortField, sortOrder, user.getDacUserId(), filterTerm);
     }
-    
+
     return addDatasetsToCollections(collections);
   }
 
@@ -401,22 +401,8 @@ public class DarCollectionService {
    * @return The updated DarCollection
    */
   public DarCollection createElectionsForDarCollection(User user, DarCollection collection) {
-    final List<String> invalidStatuses = Stream.of(
-            ElectionStatus.CLOSED, ElectionStatus.OPEN, ElectionStatus.FINAL, ElectionStatus.PENDING_APPROVAL
-    ).map(ElectionStatus::getValue).collect(Collectors.toList());
-    List<String> referenceIds = collection.getDars().values().stream().map(DataAccessRequest::getReferenceId).collect(Collectors.toList());
-    if (!referenceIds.isEmpty()) {
-      List<Election> nonCanceledElections = electionDAO.findLastElectionsByReferenceIds(referenceIds)
-        .stream()
-        .filter(e -> invalidStatuses.contains(e.getStatus()))
-        .collect(Collectors.toList());
-      if (!nonCanceledElections.isEmpty()) {
-        logger.error("Non-canceled elections exist for collection: " + collection.getDarCollectionId());
-        throw new IllegalArgumentException("Non-canceled elections exist for this collection.");
-      }
-    }
     try {
-      collectionServiceDAO.createElectionsForDarCollection(collection);
+      collectionServiceDAO.createElectionsForDarCollection(user, collection);
       collection.getDars().values().forEach(dar -> {
         Election accessElection = electionDAO.findLastElectionByReferenceIdAndType(dar.getReferenceId(), ElectionType.DATA_ACCESS.getValue());
         if (Objects.nonNull(accessElection)) {

--- a/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
@@ -8,7 +8,6 @@ import io.dropwizard.testing.ResourceHelpers;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.RandomUtils;
-import org.apache.commons.rdf.api.Dataset;
 import org.broadinstitute.consent.http.ConsentApplication;
 import org.broadinstitute.consent.http.configurations.ConsentConfiguration;
 import org.broadinstitute.consent.http.enumeration.ElectionStatus;
@@ -711,7 +710,7 @@ public class DAOTestHelper {
         DataSet dataset = createDataset();
         createAssociation(consent.getConsentId(), dataset.getDataSetId());
         Integer collectionId = darCollectionDAO.insertDarCollection(darCode, user.getDacUserId(), new Date());
-        DataAccessRequest dar = createDarForCollection(user, collectionId, dataset);
+        createDarForCollection(user, collectionId, dataset);
         createdDarCollections.add(collectionId);
         return darCollectionDAO.findDARCollectionByCollectionId(collectionId);
     }

--- a/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
@@ -470,7 +470,7 @@ public class DarCollectionServiceTest {
     initService();
 
     service.createElectionsForDarCollection(user, collection);
-    verify(darCollectionServiceDAO, times(1)).createElectionsForDarCollection(any());
+    verify(darCollectionServiceDAO, times(1)).createElectionsForDarCollection(any(), any());
     verify(electionDAO, times(1)).findLastElectionsByReferenceIds(any());
     verify(electionDAO, times(1)).findLastElectionByReferenceIdAndType(any(), any());
     verify(voteDAO, times(1)).findVotesByElectionId(any());

--- a/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
@@ -428,24 +428,6 @@ public class DarCollectionServiceTest {
     verify(darCollectionDAO, times(0)).findDARCollectionByCollectionId(anyInt());
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void testCreateElectionsForDarCollectionOpenElection() {
-    User user = new User();
-    user.setEmail("email");
-    DataAccessRequest dar = new DataAccessRequest();
-    dar.setReferenceId(UUID.randomUUID().toString());
-    DarCollection collection = createMockCollections(1).get(0);
-    collection.setDars(Map.of(dar.getReferenceId(), dar));
-    Election election = createMockElection();
-    election.setReferenceId(dar.getReferenceId());
-    election.setStatus(ElectionStatus.OPEN.getValue());
-    election.setElectionId(1);
-    when(electionDAO.findLastElectionsByReferenceIds(anyList())).thenReturn(List.of(election));
-    initService();
-
-    service.createElectionsForDarCollection(user, collection);
-  }
-
   @Test
   public void testCreateElectionsForDarCollection() throws Exception {
     User user = new User();
@@ -471,7 +453,6 @@ public class DarCollectionServiceTest {
 
     service.createElectionsForDarCollection(user, collection);
     verify(darCollectionServiceDAO, times(1)).createElectionsForDarCollection(any(), any());
-    verify(electionDAO, times(1)).findLastElectionsByReferenceIds(any());
     verify(electionDAO, times(1)).findLastElectionByReferenceIdAndType(any(), any());
     verify(voteDAO, times(1)).findVotesByElectionId(any());
     verify(emailNotifierService, times(1)).sendNewCaseMessageToList(any(), any());
@@ -493,7 +474,7 @@ public class DarCollectionServiceTest {
 
     PaginationResponse<DarCollection> collectionResponse = service.queryCollectionsByFiltersAndUserRoles(user, token, adminName);
     assertNotNull(collectionResponse);
-    int responseUnfilteredCount = (int)collectionResponse.getUnfilteredCount();
+    int responseUnfilteredCount = collectionResponse.getUnfilteredCount();
     assertEquals(unfilteredCount, responseUnfilteredCount);
     assertEquals(mockCollectionSize, (int)collectionResponse.getFilteredCount());
     assertEquals(1, (int)collectionResponse.getFilteredPageCount());

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DarCollectionServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DarCollectionServiceDAOTest.java
@@ -126,6 +126,7 @@ public class DarCollectionServiceDAOTest extends DAOTestHelper {
     DarCollection collection = setUpDarCollectionWithDacDataset();
     Optional<DataAccessRequest> dar = collection.getDars().values().stream().findFirst();
     assertTrue(dar.isPresent());
+    assertFalse(dar.get().getData().getDatasetIds().isEmpty());
     Integer datasetId = dar.get().getData().getDatasetIds().get(0);
     assertNotNull(datasetId);
     Optional<Dac> dac = dacDAO.findDacsForDatasetIds(List.of(datasetId)).stream().findFirst();

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DarCollectionServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DarCollectionServiceDAOTest.java
@@ -18,6 +18,7 @@ import org.junit.Test;
 
 import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
@@ -33,8 +34,14 @@ public class DarCollectionServiceDAOTest extends DAOTestHelper {
     serviceDAO = new DarCollectionServiceDAO(dataSetDAO, electionDAO, jdbi, userDAO);
   }
 
+  /**
+   * This test covers the case where:
+   *  - User is an admin
+   *  - Collection has 1 DAR/Dataset combinations
+   *  - Elections created should be for the DAR/Dataset for the user
+   */
   @Test
-  public void testCreateElectionsForDarCollection() throws Exception {
+  public void testCreateElectionsForDarCollectionAdmin() throws Exception {
     initService();
 
     User user = new User();
@@ -63,30 +70,124 @@ public class DarCollectionServiceDAOTest extends DAOTestHelper {
     assertTrue(createdVotes.stream().anyMatch(v -> v.getType().equals(VoteType.AGREEMENT.getValue())));
   }
 
+  /**
+   * This test covers the case where:
+   *  - User is a chairperson
+   *  - Collection has 1 DAR/Dataset combinations
+   *  - Elections created should be for the DAR/Dataset for the user
+   */
+  @Test
+  public void testCreateElectionsForDarCollectionChair() throws Exception {
+    initService();
+
+    DarCollection collection = setUpDarCollectionWithDacDataset();
+    Optional<DataAccessRequest> dar = collection.getDars().values().stream().findFirst();
+    assertTrue(dar.isPresent());
+    Integer datasetId = dar.get().getData().getDatasetIds().get(0);
+    assertNotNull(datasetId);
+    Optional<Dac> dac = dacDAO.findDacsForDatasetIds(List.of(datasetId)).stream().findFirst();
+    assertTrue(dac.isPresent());
+    List<User> dacUsers = dacDAO.findMembersByDacId(dac.get().getDacId());
+    Optional<User> chair = dacUsers.stream().filter(u -> u.hasUserRole(UserRoles.CHAIRPERSON)).findFirst();
+    assertTrue(chair.isPresent());
+
+    serviceDAO.createElectionsForDarCollection(chair.get(), collection);
+
+    List<Election> createdElections =
+        electionDAO.findLastElectionsByReferenceIds(List.of(dar.get().getReferenceId()));
+    List<Vote> createdVotes =
+        voteDAO.findVotesByElectionIds(
+            createdElections.stream().map(Election::getElectionId).collect(Collectors.toList()));
+
+    // Ensure that we have an access and rp election
+    assertFalse(createdElections.isEmpty());
+    assertTrue(createdElections.stream().anyMatch(e -> e.getElectionType().equals(ElectionType.DATA_ACCESS.getValue())));
+    assertTrue(createdElections.stream().anyMatch(e -> e.getElectionType().equals(ElectionType.RP.getValue())));
+    // Ensure that we have primary vote types
+    assertFalse(createdVotes.isEmpty());
+    assertTrue(createdVotes.stream().anyMatch(v -> v.getType().equals(VoteType.CHAIRPERSON.getValue())));
+    assertTrue(createdVotes.stream().anyMatch(v -> v.getType().equals(VoteType.FINAL.getValue())));
+    assertTrue(createdVotes.stream().anyMatch(v -> v.getType().equals(VoteType.DAC.getValue())));
+    assertTrue(createdVotes.stream().anyMatch(v -> v.getType().equals(VoteType.AGREEMENT.getValue())));
+  }
+
+  /**
+   * This test covers the case where:
+   *  - User is a chairperson
+   *  - Collection has 2 DAR/Dataset combinations
+   *  - User is a DAC chair for only one of the DAR/Dataset combinations
+   *  - Elections created should only be for the DAR/Dataset for the user
+   */
+  @Test
+  public void testCreateElectionsForDarCollectionWithMultipleDatasetsForChair() throws Exception {
+    initService();
+
+    // Start off with a collection and a single DAR
+    DarCollection collection = setUpDarCollectionWithDacDataset();
+    Optional<DataAccessRequest> dar = collection.getDars().values().stream().findFirst();
+    assertTrue(dar.isPresent());
+    Integer datasetId = dar.get().getData().getDatasetIds().get(0);
+    assertNotNull(datasetId);
+    Optional<Dac> dac = dacDAO.findDacsForDatasetIds(List.of(datasetId)).stream().findFirst();
+    assertTrue(dac.isPresent());
+    List<User> dacUsers = dacDAO.findMembersByDacId(dac.get().getDacId());
+    Optional<User> chair = dacUsers.stream().filter(u -> u.hasUserRole(UserRoles.CHAIRPERSON)).findFirst();
+    assertTrue(chair.isPresent());
+
+    // Add another DAR with Dataset to collection.
+    // This one should not be available to the chairperson created above.
+    DataAccessRequest dar2 = addDatasetWithDacToCollection(collection);
+
+    serviceDAO.createElectionsForDarCollection(chair.get(), collection);
+
+    List<Election> createdElections =
+        electionDAO.findLastElectionsByReferenceIds(List.of(dar.get().getReferenceId()));
+    List<Vote> createdVotes =
+        voteDAO.findVotesByElectionIds(
+            createdElections.stream().map(Election::getElectionId).collect(Collectors.toList()));
+
+    // Ensure that we have an access and rp election
+    assertFalse(createdElections.isEmpty());
+    assertTrue(createdElections.stream().anyMatch(e -> e.getElectionType().equals(ElectionType.DATA_ACCESS.getValue())));
+    assertTrue(createdElections.stream().anyMatch(e -> e.getElectionType().equals(ElectionType.RP.getValue())));
+    // Ensure that we have primary vote types
+    assertFalse(createdVotes.isEmpty());
+    assertTrue(createdVotes.stream().anyMatch(v -> v.getType().equals(VoteType.CHAIRPERSON.getValue())));
+    assertTrue(createdVotes.stream().anyMatch(v -> v.getType().equals(VoteType.FINAL.getValue())));
+    assertTrue(createdVotes.stream().anyMatch(v -> v.getType().equals(VoteType.DAC.getValue())));
+    assertTrue(createdVotes.stream().anyMatch(v -> v.getType().equals(VoteType.AGREEMENT.getValue())));
+
+    // Make sure we did not create elections for the DAR/Dataset that the chair does not have access to.
+    List<Election> nonCreatedElections =
+        electionDAO.findLastElectionsByReferenceIds(List.of(dar2.getReferenceId()));
+    assertTrue(nonCreatedElections.isEmpty());
+  }
+
   @Test
   public void testCreateElectionsForDarCollectionManualReview() throws Exception {
     initService();
 
     User user = new User();
+    user.addRole(new UserRole(UserRoles.ADMIN.getRoleId(), UserRoles.ADMIN.getRoleName()));
     DarCollection collection = setUpDarCollectionWithDacDataset();
-    DataAccessRequest dar = collection.getDars().values().stream().findFirst().orElse(null);
-    assertNotNull(dar);
-    assertNotNull(dar.getData());
+    Optional<DataAccessRequest> dar = collection.getDars().values().stream().findFirst();
+    assertTrue(dar.isPresent());
+    assertNotNull(dar.get().getData());
     // Any sensitive subject triggers manual review required:
-    dar.getData().setPoa(true);
+    dar.get().getData().setPoa(true);
     Date now = new Date();
     dataAccessRequestDAO.updateDataByReferenceIdVersion2(
-      dar.getReferenceId(),
-      dar.getUserId(),
+      dar.get().getReferenceId(),
+      dar.get().getUserId(),
       now,
       now,
       now,
-      dar.getData());
+      dar.get().getData());
 
     serviceDAO.createElectionsForDarCollection(user, collection);
 
     List<Election> createdElections =
-        electionDAO.findLastElectionsByReferenceIds(List.of(dar.getReferenceId()));
+        electionDAO.findLastElectionsByReferenceIds(List.of(dar.get().getReferenceId()));
     List<Vote> createdVotes =
         voteDAO.findVotesByElectionIds(
             createdElections.stream().map(Election::getElectionId).collect(Collectors.toList()));
@@ -108,6 +209,7 @@ public class DarCollectionServiceDAOTest extends DAOTestHelper {
     initService();
 
     User user = new User();
+    user.addRole(new UserRole(UserRoles.ADMIN.getRoleId(), UserRoles.ADMIN.getRoleName()));
     DarCollection collection = setUpDarCollectionWithDacDataset();
     DataAccessRequest dar = collection.getDars().values().stream().findFirst().orElse(null);
     assertNotNull(dar);
@@ -133,20 +235,28 @@ public class DarCollectionServiceDAOTest extends DAOTestHelper {
   }
 
   private DarCollection setUpDarCollectionWithDacDataset() {
+    DarCollection collection = createDarCollectionWithSingleDataAccessRequest();
+    DataAccessRequest dar = collection.getDars().values().stream().findFirst().orElse(null);
+    assertNotNull(dar);
+    assertNotNull(dar.getData());
+    dar.getData().setDatasetIds(List.of(dar.getData().getDatasetIds().get(0)));
+    Date now = new Date();
+    dataAccessRequestDAO.updateDataByReferenceIdVersion2(
+        dar.getReferenceId(), dar.getUserId(), now, now, now, dar.getData());
+    return darCollectionDAO.findDARCollectionByReferenceId(dar.getReferenceId());
+  }
+
+  private DataAccessRequest addDatasetWithDacToCollection(DarCollection collection) {
+    // Create new DAC and Dataset:
     Dac dac = createDac();
     createUserWithRoleInDac(UserRoles.CHAIRPERSON.getRoleId(), dac.getDacId());
     createUserWithRoleInDac(UserRoles.MEMBER.getRoleId(), dac.getDacId());
     Consent consent = createConsent(dac.getDacId());
     DataSet dataset = createDataset();
     createAssociation(consent.getConsentId(), dataset.getDataSetId());
-    DarCollection collection = createDarCollectionWithSingleDataAccessRequest();
-    DataAccessRequest dar = collection.getDars().values().stream().findFirst().orElse(null);
-    assertNotNull(dar);
-    assertNotNull(dar.getData());
-    dar.getData().setDatasetIds(List.of(dataset.getDataSetId()));
-    Date now = new Date();
-    dataAccessRequestDAO.updateDataByReferenceIdVersion2(
-        dar.getReferenceId(), dar.getUserId(), now, now, now, dar.getData());
-    return darCollectionDAO.findDARCollectionByReferenceId(dar.getReferenceId());
+
+    // Create new DAR with Dataset and add it to the collection
+    User user = createUser();
+    return createDarForCollection(user, collection.getDarCollectionId(), dataset);
   }
 }


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-1645

Updates to the election creation logic:
* Create elections in all cases except for Open elections. This allows for re-opening a closed, canceled, or completed election.
* For Admins, the default is to create elections for all DAR/Dataset combinations.
* For Chairs, only create elections for a DAR/Dataset combination when the dataset is in any of the Chairperson's DACs

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
