### PR TITLE
[DUOS-1740][risk=no] Quiet CI Output

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -26,13 +26,13 @@ jobs:
       - name: Test Only
         if: github.actor == 'dependabot[bot]'
         env:
-          MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
-        run: mvn clean test --no-transfer-progress
+          MAVEN_OPTS: -Dorg.slf4j.simpleLogger.defaultLogLevel=warn -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
+        run: mvn clean test  --batch-mode
       - name: Test Report
         if: github.actor != 'dependabot[bot]'
         env:
           COVERALLS_TOKEN: ${{ secrets.COVERALLS_TOKEN }}
-          MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
+          MAVEN_OPTS: -Dorg.slf4j.simpleLogger.defaultLogLevel=warn -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
         run: |
           mvn -v
-          mvn clean jacoco:prepare-agent test jacoco:report coveralls:report -DrepoToken=$COVERALLS_TOKEN --no-transfer-progress
+          mvn clean jacoco:prepare-agent test jacoco:report coveralls:report -DrepoToken=$COVERALLS_TOKEN  --batch-mode

--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -19,7 +19,7 @@ jobs:
             ${{ runner.os }}-maven-
       - name: Package
         env:
-          MAVEN_OPTS: -Dmaven.test.skip=true -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
+          MAVEN_OPTS: -Dorg.slf4j.simpleLogger.defaultLogLevel=warn -Dmaven.test.skip=true -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
         run: |
           mvn -v
-          mvn clean package --no-transfer-progress
+          mvn clean package  --batch-mode

--- a/.github/workflows/owasp.yaml
+++ b/.github/workflows/owasp.yaml
@@ -14,9 +14,11 @@ jobs:
           distribution: 'temurin'
           java-version: 17
       - name: Run Report
+        env:
+          MAVEN_OPTS: -Dorg.slf4j.simpleLogger.defaultLogLevel=warn
         run: |
           mvn -v
-          mvn dependency-check:check --no-transfer-progress
+          mvn dependency-check:check --batch-mode
       - name: Archive Report
         uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
Addresses
https://broadworkbench.atlassian.net/browse/DUOS-1740

Minor update to mvn commands to quiet the output. See also https://github.com/DataBiosphere/consent-ontology/pull/722 for additional background.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
