### PR TITLE
[DUOS-1806][risk=no] Handle potential NPE

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
@@ -283,7 +283,7 @@ public class DataAccessRequestService {
                 .map(DataAccessRequest::getData)
                 .filter(d -> DarStatus.CANCELED.getValue().equalsIgnoreCase(d.getStatus()))
                 .map(DataAccessRequestData::getReferenceId)
-                .collect(Collectors.toUnmodifiableList());
+                .collect(Collectors.toList());
         List<Integer> electionIds = electionDAO.getElectionIdsByReferenceIds(canceledReferenceIds);
         if (!electionIds.isEmpty()) {
             String errorMessage = "Found 'Open' elections for canceled DARs in collection id: " + sourceCollection.getDarCollectionId();


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-1806

Fix for bug discovered while reviewing https://github.com/DataBiosphere/duos-ui/pull/1559
`Collectors.toUnmodifiableList` was throwing an NPE when iterating over a single reference id. Moving that to a more traditional `toList` was enough to get past that error.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
