### PR TITLE
[DUOS-1923][risk=no] remove consent partial dar code storage

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/DataAccessRequestDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DataAccessRequestDAO.java
@@ -40,8 +40,7 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
       "SELECT dd.dataset_id, dar.id, dar.reference_id, dar.collection_id, dar.parent_id, dar.draft, dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date, "
           + "  (dar.data #>> '{}')::jsonb AS data FROM data_access_request dar"
           + "  LEFT JOIN dar_dataset dd on dd.reference_id = dar.reference_id "
-          + "  WHERE not (dar.data #>> '{}')::jsonb ??| array['partial_dar_code', 'partialDarCode'] "
-          + "  AND dar.draft != true "
+          + "  WHERE dar.draft != true "
           + "  AND (LOWER(dar.data->>'status') != 'archived' OR dar.data->>'status' IS NULL ) ")
   List<DataAccessRequest> findAllDataAccessRequests();
 

--- a/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequestData.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequestData.java
@@ -26,11 +26,7 @@ public class DataAccessRequestData {
             "profileName", "pubmedId", "scientificUrl", "eraExpiration", "academicEmail",
             "eraAuthorized", "nihUsername", "linkedIn", "orcid", "researcherGate", "datasetDetail",
             "datasets", "datasetId", "validRestriction", "restriction", "translatedUseRestriction",
-            "createDate", "sortDate", "additionalEmail", "checkNotifications" );
-
-    // prefix for partialDarCode, should be pulled by functions that generate/update ONLY
-    // since class is used within both drafts and submitted dars, it's best to control its implementation on the outer function call
-    public static final String partialDarCodePrefix = "temp_DAR_";
+            "createDate", "sortDate", "additionalEmail", "checkNotifications, partialDarCode" );
 
     private String referenceId;
     private String investigator;
@@ -96,8 +92,6 @@ public class DataAccessRequestData {
     private List<DatasetEntry> datasets;
     @SerializedName(value = "darCode", alternate = "dar_code")
     private String darCode;
-    @SerializedName(value = "partialDarCode", alternate = "partial_dar_code")
-    private String partialDarCode;
     private Object restriction;
     @SerializedName(value = "validRestriction", alternate = "valid_restriction")
     private Boolean validRestriction;
@@ -517,14 +511,6 @@ public class DataAccessRequestData {
 
     public void setDarCode(String darCode) {
         this.darCode = darCode;
-    }
-
-    public String getPartialDarCode() {
-        return partialDarCode;
-    }
-
-    public void setPartialDarCode(String partialDarCode) {
-        this.partialDarCode = partialDarCode;
     }
 
     public Object getRestriction() {

--- a/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequestData.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequestData.java
@@ -26,7 +26,7 @@ public class DataAccessRequestData {
             "profileName", "pubmedId", "scientificUrl", "eraExpiration", "academicEmail",
             "eraAuthorized", "nihUsername", "linkedIn", "orcid", "researcherGate", "datasetDetail",
             "datasets", "datasetId", "validRestriction", "restriction", "translatedUseRestriction",
-            "createDate", "sortDate", "additionalEmail", "checkNotifications, partialDarCode" );
+            "createDate", "sortDate", "additionalEmail", "checkNotifications", "partialDarCode" );
 
     private String referenceId;
     private String investigator;

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
@@ -223,8 +223,6 @@ public class DataAccessRequestService {
             throw new IllegalArgumentException("User and DataAccessRequest are required");
         }
         Date now = new Date();
-        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
-        dar.getData().setPartialDarCode(DataAccessRequestData.partialDarCodePrefix + sdf.format(now));
         dataAccessRequestDAO.insertDraftDataAccessRequest(
             dar.getReferenceId(),
             user.getUserId(),
@@ -313,8 +311,6 @@ public class DataAccessRequestService {
         newData.setReferenceId(referenceId);
         newData.setCreateDate(now.getTime());
         newData.setSortDate(now.getTime());
-        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
-        newData.setPartialDarCode(DataAccessRequestData.partialDarCodePrefix + sdf.format(now));
         dataAccessRequestDAO.insertDraftDataAccessRequest(
             referenceId,
             user.getUserId(),
@@ -437,7 +433,6 @@ public class DataAccessRequestService {
         long nowTime = now.getTime();
         List<DataAccessRequest> newDARList = new ArrayList<>();
         DataAccessRequestData darData = dataAccessRequest.getData();
-        darData.setPartialDarCode(null);
         if (Objects.isNull(darData.getCreateDate())) {
             darData.setCreateDate(nowTime);
         }

--- a/src/main/resources/assets/schemas/DataAccessRequest.yaml
+++ b/src/main/resources/assets/schemas/DataAccessRequest.yaml
@@ -29,10 +29,7 @@ properties:
     type: object
     description: Map of elections tied to the DAR (electionid - election)
     items:
-      $ref: './Election.yaml' 
-  partialDarCode:
-    type: string
-    description: Unique Partial DAR Code
+      $ref: './Election.yaml'
   projectTitle:
     type: string
     description: Project Title


### PR DESCRIPTION
Addresses [DUOS-1923](https://broadworkbench.atlassian.net/browse/DUOS-1923)
Summary of Changes:
- removes usages of `DataAccessRequestData.partialDarCode` 

----

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
