### PR TITLE
[DUOS-1815][risk=low] Add update own user properties endpoint

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
@@ -19,6 +19,7 @@ import org.broadinstitute.consent.http.service.ResearcherService;
 import org.broadinstitute.consent.http.service.UserService;
 import org.broadinstitute.consent.http.service.UserService.SimplifiedUser;
 import org.broadinstitute.consent.http.service.sam.SamService;
+import org.glassfish.hk2.utilities.reflection.Logger;
 
 import javax.annotation.security.PermitAll;
 import javax.annotation.security.RolesAllowed;

--- a/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
@@ -177,11 +177,10 @@ public class UserResource extends Resource {
             UserUpdateFields userUpdateFields = gson.fromJson(json, UserUpdateFields.class);
             // Ensure that we have a real user with this ID, fail if we do not.
             userService.findUserById(userId);
-            URI uri = info.getRequestUriBuilder().path("{id}").build(userId);
             User updatedUser = userService.updateUserFieldsById(userUpdateFields, userId);
             Gson gson = new Gson();
             JsonObject jsonUser = userService.findUserWithPropertiesByIdAsJsonObject(authUser, updatedUser.getUserId());
-            return Response.ok(uri).entity(gson.toJson(jsonUser)).build();
+            return Response.ok().entity(gson.toJson(jsonUser)).build();
         } catch (Exception e) {
             return createExceptionResponse(e);
         }
@@ -197,15 +196,14 @@ public class UserResource extends Resource {
             UserUpdateFields userUpdateFields = gson.fromJson(json, UserUpdateFields.class);
 
             if (Objects.nonNull(userUpdateFields.getUserRoleIds()) && !user.hasUserRole(UserRoles.ADMIN)) {
-                throw new BadRequestException("Cannot change user roles");
+                throw new BadRequestException("Cannot change user's roles.");
             }
 
             user = userService.updateUserFieldsById(userUpdateFields, user.getUserId());
             Gson gson = new Gson();
             JsonObject jsonUser = userService.findUserWithPropertiesByIdAsJsonObject(authUser, user.getUserId());
 
-            URI uri = info.getRequestUriBuilder().path("").build();
-            return Response.ok(uri).entity(gson.toJson(jsonUser)).build();
+            return Response.ok().entity(gson.toJson(jsonUser)).build();
         } catch (Exception e) {
             return createExceptionResponse(e);
         }

--- a/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
@@ -187,6 +187,26 @@ public class UserResource extends Resource {
     }
 
     @PUT
+    @Path("/me")
+    @Consumes("application/json")
+    @Produces("application/json")
+    @PermitAll
+    public Response update(@Auth AuthUser authUser, @Context UriInfo info, String json) {
+        try {
+            User user = userService.findUserByEmail(authUser.getEmail());
+            UserUpdateFields userUpdateFields = gson.fromJson(json, UserUpdateFields.class);
+            // Ensure that we have a real user with this ID, fail if we do not.
+            URI uri = info.getRequestUriBuilder().path("{id}").build(user.getUserId());
+            user = userService.updateUserFieldsById(userUpdateFields, user.getUserId());
+            Gson gson = new Gson();
+            JsonObject jsonUser = userService.findUserWithPropertiesByIdAsJsonObject(authUser, user.getUserId());
+            return Response.ok(uri).entity(gson.toJson(jsonUser)).build();
+        } catch (Exception e) {
+            return createExceptionResponse(e);
+        }
+    }
+
+    @PUT
     @Path("/{userId}/{roleId}")
     @Produces("application/json")
     @RolesAllowed({ADMIN})

--- a/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
@@ -175,11 +175,11 @@ public class UserResource extends Resource {
         try {
             UserUpdateFields userUpdateFields = gson.fromJson(json, UserUpdateFields.class);
             // Ensure that we have a real user with this ID, fail if we do not.
-            userService.findUserById(userId);
+            User user = userService.findUserById(userId);
             URI uri = info.getRequestUriBuilder().path("{id}").build(userId);
-            User user = userService.updateUserFieldsById(userUpdateFields, userId);
+            User updatedUser = userService.updateUserFieldsById(user, userUpdateFields, userId);
             Gson gson = new Gson();
-            JsonObject jsonUser = userService.findUserWithPropertiesByIdAsJsonObject(authUser, user.getUserId());
+            JsonObject jsonUser = userService.findUserWithPropertiesByIdAsJsonObject(authUser, updatedUser.getUserId());
             return Response.ok(uri).entity(gson.toJson(jsonUser)).build();
         } catch (Exception e) {
             return createExceptionResponse(e);
@@ -197,7 +197,7 @@ public class UserResource extends Resource {
             UserUpdateFields userUpdateFields = gson.fromJson(json, UserUpdateFields.class);
             // Ensure that we have a real user with this ID, fail if we do not.
             URI uri = info.getRequestUriBuilder().path("{id}").build(user.getUserId());
-            user = userService.updateUserFieldsById(userUpdateFields, user.getUserId());
+            user = userService.updateUserFieldsById(user, userUpdateFields, user.getUserId());
             Gson gson = new Gson();
             JsonObject jsonUser = userService.findUserWithPropertiesByIdAsJsonObject(authUser, user.getUserId());
             return Response.ok(uri).entity(gson.toJson(jsonUser)).build();

--- a/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
@@ -188,7 +188,6 @@ public class UserResource extends Resource {
     }
 
     @PUT
-    @Path("/me")
     @Consumes("application/json")
     @Produces("application/json")
     @PermitAll

--- a/src/main/java/org/broadinstitute/consent/http/service/UserService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/UserService.java
@@ -72,12 +72,7 @@ public class UserService {
      * @param userId The User's ID
      * @return The updated User
      */
-    public User updateUserFieldsById(@NonNull User user, UserUpdateFields userUpdateFields, Integer userId) {
-        // must be updating oneself or be an admin
-        if (!user.hasUserRole(UserRoles.ADMIN) && !user.getUserId().equals(userId)) {
-            throw new NotAuthorizedException("Cannot update user.");
-        }
-
+    public User updateUserFieldsById(UserUpdateFields userUpdateFields, Integer userId) {
         if (Objects.nonNull(userUpdateFields)) {
             // Update Primary User Fields
             if (Objects.nonNull(userUpdateFields.getDisplayName())) {
@@ -100,7 +95,7 @@ public class UserService {
             }
 
             // Handle Roles; must be admin to update roles.
-            if (user.hasUserRole(UserRoles.ADMIN) && Objects.nonNull(userUpdateFields.getUserRoleIds())) {
+            if (Objects.nonNull(userUpdateFields.getUserRoleIds())) {
                 List<Integer> currentRoleIds = userRoleDAO.findRolesByUserId(userId).stream().map(UserRole::getRoleId).collect(Collectors.toList());
                 List<Integer> roleIdsToAdd = userUpdateFields.getRoleIdsToAdd(currentRoleIds);
                 List<Integer> roleIdsToRemove = userUpdateFields.getRoleIdsToRemove(currentRoleIds);

--- a/src/main/java/org/broadinstitute/consent/http/service/UserService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/UserService.java
@@ -23,13 +23,11 @@ import org.broadinstitute.consent.http.models.UserUpdateFields;
 import org.broadinstitute.consent.http.models.Vote;
 import org.broadinstitute.consent.http.resources.Resource;
 import org.broadinstitute.consent.http.service.users.handler.UserRolesHandler;
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.jdbi.v3.core.statement.UnableToExecuteStatementException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.ws.rs.BadRequestException;
-import javax.ws.rs.NotAuthorizedException;
 import javax.ws.rs.NotFoundException;
 import java.util.ArrayList;
 import java.util.Collection;

--- a/src/main/java/org/broadinstitute/consent/http/service/UserService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/UserService.java
@@ -92,7 +92,7 @@ public class UserService {
                 userPropertyDAO.insertAll(userProps);
             }
 
-            // Handle Roles; must be admin to update roles.
+            // Handle Roles
             if (Objects.nonNull(userUpdateFields.getUserRoleIds())) {
                 List<Integer> currentRoleIds = userRoleDAO.findRolesByUserId(userId).stream().map(UserRole::getRoleId).collect(Collectors.toList());
                 List<Integer> roleIdsToAdd = userUpdateFields.getRoleIdsToAdd(currentRoleIds);

--- a/src/main/java/org/broadinstitute/consent/http/util/InstitutionUtil.java
+++ b/src/main/java/org/broadinstitute/consent/http/util/InstitutionUtil.java
@@ -43,7 +43,8 @@ public class InstitutionUtil {
                 || fieldName.equals("name")
                 || fieldName.equals("signingOfficials")
                 || fieldName.equals("displayName")
-                || fieldName.equals("userId"));
+                || fieldName.equals("userId")
+                || fieldName.equals("email"));
       }
 
       // NOTE: shouldSkipClass is mandatory when creating an ExclusionStrategy

--- a/src/main/java/org/broadinstitute/consent/http/util/InstitutionUtil.java
+++ b/src/main/java/org/broadinstitute/consent/http/util/InstitutionUtil.java
@@ -38,7 +38,12 @@ public class InstitutionUtil {
       @Override
       public boolean shouldSkipField(FieldAttributes field) {
         String fieldName = field.getName();
-        return !isAdmin && !(fieldName.equals("id") || fieldName.equals("name") || fieldName.equals("signingOfficials"));
+        
+        return !isAdmin && !(fieldName.equals("id")
+                || fieldName.equals("name")
+                || fieldName.equals("signingOfficials")
+                || fieldName.equals("displayName")
+                || fieldName.equals("userId"));
       }
 
       // NOTE: shouldSkipClass is mandatory when creating an ExclusionStrategy

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -2477,24 +2477,7 @@ paths:
   /api/match/purpose/batch/:
     $ref: './paths/getMatchesForLatestDataAccessElectionsByPurposeIds.yaml'
   /api/user:
-    post:
-      summary: Create User
-      description: Create a user with RESEARCHER role using the user's current authentication status.
-      tags:
-        - User
-      responses:
-        200:
-          description: Returns the created user.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/User'
-        400:
-          description: Unable to validate the user's google identity.
-        409:
-          description: User should be unique
-        500:
-          description: Server error.
+    $ref: './paths/user.yaml'
   /api/user/me:
     get:
       summary: Find currently authenticated user

--- a/src/main/resources/assets/paths/user.yaml
+++ b/src/main/resources/assets/paths/user.yaml
@@ -17,7 +17,7 @@ post:
     500:
       description: Server error.
 put:
-  summary: Update limited user fields by id
+  summary: Update limited user fields
   description: |
     Updates a limited number of the current user's fields
   tags:

--- a/src/main/resources/assets/paths/user.yaml
+++ b/src/main/resources/assets/paths/user.yaml
@@ -1,0 +1,64 @@
+post:
+  summary: Create User
+  description: Create a user with RESEARCHER role using the user's current authentication status.
+  tags:
+    - User
+  responses:
+    200:
+      description: Returns the created user.
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/User.yaml'
+    400:
+      description: Unable to validate the user's google identity.
+    409:
+      description: User should be unique
+    500:
+      description: Server error.
+put:
+  summary: Update limited user fields by id
+  description: |
+    Updates a limited number of the current user's fields
+  tags:
+    - User
+  requestBody:
+    description: The updated user fields in JSON format
+    required: true
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            displayName:
+              description: The display name for the user
+              type: string
+            institutionId:
+              description: The institution id for the user
+              type: number
+            emailPreference:
+              description: True for receiving email, false for disabling all email
+              type: boolean
+            eraCommonsId:
+              description: The eRA Commons id for the user
+              type: string
+            selectedSigningOfficialId:
+              description: The selected user id of the user's preferred signing official
+              type: number
+            suggestedInstitution:
+              description: The suggested institution for the user
+              type: string
+            suggestedSigningOfficial:
+              description: The suggested signing official for the user
+              type: string
+  responses:
+    200:
+      description: The user, along with researcher properties and library cards
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/User.yaml'
+    404:
+      description: User not found
+    500:
+      description: Server error.

--- a/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
@@ -391,6 +391,7 @@ public class UserResourceTest {
     UserUpdateFields userUpdateFields = new UserUpdateFields();
     Gson gson = new Gson();
     when(userService.findUserById(any())).thenReturn(user);
+    when(userService.findUserByEmail(any())).thenReturn(user);
     when(userService.updateUserFieldsById(any(), any())).thenReturn(user);
     when(userService.findUserWithPropertiesByIdAsJsonObject(any(), any())).thenReturn(gson.toJsonTree(user).getAsJsonObject());
     initResource();
@@ -402,14 +403,15 @@ public class UserResourceTest {
   public void testUpdateSelfRoles() {
     User user = createUserWithRole();
     UserUpdateFields userUpdateFields = new UserUpdateFields();
-    userUpdateFields.getRoleIdsToAdd(List.of(1)); // any roles
+    userUpdateFields.setUserRoleIds(List.of(1)); // any roles
     Gson gson = new Gson();
     when(userService.findUserById(any())).thenReturn(user);
+    when(userService.findUserByEmail(any())).thenReturn(user);
     when(userService.updateUserFieldsById(any(), any())).thenReturn(user);
     when(userService.findUserWithPropertiesByIdAsJsonObject(any(), any())).thenReturn(gson.toJsonTree(user).getAsJsonObject());
     initResource();
     Response response = userResource.updateSelf(authUser, uriInfo, gson.toJson(userUpdateFields));
-    assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+    assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
@@ -379,7 +379,47 @@ public class UserResourceTest {
     UserUpdateFields userUpdateFields = new UserUpdateFields();
     Gson gson = new Gson();
     when(userService.findUserById(any())).thenReturn(user);
-    when(userService.updateUserFieldsById(any(), any(), any())).thenReturn(user);
+    when(userService.updateUserFieldsById(any(), any())).thenReturn(user);
+    when(userService.findUserWithPropertiesByIdAsJsonObject(any(), any())).thenReturn(gson.toJsonTree(user).getAsJsonObject());
+    initResource();
+    Response response = userResource.update(authUser, uriInfo, user.getUserId(), gson.toJson(userUpdateFields));
+    assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+  }
+
+  @Test
+  public void testUpdateSelf() {
+    User user = createUserWithRole();
+    UserUpdateFields userUpdateFields = new UserUpdateFields();
+    Gson gson = new Gson();
+    when(userService.findUserById(any())).thenReturn(user);
+    when(userService.updateUserFieldsById(any(), any())).thenReturn(user);
+    when(userService.findUserWithPropertiesByIdAsJsonObject(any(), any())).thenReturn(gson.toJsonTree(user).getAsJsonObject());
+    initResource();
+    Response response = userResource.updateSelf(authUser, uriInfo, gson.toJson(userUpdateFields));
+    assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+  }
+
+  @Test
+  public void testUpdateSelfRoles() {
+    User user = createUserWithRole();
+    UserUpdateFields userUpdateFields = new UserUpdateFields();
+    userUpdateFields.getRoleIdsToAdd(List.of(1)); // any roles
+    Gson gson = new Gson();
+    when(userService.findUserById(any())).thenReturn(user);
+    when(userService.updateUserFieldsById(any(), any())).thenReturn(user);
+    when(userService.findUserWithPropertiesByIdAsJsonObject(any(), any())).thenReturn(gson.toJsonTree(user).getAsJsonObject());
+    initResource();
+    Response response = userResource.updateSelf(authUser, uriInfo, gson.toJson(userUpdateFields));
+    assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+  }
+
+  @Test
+  public void testUpdateSelfRolesNotAdmin() {
+    User user = createUserWithRole();
+    UserUpdateFields userUpdateFields = new UserUpdateFields();
+    Gson gson = new Gson();
+    when(userService.findUserById(any())).thenReturn(user);
+    when(userService.updateUserFieldsById(any(), any())).thenReturn(user);
     when(userService.findUserWithPropertiesByIdAsJsonObject(any(), any())).thenReturn(gson.toJsonTree(user).getAsJsonObject());
     initResource();
     Response response = userResource.update(authUser, uriInfo, user.getUserId(), gson.toJson(userUpdateFields));

--- a/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
@@ -400,7 +400,7 @@ public class UserResourceTest {
   }
 
   @Test
-  public void testUpdateSelfRoles() {
+  public void testUpdateSelfRolesNotAdmin() {
     User user = createUserWithRole();
     UserUpdateFields userUpdateFields = new UserUpdateFields();
     userUpdateFields.setUserRoleIds(List.of(1)); // any roles
@@ -412,19 +412,6 @@ public class UserResourceTest {
     initResource();
     Response response = userResource.updateSelf(authUser, uriInfo, gson.toJson(userUpdateFields));
     assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
-  }
-
-  @Test
-  public void testUpdateSelfRolesNotAdmin() {
-    User user = createUserWithRole();
-    UserUpdateFields userUpdateFields = new UserUpdateFields();
-    Gson gson = new Gson();
-    when(userService.findUserById(any())).thenReturn(user);
-    when(userService.updateUserFieldsById(any(), any())).thenReturn(user);
-    when(userService.findUserWithPropertiesByIdAsJsonObject(any(), any())).thenReturn(gson.toJsonTree(user).getAsJsonObject());
-    initResource();
-    Response response = userResource.update(authUser, uriInfo, user.getUserId(), gson.toJson(userUpdateFields));
-    assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
@@ -3,7 +3,6 @@ package org.broadinstitute.consent.http.resources;
 import com.google.api.client.http.HttpStatusCodes;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
-import liquibase.pro.packaged.G;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.broadinstitute.consent.http.authentication.GoogleUser;
 import org.broadinstitute.consent.http.enumeration.UserFields;

--- a/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
@@ -379,7 +379,7 @@ public class UserResourceTest {
     UserUpdateFields userUpdateFields = new UserUpdateFields();
     Gson gson = new Gson();
     when(userService.findUserById(any())).thenReturn(user);
-    when(userService.updateUserFieldsById(any(), any())).thenReturn(user);
+    when(userService.updateUserFieldsById(any(), any(), any())).thenReturn(user);
     when(userService.findUserWithPropertiesByIdAsJsonObject(any(), any())).thenReturn(gson.toJsonTree(user).getAsJsonObject());
     initResource();
     Response response = userResource.update(authUser, uriInfo, user.getUserId(), gson.toJson(userUpdateFields));

--- a/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
@@ -25,7 +25,6 @@ import org.junit.Test;
 import org.mockito.Mock;
 
 import javax.ws.rs.BadRequestException;
-import javax.ws.rs.NotAuthorizedException;
 import javax.ws.rs.NotFoundException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -90,9 +89,6 @@ public class UserServiceTest {
         User user = new User();
         user.setUserId(1);
 
-        User caller = new User();
-        caller.setUserId(2);
-        caller.setRoles(List.of(admin, researcher, chair));
         // Note that we're starting out with 1 modifiable role (Admin) and 1 that is not (Chairperson)
         // and one role that should never be removed, but can be added (Researcher)
         // When we update this user, we'll ensure that the new roles are added, old roles are deleted,

--- a/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
@@ -116,7 +116,7 @@ public class UserServiceTest {
             fields.setSuggestedSigningOfficial(RandomStringUtils.random(10, true, false));
             fields.setSuggestedInstitution(RandomStringUtils.random(10, true, false));
             assertEquals(3, fields.buildUserProperties(user.getUserId()).size());
-            service.updateUserFieldsById(caller, fields, user.getUserId());
+            service.updateUserFieldsById(fields, user.getUserId());
         } catch (Exception e) {
             fail(e.getMessage());
         }
@@ -130,128 +130,6 @@ public class UserServiceTest {
         verify(userRoleDAO, times(1)).insertUserRoles(List.of(so), 1);
         verify(userRoleDAO, times(1)).removeUserRoles( 1, List.of(admin.getRoleId()));
     }
-
-    @Test
-    public void testUpdateRoleAsNonAdmin() {
-        UserRole researcher = new UserRole(UserRoles.RESEARCHER.getRoleId(), UserRoles.RESEARCHER.getRoleName());
-        UserRole chair = new UserRole(UserRoles.CHAIRPERSON.getRoleId(), UserRoles.CHAIRPERSON.getRoleName());
-        UserRole so = new UserRole(UserRoles.SIGNINGOFFICIAL.getRoleId(), UserRoles.SIGNINGOFFICIAL.getRoleName());
-
-        User user = new User();
-        user.setUserId(1);
-        // Note that we're starting out with 1 modifiable role (Admin) and 1 that is not (Chairperson)
-        // and one role that should never be removed, but can be added (Researcher)
-        // When we update this user, we'll ensure that the new roles are added, old roles are deleted,
-        // and the researcher & chairperson roles remain.
-        when(userRoleDAO.findRolesByUserId(user.getUserId())).thenReturn(List.of(researcher, chair));
-        when(userDAO.findUserById(any())).thenReturn(user);
-        spy(userDAO);
-        spy(userPropertyDAO);
-        spy(userRoleDAO);
-        initService();
-        try {
-            UserUpdateFields fields = new UserUpdateFields();
-            // We're modifying this user to have an SO role. This should leave in place
-            // both the Researcher and Chairperson roles, but remove the Admin role.
-            fields.setUserRoleIds(List.of(so.getRoleId()));
-            fields.setDisplayName(RandomStringUtils.random(10, true, false));
-            fields.setInstitutionId(1);
-            fields.setEmailPreference(true);
-            fields.setEraCommonsId(RandomStringUtils.random(10, true, false));
-            fields.setSelectedSigningOfficialId(1);
-            fields.setSuggestedSigningOfficial(RandomStringUtils.random(10, true, false));
-            fields.setSuggestedInstitution(RandomStringUtils.random(10, true, false));
-            assertEquals(3, fields.buildUserProperties(user.getUserId()).size());
-            service.updateUserFieldsById(user, fields, user.getUserId());
-        } catch (Exception e) {
-            fail(e.getMessage());
-        }
-        // We added 3 user property values, we should have props for them:
-        verify(userDAO, times(1)).updateDisplayName(any(), any());
-        verify(userDAO, times(1)).updateInstitutionId(any(), any());
-        verify(userDAO, times(1)).updateEmailPreference(any(), any());
-        verify(userDAO, times(1)).updateEraCommonsId(any(), any());
-        verify(userPropertyDAO, times(1)).insertAll(any());
-        // Verify no role additions/deletions.
-        verify(userRoleDAO, times(0)).insertUserRoles( any(), any());
-        verify(userRoleDAO, times(0)).removeUserRoles( any(), any());
-    }
-
-    @Test(expected = NotAuthorizedException.class)
-    public void testUpdateNonAdminCannotCallForAnother() {
-        UserRole researcher = new UserRole(UserRoles.RESEARCHER.getRoleId(), UserRoles.RESEARCHER.getRoleName());
-        UserRole chair = new UserRole(UserRoles.CHAIRPERSON.getRoleId(), UserRoles.CHAIRPERSON.getRoleName());
-        UserRole so = new UserRole(UserRoles.SIGNINGOFFICIAL.getRoleId(), UserRoles.SIGNINGOFFICIAL.getRoleName());
-
-        User user = new User();
-        user.setUserId(1);
-
-        User caller = new User();
-        caller.setUserId(2);
-        // Note that we're starting out with 1 modifiable role (Admin) and 1 that is not (Chairperson)
-        // and one role that should never be removed, but can be added (Researcher)
-        // When we update this user, we'll ensure that the new roles are added, old roles are deleted,
-        // and the researcher & chairperson roles remain.
-        when(userRoleDAO.findRolesByUserId(user.getUserId())).thenReturn(List.of(researcher, chair));
-        when(userDAO.findUserById(any())).thenReturn(user);
-        spy(userDAO);
-        spy(userPropertyDAO);
-        spy(userRoleDAO);
-        initService();
-        UserUpdateFields fields = new UserUpdateFields();
-        fields.setDisplayName(RandomStringUtils.random(10, true, false));
-        fields.setInstitutionId(1);
-        fields.setEmailPreference(true);
-        fields.setEraCommonsId(RandomStringUtils.random(10, true, false));
-        fields.setSelectedSigningOfficialId(1);
-        fields.setSuggestedSigningOfficial(RandomStringUtils.random(10, true, false));
-        fields.setSuggestedInstitution(RandomStringUtils.random(10, true, false));
-        assertEquals(3, fields.buildUserProperties(user.getUserId()).size());
-        service.updateUserFieldsById(caller, fields, user.getUserId());
-    }
-
-    @Test
-    public void testUpdateUserFieldsAsNonAdmin() {
-        UserRole researcher = new UserRole(UserRoles.RESEARCHER.getRoleId(), UserRoles.RESEARCHER.getRoleName());
-        UserRole chair = new UserRole(UserRoles.CHAIRPERSON.getRoleId(), UserRoles.CHAIRPERSON.getRoleName());
-
-        User user = new User();
-        user.setUserId(1);
-        // Note that we're starting out with 1 modifiable role (Admin) and 1 that is not (Chairperson)
-        // and one role that should never be removed, but can be added (Researcher)
-        // When we update this user, we'll ensure that the new roles are added, old roles are deleted,
-        // and the researcher & chairperson roles remain.
-        when(userRoleDAO.findRolesByUserId(user.getUserId())).thenReturn(List.of(researcher, chair));
-        when(userDAO.findUserById(any())).thenReturn(user);
-        spy(userDAO);
-        spy(userPropertyDAO);
-        spy(userRoleDAO);
-        initService();
-        try {
-            UserUpdateFields fields = new UserUpdateFields();
-            fields.setDisplayName(RandomStringUtils.random(10, true, false));
-            fields.setInstitutionId(1);
-            fields.setEmailPreference(true);
-            fields.setEraCommonsId(RandomStringUtils.random(10, true, false));
-            fields.setSelectedSigningOfficialId(1);
-            fields.setSuggestedSigningOfficial(RandomStringUtils.random(10, true, false));
-            fields.setSuggestedInstitution(RandomStringUtils.random(10, true, false));
-            assertEquals(3, fields.buildUserProperties(user.getUserId()).size());
-            service.updateUserFieldsById(user, fields, user.getUserId());
-        } catch (Exception e) {
-            fail(e.getMessage());
-        }
-        // We added 3 user property values, we should have props for them:
-        verify(userDAO, times(1)).updateDisplayName(any(), any());
-        verify(userDAO, times(1)).updateInstitutionId(any(), any());
-        verify(userDAO, times(1)).updateEmailPreference(any(), any());
-        verify(userDAO, times(1)).updateEraCommonsId(any(), any());
-        verify(userPropertyDAO, times(1)).insertAll(any());
-        // Verify no role additions/deletions.
-        verify(userRoleDAO, times(0)).insertUserRoles( any(), any());
-        verify(userRoleDAO, times(0)).removeUserRoles( any(), any());
-    }
-
 
     @Test
     public void createUserTest() {


### PR DESCRIPTION
## Partially Addresses 

https://broadworkbench.atlassian.net/browse/DUOS-1815

Adds needed `PUT /api/user/` endpoint so non-admin users can update their properties.

Frontend component: https://github.com/DataBiosphere/duos-ui/pull/1672

Also fixes bug wherein signing officials are not fully returned for non-admin users; this is necessary for the linked frontend issue, so I thought it was an appropriate place to fix it.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
