### PR TITLE
[DUOS-2182][risk=medium] - Ensure results are filtered to appropriate objects.

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/DataAccessRequestDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DataAccessRequestDAO.java
@@ -67,11 +67,12 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
 
   @SqlQuery(
         " SELECT dar.user_id FROM data_access_request dar "
-          + "  LEFT JOIN dar_dataset dd ON dd.reference_id = dar.reference_id AND dd.dataset_id = :datasetId  "
+          + "  LEFT JOIN dar_dataset dd ON dd.reference_id = dar.reference_id "
           + "  WHERE dar.draft = false"
             + "  AND (EXISTS (SELECT 1 FROM election e"
           + "  INNER JOIN vote v on v.electionId = e.election_id AND LOWER(v.type) = 'final'"
           + "  WHERE v.vote = true AND LOWER(e.election_type) = 'dataaccess'"
+          + "  AND e.dataset_id = :datasetId"
             + "  AND e.reference_id = dar.reference_id))"
             + "  AND (LOWER(dar.data->>'status') != 'archived' OR dar.data->>'status' IS NULL)")
   List<Integer> findAllUserIdsWithApprovedDARsByDatasetId(@Bind("datasetId") Integer datasetId);

--- a/src/main/java/org/broadinstitute/consent/http/db/DataAccessRequestDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DataAccessRequestDAO.java
@@ -45,7 +45,7 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
 
 
   /**
-   * Find all non-draft DataAccessRequests for the given datasetId
+   * Find all non-draft, approved DataAccessRequests for the given datasetId
    *
    * @return List<DataAccessRequest>
    */
@@ -62,7 +62,7 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
               + " WHERE lower(v.type) = 'final' AND v.vote = true AND e.dataset_id = :datasetId "
               + " AND e.archived IS NOT true AND lower(e.election_type) = 'dataaccess'"
   )
-  List<DataAccessRequest> findAllDataAccessRequestsByDatasetId(@Bind("datasetId") Integer datasetId);
+  List<DataAccessRequest> findAllApprovedDataAccessRequestsByDatasetId(@Bind("datasetId") Integer datasetId);
 
 
   @SqlQuery(

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
@@ -543,7 +543,7 @@ public class DataAccessRequestService {
         }
         StringBuilder builder = new StringBuilder();
         builder.append(dataAccessReportsParser.getDatasetApprovedUsersHeader(requestingUser));
-        List<DataAccessRequest> darList = dataAccessRequestDAO.findAllDataAccessRequestsByDatasetId(datasetId);
+        List<DataAccessRequest> darList = dataAccessRequestDAO.findAllApprovedDataAccessRequestsByDatasetId(datasetId);
         if (CollectionUtils.isNotEmpty(darList)){
             for(DataAccessRequest dar: darList){
                 String referenceId = dar.getReferenceId();

--- a/src/main/java/org/broadinstitute/consent/http/service/MetricsService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/MetricsService.java
@@ -236,7 +236,7 @@ public class MetricsService {
 
     //find dars with the given datasetId in their list of datasetIds, datasetId is a String so it can be converted to jsonb in query
     //convert all dars into smaller objects that only contain the information needed
-    List<DataAccessRequest> dars = darDAO.findAllDataAccessRequestsByDatasetId(datasetId);
+    List<DataAccessRequest> dars = darDAO.findAllApprovedDataAccessRequestsByDatasetId(datasetId);
     List<Integer> darCollectionIds = dars.stream().map(DataAccessRequest::getCollectionId).collect(Collectors.toList());
     List<DarCollection> darCollections = darCollectionIds.isEmpty() ? List.of() :
             darCollectionDAO.findDARCollectionByCollectionIds(darCollectionIds);

--- a/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
@@ -377,6 +377,47 @@ public class DataAccessRequestDAOTest extends DAOTestHelper {
         assertTrue(returnedDARs.isEmpty());
     }
 
+    // See: https://broadworkbench.atlassian.net/browse/DUOS-2182
+    @Test
+    public void testEnsureOnlyDataAccessRequestsByDatasetIdReturnsJustForSpecificDatasetId(){
+        String darCode1 = "DAR-" + RandomUtils.nextInt(100, 1000);
+        String darCode2 = "DAR-" + RandomUtils.nextInt(100, 1000);
+        Dataset dataset1 = createDataset();
+        Dataset dataset2 = createDataset();
+        User user1 = createUser();
+        User user2 = createUser();
+        DataAccessRequest testDar1 = createDAR(user1, dataset1, darCode1);
+        DataAccessRequest testDar2 = createDAR(user2, dataset2, darCode2);
+
+        Election e1 = createDataAccessElection(testDar1.getReferenceId(), dataset1.getDataSetId());
+        Vote v1 = createFinalVote(dataset1.getCreateUserId(), e1.getElectionId());
+        Date now = new Date();
+        voteDAO.updateVote(true,
+                "",
+                now,
+                v1.getVoteId(),
+                false,
+                e1.getElectionId(),
+                now,
+                false);
+
+        Election e2 = createDataAccessElection(testDar2.getReferenceId(), dataset2.getDataSetId());
+        Vote v2 = createFinalVote(dataset2.getCreateUserId(), e2.getElectionId());
+        now = new Date();
+        voteDAO.updateVote(true,
+                "",
+                now,
+                v2.getVoteId(),
+                false,
+                e2.getElectionId(),
+                now,
+                false);
+
+        List<DataAccessRequest> dars = dataAccessRequestDAO.findAllDataAccessRequestsByDatasetId(dataset1.getDataSetId());
+        assertEquals(1, dars.size());
+        assertTrue(dars.get(0).datasetIds.contains(dataset1.getDataSetId()));
+    }
+
     @Test
     public void testFindAllApprovedDataAccessRequestsByDatasetId() {
         String darCode = "DAR-" + RandomUtils.nextInt(100, 1000);

--- a/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
@@ -366,13 +366,13 @@ public class DataAccessRequestDAOTest extends DAOTestHelper {
     public void testFindAllByDatasetIdArchived() {
         String darCode = "DAR-" + RandomUtils.nextInt(100, 1000);
         Dataset dataset = createDataset();
-        List<DataAccessRequest> dars = dataAccessRequestDAO.findAllDataAccessRequestsByDatasetId(dataset.getDataSetId());
+        List<DataAccessRequest> dars = dataAccessRequestDAO.findAllApprovedDataAccessRequestsByDatasetId(dataset.getDataSetId());
         assertTrue(dars.isEmpty());
 
         User user = createUserWithInstitution();
         DataAccessRequest testDar = createDAR(user, dataset, darCode);
         dataAccessRequestDAO.archiveByReferenceIds(List.of(testDar.getReferenceId()));
-        List returnedDARs = dataAccessRequestDAO.findAllDataAccessRequestsByDatasetId(dataset.getDataSetId());
+        List returnedDARs = dataAccessRequestDAO.findAllApprovedDataAccessRequestsByDatasetId(dataset.getDataSetId());
         assertTrue(returnedDARs.isEmpty());
     }
 
@@ -412,7 +412,7 @@ public class DataAccessRequestDAOTest extends DAOTestHelper {
                 now,
                 false);
 
-        List<DataAccessRequest> dars = dataAccessRequestDAO.findAllDataAccessRequestsByDatasetId(dataset1.getDataSetId());
+        List<DataAccessRequest> dars = dataAccessRequestDAO.findAllApprovedDataAccessRequestsByDatasetId(dataset1.getDataSetId());
         assertEquals(1, dars.size());
         assertTrue(dars.get(0).datasetIds.contains(dataset1.getDataSetId()));
     }
@@ -437,7 +437,7 @@ public class DataAccessRequestDAOTest extends DAOTestHelper {
         assertTrue(dataAccessRequestDAO.findAllUserIdsWithApprovedDARsByDatasetId(dataset1.getDataSetId()).isEmpty());
         assertTrue(dataAccessRequestDAO.findAllUserIdsWithApprovedDARsByDatasetId(dataset2.getDataSetId()).isEmpty());
 
-        assertEquals(0, dataAccessRequestDAO.findAllDataAccessRequestsByDatasetId(dataset2.getDataSetId()).size());
+        assertEquals(0, dataAccessRequestDAO.findAllApprovedDataAccessRequestsByDatasetId(dataset2.getDataSetId()).size());
 
         Election e1 = createDataAccessElection(testDar1.getReferenceId(), dataset1.getDataSetId());
         Vote v1 = createFinalVote(dataset1.getCreateUserId(), e1.getElectionId());

--- a/src/test/java/org/broadinstitute/consent/http/service/MetricsServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/MetricsServiceTest.java
@@ -93,7 +93,7 @@ public class MetricsServiceTest {
     collection.setDarCode("DAR-" + RandomUtils.nextInt(1, 999999999));
 
     when(dataSetDAO.findDatasetDTOWithPropertiesByDatasetId(any())).thenReturn(dataset);
-    when(darDAO.findAllDataAccessRequestsByDatasetId(any())).thenReturn(dars);
+    when(darDAO.findAllApprovedDataAccessRequestsByDatasetId(any())).thenReturn(dars);
     when(darCollectionDAO.findDARCollectionByCollectionIds(any())).thenReturn(List.of(collection));
     when(electionDAO.findLastElectionsByReferenceIdsAndType(any(), eq("DataAccess"))).thenReturn(election);
 


### PR DESCRIPTION
[DUOS-2182](https://broadworkbench.atlassian.net/browse/DUOS-2182) is a production bug that returns unintended information in a response.  
The underlying queries in two code paths were performing `LEFT JOIN` operations with terms intending to reduce the result set. LEFT JOIN will enrich, not reduce.

Tests and assertions were added to confirm the issues in` DataAccessRequestDAOTest.java` and updated queries were developed for `DataAccessRequestDAO.java` that reduced the results to only include responses with the specific dataset ID.

The impact to the MetricsService was considered, but the team indicated they're not being used in a meaningful way at this time.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
