### PR TITLE
[DUOS-2231][risk=no] Add optional email to dac create/update

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/DacDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DacDAO.java
@@ -40,7 +40,7 @@ public interface DacDAO extends Transactional<DacDAO> {
     @RegisterBeanMapper(value = Dataset.class)
     @UseRowReducer(DacWithDatasetsReducer.class)
     @SqlQuery(
-        "SELECT dac.dac_id, dac.name, dac.description, d.dataset_id, d.name AS dataset_name, DATE(d.create_date) AS dataset_create_date, "
+        "SELECT dac.dac_id, dac.email, dac.name, dac.description, d.dataset_id, d.name AS dataset_name, DATE(d.create_date) AS dataset_create_date, "
             + " d.object_id, d.active, d.needs_approval, d.alias AS dataset_alias, d.create_user_id, d.update_date AS dataset_update_date, "
             + " d.update_user_id, d.data_use AS dataset_data_use, d.sharing_plan_document, d.sharing_plan_document_name, ca.consent_id, c.translated_use_restriction "
             + " FROM dac "
@@ -115,10 +115,31 @@ public interface DacDAO extends Transactional<DacDAO> {
     @GetGeneratedKeys
     Integer createDac(@Bind("name") String name, @Bind("description") String description, @Bind("createDate") Date createDate);
 
+    /**
+     * Create a Dac given name, description, and create date
+     *
+     * @param name The name for the new DAC
+     * @param description The description for the new DAC
+     * @param email The email for the new DAC
+     * @param createDate The date this new DAC was created
+     * @return Integer
+     */
+    @SqlUpdate("INSERT INTO dac (name, description, email, create_date) VALUES (:name, :description, :email, :createDate)")
+    @GetGeneratedKeys
+    Integer createDac(@Bind("name") String name, @Bind("description") String description, @Bind("email") String email, @Bind("createDate") Date createDate);
+
     @SqlUpdate("UPDATE dac SET name = :name, description = :description, update_date = :updateDate WHERE dac_id = :dacId")
     void updateDac(
             @Bind("name") String name,
             @Bind("description") String description,
+            @Bind("updateDate") Date updateDate,
+            @Bind("dacId") Integer dacId);
+
+    @SqlUpdate("UPDATE dac SET name = :name, description = :description, email = :email, update_date = :updateDate WHERE dac_id = :dacId")
+    void updateDac(
+            @Bind("name") String name,
+            @Bind("description") String description,
+            @Bind("email") String email,
             @Bind("updateDate") Date updateDate,
             @Bind("dacId") Integer dacId);
 

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DacMapper.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DacMapper.java
@@ -31,6 +31,9 @@ public class DacMapper implements RowMapper<Dac>, RowMapperHelper {
     if (hasColumn(resultSet, "dataset_id")) {
       dac.addDatasetId(resultSet.getInt("dataset_id"));
     }
+    if (hasColumn(resultSet, "email")) {
+      dac.setEmail(resultSet.getString("email"));
+    }
     dacMap.put(dac.getDacId(), dac);
     return dac;
   }

--- a/src/main/java/org/broadinstitute/consent/http/models/Dac.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/Dac.java
@@ -30,6 +30,8 @@ public class Dac {
 
     private final List<Integer> datasetIds = new ArrayList<>();
 
+    private String email;
+
     public Dac() {
     }
 
@@ -103,6 +105,15 @@ public class Dac {
 
     public void addDatasetId(Integer datasetId) {
         this.datasetIds.add(datasetId);
+    }
+
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
     }
 
     public void addDataset(Dataset dataset) {

--- a/src/main/java/org/broadinstitute/consent/http/models/DacBuilder.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DacBuilder.java
@@ -33,6 +33,11 @@ public class DacBuilder {
         return this;
     }
 
+    public DacBuilder setEmail(String email) {
+        this.dac.setEmail(email);
+        return this;
+    }
+
     public DacBuilder setCreateDate(Date createDate) {
         this.dac.setCreateDate(createDate);
         return this;

--- a/src/main/java/org/broadinstitute/consent/http/resources/DacResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DacResource.java
@@ -71,7 +71,12 @@ public class DacResource extends Resource {
         if (dac.getDescription() == null) {
             throw new BadRequestException("DAC Description is required");
         }
-        Integer dacId = dacService.createDac(dac.getName(), dac.getDescription());
+        Integer dacId;
+        if (Objects.isNull(dac.getEmail())) {
+            dacId = dacService.createDac(dac.getName(), dac.getDescription());
+        } else {
+            dacId = dacService.createDac(dac.getName(), dac.getDescription(), dac.getEmail());
+        }
         if (dacId == null) {
             throw new Exception("Unable to create DAC with name: " + dac.getName() + " and description: " + dac.getDescription());
         }
@@ -96,7 +101,11 @@ public class DacResource extends Resource {
         if (dac.getDescription() == null) {
             throw new BadRequestException("DAC Description is required");
         }
-        dacService.updateDac(dac.getName(), dac.getDescription(), dac.getDacId());
+        if (Objects.isNull(dac.getEmail())) {
+            dacService.updateDac(dac.getName(), dac.getDescription(), dac.getDacId());
+        } else {
+            dacService.updateDac(dac.getName(), dac.getDescription(), dac.getEmail(), dac.getDacId());
+        }
         Dac savedDac = dacService.findById(dac.getDacId());
         return Response.ok().entity(unmarshal(savedDac)).build();
     }
@@ -220,7 +229,7 @@ public class DacResource extends Resource {
         try{
             User user = userService.findUserByEmail(authUser.getEmail());
             Dataset dataset = datasetService.findDatasetById(datasetId);
-            if(Objects.isNull(dataset) || !Objects.equals(dataset.getDacId(), dacId)) { 
+            if(Objects.isNull(dataset) || !Objects.equals(dataset.getDacId(), dacId)) {
                 //Vague message is intentional, don't want to reveal too much info
                 throw new NotFoundException("Dataset not found");
             }

--- a/src/main/java/org/broadinstitute/consent/http/service/DacService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DacService.java
@@ -141,9 +141,19 @@ public class DacService {
         return dacDAO.createDac(name, description, createDate);
     }
 
+    public Integer createDac(String name, String description, String email) {
+        Date createDate = new Date();
+        return dacDAO.createDac(name, description, email, createDate);
+    }
+
     public void updateDac(String name, String description, Integer dacId) {
         Date updateDate = new Date();
         dacDAO.updateDac(name, description, updateDate, dacId);
+    }
+
+    public void updateDac(String name, String description, String email, Integer dacId) {
+        Date updateDate = new Date();
+        dacDAO.updateDac(name, description, email, updateDate, dacId);
     }
 
     public void deleteDac(Integer dacId) {

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -254,125 +254,9 @@ paths:
         404:
           description: The consent for the id couldn't be found.
   /api/dac:
-    post:
-      summary: Create a DAC
-      operationId: createDac
-      description: Create a Data Access Committee
-      parameters:
-        - name: dac
-          in: body
-          required: true
-          schema:
-            $ref: '#/components/schemas/Dac'
-      tags:
-        - DAC
-      responses:
-        200:
-          description: Successfully created a DAC
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Dac'
-        400:
-          description: Bad Request. DAC Name and Description are required.
-        403:
-          description: User not authorized to request all dacs.
-        500:
-          description: Internal Server Error
-    put:
-      summary: Update a DAC
-      operationId: updateDac
-      description: Update a Data Access Committee
-      parameters:
-        - name: dac
-          in: body
-          required: true
-          schema:
-            $ref: '#/components/schemas/Dac'
-      tags:
-        - DAC
-      responses:
-        200:
-          description: Successfully upated a DAC
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Dac'
-        400:
-          description: Bad Request. DAC ID, Name, and Description are required.
-        500:
-          description: Internal Server Error
-    get:
-      summary: Get all DACs
-      description: All Data Access Committees with a list of chairpersons and members
-      parameters:
-        - name: withUsers
-          in: query
-          required: false
-          schema:
-            type: boolean
-      tags:
-        - DAC
-      responses:
-        200:
-          description: All Data Access Committees with chairpersons and members
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/Dac'
-        500:
-          description: Internal Server Error
+    $ref: 'paths/dac.yaml'
   /api/dac/{dacId}:
-    get:
-      summary: Get DAC by ID
-      operationId: getDacById
-      description: Get Data Access Committee by Id
-      parameters:
-        - name: dacId
-          in: path
-          description: The DAC ID
-          required: true
-          schema:
-            type: integer
-      tags:
-        - DAC
-      responses:
-        200:
-          description: The Data Access Committee matching the provided ID
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Dac'
-        404:
-          description: No DAC found with the given ID
-        500:
-          description: Internal Server Error
-    delete:
-      summary: Delete DAC by ID
-      operationId: deleteDac
-      description: Delete Data Access Committee by Id
-      parameters:
-        - name: dacId
-          in: path
-          description: The DAC ID
-          required: true
-          schema:
-            type: integer
-      tags:
-        - DAC
-      responses:
-        200:
-          description: The Data Access Committee matching the provided ID was deleted
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Dac'
-        404:
-          description: No DAC found with the given ID
-        500:
-          description: Internal Server Error
+    $ref: 'paths/dacById.yaml'
   /api/dac/{dacId}/dataset/{datasetId}:
     $ref: 'paths/approveDataset.yaml'
   /api/dac/{dacId}/member/{userId}:
@@ -2374,36 +2258,6 @@ components:
           type: integer
           format: int32
           description: The display order of the properties.
-    Dac:
-      type: object
-      properties:
-        dacId:
-          type: integer
-          description: The DAC Id
-        name:
-          type: string
-          description: The DAC Name
-        description:
-          type: string
-          description: The DAC Description
-        createDate:
-          type: string
-          format: date
-          description: Date created
-        updateDate:
-          type: string
-          format: date
-          description: Date last updated
-        chairpersons:
-          description: List of Chairpersons
-          type: array
-          items:
-            $ref: '#/components/schemas/User'
-        members:
-          description: List of Members
-          type: array
-          items:
-            $ref: '#/components/schemas/User'
     SimplifiedUser:
       $ref: './schemas/SimplifiedUser.yaml'
     SamSelfDiagnostics:

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -1981,6 +1981,8 @@ components:
       $ref: './schemas/ConsentAssociation.yaml'
     DarCollection:
       $ref: './schemas/DarCollection.yaml'
+    Data Access Committee:
+      $ref: './schemas/Dac.yaml'
     DataAccessRequest:
       $ref: './schemas/DataAccessRequest.yaml'
     Dataset:

--- a/src/main/resources/assets/paths/dac.yaml
+++ b/src/main/resources/assets/paths/dac.yaml
@@ -1,0 +1,72 @@
+post:
+  summary: Create a DAC
+  operationId: createDac
+  description: Create a Data Access Committee
+  requestBody:
+    description: Data Access Committee
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: '../schemas/Dac.yaml'
+  tags:
+    - DAC
+  responses:
+    200:
+      description: Successfully created a DAC
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/Dac.yaml'
+    400:
+      description: Bad Request. DAC Name and Description are required.
+    403:
+      description: User not authorized to request all dacs.
+    500:
+      description: Internal Server Error
+put:
+  summary: Update a DAC
+  operationId: updateDac
+  description: Update a Data Access Committee
+  requestBody:
+    description: Updated Data Access Committee
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: '../schemas/Dac.yaml'
+  tags:
+    - DAC
+  responses:
+    200:
+      description: Successfully upated a DAC
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/Dac.yaml'
+    400:
+      description: Bad Request. DAC ID, Name, and Description are required.
+    500:
+      description: Internal Server Error
+get:
+  summary: Get all DACs
+  description: All Data Access Committees with a list of chairpersons and members
+  parameters:
+    - name: withUsers
+      in: query
+      required: false
+      schema:
+        type: boolean
+  tags:
+    - DAC
+  responses:
+    200:
+      description: All Data Access Committees with chairpersons and members
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: '../schemas/Dac.yaml'
+    500:
+      description: Internal Server Error

--- a/src/main/resources/assets/paths/dacById.yaml
+++ b/src/main/resources/assets/paths/dacById.yaml
@@ -1,0 +1,48 @@
+get:
+  summary: Get DAC by ID
+  operationId: getDacById
+  description: Get Data Access Committee by Id
+  parameters:
+    - name: dacId
+      in: path
+      description: The DAC ID
+      required: true
+      schema:
+        type: integer
+  tags:
+    - DAC
+  responses:
+    200:
+      description: The Data Access Committee matching the provided ID
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/Dac.yaml'
+    404:
+      description: No DAC found with the given ID
+    500:
+      description: Internal Server Error
+delete:
+  summary: Delete DAC by ID
+  operationId: deleteDac
+  description: Delete Data Access Committee by Id
+  parameters:
+    - name: dacId
+      in: path
+      description: The DAC ID
+      required: true
+      schema:
+        type: integer
+  tags:
+    - DAC
+  responses:
+    200:
+      description: The Data Access Committee matching the provided ID was deleted
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/Dac.yaml'
+    404:
+      description: No DAC found with the given ID
+    500:
+      description: Internal Server Error

--- a/src/main/resources/assets/schemas/Dac.yaml
+++ b/src/main/resources/assets/schemas/Dac.yaml
@@ -1,0 +1,32 @@
+type: object
+properties:
+  dacId:
+    type: integer
+    description: The DAC Id
+  name:
+    type: string
+    description: The DAC Name
+  description:
+    type: string
+    description: The DAC Description
+  email:
+    type: string
+    description: Optional DAC Email address
+  createDate:
+    type: string
+    format: date
+    description: Date created
+  updateDate:
+    type: string
+    format: date
+    description: Date last updated
+  chairpersons:
+    description: List of Chairpersons
+    type: array
+    items:
+      $ref: './User.yaml'
+  members:
+    description: List of Members
+    type: array
+    items:
+      $ref: './User.yaml'

--- a/src/main/resources/changelog-master.xml
+++ b/src/main/resources/changelog-master.xml
@@ -109,4 +109,5 @@
     <include file="changesets/changelog-consent-104.0.xml" relativeToChangelogFile="true"/>
     <include file="changesets/changelog-consent-105.0.xml" relativeToChangelogFile="true"/>
     <include file="changesets/changelog-consent-2022-12-29-email.0.xml" relativeToChangelogFile="true"/>
+    <include file="changesets/changelog-consent-2023-01-09-dac-email.0.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/changesets/changelog-consent-2023-01-09-dac-email.0.xml
+++ b/src/main/resources/changesets/changelog-consent-2023-01-09-dac-email.0.xml
@@ -1,0 +1,9 @@
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+    <changeSet id="2023-01-09-dac-email" author="rushtong">
+        <addColumn tableName="dac">
+            <column name="email" type="varchar(255)"/>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/src/test/java/org/broadinstitute/consent/http/db/DacDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DacDAOTest.java
@@ -335,7 +335,6 @@ public class DacDAOTest extends DAOTestHelper {
     }
 
     private Dac insertDac() {
-        String testEmail = "test@email.com";
         Integer id = dacDAO.createDac(
                 "Test_" + RandomStringUtils.random(20, true, true),
                 "Test_" + RandomStringUtils.random(20, true, true),

--- a/src/test/java/org/broadinstitute/consent/http/db/DacDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DacDAOTest.java
@@ -1,5 +1,16 @@
 package org.broadinstitute.consent.http.db;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.Set;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.broadinstitute.consent.http.enumeration.DatasetPropertyType;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
@@ -13,25 +24,25 @@ import org.broadinstitute.consent.http.models.UserRole;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
 public class DacDAOTest extends DAOTestHelper {
+
+    @Test
+    public void testInsertWithoutEmail() {
+        Dac dac = insertDac();
+        assertNotNull(dac);
+    }
+
+    @Test
+    public void testInsertWithEmail() {
+        Dac dac = insertDacWithEmail();
+        assertNotNull(dac);
+    }
 
     @Test
     public void testFindAll() {
         int count = 4;
         for (int i = 1; i <= count; i++) {
-            Dac d = createDac();
+            Dac d = insertDacWithEmail();
             Dataset ds = createDatasetWithDac(d.getDacId());
             Consent c = createConsent();
             consentDAO.insertConsentAssociation(c.getConsentId(), ASSOCIATION_TYPE_TEST, ds.getDataSetId());
@@ -42,7 +53,7 @@ public class DacDAOTest extends DAOTestHelper {
 
     @Test
     public void testFindDacsForEmail() {
-        Dac dac = createDac();
+        Dac dac = insertDacWithEmail();
         User chair = createUser();
         dacDAO.addDacMember(UserRoles.CHAIRPERSON.getRoleId(), chair.getUserId(), dac.getDacId());
 
@@ -69,7 +80,7 @@ public class DacDAOTest extends DAOTestHelper {
 
     @Test
     public void testFindAllDACUsersBySearchString_case1() {
-        Dac dac = createDac();
+        Dac dac = insertDacWithEmail();
         User chair = createUser(); // Creates a user with researcher role
         dacDAO.addDacMember(UserRoles.CHAIRPERSON.getRoleId(), chair.getUserId(), dac.getDacId());
 
@@ -105,9 +116,9 @@ public class DacDAOTest extends DAOTestHelper {
     }
 
     @Test
-    public void testUpdateDac() {
+    public void testUpdateDacWithoutEmail() {
         String newValue = "New Value";
-        Dac dac = createDac();
+        Dac dac = insertDac();
         dacDAO.updateDac(newValue, newValue, new Date(), dac.getDacId());
         Dac updatedDac = dacDAO.findById(dac.getDacId());
 
@@ -116,8 +127,21 @@ public class DacDAOTest extends DAOTestHelper {
     }
 
     @Test
+    public void testUpdateDacWithEmail() {
+        String newValue = "New Value";
+        String newEmail = "new_email@test.com";
+        Dac dac = insertDacWithEmail();
+        dacDAO.updateDac(newValue, newValue, newEmail, new Date(), dac.getDacId());
+        Dac updatedDac = dacDAO.findById(dac.getDacId());
+
+        Assert.assertEquals(updatedDac.getName(), newValue);
+        Assert.assertEquals(updatedDac.getDescription(), newValue);
+        Assert.assertEquals(updatedDac.getEmail(), newEmail);
+    }
+
+    @Test
     public void testDeleteDacMembers() {
-        Dac dac = createDac();
+        Dac dac = insertDacWithEmail();
         Integer memberRoleId = UserRoles.MEMBER.getRoleId();
         User user1 = createUser();
         dacDAO.addDacMember(memberRoleId, user1.getUserId(), dac.getDacId());
@@ -131,7 +155,7 @@ public class DacDAOTest extends DAOTestHelper {
 
     @Test
     public void testDeleteDac() {
-        Dac dac = createDac();
+        Dac dac = insertDacWithEmail();
         Assert.assertNotNull(dac.getDacId());
 
         dacDAO.deleteDac(dac.getDacId());
@@ -141,7 +165,7 @@ public class DacDAOTest extends DAOTestHelper {
 
     @Test
     public void testFindMembersByDacId() {
-        Dac dac = createDac();
+        Dac dac = insertDacWithEmail();
         Integer chairRoleId = UserRoles.CHAIRPERSON.getRoleId();
         Integer memberRoleId = UserRoles.MEMBER.getRoleId();
         User user1 = createUser();
@@ -161,7 +185,7 @@ public class DacDAOTest extends DAOTestHelper {
 
     @Test
     public void testFindMembersByDacIdAndRoleId() {
-        Dac dac = createDac();
+        Dac dac = insertDacWithEmail();
         Integer chairRoleId = UserRoles.CHAIRPERSON.getRoleId();
         Integer memberRoleId = UserRoles.MEMBER.getRoleId();
         User user1 = createUser();
@@ -186,7 +210,7 @@ public class DacDAOTest extends DAOTestHelper {
 
     @Test
     public void testAddDacMember() {
-        Dac dac = createDac();
+        Dac dac = insertDacWithEmail();
         Integer roleId = UserRoles.MEMBER.getRoleId();
         User user = createUser();
         dacDAO.addDacMember(roleId, user.getUserId(), dac.getDacId());
@@ -199,7 +223,7 @@ public class DacDAOTest extends DAOTestHelper {
 
     @Test
     public void testAddDacChair() {
-        Dac dac = createDac();
+        Dac dac = insertDacWithEmail();
         Integer roleId = UserRoles.CHAIRPERSON.getRoleId();
         User user = createUser();
         dacDAO.addDacMember(roleId, user.getUserId(), dac.getDacId());
@@ -212,7 +236,7 @@ public class DacDAOTest extends DAOTestHelper {
 
     @Test
     public void testRemoveDacMember() {
-        Dac dac = createDac();
+        Dac dac = insertDacWithEmail();
         Integer chairRoleId = UserRoles.CHAIRPERSON.getRoleId();
         Integer memberRoleId = UserRoles.MEMBER.getRoleId();
         User user1 = createUser();
@@ -239,28 +263,28 @@ public class DacDAOTest extends DAOTestHelper {
 
     @Test
     public void testFindUserRolesForUser() {
-        Dac dac = createDac();
+        Dac dac = insertDacWithEmail();
         User chair = createUser(); // Creates a user with researcher role; UserRole #1
         dacDAO.addDacMember(UserRoles.CHAIRPERSON.getRoleId(), chair.getUserId(), dac.getDacId()); // ; UserRole #2
-        List<UserRole> userRoles = dacDAO.findUserRolesForUser(chair.getUserId()).stream().distinct().collect(Collectors.toList());
+        List<UserRole> userRoles = dacDAO.findUserRolesForUser(chair.getUserId()).stream().distinct().toList();
         Assert.assertEquals(userRoles.size(), 2);
     }
 
     @Test
     public void testFindUserRolesForUsers() {
-        Dac dac = createDac();
+        Dac dac = insertDacWithEmail();
         User chair = createUser(); // Creates a user with researcher role; UserRole #1
         User member = createUser(); // Creates a user with researcher role; UserRole #2
         dacDAO.addDacMember(UserRoles.CHAIRPERSON.getRoleId(), chair.getUserId(), dac.getDacId()); // ; UserRole #3
         dacDAO.addDacMember(UserRoles.MEMBER.getRoleId(), member.getUserId(), dac.getDacId()); // ; UserRole #4
         List<Integer> userIds = Arrays.asList(chair.getUserId(), member.getUserId());
-        List<UserRole> userRoles = dacDAO.findUserRolesForUsers(userIds).stream().distinct().collect(Collectors.toList());
+        List<UserRole> userRoles = dacDAO.findUserRolesForUsers(userIds).stream().distinct().toList();
         Assert.assertEquals(userRoles.size(), 4);
     }
 
     @Test
     public void testFindDacsForDatasetIds() {
-        Dac dac = createDac();
+        Dac dac = insertDacWithEmail();
         Consent consent1 = createConsent();
         Dataset dataset1 = createDatasetWithDac(dac.getDacId());
         consentDAO.insertConsentAssociation(consent1.getConsentId(), ASSOCIATION_TYPE_TEST, dataset1.getDataSetId());
@@ -275,7 +299,7 @@ public class DacDAOTest extends DAOTestHelper {
 
     @Test
     public void testFindDatasetsAssociatedWithDac_NoAssociated() {
-        Dac dac = createDac();
+        Dac dac = insertDacWithEmail();
 
         List<Dataset> results = datasetDAO.findDatasetsAssociatedWithDac(dac.getDacId());
         assertEquals(0, results.size());
@@ -283,7 +307,7 @@ public class DacDAOTest extends DAOTestHelper {
 
     @Test
     public void testFindDatasetsAssociatedWithDac_AssignedDacId() {
-        Dac dac = createDac();
+        Dac dac = insertDacWithEmail();
         Dataset datasetAssignedDac = createDatasetWithDac(dac.getDacId());
 
         List<Dataset> results = datasetDAO.findDatasetsAssociatedWithDac(dac.getDacId());
@@ -293,8 +317,8 @@ public class DacDAOTest extends DAOTestHelper {
 
     @Test
     public void testFindDatasetsAssociatedWithDac_SuggestedDacId() {
-        Dac dac = createDac();
-        
+        Dac dac = insertDacWithEmail();
+
         Dataset datasetSuggestedDac = createDataset();
         datasetDAO.insertDatasetProperties(List.of(new DatasetProperty(
                 1,
@@ -309,4 +333,24 @@ public class DacDAOTest extends DAOTestHelper {
         assertEquals(1, results.size());
         assertTrue(results.contains(datasetSuggestedDac));
     }
+
+    private Dac insertDac() {
+        String testEmail = "test@email.com";
+        Integer id = dacDAO.createDac(
+                "Test_" + RandomStringUtils.random(20, true, true),
+                "Test_" + RandomStringUtils.random(20, true, true),
+                new Date());
+        return dacDAO.findById(id);
+    }
+
+    private Dac insertDacWithEmail() {
+        String testEmail = "test@email.com";
+        Integer id = dacDAO.createDac(
+                "Test_" + RandomStringUtils.random(20, true, true),
+                "Test_" + RandomStringUtils.random(20, true, true),
+                testEmail,
+                new Date());
+        return dacDAO.findById(id);
+    }
+
 }

--- a/src/test/java/org/broadinstitute/consent/http/resources/DacResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DacResourceTest.java
@@ -186,6 +186,20 @@ public class DacResourceTest {
         assertEquals(200, response.getStatus());
     }
 
+    @Test
+    public void testCreateDacWithEmail_success() throws Exception {
+        Dac dac = new DacBuilder()
+                .setName("name")
+                .setDescription("description")
+                .setEmail("test@email.com")
+                .build();
+        when(dacService.createDac(any(), any(), any())).thenReturn(1);
+        when(dacService.findById(1)).thenReturn(dac);
+
+        Response response = dacResource.createDac(authUser, gson.toJson(dac));
+        assertEquals(200, response.getStatus());
+    }
+
     @Test(expected = BadRequestException.class)
     public void testCreateDac_badRequest_1() throws Exception {
         dacResource.createDac(authUser, null);
@@ -224,6 +238,21 @@ public class DacResourceTest {
                 .setDescription("description")
                 .build();
         doNothing().when(dacService).updateDac(isA(String.class), isA(String.class), isA(Integer.class));
+        when(dacService.findById(1)).thenReturn(dac);
+
+        Response response = dacResource.updateDac(authUser, gson.toJson(dac));
+        assertEquals(200, response.getStatus());
+    }
+
+    @Test
+    public void testUpdateDacWithEmail_success() {
+        Dac dac = new DacBuilder()
+                .setDacId(1)
+                .setName("name")
+                .setEmail("test@email.com")
+                .setDescription("description")
+                .build();
+        doNothing().when(dacService).updateDac(isA(String.class), isA(String.class), isA(String.class), isA(Integer.class));
         when(dacService.findById(1)).thenReturn(dac);
 
         Response response = dacResource.updateDac(authUser, gson.toJson(dac));
@@ -561,7 +590,7 @@ public class DacResourceTest {
         assertEquals(HttpStatusCodes.STATUS_CODE_FORBIDDEN, response.getStatus());
     }
 
-    
+
 
     private JsonArray getListFromEntityString(String str) {
         return GsonUtil.buildGson().fromJson(str, JsonArray.class);

--- a/src/test/java/org/broadinstitute/consent/http/service/DacServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DacServiceTest.java
@@ -137,8 +137,29 @@ public class DacServiceTest {
     }
 
     @Test
+    public void testCreateDacWithEmail() {
+        when(dacDAO.createDac(anyString(), anyString(), anyString(), any())).thenReturn(getDacs().get(0).getDacId());
+        initService();
+
+        Integer dacId = service.createDac("name", "description", "email@test.com");
+        Assert.assertEquals(getDacs().get(0).getDacId(), dacId);
+    }
+
+    @Test
     public void testUpdateDac() {
         doNothing().when(dacDAO).updateDac(anyString(), anyString(), any(), any());
+        initService();
+
+        try {
+            service.updateDac("name", "description", 1);
+        } catch (Exception e) {
+            Assert.fail("Update should not fail");
+        }
+    }
+
+    @Test
+    public void testUpdateDacWithEmail() {
+        doNothing().when(dacDAO).updateDac(anyString(), anyString(), anyString(), any(), any());
         initService();
 
         try {

--- a/src/test/java/org/broadinstitute/consent/http/service/DacServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DacServiceTest.java
@@ -108,7 +108,7 @@ public class DacServiceTest {
                 stream().
                 filter(d -> !d.getChairpersons().isEmpty()).
                 filter(d -> !d.getMembers().isEmpty()).
-                collect(Collectors.toList());
+                toList();
         Assert.assertFalse(dacsWithMembers.isEmpty());
         Assert.assertEquals(1, dacsWithMembers.size());
     }
@@ -163,7 +163,7 @@ public class DacServiceTest {
         initService();
 
         try {
-            service.updateDac("name", "description", 1);
+            service.updateDac("name", "description", "test@email.com",1);
         } catch (Exception e) {
             Assert.fail("Update should not fail");
         }


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-2231

This PR adds an optional email field to Data Access Committees and updates the POST/PUT endpoints to accommodate it.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
