### PR TITLE
[DUOS-1891][risk=no] Implement SupportRequestType enum

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/enumeration/SupportRequestType.java
+++ b/src/main/java/org/broadinstitute/consent/http/enumeration/SupportRequestType.java
@@ -1,0 +1,16 @@
+package org.broadinstitute.consent.http.enumeration;
+
+public enum SupportRequestType {
+
+    QUESTION("question"), INCIDENT("incident"), PROBLEM("problem"), TASK("task");
+
+    private final String value;
+
+    SupportRequestType(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/src/main/java/org/broadinstitute/consent/http/service/SupportRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/SupportRequestService.java
@@ -10,6 +10,7 @@ import com.google.gson.FieldNamingPolicy;
 import com.google.gson.GsonBuilder;
 import com.google.inject.Inject;
 import org.broadinstitute.consent.http.configurations.ServicesConfiguration;
+import org.broadinstitute.consent.http.enumeration.SupportRequestType;
 import org.broadinstitute.consent.http.models.AuthUser;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.UserUpdateFields;
@@ -34,7 +35,6 @@ public class SupportRequestService {
     private final ServicesConfiguration configuration;
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
-    private static final String TASK_REQUEST_TYPE = "task";
 
     @Inject
     public SupportRequestService(ServicesConfiguration configuration) {
@@ -53,7 +53,7 @@ public class SupportRequestService {
      * @param url         The API url of this request
      * @return A structured ticket used to make the request
      */
-    public SupportTicket createSupportTicket(String name, String type, String email, String subject, String description, String url) {
+    public SupportTicket createSupportTicket(String name, SupportRequestType type, String email, String subject, String description, String url) {
         if (Objects.isNull(name) || Objects.isNull(email)) {
             throw new IllegalArgumentException("Name and email of user requesting support is required");
         }
@@ -72,7 +72,7 @@ public class SupportRequestService {
 
         SupportRequester requester = new SupportRequester(name, email);
         List<CustomRequestField> customFields = new ArrayList<>();
-        customFields.add(new CustomRequestField(360012744452L, type));
+        customFields.add(new CustomRequestField(360012744452L, type.getValue()));
         customFields.add(new CustomRequestField(360007369412L, description));
         customFields.add(new CustomRequestField(360012744292L, name));
         customFields.add(new CustomRequestField(360012782111L, email));
@@ -164,7 +164,7 @@ public class SupportRequestService {
 
         return createSupportTicket(
                 user.getDisplayName(),
-                TASK_REQUEST_TYPE,
+                SupportRequestType.TASK,
                 user.getEmail(),
                 subject,
                 description,

--- a/src/test/java/org/broadinstitute/consent/http/service/SupportRequestServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/SupportRequestServiceTest.java
@@ -4,6 +4,7 @@ import com.google.api.client.http.HttpStatusCodes;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.RandomUtils;
 import org.broadinstitute.consent.http.configurations.ServicesConfiguration;
+import org.broadinstitute.consent.http.enumeration.SupportRequestType;
 import org.broadinstitute.consent.http.models.AuthUser;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.UserUpdateFields;
@@ -71,7 +72,7 @@ public class SupportRequestServiceTest {
     @Test
     public void testCreateSupportTicket() {
         String name = RandomStringUtils.randomAlphabetic(10);
-        String type = RandomStringUtils.randomAlphabetic(10);
+        SupportRequestType type = SupportRequestType.QUESTION;
         String email = RandomStringUtils.randomAlphabetic(10);
         String subject = RandomStringUtils.randomAlphabetic(10);
         String description = RandomStringUtils.randomAlphabetic(10);
@@ -88,7 +89,7 @@ public class SupportRequestServiceTest {
 
         List<CustomRequestField> customFields = supportRequest.getCustomFields();
         assertEquals(5, customFields.size());
-        assertTrue(customFields.contains(new CustomRequestField(360012744452L, type)));
+        assertTrue(customFields.contains(new CustomRequestField(360012744452L, type.getValue())));
         assertTrue(customFields.contains(new CustomRequestField(360007369412L, description)));
         assertTrue(customFields.contains(new CustomRequestField(360012744292L, name)));
         assertTrue(customFields.contains(new CustomRequestField(360012782111L, email)));
@@ -100,7 +101,7 @@ public class SupportRequestServiceTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void testCreateSupportTicketMissingField() {
-        String type = RandomStringUtils.randomAlphabetic(10);
+        SupportRequestType type = SupportRequestType.QUESTION;
         String email = RandomStringUtils.randomAlphabetic(10);
         String subject = RandomStringUtils.randomAlphabetic(10);
         String description = RandomStringUtils.randomAlphabetic(10);
@@ -213,7 +214,7 @@ public class SupportRequestServiceTest {
                 suggestedInstitution);
         List<CustomRequestField> customFields = supportRequest.getCustomFields();
         assertEquals(5, customFields.size());
-        assertTrue(customFields.contains(new CustomRequestField(360012744452L, "task")));
+        assertTrue(customFields.contains(new CustomRequestField(360012744452L, SupportRequestType.TASK.getValue())));
         assertTrue(customFields.contains(new CustomRequestField(360007369412L, expectedDescription)));
         assertTrue(customFields.contains(new CustomRequestField(360012744292L, displayName)));
         assertTrue(customFields.contains(new CustomRequestField(360012782111L, email)));
@@ -248,7 +249,7 @@ public class SupportRequestServiceTest {
                 suggestedSigningOfficial);
         List<CustomRequestField> customFields = supportRequest.getCustomFields();
         assertEquals(5, customFields.size());
-        assertTrue(customFields.contains(new CustomRequestField(360012744452L, "task")));
+        assertTrue(customFields.contains(new CustomRequestField(360012744452L, SupportRequestType.TASK.getValue())));
         assertTrue(customFields.contains(new CustomRequestField(360007369412L, expectedDescription)));
         assertTrue(customFields.contains(new CustomRequestField(360012744292L, displayName)));
         assertTrue(customFields.contains(new CustomRequestField(360012782111L, email)));
@@ -286,7 +287,7 @@ public class SupportRequestServiceTest {
                 suggestedInstitution);
         List<CustomRequestField> customFields = supportRequest.getCustomFields();
         assertEquals(5, customFields.size());
-        assertTrue(customFields.contains(new CustomRequestField(360012744452L, "task")));
+        assertTrue(customFields.contains(new CustomRequestField(360012744452L, SupportRequestType.TASK.getValue())));
         assertTrue(customFields.contains(new CustomRequestField(360007369412L, expectedDescription)));
         assertTrue(customFields.contains(new CustomRequestField(360012744292L, displayName)));
         assertTrue(customFields.contains(new CustomRequestField(360012782111L, email)));


### PR DESCRIPTION

Minor to change to #1651 

Creates enum for type field of a support ticket, as detailed [https://developer.zendesk.com/api-reference/ticketing/tickets/ticket-requests/#json-format](https://developer.zendesk.com/api-reference/ticketing/tickets/ticket-requests/#json-format)

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
