### PR TITLE
[DUOS-1914][risk=low] Enable endpoint to allow users to fetch DARCollectionSummary by Role

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/resources/DarCollectionResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DarCollectionResource.java
@@ -81,20 +81,20 @@ public class DarCollectionResource extends Resource {
     }
   }
 
-  // @GET
-  // @Path("role/{roleName}/summary")
-  // @Produces("application/json")
-  // @RolesAllowed({ADMIN, CHAIRPERSON, MEMBER, SIGNINGOFFICIAL, RESEARCHER})
-  // public Response getCollectionSummariesForUserByRole(@Auth AuthUser authUser, @PathParam("roleName") String roleName) {
-  //   try {
-  //     User user = userService.findUserByEmail(authUser.getEmail());
-  //     validateUserHasRoleName(user, roleName);
-  //     List<DarCollectionSummary> summaries = darCollectionService.getSummariesForRoleName(user, roleName);
-  //     return Response.ok().entity(summaries).build();
-  //   } catch (Exception e) {
-  //     return createExceptionResponse(e);
-  //   }
-  // }
+  @GET
+  @Path("role/{roleName}/summary")
+  @Produces("application/json")
+  @RolesAllowed({ADMIN, CHAIRPERSON, MEMBER, SIGNINGOFFICIAL, RESEARCHER})
+  public Response getCollectionSummariesForUserByRole(@Auth AuthUser authUser, @PathParam("roleName") String roleName) {
+    try {
+      User user = userService.findUserByEmail(authUser.getEmail());
+      validateUserHasRoleName(user, roleName);
+      List<DarCollectionSummary> summaries = darCollectionService.getSummariesForRoleName(user, roleName);
+      return Response.ok().entity(summaries).build();
+    } catch (Exception e) {
+      return createExceptionResponse(e);
+    }
+  }
 
   @GET
   @Path("{collectionId}")

--- a/src/test/java/org/broadinstitute/consent/http/resources/DarCollectionResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DarCollectionResourceTest.java
@@ -6,6 +6,7 @@ import org.broadinstitute.consent.http.enumeration.DarStatus;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.AuthUser;
 import org.broadinstitute.consent.http.models.DarCollection;
+import org.broadinstitute.consent.http.models.DarCollectionSummary;
 import org.broadinstitute.consent.http.models.DataAccessRequest;
 import org.broadinstitute.consent.http.models.DataAccessRequestData;
 import org.broadinstitute.consent.http.models.Dataset;
@@ -633,5 +634,106 @@ public class DarCollectionResourceTest {
 
     Response response = resource.createElectionsForCollection(authUser, 1);
     assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
+  }
+
+  @Test
+  public void getCollectionSummariesForUserByRole_Member() {
+    User user = new User();
+    UserRole userRole = new UserRole(UserRoles.MEMBER.getRoleId(), UserRoles.MEMBER.getRoleName());
+    user.addRole(userRole);
+    DarCollectionSummary mockSummary = new DarCollectionSummary();
+    when(userService.findUserByEmail(anyString())).thenReturn(user);
+    when(darCollectionService.getSummariesForRoleName(any(User.class), anyString()))
+      .thenReturn(List.of(mockSummary));
+    initResource();
+
+    Response response = resource.getCollectionSummariesForUserByRole(authUser, UserRoles.MEMBER.getRoleName());
+    assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+  }
+
+  @Test
+  public void getCollectionSummariesForUserByRole_Chair() {
+    User user = new User();
+    UserRole userRole = new UserRole(UserRoles.CHAIRPERSON.getRoleId(), UserRoles.CHAIRPERSON.getRoleName());
+    user.addRole(userRole);
+    DarCollectionSummary mockSummary = new DarCollectionSummary();
+    when(userService.findUserByEmail(anyString())).thenReturn(user);
+    when(darCollectionService.getSummariesForRoleName(any(User.class), anyString()))
+        .thenReturn(List.of(mockSummary));
+    initResource();
+
+    Response response = resource.getCollectionSummariesForUserByRole(authUser, UserRoles.CHAIRPERSON.getRoleName());
+    assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+  }
+
+  @Test
+  public void getCollectionSummariesForUserByRole_SO() {
+    User user = new User();
+    UserRole userRole = new UserRole(UserRoles.SIGNINGOFFICIAL.getRoleId(), UserRoles.SIGNINGOFFICIAL.getRoleName());
+    user.addRole(userRole);
+    DarCollectionSummary mockSummary = new DarCollectionSummary();
+    when(userService.findUserByEmail(anyString())).thenReturn(user);
+    when(darCollectionService.getSummariesForRoleName(any(User.class), anyString()))
+        .thenReturn(List.of(mockSummary));
+    initResource();
+
+    Response response = resource.getCollectionSummariesForUserByRole(authUser, UserRoles.SIGNINGOFFICIAL.getRoleName());
+    assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+  }
+
+  @Test
+  public void getCollectionSummariesForUserByRole_Researcher() {
+    User user = new User();
+    UserRole userRole = new UserRole(UserRoles.RESEARCHER.getRoleId(), UserRoles.RESEARCHER.getRoleName());
+    user.addRole(userRole);
+    DarCollectionSummary mockSummary = new DarCollectionSummary();
+    when(userService.findUserByEmail(anyString())).thenReturn(user);
+    when(darCollectionService.getSummariesForRoleName(any(User.class), anyString()))
+        .thenReturn(List.of(mockSummary));
+    initResource();
+
+    Response response = resource.getCollectionSummariesForUserByRole(authUser, UserRoles.RESEARCHER.getRoleName());
+    assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+  }
+
+  @Test
+  public void getCollectionSummariesForUserByRole_Admin() {
+    User user = new User();
+    UserRole userRole = new UserRole(UserRoles.ADMIN.getRoleId(), UserRoles.ADMIN.getRoleName());
+    user.addRole(userRole);
+    DarCollectionSummary mockSummary = new DarCollectionSummary();
+    when(userService.findUserByEmail(anyString())).thenReturn(user);
+    when(darCollectionService.getSummariesForRoleName(any(User.class), anyString()))
+        .thenReturn(List.of(mockSummary));
+    initResource();
+
+    Response response = resource.getCollectionSummariesForUserByRole(authUser, UserRoles.ADMIN.getRoleName());
+    assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+  }
+
+  @Test
+  public void getCollectionSummariesForUserByRole_NoRoleFound() {
+    User user = new User();
+    DarCollectionSummary mockSummary = new DarCollectionSummary();
+    when(userService.findUserByEmail(anyString())).thenReturn(user);
+    when(darCollectionService.getSummariesForRoleName(any(User.class), anyString()))
+        .thenReturn(List.of(mockSummary));
+    initResource();
+
+    Response response = resource.getCollectionSummariesForUserByRole(authUser, UserRoles.SIGNINGOFFICIAL.getRoleName());
+    assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
+  }
+
+  @Test
+  public void getCollectionSummariesForUserByRole_InvalidRoleString() {
+    User user = new User();
+    DarCollectionSummary mockSummary = new DarCollectionSummary();
+    when(userService.findUserByEmail(anyString())).thenReturn(user);
+    when(darCollectionService.getSummariesForRoleName(any(User.class), anyString()))
+        .thenReturn(List.of(mockSummary));
+    initResource();
+
+    Response response = resource.getCollectionSummariesForUserByRole(authUser, "invalid");
+    assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
   }
 }


### PR DESCRIPTION
Addresses [DUOS-1934](https://broadworkbench.atlassian.net/browse/DUOS-1934)
Partially addresses [DUOS-1914](https://broadworkbench.atlassian.net/browse/DUOS-1914)

PR enables fetch endpoint that allows users to fetch collection summaries by role. PR also adds tests for that endpoint.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
