### PR TITLE
[DUOS-2039][risk=no] Allow DataSubmitter role to be added/deleted through /api/user/{userId}/{roleId}

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/enumeration/UserRoles.java
+++ b/src/main/java/org/broadinstitute/consent/http/enumeration/UserRoles.java
@@ -65,7 +65,7 @@ public enum UserRoles {
 
     public static boolean isValidNonDACRoleId(Integer roleId) {
         List<Integer> listOfNonDacRoleIds = Arrays.asList(
-          ALUMNI.getRoleId(), ADMIN.getRoleId(), RESEARCHER.getRoleId(), DATAOWNER.getRoleId(), SIGNINGOFFICIAL.getRoleId());
+          ALUMNI.getRoleId(), ADMIN.getRoleId(), RESEARCHER.getRoleId(), DATAOWNER.getRoleId(), SIGNINGOFFICIAL.getRoleId(), DATASUBMITTER.getRoleId());
         return !Objects.isNull(roleId) && listOfNonDacRoleIds.contains(roleId);
     }
 

--- a/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
@@ -479,7 +479,7 @@ public class UserResourceTest {
     User user = createUserWithRole();
     when(userService.findUserById(any())).thenReturn(user);
     initResource();
-    Response response = userResource.deleteRoleFromUser(authUser, user.getUserId(), 8);
+    Response response = userResource.deleteRoleFromUser(authUser, user.getUserId(), 9);
     assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
   }
 


### PR DESCRIPTION
Addresses [DUOS-2039](https://broadworkbench.atlassian.net/browse/DUOS-2039)

Found while reviewing [DUOS-1669](https://broadworkbench.atlassian.net/browse/DUOS-1669) and trying to give myself the DataSubmitter role. Both endpoints affected are admin-only, and the Swagger documentation lists DataSubmitter as a valid role to add/remove, so this should be ok to go through now 

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
