### PR TITLE
[DUOS-1777][risk=no] consent add bypass for lc requirement on dar submission 

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequestData.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequestData.java
@@ -46,6 +46,7 @@ public class DataAccessRequestData {
     private String country;
     private String projectTitle;
     private Boolean checkCollaborator;
+    private Boolean checkNihDataOnly;
     private String researcher;
     private String isThePi;
     private String havePi;
@@ -247,6 +248,14 @@ public class DataAccessRequestData {
 
     public void setCheckCollaborator(Boolean checkCollaborator) {
         this.checkCollaborator = checkCollaborator;
+    }
+
+    public Boolean getCheckNihDataOnly() {
+        return checkNihDataOnly;
+    }
+
+    public void setCheckNihDataOnly(Boolean checkNihDataOnly) {
+        this.checkNihDataOnly = checkNihDataOnly;
     }
 
     public String getResearcher() {

--- a/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceVersion2.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceVersion2.java
@@ -93,12 +93,6 @@ public class DataAccessRequestResourceVersion2 extends Resource {
       @Auth AuthUser authUser, @Context UriInfo info, String dar) {
     try {
       User user = findUserByEmail(authUser.getEmail());
-      if (Objects.isNull(user.getLibraryCards()) || user.getLibraryCards().isEmpty()) {
-        return Response
-          .status(Response.Status.FORBIDDEN)
-                .entity("Library Card required for creating Data Access Requests")
-          .build();
-      }
       DataAccessRequest newDar = populateDarFromJsonString(user, dar);
       List<DataAccessRequest> results =
           dataAccessRequestService.createDataAccessRequest(user, newDar);

--- a/src/main/resources/assets/paths/darV2.yaml
+++ b/src/main/resources/assets/paths/darV2.yaml
@@ -19,8 +19,6 @@ post:
             type: array
             items:
               $ref: '../schemas/DataAccessRequest.yaml'
-    403:
-      description: A user is required to have a Library Card to submit Data Access Requests
     500:
       description: Internal Server Error.
 get:

--- a/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceVersion2Test.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceVersion2Test.java
@@ -7,11 +7,9 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.broadinstitute.consent.http.cloudstore.GCSService;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.AuthUser;
-import org.broadinstitute.consent.http.models.DarCollection;
 import org.broadinstitute.consent.http.models.DataAccessRequest;
 import org.broadinstitute.consent.http.models.DataAccessRequestData;
 import org.broadinstitute.consent.http.models.DataAccessRequestManage;
-import org.broadinstitute.consent.http.models.LibraryCard;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.UserRole;
 import org.broadinstitute.consent.http.service.DataAccessRequestService;
@@ -84,9 +82,8 @@ public class DataAccessRequestResourceVersion2Test {
   }
 
   @Test
-  public void testCreateDataAccessRequestWithLibraryCard() {
+  public void testCreateDataAccessRequest() {
     try {
-      user.addLibraryCard(new LibraryCard());
       when(userService.findUserByEmail(any())).thenReturn(user);
       DataAccessRequest dar = new DataAccessRequest();
       dar.setReferenceId(UUID.randomUUID().toString());
@@ -104,18 +101,6 @@ public class DataAccessRequestResourceVersion2Test {
     initResource();
     Response response = resource.createDataAccessRequest(authUser, info, "");
     assertEquals(Response.Status.CREATED.getStatusCode(), response.getStatus());
-  }
-
-  @Test
-  public void testCreateDataAccessRequestNoLibraryCard() {
-    try {
-      when(userService.findUserByEmail(any())).thenReturn(user);
-    } catch (Exception e) {
-      fail("Initialization Exception: " + e.getMessage());
-    }
-    initResource();
-    Response response = resource.createDataAccessRequest(authUser, info, "");
-    assertEquals(Response.Status.FORBIDDEN.getStatusCode(), response.getStatus());
   }
 
   @Test


### PR DESCRIPTION
[Link to Jira ticket](https://broadworkbench.atlassian.net/browse/DUOS-1777)
Summary of changes: 
- Remove library card requirement for submitting DARs
- Add field to DataAccessRequestData to track whether the researcher is only requesting NIH datasets for their DAR

[Link to UI PR](https://github.com/DataBiosphere/duos-ui/pull/1538)


----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
