### PR TITLE
[DUOS-1519][risk=no] add parent reference id to dar

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
@@ -31,8 +31,8 @@ public interface DarCollectionDAO {
           Vote.QUERY_FIELDS_WITH_V_PREFIX + QUERY_FIELD_SEPARATOR +
           UserProperty.QUERY_FIELDS_WITH_UP_PREFIX + QUERY_FIELD_SEPARATOR +
           "dar.id AS dar_id, dar.reference_id AS dar_reference_id, dar.collection_id AS dar_collection_id, " +
-          "dar.draft AS dar_draft, dar.user_id AS dar_userId, dar.create_date AS dar_create_date, " +
-          "dar.sort_date AS dar_sort_date, dar.submission_date AS dar_submission_date, " +
+          "dar.parent_id AS dar_parent_id, dar.draft AS dar_draft, dar.user_id AS dar_userId, " +
+          "dar.create_date AS dar_create_date, dar.sort_date AS dar_sort_date, dar.submission_date AS dar_submission_date, " +
           "dar.update_date AS dar_update_date, (dar.data #>> '{}')::jsonb AS data, " +
           "(dar.data #>> '{}')::jsonb ->> 'projectTitle' as projectTitle " +
       " FROM dar_collection c " +
@@ -150,8 +150,8 @@ public interface DarCollectionDAO {
         UserProperty.QUERY_FIELDS_WITH_UP_PREFIX + QUERY_FIELD_SEPARATOR +
         Election.QUERY_FIELDS_WITH_E_PREFIX + QUERY_FIELD_SEPARATOR +
         "dar.id AS dar_id, dar.reference_id AS dar_reference_id, dar.collection_id AS dar_collection_id, " +
-        "dar.draft AS dar_draft, dar.user_id AS dar_userId, dar.create_date AS dar_create_date, " +
-        "dar.sort_date AS dar_sort_date, dar.submission_date AS dar_submission_date, " +
+        "dar.parent_id AS dar_parent_id, dar.draft AS dar_draft, dar.user_id AS dar_userId, " +
+        "dar.create_date AS dar_create_date, dar.sort_date AS dar_sort_date, dar.submission_date AS dar_submission_date, " +
         "dar.update_date AS dar_update_date, (dar.data #>> '{}')::jsonb AS data " +
         "FROM dar_collection c " +
         "INNER JOIN dacuser u ON c.create_user_id = u.dacuserid " +
@@ -175,8 +175,8 @@ public interface DarCollectionDAO {
       Institution.QUERY_FIELDS_WITH_I_PREFIX + QUERY_FIELD_SEPARATOR +
       UserProperty.QUERY_FIELDS_WITH_UP_PREFIX + QUERY_FIELD_SEPARATOR
       + "dar.id AS dar_id, dar.reference_id AS dar_reference_id, dar.collection_id AS dar_collection_id, "
-      + "dar.draft AS dar_draft, dar.user_id AS dar_userId, dar.create_date AS dar_create_date, "
-      + "dar.sort_date AS dar_sort_date, dar.submission_date AS dar_submission_date, "
+      + "dar.parent_id AS dar_parent_id, dar.draft AS dar_draft, dar.user_id AS dar_userId, "
+      + "dar.create_date AS dar_create_date, dar.sort_date AS dar_sort_date, dar.submission_date AS dar_submission_date, "
       + "dar.update_date AS dar_update_date, (dar.data #>> '{}')::jsonb AS data, "
       + "e.electionid AS e_election_id, e.referenceid AS e_reference_id, e.status AS e_status, e.createdate AS e_create_date, "
       + "e.lastupdate AS e_last_update, e.datasetid AS e_dataset_id, e.electiontype AS e_election_type, e.latest "
@@ -211,8 +211,8 @@ public interface DarCollectionDAO {
       Institution.QUERY_FIELDS_WITH_I_PREFIX + QUERY_FIELD_SEPARATOR +
       UserProperty.QUERY_FIELDS_WITH_UP_PREFIX + QUERY_FIELD_SEPARATOR +
       "dar.id AS dar_id, dar.reference_id AS dar_reference_id, dar.collection_id AS dar_collection_id, " +
-      "dar.draft AS dar_draft, dar.user_id AS dar_userId, dar.create_date AS dar_create_date, " +
-      "dar.sort_date AS dar_sort_date, dar.submission_date AS dar_submission_date, " +
+      "dar.parent_id AS dar_parent_id, dar.draft AS dar_draft, dar.user_id AS dar_userId, " +
+      "dar.create_date AS dar_create_date, dar.sort_date AS dar_sort_date, dar.submission_date AS dar_submission_date, " +
       "dar.update_date AS dar_update_date, (dar.data #>> '{}')::jsonb AS data " +
     "FROM dar_collection c " +
     "INNER JOIN dacuser u ON c.create_user_id = u.dacuserid " +
@@ -241,8 +241,8 @@ public interface DarCollectionDAO {
       + Institution.QUERY_FIELDS_WITH_I_PREFIX + QUERY_FIELD_SEPARATOR
       + UserProperty.QUERY_FIELDS_WITH_UP_PREFIX + QUERY_FIELD_SEPARATOR
       + "dar.id AS dar_id, dar.reference_id AS dar_reference_id, dar.collection_id AS dar_collection_id, "
-      + "dar.draft AS dar_draft, dar.user_id AS dar_userId, dar.create_date AS dar_create_date, "
-      + "dar.sort_date AS dar_sort_date, dar.submission_date AS dar_submission_date, "
+      + "dar.parent_id AS dar_parent_id, dar.draft AS dar_draft, dar.user_id AS dar_userId, "
+      + "dar.create_date AS dar_create_date, dar.sort_date AS dar_sort_date, dar.submission_date AS dar_submission_date, "
       + "dar.update_date AS dar_update_date, (dar.data #>> '{}')::jsonb AS data, "
       + "e.electionid AS e_election_id, e.referenceid AS e_reference_id, e.status AS e_status, e.createdate AS e_create_date, "
       + "e.lastupdate AS e_last_update, e.datasetid AS e_dataset_id, e.electiontype AS e_election_type, e.latest, "

--- a/src/main/java/org/broadinstitute/consent/http/db/DataAccessRequestDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DataAccessRequestDAO.java
@@ -30,7 +30,7 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
    * @return List<DataAccessRequest>
    */
   @SqlQuery(
-      "SELECT id, reference_id, collection_id, draft, user_id, create_date, sort_date, submission_date, update_date, (data #>> '{}')::jsonb AS data FROM data_access_request "
+      "SELECT id, reference_id, parent_reference_id, collection_id, draft, user_id, create_date, sort_date, submission_date, update_date, (data #>> '{}')::jsonb AS data FROM data_access_request "
           + "  WHERE not (data #>> '{}')::jsonb ??| array['partial_dar_code', 'partialDarCode'] "
           + "  AND draft != true ")
   List<DataAccessRequest> findAllDataAccessRequests();
@@ -42,7 +42,7 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
    * @return List<DataAccessRequest>
    */
   @SqlQuery(
-      "SELECT id, reference_id, collection_id, draft, user_id, create_date, sort_date, submission_date, update_date, "
+      "SELECT id, reference_id, parent_reference_id, collection_id, draft, user_id, create_date, sort_date, submission_date, update_date, "
           + "(data #>> '{}')::jsonb AS data FROM data_access_request "
           + " WHERE draft = false"
           + " AND ((data #>> '{}')::jsonb->>'datasetIds')::jsonb @> :datasetId::jsonb")
@@ -54,7 +54,7 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
    * @return List<DataAccessRequest>
    */
   @SqlQuery(
-      "SELECT id, reference_id, collection_id, draft, user_id, create_date, sort_date, submission_date, update_date, (data #>> '{}')::jsonb AS data FROM data_access_request "
+      "SELECT id, reference_id, parent_reference_id, collection_id, draft, user_id, create_date, sort_date, submission_date, update_date, (data #>> '{}')::jsonb AS data FROM data_access_request "
           + "  WHERE (data #>> '{}')::jsonb ??| array['partial_dar_code', 'partialDarCode'] "
           + "  OR draft = true "
           + "  ORDER BY update_date DESC")
@@ -66,7 +66,7 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
    * @return List<DataAccessRequest>
    */
   @SqlQuery(
-      "SELECT id, reference_id, collection_id, draft, user_id, create_date, sort_date, submission_date, update_date, (data #>> '{}')::jsonb AS data FROM data_access_request "
+      "SELECT id, reference_id, parent_reference_id, collection_id, draft, user_id, create_date, sort_date, submission_date, update_date, (data #>> '{}')::jsonb AS data FROM data_access_request "
           + "  WHERE ( (data #>> '{}')::jsonb ??| array['partial_dar_code', 'partialDarCode'] "
           + "          OR draft = true ) "
           + "  AND user_id = :userId "
@@ -80,7 +80,7 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
    * @return List<DataAccessRequest>
    */
   @SqlQuery(
-      "SELECT id, reference_id, collection_id, draft, user_id, create_date, sort_date, submission_date, update_date, (data #>> '{}')::jsonb AS data FROM data_access_request "
+      "SELECT id, reference_id, parent_reference_id, collection_id, draft, user_id, create_date, sort_date, submission_date, update_date, (data #>> '{}')::jsonb AS data FROM data_access_request "
           + "  WHERE draft = false "
           + "  AND user_id = :userId "
           + "  ORDER BY sort_date DESC")
@@ -93,7 +93,7 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
    * @return DataAccessRequest
    */
   @SqlQuery(
-      "SELECT id, reference_id, collection_id, draft, user_id, create_date, sort_date, submission_date, update_date, (data #>> '{}')::jsonb AS data FROM data_access_request WHERE reference_id = :referenceId limit 1")
+      "SELECT id, reference_id, parent_reference_id, collection_id, draft, user_id, create_date, sort_date, submission_date, update_date, (data #>> '{}')::jsonb AS data FROM data_access_request WHERE reference_id = :referenceId limit 1")
   DataAccessRequest findByReferenceId(@Bind("referenceId") String referenceId);
 
   /**
@@ -103,7 +103,7 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
    * @return List<DataAccessRequest>
    */
   @SqlQuery(
-      "SELECT id, reference_id, collection_id, draft, user_id, create_date, sort_date, submission_date, update_date, (data #>> '{}')::jsonb AS data FROM data_access_request WHERE reference_id IN (<referenceIds>)")
+      "SELECT id, reference_id, parent_reference_id, collection_id, draft, user_id, create_date, sort_date, submission_date, update_date, (data #>> '{}')::jsonb AS data FROM data_access_request WHERE reference_id IN (<referenceIds>)")
   List<DataAccessRequest> findByReferenceIds(@BindList("referenceIds") List<String> referenceIds);
 
   /**
@@ -234,7 +234,7 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
    * @return List<DataAccessRequest>
    */
   @SqlQuery(
-    "SELECT id, reference_id, collection_id, draft, user_id, create_date, sort_date, submission_date, update_date, (data #>> '{}')::jsonb AS data FROM data_access_request "
+    "SELECT id, reference_id, parent_reference_id, collection_id, draft, user_id, create_date, sort_date, submission_date, update_date, (data #>> '{}')::jsonb AS data FROM data_access_request "
         + " INNER JOIN dacuser d on d.dacuserid = user_id AND d.institution_id = :institutionId "
         + " WHERE draft != true")
   List<DataAccessRequest> findAllDataAccessRequestsForInstitution(@Bind("institutionId") Integer institutionId);

--- a/src/main/java/org/broadinstitute/consent/http/db/DataAccessRequestDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DataAccessRequestDAO.java
@@ -30,7 +30,7 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
    * @return List<DataAccessRequest>
    */
   @SqlQuery(
-      "SELECT id, reference_id, parent_reference_id, collection_id, draft, user_id, create_date, sort_date, submission_date, update_date, (data #>> '{}')::jsonb AS data FROM data_access_request "
+      "SELECT id, reference_id, collection_id, parent_id, draft, user_id, create_date, sort_date, submission_date, update_date, (data #>> '{}')::jsonb AS data FROM data_access_request "
           + "  WHERE not (data #>> '{}')::jsonb ??| array['partial_dar_code', 'partialDarCode'] "
           + "  AND draft != true ")
   List<DataAccessRequest> findAllDataAccessRequests();
@@ -42,7 +42,7 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
    * @return List<DataAccessRequest>
    */
   @SqlQuery(
-      "SELECT id, reference_id, parent_reference_id, collection_id, draft, user_id, create_date, sort_date, submission_date, update_date, "
+      "SELECT id, reference_id, collection_id, parent_id, draft, user_id, create_date, sort_date, submission_date, update_date, "
           + "(data #>> '{}')::jsonb AS data FROM data_access_request "
           + " WHERE draft = false"
           + " AND ((data #>> '{}')::jsonb->>'datasetIds')::jsonb @> :datasetId::jsonb")
@@ -54,7 +54,7 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
    * @return List<DataAccessRequest>
    */
   @SqlQuery(
-      "SELECT id, reference_id, parent_reference_id, collection_id, draft, user_id, create_date, sort_date, submission_date, update_date, (data #>> '{}')::jsonb AS data FROM data_access_request "
+      "SELECT id, reference_id, collection_id, parent_id, draft, user_id, create_date, sort_date, submission_date, update_date, (data #>> '{}')::jsonb AS data FROM data_access_request "
           + "  WHERE (data #>> '{}')::jsonb ??| array['partial_dar_code', 'partialDarCode'] "
           + "  OR draft = true "
           + "  ORDER BY update_date DESC")
@@ -66,7 +66,7 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
    * @return List<DataAccessRequest>
    */
   @SqlQuery(
-      "SELECT id, reference_id, parent_reference_id, collection_id, draft, user_id, create_date, sort_date, submission_date, update_date, (data #>> '{}')::jsonb AS data FROM data_access_request "
+      "SELECT id, reference_id, collection_id, parent_id, draft, user_id, create_date, sort_date, submission_date, update_date, (data #>> '{}')::jsonb AS data FROM data_access_request "
           + "  WHERE ( (data #>> '{}')::jsonb ??| array['partial_dar_code', 'partialDarCode'] "
           + "          OR draft = true ) "
           + "  AND user_id = :userId "
@@ -80,7 +80,7 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
    * @return List<DataAccessRequest>
    */
   @SqlQuery(
-      "SELECT id, reference_id, parent_reference_id, collection_id, draft, user_id, create_date, sort_date, submission_date, update_date, (data #>> '{}')::jsonb AS data FROM data_access_request "
+      "SELECT id, reference_id, collection_id, parent_id, draft, user_id, create_date, sort_date, submission_date, update_date, (data #>> '{}')::jsonb AS data FROM data_access_request "
           + "  WHERE draft = false "
           + "  AND user_id = :userId "
           + "  ORDER BY sort_date DESC")
@@ -93,7 +93,7 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
    * @return DataAccessRequest
    */
   @SqlQuery(
-      "SELECT id, reference_id, parent_reference_id, collection_id, draft, user_id, create_date, sort_date, submission_date, update_date, (data #>> '{}')::jsonb AS data FROM data_access_request WHERE reference_id = :referenceId limit 1")
+      "SELECT id, reference_id, collection_id, parent_id,  draft, user_id, create_date, sort_date, submission_date, update_date, (data #>> '{}')::jsonb AS data FROM data_access_request WHERE reference_id = :referenceId limit 1")
   DataAccessRequest findByReferenceId(@Bind("referenceId") String referenceId);
 
   /**
@@ -103,7 +103,7 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
    * @return List<DataAccessRequest>
    */
   @SqlQuery(
-      "SELECT id, reference_id, parent_reference_id, collection_id, draft, user_id, create_date, sort_date, submission_date, update_date, (data #>> '{}')::jsonb AS data FROM data_access_request WHERE reference_id IN (<referenceIds>)")
+      "SELECT id, reference_id, collection_id, parent_id, draft, user_id, create_date, sort_date, submission_date, update_date, (data #>> '{}')::jsonb AS data FROM data_access_request WHERE reference_id IN (<referenceIds>)")
   List<DataAccessRequest> findByReferenceIds(@BindList("referenceIds") List<String> referenceIds);
 
   /**
@@ -234,7 +234,7 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
    * @return List<DataAccessRequest>
    */
   @SqlQuery(
-    "SELECT id, reference_id, parent_reference_id, collection_id, draft, user_id, create_date, sort_date, submission_date, update_date, (data #>> '{}')::jsonb AS data FROM data_access_request "
+    "SELECT id, reference_id, collection_id, parent_id, draft, user_id, create_date, sort_date, submission_date, update_date, (data #>> '{}')::jsonb AS data FROM data_access_request "
         + " INNER JOIN dacuser d on d.dacuserid = user_id AND d.institution_id = :institutionId "
         + " WHERE draft != true")
   List<DataAccessRequest> findAllDataAccessRequestsForInstitution(@Bind("institutionId") Integer institutionId);

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DataAccessRequestMapper.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DataAccessRequestMapper.java
@@ -22,6 +22,7 @@ public class DataAccessRequestMapper implements RowMapper<DataAccessRequest>, Ro
                 dar.setCollectionId(collectionId);
             }
         }
+        dar.setParentId(resultSet.getString("parent_id"));
         dar.setDraft(resultSet.getBoolean("draft"));
         dar.setUserId(resultSet.getInt("user_id"));
         dar.setCreateDate(resultSet.getTimestamp("create_date"));

--- a/src/main/java/org/broadinstitute/consent/http/models/DarCollection.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DarCollection.java
@@ -28,8 +28,8 @@ public class DarCollection {
   //This query is specific to DAR Collections, which is why it's defined here
   public static final String DAR_FILTER_QUERY_COLUMNS =
     "dar.id AS dar_id, dar.reference_id AS dar_reference_id, dar.collection_id AS dar_collection_id, " +
-      "dar.draft AS dar_draft, dar.user_id AS dar_userId, dar.create_date AS dar_create_date, " +
-      "dar.sort_date AS dar_sort_date, dar.submission_date AS dar_submission_date, " +
+      "dar.parent_id AS dar_parent_id, dar.draft AS dar_draft, dar.user_id AS dar_userId, " +
+      "dar.create_date AS dar_create_date, dar.sort_date AS dar_sort_date, dar.submission_date AS dar_submission_date, " +
       "dar.update_date AS dar_update_date, (dar.data #>> '{}')::jsonb AS data, " +
       "(dar.data #>> '{}')::jsonb ->> 'projectTitle' as projectTitle ";
 

--- a/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequest.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequest.java
@@ -25,6 +25,8 @@ public class DataAccessRequest {
 
   @JsonProperty public String referenceId;
 
+  @JsonProperty public String parentReferenceId;
+
   @JsonProperty public Integer collectionId;
 
   @JsonProperty public DataAccessRequestData data;
@@ -74,6 +76,10 @@ public class DataAccessRequest {
   public void setReferenceId(String referenceId) {
     this.referenceId = referenceId;
   }
+
+  public String getParentReferenceId() { return parentReferenceId; }
+
+  public void setParentReferenceId(String parentReferenceId) { this.parentReferenceId = parentReferenceId; }
 
   public Integer getCollectionId() { return collectionId; }
 
@@ -222,6 +228,7 @@ public class DataAccessRequest {
     if (Objects.nonNull(dar.getDraft())) copy.put("draft", dar.getDraft());
     if (Objects.nonNull(dar.getId())) copy.put("id", dar.getId());
     if (Objects.nonNull(dar.getReferenceId())) copy.put("referenceId", dar.getReferenceId());
+    if (Objects.nonNull(dar.getParentReferenceId())) copy.put("parentReferenceId", dar.getParentReferenceId());
     if (Objects.nonNull(dar.getSortDate())) copy.put("sortDate", dar.getSortDate().getTime());
     if (Objects.nonNull(dar.getSubmissionDate())) copy.put("submissionDate", dar.getSubmissionDate().getTime());
     if (Objects.nonNull(dar.getUpdateDate())) copy.put("updateDate", dar.getUpdateDate().getTime());

--- a/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequest.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequest.java
@@ -25,9 +25,9 @@ public class DataAccessRequest {
 
   @JsonProperty public String referenceId;
 
-  @JsonProperty public String parentReferenceId;
-
   @JsonProperty public Integer collectionId;
+
+  @JsonProperty public String parentId;
 
   @JsonProperty public DataAccessRequestData data;
 
@@ -77,13 +77,13 @@ public class DataAccessRequest {
     this.referenceId = referenceId;
   }
 
-  public String getParentReferenceId() { return parentReferenceId; }
-
-  public void setParentReferenceId(String parentReferenceId) { this.parentReferenceId = parentReferenceId; }
-
   public Integer getCollectionId() { return collectionId; }
 
   public void setCollectionId(Integer collectionId) { this.collectionId = collectionId; }
+
+  public String getParentId() { return parentId; }
+
+  public void setParentId(String parentId) { this.parentId = parentId; }
 
   public DataAccessRequestData getData() {
     return data;
@@ -228,7 +228,6 @@ public class DataAccessRequest {
     if (Objects.nonNull(dar.getDraft())) copy.put("draft", dar.getDraft());
     if (Objects.nonNull(dar.getId())) copy.put("id", dar.getId());
     if (Objects.nonNull(dar.getReferenceId())) copy.put("referenceId", dar.getReferenceId());
-    if (Objects.nonNull(dar.getParentReferenceId())) copy.put("parentReferenceId", dar.getParentReferenceId());
     if (Objects.nonNull(dar.getSortDate())) copy.put("sortDate", dar.getSortDate().getTime());
     if (Objects.nonNull(dar.getSubmissionDate())) copy.put("submissionDate", dar.getSubmissionDate().getTime());
     if (Objects.nonNull(dar.getUpdateDate())) copy.put("updateDate", dar.getUpdateDate().getTime());

--- a/src/main/resources/changelog-master.xml
+++ b/src/main/resources/changelog-master.xml
@@ -82,4 +82,5 @@
     <include file="changesets/changelog-consent-77.0.xml" relativeToChangelogFile="true"/>
     <include file="changesets/changelog-consent-78.0.xml" relativeToChangelogFile="true"/>
     <include file="changesets/changelog-consent-79.0.xml" relativeToChangelogFile="true"/>
+    <include file="changesets/changelog-consent-80.0.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/changesets/changelog-consent-80.0.xml
+++ b/src/main/resources/changesets/changelog-consent-80.0.xml
@@ -1,0 +1,12 @@
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet id="80.0" author="smarks">
+        <addColumn tableName="data_access_request">
+            <column name="parent_reference_id" type="varchar(255)" defaultValue="null">
+                <constraints foreignKeyName="reference_id" nullable="true"/>
+            </column>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/changesets/changelog-consent-80.0.xml
+++ b/src/main/resources/changesets/changelog-consent-80.0.xml
@@ -4,7 +4,7 @@
 
     <changeSet id="80.0" author="smarks">
         <addColumn tableName="data_access_request">
-            <column name="parent_id" type="varchar(255)" defaultValue="null">
+            <column name="parent_id" type="bigint" defaultValue="null">
                 <constraints foreignKeyName="fkParentId" nullable="true"/>
             </column>
         </addColumn>

--- a/src/main/resources/changesets/changelog-consent-80.0.xml
+++ b/src/main/resources/changesets/changelog-consent-80.0.xml
@@ -4,17 +4,17 @@
 
     <changeSet id="80.0" author="smarks">
         <addColumn tableName="data_access_request">
-            <column name="parent_reference_id" type="varchar(255)" defaultValue="null">
-                <constraints foreignKeyName="fkReferenceId" nullable="true"/>
+            <column name="parent_id" type="varchar(255)" defaultValue="null">
+                <constraints foreignKeyName="fkParentId" nullable="true"/>
             </column>
         </addColumn>
 
-        <addForeignKeyConstraint baseColumnNames="parent_reference_id"
+        <addForeignKeyConstraint baseColumnNames="parent_id"
                                  baseTableName="data_access_request"
-                                 constraintName="fkReferenceId"
+                                 constraintName="fkParentId"
                                  onDelete="NO ACTION"
                                  onUpdate="NO ACTION"
-                                 referencedColumnNames="reference_id"
+                                 referencedColumnNames="id"
                                  referencedTableName="data_access_request"/>
     </changeSet>
 </databaseChangeLog>

--- a/src/main/resources/changesets/changelog-consent-80.0.xml
+++ b/src/main/resources/changesets/changelog-consent-80.0.xml
@@ -5,8 +5,16 @@
     <changeSet id="80.0" author="smarks">
         <addColumn tableName="data_access_request">
             <column name="parent_reference_id" type="varchar(255)" defaultValue="null">
-                <constraints foreignKeyName="reference_id" nullable="true"/>
+                <constraints foreignKeyName="fkreferenceid" nullable="true"/>
             </column>
         </addColumn>
+
+        <addForeignKeyConstraint baseColumnNames="parent_reference_id"
+                                 baseTableName="data_access_request"
+                                 constraintName="fkreferenceid"
+                                 onDelete="RESTRICT"
+                                 onUpdate="RESTRICT"
+                                 referencedColumnNames="reference_id"
+                                 referencedTableName="data_access_request"/>
     </changeSet>
 </databaseChangeLog>

--- a/src/main/resources/changesets/changelog-consent-80.0.xml
+++ b/src/main/resources/changesets/changelog-consent-80.0.xml
@@ -5,15 +5,15 @@
     <changeSet id="80.0" author="smarks">
         <addColumn tableName="data_access_request">
             <column name="parent_reference_id" type="varchar(255)" defaultValue="null">
-                <constraints foreignKeyName="fkreferenceid" nullable="true"/>
+                <constraints foreignKeyName="fkReferenceId" nullable="true"/>
             </column>
         </addColumn>
 
         <addForeignKeyConstraint baseColumnNames="parent_reference_id"
                                  baseTableName="data_access_request"
-                                 constraintName="fkreferenceid"
-                                 onDelete="RESTRICT"
-                                 onUpdate="RESTRICT"
+                                 constraintName="fkReferenceId"
+                                 onDelete="NO ACTION"
+                                 onUpdate="NO ACTION"
                                  referencedColumnNames="reference_id"
                                  referencedTableName="data_access_request"/>
     </changeSet>


### PR DESCRIPTION
[Link to Jira ticket](https://broadworkbench.atlassian.net/browse/DUOS-1519)
Summary of changes:
- Add `parent_id` column (defaults to null) to the `data_access_request` table
- Create a foreign key constraint on `id` so that a non-null `parent_id` must refer to an existing DAR `id`
- Update queries from `data_access_request` table to include `parent_id`
- Add `parentId` field to the `DataAccessRequest` model


----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
