### PR TITLE
[DUOS-2197][risk=low] New Admin-only Update DataUse API

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
@@ -185,6 +185,15 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
        @Bind("datasetName") String datasetName, @Bind("updateDate") Timestamp updateDate, @Bind("updateUserId") Integer updateUserId,
        @Bind("needsApproval") Boolean needsApproval, @Bind("dacId") Integer updatedDacId);
 
+    @SqlUpdate("""
+        UPDATE dataset
+        SET data_use = :dataUse
+        WHERE dataset_id = :datasetId
+        """)
+    void updateDatasetDataUse(@Bind("datasetId") Integer datasetId, @Bind("dataUse") String dataUse);
+
+
+
     @UseRowReducer(DatasetReducer.class)
     @SqlQuery(
         "SELECT d.*, k.key, dp.property_value, dp.property_key, dp.property_type, dp.schema_property, dp.property_id, ca.consent_id, d.dac_id, c.translated_use_restriction, dar_ds_ids.id as in_use, " +

--- a/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
@@ -174,11 +174,11 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
 
     @SqlUpdate("""
                  UPDATE dataset
-                 SET name = :datasetName, 
-                     update_date = :updateDate, 
-                     update_user_id = :updateUserId, 
-                     needs_approval = :needsApproval, 
-                     dac_id = :dacId 
+                 SET name = :datasetName,
+                     update_date = :updateDate,
+                     update_user_id = :updateUserId,
+                     needs_approval = :needsApproval,
+                     dac_id = :dacId
                  WHERE dataset_id = :datasetId
                  """)
     void updateDataset(@Bind("datasetId") Integer datasetId,
@@ -191,8 +191,6 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
         WHERE dataset_id = :datasetId
         """)
     void updateDatasetDataUse(@Bind("datasetId") Integer datasetId, @Bind("dataUse") String dataUse);
-
-
 
     @UseRowReducer(DatasetReducer.class)
     @SqlQuery(

--- a/src/main/java/org/broadinstitute/consent/http/models/DataUse.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DataUse.java
@@ -3,6 +3,7 @@ package org.broadinstitute.consent.http.models;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
+import com.google.common.base.Objects;
 import com.google.gson.GsonBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -378,5 +379,73 @@ public class DataUse {
                 return Optional.empty();
             }
         }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        DataUse dataUse = (DataUse) o;
+        return Objects.equal(getGeneralUse(), dataUse.getGeneralUse())
+            && Objects.equal(getHmbResearch(), dataUse.getHmbResearch())
+            && Objects.equal(getDiseaseRestrictions(), dataUse.getDiseaseRestrictions())
+            && Objects.equal(getPopulationOriginsAncestry(), dataUse.getPopulationOriginsAncestry())
+            && Objects.equal(getPopulationStructure(), dataUse.getPopulationStructure())
+            && Objects.equal(getCommercialUse(), dataUse.getCommercialUse())
+            && Objects.equal(getMethodsResearch(), dataUse.getMethodsResearch())
+            && Objects.equal(getAggregateResearch(), dataUse.getAggregateResearch())
+            && Objects.equal(getControlSetOption(), dataUse.getControlSetOption())
+            && Objects.equal(getGender(), dataUse.getGender())
+            && Objects.equal(getPediatric(), dataUse.getPediatric())
+            && Objects.equal(getPopulationRestrictions(), dataUse.getPopulationRestrictions())
+            && Objects.equal(getOtherRestrictions(), dataUse.getOtherRestrictions())
+            && Objects.equal(getDateRestriction(), dataUse.getDateRestriction())
+            && Objects.equal(getRecontactingDataSubjects(), dataUse.getRecontactingDataSubjects())
+            && Objects.equal(getRecontactMay(), dataUse.getRecontactMay())
+            && Objects.equal(getRecontactMust(), dataUse.getRecontactMust())
+            && Objects.equal(getGenomicPhenotypicData(), dataUse.getGenomicPhenotypicData())
+            && Objects.equal(getCloudStorage(), dataUse.getCloudStorage())
+            && Objects.equal(getEthicsApprovalRequired(), dataUse.getEthicsApprovalRequired())
+            && Objects.equal(getCollaboratorRequired(), dataUse.getCollaboratorRequired())
+            && Objects.equal(getGeographicalRestrictions(), dataUse.getGeographicalRestrictions())
+            && Objects.equal(getOther(), dataUse.getOther())
+            && Objects.equal(getSecondaryOther(), dataUse.getSecondaryOther())
+            && Objects.equal(getIllegalBehavior(), dataUse.getIllegalBehavior())
+            && Objects.equal(getAddiction(), dataUse.getAddiction())
+            && Objects.equal(getSexualDiseases(), dataUse.getSexualDiseases())
+            && Objects.equal(getStigmatizeDiseases(), dataUse.getStigmatizeDiseases())
+            && Objects.equal(getVulnerablePopulations(), dataUse.getVulnerablePopulations())
+            && Objects.equal(getPsychologicalTraits(), dataUse.getPsychologicalTraits())
+            && Objects.equal(getNonBiomedical(), dataUse.getNonBiomedical())
+            && Objects.equal(getManualReview(), dataUse.getManualReview())
+            && Objects.equal(getGeneticStudiesOnly(), dataUse.getGeneticStudiesOnly())
+            && Objects.equal(getPublicationResults(), dataUse.getPublicationResults())
+            && Objects.equal(getGenomicResults(), dataUse.getGenomicResults())
+            && Objects.equal(getGenomicSummaryResults(), dataUse.getGenomicSummaryResults())
+            && Objects.equal(getCollaborationInvestigators(), dataUse.getCollaborationInvestigators())
+            && Objects.equal(getPublicationMoratorium(), dataUse.getPublicationMoratorium());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(getGeneralUse(), getHmbResearch(), getDiseaseRestrictions(),
+            getPopulationOriginsAncestry(), getPopulationStructure(), getCommercialUse(),
+            getMethodsResearch(), getAggregateResearch(), getControlSetOption(), getGender(),
+            getPediatric(), getPopulationRestrictions(), getOtherRestrictions(),
+            getDateRestriction(),
+            getRecontactingDataSubjects(), getRecontactMay(), getRecontactMust(),
+            getGenomicPhenotypicData(), getCloudStorage(), getEthicsApprovalRequired(),
+            getCollaboratorRequired(), getGeographicalRestrictions(), getOther(),
+            getSecondaryOther(),
+            getIllegalBehavior(), getAddiction(), getSexualDiseases(), getStigmatizeDiseases(),
+            getVulnerablePopulations(), getPsychologicalTraits(), getNonBiomedical(),
+            getManualReview(),
+            getGeneticStudiesOnly(), getPublicationResults(), getGenomicResults(),
+            getGenomicSummaryResults(), getCollaborationInvestigators(),
+            getPublicationMoratorium());
     }
 }

--- a/src/main/java/org/broadinstitute/consent/http/models/DataUseBuilder.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DataUseBuilder.java
@@ -3,210 +3,211 @@ package org.broadinstitute.consent.http.models;
 import java.util.List;
 
 /**
- * Syntactic sugar for creating a DataUse object.
- * Copied from org.broadinstitute.dsde.consent.ontology.resources.model.DataUseBuilder in Consent-Ontology
+ * Syntactic sugar for creating a DataUse object. Copied from
+ * org.broadinstitute.dsde.consent.ontology.resources.model.DataUseBuilder in Consent-Ontology
  */
 @SuppressWarnings("unused")
 public class DataUseBuilder {
-    private DataUse du;
-    
-    public DataUseBuilder() {
-        du = new DataUse();
-    }
-    
-    public DataUse build() {
-        return du;
-    }
-    
-    
-    public DataUseBuilder setGeneralUse(Boolean generalUse) {
-        du.setGeneralUse(generalUse);
-        return this;
-    }
-    
-    public DataUseBuilder setHmbResearch(Boolean hmbResearch) {
-        du.setHmbResearch(hmbResearch);
-        return this;
-    }
-    
-    public DataUseBuilder setDiseaseRestrictions(List<String> diseaseRestrictions) {
-        du.setDiseaseRestrictions(diseaseRestrictions);
-        return this;
-    }
-    
-    public DataUseBuilder setPopulationOriginsAncestry(Boolean populationOriginsAncestry) {
-        du.setPopulationOriginsAncestry(populationOriginsAncestry);
-        return this;
-    }
-    
-    public DataUseBuilder setPopulationStructure(Boolean populationStructure) {
-        du.setPopulationStructure(populationStructure);
-        return this;
-    }
-    
-    public DataUseBuilder setCommercialUse(Boolean commercialUse) {
-        du.setCommercialUse(commercialUse);
-        return this;
-    }
-    
-    public DataUseBuilder setMethodsResearch(Boolean methodsResearch) {
-        du.setMethodsResearch(methodsResearch);
-        return this;
-    }
-    
-    public DataUseBuilder setAggregateResearch(String aggregateResearch) {
-        du.setAggregateResearch(aggregateResearch);
-        return this;
-    }
-    
-    public DataUseBuilder setControlSetOption(String controlSetOption) {
-        du.setControlSetOption(controlSetOption);
-        return this;
-    }
-    
-    public DataUseBuilder setGender(String gender) {
-        du.setGender(gender);
-        return this;
-    }
-    
-    public DataUseBuilder setPediatric(Boolean pediatric) {
-        du.setPediatric(pediatric);
-        return this;
-    }
-    
-    public DataUseBuilder setPopulationRestrictions(List<String> populationRestrictions) {
-        du.setPopulationRestrictions(populationRestrictions);
-        return this;
-    }
-    
-    public DataUseBuilder setDateRestriction(String dateRestriction) {
-        du.setDateRestriction(dateRestriction);
-        return this;
-    }
-    
-    public DataUseBuilder setRecontactingDataSubjects(Boolean recontactingDataSubjects) {
-        du.setRecontactingDataSubjects(recontactingDataSubjects);
-        return this;
-    }
-    
-    public DataUseBuilder setRecontactMay(String recontactMay) {
-        du.setRecontactMay(recontactMay);
-        return this;
-    }
-    
-    public DataUseBuilder setRecontactMust(String recontactMust) {
-        du.setRecontactMust(recontactMust);
-        return this;
-    }
-    
-    public DataUseBuilder setGenomicPhenotypicData(String genomicPhenotypicData) {
-        du.setGenomicPhenotypicData(genomicPhenotypicData);
-        return this;
-    }
-    
-    public DataUseBuilder setOtherRestrictions(Boolean otherRestrictions) {
-        du.setOtherRestrictions(otherRestrictions);
-        return this;
-    }
-    
-    public DataUseBuilder setCloudStorage(String cloudStorage) {
-        du.setCloudStorage(cloudStorage);
-        return this;
-    }
-    
-    public DataUseBuilder setEthicsApprovalRequired(Boolean ethicsApprovalRequired) {
-        du.setEthicsApprovalRequired(ethicsApprovalRequired);
-        return this;
-    }
 
-    public DataUseBuilder setCollaboratorRequired(Boolean collaboratorRequired) {
-        du.setCollaboratorRequired(collaboratorRequired);
-        return this;
-    }
-    
-    public DataUseBuilder setGeographicalRestrictions(String geographicalRestrictions) {
-        du.setGeographicalRestrictions(geographicalRestrictions);
-        return this;
-    }
-    
-    public DataUseBuilder setOther(String other) {
-        du.setOther(other);
-        return this;
-    }
+  private final DataUse du;
 
-    public DataUseBuilder setSecondaryOther(String secondaryOther) {
-        du.setSecondaryOther(secondaryOther);
-        return this;
-    }
+  public DataUseBuilder() {
+    du = new DataUse();
+  }
 
-    public DataUseBuilder setIllegalBehavior(Boolean illegalBehavior) {
-        du.setIllegalBehavior(illegalBehavior);
-        return this;
-    }
-    
-    public DataUseBuilder setAddiction(Boolean addiction) {
-        du.setAddiction(addiction);
-        return this;
-    }
-    
-    public DataUseBuilder setSexualDiseases(Boolean sexualDiseases) {
-        du.setSexualDiseases(sexualDiseases);
-        return this;
-    }
-    
-    public DataUseBuilder setStigmatizeDiseases(Boolean stigmatizeDiseases) {
-        du.setStigmatizeDiseases(stigmatizeDiseases);
-        return this;
-    }
-    
-    public DataUseBuilder setVulnerablePopulations(Boolean vulnerablePopulations) {
-        du.setVulnerablePopulations(vulnerablePopulations);
-        return this;
-    }
-    
-    public DataUseBuilder setPsychologicalTraits(Boolean psychologicalTraits) {
-        du.setPsychologicalTraits(psychologicalTraits);
-        return this;
-    }
-    
-    public DataUseBuilder setNonBiomedical(Boolean nonBiomedical) {
-        du.setNonBiomedical(nonBiomedical);
-        return this;
-    }
+  public DataUse build() {
+    return du;
+  }
 
-    public DataUseBuilder setManualReview(Boolean manualReview) {
-        du.setManualReview(manualReview);
-        return this;
-    }
 
-    public DataUseBuilder setGeneticStudiesOnly(Boolean geneticStudiesOnly) {
-        du.setGeneticStudiesOnly(geneticStudiesOnly);
-        return this;
-    }
+  public DataUseBuilder setGeneralUse(Boolean generalUse) {
+    du.setGeneralUse(generalUse);
+    return this;
+  }
 
-    public DataUseBuilder setPublicationResults(Boolean publicationResults) {
-        du.setPublicationResults(publicationResults);
-        return this;
-    }
+  public DataUseBuilder setHmbResearch(Boolean hmbResearch) {
+    du.setHmbResearch(hmbResearch);
+    return this;
+  }
 
-    public DataUseBuilder setGenomicResults(Boolean genomicResults) {
-        du.setGenomicResults(genomicResults);
-        return this;
-    }
+  public DataUseBuilder setDiseaseRestrictions(List<String> diseaseRestrictions) {
+    du.setDiseaseRestrictions(diseaseRestrictions);
+    return this;
+  }
 
-    public DataUseBuilder setGenomicSummaryResults(String genomicSummaryResults) {
-        du.setGenomicSummaryResults(genomicSummaryResults);
-        return this;
-    }
+  public DataUseBuilder setPopulationOriginsAncestry(Boolean populationOriginsAncestry) {
+    du.setPopulationOriginsAncestry(populationOriginsAncestry);
+    return this;
+  }
 
-    public DataUseBuilder setCollaborationInvestigators(Boolean collaborationInvestigators) {
-        du.setCollaborationInvestigators(collaborationInvestigators);
-        return this;
-    }
+  public DataUseBuilder setPopulationStructure(Boolean populationStructure) {
+    du.setPopulationStructure(populationStructure);
+    return this;
+  }
 
-    public DataUseBuilder setPublicationMoratorium(String publicationMoratorium) {
-        du.setPublicationMoratorium(publicationMoratorium);
-        return this;
-    }
+  public DataUseBuilder setCommercialUse(Boolean commercialUse) {
+    du.setCommercialUse(commercialUse);
+    return this;
+  }
+
+  public DataUseBuilder setMethodsResearch(Boolean methodsResearch) {
+    du.setMethodsResearch(methodsResearch);
+    return this;
+  }
+
+  public DataUseBuilder setAggregateResearch(String aggregateResearch) {
+    du.setAggregateResearch(aggregateResearch);
+    return this;
+  }
+
+  public DataUseBuilder setControlSetOption(String controlSetOption) {
+    du.setControlSetOption(controlSetOption);
+    return this;
+  }
+
+  public DataUseBuilder setGender(String gender) {
+    du.setGender(gender);
+    return this;
+  }
+
+  public DataUseBuilder setPediatric(Boolean pediatric) {
+    du.setPediatric(pediatric);
+    return this;
+  }
+
+  public DataUseBuilder setPopulationRestrictions(List<String> populationRestrictions) {
+    du.setPopulationRestrictions(populationRestrictions);
+    return this;
+  }
+
+  public DataUseBuilder setDateRestriction(String dateRestriction) {
+    du.setDateRestriction(dateRestriction);
+    return this;
+  }
+
+  public DataUseBuilder setRecontactingDataSubjects(Boolean recontactingDataSubjects) {
+    du.setRecontactingDataSubjects(recontactingDataSubjects);
+    return this;
+  }
+
+  public DataUseBuilder setRecontactMay(String recontactMay) {
+    du.setRecontactMay(recontactMay);
+    return this;
+  }
+
+  public DataUseBuilder setRecontactMust(String recontactMust) {
+    du.setRecontactMust(recontactMust);
+    return this;
+  }
+
+  public DataUseBuilder setGenomicPhenotypicData(String genomicPhenotypicData) {
+    du.setGenomicPhenotypicData(genomicPhenotypicData);
+    return this;
+  }
+
+  public DataUseBuilder setOtherRestrictions(Boolean otherRestrictions) {
+    du.setOtherRestrictions(otherRestrictions);
+    return this;
+  }
+
+  public DataUseBuilder setCloudStorage(String cloudStorage) {
+    du.setCloudStorage(cloudStorage);
+    return this;
+  }
+
+  public DataUseBuilder setEthicsApprovalRequired(Boolean ethicsApprovalRequired) {
+    du.setEthicsApprovalRequired(ethicsApprovalRequired);
+    return this;
+  }
+
+  public DataUseBuilder setCollaboratorRequired(Boolean collaboratorRequired) {
+    du.setCollaboratorRequired(collaboratorRequired);
+    return this;
+  }
+
+  public DataUseBuilder setGeographicalRestrictions(String geographicalRestrictions) {
+    du.setGeographicalRestrictions(geographicalRestrictions);
+    return this;
+  }
+
+  public DataUseBuilder setOther(String other) {
+    du.setOther(other);
+    return this;
+  }
+
+  public DataUseBuilder setSecondaryOther(String secondaryOther) {
+    du.setSecondaryOther(secondaryOther);
+    return this;
+  }
+
+  public DataUseBuilder setIllegalBehavior(Boolean illegalBehavior) {
+    du.setIllegalBehavior(illegalBehavior);
+    return this;
+  }
+
+  public DataUseBuilder setAddiction(Boolean addiction) {
+    du.setAddiction(addiction);
+    return this;
+  }
+
+  public DataUseBuilder setSexualDiseases(Boolean sexualDiseases) {
+    du.setSexualDiseases(sexualDiseases);
+    return this;
+  }
+
+  public DataUseBuilder setStigmatizeDiseases(Boolean stigmatizeDiseases) {
+    du.setStigmatizeDiseases(stigmatizeDiseases);
+    return this;
+  }
+
+  public DataUseBuilder setVulnerablePopulations(Boolean vulnerablePopulations) {
+    du.setVulnerablePopulations(vulnerablePopulations);
+    return this;
+  }
+
+  public DataUseBuilder setPsychologicalTraits(Boolean psychologicalTraits) {
+    du.setPsychologicalTraits(psychologicalTraits);
+    return this;
+  }
+
+  public DataUseBuilder setNonBiomedical(Boolean nonBiomedical) {
+    du.setNonBiomedical(nonBiomedical);
+    return this;
+  }
+
+  public DataUseBuilder setManualReview(Boolean manualReview) {
+    du.setManualReview(manualReview);
+    return this;
+  }
+
+  public DataUseBuilder setGeneticStudiesOnly(Boolean geneticStudiesOnly) {
+    du.setGeneticStudiesOnly(geneticStudiesOnly);
+    return this;
+  }
+
+  public DataUseBuilder setPublicationResults(Boolean publicationResults) {
+    du.setPublicationResults(publicationResults);
+    return this;
+  }
+
+  public DataUseBuilder setGenomicResults(Boolean genomicResults) {
+    du.setGenomicResults(genomicResults);
+    return this;
+  }
+
+  public DataUseBuilder setGenomicSummaryResults(String genomicSummaryResults) {
+    du.setGenomicSummaryResults(genomicSummaryResults);
+    return this;
+  }
+
+  public DataUseBuilder setCollaborationInvestigators(Boolean collaborationInvestigators) {
+    du.setCollaborationInvestigators(collaborationInvestigators);
+    return this;
+  }
+
+  public DataUseBuilder setPublicationMoratorium(String publicationMoratorium) {
+    du.setPublicationMoratorium(publicationMoratorium);
+    return this;
+  }
 
 }

--- a/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
@@ -7,6 +7,7 @@ import io.dropwizard.auth.Auth;
 import org.apache.commons.collections.CollectionUtils;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.AuthUser;
+import org.broadinstitute.consent.http.models.DataUse;
 import org.broadinstitute.consent.http.models.Dataset;
 import org.broadinstitute.consent.http.models.Dictionary;
 import org.broadinstitute.consent.http.models.User;
@@ -503,6 +504,22 @@ public class DatasetResource extends Resource {
             Dataset dataset = datasetService.updateNeedsReviewDatasets(dataSetId, needsApproval);
             return Response.ok().entity(unmarshal(dataset)).build();
         }catch (Exception e){
+            return createExceptionResponse(e);
+        }
+    }
+
+    @PUT
+    @Produces("application/json")
+    @RolesAllowed(ADMIN)
+    @Path("/{id}/datause")
+    public Response updateDatasetDataUse(@Auth AuthUser authUser, @PathParam("id") Integer id, String dataUseJson) {
+        try {
+            User user = userService.findUserByEmail(authUser.getEmail());
+            Gson gson = new Gson();
+            DataUse dataUse = gson.fromJson(dataUseJson, DataUse.class);
+            Dataset dataset = datasetService.updateDatasetDataUse(user, id, dataUse);
+            return Response.ok().entity(unmarshal(dataset)).build();
+        } catch (Exception e) {
             return createExceptionResponse(e);
         }
     }

--- a/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
@@ -177,7 +177,7 @@ public class DatasetResource extends Resource {
                     files);
 
             URI uri = UriBuilder.fromPath("/api/dataset/v2").build();
-            return Response.created(uri).entity(unmarshal(datasets)).build();
+            return Response.created(uri).entity(datasets).build();
         } catch (Exception e) {
             return createExceptionResponse(e);
         }
@@ -274,7 +274,7 @@ public class DatasetResource extends Resource {
         try {
             User user = userService.findUserByEmail(authUser.getEmail());
             List<Dataset> datasets = datasetService.findAllDatasetsByUser(user);
-            return Response.ok(unmarshal(datasets)).build();
+            return Response.ok(datasets).build();
         } catch (Exception e) {
             return createExceptionResponse(e);
         }
@@ -304,7 +304,7 @@ public class DatasetResource extends Resource {
             if (Objects.isNull(dataset)) {
                 throw new NotFoundException("Could not find the dataset with id: " + datasetId.toString());
             }
-            return Response.ok(unmarshal(dataset)).build();
+            return Response.ok(dataset).build();
         } catch (Exception e){
             return createExceptionResponse(e);
         }
@@ -328,7 +328,7 @@ public class DatasetResource extends Resource {
                                 + String.join(",", differences.stream().map((i) -> i.toString()).collect(Collectors.toSet())));
 
             }
-            return Response.ok(unmarshal(datasets)).build();
+            return Response.ok(datasets).build();
         } catch (Exception e){
             return createExceptionResponse(e);
         }
@@ -473,7 +473,7 @@ public class DatasetResource extends Resource {
             User dacUser = userService.findUserByEmail(authUser.getEmail());
             Integer dacUserId = dacUser.getUserId();
             List<Map<String, String>> datasets = datasetService.autoCompleteDatasets(partial, dacUserId);
-            return Response.ok(unmarshal(datasets), MediaType.APPLICATION_JSON).build();
+            return Response.ok(datasets, MediaType.APPLICATION_JSON).build();
         } catch (Exception e) {
             return createExceptionResponse(e);
         }
@@ -519,10 +519,10 @@ public class DatasetResource extends Resource {
                 throw new NotFoundException("Dataset not found: " + id);
             }
             if (Objects.equals(dataUse, originalDataset.getDataUse())) {
-                return Response.notModified().entity(unmarshal(originalDataset)).build();
+                return Response.notModified().entity(originalDataset).build();
             }
             Dataset dataset = datasetService.updateDatasetDataUse(user, id, dataUse);
-            return Response.ok().entity(unmarshal(dataset)).build();
+            return Response.ok().entity(dataset).build();
         } catch (JsonSyntaxException jse) {
             return createExceptionResponse(new BadRequestException("Invalid JSON Syntax: " + dataUseJson));
         } catch (Exception e) {

--- a/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
@@ -514,6 +514,13 @@ public class DatasetResource extends Resource {
             User user = userService.findUserByEmail(authUser.getEmail());
             Gson gson = new Gson();
             DataUse dataUse = gson.fromJson(dataUseJson, DataUse.class);
+            Dataset originalDataset = datasetService.findDatasetById(id);
+            if (Objects.isNull(originalDataset)) {
+                throw new NotFoundException("Dataset not found: " + id);
+            }
+            if (Objects.equals(dataUse, originalDataset.getDataUse())) {
+                return Response.notModified().entity(unmarshal(originalDataset)).build();
+            }
             Dataset dataset = datasetService.updateDatasetDataUse(user, id, dataUse);
             return Response.ok().entity(unmarshal(dataset)).build();
         } catch (JsonSyntaxException jse) {

--- a/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
@@ -1,30 +1,21 @@
 package org.broadinstitute.consent.http.resources;
 
-import com.google.cloud.storage.BlobId;
 import com.google.gson.Gson;
+import com.google.gson.JsonSyntaxException;
 import com.google.inject.Inject;
 import io.dropwizard.auth.Auth;
-import org.apache.commons.collections.CollectionUtils;
-import org.broadinstitute.consent.http.enumeration.UserRoles;
-import org.broadinstitute.consent.http.models.AuthUser;
-import org.broadinstitute.consent.http.models.DataUse;
-import org.broadinstitute.consent.http.models.Dataset;
-import org.broadinstitute.consent.http.models.Dictionary;
-import org.broadinstitute.consent.http.models.User;
-import org.broadinstitute.consent.http.models.UserRole;
-import org.broadinstitute.consent.http.models.dataset_registration_v1.DatasetRegistrationSchemaV1;
-import org.broadinstitute.consent.http.models.dto.DatasetDTO;
-import org.broadinstitute.consent.http.models.dto.DatasetPropertyDTO;
-import org.broadinstitute.consent.http.service.DataAccessRequestService;
-import org.broadinstitute.consent.http.service.DatasetService;
-import org.broadinstitute.consent.http.service.UserService;
-import org.broadinstitute.consent.http.util.JsonSchemaUtil;
-import org.glassfish.jersey.media.multipart.BodyPart;
-import org.glassfish.jersey.media.multipart.FormDataBodyPart;
-import org.glassfish.jersey.media.multipart.FormDataMultiPart;
-import org.glassfish.jersey.media.multipart.FormDataParam;
-import org.json.JSONObject;
-
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 import javax.annotation.security.PermitAll;
 import javax.annotation.security.RolesAllowed;
 import javax.ws.rs.BadRequestException;
@@ -46,19 +37,25 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
-import java.io.ByteArrayInputStream;
-import java.io.InputStream;
-import java.net.URI;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
+import org.apache.commons.collections.CollectionUtils;
+import org.broadinstitute.consent.http.enumeration.UserRoles;
+import org.broadinstitute.consent.http.models.AuthUser;
+import org.broadinstitute.consent.http.models.DataUse;
+import org.broadinstitute.consent.http.models.Dataset;
+import org.broadinstitute.consent.http.models.Dictionary;
+import org.broadinstitute.consent.http.models.User;
+import org.broadinstitute.consent.http.models.UserRole;
+import org.broadinstitute.consent.http.models.dataset_registration_v1.DatasetRegistrationSchemaV1;
+import org.broadinstitute.consent.http.models.dto.DatasetDTO;
+import org.broadinstitute.consent.http.models.dto.DatasetPropertyDTO;
+import org.broadinstitute.consent.http.service.DataAccessRequestService;
+import org.broadinstitute.consent.http.service.DatasetService;
+import org.broadinstitute.consent.http.service.UserService;
+import org.broadinstitute.consent.http.util.JsonSchemaUtil;
+import org.glassfish.jersey.media.multipart.FormDataBodyPart;
+import org.glassfish.jersey.media.multipart.FormDataMultiPart;
+import org.glassfish.jersey.media.multipart.FormDataParam;
+import org.json.JSONObject;
 
 @Path("api/dataset")
 public class DatasetResource extends Resource {
@@ -519,6 +516,8 @@ public class DatasetResource extends Resource {
             DataUse dataUse = gson.fromJson(dataUseJson, DataUse.class);
             Dataset dataset = datasetService.updateDatasetDataUse(user, id, dataUse);
             return Response.ok().entity(unmarshal(dataset)).build();
+        } catch (JsonSyntaxException jse) {
+            return createExceptionResponse(new BadRequestException("Invalid JSON Syntax: " + dataUseJson));
         } catch (Exception e) {
             return createExceptionResponse(e);
         }

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -1,5 +1,25 @@
 package org.broadinstitute.consent.http.service;
 
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import javax.inject.Inject;
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.NotFoundException;
 import org.broadinstitute.consent.http.db.ConsentDAO;
 import org.broadinstitute.consent.http.db.DacDAO;
 import org.broadinstitute.consent.http.db.DataAccessRequestDAO;
@@ -26,30 +46,6 @@ import org.broadinstitute.consent.http.service.dao.DatasetServiceDAO;
 import org.glassfish.jersey.media.multipart.FormDataBodyPart;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-import javax.inject.Inject;
-import javax.ws.rs.BadRequestException;
-import javax.ws.rs.NotFoundException;
-import java.io.InputStream;
-import java.sql.SQLException;
-import java.sql.Timestamp;
-import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
-import java.util.UUID;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 public class DatasetService {
 
@@ -305,6 +301,14 @@ public class DatasetService {
         datasetDAO.updateDataset(datasetId, dataset.getDatasetName(), now, userId, dataset.getNeedsApproval(), dataset.getDacId());
         Dataset updatedDataset = getDatasetWithPropertiesById(datasetId);
         return Optional.of(updatedDataset);
+    }
+
+    public Dataset updateDatasetDataUse(User user, Integer datasetId, DataUse dataUse) {
+        if (!user.hasUserRole(UserRoles.ADMIN)) {
+            throw new IllegalArgumentException("Admin use only");
+        }
+        datasetDAO.updateDatasetDataUse(datasetId, dataUse.toString());
+        return datasetDAO.findDatasetById(datasetId);
     }
 
     private void updateDatasetProperties(List<DatasetProperty> updateProperties,

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -304,6 +304,10 @@ public class DatasetService {
     }
 
     public Dataset updateDatasetDataUse(User user, Integer datasetId, DataUse dataUse) {
+        Dataset d = datasetDAO.findDatasetById(datasetId);
+        if (Objects.isNull(d)) {
+            throw new NotFoundException("Dataset not found: " + datasetId);
+        }
         if (!user.hasUserRole(UserRoles.ADMIN)) {
             throw new IllegalArgumentException("Admin use only");
         }

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -1144,6 +1144,8 @@ paths:
           description: Server error.
   /api/dataset/{id}:
     $ref: './paths/datasetById.yaml'
+  /api/dataset/{id}/datause:
+    $ref: './paths/datasetByIdDataUse.yaml'
   /api/dataset/v2/{id}:
     $ref: './paths/datasetByIdV2.yaml'
   /api/dataset/batch:

--- a/src/main/resources/assets/paths/datasetByIdDataUse.yaml
+++ b/src/main/resources/assets/paths/datasetByIdDataUse.yaml
@@ -1,0 +1,34 @@
+put:
+  summary: Admin Only API to update the Dataset's Data Use object from JSON
+  description: Admin Only API to update the Dataset's Data Use object from JSON
+  parameters:
+    - name: id
+      in: path
+      description: ID of the Dataset
+      required: true
+      schema:
+        type: integer
+  requestBody:
+    description: Data Use object
+    required: true
+    content:
+      application/json:
+      type: object
+      description: |
+        The Data Use question/answer set for this dataset.
+        See [schema definition](https://consent-ontology.dsde-prod.broadinstitute.org/schemas/data-use)
+        for more information
+      example: { "generalUse": false, "hmbResearch": true, "diseaseRestrictions": ["http://purl.obolibrary.org/obo/DOID_602"] }
+  tags:
+    - Admin
+  responses:
+    200:
+      description: Successfully updated Dataset
+    204:
+      description: Not modified
+    400:
+      description: Bad Request (invalid input)
+    404:
+      description: Not Found
+    500:
+      description: Internal Error

--- a/src/main/resources/assets/paths/datasetByIdDataUse.yaml
+++ b/src/main/resources/assets/paths/datasetByIdDataUse.yaml
@@ -15,22 +15,22 @@ put:
       schema:
         type: integer
   requestBody:
-    description: Data Use object
+    description: |
+      The Data Use question/answer set for this dataset.
+      See [schema definition](https://consent-ontology.dsde-prod.broadinstitute.org/schemas/data-use)
+      for more information
     required: true
     content:
       application/json:
-      type: object
-      description: |
-        The Data Use question/answer set for this dataset.
-        See [schema definition](https://consent-ontology.dsde-prod.broadinstitute.org/schemas/data-use)
-        for more information
-      example: { "generalUse": false, "hmbResearch": true, "diseaseRestrictions": ["http://purl.obolibrary.org/obo/DOID_602"] }
+        schema:
+          type: object
+        example: { "generalUse": false, "hmbResearch": true, "diseaseRestrictions": ["http://purl.obolibrary.org/obo/DOID_602"] }
   tags:
     - Admin
   responses:
     200:
       description: Successfully updated Dataset
-    204:
+    304:
       description: Not modified
     400:
       description: Bad Request (invalid input)

--- a/src/main/resources/assets/paths/datasetByIdDataUse.yaml
+++ b/src/main/resources/assets/paths/datasetByIdDataUse.yaml
@@ -1,6 +1,12 @@
 put:
   summary: Admin Only API to update the Dataset's Data Use object from JSON
-  description: Admin Only API to update the Dataset's Data Use object from JSON
+  description: | 
+    Admin Only API to update the Dataset's Data Use object from JSON.
+    ## Note
+    This endpoint is restricted to updating the data use object only and does
+    not perform any logical checks to determine if match results for existing 
+    DAR elections might be impacted. It the administrator's responsibility to
+    ensure appropriate notifications are made.
   parameters:
     - name: id
       in: path

--- a/src/main/resources/assets/schemas/Consent.yaml
+++ b/src/main/resources/assets/schemas/Consent.yaml
@@ -16,7 +16,7 @@ properties:
   dataUse:
     type: object
     description: The Data Use question/answer set for this consent.
-    example: {"hmb":true}
+    example: {"hmbResearch":true}
   name:
     type: string
     description: Name to identify the consent.

--- a/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
@@ -735,14 +735,18 @@ public class DatasetDAOTest extends DAOTestHelper {
     @Test
     public void testUpdateDatasetDataUse() {
         Dataset dataset = insertDataset();
-        DataUse dataUse = new DataUseBuilder()
+        DataUse oldDataUse = dataset.getDataUse();
+        DataUse newDataUse = new DataUseBuilder()
+            .setGeneralUse(false)
+            .setCommercialUse(true)
             .setHmbResearch(true)
             .setDiseaseRestrictions(List.of("DOID_1"))
             .build();
 
-        datasetDAO.updateDatasetDataUse(dataset.getDataSetId(), dataUse.toString());
+        datasetDAO.updateDatasetDataUse(dataset.getDataSetId(), newDataUse.toString());
         Dataset updated = datasetDAO.findDatasetById(dataset.getDataSetId());
-        assertEquals(dataUse, updated.getDataUse());
+        assertEquals(newDataUse, updated.getDataUse());
+        assertNotEquals(oldDataUse, updated.getDataUse());
     }
 
     @Test

--- a/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
@@ -1,6 +1,22 @@
 package org.broadinstitute.consent.http.db;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 import com.google.gson.JsonObject;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+import java.util.stream.IntStream;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.RandomUtils;
 import org.apache.commons.lang3.tuple.Pair;
@@ -20,29 +36,11 @@ import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.dto.DatasetDTO;
 import org.junit.Test;
 
-import java.sql.Timestamp;
-import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Date;
-import java.util.List;
-import java.util.Random;
-import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-
 public class DatasetDAOTest extends DAOTestHelper {
 
     @Test
     public void testFindDatasetByIdWithDacAndConsent() {
-        Dataset dataset = createDataset();
+        Dataset dataset = insertDataset();
         Dac dac = createDac();
         Consent consent = createConsent();
         datasetDAO.updateDatasetDacId(dataset.getDataSetId(), dac.getDacId());
@@ -60,8 +58,8 @@ public class DatasetDAOTest extends DAOTestHelper {
     @Test
     public void testFindDatasetByIdWithDacAndConsentNotDeletable() {
         User user = createUser();
-        Dataset d1 = createDataset();
-        Dataset d2 = createDataset();
+        Dataset d1 = insertDataset();
+        Dataset d2 = insertDataset();
         Dac dac = createDac();
         // Create a collection that references the created datasets
         createDarCollectionWithDatasets(dac.getDacId(), user, List.of(d1, d2));
@@ -81,7 +79,7 @@ public class DatasetDAOTest extends DAOTestHelper {
 
     @Test
     public void testFindDatasetByAlias() {
-        Dataset dataset = createDataset();
+        Dataset dataset = insertDataset();
 
         Dataset foundDataset = datasetDAO.findDatasetByAlias(dataset.getAlias());
 
@@ -91,8 +89,8 @@ public class DatasetDAOTest extends DAOTestHelper {
 
     @Test
     public void testFindDatasetsByAlias() {
-        Dataset dataset1 = createDataset();
-        Dataset dataset2 = createDataset();
+        Dataset dataset1 = insertDataset();
+        Dataset dataset2 = insertDataset();
 
         List<Dataset> foundDatasets = datasetDAO.findDatasetsByAlias(List.of(dataset1.getAlias(), dataset2.getAlias()));
         List<Integer> foundDatasetIds = foundDatasets.stream().map(Dataset::getDataSetId).toList();
@@ -102,7 +100,7 @@ public class DatasetDAOTest extends DAOTestHelper {
 
     @Test
     public void testFindNeedsApprovalDataSetByDataSetId() {
-        Dataset dataset = createDataset();
+        Dataset dataset = insertDataset();
         datasetDAO.updateDatasetNeedsApproval(dataset.getDataSetId(), true);
         Dac dac = createDac();
         Consent consent = createConsent();
@@ -121,7 +119,7 @@ public class DatasetDAOTest extends DAOTestHelper {
 
     @Test
     public void testGetNIHInstitutionalFile() {
-        Dataset dataset = createDataset();
+        Dataset dataset = insertDataset();
 
         // create unrelated file with the same id as dataset id but different category, timestamp before
         createFileStorageObject(
@@ -150,7 +148,7 @@ public class DatasetDAOTest extends DAOTestHelper {
 
     @Test
     public void testGetNIHInstitutionalFile_AlwaysLatestUpdated() throws InterruptedException {
-        Dataset dataset = createDataset();
+        Dataset dataset = insertDataset();
 
 
         String fileName = RandomStringUtils.randomAlphabetic(10);
@@ -204,7 +202,7 @@ public class DatasetDAOTest extends DAOTestHelper {
 
     @Test
     public void testGetNIHInstitutionalFile_AlwaysLatestCreated() throws InterruptedException {
-        Dataset dataset = createDataset();
+        Dataset dataset = insertDataset();
 
         String fileName = RandomStringUtils.randomAlphabetic(10);
         String bucketName = RandomStringUtils.randomAlphabetic(10);
@@ -249,7 +247,7 @@ public class DatasetDAOTest extends DAOTestHelper {
 
     @Test
     public void testGetNIHInstitutionalFile_NotDeleted() {
-        Dataset dataset = createDataset();
+        Dataset dataset = insertDataset();
 
         FileStorageObject nihFile = createFileStorageObject(
                 dataset.getDataSetId().toString(),
@@ -271,7 +269,7 @@ public class DatasetDAOTest extends DAOTestHelper {
 
     @Test
     public void testGetAlternativeDataSharingFile() {
-        Dataset dataset = createDataset();
+        Dataset dataset = insertDataset();
 
         // create unrelated file with the same id as dataset id but different category, timestamp before
         createFileStorageObject(
@@ -300,7 +298,7 @@ public class DatasetDAOTest extends DAOTestHelper {
 
     @Test
     public void testGetAlternativeDataSharingPlanFile_AlwaysLatestCreated() throws InterruptedException {
-        Dataset dataset = createDataset();
+        Dataset dataset = insertDataset();
 
         String fileName = RandomStringUtils.randomAlphabetic(10);
         String bucketName = RandomStringUtils.randomAlphabetic(10);
@@ -345,7 +343,7 @@ public class DatasetDAOTest extends DAOTestHelper {
 
     @Test
     public void testGetAlternativeDataSharingPlanFile_NotDeleted() {
-        Dataset dataset = createDataset();
+        Dataset dataset = insertDataset();
 
         FileStorageObject altFile = createFileStorageObject(
                 dataset.getDataSetId().toString(),
@@ -376,7 +374,7 @@ public class DatasetDAOTest extends DAOTestHelper {
     }
     @Test
     public void testGetDataSetsForObjectIdList() {
-        Dataset dataset = createDataset();
+        Dataset dataset = insertDataset();
         Dac dac = createDac();
         Consent consent = createConsent();
         datasetDAO.updateDatasetDacId(dataset.getDataSetId(), dac.getDacId());
@@ -393,7 +391,7 @@ public class DatasetDAOTest extends DAOTestHelper {
 
     @Test
     public void testFindDatasetsByIdList() {
-        Dataset dataset = createDataset();
+        Dataset dataset = insertDataset();
         Dac dac = createDac();
         Consent consent = createConsent();
         datasetDAO.updateDatasetDacId(dataset.getDataSetId(), dac.getDacId());
@@ -411,7 +409,7 @@ public class DatasetDAOTest extends DAOTestHelper {
     // User -> UserRoles -> DACs -> Consents -> Consent Associations -> DataSets
     @Test
     public void testFindDataSetsByAuthUserEmail() {
-        Dataset dataset = createDataset();
+        Dataset dataset = insertDataset();
         Dac dac = createDac();
         Consent consent = createConsent();
         datasetDAO.updateDatasetDacId(dataset.getDataSetId(), dac.getDacId());
@@ -421,19 +419,19 @@ public class DatasetDAOTest extends DAOTestHelper {
 
         List<Dataset> datasets = datasetDAO.findDatasetsByAuthUserEmail(user.getEmail());
         assertFalse(datasets.isEmpty());
-        List<Integer> datasetIds = datasets.stream().map(Dataset::getDataSetId).collect(Collectors.toList());
+        List<Integer> datasetIds = datasets.stream().map(Dataset::getDataSetId).toList();
         assertTrue(datasetIds.contains(dataset.getDataSetId()));
     }
 
     @Test
     public void testFindNonDACDataSets() {
-        Dataset dataset = createDataset();
+        Dataset dataset = insertDataset();
         Consent consent = createConsent();
         consentDAO.insertConsentAssociation(consent.getConsentId(), ASSOCIATION_TYPE_TEST, dataset.getDataSetId());
 
         List<Dataset> datasets = datasetDAO.findNonDACDatasets();
         assertFalse(datasets.isEmpty());
-        List<Integer> datasetIds = datasets.stream().map(Dataset::getDataSetId).collect(Collectors.toList());
+        List<Integer> datasetIds = datasets.stream().map(Dataset::getDataSetId).toList();
         assertTrue(datasetIds.contains(dataset.getDataSetId()));
         // adding this here to ensure mapper does not return a false in place of a null for dacApproval
         datasets.forEach(d -> {
@@ -443,7 +441,7 @@ public class DatasetDAOTest extends DAOTestHelper {
 
     @Test
     public void testFindDatasetAndDacIds() {
-        Dataset dataset = createDataset();
+        Dataset dataset = insertDataset();
         Dac dac = createDac();
         Consent consent = createConsent();
         datasetDAO.updateDatasetDacId(dataset.getDataSetId(), dac.getDacId());
@@ -458,14 +456,14 @@ public class DatasetDAOTest extends DAOTestHelper {
 
     @Test
     public void testFindDatasetPropertiesByDatasetId() {
-        Dataset d = createDataset();
+        Dataset d = insertDataset();
         Set<DatasetProperty> properties = datasetDAO.findDatasetPropertiesByDatasetId(d.getDataSetId());
         assertEquals(properties.size(), 1);
     }
 
     @Test
     public void testUpdateDataset() {
-        Dataset d = createDataset();
+        Dataset d = insertDataset();
         Dac dac = createDac();
         String name = RandomStringUtils.random(20, true, true);
         Timestamp now = new Timestamp(new Date().getTime());
@@ -482,15 +480,15 @@ public class DatasetDAOTest extends DAOTestHelper {
 
     @Test
     public void testUpdateDatasetProperty() {
-        Dataset d = createDataset();
+        Dataset d = insertDataset();
         Set<DatasetProperty> properties = datasetDAO.findDatasetPropertiesByDatasetId(d.getDataSetId());
-        DatasetProperty originalProperty = properties.stream().collect(Collectors.toList()).get(0);
+        DatasetProperty originalProperty = properties.stream().toList().get(0);
         DatasetProperty newProperty = new DatasetProperty(d.getDataSetId(), 1, "Updated Value", DatasetPropertyType.String, new Date());
         List<DatasetProperty> updatedProperties = new ArrayList<>();
         updatedProperties.add(newProperty);
         datasetDAO.updateDatasetProperty(d.getDataSetId(), updatedProperties.get(0).getPropertyKey(), updatedProperties.get(0).getPropertyValue().toString());
         Set<DatasetProperty> returnedProperties = datasetDAO.findDatasetPropertiesByDatasetId(d.getDataSetId());
-        DatasetProperty returnedProperty = returnedProperties.stream().collect(Collectors.toList()).get(0);
+        DatasetProperty returnedProperty = returnedProperties.stream().toList().get(0);
         assertEquals(originalProperty.getPropertyKey(), returnedProperty.getPropertyKey());
         assertEquals(originalProperty.getPropertyId(), returnedProperty.getPropertyId());
         assertNotEquals(originalProperty.getPropertyValue(), returnedProperty.getPropertyValue());
@@ -498,7 +496,7 @@ public class DatasetDAOTest extends DAOTestHelper {
 
     @Test
     public void testCreateNumberTypedDatasetProperty() {
-        Dataset d = createDataset();
+        Dataset d = insertDataset();
 
         Set<DatasetProperty> oldProperties = datasetDAO.findDatasetPropertiesByDatasetId(d.getDataSetId());
         DatasetProperty propertyToDelete = new ArrayList<>(oldProperties).get(0);
@@ -525,7 +523,7 @@ public class DatasetDAOTest extends DAOTestHelper {
 
     @Test
     public void testCreateDateTypedDatasetProperty() {
-        Dataset d = createDataset();
+        Dataset d = insertDataset();
         Instant now = Instant.now();
 
         Set<DatasetProperty> oldProperties = datasetDAO.findDatasetPropertiesByDatasetId(d.getDataSetId());
@@ -553,7 +551,7 @@ public class DatasetDAOTest extends DAOTestHelper {
 
     @Test
     public void testCreateBooleanTypedDatasetProperty() {
-        Dataset d = createDataset();
+        Dataset d = insertDataset();
         Boolean bool = Boolean.FALSE;
 
         Set<DatasetProperty> oldProperties = datasetDAO.findDatasetPropertiesByDatasetId(d.getDataSetId());
@@ -581,7 +579,7 @@ public class DatasetDAOTest extends DAOTestHelper {
 
     @Test
     public void testCreateJsonTypedDatasetProperty() {
-        Dataset d = createDataset();
+        Dataset d = insertDataset();
         JsonObject jsonObject = new JsonObject();
         jsonObject.add("test", new JsonObject());
 
@@ -610,7 +608,7 @@ public class DatasetDAOTest extends DAOTestHelper {
 
     @Test
     public void testCreateStringTypedDatasetProperty() {
-        Dataset d = createDataset();
+        Dataset d = insertDataset();
         String value = "hi";
 
         Set<DatasetProperty> oldProperties = datasetDAO.findDatasetPropertiesByDatasetId(d.getDataSetId());
@@ -638,7 +636,7 @@ public class DatasetDAOTest extends DAOTestHelper {
 
     @Test
     public void testCreateTypedDatasetPropertyWithSchema() {
-        Dataset d = createDataset();
+        Dataset d = insertDataset();
         String schemaValue = "test test test test";
 
         Set<DatasetProperty> oldProperties = datasetDAO.findDatasetPropertiesByDatasetId(d.getDataSetId());
@@ -666,9 +664,9 @@ public class DatasetDAOTest extends DAOTestHelper {
 
     @Test
     public void testDeleteDatasetPropertyByKey() {
-        Dataset d = createDataset();
+        Dataset d = insertDataset();
         Set<DatasetProperty> properties = datasetDAO.findDatasetPropertiesByDatasetId(d.getDataSetId());
-        DatasetProperty propertyToDelete = properties.stream().collect(Collectors.toList()).get(0);
+        DatasetProperty propertyToDelete = properties.stream().toList().get(0);
         datasetDAO.deleteDatasetPropertyByKey(d.getDataSetId(), propertyToDelete.getPropertyKey());
         Set<DatasetProperty> returnedProperties = datasetDAO.findDatasetPropertiesByDatasetId(d.getDataSetId());
         assertNotEquals(properties.size(), returnedProperties.size());
@@ -676,32 +674,32 @@ public class DatasetDAOTest extends DAOTestHelper {
 
     @Test
     public void testFindAllDatasets() {
-        Dataset dataset = createDataset();
+        Dataset dataset = insertDataset();
         Consent consent = createConsent();
         consentDAO.insertConsentAssociation(consent.getConsentId(), ASSOCIATION_TYPE_TEST, dataset.getDataSetId());
 
         Set<DatasetDTO> datasets = datasetDAO.findAllDatasetDTOs();
         assertFalse(datasets.isEmpty());
-        List<Integer> datasetIds = datasets.stream().map(DatasetDTO::getDataSetId).collect(Collectors.toList());
+        List<Integer> datasetIds = datasets.stream().map(DatasetDTO::getDataSetId).toList();
         assertTrue(datasetIds.contains(dataset.getDataSetId()));
     }
 
     @Test
     public void testFindActiveDatasets() {
-        Dataset dataset = createDataset();
+        Dataset dataset = insertDataset();
         Consent consent = createConsent();
 
         consentDAO.insertConsentAssociation(consent.getConsentId(), ASSOCIATION_TYPE_TEST, dataset.getDataSetId());
 
         Set<DatasetDTO> datasets = datasetDAO.findActiveDatasetDTOs();
         assertFalse(datasets.isEmpty());
-        List<Integer> datasetIds = datasets.stream().map(DatasetDTO::getDataSetId).collect(Collectors.toList());
+        List<Integer> datasetIds = datasets.stream().map(DatasetDTO::getDataSetId).toList();
         assertTrue(datasetIds.contains(dataset.getDataSetId()));
     }
 
     @Test
     public void testFindDatasetsByUser() {
-        Dataset dataset = createDataset();
+        Dataset dataset = insertDataset();
         Dac dac = createDac();
         Consent consent = createConsent();
         datasetDAO.updateDatasetDacId(dataset.getDataSetId(), dac.getDacId());
@@ -711,16 +709,16 @@ public class DatasetDAOTest extends DAOTestHelper {
 
         Set<DatasetDTO> datasets = datasetDAO.findDatasetDTOsByUserId(user.getUserId());
         assertFalse(datasets.isEmpty());
-        List<Integer> datasetIds = datasets.stream().map(DatasetDTO::getDataSetId).collect(Collectors.toList());
+        List<Integer> datasetIds = datasets.stream().map(DatasetDTO::getDataSetId).toList();
         assertTrue(datasetIds.contains(dataset.getDataSetId()));
     }
 
     @Test
     public void testFindDatasetsByDacIds() {
-        Dataset dataset = createDataset();
+        Dataset dataset = insertDataset();
         Dac dac = createDac();
 
-        Dataset datasetTwo = createDataset();
+        Dataset datasetTwo = insertDataset();
         Dac dacTwo = createDac();
 
         datasetDAO.updateDatasetDacId(dataset.getDataSetId(), dac.getDacId());
@@ -730,12 +728,26 @@ public class DatasetDAOTest extends DAOTestHelper {
         createConsentAndAssociationWithDatasetId(datasetTwo.getDataSetId());
         List<Integer> datasetIds = List.of(dataset.getDataSetId(), datasetTwo.getDataSetId());
         Set<DatasetDTO> datasets = datasetDAO.findDatasetsByDacIds(List.of(dac.getDacId(), dacTwo.getDacId()));
-        datasets.stream().forEach(d -> assertTrue(datasetIds.contains(d.getDataSetId())));
+        datasets.forEach(d -> assertTrue(datasetIds.contains(d.getDataSetId())));
+    }
+
+
+    @Test
+    public void testUpdateDatasetDataUse() {
+        Dataset dataset = insertDataset();
+        DataUse dataUse = new DataUseBuilder()
+            .setHmbResearch(true)
+            .setDiseaseRestrictions(List.of("DOID_1"))
+            .build();
+
+        datasetDAO.updateDatasetDataUse(dataset.getDataSetId(), dataUse.toString());
+        Dataset updated = datasetDAO.findDatasetById(dataset.getDataSetId());
+        assertEquals(dataUse, updated.getDataUse());
     }
 
     @Test
     public void testFindDatasetWithDataUseByIdList() {
-        Dataset dataset = createDataset();
+        Dataset dataset = insertDataset();
         Dac dac = createDac();
         Consent consent = createConsent();
         datasetDAO.updateDatasetDacId(dataset.getDataSetId(), dac.getDacId());
@@ -743,7 +755,7 @@ public class DatasetDAOTest extends DAOTestHelper {
 
         Set<Dataset> datasets = datasetDAO.findDatasetWithDataUseByIdList(Collections.singletonList(dataset.getDataSetId()));
         assertFalse(datasets.isEmpty());
-        List<Integer> datasetIds = datasets.stream().map(Dataset::getDataSetId).collect(Collectors.toList());
+        List<Integer> datasetIds = datasets.stream().map(Dataset::getDataSetId).toList();
         assertTrue(datasetIds.contains(dataset.getDataSetId()));
     }
 
@@ -827,5 +839,16 @@ public class DatasetDAOTest extends DAOTestHelper {
                 createDate
         );
         return fileStorageObjectDAO.findFileById(newFileStorageObjectId);
+    }
+
+    private Dataset insertDataset() {
+        User user = createUser();
+        String name = "Name_" + RandomStringUtils.random(20, true, true);
+        Timestamp now = new Timestamp(new Date().getTime());
+        String objectId = "Object ID_" + RandomStringUtils.random(20, true, true);
+        DataUse dataUse = new DataUseBuilder().setGeneralUse(true).build();
+        Integer id = datasetDAO.insertDataset(name, now, user.getUserId(), objectId, true, dataUse.toString(), null);
+        createDatasetProperties(id);
+        return datasetDAO.findDatasetById(id);
     }
 }

--- a/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
@@ -34,6 +34,7 @@ import org.broadinstitute.consent.http.authentication.GoogleUser;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.AuthUser;
 import org.broadinstitute.consent.http.models.Consent;
+import org.broadinstitute.consent.http.models.DataUseBuilder;
 import org.broadinstitute.consent.http.models.Dataset;
 import org.broadinstitute.consent.http.models.Dictionary;
 import org.broadinstitute.consent.http.models.Error;
@@ -771,6 +772,37 @@ public class DatasetResourceTest {
         initResource();
         Response response = resource.updateNeedsReviewDataSets(1, true);
         assertEquals(500, response.getStatus());
+    }
+
+    @Test
+    public void testUpdateDatasetDataUseOK() {
+        when(userService.findUserByEmail(any())).thenReturn(new User());
+        when(datasetService.updateDatasetDataUse(any(), any(), any())).thenReturn(new Dataset());
+
+        initResource();
+        String duString = new DataUseBuilder().setGeneralUse(true).build().toString();
+        Response response = resource.updateDatasetDataUse(new AuthUser(), 1, duString);
+        assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+    }
+
+    @Test
+    public void testUpdateDatasetDataUseBadRequestJson() {
+        when(userService.findUserByEmail(any())).thenReturn(new User());
+        when(datasetService.updateDatasetDataUse(any(), any(), any())).thenReturn(new Dataset());
+
+        initResource();
+        Response response = resource.updateDatasetDataUse(new AuthUser(), 1, "invalid json");
+        assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
+    }
+
+    @Test
+    public void testUpdateDatasetDataUseBadRequestService() {
+        when(userService.findUserByEmail(any())).thenReturn(new User());
+        when(datasetService.updateDatasetDataUse(any(), any(), any())).thenThrow(new IllegalArgumentException());
+
+        initResource();
+        Response response = resource.updateDatasetDataUse(new AuthUser(), 1, "invalid json");
+        assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
     }
 
     @Test

--- a/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
@@ -669,7 +669,7 @@ public class DatasetResourceTest {
         initResource();
         Response response = resource.getDataset(1);
         assertEquals(200, response.getStatus());
-        assertEquals(GsonUtil.buildGson().toJson(ds), response.getEntity());
+        assertEquals(ds, response.getEntity());
     }
 
     @Test
@@ -689,17 +689,14 @@ public class DatasetResourceTest {
         ds2.setDataSetId(2);
         Dataset ds3 = new Dataset();
         ds3.setDataSetId(3);
+        List<Dataset> datasets = List.of(ds1,ds2,ds3);
 
-        when(datasetService.getDatasets(List.of(1,2,3))).thenReturn(List.of(
-                ds1,
-                ds2,
-                ds3
-        ));
+        when(datasetService.getDatasets(List.of(1,2,3))).thenReturn(datasets);
 
         initResource();
         Response response = resource.getDatasets(List.of(1,2,3));
         assertEquals(200, response.getStatus());
-        assertEquals(GsonUtil.buildGson().toJson(List.of(ds1,ds2,ds3)), response.getEntity());
+        assertEquals(datasets, response.getEntity());
     }
 
     @Test
@@ -710,17 +707,14 @@ public class DatasetResourceTest {
         ds2.setDataSetId(2);
         Dataset ds3 = new Dataset();
         ds3.setDataSetId(3);
+        List<Dataset> datasets = List.of(ds1,ds2,ds3);
 
-        when(datasetService.getDatasets(List.of(1,1,2,2,3,3))).thenReturn(List.of(
-                ds1,
-                ds2,
-                ds3
-        ));
+        when(datasetService.getDatasets(List.of(1,1,2,2,3,3))).thenReturn(datasets);
 
         initResource();
         Response response = resource.getDatasets(List.of(1,1,2,2,3,3));
         assertEquals(200, response.getStatus());
-        assertEquals(GsonUtil.buildGson().toJson(List.of(ds1,ds2,ds3)), response.getEntity());
+        assertEquals(datasets, response.getEntity());
     }
 
     @Test


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-2197

This PR adds a new admin-only endpoint to update the data use on existing datasets. There is no logic here for downstream side effects such as existing DAR<->Dataset Match entities no longer being valid. This is a conscious decision for the time being and any potential effects can be mitigated by regenerating elections and reprocessing match results. 

### Note
Recommended that you hide white space in the review as I did a lot of reformatting

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
