### PR TITLE
[DUOS-2205][risk=low] Support a user who has multiple chairperson or membership roles.  Allow updating DAC on a dataset.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -154,3 +154,6 @@ automation/.bsp/*
 /config/
 /config_postgres/
 /env.properties
+
+## Shade
+dependency-reduced-pom.xml

--- a/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
@@ -184,14 +184,15 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
             + "WHERE dataset_id = :datasetId")
     void updateDatasetNeedsApproval(@Bind("datasetId") Integer datasetId, @Bind("needsApproval") Boolean needsApproval);
 
-    @SqlUpdate(
-            "UPDATE dataset " +
-                " SET name = :datasetName," +
-                    " update_date = :updateDate, " +
-                    " update_user_id = :updateUserId, " +
-                    " needs_approval = :needsApproval, " +
-                    " dac_id = :dacId " +
-                " WHERE dataset_id = :datasetId")
+    @SqlUpdate("""
+                 UPDATE dataset
+                 SET name = :datasetName, 
+                     update_date = :updateDate, 
+                     update_user_id = :updateUserId, 
+                     needs_approval = :needsApproval, 
+                     dac_id = :dacId 
+                 WHERE dataset_id = :datasetId
+                 """)
     void updateDataset(@Bind("datasetId") Integer datasetId,
        @Bind("datasetName") String datasetName, @Bind("updateDate") Timestamp updateDate, @Bind("updateUserId") Integer updateUserId,
        @Bind("needsApproval") Boolean needsApproval, @Bind("dacId") Integer updatedDacId);

--- a/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
@@ -1,14 +1,9 @@
 package org.broadinstitute.consent.http.db;
 
-import java.sql.Timestamp;
-import java.time.Instant;
-import java.util.Collection;
-import java.util.List;
-import java.util.Set;
 import org.apache.commons.lang3.tuple.Pair;
 import org.broadinstitute.consent.http.db.mapper.AssociationMapper;
-import org.broadinstitute.consent.http.db.mapper.DatasetMapper;
 import org.broadinstitute.consent.http.db.mapper.DatasetDTOWithPropertiesMapper;
+import org.broadinstitute.consent.http.db.mapper.DatasetMapper;
 import org.broadinstitute.consent.http.db.mapper.DatasetPropertyMapper;
 import org.broadinstitute.consent.http.db.mapper.DatasetReducer;
 import org.broadinstitute.consent.http.db.mapper.DictionaryMapper;
@@ -32,6 +27,12 @@ import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 import org.jdbi.v3.sqlobject.statement.UseRowMapper;
 import org.jdbi.v3.sqlobject.statement.UseRowReducer;
 import org.jdbi.v3.sqlobject.transaction.Transactional;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
 
 @RegisterRowMapper(DatasetMapper.class)
 public interface DatasetDAO extends Transactional<DatasetDAO> {
@@ -188,9 +189,12 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
                 " SET name = :datasetName," +
                     " update_date = :updateDate, " +
                     " update_user_id = :updateUserId, " +
-                    " needs_approval = :needsApproval " +
+                    " needs_approval = :needsApproval, " +
+                    " dac_id = :dacId " +
                 " WHERE dataset_id = :datasetId")
-    void updateDataset(@Bind("datasetId") Integer datasetId, @Bind("datasetName") String datasetName, @Bind("updateDate") Timestamp updateDate, @Bind("updateUserId") Integer updateUserId, @Bind("needsApproval") Boolean needsApproval);
+    void updateDataset(@Bind("datasetId") Integer datasetId,
+       @Bind("datasetName") String datasetName, @Bind("updateDate") Timestamp updateDate, @Bind("updateUserId") Integer updateUserId,
+       @Bind("needsApproval") Boolean needsApproval, @Bind("dacId") Integer updatedDacId);
 
     @UseRowReducer(DatasetReducer.class)
     @SqlQuery(

--- a/src/main/java/org/broadinstitute/consent/http/models/User.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/User.java
@@ -279,7 +279,7 @@ public class User {
             this.setRoles(new ArrayList<>());
         }
 
-        if (!this.getRoles().stream().map(UserRole::getRoleId).collect(Collectors.toList()).contains(userRole.getRoleId())) {
+        if (!this.getRoles().contains(userRole)) {
             this.getRoles().add(userRole);
         }
     }

--- a/src/main/java/org/broadinstitute/consent/http/models/UserRole.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/UserRole.java
@@ -79,7 +79,7 @@ public class UserRole {
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(this.userRoleId, this.name, this.dacId);
+        return Objects.hashCode(this.userId, this.name, this.dacId);
     }
 
     @Override
@@ -88,7 +88,9 @@ public class UserRole {
             return false;
         }
         UserRole otherUserRole = (UserRole) o;
-        return Objects.equal(this.getUserRoleId(), otherUserRole.getUserRoleId());
+        return Objects.equal(this.getName(), otherUserRole.getName())
+                && Objects.equal(this.getDacId(), otherUserRole.getDacId())
+                && Objects.equal(this.getUserId(), otherUserRole.getUserId());
     }
 
     @Override

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -300,7 +300,7 @@ public class DatasetService {
         }
 
         updateDatasetProperties(propertiesToUpdate, propertiesToDelete, propertiesToAdd);
-        datasetDAO.updateDataset(datasetId, dataset.getDatasetName(), now, userId, dataset.getNeedsApproval());
+        datasetDAO.updateDataset(datasetId, dataset.getDatasetName(), now, userId, dataset.getNeedsApproval(), dataset.getDacId());
         Dataset updatedDataset = getDatasetWithPropertiesById(datasetId);
         return Optional.of(updatedDataset);
     }

--- a/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
@@ -246,15 +246,18 @@ public class DatasetDAOTest extends DAOTestHelper {
     @Test
     public void testUpdateDataset() {
         Dataset d = createDataset();
+        Dac dac = createDac();
         String name = RandomStringUtils.random(20, true, true);
         Timestamp now = new Timestamp(new Date().getTime());
         Integer userId = RandomUtils.nextInt(1, 1000);
-        datasetDAO.updateDataset(d.getDataSetId(), name, now, userId, true);
+
+        datasetDAO.updateDataset(d.getDataSetId(), name, now, userId, true, dac.getDacId());
         Dataset updated = datasetDAO.findDatasetById(d.getDataSetId());
 
         assertEquals(name, updated.getName());
         assertEquals(now, updated.getUpdateDate());
         assertEquals(userId, updated.getUpdateUserId());
+        assertEquals(dac.getDacId(), updated.getDacId());
     }
 
     @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
@@ -476,7 +476,7 @@ public class DatasetServiceTest {
         Optional<Dataset> updated = datasetService.updateDataset(datasetDTO, datasetId, 1);
         assertNotNull(updated);
         assertTrue(updated.isPresent());
-        verify(datasetDAO, times(1)).updateDataset(eq(datasetId), eq(name), any(), any(), any());
+        verify(datasetDAO, times(1)).updateDataset(eq(datasetId), eq(name), any(), any(), any(), any());
     }
 
     @Test


### PR DESCRIPTION
[DUOS-2205](https://broadworkbench.atlassian.net/browse/DUOS-2205) was a user filed bug report.  The user reported they were not able to see the dataset name on a DAR request they were voting on.  In analyzing the front end for rendering, it was observed that the backend was not returning the complete set of User Roles and dataset the user was responsible for in DAC duties. 

Root cause determination was that code considered a User Role equal with only the same user and role.  This was insufficient because it did not include the DAC the role might pertain to.  Tests were added to verify this fact and validate the code fix would support this use case.

While performing end-to-end testing for this feature, it was noted that dataset updates were not setting an updated DAC ID when changed in the UI.  This PR includes a fix for that as well.

This PR:
1) Ensures UserRole equivalence validation includes the user, the role, and the DAC ID.
2) Adds support for updating the DAC ID on a dataset.
3) Updates git-ignore so it excludes dependency-reduced-pom.xml

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
