### PR TITLE
[DUOS-2082][risk=no] Update random string generation in tests

### DIFF
--- a/src/test/java/org/broadinstitute/consent/http/db/ConsentDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/ConsentDAOTest.java
@@ -129,7 +129,7 @@ public class ConsentDAOTest extends DAOTestHelper {
     public void testUpdateConsentTranslatedUseRestriction() {
         Consent consent = createConsent();
 
-        String randomString = RandomStringUtils.random(10);
+        String randomString = RandomStringUtils.randomAlphabetic(10);
         consentDAO.updateConsentTranslatedUseRestriction(consent.getConsentId(), randomString);
         Consent foundConsent = consentDAO.findConsentById(consent.getConsentId());
         assertEquals(randomString, foundConsent.getTranslatedUseRestriction());

--- a/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
@@ -461,7 +461,7 @@ public class DAOTestHelper {
 
     protected DataAccessRequest createDataAccessRequestWithDatasetAndCollectionInfo(int collectionId, int datasetId, int userId, String darCode) {
         DataAccessRequestData data = new DataAccessRequestData();
-        data.setProjectTitle(RandomStringUtils.random(10));
+        data.setProjectTitle(RandomStringUtils.randomAlphabetic(10));
         String referenceId = RandomStringUtils.randomAlphanumeric(20);
         dataAccessRequestDAO.insertDataAccessRequest(collectionId, referenceId, userId, new Date(), new Date(), new Date(), new Date(), data);
         dataAccessRequestDAO.insertDARDatasetRelation(referenceId, datasetId);

--- a/src/test/java/org/broadinstitute/consent/http/db/DarCollectionSummaryDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DarCollectionSummaryDAOTest.java
@@ -44,7 +44,7 @@ public class DarCollectionSummaryDAOTest extends DAOTestHelper {
   }
 
   private User createUserForTest() {
-    Integer userId = userDAO.insertUser(RandomStringUtils.random(10), RandomStringUtils.randomAlphabetic(10), new Date());
+    Integer userId = userDAO.insertUser(RandomStringUtils.randomAlphabetic(10), RandomStringUtils.randomAlphabetic(10), new Date());
     return userDAO.findUserById(userId);
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/db/InstitutionDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/InstitutionDAOTest.java
@@ -126,7 +126,7 @@ public class InstitutionDAOTest extends DAOTestHelper {
 
   @Test
   public void testFindInstitutionsByName_Missing() {
-    List<Institution> found = institutionDAO.findInstitutionsByName(RandomStringUtils.random(10));
+    List<Institution> found = institutionDAO.findInstitutionsByName(RandomStringUtils.randomAlphabetic(10));
     assertTrue(found.isEmpty());
   }
 }

--- a/src/test/java/org/broadinstitute/consent/http/db/UserPropertyDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/UserPropertyDAOTest.java
@@ -18,17 +18,17 @@ public class UserPropertyDAOTest extends DAOTestHelper {
 
         UserProperty suggestedInstitution = new UserProperty();
         suggestedInstitution.setPropertyKey(UserFields.SUGGESTED_INSTITUTION.getValue());
-        suggestedInstitution.setPropertyValue(RandomStringUtils.random(10));
+        suggestedInstitution.setPropertyValue(RandomStringUtils.randomAlphabetic(10));
         suggestedInstitution.setUserId(user.getUserId());
 
         UserProperty suggestedSigningOfficial = new UserProperty();
         suggestedSigningOfficial.setPropertyKey(UserFields.SUGGESTED_SIGNING_OFFICIAL.getValue());
-        suggestedSigningOfficial.setPropertyValue(RandomStringUtils.random(10));
+        suggestedSigningOfficial.setPropertyValue(RandomStringUtils.randomAlphabetic(10));
         suggestedSigningOfficial.setUserId(user.getUserId());
 
         UserProperty notPresent = new UserProperty();
         notPresent.setPropertyKey("nonExistentKey");
-        notPresent.setPropertyValue(RandomStringUtils.random(10));
+        notPresent.setPropertyValue(RandomStringUtils.randomAlphabetic(10));
         notPresent.setUserId(user.getUserId());
 
         List<UserProperty> props = userPropertyDAO.findResearcherPropertiesByUser(

--- a/src/test/java/org/broadinstitute/consent/http/db/VoteDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/VoteDAOTest.java
@@ -470,7 +470,7 @@ public class VoteDAOTest extends DAOTestHelper {
         boolean voteValue = true;
         voteDAO.updateVote(
                 voteValue,
-                RandomStringUtils.random(10),
+                RandomStringUtils.randomAlphabetic(10),
                 new Date(),
                 v.getVoteId(),
                 false,
@@ -644,7 +644,7 @@ public class VoteDAOTest extends DAOTestHelper {
         Vote vote = createChairpersonVote(user.getUserId(), election.getElectionId());
         voteDAO.updateVote(
                 true,
-                RandomStringUtils.random(10),
+                RandomStringUtils.randomAlphabetic(10),
                 new Date(),
                 vote.getVoteId(),
                 false,

--- a/src/test/java/org/broadinstitute/consent/http/resources/DACUserResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DACUserResourceTest.java
@@ -166,7 +166,7 @@ public class DACUserResourceTest {
     public void testRetrieveDACUserWithInvalidEmail() {
         when(userService.findUserByEmail(any())).thenThrow(new NotFoundException());
         initResource();
-        resource.describe(authUser, RandomStringUtils.random(10));
+        resource.describe(authUser, RandomStringUtils.randomAlphabetic(10));
     }
 
     @Test

--- a/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceVersion2Test.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceVersion2Test.java
@@ -197,8 +197,8 @@ public class DataAccessRequestResourceVersion2Test {
   public void testGetIrbDocument() {
     when(userService.findUserByEmail(any())).thenReturn(user);
     DataAccessRequest dar = generateDataAccessRequest();
-    dar.getData().setIrbDocumentLocation(RandomStringUtils.random(10));
-    dar.getData().setIrbDocumentName(RandomStringUtils.random(10) + ".txt");
+    dar.getData().setIrbDocumentLocation(RandomStringUtils.randomAlphabetic(10));
+    dar.getData().setIrbDocumentName(RandomStringUtils.randomAlphabetic(10) + ".txt");
     when(dataAccessRequestService.findByReferenceId(any())).thenReturn(dar);
     initResource();
 
@@ -264,8 +264,8 @@ public class DataAccessRequestResourceVersion2Test {
   public void testUploadIrbDocumentWithPreviousIrbDocument() throws Exception {
     when(userService.findUserByEmail(any())).thenReturn(user);
     DataAccessRequest dar = generateDataAccessRequest();
-    dar.getData().setIrbDocumentLocation(RandomStringUtils.random(10));
-    dar.getData().setIrbDocumentName(RandomStringUtils.random(10) + ".txt");
+    dar.getData().setIrbDocumentLocation(RandomStringUtils.randomAlphabetic(10));
+    dar.getData().setIrbDocumentName(RandomStringUtils.randomAlphabetic(10) + ".txt");
     when(dataAccessRequestService.updateByReferenceId(any(), any())).thenReturn(dar);
     when(dataAccessRequestService.findByReferenceId(any())).thenReturn(dar);
     InputStream uploadInputStream = IOUtils.toInputStream("test", Charset.defaultCharset());
@@ -285,8 +285,8 @@ public class DataAccessRequestResourceVersion2Test {
   public void testGetCollaborationDocument() {
     when(userService.findUserByEmail(any())).thenReturn(user);
     DataAccessRequest dar = generateDataAccessRequest();
-    dar.getData().setCollaborationLetterLocation(RandomStringUtils.random(10));
-    dar.getData().setCollaborationLetterName(RandomStringUtils.random(10) + ".txt");
+    dar.getData().setCollaborationLetterLocation(RandomStringUtils.randomAlphabetic(10));
+    dar.getData().setCollaborationLetterName(RandomStringUtils.randomAlphabetic(10) + ".txt");
     when(dataAccessRequestService.findByReferenceId(any())).thenReturn(dar);
     initResource();
 
@@ -352,8 +352,8 @@ public class DataAccessRequestResourceVersion2Test {
   public void testUploadCollaborationDocumentWithPreviousDocument() throws Exception {
     when(userService.findUserByEmail(any())).thenReturn(user);
     DataAccessRequest dar = generateDataAccessRequest();
-    dar.getData().setCollaborationLetterLocation(RandomStringUtils.random(10));
-    dar.getData().setCollaborationLetterName(RandomStringUtils.random(10) + ".txt");
+    dar.getData().setCollaborationLetterLocation(RandomStringUtils.randomAlphabetic(10));
+    dar.getData().setCollaborationLetterName(RandomStringUtils.randomAlphabetic(10) + ".txt");
     when(dataAccessRequestService.updateByReferenceId(any(), any())).thenReturn(dar);
     when(dataAccessRequestService.findByReferenceId(any())).thenReturn(dar);
     InputStream uploadInputStream = IOUtils.toInputStream("test", Charset.defaultCharset());

--- a/src/test/java/org/broadinstitute/consent/http/resources/ElectionResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/ElectionResourceTest.java
@@ -15,6 +15,7 @@ import org.mockito.Mock;
 import javax.ws.rs.NotFoundException;
 import javax.ws.rs.core.Response;
 import java.util.Collections;
+import java.util.UUID;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
@@ -57,7 +58,7 @@ public class ElectionResourceTest {
 
     @Test
     public void testAdvanceElection() {
-        String referenceId = RandomStringUtils.random(10);
+        String referenceId = UUID.randomUUID().toString();
         Response response = electionResource.advanceElection(referenceId, "Yes");
         Assert.assertEquals(OK, response.getStatus());
     }
@@ -66,7 +67,7 @@ public class ElectionResourceTest {
     public void testAdvanceElectionError() {
         when(voteService.findVotesByReferenceId(anyString())).thenThrow(new NotFoundException());
         electionResource = new ElectionResource(voteService, electionService);
-        String referenceId = RandomStringUtils.random(10);
+        String referenceId = UUID.randomUUID().toString();
         Response response = electionResource.advanceElection(referenceId, "Yes");
         Assert.assertEquals(NOT_FOUND, response.getStatus());
     }

--- a/src/test/java/org/broadinstitute/consent/http/resources/ElectionReviewResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/ElectionReviewResourceTest.java
@@ -50,7 +50,7 @@ public class ElectionReviewResourceTest {
     public void testGetCollectElectionReview() {
         when(reviewResultsService.describeLastElectionReviewByReferenceIdAndType(any(), any())).thenReturn(new ElectionReview());
         initResource();
-        ElectionReview response = resource.getCollectElectionReview(RandomStringUtils.random(10), RandomStringUtils.random(10));
+        ElectionReview response = resource.getCollectElectionReview(RandomStringUtils.randomAlphabetic(10), RandomStringUtils.randomAlphabetic(10));
         assertNotNull(response);
     }
 

--- a/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
@@ -257,7 +257,7 @@ public class UserResourceTest {
   public void testDeleteUser() {
     doNothing().when(userService).deleteUserByEmail(any());
     initResource();
-    Response response = userResource.delete(RandomStringUtils.random(10), uriInfo);
+    Response response = userResource.delete(RandomStringUtils.randomAlphabetic(10), uriInfo);
     assertEquals(200, response.getStatus());
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/service/ResearcherServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/ResearcherServiceTest.java
@@ -13,7 +13,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 
 import javax.ws.rs.NotFoundException;
 import java.util.Collections;
@@ -23,6 +22,7 @@ import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 public class ResearcherServiceTest {
 
@@ -47,9 +47,9 @@ public class ResearcherServiceTest {
         user = new User();
         user.setEmail(authUser.getEmail());
         user.setUserId(RandomUtils.nextInt(1, 10));
-        user.setDisplayName(RandomStringUtils.random(10));
+        user.setDisplayName(RandomStringUtils.randomAlphabetic(10));
 
-        MockitoAnnotations.initMocks(this);
+        openMocks(this);
     }
 
     private void initService() {


### PR DESCRIPTION
## Addresses

https://broadworkbench.atlassian.net/browse/DUOS-2082

Usages of `RandomStringUtils.random(10)` can generate strings that our database cannot store. Use `RandomStringUtils.randomAlphabetic(10)` instead which restricts the string values to the `[a-A,z-Z]` range.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
