### PR TITLE
DUOS-1785[risk=low] Added MatchResource endpoint for bulk requests for DarCollectionReview

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/MatchDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/MatchDAO.java
@@ -30,8 +30,17 @@ public interface MatchDAO extends Transactional<MatchDAO> {
     @SqlQuery("SELECT * FROM match_entity WHERE matchid = :id ")
     Match  findMatchById(@Bind("id") Integer id);
 
-    @SqlQuery("SELECT * FROM match_entity WHERE purpose IN (<purposeId>)")
-    List<Match> findMatchesForPurposeIds(@BindList("purposeId") List<String> purposeId);
+    @SqlQuery(
+        "SELECT match_entity.* FROM match_entity " +
+        "INNER JOIN (" +
+        "   SELECT election.*, MAX(election.electionid) OVER (PARTITION BY election.referenceid, election.datasetid) AS latest " +
+        "   FROM election " +
+        "   WHERE LOWER(election.electiontype) = 'dataaccess' " +
+        ") AS e " +
+        "ON e.referenceid = match_entity.purpose " +
+        "WHERE match_entity.purpose IN (<purposeIds>) AND e.electionid = latest"
+    )
+    List<Match> findMatchesForPurposeIds(@BindList("purposeIds") List<String> purposeIds);
 
     @SqlUpdate(
             " INSERT INTO match_entity " +

--- a/src/main/java/org/broadinstitute/consent/http/db/MatchDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/MatchDAO.java
@@ -40,7 +40,10 @@ public interface MatchDAO extends Transactional<MatchDAO> {
         "ON e.referenceid = match_entity.purpose " +
         "WHERE match_entity.purpose IN (<purposeIds>) AND e.electionid = latest"
     )
-    List<Match> findMatchesForPurposeIds(@BindList("purposeIds") List<String> purposeIds);
+    List<Match> findMatchesForBatchPurposeIds(@BindList("purposeIds") List<String> purposeIds);
+
+    @SqlQuery("SELECT * FROM match_entity WHERE purpose IN (<purposeId>)")
+    List<Match> findMatchesForPurposeIds(@BindList("purposeId") List<String> purposeId);
 
     @SqlUpdate(
             " INSERT INTO match_entity " +

--- a/src/main/java/org/broadinstitute/consent/http/db/MatchDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/MatchDAO.java
@@ -40,7 +40,7 @@ public interface MatchDAO extends Transactional<MatchDAO> {
         "ON e.referenceid = match_entity.purpose " +
         "WHERE match_entity.purpose IN (<purposeIds>) AND e.electionid = latest"
     )
-    List<Match> findMatchesForBatchPurposeIds(@BindList("purposeIds") List<String> purposeIds);
+    List<Match> findMatchesForLatestDataAccessElectionsByPurposeIds(@BindList("purposeIds") List<String> purposeIds);
 
     @SqlQuery("SELECT * FROM match_entity WHERE purpose IN (<purposeId>)")
     List<Match> findMatchesForPurposeIds(@BindList("purposeId") List<String> purposeId);

--- a/src/main/java/org/broadinstitute/consent/http/resources/MatchResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/MatchResource.java
@@ -73,7 +73,7 @@ public class MatchResource extends Resource {
   }
 
   @GET
-  @Path("/purpose/bulk/{purposeIds}")
+  @Path("/purpose/batch/{purposeIds}")
   @RolesAllowed({Resource.ADMIN, Resource.CHAIRPERSON})
   public Response getMatchesForPurposeIds(
     @Auth AuthUser authUser, @QueryParam("purposeIds") String purposeIds
@@ -85,6 +85,7 @@ public class MatchResource extends Resource {
         List<String> purposeIdsList = Arrays.asList(purposeIds.split(","))
           .stream()
           .filter(id -> !id.isBlank())
+          .map(id -> id.strip())
           .collect(Collectors.toList());
 
         if(purposeIdsList.isEmpty()) {
@@ -112,5 +113,4 @@ public class MatchResource extends Resource {
       return createExceptionResponse(e);
     }
   }
-
 }

--- a/src/main/java/org/broadinstitute/consent/http/resources/MatchResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/MatchResource.java
@@ -62,7 +62,7 @@ public class MatchResource extends Resource {
   @GET
   @Path("/purpose/batch")
   @PermitAll
-  public Response getMatchesForPurposeIds(
+  public Response getMatchesForLatestDataAccessElectionsByPurposeIds(
       @Auth AuthUser authUser, @QueryParam("purposeIds") String purposeIds) {
     try {
       if (Objects.isNull(purposeIds) || purposeIds.isBlank()) {
@@ -77,7 +77,7 @@ public class MatchResource extends Resource {
         if (purposeIdsList.isEmpty()) {
           throw new BadRequestException("Invalid query params provided");
         } else {
-          List<Match> matchList = service.findMatchesForPurposeIds(purposeIdsList);
+          List<Match> matchList = service.findMatchesForLatestDataAccessElectionsByPurposeIds(purposeIdsList);
           return Response.ok().entity(matchList).build();
         }
       }

--- a/src/main/java/org/broadinstitute/consent/http/resources/MatchResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/MatchResource.java
@@ -8,12 +8,18 @@ import org.broadinstitute.consent.http.service.MatchService;
 
 import javax.annotation.security.PermitAll;
 import javax.annotation.security.RolesAllowed;
+import javax.ws.rs.BadRequestException;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Response;
+
+import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 @Path("api/match")
 public class MatchResource extends Resource {
@@ -55,13 +61,40 @@ public class MatchResource extends Resource {
 
   @GET
   @Path("/purpose/{purposeId}")
-  @RolesAllowed({Resource.ADMIN})
+  @RolesAllowed({Resource.ADMIN, Resource.CHAIRPERSON})
   public Response getMatchesForPurpose(
       @Auth AuthUser authUser, @PathParam("purposeId") String purposeId) {
     try {
       List<Match> matches = service.findMatchesByPurposeId(purposeId);
       return Response.ok().entity(matches).build();
     } catch (Exception e) {
+      return createExceptionResponse(e);
+    }
+  }
+
+  @GET
+  @Path("/purpose/bulk/{purposeIds}")
+  @RolesAllowed({Resource.ADMIN, Resource.CHAIRPERSON})
+  public Response getMatchesForPurposeIds(
+    @Auth AuthUser authUser, @QueryParam("purposeIds") String purposeIds
+  ) {
+    try {
+      if(Objects.isNull(purposeIds) || purposeIds.isBlank()) {
+        throw new BadRequestException("No purpose ids were provided");
+      } else {
+        List<String> purposeIdsList = Arrays.asList(purposeIds.split(","))
+          .stream()
+          .filter(id -> !id.isBlank())
+          .collect(Collectors.toList());
+
+        if(purposeIdsList.isEmpty()) {
+          throw new BadRequestException("Invalid query params provided");
+        } else {
+            List<Match> matchList = service.findMatchesForPurposeIds(purposeIdsList);
+            return Response.ok().entity(matchList).build();
+        }
+      }
+    } catch(Exception e) {
       return createExceptionResponse(e);
     }
   }

--- a/src/main/java/org/broadinstitute/consent/http/resources/MatchResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/MatchResource.java
@@ -60,6 +60,33 @@ public class MatchResource extends Resource {
   }
 
   @GET
+  @Path("/purpose/batch")
+  @PermitAll
+  public Response getMatchesForPurposeIds(
+      @Auth AuthUser authUser, @QueryParam("purposeIds") String purposeIds) {
+    try {
+      if (Objects.isNull(purposeIds) || purposeIds.isBlank()) {
+        throw new BadRequestException("No purpose ids were provided");
+      } else {
+        List<String> purposeIdsList = Arrays.asList(purposeIds.split(","))
+            .stream()
+            .filter(id -> !id.isBlank())
+            .map(id -> id.strip())
+            .collect(Collectors.toList());
+
+        if (purposeIdsList.isEmpty()) {
+          throw new BadRequestException("Invalid query params provided");
+        } else {
+          List<Match> matchList = service.findMatchesForPurposeIds(purposeIdsList);
+          return Response.ok().entity(matchList).build();
+        }
+      }
+    } catch (Exception e) {
+      return createExceptionResponse(e);
+    }
+  }
+
+  @GET
   @Path("/purpose/{purposeId}")
   @RolesAllowed({Resource.ADMIN, Resource.CHAIRPERSON})
   public Response getMatchesForPurpose(
@@ -68,34 +95,6 @@ public class MatchResource extends Resource {
       List<Match> matches = service.findMatchesByPurposeId(purposeId);
       return Response.ok().entity(matches).build();
     } catch (Exception e) {
-      return createExceptionResponse(e);
-    }
-  }
-
-  @GET
-  @Path("/purpose/batch/{purposeIds}")
-  @RolesAllowed({Resource.ADMIN, Resource.CHAIRPERSON})
-  public Response getMatchesForPurposeIds(
-    @Auth AuthUser authUser, @QueryParam("purposeIds") String purposeIds
-  ) {
-    try {
-      if(Objects.isNull(purposeIds) || purposeIds.isBlank()) {
-        throw new BadRequestException("No purpose ids were provided");
-      } else {
-        List<String> purposeIdsList = Arrays.asList(purposeIds.split(","))
-          .stream()
-          .filter(id -> !id.isBlank())
-          .map(id -> id.strip())
-          .collect(Collectors.toList());
-
-        if(purposeIdsList.isEmpty()) {
-          throw new BadRequestException("Invalid query params provided");
-        } else {
-            List<Match> matchList = service.findMatchesForPurposeIds(purposeIdsList);
-            return Response.ok().entity(matchList).build();
-        }
-      }
-    } catch(Exception e) {
       return createExceptionResponse(e);
     }
   }

--- a/src/main/java/org/broadinstitute/consent/http/service/MatchService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/MatchService.java
@@ -114,6 +114,10 @@ public class MatchService {
         return matchDAO.findMatchesByConsentId(consentId);
     }
 
+    public List<Match> findMatchesForPurposeIds(List<String> purposeIds) {
+        return matchDAO.findMatchesForPurposeIds(purposeIds);
+    }
+
     public void reprocessMatchesForConsent(String consentId) {
         removeMatchesForConsent(consentId);
         if (!consentDAO.checkManualReview(consentId)) {

--- a/src/main/java/org/broadinstitute/consent/http/service/MatchService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/MatchService.java
@@ -114,8 +114,8 @@ public class MatchService {
         return matchDAO.findMatchesByConsentId(consentId);
     }
 
-    public List<Match> findMatchesForPurposeIds(List<String> purposeIds) {
-        return matchDAO.findMatchesForPurposeIds(purposeIds);
+    public List<Match> findMatchesForLatestDataAccessElectionsByPurposeIds(List<String> purposeIds) {
+        return matchDAO.findMatchesForLatestDataAccessElectionsByPurposeIds(purposeIds);
     }
 
     public void reprocessMatchesForConsent(String consentId) {

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -2785,6 +2785,33 @@ paths:
                   $ref: '#/components/schemas/MatchResult'
         500:
           description: Server error.
+  /api/match/purpose/batch/{purposeIds}:
+    get:
+      summary: Get all matches for the listed research purpose (DAR) ids 
+      description: Get all matches for the listed research purpose (DAR) ids
+      tags:
+        - Data Access Request
+        - Match
+      parameters:
+        - name: purposeIds
+          in: query
+          description: Data Access Request (or research purpose) IDs (comma separated)
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: Returns a list of match results of the listed Data Access Requests. If no results are found, no data is returned.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/MatchResult'
+        500:
+          description: Server error.
+        404:
+          description: Bad request
 
   /api/user:
     post:

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -2785,34 +2785,8 @@ paths:
                   $ref: '#/components/schemas/MatchResult'
         500:
           description: Server error.
-  /api/match/purpose/batch/{purposeIds}:
-    get:
-      summary: Get all matches for the listed research purpose (DAR) ids 
-      description: Get all matches for the listed research purpose (DAR) ids
-      tags:
-        - Data Access Request
-        - Match
-      parameters:
-        - name: purposeIds
-          in: query
-          description: Data Access Request (or research purpose) IDs (comma separated)
-          required: true
-          schema:
-            type: string
-      responses:
-        200:
-          description: Returns a list of match results of the listed Data Access Requests. If no results are found, no data is returned.
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/MatchResult'
-        500:
-          description: Server error.
-        404:
-          description: Bad request
-
+  /api/match/purpose/batch/:
+    $ref: './paths/getMatchesForLatestDataAccessElectionsByPurposeIds.yaml'
   /api/user:
     post:
       summary: Create User
@@ -3401,27 +3375,7 @@ components:
     Vote:
       $ref: './schemas/Vote.yaml'
     MatchResult:
-      type: object
-      properties:
-        id:
-          type: integer
-          description: The id of the stored match result
-        consent:
-          type: string
-          description: The Consent ID
-        purpose:
-          type: string
-          description: The Data Access Request ID
-        match:
-          type: boolean
-          description: The match condition between the Consent and Data Access Request
-        failed:
-          type: boolean
-          description: Indicates a system failure or not. If true, the system was not able to
-            perform a logic match between the two objects due to a server error.
-        createDate:
-          type: string
-          description: A string representation of the date that this match result was created.
+      $ref: './schemas/MatchResult.yaml'
     Match:
       type: object
       properties:

--- a/src/main/resources/assets/paths/getMatchesForLatestDataAccessElectionsByPurposeIds.yaml
+++ b/src/main/resources/assets/paths/getMatchesForLatestDataAccessElectionsByPurposeIds.yaml
@@ -1,0 +1,26 @@
+get:
+      summary: Get all matches for the listed research purpose (DAR) ids 
+      description: Get all matches for the listed research purpose (DAR) ids
+      tags:
+        - Data Access Request
+        - Match
+      parameters:
+        - name: purposeIds
+          in: query
+          description: Data Access Request (or research purpose) IDs (comma separated)
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: Returns a list of match results of the listed Data Access Requests. If no results are found, no data is returned.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '../schemas/MatchResult.yaml'
+        500:
+          description: Server error.
+        404:
+          description: Bad request

--- a/src/main/resources/assets/schemas/MatchResult.yaml
+++ b/src/main/resources/assets/schemas/MatchResult.yaml
@@ -1,0 +1,21 @@
+type: object
+properties:
+  id:
+    type: integer
+    description: The id of the stored match result
+  consent:
+    type: string
+    description: The Consent ID
+  purpose:
+    type: string
+    description: The Data Access Request ID
+  match:
+    type: boolean
+    description: The match condition between the Consent and Data Access Request
+  failed:
+    type: boolean
+    description: Indicates a system failure or not. If true, the system was not able to
+      perform a logic match between the two objects due to a server error.
+  createDate:
+    type: string
+    description: A string representation of the date that this match result was created.

--- a/src/test/java/org/broadinstitute/consent/http/db/MatchDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/MatchDAOTest.java
@@ -143,7 +143,7 @@ public class MatchDAOTest extends DAOTestHelper {
     // This is included simply to test the DataAccess conditional on the INNER JOIN statement
     matchDAO.insertMatch(consentId, rpElection.getReferenceId(), false, false, new Date());
 
-    List<Match> matchResults = matchDAO.findMatchesForPurposeIds(List.of(darReferenceId));
+    List<Match> matchResults = matchDAO.findMatchesForBatchPurposeIds(List.of(darReferenceId));
     assertEquals(1, matchResults.size());
     Match result = matchResults.get(0);
     assertEquals(targetElection.getReferenceId(), result.getPurpose());
@@ -172,7 +172,7 @@ public class MatchDAOTest extends DAOTestHelper {
 
     //Negative testing means we'll feed the query a reference id that isn't tied to a DataAccess election
     //Again, a match like this usually isn't generated in a normal workflow unless bug occurs, but having the 'DataAccess' condition is a nice safety net
-    List<Match> matchResults = matchDAO.findMatchesForPurposeIds(List.of(darReferenceId));
+    List<Match> matchResults = matchDAO.findMatchesForBatchPurposeIds(List.of(darReferenceId));
     assertTrue(matchResults.isEmpty());
   }
 }

--- a/src/test/java/org/broadinstitute/consent/http/db/MatchDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/MatchDAOTest.java
@@ -116,7 +116,7 @@ public class MatchDAOTest extends DAOTestHelper {
   }
 
   @Test
-  public void testFindMatchesForPurposeIds() {
+  public void testFindMatchesForLatestDataAccessElectionsByPurposeIds() {
     Dataset dataset = createDataset();
     //query should pull the latest election for a given reference id
     //creating two access elections with the same reference id and datasetid to test that condition
@@ -143,14 +143,14 @@ public class MatchDAOTest extends DAOTestHelper {
     // This is included simply to test the DataAccess conditional on the INNER JOIN statement
     matchDAO.insertMatch(consentId, rpElection.getReferenceId(), false, false, new Date());
 
-    List<Match> matchResults = matchDAO.findMatchesForBatchPurposeIds(List.of(darReferenceId));
+    List<Match> matchResults = matchDAO.findMatchesForLatestDataAccessElectionsByPurposeIds(List.of(darReferenceId));
     assertEquals(1, matchResults.size());
     Match result = matchResults.get(0);
     assertEquals(targetElection.getReferenceId(), result.getPurpose());
   }
 
   @Test
-  public void testFindMatchesForPurposeIds_NegativeTest() {
+  public void testFindMatchesForLatestDataAccessElectionsByPurposeIds_NegativeTest() {
     Dataset dataset = createDataset();
     String darReferenceId = UUID.randomUUID().toString();
 
@@ -172,7 +172,7 @@ public class MatchDAOTest extends DAOTestHelper {
 
     //Negative testing means we'll feed the query a reference id that isn't tied to a DataAccess election
     //Again, a match like this usually isn't generated in a normal workflow unless bug occurs, but having the 'DataAccess' condition is a nice safety net
-    List<Match> matchResults = matchDAO.findMatchesForBatchPurposeIds(List.of(darReferenceId));
+    List<Match> matchResults = matchDAO.findMatchesForLatestDataAccessElectionsByPurposeIds(List.of(darReferenceId));
     assertTrue(matchResults.isEmpty());
   }
 }

--- a/src/test/java/org/broadinstitute/consent/http/resources/MatchResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/MatchResourceTest.java
@@ -9,7 +9,6 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-import javax.ws.rs.BadRequestException;
 import javax.ws.rs.NotFoundException;
 import javax.ws.rs.ServerErrorException;
 import javax.ws.rs.core.Response;
@@ -18,7 +17,6 @@ import java.util.List;
 import java.util.UUID;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.doNothing;

--- a/src/test/java/org/broadinstitute/consent/http/resources/MatchResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/MatchResourceTest.java
@@ -9,14 +9,18 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+import javax.ws.rs.BadRequestException;
 import javax.ws.rs.NotFoundException;
 import javax.ws.rs.ServerErrorException;
 import javax.ws.rs.core.Response;
 import java.util.Collections;
+import java.util.List;
 import java.util.UUID;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
@@ -88,8 +92,33 @@ public class MatchResourceTest {
     when(service.findMatchesByPurposeId(any())).thenReturn(Collections.singletonList(new Match()));
     initResource();
 
-    Response response = resource.getMatchesForPurpose(authUser,
-            UUID.randomUUID().toString());
+    Response response = resource.getMatchesForPurposeIds(authUser,
+      UUID.randomUUID().toString());
+    assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+  }
+
+  @Test
+  public void testGetMatchesForPurpose_EmptyParam() {
+    initResource();
+    Response response = resource.getMatchesForPurposeIds(authUser, "");
+    assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
+  }
+
+  @Test
+  public void testGetMatchesForPurpose_CommaSeparatedBlanks() {
+    initResource();
+    Response response = resource.getMatchesForPurposeIds(authUser, " , , ,");
+    assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
+  }
+
+  @Test
+  public void testGetMatchesForPurpose_PartialValidIds() {
+    Match match = new Match();
+    match.setId(2);
+    when(service.findMatchesForPurposeIds(anyList())).thenReturn(List.of(match));
+    initResource();
+
+    Response response = resource.getMatchesForPurposeIds(authUser, "3, , 5, ");
     assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/resources/MatchResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/MatchResourceTest.java
@@ -90,7 +90,7 @@ public class MatchResourceTest {
     when(service.findMatchesByPurposeId(any())).thenReturn(Collections.singletonList(new Match()));
     initResource();
 
-    Response response = resource.getMatchesForPurposeIds(authUser,
+    Response response = resource.getMatchesForLatestDataAccessElectionsByPurposeIds(authUser,
       UUID.randomUUID().toString());
     assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
   }
@@ -98,14 +98,14 @@ public class MatchResourceTest {
   @Test
   public void testGetMatchesForPurpose_EmptyParam() {
     initResource();
-    Response response = resource.getMatchesForPurposeIds(authUser, "");
+    Response response = resource.getMatchesForLatestDataAccessElectionsByPurposeIds(authUser, "");
     assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
   }
 
   @Test
   public void testGetMatchesForPurpose_CommaSeparatedBlanks() {
     initResource();
-    Response response = resource.getMatchesForPurposeIds(authUser, " , , ,");
+    Response response = resource.getMatchesForLatestDataAccessElectionsByPurposeIds(authUser, " , , ,");
     assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
   }
 
@@ -113,10 +113,10 @@ public class MatchResourceTest {
   public void testGetMatchesForPurpose_PartialValidIds() {
     Match match = new Match();
     match.setId(2);
-    when(service.findMatchesForPurposeIds(anyList())).thenReturn(List.of(match));
+    when(service.findMatchesForLatestDataAccessElectionsByPurposeIds(anyList())).thenReturn(List.of(match));
     initResource();
 
-    Response response = resource.getMatchesForPurposeIds(authUser, "3, , 5, ");
+    Response response = resource.getMatchesForLatestDataAccessElectionsByPurposeIds(authUser, "3, , 5, ");
     assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/service/MatchServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/MatchServiceTest.java
@@ -302,12 +302,14 @@ public class MatchServiceTest {
     }
 
     @Test
-    public void testFindMatchesForPurposeIds() {
-        Match mockMatch = new Match();
-        when(matchDAO.findMatchesForPurposeIds(anyList()))
+    public void testFindMatchesForLatestDataAccessElectionsByPurposeIds() {
+        Match mockMatch = new Match(1, "test", "purpose", true, true, null);
+        when(matchDAO.findMatchesForLatestDataAccessElectionsByPurposeIds(anyList()))
             .thenReturn(List.of(mockMatch));
         initService();
-        service.findMatchesForPurposeIds(List.of("test"));
+        List<Match> matches = service.findMatchesForLatestDataAccessElectionsByPurposeIds(List.of("test"));
+        assertEquals(1, matches.size());
+        assertEquals(mockMatch.getId(), matches.get(0).getId());
     }
 
     @SuppressWarnings("unchecked")

--- a/src/test/java/org/broadinstitute/consent/http/service/MatchServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/MatchServiceTest.java
@@ -50,6 +50,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.doAnswer;
@@ -298,6 +299,15 @@ public class MatchServiceTest {
         initService();
 
         service.removeMatchesForConsent(sampleConsent1.getConsentId());
+    }
+
+    @Test
+    public void testFindMatchesForPurposeIds() {
+        Match mockMatch = new Match();
+        when(matchDAO.findMatchesForPurposeIds(anyList()))
+            .thenReturn(List.of(mockMatch));
+        initService();
+        service.findMatchesForPurposeIds(List.of("test"));
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
Partially addresses [DUOS-1785](https://broadworkbench.atlassian.net/browse/DUOS-1785)

Since the codebase has moved away from updating/using `AGREEMENT` votes, the `DarCollectionReview` will need to obtain the match data via endpoint. Since the elections are bucketed by `dataUse`, the front-end can pick out one `DataAccess` election's `referenceId` per bucket and provide that as query param (via comma separated string).

This PR provides the backend adjustments to ensure that occurs by updating and/or creating endpoints, service methods, DAO queries, and tests as needed.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
