### PR TITLE
[DUOS-1748] populate library card for create user in collection query

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
@@ -3,6 +3,7 @@ package org.broadinstitute.consent.http.db;
 import java.util.Date;
 import java.util.List;
 import org.broadinstitute.consent.http.db.mapper.DarCollectionReducer;
+import org.broadinstitute.consent.http.db.mapper.LibraryCardReducer;
 import org.broadinstitute.consent.http.models.DarCollection;
 import org.broadinstitute.consent.http.models.DataAccessRequest;
 import org.broadinstitute.consent.http.models.Election;
@@ -255,7 +256,7 @@ public interface DarCollectionDAO {
       + "INNER JOIN dacuser u ON c.create_user_id = u.dacuserid "
       + "LEFT JOIN user_property up ON u.dacuserid = up.userid "
       + "LEFT JOIN institution i ON i.institution_id = u.institution_id "
-      + "LEFT JOIN library_card lc ON c.create_user_id = lc.user_id "
+      + "LEFT JOIN library_card lc ON u.dacuserid = lc.user_id "
       + "INNER JOIN data_access_request dar ON c.collection_id = dar.collection_id "
       + "LEFT JOIN ("
           + "SELECT election.*, MAX(election.electionid) OVER (PARTITION BY election.referenceid, election.electiontype) AS latest "

--- a/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
@@ -3,7 +3,6 @@ package org.broadinstitute.consent.http.db;
 import java.util.Date;
 import java.util.List;
 import org.broadinstitute.consent.http.db.mapper.DarCollectionReducer;
-import org.broadinstitute.consent.http.db.mapper.LibraryCardReducer;
 import org.broadinstitute.consent.http.models.DarCollection;
 import org.broadinstitute.consent.http.models.DataAccessRequest;
 import org.broadinstitute.consent.http.models.Election;

--- a/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
@@ -7,6 +7,7 @@ import org.broadinstitute.consent.http.models.DarCollection;
 import org.broadinstitute.consent.http.models.DataAccessRequest;
 import org.broadinstitute.consent.http.models.Election;
 import org.broadinstitute.consent.http.models.Institution;
+import org.broadinstitute.consent.http.models.LibraryCard;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.UserProperty;
 import org.broadinstitute.consent.http.models.Vote;
@@ -234,12 +235,14 @@ public interface DarCollectionDAO {
   @RegisterBeanMapper(value = Election.class, prefix = "e")
   @RegisterBeanMapper(value = Vote.class, prefix = "v")
   @RegisterBeanMapper(value = UserProperty.class, prefix = "up")
+  @RegisterBeanMapper(value = LibraryCard.class, prefix = "lc")
   @UseRowReducer(DarCollectionReducer.class)
   @SqlQuery(
     "SELECT c.*, "
       + User.QUERY_FIELDS_WITH_U_PREFIX + QUERY_FIELD_SEPARATOR
       + Institution.QUERY_FIELDS_WITH_I_PREFIX + QUERY_FIELD_SEPARATOR
       + UserProperty.QUERY_FIELDS_WITH_UP_PREFIX + QUERY_FIELD_SEPARATOR
+      + LibraryCard.QUERY_FIELDS_WITH_LC_PREFIX + QUERY_FIELD_SEPARATOR
       + "dar.id AS dar_id, dar.reference_id AS dar_reference_id, dar.collection_id AS dar_collection_id, "
       + "dar.parent_id AS dar_parent_id, dar.draft AS dar_draft, dar.user_id AS dar_userId, "
       + "dar.create_date AS dar_create_date, dar.sort_date AS dar_sort_date, dar.submission_date AS dar_submission_date, "
@@ -252,6 +255,7 @@ public interface DarCollectionDAO {
       + "INNER JOIN dacuser u ON c.create_user_id = u.dacuserid "
       + "LEFT JOIN user_property up ON u.dacuserid = up.userid "
       + "LEFT JOIN institution i ON i.institution_id = u.institution_id "
+      + "LEFT JOIN library_card lc ON c.create_user_id = lc.user_id "
       + "INNER JOIN data_access_request dar ON c.collection_id = dar.collection_id "
       + "LEFT JOIN ("
           + "SELECT election.*, MAX(election.electionid) OVER (PARTITION BY election.referenceid, election.electiontype) AS latest "

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DarCollectionReducer.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DarCollectionReducer.java
@@ -5,6 +5,7 @@ import org.broadinstitute.consent.http.models.DataAccessRequest;
 import org.broadinstitute.consent.http.models.DataAccessRequestData;
 import org.broadinstitute.consent.http.models.Election;
 import org.broadinstitute.consent.http.models.Institution;
+import org.broadinstitute.consent.http.models.LibraryCard;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.UserProperty;
 import org.broadinstitute.consent.http.models.Vote;
@@ -26,6 +27,7 @@ public class DarCollectionReducer
     User user = null;
     UserProperty userProperty = null;
     Institution institution = null;
+    LibraryCard libraryCard = null;
     DarCollection collection =
         map.computeIfAbsent(
             rowView.getColumn("collection_id", Integer.class),
@@ -66,6 +68,9 @@ public class DarCollectionReducer
         if (Objects.nonNull(rowView.getColumn("v_vote_id", Integer.class))) {
           vote = rowView.getRow(Vote.class);
         }
+        if (Objects.nonNull(rowView.getColumn("lc_id", Integer.class))) {
+          libraryCard = rowView.getRow(LibraryCard.class);
+        }
       }
     } catch (MappingException e) {
       // ignore any exceptions
@@ -85,6 +90,9 @@ public class DarCollectionReducer
     if (Objects.nonNull(user)) {
       if (Objects.nonNull(institution)) {
         user.setInstitution(institution);
+      }
+      if (Objects.nonNull(libraryCard)) {
+        user.addLibraryCard(libraryCard);
       }
       if (Objects.nonNull(userProperty)) {
         user.addProperty(userProperty);

--- a/src/main/java/org/broadinstitute/consent/http/models/LibraryCard.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/LibraryCard.java
@@ -7,9 +7,15 @@ import java.util.Date;
 public class LibraryCard {
 
   public static final String QUERY_FIELDS_WITH_LC_PREFIX =
-          "lc.id as lc_id, " +
-          "lc.user_id as lc_user_id, " +
-          "lc.institution_id AS lc_institution_id";
+          " lc.id AS lc_id, " +
+          " lc.user_id AS lc_user_id, " +
+          " lc.institution_id AS lc_institution_id, " +
+          " lc.era_commons_id AS lc_era_commons_id, " +
+          " lc.user_name AS lc_user_name, " +
+          " lc.user_email AS lc_user_email, " +
+          " lc.create_user_id AS lc_create_user_id, " +
+          " lc.create_date AS lc_create_date, " +
+          " lc.update_user_id AS lc_update_user_id ";
 
   private Integer id;
   private Integer userId;

--- a/src/main/java/org/broadinstitute/consent/http/models/LibraryCard.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/LibraryCard.java
@@ -6,6 +6,11 @@ import java.util.Date;
 
 public class LibraryCard {
 
+  public static final String QUERY_FIELDS_WITH_LC_PREFIX =
+          "lc.id as lc_id, " +
+          "lc.user_id as lc_user_id, " +
+          "lc.institution_id AS lc_institution_id";
+
   private Integer id;
   private Integer userId;
   private Integer institutionId;

--- a/src/test/java/org/broadinstitute/consent/http/db/DarCollectionDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DarCollectionDAOTest.java
@@ -115,6 +115,8 @@ public class DarCollectionDAOTest extends DAOTestHelper  {
     List<UserProperty> userProperties = returned.getCreateUser().getProperties();
     assertFalse(userProperties.isEmpty());
     userProperties.forEach(p -> assertEquals(collection.getCreateUserId(), p.getUserId()));
+
+    assertNull(returned.getCreateUser().getLibraryCards());
   }
 
   @Test
@@ -146,30 +148,11 @@ public class DarCollectionDAOTest extends DAOTestHelper  {
 
     DarCollection collection = darCollectionDAO.findDARCollectionByCollectionId(collectionId);
     User returnedUser = collection.getCreateUser();
-    List<LibraryCard> returnedLibraryCards = returnedUser.getLibraryCards();
     assertEquals(user, returnedUser);
+
+    List<LibraryCard> returnedLibraryCards = returnedUser.getLibraryCards();
     assertEquals(1, returnedLibraryCards.size());
     assertEquals(libraryCard, returnedLibraryCards.get(0));
-  }
-
-  @Test
-  public void testFindDARCollectionByCollectionIdNoLibraryCard() throws IOException {
-    User user = createUser();
-    String darCode = "DAR-" + RandomUtils.nextInt(100, 1000);
-    Integer collectionId = darCollectionDAO.insertDarCollection(darCode, user.getDacUserId(), new Date());
-    String referenceId = UUID.randomUUID().toString();
-    String darDataString = FileUtils.readFileToString(
-            new File(ResourceHelpers.resourceFilePath("dataset/dar.json")),
-            Charset.defaultCharset());
-    DataAccessRequestData data = DataAccessRequestData.fromString(darDataString);
-    Date now = new Date();
-    dataAccessRequestDAO.insertVersion3(collectionId, referenceId, user.getDacUserId(), now, now, now, now, data);
-
-    DarCollection collection = darCollectionDAO.findDARCollectionByCollectionId(collectionId);
-    User returnedUser = collection.getCreateUser();
-    List<LibraryCard> returnedLibraryCards = returnedUser.getLibraryCards();
-    assertEquals(user, returnedUser);
-    assertNull(returnedLibraryCards);
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/db/DarCollectionDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DarCollectionDAOTest.java
@@ -153,6 +153,7 @@ public class DarCollectionDAOTest extends DAOTestHelper  {
     List<LibraryCard> returnedLibraryCards = returnedUser.getLibraryCards();
     assertEquals(1, returnedLibraryCards.size());
     assertEquals(libraryCard, returnedLibraryCards.get(0));
+    assertEquals(user.getDacUserId(), returnedLibraryCards.get(0).getUserId());
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/db/DarCollectionDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DarCollectionDAOTest.java
@@ -1,6 +1,8 @@
 package org.broadinstitute.consent.http.db;
 
+import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.RandomUtils;
+import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.Consent;
 import org.broadinstitute.consent.http.models.Dac;
 import org.broadinstitute.consent.http.models.DarCollection;
@@ -9,6 +11,7 @@ import org.broadinstitute.consent.http.models.DataAccessRequestData;
 import org.broadinstitute.consent.http.models.Dataset;
 import org.broadinstitute.consent.http.models.Election;
 import org.broadinstitute.consent.http.models.Institution;
+import org.broadinstitute.consent.http.models.LibraryCard;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.UserProperty;
 import org.broadinstitute.consent.http.models.Vote;
@@ -120,6 +123,34 @@ public class DarCollectionDAOTest extends DAOTestHelper  {
     Integer userId = collection.getCreateUser().getDacUserId();
     assertFalse(userProperties.isEmpty());
     userProperties.forEach(p -> assertEquals(userId, p.getUserId()));
+  }
+
+  @Test
+  public void testFindDARCollectionByCollectionIdLibraryCard() {
+    User user = createUser();
+    String darCode = "DAR-" + RandomUtils.nextInt(100, 1000);
+    Integer collectionId = darCollectionDAO.insertDarCollection(darCode, user.getDacUserId(), new Date());
+    LibraryCard libraryCard = createLibraryCard(user);
+
+    DarCollection collection = darCollectionDAO.findDARCollectionByCollectionId(collectionId);
+    User returnedUser = collection.getCreateUser();
+    List<LibraryCard> returnedLibraryCards = returnedUser.getLibraryCards();
+    assertEquals(user, returnedUser);
+    assertEquals(1, returnedLibraryCards.size());
+    assertEquals(libraryCard, returnedLibraryCards.get(0));
+  }
+
+  @Test
+  public void testFindDARCollectionByCollectionIdNoLibraryCard() {
+    User user = createUser();
+    String darCode = "DAR-" + RandomUtils.nextInt(100, 1000);
+    Integer collectionId = darCollectionDAO.insertDarCollection(darCode, user.getDacUserId(), new Date());
+
+    DarCollection collection = darCollectionDAO.findDARCollectionByCollectionId(collectionId);
+    User returnedUser = collection.getCreateUser();
+    List<LibraryCard> returnedLibraryCards = returnedUser.getLibraryCards();
+    assertEquals(user, returnedUser);
+    assertEquals(0, returnedLibraryCards.size());
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/db/DarCollectionDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DarCollectionDAOTest.java
@@ -1,8 +1,6 @@
 package org.broadinstitute.consent.http.db;
 
-import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.RandomUtils;
-import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.Consent;
 import org.broadinstitute.consent.http.models.Dac;
 import org.broadinstitute.consent.http.models.DarCollection;


### PR DESCRIPTION
[Link to Jira ticket](https://broadworkbench.atlassian.net/browse/DUOS-1748)
Summary of changes:

- Populate library card of the create user of a collection for `DarCollectionDAO.findDARCollectionByCollectionId`
- Add tests 

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
