### PR TITLE
[DUOS-1945][risk=no] Fix cartesian product DAR results

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/DataAccessRequestDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DataAccessRequestDAO.java
@@ -1,8 +1,9 @@
 package org.broadinstitute.consent.http.db;
 
 import org.broadinstitute.consent.http.db.mapper.DataAccessRequestDataMapper;
-import org.broadinstitute.consent.http.db.mapper.DataAccessRequestMapper;
 import org.broadinstitute.consent.http.db.mapper.DarDatasetMapper;
+import org.broadinstitute.consent.http.db.mapper.DataAccessRequestMapper;
+import org.broadinstitute.consent.http.db.mapper.DataAccessRequestReducer;
 import org.broadinstitute.consent.http.models.DataAccessRequest;
 import org.broadinstitute.consent.http.models.DataAccessRequestData;
 import org.broadinstitute.consent.http.models.DarDataset;
@@ -16,6 +17,7 @@ import org.jdbi.v3.sqlobject.customizer.BindList;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 import org.jdbi.v3.sqlobject.statement.SqlBatch;
+import org.jdbi.v3.sqlobject.statement.UseRowReducer;
 import org.jdbi.v3.sqlobject.transaction.Transactional;
 
 import java.util.Date;
@@ -23,7 +25,7 @@ import java.util.List;
 
 /**
  * For all json queries, note the double `??` for jdbi3 escaped jsonb operators:
- * https://jdbi.org/#_postgresql
+ * <a href="https://jdbi.org/#_postgresql">...</a>
  */
 @RegisterRowMapper(DataAccessRequestMapper.class)
 public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO> {
@@ -33,6 +35,7 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
    *
    * @return List<DataAccessRequest>
    */
+  @UseRowReducer(DataAccessRequestReducer.class)
   @SqlQuery(
       "SELECT dd.dataset_id, dar.id, dar.reference_id, dar.collection_id, dar.parent_id, dar.draft, dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date, "
           + "  (dar.data #>> '{}')::jsonb AS data FROM data_access_request dar"
@@ -48,6 +51,7 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
    *
    * @return List<DataAccessRequest>
    */
+  @UseRowReducer(DataAccessRequestReducer.class)
   @SqlQuery(
       " SELECT dd.dataset_id, dar.id, dar.reference_id, dar.collection_id, dar.parent_id, dar.draft, dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date, "
           + "  (dar.data #>> '{}')::jsonb AS data FROM data_access_request dar "
@@ -61,12 +65,12 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
    *
    * @return List<DataAccessRequest>
    */
+  @UseRowReducer(DataAccessRequestReducer.class)
   @SqlQuery(
       "SELECT dd.dataset_id, dar.id, dar.reference_id, dar.collection_id, dar.parent_id, dar.draft, dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date, "
           + "  (dar.data #>> '{}')::jsonb AS data FROM data_access_request dar"
           + "  LEFT JOIN dar_dataset dd on dd.reference_id = dar.reference_id "
-          + "  WHERE (dar.data #>> '{}')::jsonb ??| array['partial_dar_code', 'partialDarCode'] "
-          + "  OR dar.draft = true "
+          + "  WHERE dar.draft = true "
           + "  AND (LOWER(dar.data->>'status') != 'archived' OR dar.data->>'status' IS NULL) "
           + "  ORDER BY dar.update_date DESC")
   List<DataAccessRequest> findAllDraftDataAccessRequests();
@@ -76,13 +80,13 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
    *
    * @return List<DataAccessRequest>
    */
+  @UseRowReducer(DataAccessRequestReducer.class)
   @SqlQuery(
       "SELECT dd.dataset_id, dar.id, dar.reference_id, dar.collection_id, dar.parent_id, dar.draft, dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date, "
           + "  (dar.data #>> '{}')::jsonb AS data FROM data_access_request dar"
           + "  LEFT JOIN dar_dataset dd on dd.reference_id = dar.reference_id "
-          + "  WHERE ( (dar.data #>> '{}')::jsonb ??| array['partial_dar_code', 'partialDarCode'] "
-          + "          OR dar.draft = true "
-          + "  AND (LOWER(dar.data->>'status') != 'archived' OR dar.data->>'status' IS NULL)) "
+          + "  WHERE dar.draft = true "
+          + "  AND (LOWER(dar.data->>'status') != 'archived' OR dar.data->>'status' IS NULL) "
           + "  AND dar.user_id = :userId "
           + "  ORDER BY dar.sort_date DESC")
   List<DataAccessRequest> findAllDraftsByUserId(@Bind("userId") Integer userId);
@@ -93,6 +97,7 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
    *
    * @return List<DataAccessRequest>
    */
+  @UseRowReducer(DataAccessRequestReducer.class)
   @SqlQuery(
       "SELECT dd.dataset_id, dar.id, dar.reference_id, dar.collection_id, dar.parent_id, dar.draft, dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date, "
           + "  (dar.data #>> '{}')::jsonb AS data FROM data_access_request dar"
@@ -109,6 +114,7 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
    * @param referenceId String
    * @return DataAccessRequest
    */
+  @UseRowReducer(DataAccessRequestReducer.class)
   @SqlQuery(
       "SELECT dd.dataset_id, dar.id, dar.reference_id, dar.collection_id, dar.parent_id, dar.draft, dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date, "
           + "  (dar.data #>> '{}')::jsonb AS data FROM data_access_request dar"
@@ -124,6 +130,7 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
    * @param referenceIds List of Strings
    * @return List<DataAccessRequest>
    */
+  @UseRowReducer(DataAccessRequestReducer.class)
   @SqlQuery(
       "SELECT dd.dataset_id, dar.id, dar.reference_id, dar.collection_id, dar.parent_id, dar.draft, dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date, "
           + "  (dar.data #>> '{}')::jsonb AS data FROM data_access_request dar"

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DataAccessRequestReducer.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DataAccessRequestReducer.java
@@ -1,0 +1,21 @@
+package org.broadinstitute.consent.http.db.mapper;
+
+import org.broadinstitute.consent.http.models.DataAccessRequest;
+import org.jdbi.v3.core.result.LinkedHashMapRowReducer;
+import org.jdbi.v3.core.result.RowView;
+
+import java.util.Map;
+
+public class DataAccessRequestReducer
+    implements LinkedHashMapRowReducer<Integer, DataAccessRequest>, RowMapperHelper {
+
+  @Override
+  public void accumulate(Map<Integer, DataAccessRequest> map, RowView rowView) {
+    DataAccessRequest dar =
+        map.computeIfAbsent(
+            rowView.getColumn("id", Integer.class), id -> rowView.getRow(DataAccessRequest.class));
+    if (hasColumn(rowView, "dataset_id", Integer.class)) {
+      dar.addDatasetId(rowView.getColumn("dataset_id", Integer.class));
+    }
+  }
+}

--- a/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
@@ -44,7 +44,11 @@ public class DataAccessRequestDAOTest extends DAOTestHelper {
         assertTrue(dars.isEmpty());
 
         createDataAccessRequestV3();
-        createDraftDataAccessRequest();
+        DataAccessRequest draft = createDraftDataAccessRequest();
+        Dataset d1 = createDataset();
+        Dataset d2 = createDataset();
+        dataAccessRequestDAO.insertDARDatasetRelation(draft.getReferenceId(), d1.getDataSetId());
+        dataAccessRequestDAO.insertDARDatasetRelation(draft.getReferenceId(), d2.getDataSetId());
         List<DataAccessRequest> newDars = dataAccessRequestDAO.findAllDraftDataAccessRequests();
         assertFalse(newDars.isEmpty());
         assertEquals(1, newDars.size());
@@ -54,6 +58,10 @@ public class DataAccessRequestDAOTest extends DAOTestHelper {
     @Test
     public void testFindAllDraftsByUserId() {
         DataAccessRequest dar = createDraftDataAccessRequest();
+        Dataset d1 = createDataset();
+        Dataset d2 = createDataset();
+        dataAccessRequestDAO.insertDARDatasetRelation(dar.getReferenceId(), d1.getDataSetId());
+        dataAccessRequestDAO.insertDARDatasetRelation(dar.getReferenceId(), d2.getDataSetId());
 
         List<DataAccessRequest> newDars = dataAccessRequestDAO.findAllDraftsByUserId(dar.getUserId());
         assertFalse(newDars.isEmpty());


### PR DESCRIPTION
## Addresses
API side of https://broadworkbench.atlassian.net/browse/DUOS-1945

`RowMapper` does not handle cartesian products well, but `RowReducer` does. 

See also: https://github.com/DataBiosphere/duos-ui/pull/1689

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
