### PR TITLE
DUOS-1730[risk=no] Vote API - Validate LC existence for certain vote scenarios

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
@@ -260,7 +260,7 @@ public class ConsentApplication extends Application<ConsentConfiguration> {
         env.jersey().register(new UserResource(researcherService, samService, userService, datasetService));
         env.jersey().register(new TosResource(samService));
         env.jersey().register(injector.getInstance(VersionResource.class));
-        env.jersey().register(new VoteResource(userService, voteService));
+        env.jersey().register(new VoteResource(userService, voteService, electionService));
 
         // Authentication filters
         final UserRoleDAO userRoleDAO = injector.getProvider(UserRoleDAO.class).get();

--- a/src/main/java/org/broadinstitute/consent/http/db/ElectionDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/ElectionDAO.java
@@ -136,6 +136,13 @@ public interface ElectionDAO extends Transactional<ElectionDAO> {
             " ORDER BY e.createdate ASC ")
     List<Election> findLastDataAccessElectionsWithFinalVoteByStatus(@Bind("status") String status);
 
+	@SqlQuery("SELECT e.* FROM election" +
+		"INNER JOIN data_access_request dar ON dar.reference_id = e.referenceid " +
+		"INNER JOIN dacuser du ON du.dacuserid = dar.user_id " +
+        "INNER JOIN library_card lc ON lc.user_id = du.dacuserid " +
+        "WHERE e.electionid IN (<electionIds>) ")
+	List<Election> findElectionsWithCardHoldingUsersByElectionIds(@BindList("electionIds") List <Integer> electionIds);
+
     @SqlQuery("SELECT DISTINCT e.electionId, e.datasetId, v.vote finalVote, e.status, e.createDate, e.referenceId, " +
             "       v.rationale finalRationale, v.createDate finalVoteDate, e.lastUpdate, e.finalAccessVote, " +
             "       e.electionType, e.dataUseLetter, e.dulName, e.archived, e.version " +
@@ -160,6 +167,17 @@ public interface ElectionDAO extends Transactional<ElectionDAO> {
     @UseRowMapper(SimpleElectionMapper.class)
     @SqlQuery("SELECT * FROM election WHERE referenceid = :referenceId")
     List<Election> findElectionsByReferenceId(@Bind("referenceId") String referenceId);
+
+    @UseRowMapper(SimpleElectionMapper.class)
+    @SqlQuery("SELECT * FROM election " + 
+        "INNER JOIN vote v ON v.electionid = e.electionid " +
+        "WHERE LOWER(election.electiontype) = :electionType " + 
+        "AND vote.voteid IN (<voteIds>)")
+	List<Election> findElectionsByVoteIdsAndType(
+		@BindList("voteIds") List<Integer> voteIds,
+		@Bind("electionType") String electionType
+	);
+
 
     @SqlQuery(
       "SELECT * from ( "

--- a/src/main/java/org/broadinstitute/consent/http/db/ElectionDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/ElectionDAO.java
@@ -176,8 +176,8 @@ public interface ElectionDAO extends Transactional<ElectionDAO> {
         "WHERE LOWER(e.electiontype) = :electionType " + 
         "AND v.voteid IN (<voteIds>)")
 	List<Election> findElectionsByVoteIdsAndType(
-		@BindList("voteIds") List<Integer> voteIds,
-		@Bind("electionType") String electionType
+	    @BindList("voteIds") List<Integer> voteIds,
+	    @Bind("electionType") String electionType
 	);
 
 

--- a/src/main/java/org/broadinstitute/consent/http/db/ElectionDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/ElectionDAO.java
@@ -136,12 +136,14 @@ public interface ElectionDAO extends Transactional<ElectionDAO> {
             " ORDER BY e.createdate ASC ")
     List<Election> findLastDataAccessElectionsWithFinalVoteByStatus(@Bind("status") String status);
 
-	@SqlQuery("SELECT e.* FROM election" +
-		"INNER JOIN data_access_request dar ON dar.reference_id = e.referenceid " +
-		"INNER JOIN dacuser du ON du.dacuserid = dar.user_id " +
+    @UseRowMapper(SimpleElectionMapper.class)
+    @SqlQuery(
+        "SELECT e.* FROM election e " +
+        "INNER JOIN data_access_request dar ON dar.reference_id = e.referenceid " +
+        "INNER JOIN dacuser du ON du.dacuserid = dar.user_id " +
         "INNER JOIN library_card lc ON lc.user_id = du.dacuserid " +
         "WHERE e.electionid IN (<electionIds>) ")
-	List<Election> findElectionsWithCardHoldingUsersByElectionIds(@BindList("electionIds") List <Integer> electionIds);
+    List<Election> findElectionsWithCardHoldingUsersByElectionIds(@BindList("electionIds") List <Integer> electionIds);
 
     @SqlQuery("SELECT DISTINCT e.electionId, e.datasetId, v.vote finalVote, e.status, e.createDate, e.referenceId, " +
             "       v.rationale finalRationale, v.createDate finalVoteDate, e.lastUpdate, e.finalAccessVote, " +
@@ -169,10 +171,10 @@ public interface ElectionDAO extends Transactional<ElectionDAO> {
     List<Election> findElectionsByReferenceId(@Bind("referenceId") String referenceId);
 
     @UseRowMapper(SimpleElectionMapper.class)
-    @SqlQuery("SELECT * FROM election " + 
+    @SqlQuery("SELECT * FROM election e " + 
         "INNER JOIN vote v ON v.electionid = e.electionid " +
-        "WHERE LOWER(election.electiontype) = :electionType " + 
-        "AND vote.voteid IN (<voteIds>)")
+        "WHERE LOWER(e.electiontype) = :electionType " + 
+        "AND v.voteid IN (<voteIds>)")
 	List<Election> findElectionsByVoteIdsAndType(
 		@BindList("voteIds") List<Integer> voteIds,
 		@Bind("electionType") String electionType

--- a/src/main/java/org/broadinstitute/consent/http/resources/VoteResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/VoteResource.java
@@ -4,6 +4,8 @@ package org.broadinstitute.consent.http.resources;
 import com.google.gson.Gson;
 import io.dropwizard.auth.Auth;
 
+import org.broadinstitute.consent.http.enumeration.ElectionType;
+import org.broadinstitute.consent.http.enumeration.VoteType;
 import org.broadinstitute.consent.http.models.AuthUser;
 import org.broadinstitute.consent.http.models.Election;
 import org.broadinstitute.consent.http.models.User;
@@ -16,7 +18,6 @@ import org.broadinstitute.consent.http.service.ElectionService;
 import javax.annotation.security.RolesAllowed;
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.Consumes;
-import javax.ws.rs.NotAllowedException;
 import javax.ws.rs.NotFoundException;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
@@ -157,7 +158,7 @@ public class VoteResource extends Resource {
         List<Vote> targetVotes = votes.stream()
             .filter(v -> {
                 String type = v.getType();
-                return type.equalsIgnoreCase("chairperson") || type.equalsIgnoreCase("final");
+                return type.equalsIgnoreCase(VoteType.CHAIRPERSON.getValue()) || type.equalsIgnoreCase(VoteType.FINAL.getValue());
             })
             .collect(Collectors.toList());
         //if the filtered list is populated, get the vote ids and get the full vote records for those that have type = 'DataAccess'
@@ -165,7 +166,7 @@ public class VoteResource extends Resource {
             List<Integer> voteIds = targetVotes.stream()
                 .map(Vote::getVoteId)
                 .collect(Collectors.toList());
-            List<Election> targetElections = electionService.findElectionsByVoteIdsAndType(voteIds, "dataaccess");
+            List<Election> targetElections = electionService.findElectionsByVoteIdsAndType(voteIds, ElectionType.DATA_ACCESS.getValue());
             //If DataAccess votes are present, get elections from DARs created by users with LCs
             if(!targetElections.isEmpty()) {
                 List<Integer> targetElectionIds = targetElections.stream()

--- a/src/main/java/org/broadinstitute/consent/http/service/ElectionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ElectionService.java
@@ -385,7 +385,7 @@ public class ElectionService {
     }
 
     public List<Election> findElectionsWithCardHoldingUsersByElectionIds(List<Integer> electionIds) {
-        return electionDAO.findElectionsWithCardHoldingUsersByElectionIds(electionIds);
+        return !electionIds.isEmpty() ? electionDAO.findElectionsWithCardHoldingUsersByElectionIds(electionIds) : Collections.emptyList();
     }
 
     public String darDatasetElectionStatus(String darReferenceId){
@@ -431,7 +431,7 @@ public class ElectionService {
     }
 
     public List<Election> findElectionsByVoteIdsAndType(List<Integer> voteIds, String electionType) {
-        return electionDAO.findElectionsByVoteIdsAndType(voteIds, electionType);
+        return !voteIds.isEmpty() ? electionDAO.findElectionsByVoteIdsAndType(voteIds, electionType) : Collections.emptyList();
     }
 
     public boolean isDataSetElectionOpen() {

--- a/src/main/java/org/broadinstitute/consent/http/service/ElectionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ElectionService.java
@@ -384,6 +384,10 @@ public class ElectionService {
         return closeElection;
     }
 
+    public List<Election> findElectionsWithCardHoldingUsersByElectionIds(List<Integer> electionIds) {
+        return electionDAO.findElectionsWithCardHoldingUsersByElectionIds(electionIds);
+    }
+
     public String darDatasetElectionStatus(String darReferenceId){
         DataAccessRequest dar = describeDataAccessRequestById(darReferenceId);
         List<Integer> dataSets =  Objects.nonNull(dar) && Objects.nonNull(dar.getData()) ? dar.getData().getDatasetIds() : Collections.emptyList();
@@ -424,6 +428,10 @@ public class ElectionService {
             });
         });
         return CollectionUtils.isEmpty(electionsIds) ? null : electionDAO.findElectionsByIds(electionsIds);
+    }
+
+    public List<Election> findElectionsByVoteIdsAndType(List<Integer> voteIds, String electionType) {
+        return electionDAO.findElectionsByVoteIdsAndType(voteIds, electionType);
     }
 
     public boolean isDataSetElectionOpen() {

--- a/src/test/java/org/broadinstitute/consent/http/db/ElectionDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/ElectionDAOTest.java
@@ -325,4 +325,60 @@ public class ElectionDAOTest extends DAOTestHelper {
       electionDAO.findLastElectionsByReferenceIds(Collections.singletonList(UUID.randomUUID().toString()));
     assertTrue(elections.isEmpty());
   }
+
+  @Test
+  public void testFindElectionsByVoteIdsAndType_DataAccess() {
+    DataAccessRequest dar = createDataAccessRequestV3();
+    Dataset dataset = createDataset();
+    String referenceId = dar.getReferenceId();
+    int datasetId = dataset.getDataSetId();
+    Election accessElection = createAccessElection(referenceId, datasetId);
+    Election rpElection = createRPElection(referenceId, datasetId);
+    User user = createUserWithRole(UserRoles.CHAIRPERSON.getRoleId());
+    int userId = user.getDacUserId();
+    Vote accessVote = createChairpersonVote(userId, accessElection.getElectionId());
+    Vote rpVote = createChairpersonVote(userId, rpElection.getElectionId());
+    List<Integer> voteIds = List.of(accessVote.getVoteId(), rpVote.getVoteId());
+    List<Election> elections = electionDAO.findElectionsByVoteIdsAndType(voteIds, "dataaccess");
+    
+    assertEquals(1, elections.size());
+    assertEquals(accessElection.getElectionId(), elections.get(0).getElectionId());
+  }
+
+  @Test
+  public void testFindElectionsByVoteIdsAndType_RP() {
+    DataAccessRequest dar = createDataAccessRequestV3();
+    Dataset dataset = createDataset();
+    String referenceId = dar.getReferenceId();
+    int datasetId = dataset.getDataSetId();
+    Election accessElection = createAccessElection(referenceId, datasetId);
+    Election rpElection = createRPElection(referenceId, datasetId);
+    User user = createUserWithRole(UserRoles.CHAIRPERSON.getRoleId());
+    int userId = user.getDacUserId();
+    Vote accessVote = createChairpersonVote(userId, accessElection.getElectionId());
+    Vote rpVote = createChairpersonVote(userId, rpElection.getElectionId());
+    List<Integer> voteIds = List.of(accessVote.getVoteId(), rpVote.getVoteId());
+    List<Election> elections = electionDAO.findElectionsByVoteIdsAndType(voteIds, "rp");
+    
+    assertEquals(1, elections.size());
+    assertEquals(rpElection.getElectionId(), elections.get(0).getElectionId());
+  }
+
+  @Test
+  public void testFindElectionsWithCardHoldingUsersByElectionIds() {
+    User lcUser = createUser();
+    User nonLCUser = createUser();
+    Dataset dataset = createDataset();
+    int datasetId = dataset.getDataSetId();
+    createLibraryCard(lcUser);
+    DataAccessRequest lcDAR = createDataAccessRequestWithUserIdV3(lcUser.getDacUserId());
+    DataAccessRequest nonLCDAR = createDataAccessRequestWithUserIdV3(nonLCUser.getDacUserId());
+    Election lcElection = createAccessElection(lcDAR.getReferenceId(), datasetId);
+    Election nonLCElection = createAccessElection(nonLCDAR.getReferenceId(), datasetId);
+    List<Integer> electionIds = List.of(lcElection.getElectionId(), nonLCElection.getElectionId());
+    List<Election> elections = electionDAO.findElectionsWithCardHoldingUsersByElectionIds(electionIds);
+
+    assertEquals(1, elections.size());
+    assertEquals(elections.get(0).getElectionId(), lcElection.getElectionId());
+  }
 }

--- a/src/test/java/org/broadinstitute/consent/http/service/ElectionServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/ElectionServiceTest.java
@@ -14,6 +14,8 @@ import org.broadinstitute.consent.http.db.VoteDAO;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 
@@ -634,6 +636,28 @@ public class ElectionServiceTest {
         initService();
         boolean isOpen = service.isDataSetElectionOpen();
         assertEquals(false, isOpen);
+    }
+
+    @Test
+    public void findElectionsByVoteIdsAndType() {
+        Election election = new Election();
+        when(electionDAO.findElectionsByVoteIdsAndType(anyList(), anyString()))
+                .thenReturn(List.of(election));
+        initService();
+        List<Election> elections = service.findElectionsByVoteIdsAndType(List.of(1,2), "test");
+        assertNotNull(elections);
+        assertEquals(1, elections.size());
+    }
+
+    @Test
+    public void findElectionsWithCardHoldingUsersByElectionIds() {
+        Election election = new Election();
+        when(electionDAO.findElectionsWithCardHoldingUsersByElectionIds(anyList()))
+            .thenReturn(List.of(election));
+        initService();
+        List<Election> elections = service.findElectionsWithCardHoldingUsersByElectionIds(List.of(1));
+        assertNotNull(elections);
+        assertEquals(1, elections.size());
     }
 
 }


### PR DESCRIPTION
Addresses [DUOS-1730](https://broadworkbench.atlassian.net/browse/DUOS-1730)

PR adds an Library Card check when updating votes for the following scenario...

* User vote is of type `Chairperson` or `Final`
* Election type is `DataAccess`
* Vote value is `true`

... in order to ensure that DACs can only vote Yes/True if the data requester has a Library Card associated with their account.


Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
