### PR TITLE
[DUOS-2242][risk=no] Fix status check stream closed exceptions

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/configurations/ServicesConfiguration.java
+++ b/src/main/java/org/broadinstitute/consent/http/configurations/ServicesConfiguration.java
@@ -17,6 +17,8 @@ public class ServicesConfiguration {
 
   private Integer timeoutSeconds = 10;
 
+  private Integer poolSize = 10;
+
   private boolean activateSupportNotifications = false;
 
 
@@ -106,5 +108,13 @@ public class ServicesConfiguration {
 
   public void setTimeoutSeconds(Integer timeoutSeconds) {
     this.timeoutSeconds = timeoutSeconds;
+  }
+
+  public Integer getPoolSize() {
+    return poolSize;
+  }
+
+  public void setPoolSize(Integer poolSize) {
+    this.poolSize = poolSize;
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/health/OntologyHealthCheck.java
+++ b/src/main/java/org/broadinstitute/consent/http/health/OntologyHealthCheck.java
@@ -4,13 +4,11 @@ import com.codahale.metrics.health.HealthCheck;
 import com.google.api.client.http.HttpStatusCodes;
 import com.google.gson.Gson;
 import io.dropwizard.lifecycle.Managed;
-import java.nio.charset.Charset;
-import org.apache.commons.io.IOUtils;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
-import org.apache.hc.core5.http.ClassicHttpResponse;
 import org.broadinstitute.consent.http.configurations.ServicesConfiguration;
 import org.broadinstitute.consent.http.resources.StatusResource;
 import org.broadinstitute.consent.http.util.HttpClientUtil;
+import org.broadinstitute.consent.http.util.HttpClientUtil.SimpleResponse;
 
 public class OntologyHealthCheck extends HealthCheck implements Managed {
 
@@ -28,10 +26,10 @@ public class OntologyHealthCheck extends HealthCheck implements Managed {
     try {
       String statusUrl = servicesConfiguration.getOntologyURL() + "status";
       HttpGet httpGet = new HttpGet(statusUrl);
-      try (ClassicHttpResponse response = clientUtil.getHttpResponse(httpGet)) {
-        if (response.getCode() == HttpStatusCodes.STATUS_CODE_OK) {
-          String content =
-              IOUtils.toString(response.getEntity().getContent(), Charset.defaultCharset());
+      try {
+        SimpleResponse response = clientUtil.getHttpResponse(httpGet);
+        if (response.code() == HttpStatusCodes.STATUS_CODE_OK) {
+          String content = response.entity();
           Object ontologyStatus = new Gson().fromJson(content, Object.class);
           return Result.builder()
               .withDetail(StatusResource.OK, true)
@@ -39,7 +37,7 @@ public class OntologyHealthCheck extends HealthCheck implements Managed {
               .healthy()
               .build();
         } else {
-          return Result.unhealthy("Ontology status is unhealthy: " + response.getCode());
+          return Result.unhealthy("Ontology status is unhealthy: " + response.code());
         }
       } catch (Exception e) {
         return Result.unhealthy(e);

--- a/src/main/java/org/broadinstitute/consent/http/health/SamHealthCheck.java
+++ b/src/main/java/org/broadinstitute/consent/http/health/SamHealthCheck.java
@@ -11,6 +11,7 @@ import org.apache.hc.core5.http.ClassicHttpResponse;
 import org.broadinstitute.consent.http.configurations.ServicesConfiguration;
 import org.broadinstitute.consent.http.resources.StatusResource;
 import org.broadinstitute.consent.http.util.HttpClientUtil;
+import org.broadinstitute.consent.http.util.HttpClientUtil.SimpleResponse;
 
 public class SamHealthCheck extends HealthCheck implements Managed {
 
@@ -27,10 +28,10 @@ public class SamHealthCheck extends HealthCheck implements Managed {
     try {
       String statusUrl = configuration.getSamUrl() + "status";
       HttpGet httpGet = new HttpGet(statusUrl);
-      try (ClassicHttpResponse response = clientUtil.getHttpResponse(httpGet)) {
-        if (response.getCode() == HttpStatusCodes.STATUS_CODE_OK) {
-          String content =
-              IOUtils.toString(response.getEntity().getContent(), Charset.defaultCharset());
+      try {
+        SimpleResponse response = clientUtil.getHttpResponse(httpGet);
+        if (response.code() == HttpStatusCodes.STATUS_CODE_OK) {
+          String content = response.entity();
           SamStatus samStatus = new Gson().fromJson(content, SamStatus.class);
           return Result.builder()
               .withDetail(StatusResource.OK, samStatus.ok)
@@ -38,7 +39,7 @@ public class SamHealthCheck extends HealthCheck implements Managed {
               .healthy()
               .build();
         } else {
-          return Result.unhealthy("Sam status is unhealthy: " + response.getCode());
+          return Result.unhealthy("Sam status is unhealthy: " + response.code());
         }
       } catch (Exception e) {
         return Result.unhealthy(e);

--- a/src/main/java/org/broadinstitute/consent/http/health/SendGridHealthCheck.java
+++ b/src/main/java/org/broadinstitute/consent/http/health/SendGridHealthCheck.java
@@ -10,6 +10,7 @@ import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.apache.hc.core5.http.ClassicHttpResponse;
 import org.broadinstitute.consent.http.configurations.MailConfiguration;
 import org.broadinstitute.consent.http.util.HttpClientUtil;
+import org.broadinstitute.consent.http.util.HttpClientUtil.SimpleResponse;
 
 public class SendGridHealthCheck extends HealthCheck implements Managed {
     private final HttpClientUtil clientUtil;
@@ -25,13 +26,14 @@ public class SendGridHealthCheck extends HealthCheck implements Managed {
         try {
             String statusUrl = configuration.getSendGridStatusUrl();
             HttpGet httpGet = new HttpGet(statusUrl);
-            try (ClassicHttpResponse response = clientUtil.getHttpResponse(httpGet)) {
-                if (response.getCode() == HttpStatusCodes.STATUS_CODE_OK) {
-                    String content = IOUtils.toString(response.getEntity().getContent(), Charset.defaultCharset());
+            try {
+                SimpleResponse response = clientUtil.getHttpResponse(httpGet);
+                if (response.code() == HttpStatusCodes.STATUS_CODE_OK) {
+                    String content = response.entity();
                     SendGridStatus status = new Gson().fromJson(content, SendGridStatus.class);
                     return status.getResult();
                 } else {
-                    return Result.unhealthy("SendGrid status is unhealthy: " + response.getCode());
+                    return Result.unhealthy("SendGrid status is unhealthy: " + response.code());
                 }
             } catch (Exception e) {
                 return Result.unhealthy(e);

--- a/src/test/java/org/broadinstitute/consent/http/health/OntologyHealthCheckTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/health/OntologyHealthCheckTest.java
@@ -10,10 +10,9 @@ import static org.mockito.MockitoAnnotations.openMocks;
 
 import com.codahale.metrics.health.HealthCheck;
 import com.google.api.client.http.HttpStatusCodes;
-import org.apache.hc.core5.http.ClassicHttpResponse;
-import org.apache.hc.core5.http.io.entity.StringEntity;
 import org.broadinstitute.consent.http.configurations.ServicesConfiguration;
 import org.broadinstitute.consent.http.util.HttpClientUtil;
+import org.broadinstitute.consent.http.util.HttpClientUtil.SimpleResponse;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -22,7 +21,7 @@ public class OntologyHealthCheckTest {
 
   @Mock private HttpClientUtil clientUtil;
 
-  @Mock private ClassicHttpResponse response;
+  @Mock private SimpleResponse response;
 
   @Mock private ServicesConfiguration servicesConfiguration;
 
@@ -35,7 +34,7 @@ public class OntologyHealthCheckTest {
 
   private void initHealthCheck(boolean configOk) {
     try {
-      when(response.getEntity()).thenReturn(new StringEntity("{}"));
+      when(response.entity()).thenReturn("{}");
       when(clientUtil.getHttpResponse(any())).thenReturn(response);
       if (configOk) {
         when(servicesConfiguration.getOntologyURL()).thenReturn("http://localhost:8000/");
@@ -48,7 +47,7 @@ public class OntologyHealthCheckTest {
 
   @Test
   public void testCheckSuccess() {
-    when(response.getCode()).thenReturn(HttpStatusCodes.STATUS_CODE_OK);
+    when(response.code()).thenReturn(HttpStatusCodes.STATUS_CODE_OK);
     initHealthCheck(true);
 
     HealthCheck.Result result = healthCheck.check();
@@ -57,7 +56,7 @@ public class OntologyHealthCheckTest {
 
   @Test
   public void testCheckFailure() {
-    when(response.getCode()).thenReturn(HttpStatusCodes.STATUS_CODE_SERVER_ERROR);
+    when(response.code()).thenReturn(HttpStatusCodes.STATUS_CODE_SERVER_ERROR);
     initHealthCheck(true);
 
     HealthCheck.Result result = healthCheck.check();
@@ -66,7 +65,7 @@ public class OntologyHealthCheckTest {
 
   @Test
   public void testCheckException() {
-    doThrow(new RuntimeException()).when(response).getCode();
+    doThrow(new RuntimeException()).when(response).code();
     initHealthCheck(true);
 
     HealthCheck.Result result = healthCheck.check();

--- a/src/test/java/org/broadinstitute/consent/http/health/SamHealthCheckTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/health/SamHealthCheckTest.java
@@ -10,10 +10,9 @@ import static org.mockito.MockitoAnnotations.openMocks;
 
 import com.codahale.metrics.health.HealthCheck;
 import com.google.api.client.http.HttpStatusCodes;
-import org.apache.hc.core5.http.ClassicHttpResponse;
-import org.apache.hc.core5.http.io.entity.StringEntity;
 import org.broadinstitute.consent.http.configurations.ServicesConfiguration;
 import org.broadinstitute.consent.http.util.HttpClientUtil;
+import org.broadinstitute.consent.http.util.HttpClientUtil.SimpleResponse;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -22,7 +21,7 @@ public class SamHealthCheckTest {
 
   @Mock private HttpClientUtil clientUtil;
 
-  @Mock private ClassicHttpResponse response;
+  @Mock private SimpleResponse response;
 
   @Mock private ServicesConfiguration servicesConfiguration;
 
@@ -34,11 +33,21 @@ public class SamHealthCheckTest {
   }
 
   private void initHealthCheck(boolean configOk) {
+    String okResponse = """
+        {
+          "ok": true,
+          "systems": {
+            "GooglePubSub": {"ok": true},
+            "Database": {"ok": true},
+            "GoogleGroups": {"ok": true},
+            "GoogleIam": {"ok": true},
+            "OpenDJ": {"ok": true}
+          }
+        }
+        """;
     try {
-      when(response.getEntity())
-          .thenReturn(
-              new StringEntity(
-                  "{\"ok\":true,\"systems\":{\"GooglePubSub\": {\"ok\": true},\"Database\": {\"ok\": true},\"GoogleGroups\": {\"ok\": true},\"GoogleIam\": {\"ok\": true},\"OpenDJ\": {\"ok\": true}}}"));
+      when(response.entity())
+          .thenReturn(okResponse);
       when(clientUtil.getHttpResponse(any())).thenReturn(response);
       if (configOk) {
         when(servicesConfiguration.getSamUrl()).thenReturn("http://localhost:8000/");
@@ -51,7 +60,7 @@ public class SamHealthCheckTest {
 
   @Test
   public void testCheckSuccess() throws Exception {
-    when(response.getCode()).thenReturn(HttpStatusCodes.STATUS_CODE_OK);
+    when(response.code()).thenReturn(HttpStatusCodes.STATUS_CODE_OK);
     initHealthCheck(true);
 
     HealthCheck.Result result = healthCheck.check();
@@ -60,7 +69,7 @@ public class SamHealthCheckTest {
 
   @Test
   public void testCheckFailure() throws Exception {
-    when(response.getCode()).thenReturn(HttpStatusCodes.STATUS_CODE_SERVER_ERROR);
+    when(response.code()).thenReturn(HttpStatusCodes.STATUS_CODE_SERVER_ERROR);
     initHealthCheck(true);
 
     HealthCheck.Result result = healthCheck.check();

--- a/src/test/java/org/broadinstitute/consent/http/health/SendGridHealthCheckTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/health/SendGridHealthCheckTest.java
@@ -11,10 +11,9 @@ import static org.mockito.MockitoAnnotations.openMocks;
 import com.codahale.metrics.health.HealthCheck;
 import com.google.api.client.http.HttpStatusCodes;
 import com.google.gson.Gson;
-import org.apache.hc.core5.http.ClassicHttpResponse;
-import org.apache.hc.core5.http.io.entity.StringEntity;
 import org.broadinstitute.consent.http.configurations.MailConfiguration;
 import org.broadinstitute.consent.http.util.HttpClientUtil;
+import org.broadinstitute.consent.http.util.HttpClientUtil.SimpleResponse;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -24,7 +23,7 @@ public class SendGridHealthCheckTest {
     private HttpClientUtil clientUtil;
 
     @Mock
-    private ClassicHttpResponse response;
+    private SimpleResponse response;
 
     @Mock
     private MailConfiguration mailConfiguration;
@@ -48,7 +47,7 @@ public class SendGridHealthCheckTest {
     private void initHealthCheck(SendGridStatus status, boolean configOk) {
         try {
             String statusJson = new Gson().toJson(status);
-            when(response.getEntity()).thenReturn(new StringEntity(statusJson));
+            when(response.entity()).thenReturn(statusJson);
             when(clientUtil.getHttpResponse(any())).thenReturn(response);
             if (configOk) {
                 when(mailConfiguration.getSendGridStatusUrl()).thenReturn("http://localhost:8000");
@@ -61,7 +60,7 @@ public class SendGridHealthCheckTest {
 
     @Test
     public void testCheckSuccess() throws Exception {
-        when(response.getCode()).thenReturn(HttpStatusCodes.STATUS_CODE_OK);
+        when(response.code()).thenReturn(HttpStatusCodes.STATUS_CODE_OK);
         initHealthCheck(goodStatus, true);
 
         HealthCheck.Result result = healthCheck.check();
@@ -70,7 +69,7 @@ public class SendGridHealthCheckTest {
 
     @Test
     public void testCheckFailure() throws Exception {
-        when(response.getCode()).thenReturn(HttpStatusCodes.STATUS_CODE_SERVER_ERROR);
+        when(response.code()).thenReturn(HttpStatusCodes.STATUS_CODE_SERVER_ERROR);
         initHealthCheck(goodStatus, true);
 
         HealthCheck.Result result = healthCheck.check();
@@ -79,7 +78,7 @@ public class SendGridHealthCheckTest {
 
     @Test
     public void testCheckExternalFailure() throws Exception {
-        when(response.getCode()).thenReturn(HttpStatusCodes.STATUS_CODE_OK);
+        when(response.code()).thenReturn(HttpStatusCodes.STATUS_CODE_OK);
         initHealthCheck(badStatus, true);
 
         HealthCheck.Result result = healthCheck.check();
@@ -88,7 +87,7 @@ public class SendGridHealthCheckTest {
 
     @Test
     public void testCheckException() throws Exception {
-        doThrow(new RuntimeException()).when(response).getCode();
+        doThrow(new RuntimeException()).when(response).code();
         initHealthCheck(goodStatus, true);
 
         HealthCheck.Result result = healthCheck.check();

--- a/src/test/java/org/broadinstitute/consent/http/util/HttpClientUtilTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/util/HttpClientUtilTest.java
@@ -11,9 +11,9 @@ import com.google.api.client.http.HttpStatusCodes;
 import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.apache.hc.client5.http.impl.classic.RequestFailedException;
-import org.apache.hc.core5.http.ClassicHttpResponse;
 import org.broadinstitute.consent.http.WithMockServer;
 import org.broadinstitute.consent.http.configurations.ServicesConfiguration;
+import org.broadinstitute.consent.http.util.HttpClientUtil.SimpleResponse;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -57,8 +57,8 @@ public class HttpClientUtilTest implements WithMockServer {
     mockServerClient.when(request())
       .respond(response()
       .withStatusCode(200));
-    ClassicHttpResponse response = clientUtil.getHttpResponse(new HttpGet(statusUrl));
-    assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getCode());
+    SimpleResponse response = clientUtil.getHttpResponse(new HttpGet(statusUrl));
+    assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.code());
   }
 
   @Test


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-2242

Looks like https://github.com/DataBiosphere/consent/pull/1868 borked the status checks. Anything that was reading content using the timed threads was prematurely consuming the http response entity and throwing a closed exception when the status handler tried to read the response. This PR consumes the response inside the thread and returns a new construct with that content. Also adds a configurable thread pool.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
