### PR TITLE
[DUOS-2364][risk=no] Update Sam Logging

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/SamDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/SamDAO.java
@@ -4,7 +4,6 @@ import com.google.api.client.http.EmptyContent;
 import com.google.api.client.http.GenericUrl;
 import com.google.api.client.http.HttpRequest;
 import com.google.api.client.http.HttpResponse;
-import com.google.api.client.http.HttpStatusCodes;
 import com.google.api.client.http.json.JsonHttpContent;
 import com.google.api.client.json.gson.GsonFactory;
 import com.google.common.util.concurrent.FutureCallback;
@@ -14,6 +13,13 @@ import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import javax.ws.rs.ServerErrorException;
+import javax.ws.rs.core.MediaType;
 import org.broadinstitute.consent.http.configurations.ServicesConfiguration;
 import org.broadinstitute.consent.http.models.AuthUser;
 import org.broadinstitute.consent.http.models.sam.ResourceType;
@@ -21,26 +27,16 @@ import org.broadinstitute.consent.http.models.sam.TosResponse;
 import org.broadinstitute.consent.http.models.sam.UserStatus;
 import org.broadinstitute.consent.http.models.sam.UserStatusDiagnostics;
 import org.broadinstitute.consent.http.models.sam.UserStatusInfo;
+import org.broadinstitute.consent.http.util.ConsentLogger;
 import org.broadinstitute.consent.http.util.HttpClientUtil;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import javax.ws.rs.core.MediaType;
-import java.lang.reflect.Type;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-
-public class SamDAO {
+public class SamDAO implements ConsentLogger {
 
   private final ExecutorService executorService;
   private final HttpClientUtil clientUtil;
   private final ServicesConfiguration configuration;
-  private final Logger logger = LoggerFactory.getLogger(this.getClass());
-
   public SamDAO(ServicesConfiguration configuration) {
     this.executorService = Executors.newCachedThreadPool();
     this.clientUtil = new HttpClientUtil(configuration);
@@ -51,8 +47,8 @@ public class SamDAO {
     GenericUrl genericUrl = new GenericUrl(configuration.getV1ResourceTypesUrl());
     HttpRequest request = clientUtil.buildGetRequest(genericUrl, authUser);
     HttpResponse response = clientUtil.handleHttpRequest(request);
-    if (response.getStatusCode() != HttpStatusCodes.STATUS_CODE_OK) {
-      logger.error("Error getting resource types from Sam: " + response.getStatusMessage());
+    if (!response.isSuccessStatusCode()) {
+      logException("Error getting resource types from Sam: " + response.getStatusMessage(), new ServerErrorException(response.getStatusMessage(), response.getStatusCode()));
     }
     String body = response.parseAsString();
     Type resourceTypesListType = new TypeToken<ArrayList<ResourceType>>() {}.getType();
@@ -63,8 +59,8 @@ public class SamDAO {
     GenericUrl genericUrl = new GenericUrl(configuration.getRegisterUserV2SelfInfoUrl());
     HttpRequest request = clientUtil.buildGetRequest(genericUrl, authUser);
     HttpResponse response = clientUtil.handleHttpRequest(request);
-    if (response.getStatusCode() != HttpStatusCodes.STATUS_CODE_OK) {
-      logger.error("Error getting user registration information from Sam: " + response.getStatusMessage());
+    if (!response.isSuccessStatusCode()) {
+      logException("Error getting user registration information from Sam: " + response.getStatusMessage(), new ServerErrorException(response.getStatusMessage(), response.getStatusCode()));
     }
     String body = response.parseAsString();
     return new Gson().fromJson(body, UserStatusInfo.class);
@@ -74,8 +70,8 @@ public class SamDAO {
     GenericUrl genericUrl = new GenericUrl(configuration.getV2SelfDiagnosticsUrl());
     HttpRequest request = clientUtil.buildGetRequest(genericUrl, authUser);
     HttpResponse response = clientUtil.handleHttpRequest(request);
-    if (response.getStatusCode() != HttpStatusCodes.STATUS_CODE_OK) {
-      logger.error("Error getting enabled statuses of user from Sam: " + response.getStatusMessage());
+    if (!response.isSuccessStatusCode()) {
+      logException("Error getting enabled statuses of user from Sam: " + response.getStatusMessage(), new ServerErrorException(response.getStatusMessage(), response.getStatusCode()));
     }
     String body = response.parseAsString();
     return new Gson().fromJson(body, UserStatusDiagnostics.class);
@@ -85,8 +81,8 @@ public class SamDAO {
     GenericUrl genericUrl = new GenericUrl(configuration.postRegisterUserV2SelfUrl());
     HttpRequest request = clientUtil.buildPostRequest(genericUrl, new EmptyContent(), authUser);
     HttpResponse response = clientUtil.handleHttpRequest(request);
-    if (response.getStatusCode() != HttpStatusCodes.STATUS_CODE_OK) {
-      logger.error("Error posting user registration information to Sam: " + response.getStatusMessage());
+    if (!response.isSuccessStatusCode()) {
+      logException("Error posting user registration information to Sam: " + response.getStatusMessage(), new ServerErrorException(response.getStatusMessage(), response.getStatusCode()));
     }
     String body = response.parseAsString();
     return new Gson().fromJson(body, UserStatus.class);
@@ -101,12 +97,11 @@ public class SamDAO {
         new FutureCallback<>() {
           @Override
           public void onSuccess(@Nullable UserStatus userStatus) {
-            logger.info("Successfully registered user in Sam: " + authUser.getEmail());
+            logInfo("Successfully registered user in Sam: " + authUser.getEmail());
           }
-
           @Override
           public void onFailure(@NonNull Throwable throwable) {
-            logger.error(throwable.getMessage());
+            logException(throwable.getMessage(), new ServerErrorException(throwable.getMessage(), 500));
           }
         },
         listeningExecutorService);
@@ -117,8 +112,8 @@ public class SamDAO {
     HttpRequest request = clientUtil.buildUnAuthedGetRequest(genericUrl);
     request.getHeaders().setAccept(MediaType.TEXT_PLAIN);
     HttpResponse response = clientUtil.handleHttpRequest(request);
-    if (response.getStatusCode() != HttpStatusCodes.STATUS_CODE_OK) {
-      logger.error("Error getting Terms of Service text from Sam: " + response.getStatusMessage());
+    if (!response.isSuccessStatusCode()) {
+      logException("Error getting Terms of Service text from Sam: " + response.getStatusMessage(), new ServerErrorException(response.getStatusMessage(), response.getStatusCode()));
     }
     return response.parseAsString();
   }
@@ -128,8 +123,8 @@ public class SamDAO {
     JsonHttpContent content = new JsonHttpContent(new GsonFactory(), "app.terra.bio/#terms-of-service");
     HttpRequest request = clientUtil.buildPostRequest(genericUrl, content, authUser);
     HttpResponse response = clientUtil.handleHttpRequest(request);
-    if (response.getStatusCode() != HttpStatusCodes.STATUS_CODE_OK) {
-      logger.error("Error accepting Terms of Service through Sam: " + response.getStatusMessage());
+    if (!response.isSuccessStatusCode()) {
+      logException("Error accepting Terms of Service through Sam: " + response.getStatusMessage(), new ServerErrorException(response.getStatusMessage(), response.getStatusCode()));
     }
     String body = response.parseAsString();
     return new Gson().fromJson(body, TosResponse.class);
@@ -139,8 +134,8 @@ public class SamDAO {
     GenericUrl genericUrl = new GenericUrl(configuration.tosRegistrationUrl());
     HttpRequest request = clientUtil.buildDeleteRequest(genericUrl, authUser);
     HttpResponse response = clientUtil.handleHttpRequest(request);
-    if (response.getStatusCode() != HttpStatusCodes.STATUS_CODE_OK) {
-      logger.error("Error removing Terms of Service acceptance through Sam: " + response.getStatusMessage());
+    if (!response.isSuccessStatusCode()) {
+      logException("Error removing Terms of Service acceptance through Sam: " + response.getStatusMessage(), new ServerErrorException(response.getStatusMessage(), response.getStatusCode()));
     }
     String body = response.parseAsString();
     return new Gson().fromJson(body, TosResponse.class);

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/SamDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/SamDAOTest.java
@@ -1,7 +1,21 @@
 package org.broadinstitute.consent.http.service.dao;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+import static org.mockito.MockitoAnnotations.openMocks;
+import static org.mockserver.model.HttpRequest.request;
+import static org.mockserver.model.HttpResponse.response;
+
 import com.google.api.client.http.HttpStatusCodes;
 import com.google.gson.Gson;
+import java.util.Collections;
+import java.util.List;
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.ForbiddenException;
+import javax.ws.rs.NotAuthorizedException;
+import javax.ws.rs.NotFoundException;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.RandomUtils;
 import org.broadinstitute.consent.http.WithMockServer;
@@ -23,21 +37,6 @@ import org.mockserver.client.MockServerClient;
 import org.mockserver.model.Header;
 import org.mockserver.model.MediaType;
 import org.testcontainers.containers.MockServerContainer;
-
-import javax.ws.rs.BadRequestException;
-import javax.ws.rs.ForbiddenException;
-import javax.ws.rs.NotAuthorizedException;
-import javax.ws.rs.NotFoundException;
-import java.util.Collections;
-import java.util.List;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
-import static org.mockito.MockitoAnnotations.openMocks;
-import static org.mockserver.model.HttpRequest.request;
-import static org.mockserver.model.HttpResponse.response;
 
 public class SamDAOTest implements WithMockServer {
 
@@ -77,7 +76,10 @@ public class SamDAOTest implements WithMockServer {
             .setReuseIds(RandomUtils.nextBoolean());
     List<ResourceType> mockResponseList = Collections.singletonList(resourceType);
     Gson gson = new Gson();
-    mockServerClient.when(request()).respond(response().withStatusCode(200).withBody(gson.toJson(mockResponseList)));
+    mockServerClient.when(request())
+            .respond(response()
+                    .withStatusCode(HttpStatusCodes.STATUS_CODE_OK)
+                    .withBody(gson.toJson(mockResponseList)));
 
     List<ResourceType> resourceTypeList = samDAO.getResourceTypes(authUser);
     assertFalse(resourceTypeList.isEmpty());
@@ -91,7 +93,11 @@ public class SamDAOTest implements WithMockServer {
             .setUserEmail("test@test.org")
             .setUserSubjectId(RandomStringUtils.random(10, false, true))
             .setEnabled(RandomUtils.nextBoolean());
-    mockServerClient.when(request()).respond(response().withHeader(Header.header("Content-Type", "application/json")).withStatusCode(200).withBody(userInfo.toString()));
+    mockServerClient.when(request())
+            .respond(response()
+                    .withHeader(Header.header("Content-Type", "application/json"))
+                    .withStatusCode(HttpStatusCodes.STATUS_CODE_OK)
+                    .withBody(userInfo.toString()));
 
     UserStatusInfo authUserUserInfo = samDAO.getRegistrationInfo(authUser);
     assertNotNull(authUserUserInfo);
@@ -154,7 +160,11 @@ public class SamDAOTest implements WithMockServer {
             .setInAllUsersGroup(RandomUtils.nextBoolean())
             .setInGoogleProxyGroup(RandomUtils.nextBoolean())
             .setTosAccepted(RandomUtils.nextBoolean());
-    mockServerClient.when(request()).respond(response().withHeader(Header.header("Content-Type", "application/json")).withStatusCode(200).withBody(diagnostics.toString()));
+    mockServerClient.when(request())
+            .respond(response()
+                    .withHeader(Header.header("Content-Type", "application/json"))
+                    .withStatusCode(HttpStatusCodes.STATUS_CODE_OK)
+                    .withBody(diagnostics.toString()));
 
     UserStatusDiagnostics userDiagnostics = samDAO.getSelfDiagnostics(authUser);
     assertNotNull(userDiagnostics);
@@ -168,7 +178,11 @@ public class SamDAOTest implements WithMockServer {
     UserStatus.UserInfo info = new UserStatus.UserInfo().setUserEmail("test@test.org").setUserSubjectId("subjectId");
     UserStatus.Enabled enabled = new UserStatus.Enabled().setAllUsersGroup(true).setGoogle(true).setLdap(true);
     UserStatus status = new UserStatus().setUserInfo(info).setEnabled(enabled);
-    mockServerClient.when(request()).respond(response().withHeader(Header.header("Content-Type", "application/json")).withStatusCode(200).withBody(status.toString()));
+    mockServerClient.when(request())
+            .respond(response()
+                    .withHeader(Header.header("Content-Type", "application/json"))
+                    .withStatusCode(HttpStatusCodes.STATUS_CODE_CREATED)
+                    .withBody(status.toString()));
 
     UserStatus userStatus = samDAO.postRegistrationInfo(authUser);
     assertNotNull(userStatus);
@@ -185,7 +199,11 @@ public class SamDAOTest implements WithMockServer {
     UserStatus.UserInfo info = new UserStatus.UserInfo().setUserEmail("test@test.org").setUserSubjectId("subjectId");
     UserStatus.Enabled enabled = new UserStatus.Enabled().setAllUsersGroup(true).setGoogle(true).setLdap(true);
     UserStatus status = new UserStatus().setUserInfo(info).setEnabled(enabled);
-    mockServerClient.when(request()).respond(response().withHeader(Header.header("Content-Type", "application/json")).withStatusCode(200).withBody(status.toString()));
+    mockServerClient.when(request())
+            .respond(response()
+                    .withHeader(Header.header("Content-Type", "application/json"))
+                    .withStatusCode(HttpStatusCodes.STATUS_CODE_CREATED)
+                    .withBody(status.toString()));
 
     try {
       samDAO.asyncPostRegistrationInfo(authUser);
@@ -197,7 +215,11 @@ public class SamDAOTest implements WithMockServer {
   @Test
   public void testGetToSText() {
     String mockText = "Plain Text";
-    mockServerClient.when(request()).respond(response().withHeader(Header.header("Content-Type", MediaType.TEXT_PLAIN.getType())).withStatusCode(200).withBody(mockText));
+    mockServerClient.when(request())
+            .respond(response()
+                    .withHeader(Header.header("Content-Type", MediaType.TEXT_PLAIN.getType()))
+                    .withStatusCode(HttpStatusCodes.STATUS_CODE_OK)
+                    .withBody(mockText));
 
     try {
       String text = samDAO.getToSText();
@@ -213,7 +235,11 @@ public class SamDAOTest implements WithMockServer {
       .setAdminEnabled(true).setTosAccepted(true).setGoogle(true).setAllUsersGroup(true).setLdap(true);
     UserStatus.UserInfo info = new UserStatus.UserInfo().setUserEmail("test@test.org").setUserSubjectId("subjectId");
     TosResponse tosResponse = new TosResponse().setEnabled(enabled).setUserInfo(info);
-    mockServerClient.when(request()).respond(response().withHeader(Header.header("Content-Type", "application/json")).withStatusCode(200).withBody(tosResponse.toString()));
+    mockServerClient.when(request())
+            .respond(response()
+                    .withHeader(Header.header("Content-Type", "application/json"))
+                    .withStatusCode(HttpStatusCodes.STATUS_CODE_OK)
+                    .withBody(tosResponse.toString()));
 
     try {
       samDAO.postTosAcceptedStatus(authUser);
@@ -228,7 +254,11 @@ public class SamDAOTest implements WithMockServer {
             .setAdminEnabled(true).setTosAccepted(false).setGoogle(true).setAllUsersGroup(true).setLdap(true);
     UserStatus.UserInfo info = new UserStatus.UserInfo().setUserEmail("test@test.org").setUserSubjectId("subjectId");
     TosResponse tosResponse = new TosResponse().setEnabled(enabled).setUserInfo(info);
-    mockServerClient.when(request()).respond(response().withHeader(Header.header("Content-Type", "application/json")).withStatusCode(200).withBody(tosResponse.toString()));
+    mockServerClient.when(request())
+            .respond(response()
+                    .withHeader(Header.header("Content-Type", "application/json"))
+                    .withStatusCode(HttpStatusCodes.STATUS_CODE_OK)
+                    .withBody(tosResponse.toString()));
 
     try {
       samDAO.removeTosAcceptedStatus(authUser);


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-2364

Minor refactoring of how we're logging error responses from Sam. Fixes one error case where Sam returns a `Created` response code instead of an `OK` code.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
