### PR TITLE
[DUOS-1740][risk=no] Update surefire

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
     <owl.version>5.5.0</owl.version>
     <postgres.version>42.5.4</postgres.version>
     <rdf4j-rio.version>3.7.7</rdf4j-rio.version>
+    <surefire.version>3.0.0-M9</surefire.version>
     <swagger.ui.version>4.14.0</swagger.ui.version>
     <swagger.ui.path>META-INF/resources/webjars/swagger-ui/${swagger.ui.version}/</swagger.ui.path>
     <mockserver.version>5.15.0</mockserver.version>
@@ -180,12 +181,18 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.22.2</version>
+        <version>${surefire.version}</version>
         <configuration>
-          <!-- @{argLine} is necessary here so that that the jacoco:prepare-agent output is included for tests -->
-          <!-- illegal-access=permit required for java 11 -->
-          <argLine>@{argLine} -Xmx1024m -Xverify:none -XX:TieredStopAtLevel=1 --illegal-access=permit</argLine>
+          <!-- @{argLine} is necessary here so that the jacoco:prepare-agent output is included for tests -->
+          <argLine>@{argLine} -Xmx1024m -XX:TieredStopAtLevel=1</argLine>
         </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>org.apache.maven.surefire</groupId>
+            <artifactId>surefire-junit47</artifactId>
+            <version>${surefire.version}</version>
+          </dependency>
+        </dependencies>
       </plugin>
 
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -189,7 +189,7 @@
         <dependencies>
           <dependency>
             <groupId>org.apache.maven.surefire</groupId>
-            <artifactId>surefire-junit47</artifactId>
+            <artifactId>surefire-junit4</artifactId>
             <version>${surefire.version}</version>
           </dependency>
         </dependencies>


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-1740

This PR updates the surefire plugin and configuration so that the correct junit provider is used. Something in https://github.com/DataBiosphere/consent/pull/1929 introduced a subtle change in that the default junit provider for surefire was changed. The result was that no tests were run with the default `mvn clean test` command.

Before this PR, failed test runs:
```
[INFO] --- surefire:2.22.2:test (default-test) @ consent ---
[INFO] 
```
After this PR, successful test runs:
```
[INFO] --- surefire:3.0.0-M9:test (default-test) @ consent ---
[INFO] Using configured provider org.apache.maven.surefire.junitcore.JUnitCoreProvider
```

See also: https://maven.apache.org/surefire/maven-surefire-plugin/examples/providers.html

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
