### PR TITLE
[DUOS-1689][risk=no] Add sql to back-populate missing dataset ids in elections

### DIFF
--- a/src/main/resources/changelog-master.xml
+++ b/src/main/resources/changelog-master.xml
@@ -87,4 +87,5 @@
     <include file="changesets/changelog-consent-82.0.xml" relativeToChangelogFile="true"/>
     <include file="changesets/changelog-consent-83.0.xml" relativeToChangelogFile="true"/>
     <include file="changesets/changelog-consent-84.0.xml" relativeToChangelogFile="true"/>
+    <include file="changesets/changelog-consent-85.0.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/changesets/changelog-consent-85.0.xml
+++ b/src/main/resources/changesets/changelog-consent-85.0.xml
@@ -6,7 +6,7 @@
         <sql>
             UPDATE election
             SET datasetid = (SELECT (((data #>> '{}')::jsonb->>'datasetIds')::json->>0)::bigint FROM data_access_request WHERE reference_id = referenceid LIMIT 1)
-            WHERE datasetid is null
+            WHERE datasetid IS NULL
             AND LOWER(electiontype) IN ('rp', 'dataaccess');
         </sql>
     </changeSet>

--- a/src/main/resources/changesets/changelog-consent-85.0.xml
+++ b/src/main/resources/changesets/changelog-consent-85.0.xml
@@ -2,7 +2,7 @@
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
          http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
     <changeSet id="85.0" author="grushton">
-        <!--Now back populate the dar_dataset table-->
+        <!--Back populate missing dataset ids for elections where we have a valid dataset id -->
         <sql>
             UPDATE election
             SET datasetid = (SELECT (((data #>> '{}')::jsonb->>'datasetIds')::json->>0)::bigint FROM data_access_request WHERE reference_id = referenceid LIMIT 1)

--- a/src/main/resources/changesets/changelog-consent-85.0.xml
+++ b/src/main/resources/changesets/changelog-consent-85.0.xml
@@ -1,0 +1,13 @@
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+    <changeSet id="85.0" author="grushton">
+        <!--Now back populate the dar_dataset table-->
+        <sql>
+            UPDATE election
+            SET datasetid = (SELECT (((data #>> '{}')::jsonb->>'datasetIds')::json->>0)::bigint FROM data_access_request WHERE reference_id = referenceid LIMIT 1)
+            WHERE datasetid is null
+            AND LOWER(electiontype) IN ('rp', 'dataaccess');
+        </sql>
+    </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-1689

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
