### PR TITLE
[DUOS-1896][risk=no] Deprecate user properties

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/UserPropertyDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/UserPropertyDAO.java
@@ -33,7 +33,4 @@ public interface UserPropertyDAO extends Transactional<UserPropertyDAO> {
 
     @SqlBatch("DELETE FROM user_property WHERE userid = :userId AND propertykey = :propertyKey")
     void deletePropertiesByUserAndKey(@BindBean Collection<UserProperty> researcherProperties);
-
-    @SqlQuery("SELECT * FROM user_property WHERE userid IN (<userIds>)")
-    List<UserProperty> findResearcherPropertiesByUserIds(@BindList("userIds") List<Integer> userIds);
 }

--- a/src/main/java/org/broadinstitute/consent/http/db/UserPropertyDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/UserPropertyDAO.java
@@ -17,8 +17,9 @@ import java.util.List;
 @RegisterRowMapper(UserPropertyMapper.class)
 public interface UserPropertyDAO extends Transactional<UserPropertyDAO> {
 
-    @SqlQuery("SELECT * FROM user_property WHERE userid = :userId")
-    List<UserProperty> findResearcherPropertiesByUser(@Bind("userId") Integer userId);
+    @SqlQuery("SELECT * FROM user_property WHERE userid = :userId AND propertykey IN (<properties>)")
+    List<UserProperty> findResearcherPropertiesByUser(@Bind("userId") Integer userId,
+                                                      @BindList("properties") List<String> properties);
 
     @SqlQuery("SELECT propertyvalue FROM USER_PROPERTY WHERE userid = :userId AND propertykey = 'completed'")
     String isProfileCompleted(@Bind("userId") Integer userId);

--- a/src/main/java/org/broadinstitute/consent/http/db/UserPropertyDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/UserPropertyDAO.java
@@ -21,6 +21,7 @@ public interface UserPropertyDAO extends Transactional<UserPropertyDAO> {
     List<UserProperty> findResearcherPropertiesByUser(@Bind("userId") Integer userId,
                                                       @BindList("properties") List<String> properties);
 
+    @Deprecated
     @SqlQuery("SELECT propertyvalue FROM USER_PROPERTY WHERE userid = :userId AND propertykey = 'completed'")
     String isProfileCompleted(@Bind("userId") Integer userId);
 

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/UserWithRolesMapper.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/UserWithRolesMapper.java
@@ -29,7 +29,9 @@ public class UserWithRolesMapper implements RowMapper<User>, RowMapperHelper {
       user.setCreateDate(r.getDate("create_date"));
       user.setEmailPreference(r.getBoolean("email_preference"));
       user.setRoles(new ArrayList<>());
-      if ((hasColumn(r, "completed"))) {
+
+      // populate for backwards compatibility
+      if (hasColumn(r, "completed")) {
         user.setProfileCompleted(Boolean.valueOf(r.getString("completed")));
       }
       if (hasColumn(r, "era_commons_id")) {
@@ -39,6 +41,7 @@ public class UserWithRolesMapper implements RowMapper<User>, RowMapperHelper {
       user = users.get(r.getInt("user_id"));
     }
     addRole(r, user);
+
     // Populate for backwards compatibility.
     user.setDacUserId();
     users.put(user.getUserId(), user);

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/UserWithRolesMapper.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/UserWithRolesMapper.java
@@ -29,7 +29,7 @@ public class UserWithRolesMapper implements RowMapper<User>, RowMapperHelper {
       user.setCreateDate(r.getDate("create_date"));
       user.setEmailPreference(r.getBoolean("email_preference"));
       user.setRoles(new ArrayList<>());
-      if (hasColumn(r, "completed")) {
+      if ((hasColumn(r, "completed"))) {
         user.setProfileCompleted(Boolean.valueOf(r.getString("completed")));
       }
       if (hasColumn(r, "era_commons_id")) {

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/UserWithRolesReducer.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/UserWithRolesReducer.java
@@ -87,10 +87,6 @@ public class UserWithRolesReducer implements LinkedHashMapRowReducer<Integer, Us
       if (Objects.nonNull(rowView.getColumn("up_property_id", Integer.class))) {
         UserProperty p = rowView.getRow(UserProperty.class);
         user.addProperty(p);
-        // Note that the completed field is deprecated and will be removed in a future PR.
-        if (p.getPropertyKey().equalsIgnoreCase(UserFields.COMPLETED.getValue())) {
-          user.setProfileCompleted(Boolean.valueOf(p.getPropertyValue()));
-        }
       }
     } catch (MappingException e) {
       // Ignore any attempt to map a column that doesn't exist

--- a/src/main/java/org/broadinstitute/consent/http/enumeration/UserFields.java
+++ b/src/main/java/org/broadinstitute/consent/http/enumeration/UserFields.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 public enum UserFields {
-  COMPLETED("completed", false),
   ERA_EXPIRATION_DATE("eraExpiration", false),
   ERA_STATUS("eraAuthorized", false),
   SELECTED_SIGNING_OFFICIAL_ID("selectedSigningOfficialId", false),

--- a/src/main/java/org/broadinstitute/consent/http/enumeration/UserFields.java
+++ b/src/main/java/org/broadinstitute/consent/http/enumeration/UserFields.java
@@ -4,28 +4,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 public enum UserFields {
-  DEPARTMENT("department", true),
-  STREET_ADDRESS_1("address1", true),
-  CITY("city", true),
-  ZIP_POSTAL_CODE("zipcode", true),
-  ARE_YOU_PRINCIPAL_INVESTIGATOR("isThePI", true),
-  COUNTRY("country", true),
-  DIVISION("division", false),
-  STREET_ADDRESS_2("address2", false),
-  STATE("state", false),
-  PUBMED_ID("pubmedID", false),
-  SCIENTIFIC_URL("scientificURL", false),
-  DO_YOU_HAVE_PI("havePI", false),
-  PI_NAME("piName", false),
-  PI_EMAIL("piEmail", false),
-  PI_eRA_COMMONS_ID("piERACommonsID", false),
   COMPLETED("completed", false),
-  INVESTIGATOR("investigator", false),
   ERA_EXPIRATION_DATE("eraExpiration", false),
   ERA_STATUS("eraAuthorized", false),
-  LINKEDIN_PROFILE("linkedIn", false),
-  RESEARCHER_GATE("researcherGate", false),
-  ORCID("orcid", false),
   SELECTED_SIGNING_OFFICIAL_ID("selectedSigningOfficialId", false),
   SUGGESTED_SIGNING_OFFICIAL("suggestedSigningOfficial", false),
   SUGGESTED_INSTITUTION("suggestedInstitution", false);

--- a/src/main/java/org/broadinstitute/consent/http/enumeration/UserFields.java
+++ b/src/main/java/org/broadinstitute/consent/http/enumeration/UserFields.java
@@ -2,6 +2,8 @@ package org.broadinstitute.consent.http.enumeration;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public enum UserFields {
   ERA_EXPIRATION_DATE("eraExpiration", false),
@@ -22,6 +24,10 @@ public enum UserFields {
 
   public String getValue() {
     return value;
+  }
+
+  public static List<String> getValues() {
+    return Stream.of(UserFields.values()).map(UserFields::getValue).collect(Collectors.toList());
   }
 
   public Boolean getRequired() {

--- a/src/main/java/org/broadinstitute/consent/http/models/User.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/User.java
@@ -58,6 +58,7 @@ public class User {
     @JsonProperty
     private Boolean emailPreference;
 
+    @Deprecated
     @JsonProperty
     private Boolean profileCompleted;
 

--- a/src/main/java/org/broadinstitute/consent/http/models/User.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/User.java
@@ -241,10 +241,12 @@ public class User {
         this.emailPreference = emailPreference;
     }
 
+    @Deprecated
     public Boolean getProfileCompleted() {
         return profileCompleted;
     }
 
+    @Deprecated
     public void setProfileCompleted(Boolean profileCompleted) {
         this.profileCompleted = profileCompleted;
     }

--- a/src/main/java/org/broadinstitute/consent/http/service/ResearcherService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ResearcherService.java
@@ -57,16 +57,8 @@ public class ResearcherService {
         researcherPropertiesMap.values().removeAll(Collections.singleton(null));
         if (validate) validateRequiredFields(researcherPropertiesMap);
         Map<String, String> validatedProperties = validateExistentFields(researcherPropertiesMap);
-        boolean isUpdatedProfileCompleted = Boolean.parseBoolean(validatedProperties.get(UserFields.COMPLETED.getValue()));
-        String completed = userPropertyDAO.isProfileCompleted(user.getUserId());
-        boolean isProfileCompleted = Boolean.parseBoolean(completed);
         List<UserProperty> properties = getResearcherProperties(validatedProperties, user.getUserId());
-        if (!isProfileCompleted && isUpdatedProfileCompleted) {
-            saveProperties(properties);
-            notifyAdmins(user.getUserId());
-        } else {
-            saveProperties(properties);
-        }
+        saveProperties(properties);
         return describeResearcherProperties(user.getUserId());
     }
 

--- a/src/main/java/org/broadinstitute/consent/http/service/ResearcherService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ResearcherService.java
@@ -40,6 +40,7 @@ public class ResearcherService {
         this.emailNotifierService = emailNotifierService;
     }
 
+    @Deprecated
     public List<UserProperty> setProperties(Map<String, String> researcherPropertiesMap, AuthUser authUser) throws NotFoundException, IllegalArgumentException {
         User user = validateAuthUser(authUser);
         researcherPropertiesMap.values().removeAll(Collections.singleton(null));
@@ -50,22 +51,15 @@ public class ResearcherService {
         return describeResearcherProperties(user.getUserId());
     }
 
+    @Deprecated
     public List<UserProperty> updateProperties(Map<String, String> researcherPropertiesMap, AuthUser authUser, Boolean validate) throws NotFoundException, IllegalArgumentException {
         User user = validateAuthUser(authUser);
         researcherPropertiesMap.values().removeAll(Collections.singleton(null));
         if (validate) validateRequiredFields(researcherPropertiesMap);
         Map<String, String> validatedProperties = validateExistentFields(researcherPropertiesMap);
-
-        boolean isUpdatedProfileCompleted = isCompleted(validatedProperties.keySet().stream().map((key) -> {
-            UserProperty p = new UserProperty();
-            p.setPropertyKey(key);
-            p.setPropertyValue(validatedProperties.get(key));
-            p.setUserId(user.getUserId());
-            return p;
-        }).collect(Collectors.toList()));
-
-        boolean isProfileCompleted = isCompleted(user.getProperties());
-
+        boolean isUpdatedProfileCompleted = Boolean.parseBoolean(validatedProperties.get(UserFields.COMPLETED.getValue()));
+        String completed = userPropertyDAO.isProfileCompleted(user.getUserId());
+        boolean isProfileCompleted = Boolean.parseBoolean(completed);
         List<UserProperty> properties = getResearcherProperties(validatedProperties, user.getUserId());
         if (!isProfileCompleted && isUpdatedProfileCompleted) {
             saveProperties(properties);
@@ -74,10 +68,6 @@ public class ResearcherService {
             saveProperties(properties);
         }
         return describeResearcherProperties(user.getUserId());
-    }
-
-    private boolean isCompleted(List<String> existentProperties) {
-        return existentProperties.contains(UserFields.Ins)
     }
 
     private void saveProperties(List<UserProperty> properties) {

--- a/src/main/java/org/broadinstitute/consent/http/service/ResearcherService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ResearcherService.java
@@ -92,7 +92,7 @@ public class ResearcherService {
     private List<UserProperty> describeResearcherProperties(Integer userId) {
         validateUser(userId);
         return userPropertyDAO.findResearcherPropertiesByUser(userId,
-                Arrays.stream(UserFields.values()).map(UserFields::getValue).collect(Collectors.toList()));
+                UserFields.getValues());
     }
 
     private void validateRequiredFields(Map<String, String> properties) {

--- a/src/main/java/org/broadinstitute/consent/http/service/UserService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/UserService.java
@@ -246,8 +246,7 @@ public class UserService {
     }
 
     public List<UserProperty> findAllUserProperties(Integer userId) {
-        return userPropertyDAO.findResearcherPropertiesByUser(userId,
-                Arrays.stream(UserFields.values()).map(UserFields::getValue).collect(Collectors.toList()));
+        return userPropertyDAO.findResearcherPropertiesByUser(userId, UserFields.getValues());
     }
 
     public List<User> describeAdminUsersThatWantToReceiveMails() {

--- a/src/main/java/org/broadinstitute/consent/http/service/UserService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/UserService.java
@@ -12,6 +12,7 @@ import org.broadinstitute.consent.http.db.UserDAO;
 import org.broadinstitute.consent.http.db.UserPropertyDAO;
 import org.broadinstitute.consent.http.db.UserRoleDAO;
 import org.broadinstitute.consent.http.db.VoteDAO;
+import org.broadinstitute.consent.http.enumeration.UserFields;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.AuthUser;
 import org.broadinstitute.consent.http.models.Institution;
@@ -30,6 +31,7 @@ import org.slf4j.LoggerFactory;
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.NotFoundException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
@@ -244,13 +246,13 @@ public class UserService {
     }
 
     public List<UserProperty> findAllUserProperties(Integer userId) {
-        return userPropertyDAO.findResearcherPropertiesByUser(userId);
+        return userPropertyDAO.findResearcherPropertiesByUser(userId,
+                Arrays.stream(UserFields.values()).map(UserFields::getValue).collect(Collectors.toList()));
     }
 
     public List<User> describeAdminUsersThatWantToReceiveMails() {
         return userDAO.describeUsersByRoleAndEmailPreference(UserRoles.ADMIN.getRoleName(), true);
     }
-
 
     public User updateDACUserById(Map<String, User> dac, Integer id) throws IllegalArgumentException, NotFoundException {
         User updatedUser = dac.get(UserRolesHandler.UPDATED_USER_KEY);
@@ -275,7 +277,7 @@ public class UserService {
         try {
             userDAO.updateUser(updatedUser.getDisplayName(), id, updatedUser.getInstitutionId());
         } catch (UnableToExecuteStatementException e) {
-            throw new IllegalArgumentException("Email shoud be unique.");
+            throw new IllegalArgumentException("Email should be unique.");
         }
         return userDAO.findUserById(id);
     }

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -2556,6 +2556,7 @@ paths:
     $ref: './paths/userByIdv2.yaml'
   /api/user/profile:
     post:
+      deprecated: true
       summary: Create user properties.
       description: Create properties for the current user.
       requestBody:
@@ -2577,6 +2578,7 @@ paths:
         500:
           description: Server error.
     put:
+      deprecated: true
       summary: Update user properties
       description: Updates a user.
       requestBody:

--- a/src/main/resources/assets/schemas/User.yaml
+++ b/src/main/resources/assets/schemas/User.yaml
@@ -24,6 +24,7 @@ properties:
     format: date
     description: Describes the date the User was created.
   profileCompleted:
+    deprecated: true
     type: boolean
     description: The profile is completed. Researchers only.
   roles:

--- a/src/main/resources/assets/schemas/UserProperty.yaml
+++ b/src/main/resources/assets/schemas/UserProperty.yaml
@@ -1,41 +1,12 @@
 type: object
 properties:
-  profileName:
-    type: string
-  country:
-    type: string
-  city:
-    type: string
-  address1:
-    type: string
-  address2:
-    type: string
-  orcid:
-    type: string
-  completed:
-    type: string
-  libraryCards:
-    type: array
-    description: List of string values of the organizations for all library cards the user has access to.
-    items:
-      type: string
-  zipcode:
-    type: string
-  libraryCardEntries:
-    type: array
-    items:
-      $ref: './LibraryCard.yaml'
-  institution:
-    type: string
-  nihUsername:
-    type: string
-  state:
-    type: string
-  isThePI:
-    type: string
-  department:
-    type: string
   eraAuthorized:
     type: string
   eraExpiration:
+    type: string
+  suggestedInstitution:
+    type: string
+  suggestedSigningOfficial:
+    type: string
+  selectedSigningOfficial:
     type: string

--- a/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
@@ -279,7 +279,6 @@ public class DAOTestHelper {
                 "." +
                 RandomStringUtils.randomAlphabetic(i3);
         Integer userId = userDAO.insertUser(email, "display name", new Date());
-        createUserProperty(userId, UserFields.ORCID.getValue());
         userRoleDAO.insertSingleUserRole(UserRoles.RESEARCHER.getRoleId(), userId);
         return userDAO.findUserById(userId);
     }
@@ -534,9 +533,9 @@ public class DAOTestHelper {
     protected DarCollection createDarCollectionMultipleUserProperties() {
         User user = createUser();
         Integer userId = user.getUserId();
-        createUserProperty(userId, UserFields.PI_NAME.getValue());
-        createUserProperty(userId, UserFields.PI_EMAIL.getValue());
-        createUserProperty(userId, UserFields.DEPARTMENT.getValue());
+        createUserProperty(userId, UserFields.SUGGESTED_SIGNING_OFFICIAL.getValue());
+        createUserProperty(userId, UserFields.SUGGESTED_INSTITUTION.getValue());
+        createUserProperty(userId, UserFields.ERA_STATUS.getValue());
         String darCode = "DAR-" + RandomUtils.nextInt(100, 1000);
         Integer collection_id = darCollectionDAO.insertDarCollection(darCode, user.getUserId(), new Date());
         Dataset dataset = createDataset();

--- a/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
@@ -280,6 +280,11 @@ public class DAOTestHelper {
                 RandomStringUtils.randomAlphabetic(i3);
         Integer userId = userDAO.insertUser(email, "display name", new Date());
         userRoleDAO.insertSingleUserRole(UserRoles.RESEARCHER.getRoleId(), userId);
+        UserProperty prop = new UserProperty();
+        prop.setUserId(userId);
+        prop.setPropertyKey(UserFields.SUGGESTED_INSTITUTION.getValue());
+        prop.setPropertyValue("test");
+        userPropertyDAO.insertAll(List.of(prop));
         return userDAO.findUserById(userId);
     }
 

--- a/src/test/java/org/broadinstitute/consent/http/db/UserDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/UserDAOTest.java
@@ -199,21 +199,6 @@ public class UserDAOTest extends DAOTestHelper {
     }
 
     @Test
-    public void testFindUsersWithProfileCompleted() {
-        User u = createUser();
-        UserProperty p = new UserProperty();
-        p.setPropertyKey(UserFields.COMPLETED.getValue());
-        p.setPropertyValue("true");
-        p.setUserId(u.getUserId());
-        userPropertyDAO.insertAll(Collections.singletonList(p));
-        List<User> users = new ArrayList<>(userDAO.findUsers());
-        assertNotNull(users);
-        assertFalse(users.isEmpty());
-        assertEquals(1, users.size());
-        assertTrue(users.get(0).getProfileCompleted());
-    }
-
-    @Test
     public void testDescribeUsersByRoleAndEmailPreference() {
         User researcher = createUserWithRole(UserRoles.RESEARCHER.getRoleId());
         userDAO.updateEmailPreference(researcher.getUserId(), true);

--- a/src/test/java/org/broadinstitute/consent/http/db/UserPropertyDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/UserPropertyDAOTest.java
@@ -6,6 +6,7 @@ import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.UserProperty;
 import org.junit.Assert;
 import org.junit.Test;
+import org.testcontainers.shaded.org.apache.commons.lang3.RandomStringUtils;
 
 import java.util.List;
 
@@ -17,17 +18,17 @@ public class UserPropertyDAOTest extends DAOTestHelper {
 
         UserProperty suggestedInstitution = new UserProperty();
         suggestedInstitution.setPropertyKey(UserFields.SUGGESTED_INSTITUTION.getValue());
-        suggestedInstitution.setPropertyValue("asdfasdf");
+        suggestedInstitution.setPropertyValue(RandomStringUtils.random(10));
         suggestedInstitution.setUserId(user.getUserId());
 
         UserProperty suggestedSigningOfficial = new UserProperty();
         suggestedSigningOfficial.setPropertyKey(UserFields.SUGGESTED_SIGNING_OFFICIAL.getValue());
-        suggestedSigningOfficial.setPropertyValue("afhjlsfjklsda");
+        suggestedSigningOfficial.setPropertyValue(RandomStringUtils.random(10));
         suggestedSigningOfficial.setUserId(user.getUserId());
 
         UserProperty notPresent = new UserProperty();
         notPresent.setPropertyKey("nonExistentKey");
-        notPresent.setPropertyValue("jasjsd");
+        notPresent.setPropertyValue(RandomStringUtils.random(10));
         notPresent.setUserId(user.getUserId());
 
         List<UserProperty> props = userPropertyDAO.findResearcherPropertiesByUser(
@@ -54,10 +55,10 @@ public class UserPropertyDAOTest extends DAOTestHelper {
 
         Assert.assertTrue(props.stream().anyMatch((p) ->
                 (p.getPropertyKey().equals(UserFields.SUGGESTED_INSTITUTION.getValue())
-                        && p.getPropertyValue().equals("asdfasdf"))));
+                        && p.getPropertyValue().equals(suggestedInstitution.getPropertyValue()))));
 
         Assert.assertTrue(props.stream().anyMatch((p) ->
                 (p.getPropertyKey().equals(UserFields.SUGGESTED_SIGNING_OFFICIAL.getValue())
-                        && p.getPropertyValue().equals("afhjlsfjklsda"))));
+                        && p.getPropertyValue().equals(suggestedSigningOfficial.getPropertyValue()))));
     }
 }

--- a/src/test/java/org/broadinstitute/consent/http/db/UserPropertyDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/UserPropertyDAOTest.java
@@ -1,0 +1,63 @@
+package org.broadinstitute.consent.http.db;
+
+import org.broadinstitute.consent.http.enumeration.UserFields;
+import org.broadinstitute.consent.http.enumeration.UserRoles;
+import org.broadinstitute.consent.http.models.User;
+import org.broadinstitute.consent.http.models.UserProperty;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+
+public class UserPropertyDAOTest extends DAOTestHelper {
+
+    @Test
+    public void testFindResearcherProperties() {
+        User user = createUserWithRole(UserRoles.RESEARCHER.getRoleId());
+
+        UserProperty suggestedInstitution = new UserProperty();
+        suggestedInstitution.setPropertyKey(UserFields.SUGGESTED_INSTITUTION.getValue());
+        suggestedInstitution.setPropertyValue("asdfasdf");
+        suggestedInstitution.setUserId(user.getUserId());
+
+        UserProperty suggestedSigningOfficial = new UserProperty();
+        suggestedSigningOfficial.setPropertyKey(UserFields.SUGGESTED_SIGNING_OFFICIAL.getValue());
+        suggestedSigningOfficial.setPropertyValue("afhjlsfjklsda");
+        suggestedSigningOfficial.setUserId(user.getUserId());
+
+        UserProperty notPresent = new UserProperty();
+        notPresent.setPropertyKey("nonExistentKey");
+        notPresent.setPropertyValue("jasjsd");
+        notPresent.setUserId(user.getUserId());
+
+        List<UserProperty> props = userPropertyDAO.findResearcherPropertiesByUser(
+                user.getUserId(),
+                List.of(UserFields.SUGGESTED_INSTITUTION.getValue(),
+                        UserFields.SUGGESTED_SIGNING_OFFICIAL.getValue(),
+                        UserFields.ERA_EXPIRATION_DATE.getValue()));
+
+        Assert.assertEquals(0, props.size());
+
+        userPropertyDAO.insertAll(List.of(
+                suggestedInstitution,
+                suggestedSigningOfficial,
+                notPresent
+        ));
+
+        props = userPropertyDAO.findResearcherPropertiesByUser(
+                user.getUserId(),
+                List.of(UserFields.SUGGESTED_INSTITUTION.getValue(),
+                        UserFields.SUGGESTED_SIGNING_OFFICIAL.getValue(),
+                        UserFields.ERA_EXPIRATION_DATE.getValue()));
+
+        Assert.assertEquals(2, props.size());
+
+        Assert.assertTrue(props.stream().anyMatch((p) ->
+                (p.getPropertyKey().equals(UserFields.SUGGESTED_INSTITUTION.getValue())
+                        && p.getPropertyValue().equals("asdfasdf"))));
+
+        Assert.assertTrue(props.stream().anyMatch((p) ->
+                (p.getPropertyKey().equals(UserFields.SUGGESTED_SIGNING_OFFICIAL.getValue())
+                        && p.getPropertyValue().equals("afhjlsfjklsda"))));
+    }
+}

--- a/src/test/java/org/broadinstitute/consent/http/service/ResearcherServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/ResearcherServiceTest.java
@@ -69,7 +69,7 @@ public class ResearcherServiceTest {
     public void testSetProperties() {
         UserProperty prop = new UserProperty(
                 user.getUserId(),
-                UserFields.DEPARTMENT.getValue(),
+                UserFields.SUGGESTED_INSTITUTION.getValue(),
                 RandomStringUtils.random(10, true, false));
         Map<String, String> propMap = new HashMap<>();
         propMap.put(prop.getPropertyKey(), prop.getPropertyValue());
@@ -89,133 +89,6 @@ public class ResearcherServiceTest {
         initService();
 
         service.setProperties(new HashMap<>(), authUser);
-    }
-
-    @Test
-    public void testUpdatePropertiesWithValidation() {
-        List<UserProperty> props = new ArrayList<>();
-        Map<String, String> propMap = new HashMap<>();
-        for (UserFields researcherField : UserFields.values()) {
-            if (researcherField.getRequired()) {
-                String val = RandomStringUtils.random(10, true, false);
-                props.add(new UserProperty(user.getUserId(), researcherField.getValue(), val));
-                propMap.put(researcherField.getValue(), val);
-            }
-        }
-        when(userDAO.findUserByEmail(any())).thenReturn(user);
-        when(userDAO.findUserById(any())).thenReturn(user);
-        when(userPropertyDAO.findResearcherPropertiesByUser(any(), any())).thenReturn(props);
-        initService();
-
-        List<UserProperty> foundProps = service.updateProperties(propMap, authUser, true);
-        Assert.assertFalse(foundProps.isEmpty());
-        Assert.assertEquals(props.size(), foundProps.size());
-    }
-
-    @Test
-    public void testUpdatePropertiesNoValidation() {
-        UserProperty prop = new UserProperty(
-                user.getUserId(),
-                UserFields.DEPARTMENT.getValue(),
-                RandomStringUtils.random(10, true, false));
-        Map<String, String> propMap = new HashMap<>();
-        propMap.put(prop.getPropertyKey(), prop.getPropertyValue());
-        when(userDAO.findUserByEmail(any())).thenReturn(user);
-        when(userDAO.findUserById(any())).thenReturn(user);
-        when(userPropertyDAO.findResearcherPropertiesByUser(any(), any())).thenReturn(Collections.singletonList(prop));
-        initService();
-
-        List<UserProperty> props = service.updateProperties(propMap, authUser, false);
-        Assert.assertFalse(props.isEmpty());
-        Assert.assertEquals(propMap.size(), props.size());
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testUpdatePropertiesMissingFields() {
-        UserProperty prop = new UserProperty(
-                user.getUserId(),
-                UserFields.DEPARTMENT.getValue(),
-                RandomStringUtils.random(10, true, false));
-        Map<String, String> propMap = new HashMap<>();
-        propMap.put(prop.getPropertyKey(), prop.getPropertyValue());
-        when(userDAO.findUserByEmail(any())).thenReturn(user);
-        when(userDAO.findUserById(any())).thenReturn(user);
-        initService();
-
-        service.updateProperties(propMap, authUser, true);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testUpdatePropertiesInvalidFields() {
-        UserProperty prop = new UserProperty(
-                user.getUserId(),
-                RandomStringUtils.random(10, true, false),
-                RandomStringUtils.random(10, true, false));
-        Map<String, String> propMap = new HashMap<>();
-        propMap.put(prop.getPropertyKey(), prop.getPropertyValue());
-        when(userDAO.findUserByEmail(any())).thenReturn(user);
-        when(userDAO.findUserById(any())).thenReturn(user);
-        initService();
-
-        service.updateProperties(propMap, authUser, true);
-    }
-
-    @Test
-    public void testUpdatePropertiesIncompleteProfile() throws Exception {
-        List<UserProperty> props = new ArrayList<>();
-        Map<String, String> propMap = new HashMap<>();
-        for (UserFields researcherField : UserFields.values()) {
-            if (researcherField.getRequired()) {
-                String val1 = RandomStringUtils.random(10, true, false);
-                String val2 = RandomStringUtils.random(10, true, false);
-                props.add(new UserProperty(user.getUserId(), researcherField.getValue(), val1));
-                propMap.put(researcherField.getValue(), val2);
-            }
-        }
-        props.add(new UserProperty(user.getUserId(), UserFields.COMPLETED.getValue(), Boolean.FALSE.toString()));
-        propMap.put(UserFields.COMPLETED.getValue(), Boolean.FALSE.toString());
-        when(userDAO.findUserByEmail(any())).thenReturn(user);
-        when(userDAO.findUserById(any())).thenReturn(user);
-        when(userPropertyDAO.findResearcherPropertiesByUser(any(), any())).thenReturn(props);
-        when(userPropertyDAO.isProfileCompleted(any())).thenReturn(Boolean.FALSE.toString());
-        doNothing().when(userPropertyDAO).deletePropertiesByUserAndKey(any());
-        doNothing().when(userPropertyDAO).insertAll(any());
-        doNothing().when(userPropertyDAO).deleteAllPropertiesByUser(any());
-        doNothing().when(emailNotifierService).sendNewResearcherCreatedMessage(any(), any());
-        initService();
-
-        List<UserProperty> foundProps = service.updateProperties(propMap, authUser, true);
-        Assert.assertFalse(foundProps.isEmpty());
-        Assert.assertEquals(props.size(), foundProps.size());
-        verify(emailNotifierService, times(0)).sendNewResearcherCreatedMessage(any(), any());
-    }
-
-    @Test
-    public void testUpdatePropertiesCompleteProfile() throws Exception {
-        List<UserProperty> props = new ArrayList<>();
-        Map<String, String> propMap = new HashMap<>();
-        for (UserFields researcherField : UserFields.values()) {
-            String val1 = RandomStringUtils.random(10, true, false);
-            String val2 = RandomStringUtils.random(10, true, false);
-            props.add(new UserProperty(user.getUserId(), researcherField.getValue(), val1));
-            propMap.put(researcherField.getValue(), val2);
-        }
-        props.add(new UserProperty(user.getUserId(), UserFields.COMPLETED.getValue(), Boolean.TRUE.toString()));
-        propMap.put(UserFields.COMPLETED.getValue(), Boolean.TRUE.toString());
-        when(userDAO.findUserByEmail(any())).thenReturn(user);
-        when(userDAO.findUserById(any())).thenReturn(user);
-        when(userPropertyDAO.findResearcherPropertiesByUser(any(), any())).thenReturn(props);
-        when(userPropertyDAO.isProfileCompleted(any())).thenReturn(Boolean.TRUE.toString());
-        doNothing().when(userPropertyDAO).deletePropertiesByUserAndKey(any());
-        doNothing().when(userPropertyDAO).insertAll(any());
-        doNothing().when(userPropertyDAO).deleteAllPropertiesByUser(any());
-        doNothing().when(emailNotifierService).sendNewResearcherCreatedMessage(any(), any());
-        initService();
-
-        List<UserProperty> foundProps = service.updateProperties(propMap, authUser, true);
-        Assert.assertFalse(foundProps.isEmpty());
-        Assert.assertEquals(props.size(), foundProps.size());
-        verify(emailNotifierService, never()).sendNewResearcherCreatedMessage(any(), any());
     }
 
 }

--- a/src/test/java/org/broadinstitute/consent/http/service/ResearcherServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/ResearcherServiceTest.java
@@ -75,7 +75,7 @@ public class ResearcherServiceTest {
         propMap.put(prop.getPropertyKey(), prop.getPropertyValue());
         when(userDAO.findUserByEmail(any())).thenReturn(user);
         when(userDAO.findUserById(any())).thenReturn(user);
-        when(userPropertyDAO.findResearcherPropertiesByUser(any())).thenReturn(Collections.singletonList(prop));
+        when(userPropertyDAO.findResearcherPropertiesByUser(any(), any())).thenReturn(Collections.singletonList(prop));
         initService();
 
         List<UserProperty> props = service.setProperties(propMap, authUser);
@@ -104,7 +104,7 @@ public class ResearcherServiceTest {
         }
         when(userDAO.findUserByEmail(any())).thenReturn(user);
         when(userDAO.findUserById(any())).thenReturn(user);
-        when(userPropertyDAO.findResearcherPropertiesByUser(any())).thenReturn(props);
+        when(userPropertyDAO.findResearcherPropertiesByUser(any(), any())).thenReturn(props);
         initService();
 
         List<UserProperty> foundProps = service.updateProperties(propMap, authUser, true);
@@ -122,7 +122,7 @@ public class ResearcherServiceTest {
         propMap.put(prop.getPropertyKey(), prop.getPropertyValue());
         when(userDAO.findUserByEmail(any())).thenReturn(user);
         when(userDAO.findUserById(any())).thenReturn(user);
-        when(userPropertyDAO.findResearcherPropertiesByUser(any())).thenReturn(Collections.singletonList(prop));
+        when(userPropertyDAO.findResearcherPropertiesByUser(any(), any())).thenReturn(Collections.singletonList(prop));
         initService();
 
         List<UserProperty> props = service.updateProperties(propMap, authUser, false);
@@ -176,7 +176,7 @@ public class ResearcherServiceTest {
         propMap.put(UserFields.COMPLETED.getValue(), Boolean.FALSE.toString());
         when(userDAO.findUserByEmail(any())).thenReturn(user);
         when(userDAO.findUserById(any())).thenReturn(user);
-        when(userPropertyDAO.findResearcherPropertiesByUser(any())).thenReturn(props);
+        when(userPropertyDAO.findResearcherPropertiesByUser(any(), any())).thenReturn(props);
         when(userPropertyDAO.isProfileCompleted(any())).thenReturn(Boolean.FALSE.toString());
         doNothing().when(userPropertyDAO).deletePropertiesByUserAndKey(any());
         doNothing().when(userPropertyDAO).insertAll(any());
@@ -204,7 +204,7 @@ public class ResearcherServiceTest {
         propMap.put(UserFields.COMPLETED.getValue(), Boolean.TRUE.toString());
         when(userDAO.findUserByEmail(any())).thenReturn(user);
         when(userDAO.findUserById(any())).thenReturn(user);
-        when(userPropertyDAO.findResearcherPropertiesByUser(any())).thenReturn(props);
+        when(userPropertyDAO.findResearcherPropertiesByUser(any(), any())).thenReturn(props);
         when(userPropertyDAO.isProfileCompleted(any())).thenReturn(Boolean.TRUE.toString());
         doNothing().when(userPropertyDAO).deletePropertiesByUserAndKey(any());
         doNothing().when(userPropertyDAO).insertAll(any());

--- a/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
@@ -483,7 +483,7 @@ public class UserServiceTest {
             .setUserStatusInfo(info);
         when(userDAO.findUserById(anyInt())).thenReturn(user);
         when(libraryCardDAO.findLibraryCardsByUserId(anyInt())).thenReturn(List.of(new LibraryCard()));
-        when(userPropertyDAO.findResearcherPropertiesByUser(anyInt())).thenReturn(List.of(new UserProperty()));
+        when(userPropertyDAO.findResearcherPropertiesByUser(anyInt(), any())).thenReturn(List.of(new UserProperty()));
 
         initService();
         JsonObject userJson = service.findUserWithPropertiesByIdAsJsonObject(authUser, user.getUserId());
@@ -506,7 +506,7 @@ public class UserServiceTest {
             .setUserStatusInfo(info);
         when(userDAO.findUserById(anyInt())).thenReturn(user);
         when(libraryCardDAO.findLibraryCardsByUserId(anyInt())).thenReturn(List.of(new LibraryCard()));
-        when(userPropertyDAO.findResearcherPropertiesByUser(anyInt())).thenReturn(List.of(new UserProperty()));
+        when(userPropertyDAO.findResearcherPropertiesByUser(anyInt(), any())).thenReturn(List.of(new UserProperty()));
 
         initService();
         JsonObject userJson = service.findUserWithPropertiesByIdAsJsonObject(authUser, user.getUserId());


### PR DESCRIPTION
## Addresses

https://broadworkbench.atlassian.net/browse/DUOS-1896

Deprecates user properties; filters out DAO calls by making user specify all the fields they want, instead of returning all possible fields.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
