### PR TITLE
[DUOS-2389][risk=no] Rename Vote dacuserid -> user_id

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
@@ -249,7 +249,7 @@ public interface DarCollectionDAO extends Transactional<DarCollectionDAO> {
       + "dar.update_date AS dar_update_date, (dar.data #>> '{}')::jsonb AS data, "
       + "e.election_id AS e_election_id, e.reference_id AS e_reference_id, e.status AS e_status, e.create_date AS e_create_date, "
       + "e.last_update AS e_last_update, e.dataset_id AS e_dataset_id, e.election_type AS e_election_type, e.latest, "
-      + "v.voteid as v_vote_id, v.vote as v_vote, v.dacuserid as v_dac_user_id, v.rationale as v_rationale, v.electionid as v_election_id, "
+      + "v.voteid as v_vote_id, v.vote as v_vote, v.user_id as v_user_id, v.rationale as v_rationale, v.electionid as v_election_id, "
       + "v.createdate as v_create_date, v.updatedate as v_update_date, v.type as v_type, du.display_name as v_display_name "
       + "FROM dar_collection c "
       + "INNER JOIN users u ON c.create_user_id = u.user_id "
@@ -267,7 +267,7 @@ public interface DarCollectionDAO extends Transactional<DarCollectionDAO> {
       + "LEFT JOIN vote v "
       + "ON v.electionid = e.election_id "
       + "LEFT JOIN users du "
-      + "ON du.user_id = v.dacuserid "
+      + "ON du.user_id = v.user_id "
       + "WHERE c.collection_id = :collectionId "
       + "AND (LOWER(data->>'status') != 'archived' OR data->>'status' IS NULL )"
   )

--- a/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
@@ -237,6 +237,7 @@ public interface DarCollectionDAO extends Transactional<DarCollectionDAO> {
   @RegisterBeanMapper(value = LibraryCard.class, prefix = "lc")
   @UseRowReducer(DarCollectionReducer.class)
   @SqlQuery(
+    // nosemgrep
     "SELECT c.*, "
       + User.QUERY_FIELDS_WITH_U_PREFIX + QUERY_FIELD_SEPARATOR
       + Institution.QUERY_FIELDS_WITH_I_PREFIX + QUERY_FIELD_SEPARATOR

--- a/src/main/java/org/broadinstitute/consent/http/db/DarCollectionSummaryDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DarCollectionSummaryDAO.java
@@ -35,7 +35,7 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
     LEFT JOIN (
       SELECT election.*, MAX(election.election_id) OVER(PARTITION BY election.reference_id, election.dataset_id) AS latest
       FROM election
-      WHERE LOWER(election.election_type) = 'dataaccess' AND election.dataset_id IN (<datasetIds>)"
+      WHERE LOWER(election.election_type) = 'dataaccess' AND election.dataset_id IN (<datasetIds>)
     ) AS e
       ON e.reference_id = dar.reference_id
     LEFT JOIN vote v

--- a/src/main/java/org/broadinstitute/consent/http/db/DarCollectionSummaryDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DarCollectionSummaryDAO.java
@@ -1,11 +1,11 @@
 package org.broadinstitute.consent.http.db;
 
 import java.util.List;
-import org.broadinstitute.consent.http.models.DarCollection;
-import org.broadinstitute.consent.http.models.Election;
-import org.broadinstitute.consent.http.models.DarCollectionSummary;
-import org.broadinstitute.consent.http.models.Vote;
 import org.broadinstitute.consent.http.db.mapper.DarCollectionSummaryReducer;
+import org.broadinstitute.consent.http.models.DarCollection;
+import org.broadinstitute.consent.http.models.DarCollectionSummary;
+import org.broadinstitute.consent.http.models.Election;
+import org.broadinstitute.consent.http.models.Vote;
 import org.jdbi.v3.sqlobject.config.RegisterBeanMapper;
 import org.jdbi.v3.sqlobject.customizer.Bind;
 import org.jdbi.v3.sqlobject.customizer.BindList;
@@ -24,7 +24,7 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
   (
     "SELECT c.collection_id as dar_collection_id, c.dar_code, dar.submission_date, dar.reference_id as dar_reference_id, u.display_name as researcher_name, " +
       "i.institution_name, e.election_id, e.status, e.dataset_id, e.reference_id, v.voteid as v_vote_id, dd.dataset_id as dd_datasetid, " +
-      "v.dacuserid as v_dac_user_id, v.vote as v_vote, v.electionid as v_election_id, v.createdate as v_create_date, v.updatedate as v_update_date, v.type as v_type, " +
+      "v.user_id as v_user_id, v.vote as v_vote, v.electionid as v_election_id, v.createdate as v_create_date, v.updatedate as v_update_date, v.type as v_type, " +
       "(dar.data #>> '{}')::jsonb ->> 'projectTitle' AS name " +
     "FROM dar_collection c " +
     "INNER JOIN users u " +
@@ -45,7 +45,7 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
       "ON dar.reference_id = dd.reference_id " +
     "WHERE dd.dataset_id IN (<datasetIds>) " +
     	"AND (e.latest = e.election_id OR e.election_id IS NULL) " +
-    	"AND (LOWER(v.type) = 'final' OR (v.dacuserid = :currentUserId OR v.voteid IS NULL)) " +
+    	"AND (LOWER(v.type) = 'final' OR (v.user_id = :currentUserId OR v.voteid IS NULL)) " +
         "AND (LOWER(data->>'status') != 'archived' OR data->>'status' IS NULL ) "
   )
   List<DarCollectionSummary> getDarCollectionSummariesForDAC(
@@ -156,7 +156,7 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
   (
     "SELECT c.collection_id as dar_collection_id, c.dar_code, dar.submission_date, u.display_name as researcher_name, u.user_id as researcher_id, " +
       "i.institution_name, i.institution_id, e.election_id, e.status, e.dataset_id, e.reference_id, v.voteid as v_vote_id, dd.dataset_id as dd_datasetid, " +
-      "v.dacuserid as v_dac_user_id, v.vote as v_vote, v.electionid as v_election_id, v.createdate as v_create_date, v.updatedate as v_update_date, v.type as v_type, " +
+      "v.user_id as v_user_id, v.vote as v_vote, v.electionid as v_election_id, v.createdate as v_create_date, v.updatedate as v_update_date, v.type as v_type, " +
       "(dar.data #>> '{}')::jsonb ->> 'projectTitle' AS name " +
     "FROM dar_collection c " +
     "INNER JOIN users u " +
@@ -178,7 +178,7 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
     "WHERE c.collection_id= :collectionId " +
       "AND dd.dataset_id IN (<datasetIds>) " +
       "AND (e.latest = e.election_id OR e.election_id IS NULL) " +
-      "AND (LOWER(v.type) = 'final' OR (v.dacuserid = :currentUserId OR v.voteid IS NULL)) " +
+      "AND (LOWER(v.type) = 'final' OR (v.user_id = :currentUserId OR v.voteid IS NULL)) " +
       "AND (LOWER(data->>'status') != 'archived' OR data->>'status' IS NULL )"
   )
   DarCollectionSummary getDarCollectionSummaryForDACByCollectionId(

--- a/src/main/java/org/broadinstitute/consent/http/db/DarCollectionSummaryDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DarCollectionSummaryDAO.java
@@ -43,8 +43,8 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
     INNER JOIN dar_dataset dd
       ON dar.reference_id = dd.reference_id
     WHERE dd.dataset_id IN (<datasetIds>)
-    	AND (e.latest = e.election_id OR e.election_id IS NULL)
-    	AND (LOWER(v.type) = 'final' OR (v.user_id = :currentUserId OR v.voteid IS NULL))
+      AND (e.latest = e.election_id OR e.election_id IS NULL)
+      AND (LOWER(v.type) = 'final' OR (v.user_id = :currentUserId OR v.voteid IS NULL))
       AND (LOWER(data->>'status') != 'archived' OR data->>'status' IS NULL )
     """)
   List<DarCollectionSummary> getDarCollectionSummariesForDAC(

--- a/src/main/java/org/broadinstitute/consent/http/db/DarCollectionSummaryDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DarCollectionSummaryDAO.java
@@ -20,34 +20,33 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
   @RegisterBeanMapper(value = Vote.class, prefix = "v")
   @RegisterBeanMapper(value = Election.class)
   @UseRowReducer(DarCollectionSummaryReducer.class)
-  @SqlQuery
-  (
-    "SELECT c.collection_id as dar_collection_id, c.dar_code, dar.submission_date, dar.reference_id as dar_reference_id, u.display_name as researcher_name, " +
-      "i.institution_name, e.election_id, e.status, e.dataset_id, e.reference_id, v.voteid as v_vote_id, dd.dataset_id as dd_datasetid, " +
-      "v.user_id as v_user_id, v.vote as v_vote, v.electionid as v_election_id, v.createdate as v_create_date, v.updatedate as v_update_date, v.type as v_type, " +
-      "(dar.data #>> '{}')::jsonb ->> 'projectTitle' AS name " +
-    "FROM dar_collection c " +
-    "INNER JOIN users u " +
-      "ON u.user_id = c.create_user_id " +
-    "LEFT JOIN institution i " +
-      "ON i.institution_id = u.institution_id " +
-    "INNER JOIN data_access_request dar " +
-      "ON dar.collection_id = c.collection_id " +
-    "LEFT JOIN ( " +
-      "SELECT election.*, MAX(election.election_id) OVER(PARTITION BY election.reference_id, election.dataset_id) AS latest " +
-      "FROM election " +
-      "WHERE LOWER(election.election_type) = 'dataaccess' AND election.dataset_id IN (<datasetIds>)" +
-    ") AS e " +
-      "ON e.reference_id = dar.reference_id " +
-    "LEFT JOIN vote v " +
-      "ON e.election_id = v.electionid " +
-    "INNER JOIN dar_dataset dd " +
-      "ON dar.reference_id = dd.reference_id " +
-    "WHERE dd.dataset_id IN (<datasetIds>) " +
-    	"AND (e.latest = e.election_id OR e.election_id IS NULL) " +
-    	"AND (LOWER(v.type) = 'final' OR (v.user_id = :currentUserId OR v.voteid IS NULL)) " +
-        "AND (LOWER(data->>'status') != 'archived' OR data->>'status' IS NULL ) "
-  )
+  @SqlQuery("""
+    SELECT c.collection_id as dar_collection_id, c.dar_code, dar.submission_date, dar.reference_id as dar_reference_id, u.display_name as researcher_name,
+      i.institution_name, e.election_id, e.status, e.dataset_id, e.reference_id, v.voteid as v_vote_id, dd.dataset_id as dd_datasetid,
+      v.user_id as v_user_id, v.vote as v_vote, v.electionid as v_election_id, v.createdate as v_create_date, v.updatedate as v_update_date, v.type as v_type,
+      (dar.data #>> '{}')::jsonb ->> 'projectTitle' AS name
+    FROM dar_collection c
+    INNER JOIN users u
+      ON u.user_id = c.create_user_id
+    LEFT JOIN institution i
+      ON i.institution_id = u.institution_id
+    INNER JOIN data_access_request dar
+      ON dar.collection_id = c.collection_id
+    LEFT JOIN (
+      SELECT election.*, MAX(election.election_id) OVER(PARTITION BY election.reference_id, election.dataset_id) AS latest
+      FROM election
+      WHERE LOWER(election.election_type) = 'dataaccess' AND election.dataset_id IN (<datasetIds>)"
+    ) AS e
+      ON e.reference_id = dar.reference_id
+    LEFT JOIN vote v
+      ON e.election_id = v.electionid
+    INNER JOIN dar_dataset dd
+      ON dar.reference_id = dd.reference_id
+    WHERE dd.dataset_id IN (<datasetIds>)
+    	AND (e.latest = e.election_id OR e.election_id IS NULL)
+    	AND (LOWER(v.type) = 'final' OR (v.user_id = :currentUserId OR v.voteid IS NULL))
+      AND (LOWER(data->>'status') != 'archived' OR data->>'status' IS NULL )
+    """)
   List<DarCollectionSummary> getDarCollectionSummariesForDAC(
       @Bind("currentUserId") Integer currentUserId,
       @BindList("datasetIds") List<Integer> datasetIds);
@@ -152,35 +151,34 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
   @RegisterBeanMapper(value = Vote.class, prefix = "v")
   @RegisterBeanMapper(value = Election.class)
   @UseRowReducer(DarCollectionSummaryReducer.class)
-  @SqlQuery
-  (
-    "SELECT c.collection_id as dar_collection_id, c.dar_code, dar.submission_date, u.display_name as researcher_name, u.user_id as researcher_id, " +
-      "i.institution_name, i.institution_id, e.election_id, e.status, e.dataset_id, e.reference_id, v.voteid as v_vote_id, dd.dataset_id as dd_datasetid, " +
-      "v.user_id as v_user_id, v.vote as v_vote, v.electionid as v_election_id, v.createdate as v_create_date, v.updatedate as v_update_date, v.type as v_type, " +
-      "(dar.data #>> '{}')::jsonb ->> 'projectTitle' AS name " +
-    "FROM dar_collection c " +
-    "INNER JOIN users u " +
-      "ON u.user_id = c.create_user_id " +
-    "LEFT JOIN institution i " +
-      "ON i.institution_id = u.institution_id " +
-    "INNER JOIN data_access_request dar " +
-      "ON dar.collection_id = c.collection_id " +
-    "LEFT JOIN ( " +
-      "SELECT election.*, MAX(election.election_id) OVER(PARTITION BY election.reference_id, election.dataset_id) AS latest " +
-      "FROM election " +
-      "WHERE LOWER(election.election_type) = 'dataaccess' AND election.dataset_id IN (<datasetIds>)" +
-    ") AS e " +
-      "ON e.reference_id = dar.reference_id " +
-    "LEFT JOIN vote v " +
-      "ON e.election_id = v.electionid " +
-    "INNER JOIN dar_dataset dd " +
-      "ON dar.reference_id = dd.reference_id " +
-    "WHERE c.collection_id= :collectionId " +
-      "AND dd.dataset_id IN (<datasetIds>) " +
-      "AND (e.latest = e.election_id OR e.election_id IS NULL) " +
-      "AND (LOWER(v.type) = 'final' OR (v.user_id = :currentUserId OR v.voteid IS NULL)) " +
-      "AND (LOWER(data->>'status') != 'archived' OR data->>'status' IS NULL )"
-  )
+  @SqlQuery("""
+    SELECT c.collection_id as dar_collection_id, c.dar_code, dar.submission_date, u.display_name as researcher_name, u.user_id as researcher_id,
+      i.institution_name, i.institution_id, e.election_id, e.status, e.dataset_id, e.reference_id, v.voteid as v_vote_id, dd.dataset_id as dd_datasetid,
+      v.user_id as v_user_id, v.vote as v_vote, v.electionid as v_election_id, v.createdate as v_create_date, v.updatedate as v_update_date, v.type as v_type,
+      (dar.data #>> '{}')::jsonb ->> 'projectTitle' AS name
+    FROM dar_collection c
+    INNER JOIN users u
+      ON u.user_id = c.create_user_id
+    LEFT JOIN institution i
+      ON i.institution_id = u.institution_id
+    INNER JOIN data_access_request dar
+      ON dar.collection_id = c.collection_id
+    LEFT JOIN (
+      SELECT election.*, MAX(election.election_id) OVER(PARTITION BY election.reference_id, election.dataset_id) AS latest
+      FROM election
+      WHERE LOWER(election.election_type) = 'dataaccess' AND election.dataset_id IN (<datasetIds>)
+    ) AS e
+      ON e.reference_id = dar.reference_id
+    LEFT JOIN vote v
+      ON e.election_id = v.electionid
+    INNER JOIN dar_dataset dd
+      ON dar.reference_id = dd.reference_id
+    WHERE c.collection_id= :collectionId
+      AND dd.dataset_id IN (<datasetIds>)
+      AND (e.latest = e.election_id OR e.election_id IS NULL)
+      AND (LOWER(v.type) = 'final' OR (v.user_id = :currentUserId OR v.voteid IS NULL))
+      AND (LOWER(data->>'status') != 'archived' OR data->>'status' IS NULL )
+    """)
   DarCollectionSummary getDarCollectionSummaryForDACByCollectionId(
           @Bind("currentUserId") Integer currentUserId,
           @BindList("datasetIds") List<Integer> datasetIds,

--- a/src/main/java/org/broadinstitute/consent/http/db/UserDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/UserDAO.java
@@ -1,5 +1,9 @@
 package org.broadinstitute.consent.http.db;
 
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+import java.util.Set;
 import org.broadinstitute.consent.http.db.mapper.UnregisteredUsersWithCardsReducer;
 import org.broadinstitute.consent.http.db.mapper.UserWithRolesMapper;
 import org.broadinstitute.consent.http.db.mapper.UserWithRolesReducer;
@@ -17,11 +21,6 @@ import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 import org.jdbi.v3.sqlobject.statement.UseRowMapper;
 import org.jdbi.v3.sqlobject.statement.UseRowReducer;
 import org.jdbi.v3.sqlobject.transaction.Transactional;
-
-import java.util.Collection;
-import java.util.Date;
-import java.util.List;
-import java.util.Set;
 
 public interface UserDAO extends Transactional<UserDAO> {
 
@@ -182,7 +181,7 @@ public interface UserDAO extends Transactional<UserDAO> {
             " from users du " +
             " inner join user_role ur on ur.user_id = du.user_id " +
             " inner join roles r on r.roleId = ur.role_id and r.name in (<roleNames>) " +
-            " inner join vote v on v.dacUserId = du.user_id and v.electionId in (<electionIds>) ")
+            " inner join vote v on v.user_id = du.user_id and v.electionId in (<electionIds>) ")
     Set<User> findUsersForElectionsByRoles(@BindList("electionIds") List<Integer> electionIds,
                                            @BindList("roleNames") List<String> roleNames);
 

--- a/src/main/java/org/broadinstitute/consent/http/db/UserDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/UserDAO.java
@@ -177,11 +177,13 @@ public interface UserDAO extends Transactional<UserDAO> {
     User findUserByEmailAndRoleId(@Bind("email") String email, @Bind("roleId") Integer roleId);
 
     @UseRowMapper(UserWithRolesMapper.class)
-    @SqlQuery("select du.*, r.roleId, r.name, ur.user_role_id, ur.user_id, ur.role_id, ur.dac_id " +
-            " from users du " +
-            " inner join user_role ur on ur.user_id = du.user_id " +
-            " inner join roles r on r.roleId = ur.role_id and r.name in (<roleNames>) " +
-            " inner join vote v on v.user_id = du.user_id and v.electionId in (<electionIds>) ")
+    @SqlQuery("""
+        SELECT du.*, r.roleId, r.name, ur.user_role_id, ur.user_id, ur.role_id, ur.dac_id
+        FROM users du
+        INNER JOIN user_role ur ON ur.user_id = du.user_id
+        INNER JOIN roles r ON r.roleId = ur.role_id AND r.name in (<roleNames>)
+        INNER JOIN vote v ON v.user_id = du.user_id AND v.electionId in (<electionIds>)
+        """)
     Set<User> findUsersForElectionsByRoles(@BindList("electionIds") List<Integer> electionIds,
                                            @BindList("roleNames") List<String> roleNames);
 

--- a/src/main/java/org/broadinstitute/consent/http/db/VoteDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/VoteDAO.java
@@ -24,11 +24,13 @@ public interface VoteDAO extends Transactional<VoteDAO> {
     @SqlQuery("SELECT v.* FROM vote v INNER JOIN election ON election.election_id = v.electionid WHERE election.reference_id = :referenceId")
     List<Vote> findVotesByReferenceId(@Bind("referenceId") String referenceId);
 
-    @SqlQuery(" SELECT v.*, u.email, u.display_name "
-            + " FROM vote v "
-            + " INNER JOIN election ON election.election_id = v.electionId "
-            + " INNER JOIN users u ON u.user_id = v.user_id "
-            + " WHERE election.election_id = :electionId AND LOWER(v.type) = LOWER(:type)")
+    @SqlQuery("""
+        SELECT v.*, u.email, u.display_name
+        FROM vote v
+        INNER JOIN election ON election.election_id = v.electionId
+        INNER JOIN users u ON u.user_id = v.user_id
+        WHERE election.election_id = :electionId AND LOWER(v.type) = LOWER(:type)
+        """)
     @UseRowMapper(ElectionReviewVoteMapper.class)
     List<ElectionReviewVote> findElectionReviewVotesByElectionId(@Bind("electionId") Integer electionId, @Bind("type") String type);
 
@@ -61,11 +63,12 @@ public interface VoteDAO extends Transactional<VoteDAO> {
     List<Vote> findVotesByElectionIdAndUserIds(@Bind("electionId") Integer electionId,
                                                   @BindList("userIds") List<Integer> userIds);
 
-    @SqlQuery(
-        "SELECT vote.voteId FROM vote " +
-            "INNER JOIN election ON election.election_id = vote.electionId " +
-            "WHERE election.reference_id = :referenceId " +
-            "AND vote.voteId = :voteId")
+    @SqlQuery("""
+        SELECT vote.voteId FROM vote
+        INNER JOIN election ON election.election_id = vote.electionId
+        WHERE election.reference_id = :referenceId
+        AND vote.voteId = :voteId
+        """)
     Integer checkVoteById(@Bind("referenceId") String referenceId,
                           @Bind("voteId") Integer voteId);
 
@@ -99,24 +102,26 @@ public interface VoteDAO extends Transactional<VoteDAO> {
     @SqlUpdate("update vote set reminderSent = :reminderSent where voteId = :voteId")
     void updateVoteReminderFlag(@Bind("voteId") Integer voteId, @Bind("reminderSent") boolean reminderSent);
 
-    @SqlQuery(
-        "SELECT v.* FROM vote v " +
-            "INNER JOIN election on election.election_id = v.electionId " +
-            "WHERE election.reference_id = :referenceId " +
-                "AND v.user_id = :userId " +
-                "AND LOWER(v.type) = LOWER(:type)")
+    @SqlQuery("""
+        SELECT v.* FROM vote v
+        INNER JOIN election on election.election_id = v.electionId
+        WHERE election.reference_id = :referenceId
+        AND v.user_id = :userId
+        AND LOWER(v.type) = LOWER(:type)
+        """)
     Vote findVotesByReferenceIdTypeAndUser(@Bind("referenceId") String referenceId, @Bind("userId") Integer userId, @Bind("type") String voteType);
 
     @SqlQuery("select v.* from vote v where v.electionId = :electionId and lower(v.type) = lower(:type)")
     List<Vote> findVoteByTypeAndElectionId(@Bind("electionId") Integer electionId, @Bind("type") String type);
 
-    @SqlQuery(
-        "SELECT count(*) FROM vote v " +
-            "INNER JOIN election e ON v.electionId = e.election_id " +
-            "WHERE LOWER(e.election_type) = LOWER(:type) " +
-            "AND LOWER(e.status) = 'closed' " +
-            "AND LOWER(v.type) = 'final' " +
-            "AND v.vote = :finalVote ")
+    @SqlQuery("""
+        SELECT count(*) FROM vote v
+        INNER JOIN election e ON v.electionId = e.election_id
+        WHERE LOWER(e.election_type) = LOWER(:type)
+        AND LOWER(e.status) = 'closed'
+        AND LOWER(v.type) = 'final'
+        AND v.vote = :finalVote
+        """)
     Integer findTotalFinalVoteByElectionTypeAndVote(@Bind("type") String type, @Bind("finalVote") Boolean finalVote);
 
     @SqlQuery("SELECT MAX(c) FROM (SELECT COUNT(vote) as c FROM vote WHERE lower(type) = 'dac' and electionId IN (<electionIds>) GROUP BY electionId) as members")
@@ -138,11 +143,13 @@ public interface VoteDAO extends Transactional<VoteDAO> {
     void updateRationaleByVoteIds(@BindList("voteIds") List<Integer> voteIds, @Bind("rationale") String rationale);
 
     @RegisterBeanMapper(value = User.class)
-    @SqlQuery(" SELECT DISTINCT u.* " +
-        " FROM users u " +
-        " INNER JOIN vote v ON v.user_id = u.user_id " +
-        " INNER JOIN election e ON v.electionid = e.election_id " +
-        " WHERE e.reference_id IN (<referenceIds>) ")
+    @SqlQuery("""
+        SELECT DISTINCT u.*
+        FROM users u
+        INNER JOIN vote v ON v.user_id = u.user_id
+        INNER JOIN election e ON v.electionid = e.election_id
+        WHERE e.reference_id IN (<referenceIds>)
+        """)
     List<User> findVoteUsersByElectionReferenceIdList(@BindList("referenceIds") List<String> referenceIds);
 
 }

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/ElectionReviewVoteMapper.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/ElectionReviewVoteMapper.java
@@ -15,7 +15,7 @@ public class ElectionReviewVoteMapper implements RowMapper<ElectionReviewVote> {
         new Vote(
             r.getInt("voteId"),
             (r.getString("vote") == null) ? null : r.getBoolean("vote"),
-            r.getInt("dacUserId"),
+            r.getInt("user_id"),
             r.getDate("createDate"),
             r.getDate("updateDate"),
             r.getInt("electionId"),

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/VoteMapper.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/VoteMapper.java
@@ -12,7 +12,7 @@ public class VoteMapper implements RowMapper<Vote> {
     return new Vote(
         r.getInt("voteId"),
         (r.getString("vote") == null) ? null : r.getBoolean("vote"),
-        r.getInt("dacUserId"),
+        r.getInt("user_id"),
         r.getTimestamp("createDate"),
         r.getDate("updateDate"),
         r.getInt("electionId"),

--- a/src/main/java/org/broadinstitute/consent/http/models/ConsentSummaryDetail.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/ConsentSummaryDetail.java
@@ -113,7 +113,7 @@ public class ConsentSummaryDetail implements SummaryDetail {
             v -> {
               Optional<User> user =
                   getElectionUsers().stream()
-                      .filter(u -> v.getDacUserId().equals(u.getUserId()))
+                      .filter(u -> v.getUserId().equals(u.getUserId()))
                       .findFirst();
               user.ifPresent(value -> builder.append(value.getDisplayName()));
               builder.append(TAB);

--- a/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequestSummaryDetail.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequestSummaryDetail.java
@@ -125,7 +125,7 @@ public class DataAccessRequestSummaryDetail implements SummaryDetail {
         finalVote.flatMap(
             vote ->
                 getDacMembers().stream()
-                    .filter(u -> u.getUserId().equals(vote.getDacUserId()))
+                    .filter(u -> u.getUserId().equals(vote.getUserId()))
                     .findFirst());
     Boolean agreement =
         (finalVote.isPresent() && Objects.nonNull(getMatchObject()))

--- a/src/main/java/org/broadinstitute/consent/http/models/Vote.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/Vote.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.gson.Gson;
-
 import java.util.Date;
 import java.util.List;
 
@@ -14,7 +13,7 @@ public class Vote {
   public static final String QUERY_FIELDS_WITH_V_PREFIX =
       "v.voteid as v_vote_id, "
           + " v.vote as v_vote, "
-          + " v.dacuserid as v_dac_user_id, "
+          + " v.user_id as v_user_id, "
           + " v.rationale as v_rationale, "
           + " v.electionid as v_election_id, "
           + "v.createdate as v_create_date, "
@@ -29,6 +28,9 @@ public class Vote {
 
     @JsonProperty
     private Integer dacUserId;
+
+    @JsonProperty
+    private Integer userId;
 
     @JsonProperty
     private Date createDate;
@@ -57,11 +59,12 @@ public class Vote {
     public Vote() {
     }
 
-    public Vote(Integer voteId, Boolean vote, Integer dacUserId, Date createDate, Date updateDate,
+    public Vote(Integer voteId, Boolean vote, Integer userId, Date createDate, Date updateDate,
                 Integer electionId, String rationale, String type, Boolean isReminderSent, Boolean hasConcerns) {
         this.voteId = voteId;
         this.vote = vote;
-        this.dacUserId = dacUserId;
+        this.dacUserId = userId;
+        this.userId = userId;
         this.createDate = createDate;
         this.updateDate = updateDate;
         this.electionId = electionId;
@@ -93,6 +96,14 @@ public class Vote {
 
     public void setDacUserId(Integer dacUserId) {
         this.dacUserId = dacUserId;
+    }
+
+    public Integer getUserId() {
+        return userId;
+    }
+
+    public void setUserId(Integer userId) {
+        this.userId = userId;
     }
 
     public Date getCreateDate() {

--- a/src/main/java/org/broadinstitute/consent/http/resources/DataRequestVoteResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataRequestVoteResource.java
@@ -4,23 +4,14 @@ import com.google.gson.Gson;
 import com.google.inject.Inject;
 import freemarker.template.TemplateException;
 import io.dropwizard.auth.Auth;
-import org.apache.commons.collections.CollectionUtils;
-import org.broadinstitute.consent.http.enumeration.UserRoles;
-import org.broadinstitute.consent.http.enumeration.VoteType;
-import org.broadinstitute.consent.http.models.AuthUser;
-import org.broadinstitute.consent.http.models.DarCollection;
-import org.broadinstitute.consent.http.models.Dataset;
-import org.broadinstitute.consent.http.models.Election;
-import org.broadinstitute.consent.http.models.User;
-import org.broadinstitute.consent.http.models.Vote;
-import org.broadinstitute.consent.http.service.DarCollectionService;
-import org.broadinstitute.consent.http.service.DatasetAssociationService;
-import org.broadinstitute.consent.http.service.DatasetService;
-import org.broadinstitute.consent.http.service.ElectionService;
-import org.broadinstitute.consent.http.service.EmailService;
-import org.broadinstitute.consent.http.service.UserService;
-import org.broadinstitute.consent.http.service.VoteService;
-
+import java.io.IOException;
+import java.net.URI;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
 import javax.annotation.security.PermitAll;
 import javax.annotation.security.RolesAllowed;
 import javax.mail.MessagingException;
@@ -37,14 +28,22 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
-import java.io.IOException;
-import java.net.URI;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.logging.Logger;
-import java.util.stream.Collectors;
+import org.apache.commons.collections.CollectionUtils;
+import org.broadinstitute.consent.http.enumeration.UserRoles;
+import org.broadinstitute.consent.http.enumeration.VoteType;
+import org.broadinstitute.consent.http.models.AuthUser;
+import org.broadinstitute.consent.http.models.DarCollection;
+import org.broadinstitute.consent.http.models.Dataset;
+import org.broadinstitute.consent.http.models.Election;
+import org.broadinstitute.consent.http.models.User;
+import org.broadinstitute.consent.http.models.Vote;
+import org.broadinstitute.consent.http.service.DarCollectionService;
+import org.broadinstitute.consent.http.service.DatasetAssociationService;
+import org.broadinstitute.consent.http.service.DatasetService;
+import org.broadinstitute.consent.http.service.ElectionService;
+import org.broadinstitute.consent.http.service.EmailService;
+import org.broadinstitute.consent.http.service.UserService;
+import org.broadinstitute.consent.http.service.VoteService;
 
 @Path("api/dataRequest/{requestId}/vote")
 public class DataRequestVoteResource extends Resource {
@@ -238,7 +237,7 @@ public class DataRequestVoteResource extends Resource {
         validateAuthedRoleUser(
                 Collections.singletonList(UserRoles.ADMIN),
                 user,
-                existingVote.getDacUserId());
+                existingVote.getUserId());
     }
 
     private void createDataOwnerElection(Vote vote, String referenceId) throws MessagingException, IOException, TemplateException {

--- a/src/main/java/org/broadinstitute/consent/http/resources/VoteResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/VoteResource.java
@@ -3,18 +3,9 @@ package org.broadinstitute.consent.http.resources;
 
 import com.google.gson.Gson;
 import io.dropwizard.auth.Auth;
-
-import org.broadinstitute.consent.http.enumeration.ElectionType;
-import org.broadinstitute.consent.http.enumeration.VoteType;
-import org.broadinstitute.consent.http.models.AuthUser;
-import org.broadinstitute.consent.http.models.Election;
-import org.broadinstitute.consent.http.models.User;
-import org.broadinstitute.consent.http.models.Vote;
-
-import org.broadinstitute.consent.http.service.UserService;
-import org.broadinstitute.consent.http.service.VoteService;
-import org.broadinstitute.consent.http.service.ElectionService;
-
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
 import javax.annotation.security.RolesAllowed;
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.Consumes;
@@ -23,9 +14,15 @@ import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.Response;
-import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
+import org.broadinstitute.consent.http.enumeration.ElectionType;
+import org.broadinstitute.consent.http.enumeration.VoteType;
+import org.broadinstitute.consent.http.models.AuthUser;
+import org.broadinstitute.consent.http.models.Election;
+import org.broadinstitute.consent.http.models.User;
+import org.broadinstitute.consent.http.models.Vote;
+import org.broadinstitute.consent.http.service.ElectionService;
+import org.broadinstitute.consent.http.service.UserService;
+import org.broadinstitute.consent.http.service.VoteService;
 
 @Path("api/votes")
 public class VoteResource extends Resource {
@@ -86,7 +83,7 @@ public class VoteResource extends Resource {
 
             // Validate that the user is only updating their own votes:
             User user = userService.findUserByEmail(authUser.getEmail());
-            boolean authed = votes.stream().map(Vote::getDacUserId).allMatch(id -> id.equals(user.getUserId()));
+            boolean authed = votes.stream().map(Vote::getUserId).allMatch(id -> id.equals(user.getUserId()));
             if (!authed) {
                 return createExceptionResponse(new NotFoundException());
             }
@@ -139,7 +136,7 @@ public class VoteResource extends Resource {
         }
 
         // Ensure the user is only updating their votes
-        boolean permitted = votes.stream().allMatch(vote -> vote.getDacUserId().equals(user.getUserId()));
+        boolean permitted = votes.stream().allMatch(vote -> vote.getUserId().equals(user.getUserId()));
         if (!permitted) {
             return createExceptionResponse(new NotFoundException());
         }

--- a/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
@@ -1,8 +1,25 @@
 package org.broadinstitute.consent.http.service;
 
+import static java.util.stream.Collectors.toList;
+
 import com.google.gson.Gson;
 import com.google.inject.Inject;
-
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.NotAcceptableException;
+import javax.ws.rs.NotAuthorizedException;
+import javax.ws.rs.NotFoundException;
 import org.broadinstitute.consent.http.db.DarCollectionDAO;
 import org.broadinstitute.consent.http.db.DarCollectionSummaryDAO;
 import org.broadinstitute.consent.http.db.DataAccessRequestDAO;
@@ -31,25 +48,6 @@ import org.broadinstitute.consent.http.resources.Resource;
 import org.broadinstitute.consent.http.service.dao.DarCollectionServiceDAO;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.ws.rs.BadRequestException;
-import javax.ws.rs.NotAcceptableException;
-import javax.ws.rs.NotAuthorizedException;
-import javax.ws.rs.NotFoundException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Date;
-import java.text.SimpleDateFormat;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-
-import static java.util.stream.Collectors.toList;
 
 public class DarCollectionService {
 
@@ -194,7 +192,7 @@ public class DarCollectionService {
           if(isVotable) {
             s.setStatus(DarCollectionStatus.IN_PROCESS.getValue());
             List<Vote> votes = s.getVotes().stream()
-              .filter(v -> v.getDacUserId().equals(userId) && v.getType().equals(VoteType.DAC.getValue()))
+              .filter(v -> v.getUserId().equals(userId) && v.getType().equals(VoteType.DAC.getValue()))
               .collect(Collectors.toList());
             if(!votes.isEmpty()) {
               Boolean hasVoted = votes.stream().allMatch(v -> Objects.nonNull(v.getVote()));

--- a/src/main/java/org/broadinstitute/consent/http/service/ElectionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ElectionService.java
@@ -220,7 +220,7 @@ public class ElectionService {
         List<Integer> chairIds = electionChairs.stream().map(User::getUserId).collect(Collectors.toList());
         Integer exists = mailMessageDAO.existsCollectDAREmail(darReferenceId, rpReferenceId);
         if ((exists == null)) {
-            if (((darVotes.size() == 0) && (rpElectionVotes.size() == 0) && (!chairIds.contains(vote.getDacUserId())))) {
+            if (((darVotes.size() == 0) && (rpElectionVotes.size() == 0) && (!chairIds.contains(vote.getUserId())))) {
                 return true;
             } else {
                 List<Vote> rpChairVotes = voteDAO.findVotesByElectionIdAndUserIds(rpElectionId, chairIds);

--- a/src/main/java/org/broadinstitute/consent/http/service/ElectionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ElectionService.java
@@ -2,7 +2,20 @@ package org.broadinstitute.consent.http.service;
 
 import com.google.inject.Inject;
 import freemarker.template.TemplateException;
+import java.io.IOException;
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
 import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import javax.mail.MessagingException;
+import javax.ws.rs.NotFoundException;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.consent.http.db.ConsentDAO;
@@ -33,20 +46,6 @@ import org.broadinstitute.consent.http.models.Vote;
 import org.broadinstitute.consent.http.models.dto.DatasetMailDTO;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.mail.MessagingException;
-import javax.ws.rs.NotFoundException;
-import java.io.IOException;
-import java.sql.Timestamp;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 public class ElectionService {
 
@@ -224,8 +223,8 @@ public class ElectionService {
             if (((darVotes.size() == 0) && (rpElectionVotes.size() == 0) && (!chairIds.contains(vote.getDacUserId())))) {
                 return true;
             } else {
-                List<Vote> rpChairVotes = voteDAO.findVotesByElectionIdAndDACUserIds(rpElectionId, chairIds);
-                List<Vote> darChairVotes = voteDAO.findVotesByElectionIdAndDACUserIds(vote.getElectionId(), chairIds);
+                List<Vote> rpChairVotes = voteDAO.findVotesByElectionIdAndUserIds(rpElectionId, chairIds);
+                List<Vote> darChairVotes = voteDAO.findVotesByElectionIdAndUserIds(vote.getElectionId(), chairIds);
                 if ((((rpElectionVotes.size() == 1) && (CollectionUtils.isEmpty(darVotes))))) {
                     return rpChairVotes.stream().allMatch(v -> v.getCreateDate() == null);
                 } else {

--- a/src/main/java/org/broadinstitute/consent/http/service/EmailService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/EmailService.java
@@ -381,7 +381,7 @@ public class EmailService {
     private Map<String, String> retrieveForVote(Integer voteId) {
         Vote vote = voteDAO.findVoteById(voteId);
         Election election = electionDAO.findElectionWithFinalVoteById(vote.getElectionId());
-        User user = findUserById(vote.getDacUserId());
+        User user = findUserById(vote.getUserId());
 
         Map<String, String> dataMap = new HashMap<>();
         dataMap.put("userName", user.getDisplayName());

--- a/src/main/java/org/broadinstitute/consent/http/service/EmailService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/EmailService.java
@@ -4,6 +4,21 @@ import com.google.common.collect.Streams;
 import com.google.inject.Inject;
 import com.sendgrid.Response;
 import freemarker.template.TemplateException;
+import java.io.IOException;
+import java.io.Writer;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+import javax.mail.MessagingException;
+import javax.ws.rs.NotFoundException;
 import org.apache.commons.collections.CollectionUtils;
 import org.broadinstitute.consent.http.db.ConsentDAO;
 import org.broadinstitute.consent.http.db.DarCollectionDAO;
@@ -25,22 +40,6 @@ import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.Vote;
 import org.broadinstitute.consent.http.models.dto.DatasetMailDTO;
 import org.broadinstitute.consent.http.models.mail.MailMessage;
-
-import javax.annotation.Nullable;
-import javax.mail.MessagingException;
-import javax.ws.rs.NotFoundException;
-import java.io.IOException;
-import java.io.Writer;
-import java.time.Instant;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 public class EmailService {
 
@@ -405,12 +404,12 @@ public class EmailService {
 
     private String findRpVoteId(Integer electionId, Integer dacUserId) {
         Integer rpElectionId = electionDAO.findRPElectionByElectionAccessId(electionId);
-        return (rpElectionId != null) ? ((voteDAO.findVoteByElectionIdAndDACUserId(rpElectionId, dacUserId).getVoteId()).toString()) : "";
+        return (rpElectionId != null) ? ((voteDAO.findVoteByElectionIdAndUserId(rpElectionId, dacUserId).getVoteId()).toString()) : "";
     }
 
     private String findDataAccessVoteId(Integer electionId, Integer dacUserId) {
         Integer dataAccessElectionId = electionDAO.findAccessElectionByElectionRPId(electionId);
-        return (dataAccessElectionId != null) ? ((voteDAO.findVoteByElectionIdAndDACUserId(dataAccessElectionId, dacUserId).getVoteId()).toString()) : "";
+        return (dataAccessElectionId != null) ? ((voteDAO.findVoteByElectionIdAndUserId(dataAccessElectionId, dacUserId).getVoteId()).toString()) : "";
     }
 
     private Map<String, String> retrieveForCollect(Integer electionId, User user) {

--- a/src/main/java/org/broadinstitute/consent/http/service/VoteService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/VoteService.java
@@ -1,6 +1,16 @@
 package org.broadinstitute.consent.http.service;
 
 import com.google.inject.Inject;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import javax.ws.rs.NotFoundException;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.consent.http.db.DarCollectionDAO;
@@ -28,17 +38,6 @@ import org.broadinstitute.consent.http.models.dto.DatasetMailDTO;
 import org.broadinstitute.consent.http.service.dao.VoteServiceDAO;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.ws.rs.NotFoundException;
-import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Date;
-import java.util.List;
-import java.util.Objects;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 public class VoteService {
 
@@ -262,7 +261,7 @@ public class VoteService {
                 collect(Collectors.toList());
         if (!openElectionIds.isEmpty()) {
             List<Integer> openUserVoteIds = voteDAO.findVotesByElectionIds(openElectionIds).stream().
-                    filter(v -> v.getDacUserId().equals(user.getUserId())).
+                    filter(v -> v.getUserId().equals(user.getUserId())).
                     map(Vote::getVoteId).
                     collect(Collectors.toList());
             if (!openUserVoteIds.isEmpty()) {
@@ -472,7 +471,7 @@ public class VoteService {
     private void validateVote(Vote vote) {
         if (Objects.isNull(vote) ||
                 Objects.isNull(vote.getVoteId()) ||
-                Objects.isNull(vote.getDacUserId()) ||
+                Objects.isNull(vote.getUserId()) ||
                 Objects.isNull(vote.getElectionId())) {
             throw new IllegalArgumentException("Invalid vote: " + vote);
         }

--- a/src/main/java/org/broadinstitute/consent/http/service/dao/DarCollectionServiceDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/dao/DarCollectionServiceDAO.java
@@ -136,7 +136,7 @@ public class DarCollectionServiceDAO {
 
   private Update createVoteInsert(Handle handle, String voteType, String electionType, String referenceId, Integer datasetId, Date now, Integer userId) {
     final String sql =
-        " INSERT INTO vote (createdate, dacuserid, electionid, type, remindersent) "
+        " INSERT INTO vote (createdate, user_id, electionid, type, remindersent) "
             + " (SELECT :createDate, :userId, election_id, :voteType, false "
             + "  FROM election "
             + "  WHERE election_type = :electionType "

--- a/src/main/resources/assets/schemas/Vote.yaml
+++ b/src/main/resources/assets/schemas/Vote.yaml
@@ -7,10 +7,17 @@ properties:
   vote:
     type: boolean
     description: Describe the Positive or negative value of the vote
-  dacUserId:
+  userId:
     type: integer
     format: int32
     description: Describes the id of the voter.
+  dacUserId:
+    deprecated: true
+    type: integer
+    format: int32
+    description: | 
+      This is a copy of userId visible for backwards compatibility.
+      This field will be removed in a future release.
   createDate:
     type: string
     format: date

--- a/src/main/resources/changelog-master.xml
+++ b/src/main/resources/changelog-master.xml
@@ -113,4 +113,5 @@
     <include file="changesets/changelog-consent-2023-01-09-dac-email.0.xml" relativeToChangelogFile="true"/>
     <include file="changesets/changelog-consent-2023-02-28-fix-dataset-audit.0.xml" relativeToChangelogFile="true"/>
     <include file="changesets/changelog-consent-2023-03-07-remove-use-restriction.0.xml" relativeToChangelogFile="true"/>
+    <include file="changesets/changelog-consent-2023-03-16-rename-vote-userid.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/changesets/changelog-consent-2023-03-16-rename-vote-userid.xml
+++ b/src/main/resources/changesets/changelog-consent-2023-03-16-rename-vote-userid.xml
@@ -1,0 +1,7 @@
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+  <changeSet id="changelog-consent-2023-03-16-rename-vote-userid" author="grushton">
+    <renameColumn tableName="vote" oldColumnName="dacuserid" newColumnName="user_id"/>
+  </changeSet>
+</databaseChangeLog>

--- a/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
@@ -1,17 +1,10 @@
 package org.broadinstitute.consent.http.db;
 
-import org.apache.commons.lang3.RandomStringUtils;
-import org.apache.commons.lang3.RandomUtils;
-import org.broadinstitute.consent.http.models.DarCollection;
-import org.broadinstitute.consent.http.models.DataAccessRequest;
-import org.broadinstitute.consent.http.models.DataAccessRequestData;
-import org.broadinstitute.consent.http.models.DataUseBuilder;
-import org.broadinstitute.consent.http.models.Dataset;
-import org.broadinstitute.consent.http.models.Election;
-import org.broadinstitute.consent.http.models.User;
-import org.broadinstitute.consent.http.models.DatasetProperty;
-import org.broadinstitute.consent.http.models.Vote;
-import org.junit.Test;
+import static junit.framework.TestCase.assertNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import java.sql.Timestamp;
 import java.util.ArrayList;
@@ -19,12 +12,18 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.UUID;
-
-import static junit.framework.TestCase.assertNull;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.RandomUtils;
+import org.broadinstitute.consent.http.models.DarCollection;
+import org.broadinstitute.consent.http.models.DataAccessRequest;
+import org.broadinstitute.consent.http.models.DataAccessRequestData;
+import org.broadinstitute.consent.http.models.DataUseBuilder;
+import org.broadinstitute.consent.http.models.Dataset;
+import org.broadinstitute.consent.http.models.DatasetProperty;
+import org.broadinstitute.consent.http.models.Election;
+import org.broadinstitute.consent.http.models.User;
+import org.broadinstitute.consent.http.models.Vote;
+import org.junit.Test;
 
 public class DataAccessRequestDAOTest extends DAOTestHelper {
 
@@ -419,9 +418,9 @@ public class DataAccessRequestDAOTest extends DAOTestHelper {
 
     @Test
     public void testFindAllApprovedDataAccessRequestsByDatasetId() {
-        String darCode1 = "DAR-" + RandomUtils.nextInt(100, 1000);
-        String darCode2 = "DAR-" + RandomUtils.nextInt(100, 1000);
-        String darCode3 = "DAR-" + RandomUtils.nextInt(100, 1000);
+        String darCode1 = "DAR-" + RandomUtils.nextInt(100, 1000000);
+        String darCode2 = "DAR-" + RandomUtils.nextInt(100, 1000000);
+        String darCode3 = "DAR-" + RandomUtils.nextInt(100, 1000000);
         Dataset dataset1 = createDataset();
         Dataset dataset2 = createDataset();
 

--- a/src/test/java/org/broadinstitute/consent/http/db/VoteDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/VoteDAOTest.java
@@ -194,7 +194,7 @@ public class VoteDAOTest extends DAOTestHelper {
         Election election = createDataAccessElection(consent.getConsentId(), dataset.getDataSetId());
         Vote vote = createDacVote(user.getUserId(), election.getElectionId());
 
-        Vote foundVote = voteDAO.findVoteByElectionIdAndDACUserId(election.getElectionId(), user.getUserId());
+        Vote foundVote = voteDAO.findVoteByElectionIdAndUserId(election.getElectionId(), user.getUserId());
         assertNotNull(foundVote);
         assertEquals(vote.getVoteId(), foundVote.getVoteId());
     }
@@ -207,7 +207,7 @@ public class VoteDAOTest extends DAOTestHelper {
         Election election = createDataAccessElection(consent.getConsentId(), dataset.getDataSetId());
         Vote vote = createDacVote(user.getUserId(), election.getElectionId());
 
-        List<Vote> foundVotes = voteDAO.findVotesByElectionIdAndDACUserIds(election.getElectionId(), Collections.singletonList(user.getUserId()));
+        List<Vote> foundVotes = voteDAO.findVotesByElectionIdAndUserIds(election.getElectionId(), Collections.singletonList(user.getUserId()));
         assertNotNull(foundVotes);
         assertFalse(foundVotes.isEmpty());
         assertEquals(vote.getVoteId(), foundVotes.get(0).getVoteId());

--- a/src/test/java/org/broadinstitute/consent/http/resources/DataRequestVoteResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DataRequestVoteResourceTest.java
@@ -1,5 +1,25 @@
 package org.broadinstitute.consent.http.resources;
 
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.openMocks;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.logging.Level;
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriBuilder;
+import javax.ws.rs.core.UriInfo;
 import org.broadinstitute.consent.http.WithLogHandler;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.enumeration.VoteType;
@@ -22,27 +42,6 @@ import org.broadinstitute.consent.http.service.VoteService;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
-
-import javax.ws.rs.NotFoundException;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.UriBuilder;
-import javax.ws.rs.core.UriInfo;
-import java.io.IOException;
-import java.net.URI;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-import java.util.logging.Level;
-
-import static org.junit.Assert.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.openMocks;
 
 public class DataRequestVoteResourceTest implements WithLogHandler {
     @Mock
@@ -90,7 +89,7 @@ public class DataRequestVoteResourceTest implements WithLogHandler {
     private Vote createMockVote(String voteType, Integer dacUserId, boolean voteValue) {
         Vote vote = new Vote();
         vote.setType(voteType);
-        vote.setDacUserId(dacUserId);
+        vote.setUserId(dacUserId);
         vote.setVote(voteValue);
         return vote;
     }

--- a/src/test/java/org/broadinstitute/consent/http/resources/VoteResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/VoteResourceTest.java
@@ -1,7 +1,20 @@
 package org.broadinstitute.consent.http.resources;
 
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.openMocks;
+
 import com.google.api.client.http.HttpStatusCodes;
 import com.google.gson.Gson;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import javax.ws.rs.core.Response;
 import org.broadinstitute.consent.http.models.AuthUser;
 import org.broadinstitute.consent.http.models.Election;
 import org.broadinstitute.consent.http.models.User;
@@ -12,20 +25,6 @@ import org.broadinstitute.consent.http.service.VoteService;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
-
-import javax.ws.rs.core.Response;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-
-import static org.junit.Assert.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.openMocks;
 
 public class VoteResourceTest {
 
@@ -109,7 +108,7 @@ public class VoteResourceTest {
   @Test
   public void testUpdateVotes_invalidUser() {
     user.setUserId(1);
-    vote.setDacUserId(2);
+    vote.setUserId(2);
     when(userService.findUserByEmail(any())).thenReturn(user);
     when(voteService.findVotesByIds(any())).thenReturn(List.of(vote));
     initResource();
@@ -122,7 +121,7 @@ public class VoteResourceTest {
   @Test
   public void testUpdateVotes_closedElection() {
     user.setUserId(1);
-    vote.setDacUserId(1);
+    vote.setUserId(1);
     when(userService.findUserByEmail(any())).thenReturn(user);
     doThrow(new IllegalArgumentException()).when(voteService).findVotesByIds(any());
     initResource();
@@ -135,13 +134,13 @@ public class VoteResourceTest {
   @Test
   public void testUpdateVotes_allMemberVotes() {
       user.setUserId(1);
-      vote.setDacUserId(1);
+      vote.setUserId(1);
       vote.setType("DAC");
       vote.setVote(true);
       Vote voteTwo = new Vote();
       voteTwo.setVote(true);
       voteTwo.setType("DAC");
-      voteTwo.setDacUserId(1);
+      voteTwo.setUserId(1);
       Vote.VoteUpdate voteUpdate = new Vote.VoteUpdate(true, "example", List.of(1, 2, 3));
       when(voteService.findVotesByIds(anyList())).thenReturn(List.of(vote, voteTwo));
       when(userService.findUserByEmail(any())).thenReturn(user);
@@ -156,13 +155,13 @@ public class VoteResourceTest {
   @Test
   public void testUpdateVotes_allYes_allRP() {
       user.setUserId(1);
-      vote.setDacUserId(1);
+      vote.setUserId(1);
       vote.setType("Chairperson");
       vote.setVote(true);
       Vote voteTwo = new Vote();
       voteTwo.setVote(true);
       voteTwo.setType("Chairperson");
-      voteTwo.setDacUserId(1);
+      voteTwo.setUserId(1);
       Election election = new Election();
       Election electionTwo = new Election();
       election.setElectionType("RP");
@@ -182,13 +181,13 @@ public class VoteResourceTest {
   @Test
   public void testUpdateVotes_allNo_allRP() {
       user.setUserId(1);
-      vote.setDacUserId(1);
+      vote.setUserId(1);
       vote.setType("Chairperson");
       vote.setVote(false);
       Vote voteTwo = new Vote();
       voteTwo.setVote(false);
       voteTwo.setType("Chairperson");
-      voteTwo.setDacUserId(1);
+      voteTwo.setUserId(1);
       Vote.VoteUpdate voteUpdate = new Vote.VoteUpdate(false, "example", List.of(1, 2, 3));
       when(voteService.findVotesByIds(anyList())).thenReturn(List.of(vote, voteTwo));
       when(userService.findUserByEmail(any())).thenReturn(user);
@@ -203,14 +202,14 @@ public class VoteResourceTest {
   @Test
   public void testUpdateVotes_allYes_allDataAccess_AllCards() {
       user.setUserId(1);
-      vote.setDacUserId(1);
+      vote.setUserId(1);
       vote.setVoteId(1);
       vote.setType("Chairperson");
       vote.setVote(true);
       Vote voteTwo = new Vote();
       voteTwo.setType("Chairperson");
       voteTwo.setVoteId(2);
-      voteTwo.setDacUserId(1);
+      voteTwo.setUserId(1);
       voteTwo.setVote(true);
       Election election = new Election();
       election.setElectionId(1);
@@ -233,14 +232,14 @@ public class VoteResourceTest {
   @Test
   public void testUpdateVotes_allNo_allDataAccess_AllCards() {
       user.setUserId(1);
-      vote.setDacUserId(1);
+      vote.setUserId(1);
       vote.setVoteId(1);
       vote.setType("Chairperson");
       vote.setVote(false);
       Vote voteTwo = new Vote();
       voteTwo.setType("Chairperson");
       voteTwo.setVoteId(2);
-      voteTwo.setDacUserId(1);
+      voteTwo.setUserId(1);
       voteTwo.setVote(false);
       Election election = new Election();
       election.setElectionId(1);
@@ -263,14 +262,14 @@ public class VoteResourceTest {
   @Test
   public void testUpdateVotes_allYes_allDataAccess_NotAllCards() {
       user.setUserId(1);
-      vote.setDacUserId(1);
+      vote.setUserId(1);
       vote.setVoteId(1);
       vote.setType("Chairperson");
       vote.setVote(true);
       Vote voteTwo = new Vote();
       voteTwo.setType("Chairperson");
       voteTwo.setVoteId(2);
-      voteTwo.setDacUserId(1);
+      voteTwo.setUserId(1);
       voteTwo.setVote(true);
       Election election = new Election();
       election.setElectionId(1);
@@ -294,7 +293,7 @@ public class VoteResourceTest {
   @Test
   public void testUpdateVotes_noRationale() {
     user.setUserId(1);
-    vote.setDacUserId(1);
+    vote.setUserId(1);
     when(userService.findUserByEmail(any())).thenReturn(user);
     when(voteService.findVotesByIds(any())).thenReturn(List.of(vote));
     initResource();
@@ -343,7 +342,7 @@ public class VoteResourceTest {
   @Test
   public void testUpdateVoteRationale_UserNotOwnerOfVotes() {
     user.setUserId(1);
-    vote.setDacUserId(2);
+    vote.setUserId(2);
     when(userService.findUserByEmail(any())).thenReturn(user);
     when(voteService.findVotesByIds(any())).thenReturn(List.of(vote));
     Vote.RationaleUpdate update = new Vote.RationaleUpdate();
@@ -358,7 +357,7 @@ public class VoteResourceTest {
   @Test
   public void testUpdateVoteRationale_Success() {
     user.setUserId(1);
-    vote.setDacUserId(1);
+    vote.setUserId(1);
     when(userService.findUserByEmail(any())).thenReturn(user);
     when(voteService.findVotesByIds(any())).thenReturn(List.of(vote));
     when(voteService.updateRationaleByVoteIds(any(), any())).thenReturn(List.of(vote));

--- a/src/test/java/org/broadinstitute/consent/http/service/ElectionServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/ElectionServiceTest.java
@@ -426,10 +426,10 @@ public class ElectionServiceTest {
                 .thenReturn(Set.of());
         when(mailMessageDAO.existsCollectDAREmail(null, sampleElectionRP.getReferenceId()))
                 .thenReturn(null);
-        when(voteDAO.findVotesByElectionIdAndDACUserIds(sampleElectionRP.getElectionId(),
+        when(voteDAO.findVotesByElectionIdAndUserIds(sampleElectionRP.getElectionId(),
             List.of(sampleUserChairperson.getUserId())))
                 .thenReturn(List.of(sampleVoteChairpersonApproval));
-        when(voteDAO.findVotesByElectionIdAndDACUserIds(sampleElection1.getElectionId(),
+        when(voteDAO.findVotesByElectionIdAndUserIds(sampleElection1.getElectionId(),
             List.of(sampleUserChairperson.getUserId())))
                 .thenReturn(List.of(sampleVoteChairpersonApproval));
         when(voteDAO.findPendingVotesByElectionId(sampleElectionRP.getElectionId())).thenReturn(
@@ -450,12 +450,12 @@ public class ElectionServiceTest {
                 .thenReturn(Set.of(sampleUserChairperson));
         when(mailMessageDAO.existsCollectDAREmail(null, sampleElectionRP.getReferenceId()))
                 .thenReturn(null);
-        when(voteDAO.findVotesByElectionIdAndDACUserIds(sampleElectionRP.getElectionId(),
+        when(voteDAO.findVotesByElectionIdAndUserIds(sampleElectionRP.getElectionId(),
             List.of(sampleUserChairperson.getUserId())))
                 .thenReturn(List.of(new Vote(4, true, sampleUserChairperson.getUserId(), null, null,
                     sampleElectionRP.getElectionId(), "", VoteType.AGREEMENT.getValue(),
                     false, false)));
-        when(voteDAO.findVotesByElectionIdAndDACUserIds(sampleElection1.getElectionId(),
+        when(voteDAO.findVotesByElectionIdAndUserIds(sampleElection1.getElectionId(),
             List.of(sampleUserChairperson.getUserId())))
                 .thenReturn(List.of(sampleVoteChairpersonApproval));
         when(voteDAO.findPendingVotesByElectionId(sampleElectionRP.getElectionId())).thenReturn(
@@ -476,10 +476,10 @@ public class ElectionServiceTest {
                 .thenReturn(Set.of(sampleUserChairperson));
         when(mailMessageDAO.existsCollectDAREmail(null, sampleElectionRP.getReferenceId()))
                 .thenReturn(null);
-        when(voteDAO.findVotesByElectionIdAndDACUserIds(sampleElectionRP.getElectionId(),
+        when(voteDAO.findVotesByElectionIdAndUserIds(sampleElectionRP.getElectionId(),
             List.of(sampleUserChairperson.getUserId())))
                 .thenReturn(List.of());
-        when(voteDAO.findVotesByElectionIdAndDACUserIds(sampleElection1.getElectionId(),
+        when(voteDAO.findVotesByElectionIdAndUserIds(sampleElection1.getElectionId(),
             List.of(sampleUserChairperson.getUserId())))
                 .thenReturn(List.of());
         when(voteDAO.findPendingVotesByElectionId(sampleElectionRP.getElectionId())).thenReturn(

--- a/src/test/java/org/broadinstitute/consent/http/service/ElectionServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/ElectionServiceTest.java
@@ -154,28 +154,28 @@ public class ElectionServiceTest {
 
         sampleVoteChairpersonApproval = new Vote();
         sampleVoteChairpersonApproval.setElectionId(sampleElection1.getElectionId());
-        sampleVoteChairpersonApproval.setDacUserId(sampleUserChairperson.getUserId());
+        sampleVoteChairpersonApproval.setUserId(sampleUserChairperson.getUserId());
         sampleVoteChairpersonApproval.setVote(true);
         sampleVoteChairpersonApproval.setVoteId(1);
         sampleVoteChairpersonApproval.setRationale("Go for it");
 
         sampleVoteChairpersonReject = new Vote();
         sampleVoteChairpersonReject.setElectionId(sampleElection1.getElectionId());
-        sampleVoteChairpersonReject.setDacUserId(sampleUserChairperson.getUserId());
+        sampleVoteChairpersonReject.setUserId(sampleUserChairperson.getUserId());
         sampleVoteChairpersonReject.setVote(false);
         sampleVoteChairpersonReject.setVoteId(1);
         sampleVoteChairpersonReject.setRationale("Rejection vote");
 
         sampleVoteMember = new Vote();
         sampleVoteMember.setElectionId(sampleElection1.getElectionId());
-        sampleVoteMember.setDacUserId(sampleUserMember.getUserId());
+        sampleVoteMember.setUserId(sampleUserMember.getUserId());
         sampleVoteMember.setVote(true);
         sampleVoteMember.setVoteId(2);
         sampleVoteMember.setRationale("Go for it");
 
         sampleVoteRP = new Vote();
         sampleVoteRP.setElectionId(sampleElectionRP.getElectionId());
-        sampleVoteRP.setDacUserId(sampleUserMember.getUserId());
+        sampleVoteRP.setUserId(sampleUserMember.getUserId());
         sampleVoteRP.setVote(true);
         sampleVoteRP.setVoteId(3);
         sampleVoteRP.setRationale("Yep");

--- a/src/test/java/org/broadinstitute/consent/http/service/SummaryServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/SummaryServiceTest.java
@@ -260,7 +260,7 @@ public class SummaryServiceTest {
                 v.setElectionId(electionId);
                 v.setCreateDate(new Date());
                 v.setUpdateDate(new Date());
-                v.setDacUserId(userId);
+                v.setUserId(userId);
                 return v;
             }
         ).collect(Collectors.toUnmodifiableList());

--- a/src/test/java/org/broadinstitute/consent/http/service/VoteServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/VoteServiceTest.java
@@ -614,13 +614,13 @@ public class VoteServiceTest {
         v1.setVote(true);
         v1.setType(VoteType.FINAL.getValue());
         v1.setElectionId(1);
-        v1.setDacUserId(1);
+        v1.setUserId(1);
 
         Vote v2 = new Vote();
         v2.setVote(true);
         v2.setType(VoteType.FINAL.getValue());
         v2.setElectionId(2);
-        v2.setDacUserId(1);
+        v2.setUserId(1);
 
         Dataset d1 = new Dataset();
         d1.setDataSetId(1);
@@ -687,13 +687,13 @@ public class VoteServiceTest {
         v1.setVote(true);
         v1.setType(VoteType.FINAL.getValue());
         v1.setElectionId(1);
-        v1.setDacUserId(1);
+        v1.setUserId(1);
 
         Vote v2 = new Vote();
         v2.setVote(true);
         v2.setType(VoteType.FINAL.getValue());
         v2.setElectionId(2);
-        v2.setDacUserId(1);
+        v2.setUserId(1);
 
         Dataset d1 = new Dataset();
         d1.setDataSetId(1);
@@ -763,7 +763,7 @@ public class VoteServiceTest {
         v1.setVote(false);
         v1.setType(VoteType.FINAL.getValue());
         v1.setElectionId(1);
-        v1.setDacUserId(1);
+        v1.setUserId(1);
 
         Dataset d1 = new Dataset();
         d1.setDataSetId(1);
@@ -814,7 +814,7 @@ public class VoteServiceTest {
         v1.setVote(true);
         v1.setType(VoteType.DAC.getValue());
         v1.setElectionId(1);
-        v1.setDacUserId(1);
+        v1.setUserId(1);
 
         Dataset d1 = new Dataset();
         d1.setDataSetId(1);
@@ -878,7 +878,7 @@ public class VoteServiceTest {
     private Vote setUpTestVote(Boolean vote, Boolean reminderSent) {
         Vote v = new Vote();
         v.setVoteId(RandomUtils.nextInt(1, 10));
-        v.setDacUserId(RandomUtils.nextInt(1, 10));
+        v.setUserId(RandomUtils.nextInt(1, 10));
         v.setElectionId(RandomUtils.nextInt(1, 10));
         v.setIsReminderSent(reminderSent);
         v.setVote(vote);


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-2389

This PR migrates the vote.dacuserid column to vote.user_id and keeps the old field around for backwards compatibility.

**Side note** - `semgrep` improperly complains about our concatenated string queries so I have migrated some of them to text blocks. In the case where that was more work than it is worth, I added a `nosemgrep` check. 

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
