### PR TITLE
DUOS-1686[risk=no] Bug fix for SO LC Create service method

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/service/LibraryCardService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/LibraryCardService.java
@@ -30,11 +30,11 @@ public class LibraryCardService {
         this.userDAO = userDAO;
     }
 
-    public LibraryCard createLibraryCard(LibraryCard libraryCard, User user) throws Exception {
+    public LibraryCard createLibraryCard(LibraryCard libraryCard, User user) {
         throwIfNull(libraryCard);
         Boolean isAdmin = checkIsAdmin(user);
         //If user is not an admin, use user's institutionId rather than the value provided in the payload
-        if (!isAdmin && libraryCard.getInstitutionId() != user.getInstitutionId()) {
+        if (!isAdmin && !libraryCard.getInstitutionId().equals(user.getInstitutionId())) {
             throw new BadRequestException("Card payload not valid");
         }
         checkIfCardExists(libraryCard);

--- a/src/test/java/org/broadinstitute/consent/http/service/LibraryCardServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/LibraryCardServiceTest.java
@@ -49,7 +49,7 @@ public class LibraryCardServiceTest {
 
     @Test
     // Test LC create with userId and email
-    public void testCreateLibraryCardFullUserDetails() throws Exception {
+    public void testCreateLibraryCardFullUserDetails() {
         initService();
         Institution institution = testInstitution();
         User user = testUser(institution.getId());
@@ -70,7 +70,7 @@ public class LibraryCardServiceTest {
 
     @Test
     //Test LC create with only user email (no userId)
-    public void testCreateLibraryCardPartialUserDetailsEmail() throws Exception {
+    public void testCreateLibraryCardPartialUserDetailsEmail() {
         initService();
         Institution institution = testInstitution();
         User user = testUser(institution.getId());
@@ -94,7 +94,7 @@ public class LibraryCardServiceTest {
 
     @Test
     //Test LC create with only user id (no email)
-    public void testCreateLibraryCardPartialUserDetailsId() throws Exception {
+    public void testCreateLibraryCardPartialUserDetailsId() {
         initService();
         Institution institution = testInstitution();
         User user = testUser(institution.getId());
@@ -115,16 +115,29 @@ public class LibraryCardServiceTest {
     }
 
     @Test
-    public void testCreateLibraryCardAsSO() throws Exception {
+    public void testCreateLibraryCardAsSO() {
         initService();
         Institution institution = testInstitution();
         User soUser = createUserWithRole(UserRoles.SIGNINGOFFICIAL.getRoleId(), UserRoles.SIGNINGOFFICIAL.getRoleName());
         soUser.setInstitutionId(institution.getId());
+
+        when(userDAO.findUserById(anyInt())).thenReturn(soUser);
+        when(institutionDAO.findInstitutionById(anyInt())).thenReturn(institution);
+        when(libraryCardDAO.findLibraryCardsByUserId(anyInt())).thenReturn(Collections.emptyList());
+
+        // last two calls in the function, no need to test within this service test file
+        when(libraryCardDAO.insertLibraryCard(anyInt(), anyInt(), any(), any(), any(), anyInt(), any()))
+                .thenReturn(1);
+        when(libraryCardDAO.findLibraryCardById(anyInt())).thenReturn(new LibraryCard());
+
+        LibraryCard payload = testLibraryCard(institution.getId(), soUser.getDacUserId());
+        payload.setUserEmail("testemail");
+        service.createLibraryCard(payload, soUser);
     }
 
     @Test(expected = ConsentConflictException.class)
     //Negative test, checks if error is thrown if payload email and userId don't match up to those on user record
-    public void testCreateLibraryCardIncorrectUserIdAndEmail() throws Exception {
+    public void testCreateLibraryCardIncorrectUserIdAndEmail() {
         initService();
         Institution institution = testInstitution();
         User user = testUser(institution.getId());
@@ -147,7 +160,7 @@ public class LibraryCardServiceTest {
 
     @Test(expected = ConsentConflictException.class)
     //Negative test, checks to see if error thrown if card already exists on user id and institution id
-    public void testCreateLibraryCardAlreadyExistsOnUserId() throws Exception{
+    public void testCreateLibraryCardAlreadyExistsOnUserId() {
         initService();
         Institution institution = testInstitution();
         User user = testUser(institution.getId());
@@ -162,7 +175,7 @@ public class LibraryCardServiceTest {
 
     @Test(expected = ConsentConflictException.class)
     // Negative test, checks to see if error thrown if card already exists on user email and institution id
-    public void testCreateLibraryCardAlreadyExistsOnUserEmail() throws Exception {
+    public void testCreateLibraryCardAlreadyExistsOnUserEmail() {
         initService();
         Institution institution = testInstitution();
         User user = testUser(institution.getId());
@@ -180,7 +193,7 @@ public class LibraryCardServiceTest {
 
     @Test(expected = BadRequestException.class)
     //Negative test, checks to see if error is thrown if email and userId are not provided
-    public void testCreateLibraryCardNoUserDetails() throws Exception {
+    public void testCreateLibraryCardNoUserDetails() {
         User adminUser = createUserWithRole(UserRoles.ADMIN.getRoleId(), UserRoles.ADMIN.getRoleName());
         initService();
         Institution institution = testInstitution();
@@ -192,7 +205,7 @@ public class LibraryCardServiceTest {
 
     @Test(expected = IllegalArgumentException.class)
     //Negative test, checks if error is thrown on null institutionId
-    public void testCreateLibraryCard_InvalidInstitution() throws Exception {
+    public void testCreateLibraryCard_InvalidInstitution() {
         User user = testUser(1);
         User adminUser = createUserWithRole(UserRoles.ADMIN.getRoleId(), UserRoles.ADMIN.getRoleName());
         LibraryCard libraryCard = testLibraryCard(1, user.getDacUserId());
@@ -210,14 +223,14 @@ public class LibraryCardServiceTest {
 
     @Test(expected = NotFoundException.class)
     //Negative test, checks to see if error is thrown on null payload
-    public void testCreateLibraryCardNullPayload() throws Exception {
+    public void testCreateLibraryCardNullPayload() {
         User adminUser = createUserWithRole(UserRoles.ADMIN.getRoleId(), UserRoles.ADMIN.getRoleName());
         initService();
         service.createLibraryCard(null, adminUser);
     }
 
     @Test(expected = BadRequestException.class)
-    public void testCreateLibraryCard_InvalidInstitutionId() throws Exception {
+    public void testCreateLibraryCard_InvalidInstitutionId() {
         User soUser = createUserWithRole(UserRoles.SIGNINGOFFICIAL.getRoleId(), UserRoles.SIGNINGOFFICIAL.getRoleName());
         soUser.setInstitutionId(1);
         LibraryCard card = testLibraryCard(2, 2);
@@ -225,7 +238,6 @@ public class LibraryCardServiceTest {
         initService();
         service.createLibraryCard(card, soUser);
     }
-
 
     @Test
     public void testUpdateLibraryCard() {


### PR DESCRIPTION
Addresses [DUOS-1686](https://broadworkbench.atlassian.net/browse/DUOS-1686)

PR fixes bug regarding id comparisons in `LibraryCardService.createLibraryCard` alongside new test.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
