### PR TITLE
[DUOS-2198][risk=low] Adds tests and fix to confirm needsApproval value is set and returned.

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DatasetReducer.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DatasetReducer.java
@@ -37,6 +37,10 @@ public class DatasetReducer implements LinkedHashMapRowReducer<Integer, Dataset>
       Integer dsIdInUse = rowView.getColumn("in_use", Integer.class);
       dataset.setDeletable(Objects.isNull(dsIdInUse));
     }
+    if (hasColumn(rowView, "needs_approval", Boolean.class)) {
+      Boolean needsApproval = rowView.getColumn("needs_approval", Boolean.class);
+      dataset.setNeedsApproval(needsApproval);
+    }
     if (hasColumn(rowView, "dac_approval", Boolean.class)) {
       dataset.setDacApproval(rowView.getColumn("dac_approval", Boolean.class));
     }

--- a/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
@@ -64,6 +64,7 @@ public class DatasetDAOTest extends DAOTestHelper {
         assertEquals(dac.getDacId(), dataset.getDacId());
         assertEquals(doc, dataset.getSharingPlanDocument());
         assertEquals(docName, dataset.getSharingPlanDocumentName());
+        assertFalse(dataset.getNeedsApproval());
     }
 
     @Test
@@ -142,6 +143,7 @@ public class DatasetDAOTest extends DAOTestHelper {
         assertEquals(consent.getConsentId(), datasets.get(0).getConsentId());
         assertEquals(consent.getTranslatedUseRestriction(), datasets.get(0).getTranslatedUseRestriction());
         assertFalse(datasets.get(0).getProperties().isEmpty());
+        assertTrue(datasets.get(0).getNeedsApproval());
     }
 
     @Test
@@ -554,6 +556,12 @@ public class DatasetDAOTest extends DAOTestHelper {
         assertNotNull(updatedDataset);
         assertEquals(datasetId, updatedDataset.getDataSetId());
         assertTrue(updatedDataset.getDacApproval());
+        datasetDAO.updateDatasetApproval(false, Instant.now(), userId, datasetId);
+        Dataset updatedDatasetAfterApprovalFalse = datasetDAO.findDatasetById(datasetId);
+        assertNotNull(updatedDatasetAfterApprovalFalse);
+        assertEquals(datasetId, updatedDatasetAfterApprovalFalse.getDataSetId());
+        assertFalse(updatedDatasetAfterApprovalFalse.getDacApproval());
+
     }
 
     private DarCollection createDarCollectionWithDatasets(int dacId, User user, List<Dataset> datasets) {


### PR DESCRIPTION
As part of migrating the front end to the new /api/dataset/v2/{id} endpoint in [DUOS-2198](https://broadworkbench.atlassian.net/browse/DUOS-2198) saving changes to datasets were failing because the needs approval value was not being returned.

This PR:

- Updates the Dataset Reducer to include the needs_approval value from the database.
- Adds tests to confirm the needs_approval value is set to either true or false (as appropriate).
- Validates getDacApproval will return false if present.  Additional work outside the scope of this PR will be done to refactor getDacApproval and features that rely on this value.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
