### PR TITLE
[DUOS-1976][risk=no] deprecate endpoints for DulReview, DulPreview, DulCollection, DulResultRecords

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/resources/ConsentResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/ConsentResource.java
@@ -52,6 +52,7 @@ public class ConsentResource extends Resource {
         this.matchService = matchService;
     }
 
+    @Deprecated
     @Path("{id}")
     @GET
     @Produces("application/json")

--- a/src/main/java/org/broadinstitute/consent/http/resources/ConsentVoteResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/ConsentVoteResource.java
@@ -40,6 +40,7 @@ public class ConsentVoteResource extends Resource {
         this.electionService = electionService;
     }
 
+    @Deprecated
     @POST
     @Consumes("application/json")
     @Path("/{id}")
@@ -61,6 +62,7 @@ public class ConsentVoteResource extends Resource {
         }
     }
 
+    @Deprecated
     @PUT
     @Consumes("application/json")
     @Produces("application/json")
@@ -76,6 +78,7 @@ public class ConsentVoteResource extends Resource {
         }
     }
 
+    @Deprecated
     @GET
     @Produces("application/json")
     @Path("/{id}")

--- a/src/main/java/org/broadinstitute/consent/http/resources/ElectionResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/ElectionResource.java
@@ -88,7 +88,7 @@ public class ElectionResource extends Resource {
         }
     }
 
-
+    @Deprecated
     @GET
     @Consumes("application/json")
     @Produces("application/json")

--- a/src/main/java/org/broadinstitute/consent/http/resources/ElectionReviewResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/ElectionReviewResource.java
@@ -39,6 +39,7 @@ public class ElectionReviewResource extends Resource {
         this.darService = darService;
     }
 
+    @Deprecated
     @GET
     @Produces("application/json")
     @RolesAllowed({ADMIN, MEMBER, CHAIRPERSON, ALUMNI})

--- a/src/main/java/org/broadinstitute/consent/http/resources/ElectionReviewResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/ElectionReviewResource.java
@@ -55,6 +55,7 @@ public class ElectionReviewResource extends Resource {
         return ("{ \"open\" : " + service.openElections() + " }");
     }
 
+    @Deprecated
     @GET
     @Path("/{electionId}")
     @Produces("application/json")

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -340,6 +340,7 @@ paths:
     $ref: './paths/consent.yaml'
   /api/consent/{id}:
     get:
+      deprecated: true
       summary: Get Consent by ID
       description: Returns the consent identified by the ID.
       parameters:
@@ -421,6 +422,7 @@ paths:
           description: The consent for the id couldn't be found.
   /api/consent/{consentId}/vote/{id}:
     post:
+      deprecated: true
       summary: firstVoteUpdate
       description: Returns the created vote.
       parameters:
@@ -455,6 +457,7 @@ paths:
         404:
           description: The association type wasn't send, or the application couldn't find any consents that matched the search criteria.
     put:
+      deprecated: true
       summary: updateConsentVote
       description: Returns the updated vote.
       parameters:
@@ -487,6 +490,7 @@ paths:
         400:
           description: Bad Request, malformed entity, etc.
     get:
+      deprecated: true
       summary: describe
       description: Returns the required vote.
       parameters:
@@ -1453,6 +1457,7 @@ paths:
                 format: binary
   /api/consent/{id}/dul:
     get:
+      deprecated: true
       summary: getDUL
       description: Returns Data Use Letter file specified by consentId.
       parameters:
@@ -2067,6 +2072,7 @@ paths:
           description: Server error.
   /api/electionReview:
     get:
+      deprecated: true
       summary: getCollectElectionReview
       description: Returns the ElectionReview from an Open Election identified by reference Id.
       parameters:

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -2117,6 +2117,7 @@ paths:
                 type: string
   /api/electionReview/{electionId}:
     get:
+      deprecated: true
       summary: describeElectionReviewByElectionId
       description: "Returns the ElectionReview from an Election identified by ElectionId. This endpoint doesn't filter votes by isFinalAccess attribute so the reviewVote array of the retrieved ElectionReview will contain the isFinalAccess = TRUE Vote."
       parameters:


### PR DESCRIPTION
Addresses [DUOS-1976](https://broadworkbench.atlassian.net/browse/DUOS-1976)

I wasn't able to find swagger documentation for `GET /api/election/vote/${voteId}` or the actual resource method for `GET /api/consent/${consentId}/dul`

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
