### PR TITLE
[DUOS-2112][risk=low] Add support for searching mail sent by date range.

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
@@ -60,6 +60,7 @@ import org.broadinstitute.consent.http.resources.IndexerResource;
 import org.broadinstitute.consent.http.resources.InstitutionResource;
 import org.broadinstitute.consent.http.resources.LibraryCardResource;
 import org.broadinstitute.consent.http.resources.LivenessResource;
+import org.broadinstitute.consent.http.resources.MailResource;
 import org.broadinstitute.consent.http.resources.MatchResource;
 import org.broadinstitute.consent.http.resources.MetricsResource;
 import org.broadinstitute.consent.http.resources.NihAccountResource;
@@ -258,6 +259,7 @@ public class ConsentApplication extends Application<ConsentConfiguration> {
         env.jersey().register(new VoteResource(userService, voteService, electionService));
         env.jersey().register(new LivenessResource());
         env.jersey().register(new TDRResource(tdrService, datasetService, userService, dataAccessRequestService));
+        env.jersey().register(new MailResource(emailService));
 
         // Authentication filters
         final UserRoleDAO userRoleDAO = injector.getProvider(UserRoleDAO.class).get();

--- a/src/main/java/org/broadinstitute/consent/http/db/MailMessageDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/MailMessageDAO.java
@@ -11,6 +11,7 @@ import org.jdbi.v3.sqlobject.transaction.Transactional;
 
 import javax.annotation.Nullable;
 import java.time.Instant;
+import java.util.Date;
 import java.util.List;
 
 @RegisterRowMapper(MailMessageMapper.class)
@@ -43,4 +44,13 @@ public interface MailMessageDAO extends Transactional<MailMessageDAO> {
              LIMIT :limit
              """)
     List<MailMessage> fetchMessagesByType(@Bind("emailType") Integer emailType, @Bind("limit") Integer limit, @Bind("offset") Integer offset);
+
+    @SqlQuery("""
+             SELECT entity_reference_id, email_entity_id, vote_id, user_id, email_type, date_sent, email_text, sendgrid_response, sendgrid_status, create_date FROM email_entity e
+             WHERE create_date BETWEEN SYMMETRIC :start AND :end 
+             ORDER BY create_date DESC
+             OFFSET :offset
+             LIMIT :limit
+             """)
+    List<MailMessage> fetchMessagesByCreateDate(@Bind("start") Date start, @Bind("end") Date end, @Bind("limit") Integer limit, @Bind("offset") Integer offset);
 }

--- a/src/main/java/org/broadinstitute/consent/http/db/MailMessageDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/MailMessageDAO.java
@@ -1,6 +1,7 @@
 package org.broadinstitute.consent.http.db;
 
 import org.broadinstitute.consent.http.db.mapper.MailMessageMapper;
+import org.broadinstitute.consent.http.models.mail.MailMessage;
 import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
 import org.jdbi.v3.sqlobject.customizer.Bind;
 import org.jdbi.v3.sqlobject.statement.GetGeneratedKeys;
@@ -10,6 +11,7 @@ import org.jdbi.v3.sqlobject.transaction.Transactional;
 
 import javax.annotation.Nullable;
 import java.time.Instant;
+import java.util.List;
 
 @RegisterRowMapper(MailMessageMapper.class)
 public interface MailMessageDAO extends Transactional<MailMessageDAO> {
@@ -32,4 +34,13 @@ public interface MailMessageDAO extends Transactional<MailMessageDAO> {
                 @Nullable @Bind("sendGridResponse") String sendGridResponse,
                 @Nullable @Bind("sendGridStatus") Integer sendGridStatus,
                 @Bind("createDate") Instant createDate);
+
+    @SqlQuery("""
+             SELECT entity_reference_id, email_entity_id, vote_id, user_id, email_type, date_sent, email_text, sendgrid_response, sendgrid_status, create_date FROM email_entity e
+             WHERE email_type = :emailType
+             ORDER BY create_date DESC
+             OFFSET :offset
+             LIMIT :limit
+             """)
+    List<MailMessage> fetchMessagesByType(@Bind("emailType") Integer emailType, @Bind("limit") Integer limit, @Bind("offset") Integer offset);
 }

--- a/src/main/java/org/broadinstitute/consent/http/resources/MailResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/MailResource.java
@@ -1,0 +1,39 @@
+package org.broadinstitute.consent.http.resources;
+
+import com.google.inject.Inject;
+import io.dropwizard.auth.Auth;
+import org.broadinstitute.consent.http.enumeration.EmailType;
+import org.broadinstitute.consent.http.models.AuthUser;
+import org.broadinstitute.consent.http.service.EmailService;
+
+import javax.annotation.security.RolesAllowed;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Response;
+
+import static org.broadinstitute.consent.http.resources.Resource.ADMIN;
+
+@Path("/api/mail")
+public class MailResource {
+    private final EmailService emailService;
+
+    @Inject
+    public MailResource(EmailService emailService) {
+        this.emailService = emailService;
+    }
+
+    @GET
+    @Produces("application/json")
+    @Path("/type/{type}")
+    @RolesAllowed({ADMIN})
+    public Response getEmailByType(@Auth AuthUser authUser,
+                                   @PathParam("type") EmailType emailType,
+                                   @DefaultValue ("20") @QueryParam("limit") Integer limit,
+                                   @DefaultValue("0") @QueryParam("offset") Integer offset) {
+        return Response.ok().entity(emailService.fetchEmailMessages(emailType, limit, offset)).build();
+    }
+}

--- a/src/main/java/org/broadinstitute/consent/http/service/EmailService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/EmailService.java
@@ -33,6 +33,7 @@ import java.io.IOException;
 import java.io.Writer;
 import java.time.Instant;
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -124,8 +125,12 @@ public class EmailService {
                 now);
     }
 
-    public List<MailMessage> fetchEmailMessages(EmailType emailType, Integer limit, Integer offset) {
+    public List<MailMessage> fetchEmailMessagesByType(EmailType emailType, Integer limit, Integer offset) {
         return emailDAO.fetchMessagesByType(emailType.getTypeInt(), limit, offset);
+    }
+
+    public List<MailMessage> fetchEmailMessagesByCreateDate(Date start, Date end, Integer limit, Integer offset) {
+        return emailDAO.fetchMessagesByCreateDate(start, end, limit, offset);
     }
 
     public void sendNewDARCollectionMessage(Integer collectionId) throws IOException, TemplateException {

--- a/src/main/java/org/broadinstitute/consent/http/service/EmailService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/EmailService.java
@@ -24,6 +24,7 @@ import org.broadinstitute.consent.http.models.Election;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.Vote;
 import org.broadinstitute.consent.http.models.dto.DatasetMailDTO;
+import org.broadinstitute.consent.http.models.mail.MailMessage;
 
 import javax.annotation.Nullable;
 import javax.mail.MessagingException;
@@ -121,6 +122,10 @@ public class EmailService {
                 Objects.nonNull(response) ? response.getBody() : null,
                 Objects.nonNull(response) ? response.getStatusCode() : null,
                 now);
+    }
+
+    public List<MailMessage> fetchEmailMessages(EmailType emailType, Integer limit, Integer offset) {
+        return emailDAO.fetchMessagesByType(emailType.getTypeInt(), limit, offset);
     }
 
     public void sendNewDARCollectionMessage(Integer collectionId) throws IOException, TemplateException {

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -48,7 +48,9 @@ paths:
   /api/collections/{collectionId}/resubmit:
     $ref: './paths/resubmitCollectionByCollectionId.yaml'
   /api/mail/type/{type}:
-    $ref: './paths/mail.yaml'
+    $ref: './paths/mailByType.yaml'
+  /api/mail/range:
+    $ref: './paths/mailByRange.yaml'
   /api/ontology:
     get:
       summary: List Ontology Files

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -47,6 +47,8 @@ paths:
     $ref: './paths/createCollectionElectionsByCollectionId.yaml'
   /api/collections/{collectionId}/resubmit:
     $ref: './paths/resubmitCollectionByCollectionId.yaml'
+  /api/mail/type/{type}:
+    $ref: './paths/mail.yaml'
   /api/ontology:
     get:
       summary: List Ontology Files
@@ -2111,6 +2113,8 @@ components:
       $ref: './schemas/Institution.yaml'
     LibraryCard:
       $ref: './schemas/LibraryCard.yaml'
+    MailMessage:
+      $ref: './schemas/MailMessage.yaml'
     PaginationResponse:
       $ref: './schemas/PaginationResponse.yaml'
     User:

--- a/src/main/resources/assets/paths/mail.yaml
+++ b/src/main/resources/assets/paths/mail.yaml
@@ -1,0 +1,52 @@
+get:
+  summary: Get Mail Messages
+  description: |
+    Admin only feature returns MailMessage list filtered by EmailType.
+  parameters:
+    - name: type
+      in: path
+      description: EmailType.  Possible values
+      required: true
+      schema:
+        type: string
+        enum:
+         - COLLECT
+         - NEW_CASE
+         - REMINDER
+         - NEW_DAR
+         - DISABLED_DATASET
+         - CLOSED_DATASET_ELECTION
+         - DATA_CUSTODIAN_APPROVAL
+         - RESEARCHER_DAR_APPROVED
+         - ADMIN_FLAGGED_DAR_APPROVED
+         - DAR_CANCEL
+         - DELEGATE_RESPONSIBILITIES
+         - NEW_RESEARCHER
+         - RESEARCHER_APPROVED
+    - name: limit
+      in: query
+      description: Number of results to return.  Defaults to 20 if unset.
+      required: false
+      schema:
+        type: integer
+    - name: offset
+      in: query
+      description: Offset value to page results.  Defaults to 0 if unset.
+      required: false
+      schema:
+        type: integer
+  tags:
+    - Mail
+  responses:
+    200:
+      description: A list of Mail Messages
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: '../schemas/MailMessage.yaml'
+    401:
+      description: Unauthorized.
+    500:
+      description: Internal Server Error

--- a/src/main/resources/assets/paths/mailByRange.yaml
+++ b/src/main/resources/assets/paths/mailByRange.yaml
@@ -1,0 +1,46 @@
+get:
+  summary: Get Mail Messages by Date Range.
+  description: |
+    Admin only feature returns MailMessage list filtered by Date Range.
+  parameters:
+    - name: start
+      in: query
+      description: Earliest Date to search in MM/dd/yyyy format. (e.g. 05/19/2019)
+      required: true
+      schema:
+        type: string
+    - name: end
+      in: query
+      description: Latest Date to search in MM/dd/yyyy format. (e.g. 05/20/2022)
+      required: true
+      schema:
+        type: string
+    - name: limit
+      in: query
+      description: Number of results to return.  Defaults to 20 if unset. May not be negative
+      required: false
+      schema:
+        type: integer
+    - name: offset
+      in: query
+      description: Offset value to page results.  Defaults to 0 if unset. May not be negative.
+      required: false
+      schema:
+        type: integer
+  tags:
+    - Mail
+  responses:
+    200:
+      description: A list of Mail Messages
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: '../schemas/MailMessage.yaml'
+    400:
+      description: Bad Request - Check to make sure dates are provided in the MM/dd/yyyy format and that limit and offset are not negative.
+    401:
+      description: Unauthorized.
+    500:
+      description: Internal Server Error

--- a/src/main/resources/assets/paths/mailByType.yaml
+++ b/src/main/resources/assets/paths/mailByType.yaml
@@ -1,5 +1,5 @@
 get:
-  summary: Get Mail Messages
+  summary: Get Mail Messages by EmailType.
   description: |
     Admin only feature returns MailMessage list filtered by EmailType.
   parameters:
@@ -25,13 +25,13 @@ get:
          - RESEARCHER_APPROVED
     - name: limit
       in: query
-      description: Number of results to return.  Defaults to 20 if unset.
+      description: Number of results to return.  Defaults to 20 if unset. May not be negative.
       required: false
       schema:
         type: integer
     - name: offset
       in: query
-      description: Offset value to page results.  Defaults to 0 if unset.
+      description: Offset value to page results.  Defaults to 0 if unset. May not be negative.
       required: false
       schema:
         type: integer
@@ -46,6 +46,8 @@ get:
             type: array
             items:
               $ref: '../schemas/MailMessage.yaml'
+    400:
+      description: Bad Request.  Make sure limit and offset are not negative numbers.
     401:
       description: Unauthorized.
     500:

--- a/src/main/resources/assets/schemas/LibraryCard.yaml
+++ b/src/main/resources/assets/schemas/LibraryCard.yaml
@@ -16,7 +16,7 @@ properties:
     description: eraCommonsId of associated User
   userName:
     type: string
-    decription: Name of associated user
+    description: Name of associated user
   userEmail:
     type: string
     description: Email of associated user

--- a/src/main/resources/assets/schemas/MailMessage.yaml
+++ b/src/main/resources/assets/schemas/MailMessage.yaml
@@ -1,0 +1,41 @@
+type: object
+properties:
+  emailId:
+    type: integer
+    description: ID of the email that was sent
+  voteId:
+    type: integer
+    description: ID of associated vote
+  dacUserId:
+    type: integer
+    description: ID of the user the message was sent to
+  emailType:
+    type: string
+    description: The type of email message that was sent
+  dateSent:
+    type: string
+    format: date
+    description: Date the email was sent
+  emailText:
+    type: string
+    description: The email message that was sent
+  sendgridResponse:
+    type: string
+    description: The sendgrid response message
+  sendgridStatus:
+    type: integer
+    description: The sendgrid response status code
+  createDate:
+    type: string
+    format: date
+    description: Date the email was created
+example:
+  emailId: 1
+  voteId: 2
+  dacUserId: 3
+  emailType: 8
+  dateSent: May 19, 2021
+  emailText: An email message body.
+  sendgridResponse: Ok
+  sendgridStatus: 0
+  createDate: May 19, 2021

--- a/src/main/resources/changelog-master.xml
+++ b/src/main/resources/changelog-master.xml
@@ -108,4 +108,5 @@
     <include file="changesets/changelog-consent-103.0.xml" relativeToChangelogFile="true"/>
     <include file="changesets/changelog-consent-104.0.xml" relativeToChangelogFile="true"/>
     <include file="changesets/changelog-consent-105.0.xml" relativeToChangelogFile="true"/>
+    <include file="changesets/changelog-consent-2022-12-29-email.0.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/changesets/changelog-consent-2022-12-29-email.0.xml
+++ b/src/main/resources/changesets/changelog-consent-2022-12-29-email.0.xml
@@ -1,0 +1,9 @@
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+    <changeSet id="2022-12-29-email" author="otchet">
+        <createIndex indexName="idx_create_date" tableName="email_entity">
+            <column name="create_date"/>
+        </createIndex>
+    </changeSet>
+</databaseChangeLog>

--- a/src/test/java/org/broadinstitute/consent/http/db/MailMessageDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/MailMessageDAOTest.java
@@ -8,6 +8,8 @@ import org.jdbi.v3.core.statement.UnableToExecuteStatementException;
 import org.junit.Test;
 
 import java.time.Instant;
+import java.util.Calendar;
+import java.util.Date;
 import java.util.EnumSet;
 import java.util.List;
 
@@ -248,10 +250,10 @@ public class MailMessageDAOTest extends DAOTestHelper {
         );
 
         List<MailMessage> mailMessageList = mailMessageDAO.fetchMessagesByType(EmailType.COLLECT.getTypeInt(), 1, 0);
-        assertEquals(mailMessageList.size(),1);
+        assertEquals(1, mailMessageList.size());
 
         List<MailMessage> mailMessageList2 = mailMessageDAO.fetchMessagesByType(EmailType.COLLECT.getTypeInt(), 1, 1);
-        assertEquals(mailMessageList2.size(),0);
+        assertEquals(0, mailMessageList2.size());
 
         Integer mailId2 = mailMessageDAO.insert(
                 RandomStringUtils.randomAlphanumeric(10),
@@ -266,10 +268,49 @@ public class MailMessageDAOTest extends DAOTestHelper {
         );
 
         List<MailMessage> mailMessageList3 = mailMessageDAO.fetchMessagesByType(EmailType.COLLECT.getTypeInt(), 1, 1);
-        assertEquals(mailMessageList3.size(),1);
+        assertEquals(1, mailMessageList3.size());
         assertEquals(mailId2, mailMessageList3.get(0).getEmailId());
 
         List<MailMessage> mailMessageList4 = mailMessageDAO.fetchMessagesByType(EmailType.COLLECT.getTypeInt(), 20, 0);
-        assertEquals(mailMessageList4.size(),2);
+        assertEquals(2, mailMessageList4.size());
+    }
+
+    @Test
+    public void testFetchByCreateDate_with_limit_and_offset(){
+        Date start = new Date();
+        generateMessagesInTime(2, 1);
+        Date end = new Date();
+        List<MailMessage> mailMessageList = mailMessageDAO.fetchMessagesByCreateDate(start, end, 1, 0);
+        assertEquals(1, mailMessageList.size());
+
+        Calendar startCalendar = Calendar.getInstance();
+        startCalendar.add(Calendar.DAY_OF_MONTH, -1*2*2);
+        List<MailMessage> mailMessageList2 = mailMessageDAO.fetchMessagesByCreateDate(startCalendar.getTime(), end, 2, 0);
+        assertEquals(2, mailMessageList2.size());
+
+        List<MailMessage> mailMessageList3 = mailMessageDAO.fetchMessagesByCreateDate(startCalendar.getTime(), end, 2, 1);
+        assertEquals(1, mailMessageList3.size());
+
+        List<MailMessage> mailMessageList4 = mailMessageDAO.fetchMessagesByCreateDate(startCalendar.getTime(), end, 1, 0);
+        assertEquals(1, mailMessageList4.size());
+    }
+
+    private void generateMessagesInTime(int number, int daysApart) {
+        Calendar calendar = Calendar.getInstance();
+        for (int x=0; x < number; x++){
+            mailMessageDAO.insert(
+                    RandomStringUtils.randomAlphanumeric(10),
+                    RandomUtils.nextInt(1, 1000),
+                    RandomUtils.nextInt(1, 1000),
+                    EmailType.COLLECT.getTypeInt(),
+                    calendar.toInstant(),
+                    RandomStringUtils.randomAlphanumeric(10),
+                    RandomStringUtils.randomAlphanumeric(10),
+                    RandomUtils.nextInt(200, 399),
+                    calendar.toInstant()
+            );
+            calendar.add(Calendar.DAY_OF_MONTH, -1*daysApart);
+        }
+
     }
 }

--- a/src/test/java/org/broadinstitute/consent/http/db/MailMessageDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/MailMessageDAOTest.java
@@ -3,12 +3,15 @@ package org.broadinstitute.consent.http.db;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.RandomUtils;
 import org.broadinstitute.consent.http.enumeration.EmailType;
+import org.broadinstitute.consent.http.models.mail.MailMessage;
 import org.jdbi.v3.core.statement.UnableToExecuteStatementException;
 import org.junit.Test;
 
 import java.time.Instant;
 import java.util.EnumSet;
+import java.util.List;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
@@ -206,5 +209,67 @@ public class MailMessageDAOTest extends DAOTestHelper {
                 RandomUtils.nextInt(200, 399),
                 null
         );
+    }
+
+    @Test
+    public void testFetch() {
+        EnumSet.allOf(EmailType.class).forEach(t -> {
+            Instant now = Instant.now();
+            mailMessageDAO.insert(
+                    RandomStringUtils.randomAlphanumeric(10),
+                    RandomUtils.nextInt(1, 1000),
+                    RandomUtils.nextInt(1, 1000),
+                    t.getTypeInt(),
+                    now,
+                    RandomStringUtils.randomAlphanumeric(10),
+                    RandomStringUtils.randomAlphanumeric(10),
+                    RandomUtils.nextInt(200, 399),
+                    now
+            );
+        });
+
+        EnumSet.allOf(EmailType.class).forEach(t ->
+                assertEquals(1, mailMessageDAO.fetchMessagesByType(t.getTypeInt(), 1, 0).size()));
+    }
+
+    @Test
+    public void testFetchLimitAndOffset() {
+        Instant now = Instant.now();
+        mailMessageDAO.insert(
+                RandomStringUtils.randomAlphanumeric(10),
+                RandomUtils.nextInt(1, 1000),
+                RandomUtils.nextInt(1, 1000),
+                EmailType.COLLECT.getTypeInt(),
+                now,
+                RandomStringUtils.randomAlphanumeric(10),
+                RandomStringUtils.randomAlphanumeric(10),
+                RandomUtils.nextInt(200, 399),
+                now
+        );
+
+        List<MailMessage> mailMessageList = mailMessageDAO.fetchMessagesByType(EmailType.COLLECT.getTypeInt(), 1, 0);
+        assertEquals(mailMessageList.size(),1);
+
+        List<MailMessage> mailMessageList2 = mailMessageDAO.fetchMessagesByType(EmailType.COLLECT.getTypeInt(), 1, 1);
+        assertEquals(mailMessageList2.size(),0);
+
+        Integer mailId2 = mailMessageDAO.insert(
+                RandomStringUtils.randomAlphanumeric(10),
+                RandomUtils.nextInt(1, 1000),
+                RandomUtils.nextInt(1, 1000),
+                EmailType.COLLECT.getTypeInt(),
+                now,
+                RandomStringUtils.randomAlphanumeric(10),
+                RandomStringUtils.randomAlphanumeric(10),
+                null,
+                now
+        );
+
+        List<MailMessage> mailMessageList3 = mailMessageDAO.fetchMessagesByType(EmailType.COLLECT.getTypeInt(), 1, 1);
+        assertEquals(mailMessageList3.size(),1);
+        assertEquals(mailId2, mailMessageList3.get(0).getEmailId());
+
+        List<MailMessage> mailMessageList4 = mailMessageDAO.fetchMessagesByType(EmailType.COLLECT.getTypeInt(), 20, 0);
+        assertEquals(mailMessageList4.size(),2);
     }
 }

--- a/src/test/java/org/broadinstitute/consent/http/resources/MailResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/MailResourceTest.java
@@ -17,6 +17,7 @@ import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.openMocks;
 
@@ -35,7 +36,7 @@ public class MailResourceTest {
     @Test
     public void test_MailResource() {
         initResource();
-        when(emailService.fetchEmailMessages(any(), any(), any())).thenReturn(generateMailMessageList());
+        when(emailService.fetchEmailMessagesByType(any(), any(), any())).thenReturn(generateMailMessageList());
         Response response = mailResource.getEmailByType(authUser, EmailType.COLLECT,null, null);
         assertEquals(200, response.getStatus());
     }
@@ -43,9 +44,55 @@ public class MailResourceTest {
     @Test
     public void test_MailResourceEmptyListResponse() {
         initResource();
-        when(emailService.fetchEmailMessages(any(), any(), any())).thenReturn(new ArrayList<>());
+        when(emailService.fetchEmailMessagesByType(any(), any(), any())).thenReturn(new ArrayList<>());
         Response response = mailResource.getEmailByType(authUser, EmailType.COLLECT,null, null);
         assertEquals(200, response.getStatus());
+    }
+
+    @Test
+    public void test_MailResource_date_range_EmptyListResponse() {
+        initResource();
+        when(emailService.fetchEmailMessagesByCreateDate(any(), any(), anyInt(), anyInt())).thenReturn(new ArrayList<>());
+        Response response = mailResource.getEmailByDateRange(authUser, "05/11/2021","05/11/2022",null, null);
+        assertEquals(200, response.getStatus());
+    }
+
+    @Test
+    public void test_MailResource_date_range_ListResponse() {
+        initResource();
+        when(emailService.fetchEmailMessagesByCreateDate(any(), any(), anyInt(), anyInt())).thenReturn(generateMailMessageList());
+        Response response = mailResource.getEmailByDateRange(authUser, "05/11/2021","05/11/2022",null, null);
+        assertEquals(200, response.getStatus());
+    }
+
+    @Test (expected = javax.ws.rs.BadRequestException.class)
+    public void test_MailResource_date_range_invalid_limit() {
+        initResource();
+        when(emailService.fetchEmailMessagesByCreateDate(any(), any(), anyInt(), anyInt())).thenReturn(generateMailMessageList());
+        Response response = mailResource.getEmailByDateRange(authUser, "05/11/2021","05/11/2022",-5, null);
+    }
+
+    @Test (expected = javax.ws.rs.BadRequestException.class)
+    public void test_MailResource_date_range_invalid_offset() {
+        initResource();
+        when(emailService.fetchEmailMessagesByCreateDate(any(), any(), anyInt(), anyInt())).thenReturn(generateMailMessageList());
+        Response response = mailResource.getEmailByDateRange(authUser, "05/11/2021","05/11/2022",null, -1);
+    }
+
+    @Test
+    public void test_MailResource_invalid_start_date() {
+        initResource();
+        when(emailService.fetchEmailMessagesByCreateDate(any(), any(), anyInt(), anyInt())).thenReturn(new ArrayList<>());
+        Response response = mailResource.getEmailByDateRange(authUser, "55/11/2021","05/11/2022",null, null);
+        assertEquals(400, response.getStatus());
+    }
+
+    @Test
+    public void test_MailResource_invalid_end_date() {
+        initResource();
+        when(emailService.fetchEmailMessagesByCreateDate(any(), any(), anyInt(), anyInt())).thenReturn(new ArrayList<>());
+        Response response = mailResource.getEmailByDateRange(authUser, "05/11/2021","65/98/20229",null, null);
+        assertEquals(400, response.getStatus());
     }
 
     private List<MailMessage> generateMailMessageList() {

--- a/src/test/java/org/broadinstitute/consent/http/resources/MailResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/MailResourceTest.java
@@ -1,0 +1,70 @@
+package org.broadinstitute.consent.http.resources;
+
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.RandomUtils;
+import org.broadinstitute.consent.http.enumeration.EmailType;
+import org.broadinstitute.consent.http.models.AuthUser;
+import org.broadinstitute.consent.http.models.mail.MailMessage;
+import org.broadinstitute.consent.http.service.EmailService;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import javax.ws.rs.core.Response;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.EnumSet;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.openMocks;
+
+public class MailResourceTest {
+    @Mock
+    private EmailService emailService;
+    private final AuthUser authUser = new AuthUser("test@test.com");
+
+    private MailResource mailResource;
+
+    private void initResource() {
+        openMocks(this);
+        mailResource = new MailResource(emailService);
+    }
+
+    @Test
+    public void test_MailResource() {
+        initResource();
+        when(emailService.fetchEmailMessages(any(), any(), any())).thenReturn(generateMailMessageList());
+        Response response = mailResource.getEmailByType(authUser, EmailType.COLLECT,null, null);
+        assertEquals(200, response.getStatus());
+    }
+
+    @Test
+    public void test_MailResourceEmptyListResponse() {
+        initResource();
+        when(emailService.fetchEmailMessages(any(), any(), any())).thenReturn(new ArrayList<>());
+        Response response = mailResource.getEmailByType(authUser, EmailType.COLLECT,null, null);
+        assertEquals(200, response.getStatus());
+    }
+
+    private List<MailMessage> generateMailMessageList() {
+        List<MailMessage> messageList = new ArrayList<>();
+        EnumSet.allOf(EmailType.class).forEach(t ->
+                messageList.add(generateMailMessage(t.toString())));
+        return messageList;
+    }
+    private MailMessage generateMailMessage(String emailType) {
+        return new MailMessage(
+                RandomUtils.nextInt(),
+                RandomUtils.nextInt(),
+                RandomUtils.nextInt(),
+                emailType,
+                new Date(),
+                RandomStringUtils.randomAlphanumeric(10),
+                RandomStringUtils.randomAlphanumeric(10),
+                RandomUtils.nextInt(),
+                new Date()
+        );
+    }
+}

--- a/src/test/java/org/broadinstitute/consent/http/service/EmailServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/EmailServiceTest.java
@@ -111,7 +111,17 @@ public class EmailServiceTest {
         List<MailMessage>  mailMessages = generateMailMessageList();
         initService();
         when(emailDAO.fetchMessagesByType(any(), anyInt(), anyInt())).thenReturn(mailMessages);
-        assertEquals(2, service.fetchEmailMessages(EmailType.COLLECT, 20, 0).size());
+        assertEquals(2, service.fetchEmailMessagesByType(EmailType.COLLECT, 20, 0).size());
+    }
+
+    @Test
+    public void testFetchEmailsByCreateDate(){
+        List<MailMessage>  mailMessages = generateMailMessageList();
+        initService();
+        Date startDate = new Date();
+        Date endDate = new Date();
+        when(emailDAO.fetchMessagesByCreateDate(any(), any(), anyInt(), anyInt())).thenReturn(mailMessages);
+        assertEquals(2, service.fetchEmailMessagesByCreateDate(startDate, endDate,20, 0).size());
     }
 
     private List<MailMessage> generateMailMessageList() {

--- a/src/test/java/org/broadinstitute/consent/http/service/EmailServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/EmailServiceTest.java
@@ -1,5 +1,7 @@
 package org.broadinstitute.consent.http.service;
 
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.RandomUtils;
 import org.broadinstitute.consent.http.configurations.FreeMarkerConfiguration;
 import org.broadinstitute.consent.http.configurations.MailConfiguration;
 import org.broadinstitute.consent.http.db.ConsentDAO;
@@ -8,18 +10,26 @@ import org.broadinstitute.consent.http.db.ElectionDAO;
 import org.broadinstitute.consent.http.db.MailMessageDAO;
 import org.broadinstitute.consent.http.db.UserDAO;
 import org.broadinstitute.consent.http.db.VoteDAO;
+import org.broadinstitute.consent.http.enumeration.EmailType;
 import org.broadinstitute.consent.http.mail.SendGridAPI;
 import org.broadinstitute.consent.http.mail.freemarker.FreeMarkerTemplateHelper;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.dto.DatasetMailDTO;
+import org.broadinstitute.consent.http.models.mail.MailMessage;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.openMocks;
 
 /**
@@ -96,4 +106,28 @@ public class EmailServiceTest {
         }
     }
 
+    @Test
+    public void testFetchEmails(){
+        List<MailMessage>  mailMessages = generateMailMessageList();
+        initService();
+        when(emailDAO.fetchMessagesByType(any(), anyInt(), anyInt())).thenReturn(mailMessages);
+        assertEquals(2, service.fetchEmailMessages(EmailType.COLLECT, 20, 0).size());
+    }
+
+    private List<MailMessage> generateMailMessageList() {
+        return Collections.nCopies(2, generateMailMessage());
+    }
+    private MailMessage generateMailMessage() {
+        return new MailMessage(
+                RandomUtils.nextInt(),
+                RandomUtils.nextInt(),
+                RandomUtils.nextInt(),
+                RandomStringUtils.randomAlphanumeric(10),
+                new Date(),
+                RandomStringUtils.randomAlphanumeric(10),
+                RandomStringUtils.randomAlphanumeric(10),
+                RandomUtils.nextInt(),
+                new Date()
+        );
+    }
 }


### PR DESCRIPTION
[DUOS-2112](https://broadworkbench.atlassian.net/browse/DUOS-2112) builds on work completed as part of [DUOS-2061](https://github.com/DataBiosphere/consent/pull/1862) and makes the following enhancements:

1. Endpoint and class updates for searching mail by date range added.
2. Documentation and tests added to describe and validate the feature.
3.  Limit and Offset are now validated to be greater than -1 for both searching by EmailType and Date Range.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment


[DUOS-2112]: https://broadworkbench.atlassian.net/browse/DUOS-2112?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DUOS-2112]: https://broadworkbench.atlassian.net/browse/DUOS-2112?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DUOS-2061]: https://broadworkbench.atlassian.net/browse/DUOS-2061?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ