### PR TITLE
[DUOS-2277][risk=no] New API to replace existing one for user relevant datasets

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
@@ -149,6 +149,9 @@ public class UserResource extends Resource {
                 .filter(Objects::nonNull)
                 .collect(Collectors.toList());
             List<Dataset> datasets = dacIds.isEmpty() ? List.of() : datasetService.findDatasetListByDacIds(dacIds);
+            if (datasets.isEmpty()) {
+                throw new NotFoundException("No datasets found for current user");
+            }
             return Response.ok().entity(datasets).build();
         } catch (Exception e) {
             return createExceptionResponse(e);

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -119,6 +119,13 @@ public class DatasetService {
         return datasetDAO.findDatasetsByDacIds(dacIds);
     }
 
+    public List<Dataset> findDatasetListByDacIds(List<Integer> dacIds) {
+        if(Objects.isNull(dacIds) || dacIds.isEmpty()) {
+            throw new BadRequestException("No dataset IDs provided");
+        }
+        return datasetDAO.findDatasetListByDacIds(dacIds);
+    }
+
     /**
      * Finds a Dataset by a formatted dataset identifier.
      *

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -1616,6 +1616,8 @@ paths:
           description: Server error.
   /api/user/me/dac/datasets:
     $ref: './paths/getDatasetsFromUserDacs.yaml'
+  /api/user/me/dac/datasets/v2:
+    $ref: './paths/getDatasetsFromUserDacsV2.yaml'
   /api/user/institution/{institutionId}:
     $ref: './paths/userInstitutionByInstitutionId.yaml'
   /api/user/institution/unassigned:

--- a/src/main/resources/assets/paths/getDatasetsFromUserDacsV2.yaml
+++ b/src/main/resources/assets/paths/getDatasetsFromUserDacsV2.yaml
@@ -1,12 +1,11 @@
 get:
   summary: Get datasets from currently authenticated user's DACs
   description: Get datasets from currently authenticated user's DACs
-  deprecated: true
   tags:
     - User
   responses:
     200:
-      description: Set of Datasets that are under the purview of User's dacs
+      description: List of Datasets that are under the purview of User's dacs
       content:
         application/json:
           schema:

--- a/src/main/resources/assets/paths/getDatasetsFromUserDacsV2.yaml
+++ b/src/main/resources/assets/paths/getDatasetsFromUserDacsV2.yaml
@@ -13,6 +13,6 @@ get:
             items:
               $ref: '../schemas/Dataset.yaml'
     404:
-      description: User not found
+      description: User not found or no datasets found for user
     500:
       description: Server error

--- a/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
@@ -731,6 +731,23 @@ public class DatasetDAOTest extends DAOTestHelper {
         datasets.forEach(d -> assertTrue(datasetIds.contains(d.getDataSetId())));
     }
 
+    @Test
+    public void testFindDatasetListByDacIds() {
+        Dataset dataset = insertDataset();
+        Dac dac = createDac();
+
+        Dataset datasetTwo = insertDataset();
+        Dac dacTwo = createDac();
+
+        datasetDAO.updateDatasetDacId(dataset.getDataSetId(), dac.getDacId());
+        datasetDAO.updateDatasetDacId(datasetTwo.getDataSetId(), dacTwo.getDacId());
+
+        createConsentAndAssociationWithDatasetId(dataset.getDataSetId());
+        createConsentAndAssociationWithDatasetId(datasetTwo.getDataSetId());
+        List<Integer> datasetIds = List.of(dataset.getDataSetId(), datasetTwo.getDataSetId());
+        List<Dataset> datasets = datasetDAO.findDatasetListByDacIds(List.of(dac.getDacId(), dacTwo.getDacId()));
+        datasets.forEach(d -> assertTrue(datasetIds.contains(d.getDataSetId())));
+    }
 
     @Test
     public void testUpdateDatasetDataUse() {

--- a/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
@@ -1,8 +1,41 @@
 package org.broadinstitute.consent.http.resources;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.openMocks;
+import static org.mockito.internal.verification.VerificationModeFactory.times;
+
 import com.google.api.client.http.HttpStatusCodes;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.stream.Collectors;
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.ServerErrorException;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import javax.ws.rs.core.UriBuilder;
+import javax.ws.rs.core.UriInfo;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.RandomUtils;
 import org.broadinstitute.consent.http.authentication.GoogleUser;
@@ -26,40 +59,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
-
-import javax.ws.rs.NotFoundException;
-import javax.ws.rs.ServerErrorException;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.Status;
-import javax.ws.rs.core.UriBuilder;
-import javax.ws.rs.core.UriInfo;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.sql.Timestamp;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Random;
-import java.util.stream.Collectors;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.openMocks;
-import static org.mockito.internal.verification.VerificationModeFactory.times;
 
 public class UserResourceTest {
 
@@ -948,15 +947,15 @@ public class UserResourceTest {
   }
 
   @Test
-  public void testGetDatasetsFromUserDacs() {
+  public void testGetDatasetsFromUserDacsV2() {
     User user = createUserWithRole();
     UserRole admin = new UserRole(UserRoles.ADMIN.getRoleId(), UserRoles.ADMIN.getRoleName());
     user.addRole(admin);
-    when(datasetService.findDatasetsByDacIds(anyList())).thenReturn(Collections.emptySet());
+    when(datasetService.findDatasetListByDacIds(anyList())).thenReturn(List.of());
     when(userService.findUserByEmail(anyString())).thenReturn(user);
     initResource();
 
-    Response response = userResource.getDatasetsFromUserDacs(authUser);
+    Response response = userResource.getDatasetsFromUserDacsV2(authUser);
     assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
@@ -43,6 +43,7 @@ import org.broadinstitute.consent.http.enumeration.UserFields;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.Acknowledgement;
 import org.broadinstitute.consent.http.models.AuthUser;
+import org.broadinstitute.consent.http.models.Dataset;
 import org.broadinstitute.consent.http.models.LibraryCard;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.UserProperty;
@@ -949,14 +950,38 @@ public class UserResourceTest {
   @Test
   public void testGetDatasetsFromUserDacsV2() {
     User user = createUserWithRole();
-    UserRole admin = new UserRole(UserRoles.ADMIN.getRoleId(), UserRoles.ADMIN.getRoleName());
-    user.addRole(admin);
-    when(datasetService.findDatasetListByDacIds(anyList())).thenReturn(List.of());
+    UserRole chair = new UserRole(UserRoles.CHAIRPERSON.getRoleId(), UserRoles.CHAIRPERSON.getRoleName());
+    chair.setDacId(1);
+    user.addRole(chair);
+    when(datasetService.findDatasetListByDacIds(anyList())).thenReturn(List.of(new Dataset()));
     when(userService.findUserByEmail(anyString())).thenReturn(user);
     initResource();
 
     Response response = userResource.getDatasetsFromUserDacsV2(authUser);
     assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+  }
+
+  @Test
+  public void testGetDatasetsFromUserDacsV2DatasetsNotFound() {
+    User user = createUserWithRole();
+    UserRole chair = new UserRole(UserRoles.CHAIRPERSON.getRoleId(), UserRoles.CHAIRPERSON.getRoleName());
+    chair.setDacId(1);
+    user.addRole(chair);
+    when(datasetService.findDatasetListByDacIds(anyList())).thenReturn(List.of());
+    when(userService.findUserByEmail(anyString())).thenReturn(user);
+    initResource();
+
+    Response response = userResource.getDatasetsFromUserDacsV2(authUser);
+    assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
+  }
+
+  @Test
+  public void testGetDatasetsFromUserDacsV2UserNotFound() {
+    when(userService.findUserByEmail(anyString())).thenThrow(new NotFoundException("User not found"));
+    initResource();
+
+    Response response = userResource.getDatasetsFromUserDacsV2(authUser);
+    assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
@@ -189,6 +189,26 @@ public class DatasetServiceTest {
     }
 
     @Test
+    public void testFindDatasetListByDacIds() {
+        when(datasetDAO.findDatasetListByDacIds(anyList())).thenReturn(List.of());
+        initService();
+
+        datasetService.findDatasetListByDacIds(List.of(1,2,3));
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void testFindDatasetListByDacIdsEmptyList() {
+        initService();
+        datasetService.findDatasetListByDacIds(Collections.emptyList());
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void testFindDatasetListByDacIdsNullList() {
+        initService();
+        datasetService.findDatasetListByDacIds(null);
+    }
+
+    @Test
     public void testUpdateNeedsReviewDataSets(){
         Integer dataSetId = 1;
         when(datasetDAO.findDatasetById(dataSetId))


### PR DESCRIPTION
## Addresses
Partially addresses https://broadworkbench.atlassian.net/browse/DUOS-2277

Related to [DUOS-1929](https://broadworkbench.atlassian.net/browse/DUOS-1929)
This covers API work that was discovered to be missing for chairs and members while working on a similar page for DAC-dataset-approval. This PR creates a new version of the API to get relevant datasets for a user but returning full `Dataset` objects instead of the deprecated `DatasetDTO` objects. The one main difference between the two are how they treat the `alias` value. `Dataset` treats it as a numeric value and adds a `datasetIdentifier` field for the parsed version of the numeric `alias` value while the DTO puts the identifier into the alias.

See also https://github.com/DataBiosphere/duos-ui/pull/1999 where there is some UI work related to this.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment


[DUOS-1929]: https://broadworkbench.atlassian.net/browse/DUOS-1929?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ