### PR TITLE
[DUOS-2059][risk=no] SendGrid Refactor

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
@@ -31,7 +31,7 @@ import org.broadinstitute.consent.http.db.UserDAO;
 import org.broadinstitute.consent.http.db.UserPropertyDAO;
 import org.broadinstitute.consent.http.db.UserRoleDAO;
 import org.broadinstitute.consent.http.db.VoteDAO;
-import org.broadinstitute.consent.http.mail.MailService;
+import org.broadinstitute.consent.http.mail.SendgridAPI;
 import org.broadinstitute.consent.http.mail.freemarker.FreeMarkerTemplateHelper;
 import org.broadinstitute.consent.http.service.AuditService;
 import org.broadinstitute.consent.http.service.ConsentService;
@@ -316,7 +316,7 @@ public class ConsentModule extends AbstractModule {
                 providesElectionDAO(),
                 providesUserDAO(),
                 providesMailMessageDAO(),
-                providesMailService(),
+                providesSendgridAPI(),
                 providesFreeMarkerTemplateHelper(),
                 config.getServicesConfiguration().getLocalURL(),
                 config.getMailConfiguration().isActivateEmailNotifications()
@@ -324,8 +324,8 @@ public class ConsentModule extends AbstractModule {
     }
 
     @Provides
-    MailService providesMailService() {
-        return new MailService(config.getMailConfiguration());
+    SendgridAPI providesSendgridAPI() {
+        return new SendgridAPI(config.getMailConfiguration());
     }
 
     @Provides

--- a/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
@@ -31,7 +31,7 @@ import org.broadinstitute.consent.http.db.UserDAO;
 import org.broadinstitute.consent.http.db.UserPropertyDAO;
 import org.broadinstitute.consent.http.db.UserRoleDAO;
 import org.broadinstitute.consent.http.db.VoteDAO;
-import org.broadinstitute.consent.http.mail.SendgridAPI;
+import org.broadinstitute.consent.http.mail.SendGridAPI;
 import org.broadinstitute.consent.http.mail.freemarker.FreeMarkerTemplateHelper;
 import org.broadinstitute.consent.http.service.AuditService;
 import org.broadinstitute.consent.http.service.ConsentService;
@@ -316,7 +316,7 @@ public class ConsentModule extends AbstractModule {
                 providesElectionDAO(),
                 providesUserDAO(),
                 providesMailMessageDAO(),
-                providesSendgridAPI(),
+                providesSendGridAPI(),
                 providesFreeMarkerTemplateHelper(),
                 config.getServicesConfiguration().getLocalURL(),
                 config.getMailConfiguration().isActivateEmailNotifications()
@@ -324,8 +324,8 @@ public class ConsentModule extends AbstractModule {
     }
 
     @Provides
-    SendgridAPI providesSendgridAPI() {
-        return new SendgridAPI(config.getMailConfiguration());
+    SendGridAPI providesSendGridAPI() {
+        return new SendGridAPI(config.getMailConfiguration());
     }
 
     @Provides

--- a/src/main/java/org/broadinstitute/consent/http/mail/SendGridAPI.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/SendGridAPI.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.consent.http.mail;
 
+import com.google.api.client.http.HttpStatusCodes;
 import com.sendgrid.Method;
 import com.sendgrid.Request;
 import com.sendgrid.Response;
@@ -23,6 +24,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.Writer;
+import java.util.Map;
 import java.util.Optional;
 
 public class SendGridAPI {
@@ -66,7 +68,14 @@ public class SendGridAPI {
                 // send
                 return Optional.of(sendGrid.makeCall(request));
             } catch (IOException ex) {
-                logger.error("Exception sending email: " + ex.getMessage());
+                logger.error("Exception sending email via SendGrid: " + ex.getMessage());
+                // Create a response that we can use to capture this failure.
+                Response response = new Response(
+                        HttpStatusCodes.STATUS_CODE_SERVER_ERROR,
+                        ex.getMessage(),
+                        Map.of()
+                );
+                return Optional.of(response);
             }
         }
         return Optional.empty();

--- a/src/main/java/org/broadinstitute/consent/http/mail/SendGridAPI.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/SendGridAPI.java
@@ -25,7 +25,7 @@ import java.io.IOException;
 import java.io.Writer;
 import java.util.Optional;
 
-public class SendgridAPI {
+public class SendGridAPI {
 
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
     private final String fromAccount;
@@ -44,7 +44,7 @@ public class SendgridAPI {
     private final ResearcherApprovedMessage researcherApprovedMessage = new ResearcherApprovedMessage();
     private final DataCustodianApprovalMessage dataCustodianApprovalMessage = new DataCustodianApprovalMessage();
 
-    public SendgridAPI(MailConfiguration config) {
+    public SendGridAPI(MailConfiguration config) {
         this.fromAccount = config.getGoogleAccount();
         this.sendGrid = new SendGrid(config.getSendGridApiKey());
         this.activateEmailNotifications = config.isActivateEmailNotifications();

--- a/src/main/java/org/broadinstitute/consent/http/mail/SendgridAPI.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/SendgridAPI.java
@@ -21,13 +21,11 @@ import org.broadinstitute.consent.http.mail.message.ResearcherApprovedMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.mail.MessagingException;
 import java.io.IOException;
 import java.io.Writer;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 
 public class SendgridAPI {
 
@@ -54,7 +52,7 @@ public class SendgridAPI {
         this.activateEmailNotifications = config.isActivateEmailNotifications();
     }
 
-    private void sendMessages(Collection<Mail> messages) throws MessagingException {
+    private void sendMessages(Collection<Mail> messages) {
         for (Mail message : messages) {
             sendMessage(message);
         }
@@ -82,62 +80,62 @@ public class SendgridAPI {
         return Optional.empty();
     }
 
-    public void sendCollectMessage(Set<String> toAddresses, String referenceId, String type, Writer template) throws MessagingException {
-        List<Mail> messages = collectMessageCreator.collectMessage(toAddresses, fromAccount, template, referenceId, type);
+    public void sendCollectMessage(String toAddress, String referenceId, String type, Writer template) {
+        List<Mail> messages = collectMessageCreator.collectMessage(toAddress, fromAccount, template, referenceId, type);
         sendMessages(messages);
     }
 
-    public void sendNewCaseMessage(Set<String> toAddress, String referenceId, String type, Writer template) throws MessagingException {
+    public void sendNewCaseMessage(String toAddress, String referenceId, String type, Writer template) {
         List<Mail> messages = newCaseMessageCreator.newCaseMessage(toAddress, fromAccount, template, referenceId, type);
         sendMessages(messages);
     }
 
-    public void sendReminderMessage(Set<String> addresses, String referenceId, String type, Writer template) throws MessagingException {
-        List<Mail> messages = reminderMessageCreator.reminderMessage(addresses, fromAccount, template, referenceId, type);
+    public void sendReminderMessage(String toAddress, String referenceId, String type, Writer template) {
+        List<Mail> messages = reminderMessageCreator.reminderMessage(toAddress, fromAccount, template, referenceId, type);
         sendMessages(messages);
     }
 
-    public void sendDisabledDatasetMessage(Set<String> toAddresses, String referenceId, String type, Writer template) throws MessagingException {
-        List<Mail> messages = disabledDatasetCreator.disabledDatasetMessage(toAddresses, fromAccount, template, referenceId, type);
+    public void sendDisabledDatasetMessage(String toAddress, String referenceId, String type, Writer template) {
+        List<Mail> messages = disabledDatasetCreator.disabledDatasetMessage(toAddress, fromAccount, template, referenceId, type);
         sendMessages(messages);
     }
 
-    public void sendNewDARRequests(Set<String> toAddresses, String referenceId, String type, Writer template) throws MessagingException {
-        Collection<Mail> messages = newDARMessageCreator.newDARRequestMessage(toAddresses, fromAccount, template, referenceId, type);
+    public void sendNewDARRequests(String toAddress, String referenceId, String type, Writer template) {
+        Collection<Mail> messages = newDARMessageCreator.newDARRequestMessage(toAddress, fromAccount, template, referenceId, type);
         sendMessages(messages);
     }
 
-    public void sendCancelDARRequestMessage(Set<String> toAddresses, String dataAccessRequestId, String type, Writer template) throws MessagingException {
-        Collection<Mail> messages = darCancelMessageCreator.cancelDarMessage(toAddresses, fromAccount, template, dataAccessRequestId, type);
+    public void sendCancelDARRequestMessage(String toAddress, String dataAccessRequestId, String type, Writer template) {
+        Collection<Mail> messages = darCancelMessageCreator.cancelDarMessage(toAddress, fromAccount, template, dataAccessRequestId, type);
         sendMessages(messages);
     }
 
-    public void sendClosedDatasetElectionsMessage(Set<String> toAddresses, String dataAccessRequestId, String type, Writer template) throws MessagingException {
-        Collection<Mail> messages = closedDatasetElections.closedDatasetElectionMessage(toAddresses, fromAccount, template, dataAccessRequestId, type);
+    public void sendClosedDatasetElectionsMessage(String toAddress, String dataAccessRequestId, String type, Writer template) {
+        Collection<Mail> messages = closedDatasetElections.closedDatasetElectionMessage(toAddress, fromAccount, template, dataAccessRequestId, type);
         sendMessages(messages);
     }
 
-    public void sendFlaggedDarAdminApprovedMessage(Set<String> toAddresses, String dataAccessRequestId, String type, Writer template) throws MessagingException {
-        List<Mail> messages = adminApprovedDarMessageCreator.flaggedDarMessage(toAddresses, fromAccount, template, dataAccessRequestId, type);
+    public void sendFlaggedDarAdminApprovedMessage(String toAddress, String dataAccessRequestId, String type, Writer template) {
+        List<Mail> messages = adminApprovedDarMessageCreator.flaggedDarMessage(toAddress, fromAccount, template, dataAccessRequestId, type);
         sendMessages(messages);
     }
 
-    public void sendDelegateResponsibilitiesMessage(Set<String> userAddresses, Writer template) throws MessagingException {
-        List<Mail> messages = delegateResponsibilitesMessage.delegateResponsibilitiesMessage(userAddresses, fromAccount, template);
+    public void sendDelegateResponsibilitiesMessage(String toAddress, Writer template) {
+        List<Mail> messages = delegateResponsibilitesMessage.delegateResponsibilitiesMessage(toAddress, fromAccount, template);
         sendMessages(messages);
     }
 
-    public void sendNewResearcherCreatedMessage(Set<String> toAddresses, Writer template) throws MessagingException {
-        List<Mail> messages = researcherCreatedMessage.newResearcherCreatedMessage(toAddresses, fromAccount, template, "", "");
+    public void sendNewResearcherCreatedMessage(String toAddress, Writer template) {
+        List<Mail> messages = researcherCreatedMessage.newResearcherCreatedMessage(toAddress, fromAccount, template, "", "");
         sendMessages(messages);
     }
 
-    public void sendNewResearcherApprovedMessage(Set<String> researcherEmails, Writer template, String darCode) throws MessagingException {
-        Collection<Mail> messages = researcherApprovedMessage.researcherApprovedMessage(researcherEmails, fromAccount, template, darCode);
+    public void sendNewResearcherApprovedMessage(String toAddress, Writer template, String darCode) {
+        Collection<Mail> messages = researcherApprovedMessage.researcherApprovedMessage(toAddress, fromAccount, template, darCode);
         sendMessages(messages);
     }
 
-    public void sendDataCustodianApprovalMessage(String toAddress, String darCode, Writer template) throws MessagingException {
+    public void sendDataCustodianApprovalMessage(String toAddress, String darCode, Writer template) {
         Collection<Mail> messages = dataCustodianApprovalMessage.dataCustodianApprovalMessage(toAddress, fromAccount, darCode, template);
         sendMessages(messages);
     }

--- a/src/main/java/org/broadinstitute/consent/http/mail/SendgridAPI.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/SendgridAPI.java
@@ -23,8 +23,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.Writer;
-import java.util.Collection;
-import java.util.List;
 import java.util.Optional;
 
 public class SendgridAPI {
@@ -52,12 +50,6 @@ public class SendgridAPI {
         this.activateEmailNotifications = config.isActivateEmailNotifications();
     }
 
-    private void sendMessages(Collection<Mail> messages) {
-        for (Mail message : messages) {
-            sendMessage(message);
-        }
-    }
-
     private Optional<Response> sendMessage(Mail message) {
         if (activateEmailNotifications) {
             try {
@@ -80,64 +72,64 @@ public class SendgridAPI {
         return Optional.empty();
     }
 
-    public void sendCollectMessage(String toAddress, String referenceId, String type, Writer template) {
-        List<Mail> messages = collectMessageCreator.collectMessage(toAddress, fromAccount, template, referenceId, type);
-        sendMessages(messages);
+    public Optional<Response> sendCollectMessage(String toAddress, String referenceId, String type, Writer template) {
+        Mail message = collectMessageCreator.collectMessage(toAddress, fromAccount, template, referenceId, type);
+        return sendMessage(message);
     }
 
-    public void sendNewCaseMessage(String toAddress, String referenceId, String type, Writer template) {
-        List<Mail> messages = newCaseMessageCreator.newCaseMessage(toAddress, fromAccount, template, referenceId, type);
-        sendMessages(messages);
+    public Optional<Response> sendNewCaseMessage(String toAddress, String referenceId, String type, Writer template) {
+        Mail message = newCaseMessageCreator.newCaseMessage(toAddress, fromAccount, template, referenceId, type);
+        return sendMessage(message);
     }
 
-    public void sendReminderMessage(String toAddress, String referenceId, String type, Writer template) {
-        List<Mail> messages = reminderMessageCreator.reminderMessage(toAddress, fromAccount, template, referenceId, type);
-        sendMessages(messages);
+    public Optional<Response> sendReminderMessage(String toAddress, String referenceId, String type, Writer template) {
+        Mail message = reminderMessageCreator.reminderMessage(toAddress, fromAccount, template, referenceId, type);
+        return sendMessage(message);
     }
 
-    public void sendDisabledDatasetMessage(String toAddress, String referenceId, String type, Writer template) {
-        List<Mail> messages = disabledDatasetCreator.disabledDatasetMessage(toAddress, fromAccount, template, referenceId, type);
-        sendMessages(messages);
+    public Optional<Response> sendDisabledDatasetMessage(String toAddress, String referenceId, String type, Writer template) {
+        Mail message = disabledDatasetCreator.disabledDatasetMessage(toAddress, fromAccount, template, referenceId, type);
+        return sendMessage(message);
     }
 
-    public void sendNewDARRequests(String toAddress, String referenceId, String type, Writer template) {
-        Collection<Mail> messages = newDARMessageCreator.newDARRequestMessage(toAddress, fromAccount, template, referenceId, type);
-        sendMessages(messages);
+    public Optional<Response> sendNewDARRequests(String toAddress, String referenceId, String type, Writer template) {
+        Mail message =  newDARMessageCreator.newDARRequestMessage(toAddress, fromAccount, template, referenceId, type);
+        return sendMessage(message);
     }
 
-    public void sendCancelDARRequestMessage(String toAddress, String dataAccessRequestId, String type, Writer template) {
-        Collection<Mail> messages = darCancelMessageCreator.cancelDarMessage(toAddress, fromAccount, template, dataAccessRequestId, type);
-        sendMessages(messages);
+    public Optional<Response> sendCancelDARRequestMessage(String toAddress, String dataAccessRequestId, String type, Writer template) {
+        Mail message =  darCancelMessageCreator.cancelDarMessage(toAddress, fromAccount, template, dataAccessRequestId, type);
+        return sendMessage(message);
     }
 
-    public void sendClosedDatasetElectionsMessage(String toAddress, String dataAccessRequestId, String type, Writer template) {
-        Collection<Mail> messages = closedDatasetElections.closedDatasetElectionMessage(toAddress, fromAccount, template, dataAccessRequestId, type);
-        sendMessages(messages);
+    public Optional<Response> sendClosedDatasetElectionsMessage(String toAddress, String dataAccessRequestId, String type, Writer template) {
+        Mail message =  closedDatasetElections.closedDatasetElectionMessage(toAddress, fromAccount, template, dataAccessRequestId, type);
+        return sendMessage(message);
     }
 
-    public void sendFlaggedDarAdminApprovedMessage(String toAddress, String dataAccessRequestId, String type, Writer template) {
-        List<Mail> messages = adminApprovedDarMessageCreator.flaggedDarMessage(toAddress, fromAccount, template, dataAccessRequestId, type);
-        sendMessages(messages);
+    public Optional<Response> sendFlaggedDarAdminApprovedMessage(String toAddress, String dataAccessRequestId, String type, Writer template) {
+        Mail message = adminApprovedDarMessageCreator.flaggedDarMessage(toAddress, fromAccount, template, dataAccessRequestId, type);
+        return sendMessage(message);
     }
 
-    public void sendDelegateResponsibilitiesMessage(String toAddress, Writer template) {
-        List<Mail> messages = delegateResponsibilitesMessage.delegateResponsibilitiesMessage(toAddress, fromAccount, template);
-        sendMessages(messages);
+    public Optional<Response> sendDelegateResponsibilitiesMessage(String toAddress, Writer template) {
+        Mail message = delegateResponsibilitesMessage.delegateResponsibilitiesMessage(toAddress, fromAccount, template);
+        return sendMessage(message);
     }
 
-    public void sendNewResearcherCreatedMessage(String toAddress, Writer template) {
-        List<Mail> messages = researcherCreatedMessage.newResearcherCreatedMessage(toAddress, fromAccount, template, "", "");
-        sendMessages(messages);
+    public Optional<Response> sendNewResearcherCreatedMessage(String toAddress, Writer template) {
+        Mail message = researcherCreatedMessage.newResearcherCreatedMessage(toAddress, fromAccount, template, "", "");
+        return sendMessage(message);
     }
 
-    public void sendNewResearcherApprovedMessage(String toAddress, Writer template, String darCode) {
-        Collection<Mail> messages = researcherApprovedMessage.researcherApprovedMessage(toAddress, fromAccount, template, darCode);
-        sendMessages(messages);
+    public Optional<Response> sendNewResearcherApprovedMessage(String toAddress, Writer template, String darCode) {
+        Mail message = researcherApprovedMessage.researcherApprovedMessage(toAddress, fromAccount, template, darCode);
+        return sendMessage(message);
     }
 
-    public void sendDataCustodianApprovalMessage(String toAddress, String darCode, Writer template) {
-        Collection<Mail> messages = dataCustodianApprovalMessage.dataCustodianApprovalMessage(toAddress, fromAccount, darCode, template);
-        sendMessages(messages);
+    public Optional<Response> sendDataCustodianApprovalMessage(String toAddress, String darCode, Writer template) {
+        Mail message = dataCustodianApprovalMessage.dataCustodianApprovalMessage(toAddress, fromAccount, darCode, template);
+        return sendMessage(message);
     }
 
 }

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/ClosedDatasetElectionMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/ClosedDatasetElectionMessage.java
@@ -2,17 +2,15 @@ package org.broadinstitute.consent.http.mail.message;
 
 import com.sendgrid.helpers.mail.Mail;
 
-import javax.mail.MessagingException;
 import java.io.Writer;
 import java.util.Collection;
-import java.util.Set;
 
 public class ClosedDatasetElectionMessage extends MailMessage {
 
     private final String CLOSED_DATASET_ELECTIONS = "Report of closed Dataset elections.";
 
-    public Collection<Mail> closedDatasetElectionMessage(Set<String> toAddresses, String fromAddress, Writer template, String referenceId, String type) throws MessagingException {
-        return generateEmailMessages(toAddresses, fromAddress, template, referenceId, type);
+    public Collection<Mail> closedDatasetElectionMessage(String toAddress, String fromAddress, Writer template, String referenceId, String type) {
+        return generateEmailMessage(toAddress, fromAddress, template, referenceId, type);
     }
 
     @Override

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/ClosedDatasetElectionMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/ClosedDatasetElectionMessage.java
@@ -9,7 +9,7 @@ public class ClosedDatasetElectionMessage extends MailMessage {
 
     private final String CLOSED_DATASET_ELECTIONS = "Report of closed Dataset elections.";
 
-    public Collection<Mail> closedDatasetElectionMessage(String toAddress, String fromAddress, Writer template, String referenceId, String type) {
+    public Mail closedDatasetElectionMessage(String toAddress, String fromAddress, Writer template, String referenceId, String type) {
         return generateEmailMessage(toAddress, fromAddress, template, referenceId, type);
     }
 

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/ClosedDatasetElectionMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/ClosedDatasetElectionMessage.java
@@ -3,7 +3,6 @@ package org.broadinstitute.consent.http.mail.message;
 import com.sendgrid.helpers.mail.Mail;
 
 import java.io.Writer;
-import java.util.Collection;
 
 public class ClosedDatasetElectionMessage extends MailMessage {
 

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/CollectMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/CollectMessage.java
@@ -10,7 +10,7 @@ public class CollectMessage extends MailMessage {
     private final String COLLECT_DUL = "Ready for vote collection on Data Use Limitations case id: %s.";
     private final String COLLECT_DAR = "Ready for votes collection on Data Access Request case id: %s.";
 
-    public List<Mail> collectMessage(String toAddress, String fromAddress, Writer template, String referenceId, String type) {
+    public Mail collectMessage(String toAddress, String fromAddress, Writer template, String referenceId, String type) {
         return generateEmailMessage(toAddress, fromAddress, template, referenceId, type);
     }
 

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/CollectMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/CollectMessage.java
@@ -2,18 +2,16 @@ package org.broadinstitute.consent.http.mail.message;
 
 import com.sendgrid.helpers.mail.Mail;
 
-import javax.mail.MessagingException;
 import java.io.Writer;
 import java.util.List;
-import java.util.Set;
 
 public class CollectMessage extends MailMessage {
 
     private final String COLLECT_DUL = "Ready for vote collection on Data Use Limitations case id: %s.";
     private final String COLLECT_DAR = "Ready for votes collection on Data Access Request case id: %s.";
 
-    public List<Mail> collectMessage(Set<String> toAddresses, String fromAddress, Writer template, String referenceId, String type) throws MessagingException {
-        return generateEmailMessages(toAddresses, fromAddress, template, referenceId, type);
+    public List<Mail> collectMessage(String toAddress, String fromAddress, Writer template, String referenceId, String type) {
+        return generateEmailMessage(toAddress, fromAddress, template, referenceId, type);
     }
 
     @Override

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/CollectMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/CollectMessage.java
@@ -3,7 +3,6 @@ package org.broadinstitute.consent.http.mail.message;
 import com.sendgrid.helpers.mail.Mail;
 
 import java.io.Writer;
-import java.util.List;
 
 public class CollectMessage extends MailMessage {
 

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/DarCancelMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/DarCancelMessage.java
@@ -2,17 +2,15 @@ package org.broadinstitute.consent.http.mail.message;
 
 import com.sendgrid.helpers.mail.Mail;
 
-import javax.mail.MessagingException;
 import java.io.Writer;
 import java.util.Collection;
-import java.util.Set;
 
 public class DarCancelMessage extends MailMessage {
 
     private final String CANCEL_DAR = "The Data Access Request with ID %s has been cancelled.";
 
-    public Collection<Mail> cancelDarMessage(Set<String> toAddresses, String fromAddress, Writer template, String referenceId, String type) throws MessagingException {
-        return generateEmailMessages(toAddresses, fromAddress, template, referenceId, type);
+    public Collection<Mail> cancelDarMessage(String toAddress, String fromAddress, Writer template, String referenceId, String type) {
+        return generateEmailMessage(toAddress, fromAddress, template, referenceId, type);
     }
 
     @Override

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/DarCancelMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/DarCancelMessage.java
@@ -9,7 +9,7 @@ public class DarCancelMessage extends MailMessage {
 
     private final String CANCEL_DAR = "The Data Access Request with ID %s has been cancelled.";
 
-    public Collection<Mail> cancelDarMessage(String toAddress, String fromAddress, Writer template, String referenceId, String type) {
+    public Mail cancelDarMessage(String toAddress, String fromAddress, Writer template, String referenceId, String type) {
         return generateEmailMessage(toAddress, fromAddress, template, referenceId, type);
     }
 

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/DarCancelMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/DarCancelMessage.java
@@ -3,7 +3,6 @@ package org.broadinstitute.consent.http.mail.message;
 import com.sendgrid.helpers.mail.Mail;
 
 import java.io.Writer;
-import java.util.Collection;
 
 public class DarCancelMessage extends MailMessage {
 

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/DataCustodianApprovalMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/DataCustodianApprovalMessage.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 public class DataCustodianApprovalMessage extends MailMessage {
 
-    public List<Mail> dataCustodianApprovalMessage(
+    public Mail dataCustodianApprovalMessage(
             String toAddress,
             String fromAddress,
             String darCode,

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/DataCustodianApprovalMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/DataCustodianApprovalMessage.java
@@ -2,7 +2,6 @@ package org.broadinstitute.consent.http.mail.message;
 
 import com.sendgrid.helpers.mail.Mail;
 
-import javax.mail.MessagingException;
 import java.io.Writer;
 import java.util.Collections;
 import java.util.List;
@@ -13,8 +12,8 @@ public class DataCustodianApprovalMessage extends MailMessage {
             String toAddress,
             String fromAddress,
             String darCode,
-            Writer template) throws MessagingException {
-        return generateEmailMessages(Collections.singleton(toAddress), fromAddress, template, darCode, null);
+            Writer template) {
+        return generateEmailMessage(toAddress, fromAddress, template, darCode, null);
     }
 
     @Override

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/DataCustodianApprovalMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/DataCustodianApprovalMessage.java
@@ -3,8 +3,6 @@ package org.broadinstitute.consent.http.mail.message;
 import com.sendgrid.helpers.mail.Mail;
 
 import java.io.Writer;
-import java.util.Collections;
-import java.util.List;
 
 public class DataCustodianApprovalMessage extends MailMessage {
 

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/DelegateResponsibilitiesMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/DelegateResponsibilitiesMessage.java
@@ -3,7 +3,6 @@ package org.broadinstitute.consent.http.mail.message;
 import com.sendgrid.helpers.mail.Mail;
 
 import java.io.Writer;
-import java.util.List;
 
 public class DelegateResponsibilitiesMessage extends MailMessage{
 

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/DelegateResponsibilitiesMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/DelegateResponsibilitiesMessage.java
@@ -2,17 +2,15 @@ package org.broadinstitute.consent.http.mail.message;
 
 import com.sendgrid.helpers.mail.Mail;
 
-import javax.mail.MessagingException;
 import java.io.Writer;
 import java.util.List;
-import java.util.Set;
 
 public class DelegateResponsibilitiesMessage extends MailMessage{
 
     private final String NEW_ROLES = "You have been assigned a New Role in DUOS.";
 
-    public List<Mail> delegateResponsibilitiesMessage(Set<String> toAddresses, String fromAddress, Writer template) throws MessagingException {
-        return generateEmailMessages(toAddresses, fromAddress, template, null, null);
+    public List<Mail> delegateResponsibilitiesMessage(String toAddress, String fromAddress, Writer template) {
+        return generateEmailMessage(toAddress, fromAddress, template, null, null);
     }
 
     @Override

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/DelegateResponsibilitiesMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/DelegateResponsibilitiesMessage.java
@@ -9,7 +9,7 @@ public class DelegateResponsibilitiesMessage extends MailMessage{
 
     private final String NEW_ROLES = "You have been assigned a New Role in DUOS.";
 
-    public List<Mail> delegateResponsibilitiesMessage(String toAddress, String fromAddress, Writer template) {
+    public Mail delegateResponsibilitiesMessage(String toAddress, String fromAddress, Writer template) {
         return generateEmailMessage(toAddress, fromAddress, template, null, null);
     }
 

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/DisabledDatasetMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/DisabledDatasetMessage.java
@@ -9,7 +9,7 @@ public class DisabledDatasetMessage extends MailMessage {
 
     private final static String MISSING_DATASET = "Datasets not available for Data Access Request Application id: %s.";
 
-    public List<Mail> disabledDatasetMessage(String toAddress, String fromAddress, Writer template, String referenceId, String type) {
+    public Mail disabledDatasetMessage(String toAddress, String fromAddress, Writer template, String referenceId, String type) {
         return generateEmailMessage(toAddress, fromAddress, template, referenceId, type);
     }
 

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/DisabledDatasetMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/DisabledDatasetMessage.java
@@ -2,17 +2,15 @@ package org.broadinstitute.consent.http.mail.message;
 
 import com.sendgrid.helpers.mail.Mail;
 
-import javax.mail.MessagingException;
 import java.io.Writer;
 import java.util.List;
-import java.util.Set;
 
 public class DisabledDatasetMessage extends MailMessage {
 
     private final static String MISSING_DATASET = "Datasets not available for Data Access Request Application id: %s.";
 
-    public List<Mail> disabledDatasetMessage(Set<String> toAddresses, String fromAddress, Writer template, String referenceId, String type) throws MessagingException {
-        return generateEmailMessages(toAddresses, fromAddress, template, referenceId, type);
+    public List<Mail> disabledDatasetMessage(String toAddress, String fromAddress, Writer template, String referenceId, String type) {
+        return generateEmailMessage(toAddress, fromAddress, template, referenceId, type);
     }
 
     @Override

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/DisabledDatasetMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/DisabledDatasetMessage.java
@@ -3,7 +3,6 @@ package org.broadinstitute.consent.http.mail.message;
 import com.sendgrid.helpers.mail.Mail;
 
 import java.io.Writer;
-import java.util.List;
 
 public class DisabledDatasetMessage extends MailMessage {
 

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/FlaggedDarApprovedMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/FlaggedDarApprovedMessage.java
@@ -3,7 +3,6 @@ package org.broadinstitute.consent.http.mail.message;
 import com.sendgrid.helpers.mail.Mail;
 
 import java.io.Writer;
-import java.util.List;
 
 public class FlaggedDarApprovedMessage extends MailMessage{
 

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/FlaggedDarApprovedMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/FlaggedDarApprovedMessage.java
@@ -2,18 +2,16 @@ package org.broadinstitute.consent.http.mail.message;
 
 import com.sendgrid.helpers.mail.Mail;
 
-import javax.mail.MessagingException;
 import java.io.Writer;
 import java.util.List;
-import java.util.Set;
 
 public class FlaggedDarApprovedMessage extends MailMessage{
 
     /* This message is sent to the Admin when a Dataset that requires owners Approval is approved by te DAC.*/
     private final String ADMIN_APPROVED_DAR = "%s that requires data owners reviewing approved.";
 
-    public List<Mail> flaggedDarMessage(Set<String> toAddresses, String fromAddress, Writer template, String referenceId, String type) throws MessagingException {
-        return generateEmailMessages(toAddresses, fromAddress, template, referenceId, type);
+    public List<Mail> flaggedDarMessage(String toAddress, String fromAddress, Writer template, String referenceId, String type) {
+        return generateEmailMessage(toAddress, fromAddress, template, referenceId, type);
     }
 
     @Override

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/FlaggedDarApprovedMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/FlaggedDarApprovedMessage.java
@@ -10,7 +10,7 @@ public class FlaggedDarApprovedMessage extends MailMessage{
     /* This message is sent to the Admin when a Dataset that requires owners Approval is approved by te DAC.*/
     private final String ADMIN_APPROVED_DAR = "%s that requires data owners reviewing approved.";
 
-    public List<Mail> flaggedDarMessage(String toAddress, String fromAddress, Writer template, String referenceId, String type) {
+    public Mail flaggedDarMessage(String toAddress, String fromAddress, Writer template, String referenceId, String type) {
         return generateEmailMessage(toAddress, fromAddress, template, referenceId, type);
     }
 

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/MailMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/MailMessage.java
@@ -4,23 +4,16 @@ import com.sendgrid.helpers.mail.Mail;
 import com.sendgrid.helpers.mail.objects.Content;
 import com.sendgrid.helpers.mail.objects.Email;
 
-import javax.mail.MessagingException;
 import java.io.Writer;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 public abstract class MailMessage {
 
-    protected List<Mail> generateEmailMessages(Set<String> toAddresses, String fromAddress, Writer template, String referenceId, String type) throws MessagingException {
-        if (toAddresses == null || toAddresses.isEmpty()) {
-            throw new MessagingException("List of to-addresses cannot be empty");
-        }
+    protected List<Mail> generateEmailMessage(String toAddress, String fromAddress, Writer template, String referenceId, String type) {
         Content content = new Content("text/html", template.toString());
         String subject = assignSubject(referenceId, type);
-        return toAddresses.stream().map(
-                address -> new Mail(new Email(fromAddress), subject, new Email(address), content)
-            ).collect(Collectors.toList());
+        return List.of(new Mail(new Email(fromAddress), subject, new Email(toAddress), content));
     }
 
     abstract String assignSubject(String referenceId, String type);

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/MailMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/MailMessage.java
@@ -10,10 +10,10 @@ import java.util.stream.Collectors;
 
 public abstract class MailMessage {
 
-    protected List<Mail> generateEmailMessage(String toAddress, String fromAddress, Writer template, String referenceId, String type) {
+    protected Mail generateEmailMessage(String toAddress, String fromAddress, Writer template, String referenceId, String type) {
         Content content = new Content("text/html", template.toString());
         String subject = assignSubject(referenceId, type);
-        return List.of(new Mail(new Email(fromAddress), subject, new Email(toAddress), content));
+        return new Mail(new Email(fromAddress), subject, new Email(toAddress), content);
     }
 
     abstract String assignSubject(String referenceId, String type);

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/MailMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/MailMessage.java
@@ -5,8 +5,6 @@ import com.sendgrid.helpers.mail.objects.Content;
 import com.sendgrid.helpers.mail.objects.Email;
 
 import java.io.Writer;
-import java.util.List;
-import java.util.stream.Collectors;
 
 public abstract class MailMessage {
 

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/NewCaseMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/NewCaseMessage.java
@@ -10,7 +10,7 @@ public class NewCaseMessage extends MailMessage{
     private final String NEWCASE_DUL = "Log vote on Data Use Limitations case id: %s.";
     private final String NEWCASE_DAR = "Log votes on Data Access Request case id: %s.";
 
-    public List<Mail> newCaseMessage(String toAddress, String fromAddress, Writer template, String referenceId, String type) {
+    public Mail newCaseMessage(String toAddress, String fromAddress, Writer template, String referenceId, String type) {
         return generateEmailMessage(toAddress, fromAddress, template, referenceId, type);
     }
 

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/NewCaseMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/NewCaseMessage.java
@@ -3,7 +3,6 @@ package org.broadinstitute.consent.http.mail.message;
 import com.sendgrid.helpers.mail.Mail;
 
 import java.io.Writer;
-import java.util.List;
 
 public class NewCaseMessage extends MailMessage{
 

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/NewCaseMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/NewCaseMessage.java
@@ -2,18 +2,16 @@ package org.broadinstitute.consent.http.mail.message;
 
 import com.sendgrid.helpers.mail.Mail;
 
-import javax.mail.MessagingException;
 import java.io.Writer;
 import java.util.List;
-import java.util.Set;
 
 public class NewCaseMessage extends MailMessage{
 
     private final String NEWCASE_DUL = "Log vote on Data Use Limitations case id: %s.";
     private final String NEWCASE_DAR = "Log votes on Data Access Request case id: %s.";
 
-    public List<Mail> newCaseMessage(Set<String> addresses, String fromAddress, Writer template, String referenceId, String type) throws MessagingException {
-        return generateEmailMessages(addresses, fromAddress, template, referenceId, type);
+    public List<Mail> newCaseMessage(String toAddress, String fromAddress, Writer template, String referenceId, String type) {
+        return generateEmailMessage(toAddress, fromAddress, template, referenceId, type);
     }
 
     @Override

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/NewDARRequestMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/NewDARRequestMessage.java
@@ -3,7 +3,6 @@ package org.broadinstitute.consent.http.mail.message;
 import com.sendgrid.helpers.mail.Mail;
 
 import java.io.Writer;
-import java.util.Collection;
 
 public class NewDARRequestMessage extends MailMessage{
 

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/NewDARRequestMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/NewDARRequestMessage.java
@@ -2,17 +2,15 @@ package org.broadinstitute.consent.http.mail.message;
 
 import com.sendgrid.helpers.mail.Mail;
 
-import javax.mail.MessagingException;
 import java.io.Writer;
 import java.util.Collection;
-import java.util.Set;
 
 public class NewDARRequestMessage extends MailMessage{
 
     private final String NEW_DAR_REQUEST = "Create an election for Data Access Request id: %s.";
 
-    public Collection<Mail> newDARRequestMessage(Set<String> toAddresses, String fromAddress, Writer template, String referenceId, String type) throws MessagingException {
-        return generateEmailMessages(toAddresses, fromAddress, template, referenceId, type);
+    public Collection<Mail> newDARRequestMessage(String toAddress, String fromAddress, Writer template, String referenceId, String type) {
+        return generateEmailMessage(toAddress, fromAddress, template, referenceId, type);
     }
 
     @Override

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/NewDARRequestMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/NewDARRequestMessage.java
@@ -9,7 +9,7 @@ public class NewDARRequestMessage extends MailMessage{
 
     private final String NEW_DAR_REQUEST = "Create an election for Data Access Request id: %s.";
 
-    public Collection<Mail> newDARRequestMessage(String toAddress, String fromAddress, Writer template, String referenceId, String type) {
+    public Mail newDARRequestMessage(String toAddress, String fromAddress, Writer template, String referenceId, String type) {
         return generateEmailMessage(toAddress, fromAddress, template, referenceId, type);
     }
 

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/NewResearcherCreatedMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/NewResearcherCreatedMessage.java
@@ -3,7 +3,6 @@ package org.broadinstitute.consent.http.mail.message;
 import com.sendgrid.helpers.mail.Mail;
 
 import java.io.Writer;
-import java.util.List;
 
 public class NewResearcherCreatedMessage extends MailMessage{
 

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/NewResearcherCreatedMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/NewResearcherCreatedMessage.java
@@ -9,7 +9,7 @@ public class NewResearcherCreatedMessage extends MailMessage{
 
     private final String NEW_RESEARCHER_CREATED = "Review Researcher Profile.";
 
-    public List<Mail> newResearcherCreatedMessage(String toAddress, String fromAddress, Writer template, String referenceId, String type) {
+    public Mail newResearcherCreatedMessage(String toAddress, String fromAddress, Writer template, String referenceId, String type) {
         return generateEmailMessage(toAddress, fromAddress, template, referenceId, type);
     }
 

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/NewResearcherCreatedMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/NewResearcherCreatedMessage.java
@@ -2,17 +2,15 @@ package org.broadinstitute.consent.http.mail.message;
 
 import com.sendgrid.helpers.mail.Mail;
 
-import javax.mail.MessagingException;
 import java.io.Writer;
 import java.util.List;
-import java.util.Set;
 
 public class NewResearcherCreatedMessage extends MailMessage{
 
     private final String NEW_RESEARCHER_CREATED = "Review Researcher Profile.";
 
-    public List<Mail> newResearcherCreatedMessage(Set<String> toAddress, String fromAddress, Writer template, String referenceId, String type) throws MessagingException {
-        return generateEmailMessages(toAddress, fromAddress, template, referenceId, type);
+    public List<Mail> newResearcherCreatedMessage(String toAddress, String fromAddress, Writer template, String referenceId, String type) {
+        return generateEmailMessage(toAddress, fromAddress, template, referenceId, type);
     }
 
     @Override

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/ReminderMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/ReminderMessage.java
@@ -2,10 +2,8 @@ package org.broadinstitute.consent.http.mail.message;
 
 import com.sendgrid.helpers.mail.Mail;
 
-import javax.mail.MessagingException;
 import java.io.Writer;
 import java.util.List;
-import java.util.Set;
 
 public class ReminderMessage extends MailMessage {
 
@@ -13,8 +11,8 @@ public class ReminderMessage extends MailMessage {
     private final String REMINDER_DAR = "Urgent: Log votes on Data Access Request case id: %s.";
     private final String REMINDER_RP = "Urgent: Log votes on Research Purpose Review case id: %s.";
 
-    public List<Mail> reminderMessage(Set<String> address, String fromAddress, Writer template, String referenceId, String type) throws MessagingException {
-        return generateEmailMessages(address, fromAddress, template, referenceId, type);
+    public List<Mail> reminderMessage(String toAddress, String fromAddress, Writer template, String referenceId, String type) {
+        return generateEmailMessage(toAddress, fromAddress, template, referenceId, type);
     }
 
     @Override

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/ReminderMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/ReminderMessage.java
@@ -11,7 +11,7 @@ public class ReminderMessage extends MailMessage {
     private final String REMINDER_DAR = "Urgent: Log votes on Data Access Request case id: %s.";
     private final String REMINDER_RP = "Urgent: Log votes on Research Purpose Review case id: %s.";
 
-    public List<Mail> reminderMessage(String toAddress, String fromAddress, Writer template, String referenceId, String type) {
+    public Mail reminderMessage(String toAddress, String fromAddress, Writer template, String referenceId, String type) {
         return generateEmailMessage(toAddress, fromAddress, template, referenceId, type);
     }
 

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/ReminderMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/ReminderMessage.java
@@ -3,7 +3,6 @@ package org.broadinstitute.consent.http.mail.message;
 import com.sendgrid.helpers.mail.Mail;
 
 import java.io.Writer;
-import java.util.List;
 
 public class ReminderMessage extends MailMessage {
 

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/ResearcherApprovedMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/ResearcherApprovedMessage.java
@@ -3,7 +3,6 @@ package org.broadinstitute.consent.http.mail.message;
 import com.sendgrid.helpers.mail.Mail;
 
 import java.io.Writer;
-import java.util.List;
 
 public class ResearcherApprovedMessage extends MailMessage {
 

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/ResearcherApprovedMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/ResearcherApprovedMessage.java
@@ -2,17 +2,15 @@ package org.broadinstitute.consent.http.mail.message;
 
 import com.sendgrid.helpers.mail.Mail;
 
-import javax.mail.MessagingException;
 import java.io.Writer;
 import java.util.List;
-import java.util.Set;
 
 public class ResearcherApprovedMessage extends MailMessage {
 
     private final String APPROVED_DAR = "Your DUOS Data Access Request Results";
 
-    public List<Mail> researcherApprovedMessage(Set<String> toAddresses, String fromAddress, Writer template, String darCode) throws MessagingException {
-        return generateEmailMessages(toAddresses, fromAddress, template, darCode, null);
+    public List<Mail> researcherApprovedMessage(String toAddress, String fromAddress, Writer template, String darCode) {
+        return generateEmailMessage(toAddress, fromAddress, template, darCode, null);
     }
 
     @Override

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/ResearcherApprovedMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/ResearcherApprovedMessage.java
@@ -9,7 +9,7 @@ public class ResearcherApprovedMessage extends MailMessage {
 
     private final String APPROVED_DAR = "Your DUOS Data Access Request Results";
 
-    public List<Mail> researcherApprovedMessage(String toAddress, String fromAddress, Writer template, String darCode) {
+    public Mail researcherApprovedMessage(String toAddress, String fromAddress, Writer template, String darCode) {
         return generateEmailMessage(toAddress, fromAddress, template, darCode, null);
     }
 

--- a/src/main/java/org/broadinstitute/consent/http/service/EmailNotifierService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/EmailNotifierService.java
@@ -13,7 +13,7 @@ import org.broadinstitute.consent.http.db.UserDAO;
 import org.broadinstitute.consent.http.db.VoteDAO;
 import org.broadinstitute.consent.http.enumeration.ElectionType;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
-import org.broadinstitute.consent.http.mail.SendgridAPI;
+import org.broadinstitute.consent.http.mail.SendGridAPI;
 import org.broadinstitute.consent.http.mail.freemarker.FreeMarkerTemplateHelper;
 import org.broadinstitute.consent.http.models.Consent;
 import org.broadinstitute.consent.http.models.DarCollection;
@@ -48,7 +48,7 @@ public class EmailNotifierService {
     private final MailMessageDAO emailDAO;
     private final VoteDAO voteDAO;
     private final FreeMarkerTemplateHelper templateHelper;
-    private final SendgridAPI sendgridAPI;
+    private final SendGridAPI sendGridAPI;
     private final String SERVER_URL;
     private final boolean isServiceActive;
 
@@ -86,7 +86,7 @@ public class EmailNotifierService {
     @Inject
     public EmailNotifierService(DarCollectionDAO collectionDAO, ConsentDAO consentDAO,
                                 VoteDAO voteDAO, ElectionDAO electionDAO,
-                                UserDAO userDAO, MailMessageDAO emailDAO, SendgridAPI sendgridAPI,
+                                UserDAO userDAO, MailMessageDAO emailDAO, SendGridAPI sendGridAPI,
                                 FreeMarkerTemplateHelper helper, String serverUrl, boolean serviceActive) {
         this.collectionDAO = collectionDAO;
         this.consentDAO = consentDAO;
@@ -95,7 +95,7 @@ public class EmailNotifierService {
         this.voteDAO = voteDAO;
         this.templateHelper = helper;
         this.emailDAO = emailDAO;
-        this.sendgridAPI = sendgridAPI;
+        this.sendGridAPI = sendGridAPI;
         this.SERVER_URL = serverUrl;
         this.isServiceActive = serviceActive;
     }
@@ -118,7 +118,7 @@ public class EmailNotifierService {
             for (User user : distinctUsers) {
                 Writer template = templateHelper.getNewDARRequestTemplate(SERVER_URL, user.getDisplayName(), collection.getDarCode());
                 Map<String, String> data = retrieveForNewDAR(collection.getDarCode(), user);
-                sendgridAPI.sendNewDARRequests(user.getEmail(), data.get("entityId"), data.get("electionType"), template);
+                sendGridAPI.sendNewDARRequests(user.getEmail(), data.get("entityId"), data.get("electionType"), template);
                 emailDAO.insertBulkEmailNoVotes(List.of(user.getUserId()), collection.getDarCode(), 4, new Date(), template.toString());
             }
         }
@@ -133,7 +133,7 @@ public class EmailNotifierService {
                 Map<String, String> data = retrieveForCollect(electionId, chair);
                 String collectUrl = generateCollectVoteUrl(SERVER_URL, data.get("electionType"), data.get("entityId"), data.get("electionId"));
                 Writer template = templateHelper.getCollectTemplate(data.get("userName"), data.get("electionType"), data.get("entityName"), collectUrl);
-                sendgridAPI.sendCollectMessage(data.get("email"), data.get("entityName"), data.get("electionType"), template);
+                sendGridAPI.sendCollectMessage(data.get("email"), data.get("entityName"), data.get("electionType"), template);
                 emailDAO.insertEmail(null, data.get("electionId"), Integer.valueOf(data.get("dacUserId")), 1, new Date(), template.toString());
             }
         }
@@ -144,7 +144,7 @@ public class EmailNotifierService {
             Map<String, String> data = retrieveForVote(voteId);
             String voteUrl = generateUserVoteUrl(SERVER_URL, data.get("electionType"), data.get("voteId"), data.get("entityId"), data.get("rpVoteId"));
             Writer template = templateHelper.getReminderTemplate(data.get("userName"), data.get("electionType"), data.get("entityName"), voteUrl);
-            sendgridAPI.sendReminderMessage(data.get("email"), data.get("entityName"), data.get("electionType"), template);
+            sendGridAPI.sendReminderMessage(data.get("email"), data.get("entityName"), data.get("electionType"), template);
             emailDAO.insertEmail(voteId, data.get("electionId"), Integer.valueOf(data.get("dacUserId")), 3, new Date(), template.toString());
             voteDAO.updateVoteReminderFlag(voteId, true);
         }
@@ -182,7 +182,7 @@ public class EmailNotifierService {
     public void sendDisabledDatasetsMessage(User user, List<String> disabledDatasets, String dataAcessRequestId) throws MessagingException, IOException, TemplateException {
         if(isServiceActive){
             Writer template = templateHelper.getDisabledDatasetsTemplate(user.getDisplayName(), disabledDatasets, dataAcessRequestId, SERVER_URL);
-            sendgridAPI.sendDisabledDatasetMessage(user.getEmail(), dataAcessRequestId, null, template);
+            sendGridAPI.sendDisabledDatasetMessage(user.getEmail(), dataAcessRequestId, null, template);
         }
     }
 
@@ -203,7 +203,7 @@ public class EmailNotifierService {
             List<User> users = userDAO.describeUsersByRoleAndEmailPreference(UserRoles.ADMIN.getRoleName(), true);
             if (CollectionUtils.isNotEmpty(users)) {
                 Writer template = templateHelper.getClosedDatasetElectionsTemplate(reviewedDatasets, "", "", SERVER_URL);
-                users.forEach(u -> sendgridAPI.sendClosedDatasetElectionsMessage(u.getEmail(), "", "", template));
+                users.forEach(u -> sendGridAPI.sendClosedDatasetElectionsMessage(u.getEmail(), "", "", template));
             }
 
         }
@@ -213,7 +213,7 @@ public class EmailNotifierService {
         if(isServiceActive){
             for(User admin: admins) {
                 Writer template = templateHelper.getAdminApprovedDarTemplate(admin.getDisplayName(), darCode, dataOwnersDataSets, SERVER_URL);
-                sendgridAPI.sendFlaggedDarAdminApprovedMessage(admin.getEmail(), darCode, SERVER_URL, template);
+                sendGridAPI.sendFlaggedDarAdminApprovedMessage(admin.getEmail(), darCode, SERVER_URL, template);
             }
         }
     }
@@ -222,7 +222,7 @@ public class EmailNotifierService {
         if(isServiceActive){
             User user = userDAO.findUserById(researcherId);
             Writer template = templateHelper.getResearcherDarApprovedTemplate(darCode, user.getDisplayName(), datasets, dataUseRestriction, user.getEmail());
-            sendgridAPI.sendNewResearcherApprovedMessage(user.getEmail(), template, darCode);
+            sendGridAPI.sendNewResearcherApprovedMessage(user.getEmail(), template, darCode);
         }
     }
 
@@ -234,7 +234,7 @@ public class EmailNotifierService {
         if (isServiceActive) {
             Writer template = templateHelper.getDataCustodianApprovalTemplate(datasets,
                     dataDepositorName, darCode, researcherEmail);
-            sendgridAPI.sendDataCustodianApprovalMessage(toAddress, darCode, template);
+            sendGridAPI.sendDataCustodianApprovalMessage(toAddress, darCode, template);
         }
     }
 
@@ -255,7 +255,7 @@ public class EmailNotifierService {
     }
 
     private void sendNewCaseMessage(Set<String> userAddress, String electionType, String entityId, Writer template) throws MessagingException {
-        userAddress.forEach(u -> sendgridAPI.sendNewCaseMessage(u, entityId, electionType, template));
+        userAddress.forEach(u -> sendGridAPI.sendNewCaseMessage(u, entityId, electionType, template));
     }
 
     private String generateUserVoteUrl(String serverUrl, String electionType, String voteId, String entityId, String rpVoteId) {

--- a/src/main/java/org/broadinstitute/consent/http/service/EmailNotifierService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/EmailNotifierService.java
@@ -133,7 +133,7 @@ public class EmailNotifierService {
                 Map<String, String> data = retrieveForCollect(electionId, chair);
                 String collectUrl = generateCollectVoteUrl(SERVER_URL, data.get("electionType"), data.get("entityId"), data.get("electionId"));
                 Writer template = templateHelper.getCollectTemplate(data.get("userName"), data.get("electionType"), data.get("entityName"), collectUrl);
-                sendgridAPI.sendCollectMessage(chair.getEmail(), data.get("entityName"), data.get("electionType"), template);
+                sendgridAPI.sendCollectMessage(data.get("email"), data.get("entityName"), data.get("electionType"), template);
                 emailDAO.insertEmail(null, data.get("electionId"), Integer.valueOf(data.get("dacUserId")), 1, new Date(), template.toString());
             }
         }

--- a/src/test/java/org/broadinstitute/consent/http/mail/message/ClosedDatasetElectionMessageTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mail/message/ClosedDatasetElectionMessageTest.java
@@ -9,7 +9,6 @@ import org.mockito.MockitoAnnotations;
 import javax.mail.MessagingException;
 import java.io.Writer;
 import java.util.Collection;
-import java.util.Collections;
 
 import static org.junit.Assert.assertTrue;
 
@@ -25,7 +24,7 @@ public class ClosedDatasetElectionMessageTest {
 
     @Test
     public void testMessageSubject() throws MessagingException {
-        Collection<Mail> messages = new ClosedDatasetElectionMessage().closedDatasetElectionMessage(Collections.singleton("to@address.com"), "from@address.com", template, "SomeReferenceId", "Some Type");
+        Collection<Mail> messages = new ClosedDatasetElectionMessage().closedDatasetElectionMessage("to@address.com", "from@address.com", template, "SomeReferenceId", "Some Type");
         for (Mail message: messages) {
             assertTrue(message.getSubject().equals("Report of closed Dataset elections."));
         }

--- a/src/test/java/org/broadinstitute/consent/http/mail/message/ClosedDatasetElectionMessageTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mail/message/ClosedDatasetElectionMessageTest.java
@@ -4,13 +4,13 @@ import com.sendgrid.helpers.mail.Mail;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 
 import javax.mail.MessagingException;
 import java.io.Writer;
 import java.util.Collection;
 
 import static org.junit.Assert.assertTrue;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 public class ClosedDatasetElectionMessageTest {
 
@@ -19,7 +19,7 @@ public class ClosedDatasetElectionMessageTest {
 
     @Before
     public void setUp(){
-        MockitoAnnotations.initMocks(this);
+        openMocks(this);
     }
 
     @Test

--- a/src/test/java/org/broadinstitute/consent/http/mail/message/ClosedDatasetElectionMessageTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mail/message/ClosedDatasetElectionMessageTest.java
@@ -7,9 +7,8 @@ import org.mockito.Mock;
 
 import javax.mail.MessagingException;
 import java.io.Writer;
-import java.util.Collection;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.MockitoAnnotations.openMocks;
 
 public class ClosedDatasetElectionMessageTest {
@@ -24,10 +23,8 @@ public class ClosedDatasetElectionMessageTest {
 
     @Test
     public void testMessageSubject() throws MessagingException {
-        Collection<Mail> messages = new ClosedDatasetElectionMessage().closedDatasetElectionMessage("to@address.com", "from@address.com", template, "SomeReferenceId", "Some Type");
-        for (Mail message: messages) {
-            assertTrue(message.getSubject().equals("Report of closed Dataset elections."));
-        }
+        Mail message = new ClosedDatasetElectionMessage().closedDatasetElectionMessage("to@address.com", "from@address.com", template, "SomeReferenceId", "Some Type");
+        assertEquals("Report of closed Dataset elections.", message.getSubject());
     }
 
 }

--- a/src/test/java/org/broadinstitute/consent/http/mail/message/CollectMessageTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mail/message/CollectMessageTest.java
@@ -7,9 +7,8 @@ import org.mockito.Mock;
 
 import javax.mail.MessagingException;
 import java.io.Writer;
-import java.util.List;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.MockitoAnnotations.openMocks;
 
 public class CollectMessageTest {
@@ -24,10 +23,10 @@ public class CollectMessageTest {
 
     @Test
     public void testMessageSubject() throws MessagingException {
-        List<Mail> messages = new CollectMessage().collectMessage("to@address.com", "from@address.com", template, "DUL-123", "Data Use Limitations");
-        assertTrue(messages.get(0).getSubject().equals("Ready for vote collection on Data Use Limitations case id: DUL-123."));
-        messages = new CollectMessage().collectMessage("to@address.com", "from@address.com", template, "DAR-123", "Data Access");
-        assertTrue(messages.get(0).getSubject().equals("Ready for votes collection on Data Access Request case id: DAR-123."));
+        Mail message = new CollectMessage().collectMessage("to@address.com", "from@address.com", template, "DUL-123", "Data Use Limitations");
+        assertEquals("Ready for vote collection on Data Use Limitations case id: DUL-123.", message.getSubject());
+        Mail message2 = new CollectMessage().collectMessage("to@address.com", "from@address.com", template, "DAR-123", "Data Access");
+        assertEquals("Ready for votes collection on Data Access Request case id: DAR-123.", message2.getSubject());
     }
 
 }

--- a/src/test/java/org/broadinstitute/consent/http/mail/message/CollectMessageTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mail/message/CollectMessageTest.java
@@ -8,7 +8,6 @@ import org.mockito.MockitoAnnotations;
 
 import javax.mail.MessagingException;
 import java.io.Writer;
-import java.util.Collections;
 import java.util.List;
 
 import static org.junit.Assert.assertTrue;
@@ -25,9 +24,9 @@ public class CollectMessageTest {
 
     @Test
     public void testMessageSubject() throws MessagingException {
-        List<Mail> messages = new CollectMessage().collectMessage(Collections.singleton("to@address.com"), "from@address.com", template, "DUL-123", "Data Use Limitations");
+        List<Mail> messages = new CollectMessage().collectMessage("to@address.com", "from@address.com", template, "DUL-123", "Data Use Limitations");
         assertTrue(messages.get(0).getSubject().equals("Ready for vote collection on Data Use Limitations case id: DUL-123."));
-        messages = new CollectMessage().collectMessage(Collections.singleton("to@address.com"), "from@address.com", template, "DAR-123", "Data Access");
+        messages = new CollectMessage().collectMessage("to@address.com", "from@address.com", template, "DAR-123", "Data Access");
         assertTrue(messages.get(0).getSubject().equals("Ready for votes collection on Data Access Request case id: DAR-123."));
     }
 

--- a/src/test/java/org/broadinstitute/consent/http/mail/message/CollectMessageTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mail/message/CollectMessageTest.java
@@ -4,13 +4,13 @@ import com.sendgrid.helpers.mail.Mail;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 
 import javax.mail.MessagingException;
 import java.io.Writer;
 import java.util.List;
 
 import static org.junit.Assert.assertTrue;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 public class CollectMessageTest {
 
@@ -19,7 +19,7 @@ public class CollectMessageTest {
 
     @Before
     public void setUp(){
-        MockitoAnnotations.initMocks(this);
+        openMocks(this);
     }
 
     @Test

--- a/src/test/java/org/broadinstitute/consent/http/mail/message/DarCancelMessageTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mail/message/DarCancelMessageTest.java
@@ -7,9 +7,8 @@ import org.mockito.Mock;
 
 import javax.mail.MessagingException;
 import java.io.Writer;
-import java.util.Collection;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.MockitoAnnotations.openMocks;
 
 public class DarCancelMessageTest {
@@ -24,10 +23,8 @@ public class DarCancelMessageTest {
 
     @Test
     public void testMessageSubject() throws MessagingException {
-        Collection<Mail> messages = new DarCancelMessage().cancelDarMessage("to@address.com", "from@address.com", template, "DAR-123", "Data Access");
-        for (Mail message: messages) {
-            assertTrue(message.getSubject().equals("The Data Access Request with ID DAR-123 has been cancelled."));
-        }
+        Mail message = new DarCancelMessage().cancelDarMessage("to@address.com", "from@address.com", template, "DAR-123", "Data Access");
+        assertEquals("The Data Access Request with ID DAR-123 has been cancelled.", message.getSubject());
     }
 
 }

--- a/src/test/java/org/broadinstitute/consent/http/mail/message/DarCancelMessageTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mail/message/DarCancelMessageTest.java
@@ -4,13 +4,13 @@ import com.sendgrid.helpers.mail.Mail;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 
 import javax.mail.MessagingException;
 import java.io.Writer;
 import java.util.Collection;
 
 import static org.junit.Assert.assertTrue;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 public class DarCancelMessageTest {
 
@@ -19,7 +19,7 @@ public class DarCancelMessageTest {
 
     @Before
     public void setUp(){
-        MockitoAnnotations.initMocks(this);
+        openMocks(this);
     }
 
     @Test

--- a/src/test/java/org/broadinstitute/consent/http/mail/message/DarCancelMessageTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mail/message/DarCancelMessageTest.java
@@ -9,7 +9,6 @@ import org.mockito.MockitoAnnotations;
 import javax.mail.MessagingException;
 import java.io.Writer;
 import java.util.Collection;
-import java.util.Collections;
 
 import static org.junit.Assert.assertTrue;
 
@@ -25,7 +24,7 @@ public class DarCancelMessageTest {
 
     @Test
     public void testMessageSubject() throws MessagingException {
-        Collection<Mail> messages = new DarCancelMessage().cancelDarMessage(Collections.singleton("to@address.com"), "from@address.com", template, "DAR-123", "Data Access");
+        Collection<Mail> messages = new DarCancelMessage().cancelDarMessage("to@address.com", "from@address.com", template, "DAR-123", "Data Access");
         for (Mail message: messages) {
             assertTrue(message.getSubject().equals("The Data Access Request with ID DAR-123 has been cancelled."));
         }

--- a/src/test/java/org/broadinstitute/consent/http/mail/message/DelegateResponsibilitiesMessageTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mail/message/DelegateResponsibilitiesMessageTest.java
@@ -8,7 +8,6 @@ import org.mockito.MockitoAnnotations;
 
 import javax.mail.MessagingException;
 import java.io.Writer;
-import java.util.Collections;
 import java.util.List;
 
 import static org.junit.Assert.assertTrue;
@@ -25,7 +24,7 @@ public class DelegateResponsibilitiesMessageTest {
 
     @Test
     public void testMessageSubject() throws MessagingException {
-        List<Mail> messages = new DelegateResponsibilitiesMessage().delegateResponsibilitiesMessage(Collections.singleton("to@address.com"), "from@address.com", template);
+        List<Mail> messages = new DelegateResponsibilitiesMessage().delegateResponsibilitiesMessage("to@address.com", "from@address.com", template);
         assertTrue(messages.get(0).getSubject().equals("You have been assigned a New Role in DUOS."));
     }
 

--- a/src/test/java/org/broadinstitute/consent/http/mail/message/DelegateResponsibilitiesMessageTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mail/message/DelegateResponsibilitiesMessageTest.java
@@ -7,9 +7,8 @@ import org.mockito.Mock;
 
 import javax.mail.MessagingException;
 import java.io.Writer;
-import java.util.List;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.MockitoAnnotations.openMocks;
 
 public class DelegateResponsibilitiesMessageTest {
@@ -24,8 +23,8 @@ public class DelegateResponsibilitiesMessageTest {
 
     @Test
     public void testMessageSubject() throws MessagingException {
-        List<Mail> messages = new DelegateResponsibilitiesMessage().delegateResponsibilitiesMessage("to@address.com", "from@address.com", template);
-        assertTrue(messages.get(0).getSubject().equals("You have been assigned a New Role in DUOS."));
+        Mail message = new DelegateResponsibilitiesMessage().delegateResponsibilitiesMessage("to@address.com", "from@address.com", template);
+        assertEquals("You have been assigned a New Role in DUOS.", message.getSubject());
     }
 
 }

--- a/src/test/java/org/broadinstitute/consent/http/mail/message/DelegateResponsibilitiesMessageTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mail/message/DelegateResponsibilitiesMessageTest.java
@@ -4,13 +4,13 @@ import com.sendgrid.helpers.mail.Mail;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 
 import javax.mail.MessagingException;
 import java.io.Writer;
 import java.util.List;
 
 import static org.junit.Assert.assertTrue;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 public class DelegateResponsibilitiesMessageTest {
 
@@ -19,7 +19,7 @@ public class DelegateResponsibilitiesMessageTest {
 
     @Before
     public void setUp(){
-        MockitoAnnotations.initMocks(this);
+        openMocks(this);
     }
 
     @Test

--- a/src/test/java/org/broadinstitute/consent/http/mail/message/DisabledDatasetMessageTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mail/message/DisabledDatasetMessageTest.java
@@ -7,9 +7,8 @@ import org.mockito.Mock;
 
 import javax.mail.MessagingException;
 import java.io.Writer;
-import java.util.List;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.MockitoAnnotations.openMocks;
 
 public class DisabledDatasetMessageTest {
@@ -24,8 +23,8 @@ public class DisabledDatasetMessageTest {
 
     @Test
     public void testMessageSubject() throws MessagingException {
-        List<Mail> messages = new DisabledDatasetMessage().disabledDatasetMessage("to@address.com", "from@address.com", template, "DAR-123", "SomeType");
-        assertTrue(messages.get(0).getSubject().equals("Datasets not available for Data Access Request Application id: DAR-123."));
+        Mail message = new DisabledDatasetMessage().disabledDatasetMessage("to@address.com", "from@address.com", template, "DAR-123", "SomeType");
+        assertEquals("Datasets not available for Data Access Request Application id: DAR-123.", message.getSubject());
     }
 
 }

--- a/src/test/java/org/broadinstitute/consent/http/mail/message/DisabledDatasetMessageTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mail/message/DisabledDatasetMessageTest.java
@@ -4,13 +4,13 @@ import com.sendgrid.helpers.mail.Mail;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 
 import javax.mail.MessagingException;
 import java.io.Writer;
 import java.util.List;
 
 import static org.junit.Assert.assertTrue;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 public class DisabledDatasetMessageTest {
 
@@ -19,7 +19,7 @@ public class DisabledDatasetMessageTest {
 
     @Before
     public void setUp(){
-        MockitoAnnotations.initMocks(this);
+        openMocks(this);
     }
 
     @Test

--- a/src/test/java/org/broadinstitute/consent/http/mail/message/DisabledDatasetMessageTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mail/message/DisabledDatasetMessageTest.java
@@ -8,7 +8,6 @@ import org.mockito.MockitoAnnotations;
 
 import javax.mail.MessagingException;
 import java.io.Writer;
-import java.util.Collections;
 import java.util.List;
 
 import static org.junit.Assert.assertTrue;
@@ -25,7 +24,7 @@ public class DisabledDatasetMessageTest {
 
     @Test
     public void testMessageSubject() throws MessagingException {
-        List<Mail> messages = new DisabledDatasetMessage().disabledDatasetMessage(Collections.singleton("to@address.com"), "from@address.com", template, "DAR-123", "SomeType");
+        List<Mail> messages = new DisabledDatasetMessage().disabledDatasetMessage("to@address.com", "from@address.com", template, "DAR-123", "SomeType");
         assertTrue(messages.get(0).getSubject().equals("Datasets not available for Data Access Request Application id: DAR-123."));
     }
 

--- a/src/test/java/org/broadinstitute/consent/http/mail/message/FlaggedDarApprovedMessageTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mail/message/FlaggedDarApprovedMessageTest.java
@@ -7,9 +7,8 @@ import org.mockito.Mock;
 
 import javax.mail.MessagingException;
 import java.io.Writer;
-import java.util.List;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.MockitoAnnotations.openMocks;
 
 public class FlaggedDarApprovedMessageTest {
@@ -24,8 +23,8 @@ public class FlaggedDarApprovedMessageTest {
 
     @Test
     public void testMessageSubject() throws MessagingException {
-        List<Mail> messages = new FlaggedDarApprovedMessage().flaggedDarMessage("to@address.com", "from@address.com", template, "DS-123", "SomeType");
-        assertTrue(messages.get(0).getSubject().equals("DS-123 that requires data owners reviewing approved."));
+        Mail message = new FlaggedDarApprovedMessage().flaggedDarMessage("to@address.com", "from@address.com", template, "DS-123", "SomeType");
+        assertEquals("DS-123 that requires data owners reviewing approved.", message.getSubject());
     }
 
 }

--- a/src/test/java/org/broadinstitute/consent/http/mail/message/FlaggedDarApprovedMessageTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mail/message/FlaggedDarApprovedMessageTest.java
@@ -4,14 +4,13 @@ import com.sendgrid.helpers.mail.Mail;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 
 import javax.mail.MessagingException;
 import java.io.Writer;
-import java.util.Collections;
 import java.util.List;
 
 import static org.junit.Assert.assertTrue;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 public class FlaggedDarApprovedMessageTest {
 
@@ -20,7 +19,7 @@ public class FlaggedDarApprovedMessageTest {
 
     @Before
     public void setUp(){
-        MockitoAnnotations.initMocks(this);
+        openMocks(this);
     }
 
     @Test

--- a/src/test/java/org/broadinstitute/consent/http/mail/message/FlaggedDarApprovedMessageTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mail/message/FlaggedDarApprovedMessageTest.java
@@ -25,7 +25,7 @@ public class FlaggedDarApprovedMessageTest {
 
     @Test
     public void testMessageSubject() throws MessagingException {
-        List<Mail> messages = new FlaggedDarApprovedMessage().flaggedDarMessage(Collections.singleton(("to@address.com")), "from@address.com", template, "DS-123", "SomeType");
+        List<Mail> messages = new FlaggedDarApprovedMessage().flaggedDarMessage("to@address.com", "from@address.com", template, "DS-123", "SomeType");
         assertTrue(messages.get(0).getSubject().equals("DS-123 that requires data owners reviewing approved."));
     }
 

--- a/src/test/java/org/broadinstitute/consent/http/mail/message/NewCaseMessageTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mail/message/NewCaseMessageTest.java
@@ -7,9 +7,8 @@ import org.mockito.Mock;
 
 import javax.mail.MessagingException;
 import java.io.Writer;
-import java.util.List;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.MockitoAnnotations.openMocks;
 
 public class NewCaseMessageTest {
@@ -24,10 +23,10 @@ public class NewCaseMessageTest {
 
     @Test
     public void testMessageSubject() throws MessagingException {
-        List<Mail> messages = new NewCaseMessage().newCaseMessage("to@address.com", "from@address.com", template, "DUL-123", "Data Use Limitations");
-        assertTrue(messages.get(0).getSubject().equals("Log vote on Data Use Limitations case id: DUL-123."));
-        messages = new NewCaseMessage().newCaseMessage("to@address.com", "from@address.com", template, "DAR-123", "Data Access");
-        assertTrue(messages.get(0).getSubject().equals("Log votes on Data Access Request case id: DAR-123."));
+        Mail message = new NewCaseMessage().newCaseMessage("to@address.com", "from@address.com", template, "DUL-123", "Data Use Limitations");
+        assertEquals("Log vote on Data Use Limitations case id: DUL-123.", message.getSubject());
+        Mail message2 = new NewCaseMessage().newCaseMessage("to@address.com", "from@address.com", template, "DAR-123", "Data Access");
+        assertEquals("Log votes on Data Access Request case id: DAR-123.", message2.getSubject());
     }
 
 }

--- a/src/test/java/org/broadinstitute/consent/http/mail/message/NewCaseMessageTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mail/message/NewCaseMessageTest.java
@@ -4,14 +4,13 @@ import com.sendgrid.helpers.mail.Mail;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 
 import javax.mail.MessagingException;
 import java.io.Writer;
-import java.util.Collections;
 import java.util.List;
 
 import static org.junit.Assert.assertTrue;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 public class NewCaseMessageTest {
 
@@ -20,14 +19,14 @@ public class NewCaseMessageTest {
 
     @Before
     public void setUp(){
-        MockitoAnnotations.initMocks(this);
+        openMocks(this);
     }
 
     @Test
     public void testMessageSubject() throws MessagingException {
-        List<Mail> messages = new NewCaseMessage().newCaseMessage(Collections.singleton("to@address.com"), "from@address.com", template, "DUL-123", "Data Use Limitations");
+        List<Mail> messages = new NewCaseMessage().newCaseMessage("to@address.com", "from@address.com", template, "DUL-123", "Data Use Limitations");
         assertTrue(messages.get(0).getSubject().equals("Log vote on Data Use Limitations case id: DUL-123."));
-        messages = new NewCaseMessage().newCaseMessage(Collections.singleton("to@address.com"), "from@address.com", template, "DAR-123", "Data Access");
+        messages = new NewCaseMessage().newCaseMessage("to@address.com", "from@address.com", template, "DAR-123", "Data Access");
         assertTrue(messages.get(0).getSubject().equals("Log votes on Data Access Request case id: DAR-123."));
     }
 

--- a/src/test/java/org/broadinstitute/consent/http/mail/message/NewDARRequestMessageTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mail/message/NewDARRequestMessageTest.java
@@ -7,9 +7,8 @@ import org.mockito.Mock;
 
 import javax.mail.MessagingException;
 import java.io.Writer;
-import java.util.Collection;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.MockitoAnnotations.openMocks;
 
 public class NewDARRequestMessageTest {
@@ -24,10 +23,8 @@ public class NewDARRequestMessageTest {
 
     @Test
     public void testMessageSubject() throws MessagingException {
-        Collection<Mail> messages = new NewDARRequestMessage().newDARRequestMessage("to@address.com", "from@address.com", template, "DAR-123", "Data Use Limitations");
-        for (Mail message: messages) {
-            assertTrue(message.getSubject().equals("Create an election for Data Access Request id: DAR-123."));
-        }
+        Mail message = new NewDARRequestMessage().newDARRequestMessage("to@address.com", "from@address.com", template, "DAR-123", "Data Use Limitations");
+        assertEquals("Create an election for Data Access Request id: DAR-123.", message.getSubject());
     }
 
 }

--- a/src/test/java/org/broadinstitute/consent/http/mail/message/NewDARRequestMessageTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mail/message/NewDARRequestMessageTest.java
@@ -9,7 +9,6 @@ import org.mockito.MockitoAnnotations;
 import javax.mail.MessagingException;
 import java.io.Writer;
 import java.util.Collection;
-import java.util.Collections;
 
 import static org.junit.Assert.assertTrue;
 
@@ -25,7 +24,7 @@ public class NewDARRequestMessageTest {
 
     @Test
     public void testMessageSubject() throws MessagingException {
-        Collection<Mail> messages = new NewDARRequestMessage().newDARRequestMessage(Collections.singleton("to@address.com"), "from@address.com", template, "DAR-123", "Data Use Limitations");
+        Collection<Mail> messages = new NewDARRequestMessage().newDARRequestMessage("to@address.com", "from@address.com", template, "DAR-123", "Data Use Limitations");
         for (Mail message: messages) {
             assertTrue(message.getSubject().equals("Create an election for Data Access Request id: DAR-123."));
         }

--- a/src/test/java/org/broadinstitute/consent/http/mail/message/NewDARRequestMessageTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mail/message/NewDARRequestMessageTest.java
@@ -4,13 +4,13 @@ import com.sendgrid.helpers.mail.Mail;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 
 import javax.mail.MessagingException;
 import java.io.Writer;
 import java.util.Collection;
 
 import static org.junit.Assert.assertTrue;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 public class NewDARRequestMessageTest {
 
@@ -19,7 +19,7 @@ public class NewDARRequestMessageTest {
 
     @Before
     public void setUp(){
-        MockitoAnnotations.initMocks(this);
+        openMocks(this);
     }
 
     @Test

--- a/src/test/java/org/broadinstitute/consent/http/mail/message/NewResearcherCreatedTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mail/message/NewResearcherCreatedTest.java
@@ -4,13 +4,13 @@ import com.sendgrid.helpers.mail.Mail;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 
 import javax.mail.MessagingException;
 import java.io.Writer;
 import java.util.List;
 
 import static org.junit.Assert.assertTrue;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 public class NewResearcherCreatedTest {
 
@@ -19,7 +19,7 @@ public class NewResearcherCreatedTest {
 
     @Before
     public void setUp(){
-        MockitoAnnotations.initMocks(this);
+        openMocks(this);
     }
 
     @Test

--- a/src/test/java/org/broadinstitute/consent/http/mail/message/NewResearcherCreatedTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mail/message/NewResearcherCreatedTest.java
@@ -7,9 +7,8 @@ import org.mockito.Mock;
 
 import javax.mail.MessagingException;
 import java.io.Writer;
-import java.util.List;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.MockitoAnnotations.openMocks;
 
 public class NewResearcherCreatedTest {
@@ -24,7 +23,7 @@ public class NewResearcherCreatedTest {
 
     @Test
     public void testMessageSubject() throws MessagingException {
-        List<Mail> messages = new NewResearcherCreatedMessage().newResearcherCreatedMessage("to@address.com", "from@address.com", template, "SomeReferenceId", "Some Type") ;
-        assertTrue(messages.get(0).getSubject().equals("Review Researcher Profile."));
+        Mail message = new NewResearcherCreatedMessage().newResearcherCreatedMessage("to@address.com", "from@address.com", template, "SomeReferenceId", "Some Type") ;
+        assertEquals("Review Researcher Profile.", message.getSubject());
     }
 }

--- a/src/test/java/org/broadinstitute/consent/http/mail/message/NewResearcherCreatedTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mail/message/NewResearcherCreatedTest.java
@@ -8,7 +8,6 @@ import org.mockito.MockitoAnnotations;
 
 import javax.mail.MessagingException;
 import java.io.Writer;
-import java.util.Collections;
 import java.util.List;
 
 import static org.junit.Assert.assertTrue;
@@ -25,7 +24,7 @@ public class NewResearcherCreatedTest {
 
     @Test
     public void testMessageSubject() throws MessagingException {
-        List<Mail> messages = new NewResearcherCreatedMessage().newResearcherCreatedMessage(Collections.singleton("to@address.com"), "from@address.com", template, "SomeReferenceId", "Some Type") ;
+        List<Mail> messages = new NewResearcherCreatedMessage().newResearcherCreatedMessage("to@address.com", "from@address.com", template, "SomeReferenceId", "Some Type") ;
         assertTrue(messages.get(0).getSubject().equals("Review Researcher Profile."));
     }
 }

--- a/src/test/java/org/broadinstitute/consent/http/mail/message/ReminderMessageTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mail/message/ReminderMessageTest.java
@@ -7,9 +7,8 @@ import org.mockito.Mock;
 
 import javax.mail.MessagingException;
 import java.io.Writer;
-import java.util.List;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.MockitoAnnotations.openMocks;
 
 public class ReminderMessageTest {
@@ -24,12 +23,12 @@ public class ReminderMessageTest {
 
     @Test
     public void testMessageSubject() throws MessagingException {
-        List<Mail> messages = new ReminderMessage().reminderMessage("to@address.com", "from@address.com", template, "DUL-123", "Data Use Limitations");
-        assertTrue(messages.get(0).getSubject().equals("Urgent: Log vote on Data Use Limitations case id: DUL-123."));
-        messages = new ReminderMessage().reminderMessage("to@address.com", "from@address.com", template, "DAR-123", "Data Access Request");
-        assertTrue(messages.get(0).getSubject().equals("Urgent: Log votes on Data Access Request case id: DAR-123."));
-        messages = new ReminderMessage().reminderMessage("to@address.com", "from@address.com", template, "RP-123", "Research Purpose");
-        assertTrue(messages.get(0).getSubject().equals("Urgent: Log votes on Research Purpose Review case id: RP-123."));
+        Mail message = new ReminderMessage().reminderMessage("to@address.com", "from@address.com", template, "DUL-123", "Data Use Limitations");
+        assertEquals("Urgent: Log vote on Data Use Limitations case id: DUL-123.", message.getSubject());
+        Mail message2 = new ReminderMessage().reminderMessage("to@address.com", "from@address.com", template, "DAR-123", "Data Access Request");
+        assertEquals("Urgent: Log votes on Data Access Request case id: DAR-123.", message2.getSubject());
+        Mail message3 = new ReminderMessage().reminderMessage("to@address.com", "from@address.com", template, "RP-123", "Research Purpose");
+        assertEquals("Urgent: Log votes on Research Purpose Review case id: RP-123.", message3.getSubject());
     }
 
 }

--- a/src/test/java/org/broadinstitute/consent/http/mail/message/ReminderMessageTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mail/message/ReminderMessageTest.java
@@ -4,13 +4,13 @@ import com.sendgrid.helpers.mail.Mail;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 
 import javax.mail.MessagingException;
 import java.io.Writer;
 import java.util.List;
 
 import static org.junit.Assert.assertTrue;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 public class ReminderMessageTest {
 
@@ -19,7 +19,7 @@ public class ReminderMessageTest {
 
     @Before
     public void setUp(){
-        MockitoAnnotations.initMocks(this);
+        openMocks(this);
     }
 
     @Test

--- a/src/test/java/org/broadinstitute/consent/http/mail/message/ReminderMessageTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mail/message/ReminderMessageTest.java
@@ -8,7 +8,6 @@ import org.mockito.MockitoAnnotations;
 
 import javax.mail.MessagingException;
 import java.io.Writer;
-import java.util.Collections;
 import java.util.List;
 
 import static org.junit.Assert.assertTrue;
@@ -25,11 +24,11 @@ public class ReminderMessageTest {
 
     @Test
     public void testMessageSubject() throws MessagingException {
-        List<Mail> messages = new ReminderMessage().reminderMessage(Collections.singleton("to@address.com"), "from@address.com", template, "DUL-123", "Data Use Limitations");
+        List<Mail> messages = new ReminderMessage().reminderMessage("to@address.com", "from@address.com", template, "DUL-123", "Data Use Limitations");
         assertTrue(messages.get(0).getSubject().equals("Urgent: Log vote on Data Use Limitations case id: DUL-123."));
-        messages = new ReminderMessage().reminderMessage(Collections.singleton("to@address.com"), "from@address.com", template, "DAR-123", "Data Access Request");
+        messages = new ReminderMessage().reminderMessage("to@address.com", "from@address.com", template, "DAR-123", "Data Access Request");
         assertTrue(messages.get(0).getSubject().equals("Urgent: Log votes on Data Access Request case id: DAR-123."));
-        messages = new ReminderMessage().reminderMessage(Collections.singleton("to@address.com"), "from@address.com", template, "RP-123", "Research Purpose");
+        messages = new ReminderMessage().reminderMessage("to@address.com", "from@address.com", template, "RP-123", "Research Purpose");
         assertTrue(messages.get(0).getSubject().equals("Urgent: Log votes on Research Purpose Review case id: RP-123."));
     }
 

--- a/src/test/java/org/broadinstitute/consent/http/mail/message/ResearcherApprovedMessageTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mail/message/ResearcherApprovedMessageTest.java
@@ -8,7 +8,6 @@ import org.mockito.MockitoAnnotations;
 
 import javax.mail.MessagingException;
 import java.io.Writer;
-import java.util.Collections;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
@@ -25,7 +24,7 @@ public class ResearcherApprovedMessageTest {
 
     @Test
     public void testMessageSubject() throws MessagingException {
-        List<Mail> messages = new ResearcherApprovedMessage().researcherApprovedMessage(Collections.singleton("to@address.com"), "from@address.com", template, "DAR-123");
+        List<Mail> messages = new ResearcherApprovedMessage().researcherApprovedMessage("to@address.com", "from@address.com", template, "DAR-123");
         assertEquals("Your DUOS Data Access Request Results", messages.get(0).getSubject());
     }
 

--- a/src/test/java/org/broadinstitute/consent/http/mail/message/ResearcherApprovedMessageTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mail/message/ResearcherApprovedMessageTest.java
@@ -7,7 +7,6 @@ import org.mockito.Mock;
 
 import javax.mail.MessagingException;
 import java.io.Writer;
-import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.MockitoAnnotations.openMocks;
@@ -24,13 +23,8 @@ public class ResearcherApprovedMessageTest {
 
     @Test
     public void testMessageSubject() throws MessagingException {
-        List<Mail> messages = new ResearcherApprovedMessage().researcherApprovedMessage("to@address.com", "from@address.com", template, "DAR-123");
-        assertEquals("Your DUOS Data Access Request Results", messages.get(0).getSubject());
-    }
-
-    @Test(expected = MessagingException.class)
-    public void testWithoutToAddress() throws MessagingException {
-        new ResearcherApprovedMessage().researcherApprovedMessage(null, "from@address.com", template, "DAR-123");
+        Mail message = new ResearcherApprovedMessage().researcherApprovedMessage("to@address.com", "from@address.com", template, "DAR-123");
+        assertEquals("Your DUOS Data Access Request Results", message.getSubject());
     }
 
 }

--- a/src/test/java/org/broadinstitute/consent/http/mail/message/ResearcherApprovedMessageTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mail/message/ResearcherApprovedMessageTest.java
@@ -4,13 +4,13 @@ import com.sendgrid.helpers.mail.Mail;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 
 import javax.mail.MessagingException;
 import java.io.Writer;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 public class ResearcherApprovedMessageTest {
 
@@ -19,7 +19,7 @@ public class ResearcherApprovedMessageTest {
 
     @Before
     public void setUp() {
-        MockitoAnnotations.initMocks(this);
+        openMocks(this);
     }
 
     @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/EmailNotifierServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/EmailNotifierServiceTest.java
@@ -8,7 +8,7 @@ import org.broadinstitute.consent.http.db.ElectionDAO;
 import org.broadinstitute.consent.http.db.MailMessageDAO;
 import org.broadinstitute.consent.http.db.UserDAO;
 import org.broadinstitute.consent.http.db.VoteDAO;
-import org.broadinstitute.consent.http.mail.MailService;
+import org.broadinstitute.consent.http.mail.SendgridAPI;
 import org.broadinstitute.consent.http.mail.freemarker.FreeMarkerTemplateHelper;
 import org.broadinstitute.consent.http.models.dto.DatasetMailDTO;
 import org.junit.Before;
@@ -64,14 +64,14 @@ public class EmailNotifierServiceTest {
         mConfig.setActivateEmailNotifications(serviceActive);
         mConfig.setGoogleAccount("");
         mConfig.setSendGridApiKey("");
-        MailService mailService = new MailService(mConfig);
+        SendgridAPI sendgridAPI = new SendgridAPI(mConfig);
 
         FreeMarkerConfiguration fmConfig = new FreeMarkerConfiguration();
         fmConfig.setDefaultEncoding("UTF-8");
         fmConfig.setTemplateDirectory("/freemarker");
         FreeMarkerTemplateHelper helper = new FreeMarkerTemplateHelper(fmConfig);
         service = new EmailNotifierService(collectionDAO, consentDAO, voteDAO, electionDAO, userDAO,
-                emailDAO, mailService, helper, serverUrl, serviceActive);
+                emailDAO, sendgridAPI, helper, serverUrl, serviceActive);
     }
 
     @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/EmailNotifierServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/EmailNotifierServiceTest.java
@@ -8,7 +8,7 @@ import org.broadinstitute.consent.http.db.ElectionDAO;
 import org.broadinstitute.consent.http.db.MailMessageDAO;
 import org.broadinstitute.consent.http.db.UserDAO;
 import org.broadinstitute.consent.http.db.VoteDAO;
-import org.broadinstitute.consent.http.mail.SendgridAPI;
+import org.broadinstitute.consent.http.mail.SendGridAPI;
 import org.broadinstitute.consent.http.mail.freemarker.FreeMarkerTemplateHelper;
 import org.broadinstitute.consent.http.models.dto.DatasetMailDTO;
 import org.junit.Before;
@@ -64,14 +64,14 @@ public class EmailNotifierServiceTest {
         mConfig.setActivateEmailNotifications(serviceActive);
         mConfig.setGoogleAccount("");
         mConfig.setSendGridApiKey("");
-        SendgridAPI sendgridAPI = new SendgridAPI(mConfig);
+        SendGridAPI sendGridAPI = new SendGridAPI(mConfig);
 
         FreeMarkerConfiguration fmConfig = new FreeMarkerConfiguration();
         fmConfig.setDefaultEncoding("UTF-8");
         fmConfig.setTemplateDirectory("/freemarker");
         FreeMarkerTemplateHelper helper = new FreeMarkerTemplateHelper(fmConfig);
         service = new EmailNotifierService(collectionDAO, consentDAO, voteDAO, electionDAO, userDAO,
-                emailDAO, sendgridAPI, helper, serverUrl, serviceActive);
+                emailDAO, sendGridAPI, helper, serverUrl, serviceActive);
     }
 
     @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/SendGridAPITest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/SendGridAPITest.java
@@ -1,7 +1,7 @@
 package org.broadinstitute.consent.http.service;
 
 import org.broadinstitute.consent.http.configurations.MailConfiguration;
-import org.broadinstitute.consent.http.mail.SendgridAPI;
+import org.broadinstitute.consent.http.mail.SendGridAPI;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -13,12 +13,12 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.MockitoAnnotations.openMocks;
 
-public class SendgridAPITest {
+public class SendGridAPITest {
 
     private static final String TO = "to@broadinstitute.org";
     private static final String ID = "DUL-123";
     private static final String TYPE = "Data Use Limitations";
-    private SendgridAPI sendgridAPI;
+    private SendGridAPI sendGridAPI;
 
     @Mock
     private Writer template;
@@ -30,7 +30,7 @@ public class SendgridAPITest {
         config.setSendGridApiKey("test");
         config.setGoogleAccount("from@broadinstitute.org");
         config.setActivateEmailNotifications(false);
-        sendgridAPI = new SendgridAPI(config);
+        sendGridAPI = new SendGridAPI(config);
         doNothing().when(template).write(anyString());
     }
 
@@ -48,7 +48,7 @@ public class SendgridAPITest {
     @Test
     public void testCollectMessage() {
         try {
-            sendgridAPI.sendCollectMessage(TO, ID, TYPE, template);
+            sendGridAPI.sendCollectMessage(TO, ID, TYPE, template);
         } catch (Exception e) {
             Assert.fail("Should not throw exception");
         }
@@ -57,7 +57,7 @@ public class SendgridAPITest {
     @Test
     public void testNewCaseMessage() {
         try {
-            sendgridAPI.sendNewCaseMessage(TO, ID, TYPE, template);
+            sendGridAPI.sendNewCaseMessage(TO, ID, TYPE, template);
         } catch (Exception e) {
             Assert.fail("Should not throw exception");
         }
@@ -66,7 +66,7 @@ public class SendgridAPITest {
     @Test
     public void testReminderMessage() {
         try {
-            sendgridAPI.sendReminderMessage(TO, ID, TYPE, template);
+            sendGridAPI.sendReminderMessage(TO, ID, TYPE, template);
         } catch (Exception e) {
             Assert.fail("Should not throw exception");
         }
@@ -75,7 +75,7 @@ public class SendgridAPITest {
     @Test
     public void testDisabledDatasetMessage() {
         try {
-            sendgridAPI.sendDisabledDatasetMessage(TO, ID, TYPE, template);
+            sendGridAPI.sendDisabledDatasetMessage(TO, ID, TYPE, template);
         } catch (Exception e) {
             Assert.fail("Should not throw exception");
         }
@@ -84,7 +84,7 @@ public class SendgridAPITest {
     @Test
     public void testNewDARRequests() {
         try {
-            sendgridAPI.sendNewDARRequests(TO, ID, TYPE, template);
+            sendGridAPI.sendNewDARRequests(TO, ID, TYPE, template);
         } catch (Exception e) {
             Assert.fail("Should not throw exception");
         }
@@ -93,7 +93,7 @@ public class SendgridAPITest {
     @Test
     public void testCancelDARRequestMessage() {
         try {
-            sendgridAPI.sendCancelDARRequestMessage(TO, ID, TYPE, template);
+            sendGridAPI.sendCancelDARRequestMessage(TO, ID, TYPE, template);
         } catch (Exception e) {
             Assert.fail("Should not throw exception");
         }
@@ -102,7 +102,7 @@ public class SendgridAPITest {
     @Test
     public void testFlaggedDarAdminApprovedMessage() {
         try {
-            sendgridAPI.sendFlaggedDarAdminApprovedMessage(TO, ID, TYPE, template);
+            sendGridAPI.sendFlaggedDarAdminApprovedMessage(TO, ID, TYPE, template);
         } catch (Exception e) {
             Assert.fail("Should not throw exception");
         }
@@ -111,7 +111,7 @@ public class SendgridAPITest {
     @Test
     public void testClosedDatasetElectionsMessage() {
         try {
-            sendgridAPI.sendClosedDatasetElectionsMessage(TO, ID, TYPE, template);
+            sendGridAPI.sendClosedDatasetElectionsMessage(TO, ID, TYPE, template);
         } catch (Exception e) {
             Assert.fail("Should not throw exception");
         }
@@ -120,7 +120,7 @@ public class SendgridAPITest {
     @Test
     public void testDelegateResponsibilitiesMessage() {
         try {
-            sendgridAPI.sendDelegateResponsibilitiesMessage(TO, template);
+            sendGridAPI.sendDelegateResponsibilitiesMessage(TO, template);
         } catch (Exception e) {
             Assert.fail("Should not throw exception");
         }
@@ -129,7 +129,7 @@ public class SendgridAPITest {
     @Test
     public void testNewResearcherCreatedMessage() {
         try {
-            sendgridAPI.sendNewResearcherCreatedMessage(TO, template);
+            sendGridAPI.sendNewResearcherCreatedMessage(TO, template);
         } catch (Exception e) {
             Assert.fail("Should not throw exception");
         }
@@ -138,7 +138,7 @@ public class SendgridAPITest {
     @Test
     public void testNewResearcherApprovedMessage() {
         try {
-            sendgridAPI.sendNewResearcherApprovedMessage(TO, template, "Test");
+            sendGridAPI.sendNewResearcherApprovedMessage(TO, template, "Test");
         } catch (Exception e) {
             Assert.fail("Should not throw exception");
         }
@@ -147,7 +147,7 @@ public class SendgridAPITest {
     @Test
     public void testDataCustodianApprovalMessage() {
         try {
-            sendgridAPI.sendDataCustodianApprovalMessage(TO, "Test", template);
+            sendGridAPI.sendDataCustodianApprovalMessage(TO, "Test", template);
         } catch (Exception e) {
             Assert.fail("Should not throw exception");
         }

--- a/src/test/java/org/broadinstitute/consent/http/service/SendGridAPITest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/SendGridAPITest.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.consent.http.service;
 
+import com.sendgrid.Response;
 import org.broadinstitute.consent.http.configurations.MailConfiguration;
 import org.broadinstitute.consent.http.mail.SendGridAPI;
 import org.junit.Assert;
@@ -8,7 +9,9 @@ import org.junit.Test;
 import org.mockito.Mock;
 
 import java.io.Writer;
+import java.util.Optional;
 
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.MockitoAnnotations.openMocks;
@@ -33,17 +36,6 @@ public class SendGridAPITest {
         sendGridAPI = new SendGridAPI(config);
         doNothing().when(template).write(anyString());
     }
-
-// TODO: Update to reflect new api behavior
-//    @Test(expected=MessagingException.class)
-//    public void testCollectMessageFailure() throws Exception {
-//        MailConfiguration config = new MailConfiguration();
-//        config.setSendGridApiKey("test");
-//        config.setGoogleAccount("from@broadinstitute.org");
-//        config.setActivateEmailNotifications(true);
-//        sendgridAPI = new SendgridAPI(config);
-//        sendgridAPI.sendCollectMessage(TO, ID, TYPE, template);
-//    }
 
     @Test
     public void testCollectMessage() {

--- a/src/test/java/org/broadinstitute/consent/http/service/SendgridAPITest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/SendgridAPITest.java
@@ -1,37 +1,38 @@
 package org.broadinstitute.consent.http.service;
 
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doNothing;
-
-import java.io.Writer;
-import java.util.Collections;
-import javax.mail.MessagingException;
 import org.broadinstitute.consent.http.configurations.MailConfiguration;
-import org.broadinstitute.consent.http.mail.MailService;
+import org.broadinstitute.consent.http.mail.SendgridAPI;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 
-public class MailServiceTest {
+import javax.mail.MessagingException;
+import java.io.Writer;
+import java.util.Collections;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.MockitoAnnotations.openMocks;
+
+public class SendgridAPITest {
 
     private static final String TO = "to@broadinstitute.org";
     private static final String ID = "DUL-123";
     private static final String TYPE = "Data Use Limitations";
-    private MailService mailService;
+    private SendgridAPI sendgridAPI;
 
     @Mock
     private Writer template;
 
     @Before
     public void setUp() throws Exception {
-        MockitoAnnotations.initMocks(this);
+        openMocks(this);
         MailConfiguration config = new MailConfiguration();
         config.setSendGridApiKey("test");
         config.setGoogleAccount("from@broadinstitute.org");
         config.setActivateEmailNotifications(false);
-        mailService = new MailService(config);
+        sendgridAPI = new SendgridAPI(config);
         doNothing().when(template).write(anyString());
     }
 
@@ -41,14 +42,14 @@ public class MailServiceTest {
         config.setSendGridApiKey("test");
         config.setGoogleAccount("from@broadinstitute.org");
         config.setActivateEmailNotifications(true);
-        mailService = new MailService(config);
-        mailService.sendCollectMessage(Collections.singleton(TO), ID, TYPE, template);
+        sendgridAPI = new SendgridAPI(config);
+        sendgridAPI.sendCollectMessage(Collections.singleton(TO), ID, TYPE, template);
     }
 
     @Test
     public void testCollectMessage() {
         try {
-            mailService.sendCollectMessage(Collections.singleton(TO), ID, TYPE, template);
+            sendgridAPI.sendCollectMessage(Collections.singleton(TO), ID, TYPE, template);
         } catch (Exception e) {
             Assert.fail("Should not throw exception");
         }
@@ -57,7 +58,7 @@ public class MailServiceTest {
     @Test
     public void testNewCaseMessage() {
         try {
-            mailService.sendNewCaseMessage(Collections.singleton(TO), ID, TYPE, template);
+            sendgridAPI.sendNewCaseMessage(Collections.singleton(TO), ID, TYPE, template);
         } catch (Exception e) {
             Assert.fail("Should not throw exception");
         }
@@ -66,7 +67,7 @@ public class MailServiceTest {
     @Test
     public void testReminderMessage() {
         try {
-            mailService.sendReminderMessage(Collections.singleton(TO), ID, TYPE, template);
+            sendgridAPI.sendReminderMessage(Collections.singleton(TO), ID, TYPE, template);
         } catch (Exception e) {
             Assert.fail("Should not throw exception");
         }
@@ -75,7 +76,7 @@ public class MailServiceTest {
     @Test
     public void testDisabledDatasetMessage() {
         try {
-            mailService.sendDisabledDatasetMessage(Collections.singleton(TO), ID, TYPE, template);
+            sendgridAPI.sendDisabledDatasetMessage(Collections.singleton(TO), ID, TYPE, template);
         } catch (Exception e) {
             Assert.fail("Should not throw exception");
         }
@@ -84,7 +85,7 @@ public class MailServiceTest {
     @Test
     public void testNewDARRequests() {
         try {
-            mailService.sendNewDARRequests(Collections.singleton(TO), ID, TYPE, template);
+            sendgridAPI.sendNewDARRequests(Collections.singleton(TO), ID, TYPE, template);
         } catch (Exception e) {
             Assert.fail("Should not throw exception");
         }
@@ -93,7 +94,7 @@ public class MailServiceTest {
     @Test
     public void testCancelDARRequestMessage() {
         try {
-            mailService.sendCancelDARRequestMessage(Collections.singleton(TO), ID, TYPE, template);
+            sendgridAPI.sendCancelDARRequestMessage(Collections.singleton(TO), ID, TYPE, template);
         } catch (Exception e) {
             Assert.fail("Should not throw exception");
         }
@@ -102,7 +103,7 @@ public class MailServiceTest {
     @Test
     public void testFlaggedDarAdminApprovedMessage() {
         try {
-            mailService.sendFlaggedDarAdminApprovedMessage(Collections.singleton(TO), ID, TYPE, template);
+            sendgridAPI.sendFlaggedDarAdminApprovedMessage(Collections.singleton(TO), ID, TYPE, template);
         } catch (Exception e) {
             Assert.fail("Should not throw exception");
         }
@@ -111,7 +112,7 @@ public class MailServiceTest {
     @Test
     public void testClosedDatasetElectionsMessage() {
         try {
-            mailService.sendClosedDatasetElectionsMessage(Collections.singleton(TO), ID, TYPE, template);
+            sendgridAPI.sendClosedDatasetElectionsMessage(Collections.singleton(TO), ID, TYPE, template);
         } catch (Exception e) {
             Assert.fail("Should not throw exception");
         }
@@ -120,7 +121,7 @@ public class MailServiceTest {
     @Test
     public void testDelegateResponsibilitiesMessage() {
         try {
-            mailService.sendDelegateResponsibilitiesMessage(Collections.singleton(TO), template);
+            sendgridAPI.sendDelegateResponsibilitiesMessage(Collections.singleton(TO), template);
         } catch (Exception e) {
             Assert.fail("Should not throw exception");
         }
@@ -129,7 +130,7 @@ public class MailServiceTest {
     @Test
     public void testNewResearcherCreatedMessage() {
         try {
-            mailService.sendNewResearcherCreatedMessage(Collections.singleton(TO), template);
+            sendgridAPI.sendNewResearcherCreatedMessage(Collections.singleton(TO), template);
         } catch (Exception e) {
             Assert.fail("Should not throw exception");
         }
@@ -138,7 +139,7 @@ public class MailServiceTest {
     @Test
     public void testNewResearcherApprovedMessage() {
         try {
-            mailService.sendNewResearcherApprovedMessage(Collections.singleton(TO), template, "Test");
+            sendgridAPI.sendNewResearcherApprovedMessage(Collections.singleton(TO), template, "Test");
         } catch (Exception e) {
             Assert.fail("Should not throw exception");
         }
@@ -147,7 +148,7 @@ public class MailServiceTest {
     @Test
     public void testDataCustodianApprovalMessage() {
         try {
-            mailService.sendDataCustodianApprovalMessage(TO, "Test", template);
+            sendgridAPI.sendDataCustodianApprovalMessage(TO, "Test", template);
         } catch (Exception e) {
             Assert.fail("Should not throw exception");
         }

--- a/src/test/java/org/broadinstitute/consent/http/service/SendgridAPITest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/SendgridAPITest.java
@@ -7,9 +7,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 
-import javax.mail.MessagingException;
 import java.io.Writer;
-import java.util.Collections;
 
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
@@ -36,20 +34,21 @@ public class SendgridAPITest {
         doNothing().when(template).write(anyString());
     }
 
-    @Test(expected=MessagingException.class)
-    public void testCollectMessageFailure() throws Exception {
-        MailConfiguration config = new MailConfiguration();
-        config.setSendGridApiKey("test");
-        config.setGoogleAccount("from@broadinstitute.org");
-        config.setActivateEmailNotifications(true);
-        sendgridAPI = new SendgridAPI(config);
-        sendgridAPI.sendCollectMessage(Collections.singleton(TO), ID, TYPE, template);
-    }
+// TODO: Update to reflect new api behavior
+//    @Test(expected=MessagingException.class)
+//    public void testCollectMessageFailure() throws Exception {
+//        MailConfiguration config = new MailConfiguration();
+//        config.setSendGridApiKey("test");
+//        config.setGoogleAccount("from@broadinstitute.org");
+//        config.setActivateEmailNotifications(true);
+//        sendgridAPI = new SendgridAPI(config);
+//        sendgridAPI.sendCollectMessage(TO, ID, TYPE, template);
+//    }
 
     @Test
     public void testCollectMessage() {
         try {
-            sendgridAPI.sendCollectMessage(Collections.singleton(TO), ID, TYPE, template);
+            sendgridAPI.sendCollectMessage(TO, ID, TYPE, template);
         } catch (Exception e) {
             Assert.fail("Should not throw exception");
         }
@@ -58,7 +57,7 @@ public class SendgridAPITest {
     @Test
     public void testNewCaseMessage() {
         try {
-            sendgridAPI.sendNewCaseMessage(Collections.singleton(TO), ID, TYPE, template);
+            sendgridAPI.sendNewCaseMessage(TO, ID, TYPE, template);
         } catch (Exception e) {
             Assert.fail("Should not throw exception");
         }
@@ -67,7 +66,7 @@ public class SendgridAPITest {
     @Test
     public void testReminderMessage() {
         try {
-            sendgridAPI.sendReminderMessage(Collections.singleton(TO), ID, TYPE, template);
+            sendgridAPI.sendReminderMessage(TO, ID, TYPE, template);
         } catch (Exception e) {
             Assert.fail("Should not throw exception");
         }
@@ -76,7 +75,7 @@ public class SendgridAPITest {
     @Test
     public void testDisabledDatasetMessage() {
         try {
-            sendgridAPI.sendDisabledDatasetMessage(Collections.singleton(TO), ID, TYPE, template);
+            sendgridAPI.sendDisabledDatasetMessage(TO, ID, TYPE, template);
         } catch (Exception e) {
             Assert.fail("Should not throw exception");
         }
@@ -85,7 +84,7 @@ public class SendgridAPITest {
     @Test
     public void testNewDARRequests() {
         try {
-            sendgridAPI.sendNewDARRequests(Collections.singleton(TO), ID, TYPE, template);
+            sendgridAPI.sendNewDARRequests(TO, ID, TYPE, template);
         } catch (Exception e) {
             Assert.fail("Should not throw exception");
         }
@@ -94,7 +93,7 @@ public class SendgridAPITest {
     @Test
     public void testCancelDARRequestMessage() {
         try {
-            sendgridAPI.sendCancelDARRequestMessage(Collections.singleton(TO), ID, TYPE, template);
+            sendgridAPI.sendCancelDARRequestMessage(TO, ID, TYPE, template);
         } catch (Exception e) {
             Assert.fail("Should not throw exception");
         }
@@ -103,7 +102,7 @@ public class SendgridAPITest {
     @Test
     public void testFlaggedDarAdminApprovedMessage() {
         try {
-            sendgridAPI.sendFlaggedDarAdminApprovedMessage(Collections.singleton(TO), ID, TYPE, template);
+            sendgridAPI.sendFlaggedDarAdminApprovedMessage(TO, ID, TYPE, template);
         } catch (Exception e) {
             Assert.fail("Should not throw exception");
         }
@@ -112,7 +111,7 @@ public class SendgridAPITest {
     @Test
     public void testClosedDatasetElectionsMessage() {
         try {
-            sendgridAPI.sendClosedDatasetElectionsMessage(Collections.singleton(TO), ID, TYPE, template);
+            sendgridAPI.sendClosedDatasetElectionsMessage(TO, ID, TYPE, template);
         } catch (Exception e) {
             Assert.fail("Should not throw exception");
         }
@@ -121,7 +120,7 @@ public class SendgridAPITest {
     @Test
     public void testDelegateResponsibilitiesMessage() {
         try {
-            sendgridAPI.sendDelegateResponsibilitiesMessage(Collections.singleton(TO), template);
+            sendgridAPI.sendDelegateResponsibilitiesMessage(TO, template);
         } catch (Exception e) {
             Assert.fail("Should not throw exception");
         }
@@ -130,7 +129,7 @@ public class SendgridAPITest {
     @Test
     public void testNewResearcherCreatedMessage() {
         try {
-            sendgridAPI.sendNewResearcherCreatedMessage(Collections.singleton(TO), template);
+            sendgridAPI.sendNewResearcherCreatedMessage(TO, template);
         } catch (Exception e) {
             Assert.fail("Should not throw exception");
         }
@@ -139,7 +138,7 @@ public class SendgridAPITest {
     @Test
     public void testNewResearcherApprovedMessage() {
         try {
-            sendgridAPI.sendNewResearcherApprovedMessage(Collections.singleton(TO), template, "Test");
+            sendgridAPI.sendNewResearcherApprovedMessage(TO, template, "Test");
         } catch (Exception e) {
             Assert.fail("Should not throw exception");
         }


### PR DESCRIPTION
## Addresses
Partially addresses https://broadworkbench.atlassian.net/browse/DUOS-2059

This PR makes some minor, but extensive, changes to how we send messages via SendGrid. This is already a large PR, so I am hoping to move this through before tackling the original goal of capturing SendGrid response info per email we send.

### Changes:
* Renamed the `MailService` class to `SendGridAPI` for clarity. Unfortunately, git didn't retain the rename and considers it a +/-
* Migrated all uses of sending multiple messages to sending a single message
  * I want to do this so that we can more easily track what was sent via SendGrid per message
* Lots of message and test refactoring to accomplish ☝🏽 

---
A future PR will:
* Make use of the returned SendGrid `Response` 
* Improve testing of `SendGridAPI` (the actual `SendGrid` object is not mockable in the current implementation)
* Save a SendGrid response per email entity

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
