### PR TITLE
[DUOS-2095][risk=no] Refactor sam service into service/dao

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
@@ -26,6 +26,7 @@ import org.broadinstitute.consent.http.db.InstitutionDAO;
 import org.broadinstitute.consent.http.db.LibraryCardDAO;
 import org.broadinstitute.consent.http.db.MailMessageDAO;
 import org.broadinstitute.consent.http.db.MatchDAO;
+import org.broadinstitute.consent.http.db.SamDAO;
 import org.broadinstitute.consent.http.db.UserDAO;
 import org.broadinstitute.consent.http.db.UserPropertyDAO;
 import org.broadinstitute.consent.http.db.UserRoleDAO;
@@ -359,7 +360,7 @@ public class ConsentModule extends AbstractModule {
     @Provides
     DataAccessRequestServiceDAO providesDataAccessRequestServiceDAO() {
       return new DataAccessRequestServiceDAO(
-        providesDataAccessRequestDAO(), 
+        providesDataAccessRequestDAO(),
         providesJdbi(),
         providesDARCollectionDAO()
       );
@@ -548,7 +549,11 @@ public class ConsentModule extends AbstractModule {
 
     @Provides
     SamService providesSamService() {
-        return new SamService(config.getServicesConfiguration());
+        return new SamService(providesSamDAO());
+    }
+
+    SamDAO providesSamDAO() {
+        return new SamDAO(config.getServicesConfiguration());
     }
 
     @Provides

--- a/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
@@ -552,6 +552,7 @@ public class ConsentModule extends AbstractModule {
         return new SamService(providesSamDAO());
     }
 
+    @Provides
     SamDAO providesSamDAO() {
         return new SamDAO(config.getServicesConfiguration());
     }

--- a/src/main/java/org/broadinstitute/consent/http/db/SamDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/SamDAO.java
@@ -1,0 +1,148 @@
+package org.broadinstitute.consent.http.db;
+
+import com.google.api.client.http.EmptyContent;
+import com.google.api.client.http.GenericUrl;
+import com.google.api.client.http.HttpRequest;
+import com.google.api.client.http.HttpResponse;
+import com.google.api.client.http.HttpStatusCodes;
+import com.google.api.client.http.json.JsonHttpContent;
+import com.google.api.client.json.gson.GsonFactory;
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import org.broadinstitute.consent.http.configurations.ServicesConfiguration;
+import org.broadinstitute.consent.http.models.AuthUser;
+import org.broadinstitute.consent.http.models.sam.ResourceType;
+import org.broadinstitute.consent.http.models.sam.TosResponse;
+import org.broadinstitute.consent.http.models.sam.UserStatus;
+import org.broadinstitute.consent.http.models.sam.UserStatusDiagnostics;
+import org.broadinstitute.consent.http.models.sam.UserStatusInfo;
+import org.broadinstitute.consent.http.util.HttpClientUtil;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.core.MediaType;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+public class SamDAO {
+
+  private final ExecutorService executorService;
+  private final HttpClientUtil clientUtil;
+  private final ServicesConfiguration configuration;
+  private final Logger logger = LoggerFactory.getLogger(this.getClass());
+
+  public SamDAO(ServicesConfiguration configuration) {
+    this.executorService = Executors.newCachedThreadPool();
+    this.clientUtil = new HttpClientUtil();
+        this.configuration = configuration;
+  }
+
+  public List<ResourceType> getResourceTypes(AuthUser authUser) throws Exception {
+    GenericUrl genericUrl = new GenericUrl(configuration.getV1ResourceTypesUrl());
+    HttpRequest request = clientUtil.buildGetRequest(genericUrl, authUser);
+    HttpResponse response = clientUtil.handleHttpRequest(request);
+    if (response.getStatusCode() != HttpStatusCodes.STATUS_CODE_OK) {
+      logger.error("Error getting resource types from Sam: " + response.getStatusMessage());
+    }
+    String body = response.parseAsString();
+    Type resourceTypesListType = new TypeToken<ArrayList<ResourceType>>() {}.getType();
+    return new Gson().fromJson(body, resourceTypesListType);
+  }
+
+  public UserStatusInfo getRegistrationInfo(AuthUser authUser) throws Exception {
+    GenericUrl genericUrl = new GenericUrl(configuration.getRegisterUserV2SelfInfoUrl());
+    HttpRequest request = clientUtil.buildGetRequest(genericUrl, authUser);
+    HttpResponse response = clientUtil.handleHttpRequest(request);
+    if (response.getStatusCode() != HttpStatusCodes.STATUS_CODE_OK) {
+      logger.error("Error getting user registration information from Sam: " + response.getStatusMessage());
+    }
+    String body = response.parseAsString();
+    return new Gson().fromJson(body, UserStatusInfo.class);
+  }
+
+  public UserStatusDiagnostics getSelfDiagnostics(AuthUser authUser) throws Exception {
+    GenericUrl genericUrl = new GenericUrl(configuration.getV2SelfDiagnosticsUrl());
+    HttpRequest request = clientUtil.buildGetRequest(genericUrl, authUser);
+    HttpResponse response = clientUtil.handleHttpRequest(request);
+    if (response.getStatusCode() != HttpStatusCodes.STATUS_CODE_OK) {
+      logger.error("Error getting enabled statuses of user from Sam: " + response.getStatusMessage());
+    }
+    String body = response.parseAsString();
+    return new Gson().fromJson(body, UserStatusDiagnostics.class);
+  }
+
+  public UserStatus postRegistrationInfo(AuthUser authUser) throws Exception {
+    GenericUrl genericUrl = new GenericUrl(configuration.postRegisterUserV2SelfUrl());
+    HttpRequest request = clientUtil.buildPostRequest(genericUrl, new EmptyContent(), authUser);
+    HttpResponse response = clientUtil.handleHttpRequest(request);
+    if (response.getStatusCode() != HttpStatusCodes.STATUS_CODE_OK) {
+      logger.error("Error posting user registration information to Sam: " + response.getStatusMessage());
+    }
+    String body = response.parseAsString();
+    return new Gson().fromJson(body, UserStatus.class);
+  }
+
+  public void asyncPostRegistrationInfo(AuthUser authUser) {
+    ListeningExecutorService listeningExecutorService = MoreExecutors.listeningDecorator(executorService);
+    ListenableFuture<UserStatus> userStatusFuture =
+        listeningExecutorService.submit(() -> postRegistrationInfo(authUser));
+    Futures.addCallback(
+        userStatusFuture,
+        new FutureCallback<>() {
+          @Override
+          public void onSuccess(@Nullable UserStatus userStatus) {
+            logger.info("Successfully registered user in Sam: " + authUser.getEmail());
+          }
+
+          @Override
+          public void onFailure(@NonNull Throwable throwable) {
+            logger.error(throwable.getMessage());
+          }
+        },
+        listeningExecutorService);
+  }
+
+  public String getToSText() throws Exception {
+    GenericUrl genericUrl = new GenericUrl(configuration.getToSTextUrl());
+    HttpRequest request = clientUtil.buildUnAuthedGetRequest(genericUrl);
+    request.getHeaders().setAccept(MediaType.TEXT_PLAIN);
+    HttpResponse response = clientUtil.handleHttpRequest(request);
+    if (response.getStatusCode() != HttpStatusCodes.STATUS_CODE_OK) {
+      logger.error("Error getting Terms of Service text from Sam: " + response.getStatusMessage());
+    }
+    return response.parseAsString();
+  }
+
+  public TosResponse postTosAcceptedStatus(AuthUser authUser) throws Exception {
+    GenericUrl genericUrl = new GenericUrl(configuration.tosRegistrationUrl());
+    JsonHttpContent content = new JsonHttpContent(new GsonFactory(), "app.terra.bio/#terms-of-service");
+    HttpRequest request = clientUtil.buildPostRequest(genericUrl, content, authUser);
+    HttpResponse response = clientUtil.handleHttpRequest(request);
+    if (response.getStatusCode() != HttpStatusCodes.STATUS_CODE_OK) {
+      logger.error("Error accepting Terms of Service through Sam: " + response.getStatusMessage());
+    }
+    String body = response.parseAsString();
+    return new Gson().fromJson(body, TosResponse.class);
+  }
+
+  public TosResponse removeTosAcceptedStatus(AuthUser authUser) throws Exception {
+    GenericUrl genericUrl = new GenericUrl(configuration.tosRegistrationUrl());
+    HttpRequest request = clientUtil.buildDeleteRequest(genericUrl, authUser);
+    HttpResponse response = clientUtil.handleHttpRequest(request);
+    if (response.getStatusCode() != HttpStatusCodes.STATUS_CODE_OK) {
+      logger.error("Error removing Terms of Service acceptance through Sam: " + response.getStatusMessage());
+    }
+    String body = response.parseAsString();
+    return new Gson().fromJson(body, TosResponse.class);
+  }
+}

--- a/src/main/java/org/broadinstitute/consent/http/service/sam/SamService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/sam/SamService.java
@@ -1,150 +1,54 @@
 package org.broadinstitute.consent.http.service.sam;
 
-import com.google.api.client.http.EmptyContent;
-import com.google.api.client.http.GenericUrl;
-import com.google.api.client.http.HttpRequest;
-import com.google.api.client.http.HttpResponse;
-import com.google.api.client.http.HttpStatusCodes;
-import com.google.api.client.http.json.JsonHttpContent;
-import com.google.api.client.json.gson.GsonFactory;
-import com.google.common.util.concurrent.FutureCallback;
-import com.google.common.util.concurrent.Futures;
-import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.ListeningExecutorService;
-import com.google.common.util.concurrent.MoreExecutors;
-import com.google.gson.Gson;
-import com.google.gson.reflect.TypeToken;
 import com.google.inject.Inject;
-import org.broadinstitute.consent.http.configurations.ServicesConfiguration;
+import org.broadinstitute.consent.http.db.SamDAO;
 import org.broadinstitute.consent.http.models.AuthUser;
 import org.broadinstitute.consent.http.models.sam.ResourceType;
 import org.broadinstitute.consent.http.models.sam.TosResponse;
 import org.broadinstitute.consent.http.models.sam.UserStatus;
 import org.broadinstitute.consent.http.models.sam.UserStatusDiagnostics;
 import org.broadinstitute.consent.http.models.sam.UserStatusInfo;
-import org.broadinstitute.consent.http.util.HttpClientUtil;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import javax.ws.rs.core.MediaType;
-import java.lang.reflect.Type;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 
 public class SamService {
 
-  private final ExecutorService executorService;
-  private final HttpClientUtil clientUtil;
-  private final ServicesConfiguration configuration;
-  private final Logger logger = LoggerFactory.getLogger(this.getClass());
+  private final SamDAO samDAO;
 
   @Inject
-  public SamService(ServicesConfiguration configuration) {
-    this.executorService = Executors.newCachedThreadPool();
-    this.clientUtil = new HttpClientUtil();
-    this.configuration = configuration;
+  public SamService(SamDAO samDAO) {
+    this.samDAO = samDAO;
   }
 
   public List<ResourceType> getResourceTypes(AuthUser authUser) throws Exception {
-    GenericUrl genericUrl = new GenericUrl(configuration.getV1ResourceTypesUrl());
-    HttpRequest request = clientUtil.buildGetRequest(genericUrl, authUser);
-    HttpResponse response = clientUtil.handleHttpRequest(request);
-    if (response.getStatusCode() != HttpStatusCodes.STATUS_CODE_OK) {
-      logger.error("Error getting resource types from Sam: " + response.getStatusMessage());
-    }
-    String body = response.parseAsString();
-    Type resourceTypesListType = new TypeToken<ArrayList<ResourceType>>() {}.getType();
-    return new Gson().fromJson(body, resourceTypesListType);
+    return samDAO.getResourceTypes(authUser);
   }
 
   public UserStatusInfo getRegistrationInfo(AuthUser authUser) throws Exception {
-    GenericUrl genericUrl = new GenericUrl(configuration.getRegisterUserV2SelfInfoUrl());
-    HttpRequest request = clientUtil.buildGetRequest(genericUrl, authUser);
-    HttpResponse response = clientUtil.handleHttpRequest(request);
-    if (response.getStatusCode() != HttpStatusCodes.STATUS_CODE_OK) {
-      logger.error("Error getting user registration information from Sam: " + response.getStatusMessage());
-    }
-    String body = response.parseAsString();
-    return new Gson().fromJson(body, UserStatusInfo.class);
+    return samDAO.getRegistrationInfo(authUser);
   }
 
   public UserStatusDiagnostics getSelfDiagnostics(AuthUser authUser) throws Exception {
-    GenericUrl genericUrl = new GenericUrl(configuration.getV2SelfDiagnosticsUrl());
-    HttpRequest request = clientUtil.buildGetRequest(genericUrl, authUser);
-    HttpResponse response = clientUtil.handleHttpRequest(request);
-    if (response.getStatusCode() != HttpStatusCodes.STATUS_CODE_OK) {
-      logger.error("Error getting enabled statuses of user from Sam: " + response.getStatusMessage());
-    }
-    String body = response.parseAsString();
-    return new Gson().fromJson(body, UserStatusDiagnostics.class);
+    return samDAO.getSelfDiagnostics(authUser);
   }
 
   public UserStatus postRegistrationInfo(AuthUser authUser) throws Exception {
-    GenericUrl genericUrl = new GenericUrl(configuration.postRegisterUserV2SelfUrl());
-    HttpRequest request = clientUtil.buildPostRequest(genericUrl, new EmptyContent(), authUser);
-    HttpResponse response = clientUtil.handleHttpRequest(request);
-    if (response.getStatusCode() != HttpStatusCodes.STATUS_CODE_OK) {
-      logger.error("Error posting user registration information to Sam: " + response.getStatusMessage());
-    }
-    String body = response.parseAsString();
-    return new Gson().fromJson(body, UserStatus.class);
+    return samDAO.postRegistrationInfo(authUser);
   }
 
   public void asyncPostRegistrationInfo(AuthUser authUser) {
-    ListeningExecutorService listeningExecutorService = MoreExecutors.listeningDecorator(executorService);
-    ListenableFuture<UserStatus> userStatusFuture =
-        listeningExecutorService.submit(() -> postRegistrationInfo(authUser));
-    Futures.addCallback(
-        userStatusFuture,
-        new FutureCallback<>() {
-          @Override
-          public void onSuccess(@Nullable UserStatus userStatus) {
-            logger.info("Successfully registered user in Sam: " + authUser.getEmail());
-          }
-
-          @Override
-          public void onFailure(@NonNull Throwable throwable) {
-            logger.error(throwable.getMessage());
-          }
-        },
-        listeningExecutorService);
+    samDAO.asyncPostRegistrationInfo(authUser);
   }
 
   public String getToSText() throws Exception {
-    GenericUrl genericUrl = new GenericUrl(configuration.getToSTextUrl());
-    HttpRequest request = clientUtil.buildUnAuthedGetRequest(genericUrl);
-    request.getHeaders().setAccept(MediaType.TEXT_PLAIN);
-    HttpResponse response = clientUtil.handleHttpRequest(request);
-    if (response.getStatusCode() != HttpStatusCodes.STATUS_CODE_OK) {
-      logger.error("Error getting Terms of Service text from Sam: " + response.getStatusMessage());
-    }
-    return response.parseAsString();
+    return samDAO.getToSText();
   }
 
   public TosResponse postTosAcceptedStatus(AuthUser authUser) throws Exception {
-    GenericUrl genericUrl = new GenericUrl(configuration.tosRegistrationUrl());
-    JsonHttpContent content = new JsonHttpContent(new GsonFactory(), "app.terra.bio/#terms-of-service");
-    HttpRequest request = clientUtil.buildPostRequest(genericUrl, content, authUser);
-    HttpResponse response = clientUtil.handleHttpRequest(request);
-    if (response.getStatusCode() != HttpStatusCodes.STATUS_CODE_OK) {
-      logger.error("Error accepting Terms of Service through Sam: " + response.getStatusMessage());
-    }
-    String body = response.parseAsString();
-    return new Gson().fromJson(body, TosResponse.class);
+    return samDAO.postTosAcceptedStatus(authUser);
   }
 
   public TosResponse removeTosAcceptedStatus(AuthUser authUser) throws Exception {
-    GenericUrl genericUrl = new GenericUrl(configuration.tosRegistrationUrl());
-    HttpRequest request = clientUtil.buildDeleteRequest(genericUrl, authUser);
-    HttpResponse response = clientUtil.handleHttpRequest(request);
-    if (response.getStatusCode() != HttpStatusCodes.STATUS_CODE_OK) {
-      logger.error("Error removing Terms of Service acceptance through Sam: " + response.getStatusMessage());
-    }
-    String body = response.parseAsString();
-    return new Gson().fromJson(body, TosResponse.class);
+    return samDAO.removeTosAcceptedStatus(authUser);
   }
 }

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/SamDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/SamDAOTest.java
@@ -1,4 +1,4 @@
-package org.broadinstitute.consent.http.service;
+package org.broadinstitute.consent.http.service.dao;
 
 import com.google.api.client.http.HttpStatusCodes;
 import com.google.gson.Gson;
@@ -6,6 +6,7 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.RandomUtils;
 import org.broadinstitute.consent.http.WithMockServer;
 import org.broadinstitute.consent.http.configurations.ServicesConfiguration;
+import org.broadinstitute.consent.http.db.SamDAO;
 import org.broadinstitute.consent.http.exceptions.ConsentConflictException;
 import org.broadinstitute.consent.http.models.AuthUser;
 import org.broadinstitute.consent.http.models.sam.ResourceType;
@@ -13,7 +14,6 @@ import org.broadinstitute.consent.http.models.sam.TosResponse;
 import org.broadinstitute.consent.http.models.sam.UserStatus;
 import org.broadinstitute.consent.http.models.sam.UserStatusDiagnostics;
 import org.broadinstitute.consent.http.models.sam.UserStatusInfo;
-import org.broadinstitute.consent.http.service.sam.SamService;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -39,9 +39,9 @@ import static org.mockito.MockitoAnnotations.openMocks;
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
 
-public class SamServiceTest implements WithMockServer {
+public class SamDAOTest implements WithMockServer {
 
-  private SamService service;
+  private SamDAO service;
 
   private MockServerClient mockServerClient;
 
@@ -67,7 +67,7 @@ public class SamServiceTest implements WithMockServer {
     mockServerClient.reset();
     ServicesConfiguration config = new ServicesConfiguration();
     config.setSamUrl("http://" + container.getHost() + ":" + container.getServerPort() + "/");
-    service = new SamService(config);
+    service = new SamDAO(config);
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/SamDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/SamDAOTest.java
@@ -41,7 +41,7 @@ import static org.mockserver.model.HttpResponse.response;
 
 public class SamDAOTest implements WithMockServer {
 
-  private SamDAO service;
+  private SamDAO samDAO;
 
   private MockServerClient mockServerClient;
 
@@ -67,7 +67,7 @@ public class SamDAOTest implements WithMockServer {
     mockServerClient.reset();
     ServicesConfiguration config = new ServicesConfiguration();
     config.setSamUrl("http://" + container.getHost() + ":" + container.getServerPort() + "/");
-    service = new SamDAO(config);
+    samDAO = new SamDAO(config);
   }
 
   @Test
@@ -79,7 +79,7 @@ public class SamDAOTest implements WithMockServer {
     Gson gson = new Gson();
     mockServerClient.when(request()).respond(response().withStatusCode(200).withBody(gson.toJson(mockResponseList)));
 
-    List<ResourceType> resourceTypeList = service.getResourceTypes(authUser);
+    List<ResourceType> resourceTypeList = samDAO.getResourceTypes(authUser);
     assertFalse(resourceTypeList.isEmpty());
     assertEquals(mockResponseList.size(), resourceTypeList.size());
   }
@@ -93,7 +93,7 @@ public class SamDAOTest implements WithMockServer {
             .setEnabled(RandomUtils.nextBoolean());
     mockServerClient.when(request()).respond(response().withHeader(Header.header("Content-Type", "application/json")).withStatusCode(200).withBody(userInfo.toString()));
 
-    UserStatusInfo authUserUserInfo = service.getRegistrationInfo(authUser);
+    UserStatusInfo authUserUserInfo = samDAO.getRegistrationInfo(authUser);
     assertNotNull(authUserUserInfo);
     assertEquals(userInfo.getUserEmail(), authUserUserInfo.getUserEmail());
     assertEquals(userInfo.getEnabled(), authUserUserInfo.getEnabled());
@@ -106,7 +106,7 @@ public class SamDAOTest implements WithMockServer {
             .respond(response()
                     .withHeader(Header.header("Content-Type", "application/json"))
                     .withStatusCode(HttpStatusCodes.STATUS_CODE_BAD_REQUEST));
-    service.getRegistrationInfo(authUser);
+    samDAO.getRegistrationInfo(authUser);
   }
 
   @Test (expected = NotAuthorizedException.class)
@@ -115,7 +115,7 @@ public class SamDAOTest implements WithMockServer {
             .respond(response()
                     .withHeader(Header.header("Content-Type", "application/json"))
                     .withStatusCode(HttpStatusCodes.STATUS_CODE_UNAUTHORIZED));
-    service.getRegistrationInfo(authUser);
+    samDAO.getRegistrationInfo(authUser);
   }
 
   @Test (expected = ForbiddenException.class)
@@ -124,7 +124,7 @@ public class SamDAOTest implements WithMockServer {
             .respond(response()
                     .withHeader(Header.header("Content-Type", "application/json"))
                     .withStatusCode(HttpStatusCodes.STATUS_CODE_FORBIDDEN));
-    service.getRegistrationInfo(authUser);
+    samDAO.getRegistrationInfo(authUser);
   }
 
   @Test (expected = NotFoundException.class)
@@ -134,7 +134,7 @@ public class SamDAOTest implements WithMockServer {
             .respond(response()
                     .withHeader(Header.header("Content-Type", "application/json"))
                     .withStatusCode(HttpStatusCodes.STATUS_CODE_NOT_FOUND));
-    service.getRegistrationInfo(authUser);
+    samDAO.getRegistrationInfo(authUser);
   }
 
   @Test (expected = ConsentConflictException.class)
@@ -143,7 +143,7 @@ public class SamDAOTest implements WithMockServer {
             .respond(response()
                     .withHeader(Header.header("Content-Type", "application/json"))
                     .withStatusCode(HttpStatusCodes.STATUS_CODE_CONFLICT));
-    service.getRegistrationInfo(authUser);
+    samDAO.getRegistrationInfo(authUser);
   }
 
   @Test
@@ -156,7 +156,7 @@ public class SamDAOTest implements WithMockServer {
             .setTosAccepted(RandomUtils.nextBoolean());
     mockServerClient.when(request()).respond(response().withHeader(Header.header("Content-Type", "application/json")).withStatusCode(200).withBody(diagnostics.toString()));
 
-    UserStatusDiagnostics userDiagnostics = service.getSelfDiagnostics(authUser);
+    UserStatusDiagnostics userDiagnostics = samDAO.getSelfDiagnostics(authUser);
     assertNotNull(userDiagnostics);
     assertEquals(diagnostics.getEnabled(), userDiagnostics.getEnabled());
     assertEquals(diagnostics.getInAllUsersGroup(), userDiagnostics.getInAllUsersGroup());
@@ -170,7 +170,7 @@ public class SamDAOTest implements WithMockServer {
     UserStatus status = new UserStatus().setUserInfo(info).setEnabled(enabled);
     mockServerClient.when(request()).respond(response().withHeader(Header.header("Content-Type", "application/json")).withStatusCode(200).withBody(status.toString()));
 
-    UserStatus userStatus = service.postRegistrationInfo(authUser);
+    UserStatus userStatus = samDAO.postRegistrationInfo(authUser);
     assertNotNull(userStatus);
   }
 
@@ -188,7 +188,7 @@ public class SamDAOTest implements WithMockServer {
     mockServerClient.when(request()).respond(response().withHeader(Header.header("Content-Type", "application/json")).withStatusCode(200).withBody(status.toString()));
 
     try {
-      service.asyncPostRegistrationInfo(authUser);
+      samDAO.asyncPostRegistrationInfo(authUser);
     } catch (Exception e) {
       fail(e.getMessage());
     }
@@ -200,7 +200,7 @@ public class SamDAOTest implements WithMockServer {
     mockServerClient.when(request()).respond(response().withHeader(Header.header("Content-Type", MediaType.TEXT_PLAIN.getType())).withStatusCode(200).withBody(mockText));
 
     try {
-      String text = service.getToSText();
+      String text = samDAO.getToSText();
       assertEquals(mockText, text);
     } catch (Exception e) {
       fail(e.getMessage());
@@ -216,7 +216,7 @@ public class SamDAOTest implements WithMockServer {
     mockServerClient.when(request()).respond(response().withHeader(Header.header("Content-Type", "application/json")).withStatusCode(200).withBody(tosResponse.toString()));
 
     try {
-      service.postTosAcceptedStatus(authUser);
+      samDAO.postTosAcceptedStatus(authUser);
     } catch (Exception e) {
       fail(e.getMessage());
     }
@@ -231,7 +231,7 @@ public class SamDAOTest implements WithMockServer {
     mockServerClient.when(request()).respond(response().withHeader(Header.header("Content-Type", "application/json")).withStatusCode(200).withBody(tosResponse.toString()));
 
     try {
-      service.removeTosAcceptedStatus(authUser);
+      samDAO.removeTosAcceptedStatus(authUser);
     } catch (Exception e) {
       fail(e.getMessage());
     }


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-2095

This PR separates Sam into a service and a lower level DAO class. The DAO makes http requests to Sam, the service is essentially passthroughs. This allows for other services to import the DAO without intermixing service layer classes.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
