### PR TITLE
[DUOS-1783][risk=no] Update cancel Elections for Collection workflow

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/ElectionDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/ElectionDAO.java
@@ -171,9 +171,9 @@ public interface ElectionDAO extends Transactional<ElectionDAO> {
     List<Election> findElectionsByReferenceId(@Bind("referenceId") String referenceId);
 
     @UseRowMapper(SimpleElectionMapper.class)
-    @SqlQuery("SELECT * FROM election e " + 
+    @SqlQuery("SELECT * FROM election e " +
         "INNER JOIN vote v ON v.electionid = e.electionid " +
-        "WHERE LOWER(e.electiontype) = :electionType " + 
+        "WHERE LOWER(e.electiontype) = :electionType " +
         "AND v.voteid IN (<voteIds>)")
 	List<Election> findElectionsByVoteIdsAndType(
 	    @BindList("voteIds") List<Integer> voteIds,
@@ -209,6 +209,13 @@ public interface ElectionDAO extends Transactional<ElectionDAO> {
     @UseRowMapper(ElectionMapper.class)
     List<Election> findLastElectionsByReferenceIds(
       @BindList("referenceIds") List<String> referenceIds);
+
+    @SqlQuery(" SELECT distinct e.* " +
+        " FROM election e " +
+        " WHERE LOWER(e.status) = 'open' " +
+        " AND e.referenceid IN (<referenceIds>) ")
+    @UseRowMapper(ElectionMapper.class)
+    List<Election> findOpenElectionsByReferenceIds(@BindList("referenceIds") List<String> referenceIds);
 
     @SqlQuery("select distinct e.electionId,  e.datasetId, v.vote finalVote, e.status, e.createDate, e.referenceId, v.rationale finalRationale, " +
             "v.createDate finalVoteDate, e.lastUpdate, e.finalAccessVote, e.electionType, e.dataUseLetter, e.dulName, e.archived, e.version  from election e " +

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/ElectionMapper.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/ElectionMapper.java
@@ -22,46 +22,46 @@ public class ElectionMapper implements RowMapper<Election>, RowMapperHelper {
             election = new Election();
             election.setElectionId(r.getInt(ElectionFields.ID.getValue()));
         }
-        if (r.getString(ElectionFields.TYPE.getValue()) != null) {
+        if (hasColumn(r, ElectionFields.TYPE.getValue()) && r.getString(ElectionFields.TYPE.getValue()) != null) {
             election.setElectionType(r.getString(ElectionFields.TYPE.getValue()));
         }
-        if (r.getString(ElectionFields.FINAL_VOTE.getValue()) != null) {
+        if (hasColumn(r, ElectionFields.FINAL_VOTE.getValue()) && r.getString(ElectionFields.FINAL_VOTE.getValue()) != null) {
             election.setFinalVote(r.getBoolean(ElectionFields.FINAL_VOTE.getValue()));
         }
-        if (r.getString(ElectionFields.FINAL_RATIONALE.getValue()) != null) {
+        if (hasColumn(r, ElectionFields.FINAL_RATIONALE.getValue()) && r.getString(ElectionFields.FINAL_RATIONALE.getValue()) != null) {
             election.setFinalRationale(r.getString(ElectionFields.FINAL_RATIONALE.getValue()));
         }
-        if (r.getString(ElectionFields.STATUS.getValue()) != null) {
+        if (hasColumn(r, ElectionFields.STATUS.getValue()) && r.getString(ElectionFields.STATUS.getValue()) != null) {
             election.setStatus(r.getString(ElectionFields.STATUS.getValue()));
         }
-        if (r.getDate(ElectionFields.CREATE_DATE.getValue()) != null) {
+        if (hasColumn(r, ElectionFields.CREATE_DATE.getValue()) && r.getDate(ElectionFields.CREATE_DATE.getValue()) != null) {
             election.setCreateDate(r.getDate(ElectionFields.CREATE_DATE.getValue()));
         }
-        if (r.getDate(ElectionFields.FINAL_VOTE_DATE.getValue()) != null) {
+        if (hasColumn(r, ElectionFields.FINAL_VOTE_DATE.getValue()) && r.getDate(ElectionFields.FINAL_VOTE_DATE.getValue()) != null) {
             election.setFinalVoteDate(r.getDate(ElectionFields.FINAL_VOTE_DATE.getValue()));
         }
-        if (r.getString(ElectionFields.REFERENCE_ID.getValue()) != null) {
+        if (hasColumn(r, ElectionFields.REFERENCE_ID.getValue()) && r.getString(ElectionFields.REFERENCE_ID.getValue()) != null) {
             election.setReferenceId(r.getString(ElectionFields.REFERENCE_ID.getValue()));
         }
-        if (r.getDate(ElectionFields.LAST_UPDATE.getValue()) != null) {
+        if (hasColumn(r, ElectionFields.LAST_UPDATE.getValue()) && r.getDate(ElectionFields.LAST_UPDATE.getValue()) != null) {
             election.setLastUpdate(r.getDate(ElectionFields.LAST_UPDATE.getValue()));
         }
-        if (r.getString(ElectionFields.FINAL_ACCESS_VOTE.getValue()) != null) {
+        if (hasColumn(r, ElectionFields.FINAL_ACCESS_VOTE.getValue()) && r.getString(ElectionFields.FINAL_ACCESS_VOTE.getValue()) != null) {
             election.setFinalAccessVote(r.getBoolean(ElectionFields.FINAL_ACCESS_VOTE.getValue()));
         }
-        if (r.getObject(ElectionFields.DATASET_ID.getValue()) != null) {
+        if (hasColumn(r, ElectionFields.DATASET_ID.getValue()) && r.getObject(ElectionFields.DATASET_ID.getValue()) != null) {
             election.setDataSetId(r.getInt(ElectionFields.DATASET_ID.getValue()));
         }
-        if (r.getString(ElectionFields.DATA_USE_LETTER.getValue()) != null) {
+        if (hasColumn(r, ElectionFields.DATA_USE_LETTER.getValue()) && r.getString(ElectionFields.DATA_USE_LETTER.getValue()) != null) {
             election.setDataUseLetter(r.getString(ElectionFields.DATA_USE_LETTER.getValue()));
         }
-        if (r.getString(ElectionFields.DUL_NAME.getValue()) != null) {
+        if (hasColumn(r, ElectionFields.DUL_NAME.getValue()) && r.getString(ElectionFields.DUL_NAME.getValue()) != null) {
             election.setDulName(r.getString(ElectionFields.DUL_NAME.getValue()));
         }
-        if (r.getObject(ElectionFields.VERSION.getValue()) != null) {
+        if (hasColumn(r, ElectionFields.VERSION.getValue()) && r.getObject(ElectionFields.VERSION.getValue()) != null) {
             election.setVersion(r.getInt(ElectionFields.VERSION.getValue()));
         }
-        if (r.getString(ElectionFields.ARCHIVED.getValue()) != null) {
+        if (hasColumn(r, ElectionFields.ARCHIVED.getValue()) && r.getString(ElectionFields.ARCHIVED.getValue()) != null) {
             election.setArchived(r.getBoolean(ElectionFields.ARCHIVED.getValue()));
         }
         electionMap.put(election.getElectionId(), election);

--- a/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
@@ -413,7 +413,7 @@ public class DarCollectionService {
 
   // Private helper method to mark Elections as 'Canceled'
   private void cancelElectionsForReferenceIds(List<String> referenceIds) {
-    List<Election> elections = electionDAO.findLastElectionsByReferenceIds(referenceIds);
+    List<Election> elections = electionDAO.findOpenElectionsByReferenceIds(referenceIds);
     elections.forEach(election -> {
       if (!election.getStatus().equals(ElectionStatus.CANCELED.getValue())) {
         electionDAO.updateElectionById(election.getElectionId(), ElectionStatus.CANCELED.getValue(), new Date());

--- a/src/test/java/org/broadinstitute/consent/http/db/ElectionDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/ElectionDAOTest.java
@@ -340,7 +340,7 @@ public class ElectionDAOTest extends DAOTestHelper {
     Vote rpVote = createChairpersonVote(userId, rpElection.getElectionId());
     List<Integer> voteIds = List.of(accessVote.getVoteId(), rpVote.getVoteId());
     List<Election> elections = electionDAO.findElectionsByVoteIdsAndType(voteIds, "dataaccess");
-    
+
     assertEquals(1, elections.size());
     assertEquals(accessElection.getElectionId(), elections.get(0).getElectionId());
   }
@@ -359,7 +359,7 @@ public class ElectionDAOTest extends DAOTestHelper {
     Vote rpVote = createChairpersonVote(userId, rpElection.getElectionId());
     List<Integer> voteIds = List.of(accessVote.getVoteId(), rpVote.getVoteId());
     List<Election> elections = electionDAO.findElectionsByVoteIdsAndType(voteIds, "rp");
-    
+
     assertEquals(1, elections.size());
     assertEquals(rpElection.getElectionId(), elections.get(0).getElectionId());
   }
@@ -380,5 +380,22 @@ public class ElectionDAOTest extends DAOTestHelper {
 
     assertEquals(1, elections.size());
     assertEquals(elections.get(0).getElectionId(), lcElection.getElectionId());
+  }
+
+  @Test
+  public void testFindOpenElectionsByReferenceIds() {
+    DataAccessRequest dar = createDataAccessRequestV3();
+    Dataset dataset = createDataset();
+    String referenceId = dar.getReferenceId();
+    int datasetId = dataset.getDataSetId();
+    Election accessElection = createAccessElection(referenceId, datasetId);
+    Election rpElection = createRPElection(referenceId, datasetId);
+
+    List<Election> elections = electionDAO.findOpenElectionsByReferenceIds(List.of(dar.referenceId));
+    assertEquals(2, elections.size());
+
+    electionDAO.updateElectionStatus(List.of(accessElection.getElectionId(), rpElection.getElectionId()), ElectionStatus.CANCELED.getValue());
+    List<Election> electionsV2 = electionDAO.findOpenElectionsByReferenceIds(List.of(dar.referenceId));
+    assertEquals(0, electionsV2.size());
   }
 }

--- a/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
@@ -349,14 +349,14 @@ public class DarCollectionServiceTest {
     election.setReferenceId(dar.getReferenceId());
     election.setStatus(ElectionStatus.OPEN.getValue());
     election.setElectionId(1);
-    when(electionDAO.findLastElectionsByReferenceIds(anyList())).thenReturn(List.of(election));
+    when(electionDAO.findOpenElectionsByReferenceIds(anyList())).thenReturn(List.of(election));
     spy(electionDAO);
     spy(dataAccessRequestDAO);
     spy(darCollectionDAO);
     initService();
 
     service.cancelDarCollectionElectionsAsAdmin(collection);
-    verify(electionDAO, times(1)).findLastElectionsByReferenceIds(anyList());
+    verify(electionDAO, times(1)).findOpenElectionsByReferenceIds(anyList());
     verify(electionDAO, times(1)).updateElectionById(anyInt(), anyString(), any());
     verify(dataAccessRequestDAO, times(0)).cancelByReferenceIds(anyList());
     verify(darCollectionDAO, times(1)).findDARCollectionByCollectionId(anyInt());
@@ -380,7 +380,7 @@ public class DarCollectionServiceTest {
     election.setStatus(ElectionStatus.OPEN.getValue());
     election.setElectionId(1);
     when(datasetDAO.findDatasetsByAuthUserEmail(anyString())).thenReturn(List.of(dataset));
-    when(electionDAO.findLastElectionsByReferenceIds(anyList())).thenReturn(List.of(election));
+    when(electionDAO.findOpenElectionsByReferenceIds(anyList())).thenReturn(List.of(election));
     spy(datasetDAO);
     spy(electionDAO);
     spy(dataAccessRequestDAO);
@@ -389,7 +389,7 @@ public class DarCollectionServiceTest {
 
     service.cancelDarCollectionElectionsAsChair(collection, user);
     verify(datasetDAO, times(1)).findDatasetsByAuthUserEmail(anyString());
-    verify(electionDAO, times(1)).findLastElectionsByReferenceIds(anyList());
+    verify(electionDAO, times(1)).findOpenElectionsByReferenceIds(anyList());
     verify(electionDAO, times(1)).updateElectionById(anyInt(), anyString(), any());
     verify(dataAccessRequestDAO, times(0)).cancelByReferenceIds(anyList());
     verify(darCollectionDAO, times(1)).findDARCollectionByCollectionId(anyInt());


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-1783

The current cancel elections for collection query was not pulling back all OPEN elections and therefore not canceling all elections. This had a downstream impact on creating new elections such that previously open ones were blocking the creation of new ones, along with the relevant votes for a new one. This had another downstream effect that the collection would be returned to the UI with missing elections and votes.

This PR fixes the cancel feature by ensuring that we always cancel all open elections so that subsequent operations do not fail.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
