### PR TITLE
[DUOS-1971][risk=no] Use the V2 Algorithm for DAR match generation

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/configurations/ServicesConfiguration.java
+++ b/src/main/java/org/broadinstitute/consent/http/configurations/ServicesConfiguration.java
@@ -36,6 +36,10 @@ public class ServicesConfiguration {
     return getOntologyURL() + "match";
   }
 
+  public String getMatchURL_v2() {
+    return getOntologyURL() + "match/v2";
+  }
+
   public String getValidateUseRestrictionURL() {
     return getOntologyURL() + "validate/userestriction";
   }

--- a/src/main/java/org/broadinstitute/consent/http/db/MatchDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/MatchDAO.java
@@ -106,10 +106,10 @@ public interface MatchDAO extends Transactional<MatchDAO> {
     @SqlUpdate("DELETE FROM match_entity WHERE purpose IN (<purposeIds>)")
     void deleteMatchesByPurposeIds(@BindList("purposeIds") List<String> purposeIds);
 
-    @SqlUpdate("DELETE FROM match_failure_reason WHERE match_entity_id in (SELECT matchid FROM match_entity WHERE consent IN (<consentIds>) ")
+    @SqlUpdate("DELETE FROM match_failure_reason WHERE match_entity_id in (SELECT matchid FROM match_entity WHERE consent IN (<consentIds>)) ")
     void deleteFailureReasonsByConsentIds(@BindList("consentIds") List<String> consentIds);
 
-    @SqlUpdate("DELETE FROM match_failure_reason WHERE match_entity_id in (SELECT matchid FROM match_entity WHERE purpose IN (<purposeIds>) ")
+    @SqlUpdate("DELETE FROM match_failure_reason WHERE match_entity_id in (SELECT matchid FROM match_entity WHERE purpose IN (<purposeIds>)) ")
     void deleteFailureReasonsByPurposeIds(@BindList("purposeIds") List<String> purposeIds);
 
     @SqlQuery("SELECT COUNT(*) FROM match_entity WHERE matchentity = :matchEntity AND failed = 'FALSE' ")

--- a/src/main/java/org/broadinstitute/consent/http/db/MatchDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/MatchDAO.java
@@ -68,7 +68,7 @@ public interface MatchDAO extends Transactional<MatchDAO> {
                         @Bind("createDate") Date date,
                         @Bind("algorithmVersion") String algorithmVersion);
 
-    @SqlBatch("INSERT INTO match_entity (consent, purpose, matchentity, failed, createdate) VALUES (:consent, :purpose, :match, :failed, :createDate)")
+    @SqlBatch("INSERT INTO match_entity (consent, purpose, matchentity, failed, createdate, algorithm_version) VALUES (:consent, :purpose, :match, :failed, :createDate, :algorithmVersion)")
     void insertAll(@BindBean List<Match> matches);
 
     @SqlUpdate("UPDATE match_entity SET matchentity = :match, consent = :consentId, purpose = :purposeId, failed = :failed WHERE matchid = :id ")

--- a/src/main/java/org/broadinstitute/consent/http/db/MatchDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/MatchDAO.java
@@ -1,6 +1,7 @@
 package org.broadinstitute.consent.http.db;
 
 import org.broadinstitute.consent.http.db.mapper.MatchMapper;
+import org.broadinstitute.consent.http.db.mapper.MatchReducer;
 import org.broadinstitute.consent.http.models.Match;
 import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
 import org.jdbi.v3.sqlobject.customizer.Bind;
@@ -10,6 +11,7 @@ import org.jdbi.v3.sqlobject.statement.GetGeneratedKeys;
 import org.jdbi.v3.sqlobject.statement.SqlBatch;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
+import org.jdbi.v3.sqlobject.statement.UseRowReducer;
 import org.jdbi.v3.sqlobject.transaction.Transactional;
 
 import java.util.Date;
@@ -18,31 +20,52 @@ import java.util.List;
 @RegisterRowMapper(MatchMapper.class)
 public interface MatchDAO extends Transactional<MatchDAO> {
 
-    @SqlQuery("SELECT * FROM match_entity WHERE consent = :consentId ")
+    @UseRowReducer(MatchReducer.class)
+    @SqlQuery("SELECT m.*, r.* " +
+         " FROM match_entity m " +
+         " LEFT JOIN match_failure_reason r on r.match_entity_id = m.matchid " +
+         " WHERE m.consent = :consentId ")
     List<Match> findMatchesByConsentId(@Bind("consentId") String consentId);
 
-    @SqlQuery("SELECT * FROM match_entity WHERE purpose = :purposeId ")
+    @UseRowReducer(MatchReducer.class)
+    @SqlQuery("SELECT m.*, r.* " +
+         " FROM match_entity m " +
+         " LEFT JOIN match_failure_reason r on r.match_entity_id = m.matchid " +
+         " WHERE m.purpose = :purposeId ")
     List<Match> findMatchesByPurposeId(@Bind("purposeId") String purposeId);
 
-    @SqlQuery("SELECT * FROM match_entity WHERE purpose = :purposeId AND consent = :consentId ")
+    @UseRowReducer(MatchReducer.class)
+    @SqlQuery("SELECT m.*, r.* " +
+         " FROM match_entity m " +
+         " LEFT JOIN match_failure_reason r on r.match_entity_id = m.matchid " +
+         " WHERE m.purpose = :purposeId AND m.consent = :consentId ")
     Match findMatchByPurposeIdAndConsentId(@Bind("purposeId") String purposeId, @Bind("consentId") String consentId);
 
-    @SqlQuery("SELECT * FROM match_entity WHERE matchid = :id ")
+    @UseRowReducer(MatchReducer.class)
+    @SqlQuery("SELECT m.*, r.* " +
+         " FROM match_entity m " +
+         " LEFT JOIN match_failure_reason r on r.match_entity_id = m.matchid " +
+         " WHERE m.matchid = :id ")
     Match  findMatchById(@Bind("id") Integer id);
 
+    @UseRowReducer(MatchReducer.class)
     @SqlQuery(
-        "SELECT match_entity.* FROM match_entity " +
-        "INNER JOIN (" +
+        " SELECT match_entity.*, r.* FROM match_entity " +
+        " LEFT JOIN match_failure_reason r on r.match_entity_id = match_entity.matchid " +
+        " INNER JOIN (" +
         "   SELECT election.*, MAX(election.electionid) OVER (PARTITION BY election.referenceid, election.datasetid) AS latest " +
         "   FROM election " +
         "   WHERE LOWER(election.electiontype) = 'dataaccess' " +
-        ") AS e " +
-        "ON e.referenceid = match_entity.purpose " +
-        "WHERE match_entity.purpose IN (<purposeIds>) AND e.electionid = latest"
-    )
+        " ) AS e " +
+        " ON e.referenceid = match_entity.purpose " +
+        " WHERE match_entity.purpose IN (<purposeIds>) AND e.electionid = latest")
     List<Match> findMatchesForLatestDataAccessElectionsByPurposeIds(@BindList("purposeIds") List<String> purposeIds);
 
-    @SqlQuery("SELECT * FROM match_entity WHERE purpose IN (<purposeId>)")
+    @UseRowReducer(MatchReducer.class)
+    @SqlQuery("SELECT m.*, r.* " +
+         " FROM match_entity m " +
+         " LEFT JOIN match_failure_reason r on r.match_entity_id = m.matchid " +
+         " WHERE m.purpose IN (<purposeId>) ")
     List<Match> findMatchesForPurposeIds(@BindList("purposeId") List<String> purposeId);
 
     @SqlUpdate(
@@ -71,12 +94,8 @@ public interface MatchDAO extends Transactional<MatchDAO> {
     @SqlBatch("INSERT INTO match_entity (consent, purpose, matchentity, failed, createdate, algorithm_version) VALUES (:consent, :purpose, :match, :failed, :createDate, :algorithmVersion)")
     void insertAll(@BindBean List<Match> matches);
 
-    @SqlUpdate("UPDATE match_entity SET matchentity = :match, consent = :consentId, purpose = :purposeId, failed = :failed WHERE matchid = :id ")
-    void updateMatch(@Bind("id") Integer id,
-                     @Bind("match") Boolean match,
-                     @Bind("consentId") String consent,
-                     @Bind("purposeId") String purpose,
-                     @Bind("failed") Boolean failed);
+    @SqlUpdate("INSERT INTO match_failure_reason (match_entity_id, failure_reason) VALUES (:matchId, :reason) ")
+    void insertFailureReason(@Bind("matchId") Integer matchId, @Bind("reason") String reason);
 
     @SqlUpdate("DELETE FROM match_entity WHERE consent = :consentId")
     void deleteMatchesByConsentId(@Bind("consentId") String consentId);
@@ -87,6 +106,11 @@ public interface MatchDAO extends Transactional<MatchDAO> {
     @SqlUpdate("DELETE FROM match_entity WHERE purpose IN (<purposeIds>)")
     void deleteMatchesByPurposeIds(@BindList("purposeIds") List<String> purposeIds);
 
+    @SqlUpdate("DELETE FROM match_failure_reason WHERE match_entity_id in (SELECT matchid FROM match_entity WHERE consent IN (<consentIds>) ")
+    void deleteFailureReasonsByConsentIds(@BindList("consentIds") List<String> consentIds);
+
+    @SqlUpdate("DELETE FROM match_failure_reason WHERE match_entity_id in (SELECT matchid FROM match_entity WHERE purpose IN (<purposeIds>) ")
+    void deleteFailureReasonsByPurposeIds(@BindList("purposeIds") List<String> purposeIds);
 
     @SqlQuery("SELECT COUNT(*) FROM match_entity WHERE matchentity = :matchEntity AND failed = 'FALSE' ")
     Integer countMatchesByResult(@Bind("matchEntity") Boolean matchEntity);

--- a/src/main/java/org/broadinstitute/consent/http/db/MatchDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/MatchDAO.java
@@ -47,14 +47,26 @@ public interface MatchDAO extends Transactional<MatchDAO> {
 
     @SqlUpdate(
             " INSERT INTO match_entity " +
-            " (consent, purpose, matchentity, failed, createdate) VALUES " +
-            " (:consentId, :purposeId, :match, :failed, :createDate)")
+            " (consent, purpose, matchentity, failed, createdate, algorithm_version) VALUES " +
+            " (:consentId, :purposeId, :match, :failed, :createDate, 'v1')")
     @GetGeneratedKeys
     Integer insertMatch(@Bind("consentId") String consentId,
                         @Bind("purposeId") String purposeId,
                         @Bind("match") Boolean match,
                         @Bind("failed") Boolean failed,
                         @Bind("createDate") Date date);
+
+    @SqlUpdate(
+            " INSERT INTO match_entity " +
+            " (consent, purpose, matchentity, failed, createdate, algorithm_version) VALUES " +
+            " (:consentId, :purposeId, :match, :failed, :createDate, :algorithmVersion)")
+    @GetGeneratedKeys
+    Integer insertMatch(@Bind("consentId") String consentId,
+                        @Bind("purposeId") String purposeId,
+                        @Bind("match") Boolean match,
+                        @Bind("failed") Boolean failed,
+                        @Bind("createDate") Date date,
+                        @Bind("algorithmVersion") String algorithmVersion);
 
     @SqlBatch("INSERT INTO match_entity (consent, purpose, matchentity, failed, createdate) VALUES (:consent, :purpose, :match, :failed, :createDate)")
     void insertAll(@BindBean List<Match> matches);

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/MatchMapper.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/MatchMapper.java
@@ -16,6 +16,7 @@ public class MatchMapper implements RowMapper<Match> {
         r.getString("purpose"),
         r.getBoolean("matchEntity"),
         r.getBoolean("failed"),
-        r.getDate("createDate"));
+        r.getDate("createDate"),
+        r.getString("algorithm_version"));
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/MatchReducer.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/MatchReducer.java
@@ -6,6 +6,7 @@ import org.jdbi.v3.core.result.RowView;
 
 import java.util.Date;
 import java.util.Map;
+import java.util.Objects;
 
 public class MatchReducer implements LinkedHashMapRowReducer<Integer, Match>, RowMapperHelper {
 
@@ -32,7 +33,7 @@ public class MatchReducer implements LinkedHashMapRowReducer<Integer, Match>, Ro
         }
         if (hasColumn(rowView, "failure_reason", String.class)) {
             String failure = rowView.getColumn("failure_reason", String.class);
-            if (!failure.isBlank()) {
+            if (Objects.nonNull(failure) && !failure.isBlank()) {
                 match.addFailureReason(rowView.getColumn("failure_reason", String.class));
             }
         }

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/MatchReducer.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/MatchReducer.java
@@ -21,9 +21,6 @@ public class MatchReducer implements LinkedHashMapRowReducer<Integer, Match>, Ro
         if (hasColumn(rowView, "algorithm_version", String.class)) {
             match.setAlgorithmVersion(rowView.getColumn("algorithm_version", String.class));
         }
-        if (hasColumn(rowView, "failure_reason", String.class)) {
-            match.addFailureReason(rowView.getColumn("failure_reason", String.class));
-        }
         if (hasColumn(rowView, "matchentity", Boolean.class)) {
             match.setMatch(rowView.getColumn("matchentity", Boolean.class));
         }
@@ -34,7 +31,10 @@ public class MatchReducer implements LinkedHashMapRowReducer<Integer, Match>, Ro
             match.setCreateDate(rowView.getColumn("createdate", Date.class));
         }
         if (hasColumn(rowView, "failure_reason", String.class)) {
-            match.addFailureReason(rowView.getColumn("failure_reason", String.class));
+            String failure = rowView.getColumn("failure_reason", String.class);
+            if (!failure.isBlank()) {
+                match.addFailureReason(rowView.getColumn("failure_reason", String.class));
+            }
         }
     }
 

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/MatchReducer.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/MatchReducer.java
@@ -33,6 +33,9 @@ public class MatchReducer implements LinkedHashMapRowReducer<Integer, Match>, Ro
         if (hasColumn(rowView, "createdate", Date.class)) {
             match.setCreateDate(rowView.getColumn("createdate", Date.class));
         }
+        if (hasColumn(rowView, "failure_reason", String.class)) {
+            match.addFailureReason(rowView.getColumn("failure_reason", String.class));
+        }
     }
 
 }

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/MatchReducer.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/MatchReducer.java
@@ -1,0 +1,38 @@
+package org.broadinstitute.consent.http.db.mapper;
+
+import org.broadinstitute.consent.http.models.Match;
+import org.jdbi.v3.core.result.LinkedHashMapRowReducer;
+import org.jdbi.v3.core.result.RowView;
+
+import java.util.Date;
+import java.util.Map;
+
+public class MatchReducer implements LinkedHashMapRowReducer<Integer, Match>, RowMapperHelper {
+
+    @Override
+    public void accumulate(Map<Integer, Match> map, RowView rowView) {
+        Match match = map.computeIfAbsent(rowView.getColumn("matchid", Integer.class), id -> rowView.getRow(Match.class));
+        if (hasColumn(rowView, "consent",String.class)) {
+            match.setConsent(rowView.getColumn("consent", String.class));
+        }
+        if (hasColumn(rowView, "purpose",String.class)) {
+            match.setPurpose(rowView.getColumn("purpose", String.class));
+        }
+        if (hasColumn(rowView, "algorithm_version", String.class)) {
+            match.setAlgorithmVersion(rowView.getColumn("algorithm_version", String.class));
+        }
+        if (hasColumn(rowView, "failure_reason", String.class)) {
+            match.addFailureReason(rowView.getColumn("failure_reason", String.class));
+        }
+        if (hasColumn(rowView, "matchentity", Boolean.class)) {
+            match.setMatch(rowView.getColumn("matchentity", Boolean.class));
+        }
+        if (hasColumn(rowView, "failed", Boolean.class)) {
+            match.setFailed(rowView.getColumn("failed", Boolean.class));
+        }
+        if (hasColumn(rowView, "createdate", Date.class)) {
+            match.setCreateDate(rowView.getColumn("createdate", Date.class));
+        }
+    }
+
+}

--- a/src/main/java/org/broadinstitute/consent/http/enumeration/MatchAlgorithm.java
+++ b/src/main/java/org/broadinstitute/consent/http/enumeration/MatchAlgorithm.java
@@ -1,0 +1,20 @@
+package org.broadinstitute.consent.http.enumeration;
+
+public enum MatchAlgorithm {
+    V1("v1"),
+    V2("v2");
+
+    String version;
+
+    MatchAlgorithm(String version) {
+        this.version = version;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+}

--- a/src/main/java/org/broadinstitute/consent/http/models/Match.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/Match.java
@@ -47,6 +47,16 @@ public class Match {
         this.algorithmVersion = algorithmVersion;
     }
 
+    public Match(String consentId, String purposeId, boolean failed, boolean isMatch, MatchAlgorithm algorithm, List<String> failureReasons) {
+        this.setConsent(consentId);
+        this.setPurpose(purposeId);
+        this.setFailed(failed);
+        this.setMatch(isMatch);
+        this.setCreateDate(new Date());
+        this.setAlgorithmVersion(algorithm.getVersion());
+        this.setFailureReasons(failureReasons);
+    }
+
     public Match(){
     }
 

--- a/src/main/java/org/broadinstitute/consent/http/models/Match.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/Match.java
@@ -1,7 +1,6 @@
 package org.broadinstitute.consent.http.models;
 
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import org.broadinstitute.consent.http.enumeration.MatchAlgorithm;
 
 import java.util.ArrayList;
@@ -11,25 +10,18 @@ import java.util.Objects;
 
 public class Match {
 
-    @JsonProperty
     private Integer id;
 
-    @JsonProperty
     private String consent;
 
-    @JsonProperty
     private String purpose;
 
-    @JsonProperty
     private Boolean match;
 
-    @JsonProperty
     private Boolean failed;
 
-    @JsonProperty
     private Date createDate;
 
-    @JsonProperty
     private String algorithmVersion;
 
     private List<String> failureReasons;

--- a/src/main/java/org/broadinstitute/consent/http/models/Match.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/Match.java
@@ -4,7 +4,10 @@ package org.broadinstitute.consent.http.models;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.broadinstitute.consent.http.enumeration.MatchAlgorithm;
 
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
+import java.util.Objects;
 
 public class Match {
 
@@ -28,6 +31,8 @@ public class Match {
 
     @JsonProperty
     private String algorithmVersion;
+
+    private List<String> failureReasons;
 
     @Deprecated
     public Match(Integer id, String consent, String purpose, Boolean match, Boolean failed, Date createDate){
@@ -107,5 +112,25 @@ public class Match {
 
     public void setAlgorithmVersion(String algorithmVersion) {
         this.algorithmVersion = algorithmVersion;
+    }
+
+    public List<String> getFailureReasons() {
+        if (Objects.isNull(this.failureReasons)) {
+            return List.of();
+        }
+        return failureReasons;
+    }
+
+    public void setFailureReasons(List<String> failureReasons) {
+        this.failureReasons = failureReasons;
+    }
+
+    public void addFailureReason(String reason) {
+        if (Objects.isNull(this.failureReasons)) {
+            this.failureReasons = new ArrayList<>();
+        }
+        if (!this.failureReasons.contains(reason)) {
+            this.failureReasons.add(reason);
+        }
     }
 }

--- a/src/main/java/org/broadinstitute/consent/http/models/Match.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/Match.java
@@ -2,6 +2,7 @@ package org.broadinstitute.consent.http.models;
 
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.broadinstitute.consent.http.enumeration.MatchAlgorithm;
 
 import java.util.Date;
 
@@ -25,7 +26,10 @@ public class Match {
     @JsonProperty
     private Date createDate;
 
+    @JsonProperty
+    private String algorithmVersion;
 
+    @Deprecated
     public Match(Integer id, String consent, String purpose, Boolean match, Boolean failed, Date createDate){
         this.id = id;
         this.consent = consent;
@@ -33,6 +37,17 @@ public class Match {
         this.match = match;
         this.failed = failed;
         this.createDate = createDate;
+        this.algorithmVersion = MatchAlgorithm.V1.getVersion();
+    }
+
+    public Match(Integer id, String consent, String purpose, Boolean match, Boolean failed, Date createDate, String algorithmVersion){
+        this.id = id;
+        this.consent = consent;
+        this.purpose = purpose;
+        this.match = match;
+        this.failed = failed;
+        this.createDate = createDate;
+        this.algorithmVersion = algorithmVersion;
     }
 
     public Match(){
@@ -84,5 +99,13 @@ public class Match {
 
     public void setCreateDate(Date createDate) {
         this.createDate = createDate;
+    }
+
+    public String getAlgorithmVersion() {
+        return algorithmVersion;
+    }
+
+    public void setAlgorithmVersion(String algorithmVersion) {
+        this.algorithmVersion = algorithmVersion;
     }
 }

--- a/src/main/java/org/broadinstitute/consent/http/models/Match.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/Match.java
@@ -121,7 +121,7 @@ public class Match {
         if (Objects.isNull(this.failureReasons)) {
             this.failureReasons = new ArrayList<>();
         }
-        if (!this.failureReasons.contains(reason)) {
+        if (!this.failureReasons.contains(reason) && !reason.isBlank()) {
             this.failureReasons.add(reason);
         }
     }

--- a/src/main/java/org/broadinstitute/consent/http/models/matching/DataUseRequestMatchingObject.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/matching/DataUseRequestMatchingObject.java
@@ -8,9 +8,6 @@ public class DataUseRequestMatchingObject {
 
     public DataUse purpose;
 
-    public DataUseRequestMatchingObject(){
-    }
-
     public DataUseRequestMatchingObject(DataUse consent, DataUse purpose) {
         this.consent = consent;
         this.purpose = purpose;

--- a/src/main/java/org/broadinstitute/consent/http/models/matching/DataUseRequestMatchingObject.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/matching/DataUseRequestMatchingObject.java
@@ -1,18 +1,11 @@
 package org.broadinstitute.consent.http.models.matching;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import org.broadinstitute.consent.http.enumeration.DataUseTranslationType;
-import org.broadinstitute.consent.http.models.Consent;
-import org.broadinstitute.consent.http.models.DataAccessRequest;
 import org.broadinstitute.consent.http.models.DataUse;
-import org.broadinstitute.consent.http.models.Dataset;
-import org.broadinstitute.consent.http.models.grammar.UseRestriction;
 
 public class DataUseRequestMatchingObject {
 
-    @JsonProperty
     public DataUse consent;
-    @JsonProperty
+
     public DataUse purpose;
 
     public DataUseRequestMatchingObject(){

--- a/src/main/java/org/broadinstitute/consent/http/models/matching/DataUseRequestMatchingObject.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/matching/DataUseRequestMatchingObject.java
@@ -1,0 +1,42 @@
+package org.broadinstitute.consent.http.models.matching;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.broadinstitute.consent.http.enumeration.DataUseTranslationType;
+import org.broadinstitute.consent.http.models.Consent;
+import org.broadinstitute.consent.http.models.DataAccessRequest;
+import org.broadinstitute.consent.http.models.DataUse;
+import org.broadinstitute.consent.http.models.Dataset;
+import org.broadinstitute.consent.http.models.grammar.UseRestriction;
+
+public class DataUseRequestMatchingObject {
+
+    @JsonProperty
+    public DataUse consent;
+    @JsonProperty
+    public DataUse purpose;
+
+    public DataUseRequestMatchingObject(){
+    }
+
+    public DataUseRequestMatchingObject(DataUse consent, DataUse purpose) {
+        this.consent = consent;
+        this.purpose = purpose;
+    }
+
+    public DataUse getConsent() {
+        return consent;
+    }
+
+    public void setConsent(DataUse consent) {
+        this.consent = consent;
+    }
+
+    public DataUse getPurpose() {
+        return purpose;
+    }
+
+    public void setPurpose(DataUse purpose) {
+        this.purpose = purpose;
+    }
+
+}

--- a/src/main/java/org/broadinstitute/consent/http/models/matching/DataUseResponseMatchingObject.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/matching/DataUseResponseMatchingObject.java
@@ -1,18 +1,13 @@
 package org.broadinstitute.consent.http.models.matching;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 import java.util.List;
 
 public class DataUseResponseMatchingObject {
 
-    @JsonProperty
     public boolean result;
 
-    @JsonProperty
     public DataUseRequestMatchingObject matchPair;
 
-    @JsonProperty
     public List<String> failureReasons;
 
     public DataUseResponseMatchingObject() {

--- a/src/main/java/org/broadinstitute/consent/http/models/matching/DataUseResponseMatchingObject.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/matching/DataUseResponseMatchingObject.java
@@ -1,0 +1,50 @@
+package org.broadinstitute.consent.http.models.matching;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public class DataUseResponseMatchingObject {
+
+    @JsonProperty
+    public boolean result;
+
+    @JsonProperty
+    public DataUseRequestMatchingObject matchPair;
+
+    @JsonProperty
+    public List<String> failureReasons;
+
+    public DataUseResponseMatchingObject() {
+    }
+
+    public DataUseResponseMatchingObject(boolean result, DataUseRequestMatchingObject matchPair, List<String> failureReasons) {
+        this.result = result;
+        this.matchPair = matchPair;
+        this.failureReasons = failureReasons;
+    }
+
+    public boolean isResult() {
+        return result;
+    }
+
+    public void setResult(boolean result) {
+        this.result = result;
+    }
+
+    public DataUseRequestMatchingObject getMatchPair() {
+        return matchPair;
+    }
+
+    public void setMatchPair(DataUseRequestMatchingObject matchPair) {
+        this.matchPair = matchPair;
+    }
+
+    public List<String> getFailureReasons() {
+        return failureReasons;
+    }
+
+    public void setFailureReasons(List<String> failureReasons) {
+        this.failureReasons = failureReasons;
+    }
+}

--- a/src/main/java/org/broadinstitute/consent/http/models/matching/DataUseResponseMatchingObject.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/matching/DataUseResponseMatchingObject.java
@@ -10,9 +10,6 @@ public class DataUseResponseMatchingObject {
 
     public List<String> failureReasons;
 
-    public DataUseResponseMatchingObject() {
-    }
-
     public DataUseResponseMatchingObject(boolean result, DataUseRequestMatchingObject matchPair, List<String> failureReasons) {
         this.result = result;
         this.matchPair = matchPair;

--- a/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
@@ -187,7 +187,7 @@ public class DarCollectionService {
           Boolean isVotable = elections
             .stream()
             .anyMatch(election -> election.getStatus().equalsIgnoreCase(ElectionStatus.OPEN.getValue()));
-          
+
           if(isVotable) {
             s.setStatus(DarCollectionStatus.IN_PROCESS.getValue());
             s.addAction(DarCollectionActions.VOTE.getValue());
@@ -196,7 +196,7 @@ public class DarCollectionService {
               //all canceled (complete)
               //some datasets do not have elections (in process)
               //all voted on (complete)
-              //no elections 
+              //no elections
             if(electionCount < s.getDatasetCount()) {
               s.setStatus(DarCollectionStatus.IN_PROCESS.getValue());
             } else {
@@ -206,7 +206,7 @@ public class DarCollectionService {
         }
     });
   }
-  
+
 
   private void processDarCollectionSummariesForChair(List<DarCollectionSummary> summaries) {
     summaries.forEach(s -> {
@@ -489,6 +489,7 @@ public class DarCollectionService {
     // no elections left & user has perms => safe to delete collection
 
     // delete DARs
+    matchDAO.deleteFailureReasonsByPurposeIds(referenceIds);
     matchDAO.deleteMatchesByPurposeIds(referenceIds);
     dataAccessRequestDAO.deleteDARDatasetRelationByReferenceIds(referenceIds);
     dataAccessRequestDAO.deleteByReferenceIds(referenceIds);

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
@@ -203,6 +203,7 @@ public class DataAccessRequestService {
                 throw new NotAcceptableException(message);
             }
         }
+        matchDAO.deleteFailureReasonsByPurposeIds(List.of(referenceId));
         matchDAO.deleteMatchesByPurposeId(referenceId);
         dataAccessRequestDAO.deleteDARDatasetRelationByReferenceId(referenceId);
         dataAccessRequestDAO.deleteByReferenceId(referenceId);

--- a/src/main/java/org/broadinstitute/consent/http/service/MatchService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/MatchService.java
@@ -151,7 +151,7 @@ public class MatchService {
                 } catch (Exception e) {
                     String message = "Error finding single match for purpose: " + dar.getReferenceId();
                     logger.error(message);
-                    matches.add(createMatch(dataset.getDatasetIdentifier(), dar.getReferenceId(), true, false, MatchAlgorithm.V2, List.of(message)));
+                    matches.add(new Match(dataset.getDatasetIdentifier(), dar.getReferenceId(), true, false, MatchAlgorithm.V2, List.of(message)));
                 }
             }
         });
@@ -171,7 +171,7 @@ public class MatchService {
                     matches.add(match);
                 } catch (Exception e) {
                     logger.error("Error finding  matches for consent: " + consentId);
-                    matches.add(createMatch(consentId, dar.getReferenceId(), true, false, MatchAlgorithm.V1, List.of()));
+                    matches.add(new Match(consentId, dar.getReferenceId(), true, false, MatchAlgorithm.V1, List.of()));
                 }
             }
         }
@@ -193,9 +193,9 @@ public class MatchService {
         Response res = matchServiceTargetV1.request(MediaType.APPLICATION_JSON).post(Entity.json(json));
         if (res.getStatus() == Response.Status.OK.getStatusCode()) {
             ResponseMatchingObject entity = res.readEntity(rmo);
-            match = createMatch(consent.getConsentId(), dar.getReferenceId(), false, entity.isResult(), MatchAlgorithm.V1, List.of());
+            match = new Match(consent.getConsentId(), dar.getReferenceId(), false, entity.isResult(), MatchAlgorithm.V1, List.of());
         } else {
-            match = createMatch(consent.getConsentId(), dar.getReferenceId(), true, false, MatchAlgorithm.V1, List.of());
+            match = new Match(consent.getConsentId(), dar.getReferenceId(), true, false, MatchAlgorithm.V1, List.of());
         }
         return match;
     }
@@ -216,22 +216,10 @@ public class MatchService {
         if (res.getStatus() == Response.Status.OK.getStatusCode()) {
             GenericType<DataUseResponseMatchingObject> durmo = new GenericType<>(){};
             DataUseResponseMatchingObject entity = res.readEntity(durmo);
-            match = createMatch(dataset.getDatasetIdentifier(), dar.getReferenceId(), false, entity.isResult(), MatchAlgorithm.V2, entity.getFailureReasons());
+            match = new Match(dataset.getDatasetIdentifier(), dar.getReferenceId(), false, entity.isResult(), MatchAlgorithm.V2, entity.getFailureReasons());
         } else {
-            match = createMatch(dataset.getDatasetIdentifier(), dar.getReferenceId(), true, false, MatchAlgorithm.V2, List.of());
+            match = new Match(dataset.getDatasetIdentifier(), dar.getReferenceId(), true, false, MatchAlgorithm.V2, List.of());
         }
-        return match;
-    }
-
-    private Match createMatch(String consentId, String purposeId, boolean failed, boolean isMatch, MatchAlgorithm algorithm, List<String> failureReasons) {
-        Match match = new Match();
-        match.setConsent(consentId);
-        match.setPurpose(purposeId);
-        match.setFailed(failed);
-        match.setMatch(isMatch);
-        match.setCreateDate(new Date());
-        match.setAlgorithmVersion(algorithm.getVersion());
-        match.setFailureReasons(failureReasons);
         return match;
     }
 

--- a/src/main/java/org/broadinstitute/consent/http/service/MatchService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/MatchService.java
@@ -215,7 +215,8 @@ public class MatchService {
         Response res = matchServiceTargetV2.request(MediaType.APPLICATION_JSON).post(Entity.json(json));
         if (res.getStatus() == Response.Status.OK.getStatusCode()) {
             GenericType<DataUseResponseMatchingObject> durmo = new GenericType<>(){};
-            DataUseResponseMatchingObject entity = res.readEntity(durmo);
+            String stringEntity = res.readEntity(String.class);
+            DataUseResponseMatchingObject entity = new Gson().fromJson(stringEntity, DataUseResponseMatchingObject.class);
             match = new Match(dataset.getDatasetIdentifier(), dar.getReferenceId(), false, entity.isResult(), MatchAlgorithm.V2, entity.getFailureReasons());
         } else {
             match = new Match(dataset.getDatasetIdentifier(), dar.getReferenceId(), true, false, MatchAlgorithm.V2, List.of());

--- a/src/main/java/org/broadinstitute/consent/http/service/MatchService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/MatchService.java
@@ -83,9 +83,11 @@ public class MatchService {
                 new Date(),
                 m.getAlgorithmVersion()
             );
-            m.getFailureReasons().forEach(f -> {
-                matchDAO.insertFailureReason(id, f);
-            });
+            if (!m.getFailureReasons().isEmpty()) {
+                m.getFailureReasons().forEach(f -> {
+                    matchDAO.insertFailureReason(id, f);
+                });
+            }
         });
     }
 

--- a/src/main/java/org/broadinstitute/consent/http/service/MatchService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/MatchService.java
@@ -2,7 +2,6 @@ package org.broadinstitute.consent.http.service;
 
 import com.google.gson.Gson;
 import com.google.inject.Inject;
-import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.consent.http.configurations.ServicesConfiguration;
 import org.broadinstitute.consent.http.db.ConsentDAO;
 import org.broadinstitute.consent.http.db.DataAccessRequestDAO;

--- a/src/main/resources/assets/schemas/MatchResult.yaml
+++ b/src/main/resources/assets/schemas/MatchResult.yaml
@@ -5,13 +5,13 @@ properties:
     description: The id of the stored match result
   consent:
     type: string
-    description: The Consent ID
+    description: The Consent ID or Dataset Identifier
   purpose:
     type: string
     description: The Data Access Request ID
   match:
     type: boolean
-    description: The match condition between the Consent and Data Access Request
+    description: The match condition between the Consent/Dataset and Data Access Request
   failed:
     type: boolean
     description: Indicates a system failure or not. If true, the system was not able to
@@ -19,3 +19,6 @@ properties:
   createDate:
     type: string
     description: A string representation of the date that this match result was created.
+  algorithmVersion:
+    type: string
+    description: The version of the algorithm used to generate the match.

--- a/src/main/resources/changelog-master.xml
+++ b/src/main/resources/changelog-master.xml
@@ -88,4 +88,5 @@
     <include file="changesets/changelog-consent-83.0.xml" relativeToChangelogFile="true"/>
     <include file="changesets/changelog-consent-84.0.xml" relativeToChangelogFile="true"/>
     <include file="changesets/changelog-consent-85.0.xml" relativeToChangelogFile="true"/>
+    <include file="changesets/changelog-consent-86.0.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/changelog-master.xml
+++ b/src/main/resources/changelog-master.xml
@@ -88,5 +88,5 @@
     <include file="changesets/changelog-consent-83.0.xml" relativeToChangelogFile="true"/>
     <include file="changesets/changelog-consent-84.0.xml" relativeToChangelogFile="true"/>
     <include file="changesets/changelog-consent-85.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-86.0.xml" relativeToChangelogFile="true"/>
+    <include file="changesets/changelog-consent-87.0.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/changesets/changelog-consent-14.0.xml
+++ b/src/main/resources/changesets/changelog-consent-14.0.xml
@@ -28,7 +28,7 @@
     <changeSet author="vvicario" id="58">
         <validCheckSum>ANY</validCheckSum>
         <addForeignKeyConstraint baseColumnNames="consent" baseTableName="matchentity"
-                                 constraintName="fkMatchConsent" deferrable="false" initiallyDeferred="false"
+                                 constraintName="fkmatchconsent" deferrable="false" initiallyDeferred="false"
                                  onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="consentid"
                                  referencedTableName="consents" referencesUniqueColumn="false"/>
     </changeSet>

--- a/src/main/resources/changesets/changelog-consent-86.0.xml
+++ b/src/main/resources/changesets/changelog-consent-86.0.xml
@@ -1,0 +1,15 @@
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+    <changeSet id="86.0" author="grushton">
+        <!-- Add a version to the match table to capture which algorithm version it applies to -->
+        <addColumn tableName="match_entity">
+            <column name="algorithm_version" type="varchar(255)" defaultValue="v1">
+                <constraints nullable="true"/>
+            </column>
+        </addColumn>
+        <rollback>
+            <dropColumn tableName="match_entity" columnName="algorithm_version"/>
+        </rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/changesets/changelog-consent-86.0.xml
+++ b/src/main/resources/changesets/changelog-consent-86.0.xml
@@ -8,8 +8,13 @@
                 <constraints nullable="true"/>
             </column>
         </addColumn>
+        <dropForeignKeyConstraint baseTableName="match_entity" constraintName="fkmatchconsent"/>
         <rollback>
             <dropColumn tableName="match_entity" columnName="algorithm_version"/>
+            <addForeignKeyConstraint baseColumnNames="consent" baseTableName="match_entity"
+                                     constraintName="fkmatchconsent" deferrable="false" initiallyDeferred="false"
+                                     onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="consentid"
+                                     referencedTableName="consents" referencesUniqueColumn="false"/>
         </rollback>
     </changeSet>
 </databaseChangeLog>

--- a/src/main/resources/changesets/changelog-consent-86.0.xml
+++ b/src/main/resources/changesets/changelog-consent-86.0.xml
@@ -2,6 +2,22 @@
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
          http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
     <changeSet id="86.0" author="grushton">
+        <!-- Capture failure reasons for all V2 algorithm results -->
+        <createTable tableName="match_failure_reason">
+            <column name="id" type="bigint" autoIncrement="true">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="match_entity_id" type="bigint">
+                <constraints nullable="false"/>
+            </column>
+            <column name="failure_reason" type="varchar(255)">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+        <addForeignKeyConstraint baseColumnNames="match_entity_id" baseTableName="match_failure_reason" constraintName="fk_match_failure_entity_id"
+                                 deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION"
+                                 referencedColumnNames="matchid" referencedTableName="match_entity"/>
+
         <!-- Add a version to the match table to capture which algorithm version it applies to -->
         <addColumn tableName="match_entity">
             <column name="algorithm_version" type="varchar(255)" defaultValue="v1">
@@ -10,7 +26,9 @@
         </addColumn>
         <dropForeignKeyConstraint baseTableName="match_entity" constraintName="fkmatchconsent"/>
         <rollback>
+            <dropTable tableName="match_failure_reason" cascadeConstraints="true"/>
             <dropColumn tableName="match_entity" columnName="algorithm_version"/>
+            <!-- This is the original creation of the constraint modified for postgres -->
             <addForeignKeyConstraint baseColumnNames="consent" baseTableName="match_entity"
                                      constraintName="fkmatchconsent" deferrable="false" initiallyDeferred="false"
                                      onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="consentid"

--- a/src/main/resources/changesets/changelog-consent-87.0.xml
+++ b/src/main/resources/changesets/changelog-consent-87.0.xml
@@ -1,7 +1,7 @@
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
          http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
-    <changeSet id="86.0" author="grushton">
+    <changeSet id="87.0" author="grushton">
         <!-- Capture failure reasons for all V2 algorithm results -->
         <createTable tableName="match_failure_reason">
             <column name="id" type="bigint" autoIncrement="true">

--- a/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
@@ -148,6 +148,7 @@ public class DAOTestHelper {
         testingDAO.deleteAllApprovalTimes();
         testingDAO.deleteAllVotes();
         testingDAO.deleteAllConsentAudits();
+        testingDAO.deleteAllMatchEntityFailureReasons();
         testingDAO.deleteAllMatchEntities();
         testingDAO.deleteAllConsentAssociations();
         testingDAO.deleteAllConsents();

--- a/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
@@ -255,10 +255,10 @@ public class DAOTestHelper {
     protected Match createMatch() {
         DataAccessRequest dar = createDataAccessRequestV3();
         Dac dac = createDac();
-        Consent consent = createConsent(dac.getDacId());
+        Dataset dataset = createDataset();
         Integer matchId =
         matchDAO.insertMatch(
-            consent.getConsentId(),
+            dataset.getDatasetIdentifier(),
             dar.getReferenceId(),
             RandomUtils.nextBoolean(),
             false,

--- a/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
@@ -11,6 +11,7 @@ import org.broadinstitute.consent.http.ConsentApplication;
 import org.broadinstitute.consent.http.configurations.ConsentConfiguration;
 import org.broadinstitute.consent.http.enumeration.ElectionStatus;
 import org.broadinstitute.consent.http.enumeration.ElectionType;
+import org.broadinstitute.consent.http.enumeration.MatchAlgorithm;
 import org.broadinstitute.consent.http.enumeration.UserFields;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.enumeration.VoteType;
@@ -42,7 +43,6 @@ import org.testcontainers.containers.PostgreSQLContainer;
 
 import java.sql.Timestamp;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.UUID;
@@ -262,7 +262,8 @@ public class DAOTestHelper {
             dar.getReferenceId(),
             RandomUtils.nextBoolean(),
             false,
-            new Date());
+            new Date(),
+            MatchAlgorithm.V2.getVersion());
         return matchDAO.findMatchById(matchId);
     }
 

--- a/src/test/java/org/broadinstitute/consent/http/db/MatchDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/MatchDAOTest.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.consent.http.db;
 
+import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.RandomUtils;
 import org.broadinstitute.consent.http.enumeration.MatchAlgorithm;
 import org.broadinstitute.consent.http.models.Dac;
@@ -184,4 +185,24 @@ public class MatchDAOTest extends DAOTestHelper {
     Match foundMatch = matchDAO.findMatchById(matchId);
     assertNotNull(foundMatch);
   }
+  @Test
+  public void testInsertFailureReason() {
+    Match match = makeMockMatch(UUID.randomUUID().toString());
+    match.setMatch(false);
+    match.setAlgorithmVersion(MatchAlgorithm.V2.getVersion());
+    match.addFailureReason(RandomStringUtils.randomAlphabetic(100));
+    match.addFailureReason(RandomStringUtils.randomAlphabetic(100));
+    Integer matchId = matchDAO.insertMatch(
+      match.getConsent(),
+      match.getPurpose(),
+      match.getMatch(),
+      match.getFailed(),
+      match.getCreateDate(),
+      match.getAlgorithmVersion());
+    match.getFailureReasons().forEach(f -> matchDAO.insertFailureReason(matchId, f));
+    Match foundMatch = matchDAO.findMatchById(matchId);
+    assertNotNull(foundMatch);
+    assertEquals(match.getFailureReasons().size(), foundMatch.getFailureReasons().size());
+  }
+
 }

--- a/src/test/java/org/broadinstitute/consent/http/db/MatchDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/MatchDAOTest.java
@@ -205,4 +205,46 @@ public class MatchDAOTest extends DAOTestHelper {
     assertEquals(match.getFailureReasons().size(), foundMatch.getFailureReasons().size());
   }
 
+  @Test
+  public void testDeleteFailureReasonsByConsentIds() {
+    Match match = makeMockMatch(UUID.randomUUID().toString());
+    match.setMatch(false);
+    match.setAlgorithmVersion(MatchAlgorithm.V2.getVersion());
+    match.addFailureReason(RandomStringUtils.randomAlphabetic(100));
+    match.addFailureReason(RandomStringUtils.randomAlphabetic(100));
+    Integer matchId = matchDAO.insertMatch(
+      match.getConsent(),
+      match.getPurpose(),
+      match.getMatch(),
+      match.getFailed(),
+      match.getCreateDate(),
+      match.getAlgorithmVersion());
+    match.getFailureReasons().forEach(f -> matchDAO.insertFailureReason(matchId, f));
+    matchDAO.deleteFailureReasonsByConsentIds(List.of(match.getConsent()));
+    Match foundMatch = matchDAO.findMatchById(matchId);
+    assertNotNull(foundMatch);
+    assertEquals(0, foundMatch.getFailureReasons().size());
+  }
+
+  @Test
+  public void testDeleteFailureReasonsByPurposeIds() {
+    Match match = makeMockMatch(UUID.randomUUID().toString());
+    match.setMatch(false);
+    match.setAlgorithmVersion(MatchAlgorithm.V2.getVersion());
+    match.addFailureReason(RandomStringUtils.randomAlphabetic(100));
+    match.addFailureReason(RandomStringUtils.randomAlphabetic(100));
+    Integer matchId = matchDAO.insertMatch(
+      match.getConsent(),
+      match.getPurpose(),
+      match.getMatch(),
+      match.getFailed(),
+      match.getCreateDate(),
+      match.getAlgorithmVersion());
+    match.getFailureReasons().forEach(f -> matchDAO.insertFailureReason(matchId, f));
+    matchDAO.deleteFailureReasonsByPurposeIds(List.of(match.getPurpose()));
+    Match foundMatch = matchDAO.findMatchById(matchId);
+    assertNotNull(foundMatch);
+    assertEquals(0, foundMatch.getFailureReasons().size());
+  }
+
 }

--- a/src/test/java/org/broadinstitute/consent/http/db/MatchDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/MatchDAOTest.java
@@ -16,6 +16,7 @@ import java.util.stream.IntStream;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 public class MatchDAOTest extends DAOTestHelper {
@@ -161,5 +162,26 @@ public class MatchDAOTest extends DAOTestHelper {
     //Again, a match like this usually isn't generated in a normal workflow unless bug occurs, but having the 'DataAccess' condition is a nice safety net
     List<Match> matchResults = matchDAO.findMatchesForLatestDataAccessElectionsByPurposeIds(List.of(darReferenceId));
     assertTrue(matchResults.isEmpty());
+  }
+
+  @Test
+  public void testFindMatchByPurposeIdAndConsentId() {
+    Match match = makeMockMatch(UUID.randomUUID().toString());
+    matchDAO.insertAll(List.of(match));
+    Match foundMatch = matchDAO.findMatchByPurposeIdAndConsentId(match.getPurpose(), match.getConsent());
+    assertNotNull(foundMatch);
+  }
+  @Test
+  public void testFindMatchById() {
+    Match match = makeMockMatch(UUID.randomUUID().toString());
+    Integer matchId = matchDAO.insertMatch(
+      match.getConsent(),
+      match.getPurpose(),
+      match.getMatch(),
+      match.getFailed(),
+      match.getCreateDate(),
+      match.getAlgorithmVersion());
+    Match foundMatch = matchDAO.findMatchById(matchId);
+    assertNotNull(foundMatch);
   }
 }

--- a/src/test/java/org/broadinstitute/consent/http/db/MatchDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/MatchDAOTest.java
@@ -74,21 +74,6 @@ public class MatchDAOTest extends DAOTestHelper {
   }
 
   @Test
-  public void testUpdateMatch() {
-    Match m = createMatch();
-
-    matchDAO.updateMatch(
-            m.getId(),
-            true,
-            m.getConsent(),
-            m.getPurpose(),
-            false);
-    Match found = matchDAO.findMatchById(m.getId());
-    assertTrue(found.getMatch());
-    assertFalse(found.getFailed());
-  }
-
-  @Test
   public void testDeleteMatchesByConsentId() {
     Match m = createMatch();
 

--- a/src/test/java/org/broadinstitute/consent/http/db/MatchDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/MatchDAOTest.java
@@ -1,6 +1,7 @@
 package org.broadinstitute.consent.http.db;
 
 import org.apache.commons.lang3.RandomUtils;
+import org.broadinstitute.consent.http.enumeration.MatchAlgorithm;
 import org.broadinstitute.consent.http.models.Dac;
 import org.broadinstitute.consent.http.models.Dataset;
 import org.broadinstitute.consent.http.models.Election;
@@ -68,6 +69,7 @@ public class MatchDAOTest extends DAOTestHelper {
     match.setFailed(false);
     match.setCreateDate(new Date());
     match.setMatch(RandomUtils.nextBoolean());
+    match.setAlgorithmVersion(MatchAlgorithm.V1.getVersion());
     return match;
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/db/TestingDAO.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/TestingDAO.java
@@ -15,6 +15,9 @@ public interface TestingDAO extends Transactional<TestingDAO> {
   @SqlUpdate("DELETE FROM consent_audit")
   void deleteAllConsentAudits();
 
+  @SqlUpdate("DELETE FROM match_failure_reason")
+  void deleteAllMatchEntityFailureReasons();
+
   @SqlUpdate("DELETE FROM match_entity")
   void deleteAllMatchEntities();
 

--- a/src/test/java/org/broadinstitute/consent/http/service/MatchServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/MatchServiceTest.java
@@ -177,18 +177,6 @@ public class MatchServiceTest {
     }
 
     @Test
-    public void testUpdate() {
-        initSingleMatchMocks("DAR-2", sampleConsent1);
-        doNothing().when(matchDAO).updateMatch(any(), any(), any(), any(), any());
-        when(matchDAO.findMatchById(1)).thenReturn(sampleMatch1);
-        initService();
-
-        Match match = service.update(sampleMatch1, 1);
-        assertNotNull(match);
-        assertEquals("CONS-1", match.getConsent());
-    }
-
-    @Test
     public void testFindMatchById() {
         initSingleMatchMocks("DAR-2", sampleConsent1);
         when(matchDAO.findMatchById(1)).thenReturn(sampleMatch1);


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-1971

This PR:

- Adds a version to the match table to denote which algorithm we used to store the results
- Updates DAR/Dataset matching logic to query the v2 endpoint and store the results with the v2 version
- Significant match service class test refactoring. The mocking was excessive and unnecessary.
- DOES NOT make any changes to consent/dataset matching. Those code paths are completely deprecated at present and do not need to be touched until we start removing the relevant code altogether.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
