### PR TITLE
[DUOS-1967][risk=no] SOs don't see users not in their institution

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/service/UserService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/UserService.java
@@ -208,13 +208,7 @@ public class UserService {
             case Resource.SIGNINGOFFICIAL :
                 Integer institutionId = user.getInstitutionId();
                 if (Objects.nonNull(user.getInstitutionId())) {
-                    List<User> institutionUsers = userDAO.getUsersFromInstitutionWithCards(institutionId);
-                    List<User> unregisteredUsers = userDAO.getCardsForUnregisteredUsers(institutionId);
-                    return Stream.of(
-                        institutionUsers,
-                        unregisteredUsers
-                    ).flatMap(Collection::stream)
-                    .collect(Collectors.toList());
+                    return userDAO.getUsersFromInstitutionWithCards(institutionId);
                 } else {
                     throw new NotFoundException("Signing Official (user: " + user.getDisplayName() + ") is not associated with an Institution.");
                 }

--- a/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
@@ -423,8 +423,7 @@ public class UserServiceTest {
     public void testGetUsersByUserRole_SO() {
         User u = generateUser();
         u.setInstitutionId(1);
-        when(userDAO.getUsersFromInstitutionWithCards(anyInt())).thenReturn(List.of(new User()));
-        when(userDAO.getCardsForUnregisteredUsers(anyInt())).thenReturn(List.of(new User()));
+        when(userDAO.getUsersFromInstitutionWithCards(anyInt())).thenReturn(List.of(new User(), new User()));
         initService();
 
         List<User> users = service.getUsersAsRole(u, UserRoles.SIGNINGOFFICIAL.getRoleName());
@@ -437,7 +436,7 @@ public class UserServiceTest {
         User u = generateUser();
         u.setInstitutionId(null);
         initService();
-    service.getUsersAsRole(u, UserRoles.SIGNINGOFFICIAL.getRoleName());
+        service.getUsersAsRole(u, UserRoles.SIGNINGOFFICIAL.getRoleName());
     }
 
     @Test


### PR DESCRIPTION
## Addresses

https://broadworkbench.atlassian.net/browse/DUOS-1967

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
