### PR TITLE
[DUOS-699][risk=no] Use Gson as Default Json Provider

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsp/consent/chains/AccessReviewChains.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsp/consent/chains/AccessReviewChains.scala
@@ -64,48 +64,6 @@ object AccessReviewChains {
         }
     }
 
-    def voteOnPendingDars(additionalHeaders: Map[String, String], chain: ChainBuilder, limit: Int = 2): ChainBuilder = {
-        exitBlockOnFail {
-            exec { session =>
-                implicit val pendingCaseFormat: JsonProtocols.pendingCaseFormat.type = JsonProtocols.pendingCaseFormat
-                implicit val dacFormat: JsonProtocols.dacFormat.type = JsonProtocols.dacFormat
-                implicit val userRoleFormat: JsonProtocols.userRoleFormat.type = JsonProtocols.userRoleFormat
-                implicit val userFormat: JsonProtocols.userFormat.type = JsonProtocols.userFormat
-                val pendingCasesStr: String = session(Requests.PendingCases.dataRequestPendingResponse).as[String]
-                val pendingCases: Seq[PendingCase] = pendingCasesStr.parseJson.convertTo[Seq[PendingCase]]
-
-                val automationPending: Seq[PendingCase] = pendingCases.filter { pc =>
-                    pc.projectTitle.getOrElse("") == DarService.projectTitle && !pc.alreadyVoted.getOrElse(false)
-                }
-                .sortWith { (pc1, pc2) =>
-                    pc1.createDate.getOrElse(0L) > pc2.createDate.getOrElse(0L)
-                }
-                .take(limit)
-
-                session.set("pendingCases", automationPending)
-            }
-            .repeat(session => session("pendingCases").as[Seq[PendingCase]].size, "pendingIndex") {
-                exitBlockOnFail {
-                    exec { session =>
-                        val pendingCases: Seq[PendingCase] = session("pendingCases").as[Seq[PendingCase]]
-                        val index: Int = session("pendingIndex").as[Int]
-                        val pendingCase: PendingCase = pendingCases(index)
-
-                        val session1 = session.set(AccessReviewChains.referenceId, pendingCase.referenceId.getOrElse(""))
-                        val session2 = session1.set(AccessReviewChains.voteId, pendingCase.voteId.getOrElse(0))
-                        session2
-                    }
-                    .exec(
-                        AccessReviewChains.init(additionalHeaders)
-                    )
-                    .exec(
-                        chain
-                    )
-                }
-            }
-        }
-    }
-
     def submitVote(votesString: String, additionalHeaders: Map[String, String], result: String = "true"): ChainBuilder = {
         exitBlockOnFail {
             exec { session =>

--- a/automation/src/test/scala/org/broadinstitute/dsp/consent/requests/Requests.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsp/consent/requests/Requests.scala
@@ -332,7 +332,6 @@ object Requests {
 
   object PendingCases {
     val consentPendingResponse: String = "consentPendingResponse"
-    val dataRequestPendingResponse: String = "dataRequestPendingResponse"
 
     def getPendingCasesByUserId(expectedStatus: Int, userId: String, additionalHeaders: Map[String, String]): HttpRequestBuilder = {
       http("Get Pending Cases")

--- a/automation/src/test/scala/org/broadinstitute/dsp/consent/scenarios/DataAccessScenarios.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsp/consent/scenarios/DataAccessScenarios.scala
@@ -44,36 +44,6 @@ class DataAccessScenarios extends Simulation with TestRunner {
                         }
                     }
                 )
-                .andThen(
-                    defaultPopulation(
-                        GroupedScenario("Member Voting") {
-                            exitBlockOnFail {
-                                exec(
-                                    MemberChains.loginToConsole(TestConfig.memberHeader)
-                                )
-                                  .pause(TestConfig.defaultPause)
-                                  .exec(
-                                      AccessReviewChains.voteOnPendingDars(TestConfig.memberHeader, AccessReviewChains.submitVote(AccessReviewChains.electionDacVotes, TestConfig.memberHeader))
-                                  )
-                            }
-                        }
-                    )
-                    .andThen(
-                        defaultPopulation(
-                            GroupedScenario("Chair Voting") {
-                                exitBlockOnFail {
-                                    exec(
-                                        ChairChains.loginToConsole(TestConfig.chairHeader)
-                                    )
-                                      .pause(TestConfig.defaultPause)
-                                      .exec(
-                                          AccessReviewChains.voteOnPendingDars(TestConfig.memberHeader, ChairChains.submitVote(TestConfig.chairHeader))
-                                      )
-                                }
-                            }
-                        )
-                    )
-                )
             )
         )
     )

--- a/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
@@ -100,6 +100,7 @@ import org.broadinstitute.consent.http.service.ontology.IndexerServiceImpl;
 import org.broadinstitute.consent.http.service.ontology.StoreOntologyService;
 import org.broadinstitute.consent.http.service.sam.SamService;
 import org.broadinstitute.consent.http.util.HttpClientUtil;
+import org.broadinstitute.consent.http.util.gson.JerseyGsonProvider;
 import org.eclipse.jetty.servlet.ErrorPageErrorHandler;
 import org.eclipse.jetty.servlets.CrossOriginFilter;
 import org.glassfish.jersey.server.filter.RolesAllowedDynamicFeature;
@@ -199,6 +200,8 @@ public class ConsentApplication extends Application<ConsentConfiguration> {
         System.setProperty("sun.net.http.allowRestrictedHeaders", "true");
         configureCors(env);
 
+        env.jersey().register(JerseyGsonProvider.class);
+
         // Health Checks
         env.healthChecks().register(GCS_CHECK, new GCSHealthCheck(gcsService));
         env.healthChecks().register(ES_CHECK, new ElasticSearchHealthCheck(config.getElasticSearchConfiguration()));
@@ -221,8 +224,8 @@ public class ConsentApplication extends Application<ConsentConfiguration> {
         errorHandler.addErrorPage(404, "/error/404");
         env.getApplicationContext().setErrorHandler(errorHandler);
         env.jersey().register(ResponseServerFilter.class);
-        env.jersey().register(ErrorResource.class);
 
+        env.jersey().register(ErrorResource.class);
         // Register standard application resources.
         env.jersey().register(new DataAccessRequestResourceVersion2(dataAccessRequestService, emailService, gcsService, userService, matchService));
         env.jersey().register(new DataAccessRequestResource(dataAccessRequestService, userService, consentService));

--- a/src/main/java/org/broadinstitute/consent/http/models/NIHUserAccount.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/NIHUserAccount.java
@@ -1,7 +1,5 @@
 package org.broadinstitute.consent.http.models;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import org.broadinstitute.consent.http.enumeration.UserFields;
 
 import java.util.ArrayList;
@@ -10,48 +8,44 @@ import java.util.Map;
 
 public class NIHUserAccount {
 
-    @JsonProperty("linkedNihUsername")
-    private String nihUsername;
+    private String linkedNihUsername;
 
-    @JsonProperty("datasetPermissions")
     private ArrayList datasetPermissions;
 
-    @JsonProperty("linkExpireTime")
-    private String eraExpiration;
+    private String linkExpireTime;
 
-    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Boolean status;
 
     public NIHUserAccount() {}
 
-    public NIHUserAccount(String nihUsername, ArrayList datasetPermissions, String eraExpiration, Boolean status) {
-        this.nihUsername = nihUsername;
+    public NIHUserAccount(String linkedNihUsername, ArrayList datasetPermissions, String linkExpireTime, Boolean status) {
+        this.linkedNihUsername = linkedNihUsername;
         this.datasetPermissions = datasetPermissions;
-        this.eraExpiration = eraExpiration;
+        this.linkExpireTime = linkExpireTime;
         this.status = status;
     }
 
     public Map<String, String> getNihMap() {
         Map<String, String> nihComponents = new HashMap<>();
         nihComponents.put(UserFields.ERA_STATUS.getValue(), Boolean.TRUE.toString());
-        nihComponents.put(UserFields.ERA_EXPIRATION_DATE.getValue(), this.eraExpiration);
+        nihComponents.put(UserFields.ERA_EXPIRATION_DATE.getValue(), this.linkExpireTime);
         return nihComponents;
     }
 
-    public String getNihUsername() {
-        return nihUsername;
+    public String getLinkedNihUsername() {
+        return linkedNihUsername;
     }
 
-    public void setNihUsername(String nihUsername) {
-        this.nihUsername = nihUsername;
+    public void setLinkedNihUsername(String linkedNihUsername) {
+        this.linkedNihUsername = linkedNihUsername;
     }
 
-    public String getEraExpiration() {
-        return eraExpiration;
+    public String getLinkExpireTime() {
+        return linkExpireTime;
     }
 
-    public void setEraExpiration(String eraExpiration) {
-        this.eraExpiration = eraExpiration;
+    public void setLinkExpireTime(String linkExpireTime) {
+        this.linkExpireTime = linkExpireTime;
     }
 
 

--- a/src/main/java/org/broadinstitute/consent/http/models/NIHUserAccount.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/NIHUserAccount.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.consent.http.models;
 
+import com.google.gson.annotations.SerializedName;
 import org.broadinstitute.consent.http.enumeration.UserFields;
 
 import java.util.ArrayList;
@@ -8,44 +9,46 @@ import java.util.Map;
 
 public class NIHUserAccount {
 
-    private String linkedNihUsername;
+    @SerializedName("linkedNihUsername")
+    private String nihUsername;
 
     private ArrayList datasetPermissions;
 
-    private String linkExpireTime;
+    @SerializedName("linkExpireTime")
+    private String eraExpiration;
 
     private Boolean status;
 
     public NIHUserAccount() {}
 
-    public NIHUserAccount(String linkedNihUsername, ArrayList datasetPermissions, String linkExpireTime, Boolean status) {
-        this.linkedNihUsername = linkedNihUsername;
+    public NIHUserAccount(String nihUsername, ArrayList datasetPermissions, String eraExpiration, Boolean status) {
+        this.nihUsername = nihUsername;
         this.datasetPermissions = datasetPermissions;
-        this.linkExpireTime = linkExpireTime;
+        this.eraExpiration = eraExpiration;
         this.status = status;
     }
 
     public Map<String, String> getNihMap() {
         Map<String, String> nihComponents = new HashMap<>();
         nihComponents.put(UserFields.ERA_STATUS.getValue(), Boolean.TRUE.toString());
-        nihComponents.put(UserFields.ERA_EXPIRATION_DATE.getValue(), this.linkExpireTime);
+        nihComponents.put(UserFields.ERA_EXPIRATION_DATE.getValue(), this.eraExpiration);
         return nihComponents;
     }
 
-    public String getLinkedNihUsername() {
-        return linkedNihUsername;
+    public String getNihUsername() {
+        return nihUsername;
     }
 
-    public void setLinkedNihUsername(String linkedNihUsername) {
-        this.linkedNihUsername = linkedNihUsername;
+    public void setNihUsername(String nihUsername) {
+        this.nihUsername = nihUsername;
     }
 
-    public String getLinkExpireTime() {
-        return linkExpireTime;
+    public String getEraExpiration() {
+        return eraExpiration;
     }
 
-    public void setLinkExpireTime(String linkExpireTime) {
-        this.linkExpireTime = linkExpireTime;
+    public void setEraExpiration(String eraExpiration) {
+        this.eraExpiration = eraExpiration;
     }
 
 

--- a/src/main/java/org/broadinstitute/consent/http/service/MetricsService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/MetricsService.java
@@ -53,7 +53,7 @@ public class MetricsService {
   }
 
   public class DarMetricsSummary {
-    @JsonProperty final Timestamp updateDate;
+    final Timestamp updateDate;
     @JsonProperty final String projectTitle;
     @JsonProperty final String darCode;
     @JsonProperty final String nonTechRus;

--- a/src/main/java/org/broadinstitute/consent/http/service/NihService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/NihService.java
@@ -46,7 +46,7 @@ public class NihService implements ConsentLogger {
         if (Objects.isNull(user)) {
             throw new NotFoundException("User not found: " + authUser.getEmail());
         }
-        if (StringUtils.isNotEmpty(nihAccount.getLinkedNihUsername()) && !nihAccount.getLinkedNihUsername().isEmpty()) {
+        if (StringUtils.isNotEmpty(nihAccount.getNihUsername()) && !nihAccount.getNihUsername().isEmpty()) {
             nihAccount.setEraExpiration(generateEraExpirationDates());
             nihAccount.setStatus(true);
             try {

--- a/src/main/java/org/broadinstitute/consent/http/service/NihService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/NihService.java
@@ -29,12 +29,12 @@ public class NihService {
     }
 
     public List<UserProperty> authenticateNih(NIHUserAccount nihAccount, AuthUser authUser, Integer userId) throws BadRequestException {
-        if (StringUtils.isNotEmpty(nihAccount.getNihUsername()) && !nihAccount.getNihUsername().isEmpty()) {
-            nihAccount.setEraExpiration(generateEraExpirationDates());
+        if (StringUtils.isNotEmpty(nihAccount.getLinkedNihUsername()) && !nihAccount.getLinkedNihUsername().isEmpty()) {
+            nihAccount.setLinkExpireTime(generateEraExpirationDates());
             nihAccount.setStatus(true);
             List<UserProperty> updatedProps = researcherService.updateProperties(nihAccount.getNihMap(), authUser, false);
-            libraryCardDAO.updateEraCommonsForUser(userId, nihAccount.getNihUsername());
-            userDAO.updateEraCommonsId(userId, nihAccount.getNihUsername());
+            libraryCardDAO.updateEraCommonsForUser(userId, nihAccount.getLinkedNihUsername());
+            userDAO.updateEraCommonsId(userId, nihAccount.getLinkedNihUsername());
             return updatedProps;
         } else {
             throw new BadRequestException("Invalid NIH UserName for user : " + authUser.getEmail());

--- a/src/main/java/org/broadinstitute/consent/http/util/gson/BlobIdTypeAdapter.java
+++ b/src/main/java/org/broadinstitute/consent/http/util/gson/BlobIdTypeAdapter.java
@@ -5,28 +5,24 @@ import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParseException;
-import com.google.gson.JsonPrimitive;
 import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
 
 import java.lang.reflect.Type;
-import java.time.Instant;
-import java.time.format.DateTimeParseException;
 
+/**
+ * Written to be clear this is an internal that should not be exposed via JSON.
+ */
 public class BlobIdTypeAdapter
         implements JsonSerializer<BlobId>, JsonDeserializer<BlobId> {
     @Override
     public JsonElement serialize(BlobId src, Type srcType, JsonSerializationContext context) {
-        return new JsonPrimitive(src.toGsUtilUri());
+        throw new RuntimeException("This is an internal that should not be serialized.");
     }
 
     @Override
     public BlobId deserialize(JsonElement json, Type type, JsonDeserializationContext context)
             throws JsonParseException {
-        try {
-            return BlobId.fromGsUtilUri(json.getAsString());
-        } catch (IllegalArgumentException e) {
-            throw new JsonParseException(e.getMessage());
-        }
+        throw new RuntimeException("This is an internal that should not be deserialized.");
     }
 }

--- a/src/main/java/org/broadinstitute/consent/http/util/gson/DateTypeAdapter.java
+++ b/src/main/java/org/broadinstitute/consent/http/util/gson/DateTypeAdapter.java
@@ -11,19 +11,20 @@ import com.google.gson.JsonSerializer;
 import java.lang.reflect.Type;
 import java.time.Instant;
 import java.time.format.DateTimeParseException;
+import java.util.Date;
 
-public class InstantTypeAdapter
-        implements JsonSerializer<Instant>, JsonDeserializer<Instant> {
+public class DateTypeAdapter
+        implements JsonSerializer<Date>, JsonDeserializer<Date> {
     @Override
-    public JsonElement serialize(Instant src, Type srcType, JsonSerializationContext context) {
-        return new JsonPrimitive(src.toEpochMilli());
+    public JsonElement serialize(Date src, Type srcType, JsonSerializationContext context) {
+        return new JsonPrimitive(src.getTime());
     }
 
     @Override
-    public Instant deserialize(JsonElement json, Type type, JsonDeserializationContext context)
+    public Date deserialize(JsonElement json, Type type, JsonDeserializationContext context)
             throws JsonParseException {
         try {
-            return Instant.ofEpochMilli(json.getAsLong());
+            return new Date(json.getAsLong());
         } catch (DateTimeParseException e) {
             throw new JsonParseException(e.getMessage());
         }

--- a/src/main/java/org/broadinstitute/consent/http/util/gson/GsonUtil.java
+++ b/src/main/java/org/broadinstitute/consent/http/util/gson/GsonUtil.java
@@ -5,8 +5,18 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
 import java.time.Instant;
+import java.util.Objects;
 
 public class GsonUtil {
+    private static Gson instance;
+
+    public static Gson getInstance() {
+        if (Objects.isNull(instance)) {
+            instance = buildGson();
+        }
+        return instance;
+    }
+
     public static Gson buildGson() {
         return gsonBuilderWithAdapters().create();
     }

--- a/src/main/java/org/broadinstitute/consent/http/util/gson/GsonUtil.java
+++ b/src/main/java/org/broadinstitute/consent/http/util/gson/GsonUtil.java
@@ -4,7 +4,9 @@ import com.google.cloud.storage.BlobId;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
+import java.sql.Timestamp;
 import java.time.Instant;
+import java.util.Date;
 import java.util.Objects;
 
 public class GsonUtil {
@@ -28,6 +30,15 @@ public class GsonUtil {
                         new InstantTypeAdapter())
                 .registerTypeAdapter(
                         BlobId.class,
-                        new BlobIdTypeAdapter());
+                        new BlobIdTypeAdapter())
+                .registerTypeAdapter(
+                        Date.class,
+                        new DateTypeAdapter())
+                .registerTypeAdapter(
+                        Timestamp.class,
+                        new TimestampTypeAdapter())
+                .registerTypeHierarchyAdapter(
+                        Throwable.class,
+                        new ThrowableTypeAdapter());
     }
 }

--- a/src/main/java/org/broadinstitute/consent/http/util/gson/JerseyGsonProvider.java
+++ b/src/main/java/org/broadinstitute/consent/http/util/gson/JerseyGsonProvider.java
@@ -1,0 +1,61 @@
+package org.broadinstitute.consent.http.util.gson;
+
+import com.google.gson.JsonSyntaxException;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.ext.MessageBodyReader;
+import javax.ws.rs.ext.MessageBodyWriter;
+import javax.ws.rs.ext.Provider;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
+
+@Provider
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class JerseyGsonProvider implements MessageBodyWriter<Object>,
+        MessageBodyReader<Object> {
+    @Override
+    public boolean isReadable(Class<?> aClass, Type type, Annotation[] annotations, MediaType mediaType) {
+        return true;
+    }
+
+    @Override
+    public Object readFrom(Class<Object> aClass, Type type, Annotation[] annotations, MediaType mediaType, MultivaluedMap<String, String> multivaluedMap, InputStream inputStream) throws JsonSyntaxException, WebApplicationException, IOException {
+        try (InputStreamReader reader = new InputStreamReader(inputStream, StandardCharsets.UTF_8)) {
+            return GsonUtil.getInstance().fromJson(reader, type);
+        }
+
+    }
+
+    @Override
+    public boolean isWriteable(Class<?> aClass, Type type, Annotation[] annotations, MediaType mediaType) {
+        return true;
+    }
+
+    @Override
+    public void writeTo(Object object, Class<?> aClass, Type type, Annotation[] annotations, MediaType mediaType, MultivaluedMap<String, Object> multivaluedMap, OutputStream outputStream) throws IOException, WebApplicationException {
+        try (OutputStreamWriter writer = new OutputStreamWriter(outputStream, StandardCharsets.UTF_8)) {
+            GsonUtil.getInstance().toJson(object, type, writer);
+        }
+    }
+
+    @Override
+    public long getSize(
+            Object o,
+            Class<?> type,
+            Type genericType,
+            Annotation[] annotations,
+            MediaType mediaType) {
+        return -1;
+    }
+}

--- a/src/main/java/org/broadinstitute/consent/http/util/gson/ThrowableTypeAdapter.java
+++ b/src/main/java/org/broadinstitute/consent/http/util/gson/ThrowableTypeAdapter.java
@@ -1,0 +1,16 @@
+package org.broadinstitute.consent.http.util.gson;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+
+import java.lang.reflect.Type;
+
+public class ThrowableTypeAdapter
+        implements JsonSerializer<Throwable> {
+    @Override
+    public JsonElement serialize(Throwable src, Type srcType, JsonSerializationContext context) {
+        return new JsonPrimitive(src.toString());
+    }
+}

--- a/src/main/java/org/broadinstitute/consent/http/util/gson/TimestampTypeAdapter.java
+++ b/src/main/java/org/broadinstitute/consent/http/util/gson/TimestampTypeAdapter.java
@@ -9,21 +9,22 @@ import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
 
 import java.lang.reflect.Type;
-import java.time.Instant;
+import java.sql.Timestamp;
 import java.time.format.DateTimeParseException;
+import java.util.Date;
 
-public class InstantTypeAdapter
-        implements JsonSerializer<Instant>, JsonDeserializer<Instant> {
+public class TimestampTypeAdapter
+        implements JsonSerializer<Timestamp>, JsonDeserializer<Timestamp> {
     @Override
-    public JsonElement serialize(Instant src, Type srcType, JsonSerializationContext context) {
-        return new JsonPrimitive(src.toEpochMilli());
+    public JsonElement serialize(Timestamp src, Type srcType, JsonSerializationContext context) {
+        return new JsonPrimitive(src.getTime());
     }
 
     @Override
-    public Instant deserialize(JsonElement json, Type type, JsonDeserializationContext context)
+    public Timestamp deserialize(JsonElement json, Type type, JsonDeserializationContext context)
             throws JsonParseException {
         try {
-            return Instant.ofEpochMilli(json.getAsLong());
+            return new Timestamp(json.getAsLong());
         } catch (DateTimeParseException e) {
             throw new JsonParseException(e.getMessage());
         }

--- a/src/main/resources/assets/schemas/FileStorageObject.yaml
+++ b/src/main/resources/assets/schemas/FileStorageObject.yaml
@@ -20,23 +20,20 @@ properties:
     type: integer
     description: The user who created this file
   createDate:
-    type: string
-    format: date-time
-    description: Time of creation
+    type: integer
+    description: Time of creation, in epoch milliseconds
   updateUserId:
     type: integer
     description: The user who last updated this file
   updateDate:
-    type: string
-    format: date-time
-    description: Time of last update
+    type: integer
+    description: Time of last update, in epoch milliseconds
   deleteUserId:
     type: integer
     description: The user who deleted this file
   deleteDate:
-    type: string
-    format: date-time
-    description: Time of deletion
+    type: integer
+    description: Time of deletion, in epoch milliseconds
   deleted:
     type: boolean
     description: If true, this file is deleted / archived

--- a/src/test/java/org/broadinstitute/consent/http/models/FileStorageObjectTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/FileStorageObjectTest.java
@@ -2,20 +2,19 @@ package org.broadinstitute.consent.http.models;
 
 import com.google.cloud.storage.BlobId;
 import com.google.gson.Gson;
-import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
 import org.broadinstitute.consent.http.enumeration.FileCategory;
 import org.broadinstitute.consent.http.util.gson.GsonUtil;
 import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.time.Instant;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-
-import java.io.ByteArrayInputStream;
-import java.time.Instant;
-import java.time.temporal.ChronoUnit;
 
 public class FileStorageObjectTest {
 
@@ -60,5 +59,13 @@ public class FileStorageObjectTest {
         assertEquals("asdf", fso.getFileName());
         assertNull(fso.getBlobId());
         assertNull(fso.getUploadedFile());
+    }
+
+    @Test
+    public void testFileStorageObjectDeserializationFromString_no_BlobId() {
+        String json = "{\"fileName\":\"asdf\", \"invalidField\":\"bot\", \"blobId\":\"test\"}";
+
+        FileStorageObject fso = GsonUtil.buildGson().fromJson(json, FileStorageObject.class);
+        assertNull(fso.getBlobId());
     }
 }

--- a/src/test/java/org/broadinstitute/consent/http/models/FileStorageObjectTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/FileStorageObjectTest.java
@@ -2,11 +2,15 @@ package org.broadinstitute.consent.http.models;
 
 import com.google.cloud.storage.BlobId;
 import com.google.gson.Gson;
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
 import org.broadinstitute.consent.http.enumeration.FileCategory;
 import org.broadinstitute.consent.http.util.gson.GsonUtil;
 import org.junit.Test;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayInputStream;
@@ -35,5 +39,26 @@ public class FileStorageObjectTest {
         assertEquals(fso.getFileName(), fsoJsonObject.get("fileName").getAsString());
         assertTrue(fsoJsonObject.has("category"));
         assertEquals(fso.getCategory().getValue(), fsoJsonObject.get("category").getAsString());
+
+        // should not have these fields ever
+        assertFalse(fsoJsonObject.has("blobId"));
+        assertFalse(fsoJsonObject.has("uploadedFile"));
+
+    }
+
+    @Test
+    public void testFileStorageObjectGsonDeserialization_no_BlobId() {
+
+        JsonObject jsonObject = new JsonObject();
+
+        jsonObject.add("fileName", new JsonPrimitive("asdf"));
+        jsonObject.add("blobId", new JsonPrimitive(BlobId.of("abcd", "hjkl").toGsUtilUri()));
+        jsonObject.add("uploadedFile", new JsonPrimitive("content"));
+
+        FileStorageObject fso = GsonUtil.buildGson().fromJson(jsonObject, FileStorageObject.class);
+
+        assertEquals("asdf", fso.getFileName());
+        assertNull(fso.getBlobId());
+        assertNull(fso.getUploadedFile());
     }
 }

--- a/src/test/java/org/broadinstitute/consent/http/models/FileStorageObjectTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/FileStorageObjectTest.java
@@ -11,6 +11,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 
 public class FileStorageObjectTest {
 
@@ -29,7 +30,7 @@ public class FileStorageObjectTest {
 
         assertEquals(3, fsoJsonObject.size());
         assertTrue(fsoJsonObject.has("createDate"));
-        assertEquals(fso.getCreateDate().toString(), fsoJsonObject.get("createDate").getAsString());
+        assertEquals(fso.getCreateDate().toEpochMilli(), fsoJsonObject.get("createDate").getAsLong());
         assertTrue(fsoJsonObject.has("fileName"));
         assertEquals(fso.getFileName(), fsoJsonObject.get("fileName").getAsString());
         assertTrue(fsoJsonObject.has("category"));

--- a/src/test/java/org/broadinstitute/consent/http/service/NihServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/NihServiceTest.java
@@ -79,7 +79,7 @@ public class NihServiceTest {
 
     @Test (expected = BadRequestException.class)
     public void testAuthenticateNih_BadRequest() {
-        nihUserAccount.setNihUsername("");
+        nihUserAccount.setLinkedNihUsername("");
         initService();
         service.authenticateNih(nihUserAccount, authUser, 1);
     }

--- a/src/test/java/org/broadinstitute/consent/http/service/NihServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/NihServiceTest.java
@@ -87,7 +87,7 @@ public class NihServiceTest {
         User user = new User();
         user.setUserId(1);
         when(userDAO.findUserById(any())).thenReturn(user);
-        nihUserAccount.setLinkedNihUsername("");
+        nihUserAccount.setNihUsername("");
         initService();
         try {
             service.authenticateNih(nihUserAccount, authUser, 1);

--- a/src/test/java/org/broadinstitute/consent/http/util/gson/BlobIdTypeAdapterTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/util/gson/BlobIdTypeAdapterTest.java
@@ -2,27 +2,37 @@ package org.broadinstitute.consent.http.util.gson;
 
 import com.google.cloud.storage.BlobId;
 import com.google.gson.JsonElement;
-import org.junit.Test;
+import com.google.gson.JsonPrimitive;
 import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class BlobIdTypeAdapterTest {
 
     @Test
-    public void testInstantTypeAdapter() {
+    public void testBlobIdTypeAdapter() {
         BlobId randomId = BlobId.of(
                 RandomStringUtils.randomAlphabetic(10),
                 RandomStringUtils.randomAlphabetic(10));
         String randomIdUri = randomId.toGsUtilUri();
-
+        boolean failsSerialization = false;
+        boolean failsDeserialization = false;
         BlobIdTypeAdapter adapter = new BlobIdTypeAdapter();
 
-        JsonElement elem = adapter.serialize(randomId, null, null);
-        assertEquals(randomIdUri, elem.getAsString());
+        try {
+            JsonElement elem = adapter.serialize(randomId, null, null);
+        } catch (RuntimeException rte) {
+            failsSerialization = true;
+        }
+        assertTrue(failsSerialization);
+        JsonPrimitive primitive = new JsonPrimitive(randomIdUri);
+        try {
+            BlobId returnedId = adapter.deserialize(primitive, null, null);
+        } catch (RuntimeException rte) {
+            failsDeserialization = true;
+        }
 
-        BlobId returnedId = adapter.deserialize(elem, null, null);
-
-        assertEquals(randomId, returnedId);
+        assertTrue(failsDeserialization);
     }
 }

--- a/src/test/java/org/broadinstitute/consent/http/util/gson/GsonTestObject.java
+++ b/src/test/java/org/broadinstitute/consent/http/util/gson/GsonTestObject.java
@@ -1,0 +1,43 @@
+package org.broadinstitute.consent.http.util.gson;
+
+import java.time.Instant;
+import java.util.Date;
+
+/**
+ * This object is set up to allow us to have test coverage to ensure that
+ * our Gson configuration is set up properly.
+ */
+public class GsonTestObject {
+
+    public GsonTestObject() {};
+
+    private transient String transientField;
+
+    private Date date;
+    private Instant instant;
+
+
+    public String getTransientField() {
+        return transientField;
+    }
+
+    public void setTransientField(String transientField) {
+        this.transientField = transientField;
+    }
+
+    public Date getDate() {
+        return date;
+    }
+
+    public void setDate(Date date) {
+        this.date = date;
+    }
+
+    public Instant getInstant() {
+        return instant;
+    }
+
+    public void setInstant(Instant instant) {
+        this.instant = instant;
+    }
+}

--- a/src/test/java/org/broadinstitute/consent/http/util/gson/GsonUtilTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/util/gson/GsonUtilTest.java
@@ -9,6 +9,8 @@ import org.junit.Test;
 import org.testcontainers.shaded.org.apache.commons.lang3.RandomStringUtils;
 
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalUnit;
 
 import static org.junit.Assert.assertEquals;
 
@@ -33,11 +35,11 @@ public class GsonUtilTest {
 
         String instantAsJsonString = gson.toJson(instant);
 
-        assertEquals("\"" + instant.toString() + "\"", instantAsJsonString);
+        assertEquals(Long.toString(instant.toEpochMilli()), instantAsJsonString);
 
         Instant parsed = gson.fromJson(instantAsJsonString, Instant.class);
 
-        assertEquals(instant, parsed);
+        assertEquals(instant.truncatedTo(ChronoUnit.MILLIS), parsed);
     }
 
     @Test
@@ -70,13 +72,13 @@ public class GsonUtilTest {
 
         JsonObject parsedJsonObj = gson.fromJson(fsoAsJsonString, JsonObject.class);
 
-        assertEquals(fso.getCreateDate().toString(), parsedJsonObj.get("createDate").getAsString());
+        assertEquals(fso.getCreateDate().toEpochMilli(), parsedJsonObj.get("createDate").getAsLong());
         assertEquals(fso.getBlobId().toGsUtilUri(), parsedJsonObj.get("blobId").getAsString());
         assertEquals(fso.getFileName(), parsedJsonObj.get("fileName").getAsString());
 
         FileStorageObject parsedFso = gson.fromJson(fsoAsJsonString, FileStorageObject.class);
 
-        assertEquals(fso.getCreateDate(), parsedFso.getCreateDate());
+        assertEquals(fso.getCreateDate().truncatedTo(ChronoUnit.MILLIS), parsedFso.getCreateDate());
         assertEquals(fso.getBlobId(), parsedFso.getBlobId());
         assertEquals(fso.getFileName(), parsedFso.getFileName());
     }

--- a/src/test/java/org/broadinstitute/consent/http/util/gson/GsonUtilTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/util/gson/GsonUtilTest.java
@@ -10,10 +10,10 @@ import org.testcontainers.shaded.org.apache.commons.lang3.RandomStringUtils;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
-import java.time.temporal.TemporalUnit;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 public class GsonUtilTest {
     @Test
@@ -46,16 +46,23 @@ public class GsonUtilTest {
     @Test
     public void testBlobIdJson() {
         Gson gson = GsonUtil.buildGson();
-
+        boolean serializationFailed = false;
+        boolean deserializationFailed = false;
         BlobId id = BlobId.of(RandomStringUtils.randomAlphabetic(20), RandomStringUtils.randomAlphabetic(20));
+        try {
+            String blobIdAsJsonString = gson.toJson(id);
+        } catch (RuntimeException rte) {
+            serializationFailed = true;
+        }
+        assertTrue(serializationFailed);
 
-        String blobIdAsJsonString = gson.toJson(id);
-
-        assertEquals("\"" + id.toGsUtilUri() + "\"", blobIdAsJsonString);
-
-        BlobId parsed = gson.fromJson(blobIdAsJsonString, BlobId.class);
-
-        assertEquals(id, parsed);
+        try {
+            String json = "{\"fileName\":\"asdf\", \"invalidField\":\"bot\", \"blobId\":\"test\"}";
+            BlobId parsed = gson.fromJson(json, BlobId.class);
+        } catch (RuntimeException rte) {
+            deserializationFailed = true;
+        }
+        assertTrue(deserializationFailed);
     }
 
     @Test

--- a/src/test/java/org/broadinstitute/consent/http/util/gson/GsonUtilTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/util/gson/GsonUtilTest.java
@@ -3,6 +3,7 @@ package org.broadinstitute.consent.http.util.gson;
 import com.google.cloud.storage.BlobId;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
+import org.broadinstitute.consent.http.models.FileStorageObject;
 import org.broadinstitute.consent.http.models.Vote;
 import org.junit.Test;
 import org.testcontainers.shaded.org.apache.commons.lang3.RandomStringUtils;
@@ -12,6 +13,7 @@ import java.time.temporal.ChronoUnit;
 import java.time.temporal.TemporalUnit;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 public class GsonUtilTest {
     @Test
@@ -72,13 +74,13 @@ public class GsonUtilTest {
         JsonObject parsedJsonObj = gson.fromJson(fsoAsJsonString, JsonObject.class);
 
         assertEquals(fso.getCreateDate().toEpochMilli(), parsedJsonObj.get("createDate").getAsLong());
-        assertEquals(fso.getBlobId().toGsUtilUri(), parsedJsonObj.get("blobId").getAsString());
+        assertNull(parsedJsonObj.get("blobId"));
         assertEquals(fso.getFileName(), parsedJsonObj.get("fileName").getAsString());
 
         FileStorageObject parsedFso = gson.fromJson(fsoAsJsonString, FileStorageObject.class);
 
         assertEquals(fso.getCreateDate().truncatedTo(ChronoUnit.MILLIS), parsedFso.getCreateDate());
-        assertEquals(fso.getBlobId(), parsedFso.getBlobId());
+        assertNull(parsedFso.getBlobId()); // should not be parsed, since transient
         assertEquals(fso.getFileName(), parsedFso.getFileName());
     }
 

--- a/src/test/java/org/broadinstitute/consent/http/util/gson/InstantTypeAdapterTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/util/gson/InstantTypeAdapterTest.java
@@ -13,12 +13,12 @@ public class InstantTypeAdapterTest {
     @Test
     public void testInstantTypeAdapter() {
         Instant randomTime = Instant.ofEpochMilli(new Random().nextLong());
-        String randomTimeAsIsoString = randomTime.toString();
+        long randomTimeMilli = randomTime.toEpochMilli();
 
         InstantTypeAdapter adapter = new InstantTypeAdapter();
 
         JsonElement elem = adapter.serialize(randomTime, null, null);
-        assertEquals(randomTimeAsIsoString, elem.getAsString());
+        assertEquals(randomTimeMilli, elem.getAsLong());
 
         Instant returnedInstant = adapter.deserialize(elem, null, null);
 


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DUOS-699

I don't think it's possible to remove Jackson entirely, in the sense that it is no longer a dependency. However, you can "mask over it" and make Jersey always use Gson instead, which I have done here. I have extensively checked the UI and was able to fix all of the issues I ran into; seems like the UI was robust enough to be able to handle the minor differences in how Gson and Jackson serialize.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
