### PR TITLE
[DUOS-1770][risk=no] Restrict manage v2 DARs to signing officials only

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsp/consent/models/JsonProtocols.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsp/consent/models/JsonProtocols.scala
@@ -52,43 +52,6 @@ object JsonProtocols extends DefaultJsonProtocol {
         }
     }
 
-    implicit object DataAccessRequestManageFormat extends JsonFormat[DataAccessRequestManage] {
-        def write(darm: DataAccessRequestManage): JsObject = {
-            val map = collection.mutable.Map[String, JsValue]()
-            val manualList = List("errors")
-            darm.getClass.getDeclaredFields
-                .filterNot(f => manualList.contains(f.getName))
-                .foreach { f =>
-                    f.setAccessible(true)
-                    f.get(darm) match {
-                        case Some(x: Boolean) => map += f.getName -> x.toJson
-                        case Some(y: String) => map += f.getName -> y.toJson
-                        case Some(l: Long) => map += f.getName -> l.toJson
-                        case Some(i: Int) => map += f.getName -> i.toJson
-                        case Some(u: User) => map += f.getName -> u.toJson
-                        case Some(d: Dac) => map += f.getName -> d.toJson
-                        case _ => map += f.getName -> JsNull
-                    }
-                }
-
-            if (darm.errors.isDefined)
-                map += ("errors" -> darm.errors.toJson)
-
-            JsObject(map.toMap)
-        }
-
-        def read(value: JsValue): DataAccessRequestManage = {
-            val fields = value.asJsObject.fields
-            DataAccessRequestManage(
-                dar = optionalEntryReader("dar", fields, _.convertTo[Option[DataAccessRequest]], None),
-                election = optionalEntryReader("election", fields, _.convertTo[Option[ElectionModels.Election]], None),
-                votes = optionalEntryReader("votes", fields, _.convertTo[Option[Seq[Vote]]], None),
-                researcher = optionalEntryReader("researcher", fields, _.convertTo[Option[User]], None),
-                errors = optionalEntryReader("errors", fields, _.convertTo[Option[Seq[String]]], None)
-            )
-        }
-    }
-
     implicit object ResearcherInfoFormat extends JsonFormat[ResearcherInfo] {
         def write(ri: ResearcherInfo): JsObject = {
             val map = collection.mutable.Map[String, JsValue]()

--- a/automation/src/test/scala/org/broadinstitute/dsp/consent/scenarios/DataAccessScenarios.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsp/consent/scenarios/DataAccessScenarios.scala
@@ -3,7 +3,6 @@ package org.broadinstitute.dsp.consent.scenarios
 import io.gatling.core.Predef._
 import org.broadinstitute.dsp.consent.{TestConfig, TestRunner}
 import org.broadinstitute.dsp.consent.requests.Requests
-import scala.concurrent.duration._
 import org.broadinstitute.dsp.consent.chains.{DarChains, DataSetChains, AdminChains, MemberChains, ChairChains, AccessReviewChains}
 import io.netty.handler.codec.http.HttpResponseStatus._
 import org.broadinstitute.dsp.consent.scenarios.GroupedScenarios._
@@ -38,10 +37,6 @@ class DataAccessScenarios extends Simulation with TestRunner {
                             exec(
                                 AdminChains.loginToConsole(TestConfig.adminHeader)
                             )
-                              .pause(TestConfig.defaultPause)
-                              .exec(
-                                  AdminChains.manageAccess(TestConfig.adminHeader)
-                              )
                               .pause(TestConfig.defaultPause)
                               .exec(
                                   AdminChains.createElections(TestConfig.adminHeader)

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
@@ -20,8 +20,8 @@ import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.AuthUser;
 import org.broadinstitute.consent.http.models.Consent;
 import org.broadinstitute.consent.http.models.Dac;
-import org.broadinstitute.consent.http.models.DarDataset;
 import org.broadinstitute.consent.http.models.DarCollection;
+import org.broadinstitute.consent.http.models.DarDataset;
 import org.broadinstitute.consent.http.models.DataAccessRequest;
 import org.broadinstitute.consent.http.models.DataAccessRequestData;
 import org.broadinstitute.consent.http.models.DataAccessRequestManage;
@@ -40,9 +40,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.Date;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -131,50 +129,16 @@ public class DataAccessRequestService {
         if (Objects.isNull(userRoles)) {
             throw new IllegalArgumentException("UserRoles is required");
         }
-        switch (userRoles) {
-            case SIGNINGOFFICIAL:
-                if (Objects.nonNull(user.getInstitutionId())) {
-                    List<DataAccessRequest> dars = dataAccessRequestDAO.findAllDataAccessRequestsForInstitution(user.getInstitutionId());
-                    List<DataAccessRequest> openDars = filterOutCanceledDars(dars);
-                    return createAccessRequestManageV2(openDars);
-                } else {
-                    throw new NotFoundException("Signing Official (user: " + user.getDisplayName() + ") "
-                            + "is not associated with an Institution.");
-                }
-            case RESEARCHER:
-                List<DataAccessRequest> dars = dataAccessRequestDAO.findAllDarsByUserId(user.getUserId());
-                return createAccessRequestManageV2(dars);
-            default:
-                //case for Admin, Chairperson, and Member
-                List<DataAccessRequest> allDars = findAllDataAccessRequests();
-                List<DataAccessRequest> filteredAccessList = dacService.filterDataAccessRequestsByDac(allDars, user);
-                List<DataAccessRequest> openDarList = filterOutCanceledDars(filteredAccessList);
-                openDarList.sort(sortTimeComparator());
-                return createAccessRequestManageV2(openDarList);
+        if (!Objects.equals(userRoles, UserRoles.SIGNINGOFFICIAL)) {
+            throw new IllegalArgumentException("Only the Signing Official role is supported");
         }
-    }
-
-    /**
-     * Compare DataAccessRequest sort time long values, descending order.
-     *
-     * @return Comparator
-     */
-    private Comparator<DataAccessRequest> sortTimeComparator() {
-        return (a, b) -> {
-            Long aTime = a.getData().getSortDate();
-            Long bTime = b.getData().getSortDate();
-            if (aTime == null) {
-                aTime = new Date().getTime();
-            }
-            if (bTime == null) {
-                bTime = new Date().getTime();
-            }
-            return bTime.compareTo(aTime);
-        };
-    }
-
-    public List<DataAccessRequest> findAllDataAccessRequests() {
-        return dataAccessRequestDAO.findAllDataAccessRequests();
+        if (Objects.isNull(user.getInstitutionId())) {
+            throw new NotFoundException("Signing Official (user: " + user.getDisplayName() + ") "
+                    + "is not associated with an Institution.");
+        }
+        List<DataAccessRequest> dars = dataAccessRequestDAO.findAllDataAccessRequestsForInstitution(user.getInstitutionId());
+        List<DataAccessRequest> openDars = filterOutCanceledDars(dars);
+        return createAccessRequestManageV2(openDars);
     }
 
     public List<DataAccessRequest> findAllDraftDataAccessRequests() {

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -1189,14 +1189,13 @@ paths:
       parameters:
         - name: roleName
           in: query
-          description: An optional roleName that the user is making the request as. A user can have multiple roles, so adding this parameter will filter the list accordingly.
+          description: An optional roleName that the user is making the request as. Currently supports the SO role.
           required: false
           schema:
-            type: String
+            type: string
             nullable: true
             enum:
               - SigningOfficial
-              - Researcher
       tags:
         - Data Access Request
       responses:

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -1191,7 +1191,7 @@ paths:
       parameters:
         - name: roleName
           in: query
-          description: An optional roleName that the user is making the request as. Currently supports the SO role.
+          description: An optional roleName that the user is making the request as. Currently supports the Signing Official role.
           required: false
           schema:
             type: string

--- a/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
@@ -294,40 +294,12 @@ public class DataAccessRequestServiceTest {
         assertNotNull(dar);
     }
 
-    @Test
-    public void testDescribeDataAccessRequestManageV2() {
+    @Test(expected = IllegalArgumentException.class)
+    public void testDescribeDataAccessRequestManageV2_Admin() {
         User user = new User();
-        Integer genericId = 1;
-        DataAccessRequest dar = generateDataAccessRequest();
-        dar.setData(new DataAccessRequestData());
-        dar.addDatasetId(genericId);
-        when(dataAccessRequestDAO.findAllDataAccessRequests()).thenReturn(Collections.singletonList(dar));
-        when(dacService.filterDataAccessRequestsByDac(any(), any())).thenReturn(Collections.singletonList(dar));
-
-        Election e = new Election();
-        e.setReferenceId(dar.getReferenceId());
-        e.setElectionId(genericId);
-        when(electionDAO.findLastElectionsByReferenceIdsAndType(any(), any())).thenReturn(Collections.singletonList(e));
-
-        Vote v = new Vote();
-        v.setVoteId(genericId);
-        v.setElectionId(e.getElectionId());
-        when(voteDAO.findVotesByElectionIds(any())).thenReturn(Collections.singletonList(v));
-
-        Dac d = new Dac();
-        d.setDacId(genericId);
-        d.addDatasetId(genericId);
-        when(dacDAO.findDacsForDatasetIds(any())).thenReturn(Collections.singleton(d));
+        user.setRoles(List.of(new UserRole(UserRoles.ADMIN.getRoleId(), UserRoles.ADMIN.getRoleName())));
         initService();
-
-        List<DataAccessRequestManage> manages =  service.describeDataAccessRequestManageV2(user, UserRoles.ADMIN);
-        assertNotNull(manages);
-        assertFalse(manages.isEmpty());
-        assertEquals(dar.getReferenceId(), manages.get(0).getDar().getReferenceId());
-        assertEquals(1, manages.size());
-        assertEquals(e.getElectionId(), manages.get(0).getElection().getElectionId());
-        assertEquals(d.getDacId(), manages.get(0).getDac().getDacId());
-        assertFalse(manages.get(0).getVotes().isEmpty());
+        service.describeDataAccessRequestManageV2(user, UserRoles.ADMIN);
     }
 
     @Test
@@ -378,41 +350,12 @@ public class DataAccessRequestServiceTest {
         service.describeDataAccessRequestManageV2(user, UserRoles.SIGNINGOFFICIAL);
     }
 
-    @Test
+    @Test(expected = IllegalArgumentException.class)
     public void testDescribeDataAccessRequestManageV2_Researcher() {
         User user = new User();
-        user.setRoles(Arrays.asList(new UserRole(5, UserRoles.RESEARCHER.getRoleName())));
-
-        Integer genericId = 1;
-        DataAccessRequest dar = generateDataAccessRequest();
-        dar.setData(new DataAccessRequestData());
-        dar.addDatasetId(genericId);
-        when(dataAccessRequestDAO.findAllDarsByUserId(any())).thenReturn(Collections.singletonList(dar));
-
-        Election e = new Election();
-        e.setReferenceId(dar.getReferenceId());
-        e.setElectionId(genericId);
-        when(electionDAO.findLastElectionsByReferenceIdsAndType(any(), any())).thenReturn(Collections.singletonList(e));
-
-        Vote v = new Vote();
-        v.setVoteId(genericId);
-        v.setElectionId(e.getElectionId());
-        when(voteDAO.findVotesByElectionIds(any())).thenReturn(Collections.singletonList(v));
-
-        Dac d = new Dac();
-        d.setDacId(genericId);
-        d.addDatasetId(genericId);
-        when(dacDAO.findDacsForDatasetIds(any())).thenReturn(Collections.singleton(d));
+        user.setRoles(List.of(new UserRole(UserRoles.RESEARCHER.getRoleId(), UserRoles.RESEARCHER.getRoleName())));
         initService();
-
-        List<DataAccessRequestManage> manages =  service.describeDataAccessRequestManageV2(user, UserRoles.RESEARCHER);
-        assertNotNull(manages);
-        assertFalse(manages.isEmpty());
-        assertEquals(dar.getReferenceId(), manages.get(0).getDar().getReferenceId());
-        assertEquals(1, manages.size());
-        assertEquals(e.getElectionId(), manages.get(0).getElection().getElectionId());
-        assertEquals(d.getDacId(), manages.get(0).getDac().getDacId());
-        assertFalse(manages.get(0).getVotes().isEmpty());
+        service.describeDataAccessRequestManageV2(user, UserRoles.RESEARCHER);
     }
 
     @Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-1770

All usages of this endpoint have been removed aside from the SO console. Restrict this to the SO role and clean up unused code.

Removed an automation test that tried to hit this endpoint as an admin. These tests will be re-written in Java in https://broadworkbench.atlassian.net/browse/DUOS-1684 so we're not adding additional tests for the updated methods.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
