### PR TITLE
[DUOS-2391][risk=low] Update approved users query

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/DataAccessRequestDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DataAccessRequestDAO.java
@@ -63,7 +63,20 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
   )
   List<DataAccessRequest> findAllApprovedDataAccessRequestsByDatasetId(@Bind("datasetId") Integer datasetId);
 
-
+  /**
+   * This query finds unique user ids on dar-dataset combinations where the most recent
+   * vote is true. The query accomplishes this by creating a view that is a grouping
+   * of election reference ids and LAST vote in the group of final votes for all data access
+   * elections. We need to group them due to the case of multiple elections on a dar-dataset
+   * request. Election 1 may have been denied. Election 2 may have been approved. Election 3
+   * may have been denied again. When we partition over the election reference id, we'll get all
+   * final votes. The `LAST_VALUE` function selects the last result in the partition, which
+   * would be `FALSE` in the example. Outside the JOIN, we filter on groupings where the final
+   * vote value is `TRUE` so the election in the example would be filtered out.
+   *
+   * @param datasetId The dataset id
+   * @return List of approved user ids for the dataset
+   */
   @SqlQuery("""
           SELECT DISTINCT dar.user_id
           FROM data_access_request dar

--- a/src/main/java/org/broadinstitute/consent/http/db/DataAccessRequestDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DataAccessRequestDAO.java
@@ -64,16 +64,28 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
   List<DataAccessRequest> findAllApprovedDataAccessRequestsByDatasetId(@Bind("datasetId") Integer datasetId);
 
 
-  @SqlQuery(
-        " SELECT dar.user_id FROM data_access_request dar "
-          + "  LEFT JOIN dar_dataset dd ON dd.reference_id = dar.reference_id "
-          + "  WHERE dar.draft = false"
-            + "  AND (EXISTS (SELECT 1 FROM election e"
-          + "  INNER JOIN vote v on v.electionId = e.election_id AND LOWER(v.type) = 'final'"
-          + "  WHERE v.vote = true AND LOWER(e.election_type) = 'dataaccess'"
-          + "  AND e.dataset_id = :datasetId"
-            + "  AND e.reference_id = dar.reference_id))"
-            + "  AND (LOWER(dar.data->>'status') != 'archived' OR dar.data->>'status' IS NULL)")
+  @SqlQuery("""
+          SELECT dar.user_id
+          FROM data_access_request dar
+          INNER JOIN dar_dataset dd ON dd.reference_id = dar.reference_id AND dd.dataset_id = :datasetId
+          INNER JOIN (
+            SELECT DISTINCT e.reference_id, LAST_VALUE(v.vote)
+            OVER(
+              PARTITION BY e.reference_id
+                ORDER BY v.createdate
+                RANGE BETWEEN
+                  UNBOUNDED PRECEDING AND
+                  UNBOUNDED FOLLOWING
+            ) last_vote
+            FROM election e
+            INNER JOIN vote v ON e.election_id = v.electionid AND v.vote IS NOT NULL
+            WHERE e.dataset_id = :datasetId
+            AND LOWER(e.election_type) = 'dataaccess'
+            AND LOWER(v.type) = 'final') final_access_vote ON final_access_vote.reference_id = dar.reference_id
+          WHERE dar.draft = false
+          AND final_access_vote.last_vote = TRUE
+          AND (LOWER(dar.data->>'status') != 'archived' OR dar.data->>'status' IS NULL)
+      """)
   List<Integer> findAllUserIdsWithApprovedDARsByDatasetId(@Bind("datasetId") Integer datasetId);
 
   /**

--- a/src/main/java/org/broadinstitute/consent/http/db/DataAccessRequestDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DataAccessRequestDAO.java
@@ -65,7 +65,7 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
 
 
   @SqlQuery("""
-          SELECT dar.user_id
+          SELECT DISTINCT dar.user_id
           FROM data_access_request dar
           INNER JOIN dar_dataset dd ON dd.reference_id = dar.reference_id AND dd.dataset_id = :datasetId
           INNER JOIN (

--- a/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
@@ -1,15 +1,10 @@
 package org.broadinstitute.consent.http.db;
 
-import org.apache.commons.lang3.RandomStringUtils;
-import org.apache.commons.lang3.RandomUtils;
-import org.broadinstitute.consent.http.models.DarCollection;
-import org.broadinstitute.consent.http.models.DataAccessRequest;
-import org.broadinstitute.consent.http.models.DataAccessRequestData;
-import org.broadinstitute.consent.http.models.Dataset;
-import org.broadinstitute.consent.http.models.Election;
-import org.broadinstitute.consent.http.models.User;
-import org.broadinstitute.consent.http.models.Vote;
-import org.junit.Test;
+import static junit.framework.TestCase.assertNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import java.sql.Timestamp;
 import java.util.ArrayList;
@@ -17,12 +12,18 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.UUID;
-
-import static junit.framework.TestCase.assertNull;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.RandomUtils;
+import org.broadinstitute.consent.http.models.DarCollection;
+import org.broadinstitute.consent.http.models.DataAccessRequest;
+import org.broadinstitute.consent.http.models.DataAccessRequestData;
+import org.broadinstitute.consent.http.models.DataUse;
+import org.broadinstitute.consent.http.models.DataUseBuilder;
+import org.broadinstitute.consent.http.models.Dataset;
+import org.broadinstitute.consent.http.models.Election;
+import org.broadinstitute.consent.http.models.User;
+import org.broadinstitute.consent.http.models.Vote;
+import org.junit.Test;
 
 public class DataAccessRequestDAOTest extends DAOTestHelper {
 
@@ -46,8 +47,8 @@ public class DataAccessRequestDAOTest extends DAOTestHelper {
 
         createDataAccessRequestV3();
         DataAccessRequest draft = createDraftDataAccessRequest();
-        Dataset d1 = createDataset();
-        Dataset d2 = createDataset();
+        Dataset d1 = createDARDAOTestDataset();
+        Dataset d2 = createDARDAOTestDataset();
         dataAccessRequestDAO.insertDARDatasetRelation(draft.getReferenceId(), d1.getDataSetId());
         dataAccessRequestDAO.insertDARDatasetRelation(draft.getReferenceId(), d2.getDataSetId());
         List<DataAccessRequest> newDars = dataAccessRequestDAO.findAllDraftDataAccessRequests();
@@ -59,8 +60,8 @@ public class DataAccessRequestDAOTest extends DAOTestHelper {
     @Test
     public void testFindAllDraftsByUserId() {
         DataAccessRequest dar = createDraftDataAccessRequest();
-        Dataset d1 = createDataset();
-        Dataset d2 = createDataset();
+        Dataset d1 = createDARDAOTestDataset();
+        Dataset d2 = createDARDAOTestDataset();
         dataAccessRequestDAO.insertDARDatasetRelation(dar.getReferenceId(), d1.getDataSetId());
         dataAccessRequestDAO.insertDARDatasetRelation(dar.getReferenceId(), d2.getDataSetId());
 
@@ -143,8 +144,8 @@ public class DataAccessRequestDAOTest extends DAOTestHelper {
         String darCode = "DAR-" + RandomUtils.nextInt(1, 999999999);
         Integer collection_id = darCollectionDAO.insertDarCollection(darCode, user.getUserId(), new Date());
         DataAccessRequest dar = createDataAccessRequest(user.getUserId(), collection_id, darCode);
-        Dataset d1 = createDataset();
-        Dataset d2 = createDataset();
+        Dataset d1 = createDARDAOTestDataset();
+        Dataset d2 = createDARDAOTestDataset();
         dataAccessRequestDAO.insertDARDatasetRelation(dar.getReferenceId(), d1.getDataSetId());
         dataAccessRequestDAO.insertDARDatasetRelation(dar.getReferenceId(), d2.getDataSetId());
         DataAccessRequest foundDar = dataAccessRequestDAO.findByReferenceId(dar.getReferenceId());
@@ -331,7 +332,7 @@ public class DataAccessRequestDAOTest extends DAOTestHelper {
         assertTrue(dars.isEmpty());
 
         String darCode = "DAR-" + RandomUtils.nextInt(100, 1000);
-        Dataset dataset = createDataset();
+        Dataset dataset = createDARDAOTestDataset();
         User user = createUserWithInstitution();
         DataAccessRequest testDar = createDAR(user, dataset, darCode);
         dataAccessRequestDAO.archiveByReferenceIds(List.of(testDar.getReferenceId()));
@@ -348,8 +349,8 @@ public class DataAccessRequestDAOTest extends DAOTestHelper {
 
         String darCode1 = "DAR-" + RandomUtils.nextInt(100, 200);
         String darCode2 = "DAR-" + RandomUtils.nextInt(201, 300);
-        Dataset dataset1 = createDataset();
-        Dataset dataset2 = createDataset();
+        Dataset dataset1 = createDARDAOTestDataset();
+        Dataset dataset2 = createDARDAOTestDataset();
 
         DataAccessRequest testDar1 = createDAR(user, dataset1, darCode1);
         DataAccessRequest testDar2 = createDAR(user, dataset2, darCode2);
@@ -363,7 +364,7 @@ public class DataAccessRequestDAOTest extends DAOTestHelper {
     @Test
     public void testFindAllByDatasetIdArchived() {
         String darCode = "DAR-" + RandomUtils.nextInt(100, 1000);
-        Dataset dataset = createDataset();
+        Dataset dataset = createDARDAOTestDataset();
         List<DataAccessRequest> dars = dataAccessRequestDAO.findAllApprovedDataAccessRequestsByDatasetId(dataset.getDataSetId());
         assertTrue(dars.isEmpty());
 
@@ -379,8 +380,8 @@ public class DataAccessRequestDAOTest extends DAOTestHelper {
     public void testEnsureOnlyDataAccessRequestsByDatasetIdReturnsJustForSpecificDatasetId(){
         String darCode1 = "DAR-" + RandomUtils.nextInt(100, 1000);
         String darCode2 = "DAR-" + RandomUtils.nextInt(100, 1000);
-        Dataset dataset1 = createDataset();
-        Dataset dataset2 = createDataset();
+        Dataset dataset1 = createDARDAOTestDataset();
+        Dataset dataset2 = createDARDAOTestDataset();
         User user1 = createUser();
         User user2 = createUser();
         DataAccessRequest testDar1 = createDAR(user1, dataset1, darCode1);
@@ -420,8 +421,8 @@ public class DataAccessRequestDAOTest extends DAOTestHelper {
         String darCode1 = "DAR-" + RandomUtils.nextInt(100, 1000000);
         String darCode2 = "DAR-" + RandomUtils.nextInt(100, 1000000);
         String darCode3 = "DAR-" + RandomUtils.nextInt(100, 1000000);
-        Dataset dataset1 = createDataset();
-        Dataset dataset2 = createDataset();
+        Dataset dataset1 = createDARDAOTestDataset();
+        Dataset dataset2 = createDARDAOTestDataset();
 
         assertTrue(dataAccessRequestDAO.findAllUserIdsWithApprovedDARsByDatasetId(dataset1.getDataSetId()).isEmpty());
         assertTrue(dataAccessRequestDAO.findAllUserIdsWithApprovedDARsByDatasetId(dataset2.getDataSetId()).isEmpty());
@@ -484,6 +485,44 @@ public class DataAccessRequestDAOTest extends DAOTestHelper {
         assertFalse(dataAccessRequestDAO.findAllUserIdsWithApprovedDARsByDatasetId(dataset2.getDataSetId()).contains(testDar1.getUserId()));
     }
 
+    /**
+     * Tests the case where a user has been approved for access, then denied access,
+     * and that the user does not show up as an approved user for the dataset.
+     */
+    @Test
+    public void testFindAllApprovedDataAccessRequestsByDatasetId_ApprovedThenDeniedCase() {
+        String darCode1 = "DAR-" + RandomUtils.nextInt(100, 1000000);
+        Dataset dataset1 = createDARDAOTestDataset();
+        User user1 = createUserWithInstitution();
+        DataAccessRequest testDar1 = createDAR(user1, dataset1, darCode1);
+
+        Election e1 = createDataAccessElection(testDar1.getReferenceId(), dataset1.getDataSetId());
+        Vote v1 = createFinalVote(dataset1.getCreateUserId(), e1.getElectionId());
+        Date now = new Date();
+        voteDAO.updateVote(true,
+                "",
+                now,
+                v1.getVoteId(),
+                false,
+                e1.getElectionId(),
+                now,
+                false);
+
+        Election e2 = createDataAccessElection(testDar1.getReferenceId(), dataset1.getDataSetId());
+        Vote v2 = createFinalVote(dataset1.getCreateUserId(), e2.getElectionId());
+        now = new Date();
+        voteDAO.updateVote(false,
+                "",
+                now,
+                v2.getVoteId(),
+                false,
+                e2.getElectionId(),
+                now,
+                false);
+
+        assertEquals(0, dataAccessRequestDAO.findAllUserIdsWithApprovedDARsByDatasetId(dataset1.getDataSetId()).size());
+    }
+
     // findAllDraftDataAccessRequests should exclude archived DARs
     @Test
     public void testFindAllDraftsArchived() {
@@ -520,7 +559,7 @@ public class DataAccessRequestDAOTest extends DAOTestHelper {
         assertTrue(dars.isEmpty());
 
         String darCode = "DAR-" + RandomUtils.nextInt(100, 1000);
-        Dataset dataset = createDataset();
+        Dataset dataset = createDARDAOTestDataset();
 
         DataAccessRequest testDar = createDAR(user, dataset, darCode);
         dataAccessRequestDAO.archiveByReferenceIds(List.of(testDar.getReferenceId()));
@@ -533,7 +572,7 @@ public class DataAccessRequestDAOTest extends DAOTestHelper {
     @Test
     public void testFindByReferenceIdArchived() {
         String darCode = "DAR-" + RandomUtils.nextInt(100, 1000);
-        Dataset dataset = createDataset();
+        Dataset dataset = createDARDAOTestDataset();
         User user = createUserWithInstitution();
         DataAccessRequest testDar = createDAR(user, dataset, darCode);
         dataAccessRequestDAO.archiveByReferenceIds(List.of(testDar.getReferenceId()));
@@ -546,8 +585,8 @@ public class DataAccessRequestDAOTest extends DAOTestHelper {
     public void testFindByReferenceIdsArchived() {
         String darCode1 = "DAR-" + RandomUtils.nextInt(100, 200);
         String darCode2 = "DAR-" + RandomUtils.nextInt(201, 300);
-        Dataset dataset1 = createDataset();
-        Dataset dataset2 = createDataset();
+        Dataset dataset1 = createDARDAOTestDataset();
+        Dataset dataset2 = createDARDAOTestDataset();
         User user = createUserWithInstitution();
         DataAccessRequest testDar1 = createDAR(user, dataset1, darCode1);
         DataAccessRequest testDar2 = createDAR(user, dataset2, darCode2);
@@ -568,9 +607,9 @@ public class DataAccessRequestDAOTest extends DAOTestHelper {
         String darCode1 = "DAR-" + RandomUtils.nextInt(100, 200);
         String darCode2 = "DAR-" + RandomUtils.nextInt(201, 300);
         String darCode3 = "DAR-" + RandomUtils.nextInt(301, 400);
-        Dataset dataset1 = createDataset();
-        Dataset dataset2 = createDataset();
-        Dataset dataset3 = createDataset();
+        Dataset dataset1 = createDARDAOTestDataset();
+        Dataset dataset2 = createDARDAOTestDataset();
+        Dataset dataset3 = createDARDAOTestDataset();
         DataAccessRequest testDar1 = createDAR(user, dataset1, darCode1);
         DataAccessRequest testDar2 = createDAR(user, dataset2, darCode2);
         DataAccessRequest testDar3 = createDAR(user, dataset3, darCode3);
@@ -591,9 +630,9 @@ public class DataAccessRequestDAOTest extends DAOTestHelper {
         String darCode1 = "DAR-" + RandomUtils.nextInt(100, 200);
         String darCode2 = "DAR-" + RandomUtils.nextInt(201, 300);
         String darCode3 = "DAR-" + RandomUtils.nextInt(301, 400);
-        Dataset dataset1 = createDataset();
-        Dataset dataset2 = createDataset();
-        Dataset dataset3 = createDataset();
+        Dataset dataset1 = createDARDAOTestDataset();
+        Dataset dataset2 = createDARDAOTestDataset();
+        Dataset dataset3 = createDARDAOTestDataset();
         DataAccessRequest testDar1 = createDAR(user, dataset1, darCode1);
         DataAccessRequest testDar2 = createDAR(user, dataset2, darCode2);
         DataAccessRequest testDar3 = createDAR(user, dataset3, darCode3);
@@ -603,4 +642,20 @@ public class DataAccessRequestDAOTest extends DAOTestHelper {
         List returnedDAR = dataAccessRequestDAO.findAllDataAccessRequestsForInstitution(user.getInstitutionId());
         assertEquals(1, returnedDAR.size());
     }
+
+    /**
+     * Override abstract implementation
+     * @return Dataset
+     */
+    private Dataset createDARDAOTestDataset() {
+        User user = createUser();
+        String name = "Name_" + RandomStringUtils.random(20, true, true);
+        Timestamp now = new Timestamp(new Date().getTime());
+        String objectId = "Object ID_" + RandomStringUtils.random(20, true, true);
+        DataUse dataUse = new DataUseBuilder().setGeneralUse(true).build();
+        Integer id = datasetDAO.insertDataset(name, now, user.getUserId(), objectId, false, dataUse.toString(), null);
+        createDatasetProperties(id);
+        return datasetDAO.findDatasetById(id);
+    }
+
 }

--- a/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
@@ -509,6 +509,8 @@ public class DataAccessRequestDAOTest extends DAOTestHelper {
                 now,
                 false);
 
+        assertEquals(1, dataAccessRequestDAO.findAllUserIdsWithApprovedDARsByDatasetId(dataset1.getDataSetId()).size());
+
         Election e2 = createDataAccessElection(testDar1.getReferenceId(), dataset1.getDataSetId());
         Vote v2 = createFinalVote(dataset1.getCreateUserId(), e2.getElectionId());
         now = new Date();

--- a/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
@@ -20,6 +20,7 @@ import org.broadinstitute.consent.http.models.DataAccessRequestData;
 import org.broadinstitute.consent.http.models.DataUse;
 import org.broadinstitute.consent.http.models.DataUseBuilder;
 import org.broadinstitute.consent.http.models.Dataset;
+import org.broadinstitute.consent.http.models.DatasetProperty;
 import org.broadinstitute.consent.http.models.Election;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.Vote;
@@ -336,7 +337,7 @@ public class DataAccessRequestDAOTest extends DAOTestHelper {
         User user = createUserWithInstitution();
         DataAccessRequest testDar = createDAR(user, dataset, darCode);
         dataAccessRequestDAO.archiveByReferenceIds(List.of(testDar.getReferenceId()));
-        List returnedDARs = dataAccessRequestDAO.findAllDataAccessRequests();
+        List<DataAccessRequest> returnedDARs = dataAccessRequestDAO.findAllDataAccessRequests();
         assertTrue(returnedDARs.isEmpty());
     }
 
@@ -353,9 +354,9 @@ public class DataAccessRequestDAOTest extends DAOTestHelper {
         Dataset dataset2 = createDARDAOTestDataset();
 
         DataAccessRequest testDar1 = createDAR(user, dataset1, darCode1);
-        DataAccessRequest testDar2 = createDAR(user, dataset2, darCode2);
+        createDAR(user, dataset2, darCode2);
         dataAccessRequestDAO.archiveByReferenceIds(List.of(testDar1.getReferenceId()));
-        List returnedDARs = dataAccessRequestDAO.findAllDataAccessRequests();
+        List<DataAccessRequest> returnedDARs = dataAccessRequestDAO.findAllDataAccessRequests();
         assertEquals(1, returnedDARs.size());
     }
 
@@ -371,7 +372,7 @@ public class DataAccessRequestDAOTest extends DAOTestHelper {
         User user = createUserWithInstitution();
         DataAccessRequest testDar = createDAR(user, dataset, darCode);
         dataAccessRequestDAO.archiveByReferenceIds(List.of(testDar.getReferenceId()));
-        List returnedDARs = dataAccessRequestDAO.findAllApprovedDataAccessRequestsByDatasetId(dataset.getDataSetId());
+        List<DataAccessRequest> returnedDARs = dataAccessRequestDAO.findAllApprovedDataAccessRequestsByDatasetId(dataset.getDataSetId());
         assertTrue(returnedDARs.isEmpty());
     }
 
@@ -532,7 +533,7 @@ public class DataAccessRequestDAOTest extends DAOTestHelper {
         User user = createUserWithInstitution();
         DataAccessRequest testDar = createDraftDAR(user);
         dataAccessRequestDAO.archiveByReferenceIds(List.of(testDar.getReferenceId()));
-        List returnedDARs = dataAccessRequestDAO.findAllDraftDataAccessRequests();
+        List<DataAccessRequest> returnedDARs = dataAccessRequestDAO.findAllDraftDataAccessRequests();
         assertTrue(returnedDARs.isEmpty());
     }
 
@@ -563,7 +564,7 @@ public class DataAccessRequestDAOTest extends DAOTestHelper {
 
         DataAccessRequest testDar = createDAR(user, dataset, darCode);
         dataAccessRequestDAO.archiveByReferenceIds(List.of(testDar.getReferenceId()));
-        List returnedDARs = dataAccessRequestDAO.findAllDarsByUserId(user.getUserId());
+        List<DataAccessRequest> returnedDARs = dataAccessRequestDAO.findAllDarsByUserId(user.getUserId());
         assertTrue(returnedDARs.isEmpty());
     }
 
@@ -593,7 +594,7 @@ public class DataAccessRequestDAOTest extends DAOTestHelper {
 
         dataAccessRequestDAO.archiveByReferenceIds(List.of(testDar1.getReferenceId()));
         dataAccessRequestDAO.archiveByReferenceIds(List.of(testDar2.getReferenceId()));
-        List returnedDAR = dataAccessRequestDAO.findByReferenceIds(List.of(testDar1.getReferenceId(), testDar2.getReferenceId()));
+        List<DataAccessRequest> returnedDAR = dataAccessRequestDAO.findByReferenceIds(List.of(testDar1.getReferenceId(), testDar2.getReferenceId()));
         assertTrue(returnedDAR.isEmpty());
     }
 
@@ -616,7 +617,7 @@ public class DataAccessRequestDAOTest extends DAOTestHelper {
 
         dataAccessRequestDAO.archiveByReferenceIds(List.of(testDar1.getReferenceId()));
         dataAccessRequestDAO.archiveByReferenceIds(List.of(testDar2.getReferenceId()));
-        List returnedDAR = dataAccessRequestDAO.findByReferenceIds(List.of(testDar1.getReferenceId(), testDar2.getReferenceId(), testDar3.getReferenceId()));
+        List<DataAccessRequest> returnedDAR = dataAccessRequestDAO.findByReferenceIds(List.of(testDar1.getReferenceId(), testDar2.getReferenceId(), testDar3.getReferenceId()));
         assertEquals(1, returnedDAR.size());
     }
 
@@ -635,16 +636,16 @@ public class DataAccessRequestDAOTest extends DAOTestHelper {
         Dataset dataset3 = createDARDAOTestDataset();
         DataAccessRequest testDar1 = createDAR(user, dataset1, darCode1);
         DataAccessRequest testDar2 = createDAR(user, dataset2, darCode2);
-        DataAccessRequest testDar3 = createDAR(user, dataset3, darCode3);
+        createDAR(user, dataset3, darCode3);
 
         dataAccessRequestDAO.archiveByReferenceIds(List.of(testDar1.getReferenceId()));
         dataAccessRequestDAO.archiveByReferenceIds(List.of(testDar2.getReferenceId()));
-        List returnedDAR = dataAccessRequestDAO.findAllDataAccessRequestsForInstitution(user.getInstitutionId());
+        List<DataAccessRequest> returnedDAR = dataAccessRequestDAO.findAllDataAccessRequestsForInstitution(user.getInstitutionId());
         assertEquals(1, returnedDAR.size());
     }
 
     /**
-     * Override abstract implementation
+     * Replace parent implementation of `createDataset()`
      * @return Dataset
      */
     private Dataset createDARDAOTestDataset() {
@@ -654,7 +655,14 @@ public class DataAccessRequestDAOTest extends DAOTestHelper {
         String objectId = "Object ID_" + RandomStringUtils.random(20, true, true);
         DataUse dataUse = new DataUseBuilder().setGeneralUse(true).build();
         Integer id = datasetDAO.insertDataset(name, now, user.getUserId(), objectId, false, dataUse.toString(), null);
-        createDatasetProperties(id);
+        List<DatasetProperty> list = new ArrayList<>();
+        DatasetProperty dsp = new DatasetProperty();
+        dsp.setDataSetId(id);
+        dsp.setPropertyKey(1);
+        dsp.setPropertyValue("Test_PropertyValue");
+        dsp.setCreateDate(new Date());
+        list.add(dsp);
+        datasetDAO.insertDatasetProperties(list);
         return datasetDAO.findDatasetById(id);
     }
 


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-2391

This PR updates the query for approved dataset users to look for the **_last_** final `true` vote for a specific dar+dataset election to check if the user is approved or not. Previously, we were looking for **_any_** approved election and would return a user id for the case where the user was first approved, then denied access in a subsequent election.

One edge case this PR does not cover, and is not intended to cover, is the case where a user has requested access to a dataset in more than one data access request. If the user is approved for one DAR, but denied for the other DAR, we still list that user as an approved user since they do, in fact, have an approved DAR against that dataset. To revoke that user's access, ALL DARs would need to be revoked.

### Testing
To test, create and approve (as a DAC Chair) a DAR against a dataset. Then re-open that election and vote "No" so as to deny that user access. Look at the approved user list (`GET` `/api/tdr/{identifier}/approved/users`) for the dataset in question. Before voting "No", your researcher user should show up as an approved user for the dataset. After voting "No", that user should NOT be visible in the approved user list. You can again re-open that DAR, approve it as a Chair, and then the user should now be visible again in the approved users list.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
