### PR TITLE
DUOS-1681[risk=med] Endpoint for authenticated users to get datasets under their DACs

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
@@ -257,7 +257,7 @@ public class ConsentApplication extends Application<ConsentConfiguration> {
         env.jersey().register(new SamResource(samService));
         env.jersey().register(new SwaggerResource(config.getGoogleAuthentication()));
         env.jersey().register(new StatusResource(env.healthChecks()));
-        env.jersey().register(new UserResource(researcherService, samService, userService));
+        env.jersey().register(new UserResource(researcherService, samService, userService, datasetService));
         env.jersey().register(new TosResource(samService));
         env.jersey().register(injector.getInstance(VersionResource.class));
         env.jersey().register(new VoteResource(userService, voteService));

--- a/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
@@ -245,6 +245,21 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
      * DACs -> Consents -> Consent Associations -> DataSets
      * DataSets -> DatasetProperties -> Dictionary
      *
+     * @return Set of datasets, with properties, that are associated to a single DAC.
+     */
+    @UseRowMapper(DataSetPropertiesMapper.class)
+    @SqlQuery("select d.*, k.key, p.propertyValue, c.consentId, c.dac_id, c.translatedUseRestriction, c.datause from dataset d " +
+            " left outer join datasetproperty p on p.dataSetId = d.dataSetId " +
+            " left outer join dictionary k on k.keyId = p.propertyKey " +
+            " inner join consentassociations a on a.dataSetId = d.dataSetId " +
+            " inner join consents c on c.consentId = a.consentId " +
+            " where c.dac_id IN (<dacIds>) ")
+    Set<DatasetDTO> findDatasetsByDacIds(@BindList("dacIds") List<Integer> dacIds);
+
+    /**
+     * DACs -> Consents -> Consent Associations -> DataSets
+     * DataSets -> DatasetProperties -> Dictionary
+     *
      * @return Set of datasets, with properties, that are associated to any Dac.
      */
     @UseRowMapper(DataSetPropertiesMapper.class)

--- a/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
@@ -245,7 +245,7 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
      * DACs -> Consents -> Consent Associations -> DataSets
      * DataSets -> DatasetProperties -> Dictionary
      *
-     * @return Set of datasets, with properties, that are associated to a single DAC.
+     * @return Set of datasets, with properties, that are associated with the provided DAC IDs
      */
     @UseRowMapper(DataSetPropertiesMapper.class)
     @SqlQuery("select d.*, k.key, p.propertyValue, c.consentId, c.dac_id, c.translatedUseRestriction, c.datause from dataset d " +

--- a/src/main/java/org/broadinstitute/consent/http/resources/DacResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DacResource.java
@@ -197,7 +197,6 @@ public class DacResource extends Resource {
         return Response.ok().entity(datasets).build();
     }
 
-
     @GET
     @Path("users/{term}")
     @Produces("application/json")

--- a/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
@@ -109,7 +109,7 @@ public class UserResource extends Resource {
     @GET
     @Path("/me/dac/datasets")
     @Produces("application/json")
-    @PermitAll
+    @RolesAllowed({CHAIRPERSON, MEMBER})
     public Response getDatasetsFromUserDacs(@Auth AuthUser authUser) {
         try {
             Set<DatasetDTO> datasets;

--- a/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
@@ -11,7 +11,9 @@ import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.AuthUser;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.UserRole;
+import org.broadinstitute.consent.http.models.dto.DatasetDTO;
 import org.broadinstitute.consent.http.models.dto.Error;
+import org.broadinstitute.consent.http.service.DatasetService;
 import org.broadinstitute.consent.http.service.ResearcherService;
 import org.broadinstitute.consent.http.service.UserService;
 import org.broadinstitute.consent.http.service.UserService.SimplifiedUser;
@@ -39,6 +41,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Path("api/user")
 public class UserResource extends Resource {
@@ -47,13 +51,15 @@ public class UserResource extends Resource {
     private final ResearcherService researcherService;
     private final Gson gson = new Gson();
     private final SamService samService;
+    private final DatasetService datasetService;
 
     @Inject
     public UserResource(ResearcherService researcherService,
-                        SamService samService, UserService userService) {
+                        SamService samService, UserService userService, DatasetService datasetService) {
         this.researcherService = researcherService;
         this.samService = samService;
         this.userService = userService;
+        this.datasetService = datasetService;
     }
 
     @GET
@@ -95,6 +101,25 @@ public class UserResource extends Resource {
             }
             JsonObject userJson = userService.findUserWithPropertiesByIdAsJsonObject(authUser, user.getDacUserId());
             return Response.ok(gson.toJson(userJson)).build();
+        } catch (Exception e) {
+            return createExceptionResponse(e);
+        }
+    }
+
+    @GET
+    @Path("/me/dac/datasets")
+    @Produces("application/json")
+    @PermitAll
+    public Response getDatasetsFromUserDacs(@Auth AuthUser authUser) {
+        try {
+            Set<DatasetDTO> datasets;
+            User user = userService.findUserByEmail(authUser.getEmail());
+            List<Integer> dacIds = user.getRoles().stream()
+                .filter(r -> Objects.nonNull(r.getDacId()))
+                .map(UserRole::getDacId)
+                .collect(Collectors.toList());
+            datasets = dacIds.isEmpty() ? Set.of() : datasetService.findDatasetsByDacIds(dacIds);
+            return Response.ok().entity(datasets).build();
         } catch (Exception e) {
             return createExceptionResponse(e);
         }

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -95,6 +95,10 @@ public class DatasetService {
         return datasetDAO.findNeedsApprovalDataSetByDataSetId(dataSetIdList);
     }
 
+    public Set<DatasetDTO> findDatasetsByDacIds(List<Integer> dacIds) {
+        return datasetDAO.findDatasetsByDacIds(dacIds);
+    }
+
     /**
      * Create a minimal consent from the data provided in a Dataset.
      *

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -22,6 +22,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
+import javax.ws.rs.BadRequestException;
 import javax.ws.rs.NotFoundException;
 
 import java.sql.Timestamp;
@@ -96,6 +97,9 @@ public class DatasetService {
     }
 
     public Set<DatasetDTO> findDatasetsByDacIds(List<Integer> dacIds) {
+        if(Objects.isNull(dacIds) || dacIds.isEmpty()) {
+            throw new BadRequestException("No dataset IDs provided");
+        }
         return datasetDAO.findDatasetsByDacIds(dacIds);
     }
 

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -2875,24 +2875,7 @@ paths:
         500:
           description: Server error.
   /api/user/me/dac/datasets:
-    get:
-      summary: Get datasets from currently authenticated user's DACs
-      description: Get datasets from currently authenticated user's DACs
-      tags:
-        - User
-      responses: 
-        200: 
-          description: Set of Datasets that are under the purview of User's dacs
-          content: 
-            application/json:
-              schema: 
-                type: object
-                items: 
-                  $ref: '#/components/schemas/Dataset'
-        404:
-          description: User not found
-        500:
-          description: Server error
+    $ref: './paths/getDatasetsFromUserDacs.yaml'
   /api/user/institution/{institutionId}:
     $ref: './paths/userInstitutionByInstitutionId.yaml'
   /api/user/institution/unassigned:

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -2874,6 +2874,25 @@ paths:
           description: User not found
         500:
           description: Server error.
+  /api/user/me/dac/datasets:
+    get:
+      summary: Get datasets from currently authenticated user's DACs
+      description: Get datasets from currently authenticated user's DACs
+      tags:
+        - User
+      responses: 
+        200: 
+          description: Set of Datasets that are under the purview of User's dacs
+          content: 
+            application/json:
+              schema: 
+                type: object
+                items: 
+                  $ref: '#/components/schemas/Dataset'
+        404:
+          description: User not found
+        500:
+          description: Server error
   /api/user/institution/{institutionId}:
     $ref: './paths/userInstitutionByInstitutionId.yaml'
   /api/user/institution/unassigned:

--- a/src/main/resources/assets/paths/getDatasetsFromUserDacs.yaml
+++ b/src/main/resources/assets/paths/getDatasetsFromUserDacs.yaml
@@ -1,0 +1,19 @@
+
+get:
+  summary: Get datasets from currently authenticated user's DACs
+  description: Get datasets from currently authenticated user's DACs
+  tags:
+    - User
+  responses:
+    200:
+      description: Set of Datasets that are under the purview of User's dacs
+      content:
+        application/json:
+          schema:
+            type: object
+            items:
+              $ref: '../schemas/Dataset.yaml'
+    404:
+      description: User not found
+    500:
+      description: Server error

--- a/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
@@ -149,6 +149,20 @@ public class DatasetDAOTest extends DAOTestHelper {
     }
 
     @Test
+    public void testFindDatasetsByDacIds() {
+        DataSet dataset = createDataset();
+        Dac dac = createDac();
+
+        DataSet datasetTwo = createDataset();
+        Dac dacTwo = createDac();
+        createConsentAndAssociationWithDatasetIdAndDACId(dataset.getDataSetId(), dac.getDacId());
+        createConsentAndAssociationWithDatasetIdAndDACId(datasetTwo.getDataSetId(), dacTwo.getDacId());
+        List<Integer> datasetIds = List.of(dataset.getDataSetId(), datasetTwo.getDataSetId());
+        Set<DatasetDTO> datasets = dataSetDAO.findDatasetsByDacIds(List.of(dac.getDacId(), dacTwo.getDacId()));
+        datasets.stream().forEach(d -> assertTrue(datasetIds.contains(d.getDataSetId())));
+    }
+
+    @Test
     public void testFindDatasetWithDataUseByIdList() {
         DataSet dataset = createDataset();
         Dac dac = createDac();

--- a/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
@@ -13,6 +13,7 @@ import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.UserProperty;
 import org.broadinstitute.consent.http.models.UserRole;
 import org.broadinstitute.consent.http.models.sam.UserStatusInfo;
+import org.broadinstitute.consent.http.service.DatasetService;
 import org.broadinstitute.consent.http.service.LibraryCardService;
 import org.broadinstitute.consent.http.service.ResearcherService;
 import org.broadinstitute.consent.http.service.UserService;
@@ -42,6 +43,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
@@ -57,6 +59,8 @@ public class UserResourceTest {
   @Mock private ResearcherService researcherService;
 
   @Mock private SamService samService;
+  
+  @Mock private DatasetService datasetService;
 
   private UserResource userResource;
 
@@ -85,7 +89,7 @@ public class UserResourceTest {
   }
 
   private void initResource() {
-    userResource = new UserResource(researcherService, samService, userService);
+    userResource = new UserResource(researcherService, samService, userService, datasetService);
   }
 
   @Test
@@ -435,6 +439,17 @@ public class UserResourceTest {
 
     Map<String, String> propMap = new HashMap<>();
     Response response = userResource.updateProperties(authUser, false, propMap);
+    assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+  }
+
+  @Test
+  public void testGetDatasetsFromUserDacs() {
+    User user = createUserWithRole();
+    when(datasetService.findDatasetsByDacIds(anyList())).thenReturn(Collections.emptySet());
+    when(userService.findUserByEmail(anyString())).thenReturn(user);
+    initResource();
+
+    Response response = userResource.getDatasetsFromUserDacs(authUser);
     assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
@@ -445,6 +445,8 @@ public class UserResourceTest {
   @Test
   public void testGetDatasetsFromUserDacs() {
     User user = createUserWithRole();
+    UserRole admin = new UserRole(UserRoles.ADMIN.getRoleId(), UserRoles.ADMIN.getRoleName());
+    user.addRole(admin);
     when(datasetService.findDatasetsByDacIds(anyList())).thenReturn(Collections.emptySet());
     when(userService.findUserByEmail(anyString())).thenReturn(user);
     initResource();
@@ -452,6 +454,7 @@ public class UserResourceTest {
     Response response = userResource.getDatasetsFromUserDacs(authUser);
     assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
   }
+
 
   private User createUserWithRole() {
     User user = new User();

--- a/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
@@ -19,6 +19,7 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+import javax.ws.rs.BadRequestException;
 import javax.ws.rs.NotFoundException;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -154,6 +155,18 @@ public class DatasetServiceTest {
         initService();
 
         datasetService.findDatasetsByDacIds(List.of(1,2,3));
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void testFindDatasetsByDacIdsEmptyList() {
+        initService();
+        datasetService.findDatasetsByDacIds(Collections.emptyList());
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void testFindDatasetsByDacIdsNullList() {
+        initService();
+        datasetService.findDatasetsByDacIds(null);
     }
 
     @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
@@ -40,6 +40,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
@@ -145,6 +146,14 @@ public class DatasetServiceTest {
         initService();
 
         datasetService.disableDataset(dataSetId, false);
+    }
+
+    @Test
+    public void testFindDatasetsByDacIds() {
+        when(datasetDAO.findDatasetsByDacIds(anyList())).thenReturn(Collections.emptySet());
+        initService();
+
+        datasetService.findDatasetsByDacIds(List.of(1,2,3));
     }
 
     @Test


### PR DESCRIPTION
Addresses [DUOS-1681](https://broadworkbench.atlassian.net/browse/DUOS-1681)

PR creates an endpoint under `UserResource` that allows authenticated users to get all datasets under the purview of the DACs that they belong to. Endpoint is made in anticipation of UI components requiring this data to help filter collection data on initialization.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment


[DUOS-1681]: https://broadworkbench.atlassian.net/browse/DUOS-1681?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ