### PR TITLE
[DUOS-2213][risk=no] Adds support for admins to delete one of their own acknowledgements.

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/AcknowledgementDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/AcknowledgementDAO.java
@@ -31,4 +31,6 @@ public interface AcknowledgementDAO extends Transactional<AcknowledgementDAO> {
           + " FROM acknowledgement WHERE user_id = :userId and ack_key IN (<key_list>)")
     List<Acknowledgement> findAcknowledgementsForUser(@BindList("key_list") List<String> keys, @Bind("userId") Integer userId);
 
+    @SqlUpdate("DELETE FROM acknowledgement where user_id = :userId AND ack_key = :key")
+    void deleteAcknowledgement(@Bind("key") String key, @Bind("userId") Integer userId);
 }

--- a/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
@@ -361,13 +361,31 @@ public class UserResource extends Resource {
     @Produces(MediaType.APPLICATION_JSON)
     @Path("/acknowledgements/{key}")
     @PermitAll
-    public Response getUserAcknowledgement(@Auth AuthUser authUser, @PathParam("key") String key){
+    public Response getUserAcknowledgement(@Auth AuthUser authUser, @PathParam("key") String key) {
         try {
             User user = userService.findUserByEmail(authUser.getEmail());
             Acknowledgement ack = acknowledgementService.findAcknowledgementForUserByKey(user, key);
             if (ack == null) {
                 return Response.status(Response.Status.NOT_FOUND).build();
             }
+            return Response.ok().entity(ack).build();
+        } catch (Exception e) {
+            return createExceptionResponse(e);
+        }
+    }
+
+    @DELETE
+    @Produces(MediaType.APPLICATION_JSON)
+    @Path ("/acknowledgements/{key}")
+    @RolesAllowed(ADMIN)
+    public Response deleteUserAcknowledgement(@Auth AuthUser authUser, @PathParam("key") String key) {
+        try {
+            User user = userService.findUserByEmail(authUser.getEmail());
+            Acknowledgement ack = acknowledgementService.findAcknowledgementForUserByKey(user, key);
+            if (Objects.isNull(ack)) {
+                return Response.status(Response.Status.NOT_FOUND).build();
+            }
+            acknowledgementService.deleteAcknowledgementForUserByKey(user, key);
             return Response.ok().entity(ack).build();
         } catch (Exception e) {
             return createExceptionResponse(e);

--- a/src/main/java/org/broadinstitute/consent/http/service/AcknowledgementService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/AcknowledgementService.java
@@ -36,4 +36,8 @@ public class AcknowledgementService {
     private Map<String, Acknowledgement> acknowledgementListToMap(List<Acknowledgement> acknowledgements){
         return acknowledgements.stream().collect(Collectors.toMap(Acknowledgement::getAckKey, Function.identity()));
     }
+
+    public void deleteAcknowledgementForUserByKey(User user, String key) {
+        acknowledgementDAO.deleteAcknowledgement(key, user.getUserId());
+    }
 }

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -1965,6 +1965,31 @@ paths:
           description: No acknowledgement found for the given key.
         500:
           description: Error processing the request.
+    delete:
+      summary: ADMIN ONLY - Delete Acknowledgement by key
+      description: Deletes a specific acknowledgement for the current user by acknowledgement key.  Returns the deleted acknowledgement.
+      parameters:
+        - name: key
+          in: path
+          description: The name of the key.
+          required: true
+          schema:
+            type: string
+      tags:
+        - User
+      responses:
+        200:
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Acknowledgement'
+        401:
+          description: Unauthorized, log in and try the operation again.
+        404:
+          description: No acknowledgement found for the given key.
+        500:
+          description: Error processing the request.
   /api/user/acknowledgements:
     post:
       requestBody:

--- a/src/test/java/org/broadinstitute/consent/http/db/AcknowledgementDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/AcknowledgementDAOTest.java
@@ -44,6 +44,27 @@ public class AcknowledgementDAOTest extends DAOTestHelper {
     }
 
     @Test
+    public void createAndDeleteAcknowledgement() {
+        User user = createUser();
+        Integer user_id = user.getUserId();
+        String key1 = RandomStringUtils.randomAlphabetic(100);
+        String key2 = RandomStringUtils.randomAlphabetic(100);
+        assertTrue(acknowledgementDAO.findAcknowledgementsForUser(user_id).isEmpty());
+
+        acknowledgementDAO.upsertAcknowledgement(key1, user_id);
+        acknowledgementDAO.upsertAcknowledgement(key2, user_id);
+        Acknowledgement upsertResult = acknowledgementDAO.findAcknowledgementsForUser(user_id).get(0);
+
+        assertEquals(2, acknowledgementDAO.findAcknowledgementsForUser(user_id).size());
+        assertEquals(upsertResult, acknowledgementDAO.findAcknowledgementsForUser(user_id).get(0));
+
+        acknowledgementDAO.deleteAcknowledgement(key1, user_id);
+        assertEquals(1, acknowledgementDAO.findAcknowledgementsForUser(user_id).size());
+        Acknowledgement secondAcknowledgement = acknowledgementDAO.findAcknowledgementsForUser(user_id).get(0);
+        assertEquals(key2, secondAcknowledgement.getAckKey());
+    }
+
+    @Test
     public void ensureMissingAcknowledgementWorks(){
         User user2 = createUser();
         User user3 = createUser();

--- a/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
@@ -725,6 +725,28 @@ public class UserResourceTest {
   }
 
   @Test
+  public void testDeleteAcknowledgementForUser(){
+    String acknowledgementKey = "key1";
+    User user = createUserWithRole();
+    Map<String, Acknowledgement> acknowledgementMap = getDefaultAcknowledgementForUser(user, acknowledgementKey);
+    when(acknowledgementService.findAcknowledgementForUserByKey(any(), any())).thenReturn(acknowledgementMap.get(acknowledgementKey));
+    initResource();
+
+    Response response = userResource.deleteUserAcknowledgement(authUser,acknowledgementKey);
+    assertEquals(Status.OK.getStatusCode(), response.getStatus());
+  }
+
+  @Test
+  public void testDeleteMissingAcknowledgementForUser(){
+    User user = createUserWithRole();
+    when(acknowledgementService.findAcknowledgementForUserByKey(any(), any())).thenReturn(null);
+    initResource();
+
+    Response response = userResource.deleteUserAcknowledgement(authUser, "key");
+    assertEquals(Status.NOT_FOUND.getStatusCode(), response.getStatus());
+  }
+
+  @Test
   public void testGetAllAcknowledgements(){
     String acknowledgementKey = "key1";
     User user = createUserWithRole();

--- a/src/test/java/org/broadinstitute/consent/http/service/AcknowledgementServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/AcknowledgementServiceTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.openMocks;
 
@@ -51,7 +52,7 @@ public class AcknowledgementServiceTest {
     }
 
     @Test
-    public void test_makeAcknowledgementForUser(){
+    public void test_makeAndDeleteAcknowledgementForUser(){
         User user = new User(2, "test@domain.com", "Test User", new Date(),
                 List.of(new UserRole(UserRoles.RESEARCHER.getRoleId(), UserRoles.RESEARCHER.getRoleName())));
         String key = "key2";
@@ -66,6 +67,7 @@ public class AcknowledgementServiceTest {
         when(acknowledgementDAO.findAcknowledgementsForUser(any(), any())).thenReturn(acknowledgementList);
         when(acknowledgementDAO.findAcknowledgementsForUser(anyInt())).thenReturn(acknowledgementList);
         when(acknowledgementDAO.findAcknowledgementsByKeyForUser(anyString(), anyInt())).thenReturn(key2Acknowledgement);
+        doNothing().when(acknowledgementDAO).deleteAcknowledgement(anyString(), anyInt());
         initService();
 
         Map<String, Acknowledgement> makeResponse = acknowledgementService.makeAcknowledgements(keys,user);
@@ -80,5 +82,7 @@ public class AcknowledgementServiceTest {
 
         Acknowledgement singleLookupResponse = acknowledgementService.findAcknowledgementForUserByKey(user,key);
         assertEquals(singleLookupResponse, key2Acknowledgement);
+
+        acknowledgementService.deleteAcknowledgementForUserByKey(user, key);
     }
 }


### PR DESCRIPTION
Testing DUOS-1758 required modifying code to test more than once.  [DUOS-2213](https://broadworkbench.atlassian.net/browse/DUOS-2213) allows an ADMIN user the ability to remove an acknowledgement.

This PR:

- Adds resource, service, and DAO support for removing an acknowledgement for the currently authenticated & authorized user
- Limits this capability to ADMIN users.
- Updates the API docs to include the new endpoint.


----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
