### PR TITLE
[DUOS-1762][risk=no] Fix join insert

### DIFF
--- a/src/main/resources/changesets/changelog-consent-84.0.xml
+++ b/src/main/resources/changesets/changelog-consent-84.0.xml
@@ -5,7 +5,9 @@
         <!--Now back populate the dar_dataset table-->
         <sql>
             INSERT INTO dar_dataset (dataset_id, reference_id)
-            SELECT DISTINCT jsonb_array_elements(((data #>> '{}')::jsonb->>'datasetIds')::jsonb)::INTEGER AS dataset_id, reference_id FROM data_access_request
+            SELECT DISTINCT jsonb_array_elements(((data #>> '{}')::jsonb->>'datasetIds')::jsonb)::INTEGER AS dataset_id, reference_id
+            FROM data_access_request
+            ON CONFLICT DO NOTHING
         </sql>
         <rollback>
             <sql>


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DUOS-1762

Fixes the following error we see in the deployment
```
Detail: Key (dataset_id, reference_id)=(2, 71a93420-90f4-45fb-8f1e-32056510ad5a) already exists. [Failed SQL: (0) INSERT INTO dar_dataset (dataset_id, reference_id)

SELECT DISTINCT jsonb_array_elements(((data #>> '{}')::jsonb->>'datasetIds')::jsonb)::INTEGER AS dataset_id, reference_id FROM data_access_request]
```

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
