### PR TITLE
[DUOS-1740][risk=no] Test Cleanup

### DIFF
--- a/src/test/java/org/broadinstitute/consent/http/db/ConsentDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/ConsentDAOTest.java
@@ -8,6 +8,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
+import java.util.Calendar;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
@@ -33,7 +34,7 @@ public class ConsentDAOTest extends DAOTestHelper {
     public void testFindConsentFromDatasetID() {
         Dataset dataset = createDataset();
         Consent consent = createConsent(null);
-        createAssociation(consent.getConsentId(), dataset.getDataSetId());
+        consentDAO.insertConsentAssociation(consent.getConsentId(), ASSOCIATION_TYPE_TEST, dataset.getDataSetId());
 
         Consent foundConsent = consentDAO.findConsentFromDatasetID(dataset.getDataSetId());
         assertNotNull(foundConsent);
@@ -43,7 +44,7 @@ public class ConsentDAOTest extends DAOTestHelper {
     public void testFindConsentNameFromDatasetID() {
         Dataset dataset = createDataset();
         Consent consent = createConsent(null);
-        createAssociation(consent.getConsentId(), dataset.getDataSetId());
+        consentDAO.insertConsentAssociation(consent.getConsentId(), ASSOCIATION_TYPE_TEST, dataset.getDataSetId());
 
         String name = consentDAO.findConsentNameFromDatasetID(dataset.getDataSetId());
         assertNotNull(name);
@@ -162,8 +163,10 @@ public class ConsentDAOTest extends DAOTestHelper {
     @Test
     public void testUpdateConsentSortDate() {
         Consent consent = createConsent(null);
-
-        consentDAO.updateConsentSortDate(consent.getConsentId(), yesterday());
+        final Calendar cal = Calendar.getInstance();
+        cal.add(Calendar.DATE, -1);
+        Date yesterday = cal.getTime();
+        consentDAO.updateConsentSortDate(consent.getConsentId(), yesterday);
         Consent foundConsent = consentDAO.findConsentById(consent.getConsentId());
         assertTrue(foundConsent.getSortDate().before(consent.getSortDate()));
     }
@@ -187,7 +190,7 @@ public class ConsentDAOTest extends DAOTestHelper {
     public void testFindAssociationByTypeAndId() {
         Dataset dataset = createDataset();
         Consent consent = createConsent(null);
-        createAssociation(consent.getConsentId(), dataset.getDataSetId());
+        consentDAO.insertConsentAssociation(consent.getConsentId(), ASSOCIATION_TYPE_TEST, dataset.getDataSetId());
 
         List<String> associations = consentDAO.findAssociationsByType(consent.getConsentId(), ASSOCIATION_TYPE_TEST);
         assertNotNull(associations);
@@ -204,8 +207,8 @@ public class ConsentDAOTest extends DAOTestHelper {
         Dataset dataset = createDataset();
         Dataset dataset2 = createDataset();
         Consent consent = createConsent(null);
-        createAssociation(consent.getConsentId(), dataset.getDataSetId());
-        createAssociation(consent.getConsentId(), dataset2.getDataSetId());
+        consentDAO.insertConsentAssociation(consent.getConsentId(), ASSOCIATION_TYPE_TEST, dataset.getDataSetId());
+        consentDAO.insertConsentAssociation(consent.getConsentId(), ASSOCIATION_TYPE_TEST, dataset2.getDataSetId());
 
         consentDAO.deleteOneAssociation(
                 consent.getConsentId(),
@@ -222,8 +225,8 @@ public class ConsentDAOTest extends DAOTestHelper {
         Dataset dataset = createDataset();
         Dataset dataset2 = createDataset();
         Consent consent = createConsent(null);
-        createAssociation(consent.getConsentId(), dataset.getDataSetId());
-        createAssociation(consent.getConsentId(), dataset2.getDataSetId());
+        consentDAO.insertConsentAssociation(consent.getConsentId(), ASSOCIATION_TYPE_TEST, dataset.getDataSetId());
+        consentDAO.insertConsentAssociation(consent.getConsentId(), ASSOCIATION_TYPE_TEST, dataset2.getDataSetId());
 
         consentDAO.deleteAllAssociationsForType(consent.getConsentId(), ASSOCIATION_TYPE_TEST);
         List<String> associationTypes = consentDAO.findAssociationTypesForConsent(consent.getConsentId());
@@ -240,8 +243,8 @@ public class ConsentDAOTest extends DAOTestHelper {
         Dataset dataset = createDataset();
         Dataset dataset2 = createDataset();
         Consent consent = createConsent(null);
-        createAssociation(consent.getConsentId(), dataset.getDataSetId());
-        createAssociation(consent.getConsentId(), dataset2.getDataSetId());
+        consentDAO.insertConsentAssociation(consent.getConsentId(), ASSOCIATION_TYPE_TEST, dataset.getDataSetId());
+        consentDAO.insertConsentAssociation(consent.getConsentId(), ASSOCIATION_TYPE_TEST, dataset2.getDataSetId());
 
         datasetDAO.deleteConsentAssociationsByDatasetId(dataset.getDataSetId());
         Integer deletedAssociationId = consentDAO.findAssociationsByDataSetId(dataset.getDataSetId());
@@ -260,8 +263,8 @@ public class ConsentDAOTest extends DAOTestHelper {
         Dataset dataset = createDataset();
         Dataset dataset2 = createDataset();
         Consent consent = createConsent(null);
-        createAssociation(consent.getConsentId(), dataset.getDataSetId());
-        createAssociation(consent.getConsentId(), dataset2.getDataSetId());
+        consentDAO.insertConsentAssociation(consent.getConsentId(), ASSOCIATION_TYPE_TEST, dataset.getDataSetId());
+        consentDAO.insertConsentAssociation(consent.getConsentId(), ASSOCIATION_TYPE_TEST, dataset2.getDataSetId());
 
         List<String> associationTypes = consentDAO.findAssociationTypesForConsent(consent.getConsentId());
         assertNotNull(associationTypes);
@@ -306,7 +309,7 @@ public class ConsentDAOTest extends DAOTestHelper {
     public void testFindConsentManageByStatus() {
         Consent consent = createConsent(null);
         Dataset dataset = createDataset();
-        createAssociation(consent.getConsentId(), dataset.getDataSetId());
+        consentDAO.insertConsentAssociation(consent.getConsentId(), ASSOCIATION_TYPE_TEST, dataset.getDataSetId());
         Election election = createAccessElection(consent.getConsentId(), dataset.getDataSetId());
 
         List<ConsentManage> consentManages = consentDAO.findConsentManageByStatus(election.getStatus());
@@ -318,7 +321,7 @@ public class ConsentDAOTest extends DAOTestHelper {
     public void testGetAssociationConsentIdsFromDatasetIds() {
         Consent consent = createConsent(null);
         Dataset dataset = createDataset();
-        createAssociation(consent.getConsentId(), dataset.getDataSetId());
+        consentDAO.insertConsentAssociation(consent.getConsentId(), ASSOCIATION_TYPE_TEST, dataset.getDataSetId());
         List<Integer> dataSetIds = Stream.of(dataset.getDataSetId()).collect(Collectors.toList());
 
         List<String> consentIds = consentDAO.getAssociationConsentIdsFromDatasetIds(dataSetIds);

--- a/src/test/java/org/broadinstitute/consent/http/db/ConsentDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/ConsentDAOTest.java
@@ -310,7 +310,7 @@ public class ConsentDAOTest extends DAOTestHelper {
         Consent consent = createConsent(null);
         Dataset dataset = createDataset();
         consentDAO.insertConsentAssociation(consent.getConsentId(), ASSOCIATION_TYPE_TEST, dataset.getDataSetId());
-        Election election = createAccessElection(consent.getConsentId(), dataset.getDataSetId());
+        Election election = createDataAccessElection(consent.getConsentId(), dataset.getDataSetId());
 
         List<ConsentManage> consentManages = consentDAO.findConsentManageByStatus(election.getStatus());
         List<String> consentIds = consentManages.stream().map(ConsentManage::getConsentId).collect(Collectors.toList());

--- a/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
@@ -86,7 +86,7 @@ public class DAOTestHelper {
     // of all records between test runs.
     private static TestingDAO testingDAO;
 
-    String ASSOCIATION_TYPE_TEST = RandomStringUtils.random(10, true, false);
+    public String ASSOCIATION_TYPE_TEST = RandomStringUtils.random(10, true, false);
 
     @BeforeClass
     public static void startUp() throws Exception {
@@ -166,10 +166,6 @@ public class DAOTestHelper {
         testingDAO.deleteAllDARs();
         testingDAO.deleteAllDARCollections();
         testingDAO.deleteAllCounters();
-    }
-
-    protected void createAssociation(String consentId, Integer datasetId) {
-        consentDAO.insertConsentAssociation(consentId, ASSOCIATION_TYPE_TEST, datasetId);
     }
 
     protected Election createAccessElection(String referenceId, Integer datasetId) {
@@ -261,12 +257,6 @@ public class DAOTestHelper {
         return voteDAO.findVoteById(voteId);
     }
 
-    protected Vote createPopulatedFinalVote(Integer userId, Integer electionId) {
-        Integer voteId = voteDAO.insertVote(userId, electionId, VoteType.FINAL.getValue());
-        voteDAO.updateVote(true, "rationale", new Date(), voteId, false, electionId, new Date(), false);
-        return voteDAO.findVoteById(voteId);
-    }
-
     protected Vote createChairpersonVote(Integer userId, Integer electionId) {
         Integer voteId = voteDAO.insertVote(userId, electionId, VoteType.CHAIRPERSON.getValue());
         return voteDAO.findVoteById(voteId);
@@ -274,12 +264,6 @@ public class DAOTestHelper {
 
     protected Vote createPopulatedChairpersonVote(Integer userId, Integer electionId) {
         Integer voteId = voteDAO.insertVote(userId, electionId, VoteType.CHAIRPERSON.getValue());
-        voteDAO.updateVote(true, "rationale", new Date(), voteId, false, electionId, new Date(), false);
-        return voteDAO.findVoteById(voteId);
-    }
-
-    protected Vote createPopulatedDataOwnerVote(Integer userId, Integer electionId) {
-        Integer voteId = voteDAO.insertVote(userId, electionId, VoteType.DATA_OWNER.getValue());
         voteDAO.updateVote(true, "rationale", new Date(), voteId, false, electionId, new Date(), false);
         return voteDAO.findVoteById(voteId);
     }
@@ -329,15 +313,6 @@ public class DAOTestHelper {
         Integer userId = userDAO.insertUser(email, "display name", new Date());
         createUserProperty(userId, UserFields.ORCID.getValue());
         addUserRole(UserRoles.RESEARCHER.getRoleId(), userId);
-        return userDAO.findUserById(userId);
-    }
-
-    protected User createUserMultipleProperties() {
-        User user = createUser();
-        Integer userId = user.getDacUserId();
-        createUserProperty(userId, UserFields.PI_NAME.getValue());
-        createUserProperty(userId, UserFields.PI_EMAIL.getValue());
-        createUserProperty(userId, UserFields.DEPARTMENT.getValue());
         return userDAO.findUserById(userId);
     }
 
@@ -464,13 +439,6 @@ public class DAOTestHelper {
         return libraryCardDAO.findLibraryCardById(id);
     }
 
-    protected LibraryCard createLibraryCardForInstitution(User user, Integer institutionId) {
-        String stringValue = "value";
-        Integer id = libraryCardDAO.insertLibraryCard(user.getDacUserId(), institutionId, stringValue,
-                user.getDisplayName(), user.getEmail(), user.getDacUserId(), new Date());
-        return libraryCardDAO.findLibraryCardById(id);
-    }
-
     //overloaded method, helper for INDEX SQL call
     //createInstitution called outside of helper for institution reference/data checks
     protected LibraryCard createLibraryCardForIndex(Integer institutionId) {
@@ -479,12 +447,6 @@ public class DAOTestHelper {
         Integer id = libraryCardDAO.insertLibraryCard(userId, institutionId, stringValue, stringValue, stringValue,
                 userId, new Date());
         return libraryCardDAO.findLibraryCardById(id);
-    }
-
-    protected Date yesterday() {
-        final Calendar cal = Calendar.getInstance();
-        cal.add(Calendar.DATE, -1);
-        return cal.getTime();
     }
 
     /**
@@ -601,7 +563,7 @@ public class DAOTestHelper {
 
     protected void createConsentAndAssociationWithDatasetIdAndDACId(int datasetId, int dacId ) {
         Consent consent = createConsent(dacId);
-        createAssociation(consent.getConsentId(), datasetId);
+        consentDAO.insertConsentAssociation(consent.getConsentId(), ASSOCIATION_TYPE_TEST, datasetId);
     }
 
     protected DarCollection createDarCollectionWithDatasetsAndConsentAssociation(int dacId, User user, List<Dataset> datasets) {
@@ -620,7 +582,11 @@ public class DAOTestHelper {
     }
 
     protected DarCollection createDarCollectionMultipleUserProperties() {
-        User user = createUserMultipleProperties();
+        User user = createUser();
+        Integer userId = user.getDacUserId();
+        createUserProperty(userId, UserFields.PI_NAME.getValue());
+        createUserProperty(userId, UserFields.PI_EMAIL.getValue());
+        createUserProperty(userId, UserFields.DEPARTMENT.getValue());
         String darCode = "DAR-" + RandomUtils.nextInt(100, 1000);
         Integer collection_id = darCollectionDAO.insertDarCollection(darCode, user.getDacUserId(), new Date());
         Dataset dataset = createDataset();
@@ -643,7 +609,7 @@ public class DAOTestHelper {
         createUserWithRoleInDac(UserRoles.MEMBER.getRoleId(), dac.getDacId());
         Consent consent = createConsent(dac.getDacId());
         Dataset dataset = createDataset();
-        createAssociation(consent.getConsentId(), dataset.getDataSetId());
+        consentDAO.insertConsentAssociation(consent.getConsentId(), ASSOCIATION_TYPE_TEST, dataset.getDataSetId());
         Integer collectionId = darCollectionDAO.insertDarCollection(darCode, user.getDacUserId(), new Date());
         createDarForCollection(user, collectionId, dataset);
         return darCollectionDAO.findDARCollectionByCollectionId(collectionId);

--- a/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
@@ -44,7 +44,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
-import java.util.Calendar;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -168,7 +167,20 @@ public class DAOTestHelper {
         testingDAO.deleteAllCounters();
     }
 
-    protected Election createAccessElection(String referenceId, Integer datasetId) {
+    /*
+       Utility methods in this class need to be complete from the perspective of the
+       entity. When testing, if you need a specific modification to an object, call
+       dao methods directly to do any manipulation.
+     */
+
+    /**
+     * Create a DataAccess Election with "Open" status.
+     *
+     * @param referenceId A DAR's reference id
+     * @param datasetId A dataset id
+     * @return DataAccess Election
+     */
+    protected Election createDataAccessElection(String referenceId, Integer datasetId) {
         Integer electionId = electionDAO.insertElection(
                 ElectionType.DATA_ACCESS.getValue(),
                 ElectionStatus.OPEN.getValue(),
@@ -553,7 +565,7 @@ public class DAOTestHelper {
         Dataset dataset = createDataset();
         DataAccessRequest dar = insertDAR(user.getDacUserId(), collection_id, darCode);
         Election cancelled = createCancelledAccessElection(dar.getReferenceId(), dataset.getDataSetId());
-        Election access = createAccessElection(dar.getReferenceId(), dataset.getDataSetId());
+        Election access = createDataAccessElection(dar.getReferenceId(), dataset.getDataSetId());
         createFinalVote(user.getDacUserId(), cancelled.getElectionId());
         createFinalVote(user.getDacUserId(), access.getElectionId());
         insertDAR(user.getDacUserId(), collection_id, darCode);
@@ -573,7 +585,7 @@ public class DAOTestHelper {
                 .forEach(dataset-> {
                     DataAccessRequest dar = createDataAccessRequestWithDatasetAndCollectionInfo(collectionId, dataset.getDataSetId(), user.getDacUserId(), darCode);
                     Election cancelled = createCancelledAccessElection(dar.getReferenceId(), dataset.getDataSetId());
-                    Election access = createAccessElection(dar.getReferenceId(), dataset.getDataSetId());
+                    Election access = createDataAccessElection(dar.getReferenceId(), dataset.getDataSetId());
                     createFinalVote(user.getDacUserId(), cancelled.getElectionId());
                     createFinalVote(user.getDacUserId(), access.getElectionId());
                     createConsentAndAssociationWithDatasetIdAndDACId(dataset.getDataSetId(), dacId);
@@ -592,7 +604,7 @@ public class DAOTestHelper {
         Dataset dataset = createDataset();
         DataAccessRequest dar = insertDAR(user.getDacUserId(), collection_id, darCode);
         Election cancelled = createCancelledAccessElection(dar.getReferenceId(), dataset.getDataSetId());
-        Election access = createAccessElection(dar.getReferenceId(), dataset.getDataSetId());
+        Election access = createDataAccessElection(dar.getReferenceId(), dataset.getDataSetId());
         createFinalVote(user.getDacUserId(), cancelled.getElectionId());
         createFinalVote(user.getDacUserId(), access.getElectionId());
         insertDAR(user.getDacUserId(), collection_id, darCode);

--- a/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
@@ -561,21 +561,6 @@ public class DAOTestHelper {
         return darCollectionDAO.findDARCollectionByCollectionId(collection_id);
     }
 
-
-    protected DarCollection createDarCollectionWithSingleDataAccessRequest() {
-        User user = createUser();
-        String darCode = "DAR-" + RandomUtils.nextInt(100, 1000);
-        Dac dac = createDac();
-        createUserWithRoleInDac(UserRoles.CHAIRPERSON.getRoleId(), dac.getDacId());
-        createUserWithRoleInDac(UserRoles.MEMBER.getRoleId(), dac.getDacId());
-        Consent consent = createConsent(dac.getDacId());
-        Dataset dataset = createDataset();
-        consentDAO.insertConsentAssociation(consent.getConsentId(), ASSOCIATION_TYPE_TEST, dataset.getDataSetId());
-        Integer collectionId = darCollectionDAO.insertDarCollection(darCode, user.getDacUserId(), new Date());
-        createDarForCollection(user, collectionId, dataset);
-        return darCollectionDAO.findDARCollectionByCollectionId(collectionId);
-    }
-
     protected DataAccessRequest createDarForCollection(User user, Integer collectionId, Dataset dataset) {
         Date now = new Date();
         DataAccessRequest dar = new DataAccessRequest();

--- a/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
@@ -318,7 +318,7 @@ public class DAOTestHelper {
                 RandomStringUtils.randomAlphabetic(i3);
         Integer userId = userDAO.insertUser(email, "display name", new Date());
         createUserProperty(userId, UserFields.ORCID.getValue());
-        addUserRole(UserRoles.RESEARCHER.getRoleId(), userId);
+        userRoleDAO.insertSingleUserRole(UserRoles.RESEARCHER.getRoleId(), userId);
         return userDAO.findUserById(userId);
     }
 
@@ -337,7 +337,7 @@ public class DAOTestHelper {
         Integer userId = userDAO.insertUser(email, name, new Date());
         Integer institutionId = institutionDAO.insertInstitution(RandomStringUtils.randomAlphanumeric(10), "itdirectorName", "itDirectorEmail", userId, new Date());
         userDAO.updateUser(name, userId, email, institutionId);
-        addUserRole(7, userId);
+        userRoleDAO.insertSingleUserRole(7, userId);
         return userDAO.findUserById(userId);
     }
 
@@ -351,12 +351,8 @@ public class DAOTestHelper {
                 "." +
                 RandomStringUtils.randomAlphabetic(i3);
         Integer userId = userDAO.insertUser(email, "display name", new Date());
-        addUserRole(roleId, userId);
-        return userDAO.findUserById(userId);
-    }
-
-    protected void addUserRole(int roleId, int userId) {
         userRoleDAO.insertSingleUserRole(roleId, userId);
+        return userDAO.findUserById(userId);
     }
 
     protected User createUserWithRoleInDac(Integer roleId, Integer dacId) {

--- a/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
@@ -313,6 +313,11 @@ public class DAOTestHelper {
         return matchDAO.findMatchById(matchId);
     }
 
+    /**
+     * Creates a user with default role of Researcher and random user properties
+     *
+     * @return Created User
+     */
     protected User createUser() {
         int i1 = RandomUtils.nextInt(5, 10);
         int i2 = RandomUtils.nextInt(5, 10);
@@ -328,7 +333,7 @@ public class DAOTestHelper {
         return userDAO.findUserById(userId);
     }
 
-    protected void createUserProperty(Integer userId, String field) {
+    private void createUserProperty(Integer userId, String field) {
         UserProperty property = new UserProperty();
         property.setPropertyKey(field);
         property.setPropertyValue(UUID.randomUUID().toString());
@@ -344,13 +349,6 @@ public class DAOTestHelper {
         Integer institutionId = institutionDAO.insertInstitution(RandomStringUtils.randomAlphanumeric(10), "itdirectorName", "itDirectorEmail", userId, new Date());
         userDAO.updateUser(name, userId, email, institutionId);
         addUserRole(7, userId);
-        return userDAO.findUserById(userId);
-    }
-
-    protected User createUserForInstitution(Integer institutionId) {
-        String email = RandomStringUtils.randomAlphabetic(11);
-        Integer userId = userDAO.insertUser(email, "displayName", new Date());
-        userDAO.updateUser(email, userId, "additionalEmail", institutionId);
         return userDAO.findUserById(userId);
     }
 
@@ -431,7 +429,9 @@ public class DAOTestHelper {
 
     protected LibraryCard createLibraryCard() {
         Integer institutionId = createInstitution().getId();
-        Integer userId = createUserForInstitution(institutionId).getDacUserId();
+        String email = RandomStringUtils.randomAlphabetic(11);
+        Integer userId = userDAO.insertUser(email, "displayName", new Date());
+        userDAO.updateUser(email, userId, "additionalEmail", institutionId);
         String stringValue = "value";
         Integer id = libraryCardDAO.insertLibraryCard(userId, institutionId, stringValue, stringValue, stringValue, userId, new Date());
         return libraryCardDAO.findLibraryCardById(id);

--- a/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
@@ -248,17 +248,6 @@ public class DAOTestHelper {
         return electionDAO.findElectionById(electionId);
     }
 
-    protected void closeElection(Election election) {
-        changeElectionStatus(election, ElectionStatus.CLOSED);
-    }
-
-    protected void changeElectionStatus(Election election, ElectionStatus status) {
-        electionDAO.updateElectionById(
-                election.getElectionId(),
-                status.getValue(),
-                new Date());
-    }
-
     protected Vote createDacVote(Integer userId, Integer electionId) {
         Integer voteId = voteDAO.insertVote(userId, electionId, VoteType.DAC.getValue());
         return voteDAO.findVoteById(voteId);

--- a/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
@@ -201,45 +201,10 @@ public class DAOTestHelper {
         );
         return electionDAO.findElectionById(electionId);
     }
-    protected Election createExtendedElection(String referenceId, Integer datasetId) {
-        Integer electionId = electionDAO.insertElection(
-                ElectionType.DATA_ACCESS.getValue(),
-                ElectionStatus.OPEN.getValue(),
-                new Date(),
-                referenceId,
-                Boolean.TRUE,
-                "dataUseLetter",
-                "dulName",
-                datasetId
-        );
-        return electionDAO.findElectionById(electionId);
-    }
 
     protected Election createRPElection(String referenceId, Integer datasetId) {
         Integer electionId = electionDAO.insertElection(
                 ElectionType.RP.getValue(),
-                ElectionStatus.OPEN.getValue(),
-                new Date(),
-                referenceId,
-                datasetId
-        );
-        return electionDAO.findElectionById(electionId);
-    }
-
-    protected Election createDULElection(String referenceId, Integer datasetId) {
-        Integer electionId = electionDAO.insertElection(
-                ElectionType.TRANSLATE_DUL.getValue(),
-                ElectionStatus.OPEN.getValue(),
-                new Date(),
-                referenceId,
-                datasetId
-        );
-        return electionDAO.findElectionById(electionId);
-    }
-
-    protected Election createDatasetElection(String referenceId, Integer datasetId) {
-        Integer electionId = electionDAO.insertElection(
-                ElectionType.DATA_SET.getValue(),
                 ElectionStatus.OPEN.getValue(),
                 new Date(),
                 referenceId,
@@ -286,7 +251,6 @@ public class DAOTestHelper {
                 dacId);
         return consentDAO.findConsentById(consentId);
     }
-
 
     protected Match createMatch() {
         DataAccessRequest dar = createDataAccessRequestV3();

--- a/src/test/java/org/broadinstitute/consent/http/db/DacDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DacDAOTest.java
@@ -1,15 +1,5 @@
 package org.broadinstitute.consent.http.db;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
-
 import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.Consent;
 import org.broadinstitute.consent.http.models.Dac;
@@ -20,6 +10,16 @@ import org.broadinstitute.consent.http.models.UserRole;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
 public class DacDAOTest extends DAOTestHelper {
 
     @Test
@@ -29,7 +29,7 @@ public class DacDAOTest extends DAOTestHelper {
             Dac d = createDac();
             Dataset ds = createDataset();
             Consent c = createConsent(d.getDacId());
-            createAssociation(c.getConsentId(), ds.getDataSetId());
+            consentDAO.insertConsentAssociation(c.getConsentId(), ASSOCIATION_TYPE_TEST, ds.getDataSetId());
         };
         List<Dac> dacList = dacDAO.findAll();
         Assert.assertEquals(count, dacList.size());
@@ -189,13 +189,13 @@ public class DacDAOTest extends DAOTestHelper {
     public void testFindDacsForDatasetIds() {
         Dac dac = createDac();
         Consent consent1 = createConsent(dac.getDacId());
-        Dataset dataSet1 = createDataset();
-        createAssociation(consent1.getConsentId(), dataSet1.getDataSetId());
+        Dataset dataset1 = createDataset();
+        consentDAO.insertConsentAssociation(consent1.getConsentId(), ASSOCIATION_TYPE_TEST, dataset1.getDataSetId());
 
         Consent consent2 = createConsent(dac.getDacId());
-        Dataset dataSet2 = createDataset();
-        createAssociation(consent2.getConsentId(), dataSet2.getDataSetId());
-        Set<Dac> dacs = dacDAO.findDacsForDatasetIds(Arrays.asList(dataSet1.getDataSetId(), dataSet2.getDataSetId()));
+        Dataset dataset2 = createDataset();
+        consentDAO.insertConsentAssociation(consent2.getConsentId(), ASSOCIATION_TYPE_TEST, dataset2.getDataSetId());
+        Set<Dac> dacs = dacDAO.findDacsForDatasetIds(Arrays.asList(dataset1.getDataSetId(), dataset2.getDataSetId()));
         assertFalse(dacs.isEmpty());
         assertEquals(1, dacs.size());
     }

--- a/src/test/java/org/broadinstitute/consent/http/db/DarCollectionDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DarCollectionDAOTest.java
@@ -1,8 +1,8 @@
 package org.broadinstitute.consent.http.db;
 
-import org.apache.commons.lang3.RandomStringUtils;
 import io.dropwizard.testing.ResourceHelpers;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.RandomUtils;
 import org.broadinstitute.consent.http.models.Consent;
 import org.broadinstitute.consent.http.models.Dac;
@@ -20,10 +20,10 @@ import org.junit.Test;
 import org.postgresql.util.PSQLException;
 import org.postgresql.util.PSQLState;
 
-import java.sql.Timestamp;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -50,7 +50,7 @@ public class DarCollectionDAOTest extends DAOTestHelper  {
     Election election = dar.getElections().values().stream().findFirst().orElse(null);
     Integer datasetId = election.getDataSetId();
     electionDAO.insertElection("DataSet", "Open", new Date(), referenceId, datasetId);
-  } 
+  }
 
   private List<Election> getElectionsFromCollection(DarCollection collection) {
     return collection.getDars().values().stream()
@@ -76,7 +76,7 @@ public class DarCollectionDAOTest extends DAOTestHelper  {
     generateDatasetElectionForCollection(targetCollection);
     List<UserProperty> userProperties = allAfter.get(0).getCreateUser().getProperties();
     assertFalse(userProperties.isEmpty());
-    
+
     List<Election> elections = getElectionsFromCollection(targetCollection);
     assertNotNull(elections);
     assertTrue(elections.size() > 0);
@@ -199,7 +199,7 @@ public class DarCollectionDAOTest extends DAOTestHelper  {
     dataAccessRequestDAO.updateDataByReferenceIdVersion2(dar.getReferenceId(), dar.getUserId(), new Date(), new Date(), new Date(), dar.getData());
     Dac dac = createDac();
     Consent consent = createConsent(dac.getDacId());
-    createAssociation(consent.getConsentId(), dataset.getDataSetId());
+    consentDAO.insertConsentAssociation(consent.getConsentId(), ASSOCIATION_TYPE_TEST, dataset.getDataSetId());
 
     List<Integer> collectionIds = darCollectionDAO.findDARCollectionIdsByDacIds(List.of(dac.getDacId()));
     assertFalse(collectionIds.isEmpty());
@@ -482,7 +482,7 @@ public void testGetFilteredListForResearcher_InstitutionTerm() {
     DataAccessRequest expectedDarTwo = new ArrayList<>(collections.get(1).getDars().values()).get(0);
     assertEquals(expectedDarOne.getData().getDarCode(), darResultOne.getData().getDarCode());
     assertEquals(expectedDarTwo.getData().getDarCode(), darResultTwo.getData().getDarCode());
-    
+
   }
 
   @Test
@@ -840,7 +840,7 @@ public void testGetFilteredListForResearcher_InstitutionTerm() {
     // create a DAC
     Dac dac = createDAC();
     Consent consent = createConsent(dac.getDacId());
-    createAssociation(consent.getConsentId(), dataset.getDataSetId());
+    consentDAO.insertConsentAssociation(consent.getConsentId(), ASSOCIATION_TYPE_TEST, dataset.getDataSetId());
 
     DarCollection testDarCollection = darCollectionDAO.findDARCollectionByCollectionId(collectionId);
 

--- a/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
@@ -10,7 +10,6 @@ import org.broadinstitute.consent.http.models.Dataset;
 import org.broadinstitute.consent.http.models.DatasetProperty;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.dto.DatasetDTO;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.sql.Timestamp;
@@ -36,7 +35,7 @@ public class DatasetDAOTest extends DAOTestHelper {
         Dataset dataset = createDataset();
         Dac dac = createDac();
         Consent consent = createConsent(dac.getDacId());
-        createAssociation(consent.getConsentId(), dataset.getDataSetId());
+        consentDAO.insertConsentAssociation(consent.getConsentId(), ASSOCIATION_TYPE_TEST, dataset.getDataSetId());
 
         Dataset foundDataset = datasetDAO.findDatasetById(dataset.getDataSetId());
         assertNotNull(foundDataset);
@@ -75,7 +74,7 @@ public class DatasetDAOTest extends DAOTestHelper {
         datasetDAO.updateDatasetNeedsApproval(dataset.getDataSetId(), true);
         Dac dac = createDac();
         Consent consent = createConsent(dac.getDacId());
-        createAssociation(consent.getConsentId(), dataset.getDataSetId());
+        consentDAO.insertConsentAssociation(consent.getConsentId(), ASSOCIATION_TYPE_TEST, dataset.getDataSetId());
 
         List<Dataset> datasets = datasetDAO.findNeedsApprovalDatasetByDatasetId(List.of(dataset.getDataSetId()));
         assertFalse(datasets.isEmpty());
@@ -91,7 +90,7 @@ public class DatasetDAOTest extends DAOTestHelper {
         Dataset dataset = createDataset();
         Dac dac = createDac();
         Consent consent = createConsent(dac.getDacId());
-        createAssociation(consent.getConsentId(), dataset.getDataSetId());
+        consentDAO.insertConsentAssociation(consent.getConsentId(), ASSOCIATION_TYPE_TEST, dataset.getDataSetId());
 
         List<Dataset> datasets = datasetDAO.getDatasetsForObjectIdList(List.of(dataset.getObjectId()));
         assertFalse(datasets.isEmpty());
@@ -107,7 +106,7 @@ public class DatasetDAOTest extends DAOTestHelper {
         Dataset dataset = createDataset();
         Dac dac = createDac();
         Consent consent = createConsent(dac.getDacId());
-        createAssociation(consent.getConsentId(), dataset.getDataSetId());
+        consentDAO.insertConsentAssociation(consent.getConsentId(), ASSOCIATION_TYPE_TEST, dataset.getDataSetId());
 
         List<Dataset> datasets = datasetDAO.findDatasetsByIdList(List.of(dataset.getDataSetId()));
         assertFalse(datasets.isEmpty());
@@ -123,7 +122,7 @@ public class DatasetDAOTest extends DAOTestHelper {
         Dataset dataset = createDataset();
         Dac dac = createDac();
         Consent consent = createConsent(dac.getDacId());
-        createAssociation(consent.getConsentId(), dataset.getDataSetId());
+        consentDAO.insertConsentAssociation(consent.getConsentId(), ASSOCIATION_TYPE_TEST, dataset.getDataSetId());
 
         Set<Dataset> datasets = datasetDAO.findDatasetsForConsentId(consent.getConsentId());
         assertFalse(datasets.isEmpty());
@@ -142,7 +141,7 @@ public class DatasetDAOTest extends DAOTestHelper {
         Dataset dataset = createDataset();
         Dac dac = createDac();
         Consent consent = createConsent(dac.getDacId());
-        createAssociation(consent.getConsentId(), dataset.getDataSetId());
+        consentDAO.insertConsentAssociation(consent.getConsentId(), ASSOCIATION_TYPE_TEST, dataset.getDataSetId());
         User user = createUser();
         createUserRole(UserRoles.CHAIRPERSON.getRoleId(), user.getDacUserId(), dac.getDacId());
 
@@ -156,7 +155,7 @@ public class DatasetDAOTest extends DAOTestHelper {
     public void testFindNonDACDataSets() {
         Dataset dataset = createDataset();
         Consent consent = createConsent(null);
-        createAssociation(consent.getConsentId(), dataset.getDataSetId());
+        consentDAO.insertConsentAssociation(consent.getConsentId(), ASSOCIATION_TYPE_TEST, dataset.getDataSetId());
 
         List<Dataset> datasets = datasetDAO.findNonDACDatasets();
         assertFalse(datasets.isEmpty());
@@ -169,7 +168,7 @@ public class DatasetDAOTest extends DAOTestHelper {
         Dataset dataset = createDataset();
         Dac dac = createDac();
         Consent consent = createConsent(dac.getDacId());
-        createAssociation(consent.getConsentId(), dataset.getDataSetId());
+        consentDAO.insertConsentAssociation(consent.getConsentId(), ASSOCIATION_TYPE_TEST, dataset.getDataSetId());
 
         List<Pair<Integer, Integer>> pairs = datasetDAO.findDatasetAndDacIds();
         assertFalse(pairs.isEmpty());
@@ -224,7 +223,7 @@ public class DatasetDAOTest extends DAOTestHelper {
     public void testFindAllDatasets() {
         Dataset dataset = createDataset();
         Consent consent = createConsent(null);
-        createAssociation(consent.getConsentId(), dataset.getDataSetId());
+        consentDAO.insertConsentAssociation(consent.getConsentId(), ASSOCIATION_TYPE_TEST, dataset.getDataSetId());
 
         Set<DatasetDTO> datasets = datasetDAO.findAllDatasets();
         assertFalse(datasets.isEmpty());
@@ -236,7 +235,7 @@ public class DatasetDAOTest extends DAOTestHelper {
     public void testFindActiveDatasets() {
         Dataset dataset = createDataset();
         Consent consent = createConsent(null);
-        createAssociation(consent.getConsentId(), dataset.getDataSetId());
+        consentDAO.insertConsentAssociation(consent.getConsentId(), ASSOCIATION_TYPE_TEST, dataset.getDataSetId());
 
         Set<DatasetDTO> datasets = datasetDAO.findActiveDatasets();
         assertFalse(datasets.isEmpty());
@@ -249,7 +248,7 @@ public class DatasetDAOTest extends DAOTestHelper {
         Dataset dataset = createDataset();
         Dac dac = createDac();
         Consent consent = createConsent(dac.getDacId());
-        createAssociation(consent.getConsentId(), dataset.getDataSetId());
+        consentDAO.insertConsentAssociation(consent.getConsentId(), ASSOCIATION_TYPE_TEST, dataset.getDataSetId());
         User user = createUser();
         createUserRole(UserRoles.CHAIRPERSON.getRoleId(), user.getDacUserId(), dac.getDacId());
 
@@ -278,7 +277,7 @@ public class DatasetDAOTest extends DAOTestHelper {
         Dataset dataset = createDataset();
         Dac dac = createDac();
         Consent consent = createConsent(dac.getDacId());
-        createAssociation(consent.getConsentId(), dataset.getDataSetId());
+        consentDAO.insertConsentAssociation(consent.getConsentId(), ASSOCIATION_TYPE_TEST, dataset.getDataSetId());
 
         Set<Dataset> datasets = datasetDAO.findDatasetWithDataUseByIdList(Collections.singletonList(dataset.getDataSetId()));
         assertFalse(datasets.isEmpty());

--- a/src/test/java/org/broadinstitute/consent/http/db/ElectionDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/ElectionDAOTest.java
@@ -192,7 +192,14 @@ public class ElectionDAOTest extends DAOTestHelper {
     Consent c = createConsent(dac.getDacId());
     Dataset d = createDataset();
     consentDAO.insertConsentAssociation(c.getConsentId(), ASSOCIATION_TYPE_TEST, d.getDataSetId());
-    Election e = createDatasetElection(c.getConsentId(), d.getDataSetId());
+    Integer electionId = electionDAO.insertElection(
+      ElectionType.DATA_SET.getValue(),
+      ElectionStatus.OPEN.getValue(),
+      new Date(),
+      c.getConsentId(),
+      d.getDataSetId());
+    Election e = electionDAO.findElectionById(electionId);
+
     Integer voteId = voteDAO.insertVote(u.getDacUserId(), e.getElectionId(), VoteType.DATA_OWNER.getValue());
     voteDAO.updateVote(true, "rationale", new Date(), voteId, false, e.getElectionId(), new Date(), false);
     Vote v = voteDAO.findVoteById(voteId);
@@ -210,7 +217,13 @@ public class ElectionDAOTest extends DAOTestHelper {
     Consent c = createConsent(dac.getDacId());
     Dataset d = createDataset();
     consentDAO.insertConsentAssociation(c.getConsentId(), ASSOCIATION_TYPE_TEST, d.getDataSetId());
-    Election e = createDULElection(c.getConsentId(), d.getDataSetId());
+    Integer electionId = electionDAO.insertElection(
+      ElectionType.TRANSLATE_DUL.getValue(),
+      ElectionStatus.OPEN.getValue(),
+      new Date(),
+      c.getConsentId(),
+      d.getDataSetId());
+    Election e = electionDAO.findElectionById(electionId);
     Vote v = createPopulatedChairpersonVote(u.getDacUserId(), e.getElectionId());
 
     Election election = electionDAO.findElectionWithFinalVoteById(e.getElectionId());
@@ -237,7 +250,16 @@ public class ElectionDAOTest extends DAOTestHelper {
     Consent c = createConsent(dac.getDacId());
     Dataset d = createDataset();
     consentDAO.insertConsentAssociation(c.getConsentId(), ASSOCIATION_TYPE_TEST, d.getDataSetId());
-    Election e = createExtendedElection(c.getConsentId(), d.getDataSetId());
+    Integer electionId = electionDAO.insertElection(
+      ElectionType.DATA_ACCESS.getValue(),
+      ElectionStatus.OPEN.getValue(),
+      new Date(),
+      c.getConsentId(),
+      Boolean.TRUE,
+      "dataUseLetter",
+      "dulName",
+      d.getDataSetId());
+    Election e = electionDAO.findElectionById(electionId);
     Election election = electionDAO.findElectionWithFinalVoteById(e.getElectionId());
     assertNotNull(election);
     assertEquals(e.getElectionId(), election.getElectionId());
@@ -247,7 +269,15 @@ public class ElectionDAOTest extends DAOTestHelper {
   public void testFindLastElectionsByReferenceIdsAndType() {
     DataAccessRequest dar = createDataAccessRequestV3();
     Dataset d = createDataset();
-    createExtendedElection(dar.getReferenceId(), d.getDataSetId());
+    electionDAO.insertElection(
+      ElectionType.DATA_ACCESS.getValue(),
+      ElectionStatus.OPEN.getValue(),
+      new Date(),
+      dar.getReferenceId(),
+      Boolean.TRUE,
+      "dataUseLetter",
+      "dulName",
+      d.getDataSetId());
     List<Election> elections =
         electionDAO.findLastElectionsByReferenceIdsAndType(
             Collections.singletonList(dar.getReferenceId()), ElectionType.DATA_ACCESS.getValue());
@@ -263,7 +293,13 @@ public class ElectionDAOTest extends DAOTestHelper {
     Dataset dataset = createDataset();
     Integer datasetId = dataset.getDataSetId();
     Consent consent = createConsent(dac.getDacId());
-    Election dulElection = createDULElection(consent.getConsentId(), datasetId);
+    Integer electionId = electionDAO.insertElection(
+      ElectionType.TRANSLATE_DUL.getValue(),
+      ElectionStatus.OPEN.getValue(),
+      new Date(),
+      consent.getConsentId(),
+      datasetId);
+    Election dulElection = electionDAO.findElectionById(electionId);
     Election accessElection = createDataAccessElection(accessReferenceId, datasetId);
     electionDAO.insertAccessAndConsentElection(accessElection.getElectionId(), dulElection.getElectionId());
 

--- a/src/test/java/org/broadinstitute/consent/http/db/ElectionDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/ElectionDAOTest.java
@@ -17,6 +17,7 @@ import java.util.stream.Collectors;
 import org.apache.commons.lang3.tuple.Pair;
 import org.broadinstitute.consent.http.enumeration.ElectionType;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
+import org.broadinstitute.consent.http.enumeration.VoteType;
 import org.broadinstitute.consent.http.models.Consent;
 import org.broadinstitute.consent.http.models.Dac;
 import org.broadinstitute.consent.http.models.DataAccessRequest;
@@ -83,7 +84,7 @@ public class ElectionDAOTest extends DAOTestHelper {
     Dac dac = createDac();
     Consent consent = createConsent(dac.getDacId());
     Dataset dataset = createDataset();
-    createAssociation(consent.getConsentId(), dataset.getDataSetId());
+    consentDAO.insertConsentAssociation(consent.getConsentId(), ASSOCIATION_TYPE_TEST, dataset.getDataSetId());
     Election election = createAccessElection(consent.getConsentId(), dataset.getDataSetId());
 
     Dac foundDac = electionDAO.findDacForElection(election.getElectionId());
@@ -118,7 +119,7 @@ public class ElectionDAOTest extends DAOTestHelper {
     Dac dac = createDac();
     Consent consent = createConsent(dac.getDacId());
     Dataset dataset = createDataset();
-    createAssociation(consent.getConsentId(), dataset.getDataSetId());
+    consentDAO.insertConsentAssociation(consent.getConsentId(), ASSOCIATION_TYPE_TEST, dataset.getDataSetId());
     Election election = createAccessElection(consent.getConsentId(), dataset.getDataSetId());
 
     List<Election> foundElections = electionDAO.findOpenElectionsByDacId(dac.getDacId());
@@ -143,7 +144,7 @@ public class ElectionDAOTest extends DAOTestHelper {
     Dac dac = createDac();
     Consent consent = createConsent(null);
     Dataset dataset = createDataset();
-    createAssociation(consent.getConsentId(), dataset.getDataSetId());
+    consentDAO.insertConsentAssociation(consent.getConsentId(), ASSOCIATION_TYPE_TEST, dataset.getDataSetId());
     createAccessElection(consent.getConsentId(), dataset.getDataSetId());
 
     List<Election> foundElections = electionDAO.findOpenElectionsByDacId(dac.getDacId());
@@ -156,9 +157,11 @@ public class ElectionDAOTest extends DAOTestHelper {
     Dac dac = createDac();
     Consent c = createConsent(dac.getDacId());
     Dataset d = createDataset();
-    createAssociation(c.getConsentId(), d.getDataSetId());
+    consentDAO.insertConsentAssociation(c.getConsentId(), ASSOCIATION_TYPE_TEST, d.getDataSetId());
     Election e = createAccessElection(c.getConsentId(), d.getDataSetId());
-    Vote v = createPopulatedFinalVote(u.getDacUserId(), e.getElectionId());
+    Integer voteId = voteDAO.insertVote(u.getDacUserId(), e.getElectionId(), VoteType.FINAL.getValue());
+    voteDAO.updateVote(true, "rationale", new Date(), voteId, false, e.getElectionId(), new Date(), false);
+    Vote v = voteDAO.findVoteById(voteId);
 
     Election election = electionDAO.findElectionWithFinalVoteById(e.getElectionId());
     assertNotNull(election);
@@ -172,7 +175,7 @@ public class ElectionDAOTest extends DAOTestHelper {
     Dac dac = createDac();
     Consent c = createConsent(dac.getDacId());
     Dataset d = createDataset();
-    createAssociation(c.getConsentId(), d.getDataSetId());
+    consentDAO.insertConsentAssociation(c.getConsentId(), ASSOCIATION_TYPE_TEST, d.getDataSetId());
     Election e = createRPElection(c.getConsentId(), d.getDataSetId());
     Vote v = createPopulatedChairpersonVote(u.getDacUserId(), e.getElectionId());
 
@@ -188,9 +191,11 @@ public class ElectionDAOTest extends DAOTestHelper {
     Dac dac = createDac();
     Consent c = createConsent(dac.getDacId());
     Dataset d = createDataset();
-    createAssociation(c.getConsentId(), d.getDataSetId());
+    consentDAO.insertConsentAssociation(c.getConsentId(), ASSOCIATION_TYPE_TEST, d.getDataSetId());
     Election e = createDatasetElection(c.getConsentId(), d.getDataSetId());
-    Vote v = createPopulatedDataOwnerVote(u.getDacUserId(), e.getElectionId());
+    Integer voteId = voteDAO.insertVote(u.getDacUserId(), e.getElectionId(), VoteType.DATA_OWNER.getValue());
+    voteDAO.updateVote(true, "rationale", new Date(), voteId, false, e.getElectionId(), new Date(), false);
+    Vote v = voteDAO.findVoteById(voteId);
 
     Election election = electionDAO.findElectionWithFinalVoteById(e.getElectionId());
     assertNotNull(election);
@@ -204,7 +209,7 @@ public class ElectionDAOTest extends DAOTestHelper {
     Dac dac = createDac();
     Consent c = createConsent(dac.getDacId());
     Dataset d = createDataset();
-    createAssociation(c.getConsentId(), d.getDataSetId());
+    consentDAO.insertConsentAssociation(c.getConsentId(), ASSOCIATION_TYPE_TEST, d.getDataSetId());
     Election e = createDULElection(c.getConsentId(), d.getDataSetId());
     Vote v = createPopulatedChairpersonVote(u.getDacUserId(), e.getElectionId());
 
@@ -231,7 +236,7 @@ public class ElectionDAOTest extends DAOTestHelper {
     Dac dac = createDac();
     Consent c = createConsent(dac.getDacId());
     Dataset d = createDataset();
-    createAssociation(c.getConsentId(), d.getDataSetId());
+    consentDAO.insertConsentAssociation(c.getConsentId(), ASSOCIATION_TYPE_TEST, d.getDataSetId());
     Election e = createExtendedElection(c.getConsentId(), d.getDataSetId());
     Election election = electionDAO.findElectionWithFinalVoteById(e.getElectionId());
     assertNotNull(election);
@@ -288,7 +293,7 @@ public class ElectionDAOTest extends DAOTestHelper {
     Integer datasetId = dataset.getDataSetId();
     dar.getData().setDatasetIds(Collections.singletonList(datasetId));
     dataAccessRequestDAO.updateDataByReferenceId(darReferenceId, dar.getData());
-    createAssociation(consent.getConsentId(), datasetId);
+    consentDAO.insertConsentAssociation(consent.getConsentId(), ASSOCIATION_TYPE_TEST, dataset.getDataSetId());
 
     Election cancelledAccessElection = createAccessElection(darReferenceId, datasetId);
     Election cancelledRPElection = createRPElection(darReferenceId, datasetId);

--- a/src/test/java/org/broadinstitute/consent/http/db/ElectionDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/ElectionDAOTest.java
@@ -34,7 +34,7 @@ public class ElectionDAOTest extends DAOTestHelper {
   public void testGetOpenElectionIdByReferenceId() {
     String accessReferenceId = UUID.randomUUID().toString();
     Dataset dataset = createDataset();
-    Election accessElection = createAccessElection(accessReferenceId, dataset.getDataSetId());
+    Election accessElection = createDataAccessElection(accessReferenceId, dataset.getDataSetId());
 
     Integer electionId = electionDAO.getOpenElectionIdByReferenceId(accessReferenceId);
     assertEquals(accessElection.getElectionId(), electionId);
@@ -48,8 +48,8 @@ public class ElectionDAOTest extends DAOTestHelper {
     String accessReferenceId2 = UUID.randomUUID().toString();
     Dataset dataset1 = createDataset();
     Dataset dataset2 = createDataset();
-    Election accessElection1 = createAccessElection(accessReferenceId1, dataset1.getDataSetId());
-    Election accessElection2 = createAccessElection(accessReferenceId2, dataset2.getDataSetId());
+    Election accessElection1 = createDataAccessElection(accessReferenceId1, dataset1.getDataSetId());
+    Election accessElection2 = createDataAccessElection(accessReferenceId2, dataset2.getDataSetId());
 
     List<Integer> electionIds = electionDAO.getElectionIdsByReferenceIds(List.of(accessReferenceId1, accessReferenceId2));
     assertEquals(2, electionIds.size());
@@ -64,7 +64,7 @@ public class ElectionDAOTest extends DAOTestHelper {
     String accessReferenceId = UUID.randomUUID().toString();
     String rpReferenceId = UUID.randomUUID().toString();
     Dataset dataset = createDataset();
-    Election accessElection = createAccessElection(accessReferenceId, dataset.getDataSetId());
+    Election accessElection = createDataAccessElection(accessReferenceId, dataset.getDataSetId());
     Election rpElection = createRPElection(rpReferenceId, dataset.getDataSetId());
     electionDAO.insertAccessRP(accessElection.getElectionId(), rpElection.getElectionId());
     List<Integer> electionIds =
@@ -85,7 +85,7 @@ public class ElectionDAOTest extends DAOTestHelper {
     Consent consent = createConsent(dac.getDacId());
     Dataset dataset = createDataset();
     consentDAO.insertConsentAssociation(consent.getConsentId(), ASSOCIATION_TYPE_TEST, dataset.getDataSetId());
-    Election election = createAccessElection(consent.getConsentId(), dataset.getDataSetId());
+    Election election = createDataAccessElection(consent.getConsentId(), dataset.getDataSetId());
 
     Dac foundDac = electionDAO.findDacForElection(election.getElectionId());
     assertNotNull(foundDac);
@@ -97,7 +97,7 @@ public class ElectionDAOTest extends DAOTestHelper {
     Dac dac = createDac();
     Consent consent = createConsent(dac.getDacId());
     Dataset dataset = createDataset();
-    Election election = createAccessElection(consent.getConsentId(), dataset.getDataSetId());
+    Election election = createDataAccessElection(consent.getConsentId(), dataset.getDataSetId());
 
     Dac foundDac = electionDAO.findDacForElection(election.getElectionId());
     assertNotNull(foundDac);
@@ -108,7 +108,7 @@ public class ElectionDAOTest extends DAOTestHelper {
   public void testFindDacForConsentElectionNotFound() {
     Consent consent = createConsent(null);
     Dataset dataset = createDataset();
-    Election election = createAccessElection(consent.getConsentId(), dataset.getDataSetId());
+    Election election = createDataAccessElection(consent.getConsentId(), dataset.getDataSetId());
 
     Dac foundDac = electionDAO.findDacForElection(election.getElectionId());
     Assert.assertNull(foundDac);
@@ -120,7 +120,7 @@ public class ElectionDAOTest extends DAOTestHelper {
     Consent consent = createConsent(dac.getDacId());
     Dataset dataset = createDataset();
     consentDAO.insertConsentAssociation(consent.getConsentId(), ASSOCIATION_TYPE_TEST, dataset.getDataSetId());
-    Election election = createAccessElection(consent.getConsentId(), dataset.getDataSetId());
+    Election election = createDataAccessElection(consent.getConsentId(), dataset.getDataSetId());
 
     List<Election> foundElections = electionDAO.findOpenElectionsByDacId(dac.getDacId());
     assertNotNull(foundElections);
@@ -132,7 +132,7 @@ public class ElectionDAOTest extends DAOTestHelper {
     Dac dac = createDac();
     Consent consent = createConsent(dac.getDacId());
     Dataset dataset = createDataset();
-    Election election = createAccessElection(consent.getConsentId(), dataset.getDataSetId());
+    Election election = createDataAccessElection(consent.getConsentId(), dataset.getDataSetId());
 
     List<Election> foundElections = electionDAO.findOpenElectionsByDacId(dac.getDacId());
     assertNotNull(foundElections);
@@ -145,7 +145,7 @@ public class ElectionDAOTest extends DAOTestHelper {
     Consent consent = createConsent(null);
     Dataset dataset = createDataset();
     consentDAO.insertConsentAssociation(consent.getConsentId(), ASSOCIATION_TYPE_TEST, dataset.getDataSetId());
-    createAccessElection(consent.getConsentId(), dataset.getDataSetId());
+    createDataAccessElection(consent.getConsentId(), dataset.getDataSetId());
 
     List<Election> foundElections = electionDAO.findOpenElectionsByDacId(dac.getDacId());
     Assert.assertTrue(foundElections.isEmpty());
@@ -158,7 +158,7 @@ public class ElectionDAOTest extends DAOTestHelper {
     Consent c = createConsent(dac.getDacId());
     Dataset d = createDataset();
     consentDAO.insertConsentAssociation(c.getConsentId(), ASSOCIATION_TYPE_TEST, d.getDataSetId());
-    Election e = createAccessElection(c.getConsentId(), d.getDataSetId());
+    Election e = createDataAccessElection(c.getConsentId(), d.getDataSetId());
     Integer voteId = voteDAO.insertVote(u.getDacUserId(), e.getElectionId(), VoteType.FINAL.getValue());
     voteDAO.updateVote(true, "rationale", new Date(), voteId, false, e.getElectionId(), new Date(), false);
     Vote v = voteDAO.findVoteById(voteId);
@@ -223,7 +223,7 @@ public class ElectionDAOTest extends DAOTestHelper {
   public void testFindElectionsByReferenceIdCase1() {
     DataAccessRequest dar = createDataAccessRequestV3();
     Dataset d = createDataset();
-    createAccessElection(dar.getReferenceId(), d.getDataSetId());
+    createDataAccessElection(dar.getReferenceId(), d.getDataSetId());
     createRPElection(dar.getReferenceId(), d.getDataSetId());
 
     List<Election> elections = electionDAO.findElectionsByReferenceId(dar.getReferenceId());
@@ -264,7 +264,7 @@ public class ElectionDAOTest extends DAOTestHelper {
     Integer datasetId = dataset.getDataSetId();
     Consent consent = createConsent(dac.getDacId());
     Election dulElection = createDULElection(consent.getConsentId(), datasetId);
-    Election accessElection = createAccessElection(accessReferenceId, datasetId);
+    Election accessElection = createDataAccessElection(accessReferenceId, datasetId);
     electionDAO.insertAccessAndConsentElection(accessElection.getElectionId(), dulElection.getElectionId());
 
     List<Integer> electionIds = Collections.singletonList(accessElection.getElectionId());
@@ -295,21 +295,21 @@ public class ElectionDAOTest extends DAOTestHelper {
     dataAccessRequestDAO.updateDataByReferenceId(darReferenceId, dar.getData());
     consentDAO.insertConsentAssociation(consent.getConsentId(), ASSOCIATION_TYPE_TEST, dataset.getDataSetId());
 
-    Election cancelledAccessElection = createAccessElection(darReferenceId, datasetId);
+    Election cancelledAccessElection = createDataAccessElection(darReferenceId, datasetId);
     Election cancelledRPElection = createRPElection(darReferenceId, datasetId);
     electionDAO.updateElectionById(
       cancelledAccessElection.getElectionId(), ElectionStatus.CANCELED.getValue(), new Date(), true);
     electionDAO.updateElectionById(
       cancelledRPElection.getElectionId(), ElectionStatus.CANCELED.getValue(), new Date(), true);
 
-    Election prevClosedAccessElection = createAccessElection(darReferenceId, dataset.getDataSetId());
-    Election prevClosedRPElection = createAccessElection(darReferenceId, datasetId);
+    Election prevClosedAccessElection = createDataAccessElection(darReferenceId, dataset.getDataSetId());
+    Election prevClosedRPElection = createDataAccessElection(darReferenceId, datasetId);
     electionDAO.updateElectionById(
       prevClosedAccessElection.getElectionId(), ElectionStatus.CLOSED.getValue(), new Date(), true);
     electionDAO.updateElectionById(
       prevClosedRPElection.getElectionId(), ElectionStatus.CLOSED.getValue(), new Date(), true);
 
-    Election recentClosedAccessElection = createAccessElection(darReferenceId, dataset.getDataSetId());
+    Election recentClosedAccessElection = createDataAccessElection(darReferenceId, dataset.getDataSetId());
     Election recentClosedRPElection = createRPElection(darReferenceId, datasetId);
     electionDAO.updateElectionById(
       recentClosedAccessElection.getElectionId(), ElectionStatus.CLOSED.getValue(), new Date(), true);
@@ -337,7 +337,7 @@ public class ElectionDAOTest extends DAOTestHelper {
     Dataset dataset = createDataset();
     String referenceId = dar.getReferenceId();
     int datasetId = dataset.getDataSetId();
-    Election accessElection = createAccessElection(referenceId, datasetId);
+    Election accessElection = createDataAccessElection(referenceId, datasetId);
     Election rpElection = createRPElection(referenceId, datasetId);
     User user = createUserWithRole(UserRoles.CHAIRPERSON.getRoleId());
     int userId = user.getDacUserId();
@@ -356,7 +356,7 @@ public class ElectionDAOTest extends DAOTestHelper {
     Dataset dataset = createDataset();
     String referenceId = dar.getReferenceId();
     int datasetId = dataset.getDataSetId();
-    Election accessElection = createAccessElection(referenceId, datasetId);
+    Election accessElection = createDataAccessElection(referenceId, datasetId);
     Election rpElection = createRPElection(referenceId, datasetId);
     User user = createUserWithRole(UserRoles.CHAIRPERSON.getRoleId());
     int userId = user.getDacUserId();
@@ -378,8 +378,8 @@ public class ElectionDAOTest extends DAOTestHelper {
     createLibraryCard(lcUser);
     DataAccessRequest lcDAR = createDataAccessRequestWithUserIdV3(lcUser.getDacUserId());
     DataAccessRequest nonLCDAR = createDataAccessRequestWithUserIdV3(nonLCUser.getDacUserId());
-    Election lcElection = createAccessElection(lcDAR.getReferenceId(), datasetId);
-    Election nonLCElection = createAccessElection(nonLCDAR.getReferenceId(), datasetId);
+    Election lcElection = createDataAccessElection(lcDAR.getReferenceId(), datasetId);
+    Election nonLCElection = createDataAccessElection(nonLCDAR.getReferenceId(), datasetId);
     List<Integer> electionIds = List.of(lcElection.getElectionId(), nonLCElection.getElectionId());
     List<Election> elections = electionDAO.findElectionsWithCardHoldingUsersByElectionIds(electionIds);
 
@@ -393,7 +393,7 @@ public class ElectionDAOTest extends DAOTestHelper {
     Dataset dataset = createDataset();
     String referenceId = dar.getReferenceId();
     int datasetId = dataset.getDataSetId();
-    Election accessElection = createAccessElection(referenceId, datasetId);
+    Election accessElection = createDataAccessElection(referenceId, datasetId);
     Election rpElection = createRPElection(referenceId, datasetId);
 
     List<Election> elections = electionDAO.findOpenElectionsByReferenceIds(List.of(dar.referenceId));

--- a/src/test/java/org/broadinstitute/consent/http/db/MailMessageDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/MailMessageDAOTest.java
@@ -33,7 +33,7 @@ public class MailMessageDAOTest extends DAOTestHelper {
         Dac d = createDac();
         Dataset dataset = createDataset();
         Consent c = createConsent(d.getDacId());
-        createAssociation(c.getConsentId(), dataset.getDataSetId());
+        consentDAO.insertConsentAssociation(c.getConsentId(), ASSOCIATION_TYPE_TEST, dataset.getDataSetId());
         Election e = createAccessElection(c.getConsentId(), dataset.getDataSetId());
         Vote vote = createChairpersonVote(chair.getDacUserId(), e.getElectionId());
         mailMessageDAO.insertEmail(
@@ -55,7 +55,7 @@ public class MailMessageDAOTest extends DAOTestHelper {
         Dac d = createDac();
         Dataset dataset = createDataset();
         Consent c = createConsent(d.getDacId());
-        createAssociation(c.getConsentId(), dataset.getDataSetId());
+        consentDAO.insertConsentAssociation(c.getConsentId(), ASSOCIATION_TYPE_TEST, dataset.getDataSetId());
         Election e = createAccessElection(c.getConsentId(), dataset.getDataSetId());
         mailMessageDAO.insertBulkEmailNoVotes(
                 Collections.singletonList(chair.getDacUserId()),

--- a/src/test/java/org/broadinstitute/consent/http/db/MailMessageDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/MailMessageDAOTest.java
@@ -34,7 +34,7 @@ public class MailMessageDAOTest extends DAOTestHelper {
         Dataset dataset = createDataset();
         Consent c = createConsent(d.getDacId());
         consentDAO.insertConsentAssociation(c.getConsentId(), ASSOCIATION_TYPE_TEST, dataset.getDataSetId());
-        Election e = createAccessElection(c.getConsentId(), dataset.getDataSetId());
+        Election e = createDataAccessElection(c.getConsentId(), dataset.getDataSetId());
         Vote vote = createChairpersonVote(chair.getDacUserId(), e.getElectionId());
         mailMessageDAO.insertEmail(
                 vote.getVoteId(),
@@ -56,7 +56,7 @@ public class MailMessageDAOTest extends DAOTestHelper {
         Dataset dataset = createDataset();
         Consent c = createConsent(d.getDacId());
         consentDAO.insertConsentAssociation(c.getConsentId(), ASSOCIATION_TYPE_TEST, dataset.getDataSetId());
-        Election e = createAccessElection(c.getConsentId(), dataset.getDataSetId());
+        Election e = createDataAccessElection(c.getConsentId(), dataset.getDataSetId());
         mailMessageDAO.insertBulkEmailNoVotes(
                 Collections.singletonList(chair.getDacUserId()),
                 e.getReferenceId(),

--- a/src/test/java/org/broadinstitute/consent/http/db/MatchDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/MatchDAOTest.java
@@ -121,10 +121,10 @@ public class MatchDAOTest extends DAOTestHelper {
     //query should pull the latest election for a given reference id
     //creating two access elections with the same reference id and datasetid to test that condition
     String darReferenceId = UUID.randomUUID().toString();
-    Election targetElection = createAccessElection(
+    Election targetElection = createDataAccessElection(
       darReferenceId, dataset.getDataSetId()
     );
-    Election ignoredAccessElection = createAccessElection(
+    Election ignoredAccessElection = createDataAccessElection(
       UUID.randomUUID().toString(), dataset.getDataSetId()
     );
 
@@ -155,7 +155,7 @@ public class MatchDAOTest extends DAOTestHelper {
     String darReferenceId = UUID.randomUUID().toString();
 
     //Generate access election for test
-    Election accessElection = createAccessElection(
+    Election accessElection = createDataAccessElection(
         UUID.randomUUID().toString(), dataset.getDataSetId());
 
     //Generate RP election for test

--- a/src/test/java/org/broadinstitute/consent/http/db/UserDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/UserDAOTest.java
@@ -256,7 +256,7 @@ public class UserDAOTest extends DAOTestHelper {
         Dac dac = createDac();
         User user = createUserWithRoleInDac(UserRoles.CHAIRPERSON.getRoleId(), dac.getDacId());
         Consent consent = createConsent(dac.getDacId());
-        Election election = createAccessElection(consent.getConsentId(), dataset.getDataSetId());
+        Election election = createDataAccessElection(consent.getConsentId(), dataset.getDataSetId());
         createDacVote(user.getDacUserId(), election.getElectionId());
 
         Set<User> users = userDAO.findUsersForElectionsByRoles(
@@ -273,7 +273,7 @@ public class UserDAOTest extends DAOTestHelper {
         Dac dac = createDac();
         User user = createUserWithRoleInDac(UserRoles.MEMBER.getRoleId(), dac.getDacId());
         Consent consent = createConsent(dac.getDacId());
-        Election election = createAccessElection(consent.getConsentId(), dataset.getDataSetId());
+        Election election = createDataAccessElection(consent.getConsentId(), dataset.getDataSetId());
         createDacVote(user.getDacUserId(), election.getElectionId());
 
         Set<User> users = userDAO.findUsersForElectionsByRoles(

--- a/src/test/java/org/broadinstitute/consent/http/db/UserDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/UserDAOTest.java
@@ -35,9 +35,9 @@ public class UserDAOTest extends DAOTestHelper {
         assertNotNull(user);
         assertFalse(user.getRoles().isEmpty());
 
-        addUserRole(UserRoles.ADMIN.getRoleId(), user.getDacUserId());
-        addUserRole(UserRoles.RESEARCHER.getRoleId(), user.getDacUserId());
-        addUserRole(UserRoles.DATAOWNER.getRoleId(), user.getDacUserId());
+        userRoleDAO.insertSingleUserRole(UserRoles.ADMIN.getRoleId(), user.getDacUserId());
+        userRoleDAO.insertSingleUserRole(UserRoles.RESEARCHER.getRoleId(), user.getDacUserId());
+        userRoleDAO.insertSingleUserRole(UserRoles.DATAOWNER.getRoleId(), user.getDacUserId());
 
         User user2 = userDAO.findUserById(user.getDacUserId());
         assertNotNull(user2);
@@ -130,7 +130,7 @@ public class UserDAOTest extends DAOTestHelper {
     @Test
     public void testFindUsersWithRoles() {
         User chair = createUserWithRole(UserRoles.ADMIN.getRoleId());
-        addUserRole(UserRoles.DATAOWNER.getRoleId(), chair.getDacUserId());
+        userRoleDAO.insertSingleUserRole(UserRoles.DATAOWNER.getRoleId(), chair.getDacUserId());
         Collection<Integer> userIds = Collections.singletonList(chair.getDacUserId());
         Collection<User> users = userDAO.findUsersWithRoles(userIds);
         users.forEach(u -> assertFalse("User: " + u.getDacUserId() + " has no roles", u.getRoles().isEmpty()));
@@ -143,10 +143,10 @@ public class UserDAOTest extends DAOTestHelper {
     @Test
     public void testFindDACUserByEmail() {
         User user = createUser();
-        addUserRole(UserRoles.ALUMNI.getRoleId(), user.getDacUserId());
-        addUserRole(UserRoles.ADMIN.getRoleId(), user.getDacUserId());
-        addUserRole(UserRoles.RESEARCHER.getRoleId(), user.getDacUserId());
-        addUserRole(UserRoles.DATAOWNER.getRoleId(), user.getDacUserId());
+        userRoleDAO.insertSingleUserRole(UserRoles.ALUMNI.getRoleId(), user.getDacUserId());
+        userRoleDAO.insertSingleUserRole(UserRoles.ADMIN.getRoleId(), user.getDacUserId());
+        userRoleDAO.insertSingleUserRole(UserRoles.RESEARCHER.getRoleId(), user.getDacUserId());
+        userRoleDAO.insertSingleUserRole(UserRoles.DATAOWNER.getRoleId(), user.getDacUserId());
         User user1 = userDAO.findUserByEmail(user.getEmail());
         assertNotNull(user1);
 

--- a/src/test/java/org/broadinstitute/consent/http/db/UserDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/UserDAOTest.java
@@ -289,7 +289,7 @@ public class UserDAOTest extends DAOTestHelper {
         Dac dac = createDac();
         User user = createUserWithRoleInDac(UserRoles.CHAIRPERSON.getRoleId(), dac.getDacId());
         Consent consent = createConsent(dac.getDacId());
-        createAssociation(consent.getConsentId(), dataset.getDataSetId());
+        consentDAO.insertConsentAssociation(consent.getConsentId(), ASSOCIATION_TYPE_TEST, dataset.getDataSetId());
 
         Set<User> users = userDAO.findUsersForDatasetsByRole(
                 Collections.singletonList(dataset.getDataSetId()),
@@ -307,7 +307,7 @@ public class UserDAOTest extends DAOTestHelper {
         Dac dac = createDac();
         createUserWithRoleInDac(UserRoles.MEMBER.getRoleId(), dac.getDacId());
         Consent consent = createConsent(dac.getDacId());
-        createAssociation(consent.getConsentId(), dataset.getDataSetId());
+        consentDAO.insertConsentAssociation(consent.getConsentId(), ASSOCIATION_TYPE_TEST, dataset.getDataSetId());
 
         Set<User> users = userDAO.findUsersForDatasetsByRole(
                 Collections.singletonList(dataset.getDataSetId()),

--- a/src/test/java/org/broadinstitute/consent/http/db/VoteDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/VoteDAOTest.java
@@ -1,6 +1,7 @@
 package org.broadinstitute.consent.http.db;
 
 import org.apache.commons.lang3.RandomStringUtils;
+import org.broadinstitute.consent.http.enumeration.ElectionStatus;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.enumeration.VoteType;
 import org.broadinstitute.consent.http.models.Consent;
@@ -246,28 +247,6 @@ public class VoteDAOTest extends DAOTestHelper {
         assertEquals(vote.getVoteId(), foundVotes.get(0).getVoteId());
     }
 
-//    @Test
-//    public void testFindVoteByElectionIdAndType() {
-//        User user = createUserWithRole(UserRoles.CHAIRPERSON.getRoleId());
-//        Dac dac = createDac();
-//        Consent consent = createConsent(dac.getDacId());
-//        DataSet dataset = createDataset();
-//        Election election = createAccessElection(consent.getConsentId(), dataset.getDataSetId());
-//        Vote vote = createDacVote(user.getDacUserId(), election.getElectionId());
-//
-//        Vote foundVote = voteDAO.findVoteByElectionIdAndType(election.getElectionId(), vote.getType());
-//        assertNotNull(foundVote);
-//        assertEquals(vote.getVoteId(), foundVote.getVoteId());
-//
-//        Vote foundVote2 = voteDAO.findVoteByElectionIdAndType(election.getElectionId(), vote.getType().toLowerCase());
-//        assertNotNull(foundVote2);
-//        assertEquals(vote.getVoteId(), foundVote2.getVoteId());
-//
-//        Vote foundVote3 = voteDAO.findVoteByElectionIdAndType(election.getElectionId(), vote.getType().toUpperCase());
-//        assertNotNull(foundVote3);
-//        assertEquals(vote.getVoteId(), foundVote3.getVoteId());
-//    }
-
     @Test
     public void testFindChairPersonVoteByElectionIdAndDACUserId() {
         User user = createUserWithRole(UserRoles.CHAIRPERSON.getRoleId());
@@ -429,7 +408,10 @@ public class VoteDAOTest extends DAOTestHelper {
         Dac dac = createDac();
         Consent consent = createConsent(dac.getDacId());
         Election election = createDataAccessElection(consent.getConsentId(), dataset.getDataSetId());
-        closeElection(election);
+        electionDAO.updateElectionById(
+                election.getElectionId(),
+                ElectionStatus.CLOSED.getValue(),
+                new Date());
         Vote v = createFinalVote(user.getDacUserId(), election.getElectionId());
         boolean voteValue = true;
         voteDAO.updateVote(
@@ -460,7 +442,10 @@ public class VoteDAOTest extends DAOTestHelper {
         Dac dac = createDac();
         Consent consent = createConsent(dac.getDacId());
         Election election = createDataAccessElection(consent.getConsentId(), dataset.getDataSetId());
-        closeElection(election);
+        electionDAO.updateElectionById(
+                election.getElectionId(),
+                ElectionStatus.CLOSED.getValue(),
+                new Date());
         Vote v = createDacVote(user.getDacUserId(), election.getElectionId());
         boolean voteValue = true;
         voteDAO.updateVote(

--- a/src/test/java/org/broadinstitute/consent/http/db/VoteDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/VoteDAOTest.java
@@ -36,7 +36,7 @@ public class VoteDAOTest extends DAOTestHelper {
         User user = createUserWithRole(UserRoles.CHAIRPERSON.getRoleId());
         Consent consent = createConsent(null);
         Dataset dataset = createDataset();
-        Election election = createAccessElection(consent.getConsentId(), dataset.getDataSetId());
+        Election election = createDataAccessElection(consent.getConsentId(), dataset.getDataSetId());
         Vote vote = createDacVote(user.getDacUserId(), election.getElectionId());
 
         List<Vote> votes = voteDAO.findVotesByReferenceId(election.getReferenceId());
@@ -49,7 +49,7 @@ public class VoteDAOTest extends DAOTestHelper {
         User user = createUserWithRole(UserRoles.CHAIRPERSON.getRoleId());
         Consent consent = createConsent(null);
         Dataset dataset = createDataset();
-        Election election = createAccessElection(consent.getConsentId(), dataset.getDataSetId());
+        Election election = createDataAccessElection(consent.getConsentId(), dataset.getDataSetId());
         createDacVote(user.getDacUserId(), election.getElectionId());
 
         List<ElectionReviewVote> votes = voteDAO.findElectionReviewVotesByElectionId(election.getElectionId());
@@ -62,7 +62,7 @@ public class VoteDAOTest extends DAOTestHelper {
         User user = createUserWithRole(UserRoles.CHAIRPERSON.getRoleId());
         Consent consent = createConsent(null);
         Dataset dataset = createDataset();
-        Election election = createAccessElection(consent.getConsentId(), dataset.getDataSetId());
+        Election election = createDataAccessElection(consent.getConsentId(), dataset.getDataSetId());
         Vote vote = createDacVote(user.getDacUserId(), election.getElectionId());
 
         List<ElectionReviewVote> votes = voteDAO.findElectionReviewVotesByElectionId(election.getElectionId(), vote.getType());
@@ -83,7 +83,7 @@ public class VoteDAOTest extends DAOTestHelper {
         User user = createUserWithRole(UserRoles.CHAIRPERSON.getRoleId());
         Consent consent = createConsent(null);
         Dataset dataset = createDataset();
-        Election election = createAccessElection(consent.getConsentId(), dataset.getDataSetId());
+        Election election = createDataAccessElection(consent.getConsentId(), dataset.getDataSetId());
         Vote vote = createDacVote(user.getDacUserId(), election.getElectionId());
 
         Vote foundVote = voteDAO.findVoteById(vote.getVoteId());
@@ -98,7 +98,7 @@ public class VoteDAOTest extends DAOTestHelper {
         User user4 = createUserWithRole(UserRoles.MEMBER.getRoleId());
         Consent consent = createConsent(null);
         Dataset dataset = createDataset();
-        Election election = createAccessElection(consent.getConsentId(), dataset.getDataSetId());
+        Election election = createDataAccessElection(consent.getConsentId(), dataset.getDataSetId());
         Vote vote = createDacVote(user.getDacUserId(), election.getElectionId());
         Vote vote2 = createDacVote(user2.getDacUserId(), election.getElectionId());
         Vote vote3 = createDacVote(user3.getDacUserId(), election.getElectionId());
@@ -117,7 +117,7 @@ public class VoteDAOTest extends DAOTestHelper {
         Dac dac = createDac();
         Consent consent = createConsent(dac.getDacId());
         Dataset dataset = createDataset();
-        Election election = createAccessElection(consent.getConsentId(), dataset.getDataSetId());
+        Election election = createDataAccessElection(consent.getConsentId(), dataset.getDataSetId());
         Vote vote = createDacVote(user.getDacUserId(), election.getElectionId());
 
         List<Vote> foundVotes = voteDAO.findDACVotesByElectionId(election.getElectionId());
@@ -132,12 +132,12 @@ public class VoteDAOTest extends DAOTestHelper {
         User user = createUserWithRole(UserRoles.CHAIRPERSON.getRoleId());
         Consent consent = createConsent(null);
         Dataset dataset = createDataset();
-        Election election = createAccessElection(consent.getConsentId(), dataset.getDataSetId());
+        Election election = createDataAccessElection(consent.getConsentId(), dataset.getDataSetId());
         createDacVote(user.getDacUserId(), election.getElectionId());
 
         Consent consent2 = createConsent(null);
         Dataset dataset2 = createDataset();
-        Election election2 = createAccessElection(consent2.getConsentId(), dataset2.getDataSetId());
+        Election election2 = createDataAccessElection(consent2.getConsentId(), dataset2.getDataSetId());
         createDacVote(user.getDacUserId(), election2.getElectionId());
         List<Integer> electionIds = Arrays.asList(election.getElectionId(), election2.getElectionId());
 
@@ -152,12 +152,12 @@ public class VoteDAOTest extends DAOTestHelper {
         User user = createUserWithRole(UserRoles.CHAIRPERSON.getRoleId());
         Consent consent = createConsent(null);
         Dataset dataset = createDataset();
-        Election election = createAccessElection(consent.getConsentId(), dataset.getDataSetId());
+        Election election = createDataAccessElection(consent.getConsentId(), dataset.getDataSetId());
         Vote vote = createDacVote(user.getDacUserId(), election.getElectionId());
 
         Consent consent2 = createConsent(null);
         Dataset dataset2 = createDataset();
-        Election election2 = createAccessElection(consent2.getConsentId(), dataset2.getDataSetId());
+        Election election2 = createDataAccessElection(consent2.getConsentId(), dataset2.getDataSetId());
         createDacVote(user.getDacUserId(), election2.getElectionId());
         List<Integer> electionIds = Arrays.asList(election.getElectionId(), election2.getElectionId());
 
@@ -182,7 +182,7 @@ public class VoteDAOTest extends DAOTestHelper {
         User user = createUserWithRole(UserRoles.CHAIRPERSON.getRoleId());
         Consent consent = createConsent(null);
         Dataset dataset = createDataset();
-        Election election = createAccessElection(consent.getConsentId(), dataset.getDataSetId());
+        Election election = createDataAccessElection(consent.getConsentId(), dataset.getDataSetId());
         Vote vote = createDacVote(user.getDacUserId(), election.getElectionId());
 
         List<Vote> foundVotes = voteDAO.findVotesByElectionIdAndType(election.getElectionId(), vote.getType());
@@ -207,7 +207,7 @@ public class VoteDAOTest extends DAOTestHelper {
         Dac dac = createDac();
         Consent consent = createConsent(dac.getDacId());
         Dataset dataset = createDataset();
-        Election election = createAccessElection(consent.getConsentId(), dataset.getDataSetId());
+        Election election = createDataAccessElection(consent.getConsentId(), dataset.getDataSetId());
         Vote vote = createDacVote(user.getDacUserId(), election.getElectionId());
 
         List<Vote> foundVotes = voteDAO.findPendingVotesByElectionId(election.getElectionId());
@@ -223,7 +223,7 @@ public class VoteDAOTest extends DAOTestHelper {
         Dac dac = createDac();
         Consent consent = createConsent(dac.getDacId());
         Dataset dataset = createDataset();
-        Election election = createAccessElection(consent.getConsentId(), dataset.getDataSetId());
+        Election election = createDataAccessElection(consent.getConsentId(), dataset.getDataSetId());
         Vote vote = createDacVote(user.getDacUserId(), election.getElectionId());
 
         Vote foundVote = voteDAO.findVoteByElectionIdAndDACUserId(election.getElectionId(), user.getDacUserId());
@@ -237,7 +237,7 @@ public class VoteDAOTest extends DAOTestHelper {
         Dac dac = createDac();
         Consent consent = createConsent(dac.getDacId());
         Dataset dataset = createDataset();
-        Election election = createAccessElection(consent.getConsentId(), dataset.getDataSetId());
+        Election election = createDataAccessElection(consent.getConsentId(), dataset.getDataSetId());
         Vote vote = createDacVote(user.getDacUserId(), election.getElectionId());
 
         List<Vote> foundVotes = voteDAO.findVotesByElectionIdAndDACUserIds(election.getElectionId(), Collections.singletonList(user.getDacUserId()));
@@ -274,7 +274,7 @@ public class VoteDAOTest extends DAOTestHelper {
         Dac dac = createDac();
         Consent consent = createConsent(dac.getDacId());
         Dataset dataset = createDataset();
-        Election election = createAccessElection(consent.getConsentId(), dataset.getDataSetId());
+        Election election = createDataAccessElection(consent.getConsentId(), dataset.getDataSetId());
         Vote vote = createFinalVote(user.getDacUserId(), election.getElectionId());
 
         Vote foundVote = voteDAO.findChairPersonVoteByElectionIdAndDACUserId(election.getElectionId(), user.getDacUserId());
@@ -288,7 +288,7 @@ public class VoteDAOTest extends DAOTestHelper {
         Dac dac = createDac();
         Consent consent = createConsent(dac.getDacId());
         Dataset dataset = createDataset();
-        Election election = createAccessElection(consent.getConsentId(), dataset.getDataSetId());
+        Election election = createDataAccessElection(consent.getConsentId(), dataset.getDataSetId());
         Vote vote = createDacVote(user.getDacUserId(), election.getElectionId());
 
         Integer voteId = voteDAO.checkVoteById(election.getReferenceId(), vote.getVoteId());
@@ -307,7 +307,7 @@ public class VoteDAOTest extends DAOTestHelper {
         Dac dac = createDac();
         Consent consent = createConsent(dac.getDacId());
         Dataset dataset = createDataset();
-        Election election = createAccessElection(consent.getConsentId(), dataset.getDataSetId());
+        Election election = createDataAccessElection(consent.getConsentId(), dataset.getDataSetId());
         Vote vote = createDacVote(user.getDacUserId(), election.getElectionId());
 
         voteDAO.deleteVoteById(vote.getVoteId());
@@ -321,7 +321,7 @@ public class VoteDAOTest extends DAOTestHelper {
         Dataset dataset = createDataset();
         Dac dac = createDac();
         Consent consent = createConsent(dac.getDacId());
-        Election election = createAccessElection(consent.getConsentId(), dataset.getDataSetId());
+        Election election = createDataAccessElection(consent.getConsentId(), dataset.getDataSetId());
         Vote v = createDacVote(user.getDacUserId(), election.getElectionId());
 
         Vote vote = voteDAO.findVoteById(v.getVoteId());
@@ -335,7 +335,7 @@ public class VoteDAOTest extends DAOTestHelper {
         Dataset dataset = createDataset();
         Dac dac = createDac();
         Consent consent = createConsent(dac.getDacId());
-        Election election = createAccessElection(consent.getConsentId(), dataset.getDataSetId());
+        Election election = createDataAccessElection(consent.getConsentId(), dataset.getDataSetId());
         Vote v = createDacVote(user.getDacUserId(), election.getElectionId());
 
         String rationale = "rationale";
@@ -363,7 +363,7 @@ public class VoteDAOTest extends DAOTestHelper {
         Dataset dataset = createDataset();
         Dac dac = createDac();
         Consent consent = createConsent(dac.getDacId());
-        Election election = createAccessElection(consent.getConsentId(), dataset.getDataSetId());
+        Election election = createDataAccessElection(consent.getConsentId(), dataset.getDataSetId());
         Vote v = createDacVote(user.getDacUserId(), election.getElectionId());
 
         voteDAO.updateVoteReminderFlag(v.getVoteId(), true);
@@ -381,7 +381,7 @@ public class VoteDAOTest extends DAOTestHelper {
         Dataset dataset = createDataset();
         Dac dac = createDac();
         Consent consent = createConsent(dac.getDacId());
-        Election election = createAccessElection(consent.getConsentId(), dataset.getDataSetId());
+        Election election = createDataAccessElection(consent.getConsentId(), dataset.getDataSetId());
         Vote v = createDacVote(user.getDacUserId(), election.getElectionId());
 
         Vote vote = voteDAO.findVotesByReferenceIdTypeAndUser(election.getReferenceId(), user.getDacUserId(), v.getType());
@@ -403,7 +403,7 @@ public class VoteDAOTest extends DAOTestHelper {
         Dataset dataset = createDataset();
         Dac dac = createDac();
         Consent consent = createConsent(dac.getDacId());
-        Election election = createAccessElection(consent.getConsentId(), dataset.getDataSetId());
+        Election election = createDataAccessElection(consent.getConsentId(), dataset.getDataSetId());
         Vote v = createDacVote(user.getDacUserId(), election.getElectionId());
 
         List<Vote> votes = voteDAO.findVoteByTypeAndElectionId(election.getElectionId(), v.getType());
@@ -428,7 +428,7 @@ public class VoteDAOTest extends DAOTestHelper {
         Dataset dataset = createDataset();
         Dac dac = createDac();
         Consent consent = createConsent(dac.getDacId());
-        Election election = createAccessElection(consent.getConsentId(), dataset.getDataSetId());
+        Election election = createDataAccessElection(consent.getConsentId(), dataset.getDataSetId());
         closeElection(election);
         Vote v = createFinalVote(user.getDacUserId(), election.getElectionId());
         boolean voteValue = true;
@@ -459,7 +459,7 @@ public class VoteDAOTest extends DAOTestHelper {
         Dataset dataset = createDataset();
         Dac dac = createDac();
         Consent consent = createConsent(dac.getDacId());
-        Election election = createAccessElection(consent.getConsentId(), dataset.getDataSetId());
+        Election election = createDataAccessElection(consent.getConsentId(), dataset.getDataSetId());
         closeElection(election);
         Vote v = createDacVote(user.getDacUserId(), election.getElectionId());
         boolean voteValue = true;
@@ -486,7 +486,7 @@ public class VoteDAOTest extends DAOTestHelper {
         Dataset dataset = createDataset();
         Dac dac = createDac();
         Consent consent = createConsent(dac.getDacId());
-        Election election = createAccessElection(consent.getConsentId(), dataset.getDataSetId());
+        Election election = createDataAccessElection(consent.getConsentId(), dataset.getDataSetId());
         List<Integer> userIds = Arrays.asList(user1.getDacUserId(), user2.getDacUserId(), user3.getDacUserId());
 
         voteDAO.insertVotes(userIds, election.getElectionId(), VoteType.DAC.getValue());
@@ -502,7 +502,7 @@ public class VoteDAOTest extends DAOTestHelper {
         Dataset dataset = createDataset();
         Dac dac = createDac();
         Consent consent = createConsent(dac.getDacId());
-        Election election = createAccessElection(consent.getConsentId(), dataset.getDataSetId());
+        Election election = createDataAccessElection(consent.getConsentId(), dataset.getDataSetId());
         Vote vote = createDacVote(user.getDacUserId(), election.getElectionId());
 
         List<Vote> votes = voteDAO.findDataOwnerPendingVotesByElectionId(election.getElectionId(), vote.getType());
@@ -531,7 +531,7 @@ public class VoteDAOTest extends DAOTestHelper {
         Dataset dataset = createDataset();
         Dac dac = createDac();
         Consent consent = createConsent(dac.getDacId());
-        Election election = createAccessElection(consent.getConsentId(), dataset.getDataSetId());
+        Election election = createDataAccessElection(consent.getConsentId(), dataset.getDataSetId());
         Vote vote = createDacVote(user.getDacUserId(), election.getElectionId());
 
         List<Vote> votes = voteDAO.findVotesOnOpenElections(user.getDacUserId());
@@ -547,7 +547,7 @@ public class VoteDAOTest extends DAOTestHelper {
         Dataset dataset = createDataset();
         Dac dac = createDac();
         Consent consent = createConsent(dac.getDacId());
-        Election election = createAccessElection(consent.getConsentId(), dataset.getDataSetId());
+        Election election = createDataAccessElection(consent.getConsentId(), dataset.getDataSetId());
         Vote vote = createDacVote(user.getDacUserId(), election.getElectionId());
 
         voteDAO.removeVotesByIds(Collections.singletonList(vote.getVoteId()));
@@ -561,7 +561,7 @@ public class VoteDAOTest extends DAOTestHelper {
         Dataset dataset = createDataset();
         Dac dac = createDac();
         Consent consent = createConsent(dac.getDacId());
-        Election election = createAccessElection(consent.getConsentId(), dataset.getDataSetId());
+        Election election = createDataAccessElection(consent.getConsentId(), dataset.getDataSetId());
         Vote vote = createDacVote(user.getDacUserId(), election.getElectionId());
 
         List<Vote> votes = voteDAO.findVotesByElectionIdsAndUser(
@@ -580,7 +580,7 @@ public class VoteDAOTest extends DAOTestHelper {
         Dataset dataset = createDataset();
         Dac dac = createDac();
         Consent consent = createConsent(dac.getDacId());
-        Election election = createAccessElection(consent.getConsentId(), dataset.getDataSetId());
+        Election election = createDataAccessElection(consent.getConsentId(), dataset.getDataSetId());
         createChairpersonVote(user.getDacUserId(), election.getElectionId());
 
         List<Vote> userVotes = voteDAO.findVotesByUserId(user.getDacUserId());
@@ -594,7 +594,7 @@ public class VoteDAOTest extends DAOTestHelper {
         Dataset dataset = createDataset();
         Dac dac = createDac();
         Consent consent = createConsent(dac.getDacId());
-        Election election = createAccessElection(consent.getConsentId(), dataset.getDataSetId());
+        Election election = createDataAccessElection(consent.getConsentId(), dataset.getDataSetId());
         Vote vote = createChairpersonVote(user.getDacUserId(), election.getElectionId());
         voteDAO.updateVote(
                 true,
@@ -617,7 +617,7 @@ public class VoteDAOTest extends DAOTestHelper {
         Dac dac = createDac();
         User user = createUserWithRoleInDac(UserRoles.MEMBER.getRoleId(), dac.getDacId());
         DataAccessRequest dar = createDataAccessRequestV3();
-        Election election = createAccessElection(dar.getReferenceId(), dataset.getDataSetId());
+        Election election = createDataAccessElection(dar.getReferenceId(), dataset.getDataSetId());
         Vote dacVote = createDacVote(user.getDacUserId(), election.getElectionId());
         assertNull(dacVote.getRationale());
 

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DarCollectionServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DarCollectionServiceDAOTest.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.consent.http.service.dao;
 
+import org.apache.commons.lang3.RandomUtils;
 import org.broadinstitute.consent.http.db.DAOTestHelper;
 import org.broadinstitute.consent.http.enumeration.ElectionStatus;
 import org.broadinstitute.consent.http.enumeration.ElectionType;
@@ -359,7 +360,17 @@ public class DarCollectionServiceDAOTest extends DAOTestHelper {
    * Helper method to generate a DarCollection with a Dac, a Dataset, and a create User
    */
   private DarCollection setUpDarCollectionWithDacDataset() {
-    DarCollection collection = createDarCollectionWithSingleDataAccessRequest();
+    User user = createUser();
+    String darCode = "DAR-" + RandomUtils.nextInt(100, 1000);
+    Dac dac = createDac();
+    createUserWithRoleInDac(UserRoles.CHAIRPERSON.getRoleId(), dac.getDacId());
+    createUserWithRoleInDac(UserRoles.MEMBER.getRoleId(), dac.getDacId());
+    Consent consent = createConsent(dac.getDacId());
+    Dataset dataset = createDataset();
+    consentDAO.insertConsentAssociation(consent.getConsentId(), ASSOCIATION_TYPE_TEST, dataset.getDataSetId());
+    Integer collectionId = darCollectionDAO.insertDarCollection(darCode, user.getDacUserId(), new Date());
+    createDarForCollection(user, collectionId, dataset);
+    DarCollection collection = darCollectionDAO.findDARCollectionByCollectionId(collectionId);
     DataAccessRequest dar = collection.getDars().values().stream().findFirst().orElse(null);
     assertNotNull(dar);
     assertNotNull(dar.getData());

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DarCollectionServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DarCollectionServiceDAOTest.java
@@ -381,7 +381,7 @@ public class DarCollectionServiceDAOTest extends DAOTestHelper {
     createUserWithRoleInDac(UserRoles.MEMBER.getRoleId(), dac.getDacId());
     Consent consent = createConsent(dac.getDacId());
     Dataset dataset = createDataset();
-    createAssociation(consent.getConsentId(), dataset.getDataSetId());
+    consentDAO.insertConsentAssociation(consent.getConsentId(), ASSOCIATION_TYPE_TEST, dataset.getDataSetId());
 
     // Create new DAR with Dataset and add it to the collection
     User user = createUser();

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/VoteServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/VoteServiceDAOTest.java
@@ -9,6 +9,7 @@ import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.Vote;
 import org.junit.Test;
 
+import java.util.Date;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -120,7 +121,11 @@ public class VoteServiceDAOTest extends DAOTestHelper {
     Election rpElection1 = createRPElection(dar.getReferenceId(), dataset.getDataSetId());
     Election rpElection2 = createRPElection(dar.getReferenceId(), dataset.getDataSetId());
     Election accessElection = createDataAccessElection(dar.getReferenceId(), dataset.getDataSetId());
-    changeElectionStatus(rpElection1, ElectionStatus.CLOSED);
+    electionDAO.updateElectionById(
+        rpElection1.getElectionId(),
+        ElectionStatus.CLOSED.getValue(),
+        new Date());
+
     Vote vote1 = createDacVote(user.getDacUserId(), rpElection1.getElectionId());
     Vote vote2 = createDacVote(user.getDacUserId(), rpElection2.getElectionId());
     Vote vote3 = createDacVote(user.getDacUserId(), accessElection.getElectionId());

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/VoteServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/VoteServiceDAOTest.java
@@ -33,7 +33,7 @@ public class VoteServiceDAOTest extends DAOTestHelper {
     User user = createUser();
     DataAccessRequest dar = createDataAccessRequestV3();
     Dataset dataset = createDataset();
-    Election election = createAccessElection(dar.getReferenceId(), dataset.getDataSetId());
+    Election election = createDataAccessElection(dar.getReferenceId(), dataset.getDataSetId());
     Vote vote = createFinalVote(user.getDacUserId(), election.getElectionId());
     String rationale = "rationale";
     initService();
@@ -53,7 +53,7 @@ public class VoteServiceDAOTest extends DAOTestHelper {
     User user = createUser();
     DataAccessRequest dar = createDataAccessRequestV3();
     Dataset dataset = createDataset();
-    Election election = createAccessElection(dar.getReferenceId(), dataset.getDataSetId());
+    Election election = createDataAccessElection(dar.getReferenceId(), dataset.getDataSetId());
     Vote vote = createFinalVote(user.getDacUserId(), election.getElectionId());
     initService();
 
@@ -70,7 +70,7 @@ public class VoteServiceDAOTest extends DAOTestHelper {
     User user = createUser();
     DataAccessRequest dar = createDataAccessRequestV3();
     Dataset dataset = createDataset();
-    Election election = createAccessElection(dar.getReferenceId(), dataset.getDataSetId());
+    Election election = createDataAccessElection(dar.getReferenceId(), dataset.getDataSetId());
     Vote vote = createDacVote(user.getDacUserId(), election.getElectionId());
     String rationale = "rationale";
     initService();
@@ -90,7 +90,7 @@ public class VoteServiceDAOTest extends DAOTestHelper {
     User user = createUser();
     DataAccessRequest dar = createDataAccessRequestV3();
     Dataset dataset = createDataset();
-    Election election = createAccessElection(dar.getReferenceId(), dataset.getDataSetId());
+    Election election = createDataAccessElection(dar.getReferenceId(), dataset.getDataSetId());
     Vote vote1 = createDacVote(user.getDacUserId(), election.getElectionId());
     Vote vote2 = createDacVote(user.getDacUserId(), election.getElectionId());
     Vote vote3 = createDacVote(user.getDacUserId(), election.getElectionId());
@@ -119,7 +119,7 @@ public class VoteServiceDAOTest extends DAOTestHelper {
     Dataset dataset = createDataset();
     Election rpElection1 = createRPElection(dar.getReferenceId(), dataset.getDataSetId());
     Election rpElection2 = createRPElection(dar.getReferenceId(), dataset.getDataSetId());
-    Election accessElection = createAccessElection(dar.getReferenceId(), dataset.getDataSetId());
+    Election accessElection = createDataAccessElection(dar.getReferenceId(), dataset.getDataSetId());
     changeElectionStatus(rpElection1, ElectionStatus.CLOSED);
     Vote vote1 = createDacVote(user.getDacUserId(), rpElection1.getElectionId());
     Vote vote2 = createDacVote(user.getDacUserId(), rpElection2.getElectionId());


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-1740

## Changes
This PR makes no functional or logical changes. The goal here is to start cleaning up the dao test helper to make it easier to use from other test classes. We're emphasizing tests to create objects on their own and de-emphasizing the use of the test helper to do object construction.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
