### PR TITLE
DUOS-2104[risk=no] Summary helper methods for Members now assign Update as an action

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
@@ -293,7 +293,6 @@ public class DarCollectionService {
         processDarCollectionSummariesForSO(summaries);
         break;
       case CHAIRPERSON:
-        userId = user.getUserId();
         datasetIds = datasetDAO.findDatasetDTOsByUserId(userId).stream()
             .map(d -> d.getDataSetId())
             .collect(Collectors.toList());
@@ -301,7 +300,6 @@ public class DarCollectionService {
         processDarCollectionSummariesForChair(summaries);
         break;
       case MEMBER:
-        userId = user.getUserId();
         datasetIds = datasetDAO.findDatasetDTOsByUserId(userId).stream()
           .map(d -> d.getDataSetId())
           .collect(Collectors.toList());

--- a/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
@@ -194,7 +194,7 @@ public class DarCollectionService {
           if(isVotable) {
             s.setStatus(DarCollectionStatus.IN_PROCESS.getValue());
             List<Vote> votes = s.getVotes().stream()
-              .filter(v -> v.getDacUserId() == userId && v.getType() == VoteType.DAC.getValue())
+              .filter(v -> v.getDacUserId().equals(userId) && v.getType().equals(VoteType.DAC.getValue()))
               .collect(Collectors.toList());
             if(!votes.isEmpty()) {
               Boolean hasVoted = votes.stream().allMatch(v -> Objects.nonNull(v.getVote()));

--- a/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
@@ -1092,7 +1092,7 @@ public class DarCollectionServiceTest {
     assertEquals(DarCollectionStatus.COMPLETE.getValue(), testOne.getStatus());
 
     DarCollectionSummary testTwo = summaries.get(1);
-    Set<String> expectedTwoActions = Set.of("Update");
+    Set<String> expectedTwoActions = Set.of(DarCollectionActions.UPDATE.getValue());
     assertEquals(testTwo.getActions(), expectedTwoActions);
     assertEquals(DarCollectionStatus.IN_PROCESS.getValue(), testTwo.getStatus());
 
@@ -1102,7 +1102,7 @@ public class DarCollectionServiceTest {
     assertEquals(DarCollectionStatus.UNREVIEWED.getValue(), testThree.getStatus());
 
     DarCollectionSummary testFour = summaries.get(3);
-    Set<String> expectedFourActions = Set.of("Vote");
+    Set<String> expectedFourActions = Set.of(DarCollectionActions.VOTE.getValue());
     assertEquals(testFour.getActions(), expectedFourActions);
     assertEquals(DarCollectionStatus.IN_PROCESS.getValue(), testFour.getStatus());
   }


### PR DESCRIPTION
Addresses [DUOS-2104](https://broadworkbench.atlassian.net/browse/DUOS-2104)

PR updates DAC Member helper methods in DARCollectionSummary flow to account for votes so that `Update` is assigned when a member has submitted all of their votes on a Collection (instead of `Vote`)

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
