### PR TITLE
[DUOS-1638][risk=no] Translate data use based on type when creating a dataset

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/configurations/ServicesConfiguration.java
+++ b/src/main/java/org/broadinstitute/consent/http/configurations/ServicesConfiguration.java
@@ -41,6 +41,10 @@ public class ServicesConfiguration {
     return getOntologyURL() + "schemas/data-use/dar/translate";
   }
 
+  public String getConsentTranslateUrl() {
+    return getOntologyURL() + "schemas/data-use/consent/translate";
+  }
+
   public String getSamUrl() {
     return samUrl;
   }

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -129,7 +129,7 @@ public class DatasetService {
              * data user letter
              * data user letter name
              */
-            UseRestriction useRestriction = converter.parseUseRestriction(dataset.getDataUse());
+            UseRestriction useRestriction = converter.parseUseRestriction(dataset.getDataUse(), DataUseTranslationType.DATASET);
             String translatedUseRestriction = converter.translateDataUse(dataset.getDataUse(), DataUseTranslationType.DATASET);
             consentDAO.useTransaction(h -> {
                 try {

--- a/src/main/java/org/broadinstitute/consent/http/service/MatchService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/MatchService.java
@@ -10,6 +10,7 @@ import org.broadinstitute.consent.http.db.DataAccessRequestDAO;
 import org.broadinstitute.consent.http.db.DatasetDAO;
 import org.broadinstitute.consent.http.db.ElectionDAO;
 import org.broadinstitute.consent.http.db.MatchDAO;
+import org.broadinstitute.consent.http.enumeration.DataUseTranslationType;
 import org.broadinstitute.consent.http.enumeration.ElectionType;
 import org.broadinstitute.consent.http.exceptions.UnknownIdentifierException;
 import org.broadinstitute.consent.http.models.Consent;
@@ -276,7 +277,7 @@ public class MatchService {
 
     private RequestMatchingObject createRequestObject(Consent consent, DataAccessRequest dar) {
         DataUse dataUse = useRestrictionConverter.parseDataUsePurpose(dar);
-        UseRestriction darUseRestriction = useRestrictionConverter.parseUseRestriction(dataUse);
+        UseRestriction darUseRestriction = useRestrictionConverter.parseUseRestriction(dataUse, DataUseTranslationType.PURPOSE);
         return new RequestMatchingObject(consent.getUseRestriction(), darUseRestriction);
     }
 

--- a/src/main/java/org/broadinstitute/consent/http/service/UseRestrictionConverter.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/UseRestrictionConverter.java
@@ -135,7 +135,7 @@ public class UseRestrictionConverter {
             //
             //    Diseases related entries
             //
-        
+
             List<String> ontologies = dar.getData().getOntologies()
                 .stream().map(OntologyEntry::getId).collect(Collectors.toList());
             if (CollectionUtils.isNotEmpty(ontologies)) {
@@ -181,8 +181,11 @@ public class UseRestrictionConverter {
         return dataUse;
     }
 
-    public UseRestriction parseUseRestriction(DataUse dataUse) {
-        WebTarget target = client.target(servicesConfiguration.getDARTranslateUrl());
+    public UseRestriction parseUseRestriction(DataUse dataUse, DataUseTranslationType type) {
+        String translateUrl = type.equals(DataUseTranslationType.PURPOSE) ?
+            servicesConfiguration.getDARTranslateUrl() :
+            servicesConfiguration.getConsentTranslateUrl();
+        WebTarget target = client.target(translateUrl);
         Response response = target.request(MediaType.APPLICATION_JSON).post(Entity.json(dataUse.toString()));
         if (response.getStatus() == 200) {
             try {

--- a/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
@@ -446,7 +446,7 @@ public class DatasetServiceTest {
         UseRestriction useRestriction = UseRestriction.parse("{\"type\":\"everything\"}");
         Consent consent = new Consent();
         when(consentDAO.findConsentById(anyString())).thenReturn(consent);
-        when(useRestrictionConverter.parseUseRestriction(any())).thenReturn(useRestriction);
+        when(useRestrictionConverter.parseUseRestriction(any(), any())).thenReturn(useRestriction);
         doNothing().when(consentDAO).insertConsent(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any());
         doNothing().when(consentDAO).insertConsentAssociation(any(), any(), any());
         initService();

--- a/src/test/java/org/broadinstitute/consent/http/service/UseRestrictionConverterTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/UseRestrictionConverterTest.java
@@ -117,7 +117,7 @@ public class UseRestrictionConverterTest implements WithMockServer {
         Client client = ClientBuilder.newClient();
         UseRestrictionConverter converter = new UseRestrictionConverter(client, config());
         DataUse dataUse = converter.parseDataUsePurpose("{  }");
-        UseRestriction restriction = converter.parseUseRestriction(dataUse);
+        UseRestriction restriction = converter.parseUseRestriction(dataUse, DataUseTranslationType.PURPOSE);
         assertNotNull(restriction);
         assertEquals(restriction, new Everything());
     }
@@ -132,7 +132,7 @@ public class UseRestrictionConverterTest implements WithMockServer {
         Client client = ClientBuilder.newClient();
         UseRestrictionConverter converter = new UseRestrictionConverter(client, config());
         DataUse dataUse = converter.parseDataUsePurpose("{  }");
-        UseRestriction restriction = converter.parseUseRestriction(dataUse);
+        UseRestriction restriction = converter.parseUseRestriction(dataUse, DataUseTranslationType.PURPOSE);
         assertNull(restriction);
     }
 


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-1638

Fixes a bug where we were using the wrong translation endpoint when creating a `UseRestriction` for a dataset.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
