### PR TITLE
[DUOS-2229][risk=no] Add default timeout to status checks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -370,15 +370,9 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpclient</artifactId>
-      <version>4.5.14</version>
-      <exclusions>
-        <exclusion>
-          <groupId>commons-codec</groupId>
-          <artifactId>commons-codec</artifactId>
-        </exclusion>
-      </exclusions>
+        <groupId>org.apache.httpcomponents.client5</groupId>
+        <artifactId>httpclient5</artifactId>
+        <version>5.2.1</version>
     </dependency>
 
     <!-- SourceClear fix https://broadinstitute-dsp.sourceclear.io/workspaces/jppForw/issues/vulnerabilities/31917576 -->

--- a/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
@@ -169,7 +169,7 @@ public class ConsentApplication extends Application<ConsentConfiguration> {
         final Injector injector = Guice.createInjector(new ConsentModule(config, env));
 
         // Clients
-        final HttpClientUtil clientUtil = new HttpClientUtil();
+        final HttpClientUtil clientUtil = new HttpClientUtil(config.getServicesConfiguration());
         final GCSStore googleStore = injector.getProvider(GCSStore.class).get();
 
         // Services

--- a/src/main/java/org/broadinstitute/consent/http/configurations/ServicesConfiguration.java
+++ b/src/main/java/org/broadinstitute/consent/http/configurations/ServicesConfiguration.java
@@ -1,17 +1,21 @@
 package org.broadinstitute.consent.http.configurations;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-
 import javax.validation.constraints.NotNull;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class ServicesConfiguration {
 
-  @NotNull private String ontologyURL;
+  @NotNull
+  private String ontologyURL;
 
-  @NotNull private String localURL;
+  @NotNull
+  private String localURL;
 
-  @NotNull private String samUrl;
+  @NotNull
+  private String samUrl;
+
+  private Integer timeout = 10;
 
   private boolean activateSupportNotifications = false;
 
@@ -94,5 +98,13 @@ public class ServicesConfiguration {
 
   public void setActivateSupportNotifications(boolean activateSupportNotifications) {
     this.activateSupportNotifications = activateSupportNotifications;
+  }
+
+  public Integer getTimeout() {
+    return timeout;
+  }
+
+  public void setTimeout(Integer timeout) {
+    this.timeout = timeout;
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/configurations/ServicesConfiguration.java
+++ b/src/main/java/org/broadinstitute/consent/http/configurations/ServicesConfiguration.java
@@ -15,7 +15,7 @@ public class ServicesConfiguration {
   @NotNull
   private String samUrl;
 
-  private Integer timeout = 10;
+  private Integer timeoutSeconds = 10;
 
   private boolean activateSupportNotifications = false;
 
@@ -100,11 +100,11 @@ public class ServicesConfiguration {
     this.activateSupportNotifications = activateSupportNotifications;
   }
 
-  public Integer getTimeout() {
-    return timeout;
+  public Integer getTimeoutSeconds() {
+    return timeoutSeconds;
   }
 
-  public void setTimeout(Integer timeout) {
-    this.timeout = timeout;
+  public void setTimeoutSeconds(Integer timeoutSeconds) {
+    this.timeoutSeconds = timeoutSeconds;
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/db/SamDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/SamDAO.java
@@ -43,7 +43,7 @@ public class SamDAO {
 
   public SamDAO(ServicesConfiguration configuration) {
     this.executorService = Executors.newCachedThreadPool();
-    this.clientUtil = new HttpClientUtil();
+    this.clientUtil = new HttpClientUtil(configuration);
         this.configuration = configuration;
   }
 

--- a/src/main/java/org/broadinstitute/consent/http/health/OntologyHealthCheck.java
+++ b/src/main/java/org/broadinstitute/consent/http/health/OntologyHealthCheck.java
@@ -4,14 +4,13 @@ import com.codahale.metrics.health.HealthCheck;
 import com.google.api.client.http.HttpStatusCodes;
 import com.google.gson.Gson;
 import io.dropwizard.lifecycle.Managed;
+import java.nio.charset.Charset;
 import org.apache.commons.io.IOUtils;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpGet;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.core5.http.ClassicHttpResponse;
 import org.broadinstitute.consent.http.configurations.ServicesConfiguration;
 import org.broadinstitute.consent.http.resources.StatusResource;
 import org.broadinstitute.consent.http.util.HttpClientUtil;
-
-import java.nio.charset.Charset;
 
 public class OntologyHealthCheck extends HealthCheck implements Managed {
 
@@ -29,8 +28,8 @@ public class OntologyHealthCheck extends HealthCheck implements Managed {
     try {
       String statusUrl = servicesConfiguration.getOntologyURL() + "status";
       HttpGet httpGet = new HttpGet(statusUrl);
-      try (CloseableHttpResponse response = clientUtil.getHttpResponse(httpGet)) {
-        if (response.getStatusLine().getStatusCode() == HttpStatusCodes.STATUS_CODE_OK) {
+      try (ClassicHttpResponse response = clientUtil.getHttpResponse(httpGet)) {
+        if (response.getCode() == HttpStatusCodes.STATUS_CODE_OK) {
           String content =
               IOUtils.toString(response.getEntity().getContent(), Charset.defaultCharset());
           Object ontologyStatus = new Gson().fromJson(content, Object.class);
@@ -40,7 +39,7 @@ public class OntologyHealthCheck extends HealthCheck implements Managed {
               .healthy()
               .build();
         } else {
-          return Result.unhealthy("Ontology status is unhealthy: " + response.getStatusLine());
+          return Result.unhealthy("Ontology status is unhealthy: " + response.getCode());
         }
       } catch (Exception e) {
         return Result.unhealthy(e);

--- a/src/main/java/org/broadinstitute/consent/http/health/SamHealthCheck.java
+++ b/src/main/java/org/broadinstitute/consent/http/health/SamHealthCheck.java
@@ -4,14 +4,13 @@ import com.codahale.metrics.health.HealthCheck;
 import com.google.api.client.http.HttpStatusCodes;
 import com.google.gson.Gson;
 import io.dropwizard.lifecycle.Managed;
+import java.nio.charset.Charset;
 import org.apache.commons.io.IOUtils;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpGet;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.core5.http.ClassicHttpResponse;
 import org.broadinstitute.consent.http.configurations.ServicesConfiguration;
 import org.broadinstitute.consent.http.resources.StatusResource;
 import org.broadinstitute.consent.http.util.HttpClientUtil;
-
-import java.nio.charset.Charset;
 
 public class SamHealthCheck extends HealthCheck implements Managed {
 
@@ -28,8 +27,8 @@ public class SamHealthCheck extends HealthCheck implements Managed {
     try {
       String statusUrl = configuration.getSamUrl() + "status";
       HttpGet httpGet = new HttpGet(statusUrl);
-      try (CloseableHttpResponse response = clientUtil.getHttpResponse(httpGet)) {
-        if (response.getStatusLine().getStatusCode() == HttpStatusCodes.STATUS_CODE_OK) {
+      try (ClassicHttpResponse response = clientUtil.getHttpResponse(httpGet)) {
+        if (response.getCode() == HttpStatusCodes.STATUS_CODE_OK) {
           String content =
               IOUtils.toString(response.getEntity().getContent(), Charset.defaultCharset());
           SamStatus samStatus = new Gson().fromJson(content, SamStatus.class);
@@ -39,7 +38,7 @@ public class SamHealthCheck extends HealthCheck implements Managed {
               .healthy()
               .build();
         } else {
-          return Result.unhealthy("Sam status is unhealthy: " + response.getStatusLine());
+          return Result.unhealthy("Sam status is unhealthy: " + response.getCode());
         }
       } catch (Exception e) {
         return Result.unhealthy(e);

--- a/src/main/java/org/broadinstitute/consent/http/service/SupportRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/SupportRequestService.java
@@ -36,7 +36,7 @@ public class SupportRequestService {
     @Inject
     public SupportRequestService(ServicesConfiguration configuration, InstitutionDAO institutionDAO, UserDAO userDAO) {
         this.supportTicketCreator = new SupportTicketCreator(institutionDAO, userDAO, configuration);
-        this.clientUtil = new HttpClientUtil();
+        this.clientUtil = new HttpClientUtil(configuration);
         this.configuration = configuration;
     }
 

--- a/src/main/java/org/broadinstitute/consent/http/util/HttpClientUtil.java
+++ b/src/main/java/org/broadinstitute/consent/http/util/HttpClientUtil.java
@@ -46,7 +46,7 @@ public class HttpClientUtil implements ConsentLogger {
   public ClassicHttpResponse getHttpResponse(HttpGet request) throws IOException {
     try (final CloseableHttpClient httpclient = HttpClients.createDefault()) {
       final ScheduledExecutorService executor = Executors.newScheduledThreadPool(1);
-      executor.schedule(request::cancel, configuration.getTimeout(), TimeUnit.SECONDS);
+      executor.schedule(request::cancel, configuration.getTimeoutSeconds(), TimeUnit.SECONDS);
       return httpclient.execute(request, httpResponse -> httpResponse);
     }
   }

--- a/src/main/java/org/broadinstitute/consent/http/util/HttpClientUtil.java
+++ b/src/main/java/org/broadinstitute/consent/http/util/HttpClientUtil.java
@@ -8,25 +8,47 @@ import com.google.api.client.http.HttpResponse;
 import com.google.api.client.http.HttpStatusCodes;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.http.javanet.NetHttpTransport;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpUriRequest;
-import org.apache.http.impl.client.HttpClients;
-import org.broadinstitute.consent.http.exceptions.ConsentConflictException;
-import org.broadinstitute.consent.http.models.AuthUser;
-
+import java.io.IOException;
+import java.util.Objects;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.ForbiddenException;
 import javax.ws.rs.NotAuthorizedException;
 import javax.ws.rs.NotFoundException;
 import javax.ws.rs.ServerErrorException;
 import javax.ws.rs.core.MediaType;
-import java.io.IOException;
-import java.util.Objects;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.core5.http.ClassicHttpResponse;
+import org.broadinstitute.consent.http.configurations.ServicesConfiguration;
+import org.broadinstitute.consent.http.exceptions.ConsentConflictException;
+import org.broadinstitute.consent.http.models.AuthUser;
 
-public class HttpClientUtil {
+public class HttpClientUtil implements ConsentLogger {
 
-  public CloseableHttpResponse getHttpResponse(HttpUriRequest request) throws IOException {
-    return HttpClients.createMinimal().execute(request);
+  private final ServicesConfiguration configuration;
+
+  public HttpClientUtil(ServicesConfiguration configuration) {
+    this.configuration = configuration;
+  }
+
+  /**
+   * This handles GET requests that could be subject to connection timeout errors by
+   * limiting the request to a configured default number of seconds.
+   *
+   * @param request The HttpGet request
+   * @return ClassicHttpResponse
+   * @throws IOException The exception
+   */
+  public ClassicHttpResponse getHttpResponse(HttpGet request) throws IOException {
+    try (final CloseableHttpClient httpclient = HttpClients.createDefault()) {
+      final ScheduledExecutorService executor = Executors.newScheduledThreadPool(1);
+      executor.schedule(request::cancel, configuration.getTimeout(), TimeUnit.SECONDS);
+      return httpclient.execute(request, httpResponse -> httpResponse);
+    }
   }
 
   public HttpRequest buildGetRequest(GenericUrl genericUrl, AuthUser authUser) throws Exception {
@@ -71,20 +93,19 @@ public class HttpClientUtil {
       request.setThrowExceptionOnExecuteError(false);
       HttpResponse response = request.execute();
       if (Objects.nonNull(response)) {
-        switch (response.getStatusCode()) {
-          case HttpStatusCodes.STATUS_CODE_BAD_REQUEST:
-            throw new BadRequestException(response.getStatusMessage());
-          case HttpStatusCodes.STATUS_CODE_UNAUTHORIZED:
-            throw new NotAuthorizedException(response.getStatusMessage());
-          case HttpStatusCodes.STATUS_CODE_FORBIDDEN:
-            throw new ForbiddenException(response.getStatusMessage());
-          case HttpStatusCodes.STATUS_CODE_NOT_FOUND:
-            throw new NotFoundException(response.getStatusMessage());
-          case HttpStatusCodes.STATUS_CODE_CONFLICT:
-            throw new ConsentConflictException(response.getStatusMessage());
-          default:
-            return response;
-        }
+        return switch (response.getStatusCode()) {
+          case HttpStatusCodes.STATUS_CODE_BAD_REQUEST ->
+              throw new BadRequestException(response.getStatusMessage());
+          case HttpStatusCodes.STATUS_CODE_UNAUTHORIZED ->
+              throw new NotAuthorizedException(response.getStatusMessage());
+          case HttpStatusCodes.STATUS_CODE_FORBIDDEN ->
+              throw new ForbiddenException(response.getStatusMessage());
+          case HttpStatusCodes.STATUS_CODE_NOT_FOUND ->
+              throw new NotFoundException(response.getStatusMessage());
+          case HttpStatusCodes.STATUS_CODE_CONFLICT ->
+              throw new ConsentConflictException(response.getStatusMessage());
+          default -> response;
+        };
       }
     } catch (IOException e) {
       throw new ServerErrorException("Server Error", HttpStatusCodes.STATUS_CODE_SERVER_ERROR);

--- a/src/test/java/org/broadinstitute/consent/http/health/OntologyHealthCheckTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/health/OntologyHealthCheckTest.java
@@ -10,9 +10,8 @@ import static org.mockito.MockitoAnnotations.openMocks;
 
 import com.codahale.metrics.health.HealthCheck;
 import com.google.api.client.http.HttpStatusCodes;
-import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+import org.apache.hc.core5.http.ClassicHttpResponse;
 import org.apache.hc.core5.http.io.entity.StringEntity;
-import org.apache.hc.core5.http.message.StatusLine;
 import org.broadinstitute.consent.http.configurations.ServicesConfiguration;
 import org.broadinstitute.consent.http.util.HttpClientUtil;
 import org.junit.Before;
@@ -23,9 +22,7 @@ public class OntologyHealthCheckTest {
 
   @Mock private HttpClientUtil clientUtil;
 
-  @Mock private CloseableHttpResponse response;
-
-  @Mock private StatusLine statusLine;
+  @Mock private ClassicHttpResponse response;
 
   @Mock private ServicesConfiguration servicesConfiguration;
 
@@ -51,7 +48,7 @@ public class OntologyHealthCheckTest {
 
   @Test
   public void testCheckSuccess() {
-    when(statusLine.getStatusCode()).thenReturn(HttpStatusCodes.STATUS_CODE_OK);
+    when(response.getCode()).thenReturn(HttpStatusCodes.STATUS_CODE_OK);
     initHealthCheck(true);
 
     HealthCheck.Result result = healthCheck.check();
@@ -60,7 +57,7 @@ public class OntologyHealthCheckTest {
 
   @Test
   public void testCheckFailure() {
-    when(statusLine.getStatusCode()).thenReturn(HttpStatusCodes.STATUS_CODE_SERVER_ERROR);
+    when(response.getCode()).thenReturn(HttpStatusCodes.STATUS_CODE_SERVER_ERROR);
     initHealthCheck(true);
 
     HealthCheck.Result result = healthCheck.check();

--- a/src/test/java/org/broadinstitute/consent/http/health/OntologyHealthCheckTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/health/OntologyHealthCheckTest.java
@@ -1,16 +1,5 @@
 package org.broadinstitute.consent.http.health;
 
-import com.codahale.metrics.health.HealthCheck;
-import com.google.api.client.http.HttpStatusCodes;
-import org.apache.http.StatusLine;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.entity.StringEntity;
-import org.broadinstitute.consent.http.configurations.ServicesConfiguration;
-import org.broadinstitute.consent.http.util.HttpClientUtil;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.Mock;
-
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -18,6 +7,17 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.openMocks;
+
+import com.codahale.metrics.health.HealthCheck;
+import com.google.api.client.http.HttpStatusCodes;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+import org.apache.hc.core5.http.io.entity.StringEntity;
+import org.apache.hc.core5.http.message.StatusLine;
+import org.broadinstitute.consent.http.configurations.ServicesConfiguration;
+import org.broadinstitute.consent.http.util.HttpClientUtil;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
 
 public class OntologyHealthCheckTest {
 
@@ -52,7 +52,6 @@ public class OntologyHealthCheckTest {
   @Test
   public void testCheckSuccess() {
     when(statusLine.getStatusCode()).thenReturn(HttpStatusCodes.STATUS_CODE_OK);
-    when(response.getStatusLine()).thenReturn(statusLine);
     initHealthCheck(true);
 
     HealthCheck.Result result = healthCheck.check();
@@ -62,7 +61,6 @@ public class OntologyHealthCheckTest {
   @Test
   public void testCheckFailure() {
     when(statusLine.getStatusCode()).thenReturn(HttpStatusCodes.STATUS_CODE_SERVER_ERROR);
-    when(response.getStatusLine()).thenReturn(statusLine);
     initHealthCheck(true);
 
     HealthCheck.Result result = healthCheck.check();
@@ -71,7 +69,7 @@ public class OntologyHealthCheckTest {
 
   @Test
   public void testCheckException() {
-    doThrow(new RuntimeException()).when(response).getStatusLine();
+    doThrow(new RuntimeException()).when(response).getCode();
     initHealthCheck(true);
 
     HealthCheck.Result result = healthCheck.check();

--- a/src/test/java/org/broadinstitute/consent/http/health/SamHealthCheckTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/health/SamHealthCheckTest.java
@@ -1,16 +1,5 @@
 package org.broadinstitute.consent.http.health;
 
-import com.codahale.metrics.health.HealthCheck;
-import com.google.api.client.http.HttpStatusCodes;
-import org.apache.http.StatusLine;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.entity.StringEntity;
-import org.broadinstitute.consent.http.configurations.ServicesConfiguration;
-import org.broadinstitute.consent.http.util.HttpClientUtil;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.Mock;
-
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -18,6 +7,17 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.openMocks;
+
+import com.codahale.metrics.health.HealthCheck;
+import com.google.api.client.http.HttpStatusCodes;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+import org.apache.hc.core5.http.io.entity.StringEntity;
+import org.apache.hc.core5.http.message.StatusLine;
+import org.broadinstitute.consent.http.configurations.ServicesConfiguration;
+import org.broadinstitute.consent.http.util.HttpClientUtil;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
 
 public class SamHealthCheckTest {
 
@@ -55,7 +55,6 @@ public class SamHealthCheckTest {
   @Test
   public void testCheckSuccess() throws Exception {
     when(statusLine.getStatusCode()).thenReturn(HttpStatusCodes.STATUS_CODE_OK);
-    when(response.getStatusLine()).thenReturn(statusLine);
     initHealthCheck(true);
 
     HealthCheck.Result result = healthCheck.check();
@@ -65,7 +64,6 @@ public class SamHealthCheckTest {
   @Test
   public void testCheckFailure() throws Exception {
     when(statusLine.getStatusCode()).thenReturn(HttpStatusCodes.STATUS_CODE_SERVER_ERROR);
-    when(response.getStatusLine()).thenReturn(statusLine);
     initHealthCheck(true);
 
     HealthCheck.Result result = healthCheck.check();
@@ -74,7 +72,6 @@ public class SamHealthCheckTest {
 
   @Test
   public void testCheckException() throws Exception {
-    doThrow(new RuntimeException()).when(response).getStatusLine();
     initHealthCheck(true);
 
     HealthCheck.Result result = healthCheck.check();

--- a/src/test/java/org/broadinstitute/consent/http/health/SamHealthCheckTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/health/SamHealthCheckTest.java
@@ -10,9 +10,8 @@ import static org.mockito.MockitoAnnotations.openMocks;
 
 import com.codahale.metrics.health.HealthCheck;
 import com.google.api.client.http.HttpStatusCodes;
-import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+import org.apache.hc.core5.http.ClassicHttpResponse;
 import org.apache.hc.core5.http.io.entity.StringEntity;
-import org.apache.hc.core5.http.message.StatusLine;
 import org.broadinstitute.consent.http.configurations.ServicesConfiguration;
 import org.broadinstitute.consent.http.util.HttpClientUtil;
 import org.junit.Before;
@@ -23,9 +22,7 @@ public class SamHealthCheckTest {
 
   @Mock private HttpClientUtil clientUtil;
 
-  @Mock private CloseableHttpResponse response;
-
-  @Mock private StatusLine statusLine;
+  @Mock private ClassicHttpResponse response;
 
   @Mock private ServicesConfiguration servicesConfiguration;
 
@@ -54,7 +51,7 @@ public class SamHealthCheckTest {
 
   @Test
   public void testCheckSuccess() throws Exception {
-    when(statusLine.getStatusCode()).thenReturn(HttpStatusCodes.STATUS_CODE_OK);
+    when(response.getCode()).thenReturn(HttpStatusCodes.STATUS_CODE_OK);
     initHealthCheck(true);
 
     HealthCheck.Result result = healthCheck.check();
@@ -63,7 +60,7 @@ public class SamHealthCheckTest {
 
   @Test
   public void testCheckFailure() throws Exception {
-    when(statusLine.getStatusCode()).thenReturn(HttpStatusCodes.STATUS_CODE_SERVER_ERROR);
+    when(response.getCode()).thenReturn(HttpStatusCodes.STATUS_CODE_SERVER_ERROR);
     initHealthCheck(true);
 
     HealthCheck.Result result = healthCheck.check();

--- a/src/test/java/org/broadinstitute/consent/http/health/SendGridHealthCheckTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/health/SendGridHealthCheckTest.java
@@ -1,17 +1,5 @@
 package org.broadinstitute.consent.http.health;
 
-import com.codahale.metrics.health.HealthCheck;
-import com.google.api.client.http.HttpStatusCodes;
-import com.google.gson.Gson;
-import org.apache.http.StatusLine;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.entity.StringEntity;
-import org.broadinstitute.consent.http.configurations.MailConfiguration;
-import org.broadinstitute.consent.http.util.HttpClientUtil;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.Mock;
-
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -19,6 +7,18 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.openMocks;
+
+import com.codahale.metrics.health.HealthCheck;
+import com.google.api.client.http.HttpStatusCodes;
+import com.google.gson.Gson;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+import org.apache.hc.core5.http.io.entity.StringEntity;
+import org.apache.hc.core5.http.message.StatusLine;
+import org.broadinstitute.consent.http.configurations.MailConfiguration;
+import org.broadinstitute.consent.http.util.HttpClientUtil;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
 
 public class SendGridHealthCheckTest {
     @Mock
@@ -66,7 +66,6 @@ public class SendGridHealthCheckTest {
     @Test
     public void testCheckSuccess() throws Exception {
         when(statusLine.getStatusCode()).thenReturn(HttpStatusCodes.STATUS_CODE_OK);
-        when(response.getStatusLine()).thenReturn(statusLine);
         initHealthCheck(goodStatus, true);
 
         HealthCheck.Result result = healthCheck.check();
@@ -76,7 +75,6 @@ public class SendGridHealthCheckTest {
     @Test
     public void testCheckFailure() throws Exception {
         when(statusLine.getStatusCode()).thenReturn(HttpStatusCodes.STATUS_CODE_SERVER_ERROR);
-        when(response.getStatusLine()).thenReturn(statusLine);
         initHealthCheck(goodStatus, true);
 
         HealthCheck.Result result = healthCheck.check();
@@ -86,7 +84,6 @@ public class SendGridHealthCheckTest {
     @Test
     public void testCheckExternalFailure() throws Exception {
         when(statusLine.getStatusCode()).thenReturn(HttpStatusCodes.STATUS_CODE_OK);
-        when(response.getStatusLine()).thenReturn(statusLine);
         initHealthCheck(badStatus, true);
 
         HealthCheck.Result result = healthCheck.check();
@@ -95,7 +92,7 @@ public class SendGridHealthCheckTest {
 
     @Test
     public void testCheckException() throws Exception {
-        doThrow(new RuntimeException()).when(response).getStatusLine();
+        doThrow(new RuntimeException()).when(response).getCode();
         initHealthCheck(goodStatus, true);
 
         HealthCheck.Result result = healthCheck.check();

--- a/src/test/java/org/broadinstitute/consent/http/health/SendGridHealthCheckTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/health/SendGridHealthCheckTest.java
@@ -11,9 +11,8 @@ import static org.mockito.MockitoAnnotations.openMocks;
 import com.codahale.metrics.health.HealthCheck;
 import com.google.api.client.http.HttpStatusCodes;
 import com.google.gson.Gson;
-import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+import org.apache.hc.core5.http.ClassicHttpResponse;
 import org.apache.hc.core5.http.io.entity.StringEntity;
-import org.apache.hc.core5.http.message.StatusLine;
 import org.broadinstitute.consent.http.configurations.MailConfiguration;
 import org.broadinstitute.consent.http.util.HttpClientUtil;
 import org.junit.Before;
@@ -25,10 +24,7 @@ public class SendGridHealthCheckTest {
     private HttpClientUtil clientUtil;
 
     @Mock
-    private CloseableHttpResponse response;
-
-    @Mock
-    private StatusLine statusLine;
+    private ClassicHttpResponse response;
 
     @Mock
     private MailConfiguration mailConfiguration;
@@ -65,7 +61,7 @@ public class SendGridHealthCheckTest {
 
     @Test
     public void testCheckSuccess() throws Exception {
-        when(statusLine.getStatusCode()).thenReturn(HttpStatusCodes.STATUS_CODE_OK);
+        when(response.getCode()).thenReturn(HttpStatusCodes.STATUS_CODE_OK);
         initHealthCheck(goodStatus, true);
 
         HealthCheck.Result result = healthCheck.check();
@@ -74,7 +70,7 @@ public class SendGridHealthCheckTest {
 
     @Test
     public void testCheckFailure() throws Exception {
-        when(statusLine.getStatusCode()).thenReturn(HttpStatusCodes.STATUS_CODE_SERVER_ERROR);
+        when(response.getCode()).thenReturn(HttpStatusCodes.STATUS_CODE_SERVER_ERROR);
         initHealthCheck(goodStatus, true);
 
         HealthCheck.Result result = healthCheck.check();
@@ -83,7 +79,7 @@ public class SendGridHealthCheckTest {
 
     @Test
     public void testCheckExternalFailure() throws Exception {
-        when(statusLine.getStatusCode()).thenReturn(HttpStatusCodes.STATUS_CODE_OK);
+        when(response.getCode()).thenReturn(HttpStatusCodes.STATUS_CODE_OK);
         initHealthCheck(badStatus, true);
 
         HealthCheck.Result result = healthCheck.check();

--- a/src/test/java/org/broadinstitute/consent/http/util/HttpClientUtilTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/util/HttpClientUtilTest.java
@@ -48,7 +48,7 @@ public class HttpClientUtilTest implements WithMockServer {
     mockServerClient = new MockServerClient(container.getHost(), container.getServerPort());
     mockServerClient.reset();
     ServicesConfiguration configuration = new ServicesConfiguration();
-    configuration.setTimeout(1);
+    configuration.setTimeoutSeconds(1);
     clientUtil = new HttpClientUtil(configuration);
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/util/HttpClientUtilTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/util/HttpClientUtilTest.java
@@ -1,0 +1,78 @@
+package org.broadinstitute.consent.http.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.MockitoAnnotations.openMocks;
+import static org.mockserver.model.HttpRequest.request;
+import static org.mockserver.model.HttpResponse.response;
+
+import com.google.api.client.http.HttpStatusCodes;
+import java.util.concurrent.TimeUnit;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.impl.classic.RequestFailedException;
+import org.apache.hc.core5.http.ClassicHttpResponse;
+import org.broadinstitute.consent.http.WithMockServer;
+import org.broadinstitute.consent.http.configurations.ServicesConfiguration;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockserver.client.MockServerClient;
+import org.mockserver.model.Delay;
+import org.testcontainers.containers.MockServerContainer;
+
+public class HttpClientUtilTest implements WithMockServer {
+
+  private HttpClientUtil clientUtil;
+
+  private MockServerClient mockServerClient;
+
+  private static final MockServerContainer container = new MockServerContainer(IMAGE);
+
+  private final String statusUrl = "http://" + container.getHost() + ":" + container.getServerPort() + "/";
+
+  @BeforeClass
+  public static void setUp() {
+    container.start();
+  }
+
+  @AfterClass
+  public static void tearDown() {
+    container.stop();
+  }
+
+  @Before
+  public void init() {
+    openMocks(this);
+    mockServerClient = new MockServerClient(container.getHost(), container.getServerPort());
+    mockServerClient.reset();
+    ServicesConfiguration configuration = new ServicesConfiguration();
+    configuration.setTimeout(1);
+    clientUtil = new HttpClientUtil(configuration);
+  }
+
+  @Test
+  public void testGetHttpResponseWithinTimeout() throws Exception {
+    mockServerClient.when(request())
+      .respond(response()
+      .withStatusCode(200));
+    ClassicHttpResponse response = clientUtil.getHttpResponse(new HttpGet(statusUrl));
+    assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getCode());
+  }
+
+  @Test
+  public void testGetHttpResponseOverTimeout() {
+    mockServerClient.when(request())
+      .respond(response()
+      .withStatusCode(200)
+      .withDelay(Delay.delay(TimeUnit.SECONDS, 3)));
+    try {
+      clientUtil.getHttpResponse(new HttpGet(statusUrl));
+      fail("The above request should have thrown an exception");
+    } catch (Exception e) {
+      assertTrue(e instanceof RequestFailedException);
+    }
+  }
+
+}

--- a/src/test/java/org/broadinstitute/consent/http/util/HttpClientUtilTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/util/HttpClientUtilTest.java
@@ -30,7 +30,7 @@ public class HttpClientUtilTest implements WithMockServer {
 
   private static final MockServerContainer container = new MockServerContainer(IMAGE);
 
-  private final String statusUrl = "http://" + container.getHost() + ":" + container.getServerPort() + "/";
+  private final String statusUrl = String.format("http://%s:%s/", container.getHost(), container.getServerPort());
 
   @BeforeClass
   public static void setUp() {
@@ -53,7 +53,7 @@ public class HttpClientUtilTest implements WithMockServer {
   }
 
   @Test
-  public void testGetHttpResponseWithinTimeout() throws Exception {
+  public void testGetHttpResponseUnderTimeout() throws Exception {
     mockServerClient.when(request())
       .respond(response()
       .withStatusCode(200));

--- a/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-2229

This PR adds a default timeout to the external http calls we use to access Ontology, Sam, and Sendgrid. This PR does not address our ElasticSearch status check since that uses a different client (ES vs Apache) and has not been problematic in practice. When a service fails due to a request taking longer than the configured value, we will have a functional status call but with a degraded state which is a more accurate status representation than hanging on long downstream status checks.

## Testing
Add a line to the services block of your local config with zero seconds so all calls immediately fail:
```
services:
  localURL: foo
  ontologyURL: bar
  samUrl: baz
  timeoutSeconds: 0
```

The app should run with or without this configuration as there is a default value specified in code. Future PRs will address adding this line to Consent's configuration in its helm chart.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment


[DUOS-2229]: https://broadworkbench.atlassian.net/browse/DUOS-2229?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ