### PR TITLE
DUOS-2071[risk=no] Updated DAR draft update endpoint to set (rather than add) dataset ids when processing payload

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
@@ -57,6 +57,7 @@ import org.broadinstitute.consent.http.service.UseRestrictionValidator;
 import org.broadinstitute.consent.http.service.UserService;
 import org.broadinstitute.consent.http.service.VoteService;
 import org.broadinstitute.consent.http.service.dao.DarCollectionServiceDAO;
+import org.broadinstitute.consent.http.service.dao.DataAccessRequestServiceDAO;
 import org.broadinstitute.consent.http.service.dao.VoteServiceDAO;
 import org.broadinstitute.consent.http.service.sam.SamService;
 import org.jdbi.v3.core.Jdbi;
@@ -248,7 +249,9 @@ public class ConsentModule extends AbstractModule {
         return new DataAccessRequestService(
                 providesCounterService(),
                 providesDAOContainer(),
-                providesDacService());
+                providesDacService(),
+                providesDataAccessRequestServiceDAO()
+        );
     }
 
     @Provides
@@ -351,6 +354,15 @@ public class ConsentModule extends AbstractModule {
             providesElectionDAO(),
             providesJdbi(),
             providesUserDAO());
+    }
+
+    @Provides
+    DataAccessRequestServiceDAO providesDataAccessRequestServiceDAO() {
+      return new DataAccessRequestServiceDAO(
+        providesDataAccessRequestDAO(), 
+        providesJdbi(),
+        providesDARCollectionDAO()
+      );
     }
 
     @Provides

--- a/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceVersion2.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceVersion2.java
@@ -64,7 +64,8 @@ public class DataAccessRequestResourceVersion2 extends Resource {
       EmailNotifierService emailNotifierService,
       GCSService gcsService,
       UserService userService,
-      MatchService matchService) {
+      MatchService matchService
+    ) {
     this.dataAccessRequestService = dataAccessRequestService;
     this.emailNotifierService = emailNotifierService;
     this.gcsService = gcsService;
@@ -239,7 +240,7 @@ public class DataAccessRequestResourceVersion2 extends Resource {
       // it in dar data.
       data.setReferenceId(originalDar.getReferenceId());
       originalDar.setData(data);
-      originalDar.addDatasetIds(data.getDatasetIds());
+      originalDar.setDatasetIds(data.getDatasetIds());
       DataAccessRequest updatedDar =
           dataAccessRequestService.updateByReferenceId(user, originalDar);
       return Response.ok().entity(updatedDar.convertToSimplifiedDar()).build();

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
@@ -29,6 +29,7 @@ import org.broadinstitute.consent.http.models.Dataset;
 import org.broadinstitute.consent.http.models.Election;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.Vote;
+import org.broadinstitute.consent.http.service.dao.DataAccessRequestServiceDAO;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,6 +38,7 @@ import javax.ws.rs.NotFoundException;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -67,13 +69,14 @@ public class DataAccessRequestService {
     private final UserDAO userDAO;
     private final VoteDAO voteDAO;
     private final InstitutionDAO institutionDAO;
+    private final DataAccessRequestServiceDAO dataAccessRequestServiceDAO;
 
     private final DacService dacService;
     private final DataAccessReportsParser dataAccessReportsParser;
 
     @Inject
     public DataAccessRequestService(CounterService counterService, DAOContainer container,
-            DacService dacService) {
+            DacService dacService, DataAccessRequestServiceDAO dataAccessRequestServiceDAO) {
         this.consentDAO = container.getConsentDAO();
         this.counterService = counterService;
         this.dacDAO = container.getDacDAO();
@@ -87,6 +90,7 @@ public class DataAccessRequestService {
         this.institutionDAO = container.getInstitutionDAO();
         this.dacService = dacService;
         this.dataAccessReportsParser = new DataAccessReportsParser();
+        this.dataAccessRequestServiceDAO = dataAccessRequestServiceDAO;
     }
 
     /**
@@ -182,6 +186,7 @@ public class DataAccessRequestService {
         return dar;
     }
 
+    //NOTE: rewrite method into new servicedao method on another ticket
     public DataAccessRequest insertDraftDataAccessRequest(User user, DataAccessRequest dar) {
         if (Objects.isNull(user) || Objects.isNull(dar) || Objects.isNull(dar.getReferenceId()) || Objects.isNull(dar.getData())) {
             throw new IllegalArgumentException("User and DataAccessRequest are required");
@@ -196,7 +201,6 @@ public class DataAccessRequestService {
             now,
             dar.getData()
         );
-
         syncDataAccessRequestDatasets(dar.getDatasetIds(), dar.getReferenceId());
 
         return findByReferenceId(dar.getReferenceId());
@@ -451,20 +455,11 @@ public class DataAccessRequestService {
      * @return The updated DataAccessRequest
      */
     public DataAccessRequest updateByReferenceId(User user, DataAccessRequest dar) {
-        Date now = new Date();
-        dataAccessRequestDAO.updateDataByReferenceId(dar.getReferenceId(),
-            user.getUserId(),
-            now,
-            dar.getSubmissionDate(),
-            now,
-            dar.getData());
-        if (Objects.nonNull(dar.getCollectionId())) {
-            darCollectionDAO.updateDarCollection(dar.getCollectionId(), user.getUserId(), now);
-        }
-        // Update the dar_dataset collection
-        syncDataAccessRequestDatasets(dar.getDatasetIds(), dar.getReferenceId());
-
-        return findByReferenceId(dar.getReferenceId());
+      try {
+        return dataAccessRequestServiceDAO.updateByReferenceId(user, dar);
+      } catch(SQLException e) {
+        throw new IllegalArgumentException("Update failed due to invalid parameters");
+      }
     }
 
     public List<DataAccessRequestManage> getDraftDataAccessRequestManage(Integer userId) {

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
@@ -30,6 +30,7 @@ import org.broadinstitute.consent.http.models.Election;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.Vote;
 import org.broadinstitute.consent.http.service.dao.DataAccessRequestServiceDAO;
+import org.jdbi.v3.core.statement.UnableToExecuteStatementException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -458,7 +459,12 @@ public class DataAccessRequestService {
       try {
         return dataAccessRequestServiceDAO.updateByReferenceId(user, dar);
       } catch(SQLException e) {
-        throw new IllegalArgumentException("Update failed due to invalid parameters");
+        // If I simply rethrow the error then I'll have to redefine any method that
+        // calls this function to "throw SQLException"
+        //Instead I'm going to throw an UnableToExecuteStatementException
+        //Response class will catch it, log it, and throw a 500 through the "unableToExecuteExceptionHandler"
+        //on the Resource class, just like it would with a SQLException
+        throw new UnableToExecuteStatementException(e.getMessage());
       }
     }
 

--- a/src/main/java/org/broadinstitute/consent/http/service/VoteService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/VoteService.java
@@ -19,7 +19,6 @@ import org.broadinstitute.consent.http.exceptions.UnknownIdentifierException;
 import org.broadinstitute.consent.http.models.Dac;
 import org.broadinstitute.consent.http.models.DarCollection;
 import org.broadinstitute.consent.http.models.DataAccessRequest;
-import org.broadinstitute.consent.http.models.DataAccessRequestData;
 import org.broadinstitute.consent.http.models.DataUse;
 import org.broadinstitute.consent.http.models.Dataset;
 import org.broadinstitute.consent.http.models.Election;

--- a/src/main/java/org/broadinstitute/consent/http/service/dao/DataAccessRequestServiceDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/dao/DataAccessRequestServiceDAO.java
@@ -1,0 +1,77 @@
+package org.broadinstitute.consent.http.service.dao;
+
+import com.google.inject.Inject;
+
+import org.broadinstitute.consent.http.db.DarCollectionDAO;
+import org.broadinstitute.consent.http.db.DataAccessRequestDAO;
+import org.broadinstitute.consent.http.models.DataAccessRequest;
+import org.broadinstitute.consent.http.models.User;
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.core.statement.Update;
+
+import java.sql.SQLException;
+import java.time.Instant;
+import java.util.Date;
+import java.util.List;
+import java.util.Objects;
+
+public class DataAccessRequestServiceDAO {
+
+    private final DataAccessRequestDAO dataAccessRequestDAO;
+    private final DarCollectionDAO darCollectionDAO;
+    private final Jdbi jdbi;
+
+    @Inject
+    public DataAccessRequestServiceDAO(DataAccessRequestDAO dataAccessRequestDAO, Jdbi jdbi, DarCollectionDAO darCollectionDAO) {
+        this.dataAccessRequestDAO = dataAccessRequestDAO;
+        this.jdbi = jdbi;
+        this.darCollectionDAO = darCollectionDAO;
+    }
+
+    public DataAccessRequest updateByReferenceId( User user, DataAccessRequest dar) throws SQLException {
+        Instant now = Instant.now();
+        String referenceId = dar.getReferenceId();
+        jdbi.useHandle(handle -> {
+            handle.getConnection().setAutoCommit(false);
+            handle.useTransaction(h -> {
+
+                final String updateDataByReferenceId = "UPDATE data_access_request "
+                    + "SET data = to_jsonb(:data), user_id = :userId, sort_date = :sortDate, "
+                    + "submission_date = :submissionDate, update_date = :updateDate "
+                    + "WHERE reference_id = :referenceId";
+                final String deleteDarDatasetRelationByReferenceId = "DELETE FROM dar_dataset WHERE reference_id = :referenceId";
+                final String insertDarDataset = "INSERT INTO dar_dataset (reference_id, dataset_id) "
+                    + "VALUES (:referenceId, :datasetId) "
+                    + "ON CONFLICT DO NOTHING";
+
+                Update darUpdate = h.createUpdate(updateDataByReferenceId);
+                darUpdate.bind("referenceId", referenceId);
+                darUpdate.bind("userId", user.getUserId());
+                darUpdate.bind("sortDate", now);
+                darUpdate.bind("updateDate", now);
+                darUpdate.bind("data", dar.getData().toString());
+                darUpdate.bind("submissionDate", dar.getSubmissionDate());
+                darUpdate.execute();
+
+                if(Objects.nonNull(dar.getCollectionId())) {
+                  darCollectionDAO.updateDarCollection(dar.getCollectionId(), user.getUserId(), new Date(now.getEpochSecond()));
+                }
+                
+                Update darDatasetDelete = h.createUpdate(deleteDarDatasetRelationByReferenceId);
+                darDatasetDelete.bind("referenceId", dar.getReferenceId());
+                darDatasetDelete.execute();
+
+                List<Integer> datasetIds = dar.getDatasetIds();
+                datasetIds.forEach(id -> {
+                    Update darDatasetInsert = h.createUpdate(insertDarDataset);
+                    darDatasetInsert.bind("referenceId", referenceId);
+                    darDatasetInsert.bind("datasetId", id);
+                    darDatasetInsert.execute();
+                });
+
+                h.commit();
+            });
+        });
+        return dataAccessRequestDAO.findByReferenceId(referenceId);
+    }
+}

--- a/src/main/java/org/broadinstitute/consent/http/service/dao/VoteServiceDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/dao/VoteServiceDAO.java
@@ -1,18 +1,14 @@
 package org.broadinstitute.consent.http.service.dao;
 
 import com.google.inject.Inject;
-import org.broadinstitute.consent.http.db.ElectionDAO;
 import org.broadinstitute.consent.http.db.VoteDAO;
 import org.broadinstitute.consent.http.enumeration.ElectionStatus;
-import org.broadinstitute.consent.http.enumeration.ElectionType;
 import org.broadinstitute.consent.http.enumeration.VoteType;
-import org.broadinstitute.consent.http.models.Election;
 import org.broadinstitute.consent.http.models.Vote;
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.statement.Update;
 
 import java.sql.SQLException;
-import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Objects;

--- a/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
@@ -30,6 +30,7 @@ import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.UserRole;
 import org.broadinstitute.consent.http.models.Vote;
 import org.broadinstitute.consent.http.models.grammar.Everything;
+import org.broadinstitute.consent.http.service.dao.DataAccessRequestServiceDAO;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentMatcher;
@@ -92,6 +93,8 @@ public class DataAccessRequestServiceTest {
     private InstitutionDAO institutionDAO;
     @Mock
     private MatchDAO matchDAO;
+    @Mock
+    private DataAccessRequestServiceDAO dataAccessRequestServiceDAO;
 
     private DataAccessRequestService service;
 
@@ -117,7 +120,7 @@ public class DataAccessRequestServiceTest {
         container.setElectionDAO(electionDAO);
         container.setVoteDAO(voteDAO);
         container.setMatchDAO(matchDAO);
-        service = new DataAccessRequestService(counterService, container, dacService);
+        service = new DataAccessRequestService(counterService, container, dacService, dataAccessRequestServiceDAO);
     }
 
     @Test
@@ -214,28 +217,23 @@ public class DataAccessRequestServiceTest {
     }
 
     @Test
-    public void testUpdateByReferenceIdVersion2() {
+    public void testUpdateByReferenceIdVersion2() throws Exception {
         DataAccessRequest dar = generateDataAccessRequest();
         dar.setCollectionId(RandomUtils.nextInt(0, 100));
         User user = new User(1, "email@test.org", "Display Name", new Date());
         dar.addDatasetIds(Arrays.asList(1, 2, 3));
-        doNothing().when(dataAccessRequestDAO).updateDataByReferenceId(any(), any(),
-            any(), any(), any(), any());
-        when(dataAccessRequestDAO.findByReferenceId(any())).thenReturn(dar);
+        when(dataAccessRequestServiceDAO.updateByReferenceId(any(), any())).thenReturn(dar);
         initService();
         DataAccessRequest newDar = service.updateByReferenceId(user, dar);
         assertNotNull(newDar);
     }
 
     @Test
-    public void testUpdateByReferenceIdVersion2_WithCollection() {
+    public void testUpdateByReferenceIdVersion2_WithCollection() throws Exception {
         DataAccessRequest dar = generateDataAccessRequest();
         User user = new User(1, "email@test.org", "Display Name", new Date());
         dar.addDatasetIds(Arrays.asList(1, 2, 3));
-        doNothing().when(dataAccessRequestDAO).updateDataByReferenceId(any(), any(),
-          any(), any(), any(), any());
-        doNothing().when(darCollectionDAO).updateDarCollection(any(), any(), any());
-        when(dataAccessRequestDAO.findByReferenceId(any())).thenReturn(dar);
+        when(dataAccessRequestServiceDAO.updateByReferenceId(user, dar)).thenReturn(dar);
         initService();
         DataAccessRequest newDar = service.updateByReferenceId(user, dar);
         assertNotNull(newDar);

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DataAccessRequestServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DataAccessRequestServiceDAOTest.java
@@ -1,0 +1,79 @@
+package org.broadinstitute.consent.http.service.dao;
+
+import org.apache.commons.lang3.RandomStringUtils;
+import org.broadinstitute.consent.http.db.DAOTestHelper;
+import org.broadinstitute.consent.http.models.DarCollection;
+import org.broadinstitute.consent.http.models.DarDataset;
+import org.broadinstitute.consent.http.models.DataAccessRequest;
+import org.broadinstitute.consent.http.models.DataAccessRequestData;
+import org.broadinstitute.consent.http.models.Dataset;
+import org.broadinstitute.consent.http.models.User;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.sql.Timestamp;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+public class DataAccessRequestServiceDAOTest extends DAOTestHelper {
+    public DataAccessRequestServiceDAO serviceDAO;
+
+    @Before
+    public void initService() {
+        serviceDAO = new DataAccessRequestServiceDAO(dataAccessRequestDAO, jdbi, darCollectionDAO);
+    }
+
+    @Test
+    public void testUpdateByReferenceId() throws Exception {
+      //create a dar with datasetOne connection and insert into table
+      //also means inserting DarDataset record with datasetOne tied to referenceId
+
+      Dataset datasetOne = createDataset();
+      Dataset datasetTwo = createDataset();
+      Dataset datasetThree = createDataset();
+      User user = createUser();
+      Calendar cal = Calendar.getInstance();
+      cal.set(Calendar.YEAR, 2020);
+      cal.set(Calendar.MONTH, Calendar.JANUARY);
+      cal.set(Calendar.DAY_OF_MONTH, 1);
+      Date old = cal.getTime();
+
+      String referenceId =  RandomStringUtils.randomAlphanumeric(10);
+      DarDataset oldDarDataset = new DarDataset(referenceId, datasetOne.getDataSetId());
+      DarDataset oldDarDatasetTwo = new DarDataset(referenceId, datasetTwo.getDataSetId());
+      DarCollection collection = createDarCollection();
+      Integer collectionId = collection.getDarCollectionId();
+      dataAccessRequestDAO.insertDataAccessRequest(collectionId, referenceId, user.getUserId(), old, old, old, old, new DataAccessRequestData());
+      dataAccessRequestDAO.insertAllDarDatasets(List.of(oldDarDataset, oldDarDatasetTwo));
+
+      DataAccessRequest dar = new DataAccessRequest();
+      dar.setReferenceId(referenceId);
+      dar.setCollectionId(collectionId);
+      DataAccessRequestData data = new DataAccessRequestData();
+      data.setOtherText("This is a test value");
+      List<Integer> newDatasetIds = List.of(datasetThree.getDataSetId());
+      dar.setDatasetIds(newDatasetIds);
+      dar.setData(data);
+
+      initService();
+
+      DataAccessRequest updatedDar = serviceDAO.updateByReferenceId(user, dar);
+
+      Timestamp oldTimestamp = new Timestamp(old.getTime()); 
+      assertFalse(oldTimestamp.equals(updatedDar.getSortDate()));
+      assertFalse(oldTimestamp.equals(updatedDar.getUpdateDate()));
+      assertEquals(newDatasetIds, updatedDar.getDatasetIds());
+      DataAccessRequestData updatedData = updatedDar.getData();
+      assertEquals(data.getOtherText(), updatedData.getOtherText());
+
+      DarCollection targetCollection = darCollectionDAO.findDARCollectionByCollectionId(collectionId);
+      assertEquals(user.getUserId(), targetCollection.getUpdateUserId());
+
+      // collection should have the same update date as the updated dar
+      assertEquals(dar.getUpdateDate(), collection.getUpdateDate());
+    }
+}

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DataAccessRequestServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DataAccessRequestServiceDAOTest.java
@@ -29,8 +29,6 @@ public class DataAccessRequestServiceDAOTest extends DAOTestHelper {
 
     @Test
     public void testUpdateByReferenceId() throws Exception {
-      //create a dar with datasetOne connection and insert into table
-      //also means inserting DarDataset record with datasetOne tied to referenceId
 
       Dataset datasetOne = createDataset();
       Dataset datasetTwo = createDataset();


### PR DESCRIPTION
Addresses [DUOS-2071](https://broadworkbench.atlassian.net/browse/DUOS-2071)

PR addresses bug where dataset ids were added rather than set on intermediate DAR object on the DAR draft update endpoint. The result of the above made it so that datasets could never be removed from a draft. 

PR also creates a new `DataAccessRequestServiceDAO` class with an `updateByReferenceId` to ensure that DAR, Collection, and DarDataset records are all updated within a single transaction rather than three separate ones. 

With the above addition comes updates to method references as well as new/updated tests. PR also includes misc. cleanup of unused imports.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
