### PR TITLE
DUOS-1983[risk=no] Added dac_approval column to Dataset table

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DatasetMapper.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DatasetMapper.java
@@ -14,6 +14,9 @@ public class DatasetMapper implements RowMapper<Dataset>, RowMapperHelper {
       dataset.setDataSetId(r.getInt("datasetid"));
       dataset.setObjectId(r.getString("objectid"));
       dataset.setName(r.getString("name"));
+      if(hasColumn(r, "dac_approval")) {
+        dataset.setDacApproval(r.getBoolean("dac_approval"));
+      }
       if (hasColumn(r, "createdate")) {
           dataset.setCreateDate(r.getDate("createdate"));
       }

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DatasetMapper.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DatasetMapper.java
@@ -2,6 +2,8 @@ package org.broadinstitute.consent.http.db.mapper;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.Objects;
+
 import org.broadinstitute.consent.http.models.Dataset;
 import org.broadinstitute.consent.http.models.DataUse;
 import org.jdbi.v3.core.mapper.RowMapper;
@@ -27,7 +29,9 @@ public class DatasetMapper implements RowMapper<Dataset>, RowMapperHelper {
           dataset.setUpdateDate(r.getTimestamp("update_date"));
       }
       if (hasColumn(r, "dac_approval")) {
-          dataset.setDacApproval(r.getBoolean("dac_approval"));
+        String boolString = r.getString("dac_approval");
+        Boolean value = Objects.isNull(boolString) ? null : Boolean.getBoolean(boolString);
+        dataset.setDacApproval(value);
       }
       if (hasColumn(r, "update_user_id")) {
           int userId = r.getInt("update_user_id");

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DatasetMapper.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DatasetMapper.java
@@ -30,7 +30,7 @@ public class DatasetMapper implements RowMapper<Dataset>, RowMapperHelper {
       }
       if (hasColumn(r, "dac_approval")) {
         String boolString = r.getString("dac_approval");
-        Boolean value = Objects.isNull(boolString) ? null : Boolean.getBoolean(boolString);
+        Boolean value = Objects.isNull(boolString) ? null : r.getBoolean("dac_approval");
         dataset.setDacApproval(value);
       }
       if (hasColumn(r, "update_user_id")) {

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DatasetReducer.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DatasetReducer.java
@@ -19,6 +19,10 @@ public class DatasetReducer implements LinkedHashMapRowReducer<Integer, Dataset>
     Dataset dataset =
         map.computeIfAbsent(
             rowView.getColumn("datasetid", Integer.class), id -> rowView.getRow(Dataset.class));
+
+    if(hasColumn(rowView, "dac_approval", Boolean.class)) {
+      dataset.setDacApproval(rowView.getColumn("dac_approval", Boolean.class));
+    }
     if (hasColumn(rowView, "dac_id", Integer.class)) {
       dataset.setDacId(rowView.getColumn("dac_id", Integer.class));
     }

--- a/src/main/java/org/broadinstitute/consent/http/models/Dataset.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/Dataset.java
@@ -74,7 +74,6 @@ public class Dataset {
         this.createDate = createDate;
         this.active = active;
         this.alias = alias;
-        this.dacApproval = false;
     }
 
     public Dataset(Integer dataSetId, String objectId, String name, Date createDate, Boolean active) {
@@ -84,7 +83,6 @@ public class Dataset {
         this.datasetName = name;
         this.createDate = createDate;
         this.active = active;
-        this.dacApproval = false;
     }
 
     private static String PREFIX = "DUOS-";

--- a/src/main/java/org/broadinstitute/consent/http/models/Dataset.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/Dataset.java
@@ -48,6 +48,8 @@ public class Dataset {
 
     private Set<DatasetProperty> properties;
 
+    private Boolean dacApproval;
+
     public Dataset() {
     }
 
@@ -72,6 +74,7 @@ public class Dataset {
         this.createDate = createDate;
         this.active = active;
         this.alias = alias;
+        this.dacApproval = false;
     }
 
     public Dataset(Integer dataSetId, String objectId, String name, Date createDate, Boolean active) {
@@ -81,6 +84,7 @@ public class Dataset {
         this.datasetName = name;
         this.createDate = createDate;
         this.active = active;
+        this.dacApproval = false;
     }
 
     private static String PREFIX = "DUOS-";
@@ -182,6 +186,14 @@ public class Dataset {
 
     public void setNeedsApproval(Boolean needsApproval) {
         this.needsApproval = needsApproval;
+    }
+
+    public Boolean getDacApproval() {
+        return dacApproval;
+    }
+
+    public void setDacApproval(Boolean dacApproval) {
+        this.dacApproval = dacApproval;
     }
 
     public String getConsentName() {

--- a/src/main/resources/changelog-master.xml
+++ b/src/main/resources/changelog-master.xml
@@ -93,6 +93,5 @@
     <include file="changesets/changelog-consent-88.0.xml" relativeToChangelogFile="true"/>
     <include file="changesets/changelog-consent-89.0.xml" relativeToChangelogFile="true"/>
     <include file="changesets/changelog-consent-90.0.xml" relativeToChangelogFile="true"/>
-    
     <include file="changesets/changelog-consent-92.0.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/src/main/resources/changelog-master.xml
+++ b/src/main/resources/changelog-master.xml
@@ -91,4 +91,5 @@
     <include file="changesets/changelog-consent-86.0.xml" relativeToChangelogFile="true"/>
     <include file="changesets/changelog-consent-87.0.xml" relativeToChangelogFile="true"/>
     <include file="changesets/changelog-consent-88.0.xml" relativeToChangelogFile="true"/>
+    <include file="changesets/changelog-consent-89.0.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/src/main/resources/changesets/changelog-consent-89.0.xml
+++ b/src/main/resources/changesets/changelog-consent-89.0.xml
@@ -1,0 +1,19 @@
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+  <changeSet id="89.0" author="JVThomas">
+    <!--Add mapping and dataset property type columns -->
+    <addColumn tableName="dataset">
+      <column name="dac_approval" type="boolean"/>
+    </addColumn>
+
+    <sql>
+        UPDATE dataset SET dac_approval = TRUE 
+        WHERE dataset.datasetid IN (
+          SELECT ca.datasetid FROM dataset d
+          INNER JOIN consentassociations ca ON ca.datasetid = d.datasetid
+          INNER JOIN consents c ON ca.consentid = c.consentid
+          WHERE c.dac_id IS NOT NULL
+        ) 
+      </sql>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/changesets/changelog-consent-92.0.xml
+++ b/src/main/resources/changesets/changelog-consent-92.0.xml
@@ -1,9 +1,8 @@
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
          http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
   <changeSet id="92.0" author="JVThomas">
-    <!--Add mapping and dataset property type columns -->
     <addColumn tableName="dataset">
-      <column name="dac_approval" type="boolean"/>
+      <column name="dac_approval" type="boolean" defaultValue="null"/>
     </addColumn>
 
     <sql>

--- a/src/main/resources/changesets/changelog-consent-92.0.xml
+++ b/src/main/resources/changesets/changelog-consent-92.0.xml
@@ -8,9 +8,9 @@
 
     <sql>
         UPDATE dataset SET dac_approval = TRUE 
-        WHERE dataset.datasetid IN (
+        WHERE dataset.dataset_id IN (
           SELECT ca.datasetid FROM dataset d
-          INNER JOIN consentassociations ca ON ca.datasetid = d.datasetid
+          INNER JOIN consentassociations ca ON ca.datasetid = d.dataset_id
           INNER JOIN consents c ON ca.consentid = c.consentid
           WHERE c.dac_id IS NOT NULL
         ) 


### PR DESCRIPTION
Addresses [DUOS-1983](https://broadworkbench.atlassian.net/browse/DUOS-1983)

PR adds `dac_approval` column to the `dataset` table. PR also backfills the `dac_approval` value to `TRUE` for datasets that are already associated to a DAC.

NOTE: Changelog is labeld as `92.0` intentionally to avoid conflicts with changelog updates in https://github.com/DataBiosphere/consent/pull/1709, which came earlier

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
