### PR TITLE
[DUOS-2228][risk=no] Fix flaky test

### DIFF
--- a/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
@@ -805,10 +805,12 @@ public class UserResourceTest {
   @Test
   public void testDeleteSORoleFromSOInOtherOrgSOShouldFail() {
     User user = createUserWithRole();
+    user.setUserId(1);
     UserRole so = new UserRole(UserRoles.SIGNINGOFFICIAL.getRoleId(), UserRoles.SIGNINGOFFICIAL.getRoleName());
     user.addRole(so);
     user.setInstitutionId(1);
     User activeUser = createUserWithRole();
+    activeUser.setUserId(2);
     activeUser.addRole(so);
     activeUser.setInstitutionId(2);
     assertNotEquals(user.getInstitutionId(), activeUser.getInstitutionId());

--- a/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
@@ -701,7 +701,9 @@ public class UserResourceTest {
   @Test
   public void testDeleteRoleFromUser() {
     User user = createUserWithRole();
+    user.setUserId(1);
     User activeUser = createUserWithRole();
+    activeUser.setUserId(2);
     UserRole admin = new UserRole(UserRoles.ADMIN.getRoleId(), UserRoles.ADMIN.getRoleName());
     activeUser.addRole(admin);
     when(userService.findUserById(any())).thenReturn(user);
@@ -732,6 +734,7 @@ public class UserResourceTest {
   @Test
   public void testDeleteDeniedRoleBySoShouldFail() {
     User user = createUserWithRole();
+    user.setUserId(1);
     user.addRole(new UserRole(UserRoles.ADMIN.getRoleId(), UserRoles.ADMIN.getRoleName()));
     user.addRole(new UserRole(UserRoles.CHAIRPERSON.getRoleId(), UserRoles.CHAIRPERSON.getRoleName()));
     user.addRole(new UserRole(UserRoles.MEMBER.getRoleId(), UserRoles.MEMBER.getRoleName()));
@@ -739,6 +742,7 @@ public class UserResourceTest {
     user.addRole(new UserRole(UserRoles.DATAOWNER.getRoleId(), UserRoles.DATAOWNER.getRoleName()));
     user.setInstitutionId(10);
     User activeUser = createUserWithRole();
+    activeUser.setUserId(2);
     UserRole so = new UserRole(UserRoles.SIGNINGOFFICIAL.getRoleId(), UserRoles.SIGNINGOFFICIAL.getRoleName());
     activeUser.addRole(so);
     activeUser.setInstitutionId(10);
@@ -762,11 +766,13 @@ public class UserResourceTest {
   @Test
   public void testDeletePermittedRolesBySoShouldSucceedForUserWithSameInstitution() {
     User user = createUserWithRole();
+    user.setUserId(1);
     user.addRole(new UserRole(UserRoles.SIGNINGOFFICIAL.getRoleId(), UserRoles.SIGNINGOFFICIAL.getRoleName()));
     user.addRole(new UserRole(UserRoles.DATASUBMITTER.getRoleId(), UserRoles.DATASUBMITTER.getRoleName()));
     user.addRole(new UserRole(UserRoles.ITDIRECTOR.getRoleId(), UserRoles.ITDIRECTOR.getRoleName()));
     user.setInstitutionId(10);
     User activeUser = createUserWithRole();
+    activeUser.setUserId(2);
     UserRole so = new UserRole(UserRoles.SIGNINGOFFICIAL.getRoleId(), UserRoles.SIGNINGOFFICIAL.getRoleName());
     activeUser.addRole(so);
     activeUser.setInstitutionId(10);
@@ -784,10 +790,12 @@ public class UserResourceTest {
   @Test
   public void testDeletePermittedRolesBySoShouldFailForUserWitNullInstitution() {
     User user = createUserWithRole();
+    user.setUserId(1);
     user.addRole(new UserRole(UserRoles.SIGNINGOFFICIAL.getRoleId(), UserRoles.SIGNINGOFFICIAL.getRoleName()));
     user.addRole(new UserRole(UserRoles.DATASUBMITTER.getRoleId(), UserRoles.DATASUBMITTER.getRoleName()));
     user.addRole(new UserRole(UserRoles.ITDIRECTOR.getRoleId(), UserRoles.ITDIRECTOR.getRoleName()));
     User activeUser = createUserWithRole();
+    activeUser.setUserId(2);
     UserRole so = new UserRole(UserRoles.SIGNINGOFFICIAL.getRoleId(), UserRoles.SIGNINGOFFICIAL.getRoleName());
     activeUser.addRole(so);
     activeUser.setInstitutionId(10);
@@ -836,7 +844,9 @@ public class UserResourceTest {
   @Test
   public void testDeleteRoleFromUser_UserWithoutRole() {
     User user = createUserWithRole();
+    user.setUserId(1);
     User activeUser = createUserWithRole();
+    activeUser.setUserId(2);
     UserRole admin = new UserRole(UserRoles.ADMIN.getRoleId(), UserRoles.ADMIN.getRoleName());
     activeUser.addRole(admin);
     when(userService.findUserById(any())).thenReturn(user);


### PR DESCRIPTION
[DUOS-2228](https://broadworkbench.atlassian.net/browse/DUOS-2228) was an observed flaky test via a Github action on an unrelated component.

Root cause: 400 responses can be thrown from the method being manipulated when the user tries to remove the signing official role from themselves.  This can happen randomly in tests because the userId fields can collide between the "user" and "activeUser" via the createUserWithRole method.  This PR modifies the tests to set specific User IDs for the users to guarantee the outcome.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment


[DUOS-2228]: https://broadworkbench.atlassian.net/browse/DUOS-2228?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DUOS-2228]: https://broadworkbench.atlassian.net/browse/DUOS-2228?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ