### PR TITLE
[DUOS-1891][risk=low] Modify PUT /api/user to send support requests

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
@@ -93,6 +93,7 @@ import org.broadinstitute.consent.http.service.PendingCaseService;
 import org.broadinstitute.consent.http.service.ResearcherService;
 import org.broadinstitute.consent.http.service.ReviewResultsService;
 import org.broadinstitute.consent.http.service.SummaryService;
+import org.broadinstitute.consent.http.service.SupportRequestService;
 import org.broadinstitute.consent.http.service.UseRestrictionValidator;
 import org.broadinstitute.consent.http.service.UserService;
 import org.broadinstitute.consent.http.service.VoteService;
@@ -192,6 +193,7 @@ public class ConsentApplication extends Application<ConsentConfiguration> {
         final OAuthAuthenticator authenticator = injector.getProvider(OAuthAuthenticator.class).get();
         final LibraryCardService libraryCardService = injector.getProvider(LibraryCardService.class).get();
         final SamService samService = injector.getProvider(SamService.class).get();
+        final SupportRequestService supportRequestService = injector.getProvider(SupportRequestService.class).get();
 
         System.setProperty("sun.net.http.allowRestrictedHeaders", "true");
         configureCors(env);
@@ -253,7 +255,7 @@ public class ConsentApplication extends Application<ConsentConfiguration> {
         env.jersey().register(new SamResource(samService, userService));
         env.jersey().register(new SwaggerResource(config.getGoogleAuthentication()));
         env.jersey().register(new StatusResource(env.healthChecks()));
-        env.jersey().register(new UserResource(researcherService, samService, userService, datasetService));
+        env.jersey().register(new UserResource(researcherService, samService, userService, datasetService, supportRequestService));
         env.jersey().register(new TosResource(samService));
         env.jersey().register(injector.getInstance(VersionResource.class));
         env.jersey().register(new VoteResource(userService, voteService, electionService));

--- a/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
@@ -50,6 +50,7 @@ import org.broadinstitute.consent.http.service.PendingCaseService;
 import org.broadinstitute.consent.http.service.ResearcherService;
 import org.broadinstitute.consent.http.service.ReviewResultsService;
 import org.broadinstitute.consent.http.service.SummaryService;
+import org.broadinstitute.consent.http.service.SupportRequestService;
 import org.broadinstitute.consent.http.service.UseRestrictionConverter;
 import org.broadinstitute.consent.http.service.UseRestrictionValidator;
 import org.broadinstitute.consent.http.service.UserService;
@@ -525,5 +526,10 @@ public class ConsentModule extends AbstractModule {
     @Provides
     SamService providesSamService() {
         return new SamService(config.getServicesConfiguration());
+    }
+
+    @Provides
+    SupportRequestService providesSupportRequestService() {
+        return new SupportRequestService(config.getServicesConfiguration());
     }
 }

--- a/src/main/java/org/broadinstitute/consent/http/configurations/ServicesConfiguration.java
+++ b/src/main/java/org/broadinstitute/consent/http/configurations/ServicesConfiguration.java
@@ -13,6 +13,8 @@ public class ServicesConfiguration {
 
   @NotNull private String samUrl;
 
+  private boolean activateSupportNotifications = false;
+
   public String getOntologyURL() {
     return ontologyURL;
   }
@@ -81,4 +83,11 @@ public class ServicesConfiguration {
     return "https://broadinstitute.zendesk.com/api/v2/requests.json";
   }
 
+  public boolean isActivateSupportNotifications() {
+    return activateSupportNotifications;
+  }
+
+  public void setActivateSupportNotifications(boolean activateSupportNotifications) {
+    this.activateSupportNotifications = activateSupportNotifications;
+  }
 }

--- a/src/main/java/org/broadinstitute/consent/http/configurations/ServicesConfiguration.java
+++ b/src/main/java/org/broadinstitute/consent/http/configurations/ServicesConfiguration.java
@@ -15,6 +15,7 @@ public class ServicesConfiguration {
 
   private boolean activateSupportNotifications = false;
 
+
   public String getOntologyURL() {
     return ontologyURL;
   }

--- a/src/main/java/org/broadinstitute/consent/http/enumeration/SupportRequestType.java
+++ b/src/main/java/org/broadinstitute/consent/http/enumeration/SupportRequestType.java
@@ -1,0 +1,16 @@
+package org.broadinstitute.consent.http.enumeration;
+
+public enum SupportRequestType {
+
+    QUESTION("question"), INCIDENT("incident"), PROBLEM("problem"), TASK("task");
+
+    private final String value;
+
+    SupportRequestType(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
@@ -203,8 +203,6 @@ public class UserResource extends Resource {
             }
 
             user = userService.updateUserFieldsById(userUpdateFields, user.getUserId());
-            URI uri = info.getRequestUriBuilder().path("{id}").build(userId);
-            User user = userService.updateUserFieldsById(userUpdateFields, userId);
             supportRequestService.handleSuggestedUserFieldsSupportRequest(userUpdateFields, user, authUser);
             Gson gson = new Gson();
             JsonObject jsonUser = userService.findUserWithPropertiesByIdAsJsonObject(authUser, user.getUserId());

--- a/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
@@ -181,7 +181,7 @@ public class UserResource extends Resource {
             userService.findUserById(userId);
             URI uri = info.getRequestUriBuilder().path("{id}").build(userId);
             User user = userService.updateUserFieldsById(userUpdateFields, userId);
-            supportRequestService.sendSuggestedPropertiesToSupport(userUpdateFields, user, authUser);
+            supportRequestService.handleSuggestedUserFieldsSupportRequest(userUpdateFields, user, authUser);
             Gson gson = new Gson();
             JsonObject jsonUser = userService.findUserWithPropertiesByIdAsJsonObject(authUser, user.getUserId());
             return Response.ok(uri).entity(gson.toJson(jsonUser)).build();

--- a/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
@@ -16,6 +16,7 @@ import org.broadinstitute.consent.http.models.dto.DatasetDTO;
 import org.broadinstitute.consent.http.models.dto.Error;
 import org.broadinstitute.consent.http.service.DatasetService;
 import org.broadinstitute.consent.http.service.ResearcherService;
+import org.broadinstitute.consent.http.service.SupportRequestService;
 import org.broadinstitute.consent.http.service.UserService;
 import org.broadinstitute.consent.http.service.UserService.SimplifiedUser;
 import org.broadinstitute.consent.http.service.sam.SamService;
@@ -53,14 +54,16 @@ public class UserResource extends Resource {
     private final Gson gson = new Gson();
     private final SamService samService;
     private final DatasetService datasetService;
+    private final SupportRequestService supportRequestService;
 
     @Inject
-    public UserResource(ResearcherService researcherService,
-                        SamService samService, UserService userService, DatasetService datasetService) {
+    public UserResource(ResearcherService researcherService, SamService samService, UserService userService,
+                        DatasetService datasetService, SupportRequestService supportRequestService) {
         this.researcherService = researcherService;
         this.samService = samService;
         this.userService = userService;
         this.datasetService = datasetService;
+        this.supportRequestService = supportRequestService;
     }
 
     @GET
@@ -178,6 +181,7 @@ public class UserResource extends Resource {
             userService.findUserById(userId);
             URI uri = info.getRequestUriBuilder().path("{id}").build(userId);
             User user = userService.updateUserFieldsById(userUpdateFields, userId);
+            supportRequestService.sendSuggestedPropertiesToSupport(userUpdateFields, user, authUser);
             Gson gson = new Gson();
             JsonObject jsonUser = userService.findUserWithPropertiesByIdAsJsonObject(authUser, user.getUserId());
             return Response.ok(uri).entity(gson.toJson(jsonUser)).build();

--- a/src/main/java/org/broadinstitute/consent/http/service/SupportRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/SupportRequestService.java
@@ -96,7 +96,7 @@ public class SupportRequestService {
         HttpResponse response = clientUtil.handleHttpRequest(request);
 
         if (response.getStatusCode() != HttpStatusCodes.STATUS_CODE_OK) {
-            logger.error(response.getStatusMessage());
+            logger.error("Error posting ticket to support: " + response.getStatusMessage());
             throw new ServerErrorException(response.getStatusMessage(), HttpStatusCodes.STATUS_CODE_SERVER_ERROR);
         }
     }
@@ -120,6 +120,7 @@ public class SupportRequestService {
                     SupportTicket ticket = createSuggestedUserFieldsTicket(userUpdateFields, user);
                     postTicketToSupport(ticket, authUser);
                 } catch (Exception e) {
+                    logger.error("Exception sending suggested user fields support request: " + e.getMessage());
                     throw new ServerErrorException("Unable to send support ticket for user with email: " + user.getEmail(),
                             HttpStatusCodes.STATUS_CODE_SERVER_ERROR);
                 }

--- a/src/main/java/org/broadinstitute/consent/http/service/SupportRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/SupportRequestService.java
@@ -104,9 +104,10 @@ public class SupportRequestService {
 
     /**
      * Creates and sends a support ticket for a user requesting an unfamiliar institution and/or signing official, if provided
+     *
      * @param userUpdateFields A UserUpdateFields object containing update information for the user
-     * @param user The user requesting the institution and/or signing official
-     * @param authUser AuthUser object used to build POST request
+     * @param user             The user requesting the institution and/or signing official
+     * @param authUser         AuthUser object used to build POST request
      */
     public void handleSuggestedUserFieldsSupportRequest(UserUpdateFields userUpdateFields, User user, AuthUser authUser) {
         if (Objects.nonNull(userUpdateFields) && Objects.nonNull(user)) {
@@ -128,8 +129,9 @@ public class SupportRequestService {
 
     /**
      * Generates a support ticket for a user requesting an unfamiliar institution and/or signing official
+     *
      * @param userUpdateFields A UserUpdateFields object containing update information for the user
-     * @param user The user requesting the institution and/or signing official
+     * @param user             The user requesting the institution and/or signing official
      * @return A support ticket detailing the requested user fields
      * @throws IllegalArgumentException if both suggestedInstitution and suggestedSigningOfficial are null, preventing ticket creation
      */
@@ -152,7 +154,7 @@ public class SupportRequestService {
                     user.getDisplayName(),
                     user.getEmail(),
                     suggestedInstitution);
-        } else if (Objects.nonNull(suggestedSigningOfficial)){
+        } else if (Objects.nonNull(suggestedSigningOfficial)) {
             subject = "New Signing Official Request";
             description = String.format("User %s [%s] has requested a new signing official: {%s}",
                     user.getDisplayName(),

--- a/src/main/java/org/broadinstitute/consent/http/service/SupportRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/SupportRequestService.java
@@ -109,7 +109,7 @@ public class SupportRequestService {
      * @param authUser AuthUser object used to build POST request
      */
     public void handleSuggestedUserFieldsSupportRequest(UserUpdateFields userUpdateFields, User user, AuthUser authUser) {
-        if (Objects.nonNull(userUpdateFields) || Objects.nonNull(user)) {
+        if (Objects.nonNull(userUpdateFields) && Objects.nonNull(user)) {
             String suggestedInstitution = userUpdateFields.getSuggestedInstitution();
             String suggestedSigningOfficial = userUpdateFields.getSuggestedSigningOfficial();
 

--- a/src/main/java/org/broadinstitute/consent/http/service/SupportRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/SupportRequestService.java
@@ -10,6 +10,7 @@ import com.google.gson.FieldNamingPolicy;
 import com.google.gson.GsonBuilder;
 import com.google.inject.Inject;
 import org.broadinstitute.consent.http.configurations.ServicesConfiguration;
+import org.broadinstitute.consent.http.enumeration.SupportRequestType;
 import org.broadinstitute.consent.http.models.AuthUser;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.UserUpdateFields;
@@ -34,7 +35,6 @@ public class SupportRequestService {
     private final ServicesConfiguration configuration;
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
-    private static final String TASK_REQUEST_TYPE = "task";
 
     @Inject
     public SupportRequestService(ServicesConfiguration configuration) {
@@ -53,7 +53,7 @@ public class SupportRequestService {
      * @param url         The API url of this request
      * @return A structured ticket used to make the request
      */
-    public SupportTicket createSupportTicket(String name, String type, String email, String subject, String description, String url) {
+    public SupportTicket createSupportTicket(String name, SupportRequestType type, String email, String subject, String description, String url) {
         if (Objects.isNull(name) || Objects.isNull(email)) {
             throw new IllegalArgumentException("Name and email of user requesting support is required");
         }
@@ -72,7 +72,7 @@ public class SupportRequestService {
 
         SupportRequester requester = new SupportRequester(name, email);
         List<CustomRequestField> customFields = new ArrayList<>();
-        customFields.add(new CustomRequestField(360012744452L, type));
+        customFields.add(new CustomRequestField(360012744452L, type.getValue()));
         customFields.add(new CustomRequestField(360007369412L, description));
         customFields.add(new CustomRequestField(360012744292L, name));
         customFields.add(new CustomRequestField(360012782111L, email));
@@ -164,7 +164,7 @@ public class SupportRequestService {
 
         return createSupportTicket(
                 user.getDisplayName(),
-                TASK_REQUEST_TYPE,
+                SupportRequestType.TASK,
                 user.getEmail(),
                 subject,
                 description,

--- a/src/main/resources/assets/paths/user.yaml
+++ b/src/main/resources/assets/paths/user.yaml
@@ -19,7 +19,8 @@ post:
 put:
   summary: Update limited user fields
   description: |
-    Updates a limited number of the current user's fields
+    Updates a limited number of the current user's fields 
+    and sends a support request if suggestedInstitution or suggestedSigningOfficial are populated
   tags:
     - User
   requestBody:

--- a/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
@@ -380,35 +380,6 @@ public class UserResourceTest {
   }
 
   @Test
-  public void testUpdate() {
-    User user = createUserWithRole();
-    UserUpdateFields userUpdateFields = new UserUpdateFields();
-    Gson gson = new Gson();
-    when(userService.findUserById(any())).thenReturn(user);
-    when(userService.updateUserFieldsById(any(), any())).thenReturn(user);
-    when(userService.findUserWithPropertiesByIdAsJsonObject(any(), any())).thenReturn(gson.toJsonTree(user).getAsJsonObject());
-    spy(supportRequestService);
-    initResource();
-    Response response = userResource.update(authUser, uriInfo, user.getUserId(), gson.toJson(userUpdateFields));
-    assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
-    verify(supportRequestService, times(1)).handleSuggestedUserFieldsSupportRequest(any(), any(), any());
-  }
-
-  @Test
-  public void testUpdateSupportRequestError() {
-    User user = createUserWithRole();
-    UserUpdateFields userUpdateFields = new UserUpdateFields();
-    Gson gson = new Gson();
-    when(userService.findUserById(any())).thenReturn(user);
-    when(userService.updateUserFieldsById(any(), any())).thenReturn(user);
-    when(userService.findUserWithPropertiesByIdAsJsonObject(any(), any())).thenReturn(gson.toJsonTree(user).getAsJsonObject());
-    doThrow(new ServerErrorException(HttpStatusCodes.STATUS_CODE_SERVER_ERROR)).when(supportRequestService).handleSuggestedUserFieldsSupportRequest(any(), any(), any());
-    initResource();
-    Response response = userResource.update(authUser, uriInfo, user.getUserId(), gson.toJson(userUpdateFields));
-    assertEquals(HttpStatusCodes.STATUS_CODE_SERVER_ERROR, response.getStatus());
-  }
-
-  @Test
   public void testUpdateSelf() {
     User user = createUserWithRole();
     UserUpdateFields userUpdateFields = new UserUpdateFields();
@@ -417,9 +388,11 @@ public class UserResourceTest {
     when(userService.findUserByEmail(any())).thenReturn(user);
     when(userService.updateUserFieldsById(any(), any())).thenReturn(user);
     when(userService.findUserWithPropertiesByIdAsJsonObject(any(), any())).thenReturn(gson.toJsonTree(user).getAsJsonObject());
+    spy(supportRequestService);
     initResource();
     Response response = userResource.updateSelf(authUser, uriInfo, gson.toJson(userUpdateFields));
     assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+    verify(supportRequestService, times(1)).handleSuggestedUserFieldsSupportRequest(any(), any(), any());
   }
 
   @Test
@@ -432,9 +405,41 @@ public class UserResourceTest {
     when(userService.findUserByEmail(any())).thenReturn(user);
     when(userService.updateUserFieldsById(any(), any())).thenReturn(user);
     when(userService.findUserWithPropertiesByIdAsJsonObject(any(), any())).thenReturn(gson.toJsonTree(user).getAsJsonObject());
+    spy(supportRequestService);
     initResource();
     Response response = userResource.updateSelf(authUser, uriInfo, gson.toJson(userUpdateFields));
     assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
+    //no support request sent if update to user fails
+    verify(supportRequestService, times(0)).handleSuggestedUserFieldsSupportRequest(any(), any(), any());
+  }
+
+  @Test
+  public void testUpdateSelfSupportRequestError() {
+    User user = createUserWithRole();
+    UserUpdateFields userUpdateFields = new UserUpdateFields();
+    Gson gson = new Gson();
+    when(userService.findUserById(any())).thenReturn(user);
+    when(userService.findUserByEmail(any())).thenReturn(user);
+    when(userService.updateUserFieldsById(any(), any())).thenReturn(user);
+    when(userService.findUserWithPropertiesByIdAsJsonObject(any(), any())).thenReturn(gson.toJsonTree(user).getAsJsonObject());
+    doThrow(new ServerErrorException(HttpStatusCodes.STATUS_CODE_SERVER_ERROR))
+            .when(supportRequestService).handleSuggestedUserFieldsSupportRequest(any(), any(), any());
+    initResource();
+    Response response = userResource.updateSelf(authUser, uriInfo, gson.toJson(userUpdateFields));
+    assertEquals(HttpStatusCodes.STATUS_CODE_SERVER_ERROR, response.getStatus());
+  }
+
+  @Test
+  public void testUpdate() {
+    User user = createUserWithRole();
+    UserUpdateFields userUpdateFields = new UserUpdateFields();
+    Gson gson = new Gson();
+    when(userService.findUserById(any())).thenReturn(user);
+    when(userService.updateUserFieldsById(any(), any())).thenReturn(user);
+    when(userService.findUserWithPropertiesByIdAsJsonObject(any(), any())).thenReturn(gson.toJsonTree(user).getAsJsonObject());
+    initResource();
+    Response response = userResource.update(authUser, uriInfo, user.getUserId(), gson.toJson(userUpdateFields));
+    assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
@@ -402,7 +402,7 @@ public class UserResourceTest {
     when(userService.findUserById(any())).thenReturn(user);
     when(userService.updateUserFieldsById(any(), any())).thenReturn(user);
     when(userService.findUserWithPropertiesByIdAsJsonObject(any(), any())).thenReturn(gson.toJsonTree(user).getAsJsonObject());
-    doThrow(new ServerErrorException(HttpStatusCodes.STATUS_CODE_SERVER_ERROR)).when(supportRequestService).sendSuggestedPropertiesToSupport(any(), any(), any());
+    doThrow(new ServerErrorException(HttpStatusCodes.STATUS_CODE_SERVER_ERROR)).when(supportRequestService).handleSuggestedUserFieldsSupportRequest(any(), any(), any());
     initResource();
     Response response = userResource.update(authUser, uriInfo, user.getUserId(), gson.toJson(userUpdateFields));
     assertEquals(HttpStatusCodes.STATUS_CODE_SERVER_ERROR, response.getStatus());

--- a/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
@@ -391,7 +391,7 @@ public class UserResourceTest {
     initResource();
     Response response = userResource.update(authUser, uriInfo, user.getUserId(), gson.toJson(userUpdateFields));
     assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
-    verify(supportRequestService, times(1)).sendSuggestedPropertiesToSupport(any(), any(), any());
+    verify(supportRequestService, times(1)).handleSuggestedUserFieldsSupportRequest(any(), any(), any());
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
@@ -426,7 +426,6 @@ public class UserResourceTest {
     assertEquals(HttpStatusCodes.STATUS_CODE_SERVER_ERROR, response.getStatus());
   }
 
-
   @Test
   public void testDeleteRoleFromUser() {
     User user = createUserWithRole();

--- a/src/test/java/org/broadinstitute/consent/http/service/SupportRequestServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/SupportRequestServiceTest.java
@@ -113,7 +113,7 @@ public class SupportRequestServiceTest {
         SupportTicket ticket = generateTicket();
         SupportTicket.SupportRequest supportRequest = ticket.getRequest();
         CustomRequestField customField = supportRequest.getCustomFields().get(0);
-        String ticketJson =  String.format("{\n" +
+        String ticketJson = String.format("{\n" +
                         "  \"request\": {\n" +
                         "    \"requester\": {\n" +
                         "      \"name\": \"%s\",\n" +

--- a/src/test/java/org/broadinstitute/consent/http/service/SupportRequestServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/SupportRequestServiceTest.java
@@ -4,6 +4,7 @@ import com.google.api.client.http.HttpStatusCodes;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.RandomUtils;
 import org.broadinstitute.consent.http.configurations.ServicesConfiguration;
+import org.broadinstitute.consent.http.enumeration.SupportRequestType;
 import org.broadinstitute.consent.http.models.AuthUser;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.UserUpdateFields;
@@ -71,7 +72,7 @@ public class SupportRequestServiceTest {
     @Test
     public void testCreateSupportTicket() {
         String name = RandomStringUtils.randomAlphabetic(10);
-        String type = RandomStringUtils.randomAlphabetic(10);
+        SupportRequestType type = SupportRequestType.QUESTION;
         String email = RandomStringUtils.randomAlphabetic(10);
         String subject = RandomStringUtils.randomAlphabetic(10);
         String description = RandomStringUtils.randomAlphabetic(10);
@@ -88,7 +89,7 @@ public class SupportRequestServiceTest {
 
         List<CustomRequestField> customFields = supportRequest.getCustomFields();
         assertEquals(5, customFields.size());
-        assertTrue(customFields.contains(new CustomRequestField(360012744452L, type)));
+        assertTrue(customFields.contains(new CustomRequestField(360012744452L, type.getValue())));
         assertTrue(customFields.contains(new CustomRequestField(360007369412L, description)));
         assertTrue(customFields.contains(new CustomRequestField(360012744292L, name)));
         assertTrue(customFields.contains(new CustomRequestField(360012782111L, email)));
@@ -100,7 +101,7 @@ public class SupportRequestServiceTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void testCreateSupportTicketMissingField() {
-        String type = RandomStringUtils.randomAlphabetic(10);
+        SupportRequestType type = SupportRequestType.QUESTION;
         String email = RandomStringUtils.randomAlphabetic(10);
         String subject = RandomStringUtils.randomAlphabetic(10);
         String description = RandomStringUtils.randomAlphabetic(10);
@@ -213,7 +214,7 @@ public class SupportRequestServiceTest {
                 suggestedInstitution);
         List<CustomRequestField> customFields = supportRequest.getCustomFields();
         assertEquals(5, customFields.size());
-        assertTrue(customFields.contains(new CustomRequestField(360012744452L, "task")));
+        assertTrue(customFields.contains(new CustomRequestField(360012744452L, SupportRequestType.TASK.getValue())));
         assertTrue(customFields.contains(new CustomRequestField(360007369412L, expectedDescription)));
         assertTrue(customFields.contains(new CustomRequestField(360012744292L, displayName)));
         assertTrue(customFields.contains(new CustomRequestField(360012782111L, email)));
@@ -248,7 +249,7 @@ public class SupportRequestServiceTest {
                 suggestedSigningOfficial);
         List<CustomRequestField> customFields = supportRequest.getCustomFields();
         assertEquals(5, customFields.size());
-        assertTrue(customFields.contains(new CustomRequestField(360012744452L, "task")));
+        assertTrue(customFields.contains(new CustomRequestField(360012744452L, SupportRequestType.TASK.getValue())));
         assertTrue(customFields.contains(new CustomRequestField(360007369412L, expectedDescription)));
         assertTrue(customFields.contains(new CustomRequestField(360012744292L, displayName)));
         assertTrue(customFields.contains(new CustomRequestField(360012782111L, email)));
@@ -286,7 +287,7 @@ public class SupportRequestServiceTest {
                 suggestedInstitution);
         List<CustomRequestField> customFields = supportRequest.getCustomFields();
         assertEquals(5, customFields.size());
-        assertTrue(customFields.contains(new CustomRequestField(360012744452L, "task")));
+        assertTrue(customFields.contains(new CustomRequestField(360012744452L, SupportRequestType.TASK.getValue())));
         assertTrue(customFields.contains(new CustomRequestField(360007369412L, expectedDescription)));
         assertTrue(customFields.contains(new CustomRequestField(360012744292L, displayName)));
         assertTrue(customFields.contains(new CustomRequestField(360012782111L, email)));

--- a/src/test/java/org/broadinstitute/consent/http/service/SupportRequestServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/SupportRequestServiceTest.java
@@ -60,6 +60,7 @@ public class SupportRequestServiceTest {
     public void setUp() throws Exception {
         MockitoAnnotations.openMocks(this);
         mockServerClient = new MockServerClient(container.getHost(), container.getServerPort());
+        when(config.isActivateSupportNotifications()).thenReturn(true);
         when(config.postSupportRequestUrl()).thenReturn("http://" + container.getHost() + ":" + container.getServerPort() + "/");
         service = new SupportRequestService(config);
     }
@@ -150,6 +151,15 @@ public class SupportRequestServiceTest {
         assertEquals(1, requests.length);
         Object requestBody = requests[0].getBody().getValue();
         assertEquals(expectedBody, requestBody);
+    }
+
+    @Test
+    public void testPostTicketToSupportNotificationsNotActivated() throws Exception {
+        SupportTicket ticket = generateTicket();
+        when(config.isActivateSupportNotifications()).thenReturn(false);
+        // verify no requests sent if activateSupportNotifications is false; throw error if post attempted
+        mockServerClient.when(request()).error(new HttpError());
+        service.postTicketToSupport(ticket, authUser);
     }
 
     @Test(expected = ServerErrorException.class)

--- a/src/test/java/org/broadinstitute/consent/http/service/SupportRequestServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/SupportRequestServiceTest.java
@@ -113,7 +113,7 @@ public class SupportRequestServiceTest {
         SupportTicket ticket = generateTicket();
         SupportTicket.SupportRequest supportRequest = ticket.getRequest();
         CustomRequestField customField = supportRequest.getCustomFields().get(0);
-        String ticketJson = String.format("{\n" +
+        String expectedBody = String.format("{\n" +
                         "  \"request\": {\n" +
                         "    \"requester\": {\n" +
                         "      \"name\": \"%s\",\n" +
@@ -148,7 +148,7 @@ public class SupportRequestServiceTest {
         HttpRequest[] requests = mockServerClient.retrieveRecordedRequests(null);
         assertEquals(1, requests.length);
         Object requestBody = requests[0].getBody().getValue();
-        assertEquals(ticketJson, requestBody);
+        assertEquals(expectedBody, requestBody);
     }
 
     @Test(expected = ServerErrorException.class)

--- a/src/test/java/org/broadinstitute/consent/http/service/SupportRequestServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/SupportRequestServiceTest.java
@@ -5,6 +5,8 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.RandomUtils;
 import org.broadinstitute.consent.http.configurations.ServicesConfiguration;
 import org.broadinstitute.consent.http.models.AuthUser;
+import org.broadinstitute.consent.http.models.User;
+import org.broadinstitute.consent.http.models.UserUpdateFields;
 import org.broadinstitute.consent.http.models.support.CustomRequestField;
 import org.broadinstitute.consent.http.models.support.SupportRequestComment;
 import org.broadinstitute.consent.http.models.support.SupportRequester;
@@ -17,7 +19,9 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockserver.client.MockServerClient;
 import org.mockserver.model.Header;
+import org.mockserver.model.HttpError;
 import org.mockserver.model.HttpRequest;
+import org.mockserver.verify.VerificationTimes;
 import org.testcontainers.containers.MockServerContainer;
 
 import javax.ws.rs.ServerErrorException;
@@ -29,6 +33,7 @@ import static org.broadinstitute.consent.http.WithMockServer.IMAGE;
 import static org.eclipse.jetty.util.component.LifeCycle.stop;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 import static org.mockserver.model.HttpRequest.request;
@@ -106,69 +111,9 @@ public class SupportRequestServiceTest {
     @Test
     public void testPostTicketToSupport() throws Exception {
         SupportTicket ticket = generateTicket();
-        mockServerClient.when(request().withMethod("POST"))
-                .respond(response()
-                        .withHeader(Header.header("Content-Type", "application/json"))
-                        .withStatusCode(HttpStatusCodes.STATUS_CODE_OK));
-        service.postTicketToSupport(ticket, authUser);
-
-        HttpRequest[] requests = mockServerClient.retrieveRecordedRequests(null);
-        assertEquals(1, requests.length);
-        Object requestBody = requests[0].getBody().getValue();
-        assertEquals(convertTicketToJson(ticket), requestBody);
-    }
-
-    @Test(expected = ServerErrorException.class)
-    public void testPostTicketToSupportServerError() throws Exception {
-        mockServerClient.when(request())
-                .respond(response()
-                        .withHeader(Header.header("Content-Type", "application/json"))
-                        .withStatusCode(HttpStatusCodes.STATUS_CODE_SERVER_ERROR));
-        service.postTicketToSupport(generateTicket(), authUser);
-    }
-
-    @Test
-    public void testSendSuggestedPropertiesToSupport_NoUpdates() {
-
-    }
-
-    @Test
-    public void testSendSuggestedPropertiesToSupport_Institution() {
-
-    }
-
-    @Test
-    public void testSendSuggestedPropertiesToSupport_SigningOfficial() {
-
-    }
-
-    @Test
-    public void testSendSuggestedPropertiesToSupport_InstitutionSigningOfficial() {
-
-    }
-
-
-    //creates support ticket with random values for testing postTicketToSupport
-    private SupportTicket generateTicket() {
-        SupportRequester requester = new SupportRequester(
-                RandomStringUtils.randomAlphabetic(10),
-                RandomStringUtils.randomAlphabetic(10)
-        );
-        String subject = RandomStringUtils.randomAlphabetic(10);
-        List<CustomRequestField> customFields = new ArrayList<>();
-        customFields.add(new CustomRequestField(
-                RandomUtils.nextLong(),
-                RandomStringUtils.randomAlphabetic(10)
-        ));
-        SupportRequestComment comment = new SupportRequestComment(RandomStringUtils.randomAlphabetic(10));
-
-        return new SupportTicket(requester, subject, customFields, comment);
-    }
-
-    private String convertTicketToJson(SupportTicket ticket) {
         SupportTicket.SupportRequest supportRequest = ticket.getRequest();
         CustomRequestField customField = supportRequest.getCustomFields().get(0);
-        return String.format("{\n" +
+        String ticketJson =  String.format("{\n" +
                         "  \"request\": {\n" +
                         "    \"requester\": {\n" +
                         "      \"name\": \"%s\",\n" +
@@ -193,5 +138,194 @@ public class SupportRequestServiceTest {
                 customField.getId(),
                 customField.getValue(),
                 supportRequest.getComment().getBody());
+
+        mockServerClient.when(request().withMethod("POST"))
+                .respond(response()
+                        .withHeader(Header.header("Content-Type", "application/json"))
+                        .withStatusCode(HttpStatusCodes.STATUS_CODE_OK));
+        service.postTicketToSupport(ticket, authUser);
+
+        HttpRequest[] requests = mockServerClient.retrieveRecordedRequests(null);
+        assertEquals(1, requests.length);
+        Object requestBody = requests[0].getBody().getValue();
+        assertEquals(ticketJson, requestBody);
+    }
+
+    @Test(expected = ServerErrorException.class)
+    public void testPostTicketToSupportServerError() throws Exception {
+        mockServerClient.when(request())
+                .respond(response()
+                        .withHeader(Header.header("Content-Type", "application/json"))
+                        .withStatusCode(HttpStatusCodes.STATUS_CODE_SERVER_ERROR));
+        service.postTicketToSupport(generateTicket(), authUser);
+    }
+
+    @Test
+    public void testHandleSuggestedUserFieldsSupportRequest() {
+        String displayName = RandomStringUtils.randomAlphabetic(10);
+        String email = RandomStringUtils.randomAlphabetic(10);
+        User user = new User();
+        user.setDisplayName(displayName);
+        user.setEmail(email);
+        UserUpdateFields updateFields = new UserUpdateFields();
+        updateFields.setSuggestedInstitution(RandomStringUtils.randomAlphabetic(10));
+
+        mockServerClient.when(request())
+                .respond(response()
+                        .withHeader(Header.header("Content-Type", "application/json"))
+                        .withStatusCode(HttpStatusCodes.STATUS_CODE_OK));
+        service.handleSuggestedUserFieldsSupportRequest(updateFields, user, authUser);
+        mockServerClient.verify(request().withMethod("POST"), VerificationTimes.exactly(1));
+    }
+
+    @Test
+    public void testHandleSuggestedUserFieldsSupportRequest_NoUpdates() {
+        UserUpdateFields updateFields = new UserUpdateFields();
+        // verify no requests sent if no suggested user fields are provided; fail if request attempted
+        mockServerClient.when(request()).error(new HttpError());
+        service.handleSuggestedUserFieldsSupportRequest(updateFields, new User(), authUser);
+        assertNull(updateFields.getSuggestedInstitution());
+        assertNull(updateFields.getSuggestedSigningOfficial());
+    }
+
+    @Test
+    public void testCreateSuggestedUserFieldsTicket_Institution() {
+        String displayName = RandomStringUtils.randomAlphabetic(10);
+        String email = RandomStringUtils.randomAlphabetic(10);
+        User user = new User();
+        user.setDisplayName(displayName);
+        user.setEmail(email);
+
+        String suggestedInstitution = RandomStringUtils.randomAlphabetic(10);
+        UserUpdateFields updateFields = new UserUpdateFields();
+        updateFields.setSuggestedInstitution(suggestedInstitution);
+
+        SupportTicket ticket = service.createSuggestedUserFieldsTicket(updateFields, user);
+        SupportTicket.SupportRequest supportRequest = ticket.getRequest();
+        assertEquals(displayName, supportRequest.getRequester().getName());
+        assertEquals(email, supportRequest.getRequester().getEmail());
+        assertEquals("New Institution Request", supportRequest.getSubject());
+        assertEquals(360000669472L, supportRequest.getTicketFormId());
+
+        String expectedDescription = String.format("User %s [%s] has requested a new institution: {%s}",
+                user.getDisplayName(),
+                user.getEmail(),
+                suggestedInstitution);
+        List<CustomRequestField> customFields = supportRequest.getCustomFields();
+        assertEquals(5, customFields.size());
+        assertTrue(customFields.contains(new CustomRequestField(360012744452L, "task")));
+        assertTrue(customFields.contains(new CustomRequestField(360007369412L, expectedDescription)));
+        assertTrue(customFields.contains(new CustomRequestField(360012744292L, displayName)));
+        assertTrue(customFields.contains(new CustomRequestField(360012782111L, email)));
+        assertTrue(customFields.contains(new CustomRequestField(360018545031L, email)));
+
+        String commentBody = expectedDescription + "\n\n------------------\nSubmitted from: " + config.postSupportRequestUrl();
+        assertEquals(commentBody, supportRequest.getComment().getBody());
+    }
+
+    @Test
+    public void testCreateSuggestedUserFieldsTicket_SigningOfficial() {
+        String displayName = RandomStringUtils.randomAlphabetic(10);
+        String email = RandomStringUtils.randomAlphabetic(10);
+        User user = new User();
+        user.setDisplayName(displayName);
+        user.setEmail(email);
+
+        String suggestedSigningOfficial = RandomStringUtils.randomAlphabetic(10);
+        UserUpdateFields updateFields = new UserUpdateFields();
+        updateFields.setSuggestedSigningOfficial(suggestedSigningOfficial);
+
+        SupportTicket ticket = service.createSuggestedUserFieldsTicket(updateFields, user);
+        SupportTicket.SupportRequest supportRequest = ticket.getRequest();
+        assertEquals(displayName, supportRequest.getRequester().getName());
+        assertEquals(email, supportRequest.getRequester().getEmail());
+        assertEquals("New Signing Official Request", supportRequest.getSubject());
+        assertEquals(360000669472L, supportRequest.getTicketFormId());
+
+        String expectedDescription = String.format("User %s [%s] has requested a new signing official: {%s}",
+                user.getDisplayName(),
+                user.getEmail(),
+                suggestedSigningOfficial);
+        List<CustomRequestField> customFields = supportRequest.getCustomFields();
+        assertEquals(5, customFields.size());
+        assertTrue(customFields.contains(new CustomRequestField(360012744452L, "task")));
+        assertTrue(customFields.contains(new CustomRequestField(360007369412L, expectedDescription)));
+        assertTrue(customFields.contains(new CustomRequestField(360012744292L, displayName)));
+        assertTrue(customFields.contains(new CustomRequestField(360012782111L, email)));
+        assertTrue(customFields.contains(new CustomRequestField(360018545031L, email)));
+
+        String commentBody = expectedDescription + "\n\n------------------\nSubmitted from: " + config.postSupportRequestUrl();
+        assertEquals(commentBody, supportRequest.getComment().getBody());
+    }
+
+    @Test
+    public void testCreateSuggestedUserFieldsTicket_InstitutionSigningOfficial() {
+        String displayName = RandomStringUtils.randomAlphabetic(10);
+        String email = RandomStringUtils.randomAlphabetic(10);
+        User user = new User();
+        user.setDisplayName(displayName);
+        user.setEmail(email);
+
+        String suggestedSigningOfficial = RandomStringUtils.randomAlphabetic(10);
+        String suggestedInstitution = RandomStringUtils.randomAlphabetic(10);
+        UserUpdateFields updateFields = new UserUpdateFields();
+        updateFields.setSuggestedSigningOfficial(suggestedSigningOfficial);
+        updateFields.setSuggestedInstitution(suggestedInstitution);
+
+        SupportTicket ticket = service.createSuggestedUserFieldsTicket(updateFields, user);
+        SupportTicket.SupportRequest supportRequest = ticket.getRequest();
+        assertEquals(displayName, supportRequest.getRequester().getName());
+        assertEquals(email, supportRequest.getRequester().getEmail());
+        assertEquals("New Institution and Signing Official Request", supportRequest.getSubject());
+        assertEquals(360000669472L, supportRequest.getTicketFormId());
+
+        String expectedDescription = String.format("User %s [%s] has requested a new signing official: {%s} and has requested a new institution: {%s}",
+                user.getDisplayName(),
+                user.getEmail(),
+                suggestedSigningOfficial,
+                suggestedInstitution);
+        List<CustomRequestField> customFields = supportRequest.getCustomFields();
+        assertEquals(5, customFields.size());
+        assertTrue(customFields.contains(new CustomRequestField(360012744452L, "task")));
+        assertTrue(customFields.contains(new CustomRequestField(360007369412L, expectedDescription)));
+        assertTrue(customFields.contains(new CustomRequestField(360012744292L, displayName)));
+        assertTrue(customFields.contains(new CustomRequestField(360012782111L, email)));
+        assertTrue(customFields.contains(new CustomRequestField(360018545031L, email)));
+
+        String commentBody = expectedDescription + "\n\n------------------\nSubmitted from: " + config.postSupportRequestUrl();
+        assertEquals(commentBody, supportRequest.getComment().getBody());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testCreateSuggestedUserFieldsTicket_NoFieldsError() {
+        String displayName = RandomStringUtils.randomAlphabetic(10);
+        String email = RandomStringUtils.randomAlphabetic(10);
+        User user = new User();
+        user.setDisplayName(displayName);
+        user.setEmail(email);
+        //fail to create ticket if both suggestedSigningOfficial and suggestedInstitution are null
+        UserUpdateFields updateFields = new UserUpdateFields();
+        assertNull(updateFields.getSuggestedSigningOfficial());
+        assertNull(updateFields.getSuggestedInstitution());
+
+        service.createSuggestedUserFieldsTicket(updateFields, user);
+    }
+
+
+    //creates support ticket with random values for testing postTicketToSupport
+    private SupportTicket generateTicket() {
+        SupportRequester requester = new SupportRequester(
+                RandomStringUtils.randomAlphabetic(10),
+                RandomStringUtils.randomAlphabetic(10)
+        );
+        String subject = RandomStringUtils.randomAlphabetic(10);
+        List<CustomRequestField> customFields = new ArrayList<>();
+        customFields.add(new CustomRequestField(
+                RandomUtils.nextLong(),
+                RandomStringUtils.randomAlphabetic(10)
+        ));
+        SupportRequestComment comment = new SupportRequestComment(RandomStringUtils.randomAlphabetic(10));
+
+        return new SupportTicket(requester, subject, customFields, comment);
     }
 }

--- a/src/test/java/org/broadinstitute/consent/http/service/SupportRequestServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/SupportRequestServiceTest.java
@@ -106,34 +106,6 @@ public class SupportRequestServiceTest {
     @Test
     public void testPostTicketToSupport() throws Exception {
         SupportTicket ticket = generateTicket();
-        SupportTicket.SupportRequest supportRequest = ticket.getRequest();
-        CustomRequestField customField = supportRequest.getCustomFields().get(0);
-        String expectedBody = String.format("{\n" +
-                "  \"request\": {\n" +
-                "    \"requester\": {\n" +
-                "      \"name\": \"%s\",\n" +
-                "      \"email\": \"%s\"\n" +
-                "    },\n" +
-                "    \"subject\": \"%s\",\n" +
-                "    \"custom_fields\": [\n" +
-                "      {\n" +
-                "        \"id\": %d,\n" +
-                "        \"value\": \"%s\"\n" +
-                "      }\n" +
-                "    ],\n" +
-                "    \"comment\": {\n" +
-                "      \"body\": \"%s\"\n" +
-                "    },\n" +
-                "    \"ticket_form_id\": 360000669472\n" +
-                "  }\n" +
-                "}",
-                supportRequest.getRequester().getName(),
-                supportRequest.getRequester().getEmail(),
-                supportRequest.getSubject(),
-                customField.getId(),
-                customField.getValue(),
-                supportRequest.getComment().getBody());
-
         mockServerClient.when(request().withMethod("POST"))
                 .respond(response()
                         .withHeader(Header.header("Content-Type", "application/json"))
@@ -143,7 +115,7 @@ public class SupportRequestServiceTest {
         HttpRequest[] requests = mockServerClient.retrieveRecordedRequests(null);
         assertEquals(1, requests.length);
         Object requestBody = requests[0].getBody().getValue();
-        assertEquals(expectedBody, requestBody);
+        assertEquals(convertTicketToJson(ticket), requestBody);
     }
 
     @Test(expected = ServerErrorException.class)
@@ -154,6 +126,27 @@ public class SupportRequestServiceTest {
                         .withStatusCode(HttpStatusCodes.STATUS_CODE_SERVER_ERROR));
         service.postTicketToSupport(generateTicket(), authUser);
     }
+
+    @Test
+    public void testSendSuggestedPropertiesToSupport_NoUpdates() {
+
+    }
+
+    @Test
+    public void testSendSuggestedPropertiesToSupport_Institution() {
+
+    }
+
+    @Test
+    public void testSendSuggestedPropertiesToSupport_SigningOfficial() {
+
+    }
+
+    @Test
+    public void testSendSuggestedPropertiesToSupport_InstitutionSigningOfficial() {
+
+    }
+
 
     //creates support ticket with random values for testing postTicketToSupport
     private SupportTicket generateTicket() {
@@ -170,5 +163,35 @@ public class SupportRequestServiceTest {
         SupportRequestComment comment = new SupportRequestComment(RandomStringUtils.randomAlphabetic(10));
 
         return new SupportTicket(requester, subject, customFields, comment);
+    }
+
+    private String convertTicketToJson(SupportTicket ticket) {
+        SupportTicket.SupportRequest supportRequest = ticket.getRequest();
+        CustomRequestField customField = supportRequest.getCustomFields().get(0);
+        return String.format("{\n" +
+                        "  \"request\": {\n" +
+                        "    \"requester\": {\n" +
+                        "      \"name\": \"%s\",\n" +
+                        "      \"email\": \"%s\"\n" +
+                        "    },\n" +
+                        "    \"subject\": \"%s\",\n" +
+                        "    \"custom_fields\": [\n" +
+                        "      {\n" +
+                        "        \"id\": %d,\n" +
+                        "        \"value\": \"%s\"\n" +
+                        "      }\n" +
+                        "    ],\n" +
+                        "    \"comment\": {\n" +
+                        "      \"body\": \"%s\"\n" +
+                        "    },\n" +
+                        "    \"ticket_form_id\": 360000669472\n" +
+                        "  }\n" +
+                        "}",
+                supportRequest.getRequester().getName(),
+                supportRequest.getRequester().getEmail(),
+                supportRequest.getSubject(),
+                customField.getId(),
+                customField.getValue(),
+                supportRequest.getComment().getBody());
     }
 }


### PR DESCRIPTION
Addresses  [DUOS-1891](https://broadworkbench.atlassian.net/browse/DUOS-1891)
Summary of Changes:
- Create method in `SupportRequestService` to handle creating and sending a Zendesk support ticket when `PUT /api/user` endpoint has been provided a `suggestedInstitution` and/or `suggestedSigningOfficial`
       - Do nothing if both are null 
       - Different subject and description based on which user update fields are provided 
- Add tests to make sure the request is being sent in the appropriate scenarios with the correct information 

See #1652 for minor PR swapping out a string for an enum in support ticket creation 

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
