### PR TITLE
[DUOS-1955][risk=no] Dynamically Synchronize Dataset Properties

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
@@ -59,6 +59,7 @@ import org.broadinstitute.consent.http.service.UserService;
 import org.broadinstitute.consent.http.service.VoteService;
 import org.broadinstitute.consent.http.service.dao.DarCollectionServiceDAO;
 import org.broadinstitute.consent.http.service.dao.DataAccessRequestServiceDAO;
+import org.broadinstitute.consent.http.service.dao.DatasetServiceDAO;
 import org.broadinstitute.consent.http.service.dao.VoteServiceDAO;
 import org.broadinstitute.consent.http.service.sam.SamService;
 import org.jdbi.v3.core.Jdbi;
@@ -256,12 +257,19 @@ public class ConsentModule extends AbstractModule {
     }
 
     @Provides
+    DatasetServiceDAO providesDatasetServiceDAO() {
+        return new DatasetServiceDAO(
+                jdbi,
+                providesDatasetDAO());
+    }
+
+    @Provides
     DatasetService providesDatasetService() {
         return new DatasetService(
                 providesConsentDAO(),
                 providesDataAccessRequestDAO(),
                 providesDatasetDAO(),
-                providesGCSService(),
+                providesDatasetServiceDAO(),
                 providesUserRoleDAO(),
                 providesUseRestrictionConverter());
     }

--- a/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
@@ -261,7 +261,10 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
     Set<DatasetDTO> findDatasetDTOWithPropertiesByDatasetId(@Bind("datasetId") Integer datasetId);
 
     @UseRowMapper(DatasetPropertyMapper.class)
-    @SqlQuery("SELECT * FROM dataset_property WHERE dataset_id = :datasetId")
+    @SqlQuery(
+        " SELECT p.*, d.key FROM dataset_property p " +
+        " INNER JOIN dictionary d ON p.property_key = d.key_id " +
+        " WHERE p.dataset_id = :datasetId ")
     Set<DatasetProperty> findDatasetPropertiesByDatasetId(@Bind("datasetId") Integer datasetId);
 
     @Deprecated
@@ -280,7 +283,7 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
     List<Dictionary> getMappedFieldsOrderByReceiveOrder();
 
     @RegisterRowMapper(DictionaryMapper.class)
-    @SqlQuery("SELECT * FROM dictionary d")
+    @SqlQuery("SELECT * FROM dictionary")
     List<Dictionary> getDictionaryTerms();
 
     @RegisterRowMapper(DictionaryMapper.class)

--- a/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
@@ -278,16 +278,18 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
             " WHERE d.dataset_id IN (<dataSetIdList>) ORDER BY d.dataset_id, k.receive_order ")
     Set<DatasetDTO> findDatasetsByReceiveOrder(@BindList("dataSetIdList") List<Integer> dataSetIdList);
 
+    @Deprecated // Use getDictionaryTerms()
     @RegisterRowMapper(DictionaryMapper.class)
-    @SqlQuery("SELECT * FROM dictionary d ORDER BY receiveOrder")
+    @SqlQuery("SELECT * FROM dictionary d ORDER BY receive_order")
     List<Dictionary> getMappedFieldsOrderByReceiveOrder();
 
     @RegisterRowMapper(DictionaryMapper.class)
-    @SqlQuery("SELECT * FROM dictionary")
+    @SqlQuery("SELECT * FROM dictionary ORDER BY key_id")
     List<Dictionary> getDictionaryTerms();
 
+    @Deprecated // Use getDictionaryTerms()
     @RegisterRowMapper(DictionaryMapper.class)
-    @SqlQuery("SELECT * FROM dictionary d WHERE d.displayOrder IS NOT NULL  ORDER BY displayOrder")
+    @SqlQuery("SELECT * FROM dictionary d WHERE d.display_order IS NOT NULL ORDER BY display_order")
     List<Dictionary> getMappedFieldsOrderByDisplayOrder();
 
     @UseRowReducer(DatasetReducer.class)

--- a/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
@@ -280,6 +280,10 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
     List<Dictionary> getMappedFieldsOrderByReceiveOrder();
 
     @RegisterRowMapper(DictionaryMapper.class)
+    @SqlQuery("SELECT * FROM dictionary d")
+    List<Dictionary> getDictionaryTerms();
+
+    @RegisterRowMapper(DictionaryMapper.class)
     @SqlQuery("SELECT * FROM dictionary d WHERE d.displayOrder IS NOT NULL  ORDER BY displayOrder")
     List<Dictionary> getMappedFieldsOrderByDisplayOrder();
 

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DatasetPropertyMapper.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DatasetPropertyMapper.java
@@ -8,10 +8,10 @@ import org.broadinstitute.consent.http.models.DatasetProperty;
 import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.core.statement.StatementContext;
 
-public class DatasetPropertyMapper implements RowMapper<DatasetProperty> {
+public class DatasetPropertyMapper implements RowMapper<DatasetProperty>, RowMapperHelper {
 
     public DatasetProperty map(ResultSet r, StatementContext ctx) throws SQLException {
-      return new DatasetProperty(
+        DatasetProperty prop = new DatasetProperty(
           r.getInt("property_id"),
           r.getInt("dataset_id"),
           r.getInt("property_key"),
@@ -20,5 +20,9 @@ public class DatasetPropertyMapper implements RowMapper<DatasetProperty> {
           DatasetPropertyType.parse(r.getString("property_type")),
           r.getTimestamp("create_date")
       );
+      if (hasColumn(r, "key")) {
+          prop.setPropertyName(r.getString("key"));
+      }
+      return prop;
     }
 }

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DictionaryMapper.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DictionaryMapper.java
@@ -10,10 +10,10 @@ public class DictionaryMapper implements RowMapper<Dictionary> {
   @Override
   public Dictionary map(ResultSet r, StatementContext statementContext) throws SQLException {
     return new Dictionary(
-        r.getInt("keyId"),
+        r.getInt("key_id"),
         r.getString("key"),
         r.getBoolean("required"),
-        r.getInt("displayOrder"),
-        r.getInt("receiveOrder"));
+        r.getInt("display_order"),
+        r.getInt("receive_order"));
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/models/Dictionary.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/Dictionary.java
@@ -1,13 +1,14 @@
 package org.broadinstitute.consent.http.models;
 
-import java.util.Date;
-
 public class Dictionary {
 
     private Integer keyId;
     private String key;
+    @Deprecated
     private Boolean required;
+    @Deprecated
     private Integer displayOrder;
+    @Deprecated
     private Integer receiveOrder;
 
     public Dictionary(Integer keyId, String key, Boolean required, Integer displayOrder, Integer receiveOrder){
@@ -38,26 +39,32 @@ public class Dictionary {
         this.key = key;
     }
 
+    @Deprecated
     public Boolean getRequired() {
         return required;
     }
 
+    @Deprecated
     public void setRequired(Boolean required) {
         this.required = required;
     }
 
+    @Deprecated
     public Integer getDisplayOrder() {
         return displayOrder;
     }
 
+    @Deprecated
     public void setDisplayOrder(Integer displayOrder) {
         this.displayOrder = displayOrder;
     }
 
+    @Deprecated
     public Integer getReceiveOrder() {
         return receiveOrder;
     }
 
+    @Deprecated
     public void setReceiveOrder(Integer receiveOrder) {
         this.receiveOrder = receiveOrder;
     }

--- a/src/main/java/org/broadinstitute/consent/http/models/Dictionary.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/Dictionary.java
@@ -8,7 +8,6 @@ public class Dictionary {
     private String key;
     private Boolean required;
     private Integer displayOrder;
-    private Date createDate;
     private Integer receiveOrder;
 
     public Dictionary(Integer keyId, String key, Boolean required, Integer displayOrder, Integer receiveOrder){
@@ -53,14 +52,6 @@ public class Dictionary {
 
     public void setDisplayOrder(Integer displayOrder) {
         this.displayOrder = displayOrder;
-    }
-
-    public Date getCreateDate() {
-        return createDate;
-    }
-
-    public void setCreateDate(Date createDate) {
-        this.createDate = createDate;
     }
 
     public Integer getReceiveOrder() {

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -80,10 +80,12 @@ public class DatasetService {
         return datasetDAO.findDatasetsByReceiveOrder(dataSetId);
     }
 
+    @Deprecated
     public Collection<Dictionary> describeDictionaryByDisplayOrder() {
         return datasetDAO.getMappedFieldsOrderByDisplayOrder();
     }
 
+    @Deprecated
     public Collection<Dictionary> describeDictionaryByReceiveOrder() {
         return datasetDAO.getMappedFieldsOrderByReceiveOrder();
     }

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -21,6 +21,7 @@ import org.broadinstitute.consent.http.models.dataset_registration_v1.DatasetReg
 import org.broadinstitute.consent.http.models.dto.DatasetDTO;
 import org.broadinstitute.consent.http.models.dto.DatasetPropertyDTO;
 import org.broadinstitute.consent.http.models.grammar.UseRestriction;
+import org.broadinstitute.consent.http.service.dao.DatasetServiceDAO;
 import org.glassfish.jersey.media.multipart.FormDataContentDisposition;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -30,6 +31,7 @@ import javax.inject.Inject;
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.NotFoundException;
 import java.io.InputStream;
+import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -55,17 +57,17 @@ public class DatasetService {
     private final ConsentDAO consentDAO;
     private final DataAccessRequestDAO dataAccessRequestDAO;
     private final DatasetDAO datasetDAO;
-    private final GCSService gcsService;
+    private final DatasetServiceDAO datasetServiceDAO;
     private final UserRoleDAO userRoleDAO;
     private final UseRestrictionConverter converter;
 
     @Inject
     public DatasetService(ConsentDAO consentDAO, DataAccessRequestDAO dataAccessRequestDAO, DatasetDAO dataSetDAO,
-                          GCSService gcsService, UserRoleDAO userRoleDAO, UseRestrictionConverter converter) {
+                          DatasetServiceDAO datasetServiceDAO, UserRoleDAO userRoleDAO, UseRestrictionConverter converter) {
         this.consentDAO = consentDAO;
         this.dataAccessRequestDAO = dataAccessRequestDAO;
         this.datasetDAO = dataSetDAO;
-        this.gcsService = gcsService;
+        this.datasetServiceDAO = datasetServiceDAO;
         this.userRoleDAO = userRoleDAO;
         this.converter = converter;
     }
@@ -318,6 +320,20 @@ public class DatasetService {
     }
 
 
+    /**
+     * This method will create new, update existing, and delete unused properties for a dataset.
+     * It will also create new Dictionary keys for properties where keys do not exist.
+     *
+     * @param datasetId The Dataset ID
+     * @param properties List of DatasetProperty objects
+     * @return List of updated DatasetProperty objects
+     * @throws SQLException The Exception
+     */
+    public List<DatasetProperty> synchronizeDatasetProperties(Integer datasetId, List<DatasetProperty> properties) throws SQLException {
+        return datasetServiceDAO.synchronizeDatasetProperties(datasetId, properties);
+    }
+
+    @Deprecated // Use synchronizeDatasetProperties() instead
     public List<DatasetProperty> processDatasetProperties(Integer datasetId,
                                                           List<DatasetPropertyDTO> properties) {
         Date now = new Date();

--- a/src/main/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAO.java
@@ -1,0 +1,150 @@
+package org.broadinstitute.consent.http.service.dao;
+
+import com.google.inject.Inject;
+import org.broadinstitute.consent.http.db.DatasetDAO;
+import org.broadinstitute.consent.http.models.DatasetProperty;
+import org.broadinstitute.consent.http.models.Dictionary;
+import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.core.statement.Update;
+
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Set;
+
+public class DatasetServiceDAO {
+
+    private final Jdbi jdbi;
+    private final DatasetDAO datasetDAO;
+
+    @Inject
+    public DatasetServiceDAO(Jdbi jdbi, DatasetDAO datasetDAO) {
+        this.jdbi = jdbi;
+        this.datasetDAO = datasetDAO;
+    }
+
+    public List<DatasetProperty> synchronizeDatasetProperties(Integer datasetId, List<DatasetProperty> properties) throws SQLException {
+        Timestamp now = new Timestamp(new Date().getTime());
+        jdbi.useHandle(
+                handle -> {
+                    // By default, new connections are set to auto-commit which breaks our rollback strategy.
+                    // Turn that off for this connection. This will not affect existing or new connections and
+                    // only applies to the current one in this handle.
+                    handle.getConnection().setAutoCommit(false);
+                    // 1. Generate inserts for missing dictionary terms
+                    // 2. Generate inserts for new dataset properties
+                    // 3. Generate updates for existing dataset properties
+                    // 4. Generate deletes for outdated dataset properties
+                    List<Update> updates = new ArrayList<>(generateDictionaryInsertsForProperties(handle, properties));
+                    updates.addAll(generatePropertyInserts(handle, datasetId, properties, now));
+                    updates.addAll(generatePropertyUpdates(handle, datasetId, properties));
+                    updates.addAll(generatePropertyDeletes(handle, datasetId, properties));
+                    updates.forEach(Update::execute);
+                    handle.commit();
+                }
+        );
+        return List.of();
+    }
+
+    private List<Update> generateDictionaryInsertsForProperties(Handle handle, List<DatasetProperty> properties) {
+        List<Dictionary> dictionaryTerms = datasetDAO.getDictionaryTerms();
+        List<String> keyValues = dictionaryTerms.stream().map(Dictionary::getKey).toList();
+        List<Update> updates = new ArrayList<>();
+        properties.forEach(prop -> {
+            if (!keyValues.contains(prop.getPropertyName())) {
+                updates.add(createDictionaryInsert(handle, prop.getPropertyName()));
+            }
+        });
+        return updates;
+    }
+
+    private Update createDictionaryInsert(Handle handle, String key) {
+        final String sql = " INSERT INTO dictionary (key, required) VALUES (:key, FALSE) ON CONFLICT DO NOTHING ";
+        Update insert = handle.createUpdate(sql);
+        insert.bind("key", key);
+        return insert;
+    }
+
+    private List<Update> generatePropertyInserts(Handle handle, Integer datasetId, List<DatasetProperty> properties, Timestamp now) {
+        List<Update> updates = new ArrayList<>();
+        Set<DatasetProperty> existingProps = datasetDAO.findDatasetPropertiesByDatasetId(datasetId);
+        List<String> existingPropNames = existingProps.stream().map(DatasetProperty::getPropertyName).toList();
+        // Generate new inserts for props we don't know about yet
+        properties.forEach(prop -> {
+            if (!existingPropNames.contains(prop.getPropertyName())) {
+                prop.setDataSetId(datasetId);
+                prop.setCreateDate(now);
+                updates.add(createPropertyInsert(handle, prop, now));
+            }
+        });
+        return updates;
+    }
+
+    private List<Update> generatePropertyUpdates(Handle handle, Integer datasetId, List<DatasetProperty> properties) {
+        Set<DatasetProperty> existingProps = datasetDAO.findDatasetPropertiesByDatasetId(datasetId);
+        List<Update> updates = new ArrayList<>();
+        List<String> existingPropNames = existingProps.stream().map(DatasetProperty::getPropertyName).toList();
+        // Generate updates for props we already know
+        properties.forEach(prop -> {
+            if (existingPropNames.contains(prop.getPropertyName())) {
+                prop.setDataSetId(datasetId);
+                updates.add(createPropertyUpdate(handle, prop));
+            }
+        });
+        return updates;
+    }
+
+    private List<Update> generatePropertyDeletes(Handle handle, Integer datasetId, List<DatasetProperty> properties) {
+        List<Update> updates = new ArrayList<>();
+        Set<DatasetProperty> existingProps = datasetDAO.findDatasetPropertiesByDatasetId(datasetId);
+        List<String> newPropNames = properties.stream().map(DatasetProperty::getPropertyName).toList();
+        // Generate deletes for existing props not enumerated in the new props
+        existingProps.forEach(existingProp -> {
+            if (!newPropNames.contains(existingProp.getPropertyName())) {
+                updates.add(createPropertyDelete(handle, existingProp));
+            }
+        });
+        return updates;
+    }
+
+    private Update createPropertyInsert(Handle handle, DatasetProperty property, Timestamp now) {
+        // TODO - the key will need to be a subquery
+        final String sql = """
+            INSERT INTO dataset_property (dataset_id, property_key, schema_property, property_value, property_type, create_date ) 
+            VALUES (:datasetId, :propertyKey, :schemaProperty, :propertyStringValue, :propertyTypeValue, :createDate)
+        """;
+        Update insert = handle.createUpdate(sql);
+        insert.bind("datasetId", property.getDataSetId());
+        insert.bind("propertyKey", property.getPropertyKey());
+        insert.bind("schemaProperty", property.getSchemaProperty());
+        insert.bind("propertyStringValue", property.getPropertyValueAsString());
+        insert.bind("propertyTypeValue", property.getPropertyTypeAsString());
+        insert.bind("createDate", now);
+        return insert;
+    }
+
+    private Update createPropertyUpdate(Handle handle, DatasetProperty property) {
+        final String sql = """
+            UPDATE dataset_property
+            SET property_value = :propertyStringValue
+            WHERE dataset_id = :datasetId
+        """;
+        Update insert = handle.createUpdate(sql);
+        insert.bind("datasetId", property.getDataSetId());
+        insert.bind("propertyStringValue", property.getPropertyValueAsString());
+        return insert;
+    }
+
+    private Update createPropertyDelete(Handle handle, DatasetProperty property) {
+        final String sql = """
+            DELETE FROM dataset_property
+            WHERE dataset_id = :datasetId
+        """;
+        Update insert = handle.createUpdate(sql);
+        insert.bind("datasetId", property.getDataSetId());
+        return insert;
+    }
+}

--- a/src/main/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAO.java
@@ -12,6 +12,7 @@ import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -54,7 +55,7 @@ public class DatasetServiceDAO {
 
     private List<Update> generateDictionaryInserts(Handle handle, List<DatasetProperty> properties) {
         List<Dictionary> dictionaryTerms = datasetDAO.getDictionaryTerms();
-        List<String> keyValues = dictionaryTerms.stream().map(Dictionary::getKey).toList();
+        HashSet<String> keyValues = new HashSet<>(dictionaryTerms.stream().map(Dictionary::getKey).toList());
         List<Update> updates = new ArrayList<>();
         properties.forEach(prop -> {
             if (!keyValues.contains(prop.getPropertyName())) {
@@ -80,7 +81,7 @@ public class DatasetServiceDAO {
     private List<Update> generatePropertyInserts(Handle handle, Integer datasetId, List<DatasetProperty> properties, Set<DatasetProperty> existingProps) {
         Timestamp now = new Timestamp(new Date().getTime());
         List<Update> updates = new ArrayList<>();
-        List<String> existingPropNames = existingProps.stream().map(DatasetProperty::getPropertyName).toList();
+        HashSet<String> existingPropNames = new HashSet<>(existingProps.stream().map(DatasetProperty::getPropertyName).toList());
         // Generate new inserts for props we don't know about yet
         properties.forEach(prop -> {
             if (!existingPropNames.contains(prop.getPropertyName())) {
@@ -114,7 +115,7 @@ public class DatasetServiceDAO {
 
     private List<Update> generatePropertyUpdates(Handle handle, Integer datasetId, List<DatasetProperty> properties, Set<DatasetProperty> existingProps) {
         List<Update> updates = new ArrayList<>();
-        List<String> existingPropNames = existingProps.stream().map(DatasetProperty::getPropertyName).toList();
+        HashSet<String> existingPropNames = new HashSet<>(existingProps.stream().map(DatasetProperty::getPropertyName).toList());
         // Generate value updates for props that exist
         properties.forEach(prop -> {
             if (existingPropNames.contains(prop.getPropertyName())) {
@@ -145,7 +146,7 @@ public class DatasetServiceDAO {
 
     private List<Update> generatePropertyDeletes(Handle handle, List<DatasetProperty> properties, Set<DatasetProperty> existingProps) {
         List<Update> updates = new ArrayList<>();
-        List<String> newPropNames = properties.stream().map(DatasetProperty::getPropertyName).toList();
+        HashSet<String> newPropNames = new HashSet<>(properties.stream().map(DatasetProperty::getPropertyName).toList());
         // Generate deletes for existing props that do not exist in the new props
         existingProps.forEach(existingProp -> {
             if (!newPropNames.contains(existingProp.getPropertyName())) {

--- a/src/main/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAO.java
@@ -27,7 +27,6 @@ public class DatasetServiceDAO {
     }
 
     public List<DatasetProperty> synchronizeDatasetProperties(Integer datasetId, List<DatasetProperty> properties) throws SQLException {
-        Timestamp now = new Timestamp(new Date().getTime());
         jdbi.useHandle(
                 handle -> {
                     // By default, new connections are set to auto-commit which breaks our rollback strategy.
@@ -41,7 +40,7 @@ public class DatasetServiceDAO {
                     List<Update> updates = new ArrayList<>(generateDictionaryInsertsForProperties(handle, properties));
                     // We need to know existing properties for all property operations
                     Set<DatasetProperty> existingProps = datasetDAO.findDatasetPropertiesByDatasetId(datasetId);
-                    updates.addAll(generatePropertyInserts(handle, datasetId, properties, existingProps, now));
+                    updates.addAll(generatePropertyInserts(handle, datasetId, properties, existingProps));
                     updates.addAll(generatePropertyUpdates(handle, datasetId, properties, existingProps));
                     updates.addAll(generatePropertyDeletes(handle, properties, existingProps));
                     updates.forEach(Update::execute);
@@ -70,7 +69,8 @@ public class DatasetServiceDAO {
         return insert;
     }
 
-    private List<Update> generatePropertyInserts(Handle handle, Integer datasetId, List<DatasetProperty> properties, Set<DatasetProperty> existingProps, Timestamp now) {
+    private List<Update> generatePropertyInserts(Handle handle, Integer datasetId, List<DatasetProperty> properties, Set<DatasetProperty> existingProps) {
+        Timestamp now = new Timestamp(new Date().getTime());
         List<Update> updates = new ArrayList<>();
         List<String> existingPropNames = existingProps.stream().map(DatasetProperty::getPropertyName).toList();
         // Generate new inserts for props we don't know about yet
@@ -110,7 +110,7 @@ public class DatasetServiceDAO {
     }
 
     private Update createPropertyInsert(Handle handle, DatasetProperty property, Timestamp now) {
-        // TODO - the key will need to be a subquery
+        // TODO - the key will need to be a subquery since it could be a previous insert into dictionary
         final String sql = """
             INSERT INTO dataset_property (dataset_id, property_key, schema_property, property_value, property_type, create_date ) 
             VALUES (:datasetId, :propertyKey, :schemaProperty, :propertyStringValue, :propertyTypeValue, :createDate)

--- a/src/main/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAO.java
@@ -151,9 +151,11 @@ public class DatasetServiceDAO {
         final String sql = """
             DELETE FROM dataset_property
             WHERE dataset_id = :datasetId
+            AND property_key = :propertyKey
         """;
         Update insert = handle.createUpdate(sql);
         insert.bind("datasetId", property.getDataSetId());
+        insert.bind("propertyKey", property.getPropertyKey());
         return insert;
     }
 }

--- a/src/main/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAO.java
@@ -37,7 +37,7 @@ public class DatasetServiceDAO {
                     // 2. Generate inserts for new dataset properties
                     // 3. Generate updates for existing dataset properties
                     // 4. Generate deletes for outdated dataset properties
-                    List<Update> updates = new ArrayList<>(generateDictionaryInsertsForProperties(handle, properties));
+                    List<Update> updates = new ArrayList<>(generateDictionaryInserts(handle, properties));
                     // We need to know existing properties for all property operations
                     Set<DatasetProperty> existingProps = datasetDAO.findDatasetPropertiesByDatasetId(datasetId);
                     updates.addAll(generatePropertyInserts(handle, datasetId, properties, existingProps));
@@ -52,7 +52,7 @@ public class DatasetServiceDAO {
 
     // Helper methods to generate Dictionary inserts
 
-    private List<Update> generateDictionaryInsertsForProperties(Handle handle, List<DatasetProperty> properties) {
+    private List<Update> generateDictionaryInserts(Handle handle, List<DatasetProperty> properties) {
         List<Dictionary> dictionaryTerms = datasetDAO.getDictionaryTerms();
         List<String> keyValues = dictionaryTerms.stream().map(Dictionary::getKey).toList();
         List<Update> updates = new ArrayList<>();

--- a/src/main/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAO.java
@@ -67,7 +67,7 @@ public class DatasetServiceDAO {
     private Update createDictionaryInsert(Handle handle, String key) {
         final String sql = """
             INSERT INTO dictionary (key, required)
-            VALUES (:key, FALSE) 
+            VALUES (:key, FALSE)
             ON CONFLICT DO NOTHING
         """;
         Update insert = handle.createUpdate(sql);

--- a/src/main/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAO.java
@@ -66,7 +66,7 @@ public class DatasetServiceDAO {
 
     private Update createDictionaryInsert(Handle handle, String key) {
         final String sql = """
-            INSERT INTO dictionary (key, required) 
+            INSERT INTO dictionary (key, required)
             VALUES (:key, FALSE) 
             ON CONFLICT DO NOTHING
         """;

--- a/src/main/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAO.java
@@ -65,7 +65,11 @@ public class DatasetServiceDAO {
     }
 
     private Update createDictionaryInsert(Handle handle, String key) {
-        final String sql = " INSERT INTO dictionary (key, required) VALUES (:key, FALSE) ON CONFLICT DO NOTHING ";
+        final String sql = """
+            INSERT INTO dictionary (key, required) 
+            VALUES (:key, FALSE) 
+            ON CONFLICT DO NOTHING
+        """;
         Update insert = handle.createUpdate(sql);
         insert.bind("key", key);
         return insert;
@@ -126,10 +130,14 @@ public class DatasetServiceDAO {
             UPDATE dataset_property
             SET property_value = :propertyStringValue
             WHERE dataset_id = :datasetId
+            AND property_key = :propertyKey
+            AND property_id = :propertyId
         """;
         Update insert = handle.createUpdate(sql);
         insert.bind("datasetId", property.getDataSetId());
         insert.bind("propertyStringValue", property.getPropertyValueAsString());
+        insert.bind("propertyKey", property.getPropertyKey());
+        insert.bind("propertyId", property.getPropertyId());
         return insert;
     }
 
@@ -152,10 +160,12 @@ public class DatasetServiceDAO {
             DELETE FROM dataset_property
             WHERE dataset_id = :datasetId
             AND property_key = :propertyKey
+            AND property_id = :propertyId
         """;
         Update insert = handle.createUpdate(sql);
         insert.bind("datasetId", property.getDataSetId());
         insert.bind("propertyKey", property.getPropertyKey());
+        insert.bind("propertyId", property.getPropertyId());
         return insert;
     }
 }

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -3106,17 +3106,16 @@ components:
           format: int32
           description: Value of the key.
         required:
+          deprecated: true
           type: boolean
           description: Defines if this attribute is required to create a Dataset
         displayOrder:
+          deprecated: true
           type: integer
           format: int32
           description: Defines the position of the attribute in the .tsv file
-        createDate:
-          type: string
-          format: date
-          description: Describes the date the Dictionary was created.
         receiveOrder:
+          deprecated: true
           type: integer
           format: int32
           description: The display order of the properties.

--- a/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
@@ -164,6 +164,7 @@ public class DAOTestHelper {
         testingDAO.deleteAllAccessRps();
         testingDAO.deleteAllElections();
         testingDAO.deleteAllDatasetProperties();
+        testingDAO.deleteAllDictionaryTerms();
         testingDAO.deleteAllDatasetAssociations();
         testingDAO.deleteAllDatasets();
         testingDAO.deleteAllDacUserRoles();

--- a/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
@@ -13,6 +13,7 @@ import org.broadinstitute.consent.http.models.DataUse;
 import org.broadinstitute.consent.http.models.DataUseBuilder;
 import org.broadinstitute.consent.http.models.Dataset;
 import org.broadinstitute.consent.http.models.DatasetProperty;
+import org.broadinstitute.consent.http.models.Dictionary;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.dto.DatasetDTO;
 import org.junit.Test;
@@ -143,6 +144,15 @@ public class DatasetDAOTest extends DAOTestHelper {
         assertFalse(datasets.get(0).getProperties().isEmpty());
     }
 
+    @Test
+    public void testGetDictionaryTerms() {
+        List<Dictionary> terms = datasetDAO.getDictionaryTerms();
+        assertFalse(terms.isEmpty());
+        terms.forEach(t -> {
+            assertNotNull(t.getKeyId());
+            assertNotNull(t.getKey());
+        });
+    }
     @Test
     public void testGetDataSetsForObjectIdList() {
         Dataset dataset = createDataset();

--- a/src/test/java/org/broadinstitute/consent/http/db/TestingDAO.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/TestingDAO.java
@@ -36,6 +36,13 @@ public interface TestingDAO extends Transactional<TestingDAO> {
   @SqlUpdate("DELETE FROM dataset_property")
   void deleteAllDatasetProperties();
 
+  /**
+   * This only deletes new keys created through tests
+   * Keys 1-11 are existing keys required for many legacy tests.
+   */
+  @SqlUpdate("DELETE FROM dictionary WHERE key_id > 11")
+  void deleteAllDictionaryTerms();
+
   @SqlUpdate("DELETE FROM dataset_user_association")
   void deleteAllDatasetAssociations();
 

--- a/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
@@ -19,6 +19,7 @@ import org.broadinstitute.consent.http.models.UserRole;
 import org.broadinstitute.consent.http.models.dto.DatasetDTO;
 import org.broadinstitute.consent.http.models.dto.DatasetPropertyDTO;
 import org.broadinstitute.consent.http.models.grammar.UseRestriction;
+import org.broadinstitute.consent.http.service.dao.DatasetServiceDAO;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -70,7 +71,7 @@ public class DatasetServiceTest {
     private DatasetDAO datasetDAO;
 
     @Mock
-    private GCSService gcsService;
+    private DatasetServiceDAO datasetServiceDAO;
 
     @Mock
     private UserRoleDAO userRoleDAO;
@@ -84,7 +85,7 @@ public class DatasetServiceTest {
     }
 
     private void initService() {
-        datasetService = new DatasetService(consentDAO, dataAccessRequestDAO, datasetDAO, gcsService, userRoleDAO, useRestrictionConverter);
+        datasetService = new DatasetService(consentDAO, dataAccessRequestDAO, datasetDAO, datasetServiceDAO, userRoleDAO, useRestrictionConverter);
     }
 
     @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAOTest.java
@@ -45,6 +45,7 @@ public class DatasetServiceDAOTest extends DAOTestHelper {
         List<Dictionary> dictionaryTerms = datasetDAO.getDictionaryTerms();
         Dictionary dictionary = dictionaryTerms.get(0);
         Dataset dataset = createSampleDataset();
+        // Creating a prop that will be added
         DatasetProperty prop = createUnsavedPropWithKeyName(dataset, dictionary.getKey());
         List<DatasetProperty> synchronizedProps = serviceDAO.synchronizeDatasetProperties(dataset.getDataSetId(), List.of(prop));
         assertEquals(1, synchronizedProps.size());
@@ -55,6 +56,7 @@ public class DatasetServiceDAOTest extends DAOTestHelper {
     public void testSynchronizeDatasetProperties_case2() throws Exception {
         String newPropName = "New Prop Name";
         Dataset dataset = createSampleDataset();
+        // Creating a prop that will be added
         DatasetProperty prop = createUnsavedPropWithKeyName(dataset, newPropName);
         List<DatasetProperty> synchronizedProps = serviceDAO.synchronizeDatasetProperties(dataset.getDataSetId(), List.of(prop));
         assertEquals(1, synchronizedProps.size());
@@ -67,6 +69,7 @@ public class DatasetServiceDAOTest extends DAOTestHelper {
         Dataset dataset = createSampleDataset();
         List<Dictionary> dictionaryTerms = datasetDAO.getDictionaryTerms();
         Dictionary dictionary = dictionaryTerms.get(0);
+        // Saving a prop that will be updated
         DatasetProperty prop = savePropWithDictionaryTerm(dataset, dictionary);
         String newPropVal = RandomStringUtils.randomAlphabetic(10);
         prop.setPropertyValue(newPropVal);
@@ -81,8 +84,9 @@ public class DatasetServiceDAOTest extends DAOTestHelper {
         Dictionary dict1 = dictionaryTerms.get(0);
         Dictionary dict2 = dictionaryTerms.get(1);
         Dataset dataset = createSampleDataset();
-        // Saving a prop that should be deleted via synchronization
+        // Saving a prop that will be deleted via synchronization
         savePropWithDictionaryTerm(dataset, dict1);
+        // Creating a prop that will be added
         DatasetProperty propToAdd = createUnsavedPropWithKeyName(dataset, dict2.getKey());
         List<DatasetProperty> synchronizedProps = serviceDAO.synchronizeDatasetProperties(dataset.getDataSetId(), List.of(propToAdd));
         assertEquals(1, synchronizedProps.size());
@@ -95,8 +99,9 @@ public class DatasetServiceDAOTest extends DAOTestHelper {
         Dictionary dict1 = dictionaryTerms.get(0);
         String newPropName = "New Prop Name";
         Dataset dataset = createSampleDataset();
-        // Saving a prop that should be deleted via synchronization
+        // Saving a prop that will be deleted via synchronization
         savePropWithDictionaryTerm(dataset, dict1);
+        // Creating a prop that will be added
         DatasetProperty propToAdd = createUnsavedPropWithKeyName(dataset, newPropName);
         List<DatasetProperty> synchronizedProps = serviceDAO.synchronizeDatasetProperties(dataset.getDataSetId(), List.of(propToAdd));
         assertEquals(1, synchronizedProps.size());
@@ -109,8 +114,9 @@ public class DatasetServiceDAOTest extends DAOTestHelper {
         Dictionary dict1 = dictionaryTerms.get(0);
         Dictionary dict2 = dictionaryTerms.get(1);
         Dataset dataset = createSampleDataset();
-        // Saving a prop that should be deleted via synchronization
+        // Saving a prop that will be deleted via synchronization
         savePropWithDictionaryTerm(dataset, dict1);
+        // Saving a prop that will be updated
         DatasetProperty propToUpdate = savePropWithDictionaryTerm(dataset, dict2);
         String newPropVal = RandomStringUtils.randomAlphabetic(10);
         propToUpdate.setPropertyValue(newPropVal);

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAOTest.java
@@ -16,7 +16,7 @@ import org.junit.Test;
 import java.sql.Timestamp;
 import java.util.Date;
 import java.util.List;
-import java.util.Set;
+import java.util.Optional;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -167,8 +167,11 @@ public class DatasetServiceDAOTest extends DAOTestHelper {
         prop.setSchemaProperty("testSchemaProp");
         prop.setPropertyType(DatasetPropertyType.String);
         datasetDAO.insertDatasetProperties(List.of(prop));
-        Set<DatasetProperty> props = datasetDAO.findDatasetPropertiesByDatasetId(dataset.getDataSetId());
-        return props.stream().toList().get(0);
+        Optional<DatasetProperty> optional = datasetDAO.findDatasetPropertiesByDatasetId(dataset.getDataSetId())
+            .stream()
+            .filter(p -> p.getPropertyKey().equals(dictionary.getKeyId()))
+            .findFirst();
+        return optional.orElse(null);
     }
 
     /**

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAOTest.java
@@ -1,0 +1,100 @@
+package org.broadinstitute.consent.http.service.dao;
+
+import org.apache.commons.lang3.RandomStringUtils;
+import org.broadinstitute.consent.http.db.DAOTestHelper;
+import org.broadinstitute.consent.http.enumeration.DatasetPropertyType;
+import org.broadinstitute.consent.http.models.Dac;
+import org.broadinstitute.consent.http.models.DataUse;
+import org.broadinstitute.consent.http.models.DataUseBuilder;
+import org.broadinstitute.consent.http.models.Dataset;
+import org.broadinstitute.consent.http.models.DatasetProperty;
+import org.broadinstitute.consent.http.models.Dictionary;
+import org.broadinstitute.consent.http.models.User;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.sql.Timestamp;
+import java.util.Date;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+
+public class DatasetServiceDAOTest extends DAOTestHelper {
+
+    private DatasetServiceDAO serviceDAO;
+
+    @Before
+    public void setUp() {
+        serviceDAO = new DatasetServiceDAO(jdbi, datasetDAO);
+    }
+
+    /*
+     * The following DatasetProperty synchronization test cases are covered here:
+     *  1. Add new dataset property with an existing dictionary key
+     *  2. Add new dataset property without an existing dictionary key
+     *  3. Update existing dataset property
+     *  4. Add new dataset property with an existing dictionary key + Delete existing property
+     *  5. Add new dataset property without an existing dictionary key + Delete existing property
+     *  6. Update existing dataset property + Delete existing property
+     */
+
+    @Test
+    public void testSynchronizeDatasetProperties_case3() throws Exception {
+        Dataset dataset = createSampleDataset();
+        List<Dictionary> dictionaryTerms = datasetDAO.getDictionaryTerms();
+        Dictionary dictionary = dictionaryTerms.get(0);
+        DatasetProperty prop = createSamplePropFromDictionaryTerm(dataset, dictionary);
+        String newPropVal = RandomStringUtils.randomAlphabetic(10);
+        prop.setPropertyValue(newPropVal);
+        List<DatasetProperty> synchronizedProps = serviceDAO.synchronizeDatasetProperties(dataset.getDataSetId(), List.of(prop));
+        assertEquals(1, synchronizedProps.size());
+        assertEquals(newPropVal, synchronizedProps.get(0).getPropertyValueAsString());
+    }
+
+    // Helper methods
+
+    /**
+     * Creates a new sample Dataset along with a User and a Dac
+     *
+     * @return Dataset
+     */
+    private Dataset createSampleDataset() {
+        User user = createUser();
+        Dac dac = createDac();
+        DataUse dataUse = new DataUseBuilder().setHmbResearch(true).build();
+        Timestamp now = new Timestamp(new Date().getTime());
+        Integer id = datasetDAO.insertDataset(
+                RandomStringUtils.randomAlphabetic(10),
+                now,
+                user.getUserId(),
+                RandomStringUtils.randomAlphabetic(10),
+                true,
+                dataUse.toString(),
+                dac.getDacId()
+        );
+        return datasetDAO.findDatasetById(id);
+    }
+
+    /**
+     * Creates a DatasetProperty that uses an existing Dictionary term
+     *
+     * @param dataset    The Dataset
+     * @param dictionary The Dictionary
+     * @return The created DatasetProperty
+     */
+    private DatasetProperty createSamplePropFromDictionaryTerm(Dataset dataset, Dictionary dictionary) {
+        DatasetProperty prop = new DatasetProperty();
+        prop.setDataSetId(dataset.getDataSetId());
+        prop.setPropertyKey(dictionary.getKeyId());
+        prop.setPropertyName(dictionary.getKey());
+        prop.setPropertyValue(RandomStringUtils.randomAlphabetic(10));
+        prop.setCreateDate(new Date());
+        prop.setSchemaProperty("testSchemaProp");
+        prop.setPropertyType(DatasetPropertyType.String);
+        datasetDAO.insertDatasetProperties(List.of(prop));
+        Set<DatasetProperty> props = datasetDAO.findDatasetPropertiesByDatasetId(dataset.getDataSetId());
+        return props.stream().toList().get(0);
+    }
+
+}

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAOTest.java
@@ -89,6 +89,20 @@ public class DatasetServiceDAOTest extends DAOTestHelper {
         assertEquals(dict2.getKey(), synchronizedProps.get(0).getPropertyName());
     }
 
+    @Test
+    public void testSynchronizeDatasetProperties_case5() throws Exception {
+        List<Dictionary> dictionaryTerms = datasetDAO.getDictionaryTerms();
+        Dictionary dict1 = dictionaryTerms.get(0);
+        String newPropName = "New Prop Name";
+        Dataset dataset = createSampleDataset();
+        // Saving a prop that should be deleted via synchronization
+        savePropWithDictionaryTerm(dataset, dict1);
+        DatasetProperty propToAdd = createUnsavedPropWithKeyName(dataset, newPropName);
+        List<DatasetProperty> synchronizedProps = serviceDAO.synchronizeDatasetProperties(dataset.getDataSetId(), List.of(propToAdd));
+        assertEquals(1, synchronizedProps.size());
+        assertEquals(newPropName, synchronizedProps.get(0).getPropertyName());
+    }
+
     // Helper methods
 
     /**

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAOTest.java
@@ -103,6 +103,23 @@ public class DatasetServiceDAOTest extends DAOTestHelper {
         assertEquals(newPropName, synchronizedProps.get(0).getPropertyName());
     }
 
+    @Test
+    public void testSynchronizeDatasetProperties_case6() throws Exception {
+        List<Dictionary> dictionaryTerms = datasetDAO.getDictionaryTerms();
+        Dictionary dict1 = dictionaryTerms.get(0);
+        Dictionary dict2 = dictionaryTerms.get(1);
+        Dataset dataset = createSampleDataset();
+        // Saving a prop that should be deleted via synchronization
+        savePropWithDictionaryTerm(dataset, dict1);
+        DatasetProperty propToUpdate = savePropWithDictionaryTerm(dataset, dict2);
+        String newPropVal = RandomStringUtils.randomAlphabetic(10);
+        propToUpdate.setPropertyValue(newPropVal);
+        List<DatasetProperty> synchronizedProps = serviceDAO.synchronizeDatasetProperties(dataset.getDataSetId(), List.of(propToUpdate));
+        assertEquals(1, synchronizedProps.size());
+        assertEquals(dict2.getKey(), synchronizedProps.get(0).getPropertyName());
+        assertEquals(newPropVal, synchronizedProps.get(0).getPropertyValueAsString());
+    }
+
     // Helper methods
 
     /**

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAOTest.java
@@ -19,6 +19,8 @@ import java.util.List;
 import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 public class DatasetServiceDAOTest extends DAOTestHelper {
 
@@ -38,6 +40,17 @@ public class DatasetServiceDAOTest extends DAOTestHelper {
      *  5. Add new dataset property without an existing dictionary key + Delete existing property
      *  6. Update existing dataset property + Delete existing property
      */
+
+    @Test
+    public void testSynchronizeDatasetProperties_case2() throws Exception {
+        String newPropName = "New Prop Name";
+        Dataset dataset = createSampleDataset();
+        DatasetProperty prop = createSamplePropNoDictionary(dataset, newPropName);
+        List<DatasetProperty> synchronizedProps = serviceDAO.synchronizeDatasetProperties(dataset.getDataSetId(), List.of(prop));
+        assertEquals(1, synchronizedProps.size());
+        List<String> dictionaryTerms = datasetDAO.getDictionaryTerms().stream().map(Dictionary::getKey).toList();
+        assertTrue(dictionaryTerms.contains(newPropName));
+    }
 
     @Test
     public void testSynchronizeDatasetProperties_case3() throws Exception {
@@ -77,7 +90,7 @@ public class DatasetServiceDAOTest extends DAOTestHelper {
     }
 
     /**
-     * Creates a DatasetProperty that uses an existing Dictionary term
+     * Creates a saved DatasetProperty that uses an existing Dictionary term
      *
      * @param dataset    The Dataset
      * @param dictionary The Dictionary
@@ -95,6 +108,23 @@ public class DatasetServiceDAOTest extends DAOTestHelper {
         datasetDAO.insertDatasetProperties(List.of(prop));
         Set<DatasetProperty> props = datasetDAO.findDatasetPropertiesByDatasetId(dataset.getDataSetId());
         return props.stream().toList().get(0);
+    }
+
+    /**
+     * Populates an unsaved DatasetProperty that does not use an existing Dictionary term
+     *
+     * @param dataset    The Dataset
+     * @return The populated DatasetProperty
+     */
+    private DatasetProperty createSamplePropNoDictionary(Dataset dataset, String keyName) {
+        DatasetProperty prop = new DatasetProperty();
+        prop.setDataSetId(dataset.getDataSetId());
+        prop.setPropertyName(keyName);
+        prop.setPropertyValue(RandomStringUtils.randomAlphabetic(10));
+        prop.setCreateDate(new Date());
+        prop.setSchemaProperty("testSchemaProp");
+        prop.setPropertyType(DatasetPropertyType.String);
+        return prop;
     }
 
 }

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAOTest.java
@@ -19,7 +19,6 @@ import java.util.List;
 import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 public class DatasetServiceDAOTest extends DAOTestHelper {

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAOTest.java
@@ -41,6 +41,17 @@ public class DatasetServiceDAOTest extends DAOTestHelper {
      */
 
     @Test
+    public void testSynchronizeDatasetProperties_case1() throws Exception {
+        List<Dictionary> dictionaryTerms = datasetDAO.getDictionaryTerms();
+        Dictionary dictionary = dictionaryTerms.get(0);
+        Dataset dataset = createSampleDataset();
+        DatasetProperty prop = createSamplePropNoDictionary(dataset, dictionary.getKey());
+        List<DatasetProperty> synchronizedProps = serviceDAO.synchronizeDatasetProperties(dataset.getDataSetId(), List.of(prop));
+        assertEquals(1, synchronizedProps.size());
+        assertEquals(dictionary.getKey(), synchronizedProps.get(0).getPropertyName());
+    }
+
+    @Test
     public void testSynchronizeDatasetProperties_case2() throws Exception {
         String newPropName = "New Prop Name";
         Dataset dataset = createSampleDataset();


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-1955

This PR doesn't update any existing logic, it just puts in place the ability to synchronize dataset properties along with dictionary terms for both existing and new dictionary terms. This will be used/update in a future PR that generates datasets using new terms that we don't currently have saved.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
