### PR TITLE
[DUOS-2291][risk=no] Add create user info to select Dataset APIs

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
@@ -464,24 +464,6 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
     List<Association> getAssociationsForDatasetIdList(@BindList("dataSetIdList") List<Integer> dataSetIdList);
 
     /**
-     * DACs -> Consents -> Consent Associations -> Datasets
-     * Datasets -> DatasetProperties -> Dictionary
-     *
-     * @return Set of datasets, with properties, that are associated to a single DAC.
-     */
-    @Deprecated
-    @UseRowMapper(DatasetDTOWithPropertiesMapper.class)
-    @SqlQuery(
-        "SELECT d.*, k.key, p.property_value, c.consent_id, d.dac_id, c.translated_use_restriction " +
-            " FROM dataset d " +
-            " LEFT OUTER JOIN dataset_property p ON p.dataset_id = d.dataset_id " +
-            " LEFT OUTER JOIN dictionary k ON k.key_id = p.property_key " +
-            " INNER JOIN consent_associations a ON a.dataset_id = d.dataset_id " +
-            " INNER JOIN consents c ON c.consent_id = a.consent_id " +
-            " WHERE d.dac_id = :dacId ")
-    Set<DatasetDTO> findDatasetsByDac(@Bind("dacId") Integer dacId);
-
-    /**
      * Finds all datasets which are assigned to this DAC and which
      * have been requested for this DAC.
      *

--- a/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
@@ -283,18 +283,39 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
     """)
     List<Dataset> getActiveDatasets();
 
+    @RegisterBeanMapper(value = User.class, prefix = "u")
     @UseRowReducer(DatasetReducer.class)
-    @SqlQuery(
-        "SELECT d.*, k.key, dp.property_value, dp.property_key, dp.property_id, ca.consent_id, d.dac_id, c.translated_use_restriction, dar_ds_ids.id as in_use, " +
-            FileStorageObject.QUERY_FIELDS_WITH_FSO_PREFIX +
-            " FROM dataset d " +
-            " LEFT JOIN (SELECT DISTINCT dataset_id AS id FROM dar_dataset) dar_ds_ids ON dar_ds_ids.id = d.dataset_id " +
-            " LEFT JOIN dataset_property dp ON dp.dataset_id = d.dataset_id " +
-            " LEFT JOIN dictionary k ON k.key_id = dp.property_key " +
-            " LEFT JOIN consent_associations ca ON ca.dataset_id = d.dataset_id " +
-            " LEFT JOIN file_storage_object fso ON fso.entity_id = d.dataset_id::text AND fso.deleted = false " +
-            " LEFT JOIN consents c ON c.consent_id = ca.consent_id " +
-            " WHERE d.alias = :alias")
+    @SqlQuery("""
+        SELECT d.dataset_id, d.name, d.create_date, d.create_user_id, d.update_date,
+            d.update_user_id, d.object_id, d.active, d.dac_id, d.alias, d.data_use, d.dac_approval,
+            dar_ds_ids.id AS in_use,
+            u.user_id AS u_user_id, u.email AS u_email, u.display_name AS u_display_name,
+            u.create_date AS u_create_date, u.email_preference AS u_email_preference,
+            u.institution_id AS u_institution_id, u.era_commons_id AS u_era_commons_id,
+            k.key, dp.property_value, dp.property_key, dp.property_type, dp.schema_property, dp.property_id,
+            ca.consent_id, c.translated_use_restriction,
+            fso.file_storage_object_id AS fso_file_storage_object_id,
+            fso.entity_id AS fso_entity_id,
+            fso.file_name AS fso_file_name,
+            fso.category AS fso_category,
+            fso.gcs_file_uri AS fso_gcs_file_uri,
+            fso.media_type AS fso_media_type,
+            fso.create_date AS fso_create_date,
+            fso.create_user_id AS fso_create_user_id,
+            fso.update_date AS fso_update_date,
+            fso.update_user_id AS fso_update_user_id,
+            fso.deleted AS fso_deleted,
+            fso.delete_user_id AS fso_delete_user_id
+        FROM dataset d
+        LEFT JOIN users u on d.create_user_id = u.user_id
+        LEFT JOIN (SELECT DISTINCT dataset_id AS id FROM dar_dataset) dar_ds_ids ON dar_ds_ids.id = d.dataset_id
+        LEFT JOIN dataset_property dp ON dp.dataset_id = d.dataset_id
+        LEFT JOIN dictionary k ON k.key_id = dp.property_key
+        LEFT JOIN consent_associations ca ON ca.dataset_id = d.dataset_id
+        LEFT JOIN file_storage_object fso ON fso.entity_id = d.dataset_id::text AND fso.deleted = false
+        LEFT JOIN consents c ON c.consent_id = ca.consent_id
+        WHERE d.alias = :alias
+    """)
     Dataset findDatasetByAlias(@Bind("alias") Integer alias);
 
     @UseRowReducer(DatasetReducer.class)

--- a/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
@@ -35,6 +35,7 @@ import org.jdbi.v3.sqlobject.statement.UseRowMapper;
 import org.jdbi.v3.sqlobject.statement.UseRowReducer;
 import org.jdbi.v3.sqlobject.transaction.Transactional;
 
+@RegisterBeanMapper(value = User.class, prefix = "u")
 @RegisterRowMapper(DatasetMapper.class)
 @RegisterRowMapper(FileStorageObjectMapperWithFSOPrefix.class)
 public interface DatasetDAO extends Transactional<DatasetDAO> {
@@ -57,7 +58,6 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
         @Bind("dataUse") String dataUse,
         @Bind("dacId") Integer dacId);
 
-    @RegisterBeanMapper(value = User.class, prefix = "u")
     @UseRowReducer(DatasetReducer.class)
     @SqlQuery("""
         SELECT d.dataset_id, d.name, d.create_date, d.create_user_id, d.update_date,
@@ -92,7 +92,6 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
     """)
     Dataset findDatasetById(@Bind("datasetId") Integer datasetId);
 
-    @RegisterBeanMapper(value = User.class, prefix = "u")
     @UseRowReducer(DatasetReducer.class)
     @SqlQuery("""
         SELECT d.dataset_id, d.name, d.create_date, d.create_user_id, d.update_date,
@@ -127,7 +126,6 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
     """)
     List<Dataset> findDatasetsByIdList(@BindList("datasetIds") List<Integer> datasetIds);
 
-    @RegisterBeanMapper(value = User.class, prefix = "u")
     @UseRowReducer(DatasetReducer.class)
     @SqlQuery("""
         SELECT d.dataset_id, d.name, d.create_date, d.create_user_id, d.update_date,
@@ -169,7 +167,6 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
      * @param email User email
      * @return List of datasets that are visible to the user via DACs.
      */
-    @RegisterBeanMapper(value = User.class, prefix = "u")
     @UseRowReducer(DatasetReducer.class)
     @SqlQuery("""
         SELECT d.dataset_id, d.name, d.create_date, d.create_user_id, d.update_date,
@@ -212,7 +209,6 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
      * @param dacId id
      * @return all datasets associated with DAC
      */
-    @RegisterBeanMapper(value = User.class, prefix = "u")
     @UseRowReducer(DatasetReducer.class)
     @SqlQuery("""
         SELECT d.dataset_id, d.name, d.create_date, d.create_user_id, d.update_date,
@@ -248,7 +244,6 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
     """)
     List<Dataset> findDatasetsAssociatedWithDac(@Bind("dacId") Integer dacId);
 
-    @RegisterBeanMapper(value = User.class, prefix = "u")
     @UseRowReducer(DatasetReducer.class)
     @SqlQuery("""
         SELECT d.dataset_id, d.name, d.create_date, d.create_user_id, d.update_date,
@@ -283,7 +278,6 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
     """)
     List<Dataset> getActiveDatasets();
 
-    @RegisterBeanMapper(value = User.class, prefix = "u")
     @UseRowReducer(DatasetReducer.class)
     @SqlQuery("""
         SELECT d.dataset_id, d.name, d.create_date, d.create_user_id, d.update_date,

--- a/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
@@ -205,6 +205,49 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
     """)
     List<Dataset> findDatasetsByAuthUserEmail(@Bind("email") String email);
 
+    /**
+     * Finds all datasets which are assigned to this DAC and which
+     * have been requested for this DAC.
+     *
+     * @param dacId id
+     * @return all datasets associated with DAC
+     */
+    @RegisterBeanMapper(value = User.class, prefix = "u")
+    @UseRowReducer(DatasetReducer.class)
+    @SqlQuery("""
+        SELECT d.dataset_id, d.name, d.create_date, d.create_user_id, d.update_date,
+            d.update_user_id, d.object_id, d.active, d.dac_id, d.alias, d.data_use, d.dac_approval,
+            dar_ds_ids.id AS in_use,
+            u.user_id AS u_user_id, u.email AS u_email, u.display_name AS u_display_name,
+            u.create_date AS u_create_date, u.email_preference AS u_email_preference,
+            u.institution_id AS u_institution_id, u.era_commons_id AS u_era_commons_id,
+            k.key, dp.property_value, dp.property_key, dp.property_type, dp.schema_property, dp.property_id,
+            ca.consent_id, c.translated_use_restriction,
+            fso.file_storage_object_id AS fso_file_storage_object_id,
+            fso.entity_id AS fso_entity_id,
+            fso.file_name AS fso_file_name,
+            fso.category AS fso_category,
+            fso.gcs_file_uri AS fso_gcs_file_uri,
+            fso.media_type AS fso_media_type,
+            fso.create_date AS fso_create_date,
+            fso.create_user_id AS fso_create_user_id,
+            fso.update_date AS fso_update_date,
+            fso.update_user_id AS fso_update_user_id,
+            fso.deleted AS fso_deleted,
+            fso.delete_user_id AS fso_delete_user_id
+        FROM dataset d
+        LEFT JOIN users u on d.create_user_id = u.user_id
+        LEFT JOIN (SELECT DISTINCT dataset_id AS id FROM dar_dataset) dar_ds_ids ON dar_ds_ids.id = d.dataset_id
+        LEFT JOIN dataset_property dp ON dp.dataset_id = d.dataset_id
+        LEFT JOIN dictionary k ON k.key_id = dp.property_key
+        LEFT JOIN consent_associations ca ON ca.dataset_id = d.dataset_id
+        LEFT JOIN file_storage_object fso ON fso.entity_id = d.dataset_id::text AND fso.deleted = false
+        LEFT JOIN consents c ON c.consent_id = ca.consent_id
+        WHERE d.dac_id = :dacId
+        OR (dp.schema_property = 'dataAccessCommitteeId' AND dp.property_value = :dacId::text)
+    """)
+    List<Dataset> findDatasetsAssociatedWithDac(@Bind("dacId") Integer dacId);
+
     @UseRowReducer(DatasetReducer.class)
     @SqlQuery(
         "SELECT d.*, k.key, dp.property_value, dp.property_key, dp.property_id, ca.consent_id, d.dac_id, c.translated_use_restriction, dar_ds_ids.id as in_use, " +
@@ -458,27 +501,6 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
             + "INNER JOIN dataset ds ON ds.dataset_id = ca.dataset_id "
             + "WHERE ds.dataset_id IN (<dataSetIdList>)")
     List<Association> getAssociationsForDatasetIdList(@BindList("dataSetIdList") List<Integer> dataSetIdList);
-
-    /**
-     * Finds all datasets which are assigned to this DAC and which
-     * have been requested for this DAC.
-     *
-     * @param dacId id
-     * @return all datasets associated with DAC
-     */
-    @UseRowReducer(DatasetReducer.class)
-    @SqlQuery("SELECT d.*, k.key, dp.property_value, dp.property_key, dp.property_type, dp.schema_property, dp.property_id, ca.consent_id, c.translated_use_restriction, dar_ds_ids.id as in_use, " +
-            FileStorageObject.QUERY_FIELDS_WITH_FSO_PREFIX +
-            " FROM dataset d " +
-            " LEFT JOIN (SELECT DISTINCT dataset_id AS id FROM dar_dataset) dar_ds_ids ON dar_ds_ids.id = d.dataset_id " +
-            " LEFT JOIN dataset_property dp ON dp.dataset_id = d.dataset_id " +
-            " LEFT JOIN dictionary k ON k.key_id = dp.property_key " +
-            " LEFT JOIN consent_associations ca ON ca.dataset_id = d.dataset_id " +
-            " LEFT JOIN file_storage_object fso ON fso.entity_id = d.dataset_id::text AND fso.deleted = false " +
-            " LEFT JOIN consents c ON c.consent_id = ca.consent_id " +
-            " WHERE d.dac_id = :dacId " +
-            " OR (dp.schema_property = 'dataAccessCommitteeId' AND dp.property_value = :dacId::text)")
-    List<Dataset> findDatasetsAssociatedWithDac(@Bind("dacId") Integer dacId);
 
     /**
      * DACs -> Consents -> Consent Associations -> Datasets

--- a/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
@@ -83,7 +83,7 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
             fso.deleted AS fso_deleted,
             fso.delete_user_id AS fso_delete_user_id
         FROM dataset d
-        INNER JOIN users u on d.create_user_id = u.user_id
+        LEFT JOIN users u on d.create_user_id = u.user_id
         LEFT JOIN (SELECT DISTINCT dataset_id AS id FROM dar_dataset) dar_ds_ids ON dar_ds_ids.id = d.dataset_id
         LEFT JOIN dataset_property dp ON dp.dataset_id = d.dataset_id
         LEFT JOIN dictionary k ON k.key_id = dp.property_key
@@ -118,7 +118,7 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
             fso.deleted AS fso_deleted,
             fso.delete_user_id AS fso_delete_user_id
         FROM dataset d
-        INNER JOIN users u on d.create_user_id = u.user_id
+        LEFT JOIN users u on d.create_user_id = u.user_id
         LEFT JOIN (SELECT DISTINCT dataset_id AS id FROM dar_dataset) dar_ds_ids ON dar_ds_ids.id = d.dataset_id
         LEFT JOIN dataset_property dp ON dp.dataset_id = d.dataset_id
         LEFT JOIN dictionary k ON k.key_id = dp.property_key
@@ -153,7 +153,7 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
             fso.deleted AS fso_deleted,
             fso.delete_user_id AS fso_delete_user_id
         FROM dataset d
-        INNER JOIN users u on d.create_user_id = u.user_id
+        LEFT JOIN users u on d.create_user_id = u.user_id
         LEFT JOIN (SELECT DISTINCT dataset_id AS id FROM dar_dataset) dar_ds_ids ON dar_ds_ids.id = d.dataset_id
         LEFT JOIN dataset_property dp ON dp.dataset_id = d.dataset_id
         LEFT JOIN dictionary k ON k.key_id = dp.property_key
@@ -162,6 +162,52 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
         LEFT JOIN consents c ON c.consent_id = ca.consent_id
     """)
     List<Dataset> findAllDatasets();
+
+    /**
+     * Original implementation of dacs -> datasets is via an association through consent
+     * User -> UserRoles -> DACs -> Consents -> Consent Associations -> Datasets
+     *
+     * Subsequent refactoring moves the dataset to a top level field on the DAC
+     * User -> UserRoles -> DACs -> Datasets
+     *
+     * @param email User email
+     * @return List of datasets that are visible to the user via DACs.
+     */
+    @RegisterBeanMapper(value = User.class, prefix = "u")
+    @UseRowReducer(DatasetReducer.class)
+    @SqlQuery("""
+        SELECT d.dataset_id, d.name, d.create_date, d.create_user_id, d.update_date,
+            d.update_user_id, d.object_id, d.active, d.dac_id, d.alias, d.data_use, d.dac_approval,
+            dar_ds_ids.id AS in_use,
+            u.user_id AS u_user_id, u.email AS u_email, u.display_name AS u_display_name,
+            u.create_date AS u_create_date, u.email_preference AS u_email_preference,
+            u.institution_id AS u_institution_id, u.era_commons_id AS u_era_commons_id,
+            k.key, dp.property_value, dp.property_key, dp.property_type, dp.schema_property, dp.property_id,
+            ca.consent_id, c.translated_use_restriction,
+            fso.file_storage_object_id AS fso_file_storage_object_id,
+            fso.entity_id AS fso_entity_id,
+            fso.file_name AS fso_file_name,
+            fso.category AS fso_category,
+            fso.gcs_file_uri AS fso_gcs_file_uri,
+            fso.media_type AS fso_media_type,
+            fso.create_date AS fso_create_date,
+            fso.create_user_id AS fso_create_user_id,
+            fso.update_date AS fso_update_date,
+            fso.update_user_id AS fso_update_user_id,
+            fso.deleted AS fso_deleted,
+            fso.delete_user_id AS fso_delete_user_id
+        FROM dataset d
+        LEFT JOIN users u on d.create_user_id = u.user_id
+        LEFT JOIN (SELECT DISTINCT dataset_id AS id FROM dar_dataset) dar_ds_ids ON dar_ds_ids.id = d.dataset_id
+        LEFT JOIN dataset_property dp ON dp.dataset_id = d.dataset_id
+        LEFT JOIN dictionary k ON k.key_id = dp.property_key
+        LEFT JOIN consent_associations ca ON ca.dataset_id = d.dataset_id
+        LEFT JOIN file_storage_object fso ON fso.entity_id = d.dataset_id::text AND fso.deleted = false
+        LEFT JOIN consents c ON c.consent_id = ca.consent_id
+        INNER JOIN user_role dac_role ON dac_role.dac_id = d.dac_id
+        INNER JOIN users dac_user ON dac_role.user_id = dac_user.user_id AND dac_user.email = :email
+    """)
+    List<Dataset> findDatasetsByAuthUserEmail(@Bind("email") String email);
 
     @UseRowReducer(DatasetReducer.class)
     @SqlQuery(
@@ -430,27 +476,6 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
             + "INNER JOIN dataset ds ON ds.dataset_id = ca.dataset_id "
             + "WHERE ds.dataset_id IN (<dataSetIdList>)")
     List<Association> getAssociationsForDatasetIdList(@BindList("dataSetIdList") List<Integer> dataSetIdList);
-
-    /**
-     * User -> UserRoles -> DACs -> Consents -> Consent Associations -> Datasets
-     *
-     * @param email User email
-     * @return List of datasets that are visible to the user via DACs.
-     */
-    @UseRowReducer(DatasetReducer.class)
-    @SqlQuery(
-        "SELECT d.*, k.key, dp.property_value, dp.property_key, dp.property_type, dp.schema_property, dp.property_id, ca.consent_id, d.dac_id, c.translated_use_restriction, dar_ds_ids.id as in_use, " +
-            FileStorageObject.QUERY_FIELDS_WITH_FSO_PREFIX +
-            " FROM dataset d " +
-            " LEFT JOIN (SELECT DISTINCT dataset_id AS id FROM dar_dataset) dar_ds_ids ON dar_ds_ids.id = d.dataset_id " +
-            " LEFT JOIN dataset_property dp ON dp.dataset_id = d.dataset_id " +
-            " LEFT JOIN dictionary k ON k.key_id = dp.property_key " +
-            " LEFT JOIN consent_associations ca ON ca.dataset_id = d.dataset_id " +
-            " LEFT JOIN file_storage_object fso ON fso.entity_id = d.dataset_id::text AND fso.deleted = false " +
-            " LEFT JOIN consents c ON c.consent_id = ca.consent_id " +
-            " INNER JOIN user_role ur ON ur.dac_id = d.dac_id " +
-            " INNER JOIN users u ON ur.user_id = u.user_id AND u.email = :email ")
-    List<Dataset> findDatasetsByAuthUserEmail(@Bind("email") String email);
 
     /**
      * DACs -> Consents -> Consent Associations -> Datasets

--- a/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
@@ -129,6 +129,40 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
     """)
     List<Dataset> findDatasetsByIdList(@BindList("datasetIds") List<Integer> datasetIds);
 
+    @RegisterBeanMapper(value = User.class, prefix = "u")
+    @UseRowReducer(DatasetReducer.class)
+    @SqlQuery("""
+        SELECT d.dataset_id, d.name, d.create_date, d.create_user_id, d.update_date,
+            d.update_user_id, d.object_id, d.active, d.dac_id, d.alias, d.data_use, d.dac_approval,
+            dar_ds_ids.id AS in_use,
+            u.user_id AS u_user_id, u.email AS u_email, u.display_name AS u_display_name,
+            u.create_date AS u_create_date, u.email_preference AS u_email_preference,
+            u.institution_id AS u_institution_id, u.era_commons_id AS u_era_commons_id,
+            k.key, dp.property_value, dp.property_key, dp.property_type, dp.schema_property, dp.property_id,
+            ca.consent_id, c.translated_use_restriction,
+            fso.file_storage_object_id AS fso_file_storage_object_id,
+            fso.entity_id AS fso_entity_id,
+            fso.file_name AS fso_file_name,
+            fso.category AS fso_category,
+            fso.gcs_file_uri AS fso_gcs_file_uri,
+            fso.media_type AS fso_media_type,
+            fso.create_date AS fso_create_date,
+            fso.create_user_id AS fso_create_user_id,
+            fso.update_date AS fso_update_date,
+            fso.update_user_id AS fso_update_user_id,
+            fso.deleted AS fso_deleted,
+            fso.delete_user_id AS fso_delete_user_id
+        FROM dataset d
+        INNER JOIN users u on d.create_user_id = u.user_id
+        LEFT JOIN (SELECT DISTINCT dataset_id AS id FROM dar_dataset) dar_ds_ids ON dar_ds_ids.id = d.dataset_id
+        LEFT JOIN dataset_property dp ON dp.dataset_id = d.dataset_id
+        LEFT JOIN dictionary k ON k.key_id = dp.property_key
+        LEFT JOIN consent_associations ca ON ca.dataset_id = d.dataset_id
+        LEFT JOIN file_storage_object fso ON fso.entity_id = d.dataset_id::text AND fso.deleted = false
+        LEFT JOIN consents c ON c.consent_id = ca.consent_id
+    """)
+    List<Dataset> findAllDatasets();
+
     @UseRowReducer(DatasetReducer.class)
     @SqlQuery(
         "SELECT d.*, k.key, dp.property_value, dp.property_key, dp.property_id, ca.consent_id, d.dac_id, c.translated_use_restriction, dar_ds_ids.id as in_use, " +
@@ -360,19 +394,6 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
             " LEFT JOIN consents c ON c.consent_id = ca.consent_id " +
             " WHERE d.object_id IN (<objectIdList>) ")
     List<Dataset> getDatasetsForObjectIdList(@BindList("objectIdList") List<String> objectIdList);
-
-    @UseRowReducer(DatasetReducer.class)
-    @SqlQuery(
-        "SELECT d.*, k.key, dp.property_value, dp.property_key, dp.property_type, dp.schema_property, dp.property_id, ca.consent_id, d.dac_id, c.translated_use_restriction, dar_ds_ids.id as in_use, " +
-            FileStorageObject.QUERY_FIELDS_WITH_FSO_PREFIX +
-            " FROM dataset d " +
-            " LEFT JOIN (SELECT DISTINCT dataset_id AS id FROM dar_dataset) dar_ds_ids ON dar_ds_ids.id = d.dataset_id " +
-            " LEFT JOIN dataset_property dp ON dp.dataset_id = d.dataset_id " +
-            " LEFT JOIN dictionary k ON k.key_id = dp.property_key " +
-            " LEFT JOIN consent_associations ca ON ca.dataset_id = d.dataset_id " +
-            " LEFT JOIN file_storage_object fso ON fso.entity_id = d.dataset_id::text AND fso.deleted = false " +
-            " LEFT JOIN consents c ON c.consent_id = ca.consent_id ")
-    List<Dataset> getAllDatasets();
 
     @UseRowReducer(DatasetReducer.class)
     @SqlQuery(

--- a/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
@@ -435,20 +435,6 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
             " LEFT JOIN (SELECT DISTINCT dataset_id AS id FROM dar_dataset) dar_ds_ids ON dar_ds_ids.id = d.dataset_id " +
             " LEFT JOIN dataset_property dp ON dp.dataset_id = d.dataset_id " +
             " LEFT JOIN dictionary k ON k.key_id = dp.property_key " +
-            " LEFT JOIN file_storage_object fso ON fso.entity_id = d.dataset_id::text AND fso.deleted = false " +
-            " LEFT JOIN consent_associations ca ON ca.dataset_id = d.dataset_id " +
-            " LEFT JOIN consents c ON c.consent_id = ca.consent_id " +
-            " WHERE d.object_id IN (<objectIdList>) ")
-    List<Dataset> getDatasetsForObjectIdList(@BindList("objectIdList") List<String> objectIdList);
-
-    @UseRowReducer(DatasetReducer.class)
-    @SqlQuery(
-        "SELECT d.*, k.key, dp.property_value, dp.property_key, dp.property_type, dp.schema_property, dp.property_id, ca.consent_id, d.dac_id, c.translated_use_restriction, dar_ds_ids.id as in_use, " +
-            FileStorageObject.QUERY_FIELDS_WITH_FSO_PREFIX +
-            " FROM dataset d " +
-            " LEFT JOIN (SELECT DISTINCT dataset_id AS id FROM dar_dataset) dar_ds_ids ON dar_ds_ids.id = d.dataset_id " +
-            " LEFT JOIN dataset_property dp ON dp.dataset_id = d.dataset_id " +
-            " LEFT JOIN dictionary k ON k.key_id = dp.property_key " +
             " LEFT JOIN consent_associations ca ON ca.dataset_id = d.dataset_id " +
             " LEFT JOIN file_storage_object fso ON fso.entity_id = d.dataset_id::text AND fso.deleted = false " +
             " LEFT JOIN consents c ON c.consent_id = ca.consent_id " +

--- a/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
@@ -465,16 +465,6 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
 
     /**
      * DACs -> Consents -> Consent Associations -> Datasets
-     *
-     * @return List of datasets that are not owned by a DAC.
-     */
-    @SqlQuery(
-        "SELECT d.* from dataset d " +
-            " WHERE d.dac_id IS NULL ")
-    List<Dataset> findNonDACDatasets();
-
-    /**
-     * DACs -> Consents -> Consent Associations -> Datasets
      * Datasets -> DatasetProperties -> Dictionary
      *
      * @return Set of datasets, with properties, that are associated to a single DAC.

--- a/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
@@ -5,7 +5,6 @@ import java.time.Instant;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
-import org.apache.commons.lang3.tuple.Pair;
 import org.broadinstitute.consent.http.db.mapper.AssociationMapper;
 import org.broadinstitute.consent.http.db.mapper.DatasetDTOWithPropertiesMapper;
 import org.broadinstitute.consent.http.db.mapper.DatasetMapper;
@@ -13,7 +12,6 @@ import org.broadinstitute.consent.http.db.mapper.DatasetPropertyMapper;
 import org.broadinstitute.consent.http.db.mapper.DatasetReducer;
 import org.broadinstitute.consent.http.db.mapper.DictionaryMapper;
 import org.broadinstitute.consent.http.db.mapper.FileStorageObjectMapperWithFSOPrefix;
-import org.broadinstitute.consent.http.db.mapper.ImmutablePairOfIntsMapper;
 import org.broadinstitute.consent.http.models.Association;
 import org.broadinstitute.consent.http.models.Dataset;
 import org.broadinstitute.consent.http.models.DatasetAudit;
@@ -531,17 +529,6 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
             " INNER JOIN consents c ON c.consent_id = a.consent_id " +
             " WHERE d.dac_id IS NOT NULL ")
     Set<DatasetDTO> findDatasetsWithDacs();
-
-    /**
-     * DACs -> Consents -> Consent Associations -> Datasets
-     *
-     * @return List of dataset id and its associated dac id
-     */
-    @RegisterRowMapper(ImmutablePairOfIntsMapper.class)
-    @SqlQuery(
-        "SELECT DISTINCT d.dataset_id, d.dac_id FROM dataset d " +
-            " WHERE d.dac_id IS NOT NULL ")
-    List<Pair<Integer, Integer>> findDatasetAndDacIds();
 
     @SqlUpdate(
         "UPDATE dataset " +

--- a/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
@@ -162,10 +162,8 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
     List<Dataset> findAllDatasets();
 
     /**
-     * Original implementation of dacs -> datasets is via an association through consent
-     * User -> UserRoles -> DACs -> Consents -> Consent Associations -> Datasets
-     *
-     * Subsequent refactoring moves the dataset to a top level field on the DAC
+     * Original implementation of dacs -> datasets is via an association through consent.
+     * Subsequent refactoring moves the dataset to a top level field on the DAC:
      * User -> UserRoles -> DACs -> Datasets
      *
      * @param email User email

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DatasetReducer.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DatasetReducer.java
@@ -1,17 +1,17 @@
 package org.broadinstitute.consent.http.db.mapper;
 
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 import org.broadinstitute.consent.http.enumeration.DatasetPropertyType;
 import org.broadinstitute.consent.http.models.DataUse;
 import org.broadinstitute.consent.http.models.Dataset;
 import org.broadinstitute.consent.http.models.DatasetProperty;
 import org.broadinstitute.consent.http.models.FileStorageObject;
+import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.service.DatasetService;
 import org.jdbi.v3.core.result.LinkedHashMapRowReducer;
 import org.jdbi.v3.core.result.RowView;
-
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
 
 public class DatasetReducer implements LinkedHashMapRowReducer<Integer, Dataset>, RowMapperHelper {
 
@@ -92,6 +92,10 @@ public class DatasetReducer implements LinkedHashMapRowReducer<Integer, Dataset>
       }
     }
 
+    if (hasColumn(rowView, "u_user_id", Integer.class)) {
+      User user = rowView.getRow(User.class);
+      dataset.setCreateUser(user);
+    }
 
     // The name property doesn't always come through, add it manually:
     Optional<DatasetProperty> nameProp =

--- a/src/main/java/org/broadinstitute/consent/http/models/Dataset.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/Dataset.java
@@ -1,14 +1,13 @@
 package org.broadinstitute.consent.http.models;
 
-import org.apache.commons.lang3.StringUtils;
-import org.checkerframework.checker.nullness.qual.NonNull;
-
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import org.apache.commons.lang3.StringUtils;
+import org.checkerframework.checker.nullness.qual.NonNull;
 
 public class Dataset {
 
@@ -55,6 +54,8 @@ public class Dataset {
     private Set<DatasetProperty> properties;
 
     private Boolean dacApproval;
+
+    private User createUser;
 
     public Dataset() {
     }
@@ -370,5 +371,13 @@ public class Dataset {
 
     public void setAlternativeDataSharingPlanFile(FileStorageObject alternativeDataSharingPlanFile) {
         this.alternativeDataSharingPlanFile = alternativeDataSharingPlanFile;
+    }
+
+    public User getCreateUser() {
+        return createUser;
+    }
+
+    public void setCreateUser(User createUser) {
+        this.createUser = createUser;
     }
 }

--- a/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
@@ -4,26 +4,18 @@ import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
 import com.google.inject.Inject;
 import io.dropwizard.auth.Auth;
-import org.apache.commons.collections.CollectionUtils;
-import org.broadinstitute.consent.http.enumeration.UserRoles;
-import org.broadinstitute.consent.http.models.AuthUser;
-import org.broadinstitute.consent.http.models.DataUse;
-import org.broadinstitute.consent.http.models.Dataset;
-import org.broadinstitute.consent.http.models.Dictionary;
-import org.broadinstitute.consent.http.models.User;
-import org.broadinstitute.consent.http.models.UserRole;
-import org.broadinstitute.consent.http.models.dataset_registration_v1.DatasetRegistrationSchemaV1;
-import org.broadinstitute.consent.http.models.dto.DatasetDTO;
-import org.broadinstitute.consent.http.models.dto.DatasetPropertyDTO;
-import org.broadinstitute.consent.http.service.DataAccessRequestService;
-import org.broadinstitute.consent.http.service.DatasetService;
-import org.broadinstitute.consent.http.service.UserService;
-import org.broadinstitute.consent.http.util.JsonSchemaUtil;
-import org.glassfish.jersey.media.multipart.FormDataBodyPart;
-import org.glassfish.jersey.media.multipart.FormDataMultiPart;
-import org.glassfish.jersey.media.multipart.FormDataParam;
-import org.json.JSONObject;
-
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 import javax.annotation.security.PermitAll;
 import javax.annotation.security.RolesAllowed;
 import javax.ws.rs.BadRequestException;
@@ -45,18 +37,25 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
-import java.io.ByteArrayInputStream;
-import java.io.InputStream;
-import java.net.URI;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
+import org.apache.commons.collections.CollectionUtils;
+import org.broadinstitute.consent.http.enumeration.UserRoles;
+import org.broadinstitute.consent.http.models.AuthUser;
+import org.broadinstitute.consent.http.models.DataUse;
+import org.broadinstitute.consent.http.models.Dataset;
+import org.broadinstitute.consent.http.models.Dictionary;
+import org.broadinstitute.consent.http.models.User;
+import org.broadinstitute.consent.http.models.UserRole;
+import org.broadinstitute.consent.http.models.dataset_registration_v1.DatasetRegistrationSchemaV1;
+import org.broadinstitute.consent.http.models.dto.DatasetDTO;
+import org.broadinstitute.consent.http.models.dto.DatasetPropertyDTO;
+import org.broadinstitute.consent.http.service.DataAccessRequestService;
+import org.broadinstitute.consent.http.service.DatasetService;
+import org.broadinstitute.consent.http.service.UserService;
+import org.broadinstitute.consent.http.util.JsonSchemaUtil;
+import org.glassfish.jersey.media.multipart.FormDataBodyPart;
+import org.glassfish.jersey.media.multipart.FormDataMultiPart;
+import org.glassfish.jersey.media.multipart.FormDataParam;
+import org.json.JSONObject;
 
 @Path("api/dataset")
 public class DatasetResource extends Resource {
@@ -299,7 +298,7 @@ public class DatasetResource extends Resource {
     @PermitAll
     public Response getDataset(@PathParam("datasetId") Integer datasetId){
         try {
-            Dataset dataset = datasetService.getDataset(datasetId);
+            Dataset dataset = datasetService.findDatasetById(datasetId);
             if (Objects.isNull(dataset)) {
                 throw new NotFoundException("Could not find the dataset with id: " + datasetId.toString());
             }

--- a/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
@@ -314,7 +314,7 @@ public class DatasetResource extends Resource {
     @PermitAll
     public Response getDatasets(@QueryParam("ids") List<Integer> datasetIds){
         try {
-            List<Dataset> datasets = datasetService.getDatasets(datasetIds);
+            List<Dataset> datasets = datasetService.findDatasetsByIds(datasetIds);
 
             Set<Integer> foundIds = datasets.stream().map(Dataset::getDataSetId).collect(Collectors.toSet());
             if (!foundIds.containsAll(datasetIds)) {

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -264,6 +264,10 @@ public class DatasetService {
         Dataset dataset = datasetDAO.findDatasetById(datasetId);
         Set<DatasetProperty> properties = getDatasetProperties(datasetId);
         dataset.setProperties(properties);
+
+
+
+
         return dataset;
     }
 

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -548,7 +548,7 @@ public class DatasetService {
 
     public List<Dataset> findAllDatasetsByUser(User user) {
         if (user.hasUserRole(UserRoles.ADMIN)) {
-            return datasetDAO.getAllDatasets();
+            return datasetDAO.findAllDatasets();
         } else {
             List<Dataset> datasets = datasetDAO.getActiveDatasets();
             if (user.hasUserRole(UserRoles.CHAIRPERSON)) {

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -542,7 +542,7 @@ public class DatasetService {
         }
     }
 
-    public List<Dataset> getDatasets(List<Integer> datasetIds) {
+    public List<Dataset> findDatasetsByIds(List<Integer> datasetIds) {
         return datasetDAO.findDatasetsByIdList(datasetIds);
     }
 

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -562,10 +562,6 @@ public class DatasetService {
         }
     }
 
-    public Dataset getDataset(Integer datasetId) {
-        return this.datasetDAO.findDatasetById(datasetId);
-    }
-
     public List<Dataset> getDatasets(List<Integer> datasetIds) {
         return this.datasetDAO.findDatasetsByIdList(datasetIds);
     }

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -260,17 +260,6 @@ public class DatasetService {
         return datasetDAO.findDatasetPropertiesByDatasetId(datasetId);
     }
 
-    public Dataset getDatasetWithPropertiesById(Integer datasetId) {
-        Dataset dataset = datasetDAO.findDatasetById(datasetId);
-        Set<DatasetProperty> properties = getDatasetProperties(datasetId);
-        dataset.setProperties(properties);
-
-
-
-
-        return dataset;
-    }
-
     public Optional<Dataset> updateDataset(DatasetDTO dataset, Integer datasetId, Integer userId) {
         Timestamp now = new Timestamp(new Date().getTime());
 
@@ -281,7 +270,7 @@ public class DatasetService {
             throw new IllegalArgumentException("Dataset 'Needs Approval' field cannot be null");
         }
 
-        Dataset old = getDatasetWithPropertiesById(datasetId);
+        Dataset old = findDatasetById(datasetId);
         Set<DatasetProperty> oldProperties = old.getProperties();
 
         List<DatasetPropertyDTO> updateDatasetPropertyDTOs = dataset.getProperties();
@@ -310,7 +299,7 @@ public class DatasetService {
 
         updateDatasetProperties(propertiesToUpdate, propertiesToDelete, propertiesToAdd);
         datasetDAO.updateDataset(datasetId, dataset.getDatasetName(), now, userId, dataset.getNeedsApproval(), dataset.getDacId());
-        Dataset updatedDataset = getDatasetWithPropertiesById(datasetId);
+        Dataset updatedDataset = findDatasetById(datasetId);
         return Optional.of(updatedDataset);
     }
 

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -252,10 +252,6 @@ public class DatasetService {
         return datasetDAO.findDatasetById(id);
     }
 
-    public Set<Dataset> getDatasetWithDataUseByIds(List<Integer> datasetIds) {
-        return datasetDAO.findDatasetWithDataUseByIdList(datasetIds);
-    }
-
     public Set<DatasetProperty> getDatasetProperties(Integer datasetId) {
         return datasetDAO.findDatasetPropertiesByDatasetId(datasetId);
     }

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -436,8 +436,7 @@ public class DatasetService {
 
 
     public List<Dataset> searchDatasets(String query, User user) {
-        List<Dataset> datasets = this.findAllDatasetsByUser(user);
-
+        List<Dataset> datasets = findAllDatasetsByUser(user);
         return datasets.stream().filter(ds -> ds.isStringMatch(query)).toList();
     }
 
@@ -487,7 +486,7 @@ public class DatasetService {
         try {
             // if approval state changed
             if (currentApprovalState != datasetReturn.getDacApproval()) {
-                this.sendDatasetApprovalNotificationEmail(dataset, user, approval);
+                sendDatasetApprovalNotificationEmail(dataset, user, approval);
             }
         } catch (Exception e) {
             logger.error("Unable to notifier Data Submitter of dataset approval status: " + dataset.getDatasetIdentifier());
@@ -496,14 +495,14 @@ public class DatasetService {
     }
 
     private void sendDatasetApprovalNotificationEmail(Dataset dataset, User user, Boolean approval) throws Exception {
-        Dac dac = this.dacDAO.findById(dataset.getDacId());
+        Dac dac = dacDAO.findById(dataset.getDacId());
         if (approval) {
-            this.emailService.sendDatasetApprovedMessage(
+            emailService.sendDatasetApprovedMessage(
                     user,
                     dac.getName(),
                     dataset.getDatasetIdentifier());
         } else {
-            this.emailService.sendDatasetDeniedMessage(
+            emailService.sendDatasetDeniedMessage(
                     user,
                     dac.getName(),
                     dataset.getDatasetIdentifier());
@@ -544,7 +543,7 @@ public class DatasetService {
     }
 
     public List<Dataset> getDatasets(List<Integer> datasetIds) {
-        return this.datasetDAO.findDatasetsByIdList(datasetIds);
+        return datasetDAO.findDatasetsByIdList(datasetIds);
     }
 
     /**

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -252,10 +252,6 @@ public class DatasetService {
         return datasetDAO.findDatasetById(id);
     }
 
-    public Set<DatasetProperty> getDatasetProperties(Integer datasetId) {
-        return datasetDAO.findDatasetPropertiesByDatasetId(datasetId);
-    }
-
     public Optional<Dataset> updateDataset(DatasetDTO dataset, Integer datasetId, Integer userId) {
         Timestamp now = new Timestamp(new Date().getTime());
 

--- a/src/main/resources/assets/schemas/Dataset.yaml
+++ b/src/main/resources/assets/schemas/Dataset.yaml
@@ -11,6 +11,13 @@ properties:
     type: integer
     format: int32
     description: The dataset id, integer format
+  createUserId:
+    type: integer
+    format: int32
+    description: The create user id, if available
+  createUser:
+    description: The create user, if available
+    $ref: './User.yaml'
   dacId:
     type: string
     description: The id of the DAC this dataset belongs to, if defined.

--- a/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
@@ -884,20 +884,18 @@ public class DatasetDAOTest extends DAOTestHelper {
     protected Consent insertConsent() {
         String consentId = UUID.randomUUID().toString();
         consentDAO.insertConsent(consentId,
-                false,
+            false,
             """
-                {"type":"everything"}
-                """,
+            {"type":"everything"}""",
             """
-                {"generalUse":true}
-                """,
-                "dul",
-                consentId,
-                "dulName",
-                new Date(),
-                new Date(),
-                "Everything",
-                "Group");
+            {"generalUse":true}""",
+            "dul",
+            consentId,
+            "dulName",
+            new Date(),
+            new Date(),
+            "Everything",
+            "Group");
         return consentDAO.findConsentById(consentId);
     }
 

--- a/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
@@ -20,7 +20,6 @@ import java.util.UUID;
 import java.util.stream.IntStream;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.RandomUtils;
-import org.apache.commons.lang3.tuple.Pair;
 import org.broadinstitute.consent.http.enumeration.DatasetPropertyType;
 import org.broadinstitute.consent.http.enumeration.FileCategory;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
@@ -408,37 +407,6 @@ public class DatasetDAOTest extends DAOTestHelper {
         assertFalse(datasets.isEmpty());
         List<Integer> datasetIds = datasets.stream().map(Dataset::getDataSetId).toList();
         assertTrue(datasetIds.contains(dataset.getDataSetId()));
-    }
-
-//    @Test
-//    public void testFindNonDACDataSets() {
-//        Dataset dataset = insertDataset();
-//        Consent consent = insertConsent();
-//        consentDAO.insertConsentAssociation(consent.getConsentId(), ASSOCIATION_TYPE_TEST, dataset.getDataSetId());
-//
-//        List<Dataset> datasets = datasetDAO.findNonDACDatasets();
-//        assertFalse(datasets.isEmpty());
-//        List<Integer> datasetIds = datasets.stream().map(Dataset::getDataSetId).toList();
-//        assertTrue(datasetIds.contains(dataset.getDataSetId()));
-//        // adding this here to ensure mapper does not return a false in place of a null for dacApproval
-//        datasets.forEach(d -> {
-//            assertTrue(d.getDacApproval() == null);
-//        });
-//    }
-
-    @Test
-    public void testFindDatasetAndDacIds() {
-        Dataset dataset = insertDataset();
-        Dac dac = insertDac();
-        Consent consent = insertConsent();
-        datasetDAO.updateDatasetDacId(dataset.getDataSetId(), dac.getDacId());
-        consentDAO.insertConsentAssociation(consent.getConsentId(), ASSOCIATION_TYPE_TEST, dataset.getDataSetId());
-
-        List<Pair<Integer, Integer>> pairs = datasetDAO.findDatasetAndDacIds();
-        assertFalse(pairs.isEmpty());
-        assertEquals(1, pairs.size());
-        assertEquals(pairs.get(0).getLeft(), dataset.getDataSetId());
-        assertEquals(pairs.get(0).getRight(), dac.getDacId());
     }
 
     @Test

--- a/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
@@ -410,21 +410,21 @@ public class DatasetDAOTest extends DAOTestHelper {
         assertTrue(datasetIds.contains(dataset.getDataSetId()));
     }
 
-    @Test
-    public void testFindNonDACDataSets() {
-        Dataset dataset = insertDataset();
-        Consent consent = insertConsent();
-        consentDAO.insertConsentAssociation(consent.getConsentId(), ASSOCIATION_TYPE_TEST, dataset.getDataSetId());
-
-        List<Dataset> datasets = datasetDAO.findNonDACDatasets();
-        assertFalse(datasets.isEmpty());
-        List<Integer> datasetIds = datasets.stream().map(Dataset::getDataSetId).toList();
-        assertTrue(datasetIds.contains(dataset.getDataSetId()));
-        // adding this here to ensure mapper does not return a false in place of a null for dacApproval
-        datasets.forEach(d -> {
-            assertTrue(d.getDacApproval() == null);
-        });
-    }
+//    @Test
+//    public void testFindNonDACDataSets() {
+//        Dataset dataset = insertDataset();
+//        Consent consent = insertConsent();
+//        consentDAO.insertConsentAssociation(consent.getConsentId(), ASSOCIATION_TYPE_TEST, dataset.getDataSetId());
+//
+//        List<Dataset> datasets = datasetDAO.findNonDACDatasets();
+//        assertFalse(datasets.isEmpty());
+//        List<Integer> datasetIds = datasets.stream().map(Dataset::getDataSetId).toList();
+//        assertTrue(datasetIds.contains(dataset.getDataSetId()));
+//        // adding this here to ensure mapper does not return a false in place of a null for dacApproval
+//        datasets.forEach(d -> {
+//            assertTrue(d.getDacApproval() == null);
+//        });
+//    }
 
     @Test
     public void testFindDatasetAndDacIds() {

--- a/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
@@ -677,6 +677,24 @@ public class DatasetDAOTest extends DAOTestHelper {
 
     @Test
     public void testFindAllDatasets() {
+        List<Dataset> datasetList = IntStream.range(1, 5).mapToObj(i -> {
+            Dataset dataset = insertDataset();
+            Consent consent = insertConsent();
+            consentDAO.insertConsentAssociation(consent.getConsentId(), ASSOCIATION_TYPE_TEST, dataset.getDataSetId());
+            return dataset;
+        }).toList();
+
+        List<Dataset> datasets = datasetDAO.findAllDatasets();
+        assertFalse(datasets.isEmpty());
+        assertEquals(datasetList.size(), datasets.size());
+        List<Integer> insertedDatasetIds = datasetList.stream().map(Dataset::getDataSetId).toList();
+        List<Integer> foundDatasetIds = datasets.stream().map(Dataset::getDataSetId).toList();
+        assertTrue(foundDatasetIds.containsAll(insertedDatasetIds));
+        assertTrue(insertedDatasetIds.containsAll(foundDatasetIds));
+    }
+
+    @Test
+    public void testFindAllDatasetDTOs() {
         Dataset dataset = insertDataset();
         Consent consent = insertConsent();
         consentDAO.insertConsentAssociation(consent.getConsentId(), ASSOCIATION_TYPE_TEST, dataset.getDataSetId());

--- a/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
@@ -16,6 +16,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Random;
 import java.util.Set;
+import java.util.UUID;
 import java.util.stream.IntStream;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.RandomUtils;
@@ -41,8 +42,8 @@ public class DatasetDAOTest extends DAOTestHelper {
     @Test
     public void testFindDatasetByIdWithDacAndConsent() {
         Dataset dataset = insertDataset();
-        Dac dac = createDac();
-        Consent consent = createConsent();
+        Dac dac = insertDac();
+        Consent consent = insertConsent();
         datasetDAO.updateDatasetDacId(dataset.getDataSetId(), dac.getDacId());
         consentDAO.insertConsentAssociation(consent.getConsentId(), ASSOCIATION_TYPE_TEST, dataset.getDataSetId());
 
@@ -53,6 +54,7 @@ public class DatasetDAOTest extends DAOTestHelper {
         assertEquals(consent.getTranslatedUseRestriction(), foundDataset.getTranslatedUseRestriction());
         assertFalse(foundDataset.getProperties().isEmpty());
         assertTrue(foundDataset.getDeletable());
+        assertNotNull(foundDataset.getCreateUser());
     }
 
     @Test
@@ -60,7 +62,7 @@ public class DatasetDAOTest extends DAOTestHelper {
         User user = createUser();
         Dataset d1 = insertDataset();
         Dataset d2 = insertDataset();
-        Dac dac = createDac();
+        Dac dac = insertDac();
         // Create a collection that references the created datasets
         createDarCollectionWithDatasets(dac.getDacId(), user, List.of(d1, d2));
 
@@ -102,8 +104,8 @@ public class DatasetDAOTest extends DAOTestHelper {
     public void testFindNeedsApprovalDataSetByDataSetId() {
         Dataset dataset = insertDataset();
         datasetDAO.updateDatasetNeedsApproval(dataset.getDataSetId(), true);
-        Dac dac = createDac();
-        Consent consent = createConsent();
+        Dac dac = insertDac();
+        Consent consent = insertConsent();
         datasetDAO.updateDatasetDacId(dataset.getDataSetId(), dac.getDacId());
         consentDAO.insertConsentAssociation(consent.getConsentId(), ASSOCIATION_TYPE_TEST, dataset.getDataSetId());
 
@@ -375,8 +377,8 @@ public class DatasetDAOTest extends DAOTestHelper {
     @Test
     public void testGetDataSetsForObjectIdList() {
         Dataset dataset = insertDataset();
-        Dac dac = createDac();
-        Consent consent = createConsent();
+        Dac dac = insertDac();
+        Consent consent = insertConsent();
         datasetDAO.updateDatasetDacId(dataset.getDataSetId(), dac.getDacId());
         consentDAO.insertConsentAssociation(consent.getConsentId(), ASSOCIATION_TYPE_TEST, dataset.getDataSetId());
 
@@ -392,8 +394,8 @@ public class DatasetDAOTest extends DAOTestHelper {
     @Test
     public void testFindDatasetsByIdList() {
         Dataset dataset = insertDataset();
-        Dac dac = createDac();
-        Consent consent = createConsent();
+        Dac dac = insertDac();
+        Consent consent = insertConsent();
         datasetDAO.updateDatasetDacId(dataset.getDataSetId(), dac.getDacId());
         consentDAO.insertConsentAssociation(consent.getConsentId(), ASSOCIATION_TYPE_TEST, dataset.getDataSetId());
 
@@ -404,14 +406,15 @@ public class DatasetDAOTest extends DAOTestHelper {
         assertEquals(consent.getConsentId(), datasets.get(0).getConsentId());
         assertEquals(consent.getTranslatedUseRestriction(), datasets.get(0).getTranslatedUseRestriction());
         assertFalse(datasets.get(0).getProperties().isEmpty());
+        assertNotNull(datasets.get(0).getCreateUser());
     }
 
     // User -> UserRoles -> DACs -> Consents -> Consent Associations -> DataSets
     @Test
     public void testFindDataSetsByAuthUserEmail() {
         Dataset dataset = insertDataset();
-        Dac dac = createDac();
-        Consent consent = createConsent();
+        Dac dac = insertDac();
+        Consent consent = insertConsent();
         datasetDAO.updateDatasetDacId(dataset.getDataSetId(), dac.getDacId());
         consentDAO.insertConsentAssociation(consent.getConsentId(), ASSOCIATION_TYPE_TEST, dataset.getDataSetId());
         User user = createUser();
@@ -426,7 +429,7 @@ public class DatasetDAOTest extends DAOTestHelper {
     @Test
     public void testFindNonDACDataSets() {
         Dataset dataset = insertDataset();
-        Consent consent = createConsent();
+        Consent consent = insertConsent();
         consentDAO.insertConsentAssociation(consent.getConsentId(), ASSOCIATION_TYPE_TEST, dataset.getDataSetId());
 
         List<Dataset> datasets = datasetDAO.findNonDACDatasets();
@@ -442,8 +445,8 @@ public class DatasetDAOTest extends DAOTestHelper {
     @Test
     public void testFindDatasetAndDacIds() {
         Dataset dataset = insertDataset();
-        Dac dac = createDac();
-        Consent consent = createConsent();
+        Dac dac = insertDac();
+        Consent consent = insertConsent();
         datasetDAO.updateDatasetDacId(dataset.getDataSetId(), dac.getDacId());
         consentDAO.insertConsentAssociation(consent.getConsentId(), ASSOCIATION_TYPE_TEST, dataset.getDataSetId());
 
@@ -464,7 +467,7 @@ public class DatasetDAOTest extends DAOTestHelper {
     @Test
     public void testUpdateDataset() {
         Dataset d = insertDataset();
-        Dac dac = createDac();
+        Dac dac = insertDac();
         String name = RandomStringUtils.random(20, true, true);
         Timestamp now = new Timestamp(new Date().getTime());
         Integer userId = RandomUtils.nextInt(1, 1000);
@@ -675,7 +678,7 @@ public class DatasetDAOTest extends DAOTestHelper {
     @Test
     public void testFindAllDatasets() {
         Dataset dataset = insertDataset();
-        Consent consent = createConsent();
+        Consent consent = insertConsent();
         consentDAO.insertConsentAssociation(consent.getConsentId(), ASSOCIATION_TYPE_TEST, dataset.getDataSetId());
 
         Set<DatasetDTO> datasets = datasetDAO.findAllDatasetDTOs();
@@ -687,7 +690,7 @@ public class DatasetDAOTest extends DAOTestHelper {
     @Test
     public void testFindActiveDatasets() {
         Dataset dataset = insertDataset();
-        Consent consent = createConsent();
+        Consent consent = insertConsent();
 
         consentDAO.insertConsentAssociation(consent.getConsentId(), ASSOCIATION_TYPE_TEST, dataset.getDataSetId());
 
@@ -700,8 +703,8 @@ public class DatasetDAOTest extends DAOTestHelper {
     @Test
     public void testFindDatasetsByUser() {
         Dataset dataset = insertDataset();
-        Dac dac = createDac();
-        Consent consent = createConsent();
+        Dac dac = insertDac();
+        Consent consent = insertConsent();
         datasetDAO.updateDatasetDacId(dataset.getDataSetId(), dac.getDacId());
         consentDAO.insertConsentAssociation(consent.getConsentId(), ASSOCIATION_TYPE_TEST, dataset.getDataSetId());
         User user = createUser();
@@ -716,10 +719,10 @@ public class DatasetDAOTest extends DAOTestHelper {
     @Test
     public void testFindDatasetsByDacIds() {
         Dataset dataset = insertDataset();
-        Dac dac = createDac();
+        Dac dac = insertDac();
 
         Dataset datasetTwo = insertDataset();
-        Dac dacTwo = createDac();
+        Dac dacTwo = insertDac();
 
         datasetDAO.updateDatasetDacId(dataset.getDataSetId(), dac.getDacId());
         datasetDAO.updateDatasetDacId(datasetTwo.getDataSetId(), dacTwo.getDacId());
@@ -734,10 +737,10 @@ public class DatasetDAOTest extends DAOTestHelper {
     @Test
     public void testFindDatasetListByDacIds() {
         Dataset dataset = insertDataset();
-        Dac dac = createDac();
+        Dac dac = insertDac();
 
         Dataset datasetTwo = insertDataset();
-        Dac dacTwo = createDac();
+        Dac dacTwo = insertDac();
 
         datasetDAO.updateDatasetDacId(dataset.getDataSetId(), dac.getDacId());
         datasetDAO.updateDatasetDacId(datasetTwo.getDataSetId(), dacTwo.getDacId());
@@ -769,8 +772,8 @@ public class DatasetDAOTest extends DAOTestHelper {
     @Test
     public void testFindDatasetWithDataUseByIdList() {
         Dataset dataset = insertDataset();
-        Dac dac = createDac();
-        Consent consent = createConsent();
+        Dac dac = insertDac();
+        Consent consent = insertConsent();
         datasetDAO.updateDatasetDacId(dataset.getDataSetId(), dac.getDacId());
         consentDAO.insertConsentAssociation(consent.getConsentId(), ASSOCIATION_TYPE_TEST, dataset.getDataSetId());
 
@@ -802,19 +805,16 @@ public class DatasetDAOTest extends DAOTestHelper {
 
     @Test
     public void testUpdateDatasetApproval() {
-        User user = createUser();
-        Integer userId = user.getUserId();
-        Integer datasetId = datasetDAO.insertDataset(RandomStringUtils.randomAlphabetic(10), null,
-            null, RandomStringUtils.randomAlphabetic(10), true, null, null);
-        datasetDAO.updateDatasetApproval(true, Instant.now(), userId, datasetId);
-        Dataset updatedDataset = datasetDAO.findDatasetById(datasetId);
+        User updateUser = createUser();
+        Dataset dataset = insertDataset();
+        datasetDAO.updateDatasetApproval(true, Instant.now(), updateUser.getUserId(), dataset.getDataSetId());
+        Dataset updatedDataset = datasetDAO.findDatasetById(dataset.getDataSetId());
         assertNotNull(updatedDataset);
-        assertEquals(datasetId, updatedDataset.getDataSetId());
         assertTrue(updatedDataset.getDacApproval());
-        datasetDAO.updateDatasetApproval(false, Instant.now(), userId, datasetId);
-        Dataset updatedDatasetAfterApprovalFalse = datasetDAO.findDatasetById(datasetId);
+        datasetDAO.updateDatasetApproval(false, Instant.now(), updateUser.getUserId(), dataset.getDataSetId());
+        Dataset updatedDatasetAfterApprovalFalse = datasetDAO.findDatasetById(dataset.getDataSetId());
         assertNotNull(updatedDatasetAfterApprovalFalse);
-        assertEquals(datasetId, updatedDatasetAfterApprovalFalse.getDataSetId());
+        assertEquals(dataset.getDataSetId(), updatedDatasetAfterApprovalFalse.getDataSetId());
         assertFalse(updatedDatasetAfterApprovalFalse.getDacApproval());
 
     }
@@ -872,4 +872,29 @@ public class DatasetDAOTest extends DAOTestHelper {
         createDatasetProperties(id);
         return datasetDAO.findDatasetById(id);
     }
+
+    private Dac insertDac() {
+        Integer id = dacDAO.createDac(
+                "Test_" + RandomStringUtils.random(20, true, true),
+                "Test_" + RandomStringUtils.random(20, true, true),
+                new Date());
+        return dacDAO.findById(id);
+    }
+
+    protected Consent insertConsent() {
+        String consentId = UUID.randomUUID().toString();
+        consentDAO.insertConsent(consentId,
+                false,
+                "{\"type\":\"everything\"}",
+                "{\"generalUse\": true }",
+                "dul",
+                consentId,
+                "dulName",
+                new Date(),
+                new Date(),
+                "Everything",
+                "Group");
+        return consentDAO.findConsentById(consentId);
+    }
+
 }

--- a/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
@@ -855,8 +855,12 @@ public class DatasetDAOTest extends DAOTestHelper {
         String consentId = UUID.randomUUID().toString();
         consentDAO.insertConsent(consentId,
                 false,
-                "{\"type\":\"everything\"}",
-                "{\"generalUse\": true }",
+            """
+                {"type":"everything"}
+                """,
+            """
+                {"generalUse":true}
+                """,
                 "dul",
                 consentId,
                 "dulName",

--- a/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
@@ -57,6 +57,36 @@ public class DatasetDAOTest extends DAOTestHelper {
     }
 
     @Test
+    public void testGetActiveDatasets_positive_case() {
+        // This inserts a dataset with the active property set to true
+        Dataset ds = insertDataset();
+        Dac dac = insertDac();
+        Consent consent = insertConsent();
+        datasetDAO.updateDatasetDacId(ds.getDataSetId(), dac.getDacId());
+        consentDAO.insertConsentAssociation(consent.getConsentId(), ASSOCIATION_TYPE_TEST, ds.getDataSetId());
+
+        List<Dataset> activeDatasets = datasetDAO.getActiveDatasets();
+        assertFalse(activeDatasets.isEmpty());
+        assertEquals(1, activeDatasets.size());
+        assertTrue(activeDatasets.get(0).getActive());
+    }
+
+    @Test
+    public void testGetActiveDatasets_negative_case() {
+        // This inserts a dataset with the active property set to true
+        Dataset ds = insertDataset();
+        // Update so it is inactive
+        datasetDAO.updateDatasetActive(ds.getDataSetId(), false);
+        Dac dac = insertDac();
+        Consent consent = insertConsent();
+        datasetDAO.updateDatasetDacId(ds.getDataSetId(), dac.getDacId());
+        consentDAO.insertConsentAssociation(consent.getConsentId(), ASSOCIATION_TYPE_TEST, ds.getDataSetId());
+
+        List<Dataset> activeDatasets = datasetDAO.getActiveDatasets();
+        assertTrue(activeDatasets.isEmpty());
+    }
+
+    @Test
     public void testFindDatasetByIdWithDacAndConsentNotDeletable() {
         User user = createUser();
         Dataset d1 = insertDataset();

--- a/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
@@ -374,22 +374,6 @@ public class DatasetDAOTest extends DAOTestHelper {
             assertNotNull(t.getKey());
         });
     }
-    @Test
-    public void testGetDataSetsForObjectIdList() {
-        Dataset dataset = insertDataset();
-        Dac dac = insertDac();
-        Consent consent = insertConsent();
-        datasetDAO.updateDatasetDacId(dataset.getDataSetId(), dac.getDacId());
-        consentDAO.insertConsentAssociation(consent.getConsentId(), ASSOCIATION_TYPE_TEST, dataset.getDataSetId());
-
-        List<Dataset> datasets = datasetDAO.getDatasetsForObjectIdList(List.of(dataset.getObjectId()));
-        assertFalse(datasets.isEmpty());
-        assertEquals(1, datasets.size());
-        assertEquals(dac.getDacId(), datasets.get(0).getDacId());
-        assertEquals(consent.getConsentId(), datasets.get(0).getConsentId());
-        assertEquals(consent.getTranslatedUseRestriction(), datasets.get(0).getTranslatedUseRestriction());
-        assertFalse(datasets.get(0).getProperties().isEmpty());
-    }
 
     @Test
     public void testFindDatasetsByIdList() {

--- a/src/test/java/org/broadinstitute/consent/http/resources/DarCollectionResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DarCollectionResourceTest.java
@@ -1,6 +1,26 @@
 package org.broadinstitute.consent.http.resources;
 
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.openMocks;
+
 import com.google.api.client.http.HttpStatusCodes;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.InternalServerErrorException;
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.core.Response;
 import org.apache.commons.lang3.RandomUtils;
 import org.broadinstitute.consent.http.enumeration.DarStatus;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
@@ -21,29 +41,6 @@ import org.broadinstitute.consent.http.service.UserService;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
-
-import javax.ws.rs.BadRequestException;
-import javax.ws.rs.InternalServerErrorException;
-import javax.ws.rs.NotFoundException;
-import javax.ws.rs.core.Response;
-
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
-
-import static org.junit.Assert.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.openMocks;
 
 public class DarCollectionResourceTest {
   private final AuthUser authUser = new AuthUser("test@test.com");
@@ -104,7 +101,6 @@ public class DarCollectionResourceTest {
     mockCollectionsList.add(mockDarCollection());
     when(userService.findUserByEmail(anyString())).thenReturn(researcher);
     when(darCollectionService.getCollectionsForUser(any(User.class))).thenReturn(mockCollectionsList);
-    when(datasetService.getDatasetWithDataUseByIds(any())).thenReturn(mockDatasetsForResearcherCollection());
     initResource();
 
     Response response = resource.getCollectionsForResearcher(authUser);

--- a/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
@@ -691,7 +691,7 @@ public class DatasetResourceTest {
         ds3.setDataSetId(3);
         List<Dataset> datasets = List.of(ds1,ds2,ds3);
 
-        when(datasetService.getDatasets(List.of(1,2,3))).thenReturn(datasets);
+        when(datasetService.findDatasetsByIds(List.of(1,2,3))).thenReturn(datasets);
 
         initResource();
         Response response = resource.getDatasets(List.of(1,2,3));
@@ -709,7 +709,7 @@ public class DatasetResourceTest {
         ds3.setDataSetId(3);
         List<Dataset> datasets = List.of(ds1,ds2,ds3);
 
-        when(datasetService.getDatasets(List.of(1,1,2,2,3,3))).thenReturn(datasets);
+        when(datasetService.findDatasetsByIds(List.of(1,1,2,2,3,3))).thenReturn(datasets);
 
         initResource();
         Response response = resource.getDatasets(List.of(1,1,2,2,3,3));
@@ -724,7 +724,7 @@ public class DatasetResourceTest {
         Dataset ds2 = new Dataset();
         ds2.setDataSetId(2);
 
-        when(datasetService.getDatasets(List.of(1,1,2,2,3,3))).thenReturn(List.of(
+        when(datasetService.findDatasetsByIds(List.of(1,1,2,2,3,3))).thenReturn(List.of(
                 ds1,
                 ds2
         ));
@@ -745,7 +745,7 @@ public class DatasetResourceTest {
         Dataset ds3 = new Dataset();
         ds3.setDataSetId(3);
 
-        when(datasetService.getDatasets(List.of(1,2,3,4))).thenReturn(List.of(
+        when(datasetService.findDatasetsByIds(List.of(1,2,3,4))).thenReturn(List.of(
                 ds1,
                 ds3
         ));

--- a/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
@@ -665,7 +665,7 @@ public class DatasetResourceTest {
         Dataset ds = new Dataset();
         ds.setDataSetId(1);
         ds.setName("asdfasdfasdfasdfasdfasdf");
-        when(datasetService.getDataset(1)).thenReturn(ds);
+        when(datasetService.findDatasetById(1)).thenReturn(ds);
         initResource();
         Response response = resource.getDataset(1);
         assertEquals(200, response.getStatus());
@@ -674,7 +674,7 @@ public class DatasetResourceTest {
 
     @Test
     public void testGetDatasetNotFound() {
-        when(datasetService.getDataset(1)).thenReturn(null);
+        when(datasetService.findDatasetById(1)).thenReturn(null);
 
         initResource();
         Response response = resource.getDataset(1);

--- a/src/test/java/org/broadinstitute/consent/http/service/DacServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DacServiceTest.java
@@ -1,6 +1,27 @@
 package org.broadinstitute.consent.http.service;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.openMocks;
+
 import com.google.gson.Gson;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import javax.ws.rs.BadRequestException;
 import org.broadinstitute.consent.http.db.DacDAO;
 import org.broadinstitute.consent.http.db.DataAccessRequestDAO;
 import org.broadinstitute.consent.http.db.DatasetDAO;
@@ -24,28 +45,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
-
-import javax.ws.rs.BadRequestException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.UUID;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-import java.util.stream.Stream;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.atLeastOnce;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.openMocks;
 
 public class DacServiceTest {
 
@@ -347,8 +346,6 @@ public class DacServiceTest {
         List<Dataset> memberDataSets = Collections.singletonList(getDatasets().get(0));
         when(dataSetDAO.findDatasetsByAuthUserEmail(getMember().getEmail())).thenReturn(memberDataSets);
 
-        // There are no additional unassociated datasets
-        when(dataSetDAO.findNonDACDatasets()).thenReturn(Collections.emptyList());
         initService();
 
         List<DataAccessRequest> dars = getDataAccessRequests();
@@ -365,9 +362,6 @@ public class DacServiceTest {
         List<Dataset> memberDataSets = Collections.singletonList(getDatasets().get(0));
         when(dataSetDAO.findDatasetsByAuthUserEmail(getMember().getEmail())).thenReturn(memberDataSets);
 
-        // There are additional unassociated datasets
-        List<Dataset> unassociatedDataSets = getDatasets().subList(1, getDatasets().size());
-        when(dataSetDAO.findNonDACDatasets()).thenReturn(unassociatedDataSets);
         initService();
 
         List<DataAccessRequest> dars = getDataAccessRequests();
@@ -384,9 +378,6 @@ public class DacServiceTest {
         List<Dataset> memberDataSets = Collections.emptyList();
         when(dataSetDAO.findDatasetsByAuthUserEmail(getMember().getEmail())).thenReturn(memberDataSets);
 
-        // There are additional unassociated datasets
-        List<Dataset> unassociatedDataSets = getDatasets().subList(1, getDatasets().size());
-        when(dataSetDAO.findNonDACDatasets()).thenReturn(unassociatedDataSets);
         initService();
 
         List<DataAccessRequest> dars = getDataAccessRequests();

--- a/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
@@ -271,24 +271,6 @@ public class DatasetServiceTest {
     }
 
     @Test
-    public void testGetDatasetProperties() {
-        when(datasetDAO.findDatasetPropertiesByDatasetId(anyInt())).thenReturn(Collections.emptySet());
-        initService();
-
-        assertTrue(datasetService.getDatasetProperties(1).isEmpty());
-    }
-
-    @Test
-    public void testGetDatasetWithPropertiesById() {
-        int datasetId = 1;
-        when(datasetDAO.findDatasetPropertiesByDatasetId(datasetId)).thenReturn(getDatasetProperties());
-        when(datasetDAO.findDatasetById(datasetId)).thenReturn(getDatasets().get(0));
-        initService();
-
-        assertEquals(datasetService.getDatasetProperties(datasetId), datasetDAO.findDatasetPropertiesByDatasetId(1));
-    }
-
-    @Test
     public void testProcessDatasetProperties() {
         when(datasetDAO.getMappedFieldsOrderByReceiveOrder()).thenReturn(getDictionaries());
         initService();

--- a/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
@@ -606,7 +606,7 @@ public class DatasetServiceTest {
         User u = new User();
         u.addRole(new UserRole(UserRoles.ADMIN.getRoleId(), UserRoles.ADMIN.getRoleName()));
 
-        when(datasetDAO.getAllDatasets()).thenReturn(List.of(ds1, ds2));
+        when(datasetDAO.findAllDatasets()).thenReturn(List.of(ds1, ds2));
 
         initService();
 
@@ -680,7 +680,7 @@ public class DatasetServiceTest {
         user.addRole(admin);
         Dataset dataset = new Dataset();
         dataset.setDataSetId(1);
-        when(datasetDAO.getAllDatasets()).thenReturn(List.of(dataset));
+        when(datasetDAO.findAllDatasets()).thenReturn(List.of(dataset));
         spy(datasetDAO);
         initService();
 
@@ -688,7 +688,7 @@ public class DatasetServiceTest {
         assertFalse(datasets.isEmpty());
         assertEquals(1, datasets.size());
         assertEquals(dataset.getDataSetId(), datasets.get(0).getDataSetId());
-        verify(datasetDAO, times(1)).getAllDatasets();
+        verify(datasetDAO, times(1)).findAllDatasets();
         verify(datasetDAO, times(0)).getActiveDatasets();
         verify(datasetDAO, times(0)).findDatasetsByAuthUserEmail(any());
     }
@@ -716,7 +716,7 @@ public class DatasetServiceTest {
         assertTrue(datasets.contains(d1));
         assertTrue(datasets.contains(d2));
         assertTrue(datasets.contains(d3));
-        verify(datasetDAO, times(0)).getAllDatasets();
+        verify(datasetDAO, times(0)).findAllDatasets();
         verify(datasetDAO, times(1)).getActiveDatasets();
         verify(datasetDAO, times(1)).findDatasetsByAuthUserEmail(any());
     }
@@ -739,7 +739,7 @@ public class DatasetServiceTest {
         assertEquals(2, datasets.size());
         assertTrue(datasets.contains(d1));
         assertTrue(datasets.contains(d2));
-        verify(datasetDAO, times(0)).getAllDatasets();
+        verify(datasetDAO, times(0)).findAllDatasets();
         verify(datasetDAO, times(1)).getActiveDatasets();
         verify(datasetDAO, times(0)).findDatasetsByAuthUserEmail(any());
     }

--- a/src/test/java/org/broadinstitute/consent/http/service/VoteServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/VoteServiceTest.java
@@ -1,5 +1,27 @@
 package org.broadinstitute.consent.http.service;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.openMocks;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import javax.ws.rs.NotFoundException;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.RandomUtils;
 import org.broadinstitute.consent.http.db.DarCollectionDAO;
@@ -28,29 +50,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
-
-import javax.ws.rs.NotFoundException;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.UUID;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.openMocks;
 
 public class VoteServiceTest {
 
@@ -868,7 +867,6 @@ public class VoteServiceTest {
         user.setRoles(Collections.singletonList(chairRole));
         Election e = new Election();
         when(electionDAO.findElectionById(anyInt())).thenReturn(e);
-        when(datasetDAO.findDatasetAndDacIds()).thenReturn(Collections.emptyList());
         when(userDAO.findUsersEnabledToVoteByDAC(anyInt())).thenReturn(Collections.singleton(user));
         when(userDAO.findNonDacUsersEnabledToVote()).thenReturn(Collections.singleton(user));
         Vote v = new Vote();


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-2291

This PR adds the create user, when available, to the following dataset APIs:
* GET /api/dac/{dacId}/datasets
* GET /api/dataset/batch
* GET /api/dataset/search
* GET /api/dataset/v2
* GET /api/dataset/v2/{id}
* GET /api/tdr/{identifier}

Additionally, this PR cleans up a lot of duplicate and unused code.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
