### PR TITLE
[DUOS-1388][risk=no] Remove user profile completed

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/UserPropertyDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/UserPropertyDAO.java
@@ -21,10 +21,6 @@ public interface UserPropertyDAO extends Transactional<UserPropertyDAO> {
     List<UserProperty> findResearcherPropertiesByUser(@Bind("userId") Integer userId,
                                                       @BindList("properties") List<String> properties);
 
-    @Deprecated
-    @SqlQuery("SELECT propertyvalue FROM USER_PROPERTY WHERE userid = :userId AND propertykey = 'completed'")
-    String isProfileCompleted(@Bind("userId") Integer userId);
-
     @SqlBatch("INSERT INTO user_property (userid, propertykey, propertyvalue) VALUES (:userId, :propertyKey, :propertyValue)")
     void insertAll(@BindBean Collection<UserProperty> researcherProperties);
 

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/UserWithRolesMapper.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/UserWithRolesMapper.java
@@ -30,10 +30,6 @@ public class UserWithRolesMapper implements RowMapper<User>, RowMapperHelper {
       user.setEmailPreference(r.getBoolean("email_preference"));
       user.setRoles(new ArrayList<>());
 
-      // populate for backwards compatibility
-      if (hasColumn(r, "completed")) {
-        user.setProfileCompleted(Boolean.valueOf(r.getString("completed")));
-      }
       if (hasColumn(r, "era_commons_id")) {
         user.setEraCommonsId(r.getString("era_commons_id"));
       }

--- a/src/main/java/org/broadinstitute/consent/http/models/User.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/User.java
@@ -58,10 +58,6 @@ public class User {
     @JsonProperty
     private Boolean emailPreference;
 
-    @Deprecated
-    @JsonProperty
-    private Boolean profileCompleted;
-
     @JsonProperty
     private Integer institutionId;
 
@@ -240,16 +236,6 @@ public class User {
 
     public void setEmailPreference(Boolean emailPreference) {
         this.emailPreference = emailPreference;
-    }
-
-    @Deprecated
-    public Boolean getProfileCompleted() {
-        return profileCompleted;
-    }
-
-    @Deprecated
-    public void setProfileCompleted(Boolean profileCompleted) {
-        this.profileCompleted = profileCompleted;
     }
 
     public Integer getInstitutionId() {

--- a/src/main/resources/assets/schemas/User.yaml
+++ b/src/main/resources/assets/schemas/User.yaml
@@ -23,10 +23,6 @@ properties:
     type: string
     format: date
     description: Describes the date the User was created.
-  profileCompleted:
-    deprecated: true
-    type: boolean
-    description: The profile is completed. Researchers only.
   roles:
     type: array
     items:


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-1388

Finalize the removal of backend usages of user profile completed. All UI work has been completed for two releases now.

See also: https://github.com/DataBiosphere/duos-ui/pull/1745

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
