### PR TITLE
[DUOS-1969][risk=no] Copy data use from consents to datasets

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/DacDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DacDAO.java
@@ -7,6 +7,7 @@ import org.broadinstitute.consent.http.db.mapper.UserRoleMapper;
 import org.broadinstitute.consent.http.db.mapper.UserWithRolesMapper;
 import org.broadinstitute.consent.http.db.mapper.UserWithRolesReducer;
 import org.broadinstitute.consent.http.models.Dac;
+import org.broadinstitute.consent.http.models.Dataset;
 import org.broadinstitute.consent.http.models.Role;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.UserRole;
@@ -37,12 +38,12 @@ public interface DacDAO extends Transactional<DacDAO> {
      * @return List<Dac>
      */
     @RegisterBeanMapper(value = Dac.class)
-    @RegisterBeanMapper(value = DatasetDTO.class)
+    @RegisterBeanMapper(value = Dataset.class)
     @UseRowReducer(DacWithDatasetsReducer.class)
     @SqlQuery(
         "SELECT dac.dac_id, dac.name, dac.description, d.datasetid, d.name AS dataset_name, DATE(d.createdate) AS dataset_create_date, "
             + " d.objectid, d.active, d.needs_approval, d.alias AS dataset_alias, d.create_user_id, d.update_date AS dataset_update_date, "
-            + " d.update_user_id, d.datause AS dataset_data_use, ca.consentid, c.translateduserestriction "
+            + " d.update_user_id, d.data_use AS dataset_data_use, ca.consentid, c.translateduserestriction "
             + " FROM dac "
             + " LEFT OUTER JOIN consents c ON c.dac_id = dac.dac_id "
             + " LEFT OUTER JOIN consentassociations ca ON ca.consentid = c.consentid "

--- a/src/main/java/org/broadinstitute/consent/http/db/DacDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DacDAO.java
@@ -42,7 +42,7 @@ public interface DacDAO extends Transactional<DacDAO> {
     @SqlQuery(
         "SELECT dac.dac_id, dac.name, dac.description, d.datasetid, d.name AS dataset_name, DATE(d.createdate) AS dataset_create_date, "
             + " d.objectid, d.active, d.needs_approval, d.alias AS dataset_alias, d.create_user_id, d.update_date AS dataset_update_date, "
-            + " d.update_user_id, ca.consentid, c.translateduserestriction, c.datause AS consent_data_use "
+            + " d.update_user_id, d.datause AS dataset_data_use, ca.consentid, c.translateduserestriction "
             + " FROM dac "
             + " LEFT OUTER JOIN consents c ON c.dac_id = dac.dac_id "
             + " LEFT OUTER JOIN consentassociations ca ON ca.consentid = c.consentid "

--- a/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
@@ -36,12 +36,18 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
 
     String CHAIRPERSON = Resource.CHAIRPERSON;
 
-    @SqlUpdate("INSERT INTO dataset (name, createdate, create_user_id, update_date, update_user_id, objectId, active, alias) (SELECT :name, :createDate, :createUserId, :createDate, :createUserId, :objectId, :active, COALESCE(MAX(alias),0)+1 FROM dataset)")
+    @SqlUpdate("INSERT INTO dataset (name, createdate, create_user_id, update_date, update_user_id, objectId, active, alias, data_use) (SELECT :name, :createDate, :createUserId, :createDate, :createUserId, :objectId, :active, COALESCE(MAX(alias),0)+1, :dataUse FROM dataset)")
     @GetGeneratedKeys
-    Integer insertDataset(@Bind("name") String name, @Bind("createDate") Timestamp createDate, @Bind("createUserId") Integer createUserId, @Bind("objectId") String objectId, @Bind("active") Boolean active);
+    Integer insertDataset(
+        @Bind("name") String name,
+        @Bind("createDate") Timestamp createDate,
+        @Bind("createUserId") Integer createUserId,
+        @Bind("objectId") String objectId,
+        @Bind("active") Boolean active,
+        @Bind("dataUse") String dataUse);
 
     @UseRowReducer(DatasetReducer.class)
-    @SqlQuery(" SELECT d.*, k.key, dp.propertyvalue, dp.propertykey, dp.propertyid, ca.consentid, c.dac_id, c.translateduserestriction, c.datause, dar_ds_ids.id as in_use " +
+    @SqlQuery(" SELECT d.*, k.key, dp.propertyvalue, dp.propertykey, dp.propertyid, ca.consentid, c.dac_id, c.translateduserestriction, dar_ds_ids.id as in_use " +
         " FROM dataset d " +
         " LEFT JOIN (SELECT DISTINCT dataset_id AS id FROM dar_dataset) dar_ds_ids ON dar_ds_ids.id = d.datasetid " +
         " LEFT JOIN datasetproperty dp ON dp.datasetid = d.datasetid " +
@@ -52,7 +58,7 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
     Dataset findDatasetById(@Bind("datasetId") Integer datasetId);
 
     @UseRowReducer(DatasetReducer.class)
-    @SqlQuery(" SELECT d.*, k.key, dp.propertyvalue, dp.propertykey, dp.propertyid, ca.consentid, c.dac_id, c.translateduserestriction, c.datause, dar_ds_ids.id as in_use " +
+    @SqlQuery(" SELECT d.*, k.key, dp.propertyvalue, dp.propertykey, dp.propertyid, ca.consentid, c.dac_id, c.translateduserestriction, dar_ds_ids.id as in_use " +
             " FROM dataset d " +
             " LEFT JOIN (SELECT DISTINCT dataset_id AS id FROM dar_dataset) dar_ds_ids ON dar_ds_ids.id = d.datasetid " +
             " LEFT JOIN datasetproperty dp ON dp.datasetid = d.datasetid " +
@@ -66,7 +72,7 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
     Integer findDatasetIdByObjectId(@Bind("objectId") String objectId);
 
     @UseRowReducer(DatasetReducer.class)
-    @SqlQuery(" SELECT d.*, k.key, dp.propertyvalue, dp.propertykey, dp.propertyid, ca.consentid, c.dac_id, c.translateduserestriction, c.datause, dar_ds_ids.id as in_use " +
+    @SqlQuery(" SELECT d.*, k.key, dp.propertyvalue, dp.propertykey, dp.propertyid, ca.consentid, c.dac_id, c.translateduserestriction, dar_ds_ids.id as in_use " +
         " FROM dataset d " +
         " LEFT JOIN (SELECT DISTINCT dataset_id AS id FROM dar_dataset) dar_ds_ids ON dar_ds_ids.id = d.datasetid " +
         " LEFT JOIN datasetproperty dp ON dp.datasetid = d.datasetid " +
@@ -78,7 +84,7 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
     List<Dataset> findNeedsApprovalDatasetByDatasetId(@BindList("datasetIdList") List<Integer> datasetIdList);
 
     @Deprecated
-    @SqlBatch("INSERT INTO dataset (name, createdate, objectid, active, alias) VALUES (:name, :createDate, :objectId, :active, :alias)")
+    @SqlBatch("INSERT INTO dataset (name, createdate, objectid, active, alias, data_use) VALUES (:name, :createDate, :objectId, :active, :alias, :dataUse)")
     void insertAll(@BindBean Collection<Dataset> dataSets);
 
     @SqlBatch("INSERT INTO datasetproperty (datasetid, propertykey, propertyvalue, createdate )" +
@@ -125,7 +131,7 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
     void updateDataset(@Bind("datasetId") Integer datasetId, @Bind("datasetName") String datasetName, @Bind("updateDate") Timestamp updateDate, @Bind("updateUserId") Integer updateUserId, @Bind("needsApproval") Boolean needsApproval);
 
     @UseRowReducer(DatasetReducer.class)
-    @SqlQuery(" SELECT d.*, k.key, dp.propertyvalue, dp.propertykey, dp.propertyid, ca.consentid, c.dac_id, c.translateduserestriction, c.datause, dar_ds_ids.id as in_use " +
+    @SqlQuery(" SELECT d.*, k.key, dp.propertyvalue, dp.propertykey, dp.propertyid, ca.consentid, c.dac_id, c.translateduserestriction, dar_ds_ids.id as in_use " +
         " FROM dataset d " +
         " LEFT JOIN (SELECT DISTINCT dataset_id AS id FROM dar_dataset) dar_ds_ids ON dar_ds_ids.id = d.datasetid " +
         " LEFT JOIN datasetproperty dp ON dp.datasetid = d.datasetid " +
@@ -138,7 +144,7 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
 
     @UseRowMapper(DatasetPropertiesMapper.class)
     @SqlQuery(
-        " SELECT d.*, k.key, dp.propertyvalue, ca.consentid, c.dac_id, c.translateduserestriction, c.datause "
+        " SELECT d.*, k.key, dp.propertyvalue, ca.consentid, c.dac_id, c.translateduserestriction "
             + " FROM dataset d "
             + " LEFT OUTER JOIN datasetproperty dp ON dp.datasetid = d.datasetid "
             + " LEFT OUTER JOIN dictionary k ON k.keyid = dp.propertykey "
@@ -152,7 +158,7 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
 
     @UseRowMapper(DatasetPropertiesMapper.class)
     @SqlQuery(
-        " SELECT d.*, k.key, dp.propertyvalue, ca.consentid, c.dac_id, c.translateduserestriction, c.datause "
+        " SELECT d.*, k.key, dp.propertyvalue, ca.consentid, c.dac_id, c.translateduserestriction "
             + " FROM dataset d "
             + " LEFT OUTER JOIN datasetproperty dp ON dp.datasetid = d.datasetid "
             + " LEFT OUTER JOIN dictionary k ON k.keyid = dp.propertykey "
@@ -164,7 +170,7 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
 
     @UseRowMapper(DatasetPropertiesMapper.class)
     @SqlQuery(
-        " SELECT d.*, k.key, dp.propertyvalue, ca.consentid, c.dac_id, c.translateduserestriction, c.datause "
+        " SELECT d.*, k.key, dp.propertyvalue, ca.consentid, c.dac_id, c.translateduserestriction "
             + " FROM dataset d "
             + " LEFT OUTER JOIN datasetproperty dp ON dp.datasetid = d.datasetid "
             + " LEFT OUTER JOIN dictionary k ON k.keyid = dp.propertykey "
@@ -174,7 +180,7 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
     Set<DatasetDTO> findAllDatasets();
 
     @UseRowMapper(DatasetPropertiesMapper.class)
-    @SqlQuery("SELECT d.*, k.key, dp.propertyvalue, ca.consentid, c.dac_id, c.translateduserestriction, c.datause " +
+    @SqlQuery("SELECT d.*, k.key, dp.propertyvalue, ca.consentid, c.dac_id, c.translateduserestriction " +
           "FROM dataset d " +
           "LEFT OUTER JOIN datasetproperty dp ON dp.datasetid = d.datasetid " +
           "LEFT OUTER JOIN dictionary k ON k.keyid = dp.propertykey " +
@@ -184,16 +190,14 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
     Set<DatasetDTO> findDatasetDTOWithPropertiesByDatasetId(@Bind("datasetId") Integer datasetId);
 
     @UseRowMapper(DatasetPropertyMapper.class)
-    @SqlQuery(
-        "SELECT * FROM datasetproperty WHERE datasetid = :datasetId"
-    )
+    @SqlQuery("SELECT * FROM datasetproperty WHERE datasetid = :datasetId")
     Set<DatasetProperty> findDatasetPropertiesByDatasetId(@Bind("datasetId") Integer datasetId);
 
     @UseRowMapper(DatasetPropertiesMapper.class)
-    @SqlQuery("SELECT d.*, k.key, dp.propertyValue, ca.consentId, c.dac_id, c.translatedUseRestriction, c.datause " +
-            "FROM dataset d INNER JOIN datasetproperty dp ON dp.datasetid = d.datasetid INNER JOIN dictionary k ON k.keyId = dp.propertyKey " +
-            "INNER JOIN consentassociations ca ON ca.datasetid = d.datasetid INNER JOIN consents c ON c.consentId = ca.consentId " +
-            "WHERE d.datasetid IN (<dataSetIdList>) ORDER BY d.datasetid, k.receiveOrder")
+    @SqlQuery(" SELECT d.*, k.key, dp.propertyvalue, ca.consentid, c.dac_id, c.translateduserestriction " +
+            " FROM dataset d INNER JOIN datasetproperty dp ON dp.datasetid = d.datasetid INNER JOIN dictionary k ON k.keyid = dp.propertykey " +
+            " INNER JOIN consentassociations ca ON ca.datasetid = d.datasetid INNER JOIN consents c ON c.consentid = ca.consentid " +
+            " WHERE d.datasetid IN (<dataSetIdList>) ORDER BY d.datasetid, k.receiveorder ")
     Set<DatasetDTO> findDatasetsByReceiveOrder(@BindList("dataSetIdList") List<Integer> dataSetIdList);
 
     @RegisterRowMapper(DictionaryMapper.class)
@@ -205,7 +209,7 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
     List<Dictionary> getMappedFieldsOrderByDisplayOrder();
 
     @UseRowReducer(DatasetReducer.class)
-    @SqlQuery(" SELECT d.*, k.key, dp.propertyvalue, dp.propertykey, dp.propertyid, ca.consentid, c.dac_id, c.translateduserestriction, c.datause, dar_ds_ids.id as in_use " +
+    @SqlQuery(" SELECT d.*, k.key, dp.propertyvalue, dp.propertykey, dp.propertyid, ca.consentid, c.dac_id, c.translateduserestriction, dar_ds_ids.id as in_use " +
         " FROM dataset d " +
         " LEFT JOIN (SELECT DISTINCT dataset_id AS id FROM dar_dataset) dar_ds_ids ON dar_ds_ids.id = d.datasetid " +
         " LEFT JOIN datasetproperty dp ON dp.datasetid = d.datasetid " +
@@ -216,7 +220,7 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
     List<Dataset> getDatasetsForObjectIdList(@BindList("objectIdList") List<String> objectIdList);
 
     @UseRowReducer(DatasetReducer.class)
-    @SqlQuery(" SELECT d.*, k.key, dp.propertyvalue, dp.propertykey, dp.propertyid, ca.consentid, c.dac_id, c.translateduserestriction, c.datause, dar_ds_ids.id as in_use " +
+    @SqlQuery(" SELECT d.*, k.key, dp.propertyvalue, dp.propertykey, dp.propertyid, ca.consentid, c.dac_id, c.translateduserestriction, dar_ds_ids.id as in_use " +
         " FROM dataset d " +
         " LEFT JOIN (SELECT DISTINCT dataset_id AS id FROM dar_dataset) dar_ds_ids ON dar_ds_ids.id = d.datasetid " +
         " LEFT JOIN datasetproperty dp ON dp.datasetid = d.datasetid " +
@@ -226,7 +230,7 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
     List<Dataset> getAllDatasets();
 
     @UseRowReducer(DatasetReducer.class)
-    @SqlQuery(" SELECT d.*, k.key, dp.propertyvalue, dp.propertykey, dp.propertyid, ca.consentid, c.dac_id, c.translateduserestriction, c.datause, dar_ds_ids.id as in_use " +
+    @SqlQuery(" SELECT d.*, k.key, dp.propertyvalue, dp.propertykey, dp.propertyid, ca.consentid, c.dac_id, c.translateduserestriction, dar_ds_ids.id as in_use " +
         " FROM dataset d " +
         " LEFT JOIN (SELECT DISTINCT dataset_id AS id FROM dar_dataset) dar_ds_ids ON dar_ds_ids.id = d.datasetid " +
         " LEFT JOIN datasetproperty dp ON dp.datasetid = d.datasetid " +
@@ -246,7 +250,7 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
     Dataset getDatasetByName(@Bind("name") String name);
 
     @UseRowReducer(DatasetReducer.class)
-    @SqlQuery(" SELECT d.*, k.key, dp.propertyvalue, dp.propertykey, dp.propertyid, ca.consentid, c.dac_id, c.translateduserestriction, c.datause, dar_ds_ids.id as in_use " +
+    @SqlQuery(" SELECT d.*, k.key, dp.propertyvalue, dp.propertykey, dp.propertyid, ca.consentid, c.dac_id, c.translateduserestriction, dar_ds_ids.id as in_use " +
         " FROM dataset d " +
         " LEFT JOIN (SELECT DISTINCT dataset_id AS id FROM dar_dataset) dar_ds_ids ON dar_ds_ids.id = d.datasetid " +
         " LEFT JOIN datasetproperty dp ON dp.datasetid = d.datasetid " +
@@ -267,7 +271,7 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
      * @return List of datasets that are visible to the user via DACs.
      */
     @UseRowReducer(DatasetReducer.class)
-    @SqlQuery(" SELECT d.*, k.key, dp.propertyvalue, dp.propertykey, dp.propertyid, ca.consentid, c.dac_id, c.translateduserestriction, c.datause, dar_ds_ids.id as in_use " +
+    @SqlQuery(" SELECT d.*, k.key, dp.propertyvalue, dp.propertykey, dp.propertyid, ca.consentid, c.dac_id, c.translateduserestriction, dar_ds_ids.id as in_use " +
         " FROM dataset d " +
         " LEFT JOIN (SELECT DISTINCT dataset_id AS id FROM dar_dataset) dar_ds_ids ON dar_ds_ids.id = d.datasetid " +
         " LEFT JOIN datasetproperty dp ON dp.datasetid = d.datasetid " +
@@ -296,11 +300,12 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
      * @return Set of datasets, with properties, that are associated to a single DAC.
      */
     @UseRowMapper(DatasetPropertiesMapper.class)
-    @SqlQuery("SELECT d.*, k.key, p.propertyValue, c.consentId, c.dac_id, c.translatedUseRestriction, c.datause FROM dataset d " +
+    @SqlQuery("SELECT d.*, k.key, p.propertyValue, c.consentId, c.dac_id, c.translatedUseRestriction " +
+            " FROM dataset d " +
             " LEFT OUTER JOIN datasetproperty p ON p.datasetid = d.datasetid " +
-            " LEFT OUTER JOIN dictionary k ON k.keyId = p.propertyKey " +
+            " LEFT OUTER JOIN dictionary k ON k.keyid = p.propertykey " +
             " INNER JOIN consentassociations a ON a.datasetid = d.datasetid " +
-            " INNER JOIN consents c ON c.consentId = a.consentId " +
+            " INNER JOIN consents c ON c.consentid = a.consentid " +
             " WHERE c.dac_id = :dacId ")
     Set<DatasetDTO> findDatasetsByDac(@Bind("dacId") Integer dacId);
 
@@ -311,11 +316,12 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
      * @return Set of datasets, with properties, that are associated with the provided DAC IDs
      */
     @UseRowMapper(DatasetPropertiesMapper.class)
-    @SqlQuery("SELECT d.*, k.key, p.propertyValue, c.consentId, c.dac_id, c.translatedUseRestriction, c.datause FROM dataset d " +
+    @SqlQuery("SELECT d.*, k.key, p.propertyvalue, c.consentid, c.dac_id, c.translateduserestriction " +
+            " FROM dataset d " +
             " LEFT OUTER JOIN datasetproperty p ON p.datasetid = d.datasetid " +
-            " LEFT OUTER JOIN dictionary k ON k.keyId = p.propertyKey " +
+            " LEFT OUTER JOIN dictionary k ON k.keyid = p.propertykey " +
             " INNER JOIN consentassociations a ON a.datasetid = d.datasetid " +
-            " INNER JOIN consents c ON c.consentId = a.consentId " +
+            " INNER JOIN consents c ON c.consentid = a.consentid " +
             " WHERE c.dac_id IN (<dacIds>) ")
     Set<DatasetDTO> findDatasetsByDacIds(@BindList("dacIds") List<Integer> dacIds);
 
@@ -326,7 +332,7 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
      * @return Set of datasets, with properties, that are associated to any Dac.
      */
     @UseRowMapper(DatasetPropertiesMapper.class)
-    @SqlQuery("SELECT d.*, k.key, p.propertyvalue, c.consentid, c.dac_id, c.translateduserestriction, c.datause " +
+    @SqlQuery("SELECT d.*, k.key, p.propertyvalue, c.consentid, c.dac_id, c.translateduserestriction " +
             " FROM dataset d " +
             " LEFT OUTER JOIN datasetproperty p ON p.datasetid = d.datasetid " +
             " LEFT OUTER JOIN dictionary k ON k.keyid = p.propertykey " +
@@ -348,7 +354,7 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
     List<Pair<Integer, Integer>> findDatasetAndDacIds();
 
     @UseRowReducer(DatasetReducer.class)
-    @SqlQuery(" SELECT d.*, k.key, dp.propertyvalue, dp.propertykey, dp.propertyid, ca.consentid, c.dac_id, c.translateduserestriction, c.datause, dar_ds_ids.id as in_use " +
+    @SqlQuery(" SELECT d.*, k.key, dp.propertyvalue, dp.propertykey, dp.propertyid, ca.consentid, c.dac_id, c.translateduserestriction, dar_ds_ids.id as in_use " +
         " FROM dataset d " +
         " LEFT JOIN (SELECT DISTINCT dataset_id AS id FROM dar_dataset) dar_ds_ids ON dar_ds_ids.id = d.datasetid " +
         " LEFT JOIN datasetproperty dp ON dp.datasetid = d.datasetid " +

--- a/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
@@ -7,7 +7,7 @@ import java.util.Set;
 import org.apache.commons.lang3.tuple.Pair;
 import org.broadinstitute.consent.http.db.mapper.AssociationMapper;
 import org.broadinstitute.consent.http.db.mapper.DatasetMapper;
-import org.broadinstitute.consent.http.db.mapper.DatasetPropertiesMapper;
+import org.broadinstitute.consent.http.db.mapper.DatasetDTOWithPropertiesMapper;
 import org.broadinstitute.consent.http.db.mapper.DatasetPropertyMapper;
 import org.broadinstitute.consent.http.db.mapper.DatasetReducer;
 import org.broadinstitute.consent.http.db.mapper.DictionaryMapper;
@@ -142,7 +142,7 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
         " ORDER BY d.datasetid, k.displayorder")
     Set<Dataset> findDatasetWithDataUseByIdList(@BindList("datasetIds") List<Integer> datasetIds);
 
-    @UseRowMapper(DatasetPropertiesMapper.class)
+    @UseRowMapper(DatasetDTOWithPropertiesMapper.class)
     @SqlQuery(
         " SELECT d.*, k.key, dp.propertyvalue, ca.consentid, c.dac_id, c.translateduserestriction "
             + " FROM dataset d "
@@ -156,7 +156,7 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
             + " ORDER BY d.datasetid ")
     Set<DatasetDTO> findDatasetsByUserId(@Bind("userId") Integer userId);
 
-    @UseRowMapper(DatasetPropertiesMapper.class)
+    @UseRowMapper(DatasetDTOWithPropertiesMapper.class)
     @SqlQuery(
         " SELECT d.*, k.key, dp.propertyvalue, ca.consentid, c.dac_id, c.translateduserestriction "
             + " FROM dataset d "
@@ -168,7 +168,7 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
             + " ORDER BY d.datasetid ")
     Set<DatasetDTO> findActiveDatasets();
 
-    @UseRowMapper(DatasetPropertiesMapper.class)
+    @UseRowMapper(DatasetDTOWithPropertiesMapper.class)
     @SqlQuery(
         " SELECT d.*, k.key, dp.propertyvalue, ca.consentid, c.dac_id, c.translateduserestriction "
             + " FROM dataset d "
@@ -179,7 +179,7 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
             + " ORDER BY d.datasetid ")
     Set<DatasetDTO> findAllDatasets();
 
-    @UseRowMapper(DatasetPropertiesMapper.class)
+    @UseRowMapper(DatasetDTOWithPropertiesMapper.class)
     @SqlQuery("SELECT d.*, k.key, dp.propertyvalue, ca.consentid, c.dac_id, c.translateduserestriction " +
           "FROM dataset d " +
           "LEFT OUTER JOIN datasetproperty dp ON dp.datasetid = d.datasetid " +
@@ -193,7 +193,7 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
     @SqlQuery("SELECT * FROM datasetproperty WHERE datasetid = :datasetId")
     Set<DatasetProperty> findDatasetPropertiesByDatasetId(@Bind("datasetId") Integer datasetId);
 
-    @UseRowMapper(DatasetPropertiesMapper.class)
+    @UseRowMapper(DatasetDTOWithPropertiesMapper.class)
     @SqlQuery(" SELECT d.*, k.key, dp.propertyvalue, ca.consentid, c.dac_id, c.translateduserestriction " +
             " FROM dataset d INNER JOIN datasetproperty dp ON dp.datasetid = d.datasetid INNER JOIN dictionary k ON k.keyid = dp.propertykey " +
             " INNER JOIN consentassociations ca ON ca.datasetid = d.datasetid INNER JOIN consents c ON c.consentid = ca.consentid " +
@@ -299,7 +299,7 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
      *
      * @return Set of datasets, with properties, that are associated to a single DAC.
      */
-    @UseRowMapper(DatasetPropertiesMapper.class)
+    @UseRowMapper(DatasetDTOWithPropertiesMapper.class)
     @SqlQuery("SELECT d.*, k.key, p.propertyValue, c.consentId, c.dac_id, c.translatedUseRestriction " +
             " FROM dataset d " +
             " LEFT OUTER JOIN datasetproperty p ON p.datasetid = d.datasetid " +
@@ -315,7 +315,7 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
      *
      * @return Set of datasets, with properties, that are associated with the provided DAC IDs
      */
-    @UseRowMapper(DatasetPropertiesMapper.class)
+    @UseRowMapper(DatasetDTOWithPropertiesMapper.class)
     @SqlQuery("SELECT d.*, k.key, p.propertyvalue, c.consentid, c.dac_id, c.translateduserestriction " +
             " FROM dataset d " +
             " LEFT OUTER JOIN datasetproperty p ON p.datasetid = d.datasetid " +
@@ -331,7 +331,7 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
      *
      * @return Set of datasets, with properties, that are associated to any Dac.
      */
-    @UseRowMapper(DatasetPropertiesMapper.class)
+    @UseRowMapper(DatasetDTOWithPropertiesMapper.class)
     @SqlQuery("SELECT d.*, k.key, p.propertyvalue, c.consentid, c.dac_id, c.translateduserestriction " +
             " FROM dataset d " +
             " LEFT OUTER JOIN datasetproperty p ON p.datasetid = d.datasetid " +

--- a/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
@@ -85,7 +85,7 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
 
     @Deprecated
     @SqlBatch("INSERT INTO dataset (name, createdate, objectid, active, alias, data_use) VALUES (:name, :createDate, :objectId, :active, :alias, :dataUse)")
-    void insertAll(@BindBean Collection<Dataset> dataSets);
+    void insertAll(@BindBean Collection<Dataset> datasets);
 
     @SqlBatch("INSERT INTO datasetproperty (datasetid, propertykey, propertyvalue, createdate )" +
             " VALUES (:dataSetId, :propertyKey, :propertyValue, :createDate)")

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DacMapper.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DacMapper.java
@@ -25,7 +25,7 @@ public class DacMapper implements RowMapper<Dac>, RowMapperHelper {
     dac.setDescription(resultSet.getString("description"));
     dac.setCreateDate(resultSet.getDate("create_date"));
     dac.setUpdateDate(resultSet.getDate("update_date"));
-    if (hasColumn(resultSet, "electionId")) {
+    if (hasColumn(resultSet, "electionid")) {
       dac.addElectionId(resultSet.getInt("electionid"));
     }
     if (hasColumn(resultSet, "datasetid")) {

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DacWithDatasetsReducer.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DacWithDatasetsReducer.java
@@ -31,9 +31,9 @@ public class DacWithDatasetsReducer implements LinkedHashMapRowReducer<Integer, 
       if (Objects.nonNull(rowView.getColumn("datasetid", Integer.class))) {
         DatasetDTO dto = rowView.getRow(DatasetDTO.class);
 
-        try { 
-          //aliased columns must be set directly 
-          
+        try {
+          //aliased columns must be set directly
+
           if (Objects.nonNull(rowView.getColumn("dataset_alias", String.class))) {
             String dsAlias = rowView.getColumn("dataset_alias", String.class);
             try {
@@ -56,9 +56,9 @@ public class DacWithDatasetsReducer implements LinkedHashMapRowReducer<Integer, 
         } catch (Exception e) {
           //no values for these columns
         }
-        
-        if (Objects.nonNull(rowView.getColumn("consent_data_use", String.class))) {
-          String duStr = rowView.getColumn("consent_data_use", String.class);
+
+        if (Objects.nonNull(rowView.getColumn("dataset_data_use", String.class))) {
+          String duStr = rowView.getColumn("dataset_data_use", String.class);
           Optional<DataUse> du = DataUse.parseDataUse(duStr);
           du.ifPresent(dto::setDataUse);
         }

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DacWithDatasetsReducer.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DacWithDatasetsReducer.java
@@ -2,7 +2,7 @@ package org.broadinstitute.consent.http.db.mapper;
 
 import org.broadinstitute.consent.http.models.Dac;
 import org.broadinstitute.consent.http.models.DataUse;
-import org.broadinstitute.consent.http.models.dto.DatasetDTO;
+import org.broadinstitute.consent.http.models.Dataset;
 import org.jdbi.v3.core.mapper.MappingException;
 import org.jdbi.v3.core.result.LinkedHashMapRowReducer;
 import org.jdbi.v3.core.result.RowView;
@@ -29,7 +29,7 @@ public class DacWithDatasetsReducer implements LinkedHashMapRowReducer<Integer, 
               rowView.getColumn("dac_id", Integer.class), id -> rowView.getRow(Dac.class));
 
       if (Objects.nonNull(rowView.getColumn("datasetid", Integer.class))) {
-        DatasetDTO dto = rowView.getRow(DatasetDTO.class);
+        Dataset dataset = rowView.getRow(Dataset.class);
 
         try {
           //aliased columns must be set directly
@@ -37,7 +37,7 @@ public class DacWithDatasetsReducer implements LinkedHashMapRowReducer<Integer, 
           if (Objects.nonNull(rowView.getColumn("dataset_alias", String.class))) {
             String dsAlias = rowView.getColumn("dataset_alias", String.class);
             try {
-              dto.setAlias(Integer.parseInt(dsAlias));
+              dataset.setAlias(Integer.parseInt(dsAlias));
             } catch (Exception e) {
               logger.error("Exception parsing dataset alias: " + dsAlias, e);
             }
@@ -45,12 +45,12 @@ public class DacWithDatasetsReducer implements LinkedHashMapRowReducer<Integer, 
 
           if (Objects.nonNull(rowView.getColumn("dataset_create_date", Date.class))) {
             Date createDate = rowView.getColumn("dataset_create_date", Date.class);
-            dto.setCreateDate(createDate);
+            dataset.setCreateDate(createDate);
           }
 
           if (Objects.nonNull(rowView.getColumn("dataset_update_date", Timestamp.class))) {
             Timestamp updateDate = rowView.getColumn("dataset_update_date", Timestamp.class);
-            dto.setUpdateDate(updateDate);
+            dataset.setUpdateDate(updateDate);
           }
 
         } catch (Exception e) {
@@ -60,11 +60,11 @@ public class DacWithDatasetsReducer implements LinkedHashMapRowReducer<Integer, 
         if (Objects.nonNull(rowView.getColumn("dataset_data_use", String.class))) {
           String duStr = rowView.getColumn("dataset_data_use", String.class);
           Optional<DataUse> du = DataUse.parseDataUse(duStr);
-          du.ifPresent(dto::setDataUse);
+          du.ifPresent(dataset::setDataUse);
         }
 
-        if (Objects.nonNull(dto)) {
-          dac.addDatasetDTO(dto);
+        if (Objects.nonNull(dataset)) {
+          dac.addDataset(dataset);
         }
 
       }

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DatasetDTOWithPropertiesMapper.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DatasetDTOWithPropertiesMapper.java
@@ -11,70 +11,74 @@ import org.broadinstitute.consent.http.models.dto.DatasetPropertyDTO;
 import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.core.statement.StatementContext;
 
-public class DatasetPropertiesMapper implements RowMapper<DatasetDTO>, RowMapperHelper {
+public class DatasetDTOWithPropertiesMapper implements RowMapper<DatasetDTO>, RowMapperHelper {
 
-  private final Map<Integer, DatasetDTO> dataSets = new LinkedHashMap<>();
+  private final Map<Integer, DatasetDTO> datasetDTOs = new LinkedHashMap<>();
   private static final String PROPERTY_KEY = "key";
   private static final String PROPERTY_PROPERTYVALUE = "propertyValue";
 
   public DatasetDTO map(ResultSet r, StatementContext ctx) throws SQLException {
 
-    DatasetDTO dataSetDTO;
+    DatasetDTO datasetDTO;
     Integer dataSetId = r.getInt("dataSetId");
     String consentId = r.getString("consentId");
     Integer alias = r.getInt("alias");
-    if (!dataSets.containsKey(dataSetId)) {
-      dataSetDTO = new DatasetDTO(new ArrayList<>());
+    if (!datasetDTOs.containsKey(dataSetId)) {
+      datasetDTO = new DatasetDTO(new ArrayList<>());
       if (hasColumn(r, "dac_id")) {
         int dacId = r.getInt("dac_id");
         if (dacId > 0) {
-          dataSetDTO.setDacId(dacId);
+          datasetDTO.setDacId(dacId);
         }
       }
-      dataSetDTO.setConsentId(consentId);
-      dataSetDTO.setAlias(alias);
-      dataSetDTO.setDataSetId(dataSetId);
-      dataSetDTO.setActive(r.getBoolean("active"));
-      dataSetDTO.setTranslatedUseRestriction(r.getString("translatedUseRestriction"));
+      datasetDTO.setConsentId(consentId);
+      datasetDTO.setAlias(alias);
+      datasetDTO.setDataSetId(dataSetId);
+      datasetDTO.setActive(r.getBoolean("active"));
+      datasetDTO.setTranslatedUseRestriction(r.getString("translatedUseRestriction"));
+      // Consents store DataUse in `datause` while Datasets store it in `ata_use`. Capture both cases for safety.
       if (hasColumn(r, "datause")) {
-        dataSetDTO.setDataUse(DataUse.parseDataUse(r.getString("datause")).orElse(null));
+        datasetDTO.setDataUse(DataUse.parseDataUse(r.getString("datause")).orElse(null));
+      }
+      if (hasColumn(r, "data_use")) {
+        datasetDTO.setDataUse(DataUse.parseDataUse(r.getString("data_use")).orElse(null));
       }
       if (hasColumn(r, "createdate")) {
-          dataSetDTO.setCreateDate(r.getDate("createdate"));
+          datasetDTO.setCreateDate(r.getDate("createdate"));
       }
       if (hasColumn(r, "create_user_id")) {
           int userId = r.getInt("create_user_id");
           if (userId > 0) {
-              dataSetDTO.setCreateUserId(userId);
+              datasetDTO.setCreateUserId(userId);
           }
       }
       if (hasColumn(r, "update_date")) {
-          dataSetDTO.setUpdateDate(r.getTimestamp("update_date"));
+          datasetDTO.setUpdateDate(r.getTimestamp("update_date"));
       }
       if (hasColumn(r, "update_user_id")) {
           int userId = r.getInt("update_user_id");
           if (userId > 0) {
-              dataSetDTO.setUpdateUserId(userId);
+              datasetDTO.setUpdateUserId(userId);
           }
       }
       DatasetPropertyDTO property = new DatasetPropertyDTO("Dataset Name", r.getString("name"));
-      dataSetDTO.addProperty(property);
+      datasetDTO.addProperty(property);
       property =
           new DatasetPropertyDTO(r.getString(PROPERTY_KEY), r.getString(PROPERTY_PROPERTYVALUE));
       if (property.getPropertyName() != null) {
-        dataSetDTO.addProperty(property);
+        datasetDTO.addProperty(property);
       }
-      dataSetDTO.setNeedsApproval(r.getBoolean("needs_approval"));
-      dataSetDTO.setObjectId(r.getString("objectId"));
-      dataSets.put(dataSetId, dataSetDTO);
+      datasetDTO.setNeedsApproval(r.getBoolean("needs_approval"));
+      datasetDTO.setObjectId(r.getString("objectId"));
+      datasetDTOs.put(dataSetId, datasetDTO);
     } else {
-      dataSetDTO = dataSets.get(dataSetId);
+      datasetDTO = datasetDTOs.get(dataSetId);
       DatasetPropertyDTO property =
           new DatasetPropertyDTO(r.getString(PROPERTY_KEY), r.getString(PROPERTY_PROPERTYVALUE));
       if (property.getPropertyName() != null) {
-        dataSetDTO.addProperty(property);
+        datasetDTO.addProperty(property);
       }
     }
-    return dataSetDTO;
+    return datasetDTO;
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DatasetDTOWithPropertiesMapper.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DatasetDTOWithPropertiesMapper.java
@@ -36,7 +36,7 @@ public class DatasetDTOWithPropertiesMapper implements RowMapper<DatasetDTO>, Ro
       datasetDTO.setDataSetId(dataSetId);
       datasetDTO.setActive(r.getBoolean("active"));
       datasetDTO.setTranslatedUseRestriction(r.getString("translatedUseRestriction"));
-      // Consents store DataUse in `datause` while Datasets store it in `ata_use`. Capture both cases for safety.
+      // Consents store DataUse in `datause` while Datasets store it in `data_use`. Capture both cases for safety.
       if (hasColumn(r, "datause")) {
         datasetDTO.setDataUse(DataUse.parseDataUse(r.getString("datause")).orElse(null));
       }

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DatasetMapper.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DatasetMapper.java
@@ -11,8 +11,8 @@ public class DatasetMapper implements RowMapper<Dataset>, RowMapperHelper {
 
   public Dataset map(ResultSet r, StatementContext ctx) throws SQLException {
       Dataset dataset = new Dataset();
-      dataset.setDataSetId(r.getInt("dataSetId"));
-      dataset.setObjectId(r.getString("objectId"));
+      dataset.setDataSetId(r.getInt("datasetid"));
+      dataset.setObjectId(r.getString("objectid"));
       dataset.setName(r.getString("name"));
       if (hasColumn(r, "createdate")) {
           dataset.setCreateDate(r.getDate("createdate"));
@@ -32,8 +32,8 @@ public class DatasetMapper implements RowMapper<Dataset>, RowMapperHelper {
               dataset.setUpdateUserId(userId);
           }
       }
-      if (hasColumn(r, "dataUse")) {
-        dataset.setDataUse(DataUse.parseDataUse(r.getString("datause")).orElse(null));
+      if (hasColumn(r, "data_use")) {
+        dataset.setDataUse(DataUse.parseDataUse(r.getString("data_use")).orElse(null));
       }
       dataset.setActive(r.getBoolean("active"));
       dataset.setAlias(r.getInt("alias"));

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DatasetMapper.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DatasetMapper.java
@@ -32,7 +32,7 @@ public class DatasetMapper implements RowMapper<Dataset>, RowMapperHelper {
               dataset.setUpdateUserId(userId);
           }
       }
-      if(hasColumn(r, "dataUse")) {
+      if (hasColumn(r, "dataUse")) {
         dataset.setDataUse(DataUse.parseDataUse(r.getString("datause")).orElse(null));
       }
       dataset.setActive(r.getBoolean("active"));

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DatasetReducer.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DatasetReducer.java
@@ -24,9 +24,9 @@ public class DatasetReducer implements LinkedHashMapRowReducer<Integer, Dataset>
     if (hasColumn(rowView, "consentid", String.class)) {
       dataset.setConsentId(rowView.getColumn("consentid", String.class));
     }
-    if (hasColumn(rowView, "datause", String.class)) {
+    if (hasColumn(rowView, "data_use", String.class)) {
       dataset.setDataUse(
-          DataUse.parseDataUse(rowView.getColumn("datause", String.class)).orElse(null));
+          DataUse.parseDataUse(rowView.getColumn("data_use", String.class)).orElse(null));
     }
     if (hasColumn(rowView, "translateduserestriction", String.class)) {
       dataset.setTranslatedUseRestriction(

--- a/src/main/java/org/broadinstitute/consent/http/models/Dac.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/Dac.java
@@ -105,10 +105,21 @@ public class Dac {
         this.datasetIds.add(datasetId);
     }
 
+    public List<Dataset> getDatasets() {
+        return datasets;
+    }
+
+    public void setDatasets(List<Dataset> datasets) {
+        this.datasets = datasets;
+    }
+
     public void addDataset(Dataset dataset) {
-        if ( Objects.isNull(datasets)) {
+        if (Objects.isNull(datasets)) {
             datasets = new ArrayList<>();
         }
         datasets.add(dataset);
+        if (!datasetIds.contains(dataset.getDataSetId())) {
+            addDatasetId(dataset.getDataSetId());
+        }
     }
 }

--- a/src/main/java/org/broadinstitute/consent/http/models/Dac.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/Dac.java
@@ -105,14 +105,6 @@ public class Dac {
         this.datasetIds.add(datasetId);
     }
 
-    public List<Dataset> getDatasets() {
-        return datasets;
-    }
-
-    public void setDatasets(List<Dataset> datasets) {
-        this.datasets = datasets;
-    }
-
     public void addDataset(Dataset dataset) {
         if (Objects.isNull(datasets)) {
             datasets = new ArrayList<>();

--- a/src/main/java/org/broadinstitute/consent/http/models/Dac.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/Dac.java
@@ -1,10 +1,5 @@
 package org.broadinstitute.consent.http.models;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import org.broadinstitute.consent.http.models.dto.DatasetDTO;
-
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -13,36 +8,27 @@ import java.util.Objects;
 /**
  * Entity representing a Data Access Committee
  */
-@JsonInclude(Include.NON_NULL)
 public class Dac {
 
-    @JsonProperty
     private Integer dacId;
 
-    @JsonProperty
     private String name;
 
-    @JsonProperty
     private String description;
 
-    @JsonProperty
     private Date createDate;
 
-    @JsonProperty
     private Date updateDate;
 
-    @JsonProperty
     private List<User> chairpersons;
 
-    @JsonProperty
     private List<User> members;
 
-    @JsonProperty
-    private List<DatasetDTO> datasets;
+    private List<Dataset> datasets;
 
-    private List<Integer> electionIds = new ArrayList<>();
+    private final List<Integer> electionIds = new ArrayList<>();
 
-    private List<Integer> datasetIds = new ArrayList<>();
+    private final List<Integer> datasetIds = new ArrayList<>();
 
     public Dac() {
     }
@@ -119,10 +105,10 @@ public class Dac {
         this.datasetIds.add(datasetId);
     }
 
-    public void addDatasetDTO(DatasetDTO dto) {
+    public void addDataset(Dataset dataset) {
         if ( Objects.isNull(datasets)) {
             datasets = new ArrayList<>();
         }
-        datasets.add(dto);
+        datasets.add(dataset);
     }
 }

--- a/src/main/java/org/broadinstitute/consent/http/models/Dataset.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/Dataset.java
@@ -1,8 +1,5 @@
 package org.broadinstitute.consent.http.models;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.Date;
@@ -10,65 +7,45 @@ import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
 
-@JsonInclude(Include.NON_NULL)
 public class Dataset {
 
-    @JsonProperty
     private Integer dataSetId;
 
-    @JsonProperty
     private String objectId;
 
-    @JsonProperty
     private String name;
 
     // For backwards compatibility with DatasetDTO, this is an alias to the name property.
-    @JsonProperty
     private String datasetName;
 
-    @JsonProperty
     private Date createDate;
 
-    @JsonProperty
     private Integer createUserId;
 
-    @JsonProperty
     private Date updateDate;
 
-    @JsonProperty
     private Integer updateUserId;
 
-    @JsonProperty
     private Boolean active;
 
-    @JsonProperty
     private String consentName;
 
-    @JsonProperty
     private Boolean needsApproval;
 
-    @JsonProperty
     private Integer alias;
 
-    @JsonProperty
     private String datasetIdentifier;
 
-    @JsonProperty
     public DataUse dataUse;
 
-    @JsonProperty
     private Integer dacId;
 
-    @JsonProperty
     private String consentId;
 
-    @JsonProperty
     private String translatedUseRestriction;
 
-    @JsonProperty
     private Boolean deletable;
 
-    @JsonProperty
     private Set<DatasetProperty> properties;
 
     public Dataset() {

--- a/src/main/java/org/broadinstitute/consent/http/resources/DacResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DacResource.java
@@ -50,7 +50,7 @@ public class DacResource extends Resource {
     public Response findAll(@Auth AuthUser authUser, @QueryParam("withUsers") Optional<Boolean> withUsers) {
         final Boolean includeUsers = withUsers.orElse(true);
         List<Dac> dacs = dacService.findDacsWithMembersOption(includeUsers);
-        return Response.ok().entity(dacs).build();
+        return Response.ok().entity(unmarshal(dacs)).build();
     }
 
     @POST
@@ -72,7 +72,7 @@ public class DacResource extends Resource {
             throw new Exception("Unable to create DAC with name: " + dac.getName() + " and description: " + dac.getDescription());
         }
         Dac savedDac = dacService.findById(dacId);
-        return Response.ok().entity(savedDac).build();
+        return Response.ok().entity(unmarshal(savedDac)).build();
     }
 
     @PUT
@@ -94,7 +94,7 @@ public class DacResource extends Resource {
         }
         dacService.updateDac(dac.getName(), dac.getDescription(), dac.getDacId());
         Dac savedDac = dacService.findById(dac.getDacId());
-        return Response.ok().entity(savedDac).build();
+        return Response.ok().entity(unmarshal(savedDac)).build();
     }
 
     @GET
@@ -103,7 +103,7 @@ public class DacResource extends Resource {
     @RolesAllowed({ADMIN, MEMBER, CHAIRPERSON})
     public Response findById(@PathParam("dacId") Integer dacId) {
         Dac dac = findDacById(dacId);
-        return Response.ok().entity(dac).build();
+        return Response.ok().entity(unmarshal(dac)).build();
     }
 
     @DELETE
@@ -194,7 +194,7 @@ public class DacResource extends Resource {
     public Response findAllDacDatasets(@Auth AuthUser user, @PathParam("dacId") Integer dacId) {
         findDacById(dacId);
         Set<DatasetDTO> datasets = dacService.findDatasetsByDacId(user, dacId);
-        return Response.ok().entity(datasets).build();
+        return Response.ok().entity(unmarshal(datasets)).build();
     }
 
     @GET

--- a/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
@@ -170,7 +170,7 @@ public class DatasetResource extends Resource {
             Optional<Dataset> updatedDataset = datasetService.updateDataset(inputDataset, datasetId, userId);
             if (updatedDataset.isPresent()) {
                 URI uri = info.getRequestUriBuilder().replacePath("api/dataset/{datasetId}").build(updatedDataset.get().getDataSetId());
-                return Response.ok(uri).entity(unmarshal(updatedDataset.get())).build();
+                return Response.ok(uri).entity(updatedDataset.get()).build();
             }
             else {
                 return Response.noContent().build();
@@ -229,7 +229,7 @@ public class DatasetResource extends Resource {
     public Response validateDatasetName(@QueryParam("name") String name) {
         try {
             Dataset datasetWithName = datasetService.getDatasetByName(name);
-            return Response.ok().entity(unmarshal(datasetWithName.getDataSetId())).build();
+            return Response.ok().entity(datasetWithName.getDataSetId()).build();
         } catch (Exception e) {
             throw new NotFoundException("Could not find the dataset with name: " + name);
         }

--- a/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
@@ -170,7 +170,7 @@ public class DatasetResource extends Resource {
             Optional<Dataset> updatedDataset = datasetService.updateDataset(inputDataset, datasetId, userId);
             if (updatedDataset.isPresent()) {
                 URI uri = info.getRequestUriBuilder().replacePath("api/dataset/{datasetId}").build(updatedDataset.get().getDataSetId());
-                return Response.ok(uri).entity(updatedDataset.get()).build();
+                return Response.ok(uri).entity(unmarshal(updatedDataset.get())).build();
             }
             else {
                 return Response.noContent().build();
@@ -229,7 +229,7 @@ public class DatasetResource extends Resource {
     public Response validateDatasetName(@QueryParam("name") String name) {
         try {
             Dataset datasetWithName = datasetService.getDatasetByName(name);
-            return Response.ok().entity(datasetWithName.getDataSetId()).build();
+            return Response.ok().entity(unmarshal(datasetWithName.getDataSetId())).build();
         } catch (Exception e) {
             throw new NotFoundException("Could not find the dataset with name: " + name);
         }
@@ -370,8 +370,8 @@ public class DatasetResource extends Resource {
     @RolesAllowed(ADMIN)
     public Response updateNeedsReviewDataSets(@QueryParam("dataSetId") Integer dataSetId, @QueryParam("needsApproval") Boolean needsApproval){
         try{
-            Dataset dataSet = datasetService.updateNeedsReviewDataSets(dataSetId, needsApproval);
-            return Response.ok().entity(dataSet).build();
+            Dataset dataset = datasetService.updateNeedsReviewDatasets(dataSetId, needsApproval);
+            return Response.ok().entity(unmarshal(dataset)).build();
         }catch (Exception e){
             return createExceptionResponse(e);
         }

--- a/src/main/java/org/broadinstitute/consent/http/resources/Resource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/Resource.java
@@ -1,6 +1,8 @@
 package org.broadinstitute.consent.http.resources;
 
 import java.util.Objects;
+
+import com.google.gson.Gson;
 import org.apache.commons.io.IOUtils;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.exceptions.ConsentConflictException;
@@ -212,6 +214,10 @@ abstract public class Resource {
         if (Objects.isNull(thisRole) || !user.hasUserRole(thisRole)) {
             throw new BadRequestException("Invalid role selection: " + roleName);
         }
+    }
+
+    protected String unmarshal(Object o) {
+        return new Gson().toJson(o);
     }
 
 }

--- a/src/main/java/org/broadinstitute/consent/http/resources/Resource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/Resource.java
@@ -175,10 +175,10 @@ abstract public class Resource {
      * If the user has one of the provided roles, then access is allowed.
      * If not, then the authenticated user must have the same identity as the
      * `userId` parameter they are requesting information for.
-     *
+     * <p>
      * Typically, we use this to ensure that a non-privileged user is the creator
      * of an entity. In those cases, pass in an empty list of privileged roles.
-     *
+     * <p>
      * Privileged users such as admins, chairpersons, and members, may be allowed
      * access to some resources even if they are not the creator/owner.
      *
@@ -201,7 +201,7 @@ abstract public class Resource {
      * Validate that the user has the actual role name provided. This is useful
      * for determining when a user hits an endpoint that is permitted to multiple
      * different roles and is requesting a role-specific view of a data entity.
-     *
+     * <p>
      * In these cases, we need to make sure that the role name provided is a real
      * one and that the user actually has that role to prevent escalated privilege
      * violations.
@@ -216,6 +216,13 @@ abstract public class Resource {
         }
     }
 
+    /**
+     * Unmarshal an object using `Gson`. In general, we should prefer Gson over Jackson
+     * for ease of use and less boilerplate code.
+     *
+     * @param o The object to unmarshal
+     * @return String version of the object
+     */
     protected String unmarshal(Object o) {
         return new Gson().toJson(o);
     }

--- a/src/main/java/org/broadinstitute/consent/http/resources/Resource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/Resource.java
@@ -217,8 +217,8 @@ abstract public class Resource {
     }
 
     /**
-     * Unmarshal an object using `Gson`. In general, we should prefer Gson over Jackson
-     * for ease of use and less boilerplate code.
+     * Unmarshal/serialize an object using `Gson`. In general, we should prefer Gson
+     * over Jackson for ease of use and the need for far less boilerplate code.
      *
      * @param o The object to unmarshal
      * @return String version of the object

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -198,7 +198,7 @@ public class DatasetService {
         Timestamp now = new Timestamp(new Date().getTime());
         Integer createdDatasetId = datasetDAO.inTransaction(h -> {
             try {
-                Integer id = h.insertDataset(name, now, userId, dataset.getObjectId(), dataset.getActive());
+                Integer id = h.insertDataset(name, now, userId, dataset.getObjectId(), dataset.getActive(), dataset.getDataUse().toString());
                 List<DatasetProperty> propertyList = processDatasetProperties(id, dataset.getProperties());
                 h.insertDatasetProperties(propertyList);
                 h.updateDatasetNeedsApproval(id, dataset.getNeedsApproval());

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -9,8 +9,6 @@ import org.broadinstitute.consent.http.enumeration.AssociationType;
 import org.broadinstitute.consent.http.enumeration.DataUseTranslationType;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.Consent;
-import org.broadinstitute.consent.http.models.DataAccessRequest;
-import org.broadinstitute.consent.http.models.DataAccessRequestData;
 import org.broadinstitute.consent.http.models.Dataset;
 import org.broadinstitute.consent.http.models.DatasetAudit;
 import org.broadinstitute.consent.http.models.DatasetProperty;
@@ -87,16 +85,16 @@ public class DatasetService {
         }
     }
 
-    public Dataset updateNeedsReviewDataSets(Integer dataSetId, Boolean needsApproval) {
-        if (datasetDAO.findDatasetById(dataSetId) == null) {
+    public Dataset updateNeedsReviewDatasets(Integer datasetId, Boolean needsApproval) {
+        if (datasetDAO.findDatasetById(datasetId) == null) {
             throw new NotFoundException("DataSet doesn't exist");
         }
-        datasetDAO.updateDatasetNeedsApproval(dataSetId, needsApproval);
-        return datasetDAO.findDatasetById(dataSetId);
+        datasetDAO.updateDatasetNeedsApproval(datasetId, needsApproval);
+        return datasetDAO.findDatasetById(datasetId);
     }
 
-    public List<Dataset> findNeedsApprovalDataSetByObjectId(List<Integer> dataSetIdList) {
-        return datasetDAO.findNeedsApprovalDatasetByDatasetId(dataSetIdList);
+    public List<Dataset> findNeedsApprovalDataSetByObjectId(List<Integer> datasetIdList) {
+        return datasetDAO.findNeedsApprovalDatasetByDatasetId(datasetIdList);
     }
 
     public Set<DatasetDTO> findDatasetsByDacIds(List<Integer> dacIds) {

--- a/src/main/resources/changelog-master.xml
+++ b/src/main/resources/changelog-master.xml
@@ -88,4 +88,5 @@
     <include file="changesets/changelog-consent-83.0.xml" relativeToChangelogFile="true"/>
     <include file="changesets/changelog-consent-84.0.xml" relativeToChangelogFile="true"/>
     <include file="changesets/changelog-consent-85.0.xml" relativeToChangelogFile="true"/>
+    <include file="changesets/changelog-consent-87.0.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/changelog-master.xml
+++ b/src/main/resources/changelog-master.xml
@@ -88,5 +88,5 @@
     <include file="changesets/changelog-consent-83.0.xml" relativeToChangelogFile="true"/>
     <include file="changesets/changelog-consent-84.0.xml" relativeToChangelogFile="true"/>
     <include file="changesets/changelog-consent-85.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-87.0.xml" relativeToChangelogFile="true"/>
+    <include file="changesets/changelog-consent-86.0.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/changesets/changelog-consent-86.0.xml
+++ b/src/main/resources/changesets/changelog-consent-86.0.xml
@@ -1,7 +1,7 @@
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
          http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
-    <changeSet id="87.0" author="grushton">
+    <changeSet id="86.0" author="grushton">
         <!-- Copy over consent data use strings into their associated dataset  -->
         <addColumn tableName="dataset">
             <column name="data_use" type="text"/>

--- a/src/main/resources/changesets/changelog-consent-87.0.xml
+++ b/src/main/resources/changesets/changelog-consent-87.0.xml
@@ -1,0 +1,22 @@
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+    <changeSet id="87.0" author="grushton">
+        <!-- Copy over consent data use strings into their associated dataset  -->
+        <addColumn tableName="dataset">
+            <column name="data_use" type="text"/>
+        </addColumn>
+        <sql>
+            UPDATE dataset d
+            SET data_use = (SELECT c.datause
+                              FROM consents c
+                              INNER JOIN consentassociations ca
+                                  ON c.consentid = ca.consentid
+                                  AND ca.datasetid = d.datasetid)
+            WHERE data_use IS NULL;
+        </sql>
+        <rollback>
+            <dropColumn tableName="dataset" columnName="data_use"/>
+        </rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
@@ -19,6 +19,7 @@ import org.broadinstitute.consent.http.models.Dac;
 import org.broadinstitute.consent.http.models.DarCollection;
 import org.broadinstitute.consent.http.models.DataAccessRequest;
 import org.broadinstitute.consent.http.models.DataAccessRequestData;
+import org.broadinstitute.consent.http.models.DataUse;
 import org.broadinstitute.consent.http.models.DataUseBuilder;
 import org.broadinstitute.consent.http.models.Dataset;
 import org.broadinstitute.consent.http.models.DatasetEntry;
@@ -374,7 +375,8 @@ public class DAOTestHelper {
         String name = "Name_" + RandomStringUtils.random(20, true, true);
         Timestamp now = new Timestamp(new Date().getTime());
         String objectId = "Object ID_" + RandomStringUtils.random(20, true, true);
-        Integer id = datasetDAO.insertDataset(name, now, user.getUserId(), objectId, true, new DataUseBuilder().setGeneralUse(true).build().toString());
+        DataUse dataUse = new DataUseBuilder().setGeneralUse(true).build();
+        Integer id = datasetDAO.insertDataset(name, now, user.getUserId(), objectId, true, dataUse.toString());
         createDatasetProperties(id);
         return datasetDAO.findDatasetById(id);
     }

--- a/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
@@ -19,6 +19,7 @@ import org.broadinstitute.consent.http.models.Dac;
 import org.broadinstitute.consent.http.models.DarCollection;
 import org.broadinstitute.consent.http.models.DataAccessRequest;
 import org.broadinstitute.consent.http.models.DataAccessRequestData;
+import org.broadinstitute.consent.http.models.DataUseBuilder;
 import org.broadinstitute.consent.http.models.Dataset;
 import org.broadinstitute.consent.http.models.DatasetEntry;
 import org.broadinstitute.consent.http.models.DatasetProperty;
@@ -373,7 +374,7 @@ public class DAOTestHelper {
         String name = "Name_" + RandomStringUtils.random(20, true, true);
         Timestamp now = new Timestamp(new Date().getTime());
         String objectId = "Object ID_" + RandomStringUtils.random(20, true, true);
-        Integer id = datasetDAO.insertDataset(name, now, user.getUserId(), objectId, true);
+        Integer id = datasetDAO.insertDataset(name, now, user.getUserId(), objectId, true, new DataUseBuilder().setGeneralUse(true).build().toString());
         createDatasetProperties(id);
         return datasetDAO.findDatasetById(id);
     }

--- a/src/test/java/org/broadinstitute/consent/http/db/DarCollectionSummaryDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DarCollectionSummaryDAOTest.java
@@ -8,6 +8,7 @@ import org.broadinstitute.consent.http.models.Dac;
 import org.broadinstitute.consent.http.models.DarCollectionSummary;
 import org.broadinstitute.consent.http.models.DataAccessRequest;
 import org.broadinstitute.consent.http.models.DataAccessRequestData;
+import org.broadinstitute.consent.http.models.DataUseBuilder;
 import org.broadinstitute.consent.http.models.Dataset;
 import org.broadinstitute.consent.http.models.Election;
 import org.broadinstitute.consent.http.models.Institution;
@@ -58,7 +59,7 @@ public class DarCollectionSummaryDAOTest extends DAOTestHelper {
   }
 
   private Dataset createDataset(Integer userId) {
-    Integer datasetId = datasetDAO.insertDataset(RandomStringUtils.randomAlphabetic(20), new Timestamp(System.currentTimeMillis()), userId, null, true);
+    Integer datasetId = datasetDAO.insertDataset(RandomStringUtils.randomAlphabetic(20), new Timestamp(System.currentTimeMillis()), userId, null, true, new DataUseBuilder().setGeneralUse(true).build().toString());
     return datasetDAO.findDatasetById(datasetId);
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
@@ -5,6 +5,7 @@ import org.apache.commons.lang3.RandomUtils;
 import org.broadinstitute.consent.http.models.DarCollection;
 import org.broadinstitute.consent.http.models.DataAccessRequest;
 import org.broadinstitute.consent.http.models.DataAccessRequestData;
+import org.broadinstitute.consent.http.models.DataUseBuilder;
 import org.broadinstitute.consent.http.models.Dataset;
 import org.broadinstitute.consent.http.models.Election;
 import org.broadinstitute.consent.http.models.User;
@@ -590,7 +591,7 @@ public class DataAccessRequestDAOTest extends DAOTestHelper {
         String name = "Name_" + RandomStringUtils.random(20, true, true);
         Timestamp now = new Timestamp(new Date().getTime());
         String objectId = "Object ID_" + RandomStringUtils.random(20, true, true);
-        Integer id = datasetDAO.insertDataset(name, now, user.getUserId(), objectId, true);
+        Integer id = datasetDAO.insertDataset(name, now, user.getUserId(), objectId, true, new DataUseBuilder().setGeneralUse(true).build().toString());
         createDatasetPropertiesLocal(id);
         return datasetDAO.findDatasetById(id);
     }

--- a/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
@@ -636,7 +636,7 @@ public class DatasetResourceTest {
     @Test
     public void testUpdateNeedsReviewDataSetsSuccess() {
         Dataset dataSet = new Dataset();
-        when(datasetService.updateNeedsReviewDataSets(any(), any())).thenReturn(dataSet);
+        when(datasetService.updateNeedsReviewDatasets(any(), any())).thenReturn(dataSet);
 
         initResource();
         Response response = resource.updateNeedsReviewDataSets(1, true);
@@ -645,7 +645,7 @@ public class DatasetResourceTest {
 
     @Test
     public void testUpdateNeedsReviewDataSetsError() {
-        doThrow(new RuntimeException()).when(datasetService).updateNeedsReviewDataSets(any(), any());
+        doThrow(new RuntimeException()).when(datasetService).updateNeedsReviewDatasets(any(), any());
 
         initResource();
         Response response = resource.updateNeedsReviewDataSets(1, true);

--- a/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
@@ -184,7 +184,7 @@ public class DatasetServiceTest {
         doNothing().when(datasetDAO).updateDatasetNeedsApproval(any(), any());
         initService();
 
-        Dataset dataSet = datasetService.updateNeedsReviewDataSets(dataSetId, true);
+        Dataset dataSet = datasetService.updateNeedsReviewDatasets(dataSetId, true);
         assertNotNull(dataSet);
     }
 

--- a/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
@@ -85,7 +85,7 @@ public class DatasetServiceTest {
     public void testCreateDataset() throws Exception {
         DatasetDTO test = getDatasetDTO();
         Dataset mockDataset = getDatasets().get(0);
-        when(datasetDAO.insertDataset(anyString(), any(), anyInt(), anyString(), anyBoolean())).thenReturn(mockDataset.getDataSetId());
+        when(datasetDAO.insertDataset(anyString(), any(), anyInt(), anyString(), anyBoolean(), any())).thenReturn(mockDataset.getDataSetId());
         when(datasetDAO.findDatasetById(any())).thenReturn(mockDataset);
         when(datasetDAO.findDatasetPropertiesByDatasetId(any())).thenReturn(getDatasetProperties());
         when(datasetDAO.findDatasetDTOWithPropertiesByDatasetId(any())).thenReturn(Collections.singleton(test));


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-1969

- Copy all `DataUse` objects over to the `dataset` table.
- Refactor creation and querying from `consents` to `dataset`
- Refactor `Dac` to have a full Dataset object instead of the deprecated DTO.
- Add new `unmarshal` pattern for serializing returned API objects with `Gson` instead of `Jackson`

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
