### PR TITLE
[DUOS=1806][risk=no] Return populated collection after cancel

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
@@ -324,7 +324,7 @@ public class DarCollectionService {
       dataAccessRequestDAO.cancelByReferenceIds(activeDarIds);
     }
 
-    return darCollectionDAO.findDARCollectionByCollectionId(collection.getDarCollectionId());
+    return getByCollectionId(collection.getDarCollectionId());
   }
 
   /**

--- a/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
@@ -307,6 +307,7 @@ public class DarCollectionServiceTest {
     DarCollection collection = createMockCollections(1).get(0);
     collection.setDars(Map.of(dar.getReferenceId(), dar));
     when(electionDAO.findLastElectionsByReferenceIds(anyList())).thenReturn(List.of());
+    when(darCollectionDAO.findDARCollectionByCollectionId(any())).thenReturn(collection);
     spy(electionDAO);
     spy(dataAccessRequestDAO);
     spy(darCollectionDAO);


### PR DESCRIPTION
## Addresses
Partially addresses https://broadworkbench.atlassian.net/browse/DUOS-1806
Necessary to return the datasets when a collection is canceled.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
