### PR TITLE
DUOS-1679[risk=no] Add elections to DarCollectionsDAO.findAllDarCollections

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
@@ -141,12 +141,14 @@ public interface DarCollectionDAO {
   @RegisterBeanMapper(value = DarCollection.class)
   @RegisterBeanMapper(value = DataAccessRequest.class, prefix = "dar")
   @RegisterBeanMapper(value = UserProperty.class, prefix = "up")
+  @RegisterBeanMapper(value = Election.class, prefix = "e")
   @UseRowReducer(DarCollectionReducer.class)
   @SqlQuery(
     " SELECT c.*, " +
         User.QUERY_FIELDS_WITH_U_PREFIX + QUERY_FIELD_SEPARATOR +
         Institution.QUERY_FIELDS_WITH_I_PREFIX + QUERY_FIELD_SEPARATOR +
         UserProperty.QUERY_FIELDS_WITH_UP_PREFIX + QUERY_FIELD_SEPARATOR +
+        Election.QUERY_FIELDS_WITH_E_PREFIX + QUERY_FIELD_SEPARATOR +
         "dar.id AS dar_id, dar.reference_id AS dar_reference_id, dar.collection_id AS dar_collection_id, " +
         "dar.draft AS dar_draft, dar.user_id AS dar_userId, dar.create_date AS dar_create_date, " +
         "dar.sort_date AS dar_sort_date, dar.submission_date AS dar_submission_date, " +
@@ -155,7 +157,9 @@ public interface DarCollectionDAO {
         "INNER JOIN dacuser u ON c.create_user_id = u.dacuserid " +
         "LEFT JOIN user_property up ON u.dacuserid = up.userid " +
         "INNER JOIN data_access_request dar on c.collection_id = dar.collection_id " +
-        "LEFT JOIN institution i ON i.institution_id = u.institution_id "
+        "LEFT JOIN institution i ON i.institution_id = u.institution_id " +
+        " LEFT JOIN (SELECT election.*, MAX(election.electionid) OVER (PARTITION BY election.referenceid, election.electiontype) AS latest FROM election) AS e " +
+        "   ON dar.reference_id = e.referenceid AND (e.latest = e.electionid OR e.latest IS NULL) "
   )
   List<DarCollection> findAllDARCollections();
 

--- a/src/test/java/org/broadinstitute/consent/http/db/DarCollectionDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DarCollectionDAOTest.java
@@ -43,6 +43,13 @@ public class DarCollectionDAOTest extends DAOTestHelper  {
     assertEquals(1, allAfter.size());
     List<UserProperty> userProperties = allAfter.get(0).getCreateUser().getProperties();
     assertFalse(userProperties.isEmpty());
+    List<Election> elections = collection.getDars().values().stream()
+      .map(DataAccessRequest::getElections)
+      .map(electionMap -> electionMap.values())
+      .flatMap(Collection::stream)
+      .collect(Collectors.toList());
+    assertNotNull(elections);
+    assertTrue(elections.size() > 0);
     userProperties.forEach(p -> assertEquals(collection.getCreateUserId(), p.getUserId()));
   }
 


### PR DESCRIPTION
Addresses [DUOS-1679](https://broadworkbench.atlassian.net/browse/DUOS-1679)

PR adds elections to the admin collection query (`DarCollectionsDAO.findAllDarCollections`). Update required for dynamic rendering on the Admin Console UI.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
