### PR TITLE
[DUOS-2246][risk=no] Fix update self institution logic

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/resources/InstitutionResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/InstitutionResource.java
@@ -29,7 +29,7 @@ public class InstitutionResource extends Resource {
   private final UserService userService;
   private final InstitutionService institutionService;
   /*
-    NOTE: InstitutionUtil will provide a configured GsonBuilder to help format the JSON response
+    NOTE: InstitutionUtil will provide a configured GsonBuilder to help format the JSON response.
     Response needs to be filtered based on user roles (Admins would see all, non-admins would not)
     As such, any @PermitAll route would require the entity (Institution) to be formatted with the GsonBuilder
     as opposed to being passed into the response directly.
@@ -55,7 +55,7 @@ public class InstitutionResource extends Resource {
     } catch(Exception e) {
       return createExceptionResponse(e);
     }
-  };
+  }
 
   @GET
   @Produces("application/json")
@@ -119,5 +119,5 @@ public class InstitutionResource extends Resource {
     } catch(Exception e) {
       return createExceptionResponse(e);
     }
-  };
+  }
 }

--- a/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
@@ -2,6 +2,7 @@ package org.broadinstitute.consent.http.resources;
 
 
 import com.google.api.client.http.HttpStatusCodes;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.google.gson.reflect.TypeToken;
@@ -222,7 +223,8 @@ public class UserResource extends Resource {
         }
     }
 
-    private boolean canUpdateInstitution(User user, Integer newInstitutionId) {
+    @VisibleForTesting
+    protected boolean canUpdateInstitution(User user, Integer newInstitutionId) {
         if ((!Objects.isNull(user.getUserId()) || !Objects.isNull(newInstitutionId)) && !Objects.equals(user.getInstitutionId(), newInstitutionId)) {
             if (user.hasUserRole(UserRoles.ADMIN)) {
                 return true; // admins can do everything.

--- a/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
@@ -227,17 +227,15 @@ public class UserResource extends Resource {
             if (user.hasUserRole(UserRoles.ADMIN)) {
                 return true; // admins can do everything.
             }
-
             if (user.hasUserRole(UserRoles.SIGNINGOFFICIAL) || user.hasUserRole(UserRoles.ITDIRECTOR)) {
                 // can only update institution if not set.
                 return Objects.isNull(user.getInstitutionId()) && Objects.nonNull(newInstitutionId);
             }
-
-            return false;
+            // User is not restricted based on role
+            return true;
         } else {
             return true; // no op, no change, supports keeping no institution set to no institution.
         }
-
     }
 
     @PUT

--- a/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
@@ -668,6 +668,68 @@ public class UserResourceTest {
   }
 
   @Test
+  public void testCanUpdateInstitution() {
+    initResource();
+
+    // User with no roles and no institution can update their institution
+    User u1 = new User();
+    boolean canUpdate = userResource.canUpdateInstitution(u1, 1);
+    assertTrue(canUpdate);
+
+    // Researcher user with no institution can update their institution
+    User u2 = new User();
+    u2.addRole(new UserRole(UserRoles.RESEARCHER.getRoleId(), UserRoles.RESEARCHER.getRoleName()));
+    canUpdate = userResource.canUpdateInstitution(u2, 1);
+    assertTrue(canUpdate);
+
+    // Researcher user with an institution can update their institution
+    User u3 = new User();
+    u3.setInstitutionId(10);
+    u3.addRole(new UserRole(UserRoles.RESEARCHER.getRoleId(), UserRoles.RESEARCHER.getRoleName()));
+    canUpdate = userResource.canUpdateInstitution(u3, 1);
+    assertTrue(canUpdate);
+
+    // SO user with no institution can update their institution
+    User u4 = new User();
+    u4.addRole(new UserRole(UserRoles.SIGNINGOFFICIAL.getRoleId(), UserRoles.SIGNINGOFFICIAL.getRoleName()));
+    canUpdate = userResource.canUpdateInstitution(u4, 1);
+    assertTrue(canUpdate);
+
+    // SO user with an institution CANNOT update their institution
+    User u4a = new User();
+    u4a.setInstitutionId(10);
+    u4a.addRole(new UserRole(UserRoles.SIGNINGOFFICIAL.getRoleId(), UserRoles.SIGNINGOFFICIAL.getRoleName()));
+    canUpdate = userResource.canUpdateInstitution(u4a, 1);
+    assertFalse(canUpdate);
+
+    // IT user with no institution can update their institution
+    User u5 = new User();
+    u5.addRole(new UserRole(UserRoles.ITDIRECTOR.getRoleId(), UserRoles.ITDIRECTOR.getRoleName()));
+    canUpdate = userResource.canUpdateInstitution(u5, 1);
+    assertTrue(canUpdate);
+
+    // IT user with an institution CANNOT update their institution
+    User u5a = new User();
+    u5a.setInstitutionId(10);
+    u5a.addRole(new UserRole(UserRoles.ITDIRECTOR.getRoleId(), UserRoles.ITDIRECTOR.getRoleName()));
+    canUpdate = userResource.canUpdateInstitution(u5a, 1);
+    assertFalse(canUpdate);
+
+    // Admin user with no institution can update their institution
+    User u6 = new User();
+    u6.addRole(new UserRole(UserRoles.ADMIN.getRoleId(), UserRoles.ADMIN.getRoleName()));
+    canUpdate = userResource.canUpdateInstitution(u6, 1);
+    assertTrue(canUpdate);
+
+    // Admin user with an institution can update their institution
+    User u7 = new User();
+    u7.setInstitutionId(10);
+    u7.addRole(new UserRole(UserRoles.ADMIN.getRoleId(), UserRoles.ADMIN.getRoleName()));
+    canUpdate = userResource.canUpdateInstitution(u7, 1);
+    assertTrue(canUpdate);
+  }
+
+  @Test
   public void testUpdate() {
     User user = createUserWithRole();
     UserUpdateFields userUpdateFields = new UserUpdateFields();


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-2246

Minor update to the logic around a user updating their own institution. Previous logic was preventing non-admin, non-SO, non-IT users from updating their institution. 

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
