### PR TITLE
DUOS-1914[risk=no] Added service method for DarCollectionSummary

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
@@ -198,7 +198,8 @@ public class ConsentModule extends AbstractModule {
             providesDataAccessRequestDAO(),
             providesEmailNotifierService(),
             providesVoteDAO(),
-            providesMatchDAO()
+            providesMatchDAO(),
+            providesDarCollectionSummaryDAO()
         );
     }
 

--- a/src/main/java/org/broadinstitute/consent/http/db/DarCollectionSummaryDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DarCollectionSummaryDAO.java
@@ -115,9 +115,10 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
   @UseRowReducer(DarCollectionSummaryReducer.class)
   @SqlQuery
   (
-    "SELECT c.collection_id as dar_collection_id, c.dar_code, dar.submission_date, u.display_name as researcher_name, " +
+    "SELECT c.collection_id as dar_collection_id, c.dar_code, dar.submission_date, dar.reference_id as dar_reference_id, u.display_name as researcher_name, " +
       "i.institution_name, e.electionid, e.status, e.datasetid, e.referenceid, dd.dataset_id as dd_datasetid, " +      
-      "(dar.data #>> '{}')::jsonb ->> 'projectTitle' AS name " +
+      "(dar.data #>> '{}')::jsonb ->> 'projectTitle' AS name, " +
+      "(dar.data #>> '{}')::jsonb ->> 'status' AS dar_status " +
     "FROM dar_collection c " +
     "INNER JOIN users u " +
       "ON u.user_id = c.create_user_id " +

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DarCollectionSummaryReducer.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DarCollectionSummaryReducer.java
@@ -3,6 +3,7 @@ package org.broadinstitute.consent.http.db.mapper;
 import org.broadinstitute.consent.http.models.DarCollectionSummary;
 import org.broadinstitute.consent.http.models.Election;
 import org.broadinstitute.consent.http.models.Vote;
+import org.broadinstitute.consent.http.models.DataAccessRequestData;
 
 import java.lang.Integer;
 import java.util.Objects;
@@ -25,11 +26,22 @@ public class DarCollectionSummaryReducer implements LinkedHashMapRowReducer<Inte
     Election election;
     Vote vote;
     Integer datasetId;
+    String darStatus;
+    String darReferenceId;
     try {
-
       datasetId = rowView.getColumn("dd_datasetid", Integer.class);
       if (Objects.nonNull(datasetId)) {
         summary.addDatasetId(datasetId);
+      }
+      
+      try{
+        darStatus = rowView.getColumn("dar_status", String.class);
+        darReferenceId = rowView.getColumn("dar_reference_id", String.class);
+        if (Objects.nonNull(darStatus)) {
+          summary.addStatus(darStatus, darReferenceId);
+        }
+      } catch(MappingException e) {
+        //ignore exception, it means dar_status and dar_reference_id wasn't included for this query
       }
 
       election = rowView.getRow(Election.class);

--- a/src/main/java/org/broadinstitute/consent/http/enumeration/ElectionStatus.java
+++ b/src/main/java/org/broadinstitute/consent/http/enumeration/ElectionStatus.java
@@ -23,6 +23,15 @@ public enum ElectionStatus {
         return null;
     }
 
+    public static ElectionStatus getStatusFromString(String value) {
+        for (ElectionStatus e : ElectionStatus.values()) {
+            if (e.getValue().equalsIgnoreCase(value)) {
+                return e;
+            }
+        }
+        return null;
+    }
+
     public static String getValues() {
         StringBuilder values = new StringBuilder();
         for (ElectionStatus e : ElectionStatus.values()) {

--- a/src/main/java/org/broadinstitute/consent/http/models/DarCollectionSummary.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DarCollectionSummary.java
@@ -46,12 +46,14 @@ public class DarCollectionSummary {
   private Set<Integer> datasetIds;
   private List<Vote> votes;
   private Map<Integer, Election> elections;
+  private Map<String, String> darStatuses;
 
   public DarCollectionSummary() {
     this.votes = new ArrayList<>();
     this.actions = new HashSet<>();
     this.elections = new HashMap<>();
     this.datasetIds = new HashSet<>();
+    this.darStatuses = new HashMap<>();
     this.datasetCount = 0;
   }
 
@@ -167,6 +169,14 @@ public class DarCollectionSummary {
   public void addAction(String action) {
     String newAction = DarCollectionActions.valueOf(action.toUpperCase()).getValue();
     actions.add(newAction);
+  }
+
+  public void addStatus(String status, String referenceId) {
+    darStatuses.put(referenceId, status);
+  }
+
+  public Map<String, String> getDarStatuses() {
+    return darStatuses;
   }
 
   @Override

--- a/src/main/java/org/broadinstitute/consent/http/resources/DarCollectionResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DarCollectionResource.java
@@ -81,20 +81,20 @@ public class DarCollectionResource extends Resource {
     }
   }
 
-  // @GET
-  // @Path("role/{roleName}/summary")
-  // @Produces("application/json")
-  // @RolesAllowed({ADMIN, CHAIRPERSON, MEMBER, SIGNINGOFFICIAL, RESEARCHER})
-  // public Response getCollectionSummariesForUserByRole(@Auth AuthUser authUser, @PathParam("roleName") String roleName) {
-  //   try {
-  //     User user = userService.findUserByEmail(authUser.getEmail());
-  //     validateUserHasRoleName(user, roleName);
-  //     List<DarCollectionSummary> summaries = darCollectionService.getSummariesForRoleName(user, roleName);
-  //     return Response.ok().entity(summaries).build();
-  //   } catch (Exception e) {
-  //     return createExceptionResponse(e);
-  //   }
-  // }
+  @GET
+  @Path("role/{roleName}/summary")
+  @Produces("application/json")
+  @RolesAllowed({ADMIN, CHAIRPERSON, MEMBER, SIGNINGOFFICIAL, RESEARCHER})
+  public Response getCollectionSummariesForUserByRole(@Auth AuthUser authUser, @PathParam("roleName") String roleName) {
+    try {
+      User user = userService.findUserByEmail(authUser.getEmail());
+      validateUserHasRoleName(user, roleName);
+      List<DarCollectionSummary> summaries = darCollectionService.getSummariesForRoleName(user, roleName);
+      return Response.ok().entity(summaries).build();
+    } catch (Exception e) {
+      return createExceptionResponse(e);
+    }
+  }
 
   @GET
   @Path("{collectionId}")

--- a/src/main/java/org/broadinstitute/consent/http/resources/DarCollectionResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DarCollectionResource.java
@@ -89,7 +89,6 @@ public class DarCollectionResource extends Resource {
     try {
       User user = userService.findUserByEmail(authUser.getEmail());
       validateUserHasRoleName(user, roleName);
-      // TODO: Replace with DarCollectionSummary when available
       List<DarCollectionSummary> summaries = darCollectionService.getSummariesForRoleName(user, roleName);
       return Response.ok().entity(summaries).build();
     } catch (Exception e) {

--- a/src/main/java/org/broadinstitute/consent/http/resources/DarCollectionResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DarCollectionResource.java
@@ -7,6 +7,7 @@ import org.broadinstitute.consent.http.enumeration.DarStatus;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.AuthUser;
 import org.broadinstitute.consent.http.models.DarCollection;
+import org.broadinstitute.consent.http.models.DarCollectionSummary;
 import org.broadinstitute.consent.http.models.DataAccessRequest;
 import org.broadinstitute.consent.http.models.Dataset;
 import org.broadinstitute.consent.http.models.PaginationResponse;
@@ -89,7 +90,7 @@ public class DarCollectionResource extends Resource {
       User user = userService.findUserByEmail(authUser.getEmail());
       validateUserHasRoleName(user, roleName);
       // TODO: Replace with DarCollectionSummary when available
-      List<Object> summaries = darCollectionService.getSummariesForRoleName(user, roleName);
+      List<DarCollectionSummary> summaries = darCollectionService.getSummariesForRoleName(user, roleName);
       return Response.ok().entity(summaries).build();
     } catch (Exception e) {
       return createExceptionResponse(e);

--- a/src/main/java/org/broadinstitute/consent/http/resources/DarCollectionResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DarCollectionResource.java
@@ -81,20 +81,20 @@ public class DarCollectionResource extends Resource {
     }
   }
 
-  @GET
-  @Path("role/{roleName}/summary")
-  @Produces("application/json")
-  @RolesAllowed({ADMIN, CHAIRPERSON, MEMBER, SIGNINGOFFICIAL, RESEARCHER})
-  public Response getCollectionSummariesForUserByRole(@Auth AuthUser authUser, @PathParam("roleName") String roleName) {
-    try {
-      User user = userService.findUserByEmail(authUser.getEmail());
-      validateUserHasRoleName(user, roleName);
-      List<DarCollectionSummary> summaries = darCollectionService.getSummariesForRoleName(user, roleName);
-      return Response.ok().entity(summaries).build();
-    } catch (Exception e) {
-      return createExceptionResponse(e);
-    }
-  }
+  // @GET
+  // @Path("role/{roleName}/summary")
+  // @Produces("application/json")
+  // @RolesAllowed({ADMIN, CHAIRPERSON, MEMBER, SIGNINGOFFICIAL, RESEARCHER})
+  // public Response getCollectionSummariesForUserByRole(@Auth AuthUser authUser, @PathParam("roleName") String roleName) {
+  //   try {
+  //     User user = userService.findUserByEmail(authUser.getEmail());
+  //     validateUserHasRoleName(user, roleName);
+  //     List<DarCollectionSummary> summaries = darCollectionService.getSummariesForRoleName(user, roleName);
+  //     return Response.ok().entity(summaries).build();
+  //   } catch (Exception e) {
+  //     return createExceptionResponse(e);
+  //   }
+  // }
 
   @GET
   @Path("{collectionId}")

--- a/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
@@ -113,7 +113,7 @@ public class DarCollectionService {
 
   private void processDarCollectionSummariesForAdmin(List<DarCollectionSummary> summaries) {
     //if at least one election is open, show cancel
-    //if at least one election is not open, show cancel
+    //if at least one non-open/absent election, show open
     summaries.forEach(s -> {
       Map<String, Integer> statusCount = new HashMap<>();
       Map<Integer, Election> elections = s.getElections();

--- a/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
@@ -74,6 +74,10 @@ public class DarCollectionService {
   }
 
   private void updateStatusCount(Map<String, Integer> statusCount, String status) {
+    if(Objects.isNull(status)) {
+      //If the status is null, track it as Undefined to ensure election is accounted for
+      status = "Undefined";
+    }
     Integer count = statusCount.get(status);
     if(Objects.isNull(count)) {
       statusCount.put(status, 0);

--- a/src/test/java/org/broadinstitute/consent/http/db/DarCollectionSummaryDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DarCollectionSummaryDAOTest.java
@@ -354,6 +354,8 @@ public class DarCollectionSummaryDAOTest extends DAOTestHelper {
           .forEach((e) -> {
             assertEquals(electionId, e.getKey());
           });
+      assertEquals(1, s.getDarStatuses().size());
+      s.getDarStatuses().values().forEach(status -> assertEquals("test", status));
       assertEquals(1, s.getDatasetCount());
     });
   }

--- a/src/test/java/org/broadinstitute/consent/http/db/DarCollectionSummaryDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DarCollectionSummaryDAOTest.java
@@ -32,6 +32,7 @@ public class DarCollectionSummaryDAOTest extends DAOTestHelper {
     Date submissionDate = new Date();
     DataAccessRequestData data = new DataAccessRequestData();
     data.setProjectTitle(RandomStringUtils.randomAlphabetic(20));
+    data.setStatus("test");
     dataAccessRequestDAO.insertDataAccessRequest(collectionId, referenceId, userId, createDate, new Date(), submissionDate, new Date(), data);
     return dataAccessRequestDAO.findByReferenceId(referenceId);
   }
@@ -491,7 +492,8 @@ public class DarCollectionSummaryDAOTest extends DAOTestHelper {
       assertEquals(1, s.getDatasetIds().size());
       s.getDatasetIds().stream()
           .forEach((id) -> assertTrue(targetDatasets.contains(id)));
-
+      s.getDarStatuses().values()
+        .forEach((st) -> assertTrue(st.equalsIgnoreCase("test")));
       assertEquals(0, s.getElections().size());
       assertEquals(1, s.getDatasetCount());
     });

--- a/src/test/java/org/broadinstitute/consent/http/resources/DarCollectionResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DarCollectionResourceTest.java
@@ -6,6 +6,7 @@ import org.broadinstitute.consent.http.enumeration.DarStatus;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.AuthUser;
 import org.broadinstitute.consent.http.models.DarCollection;
+import org.broadinstitute.consent.http.models.DarCollectionSummary;
 import org.broadinstitute.consent.http.models.DataAccessRequest;
 import org.broadinstitute.consent.http.models.DataAccessRequestData;
 import org.broadinstitute.consent.http.models.Dataset;
@@ -633,5 +634,106 @@ public class DarCollectionResourceTest {
 
     Response response = resource.createElectionsForCollection(authUser, 1);
     assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
+  }
+
+  @Test
+  public void getCollectionSummariesForUserByRole_Member() {
+    User user = new User();
+    UserRole userRole = new UserRole(UserRoles.MEMBER.getRoleId(), UserRoles.MEMBER.getRoleName());
+    user.addRole(userRole);
+    DarCollectionSummary mockSummary = new DarCollectionSummary();
+    when(userService.findUserByEmail(anyString())).thenReturn(user);
+    when(darCollectionService.getSummariesForRoleName(any(User.class), anyString()))
+      .thenReturn(List.of(mockSummary));
+    initResource();
+
+    Response response = resource.getCollectionSummariesForUserByRole(authUser, UserRoles.MEMBER.getRoleName());
+    assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+  }
+
+  @Test
+  public void getCollectionSummariesForUserByRole_Chair() {
+    User user = new User();
+    UserRole userRole = new UserRole(UserRoles.CHAIRPERSON.getRoleId(), UserRoles.CHAIRPERSON.getRoleName());
+    user.addRole(userRole);
+    DarCollectionSummary mockSummary = new DarCollectionSummary();
+    when(userService.findUserByEmail(anyString())).thenReturn(user);
+    when(darCollectionService.getSummariesForRoleName(any(User.class), anyString()))
+        .thenReturn(List.of(mockSummary));
+    initResource();
+
+    Response response = resource.getCollectionSummariesForUserByRole(authUser, UserRoles.CHAIRPERSON.getRoleName());
+    assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+  }
+
+  @Test
+  public void getCollectionSummariesForUserByRole_SO() {
+    User user = new User();
+    UserRole userRole = new UserRole(UserRoles.SIGNINGOFFICIAL.getRoleId(), UserRoles.SIGNINGOFFICIAL.getRoleName());
+    user.addRole(userRole);
+    DarCollectionSummary mockSummary = new DarCollectionSummary();
+    when(userService.findUserByEmail(anyString())).thenReturn(user);
+    when(darCollectionService.getSummariesForRoleName(any(User.class), anyString()))
+        .thenReturn(List.of(mockSummary));
+    initResource();
+
+    Response response = resource.getCollectionSummariesForUserByRole(authUser, UserRoles.SIGNINGOFFICIAL.getRoleName());
+    assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+  }
+
+  @Test
+  public void getCollectionSummariesForUserByRole_Researcher() {
+    User user = new User();
+    UserRole userRole = new UserRole(UserRoles.RESEARCHER.getRoleId(), UserRoles.RESEARCHER.getRoleName());
+    user.addRole(userRole);
+    DarCollectionSummary mockSummary = new DarCollectionSummary();
+    when(userService.findUserByEmail(anyString())).thenReturn(user);
+    when(darCollectionService.getSummariesForRoleName(any(User.class), anyString()))
+        .thenReturn(List.of(mockSummary));
+    initResource();
+
+    Response response = resource.getCollectionSummariesForUserByRole(authUser, UserRoles.RESEARCHER.getRoleName());
+    assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+  }
+
+  @Test
+  public void getCollectionSummariesForUserByRole_Admin() {
+    User user = new User();
+    UserRole userRole = new UserRole(UserRoles.ADMIN.getRoleId(), UserRoles.ADMIN.getRoleName());
+    user.addRole(userRole);
+    DarCollectionSummary mockSummary = new DarCollectionSummary();
+    when(userService.findUserByEmail(anyString())).thenReturn(user);
+    when(darCollectionService.getSummariesForRoleName(any(User.class), anyString()))
+        .thenReturn(List.of(mockSummary));
+    initResource();
+
+    Response response = resource.getCollectionSummariesForUserByRole(authUser, UserRoles.ADMIN.getRoleName());
+    assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+  }
+
+  @Test
+  public void getCollectionSummariesForUserByRole_NoRoleFound() {
+    User user = new User();
+    DarCollectionSummary mockSummary = new DarCollectionSummary();
+    when(userService.findUserByEmail(anyString())).thenReturn(user);
+    when(darCollectionService.getSummariesForRoleName(any(User.class), anyString()))
+        .thenReturn(List.of(mockSummary));
+    initResource();
+
+    Response response = resource.getCollectionSummariesForUserByRole(authUser, UserRoles.SIGNINGOFFICIAL.getRoleName());
+    assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
+  }
+
+  @Test
+  public void getCollectionSummariesForUserByRole_InvalidRoleString() {
+    User user = new User();
+    DarCollectionSummary mockSummary = new DarCollectionSummary();
+    when(userService.findUserByEmail(anyString())).thenReturn(user);
+    when(darCollectionService.getSummariesForRoleName(any(User.class), anyString()))
+        .thenReturn(List.of(mockSummary));
+    initResource();
+
+    Response response = resource.getCollectionSummariesForUserByRole(authUser, "invalid");
+    assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
   }
 }

--- a/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
@@ -27,9 +27,7 @@ import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.UserRole;
 import org.broadinstitute.consent.http.service.dao.DarCollectionServiceDAO;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.mockito.Mock;
 
 import javax.ws.rs.BadRequestException;
@@ -37,7 +35,6 @@ import javax.ws.rs.NotAcceptableException;
 import javax.ws.rs.NotAuthorizedException;
 import javax.ws.rs.NotFoundException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Calendar;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -48,7 +45,6 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import static java.util.stream.Collectors.toList;
 import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;


### PR DESCRIPTION
Partially addresses [DUOS-1912](https://broadworkbench.atlassian.net/browse/DUOS-1914). 
Linked ticket is [DUOS-1930](https://broadworkbench.atlassian.net/browse/DUOS-1930)

PR adds service methods (public and private) for fetching DAR Collection Summaries by role name. PR also includes extensive test suite and a small update to `ElectionStatus.java`, `DarCollectionSummaryDAO`, and `DarCollectionSummaryReducer`

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
