### PR TITLE
[DUOS-2185][risk=no] Use custom Gson adapters

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
@@ -65,7 +65,9 @@ import org.broadinstitute.consent.http.service.dao.DataAccessRequestServiceDAO;
 import org.broadinstitute.consent.http.service.dao.DatasetServiceDAO;
 import org.broadinstitute.consent.http.service.dao.VoteServiceDAO;
 import org.broadinstitute.consent.http.service.sam.SamService;
+import org.broadinstitute.consent.http.util.gson.GsonUtil;
 import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.gson2.Gson2Config;
 import org.jdbi.v3.gson2.Gson2Plugin;
 import org.jdbi.v3.guava.GuavaPlugin;
 import org.jdbi.v3.sqlobject.SqlObjectPlugin;
@@ -115,6 +117,7 @@ public class ConsentModule extends AbstractModule {
         jdbi.installPlugin(new SqlObjectPlugin());
         jdbi.installPlugin(new Gson2Plugin());
         jdbi.installPlugin(new GuavaPlugin());
+        jdbi.getConfig().get(Gson2Config.class).setGson(GsonUtil.buildGson());
 
         this.consentDAO = this.jdbi.onDemand(ConsentDAO.class);
         this.counterDAO = this.jdbi.onDemand(CounterDAO.class);

--- a/src/main/java/org/broadinstitute/consent/http/models/DarCollection.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DarCollection.java
@@ -2,7 +2,9 @@ package org.broadinstitute.consent.http.models;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.broadinstitute.consent.http.util.gson.GsonUtil;
 
 import java.sql.Timestamp;
 import java.util.HashSet;
@@ -75,7 +77,7 @@ public class DarCollection {
   }
 
   public DarCollection deepCopy() {
-    Gson gson = new Gson();
+    Gson gson = GsonUtil.buildGson();
     String json = gson.toJson(this);
     return gson.fromJson(json, DarCollection.class);
   }
@@ -190,6 +192,6 @@ public class DarCollection {
 
   @Override
   public String toString() {
-    return new Gson().toJson(this);
+    return GsonUtil.buildGson().toJson(this);
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/models/DarCollection.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DarCollection.java
@@ -2,7 +2,6 @@ package org.broadinstitute.consent.http.models;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.broadinstitute.consent.http.util.gson.GsonUtil;
 

--- a/src/main/java/org/broadinstitute/consent/http/resources/DacResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DacResource.java
@@ -32,6 +32,7 @@ import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.service.DacService;
 import org.broadinstitute.consent.http.service.DatasetService;
 import org.broadinstitute.consent.http.service.UserService;
+import org.broadinstitute.consent.http.util.gson.GsonUtil;
 
 @Path("api/dac")
 public class DacResource extends Resource {
@@ -54,14 +55,14 @@ public class DacResource extends Resource {
     public Response findAll(@Auth AuthUser authUser, @QueryParam("withUsers") Optional<Boolean> withUsers) {
         final Boolean includeUsers = withUsers.orElse(true);
         List<Dac> dacs = dacService.findDacsWithMembersOption(includeUsers);
-        return Response.ok().entity(unmarshal(dacs)).build();
+        return Response.ok(dacs).build();
     }
 
     @POST
     @Produces("application/json")
     @RolesAllowed({ADMIN})
     public Response createDac(@Auth AuthUser authUser, String json) throws Exception {
-        Dac dac = new Gson().fromJson(json, Dac.class);
+        Dac dac = GsonUtil.buildGson().fromJson(json, Dac.class);
         if (dac == null) {
             throw new BadRequestException("DAC is required");
         }
@@ -76,14 +77,14 @@ public class DacResource extends Resource {
             throw new Exception("Unable to create DAC with name: " + dac.getName() + " and description: " + dac.getDescription());
         }
         Dac savedDac = dacService.findById(dacId);
-        return Response.ok().entity(unmarshal(savedDac)).build();
+        return Response.ok(savedDac).build();
     }
 
     @PUT
     @Produces("application/json")
     @RolesAllowed({ADMIN})
     public Response updateDac(@Auth AuthUser authUser, String json) {
-        Dac dac = new Gson().fromJson(json, Dac.class);
+        Dac dac = GsonUtil.buildGson().fromJson(json, Dac.class);
         if (dac == null) {
             throw new BadRequestException("DAC is required");
         }
@@ -98,7 +99,7 @@ public class DacResource extends Resource {
         }
         dacService.updateDac(dac.getName(), dac.getDescription(), dac.getDacId());
         Dac savedDac = dacService.findById(dac.getDacId());
-        return Response.ok().entity(unmarshal(savedDac)).build();
+        return Response.ok(savedDac).build();
     }
 
     @GET
@@ -107,7 +108,7 @@ public class DacResource extends Resource {
     @RolesAllowed({ADMIN, MEMBER, CHAIRPERSON})
     public Response findById(@PathParam("dacId") Integer dacId) {
         Dac dac = findDacById(dacId);
-        return Response.ok().entity(unmarshal(dac)).build();
+        return Response.ok(dac).build();
     }
 
     @DELETE
@@ -231,7 +232,7 @@ public class DacResource extends Resource {
             if(Objects.isNull(json) || json.isBlank()) {
                 throw new BadRequestException("Request body is empty");
             }
-            DatasetApproval payload = new Gson().fromJson(json, DatasetApproval.class);
+            DatasetApproval payload = GsonUtil.buildGson().fromJson(json, DatasetApproval.class);
             if(Objects.isNull(payload.getApproval())) {
                 throw new BadRequestException("Invalid request payload");
             }

--- a/src/main/java/org/broadinstitute/consent/http/resources/DacResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DacResource.java
@@ -1,6 +1,5 @@
 package org.broadinstitute.consent.http.resources;
 
-import com.google.gson.Gson;
 import com.google.inject.Inject;
 import io.dropwizard.auth.Auth;
 import java.util.List;
@@ -55,7 +54,7 @@ public class DacResource extends Resource {
     public Response findAll(@Auth AuthUser authUser, @QueryParam("withUsers") Optional<Boolean> withUsers) {
         final Boolean includeUsers = withUsers.orElse(true);
         List<Dac> dacs = dacService.findDacsWithMembersOption(includeUsers);
-        return Response.ok(dacs).build();
+        return Response.ok().entity(unmarshal(dacs)).build();
     }
 
     @POST
@@ -77,7 +76,7 @@ public class DacResource extends Resource {
             throw new Exception("Unable to create DAC with name: " + dac.getName() + " and description: " + dac.getDescription());
         }
         Dac savedDac = dacService.findById(dacId);
-        return Response.ok(savedDac).build();
+        return Response.ok().entity(unmarshal(savedDac)).build();
     }
 
     @PUT
@@ -99,7 +98,7 @@ public class DacResource extends Resource {
         }
         dacService.updateDac(dac.getName(), dac.getDescription(), dac.getDacId());
         Dac savedDac = dacService.findById(dac.getDacId());
-        return Response.ok(savedDac).build();
+        return Response.ok().entity(unmarshal(savedDac)).build();
     }
 
     @GET
@@ -108,7 +107,7 @@ public class DacResource extends Resource {
     @RolesAllowed({ADMIN, MEMBER, CHAIRPERSON})
     public Response findById(@PathParam("dacId") Integer dacId) {
         Dac dac = findDacById(dacId);
-        return Response.ok(dac).build();
+        return Response.ok().entity(unmarshal(dac)).build();
     }
 
     @DELETE

--- a/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
@@ -247,7 +247,7 @@ public class DatasetResource extends Resource {
         try {
             User user = userService.findUserByEmail(authUser.getEmail());
             List<Dataset> datasets = datasetService.findAllDatasetsByUser(user);
-            return Response.ok(datasets).build();
+            return Response.ok(unmarshal(datasets)).build();
         } catch (Exception e) {
             return createExceptionResponse(e);
         }
@@ -315,7 +315,7 @@ public class DatasetResource extends Resource {
     public Response validateDatasetName(@QueryParam("name") String name) {
         try {
             Dataset datasetWithName = datasetService.getDatasetByName(name);
-            return Response.ok(datasetWithName.getDataSetId()).build();
+            return Response.ok().entity(datasetWithName.getDataSetId()).build();
         } catch (Exception e) {
             throw new NotFoundException("Could not find the dataset with name: " + name);
         }
@@ -460,7 +460,7 @@ public class DatasetResource extends Resource {
         try {
             User user = userService.findUserByEmail(authUser.getEmail());
             List<Dataset> datasets = datasetService.searchDatasets(query, user);
-            return Response.ok(datasets).build();
+            return Response.ok().entity(datasets).build();
         } catch (Exception e) {
             return createExceptionResponse(e);
         }
@@ -472,7 +472,7 @@ public class DatasetResource extends Resource {
     public Response updateNeedsReviewDataSets(@QueryParam("dataSetId") Integer dataSetId, @QueryParam("needsApproval") Boolean needsApproval){
         try{
             Dataset dataset = datasetService.updateNeedsReviewDatasets(dataSetId, needsApproval);
-            return Response.ok(dataset).build();
+            return Response.ok().entity(unmarshal(dataset)).build();
         }catch (Exception e){
             return createExceptionResponse(e);
         }

--- a/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
@@ -247,8 +247,7 @@ public class DatasetResource extends Resource {
         try {
             User user = userService.findUserByEmail(authUser.getEmail());
             List<Dataset> datasets = datasetService.findAllDatasetsByUser(user);
-            Gson gson = new Gson();
-            return Response.ok(gson.toJson(datasets)).build();
+            return Response.ok(datasets).build();
         } catch (Exception e) {
             return createExceptionResponse(e);
         }
@@ -316,7 +315,7 @@ public class DatasetResource extends Resource {
     public Response validateDatasetName(@QueryParam("name") String name) {
         try {
             Dataset datasetWithName = datasetService.getDatasetByName(name);
-            return Response.ok().entity(datasetWithName.getDataSetId()).build();
+            return Response.ok(datasetWithName.getDataSetId()).build();
         } catch (Exception e) {
             throw new NotFoundException("Could not find the dataset with name: " + name);
         }
@@ -461,7 +460,7 @@ public class DatasetResource extends Resource {
         try {
             User user = userService.findUserByEmail(authUser.getEmail());
             List<Dataset> datasets = datasetService.searchDatasets(query, user);
-            return Response.ok().entity(datasets).build();
+            return Response.ok(datasets).build();
         } catch (Exception e) {
             return createExceptionResponse(e);
         }
@@ -473,7 +472,7 @@ public class DatasetResource extends Resource {
     public Response updateNeedsReviewDataSets(@QueryParam("dataSetId") Integer dataSetId, @QueryParam("needsApproval") Boolean needsApproval){
         try{
             Dataset dataset = datasetService.updateNeedsReviewDatasets(dataSetId, needsApproval);
-            return Response.ok().entity(unmarshal(dataset)).build();
+            return Response.ok(dataset).build();
         }catch (Exception e){
             return createExceptionResponse(e);
         }

--- a/src/main/java/org/broadinstitute/consent/http/resources/Resource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/Resource.java
@@ -1,6 +1,5 @@
 package org.broadinstitute.consent.http.resources;
 
-import com.google.gson.Gson;
 import com.google.gson.stream.MalformedJsonException;
 import io.sentry.Sentry;
 import io.sentry.SentryEvent;
@@ -12,6 +11,7 @@ import org.broadinstitute.consent.http.exceptions.UpdateConsentException;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.dto.Error;
 import org.broadinstitute.consent.http.util.ConsentLogger;
+import org.broadinstitute.consent.http.util.gson.GsonUtil;
 import org.glassfish.jersey.media.multipart.ContentDisposition;
 import org.jdbi.v3.core.statement.UnableToExecuteStatementException;
 import org.owasp.fileio.FileValidator;
@@ -225,7 +225,7 @@ abstract public class Resource implements ConsentLogger {
      * @return String version of the object
      */
     protected String unmarshal(Object o) {
-        return new Gson().toJson(o);
+        return GsonUtil.buildGson().toJson(o);
     }
 
 }

--- a/src/main/java/org/broadinstitute/consent/http/util/gson/BlobIdTypeAdapter.java
+++ b/src/main/java/org/broadinstitute/consent/http/util/gson/BlobIdTypeAdapter.java
@@ -1,0 +1,32 @@
+package org.broadinstitute.consent.http.util.gson;
+
+import com.google.cloud.storage.BlobId;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+
+import java.lang.reflect.Type;
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
+
+public class BlobIdTypeAdapter
+        implements JsonSerializer<BlobId>, JsonDeserializer<BlobId> {
+    @Override
+    public JsonElement serialize(BlobId src, Type srcType, JsonSerializationContext context) {
+        return new JsonPrimitive(src.toGsUtilUri());
+    }
+
+    @Override
+    public BlobId deserialize(JsonElement json, Type type, JsonDeserializationContext context)
+            throws JsonParseException {
+        try {
+            return BlobId.fromGsUtilUri(json.getAsString());
+        } catch (IllegalArgumentException e) {
+            throw new JsonParseException(e.getMessage());
+        }
+    }
+}

--- a/src/main/java/org/broadinstitute/consent/http/util/gson/GsonUtil.java
+++ b/src/main/java/org/broadinstitute/consent/http/util/gson/GsonUtil.java
@@ -1,0 +1,23 @@
+package org.broadinstitute.consent.http.util.gson;
+
+import com.google.cloud.storage.BlobId;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+import java.time.Instant;
+
+public class GsonUtil {
+    public static Gson buildGson() {
+        return gsonBuilderWithAdapters().create();
+    }
+
+    public static GsonBuilder gsonBuilderWithAdapters() {
+        return new GsonBuilder()
+                .registerTypeAdapter(
+                        Instant.class,
+                        new InstantTypeAdapter())
+                .registerTypeAdapter(
+                        BlobId.class,
+                        new BlobIdTypeAdapter());
+    }
+}

--- a/src/main/java/org/broadinstitute/consent/http/util/gson/InstantTypeAdapter.java
+++ b/src/main/java/org/broadinstitute/consent/http/util/gson/InstantTypeAdapter.java
@@ -1,0 +1,31 @@
+package org.broadinstitute.consent.http.util.gson;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+
+import java.lang.reflect.Type;
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
+
+public class InstantTypeAdapter
+        implements JsonSerializer<Instant>, JsonDeserializer<Instant> {
+    @Override
+    public JsonElement serialize(Instant src, Type srcType, JsonSerializationContext context) {
+        return new JsonPrimitive(src.toString());
+    }
+
+    @Override
+    public Instant deserialize(JsonElement json, Type type, JsonDeserializationContext context)
+            throws JsonParseException {
+        try {
+            return Instant.parse(json.getAsString());
+        } catch (DateTimeParseException e) {
+            throw new JsonParseException(e.getMessage());
+        }
+    }
+}

--- a/src/test/java/org/broadinstitute/consent/http/util/gson/BlobIdTypeAdapterTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/util/gson/BlobIdTypeAdapterTest.java
@@ -1,0 +1,28 @@
+package org.broadinstitute.consent.http.util.gson;
+
+import com.google.cloud.storage.BlobId;
+import com.google.gson.JsonElement;
+import org.junit.Test;
+import org.apache.commons.lang3.RandomStringUtils;
+
+import static org.junit.Assert.assertEquals;
+
+public class BlobIdTypeAdapterTest {
+
+    @Test
+    public void testInstantTypeAdapter() {
+        BlobId randomId = BlobId.of(
+                RandomStringUtils.randomAlphabetic(10),
+                RandomStringUtils.randomAlphabetic(10));
+        String randomIdUri = randomId.toGsUtilUri();
+
+        BlobIdTypeAdapter adapter = new BlobIdTypeAdapter();
+
+        JsonElement elem = adapter.serialize(randomId, null, null);
+        assertEquals(randomIdUri, elem.getAsString());
+
+        BlobId returnedId = adapter.deserialize(elem, null, null);
+
+        assertEquals(randomId, returnedId);
+    }
+}

--- a/src/test/java/org/broadinstitute/consent/http/util/gson/GsonUtilTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/util/gson/GsonUtilTest.java
@@ -1,0 +1,56 @@
+package org.broadinstitute.consent.http.util.gson;
+
+import com.google.cloud.storage.BlobId;
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import org.broadinstitute.consent.http.models.Dataset;
+import org.junit.Test;
+import org.testcontainers.shaded.org.apache.commons.lang3.RandomStringUtils;
+
+import java.time.Instant;
+
+import static org.junit.Assert.assertEquals;
+
+public class GsonUtilTest {
+    @Test
+    public void testBuildJson() {
+        Gson gson = GsonUtil.buildGson();
+
+        Dataset ds = new Dataset();
+        ds.setName(RandomStringUtils.randomAlphanumeric(20));
+
+        JsonObject jsonObject = gson.fromJson(gson.toJson(ds), JsonObject.class);
+
+        assertEquals(ds.getName(), jsonObject.get("name").getAsString());
+    }
+
+    @Test
+    public void testInstantJson() {
+        Gson gson = GsonUtil.buildGson();
+
+        Instant instant = Instant.now();
+
+        String instantAsJsonString = gson.toJson(instant);
+
+        assertEquals("\"" + instant.toString() + "\"", instantAsJsonString);
+
+        Instant parsed = gson.fromJson(instantAsJsonString, Instant.class);
+
+        assertEquals(instant, parsed);
+    }
+
+    @Test
+    public void testBlobIdJson() {
+        Gson gson = GsonUtil.buildGson();
+
+        BlobId id = BlobId.of(RandomStringUtils.randomAlphabetic(20), RandomStringUtils.randomAlphabetic(20));
+
+        String blobIdAsJsonString = gson.toJson(id);
+
+        assertEquals("\"" + id.toGsUtilUri() + "\"", blobIdAsJsonString);
+
+        BlobId parsed = gson.fromJson(blobIdAsJsonString, BlobId.class);
+
+        assertEquals(id, parsed);
+    }
+}

--- a/src/test/java/org/broadinstitute/consent/http/util/gson/GsonUtilTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/util/gson/GsonUtilTest.java
@@ -4,10 +4,13 @@ import com.google.cloud.storage.BlobId;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import org.broadinstitute.consent.http.models.Dataset;
+import org.broadinstitute.consent.http.models.FileStorageObject;
+import org.broadinstitute.consent.http.models.Vote;
 import org.junit.Test;
 import org.testcontainers.shaded.org.apache.commons.lang3.RandomStringUtils;
 
 import java.time.Instant;
+import java.util.Random;
 
 import static org.junit.Assert.assertEquals;
 
@@ -16,12 +19,12 @@ public class GsonUtilTest {
     public void testBuildJson() {
         Gson gson = GsonUtil.buildGson();
 
-        Dataset ds = new Dataset();
-        ds.setName(RandomStringUtils.randomAlphanumeric(20));
+        Vote ds = new Vote();
+        ds.setDisplayName(RandomStringUtils.randomAlphanumeric(20));
 
         JsonObject jsonObject = gson.fromJson(gson.toJson(ds), JsonObject.class);
 
-        assertEquals(ds.getName(), jsonObject.get("name").getAsString());
+        assertEquals(ds.getDisplayName(), jsonObject.get("displayName").getAsString());
     }
 
     @Test
@@ -52,5 +55,33 @@ public class GsonUtilTest {
         BlobId parsed = gson.fromJson(blobIdAsJsonString, BlobId.class);
 
         assertEquals(id, parsed);
+    }
+
+    @Test
+    public void testBuildJsonWithCustomObjects() {
+        Gson gson = GsonUtil.buildGson();
+
+        FileStorageObject fso = new FileStorageObject();
+        fso.setCreateDate(Instant.now());
+        fso.setBlobId(BlobId.of(
+                RandomStringUtils.randomAlphabetic(5),
+                RandomStringUtils.randomAlphabetic(10)));
+        fso.setFileName(RandomStringUtils.randomAlphanumeric(20));
+
+        String fsoAsJsonString = gson.toJson(fso);
+
+        JsonObject parsedJsonObj = gson.fromJson(fsoAsJsonString, JsonObject.class);
+
+        assertEquals(fso.getCreateDate().toString(), parsedJsonObj.get("createDate").getAsString());
+        assertEquals(fso.getBlobId().toGsUtilUri(), parsedJsonObj.get("blobId").getAsString());
+        assertEquals(fso.getFileName(), parsedJsonObj.get("fileName").getAsString());
+
+        FileStorageObject parsedFso = gson.fromJson(fsoAsJsonString, FileStorageObject.class);
+
+        assertEquals(fso.getCreateDate(), parsedFso.getCreateDate());
+        assertEquals(fso.getBlobId(), parsedFso.getBlobId());
+        assertEquals(fso.getFileName(), parsedFso.getFileName());
+
+
     }
 }

--- a/src/test/java/org/broadinstitute/consent/http/util/gson/GsonUtilTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/util/gson/GsonUtilTest.java
@@ -3,14 +3,12 @@ package org.broadinstitute.consent.http.util.gson;
 import com.google.cloud.storage.BlobId;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
-import org.broadinstitute.consent.http.models.Dataset;
 import org.broadinstitute.consent.http.models.FileStorageObject;
 import org.broadinstitute.consent.http.models.Vote;
 import org.junit.Test;
 import org.testcontainers.shaded.org.apache.commons.lang3.RandomStringUtils;
 
 import java.time.Instant;
-import java.util.Random;
 
 import static org.junit.Assert.assertEquals;
 
@@ -81,7 +79,5 @@ public class GsonUtilTest {
         assertEquals(fso.getCreateDate(), parsedFso.getCreateDate());
         assertEquals(fso.getBlobId(), parsedFso.getBlobId());
         assertEquals(fso.getFileName(), parsedFso.getFileName());
-
-
     }
 }

--- a/src/test/java/org/broadinstitute/consent/http/util/gson/InstantTypeAdapterTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/util/gson/InstantTypeAdapterTest.java
@@ -1,0 +1,27 @@
+package org.broadinstitute.consent.http.util.gson;
+
+import com.google.gson.JsonElement;
+import org.junit.Test;
+
+import java.time.Instant;
+import java.util.Random;
+
+import static org.junit.Assert.assertEquals;
+
+public class InstantTypeAdapterTest {
+
+    @Test
+    public void testInstantTypeAdapter() {
+        Instant randomTime = Instant.ofEpochMilli(new Random().nextLong());
+        String randomTimeAsIsoString = randomTime.toString();
+
+        InstantTypeAdapter adapter = new InstantTypeAdapter();
+
+        JsonElement elem = adapter.serialize(randomTime, null, null);
+        assertEquals(randomTimeAsIsoString, elem.getAsString());
+
+        Instant returnedInstant = adapter.deserialize(elem, null, null);
+
+        assertEquals(randomTime, returnedInstant);
+    }
+}


### PR DESCRIPTION
### Partially Addresses

https://broadworkbench.atlassian.net/browse/DUOS-2185

This is only one component of 2185 - for the ticket, custom Gson adapters needed to be added. This PR just has the Gson adapters and updates the `Gson` object of all of the places (I believe) that broke due to the addition of the FileStorageObject. This needs to be merged first before the second half of the ticket can be merged.


----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
