### PR TITLE
[DUOS-1763][risk=no] Migrate DAR Dataset lookups to join table.

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
@@ -186,7 +186,7 @@ public interface DarCollectionDAO extends Transactional<DarCollectionDAO> {
   @RegisterBeanMapper(value = Election.class, prefix = "e")
   @RegisterBeanMapper(value = UserProperty.class, prefix = "up")
   @UseRowReducer(DarCollectionReducer.class)
-  @SqlQuery("SELECT c.*, " +
+  @SqlQuery("SELECT c.*, dd.dataset_id, " +
       User.QUERY_FIELDS_WITH_U_PREFIX + QUERY_FIELD_SEPARATOR +
       Institution.QUERY_FIELDS_WITH_I_PREFIX + QUERY_FIELD_SEPARATOR +
       UserProperty.QUERY_FIELDS_WITH_UP_PREFIX + QUERY_FIELD_SEPARATOR
@@ -198,6 +198,7 @@ public interface DarCollectionDAO extends Transactional<DarCollectionDAO> {
       + "e.lastupdate AS e_last_update, e.datasetid AS e_dataset_id, e.electiontype AS e_election_type, e.latest "
       + "FROM dar_collection c "
       + "INNER JOIN data_access_request dar ON c.collection_id = dar.collection_id "
+      + "LEFT JOIN dar_dataset dd ON dd.reference_id = dar.reference_id "
       + "INNER JOIN users u ON c.create_user_id = u.user_id "
       + "LEFT JOIN user_property up ON u.user_id = up.userid "
       + "LEFT JOIN institution i ON i.institution_id = u.institution_id "

--- a/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
@@ -158,6 +158,7 @@ public interface DarCollectionDAO extends Transactional<DarCollectionDAO> {
         Institution.QUERY_FIELDS_WITH_I_PREFIX + QUERY_FIELD_SEPARATOR +
         UserProperty.QUERY_FIELDS_WITH_UP_PREFIX + QUERY_FIELD_SEPARATOR +
         Election.QUERY_FIELDS_WITH_E_PREFIX + QUERY_FIELD_SEPARATOR +
+        "dd.dataset_id, " +
         "dar.id AS dar_id, dar.reference_id AS dar_reference_id, dar.collection_id AS dar_collection_id, " +
         "dar.parent_id AS dar_parent_id, dar.draft AS dar_draft, dar.user_id AS dar_userId, " +
         "dar.create_date AS dar_create_date, dar.sort_date AS dar_sort_date, dar.submission_date AS dar_submission_date, " +
@@ -166,6 +167,7 @@ public interface DarCollectionDAO extends Transactional<DarCollectionDAO> {
         "INNER JOIN users u ON c.create_user_id = u.user_id " +
         "LEFT JOIN user_property up ON u.user_id = up.userid " +
         "INNER JOIN data_access_request dar on c.collection_id = dar.collection_id " +
+        "LEFT JOIN dar_dataset dd on dd.reference_id = dar.reference_id " +
         "LEFT JOIN institution i ON i.institution_id = u.institution_id " +
         "LEFT JOIN (" +
         "   SELECT election.*, MAX(election.electionid) OVER (PARTITION BY election.referenceid, election.electiontype) AS latest FROM election " +
@@ -259,6 +261,7 @@ public interface DarCollectionDAO extends Transactional<DarCollectionDAO> {
       + Institution.QUERY_FIELDS_WITH_I_PREFIX + QUERY_FIELD_SEPARATOR
       + UserProperty.QUERY_FIELDS_WITH_UP_PREFIX + QUERY_FIELD_SEPARATOR
       + LibraryCard.QUERY_FIELDS_WITH_LC_PREFIX + QUERY_FIELD_SEPARATOR
+      + "dd.dataset_id, "
       + "dar.id AS dar_id, dar.reference_id AS dar_reference_id, dar.collection_id AS dar_collection_id, "
       + "dar.parent_id AS dar_parent_id, dar.draft AS dar_draft, dar.user_id AS dar_userId, "
       + "dar.create_date AS dar_create_date, dar.sort_date AS dar_sort_date, dar.submission_date AS dar_submission_date, "
@@ -273,6 +276,7 @@ public interface DarCollectionDAO extends Transactional<DarCollectionDAO> {
       + "LEFT JOIN institution i ON i.institution_id = u.institution_id "
       + "LEFT JOIN library_card lc ON u.user_id = lc.user_id "
       + "INNER JOIN data_access_request dar ON c.collection_id = dar.collection_id "
+      + "LEFT JOIN dar_dataset dd on dd.reference_id = dar.reference_id "
       + "LEFT JOIN ("
           + "SELECT election.*, MAX(election.electionid) OVER (PARTITION BY election.referenceid, election.electiontype) AS latest "
           + "FROM election "

--- a/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
@@ -26,7 +26,7 @@ public interface DarCollectionDAO extends Transactional<DarCollectionDAO> {
   String QUERY_FIELD_SEPARATOR = ", ";
 
   String getCollectionAndDars =
-      " SELECT c.*, i.institution_name, u.display_name AS researcher, " +
+      " SELECT c.*, i.institution_name, u.display_name AS researcher, dd.dataset_id, " +
           User.QUERY_FIELDS_WITH_U_PREFIX + QUERY_FIELD_SEPARATOR +
           Institution.QUERY_FIELDS_WITH_I_PREFIX + QUERY_FIELD_SEPARATOR +
           Election.QUERY_FIELDS_WITH_E_PREFIX + QUERY_FIELD_SEPARATOR +
@@ -38,6 +38,7 @@ public interface DarCollectionDAO extends Transactional<DarCollectionDAO> {
       " LEFT JOIN user_property up ON u.user_id = up.userid AND up.propertykey in ('isThePI', 'piName', 'havePI', 'piERACommonsID') " +
       " LEFT JOIN institution i ON i.institution_id = u.institution_id " +
       " INNER JOIN data_access_request dar ON c.collection_id = dar.collection_id " +
+      " LEFT JOIN dar_dataset dd ON dd.reference_id = dar.reference_id " +
       " LEFT JOIN (" +
       "   SELECT election.*, MAX(election.electionid) OVER (PARTITION BY election.referenceid, election.electiontype) AS latest " +
       "   FROM election " +

--- a/src/main/java/org/broadinstitute/consent/http/db/DataAccessRequestDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DataAccessRequestDAO.java
@@ -49,11 +49,10 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
    * @return List<DataAccessRequest>
    */
   @SqlQuery(
-      "SELECT dd.dataset_id, dar.id, dar.reference_id, dar.collection_id, dar.parent_id, dar.draft, dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date, "
-          + "  (dar.data #>> '{}')::jsonb AS data FROM data_access_request dar"
-          + "  LEFT JOIN dar_dataset dd on dd.reference_id = dar.reference_id "
+      " SELECT dd.dataset_id, dar.id, dar.reference_id, dar.collection_id, dar.parent_id, dar.draft, dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date, "
+          + "  (dar.data #>> '{}')::jsonb AS data FROM data_access_request dar "
+          + "  LEFT JOIN dar_dataset dd ON dd.reference_id = dar.reference_id AND dd.dataset_id = :datasetId::int  "
           + "  WHERE dar.draft = false"
-          + "  AND ((dar.data #>> '{}')::jsonb->>'datasetIds')::jsonb @> :datasetId::jsonb"
           + "  AND (LOWER(dar.data->>'status') != 'archived' OR dar.data->>'status' IS NULL) ")
   List<DataAccessRequest> findAllDataAccessRequestsByDatasetId(@Bind("datasetId") String datasetId);
 

--- a/src/main/java/org/broadinstitute/consent/http/db/DataAccessRequestDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DataAccessRequestDAO.java
@@ -281,10 +281,10 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
    * @param referenceId String
    * @param datasetId Integer
    */
-  @SqlUpdate("INSERT INTO dar_dataset (reference_id, dataset_id) VALUES (:referenceId, :datasetId)")
+  @SqlUpdate("INSERT INTO dar_dataset (reference_id, dataset_id) VALUES (:referenceId, :datasetId) ON CONFLICT DO NOTHING ")
   void insertDARDatasetRelation(@Bind("referenceId") String referenceId, @Bind("datasetId") Integer datasetId);
 
-  @SqlBatch("INSERT INTO dar_dataset (reference_id, dataset_id) VALUES (:referenceId, :datasetId)")
+  @SqlBatch("INSERT INTO dar_dataset (reference_id, dataset_id) VALUES (:referenceId, :datasetId) ON CONFLICT DO NOTHING ")
   void insertAllDarDatasets(@BindBean List<DarDataset> darDatasets);
 
   /**
@@ -318,6 +318,9 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
    */
   @SqlQuery("SELECT distinct dataset_id FROM dar_dataset WHERE reference_id IN (<referenceIds>)")
   List<Integer> findAllDARDatasetRelations(@BindList("referenceIds") List<String> referenceIds);
+
+  @SqlQuery("SELECT distinct dataset_id FROM dar_dataset ")
+  List<Integer> findAllDARDatasetRelationDatasetIds();
 
   /**
    * Returns all dataset_ids that match any of the referenceIds inside of the "referenceIds" list

--- a/src/main/java/org/broadinstitute/consent/http/db/DataAccessRequestDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DataAccessRequestDAO.java
@@ -2,6 +2,7 @@ package org.broadinstitute.consent.http.db;
 
 import org.broadinstitute.consent.http.db.mapper.DataAccessRequestDataMapper;
 import org.broadinstitute.consent.http.db.mapper.DataAccessRequestMapper;
+import org.broadinstitute.consent.http.db.mapper.DarDatasetMapper;
 import org.broadinstitute.consent.http.models.DataAccessRequest;
 import org.broadinstitute.consent.http.models.DataAccessRequestData;
 import org.broadinstitute.consent.http.models.DarDataset;
@@ -33,10 +34,12 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
    * @return List<DataAccessRequest>
    */
   @SqlQuery(
-      "SELECT id, reference_id, collection_id, parent_id, draft, user_id, create_date, sort_date, submission_date, update_date, (data #>> '{}')::jsonb AS data FROM data_access_request "
-          + "  WHERE not (data #>> '{}')::jsonb ??| array['partial_dar_code', 'partialDarCode'] "
-          + "  AND draft != true "
-          + "  AND (LOWER(data->>'status') != 'archived' OR data->>'status' IS NULL ) ")
+      "SELECT dd.dataset_id, dar.id, dar.reference_id, dar.collection_id, dar.parent_id, dar.draft, dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date, "
+          + "  (dar.data #>> '{}')::jsonb AS data FROM data_access_request dar"
+          + "  LEFT JOIN dar_dataset dd on dd.reference_id = dar.reference_id "
+          + "  WHERE not (dar.data #>> '{}')::jsonb ??| array['partial_dar_code', 'partialDarCode'] "
+          + "  AND dar.draft != true "
+          + "  AND (LOWER(dar.data->>'status') != 'archived' OR dar.data->>'status' IS NULL ) ")
   List<DataAccessRequest> findAllDataAccessRequests();
 
 
@@ -46,11 +49,12 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
    * @return List<DataAccessRequest>
    */
   @SqlQuery(
-      "SELECT id, reference_id, collection_id, parent_id, draft, user_id, create_date, sort_date, submission_date, update_date, "
-          + "(data #>> '{}')::jsonb AS data FROM data_access_request "
-          + " WHERE draft = false"
-          + " AND ((data #>> '{}')::jsonb->>'datasetIds')::jsonb @> :datasetId::jsonb"
-          + " AND (LOWER(data->>'status') != 'archived' OR data->>'status' IS NULL) ")
+      "SELECT dd.dataset_id, dar.id, dar.reference_id, dar.collection_id, dar.parent_id, dar.draft, dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date, "
+          + "  (dar.data #>> '{}')::jsonb AS data FROM data_access_request dar"
+          + "  LEFT JOIN dar_dataset dd on dd.reference_id = dar.reference_id "
+          + "  WHERE dar.draft = false"
+          + "  AND ((dar.data #>> '{}')::jsonb->>'datasetIds')::jsonb @> :datasetId::jsonb"
+          + "  AND (LOWER(dar.data->>'status') != 'archived' OR dar.data->>'status' IS NULL) ")
   List<DataAccessRequest> findAllDataAccessRequestsByDatasetId(@Bind("datasetId") String datasetId);
 
   /**
@@ -59,11 +63,13 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
    * @return List<DataAccessRequest>
    */
   @SqlQuery(
-      "SELECT id, reference_id, collection_id, parent_id, draft, user_id, create_date, sort_date, submission_date, update_date, (data #>> '{}')::jsonb AS data FROM data_access_request "
-          + "  WHERE (data #>> '{}')::jsonb ??| array['partial_dar_code', 'partialDarCode'] "
-          + "  OR draft = true "
-          + "  AND (LOWER(data->>'status') != 'archived' OR data->>'status' IS NULL) "
-          + "  ORDER BY update_date DESC")
+      "SELECT dd.dataset_id, dar.id, dar.reference_id, dar.collection_id, dar.parent_id, dar.draft, dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date, "
+          + "  (dar.data #>> '{}')::jsonb AS data FROM data_access_request dar"
+          + "  LEFT JOIN dar_dataset dd on dd.reference_id = dar.reference_id "
+          + "  WHERE (dar.data #>> '{}')::jsonb ??| array['partial_dar_code', 'partialDarCode'] "
+          + "  OR dar.draft = true "
+          + "  AND (LOWER(dar.data->>'status') != 'archived' OR dar.data->>'status' IS NULL) "
+          + "  ORDER BY dar.update_date DESC")
   List<DataAccessRequest> findAllDraftDataAccessRequests();
 
   /**
@@ -72,12 +78,14 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
    * @return List<DataAccessRequest>
    */
   @SqlQuery(
-      "SELECT id, reference_id, collection_id, parent_id, draft, user_id, create_date, sort_date, submission_date, update_date, (data #>> '{}')::jsonb AS data FROM data_access_request "
-          + "  WHERE ( (data #>> '{}')::jsonb ??| array['partial_dar_code', 'partialDarCode'] "
-          + "          OR draft = true "
-          + "  AND (LOWER(data->>'status') != 'archived' OR data->>'status' IS NULL)) "
-          + "  AND user_id = :userId "
-          + "  ORDER BY sort_date DESC")
+      "SELECT dd.dataset_id, dar.id, dar.reference_id, dar.collection_id, dar.parent_id, dar.draft, dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date, "
+          + "  (dar.data #>> '{}')::jsonb AS data FROM data_access_request dar"
+          + "  LEFT JOIN dar_dataset dd on dd.reference_id = dar.reference_id "
+          + "  WHERE ( (dar.data #>> '{}')::jsonb ??| array['partial_dar_code', 'partialDarCode'] "
+          + "          OR dar.draft = true "
+          + "  AND (LOWER(dar.data->>'status') != 'archived' OR dar.data->>'status' IS NULL)) "
+          + "  AND dar.user_id = :userId "
+          + "  ORDER BY dar.sort_date DESC")
   List<DataAccessRequest> findAllDraftsByUserId(@Bind("userId") Integer userId);
 
 
@@ -87,11 +95,13 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
    * @return List<DataAccessRequest>
    */
   @SqlQuery(
-      "SELECT id, reference_id, collection_id, parent_id, draft, user_id, create_date, sort_date, submission_date, update_date, (data #>> '{}')::jsonb AS data FROM data_access_request "
-          + "  WHERE draft = false "
-          + "  AND user_id = :userId "
-          + "  AND (LOWER(data->>'status') != 'archived' OR data->>'status' IS NULL) "
-          + "  ORDER BY sort_date DESC")
+      "SELECT dd.dataset_id, dar.id, dar.reference_id, dar.collection_id, dar.parent_id, dar.draft, dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date, "
+          + "  (dar.data #>> '{}')::jsonb AS data FROM data_access_request dar"
+          + "  LEFT JOIN dar_dataset dd on dd.reference_id = dar.reference_id "
+          + "  WHERE dar.draft = false "
+          + "  AND dar.user_id = :userId "
+          + "  AND (LOWER(dar.data->>'status') != 'archived' OR dar.data->>'status' IS NULL) "
+          + "  ORDER BY dar.sort_date DESC")
   List<DataAccessRequest> findAllDarsByUserId(@Bind("userId") Integer userId);
 
   /**
@@ -101,10 +111,12 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
    * @return DataAccessRequest
    */
   @SqlQuery(
-      "SELECT id, reference_id, collection_id, parent_id,  draft, user_id, create_date, sort_date, submission_date, update_date, (data #>> '{}')::jsonb AS data FROM data_access_request "
-          + "WHERE reference_id = :referenceId "
-          + "AND (LOWER(data->>'status') != 'archived' OR data->>'status' IS NULL) "
-          + "limit 1 ")
+      "SELECT dd.dataset_id, dar.id, dar.reference_id, dar.collection_id, dar.parent_id, dar.draft, dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date, "
+          + "  (dar.data #>> '{}')::jsonb AS data FROM data_access_request dar"
+          + "  LEFT JOIN dar_dataset dd on dd.reference_id = dar.reference_id "
+          + "  WHERE dar.reference_id = :referenceId "
+          + "  AND (LOWER(dar.data->>'status') != 'archived' OR dar.data->>'status' IS NULL) "
+          + "  limit 1 ")
   DataAccessRequest findByReferenceId(@Bind("referenceId") String referenceId);
 
   /**
@@ -114,9 +126,11 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
    * @return List<DataAccessRequest>
    */
   @SqlQuery(
-      "SELECT id, reference_id, collection_id, parent_id, draft, user_id, create_date, sort_date, submission_date, update_date, (data #>> '{}')::jsonb AS data FROM data_access_request "
-        + "WHERE reference_id IN (<referenceIds>) "
-        + "AND (LOWER(data->>'status') != 'archived' OR data->>'status' IS NULL) ")
+      "SELECT dd.dataset_id, dar.id, dar.reference_id, dar.collection_id, dar.parent_id, dar.draft, dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date, "
+          + "  (dar.data #>> '{}')::jsonb AS data FROM data_access_request dar"
+          + "  LEFT JOIN dar_dataset dd on dd.reference_id = dar.reference_id "
+          + "  WHERE dar.reference_id IN (<referenceIds>) "
+          + "  AND (LOWER(dar.data->>'status') != 'archived' OR dar.data->>'status' IS NULL) ")
   List<DataAccessRequest> findByReferenceIds(@BindList("referenceIds") List<String> referenceIds);
 
   /**
@@ -267,10 +281,10 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
    * @param referenceId String
    * @param datasetId Integer
    */
-  @SqlUpdate("INSERT INTO dar_dataset (reference_id, dataset_id) VALUES (:referenceId, :datasetId) ON CONFLICT DO NOTHING ")
+  @SqlUpdate("INSERT INTO dar_dataset (reference_id, dataset_id) VALUES (:referenceId, :datasetId)")
   void insertDARDatasetRelation(@Bind("referenceId") String referenceId, @Bind("datasetId") Integer datasetId);
 
-  @SqlBatch("INSERT INTO dar_dataset (reference_id, dataset_id) VALUES (:referenceId, :datasetId) ON CONFLICT DO NOTHING ")
+  @SqlBatch("INSERT INTO dar_dataset (reference_id, dataset_id) VALUES (:referenceId, :datasetId)")
   void insertAllDarDatasets(@BindBean List<DarDataset> darDatasets);
 
   /**
@@ -294,8 +308,31 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
    *
    * @param referenceId String
    */
-  @SqlQuery(
-  "SELECT distinct dataset_id FROM dar_dataset WHERE reference_id = :referenceId ")
+  @SqlQuery("SELECT distinct dataset_id FROM dar_dataset WHERE reference_id = :referenceId ")
   List<Integer> findDARDatasetRelations(@Bind("referenceId") String referenceId);
 
+  /**
+   * Returns all dataset_ids that match any of the referenceIds inside of the "referenceIds" list
+   *
+   * @param referenceIds List<String>
+   */
+  @SqlQuery("SELECT distinct dataset_id FROM dar_dataset WHERE reference_id IN (<referenceIds>)")
+  List<Integer> findAllDARDatasetRelations(@BindList("referenceIds") List<String> referenceIds);
+
+  /**
+   * Returns all dataset_ids that match any of the referenceIds inside of the "referenceIds" list
+   *
+   * @param referenceIds List<String>
+   */
+  @RegisterRowMapper(DarDatasetMapper.class)
+  @SqlQuery("SELECT distinct reference_id, dataset_id FROM dar_dataset WHERE reference_id IN (<referenceIds>)")
+  List<DarDataset> findAllDARDatasets(@BindList("referenceIds") List<String> referenceIds);
+
+  @SqlQuery(
+      " SELECT distinct d.reference_id "
+          + " FROM dar_dataset d "
+          + " INNER JOIN data_access_request dar ON dar.reference_id = d.reference_id AND dar.collection_id = :collectionId "
+          + " WHERE d.dataset_id IN <datasetIds> ")
+  List<String> findReferenceIdsForDatasetIdsWithCollectionId(
+      @BindList("datasetIds") List<Integer> datasetIds, @Bind("collectionId") Integer collectionId);
 }

--- a/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
@@ -43,7 +43,7 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
     @UseRowReducer(DatasetReducer.class)
     @SqlQuery(" SELECT d.*, k.key, dp.propertyvalue, dp.propertykey, dp.propertyid, ca.consentid, c.dac_id, c.translateduserestriction, c.datause, dar_ds_ids.id as in_use " +
         " FROM dataset d " +
-        " LEFT JOIN (SELECT DISTINCT jsonb_array_elements(((data #>> '{}')::jsonb->>'datasetIds')::jsonb)::INTEGER AS id FROM data_access_request) dar_ds_ids ON dar_ds_ids.id = d.datasetid " +
+        " LEFT JOIN (SELECT DISTINCT dataset_id AS id FROM dar_dataset) dar_ds_ids ON dar_ds_ids.id = d.datasetid " +
         " LEFT JOIN datasetproperty dp ON dp.datasetid = d.datasetid " +
         " LEFT JOIN dictionary k ON k.keyid = dp.propertykey " +
         " LEFT JOIN consentassociations ca ON ca.datasetid = d.datasetid " +

--- a/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
@@ -57,7 +57,7 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
     @UseRowReducer(DatasetReducer.class)
     @SqlQuery(" SELECT d.*, k.key, dp.propertyvalue, dp.propertykey, dp.propertyid, ca.consentid, c.dac_id, c.translateduserestriction, c.datause, dar_ds_ids.id as in_use " +
         " FROM dataset d " +
-        " LEFT JOIN (SELECT DISTINCT jsonb_array_elements(((data #>> '{}')::jsonb->>'datasetIds')::jsonb)::INTEGER AS id FROM data_access_request) dar_ds_ids ON dar_ds_ids.id = d.datasetid " +
+        " LEFT JOIN (SELECT DISTINCT dataset_id AS id FROM dar_dataset) dar_ds_ids ON dar_ds_ids.id = d.datasetid " +
         " LEFT JOIN datasetproperty dp ON dp.datasetid = d.datasetid " +
         " LEFT JOIN dictionary k ON k.keyid = dp.propertykey " +
         " LEFT JOIN consentassociations ca ON ca.datasetid = d.datasetid " +
@@ -116,7 +116,7 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
     @UseRowReducer(DatasetReducer.class)
     @SqlQuery(" SELECT d.*, k.key, dp.propertyvalue, dp.propertykey, dp.propertyid, ca.consentid, c.dac_id, c.translateduserestriction, c.datause, dar_ds_ids.id as in_use " +
         " FROM dataset d " +
-        " LEFT JOIN (SELECT DISTINCT jsonb_array_elements(((data #>> '{}')::jsonb->>'datasetIds')::jsonb)::INTEGER AS id FROM data_access_request) dar_ds_ids ON dar_ds_ids.id = d.datasetid " +
+        " LEFT JOIN (SELECT DISTINCT dataset_id AS id FROM dar_dataset) dar_ds_ids ON dar_ds_ids.id = d.datasetid " +
         " LEFT JOIN datasetproperty dp ON dp.datasetid = d.datasetid " +
         " LEFT JOIN dictionary k ON k.keyid = dp.propertykey " +
         " LEFT JOIN consentassociations ca ON ca.datasetid = d.datasetid " +
@@ -196,7 +196,7 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
     @UseRowReducer(DatasetReducer.class)
     @SqlQuery(" SELECT d.*, k.key, dp.propertyvalue, dp.propertykey, dp.propertyid, ca.consentid, c.dac_id, c.translateduserestriction, c.datause, dar_ds_ids.id as in_use " +
         " FROM dataset d " +
-        " LEFT JOIN (SELECT DISTINCT jsonb_array_elements(((data #>> '{}')::jsonb->>'datasetIds')::jsonb)::INTEGER AS id FROM data_access_request) dar_ds_ids ON dar_ds_ids.id = d.datasetid " +
+        " LEFT JOIN (SELECT DISTINCT dataset_id AS id FROM dar_dataset) dar_ds_ids ON dar_ds_ids.id = d.datasetid " +
         " LEFT JOIN datasetproperty dp ON dp.datasetid = d.datasetid " +
         " LEFT JOIN dictionary k ON k.keyid = dp.propertykey " +
         " LEFT JOIN consentassociations ca ON ca.datasetid = d.datasetid " +
@@ -207,7 +207,7 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
     @UseRowReducer(DatasetReducer.class)
     @SqlQuery(" SELECT d.*, k.key, dp.propertyvalue, dp.propertykey, dp.propertyid, ca.consentid, c.dac_id, c.translateduserestriction, c.datause, dar_ds_ids.id as in_use " +
         " FROM dataset d " +
-        " LEFT JOIN (SELECT DISTINCT jsonb_array_elements(((data #>> '{}')::jsonb->>'datasetIds')::jsonb)::INTEGER AS id FROM data_access_request) dar_ds_ids ON dar_ds_ids.id = d.datasetid " +
+        " LEFT JOIN (SELECT DISTINCT dataset_id AS id FROM dar_dataset) dar_ds_ids ON dar_ds_ids.id = d.datasetid " +
         " LEFT JOIN datasetproperty dp ON dp.datasetid = d.datasetid " +
         " LEFT JOIN dictionary k ON k.keyid = dp.propertykey " +
         " LEFT JOIN consentassociations ca ON ca.datasetid = d.datasetid " +
@@ -217,7 +217,7 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
     @UseRowReducer(DatasetReducer.class)
     @SqlQuery(" SELECT d.*, k.key, dp.propertyvalue, dp.propertykey, dp.propertyid, ca.consentid, c.dac_id, c.translateduserestriction, c.datause, dar_ds_ids.id as in_use " +
         " FROM dataset d " +
-        " LEFT JOIN (SELECT DISTINCT jsonb_array_elements(((data #>> '{}')::jsonb->>'datasetIds')::jsonb)::INTEGER AS id FROM data_access_request) dar_ds_ids ON dar_ds_ids.id = d.datasetid " +
+        " LEFT JOIN (SELECT DISTINCT dataset_id AS id FROM dar_dataset) dar_ds_ids ON dar_ds_ids.id = d.datasetid " +
         " LEFT JOIN datasetproperty dp ON dp.datasetid = d.datasetid " +
         " LEFT JOIN dictionary k ON k.keyid = dp.propertykey " +
         " LEFT JOIN consentassociations ca ON ca.datasetid = d.datasetid " +
@@ -237,7 +237,7 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
     @UseRowReducer(DatasetReducer.class)
     @SqlQuery(" SELECT d.*, k.key, dp.propertyvalue, dp.propertykey, dp.propertyid, ca.consentid, c.dac_id, c.translateduserestriction, c.datause, dar_ds_ids.id as in_use " +
         " FROM dataset d " +
-        " LEFT JOIN (SELECT DISTINCT jsonb_array_elements(((data #>> '{}')::jsonb->>'datasetIds')::jsonb)::INTEGER AS id FROM data_access_request) dar_ds_ids ON dar_ds_ids.id = d.datasetid " +
+        " LEFT JOIN (SELECT DISTINCT dataset_id AS id FROM dar_dataset) dar_ds_ids ON dar_ds_ids.id = d.datasetid " +
         " LEFT JOIN datasetproperty dp ON dp.datasetid = d.datasetid " +
         " LEFT JOIN dictionary k ON k.keyid = dp.propertykey " +
         " LEFT JOIN consentassociations ca ON ca.datasetid = d.datasetid " +
@@ -258,7 +258,7 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
     @UseRowReducer(DatasetReducer.class)
     @SqlQuery(" SELECT d.*, k.key, dp.propertyvalue, dp.propertykey, dp.propertyid, ca.consentid, c.dac_id, c.translateduserestriction, c.datause, dar_ds_ids.id as in_use " +
         " FROM dataset d " +
-        " LEFT JOIN (SELECT DISTINCT jsonb_array_elements(((data #>> '{}')::jsonb->>'datasetIds')::jsonb)::INTEGER AS id FROM data_access_request) dar_ds_ids ON dar_ds_ids.id = d.datasetid " +
+        " LEFT JOIN (SELECT DISTINCT dataset_id AS id FROM dar_dataset) dar_ds_ids ON dar_ds_ids.id = d.datasetid " +
         " LEFT JOIN datasetproperty dp ON dp.datasetid = d.datasetid " +
         " LEFT JOIN dictionary k ON k.keyid = dp.propertykey " +
         " LEFT JOIN consentassociations ca ON ca.datasetid = d.datasetid " +
@@ -339,7 +339,7 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
     @UseRowReducer(DatasetReducer.class)
     @SqlQuery(" SELECT d.*, k.key, dp.propertyvalue, dp.propertykey, dp.propertyid, ca.consentid, c.dac_id, c.translateduserestriction, c.datause, dar_ds_ids.id as in_use " +
         " FROM dataset d " +
-        " LEFT JOIN (SELECT DISTINCT jsonb_array_elements(((data #>> '{}')::jsonb->>'datasetIds')::jsonb)::INTEGER AS id FROM data_access_request) dar_ds_ids ON dar_ds_ids.id = d.datasetid " +
+        " LEFT JOIN (SELECT DISTINCT dataset_id AS id FROM dar_dataset) dar_ds_ids ON dar_ds_ids.id = d.datasetid " +
         " LEFT JOIN datasetproperty dp ON dp.datasetid = d.datasetid " +
         " LEFT JOIN dictionary k ON k.keyid = dp.propertykey " +
         " INNER JOIN consentassociations ca ON ca.datasetid = d.datasetid " +

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DarCollectionReducer.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DarCollectionReducer.java
@@ -56,6 +56,9 @@ public class DarCollectionReducer
           } else {
             dar = savedDar;
           }
+          if (Objects.nonNull(rowView.getColumn("dataset_id", Integer.class))) {
+            dar.addDatasetId(rowView.getColumn("dataset_id", Integer.class));
+          }
         }
         if (Objects.nonNull(rowView.getColumn("e_election_id", Integer.class))) {
           election = rowView.getRow(Election.class);

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DarDatasetMapper.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DarDatasetMapper.java
@@ -1,0 +1,19 @@
+package org.broadinstitute.consent.http.db.mapper;
+
+import org.broadinstitute.consent.http.models.DarDataset;
+import org.jdbi.v3.core.mapper.RowMapper;
+import org.jdbi.v3.core.statement.StatementContext;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+public class DarDatasetMapper implements RowMapper<DarDataset>, RowMapperHelper{
+    @Override
+    public DarDataset map(ResultSet resultSet, StatementContext statementContext) throws SQLException {
+        DarDataset darDataset = new DarDataset();
+        darDataset.setReferenceId(resultSet.getString("reference_id"));
+        darDataset.setDatasetId(resultSet.getInt("dataset_id"));
+
+        return darDataset;
+    }
+}

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DataAccessRequestMapper.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DataAccessRequestMapper.java
@@ -31,6 +31,9 @@ public class DataAccessRequestMapper implements RowMapper<DataAccessRequest>, Ro
         dar.setUpdateDate(resultSet.getTimestamp("update_date"));
         String darDataString = resultSet.getObject("data", PGobject.class).getValue();
         DataAccessRequestData data = translate(darDataString);
+        if (hasColumn(resultSet, "dataset_id")) {
+            dar.addDatasetId(resultSet.getInt("dataset_id"));
+        }
         dar.setData(data);
         return dar;
     }

--- a/src/main/java/org/broadinstitute/consent/http/models/DarDataset.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DarDataset.java
@@ -4,6 +4,9 @@ public class DarDataset {
     private String referenceId;
     private Integer datasetId;
 
+    public DarDataset() {
+    }
+
     public DarDataset(String referenceId, Integer datasetId) {
         this.referenceId = referenceId;
         this.datasetId = datasetId;
@@ -13,7 +16,7 @@ public class DarDataset {
         return this.datasetId;
     }
 
-    public void setId(Integer datasetId) {
+    public void setDatasetId(Integer datasetId) {
         this.datasetId = datasetId;
     }
 
@@ -21,7 +24,7 @@ public class DarDataset {
         return this.referenceId;
     }
 
-    public void setName(String referenceId) {
+    public void setReferenceId(String referenceId) {
         this.referenceId = referenceId;
     }
 }

--- a/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequest.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequest.java
@@ -19,6 +19,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @JsonInclude(Include.NON_NULL)
 public class DataAccessRequest {
@@ -177,14 +179,20 @@ public class DataAccessRequest {
     if (Objects.isNull(datasetIds)) {
       datasetIds = new ArrayList<>();
     }
-    datasetIds.add(id);
+    if (!datasetIds.contains(id)) {
+      datasetIds.add(id);
+    }
   }
 
   public void addDatasetIds(List<Integer> ids) {
-    if (Objects.nonNull(ids)) {
-      datasetIds = ids;
-    } else {
+    if (Objects.isNull(datasetIds)) {
       datasetIds = new ArrayList<>();
+    }
+    if (Objects.nonNull(ids) && !ids.isEmpty()) {
+      datasetIds = Stream.of(datasetIds, ids)
+        .flatMap(List::stream)
+        .distinct()
+        .collect(Collectors.toList());
     }
   }
 

--- a/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequest.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequest.java
@@ -167,6 +167,9 @@ public class DataAccessRequest {
   }
 
   public List<Integer> getDatasetIds() {
+    if (Objects.isNull(datasetIds)) {
+      return List.of();
+    }
     return datasetIds;
   }
 
@@ -183,6 +186,10 @@ public class DataAccessRequest {
     } else {
       datasetIds = new ArrayList<>();
     }
+  }
+
+  public void setDatasetIds(List<Integer> datasetIds) {
+    this.datasetIds = datasetIds;
   }
 
   /**

--- a/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequest.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequest.java
@@ -13,8 +13,10 @@ import com.google.gson.reflect.TypeToken;
 
 import java.lang.reflect.Type;
 import java.sql.Timestamp;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -48,6 +50,8 @@ public class DataAccessRequest {
   @JsonProperty public Timestamp updateDate;
 
   @JsonProperty private Map<Integer, Election> elections;
+
+  @JsonProperty public List<Integer> datasetIds;
 
   public DataAccessRequest() {
     this.elections = new HashMap<>();
@@ -159,6 +163,25 @@ public class DataAccessRequest {
       if (Objects.isNull(savedRecord)) {
         elections.put(electionId, election);
       }
+    }
+  }
+
+  public List<Integer> getDatasetIds() {
+    return datasetIds;
+  }
+
+  public void addDatasetId(Integer id) {
+    if (Objects.isNull(datasetIds)) {
+      datasetIds = new ArrayList<>();
+    }
+    datasetIds.add(id);
+  }
+
+  public void addDatasetIds(List<Integer> ids) {
+    if (Objects.nonNull(ids)) {
+      datasetIds = ids;
+    } else {
+      datasetIds = new ArrayList<>();
     }
   }
 

--- a/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequestSummaryDetail.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequestSummaryDetail.java
@@ -95,7 +95,7 @@ public class DataAccessRequestSummaryDetail implements SummaryDetail {
   @Override
   public String toString() {
     List<String> dataSetUUIds =
-        getDar().getData().getDatasetIds().stream()
+        getDar().getDatasetIds().stream()
             .map(Dataset::parseAliasToIdentifier)
             .collect(Collectors.toList());
     Optional<Vote> chairPersonRPVote =

--- a/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
@@ -152,7 +152,7 @@ public class DataAccessRequestResource extends Resource {
     private Optional<Integer> getDatasetIdForDarId(String id) {
         DataAccessRequest dar = dataAccessRequestService.findByReferenceId(id);
         List<Integer> datasetIdList = (Objects.nonNull(dar.getData())) ?
-                dar.getData().getDatasetIds() :
+                dar.getDatasetIds() :
                 Collections.emptyList();
         if (datasetIdList == null || datasetIdList.isEmpty()) {
             return Optional.empty();

--- a/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceVersion2.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceVersion2.java
@@ -403,6 +403,8 @@ public class DataAccessRequestResourceVersion2 extends Resource {
       data.setReferenceId(referenceId);
     }
     newDar.setData(data);
+    // TODO: Update the UI to pass in dataset ids on the DAR object itself.
+    newDar.setDatasetIds(data.getDatasetIds());
     return newDar;
   }
 

--- a/src/main/java/org/broadinstitute/consent/http/resources/DataRequestVoteResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataRequestVoteResource.java
@@ -254,7 +254,7 @@ public class DataRequestVoteResource extends Resource {
             agreementVote = vote;
         }
         if((finalVote != null && finalVote.getVote() != null && finalVote.getVote()) && (agreementVote == null || (agreementVote != null && agreementVote.getVote() != null))){
-            List<Dataset> needsApprovedDataSets = datasetService.findNeedsApprovalDataSetByObjectId(dar.getData().getDatasetIds());
+            List<Dataset> needsApprovedDataSets = datasetService.findNeedsApprovalDataSetByObjectId(dar.getDatasetIds());
             List<Integer> dataSetIds = needsApprovedDataSets.stream().map(Dataset::getDataSetId).collect(Collectors.toList());
             if(CollectionUtils.isNotEmpty(needsApprovedDataSets)){
                 Map<User, List<Dataset>> dataOwnerDataSet = datasetAssociationService.findDataOwnersWithAssociatedDataSets(dataSetIds);

--- a/src/main/java/org/broadinstitute/consent/http/resources/ElectionReviewResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/ElectionReviewResource.java
@@ -72,7 +72,7 @@ public class ElectionReviewResource extends Resource {
         DataAccessRequest dar = darService.findByReferenceId(election.getReferenceId());
         List<Integer> dataSetId = new ArrayList<>();
         if (Objects.nonNull(dar) && Objects.nonNull(dar.getData())) {
-            dataSetId.addAll(dar.getData().getDatasetIds());
+            dataSetId.addAll(dar.getDatasetIds());
         }
         Consent consent = consentService.getConsentFromDatasetID(dataSetId.get(0));
         ElectionReview accessElectionReview = service.describeElectionReviewByElectionId(electionId);

--- a/src/main/java/org/broadinstitute/consent/http/service/DacService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DacService.java
@@ -284,7 +284,7 @@ public class DacService {
                 return documents.
                   stream().
                   filter(d -> {
-                      List<Integer> datasetIds = d.getData().getDatasetIds();
+                      List<Integer> datasetIds = d.getDatasetIds();
                       return accessibleDatasetIds.stream().anyMatch(datasetIds::contains);
                   }).
                   collect(Collectors.toList());

--- a/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
@@ -272,7 +272,7 @@ public class DarCollectionService {
     List<Integer> datasetIds = collections.stream()
       .map(d-> d.getDars().values())
       .flatMap(Collection::stream)
-      .map(d -> d.getData().getDatasetIds())
+      .map(d -> d.getDatasetIds())
       .flatMap(Collection::stream)
       .collect(Collectors.toList());
     if(!datasetIds.isEmpty()) {
@@ -286,8 +286,7 @@ public class DarCollectionService {
 
       return collections.stream().map(c -> {
         Set<Dataset> collectionDatasets = c.getDars().values().stream()
-          .map(DataAccessRequest::getData)
-          .map(DataAccessRequestData::getDatasetIds)
+          .map(DataAccessRequest::getDatasetIds)
           .flatMap(Collection::stream)
           .map(datasetMap::get)
           .filter(Objects::nonNull) // filtering out nulls which were getting captured by map
@@ -390,7 +389,7 @@ public class DarCollectionService {
 
     // Filter the list of DARs we can operate on by the datasets accessible to this chairperson
     List<DataAccessRequest> dars = collection.getDars().values().stream()
-      .filter(d -> datasetIds.containsAll(d.getData().getDatasetIds()))
+      .filter(d -> datasetIds.containsAll(d.getDatasetIds()))
       .collect(Collectors.toList());
 
     List<String> referenceIds = dars.stream()

--- a/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
@@ -269,12 +269,12 @@ public class DarCollectionService {
    */
   public List<DarCollection> addDatasetsToCollections(List<DarCollection> collections, List<Integer> filterDatasetIds) {
     // get datasetIds from each DAR from each collection
-    List<Integer> datasetIds = collections.stream()
-      .map(d-> d.getDars().values())
-      .flatMap(Collection::stream)
-      .map(d -> d.getDatasetIds())
-      .flatMap(Collection::stream)
+    List<String> referenceIds = collections.stream()
+      .map(DarCollection::getDars)
+      .map(Map::keySet)
+      .flatMap(Set::stream)
       .collect(Collectors.toList());
+    List<Integer> datasetIds = referenceIds.isEmpty() ? List.of() : dataAccessRequestDAO.findAllDARDatasetRelations(referenceIds);
     if(!datasetIds.isEmpty()) {
       // if filterDatasetIds has values, get the intersection between that and datasetIds
       if (!filterDatasetIds.isEmpty()) {

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
@@ -219,7 +219,7 @@ public class DataAccessRequestService {
         return dar;
     }
 
-    // TODO This needs to go away with this PR.
+    // TODO This needs be removed in a follow-on PR that refactors all usages to a non-deprecated update method.
     @Deprecated // Use updateByReferenceIdVersion2
     public DataAccessRequest updateByReferenceId(String referencedId, DataAccessRequestData darData) {
         darData.setSortDate(new Date().getTime());

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
@@ -452,7 +452,7 @@ public class DataAccessRequestService {
             darData.setCreateDate(nowTime);
         }
         darData.setSortDate(nowTime);
-        List<Integer> datasets = dataAccessRequest.getDatasetIds();
+        List<Integer> datasets = dataAccessRequestDAO.findDARDatasetRelations(dataAccessRequest.getReferenceId());
         if (CollectionUtils.isNotEmpty(datasets)) {
             String darCodeSequence = "DAR-" + counterService.getNextDarSequence();
             Integer collectionId = darCollectionDAO.insertDarCollection(darCodeSequence, user.getUserId(), now);

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -9,6 +9,7 @@ import org.broadinstitute.consent.http.enumeration.AssociationType;
 import org.broadinstitute.consent.http.enumeration.DataUseTranslationType;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.Consent;
+import org.broadinstitute.consent.http.models.DataAccessRequest;
 import org.broadinstitute.consent.http.models.DataAccessRequestData;
 import org.broadinstitute.consent.http.models.Dataset;
 import org.broadinstitute.consent.http.models.DatasetAudit;
@@ -373,14 +374,7 @@ public class DatasetService {
 
     @Deprecated
     public Set<DatasetDTO> describeDatasets(Integer userId) {
-        List<DataAccessRequestData> darDatas = dataAccessRequestDAO.findAllDataAccessRequestDatas();
-        List<Integer> datasetIdsInUse = darDatas
-                .stream()
-                .map(DataAccessRequestData::getDatasetIds)
-                .filter(Objects::nonNull)
-                .filter(l -> !l.isEmpty())
-                .flatMap(List::stream)
-                .collect(Collectors.toList());
+        List<Integer> datasetIdsInUse = dataAccessRequestDAO.findAllDARDatasetRelationDatasetIds();
         HashSet<DatasetDTO> datasets = new HashSet<>();
         if (userHasRole(UserRoles.ADMIN.getRoleName(), userId)) {
             datasets.addAll(datasetDAO.findAllDatasets());

--- a/src/main/java/org/broadinstitute/consent/http/service/ElectionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ElectionService.java
@@ -427,7 +427,7 @@ public class ElectionService {
     }
 
     private List<Dataset> verifyActiveDataSets(DataAccessRequest dar, String referenceId) throws Exception {
-        List<Integer> dataSets = Objects.nonNull(dar) && Objects.nonNull(dar.getData()) ? dar.getData().getDatasetIds() : Collections.emptyList();
+        List<Integer> dataSets = Objects.nonNull(dar) && Objects.nonNull(dar.getData()) ? dar.getDatasetIds() : Collections.emptyList();
         List<Dataset> dataSetList = dataSets.isEmpty() ? Collections.emptyList() : dataSetDAO.findDatasetsByIdList(dataSets);
         List<String> disabledDataSets = dataSetList.stream()
                 .filter(ds -> !ds.getActive())
@@ -461,7 +461,7 @@ public class ElectionService {
             entry.setObjectId(dataSet.getObjectId());
             activeDatasetDetailEntries.add(entry);
         });
-        dar.getData().setDatasetIds(activeDatasetIds);
+        dar.setDatasetIds(activeDatasetIds);
         dar.getData().setDatasetDetail(activeDatasetDetailEntries);
         dataAccessRequestService.updateByReferenceId(referenceId, dar.getData());
     }
@@ -484,7 +484,7 @@ public class ElectionService {
             case DATA_ACCESS:
             case RP:
                 DataAccessRequest dar = dataAccessRequestService.findByReferenceId(referenceId);
-                List<Integer> datasetIdList = Objects.nonNull(dar) && Objects.nonNull(dar.getData()) ? dar.getData().getDatasetIds() : Collections.emptyList();
+                List<Integer> datasetIdList = Objects.nonNull(dar) ? dar.getDatasetIds() : Collections.emptyList();
                 if (datasetIdList != null && !datasetIdList.isEmpty()) {
                     if (datasetIdList.size() > 1) {
                         logger.warn("DAR " +
@@ -605,7 +605,7 @@ public class ElectionService {
 
     private void sendResearcherNotification(String referenceId) throws Exception {
         DataAccessRequest dar = dataAccessRequestService.findByReferenceId(referenceId);
-        List<Integer> dataSetIdList = dar.getData().getDatasetIds();
+        List<Integer> dataSetIdList = dar.getDatasetIds();
         if (CollectionUtils.isNotEmpty(dataSetIdList)) {
             List<Dataset> dataSets = dataSetDAO.findDatasetsByIdList(dataSetIdList);
             List<DatasetMailDTO> datasetsDetail = new ArrayList<>();
@@ -641,7 +641,7 @@ public class ElectionService {
         final User researcher = (Objects.nonNull(dar) && Objects.nonNull(dar.getUserId())) ?
                 userDAO.findUserById(dar.getUserId()) :
                 null;
-        List<Integer> datasetIdList = dar.getData().getDatasetIds();
+        List<Integer> datasetIdList = dar.getDatasetIds();
         if (CollectionUtils.isNotEmpty(datasetIdList)) {
             Map<Integer, List<DatasetAssociation>> userToAssociationMap = datasetAssociationDAO.
                     getDatasetAssociations(datasetIdList).stream().

--- a/src/main/java/org/broadinstitute/consent/http/service/EmailNotifierService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/EmailNotifierService.java
@@ -119,8 +119,7 @@ public class EmailNotifierService {
             DarCollection collection = collectionDAO.findDARCollectionByCollectionId(collectionId);
             List<User> admins = userDAO.describeUsersByRoleAndEmailPreference(UserRoles.ADMIN.getRoleName(), true);
             List<Integer> datasetIds = collection.getDars().values().stream()
-                    .map(DataAccessRequest::getData)
-                    .map(DataAccessRequestData::getDatasetIds)
+                    .map(DataAccessRequest::getDatasetIds)
                     .flatMap(List::stream)
                     .collect(Collectors.toList());
             Set<User> chairPersons = userDAO.findUsersForDatasetsByRole(datasetIds, Collections.singletonList(UserRoles.CHAIRPERSON.getRoleName()));

--- a/src/main/java/org/broadinstitute/consent/http/service/MatchService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/MatchService.java
@@ -163,7 +163,7 @@ public class MatchService {
         Match match = null;
         DataAccessRequest dar = dataAccessRequestDAO.findByReferenceId(purposeId);
         if (Objects.nonNull(dar)) {
-            List<Integer> dataSetIdList = dar.getData().getDatasetIds();
+            List<Integer> dataSetIdList = dar.getDatasetIds();
             Consent consent = findRelatedConsent(dataSetIdList);
             if (Objects.nonNull(consent)) {
                 try {
@@ -270,7 +270,7 @@ public class MatchService {
 
     private List<DataAccessRequest> findRelatedDars(List<Integer> dataSetIds) {
         return dataAccessRequestDAO.findAllDataAccessRequests().stream()
-                .filter(d -> !Collections.disjoint(dataSetIds, d.getData().getDatasetIds()))
+                .filter(d -> !Collections.disjoint(dataSetIds, d.getDatasetIds()))
                 .collect(Collectors.toList());
     }
 

--- a/src/main/java/org/broadinstitute/consent/http/service/MetricsService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/MetricsService.java
@@ -88,8 +88,7 @@ public class MetricsService {
       dars.stream().map(DataAccessRequest::getReferenceId).collect(Collectors.toList());
     List<Integer> datasetIds =
       dars.stream()
-        .map(DataAccessRequest::getData)
-        .map(DataAccessRequestData::getDatasetIds)
+        .map(DataAccessRequest::getDatasetIds)
         .flatMap(List::stream)
         .collect(Collectors.toList());
     List<Dataset> datasets = dataSetDAO.findDatasetsByIdList(datasetIds);
@@ -118,7 +117,7 @@ public class MetricsService {
       .map(
         dataAccessRequest -> {
           Integer datasetId =
-            dataAccessRequest.getData().getDatasetIds().stream().findFirst().orElse(0);
+            dataAccessRequest.getDatasetIds().stream().findFirst().orElse(0);
 
           Dataset dataset =
             datasets.stream()

--- a/src/main/java/org/broadinstitute/consent/http/service/SummaryService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/SummaryService.java
@@ -223,9 +223,7 @@ public class SummaryService {
       List<Integer> datasetIds =
           dataAccessRequests.stream()
             .filter(Objects::nonNull)
-            .map(DataAccessRequest::getData)
-            .filter(Objects::nonNull)
-            .map(DataAccessRequestData::getDatasetIds)
+            .map(DataAccessRequest::getDatasetIds)
             .flatMap(List::stream)
             .filter(Objects::nonNull)
             .collect(Collectors.toList());
@@ -283,7 +281,7 @@ public class SummaryService {
         List<User> dacMembers = voteUsers.stream().filter(v -> dacUserIds.contains(v.getUserId())).collect(Collectors.toList());
 
         if (Objects.nonNull(dar) && Objects.nonNull(dar.getData())) {
-          List<Integer> datasetId = dar.getData().getDatasetIds();
+          List<Integer> datasetId = dar.getDatasetIds();
           if (CollectionUtils.isNotEmpty(datasetId)) {
             Optional<User> darUser = darUsers.stream().filter(u -> u.getUserId().equals(dar.getUserId())).findFirst();
             details.add(new DataAccessRequestSummaryDetail(

--- a/src/main/java/org/broadinstitute/consent/http/service/VoteService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/VoteService.java
@@ -374,8 +374,7 @@ public class VoteService {
         collections.forEach(c -> {
             // Get the datasets in this collection that have been approved
             List<Integer> collectionDatasetIds = c.getDars().values().stream()
-                .map(DataAccessRequest::getData)
-                .map(DataAccessRequestData::getDatasetIds)
+                .map(DataAccessRequest::getDatasetIds)
                 .flatMap(List::stream)
                 .distinct()
                 .collect(Collectors.toList());

--- a/src/main/java/org/broadinstitute/consent/http/service/dao/DarCollectionServiceDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/dao/DarCollectionServiceDAO.java
@@ -85,7 +85,7 @@ public class DarCollectionServiceDAO {
 
                 // If the user is not an admin, then the dataset must be in the list of the user's DAC Datasets
                 // Otherwise, we need to skip election creation for this DAR as well.
-                Integer datasetId = dar.getData().getDatasetIds().get(0);
+                Integer datasetId = dar.getDatasetIds().get(0);
                 if (!isAdmin && !dacUserDatasetIds.contains(datasetId)) {
                     ignore = true;
                 }

--- a/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
@@ -497,7 +497,7 @@ public class DAOTestHelper {
 
     protected DarCollection createDarCollection() {
         User user = createUserWithInstitution();
-        String darCode = "DAR-" + RandomUtils.nextInt(100, 1000);
+        String darCode = "DAR-" + RandomUtils.nextInt(1, 10000);
         Integer collection_id = darCollectionDAO.insertDarCollection(darCode, user.getUserId(), new Date());
         Dataset dataset = createDataset();
         DataAccessRequest dar = createDataAccessRequest(user.getUserId(), collection_id, darCode);

--- a/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
@@ -441,11 +441,10 @@ public class DAOTestHelper {
 
     protected DataAccessRequest createDataAccessRequestWithDatasetAndCollectionInfo(int collectionId, int datasetId, int userId, String darCode) {
         DataAccessRequestData data = new DataAccessRequestData();
-        List<Integer> datasetIds = Collections.singletonList(datasetId);
-        data.setDatasetIds(datasetIds);
         data.setProjectTitle(RandomStringUtils.random(10));
         String referenceId = RandomStringUtils.randomAlphanumeric(20);
         dataAccessRequestDAO.insertDataAccessRequest(collectionId, referenceId, userId, new Date(), new Date(), new Date(), new Date(), data);
+        dataAccessRequestDAO.insertDARDatasetRelation(referenceId, datasetId);
         return dataAccessRequestDAO.findByReferenceId(referenceId);
     }
 
@@ -502,6 +501,7 @@ public class DAOTestHelper {
         Integer collection_id = darCollectionDAO.insertDarCollection(darCode, user.getUserId(), new Date());
         Dataset dataset = createDataset();
         DataAccessRequest dar = createDataAccessRequest(user.getUserId(), collection_id, darCode);
+        dataAccessRequestDAO.insertDARDatasetRelation(dar.getReferenceId(), dataset.getDataSetId());
         Election cancelled = createCancelledAccessElection(dar.getReferenceId(), dataset.getDataSetId());
         Election access = createDataAccessElection(dar.getReferenceId(), dataset.getDataSetId());
         createFinalVote(user.getUserId(), cancelled.getElectionId());
@@ -541,6 +541,7 @@ public class DAOTestHelper {
         Integer collection_id = darCollectionDAO.insertDarCollection(darCode, user.getUserId(), new Date());
         Dataset dataset = createDataset();
         DataAccessRequest dar = createDataAccessRequest(user.getUserId(), collection_id, darCode);
+        dataAccessRequestDAO.insertDARDatasetRelation(dar.getReferenceId(), dataset.getDataSetId());
         Election cancelled = createCancelledAccessElection(dar.getReferenceId(), dataset.getDataSetId());
         Election access = createDataAccessElection(dar.getReferenceId(), dataset.getDataSetId());
         createFinalVote(user.getUserId(), cancelled.getElectionId());
@@ -555,11 +556,11 @@ public class DAOTestHelper {
         DataAccessRequest dar = new DataAccessRequest();
         dar.setReferenceId(UUID.randomUUID().toString());
         DataAccessRequestData data = new DataAccessRequestData();
-        data.setDatasetIds(List.of(dataset.getDataSetId()));
         dar.setData(data);
         dataAccessRequestDAO.insertDraftDataAccessRequest(dar.getReferenceId(), user.getUserId(), now, now, now, now, data);
         dataAccessRequestDAO.updateDraftForCollection(collectionId, dar.getReferenceId());
         dataAccessRequestDAO.updateDraftByReferenceId(dar.getReferenceId(), false);
+        dataAccessRequestDAO.insertDARDatasetRelation(dar.getReferenceId(), dataset.getDataSetId());
         return dataAccessRequestDAO.findByReferenceId(dar.getReferenceId());
     }
 }

--- a/src/test/java/org/broadinstitute/consent/http/db/DarCollectionDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DarCollectionDAOTest.java
@@ -314,6 +314,7 @@ public class DarCollectionDAOTest extends DAOTestHelper  {
   @Test
   public void testDeleteByCollectionId() {
     DarCollection collection = createDarCollection();
+    collection.getDars().keySet().forEach(k -> dataAccessRequestDAO.deleteDARDatasetRelationByReferenceId(k));
     dataAccessRequestDAO.deleteByCollectionId(collection.getDarCollectionId());
     darCollectionDAO.deleteByCollectionId(collection.getDarCollectionId());
     assertNull(darCollectionDAO.findDARCollectionByCollectionId(collection.getDarCollectionId()));
@@ -787,8 +788,6 @@ public void testGetFilteredListForResearcher_InstitutionTerm() {
     testDar.setSubmissionDate(now);
     testDar.setUpdateDate(now);
     DataAccessRequestData contents = new DataAccessRequestData();
-    // add data datasetId
-    contents.setDatasetIds(List.of(dataset.getDataSetId()));
     testDar.setData(contents);
 
     dataAccessRequestDAO.insertDataAccessRequest(
@@ -801,6 +800,7 @@ public void testGetFilteredListForResearcher_InstitutionTerm() {
             testDar.getUpdateDate(),
             testDar.getData()
     );
+    dataAccessRequestDAO.insertDARDatasetRelation(testDar.getReferenceId(), dataset.getDataSetId());
     return testDar;
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/db/DarCollectionDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DarCollectionDAOTest.java
@@ -183,7 +183,7 @@ public class DarCollectionDAOTest extends DAOTestHelper  {
     if (Objects.isNull(dar)) {
       fail("DAR was not created in collection");
     }
-    dar.getData().setDatasetIds(List.of(dataset.getDataSetId()));
+    dataAccessRequestDAO.insertDARDatasetRelation(dar.getReferenceId(), dataset.getDataSetId());
     dataAccessRequestDAO.updateDataByReferenceIdVersion2(dar.getReferenceId(), dar.getUserId(), new Date(), new Date(), new Date(), dar.getData());
     Dac dac = createDac();
     Consent consent = createConsent(dac.getDacId());

--- a/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
@@ -260,8 +260,6 @@ public class DataAccessRequestDAOTest extends DAOTestHelper {
         testDar.setSubmissionDate(now);
         testDar.setUpdateDate(now);
         DataAccessRequestData contents = new DataAccessRequestData();
-        // add data datasetId
-        contents.setDatasetIds(List.of(dataset.getDataSetId()));
         testDar.setData(contents);
         dataAccessRequestDAO.insertDataAccessRequest(
                 testDar.getCollectionId(),
@@ -274,7 +272,7 @@ public class DataAccessRequestDAOTest extends DAOTestHelper {
                 testDar.getData()
         );
         dataAccessRequestDAO.insertDARDatasetRelation(testDar.getReferenceId(), dataset.getDataSetId());
-        return testDar;
+        return dataAccessRequestDAO.findByReferenceId(testDar.getReferenceId());
     }
 
     // local method to create a Draft DAR
@@ -474,7 +472,7 @@ public class DataAccessRequestDAOTest extends DAOTestHelper {
 
         assertNotNull(dataSetIds);
         assertFalse(dataSetIds.isEmpty());
-        assertEquals(dataSetIds, testDar1.getData().getDatasetIds());
+        assertEquals(dataSetIds, testDar1.getDatasetIds());
     }
 
     @Test
@@ -486,7 +484,7 @@ public class DataAccessRequestDAOTest extends DAOTestHelper {
         List<Integer> returned = dataAccessRequestDAO.findDARDatasetRelations(testDar1.getReferenceId());
 
         assertNotNull(returned);
-        assertEquals(testDar1.getData().getDatasetIds(), returned);
+        assertEquals(testDar1.getDatasetIds(), returned);
 
         dataAccessRequestDAO.deleteDARDatasetRelationByReferenceId(testDar1.getReferenceId());
         List<Integer> returnedAfter = dataAccessRequestDAO.findDARDatasetRelations(testDar1.getReferenceId());
@@ -510,8 +508,8 @@ public class DataAccessRequestDAOTest extends DAOTestHelper {
         assertNotNull(returnedDarDatasets1);
         assertNotNull(returnedDarDatasets2);
 
-        assertEquals(testDar1.getData().getDatasetIds(), returnedDarDatasets1);
-        assertEquals(testDar2.getData().getDatasetIds(), returnedDarDatasets2);
+        assertEquals(testDar1.getDatasetIds(), returnedDarDatasets1);
+        assertEquals(testDar2.getDatasetIds(), returnedDarDatasets2);
 
         dataAccessRequestDAO.deleteDARDatasetRelationByReferenceIds(List.of(testDar1.getReferenceId(), testDar2.getReferenceId()));
 

--- a/src/test/java/org/broadinstitute/consent/http/db/ElectionDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/ElectionDAOTest.java
@@ -327,7 +327,7 @@ public class ElectionDAOTest extends DAOTestHelper {
 
     String darReferenceId = dar.getReferenceId();
     Integer datasetId = dataset.getDataSetId();
-    dar.getData().setDatasetIds(Collections.singletonList(datasetId));
+    dataAccessRequestDAO.insertDARDatasetRelation(dar.getReferenceId(), datasetId);
     dataAccessRequestDAO.updateDataByReferenceId(darReferenceId, dar.getData());
     consentDAO.insertConsentAssociation(consent.getConsentId(), ASSOCIATION_TYPE_TEST, dataset.getDataSetId());
 

--- a/src/test/java/org/broadinstitute/consent/http/models/DarManualReviewTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/DarManualReviewTest.java
@@ -21,7 +21,7 @@ public class DarManualReviewTest {
   public void testManualReviewFalse() {
     assertFalse(dar.requiresManualReview());
     // There are many fields we could check, but this one is enough to prove our logic.
-    dar.getData().setDatasetIds(Collections.singletonList(1));
+    dar.addDatasetId(1);
     assertFalse(dar.requiresManualReview());
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/resources/DarCollectionResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DarCollectionResourceTest.java
@@ -67,7 +67,7 @@ public class DarCollectionResourceTest {
   private DataAccessRequest mockDataAccessRequestWithDatasetIds() {
     DataAccessRequest dar = new DataAccessRequest();
     DataAccessRequestData data = new DataAccessRequestData();
-    data.setDatasetIds(List.of(RandomUtils.nextInt(1, 100)));
+    dar.addDatasetId(RandomUtils.nextInt(1, 100));
     dar.setData(data);
     return dar;
   }

--- a/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceTest.java
@@ -103,7 +103,7 @@ public class DataAccessRequestResourceTest {
     @Test(expected = NotFoundException.class)
     public void testDescribeConsentForDarCase4() {
         DataAccessRequest dar = generateDataAccessRequest();
-        dar.getData().setDatasetIds(null);
+        dar.setDatasetIds(null);
         when(dataAccessRequestService.findByReferenceId(any())).thenReturn(dar);
         resource = new DataAccessRequestResource(dataAccessRequestService, userService, consentService);
         resource.describeConsentForDAR(authUser, dar.getReferenceId());
@@ -212,7 +212,7 @@ public class DataAccessRequestResourceTest {
         DataAccessRequestData data = new DataAccessRequestData();
         dar.setReferenceId(UUID.randomUUID().toString());
         data.setReferenceId(dar.getReferenceId());
-        data.setDatasetIds(Arrays.asList(1, 2));
+        dar.setDatasetIds(Arrays.asList(1, 2));
         dar.setData(data);
         dar.setUserId(1);
         return dar;

--- a/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceVersion2Test.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceVersion2Test.java
@@ -375,7 +375,7 @@ public class DataAccessRequestResourceVersion2Test {
     DataAccessRequestData data = new DataAccessRequestData();
     dar.setReferenceId(UUID.randomUUID().toString());
     data.setReferenceId(dar.getReferenceId());
-    data.setDatasetIds(Arrays.asList(1, 2));
+    dar.setDatasetIds(Arrays.asList(1, 2));
     dar.setData(data);
     dar.setUserId(user.getUserId());
     dar.setCreateDate(now);

--- a/src/test/java/org/broadinstitute/consent/http/resources/DataRequestVoteResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DataRequestVoteResourceTest.java
@@ -97,7 +97,7 @@ public class DataRequestVoteResourceTest implements WithLogHandler {
     private DataAccessRequest createMockDAR() {
         DataAccessRequest dar = new DataAccessRequest();
         DataAccessRequestData darData = new DataAccessRequestData();
-        darData.setDatasetIds(List.of(1));
+        dar.setDatasetIds(List.of(1));
         darData.setDarCode("");
         dar.setData(darData);
         dar.setReferenceId("");

--- a/src/test/java/org/broadinstitute/consent/http/resources/ElectionReviewResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/ElectionReviewResourceTest.java
@@ -82,7 +82,7 @@ public class ElectionReviewResourceTest {
         when(electionService.getConsentElectionByDARElectionId(e.getElectionId())).thenReturn(consentElection);
         DataAccessRequest dar = new DataAccessRequest();
         DataAccessRequestData data = new DataAccessRequestData();
-        data.setDatasetIds(Collections.singletonList(1));
+        dar.addDatasetId(1);
         dar.setData(data);
         when(darService.findByReferenceId(any())).thenReturn(dar);
         when(consentService.getConsentFromDatasetID(any())).thenReturn(new Consent());

--- a/src/test/java/org/broadinstitute/consent/http/service/DacServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DacServiceTest.java
@@ -703,13 +703,13 @@ public class DacServiceTest {
                 mapToObj(i -> {
                     String referenceId = UUID.randomUUID().toString();
                     List<Integer> dataSetIds = Collections.singletonList(i);
-                    DataAccessRequest doc = new DataAccessRequest();
-                    doc.setReferenceId(referenceId);
+                    DataAccessRequest dar = new DataAccessRequest();
+                    dar.setReferenceId(referenceId);
                     DataAccessRequestData data = new DataAccessRequestData();
-                    data.setDatasetIds(dataSetIds);
+                    dar.setDatasetIds(dataSetIds);
                     data.setReferenceId(referenceId);
-                    doc.setData(data);
-                    return doc;
+                    dar.setData(data);
+                    return dar;
                 }).collect(Collectors.toList());
     }
 

--- a/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
@@ -270,6 +270,7 @@ public class DarCollectionServiceTest {
       .collect(Collectors.toList());
 
     when(datasetDAO.findDatasetWithDataUseByIdList(anyList())).thenReturn(datasets);
+    when(dataAccessRequestDAO.findAllDARDatasetRelations(any())).thenReturn(datasetIds);
     initService();
 
     collections = service.addDatasetsToCollections(collections, List.of());
@@ -302,6 +303,7 @@ public class DarCollectionServiceTest {
 
     // mocking out findDatasetWithDataUseByIdList to only return one of the datasets
     when(datasetDAO.findDatasetWithDataUseByIdList(List.of(dataset.getDataSetId()))).thenReturn(new HashSet<>(List.of(dataset)));
+    when(dataAccessRequestDAO.findAllDARDatasetRelations(any())).thenReturn(datasetIds);
 
     initService();
 

--- a/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
@@ -423,7 +423,7 @@ public class DarCollectionServiceTest {
     DataAccessRequest dar = new DataAccessRequest();
     dar.setReferenceId(UUID.randomUUID().toString());
     DataAccessRequestData data = new DataAccessRequestData();
-    data.setDatasetIds(List.of(dataset.getDataSetId()));
+    dar.addDatasetId(dataset.getDataSetId());
     dar.setData(data);
     DarCollection collection = createMockCollections(1).get(0);
     collection.setDars(Map.of(dar.getReferenceId(), dar));
@@ -456,7 +456,7 @@ public class DarCollectionServiceTest {
     DataAccessRequest dar = new DataAccessRequest();
     dar.setReferenceId(UUID.randomUUID().toString());
     DataAccessRequestData data = new DataAccessRequestData();
-    data.setDatasetIds(List.of(dataset.getDataSetId()));
+    dar.addDatasetId(dataset.getDataSetId());
     dar.setData(data);
     DarCollection collection = createMockCollections(1).get(0);
     collection.setDars(Map.of(dar.getReferenceId(), dar));
@@ -650,7 +650,7 @@ public class DarCollectionServiceTest {
 
     Integer datasetId = RandomUtils.nextInt(1, 100);
     datasets.add(generateMockDatasetWithDataUse(datasetId));
-    data.setDatasetIds(Collections.singletonList(datasetId));
+    dar.addDatasetId(datasetId);
     dar.setData(data);
     dar.setReferenceId(UUID.randomUUID().toString());
     return dar;

--- a/src/test/java/org/broadinstitute/consent/http/service/DataAccessReportsParserTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DataAccessReportsParserTest.java
@@ -148,7 +148,6 @@ public class DataAccessReportsParserTest {
         List<DatasetDetailEntry> detailsList = new ArrayList<>();
         detailsList.add(datasetDetail);
         data.setDatasetDetail(detailsList);
-        data.setDatasetIds(new ArrayList<>());
         data.setDarCode(DAR_CODE);
         data.setTranslatedUseRestriction(TRANSLATED_USE_RESTRICTION);
         data.setNonTechRus(RUS_SUMMARY);

--- a/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
@@ -123,7 +123,7 @@ public class DataAccessRequestServiceTest {
         Integer genericId = 1;
         DataAccessRequest dar = generateDataAccessRequest();
         dar.setData(new DataAccessRequestData());
-        dar.getData().setDatasetIds(Collections.singletonList(genericId));
+        dar.addDatasetId(genericId);
         when(dataAccessRequestDAO.findAllDataAccessRequests()).thenReturn(Collections.singletonList(dar));
         Election e = new Election();
         e.setReferenceId(dar.getReferenceId());
@@ -180,7 +180,7 @@ public class DataAccessRequestServiceTest {
     @Test
     public void testCreateDataAccessRequest_Update() {
         DataAccessRequest dar = generateDataAccessRequest();
-        dar.getData().setDatasetIds(Arrays.asList(1, 2, 3));
+        dar.addDatasetIds(Arrays.asList(1, 2, 3));
         User user = new User(1, "email@test.org", "Display Name", new Date());
         when(counterService.getNextDarSequence()).thenReturn(1);
         when(dataAccessRequestDAO.findByReferenceId(any())).thenReturn(dar);
@@ -195,7 +195,7 @@ public class DataAccessRequestServiceTest {
     @Test
     public void testCreateDataAccessRequest_Create() {
         DataAccessRequest dar = generateDataAccessRequest();
-        dar.getData().setDatasetIds(Arrays.asList(1, 2, 3));
+        dar.addDatasetIds(Arrays.asList(1, 2, 3));
         dar.setCreateDate(new Timestamp(1000));
         dar.setSortDate(new Timestamp(1000));
         dar.setReferenceId("id");
@@ -219,7 +219,7 @@ public class DataAccessRequestServiceTest {
         DataAccessRequest dar = generateDataAccessRequest();
         dar.setCollectionId(RandomUtils.nextInt(0, 100));
         User user = new User(1, "email@test.org", "Display Name", new Date());
-        dar.getData().setDatasetIds(Arrays.asList(1, 2, 3));
+        dar.addDatasetIds(Arrays.asList(1, 2, 3));
         doNothing().when(dataAccessRequestDAO).updateDataByReferenceIdVersion2(any(), any(),
             any(), any(), any(), any());
         when(dataAccessRequestDAO.findByReferenceId(any())).thenReturn(dar);
@@ -232,7 +232,7 @@ public class DataAccessRequestServiceTest {
     public void testUpdateByReferenceIdVersion2_WithCollection() {
         DataAccessRequest dar = generateDataAccessRequest();
         User user = new User(1, "email@test.org", "Display Name", new Date());
-        dar.getData().setDatasetIds(Arrays.asList(1, 2, 3));
+        dar.addDatasetIds(Arrays.asList(1, 2, 3));
         doNothing().when(dataAccessRequestDAO).updateDataByReferenceIdVersion2(any(), any(),
           any(), any(), any(), any());
         doNothing().when(darCollectionDAO).updateDarCollection(any(), any(), any());
@@ -272,7 +272,7 @@ public class DataAccessRequestServiceTest {
         Integer genericId = 1;
         DataAccessRequest dar = generateDataAccessRequest();
         dar.setData(new DataAccessRequestData());
-        dar.getData().setDatasetIds(Collections.singletonList(genericId));
+        dar.addDatasetId(genericId);
         when(dataAccessRequestDAO.findAllDataAccessRequests()).thenReturn(Collections.singletonList(dar));
         when(dacService.filterDataAccessRequestsByDac(any(), any())).thenReturn(Collections.singletonList(dar));
 
@@ -312,7 +312,7 @@ public class DataAccessRequestServiceTest {
         Integer genericId = 1;
         DataAccessRequest dar = generateDataAccessRequest();
         dar.setData(new DataAccessRequestData());
-        dar.getData().setDatasetIds(Collections.singletonList(genericId));
+        dar.addDatasetId(genericId);
         when(dataAccessRequestDAO.findAllDataAccessRequestsForInstitution(any())).thenReturn(Collections.singletonList(dar));
 
         Election e = new Election();
@@ -358,7 +358,7 @@ public class DataAccessRequestServiceTest {
         Integer genericId = 1;
         DataAccessRequest dar = generateDataAccessRequest();
         dar.setData(new DataAccessRequestData());
-        dar.getData().setDatasetIds(Collections.singletonList(genericId));
+        dar.addDatasetId(genericId);
         when(dataAccessRequestDAO.findAllDarsByUserId(any())).thenReturn(Collections.singletonList(dar));
 
         Election e = new Election();
@@ -533,7 +533,7 @@ public class DataAccessRequestServiceTest {
         dar.setUserId(userId);
         dar.setReferenceId(UUID.randomUUID().toString());
         data.setReferenceId(dar.getReferenceId());
-        data.setDatasetIds(Collections.singletonList(1));
+        dar.addDatasetId(1);
         data.setForProfit(false);
         data.setAcademicEmail("acad@email.com");
         data.setAddiction(false);
@@ -616,7 +616,7 @@ public class DataAccessRequestServiceTest {
         dar.setReferenceId("referenceId");
         dar.setUserId(1);
         DataAccessRequestData data = new DataAccessRequestData();
-        data.setDatasetIds(Arrays.asList(361));
+        dar.addDatasetId(361);
         dar.setData(data);
         when(dataAccessRequestDAO.findAllDraftDataAccessRequests()).thenReturn(Arrays.asList(dar));
         initService();
@@ -630,7 +630,7 @@ public class DataAccessRequestServiceTest {
         dar.setReferenceId("referenceId");
         dar.setUserId(1);
         DataAccessRequestData data = new DataAccessRequestData();
-        data.setDatasetIds(Arrays.asList(361));
+        dar.addDatasetId(361);
         dar.setData(data);
         when(dataAccessRequestDAO.findAllDraftsByUserId(any())).thenReturn(Arrays.asList(dar));
         initService();
@@ -696,8 +696,8 @@ public class DataAccessRequestServiceTest {
         DataAccessRequestData data = new DataAccessRequestData();
         data.setReferenceId(UUID.randomUUID().toString());
         data.setStatus(DarStatus.CANCELED.getValue());
-        data.setDatasetIds(List.of());
         dar.setData(data);
+        dar.setDatasetIds(null);
         dar.setReferenceId(data.getReferenceId());
         sourceCollection.addDar(dar);
         initService();
@@ -711,7 +711,7 @@ public class DataAccessRequestServiceTest {
         DataAccessRequest dar = new DataAccessRequest();
         DataAccessRequestData data = new DataAccessRequestData();
         data.setStatus(DarStatus.CANCELED.getValue());
-        data.setDatasetIds(List.of(1));
+        dar.addDatasetId(1);
         data.setReferenceId(UUID.randomUUID().toString());
         dar.setData(data);
         dar.setReferenceId(data.getReferenceId());
@@ -728,7 +728,7 @@ public class DataAccessRequestServiceTest {
         DataAccessRequest dar = new DataAccessRequest();
         DataAccessRequestData data = new DataAccessRequestData();
         data.setStatus(DarStatus.CANCELED.getValue());
-        data.setDatasetIds(List.of(1));
+        dar.addDatasetId(1);
         data.setReferenceId(UUID.randomUUID().toString());
         dar.setData(data);
         dar.setReferenceId(data.getReferenceId());

--- a/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
@@ -180,10 +180,11 @@ public class DataAccessRequestServiceTest {
     @Test
     public void testCreateDataAccessRequest_Update() {
         DataAccessRequest dar = generateDataAccessRequest();
-        dar.addDatasetIds(Arrays.asList(1, 2, 3));
+        dar.addDatasetIds(List.of(1, 2, 3));
         User user = new User(1, "email@test.org", "Display Name", new Date());
         when(counterService.getNextDarSequence()).thenReturn(1);
         when(dataAccessRequestDAO.findByReferenceId(any())).thenReturn(dar);
+        when(dataAccessRequestDAO.findDARDatasetRelations(any())).thenReturn(List.of(1, 2, 3));
         doNothing().when(dataAccessRequestDAO).updateDraftByReferenceId(any(), any());
         doNothing().when(dataAccessRequestDAO).updateDataByReferenceIdVersion2(any(), any(), any(), any(), any(), any());
         doNothing().when(dataAccessRequestDAO).insertDraftDataAccessRequest(any(), any(), any(), any(), any(), any(), any());
@@ -195,7 +196,7 @@ public class DataAccessRequestServiceTest {
     @Test
     public void testCreateDataAccessRequest_Create() {
         DataAccessRequest dar = generateDataAccessRequest();
-        dar.addDatasetIds(Arrays.asList(1, 2, 3));
+        dar.addDatasetIds(List.of(1, 2, 3));
         dar.setCreateDate(new Timestamp(1000));
         dar.setSortDate(new Timestamp(1000));
         dar.setReferenceId("id");
@@ -203,6 +204,7 @@ public class DataAccessRequestServiceTest {
         when(counterService.getNextDarSequence()).thenReturn(1);
         when(dataAccessRequestDAO.findByReferenceId("id")).thenReturn(null);
         when(dataAccessRequestDAO.findByReferenceId(argThat(new LongerThanTwo()))).thenReturn(dar);
+        when(dataAccessRequestDAO.findDARDatasetRelations(any())).thenReturn(List.of(1, 2, 3));
         when(darCollectionDAO.insertDarCollection(anyString(), anyInt(), any(Date.class))).thenReturn(RandomUtils.nextInt(1,100));
         doNothing().when(dataAccessRequestDAO).insertDataAccessRequest(anyInt(), anyString(), anyInt(), any(Date.class), any(Date.class), any(Date.class), any(Date.class), any(DataAccessRequestData.class));
         initService();

--- a/src/test/java/org/broadinstitute/consent/http/service/ElectionServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/ElectionServiceTest.java
@@ -147,7 +147,6 @@ public class ElectionServiceTest {
         sampleDataAccessRequest1.setUserId(2);
         DataAccessRequestData data = new DataAccessRequestData();
         data.setReferenceId(sampleElection1.getReferenceId());
-        data.setDatasetIds(Arrays.asList(sampleDataset1.getDataSetId()));
         DatasetEntry entry = new DatasetEntry();
         entry.setKey(sampleDataset1.getConsentName());
         entry.setValue(sampleDataset1.getName());
@@ -158,6 +157,7 @@ public class ElectionServiceTest {
         entryDetail.setObjectId(sampleDataset1.getObjectId());
         data.setDatasetDetail(Arrays.asList(entryDetail));
         sampleDataAccessRequest1.setData(data);
+        sampleDataAccessRequest1.addDatasetId(sampleDataset1.getDataSetId());
 
         sampleDac1 = new Dac();
         sampleDac1.setDacId(1);

--- a/src/test/java/org/broadinstitute/consent/http/service/MatchServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/MatchServiceTest.java
@@ -320,7 +320,6 @@ public class MatchServiceTest {
         when(consentDAO.findConsentById(any())).thenReturn(consent);
         when(consentDAO.checkConsentById(any())).thenReturn(consent.getConsentId());
         List<Dataset> dataSets = getSampleDataAccessRequest(referenceId)
-                .getData()
                 .getDatasetIds()
                 .stream()
                 .map(id -> {
@@ -344,7 +343,7 @@ public class MatchServiceTest {
         DataAccessRequestData data = new DataAccessRequestData();
         data.setReferenceId(referenceId);
         data.setHmb(true);
-        data.setDatasetIds(Collections.singletonList(1));
+        dar.addDatasetId(1);
         dar.setData(data);
         return dar;
     }

--- a/src/test/java/org/broadinstitute/consent/http/service/MetricsServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/MetricsServiceTest.java
@@ -171,7 +171,7 @@ public class MetricsServiceTest {
               dar.setId(count);
               dar.setReferenceId(referenceId);
               DataAccessRequestData data = new DataAccessRequestData();
-              data.setDatasetIds(dataSetIds);
+              dar.setDatasetIds(dataSetIds);
               data.setReferenceId(referenceId);
               data.setProjectTitle(UUID.randomUUID().toString());
               dar.setData(data);

--- a/src/test/java/org/broadinstitute/consent/http/service/SummaryServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/SummaryServiceTest.java
@@ -96,14 +96,14 @@ public class SummaryServiceTest {
         List<Integer> rpElectionIds = rpElections.stream().map(Election::getElectionId).collect(Collectors.toList());
         List<Integer> consentElectionIds = consentElections.stream().map(Election::getElectionId).collect(Collectors.toList());
         List<DataAccessRequest> dars = List.of(createDAR(accessElections.get(0).getReferenceId(), darUser.getUserId()));
-        List<Association> associations = List.of(createAssociation(dars.get(0).getData().getDatasetIds().get(0), consentElections.get(0).getReferenceId()));
+        List<Association> associations = List.of(createAssociation(dars.get(0).getDatasetIds().get(0), consentElections.get(0).getReferenceId()));
         List<String> associatedConsentIds = List.of(consentElections.get(0).getReferenceId());
         List<Vote> accessVotes = createVotes(accessElections.get(0).getElectionId(), voteUser.getUserId());
         List<Vote> rpVotes = createVotes(rpElections.get(0).getElectionId(), voteUser.getUserId());
         List<Vote> consentVotes = createVotes(consentElections.get(0).getElectionId(), voteUser.getUserId());
         List<Match> matchList = List.of(createMatch(associatedConsentIds.get(0), dars.get(0).getReferenceId()));
         List<String> referenceIds = List.of(accessElections.get(0).getReferenceId());
-        List<Integer> datasetIds = dars.get(0).getData().getDatasetIds();
+        List<Integer> datasetIds = dars.get(0).getDatasetIds();
 
         when(electionDAO.findElectionsWithFinalVoteByTypeAndStatus(ElectionType.DATA_ACCESS.getValue(), ElectionStatus.CLOSED.getValue())).thenReturn(accessElections);
         when(electionDAO.findElectionsWithFinalVoteByTypeAndStatus(ElectionType.RP.getValue(), ElectionStatus.CLOSED.getValue())).thenReturn(rpElections);
@@ -212,11 +212,11 @@ public class SummaryServiceTest {
 
     private DataAccessRequest createDAR(String referenceId, Integer userId) {
         DataAccessRequestData data = new DataAccessRequestData();
-        data.setDatasetIds(List.of(1));
         data.setReferenceId(referenceId);
         data.setDarCode("DAR-" + RandomUtils.nextInt(100, 200));
         data.setProjectTitle("Project-TEST");
         DataAccessRequest dar = new DataAccessRequest();
+        dar.addDatasetId(1);
         dar.setReferenceId(referenceId);
         dar.setUserId(userId);
         dar.setData(data);

--- a/src/test/java/org/broadinstitute/consent/http/service/VoteServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/VoteServiceTest.java
@@ -32,7 +32,6 @@ import org.mockito.Mock;
 import javax.ws.rs.NotFoundException;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.UUID;
 
@@ -650,14 +649,14 @@ public class VoteServiceTest {
 
         DataAccessRequest dar1 = new DataAccessRequest();
         DataAccessRequestData data1 = new DataAccessRequestData();
-        data1.setDatasetIds(List.of(d1.getDataSetId()));
+        dar1.addDatasetId(d1.getDataSetId());
         dar1.setCollectionId(1);
         dar1.setData(data1);
         dar1.setReferenceId(referenceId1);
 
         DataAccessRequest dar2 = new DataAccessRequest();
         DataAccessRequestData data2 = new DataAccessRequestData();
-        data2.setDatasetIds(List.of(d2.getDataSetId()));
+        dar2.addDatasetId(d2.getDataSetId());
         dar2.setCollectionId(1);
         dar2.setData(data2);
         dar2.setReferenceId(referenceId2);
@@ -723,14 +722,14 @@ public class VoteServiceTest {
 
         DataAccessRequest dar1 = new DataAccessRequest();
         DataAccessRequestData data1 = new DataAccessRequestData();
-        data1.setDatasetIds(List.of(d1.getDataSetId()));
+        dar1.addDatasetId(d1.getDataSetId());
         dar1.setCollectionId(1);
         dar1.setData(data1);
         dar1.setReferenceId(referenceId1);
 
         DataAccessRequest dar2 = new DataAccessRequest();
         DataAccessRequestData data2 = new DataAccessRequestData();
-        data2.setDatasetIds(List.of(d2.getDataSetId()));
+        dar2.addDatasetId(d2.getDataSetId());
         dar2.setCollectionId(2);
         dar2.setData(data2);
         dar2.setReferenceId(referenceId2);
@@ -781,7 +780,7 @@ public class VoteServiceTest {
 
         DataAccessRequest dar1 = new DataAccessRequest();
         DataAccessRequestData data1 = new DataAccessRequestData();
-        data1.setDatasetIds(List.of(d1.getDataSetId()));
+        dar1.addDatasetId(d1.getDataSetId());
         dar1.setCollectionId(1);
         dar1.setData(data1);
         dar1.setReferenceId(referenceId1);
@@ -832,7 +831,7 @@ public class VoteServiceTest {
 
         DataAccessRequest dar1 = new DataAccessRequest();
         DataAccessRequestData data1 = new DataAccessRequestData();
-        data1.setDatasetIds(List.of(d1.getDataSetId()));
+        dar1.addDatasetId(d1.getDataSetId());
         dar1.setCollectionId(1);
         dar1.setData(data1);
         dar1.setReferenceId(referenceId1);

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DarCollectionServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DarCollectionServiceDAOTest.java
@@ -374,7 +374,7 @@ public class DarCollectionServiceDAOTest extends DAOTestHelper {
     DataAccessRequest dar = collection.getDars().values().stream().findFirst().orElse(null);
     assertNotNull(dar);
     assertNotNull(dar.getData());
-    dar.getData().setDatasetIds(List.of(dar.getData().getDatasetIds().get(0)));
+    dataAccessRequestDAO.insertDARDatasetRelation(dar.getReferenceId(), dataset.getDataSetId());
     Date now = new Date();
     dataAccessRequestDAO.updateDataByReferenceIdVersion2(
         dar.getReferenceId(), dar.getUserId(), now, now, now, dar.getData());

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DarCollectionServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DarCollectionServiceDAOTest.java
@@ -165,7 +165,7 @@ public class DarCollectionServiceDAOTest extends DAOTestHelper {
     DarCollection collection = setUpDarCollectionWithDacDataset();
     Optional<DataAccessRequest> dar = collection.getDars().values().stream().findFirst();
     assertTrue(dar.isPresent());
-    Integer datasetId = dar.get().getData().getDatasetIds().get(0);
+    Integer datasetId = dar.get().getDatasetIds().get(0);
     assertNotNull(datasetId);
     Optional<Dac> dac = dacDAO.findDacsForDatasetIds(List.of(datasetId)).stream().findFirst();
     assertTrue(dac.isPresent());
@@ -209,8 +209,8 @@ public class DarCollectionServiceDAOTest extends DAOTestHelper {
     DarCollection collection = setUpDarCollectionWithDacDataset();
     Optional<DataAccessRequest> dar = collection.getDars().values().stream().findFirst();
     assertTrue(dar.isPresent());
-    assertFalse(dar.get().getData().getDatasetIds().isEmpty());
-    Integer datasetId = dar.get().getData().getDatasetIds().get(0);
+    assertFalse(dar.get().getDatasetIds().isEmpty());
+    Integer datasetId = dar.get().getDatasetIds().get(0);
     assertNotNull(datasetId);
 
     // Find the dac chairperson for the current DAR/Dataset combination
@@ -311,8 +311,8 @@ public class DarCollectionServiceDAOTest extends DAOTestHelper {
     DarCollection collection = setUpDarCollectionWithDacDataset();
     Optional<DataAccessRequest> dar = collection.getDars().values().stream().findFirst();
     assertTrue(dar.isPresent());
-    assertFalse(dar.get().getData().getDatasetIds().isEmpty());
-    Integer datasetId = dar.get().getData().getDatasetIds().get(0);
+    assertFalse(dar.get().getDatasetIds().isEmpty());
+    Integer datasetId = dar.get().getDatasetIds().get(0);
     assertNotNull(datasetId);
 
     // Find the dac chairperson for the current DAR/Dataset combination


### PR DESCRIPTION
## Addresses
Partially addresses https://broadworkbench.atlassian.net/browse/DUOS-1763

This PR moves almost all usages of `DataAccessRequestData.get/setDatasetIds()` to `DataAccessRequest.get/setDatasetIds()`. There is one more deprecated service method (`DataAccessRequestService.updateByReferenceId()`) we need to remove before getting rid of those methods entirely. I will tackle that in a separate PR to keep these PRs as small as possible.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
