### PR TITLE
[DUOS-1715][risk=no] Limit info sent to users based on role

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/models/User.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/User.java
@@ -11,6 +11,7 @@ import org.broadinstitute.consent.http.authentication.GoogleUser;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
 
 import java.beans.Transient;
+import java.util.EnumSet;
 import java.util.stream.Collectors;
 
 import java.util.ArrayList;
@@ -361,6 +362,12 @@ public class User {
           .stream()
           .map(UserRole::getRoleId)
           .collect(Collectors.toList());
+    }
+
+    @Transient
+    public boolean doesUserHaveRole(EnumSet<UserRoles> userRoles) {
+        List<Integer> queriedRoleIds = userRoles.stream().map(UserRoles::getRoleId).collect(Collectors.toList());
+        return getUserRoleIdsFromUser().stream().anyMatch(queriedRoleIds::contains);
     }
 
 }

--- a/src/main/java/org/broadinstitute/consent/http/models/User.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/User.java
@@ -365,7 +365,7 @@ public class User {
     }
 
     @Transient
-    public boolean doesUserHaveRole(EnumSet<UserRoles> userRoles) {
+    public boolean doesUserHaveAnyRoleInSet(EnumSet<UserRoles> userRoles) {
         List<Integer> queriedRoleIds = userRoles.stream().map(UserRoles::getRoleId).collect(Collectors.toList());
         return getUserRoleIdsFromUser().stream().anyMatch(queriedRoleIds::contains);
     }

--- a/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
@@ -381,9 +381,10 @@ public class DatasetResource extends Resource {
     @Produces(MediaType.APPLICATION_OCTET_STREAM)
     @PermitAll
     @Path("/{datasetId}/approved/users")
-    public Response downloadDatasetApprovedUsers(@PathParam("datasetId") Integer datasetId) {
+    public Response downloadDatasetApprovedUsers(@Auth AuthUser authUser, @PathParam("datasetId") Integer datasetId) {
         try {
-            return Response.ok(darService.createDataSetApprovedUsersDocument(datasetId))
+            String content = darService.getDatasetApprovedUsersContent(authUser, datasetId);
+            return Response.ok(content)
                     .header(HttpHeaders.CONTENT_DISPOSITION,"attachment; filename=DatasetApprovedUsers.tsv")
                     .build();
         } catch (Exception e) {

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessReportsParser.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessReportsParser.java
@@ -58,7 +58,7 @@ public class DataAccessReportsParser {
 
   public String getDatasetApprovedUsersHeader(User user) {
     StringBuilder builder = new StringBuilder();
-    if (user.doesUserHaveRole(EnumSet.of(UserRoles.ADMIN, UserRoles.CHAIRPERSON, UserRoles.MEMBER))) {
+    if (user.doesUserHaveAnyRoleInSet(EnumSet.of(UserRoles.ADMIN, UserRoles.CHAIRPERSON, UserRoles.MEMBER))) {
       builder
           .append(HeaderDAR.USERNAME.getValue())
           .append(DEFAULT_SEPARATOR)
@@ -104,7 +104,7 @@ public class DataAccessReportsParser {
 
     public String getDataSetApprovedUsersLine(User user, String email, String name, String institution, String darCode, Date approvalDate) {
       StringBuilder builder = new StringBuilder();
-      if (user.doesUserHaveRole(EnumSet.of(UserRoles.ADMIN, UserRoles.CHAIRPERSON, UserRoles.MEMBER))) {
+      if (user.doesUserHaveAnyRoleInSet(EnumSet.of(UserRoles.ADMIN, UserRoles.CHAIRPERSON, UserRoles.MEMBER))) {
         builder
             .append(email)
             .append(DEFAULT_SEPARATOR)

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessReportsParser.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessReportsParser.java
@@ -19,8 +19,6 @@ import java.util.Date;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 public class DataAccessReportsParser {
 
@@ -56,17 +54,6 @@ public class DataAccessReportsParser {
                         HeaderDAR.CODED_VERSION_DAR.getValue() + DEFAULT_SEPARATOR +
                         HeaderDAR.DATE_REQUEST_APPROVAL_DISAPROVAL.getValue() + DEFAULT_SEPARATOR +
                         HeaderDAR.APPROVED_DISAPPROVED.getValue() + END_OF_LINE);
-    }
-
-
-    public void setDataSetApprovedUsersHeader(FileWriter darWriter) throws IOException {
-        darWriter.write(
-                HeaderDAR.USERNAME.getValue() + DEFAULT_SEPARATOR +
-                        HeaderDAR.NAME.getValue() + DEFAULT_SEPARATOR +
-                        HeaderDAR.ORGANIZATION.getValue() + DEFAULT_SEPARATOR +
-                        HeaderDAR.DAR_ID.getValue() + DEFAULT_SEPARATOR +
-                        HeaderDAR.DATE_REQUEST_APPROVAL.getValue() + DEFAULT_SEPARATOR +
-                        HeaderDAR.RENEWAL_DATE.getValue() + END_OF_LINE);
     }
 
   public String getDatasetApprovedUsersHeader(User user) {
@@ -113,17 +100,6 @@ public class DataAccessReportsParser {
         String content2 = formatTimeToDate(election.getFinalVoteDate().getTime()) + DEFAULT_SEPARATOR +
                           finalVote;
         addDARLine(darWriter, dar, "", content2, consentName, translatedUseRestriction);
-    }
-
-
-    public void addDataSetApprovedUsersLine(FileWriter darWriter, String email, String name, String institution, String darCode, Date approvalDate) throws IOException {
-        darWriter.write(
-                email + DEFAULT_SEPARATOR +
-                    name + DEFAULT_SEPARATOR +
-                    institution + DEFAULT_SEPARATOR +
-                    darCode + DEFAULT_SEPARATOR +
-                    formatTimeToDate(approvalDate.getTime()) + DEFAULT_SEPARATOR +
-                    " - " + END_OF_LINE);
     }
 
     public String getDataSetApprovedUsersLine(User user, String email, String name, String institution, String darCode, Date approvalDate) {

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessReportsParser.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessReportsParser.java
@@ -2,19 +2,25 @@ package org.broadinstitute.consent.http.service;
 
 import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.consent.http.enumeration.HeaderDAR;
+import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.DataAccessRequest;
 import org.broadinstitute.consent.http.models.Dataset;
 import org.broadinstitute.consent.http.models.DatasetDetailEntry;
 import org.broadinstitute.consent.http.models.Election;
+import org.broadinstitute.consent.http.models.User;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import java.io.FileWriter;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class DataAccessReportsParser {
 
@@ -63,6 +69,34 @@ public class DataAccessReportsParser {
                         HeaderDAR.RENEWAL_DATE.getValue() + END_OF_LINE);
     }
 
+  public String getDatasetApprovedUsersHeader(User user) {
+    StringBuilder builder = new StringBuilder();
+    if (user.doesUserHaveRole(EnumSet.of(UserRoles.ADMIN, UserRoles.CHAIRPERSON, UserRoles.MEMBER))) {
+      builder
+          .append(HeaderDAR.USERNAME.getValue())
+          .append(DEFAULT_SEPARATOR)
+          .append(HeaderDAR.NAME.getValue())
+          .append(DEFAULT_SEPARATOR)
+          .append(HeaderDAR.ORGANIZATION.getValue())
+          .append(DEFAULT_SEPARATOR)
+          .append(HeaderDAR.DAR_ID.getValue())
+          .append(DEFAULT_SEPARATOR)
+          .append(HeaderDAR.DATE_REQUEST_APPROVAL.getValue())
+          .append(END_OF_LINE);
+    } else {
+      builder
+          .append(HeaderDAR.NAME.getValue())
+          .append(DEFAULT_SEPARATOR)
+          .append(HeaderDAR.ORGANIZATION.getValue())
+          .append(DEFAULT_SEPARATOR)
+          .append(HeaderDAR.DAR_ID.getValue())
+          .append(DEFAULT_SEPARATOR)
+          .append(HeaderDAR.DATE_REQUEST_APPROVAL.getValue())
+          .append(END_OF_LINE);
+    }
+    return builder.toString();
+  }
+
     public void addApprovedDARLine(FileWriter darWriter, Election election, DataAccessRequest dar, String profileName, String institution, String consentName, String translatedUseRestriction) throws IOException {
         String rusSummary = Objects.nonNull(dar.getData()) && StringUtils.isNotEmpty(dar.getData().getNonTechRus()) ?  dar.getData().getNonTechRus().replace("\n", " ") : "";
         String content1 =  profileName + DEFAULT_SEPARATOR + institution + DEFAULT_SEPARATOR;
@@ -90,6 +124,34 @@ public class DataAccessReportsParser {
                     darCode + DEFAULT_SEPARATOR +
                     formatTimeToDate(approvalDate.getTime()) + DEFAULT_SEPARATOR +
                     " - " + END_OF_LINE);
+    }
+
+    public String getDataSetApprovedUsersLine(User user, String email, String name, String institution, String darCode, Date approvalDate) {
+      StringBuilder builder = new StringBuilder();
+      if (user.doesUserHaveRole(EnumSet.of(UserRoles.ADMIN, UserRoles.CHAIRPERSON, UserRoles.MEMBER))) {
+        builder
+            .append(email)
+            .append(DEFAULT_SEPARATOR)
+            .append(name)
+            .append(DEFAULT_SEPARATOR)
+            .append(institution)
+            .append(DEFAULT_SEPARATOR)
+            .append(darCode)
+            .append(DEFAULT_SEPARATOR)
+            .append(formatTimeToDate(approvalDate.getTime()))
+            .append(END_OF_LINE);
+      } else {
+        builder
+            .append(name)
+            .append(DEFAULT_SEPARATOR)
+            .append(institution)
+            .append(DEFAULT_SEPARATOR)
+            .append(darCode)
+            .append(DEFAULT_SEPARATOR)
+            .append(formatTimeToDate(approvalDate.getTime()))
+            .append(END_OF_LINE);
+      }
+      return builder.toString();
     }
 
     private String formatTimeToDate(long time) {

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessReportsParser.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessReportsParser.java
@@ -60,27 +60,18 @@ public class DataAccessReportsParser {
     StringBuilder builder = new StringBuilder();
     if (user.doesUserHaveAnyRoleInSet(EnumSet.of(UserRoles.ADMIN, UserRoles.CHAIRPERSON, UserRoles.MEMBER))) {
       builder
-          .append(HeaderDAR.USERNAME.getValue())
-          .append(DEFAULT_SEPARATOR)
-          .append(HeaderDAR.NAME.getValue())
-          .append(DEFAULT_SEPARATOR)
-          .append(HeaderDAR.ORGANIZATION.getValue())
-          .append(DEFAULT_SEPARATOR)
-          .append(HeaderDAR.DAR_ID.getValue())
-          .append(DEFAULT_SEPARATOR)
-          .append(HeaderDAR.DATE_REQUEST_APPROVAL.getValue())
-          .append(END_OF_LINE);
-    } else {
-      builder
-          .append(HeaderDAR.NAME.getValue())
-          .append(DEFAULT_SEPARATOR)
-          .append(HeaderDAR.ORGANIZATION.getValue())
-          .append(DEFAULT_SEPARATOR)
-          .append(HeaderDAR.DAR_ID.getValue())
-          .append(DEFAULT_SEPARATOR)
-          .append(HeaderDAR.DATE_REQUEST_APPROVAL.getValue())
-          .append(END_OF_LINE);
+        .append(HeaderDAR.USERNAME.getValue())
+        .append(DEFAULT_SEPARATOR);
     }
+    builder
+        .append(HeaderDAR.NAME.getValue())
+        .append(DEFAULT_SEPARATOR)
+        .append(HeaderDAR.ORGANIZATION.getValue())
+        .append(DEFAULT_SEPARATOR)
+        .append(HeaderDAR.DAR_ID.getValue())
+        .append(DEFAULT_SEPARATOR)
+        .append(HeaderDAR.DATE_REQUEST_APPROVAL.getValue())
+        .append(END_OF_LINE);
     return builder.toString();
   }
 
@@ -107,26 +98,17 @@ public class DataAccessReportsParser {
       if (user.doesUserHaveAnyRoleInSet(EnumSet.of(UserRoles.ADMIN, UserRoles.CHAIRPERSON, UserRoles.MEMBER))) {
         builder
             .append(email)
-            .append(DEFAULT_SEPARATOR)
-            .append(name)
-            .append(DEFAULT_SEPARATOR)
-            .append(institution)
-            .append(DEFAULT_SEPARATOR)
-            .append(darCode)
-            .append(DEFAULT_SEPARATOR)
-            .append(formatTimeToDate(approvalDate.getTime()))
-            .append(END_OF_LINE);
-      } else {
-        builder
-            .append(name)
-            .append(DEFAULT_SEPARATOR)
-            .append(institution)
-            .append(DEFAULT_SEPARATOR)
-            .append(darCode)
-            .append(DEFAULT_SEPARATOR)
-            .append(formatTimeToDate(approvalDate.getTime()))
-            .append(END_OF_LINE);
+            .append(DEFAULT_SEPARATOR);
       }
+      builder
+          .append(name)
+          .append(DEFAULT_SEPARATOR)
+          .append(institution)
+          .append(DEFAULT_SEPARATOR)
+          .append(darCode)
+          .append(DEFAULT_SEPARATOR)
+          .append(formatTimeToDate(approvalDate.getTime()))
+          .append(END_OF_LINE);
       return builder.toString();
     }
 

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -2052,36 +2052,7 @@ paths:
   /api/dataset/{id}:
     $ref: './paths/datasetById.yaml'
   /api/dataset/{id}/approved/users:
-    get:
-      summary: Dataset Approved Users
-      description: Dataset Approved Users
-      parameters:
-        - name: id
-          in: path
-          description: The dataset id
-          required: true
-          schema:
-            type: integer
-      tags:
-        - Datasets
-      responses:
-        200:
-          description: Dataset Approved Users
-          content:
-            text/plain:
-              schema:
-                type: string
-          headers:
-            Content-type:
-              schema:
-                type: string
-              description: text/plain
-            Content-Disposition:
-              schema:
-                type: string
-              description: attachment; filename=DatasetApprovedUsers.tsv
-        500:
-          description: Server error.
+    $ref: './paths/datasetByIdApprovedUsers.yaml'
   /api/dataset/download:
     post:
       summary: Download datasets by id list

--- a/src/main/resources/assets/paths/datasetByIdApprovedUsers.yaml
+++ b/src/main/resources/assets/paths/datasetByIdApprovedUsers.yaml
@@ -1,0 +1,22 @@
+get:
+  summary: Download Dataset Approved Users
+  description: Download a list of approved users for a dataset
+  parameters:
+    - name: id
+      in: path
+      description: The dataset id
+      required: true
+      schema:
+        type: integer
+  tags:
+    - Datasets
+  responses:
+    200:
+      description: Download Dataset Approved Users
+      content:
+        application/octet-stream:
+          schema:
+            type: string
+            format: binary
+    500:
+      description: Server error.

--- a/src/main/resources/assets/paths/datasetByIdApprovedUsers.yaml
+++ b/src/main/resources/assets/paths/datasetByIdApprovedUsers.yaml
@@ -18,5 +18,7 @@ get:
           schema:
             type: string
             format: binary
+    404:
+      description: Unknown user
     500:
       description: Server error.

--- a/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
@@ -656,16 +656,16 @@ public class DatasetResourceTest {
     public void testDownloadDatasetApprovedUsersSuccess() {
         List<String> header = List.of("attachment; filename=DatasetApprovedUsers.tsv");
         initResource();
-        Response response = resource.downloadDatasetApprovedUsers(1);
+        Response response = resource.downloadDatasetApprovedUsers(new AuthUser(), 1);
         assertEquals(200, response.getStatus());
         assertEquals(header, response.getHeaders().get("Content-Disposition"));
     }
 
     @Test
-    public void testDownloadDatasetApprovedUsersError() throws Exception {
-        doThrow(new RuntimeException()).when(darService).createDataSetApprovedUsersDocument(any());
+    public void testDownloadDatasetApprovedUsersError() {
+        doThrow(new RuntimeException()).when(darService).getDatasetApprovedUsersContent(any(), any());
         initResource();
-        Response response = resource.downloadDatasetApprovedUsers(1);
+        Response response = resource.downloadDatasetApprovedUsers(new AuthUser(), 1);
         assertEquals(500, response.getStatus());
     }
 

--- a/src/test/java/org/broadinstitute/consent/http/service/DataAccessReportsParserTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DataAccessReportsParserTest.java
@@ -132,39 +132,6 @@ public class DataAccessReportsParserTest {
         assertTrue(i == 2);
     }
 
-    @Test
-    public void testDataSetApprovedUsers() throws IOException{
-        File file = File.createTempFile("DataSetApprovedUsers", ".tsv");
-        FileWriter darWriter = new FileWriter(file);
-        parser.setDataSetApprovedUsersHeader(darWriter);
-        Date approvalDate = new Date();
-        parser.addDataSetApprovedUsersLine(darWriter, EMAIL, REQUESTER, ORGANIZATION, DAR_CODE, approvalDate);
-        darWriter.flush();
-        Stream<String> stream = Files.lines(Paths.get(file.getPath()));
-        Iterator<String> iterator = stream.iterator();
-        int i = 0;
-        while (iterator.hasNext()) {
-            String line = iterator.next();
-            String[] columns = line.split("\t");
-            assertTrue(columns.length == 6);
-            if(i == 0) {
-                assertTrue(columns[0].equals(HeaderDAR.USERNAME.getValue()));
-                assertTrue(columns[1].equals(HeaderDAR.NAME.getValue()));
-                assertTrue(columns[2].equals(HeaderDAR.ORGANIZATION.getValue()));
-                assertTrue(columns[3].equals(HeaderDAR.DAR_ID.getValue()));
-                assertTrue(columns[4].equals(HeaderDAR.DATE_REQUEST_APPROVAL.getValue()));
-                assertTrue(columns[5].equals(HeaderDAR.RENEWAL_DATE.getValue()));
-            }
-            if (i == 1) {
-                assertTrue(columns[0].equals(EMAIL));
-                assertTrue(columns[1].equals(REQUESTER));
-                assertTrue(columns[2].equals(ORGANIZATION));
-                assertTrue(columns[3].equals(DAR_CODE));
-            }
-            i++;
-        }
-    }
-
     private Election createElection(Date currentDate){
         Election election = new Election();
         election.setFinalVoteDate(currentDate);

--- a/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
@@ -459,7 +459,7 @@ public class DataAccessRequestServiceTest {
     }
 
     @Test
-    public void testCreateDataSetApprovedUsersDocumentAsNonPrivilegedUser() {
+    public void testCreateDatasetApprovedUsersContentAsNonPrivilegedUser() {
         DataAccessRequest dar = generateDataAccessRequest();
         dar.setUserId(1);
         User user = new User();
@@ -490,7 +490,7 @@ public class DataAccessRequestServiceTest {
     }
 
     @Test
-    public void testCreateDataSetApprovedUsersDocumentAsPrivilegedUser() {
+    public void testCreateDatasetApprovedUsersContentAsPrivilegedUser() {
         DataAccessRequest dar = generateDataAccessRequest();
         dar.setUserId(1);
         User user = new User();
@@ -605,10 +605,10 @@ public class DataAccessRequestServiceTest {
         return dar;
     }
 
-    private Election generateElection(Integer dataSetId) {
+    private Election generateElection(Integer datasetId) {
         String refId = UUID.randomUUID().toString();
         Election election = new Election();
-        election.setDataSetId(dataSetId);
+        election.setDataSetId(datasetId);
         election.setReferenceId(refId);
 
         return election;

--- a/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
@@ -3,6 +3,7 @@ package org.broadinstitute.consent.http.service;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
@@ -35,6 +36,7 @@ import org.broadinstitute.consent.http.db.InstitutionDAO;
 import org.broadinstitute.consent.http.db.UserDAO;
 import org.broadinstitute.consent.http.db.VoteDAO;
 import org.broadinstitute.consent.http.enumeration.DarStatus;
+import org.broadinstitute.consent.http.enumeration.HeaderDAR;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.AuthUser;
 import org.broadinstitute.consent.http.models.Consent;
@@ -56,7 +58,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentMatcher;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 
 public class DataAccessRequestServiceTest {
 
@@ -458,7 +459,7 @@ public class DataAccessRequestServiceTest {
     }
 
     @Test
-    public void testCreateDataSetApprovedUsersDocument() {
+    public void testCreateDataSetApprovedUsersDocumentAsNonPrivilegedUser() {
         DataAccessRequest dar = generateDataAccessRequest();
         dar.setUserId(1);
         User user = new User();
@@ -474,15 +475,49 @@ public class DataAccessRequestServiceTest {
                 .thenReturn(dar);
         when(electionDAO.findApprovalAccessElectionDate(dar.getReferenceId()))
                 .thenReturn(new Date());
-
+        when(userDAO.findUserByEmail(any())).thenReturn(user);
 
         initService();
 
         try {
-            File file = service.createDataSetApprovedUsersDocument(1);
+            String approvedUsers = service.getDatasetApprovedUsersContent(new AuthUser(), 1);
+            System.out.println(approvedUsers);
+            assertNotNull(approvedUsers);
+            assertFalse(approvedUsers.contains(HeaderDAR.USERNAME.getValue()));
+        } catch (Exception ioe) {
+            assert false;
+        }
+    }
 
-            assertNotNull(file);
-        } catch (IOException ioe) {
+    @Test
+    public void testCreateDataSetApprovedUsersDocumentAsPrivilegedUser() {
+        DataAccessRequest dar = generateDataAccessRequest();
+        dar.setUserId(1);
+        User user = new User();
+        UserRole userRole = new UserRole(UserRoles.ADMIN.getRoleId(), UserRoles.ADMIN.getRoleName());
+        user.addRole(userRole);
+        user.setDacUserId(1);
+        user.setDisplayName("displayName");
+        user.setInstitutionId(1);
+        Institution institution = new Institution();
+        institution.setName("Institution");
+        when(institutionDAO.findInstitutionById(any())).thenReturn(institution);
+        when(dataAccessRequestDAO.findAllDataAccessRequests())
+                .thenReturn(Collections.singletonList(dar));
+        when(dataAccessRequestDAO.findByReferenceId(dar.getReferenceId()))
+                .thenReturn(dar);
+        when(electionDAO.findApprovalAccessElectionDate(dar.getReferenceId()))
+                .thenReturn(new Date());
+        when(userDAO.findUserByEmail(any())).thenReturn(user);
+
+        initService();
+
+        try {
+            String approvedUsers = service.getDatasetApprovedUsersContent(new AuthUser(), 1);
+            System.out.println(approvedUsers);
+            assertNotNull(approvedUsers);
+            assertTrue(approvedUsers.contains(HeaderDAR.USERNAME.getValue()));
+        } catch (Exception ioe) {
             assert false;
         }
     }


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-1715

If the user has Admin, Chair, or Member roles, show the email address of approved users. Otherwise, filter that column from the results.

## Example downloads:

### Privileged view:
<img width="1252" alt="Screen Shot 2022-04-28 at 3 47 07 PM" src="https://user-images.githubusercontent.com/116679/165833829-d25fcc78-a1ab-4fcb-88ca-0452f058c6b8.png">


### Non-privileged view:
<img width="1257" alt="Screen Shot 2022-04-28 at 3 46 43 PM" src="https://user-images.githubusercontent.com/116679/165833851-43721263-fe3d-4cd5-97bb-0884114e3fbf.png">


----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
