### PR TITLE
[DUOS-1892][risk=no] update get institution by to include signing officials 

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
@@ -462,7 +462,7 @@ public class ConsentModule extends AbstractModule {
 
     @Provides
     InstitutionService providesInstitutionService() {
-        return new InstitutionService(providesInstitutionDAO());
+        return new InstitutionService(providesInstitutionDAO(), providesUserDAO());
     }
 
     @Provides

--- a/src/main/java/org/broadinstitute/consent/http/service/InstitutionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/InstitutionService.java
@@ -65,10 +65,13 @@ public class InstitutionService {
   public Institution findInstitutionById(Integer id) {
     Institution institution = institutionDAO.findInstitutionById(id);
     isInstitutionNull(institution);
+
     List<SimplifiedUser> signingOfficials = userDAO.getSOsByInstitution(id).stream()
             .map(SimplifiedUser::new)
             .collect(Collectors.toList());
-    return institutionDAO.findInstitutionById(id);
+    institution.setSigningOfficials(signingOfficials);
+
+    return institution;
   }
 
   public List<Institution> findAllInstitutions() {

--- a/src/main/java/org/broadinstitute/consent/http/service/InstitutionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/InstitutionService.java
@@ -3,21 +3,26 @@ package org.broadinstitute.consent.http.service;
 import com.google.inject.Inject;
 
 import org.broadinstitute.consent.http.db.InstitutionDAO;
+import org.broadinstitute.consent.http.db.UserDAO;
 import org.broadinstitute.consent.http.models.Institution;
+import org.broadinstitute.consent.http.service.UserService.SimplifiedUser;
 
 import java.util.Date;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 import javax.ws.rs.NotFoundException;
 
 public class InstitutionService {
 
   private final InstitutionDAO institutionDAO;
+  private final UserDAO userDAO;
 
   @Inject
-  public InstitutionService(InstitutionDAO institutionDAO) {
+  public InstitutionService(InstitutionDAO institutionDAO, UserDAO userDAO) {
     this.institutionDAO = institutionDAO;
+    this.userDAO = userDAO;
   }
 
   public Institution createInstitution(Institution institution, Integer userId) {
@@ -60,6 +65,9 @@ public class InstitutionService {
   public Institution findInstitutionById(Integer id) {
     Institution institution = institutionDAO.findInstitutionById(id);
     isInstitutionNull(institution);
+    List<SimplifiedUser> signingOfficials = userDAO.getSOsByInstitution(id).stream()
+            .map(SimplifiedUser::new)
+            .collect(Collectors.toList());
     return institutionDAO.findInstitutionById(id);
   }
 

--- a/src/main/java/org/broadinstitute/consent/http/util/InstitutionUtil.java
+++ b/src/main/java/org/broadinstitute/consent/http/util/InstitutionUtil.java
@@ -38,11 +38,7 @@ public class InstitutionUtil {
       @Override
       public boolean shouldSkipField(FieldAttributes field) {
         String fieldName = field.getName();
-        if (!isAdmin && (fieldName != "id" && fieldName != "name")) {
-          return true;
-        } else {
-          return false;
-        }
+        return !isAdmin && (!fieldName.equals("id") && !fieldName.equals("name") && !fieldName.equals("signingOfficials"));
       }
 
       // NOTE: shouldSkipClass is mandatory when creating an ExclusionStrategy

--- a/src/main/java/org/broadinstitute/consent/http/util/InstitutionUtil.java
+++ b/src/main/java/org/broadinstitute/consent/http/util/InstitutionUtil.java
@@ -38,7 +38,7 @@ public class InstitutionUtil {
       @Override
       public boolean shouldSkipField(FieldAttributes field) {
         String fieldName = field.getName();
-        return !isAdmin && (!fieldName.equals("id") && !fieldName.equals("name") && !fieldName.equals("signingOfficials"));
+        return !isAdmin && !(fieldName.equals("id") || fieldName.equals("name") || fieldName.equals("signingOfficials"));
       }
 
       // NOTE: shouldSkipClass is mandatory when creating an ExclusionStrategy

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -2203,73 +2203,7 @@ paths:
   /api/institutions:
     $ref: './paths/institutions.yaml'
   /api/institutions/{id}:
-    get:
-      summary: Institution GET
-      description: Fetches Institution based on id param
-      tags:
-        - Institutions
-      parameters:
-        - name: id
-          in: path
-          description: Institution ID
-          required: true
-          schema:
-            type: string
-      responses:
-        200:
-          description: Returns target institution.
-            Admin will see all details while non-Admins will only see a subset.
-        404:
-          description: Institution not found
-        500:
-          description: Internal Server Error
-    put:
-      summary: Institution UPDATE
-      description: Updates institution based on id and json payload
-      tags:
-        - Institutions
-      parameters:
-        - name: id
-          in: path
-          description: Institution ID
-          required: true
-          schema:
-            type: string
-      requestBody:
-        description: Required JSON payload representing updated Institution
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Institution'
-      responses:
-        200:
-          description: Updates and returns target institution
-        400:
-          description: Bad Request
-        404:
-          description: Institution not found
-        500:
-          description: Internal Server Error
-    delete:
-      summary: Institution DELETE
-      description: Deletes institution based on id
-      tags:
-        - Institutions
-      parameters:
-        - name: id
-          in: path
-          description: Institution ID
-          required: True
-          schema:
-            type: string
-      responses:
-        204:
-          description: Deletes target institution (no return entity)
-        404:
-          description: Institution not found
-        500:
-          description: Internal Server Error
+    $ref: './paths/institutionById.yaml'
   /api/libraryCards:
     get:
       summary: Library Card INDEX resource

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -3439,18 +3439,7 @@ components:
           items:
             $ref: '#/components/schemas/User'
     SimplifiedUser:
-      type: object
-      properties:
-        userId:
-          type: integer
-          description: ID of the user
-        dacUserId:
-          deprecated: true
-          type: integer
-          description: ID of the user
-        displayName:
-          type: string
-          description: Name of the user
+      $ref: './schemas/SimplifiedUser.yaml'
     SamSelfDiagnostics:
       $ref: './schemas/SamSelfDiagnostics.yaml'
     SamUserInfo:

--- a/src/main/resources/assets/paths/institutionById.yaml
+++ b/src/main/resources/assets/paths/institutionById.yaml
@@ -36,7 +36,7 @@ put:
     content:
       application/json:
         schema:
-          $ref: '#/components/schemas/Institution'
+          $ref: '../schemas/Institution.yaml'
   responses:
     200:
       description: Updates and returns target institution

--- a/src/main/resources/assets/paths/institutionById.yaml
+++ b/src/main/resources/assets/paths/institutionById.yaml
@@ -14,13 +14,17 @@ get:
     200:
       description: Returns target institution and its signing officials.
         Admin will see all details while non-Admins will only see a subset.
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/Institution.yaml'
     404:
       description: Institution not found
     500:
       description: Internal Server Error
 put:
   summary: Institution UPDATE
-  description: Updates institution based on id and json payload
+  description: Updates institution based on id and json payload. Does not update signing officials of an institution
   tags:
     - Institutions
   parameters:

--- a/src/main/resources/assets/paths/institutionById.yaml
+++ b/src/main/resources/assets/paths/institutionById.yaml
@@ -1,0 +1,67 @@
+get:
+  summary: Institution GET
+  description: Fetches Institution based on id param
+  tags:
+    - Institutions
+  parameters:
+    - name: id
+      in: path
+      description: Institution ID
+      required: true
+      schema:
+        type: string
+  responses:
+    200:
+      description: Returns target institution and its signing officials.
+        Admin will see all details while non-Admins will only see a subset.
+    404:
+      description: Institution not found
+    500:
+      description: Internal Server Error
+put:
+  summary: Institution UPDATE
+  description: Updates institution based on id and json payload
+  tags:
+    - Institutions
+  parameters:
+    - name: id
+      in: path
+      description: Institution ID
+      required: true
+      schema:
+        type: string
+  requestBody:
+    description: Required JSON payload representing updated Institution
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/Institution'
+  responses:
+    200:
+      description: Updates and returns target institution
+    400:
+      description: Bad Request
+    404:
+      description: Institution not found
+    500:
+      description: Internal Server Error
+delete:
+  summary: Institution DELETE
+  description: Deletes institution based on id
+  tags:
+    - Institutions
+  parameters:
+    - name: id
+      in: path
+      description: Institution ID
+      required: True
+      schema:
+        type: string
+  responses:
+    204:
+      description: Deletes target institution (no return entity)
+    404:
+      description: Institution not found
+    500:
+      description: Internal Server Error

--- a/src/main/resources/assets/schemas/Institution.yaml
+++ b/src/main/resources/assets/schemas/Institution.yaml
@@ -20,3 +20,8 @@ properties:
     type: string
     format: Date
     description: Institution's last update date
+  signingOfficials:
+    description: Signing officials belonging to the institution.
+    type: array
+    items:
+      $ref: './SimplifiedUser.yaml'

--- a/src/main/resources/assets/schemas/SimplifiedUser.yaml
+++ b/src/main/resources/assets/schemas/SimplifiedUser.yaml
@@ -1,0 +1,15 @@
+type: object
+properties:
+  userId:
+    type: integer
+    description: ID of the user
+  dacUserId:
+    deprecated: true
+    type: integer
+    description: ID of the user
+  displayName:
+    type: string
+    description: Name of the user
+  email:
+    type: string
+    description: Email of the user

--- a/src/test/java/org/broadinstitute/consent/http/service/InstitutionServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/InstitutionServiceTest.java
@@ -1,6 +1,7 @@
 package org.broadinstitute.consent.http.service;
 
 import org.broadinstitute.consent.http.db.InstitutionDAO;
+import org.broadinstitute.consent.http.db.UserDAO;
 import org.broadinstitute.consent.http.models.Institution;
 import org.junit.Assert;
 import static org.junit.Assert.assertEquals;
@@ -30,13 +31,16 @@ public class InstitutionServiceTest {
   @Mock
   private InstitutionDAO institutionDAO;
 
+  @Mock
+  private UserDAO userDAO;
+
   @Before
   public void setUp() {
     MockitoAnnotations.initMocks(this);
   }
 
   private void initService() {
-    service = new InstitutionService(institutionDAO);
+    service = new InstitutionService(institutionDAO, userDAO);
   }
 
   private Institution initMockModel() {
@@ -123,7 +127,7 @@ public class InstitutionServiceTest {
   public void testDeleteInstitutionByIdFail() {
     initService();
     when(institutionDAO.findInstitutionById(anyInt())).thenThrow(new NotFoundException());
-    service.deleteInstitutionById(1);  
+    service.deleteInstitutionById(1);
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/InstitutionServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/InstitutionServiceTest.java
@@ -6,6 +6,8 @@ import org.broadinstitute.consent.http.db.InstitutionDAO;
 import org.broadinstitute.consent.http.db.UserDAO;
 import org.broadinstitute.consent.http.models.Institution;
 import org.broadinstitute.consent.http.models.User;
+import org.broadinstitute.consent.http.service.UserService.SimplifiedUser;
+
 import org.junit.Assert;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -158,7 +160,7 @@ public class InstitutionServiceTest {
     initService();
 
     Institution institution = service.findInstitutionById(anyInt());
-    List<UserService.SimplifiedUser> signingOfficials = institution.getSigningOfficials();
+    List<SimplifiedUser> signingOfficials = institution.getSigningOfficials();
     assertEquals(getInstitutions().get(0), institution);
     assertEquals(1, signingOfficials.size());
     assertEquals(u.getDisplayName(), signingOfficials.get(0).displayName);


### PR DESCRIPTION
Addresses [DUOS-1892](https://broadworkbench.atlassian.net/browse/DUOS-1892)
Summary of Changes:
- Modified GET `/api/institutions/{id}` endpoint to include an array of signing officials belonging to the institution in its response 
- Added tests in `InstitutionServiceTest`
- Moved yaml docs for the endpoint to a separate path and documented change to endpoint  
----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
