### PR TITLE
[DUOS-1687][risk=no] Fix javascript media type

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/resources/SwaggerResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/SwaggerResource.java
@@ -18,12 +18,10 @@ import org.parboiled.common.FileUtils;
 public class SwaggerResource {
 
   private static final Logger logger = Logger.getLogger(SwaggerResource.class.getName());
-  // Default swagger ui library if not found in properties
-  // should not hard-code the actual version here!
   private static final String DEFAULT_LIB = "META-INF/resources/webjars/swagger-ui/latest/";
   private static final String MEDIA_TYPE_GIF = new MediaType("image", "gif").toString();
   protected static final String MEDIA_TYPE_CSS = new MediaType("text", "css").toString();
-  protected static final String MEDIA_TYPE_JS = new MediaType("application", "js").toString();
+  protected static final String MEDIA_TYPE_JS = new MediaType("application", "javascript").toString();
   protected static final String MEDIA_TYPE_PNG = new MediaType("image", "png").toString();
 
   private final GoogleOAuth2Config config;


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-1687
See also: https://github.com/DataBiosphere/consent-ontology/pull/614

## Testing
To test, add this block to your local `site.conf` WITHOUT the changes in this PR:
```
Header unset X-XSS-Protection
Header always set X-XSS-Protection "1; mode=block"
Header unset X-Content-Type-Options
Header always set X-Content-Type-Options: nosniff
Header unset Strict-Transport-Security
Header always set Strict-Transport-Security "max-age=31536000; includeSubDomains"
```
That will break the loading of the swagger page. FF shows this message:
```
The resource from “https://local.broadinstitute.org:27443/swagger-ui-bundle.js” was blocked due to MIME type (“application/js”) mismatch (X-Content-Type-Options: nosniff).
```

Then apply the contents of this PR with that same `site.conf` change and the page should load correctly.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
