### PR TITLE
[DUOS-1792][risk=no] filter out canceled dars

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
@@ -89,7 +89,11 @@ public class DarCollectionService {
     } else {
       collections.addAll(getCollectionsForUser(user));
     }
-    return collections;
+    return collections.stream().filter(collection -> !containsCanceledDars(collection)).collect(Collectors.toList());
+  }
+
+  private boolean containsCanceledDars(DarCollection collection) {
+    return collection.getDars().values().stream().anyMatch(DataAccessRequest::isCanceled);
   }
 
   /**
@@ -199,8 +203,8 @@ public class DarCollectionService {
 
   private List<Integer> getDacIdsFromUser (User user) {
     return user.getRoles().stream()
-            .filter(role -> Objects.nonNull(role.getDacId()))
             .map(UserRole::getDacId)
+            .filter(Objects::nonNull)
             .distinct()
             .collect(Collectors.toList());
   }

--- a/src/main/resources/assets/paths/collectionsByRoleName.yaml
+++ b/src/main/resources/assets/paths/collectionsByRoleName.yaml
@@ -1,6 +1,11 @@
 get:
   summary: Get DAR Collection(s) By Role Name
-  description: Returns DAR collections by Role Name
+  description: |
+    Returns DAR collections by Role Name
+      * Admin - all DAR collections
+      * DAC Chair/Member - collections requesting datasets associated with their DAC 
+      * Signing Official - collections created by researchers belonging to their institution 
+    Canceled DAR collections are not returned
   tags:
     - DAR Collection
   parameters:

--- a/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
@@ -7,6 +7,7 @@ import org.broadinstitute.consent.http.db.DataAccessRequestDAO;
 import org.broadinstitute.consent.http.db.DatasetDAO;
 import org.broadinstitute.consent.http.db.ElectionDAO;
 import org.broadinstitute.consent.http.db.VoteDAO;
+import org.broadinstitute.consent.http.enumeration.DarStatus;
 import org.broadinstitute.consent.http.enumeration.ElectionStatus;
 import org.broadinstitute.consent.http.enumeration.ElectionType;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
@@ -132,6 +133,23 @@ public class DarCollectionServiceTest {
 
     List<DarCollection> collections = service.getCollectionsForUserByRoleName(user, null);
     assertEquals(1, collections.size());
+  }
+
+  @Test
+  public void testGetCollectionsForUserByRoleName_NoCanceledCollections() {
+    User user = new User();
+    user.addRole(new UserRole(UserRoles.ADMIN.getRoleId(), UserRoles.ADMIN.getRoleName()));
+    DataAccessRequestData canceledDarData = new DataAccessRequestData();
+    canceledDarData.setStatus(DarStatus.CANCELED.getValue());
+    DataAccessRequest canceledDar = new DataAccessRequest();
+    canceledDar.setData(canceledDarData);
+    DarCollection canceledCollection = new DarCollection();
+    canceledCollection.addDar(canceledDar);
+    when(darCollectionDAO.findAllDARCollections()).thenReturn(List.of(canceledCollection));
+    initService();
+
+    List<DarCollection> collections = service.getCollectionsForUserByRoleName(user, UserRoles.ADMIN.getRoleName());
+    assertEquals(0, collections.size());
   }
 
   @Test


### PR DESCRIPTION
[Link to Jira ticket](https://broadworkbench.atlassian.net/browse/DUOS-1792)
Summary of changes:

- Filter out collections that contain a DAR with a Canceled status from the `api/collections/role/{roleName}` 
- Add test to ensure collections with canceled DARs are not returned 

Testing:
- As a researcher, have or create a DAR that is visible to other users/roles that you have on the admin/chair/member/signing official consoles
- Cancel DAR as researcher 
- Check that the DAR is no longer visible on the different consoles

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
