### PR TITLE
[DUOS-2389][risk=no] Remove dac user id from user, simplified user, and vote

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/UserWithRolesMapper.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/UserWithRolesMapper.java
@@ -38,8 +38,6 @@ public class UserWithRolesMapper implements RowMapper<User>, RowMapperHelper {
     }
     addRole(r, user);
 
-    // Populate for backwards compatibility.
-    user.setDacUserId();
     users.put(user.getUserId(), user);
     return user;
   }

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/UserWithRolesReducer.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/UserWithRolesReducer.java
@@ -1,5 +1,7 @@
 package org.broadinstitute.consent.http.db.mapper;
 
+import java.util.Map;
+import java.util.Objects;
 import org.broadinstitute.consent.http.models.Institution;
 import org.broadinstitute.consent.http.models.LibraryCard;
 import org.broadinstitute.consent.http.models.User;
@@ -8,9 +10,6 @@ import org.broadinstitute.consent.http.models.UserRole;
 import org.jdbi.v3.core.mapper.MappingException;
 import org.jdbi.v3.core.result.LinkedHashMapRowReducer;
 import org.jdbi.v3.core.result.RowView;
-
-import java.util.Map;
-import java.util.Objects;
 
 /**
  * This class works well for individual Users as well as collections.
@@ -29,8 +28,6 @@ public class UserWithRolesReducer implements LinkedHashMapRowReducer<Integer, Us
         map.computeIfAbsent(
             userId,
             id -> rowView.getRow(User.class));
-    // Populate for backwards compatibility.
-    user.setDacUserId();
 
     try {
       // Some queries look for `user_role_id` while those that use a prefix look for `u_user_role_id`

--- a/src/main/java/org/broadinstitute/consent/http/models/User.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/User.java
@@ -3,22 +3,20 @@ package org.broadinstitute.consent.http.models;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
+import java.beans.Transient;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
 import net.gcardone.junidecode.Junidecode;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.broadinstitute.consent.http.authentication.GoogleUser;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
-
-import java.beans.Transient;
-import java.util.EnumSet;
-import java.util.stream.Collectors;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.List;
-import java.util.Objects;
 
 public class User {
 
@@ -33,12 +31,6 @@ public class User {
 
     @JsonProperty
     private Integer userId;
-
-    // This will be removed in a future release.
-    // It is maintained here for backwards compatibility with the UI.
-    @JsonProperty
-    @Deprecated
-    private Integer dacUserId;
 
     @JsonProperty
     private String email;
@@ -81,7 +73,6 @@ public class User {
 
     public User(Integer userId, String email, String displayName, Date createDate) {
         this.userId = userId;
-        this.dacUserId = userId;
         this.email = email;
         this.displayName = displayName;
         this.createDate = createDate;
@@ -90,7 +81,6 @@ public class User {
     public User(Integer userId, String email, String displayName, Date createDate,
                 List<UserRole> roles) {
         this.userId = userId;
-        this.dacUserId = userId;
         this.email = email;
         this.displayName = displayName;
         this.createDate = createDate;
@@ -178,16 +168,6 @@ public class User {
         if (Objects.nonNull(u.getInstitutionId())) {
             this.setInstitutionId(u.getInstitutionId());
         }
-    }
-
-    @Deprecated // Use getUserId(). This is maintained for backward compatibility with existing UI functionality.
-    public Integer getDacUserId() {
-        return userId;
-    }
-
-    @Deprecated // This is maintained for backward compatibility with existing UI functionality.
-    public void setDacUserId() {
-        this.dacUserId = this.getUserId();
     }
 
     public String getEmail() {
@@ -362,7 +342,7 @@ public class User {
                 })
                 .collect(Collectors.toList());
         return !targetRoles.isEmpty();
-        
+
     }
 
 }

--- a/src/main/java/org/broadinstitute/consent/http/models/Vote.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/Vote.java
@@ -27,9 +27,6 @@ public class Vote {
     private Boolean vote;
 
     @JsonProperty
-    private Integer dacUserId;
-
-    @JsonProperty
     private Integer userId;
 
     @JsonProperty
@@ -63,7 +60,6 @@ public class Vote {
                 Integer electionId, String rationale, String type, Boolean isReminderSent, Boolean hasConcerns) {
         this.voteId = voteId;
         this.vote = vote;
-        this.dacUserId = userId;
         this.userId = userId;
         this.createDate = createDate;
         this.updateDate = updateDate;
@@ -88,14 +84,6 @@ public class Vote {
 
     public void setVote(Boolean vote) {
         this.vote = vote;
-    }
-
-    public Integer getDacUserId() {
-        return dacUserId;
-    }
-
-    public void setDacUserId(Integer dacUserId) {
-        this.dacUserId = dacUserId;
     }
 
     public Integer getUserId() {

--- a/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
@@ -4,27 +4,18 @@ import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
 import com.google.inject.Inject;
 import io.dropwizard.auth.Auth;
-import org.apache.commons.collections.CollectionUtils;
-import org.broadinstitute.consent.http.enumeration.UserRoles;
-import org.broadinstitute.consent.http.models.AuthUser;
-import org.broadinstitute.consent.http.models.DataUse;
-import org.broadinstitute.consent.http.models.Dataset;
-import org.broadinstitute.consent.http.models.Dictionary;
-import org.broadinstitute.consent.http.models.User;
-import org.broadinstitute.consent.http.models.UserRole;
-import org.broadinstitute.consent.http.models.dataset_registration_v1.DatasetRegistrationSchemaV1;
-import org.broadinstitute.consent.http.models.dto.DatasetDTO;
-import org.broadinstitute.consent.http.models.dto.DatasetPropertyDTO;
-import org.broadinstitute.consent.http.service.DataAccessRequestService;
-import org.broadinstitute.consent.http.service.DatasetRegistrationService;
-import org.broadinstitute.consent.http.service.DatasetService;
-import org.broadinstitute.consent.http.service.UserService;
-import org.broadinstitute.consent.http.util.JsonSchemaUtil;
-import org.glassfish.jersey.media.multipart.FormDataBodyPart;
-import org.glassfish.jersey.media.multipart.FormDataMultiPart;
-import org.glassfish.jersey.media.multipart.FormDataParam;
-import org.json.JSONObject;
-
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 import javax.annotation.security.PermitAll;
 import javax.annotation.security.RolesAllowed;
 import javax.ws.rs.BadRequestException;
@@ -46,18 +37,26 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
-import java.io.ByteArrayInputStream;
-import java.io.InputStream;
-import java.net.URI;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
+import org.apache.commons.collections.CollectionUtils;
+import org.broadinstitute.consent.http.enumeration.UserRoles;
+import org.broadinstitute.consent.http.models.AuthUser;
+import org.broadinstitute.consent.http.models.DataUse;
+import org.broadinstitute.consent.http.models.Dataset;
+import org.broadinstitute.consent.http.models.Dictionary;
+import org.broadinstitute.consent.http.models.User;
+import org.broadinstitute.consent.http.models.UserRole;
+import org.broadinstitute.consent.http.models.dataset_registration_v1.DatasetRegistrationSchemaV1;
+import org.broadinstitute.consent.http.models.dto.DatasetDTO;
+import org.broadinstitute.consent.http.models.dto.DatasetPropertyDTO;
+import org.broadinstitute.consent.http.service.DataAccessRequestService;
+import org.broadinstitute.consent.http.service.DatasetRegistrationService;
+import org.broadinstitute.consent.http.service.DatasetService;
+import org.broadinstitute.consent.http.service.UserService;
+import org.broadinstitute.consent.http.util.JsonSchemaUtil;
+import org.glassfish.jersey.media.multipart.FormDataBodyPart;
+import org.glassfish.jersey.media.multipart.FormDataMultiPart;
+import org.glassfish.jersey.media.multipart.FormDataParam;
+import org.json.JSONObject;
 
 
 @Path("api/dataset")
@@ -473,9 +472,9 @@ public class DatasetResource extends Resource {
     @Deprecated
     public Response datasetAutocomplete(@Auth AuthUser authUser, @PathParam("partial") String partial){
         try {
-            User dacUser = userService.findUserByEmail(authUser.getEmail());
-            Integer dacUserId = dacUser.getUserId();
-            List<Map<String, String>> datasets = datasetService.autoCompleteDatasets(partial, dacUserId);
+            User user = userService.findUserByEmail(authUser.getEmail());
+            Integer userId = user.getUserId();
+            List<Map<String, String>> datasets = datasetService.autoCompleteDatasets(partial, userId);
             return Response.ok(datasets, MediaType.APPLICATION_JSON).build();
         } catch (Exception e) {
             return createExceptionResponse(e);

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -439,8 +439,8 @@ public class DatasetService {
     }
 
     @Deprecated
-    public List<Map<String, String>> autoCompleteDatasets(String partial, Integer dacUserId) {
-        Set<DatasetDTO> datasets = describeDatasets(dacUserId);
+    public List<Map<String, String>> autoCompleteDatasets(String partial, Integer userId) {
+        Set<DatasetDTO> datasets = describeDatasets(userId);
         String lowercasePartial = partial.toLowerCase();
         Set<DatasetDTO> filteredDatasetsContainingPartial = datasets.stream()
                 .filter(ds -> filterDatasetOnProperties(ds, lowercasePartial))
@@ -520,8 +520,8 @@ public class DatasetService {
                 });
     }
 
-    private boolean userHasRole(String roleName, Integer dacUserId) {
-        return userRoleDAO.findRoleByNameAndUser(roleName, dacUserId) != null;
+    private boolean userHasRole(String roleName, Integer userId) {
+        return userRoleDAO.findRoleByNameAndUser(roleName, userId) != null;
     }
 
     public List<Dataset> findAllDatasetsByUser(User user) {

--- a/src/main/java/org/broadinstitute/consent/http/service/EmailService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/EmailService.java
@@ -402,14 +402,14 @@ public class EmailService {
         return dataMap;
     }
 
-    private String findRpVoteId(Integer electionId, Integer dacUserId) {
+    private String findRpVoteId(Integer electionId, Integer userId) {
         Integer rpElectionId = electionDAO.findRPElectionByElectionAccessId(electionId);
-        return (rpElectionId != null) ? ((voteDAO.findVoteByElectionIdAndUserId(rpElectionId, dacUserId).getVoteId()).toString()) : "";
+        return (rpElectionId != null) ? ((voteDAO.findVoteByElectionIdAndUserId(rpElectionId, userId).getVoteId()).toString()) : "";
     }
 
-    private String findDataAccessVoteId(Integer electionId, Integer dacUserId) {
+    private String findDataAccessVoteId(Integer electionId, Integer userId) {
         Integer dataAccessElectionId = electionDAO.findAccessElectionByElectionRPId(electionId);
-        return (dataAccessElectionId != null) ? ((voteDAO.findVoteByElectionIdAndUserId(dataAccessElectionId, dacUserId).getVoteId()).toString()) : "";
+        return (dataAccessElectionId != null) ? ((voteDAO.findVoteByElectionIdAndUserId(dataAccessElectionId, userId).getVoteId()).toString()) : "";
     }
 
     private Map<String, String> retrieveForCollect(Integer electionId, User user) {

--- a/src/main/java/org/broadinstitute/consent/http/service/SummaryService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/SummaryService.java
@@ -164,9 +164,9 @@ public class SummaryService {
           Integer maxNumberOfDACMembers = voteDAO.findMaxNumberOfDACMembers(electionIds);
           Collection<Consent> consents = consentDAO.findConsentsFromConsentsIDs(consentIds);
           List<Vote> votes = voteDAO.findVotesByElectionIds(electionIds);
-          Collection<Integer> dacUserIds =
+          Collection<Integer> userIds =
               votes.stream().map(Vote::getUserId).collect(Collectors.toSet());
-          Collection<User> users = userDAO.findUsers(dacUserIds);
+          Collection<User> users = userDAO.findUsers(userIds);
           for (Election election : reviewedElections) {
             Optional<Consent> electionConsent =
                 consents.stream()
@@ -279,8 +279,8 @@ public class SummaryService {
             .filter(d -> d.getReferenceId().equalsIgnoreCase(accessElection.getReferenceId()))
             .findFirst();
         DataAccessRequest dar = darOption.orElse(null);
-        List<Integer> dacUserIds = accessElectionVotes.stream().map(Vote::getUserId).distinct().collect(Collectors.toList());
-        List<User> dacMembers = voteUsers.stream().filter(v -> dacUserIds.contains(v.getUserId())).collect(Collectors.toList());
+        List<Integer> userIds = accessElectionVotes.stream().map(Vote::getUserId).distinct().collect(Collectors.toList());
+        List<User> dacMembers = voteUsers.stream().filter(v -> userIds.contains(v.getUserId())).collect(Collectors.toList());
 
         if (Objects.nonNull(dar) && Objects.nonNull(dar.getData())) {
           List<Integer> datasetId = dar.getDatasetIds();

--- a/src/main/java/org/broadinstitute/consent/http/service/UserService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/UserService.java
@@ -4,6 +4,15 @@ import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.inject.Inject;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.NotFoundException;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.consent.http.db.InstitutionDAO;
@@ -28,16 +37,6 @@ import org.broadinstitute.consent.http.resources.Resource;
 import org.broadinstitute.consent.http.service.dao.UserServiceDAO;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.ws.rs.BadRequestException;
-import javax.ws.rs.NotFoundException;
-import java.util.Collections;
-import java.util.Date;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 public class UserService {
 
@@ -151,14 +150,11 @@ public class UserService {
 
     public static class SimplifiedUser {
         public Integer userId;
-        @Deprecated
-        public Integer dacUserId;
         public String displayName;
         public String email;
 
         public SimplifiedUser(User user) {
             this.userId = user.getUserId();
-            this.dacUserId = user.getUserId();
             this.displayName = user.getDisplayName();
             this.email = user.getEmail();
         }
@@ -168,11 +164,6 @@ public class UserService {
 
         public void setUserId(Integer userId) {
             this.userId = userId;
-        }
-
-        @Deprecated
-        public void setDacUserId(Integer userId) {
-            this.dacUserId = userId;
         }
 
         public void setDisplayName(String name) {

--- a/src/main/resources/assets/schemas/SimplifiedUser.yaml
+++ b/src/main/resources/assets/schemas/SimplifiedUser.yaml
@@ -3,10 +3,6 @@ properties:
   userId:
     type: integer
     description: ID of the user
-  dacUserId:
-    deprecated: true
-    type: integer
-    description: ID of the user
   displayName:
     type: string
     description: Name of the user

--- a/src/main/resources/assets/schemas/User.yaml
+++ b/src/main/resources/assets/schemas/User.yaml
@@ -3,13 +3,6 @@ properties:
   userId:
     type: integer
     description: ID of the user
-  dacUserId:
-    deprecated: true
-    type: integer
-    description: | 
-      ID of the user. This is a deprecated field and will be removed in a 
-      future release. It is a duplicate of the `userId` field and is still
-      in use in the UI.
   email:
     type: string
     description: Email of the user

--- a/src/main/resources/assets/schemas/Vote.yaml
+++ b/src/main/resources/assets/schemas/Vote.yaml
@@ -11,13 +11,6 @@ properties:
     type: integer
     format: int32
     description: Describes the id of the voter.
-  dacUserId:
-    deprecated: true
-    type: integer
-    format: int32
-    description: | 
-      This is a copy of userId visible for backwards compatibility.
-      This field will be removed in a future release.
   createDate:
     type: string
     format: date

--- a/src/test/java/org/broadinstitute/consent/http/service/SummaryServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/SummaryServiceTest.java
@@ -191,13 +191,13 @@ public class SummaryServiceTest {
         return Arrays.asList(e1, e2, e3, e4);
     }
 
-    private List<Vote> randomVotesList(Integer dacUserId, String voteType){
-        Vote v1 = new Vote(1, false, dacUserId, new Date(), new Date(), 1, "", voteType, false, false);
-        Vote v2 = new Vote(2, false, dacUserId, new Date(), new Date(), 2, "", voteType, false, false);
-        Vote v3 = new Vote(3, false, dacUserId, new Date(), new Date(), 3, "", voteType, false, false);
-        Vote v4 = new Vote(4, true, dacUserId, new Date(), new Date(), 4, "", voteType, false, false);
-        Vote v5 = new Vote(5, true, dacUserId, new Date(), new Date(), 5, "", voteType, false, false);
-        Vote nul = new Vote(6, null, dacUserId, new Date(), new Date(), 6, "", voteType, false, false);
+    private List<Vote> randomVotesList(Integer userId, String voteType){
+        Vote v1 = new Vote(1, false, userId, new Date(), new Date(), 1, "", voteType, false, false);
+        Vote v2 = new Vote(2, false, userId, new Date(), new Date(), 2, "", voteType, false, false);
+        Vote v3 = new Vote(3, false, userId, new Date(), new Date(), 3, "", voteType, false, false);
+        Vote v4 = new Vote(4, true, userId, new Date(), new Date(), 4, "", voteType, false, false);
+        Vote v5 = new Vote(5, true, userId, new Date(), new Date(), 5, "", voteType, false, false);
+        Vote nul = new Vote(6, null, userId, new Date(), new Date(), 6, "", voteType, false, false);
         return Arrays.asList(v1, v2, v3, v4, v5, nul);
     }
 


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-2389

Part 3 of DUOS-2389. This PR removes the dac user id from the user, simplified user, and vote objects.
Includes some minor method and property renaming for clarity.


----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
