### PR TITLE
[DUOS-1691] Add a reject ToS passthrough to Sam

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/configurations/ServicesConfiguration.java
+++ b/src/main/java/org/broadinstitute/consent/http/configurations/ServicesConfiguration.java
@@ -69,7 +69,7 @@ public class ServicesConfiguration {
     return getSamUrl() + "tos/text";
   }
 
-  public String postTosAcceptedUrl() {
+  public String tosRegistrationUrl() {
     return getSamUrl() + "register/user/v1/termsofservice";
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/resources/SamResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/SamResource.java
@@ -14,6 +14,7 @@ import org.broadinstitute.consent.http.service.UserService;
 import org.broadinstitute.consent.http.service.sam.SamService;
 
 import javax.annotation.security.PermitAll;
+import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.NotFoundException;
 import javax.ws.rs.POST;
@@ -113,6 +114,20 @@ public class SamResource extends Resource {
         return createExceptionResponse(e);
       }
       TosResponse tosResponse = samService.postTosAcceptedStatus(authUser);
+      return Response.ok().entity(tosResponse).build();
+    } catch (Exception e) {
+      return createExceptionResponse(e);
+    }
+  }
+
+
+  @Path("register/self/tos")
+  @DELETE
+  @Produces("application/json")
+  @PermitAll
+  public Response removeTos(@Auth AuthUser authUser) {
+    try {
+      TosResponse tosResponse = samService.removeTosAcceptedStatus(authUser);
       return Response.ok().entity(tosResponse).build();
     } catch (Exception e) {
       return createExceptionResponse(e);

--- a/src/main/java/org/broadinstitute/consent/http/service/sam/SamService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/sam/SamService.java
@@ -110,9 +110,17 @@ public class SamService {
   }
 
   public TosResponse postTosAcceptedStatus(AuthUser authUser) throws Exception {
-    GenericUrl genericUrl = new GenericUrl(configuration.postTosAcceptedUrl());
+    GenericUrl genericUrl = new GenericUrl(configuration.tosRegistrationUrl());
     JsonHttpContent content = new JsonHttpContent(new GsonFactory(), "app.terra.bio/#terms-of-service");
     HttpRequest request = clientUtil.buildPostRequest(genericUrl, content, authUser);
+    HttpResponse response = clientUtil.handleHttpRequest(request);
+    String body = response.parseAsString();
+    return new Gson().fromJson(body, TosResponse.class);
+  }
+
+  public TosResponse removeTosAcceptedStatus(AuthUser authUser) throws Exception {
+    GenericUrl genericUrl = new GenericUrl(configuration.tosRegistrationUrl());
+    HttpRequest request = clientUtil.buildDeleteRequest(genericUrl, authUser);
     HttpResponse response = clientUtil.handleHttpRequest(request);
     String body = response.parseAsString();
     return new Gson().fromJson(body, TosResponse.class);

--- a/src/main/java/org/broadinstitute/consent/http/util/HttpClientUtil.java
+++ b/src/main/java/org/broadinstitute/consent/http/util/HttpClientUtil.java
@@ -51,6 +51,14 @@ public class HttpClientUtil {
     return request;
   }
 
+  public HttpRequest buildDeleteRequest(GenericUrl genericUrl, AuthUser authUser)
+      throws Exception {
+    HttpTransport transport = new NetHttpTransport();
+    HttpRequest request = transport.createRequestFactory().buildDeleteRequest(genericUrl);
+    request.setHeaders(buildHeaders(authUser));
+    return request;
+  }
+
   public HttpResponse handleHttpRequest(HttpRequest request) {
     try {
       request.setThrowExceptionOnExecuteError(false);

--- a/src/main/resources/assets/paths/samRegisterSelfTos.yaml
+++ b/src/main/resources/assets/paths/samRegisterSelfTos.yaml
@@ -12,3 +12,17 @@ post:
             $ref: '../schemas/SamTosResponse.yaml'
     500:
       description: Internal Server Error
+delete:
+  summary: Reject ToS for current user in the Sam system using current login credentials
+  description: Reject ToS for current user in the Sam system using current login credentials
+  tags:
+    - Sam
+  responses:
+    200:
+      description: Reject ToS
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/SamTosResponse.yaml'
+    500:
+      description: Internal Server Error

--- a/src/test/java/org/broadinstitute/consent/http/resources/SamResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/SamResourceTest.java
@@ -172,4 +172,17 @@ public class SamResourceTest {
     assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
     verify(samService, times(1)).postRegistrationInfo(any());
   }
+
+  @Test
+  public void testRemoveSelfTos() throws Exception {
+    TosResponse.Enabled enabled = new TosResponse.Enabled()
+            .setAdminEnabled(true).setTosAccepted(false).setGoogle(true).setAllUsersGroup(true).setLdap(true);
+    UserStatus.UserInfo info = new UserStatus.UserInfo().setUserEmail("test@test.org").setUserSubjectId("subjectId");
+    TosResponse tosResponse = new TosResponse().setEnabled(enabled).setUserInfo(info);
+    when(samService.removeTosAcceptedStatus(any())).thenReturn(tosResponse);
+    initResource();
+    Response response = resource.removeTos(authUser);
+    assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+  }
+
 }

--- a/src/test/java/org/broadinstitute/consent/http/service/SamServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/SamServiceTest.java
@@ -209,4 +209,19 @@ public class SamServiceTest implements WithMockServer {
       fail(e.getMessage());
     }
   }
+
+  @Test
+  public void testRemoveTosAcceptedStatus() {
+    TosResponse.Enabled enabled = new TosResponse.Enabled()
+            .setAdminEnabled(true).setTosAccepted(false).setGoogle(true).setAllUsersGroup(true).setLdap(true);
+    UserStatus.UserInfo info = new UserStatus.UserInfo().setUserEmail("test@test.org").setUserSubjectId("subjectId");
+    TosResponse tosResponse = new TosResponse().setEnabled(enabled).setUserInfo(info);
+    mockServerClient.when(request()).respond(response().withHeader(Header.header("Content-Type", "application/json")).withStatusCode(200).withBody(tosResponse.toString()));
+
+    try {
+      service.removeTosAcceptedStatus(authUser);
+    } catch (Exception e) {
+      fail(e.getMessage());
+    }
+  }
 }


### PR DESCRIPTION
## Addresses

https://broadworkbench.atlassian.net/browse/DUOS-1691

Adds endpoint which allows rejecting the ToS (in Sam) after a user has already logged in / accepted the ToS.

Related UI branch: https://github.com/DataBiosphere/duos-ui/tree/DUOS-1692-reject-tos

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
