### PR TITLE
[DUOS-1722][risk=no] Update email handling logic for DAR Collection

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
@@ -226,7 +226,7 @@ public class ConsentApplication extends Application<ConsentConfiguration> {
 
         // Register standard application resources.
         env.jersey().register(new ApprovalExpirationTimeResource(approvalExpirationTimeService, userService));
-        env.jersey().register(new DataAccessRequestResourceVersion2(dataAccessRequestService, gcsService, userService, matchService));
+        env.jersey().register(new DataAccessRequestResourceVersion2(dataAccessRequestService, emailNotifierService, gcsService, userService, matchService));
         env.jersey().register(new DataAccessRequestResource(dataAccessRequestService, userService, consentService, electionService));
         env.jersey().register(new DatasetResource(consentService, datasetService, userService, dataAccessRequestService));
         env.jersey().register(new DatasetAssociationsResource(datasetAssociationService));

--- a/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
@@ -226,7 +226,7 @@ public class ConsentApplication extends Application<ConsentConfiguration> {
 
         // Register standard application resources.
         env.jersey().register(new ApprovalExpirationTimeResource(approvalExpirationTimeService, userService));
-        env.jersey().register(new DataAccessRequestResourceVersion2(dataAccessRequestService, emailNotifierService, gcsService, userService, matchService));
+        env.jersey().register(new DataAccessRequestResourceVersion2(dataAccessRequestService, gcsService, userService, matchService));
         env.jersey().register(new DataAccessRequestResource(dataAccessRequestService, userService, consentService, electionService));
         env.jersey().register(new DatasetResource(consentService, datasetService, userService, dataAccessRequestService));
         env.jersey().register(new DatasetAssociationsResource(datasetAssociationService));

--- a/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
@@ -7,7 +7,6 @@ import io.dropwizard.Configuration;
 import io.dropwizard.client.JerseyClientBuilder;
 import io.dropwizard.jdbi3.JdbiFactory;
 import io.dropwizard.setup.Environment;
-import javax.ws.rs.client.Client;
 import org.broadinstitute.consent.http.authentication.OAuthAuthenticator;
 import org.broadinstitute.consent.http.cloudstore.GCSService;
 import org.broadinstitute.consent.http.cloudstore.GCSStore;
@@ -64,6 +63,8 @@ import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.gson2.Gson2Plugin;
 import org.jdbi.v3.guava.GuavaPlugin;
 import org.jdbi.v3.sqlobject.SqlObjectPlugin;
+
+import javax.ws.rs.client.Client;
 
 public class ConsentModule extends AbstractModule {
 
@@ -252,8 +253,7 @@ public class ConsentModule extends AbstractModule {
         return new DataAccessRequestService(
                 providesCounterService(),
                 providesDAOContainer(),
-                providesDacService(),
-                providesEmailNotifierService());
+                providesDacService());
     }
 
     @Provides

--- a/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
@@ -252,7 +252,8 @@ public class ConsentModule extends AbstractModule {
         return new DataAccessRequestService(
                 providesCounterService(),
                 providesDAOContainer(),
-                providesDacService());
+                providesDacService(),
+                providesEmailNotifierService());
     }
 
     @Provides
@@ -300,6 +301,7 @@ public class ConsentModule extends AbstractModule {
     @Provides
     EmailNotifierService providesEmailNotifierService() {
         return new EmailNotifierService(
+                providesDARCollectionDAO(),
                 providesConsentDAO(),
                 providesDataAccessRequestService(),
                 providesVoteDAO(),

--- a/src/main/java/org/broadinstitute/consent/http/mail/freemarker/FreeMarkerTemplateHelper.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/freemarker/FreeMarkerTemplateHelper.java
@@ -51,7 +51,7 @@ public class FreeMarkerTemplateHelper {
 
     public Writer getNewDARRequestTemplate(String serverUrl, String userName, String entityId) throws IOException, TemplateException {
         Template temp = freeMarkerConfig.getTemplate("new-request.html");
-        return generateNewDARRequestTemplate(serverUrl, temp, userName, entityId);
+        return generateNewDARRequestTemplate(temp, serverUrl, userName, entityId);
     }
 
     public Writer getCancelledDarTemplate(String userType, String entityId, String serverUrl) throws IOException, TemplateException {
@@ -147,7 +147,7 @@ public class FreeMarkerTemplateHelper {
         return out;
     }
 
-    private Writer generateNewDARRequestTemplate(String serverUrl, Template temp, String userName, String entityId) throws IOException, TemplateException {
+    private Writer generateNewDARRequestTemplate(Template temp, String serverUrl, String userName, String entityId) throws IOException, TemplateException {
         NewDarRequestModel model = new NewDarRequestModel(serverUrl, userName, entityId);
         Writer out = new StringWriter();
         temp.process(model, out);

--- a/src/main/java/org/broadinstitute/consent/http/mail/freemarker/FreeMarkerTemplateHelper.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/freemarker/FreeMarkerTemplateHelper.java
@@ -50,9 +50,9 @@ public class FreeMarkerTemplateHelper {
         return generateTemplate(user, election, entityId, temp, serverUrl);
     }
 
-    public Writer getNewDARRequestTemplate(String serverUrl) throws IOException, TemplateException {
+    public Writer getNewDARRequestTemplate(String serverUrl, String userName, String entityId) throws IOException, TemplateException {
         Template temp = freeMarkerConfig.getTemplate("new-request.html");
-        return generateNewDARRequestTemplate(serverUrl+CREATE_DAR_URL, temp);
+        return generateNewDARRequestTemplate(serverUrl+CREATE_DAR_URL, temp, userName, entityId);
     }
 
     public Writer getCancelledDarTemplate(String userType, String entityId, String serverUrl) throws IOException, TemplateException {
@@ -148,8 +148,8 @@ public class FreeMarkerTemplateHelper {
         return out;
     }
 
-    private Writer generateNewDARRequestTemplate(String serverUrl, Template temp) throws IOException, TemplateException {
-        NewDarRequestModel model = new NewDarRequestModel(serverUrl);
+    private Writer generateNewDARRequestTemplate(String serverUrl, Template temp, String userName, String entityId) throws IOException, TemplateException {
+        NewDarRequestModel model = new NewDarRequestModel(serverUrl, userName, entityId);
         Writer out = new StringWriter();
         temp.process(model, out);
         return out;

--- a/src/main/java/org/broadinstitute/consent/http/mail/freemarker/FreeMarkerTemplateHelper.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/freemarker/FreeMarkerTemplateHelper.java
@@ -21,7 +21,6 @@ public class FreeMarkerTemplateHelper {
 
 
     Configuration freeMarkerConfig;
-    private final String CREATE_DAR_URL = "admin_manage_access";
 
     public FreeMarkerTemplateHelper(FreeMarkerConfiguration config) {
         freeMarkerConfig = new Configuration(Configuration.VERSION_2_3_22);
@@ -52,7 +51,7 @@ public class FreeMarkerTemplateHelper {
 
     public Writer getNewDARRequestTemplate(String serverUrl, String userName, String entityId) throws IOException, TemplateException {
         Template temp = freeMarkerConfig.getTemplate("new-request.html");
-        return generateNewDARRequestTemplate(serverUrl+CREATE_DAR_URL, temp, userName, entityId);
+        return generateNewDARRequestTemplate(serverUrl, temp, userName, entityId);
     }
 
     public Writer getCancelledDarTemplate(String userType, String entityId, String serverUrl) throws IOException, TemplateException {

--- a/src/main/java/org/broadinstitute/consent/http/mail/freemarker/NewDarRequestModel.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/freemarker/NewDarRequestModel.java
@@ -4,14 +4,25 @@ public class NewDarRequestModel {
 
     /* This model works for templates: new-request. */
 
-    private String serverUrl;
+    private final String serverUrl;
+    private final String userName;
+    private final String entityId;
 
-    public NewDarRequestModel(String serverUrl) {
+    public NewDarRequestModel(String serverUrl, String userName, String entityId) {
         this.serverUrl = serverUrl;
+        this.userName = userName;
+        this.entityId = entityId;
     }
 
     public String getServerUrl() {
         return serverUrl;
     }
 
+    public String getUserName() {
+        return userName;
+    }
+
+    public String getEntityId() {
+        return entityId;
+    }
 }

--- a/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceVersion2.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceVersion2.java
@@ -13,7 +13,6 @@ import org.broadinstitute.consent.http.models.DataAccessRequestManage;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.dto.Error;
 import org.broadinstitute.consent.http.service.DataAccessRequestService;
-import org.broadinstitute.consent.http.service.EmailNotifierService;
 import org.broadinstitute.consent.http.service.MatchService;
 import org.broadinstitute.consent.http.service.UserService;
 import org.glassfish.jersey.media.multipart.FormDataContentDisposition;
@@ -53,7 +52,6 @@ public class DataAccessRequestResourceVersion2 extends Resource {
 
   private final Logger logger = LoggerFactory.getLogger(this.getClass());
   private final DataAccessRequestService dataAccessRequestService;
-  private final EmailNotifierService emailNotifierService;
   private final GCSService gcsService;
   private final MatchService matchService;
   private final UserService userService;
@@ -61,12 +59,10 @@ public class DataAccessRequestResourceVersion2 extends Resource {
   @Inject
   public DataAccessRequestResourceVersion2(
       DataAccessRequestService dataAccessRequestService,
-      EmailNotifierService emailNotifierService,
       GCSService gcsService,
       UserService userService,
       MatchService matchService) {
     this.dataAccessRequestService = dataAccessRequestService;
-    this.emailNotifierService = emailNotifierService;
     this.gcsService = gcsService;
     this.userService = userService;
     this.matchService = matchService;
@@ -105,8 +101,6 @@ public class DataAccessRequestResourceVersion2 extends Resource {
       URI uri = info.getRequestUriBuilder().build();
       for (DataAccessRequest r : results) {
         matchService.reprocessMatchesForPurpose(r.getReferenceId());
-        emailNotifierService.sendNewDARRequestMessage(
-            r.getData().getDarCode(), r.getData().getDatasetIds());
       }
       return Response.created(uri)
           .entity(

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
@@ -75,11 +75,12 @@ public class DataAccessRequestService {
 
     private final DacService dacService;
     private final DataAccessReportsParser dataAccessReportsParser;
+    private final EmailNotifierService emailNotifierService;
     private static final String SUFFIX = "-A-";
 
     @Inject
     public DataAccessRequestService(CounterService counterService, DAOContainer container,
-            DacService dacService) {
+            DacService dacService, EmailNotifierService emailNotifierService) {
         this.consentDAO = container.getConsentDAO();
         this.counterService = counterService;
         this.dacDAO = container.getDacDAO();
@@ -93,6 +94,7 @@ public class DataAccessRequestService {
         this.institutionDAO = container.getInstitutionDAO();
         this.dacService = dacService;
         this.dataAccessReportsParser = new DataAccessReportsParser();
+        this.emailNotifierService = emailNotifierService;
     }
 
     /**
@@ -453,6 +455,11 @@ public class DataAccessRequestService {
                     DataAccessRequest createdDar = insertSubmittedDataAccessRequest(user, referenceId, darData, collectionId, now);
                     newDARList.add(createdDar);
                 }
+            }
+            try {
+                emailNotifierService.sendNewDARCollectionMessage(collectionId);
+            } catch (Exception e) {
+                logger.error("Exception sending email for collection id: " + collectionId, e);
             }
         }
         return newDARList;

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
@@ -1,28 +1,7 @@
 package org.broadinstitute.consent.http.service;
 
-import static java.util.stream.Collectors.toList;
-
 import com.google.gson.Gson;
 import com.google.inject.Inject;
-import java.io.File;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
-import java.util.UUID;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-import javax.ws.rs.NotAcceptableException;
-import javax.ws.rs.NotFoundException;
 import org.apache.commons.collections.CollectionUtils;
 import org.broadinstitute.consent.http.db.ConsentDAO;
 import org.broadinstitute.consent.http.db.DAOContainer;
@@ -56,6 +35,28 @@ import org.broadinstitute.consent.http.util.DarUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.ws.rs.NotAcceptableException;
+import javax.ws.rs.NotFoundException;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static java.util.stream.Collectors.toList;
+
 @SuppressWarnings("UnusedReturnValue")
 public class DataAccessRequestService {
 
@@ -75,12 +76,11 @@ public class DataAccessRequestService {
 
     private final DacService dacService;
     private final DataAccessReportsParser dataAccessReportsParser;
-    private final EmailNotifierService emailNotifierService;
     private static final String SUFFIX = "-A-";
 
     @Inject
     public DataAccessRequestService(CounterService counterService, DAOContainer container,
-            DacService dacService, EmailNotifierService emailNotifierService) {
+            DacService dacService) {
         this.consentDAO = container.getConsentDAO();
         this.counterService = counterService;
         this.dacDAO = container.getDacDAO();
@@ -94,7 +94,6 @@ public class DataAccessRequestService {
         this.institutionDAO = container.getInstitutionDAO();
         this.dacService = dacService;
         this.dataAccessReportsParser = new DataAccessReportsParser();
-        this.emailNotifierService = emailNotifierService;
     }
 
     /**
@@ -455,11 +454,6 @@ public class DataAccessRequestService {
                     DataAccessRequest createdDar = insertSubmittedDataAccessRequest(user, referenceId, darData, collectionId, now);
                     newDARList.add(createdDar);
                 }
-            }
-            try {
-                emailNotifierService.sendNewDARCollectionMessage(collectionId);
-            } catch (Exception e) {
-                logger.error("Exception sending email for collection id: " + collectionId, e);
             }
         }
         return newDARList;

--- a/src/main/java/org/broadinstitute/consent/http/service/EmailNotifierService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/EmailNotifierService.java
@@ -113,26 +113,26 @@ public class EmailNotifierService {
 
     public void sendNewDARCollectionMessage(Integer collectionId) throws MessagingException, IOException, TemplateException {
         if (isServiceActive) {
-            DarCollection collection = collectionDAO.findDARCollectionByCollectionId(collectionId);
-            List<User> users = userDAO.describeUsersByRoleAndEmailPreference(UserRoles.ADMIN.getRoleName(), true);
-            List<Integer> datasetIds = collection.getDars().values().stream()
-                    .map(DataAccessRequest::getData)
-                    .map(DataAccessRequestData::getDatasetIds)
-                    .flatMap(List::stream)
-                    .collect(Collectors.toList());
-            List<User> chairPersons = userDAO
-                .findUsersForDatasetsByRole(datasetIds, Collections.singletonList(UserRoles.CHAIRPERSON.getRoleName()))
-                .stream()
-                .filter(u -> Boolean.TRUE.equals(u.getEmailPreference()))
-                .collect(Collectors.toList());
-            users.addAll(chairPersons);
-            List<Integer> userIds = users.stream().map(User::getDacUserId).collect(Collectors.toList());
-            Writer template = templateHelper.getNewDARRequestTemplate(SERVER_URL);
-            for (User user : users) {
-                Map<String, String> data = retrieveForNewDAR(collection.getDarCode(), user);
-                mailService.sendNewDARRequests(getEmails(List.of(user)), data.get("entityId"), data.get("electionType"), template);
-            }
-            emailDAO.insertBulkEmailNoVotes(userIds, collection.getDarCode(), 4, new Date(), template.toString());
+//            DarCollection collection = collectionDAO.findDARCollectionByCollectionId(collectionId);
+//            List<User> users = userDAO.describeUsersByRoleAndEmailPreference(UserRoles.ADMIN.getRoleName(), true);
+//            List<Integer> datasetIds = collection.getDars().values().stream()
+//                    .map(DataAccessRequest::getData)
+//                    .map(DataAccessRequestData::getDatasetIds)
+//                    .flatMap(List::stream)
+//                    .collect(Collectors.toList());
+//            List<User> chairPersons = userDAO
+//                .findUsersForDatasetsByRole(datasetIds, Collections.singletonList(UserRoles.CHAIRPERSON.getRoleName()))
+//                .stream()
+//                .filter(u -> Boolean.TRUE.equals(u.getEmailPreference()))
+//                .collect(Collectors.toList());
+//            users.addAll(chairPersons);
+//            List<Integer> userIds = users.stream().map(User::getDacUserId).collect(Collectors.toList());
+//            Writer template = templateHelper.getNewDARRequestTemplate(SERVER_URL);
+//            for (User user : users) {
+//                Map<String, String> data = retrieveForNewDAR(collection.getDarCode(), user);
+//                mailService.sendNewDARRequests(getEmails(List.of(user)), data.get("entityId"), data.get("electionType"), template);
+//            }
+//            emailDAO.insertBulkEmailNoVotes(userIds, collection.getDarCode(), 4, new Date(), template.toString());
         }
     }
 

--- a/src/main/java/org/broadinstitute/consent/http/service/EmailNotifierService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/EmailNotifierService.java
@@ -113,26 +113,25 @@ public class EmailNotifierService {
 
     public void sendNewDARCollectionMessage(Integer collectionId) throws MessagingException, IOException, TemplateException {
         if (isServiceActive) {
-//            DarCollection collection = collectionDAO.findDARCollectionByCollectionId(collectionId);
-//            List<User> users = userDAO.describeUsersByRoleAndEmailPreference(UserRoles.ADMIN.getRoleName(), true);
-//            List<Integer> datasetIds = collection.getDars().values().stream()
-//                    .map(DataAccessRequest::getData)
-//                    .map(DataAccessRequestData::getDatasetIds)
-//                    .flatMap(List::stream)
-//                    .collect(Collectors.toList());
-//            List<User> chairPersons = userDAO
-//                .findUsersForDatasetsByRole(datasetIds, Collections.singletonList(UserRoles.CHAIRPERSON.getRoleName()))
-//                .stream()
-//                .filter(u -> Boolean.TRUE.equals(u.getEmailPreference()))
-//                .collect(Collectors.toList());
-//            users.addAll(chairPersons);
-//            List<Integer> userIds = users.stream().map(User::getDacUserId).collect(Collectors.toList());
-//            Writer template = templateHelper.getNewDARRequestTemplate(SERVER_URL);
-//            for (User user : users) {
-//                Map<String, String> data = retrieveForNewDAR(collection.getDarCode(), user);
-//                mailService.sendNewDARRequests(getEmails(List.of(user)), data.get("entityId"), data.get("electionType"), template);
-//            }
-//            emailDAO.insertBulkEmailNoVotes(userIds, collection.getDarCode(), 4, new Date(), template.toString());
+            DarCollection collection = collectionDAO.findDARCollectionByCollectionId(collectionId);
+            List<User> users = userDAO.describeUsersByRoleAndEmailPreference(UserRoles.ADMIN.getRoleName(), true);
+            List<Integer> datasetIds = collection.getDars().values().stream()
+                    .map(DataAccessRequest::getData)
+                    .map(DataAccessRequestData::getDatasetIds)
+                    .flatMap(List::stream)
+                    .collect(Collectors.toList());
+            List<User> chairPersons = userDAO
+                .findUsersForDatasetsByRole(datasetIds, Collections.singletonList(UserRoles.CHAIRPERSON.getRoleName()))
+                .stream()
+                .filter(u -> Boolean.TRUE.equals(u.getEmailPreference()))
+                .collect(Collectors.toList());
+            users.addAll(chairPersons);
+            for (User user : users) {
+                Writer template = templateHelper.getNewDARRequestTemplate(SERVER_URL, user.getDisplayName(), collection.getDarCode());
+                Map<String, String> data = retrieveForNewDAR(collection.getDarCode(), user);
+                mailService.sendNewDARRequests(getEmails(List.of(user)), data.get("entityId"), data.get("electionType"), template);
+                emailDAO.insertBulkEmailNoVotes(List.of(user.getDacUserId()), collection.getDarCode(), 4, new Date(), template.toString());
+            }
         }
     }
 

--- a/src/main/java/org/broadinstitute/consent/http/service/EmailNotifierService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/EmailNotifierService.java
@@ -260,7 +260,12 @@ public class EmailNotifierService {
 
     private Set<String> getEmails(List<User> users) {
         Set<String> emails = users.stream()
-                .map(u -> List.of(u.getEmail(), u.getAdditionalEmail()))
+                .map(u -> {
+                    if (Objects.nonNull(u.getAdditionalEmail())) {
+                        return List.of(u.getEmail(), u.getAdditionalEmail());
+                    }
+                    return List.of(u.getEmail());
+                })
                 .flatMap(Collection::stream)
                 .filter(StringUtils::isNotEmpty)
                 .collect(Collectors.toSet());

--- a/src/main/resources/freemarker/new-request.html
+++ b/src/main/resources/freemarker/new-request.html
@@ -33,8 +33,8 @@
         <tr>
             <td align="left"
                 style="border-collapse: collapse; font-family: 'Roboto', sans-serif; font-size: 16px; color: #777777; text-align: left; line-height: 25px; padding: 0px 30px 30px 30px;">
-                A new Data Access Request, ${entityId} has been created. Please click on the following link to make the Data Access
-                Committee vote on it.
+                A new Data Access Request, ${entityId}, has been created. Please click on the following link to create
+                an election for the Data Access Committee to vote on it.
             </td>
         </tr>
         <tr style="margin-top: 20px; margin-bottom: 40px;">

--- a/src/main/resources/freemarker/new-request.html
+++ b/src/main/resources/freemarker/new-request.html
@@ -1,41 +1,57 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" style="font-family: 'Roboto', sans-serif;">
+<html xmlns="http://www.w3.org/1999/xhtml" style="" lang="en">
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Broad Data Use Oversight System - New Data Access Request</title>
 </head>
 
-<body style="font-family: 'Roboto', sans-serif; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none; width: 100%; height: 100%; color: #777777; margin: 0;">
-<center style="font-family: 'Roboto', sans-serif;">
-    <table width="600" bgcolor="#eeeeee" style="border-collapse: collapse; font-family: 'Roboto', sans-serif; box-shadow: 3px 3px 0 #cccccc; border-radius: 5px; -moz-border-radius: 5px; margin-top: 20px; background-color: #eeeeee;">
-        <tr width="600" style="font-family: 'Roboto', sans-serif;">
-            <td align="left" style="font-family: 'Roboto', sans-serif; font-size: 14px; color: #777777; text-align: left; line-height: 21px; padding: 20px 30px 25px 30px;">
-                <img src="http://imageshack.com/a/img905/7554/gjprR0.png" alt="Broad Institute Logo" style=" margin-top: 10px; display: inline-block; font-family: 'Roboto', sans-serif;">
+<body style="font-family: 'Montserat', sans-serif; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none; width: 100%; height: 100%; color: #777777; margin: 0; line-height: 21px; text-align: center; ">
+
+<div style="width: 100%">
+    <table align="center"
+           style="background-color: #eeeeee; min-width: 600px; max-width: 600px; border-collapse: collapse; box-shadow: 3px 3px 0 #cccccc; border-radius: 5px; -moz-border-radius: 5px; margin-top: 20px;">
+        <tr style="">
+            <td style="font-size: 14px; text-align: left; padding: 20px 30px 25px 30px;">
+                <a href="${serverUrl}">
+                    <img src="https://imageshack.com/a/img905/7554/gjprR0.png" alt="Broad Institute Logo"
+                         style=" margin-top: 10px; display: inline-block; ">
+                </a>
             </td>
         </tr>
-        <tr width="600" align="center" bgcolor="#dedede" style="font-family: 'Roboto', sans-serif; background-color: #dedede; display: inline-table; text-align: center; margin: 0;">
-            <td width="600" align="center" style="border-collapse: collapse; font-family: 'Roboto', sans-serif; font-size: 26px; color: #777777; text-align: center; line-height: 21px; font-weight: bold; padding: 30px;">Broad Data Use Oversight System</td>
-        </tr>
-        <tr align="center" style="font-family: 'Roboto', sans-serif; padding-top: 20px; margin-top: 20px;">
-            <td id="userName" align="left" style="border-collapse: collapse; font-family: 'Roboto', sans-serif; font-size: 22px; color: #777777; text-align: left; line-height: 21px; display: block; font-weight: 500; padding: 25px 30px 20px 30px;">Hello Admin!</td>
-        </tr>
-        <tr width="600" style="font-family: 'Roboto', sans-serif;">
-            <td align="left" style="border-collapse: collapse; font-family: 'Roboto', sans-serif; font-size: 16px; color: #777777; text-align: left; line-height: 25px; padding: 0px 30px 30px 30px;">
-                A new Data Access Request has been created. Please click on the following link to make the Data Access Committee vote on it.
+        <tr style="min-width: 600px; max-width: 600px; background-color: #dedede; display: inline-table; margin: 0;">
+            <td style="border-collapse: collapse; font-size: 26px; font-weight: bold; padding: 30px;">
+                Broad Data Use Oversight System
             </td>
         </tr>
-        <tr width="600" style="font-family: 'Roboto', sans-serif; margin-top: 20px; margin-bottom: 40px;">
-            <td align="center" style="border-collapse: collapse; font-family: 'Roboto', sans-serif; font-size: 20px; color: #00609F; text-align: center;">
-                <a href="${serverUrl}" align="center" style="text-decoration: none; font-family: 'Roboto', sans-serif; color: #00609F; display: inline-block; font-size: 20px; font-weight: bold; text-align: center; padding-bottom: 30px;">Click here to create an election</a>
+        <tr style="padding-top: 20px; margin-top: 20px;">
+            <td id="userName"
+                style="border-collapse: collapse; font-size: 22px; text-align: left; display: block; font-weight: 500; padding: 25px 30px 20px 30px;">
+                Hello ${userName}!
+            </td>
+        </tr>
+        <tr>
+            <td align="left"
+                style="border-collapse: collapse; font-family: 'Roboto', sans-serif; font-size: 16px; color: #777777; text-align: left; line-height: 25px; padding: 0px 30px 30px 30px;">
+                A new Data Access Request, ${entityId} has been created. Please click on the following link to make the Data Access
+                Committee vote on it.
+            </td>
+        </tr>
+        <tr style="margin-top: 20px; margin-bottom: 40px;">
+            <td style="border-collapse: collapse; font-size: 20px; text-align: center;">
+                <a href="${serverUrl}"
+                   style="text-decoration: none; color: #00609F; display: inline-block; font-size: 20px; font-weight: bold; padding-bottom: 30px;">Login
+                    to create an election</a>
             </td>
         </tr>
     </table>
-    <table width ="600" style="font-family: 'Roboto', sans-serif; margin-top: 15px;">
-        <tr align="center" style="font-family: 'Roboto', sans-serif; color: #999999;">
-            <td align="center" valign="middle" style="padding: 0 10px 0 10px; border-collapse: collapse; font-family: 'Roboto', sans-serif; font-size: 14px; color: #999999; text-align: center; line-height: 21px; display: inline-block; vertical-align: middle;">	&#169; Broad Institute </td>
+    <table align="center" style="margin-top: 15px; vertical-align: middle; ">
+        <tr>
+            <td style="padding: 0 10px 0 10px; border: 0; font-size: 14px; color: #999999; display: inline-block;">
+                &#169; Broad Institute
+            </td>
         </tr>
     </table>
-</center>
+</div>
 </body>
 </html>

--- a/src/test/java/org/broadinstitute/consent/http/mail/freemarker/FreeMarkerTemplateHelperTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mail/freemarker/FreeMarkerTemplateHelperTest.java
@@ -1,24 +1,31 @@
 package org.broadinstitute.consent.http.mail.freemarker;
 
 import org.broadinstitute.consent.http.configurations.FreeMarkerConfiguration;
-import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.Dataset;
 import org.broadinstitute.consent.http.models.Election;
+import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.darsummary.SummaryItem;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 
 import java.io.IOException;
 import java.io.Writer;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 public class FreeMarkerTemplateHelperTest {
 
@@ -29,7 +36,7 @@ public class FreeMarkerTemplateHelperTest {
 
     @Before
     public void setUp() throws IOException {
-        MockitoAnnotations.initMocks(this);
+        openMocks(this);
         when(freeMarkerConfig.getTemplateDirectory()).thenReturn("/freemarker");
         when(freeMarkerConfig.getDefaultEncoding()).thenReturn("UTF-8");
         helper = new FreeMarkerTemplateHelper(freeMarkerConfig);
@@ -78,11 +85,14 @@ public class FreeMarkerTemplateHelperTest {
 
     @Test
     public void testGetNewDARRequestTemplate() throws Exception {
-        Writer template = helper.getNewDARRequestTemplate("localhost:1234");
+        Writer template = helper.getNewDARRequestTemplate("localhost:1234", "Admin", "Entity");
         String templateString = template.toString();
         final Document parsedTemplate = getAsHtmlDoc(templateString);
-        assertTrue(parsedTemplate.title().equals("Broad Data Use Oversight System - New Data Access Request"));
-        assertTrue(parsedTemplate.getElementById("userName").text().equals("Hello Admin!"));
+        assertEquals("Broad Data Use Oversight System - New Data Access Request", parsedTemplate.title());
+        Element userNameElement = parsedTemplate.getElementById("userName");
+        assertNotNull(userNameElement);
+        assertNotNull(userNameElement.text());
+        assertEquals("Hello Admin!", userNameElement.text());
     }
 
     @Test

--- a/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceVersion2Test.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceVersion2Test.java
@@ -7,6 +7,7 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.broadinstitute.consent.http.cloudstore.GCSService;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.AuthUser;
+import org.broadinstitute.consent.http.models.DarCollection;
 import org.broadinstitute.consent.http.models.DataAccessRequest;
 import org.broadinstitute.consent.http.models.DataAccessRequestData;
 import org.broadinstitute.consent.http.models.DataAccessRequestManage;
@@ -87,8 +88,14 @@ public class DataAccessRequestResourceVersion2Test {
     try {
       user.addLibraryCard(new LibraryCard());
       when(userService.findUserByEmail(any())).thenReturn(user);
+      DataAccessRequest dar = new DataAccessRequest();
+      dar.setReferenceId(UUID.randomUUID().toString());
+      dar.setCollectionId(1);
+      DataAccessRequestData data = new DataAccessRequestData();
+      data.setReferenceId(dar.getReferenceId());
+      dar.setData(data);
       when(dataAccessRequestService.createDataAccessRequest(any(), any()))
-          .thenReturn(Collections.emptyList());
+          .thenReturn(List.of(dar));
       doNothing().when(matchService).reprocessMatchesForPurpose(any());
       doNothing().when(emailNotifierService).sendNewDARCollectionMessage(any());
     } catch (Exception e) {

--- a/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceVersion2Test.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceVersion2Test.java
@@ -14,7 +14,6 @@ import org.broadinstitute.consent.http.models.LibraryCard;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.UserRole;
 import org.broadinstitute.consent.http.service.DataAccessRequestService;
-import org.broadinstitute.consent.http.service.EmailNotifierService;
 import org.broadinstitute.consent.http.service.MatchService;
 import org.broadinstitute.consent.http.service.UserService;
 import org.glassfish.jersey.media.multipart.FormDataContentDisposition;
@@ -51,7 +50,6 @@ public class DataAccessRequestResourceVersion2Test {
 
   @Mock private DataAccessRequestService dataAccessRequestService;
   @Mock private MatchService matchService;
-  @Mock private EmailNotifierService emailNotifierService;
   @Mock private GCSService gcsService;
   @Mock private UserService userService;
   @Mock private UriInfo info;
@@ -76,7 +74,7 @@ public class DataAccessRequestResourceVersion2Test {
       when(info.getRequestUriBuilder()).thenReturn(builder);
       resource =
           new DataAccessRequestResourceVersion2(
-              dataAccessRequestService, emailNotifierService, gcsService, userService, matchService);
+              dataAccessRequestService, gcsService, userService, matchService);
     } catch (Exception e) {
       fail("Initialization Exception: " + e.getMessage());
     }
@@ -90,7 +88,6 @@ public class DataAccessRequestResourceVersion2Test {
       when(dataAccessRequestService.createDataAccessRequest(any(), any()))
           .thenReturn(Collections.emptyList());
       doNothing().when(matchService).reprocessMatchesForPurpose(any());
-      doNothing().when(emailNotifierService).sendNewDARRequestMessage(any(), any());
     } catch (Exception e) {
       fail("Initialization Exception: " + e.getMessage());
     }

--- a/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceVersion2Test.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceVersion2Test.java
@@ -14,6 +14,7 @@ import org.broadinstitute.consent.http.models.LibraryCard;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.UserRole;
 import org.broadinstitute.consent.http.service.DataAccessRequestService;
+import org.broadinstitute.consent.http.service.EmailNotifierService;
 import org.broadinstitute.consent.http.service.MatchService;
 import org.broadinstitute.consent.http.service.UserService;
 import org.glassfish.jersey.media.multipart.FormDataContentDisposition;
@@ -50,6 +51,7 @@ public class DataAccessRequestResourceVersion2Test {
 
   @Mock private DataAccessRequestService dataAccessRequestService;
   @Mock private MatchService matchService;
+  @Mock private EmailNotifierService emailNotifierService;
   @Mock private GCSService gcsService;
   @Mock private UserService userService;
   @Mock private UriInfo info;
@@ -74,7 +76,7 @@ public class DataAccessRequestResourceVersion2Test {
       when(info.getRequestUriBuilder()).thenReturn(builder);
       resource =
           new DataAccessRequestResourceVersion2(
-              dataAccessRequestService, gcsService, userService, matchService);
+              dataAccessRequestService, emailNotifierService, gcsService, userService, matchService);
     } catch (Exception e) {
       fail("Initialization Exception: " + e.getMessage());
     }
@@ -88,6 +90,7 @@ public class DataAccessRequestResourceVersion2Test {
       when(dataAccessRequestService.createDataAccessRequest(any(), any()))
           .thenReturn(Collections.emptyList());
       doNothing().when(matchService).reprocessMatchesForPurpose(any());
+      doNothing().when(emailNotifierService).sendNewDARCollectionMessage(any());
     } catch (Exception e) {
       fail("Initialization Exception: " + e.getMessage());
     }

--- a/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
@@ -86,8 +86,6 @@ public class DataAccessRequestServiceTest {
     private InstitutionDAO institutionDAO;
     @Mock
     private ElectionService electionService;
-    @Mock
-    private EmailNotifierService emailNotifierService;
 
     private DataAccessRequestService service;
 
@@ -112,7 +110,7 @@ public class DataAccessRequestServiceTest {
         container.setDatasetDAO(dataSetDAO);
         container.setElectionDAO(electionDAO);
         container.setVoteDAO(voteDAO);
-        service = new DataAccessRequestService(counterService, container, dacService, emailNotifierService);
+        service = new DataAccessRequestService(counterService, container, dacService);
     }
 
     @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
@@ -11,6 +11,7 @@ import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.io.File;
 import java.io.IOException;
@@ -85,12 +86,14 @@ public class DataAccessRequestServiceTest {
     private InstitutionDAO institutionDAO;
     @Mock
     private ElectionService electionService;
+    @Mock
+    private EmailNotifierService emailNotifierService;
 
     private DataAccessRequestService service;
 
     @Before
     public void setUp() {
-        MockitoAnnotations.openMocks(this);
+        openMocks(this);
         doNothings();
     }
 
@@ -109,7 +112,7 @@ public class DataAccessRequestServiceTest {
         container.setDatasetDAO(dataSetDAO);
         container.setElectionDAO(electionDAO);
         container.setVoteDAO(voteDAO);
-        service = new DataAccessRequestService(counterService, container, dacService);
+        service = new DataAccessRequestService(counterService, container, dacService, emailNotifierService);
     }
 
     @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/EmailNotifierServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/EmailNotifierServiceTest.java
@@ -1,6 +1,7 @@
 package org.broadinstitute.consent.http.service;
 
 import static org.junit.Assert.fail;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -8,6 +9,7 @@ import java.util.UUID;
 import org.broadinstitute.consent.http.configurations.FreeMarkerConfiguration;
 import org.broadinstitute.consent.http.configurations.MailConfiguration;
 import org.broadinstitute.consent.http.db.ConsentDAO;
+import org.broadinstitute.consent.http.db.DarCollectionDAO;
 import org.broadinstitute.consent.http.db.ElectionDAO;
 import org.broadinstitute.consent.http.db.MailMessageDAO;
 import org.broadinstitute.consent.http.db.UserDAO;
@@ -32,6 +34,9 @@ import org.mockito.MockitoAnnotations;
 public class EmailNotifierServiceTest {
 
     private EmailNotifierService service;
+
+    @Mock
+    private DarCollectionDAO collectionDAO;
 
     @Mock
     private ConsentDAO consentDAO;
@@ -64,7 +69,7 @@ public class EmailNotifierServiceTest {
         String serverUrl =  "http://localhost:8000/#/";
         boolean serviceActive = false;
 
-        MockitoAnnotations.initMocks(this.getClass());
+        openMocks(this.getClass());
         MailConfiguration mConfig = new MailConfiguration();
         mConfig.setActivateEmailNotifications(serviceActive);
         mConfig.setGoogleAccount("");
@@ -75,7 +80,7 @@ public class EmailNotifierServiceTest {
         fmConfig.setDefaultEncoding("UTF-8");
         fmConfig.setTemplateDirectory("/freemarker");
         FreeMarkerTemplateHelper helper = new FreeMarkerTemplateHelper(fmConfig);
-        service = new EmailNotifierService(consentDAO, dataAccessRequestService, voteDAO, electionDAO, userDAO,
+        service = new EmailNotifierService(collectionDAO, consentDAO, dataAccessRequestService, voteDAO, electionDAO, userDAO,
                 emailDAO, mailService, helper, serverUrl, serviceActive,
             userPropertyDAO);
     }


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-1722

Updates email handling logic for DAR Collection emails. Now we send one email per collection instead of one email per DAR to each relevant user. In this case, relevant users are admins and chairs (related to the datasets) who have elected to receive email.

### Example email:

![Screen Shot 2022-04-22 at 1 09 29 PM](https://user-images.githubusercontent.com/116679/164762823-d0d83169-e0d9-4918-b4e1-40f369a168d4.png)

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
