### PR TITLE
[DUOS-2380][risk=no] Check for success in `postTicketToSupport`

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/service/SupportRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/SupportRequestService.java
@@ -15,23 +15,19 @@ import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.UserUpdateFields;
 import org.broadinstitute.consent.http.models.support.SupportTicket;
 import org.broadinstitute.consent.http.models.support.SupportTicketCreator;
+import org.broadinstitute.consent.http.util.ConsentLogger;
 import org.broadinstitute.consent.http.util.HttpClientUtil;
 
 import javax.ws.rs.ServerErrorException;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 
-public class SupportRequestService {
+public class SupportRequestService implements ConsentLogger {
 
     private final SupportTicketCreator supportTicketCreator;
     private final HttpClientUtil clientUtil;
     private final ServicesConfiguration configuration;
-    private final Logger logger = LoggerFactory.getLogger(this.getClass());
-
 
     @Inject
     public SupportRequestService(ServicesConfiguration configuration, InstitutionDAO institutionDAO, UserDAO userDAO) {
@@ -42,6 +38,7 @@ public class SupportRequestService {
 
     /**
      * Posts the given SupportTicket as JSON to the Support Request API if notifications are enabled
+     *
      * @param ticket SupportTicket to be sent to support application
      * @throws Exception if an error occurs while posting the HttpRequest
      */
@@ -58,12 +55,15 @@ public class SupportRequestService {
             HttpRequest request = clientUtil.buildUnAuthedPostRequest(genericUrl, content);
             HttpResponse response = clientUtil.handleHttpRequest(request);
 
-            if (response.getStatusCode() != HttpStatusCodes.STATUS_CODE_CREATED) {
-                logger.error("Error posting ticket to support: " + response.getStatusMessage());
-                throw new ServerErrorException(response.getStatusMessage(), HttpStatusCodes.STATUS_CODE_SERVER_ERROR);
+            if (!response.isSuccessStatusCode()) {
+                String errorMessage = "Error posting ticket to support: " + response.getStatusMessage();
+                var errorException = new ServerErrorException(response.getStatusMessage(),
+                        HttpStatusCodes.STATUS_CODE_SERVER_ERROR);
+                logException(errorMessage, errorException);
+                throw errorException;
             }
         } else {
-            logger.debug("Not configured to send support requests");
+            logDebug("Not configured to send support requests");
         }
     }
 
@@ -87,9 +87,12 @@ public class SupportRequestService {
                     SupportTicket ticket = supportTicketCreator.createInstitutionSOSupportTicket(userUpdateFields, user);
                     postTicketToSupport(ticket);
                 } catch (Exception e) {
-                    logger.error("Exception sending suggested user fields support request: " + e.getMessage());
-                    throw new ServerErrorException("Unable to send support ticket for user with email: " + user.getEmail(),
+                    String errorMessage = "Exception sending suggested user fields support request: " + e.getMessage();
+                    var errorException = new ServerErrorException("Unable to send support ticket for user with email:" +
+                            " " + user.getEmail(),
                             HttpStatusCodes.STATUS_CODE_SERVER_ERROR);
+                    logException(errorMessage, errorException);
+                    throw errorException;
                 }
             }
         }


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DUOS-2380

### Summary

Sendgrid can return an `OK` success code instead of `Created`. Check for a successful response code in `postTicketToSupport` instead and use newer logging methods.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
