### PR TITLE
[DUOS-2446][risk=no] Add Study/StudyProperty Tables

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
@@ -7,7 +7,6 @@ import io.dropwizard.Configuration;
 import io.dropwizard.client.JerseyClientBuilder;
 import io.dropwizard.jdbi3.JdbiFactory;
 import io.dropwizard.setup.Environment;
-import javax.ws.rs.client.Client;
 import org.broadinstitute.consent.http.authentication.OAuthAuthenticator;
 import org.broadinstitute.consent.http.cloudstore.GCSService;
 import org.broadinstitute.consent.http.cloudstore.GCSStore;
@@ -30,6 +29,7 @@ import org.broadinstitute.consent.http.db.LibraryCardDAO;
 import org.broadinstitute.consent.http.db.MailMessageDAO;
 import org.broadinstitute.consent.http.db.MatchDAO;
 import org.broadinstitute.consent.http.db.SamDAO;
+import org.broadinstitute.consent.http.db.StudyDAO;
 import org.broadinstitute.consent.http.db.UserDAO;
 import org.broadinstitute.consent.http.db.UserPropertyDAO;
 import org.broadinstitute.consent.http.db.UserRoleDAO;
@@ -74,6 +74,8 @@ import org.jdbi.v3.gson2.Gson2Plugin;
 import org.jdbi.v3.guava.GuavaPlugin;
 import org.jdbi.v3.sqlobject.SqlObjectPlugin;
 
+import javax.ws.rs.client.Client;
+
 public class ConsentModule extends AbstractModule {
 
     @Inject
@@ -87,6 +89,7 @@ public class ConsentModule extends AbstractModule {
     private final CounterDAO counterDAO;
     private final ElectionDAO electionDAO;
     private final VoteDAO voteDAO;
+    private final StudyDAO studyDAO;
     private final DatasetDAO datasetDAO;
     private final DatasetAssociationDAO datasetAssociationDAO;
     private final DacDAO dacDAO;
@@ -123,6 +126,7 @@ public class ConsentModule extends AbstractModule {
         this.counterDAO = this.jdbi.onDemand(CounterDAO.class);
         this.electionDAO = this.jdbi.onDemand(ElectionDAO.class);
         this.voteDAO = this.jdbi.onDemand(VoteDAO.class);
+        this.studyDAO = this.jdbi.onDemand(StudyDAO.class);
         this.datasetDAO = this.jdbi.onDemand(DatasetDAO.class);
         this.datasetAssociationDAO = this.jdbi.onDemand(DatasetAssociationDAO.class);
         this.dacDAO = this.jdbi.onDemand(DacDAO.class);
@@ -166,6 +170,7 @@ public class ConsentModule extends AbstractModule {
         container.setUserDAO(providesUserDAO());
         container.setUserRoleDAO(providesUserRoleDAO());
         container.setVoteDAO(providesVoteDAO());
+        container.setStudyDAO(providesStudyDAO());
         container.setInstitutionDAO(providesInstitutionDAO());
         container.setFileStorageObjectDAO(providesFileStorageObjectDAO());
         container.setAcknowledgementDAO(providesAcknowledgementDAO());
@@ -375,6 +380,11 @@ public class ConsentModule extends AbstractModule {
     @Provides
     VoteDAO providesVoteDAO() {
         return voteDAO;
+    }
+
+    @Provides
+    StudyDAO providesStudyDAO() {
+        return studyDAO;
     }
 
     @Provides

--- a/src/main/java/org/broadinstitute/consent/http/db/DAOContainer.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DAOContainer.java
@@ -22,6 +22,7 @@ public class DAOContainer {
   private UserDAO userDAO;
   private UserRoleDAO userRoleDAO;
   private VoteDAO voteDAO;
+  private StudyDAO studyDAO;
   private ConsentAuditDAO consentAuditDAO;
   private InstitutionDAO institutionDAO;
   private FileStorageObjectDAO fileStorageObjectDAO;
@@ -151,6 +152,14 @@ public class DAOContainer {
 
   public void setVoteDAO(VoteDAO voteDAO) {
     this.voteDAO = voteDAO;
+  }
+
+  public StudyDAO getStudyDAO() {
+    return studyDAO;
+  }
+
+  public void setStudyDAO(StudyDAO studyDAO) {
+    this.studyDAO = studyDAO;
   }
 
   public ConsentAuditDAO getConsentAuditDAO() {

--- a/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
@@ -74,11 +74,22 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
             k.key, dp.property_value, dp.property_key, dp.property_type, dp.schema_property, dp.property_id,
             ca.consent_id, c.translated_use_restriction,
             fso.file_storage_object_id AS fso_file_storage_object_id,
-            s.study_id AS s_study_id, s.name AS s_name,
-            s.description AS s_description, s.data_types AS s_data_types,
-            s.pi_name AS s_pi_name, s.public_visibility AS s_public_visibility,
-            sp.study_property_id AS sp_study_property_id, sp.key AS sp_key,
-            sp.type AS sp_type, sp.value AS sp_value,
+            s.study_id AS s_study_id,
+            s.name AS s_name,
+            s.description AS s_description,
+            s.data_types AS s_data_types,
+            s.pi_name AS s_pi_name,
+            s.create_user_id AS s_create_user_id,
+            s.create_date AS s_create_date,
+            s.update_user_id AS s_user_id,
+            s.update_date AS s_update_date,
+            s.public_visibility AS s_public_visibility,
+            s_dataset.dataset_id AS s_dataset_id,
+            sp.study_property_id AS sp_study_property_id,
+            sp.study_id AS sp_study_id,
+            sp.key AS sp_key,
+            sp.value AS sp_value,
+            sp.type AS sp_type,
             fso.entity_id AS fso_entity_id,
             fso.file_name AS fso_file_name,
             fso.category AS fso_category,
@@ -96,10 +107,11 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
         LEFT JOIN dataset_property dp ON dp.dataset_id = d.dataset_id
         LEFT JOIN dictionary k ON k.key_id = dp.property_key
         LEFT JOIN consent_associations ca ON ca.dataset_id = d.dataset_id
-        LEFT JOIN file_storage_object fso ON fso.entity_id = d.dataset_id::text AND fso.deleted = false
-        LEFT JOIN consents c ON c.consent_id = ca.consent_id
         LEFT JOIN study s ON s.study_id = d.study_id
         LEFT JOIN study_property sp ON sp.study_id = s.study_id
+        LEFT JOIN dataset s_dataset ON s_dataset.study_id = s.study_id
+        LEFT JOIN file_storage_object fso ON (fso.entity_id = d.dataset_id::text OR fso.entity_id = s.uuid::text) AND fso.deleted = false
+        LEFT JOIN consents c ON c.consent_id = ca.consent_id
         WHERE d.dataset_id = :datasetId
     """)
     Dataset findDatasetById(@Bind("datasetId") Integer datasetId);
@@ -114,6 +126,22 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
             u.institution_id AS u_institution_id, u.era_commons_id AS u_era_commons_id,
             k.key, dp.property_value, dp.property_key, dp.property_type, dp.schema_property, dp.property_id,
             ca.consent_id, c.translated_use_restriction,
+            s.study_id AS s_study_id,
+            s.name AS s_name,
+            s.description AS s_description,
+            s.data_types AS s_data_types,
+            s.pi_name AS s_pi_name,
+            s.create_user_id AS s_create_user_id,
+            s.create_date AS s_create_date,
+            s.update_user_id AS s_user_id,
+            s.update_date AS s_update_date,
+            s.public_visibility AS s_public_visibility,
+            s_dataset.dataset_id AS s_dataset_id,
+            sp.study_property_id AS sp_study_property_id,
+            sp.study_id AS sp_study_id,
+            sp.key AS sp_key,
+            sp.value AS sp_value,
+            sp.type AS sp_type,
             fso.file_storage_object_id AS fso_file_storage_object_id,
             fso.entity_id AS fso_entity_id,
             fso.file_name AS fso_file_name,
@@ -132,6 +160,9 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
         LEFT JOIN dataset_property dp ON dp.dataset_id = d.dataset_id
         LEFT JOIN dictionary k ON k.key_id = dp.property_key
         LEFT JOIN consent_associations ca ON ca.dataset_id = d.dataset_id
+        LEFT JOIN study s ON s.study_id = d.study_id
+        LEFT JOIN study_property sp ON sp.study_id = s.study_id
+        LEFT JOIN dataset s_dataset ON s_dataset.study_id = s.study_id
         LEFT JOIN file_storage_object fso ON fso.entity_id = d.dataset_id::text AND fso.deleted = false
         LEFT JOIN consents c ON c.consent_id = ca.consent_id
         WHERE d.dataset_id in (<datasetIds>)
@@ -148,6 +179,22 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
             u.institution_id AS u_institution_id, u.era_commons_id AS u_era_commons_id,
             k.key, dp.property_value, dp.property_key, dp.property_type, dp.schema_property, dp.property_id,
             ca.consent_id, c.translated_use_restriction,
+            s.study_id AS s_study_id,
+            s.name AS s_name,
+            s.description AS s_description,
+            s.data_types AS s_data_types,
+            s.pi_name AS s_pi_name,
+            s.create_user_id AS s_create_user_id,
+            s.create_date AS s_create_date,
+            s.update_user_id AS s_user_id,
+            s.update_date AS s_update_date,
+            s.public_visibility AS s_public_visibility,
+            s_dataset.dataset_id AS s_dataset_id,
+            sp.study_property_id AS sp_study_property_id,
+            sp.study_id AS sp_study_id,
+            sp.key AS sp_key,
+            sp.value AS sp_value,
+            sp.type AS sp_type,
             fso.file_storage_object_id AS fso_file_storage_object_id,
             fso.entity_id AS fso_entity_id,
             fso.file_name AS fso_file_name,
@@ -166,7 +213,10 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
         LEFT JOIN dataset_property dp ON dp.dataset_id = d.dataset_id
         LEFT JOIN dictionary k ON k.key_id = dp.property_key
         LEFT JOIN consent_associations ca ON ca.dataset_id = d.dataset_id
-        LEFT JOIN file_storage_object fso ON fso.entity_id = d.dataset_id::text AND fso.deleted = false
+        LEFT JOIN study s ON s.study_id = d.study_id
+        LEFT JOIN study_property sp ON sp.study_id = s.study_id
+        LEFT JOIN dataset s_dataset ON s_dataset.study_id = s.study_id
+        LEFT JOIN file_storage_object fso ON (fso.entity_id = d.dataset_id::text OR fso.entity_id = s.uuid::text) AND fso.deleted = false
         LEFT JOIN consents c ON c.consent_id = ca.consent_id
     """)
     List<Dataset> findAllDatasets();
@@ -189,6 +239,22 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
             u.institution_id AS u_institution_id, u.era_commons_id AS u_era_commons_id,
             k.key, dp.property_value, dp.property_key, dp.property_type, dp.schema_property, dp.property_id,
             ca.consent_id, c.translated_use_restriction,
+            s.study_id AS s_study_id,
+            s.name AS s_name,
+            s.description AS s_description,
+            s.data_types AS s_data_types,
+            s.pi_name AS s_pi_name,
+            s.create_user_id AS s_create_user_id,
+            s.create_date AS s_create_date,
+            s.update_user_id AS s_user_id,
+            s.update_date AS s_update_date,
+            s.public_visibility AS s_public_visibility,
+            s_dataset.dataset_id AS s_dataset_id,
+            sp.study_property_id AS sp_study_property_id,
+            sp.study_id AS sp_study_id,
+            sp.key AS sp_key,
+            sp.value AS sp_value,
+            sp.type AS sp_type,
             fso.file_storage_object_id AS fso_file_storage_object_id,
             fso.entity_id AS fso_entity_id,
             fso.file_name AS fso_file_name,
@@ -207,7 +273,10 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
         LEFT JOIN dataset_property dp ON dp.dataset_id = d.dataset_id
         LEFT JOIN dictionary k ON k.key_id = dp.property_key
         LEFT JOIN consent_associations ca ON ca.dataset_id = d.dataset_id
-        LEFT JOIN file_storage_object fso ON fso.entity_id = d.dataset_id::text AND fso.deleted = false
+        LEFT JOIN study s ON s.study_id = d.study_id
+        LEFT JOIN study_property sp ON sp.study_id = s.study_id
+        LEFT JOIN dataset s_dataset ON s_dataset.study_id = s.study_id
+        LEFT JOIN file_storage_object fso ON (fso.entity_id = d.dataset_id::text OR fso.entity_id = s.uuid::text) AND fso.deleted = false
         LEFT JOIN consents c ON c.consent_id = ca.consent_id
         INNER JOIN user_role dac_role ON dac_role.dac_id = d.dac_id
         INNER JOIN users dac_user ON dac_role.user_id = dac_user.user_id AND dac_user.email = :email
@@ -231,6 +300,22 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
             u.institution_id AS u_institution_id, u.era_commons_id AS u_era_commons_id,
             k.key, dp.property_value, dp.property_key, dp.property_type, dp.schema_property, dp.property_id,
             ca.consent_id, c.translated_use_restriction,
+            s.study_id AS s_study_id,
+            s.name AS s_name,
+            s.description AS s_description,
+            s.data_types AS s_data_types,
+            s.pi_name AS s_pi_name,
+            s.create_user_id AS s_create_user_id,
+            s.create_date AS s_create_date,
+            s.update_user_id AS s_user_id,
+            s.update_date AS s_update_date,
+            s.public_visibility AS s_public_visibility,
+            s_dataset.dataset_id AS s_dataset_id,
+            sp.study_property_id AS sp_study_property_id,
+            sp.study_id AS sp_study_id,
+            sp.key AS sp_key,
+            sp.value AS sp_value,
+            sp.type AS sp_type,
             fso.file_storage_object_id AS fso_file_storage_object_id,
             fso.entity_id AS fso_entity_id,
             fso.file_name AS fso_file_name,
@@ -249,7 +334,10 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
         LEFT JOIN dataset_property dp ON dp.dataset_id = d.dataset_id
         LEFT JOIN dictionary k ON k.key_id = dp.property_key
         LEFT JOIN consent_associations ca ON ca.dataset_id = d.dataset_id
-        LEFT JOIN file_storage_object fso ON fso.entity_id = d.dataset_id::text AND fso.deleted = false
+        LEFT JOIN study s ON s.study_id = d.study_id
+        LEFT JOIN study_property sp ON sp.study_id = s.study_id
+        LEFT JOIN dataset s_dataset ON s_dataset.study_id = s.study_id
+        LEFT JOIN file_storage_object fso ON (fso.entity_id = d.dataset_id::text OR fso.entity_id = s.uuid::text) AND fso.deleted = false
         LEFT JOIN consents c ON c.consent_id = ca.consent_id
         WHERE d.dac_id = :dacId
         OR (dp.schema_property = 'dataAccessCommitteeId' AND dp.property_value = :dacId::text)
@@ -266,6 +354,22 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
             u.institution_id AS u_institution_id, u.era_commons_id AS u_era_commons_id,
             k.key, dp.property_value, dp.property_key, dp.property_type, dp.schema_property, dp.property_id,
             ca.consent_id, c.translated_use_restriction,
+            s.study_id AS s_study_id,
+            s.name AS s_name,
+            s.description AS s_description,
+            s.data_types AS s_data_types,
+            s.pi_name AS s_pi_name,
+            s.create_user_id AS s_create_user_id,
+            s.create_date AS s_create_date,
+            s.update_user_id AS s_user_id,
+            s.update_date AS s_update_date,
+            s.public_visibility AS s_public_visibility,
+            s_dataset.dataset_id AS s_dataset_id,
+            sp.study_property_id AS sp_study_property_id,
+            sp.study_id AS sp_study_id,
+            sp.key AS sp_key,
+            sp.value AS sp_value,
+            sp.type AS sp_type,
             fso.file_storage_object_id AS fso_file_storage_object_id,
             fso.entity_id AS fso_entity_id,
             fso.file_name AS fso_file_name,
@@ -284,7 +388,10 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
         LEFT JOIN dataset_property dp ON dp.dataset_id = d.dataset_id
         LEFT JOIN dictionary k ON k.key_id = dp.property_key
         LEFT JOIN consent_associations ca ON ca.dataset_id = d.dataset_id
-        LEFT JOIN file_storage_object fso ON fso.entity_id = d.dataset_id::text AND fso.deleted = false
+        LEFT JOIN study s ON s.study_id = d.study_id
+        LEFT JOIN study_property sp ON sp.study_id = s.study_id
+        LEFT JOIN dataset s_dataset ON s_dataset.study_id = s.study_id
+        LEFT JOIN file_storage_object fso ON (fso.entity_id = d.dataset_id::text OR fso.entity_id = s.uuid::text) AND fso.deleted = false
         LEFT JOIN consents c ON c.consent_id = ca.consent_id
         WHERE d.name IS NOT NULL AND d.active = true
     """)
@@ -308,6 +415,22 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
             u.institution_id AS u_institution_id, u.era_commons_id AS u_era_commons_id,
             k.key, dp.property_value, dp.property_key, dp.property_type, dp.schema_property, dp.property_id,
             ca.consent_id, c.translated_use_restriction,
+            s.study_id AS s_study_id,
+            s.name AS s_name,
+            s.description AS s_description,
+            s.data_types AS s_data_types,
+            s.pi_name AS s_pi_name,
+            s.create_user_id AS s_create_user_id,
+            s.create_date AS s_create_date,
+            s.update_user_id AS s_user_id,
+            s.update_date AS s_update_date,
+            s.public_visibility AS s_public_visibility,
+            s_dataset.dataset_id AS s_dataset_id,
+            sp.study_property_id AS sp_study_property_id,
+            sp.study_id AS sp_study_id,
+            sp.key AS sp_key,
+            sp.value AS sp_value,
+            sp.type AS sp_type,
             fso.file_storage_object_id AS fso_file_storage_object_id,
             fso.entity_id AS fso_entity_id,
             fso.file_name AS fso_file_name,
@@ -326,7 +449,10 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
         LEFT JOIN dataset_property dp ON dp.dataset_id = d.dataset_id
         LEFT JOIN dictionary k ON k.key_id = dp.property_key
         LEFT JOIN consent_associations ca ON ca.dataset_id = d.dataset_id
-        LEFT JOIN file_storage_object fso ON fso.entity_id = d.dataset_id::text AND fso.deleted = false
+        LEFT JOIN study s ON s.study_id = d.study_id
+        LEFT JOIN study_property sp ON sp.study_id = s.study_id
+        LEFT JOIN dataset s_dataset ON s_dataset.study_id = s.study_id
+        LEFT JOIN file_storage_object fso ON (fso.entity_id = d.dataset_id::text OR fso.entity_id = s.uuid::text) AND fso.deleted = false
         LEFT JOIN consents c ON c.consent_id = ca.consent_id
         WHERE d.alias = :alias
     """)
@@ -334,16 +460,39 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
 
     @UseRowReducer(DatasetReducer.class)
     @SqlQuery(
-            "SELECT d.*, k.key, dp.property_value, dp.property_key, dp.property_id, ca.consent_id, d.dac_id, c.translated_use_restriction, dar_ds_ids.id as in_use, " +
-                    FileStorageObject.QUERY_FIELDS_WITH_FSO_PREFIX +
-                    " FROM dataset d " +
-                    " LEFT JOIN (SELECT DISTINCT dataset_id AS id FROM dar_dataset) dar_ds_ids ON dar_ds_ids.id = d.dataset_id " +
-                    " LEFT JOIN dataset_property dp ON dp.dataset_id = d.dataset_id " +
-                    " LEFT JOIN dictionary k ON k.key_id = dp.property_key " +
-                    " LEFT JOIN consent_associations ca ON ca.dataset_id = d.dataset_id " +
-                    " LEFT JOIN file_storage_object fso ON fso.entity_id = d.dataset_id::text AND fso.deleted = false " +
-                    " LEFT JOIN consents c ON c.consent_id = ca.consent_id " +
-                    " WHERE d.alias IN (<aliases>)")
+            """
+                    SELECT d.*, k.key, dp.property_value, dp.property_key, dp.property_id, ca.consent_id, d.dac_id, c.translated_use_restriction, dar_ds_ids.id as in_use,
+                        s.study_id AS s_study_id,
+                        s.name AS s_name,
+                        s.description AS s_description,
+                        s.data_types AS s_data_types,
+                        s.pi_name AS s_pi_name,
+                        s.create_user_id AS s_create_user_id,
+                        s.create_date AS s_create_date,
+                        s.update_user_id AS s_user_id,
+                        s.update_date AS s_update_date,
+                        s.public_visibility AS s_public_visibility,
+                        s_dataset.dataset_id AS s_dataset_id,
+                        sp.study_property_id AS sp_study_property_id,
+                        sp.study_id AS sp_study_id,
+                        sp.key AS sp_key,
+                        sp.value AS sp_value,
+                        sp.type AS sp_type,
+                    """
+                    + FileStorageObject.QUERY_FIELDS_WITH_FSO_PREFIX + " " +
+                    """
+                        FROM dataset d
+                        LEFT JOIN (SELECT DISTINCT dataset_id AS id FROM dar_dataset) dar_ds_ids ON dar_ds_ids.id = d.dataset_id
+                        LEFT JOIN dataset_property dp ON dp.dataset_id = d.dataset_id
+                        LEFT JOIN dictionary k ON k.key_id = dp.property_key
+                        LEFT JOIN consent_associations ca ON ca.dataset_id = d.dataset_id
+                        LEFT JOIN study s ON s.study_id = d.study_id
+                        LEFT JOIN study_property sp ON sp.study_id = s.study_id
+                        LEFT JOIN dataset s_dataset ON s_dataset.study_id = s.study_id
+                        LEFT JOIN file_storage_object fso ON (fso.entity_id = d.dataset_id::text OR fso.entity_id = s.uuid::text) AND fso.deleted = false
+                        LEFT JOIN consents c ON c.consent_id = ca.consent_id
+                        WHERE d.alias IN (<aliases>)
+                   """ )
     List<Dataset> findDatasetsByAlias(@BindList("aliases") List<Integer> aliases);
 
     @Deprecated
@@ -380,6 +529,15 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
             + "WHERE dataset_id = :datasetId "
                 + "AND property_key = :propertyKey")
     void updateDatasetProperty(@Bind("datasetId") Integer datasetId, @Bind("propertyKey") Integer propertyKey, @Bind("propertyValue") String propertyValue);
+
+    @SqlUpdate(
+        """
+        UPDATE dataset
+        SET study_id = :studyId
+        WHERE dataset_id = :datasetId
+        """
+    )
+    void updateStudyId(@Bind("datasetId") Integer datasetId, @Bind("studyId") Integer studyId);
 
     @SqlUpdate(
         "DELETE from dataset_property "
@@ -424,17 +582,40 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
 
     @UseRowReducer(DatasetReducer.class)
     @SqlQuery(
-        "SELECT d.*, k.key, dp.property_value, dp.property_key, dp.property_type, dp.schema_property, dp.property_id, ca.consent_id, d.dac_id, c.translated_use_restriction, dar_ds_ids.id as in_use, " +
-            FileStorageObject.QUERY_FIELDS_WITH_FSO_PREFIX +
-            " FROM dataset d " +
-            " LEFT JOIN (SELECT DISTINCT dataset_id AS id FROM dar_dataset) dar_ds_ids ON dar_ds_ids.id = d.dataset_id " +
-            " LEFT JOIN dataset_property dp ON dp.dataset_id = d.dataset_id " +
-            " LEFT JOIN dictionary k ON k.key_id = dp.property_key " +
-            " LEFT JOIN consent_associations ca ON ca.dataset_id = d.dataset_id " +
-            " LEFT JOIN file_storage_object fso ON fso.entity_id = d.dataset_id::text AND fso.deleted = false " +
-            " LEFT JOIN consents c ON c.consent_id = ca.consent_id " +
-            " WHERE d.dataset_id IN (<datasetIds>)" +
-            " ORDER BY d.dataset_id, k.display_order")
+        """
+        SELECT d.*, k.key, dp.property_value, dp.property_key, dp.property_type, dp.schema_property, dp.property_id, ca.consent_id, d.dac_id, c.translated_use_restriction, dar_ds_ids.id as in_use,
+            s.study_id AS s_study_id,
+            s.name AS s_name,
+            s.description AS s_description,
+            s.data_types AS s_data_types,
+            s.pi_name AS s_pi_name,
+            s.create_user_id AS s_create_user_id,
+            s.create_date AS s_create_date,
+            s.update_user_id AS s_user_id,
+            s.update_date AS s_update_date,
+            s.public_visibility AS s_public_visibility,
+            s_dataset.dataset_id AS s_dataset_id,
+            sp.study_property_id AS sp_study_property_id,
+            sp.study_id AS sp_study_id,
+            sp.key AS sp_key,
+            sp.value AS sp_value,
+            sp.type AS sp_type,
+        """
+        + FileStorageObject.QUERY_FIELDS_WITH_FSO_PREFIX + " "  +
+        """
+            FROM dataset d
+            LEFT JOIN (SELECT DISTINCT dataset_id AS id FROM dar_dataset) dar_ds_ids ON dar_ds_ids.id = d.dataset_id
+            LEFT JOIN dataset_property dp ON dp.dataset_id = d.dataset_id
+            LEFT JOIN dictionary k ON k.key_id = dp.property_key
+            LEFT JOIN consent_associations ca ON ca.dataset_id = d.dataset_id
+            LEFT JOIN study s ON s.study_id = d.study_id
+            LEFT JOIN study_property sp ON sp.study_id = s.study_id
+            LEFT JOIN dataset s_dataset ON s_dataset.study_id = s.study_id
+            LEFT JOIN file_storage_object fso ON (fso.entity_id = d.dataset_id::text OR fso.entity_id = s.uuid::text) AND fso.deleted = false
+            LEFT JOIN consents c ON c.consent_id = ca.consent_id
+            WHERE d.dataset_id IN (<datasetIds>)
+            ORDER BY d.dataset_id, k.display_order
+        """)
     Set<Dataset> findDatasetWithDataUseByIdList(@BindList("datasetIds") List<Integer> datasetIds);
 
     @Deprecated

--- a/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
@@ -13,6 +13,7 @@ import org.broadinstitute.consent.http.models.DatasetAudit;
 import org.broadinstitute.consent.http.models.DatasetProperty;
 import org.broadinstitute.consent.http.models.Dictionary;
 import org.broadinstitute.consent.http.models.FileStorageObject;
+import org.broadinstitute.consent.http.models.Study;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.dto.DatasetDTO;
 import org.broadinstitute.consent.http.resources.Resource;
@@ -37,6 +38,7 @@ import java.util.List;
 import java.util.Set;
 
 @RegisterBeanMapper(value = User.class, prefix = "u")
+@RegisterBeanMapper(value = Study.class, prefix = "s")
 @RegisterRowMapper(DatasetMapper.class)
 @RegisterRowMapper(FileStorageObjectMapperWithFSOPrefix.class)
 public interface DatasetDAO extends Transactional<DatasetDAO> {
@@ -72,6 +74,11 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
             k.key, dp.property_value, dp.property_key, dp.property_type, dp.schema_property, dp.property_id,
             ca.consent_id, c.translated_use_restriction,
             fso.file_storage_object_id AS fso_file_storage_object_id,
+            s.study_id AS s_study_id, s.name AS s_name,
+            s.description AS s_description, s.data_types AS s_data_types,
+            s.pi_name AS s_pi_name, s.public_visibility AS s_public_visibility,
+            sp.study_property_id AS sp_study_property_id, sp.key AS sp_key,
+            sp.type AS sp_type, sp.value AS sp_value,
             fso.entity_id AS fso_entity_id,
             fso.file_name AS fso_file_name,
             fso.category AS fso_category,
@@ -91,6 +98,8 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
         LEFT JOIN consent_associations ca ON ca.dataset_id = d.dataset_id
         LEFT JOIN file_storage_object fso ON fso.entity_id = d.dataset_id::text AND fso.deleted = false
         LEFT JOIN consents c ON c.consent_id = ca.consent_id
+        LEFT JOIN study s ON s.study_id = d.study_id
+        LEFT JOIN study_property sp ON sp.study_id = s.study_id
         WHERE d.dataset_id = :datasetId
     """)
     Dataset findDatasetById(@Bind("datasetId") Integer datasetId);

--- a/src/main/java/org/broadinstitute/consent/http/db/StudyDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/StudyDAO.java
@@ -1,8 +1,11 @@
 package org.broadinstitute.consent.http.db;
 
+import org.broadinstitute.consent.http.db.mapper.FileStorageObjectMapperWithFSOPrefix;
 import org.broadinstitute.consent.http.db.mapper.StudyReducer;
+import org.broadinstitute.consent.http.models.FileStorageObject;
 import org.broadinstitute.consent.http.models.Study;
 import org.jdbi.v3.sqlobject.config.RegisterBeanMapper;
+import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
 import org.jdbi.v3.sqlobject.customizer.Bind;
 import org.jdbi.v3.sqlobject.statement.GetGeneratedKeys;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
@@ -10,9 +13,12 @@ import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 import org.jdbi.v3.sqlobject.statement.UseRowReducer;
 import org.jdbi.v3.sqlobject.transaction.Transactional;
 
+import java.time.Instant;
 import java.util.List;
+import java.util.UUID;
 
 @RegisterBeanMapper(Study.class)
+@RegisterRowMapper(FileStorageObjectMapperWithFSOPrefix.class)
 public interface StudyDAO extends Transactional<StudyDAO> {
 
 
@@ -21,36 +27,49 @@ public interface StudyDAO extends Transactional<StudyDAO> {
         SELECT
             s.*,
             sp.study_property_id AS sp_study_property_id,
+            sp.study_id AS sp_study_id,
             sp.key AS sp_key,
             sp.value AS sp_value,
             sp.type AS sp_type,
-            
+            d.dataset_id AS s_dataset_id,
+        """
+        + FileStorageObject.QUERY_FIELDS_WITH_FSO_PREFIX + " " +
+        """
         FROM
             study s
-        INNER JOIN study_property sp ON sp.study_id = s.study_id
+        LEFT JOIN study_property sp ON sp.study_id = s.study_id
+        LEFT JOIN file_storage_object fso ON fso.entity_id = s.uuid::text AND fso.deleted = false
+        LEFT JOIN dataset d ON d.study_id = s.study_id
+        WHERE s.study_id = :studyId
     """)
     Study findStudyById(@Bind("studyId") Integer studyId);
 
-    @GetGeneratedKeys
     @SqlUpdate("""
         INSERT INTO study (
             name, description,
-            data_types, pi_name,
-            public_visibility
+            pi_name, data_types,
+            public_visibility,
+            create_user_id, create_date,
+            uuid
         ) VALUES (
             :name, :description,
-            :dataTypes, :piName,
-            :publicVisibility
+            :piName, :dataTypes,
+            :publicVisibility,
+            :createUserId, :createDate,
+            :uuid
         )
     """)
+    @GetGeneratedKeys
     Integer insertStudy(@Bind("name") String name,
                         @Bind("description") String description,
-                        @Bind("dataTypes") List<String> dataTypes,
                         @Bind("piName") String piName,
-                        @Bind("publicVisibility") Boolean publicVisibility);
+                        @Bind("dataTypes") List<String> dataTypes,
+                        @Bind("publicVisibility") Boolean publicVisibility,
+                        @Bind("createUserId") Integer createUserId,
+                        @Bind("createDate") Instant createDate,
+                        @Bind("uuid") UUID uuid);
 
 
-    @GetGeneratedKeys
     @SqlUpdate("""
         INSERT INTO study_property (
             study_id, key,
@@ -60,10 +79,11 @@ public interface StudyDAO extends Transactional<StudyDAO> {
             :type, :value
         )
     """)
+    @GetGeneratedKeys
     Integer insertStudyProperty(
             @Bind("studyId") Integer studyId,
-            @Bind("studyId") String key,
-            @Bind("studyId") String type,
-            @Bind("studyId") String value
+            @Bind("key") String key,
+            @Bind("type") String type,
+            @Bind("value") String value
     );
 }

--- a/src/main/java/org/broadinstitute/consent/http/db/StudyDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/StudyDAO.java
@@ -1,0 +1,69 @@
+package org.broadinstitute.consent.http.db;
+
+import org.broadinstitute.consent.http.db.mapper.StudyReducer;
+import org.broadinstitute.consent.http.models.Study;
+import org.jdbi.v3.sqlobject.config.RegisterBeanMapper;
+import org.jdbi.v3.sqlobject.customizer.Bind;
+import org.jdbi.v3.sqlobject.statement.GetGeneratedKeys;
+import org.jdbi.v3.sqlobject.statement.SqlQuery;
+import org.jdbi.v3.sqlobject.statement.SqlUpdate;
+import org.jdbi.v3.sqlobject.statement.UseRowReducer;
+import org.jdbi.v3.sqlobject.transaction.Transactional;
+
+import java.util.List;
+
+@RegisterBeanMapper(Study.class)
+public interface StudyDAO extends Transactional<StudyDAO> {
+
+
+    @UseRowReducer(StudyReducer.class)
+    @SqlQuery("""
+        SELECT
+            s.*,
+            sp.study_property_id AS sp_study_property_id,
+            sp.key AS sp_key,
+            sp.value AS sp_value,
+            sp.type AS sp_type,
+            
+        FROM
+            study s
+        INNER JOIN study_property sp ON sp.study_id = s.study_id
+    """)
+    Study findStudyById(@Bind("studyId") Integer studyId);
+
+    @GetGeneratedKeys
+    @SqlUpdate("""
+        INSERT INTO study (
+            name, description,
+            data_types, pi_name,
+            public_visibility
+        ) VALUES (
+            :name, :description,
+            :dataTypes, :piName,
+            :publicVisibility
+        )
+    """)
+    Integer insertStudy(@Bind("name") String name,
+                        @Bind("description") String description,
+                        @Bind("dataTypes") List<String> dataTypes,
+                        @Bind("piName") String piName,
+                        @Bind("publicVisibility") Boolean publicVisibility);
+
+
+    @GetGeneratedKeys
+    @SqlUpdate("""
+        INSERT INTO study_property (
+            study_id, key,
+            type, value
+        ) VALUES (
+            :studyId, :key,
+            :type, :value
+        )
+    """)
+    Integer insertStudyProperty(
+            @Bind("studyId") Integer studyId,
+            @Bind("studyId") String key,
+            @Bind("studyId") String type,
+            @Bind("studyId") String value
+    );
+}

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DatasetPropertyMapper.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DatasetPropertyMapper.java
@@ -1,12 +1,12 @@
 package org.broadinstitute.consent.http.db.mapper;
 
-import java.sql.ResultSet;
-import java.sql.SQLException;
-
-import org.broadinstitute.consent.http.enumeration.DatasetPropertyType;
+import org.broadinstitute.consent.http.enumeration.PropertyType;
 import org.broadinstitute.consent.http.models.DatasetProperty;
 import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.core.statement.StatementContext;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
 
 public class DatasetPropertyMapper implements RowMapper<DatasetProperty>, RowMapperHelper {
 
@@ -17,7 +17,7 @@ public class DatasetPropertyMapper implements RowMapper<DatasetProperty>, RowMap
           r.getInt("property_key"),
           r.getString("schema_property"),
           r.getString("property_value"),
-          DatasetPropertyType.parse(r.getString("property_type")),
+          PropertyType.parse(r.getString("property_type")),
           r.getTimestamp("create_date")
       );
       if (hasColumn(r, "key")) {

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DatasetReducer.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DatasetReducer.java
@@ -1,10 +1,11 @@
 package org.broadinstitute.consent.http.db.mapper;
 
-import org.broadinstitute.consent.http.enumeration.DatasetPropertyType;
+import org.broadinstitute.consent.http.enumeration.PropertyType;
 import org.broadinstitute.consent.http.models.DataUse;
 import org.broadinstitute.consent.http.models.Dataset;
 import org.broadinstitute.consent.http.models.DatasetProperty;
 import org.broadinstitute.consent.http.models.FileStorageObject;
+import org.broadinstitute.consent.http.models.Study;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.service.DatasetService;
 import org.jdbi.v3.core.result.LinkedHashMapRowReducer;
@@ -50,9 +51,9 @@ public class DatasetReducer implements LinkedHashMapRowReducer<Integer, Dataset>
         && hasColumn(rowView, "property_value", String.class)) {
       String keyName = rowView.getColumn("key", String.class);
       String propVal = rowView.getColumn("property_value", String.class);
-      DatasetPropertyType propType = DatasetPropertyType.String;
+      PropertyType propType = PropertyType.String;
       if (hasColumn(rowView, "property_type", String.class)) {
-          propType = DatasetPropertyType.parse(rowView.getColumn("property_type", String.class));
+          propType = PropertyType.parse(rowView.getColumn("property_type", String.class));
       }
 
       if (Objects.nonNull(keyName) && Objects.nonNull(propVal)) {
@@ -98,6 +99,12 @@ public class DatasetReducer implements LinkedHashMapRowReducer<Integer, Dataset>
       dataset.setCreateUser(user);
     }
 
+    if (hasColumn(rowView, "s_study_id", Integer.class)) {
+      Study study = rowView.getRow(Study.class);
+      new StudyReducer().reduceStudy(study, rowView);
+      dataset.setStudy(study);
+    }
+
     // The name property doesn't always come through, add it manually:
     Optional<DatasetProperty> nameProp =
       Objects.isNull(dataset.getProperties()) ?
@@ -112,7 +119,7 @@ public class DatasetReducer implements LinkedHashMapRowReducer<Integer, Dataset>
       name.setPropertyName(DatasetService.DATASET_NAME_KEY);
       name.setPropertyValue(dataset.getName());
       name.setDataSetId(dataset.getDataSetId());
-      name.setPropertyType(DatasetPropertyType.String);
+      name.setPropertyType(PropertyType.String);
       dataset.addProperty(name);
     }
     dataset.setDatasetName(dataset.getName());

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DatasetReducer.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DatasetReducer.java
@@ -73,6 +73,13 @@ public class DatasetReducer implements LinkedHashMapRowReducer<Integer, Dataset>
       }
     }
 
+    if (hasColumn(rowView, "s_study_id", Integer.class)) {
+      if (Objects.isNull(dataset.getStudy())) {
+        dataset.setStudy(rowView.getRow(Study.class));
+      }
+      new StudyReducer().reduceStudy(dataset.getStudy(), rowView);
+    }
+
     if (hasColumn(rowView, "fso_file_storage_object_id", Integer.class)
       && Objects.nonNull(rowView.getColumn("fso_file_storage_object_id", Integer.class))
     ) {
@@ -97,12 +104,6 @@ public class DatasetReducer implements LinkedHashMapRowReducer<Integer, Dataset>
     if (hasColumn(rowView, "u_user_id", Integer.class)) {
       User user = rowView.getRow(User.class);
       dataset.setCreateUser(user);
-    }
-
-    if (hasColumn(rowView, "s_study_id", Integer.class)) {
-      Study study = rowView.getRow(Study.class);
-      new StudyReducer().reduceStudy(study, rowView);
-      dataset.setStudy(study);
     }
 
     // The name property doesn't always come through, add it manually:

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/StudyReducer.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/StudyReducer.java
@@ -1,0 +1,70 @@
+package org.broadinstitute.consent.http.db.mapper;
+
+import org.broadinstitute.consent.http.enumeration.PropertyType;
+import org.broadinstitute.consent.http.models.FileStorageObject;
+import org.broadinstitute.consent.http.models.Study;
+import org.broadinstitute.consent.http.models.StudyProperty;
+import org.jdbi.v3.core.result.LinkedHashMapRowReducer;
+import org.jdbi.v3.core.result.RowView;
+
+import java.util.Map;
+import java.util.Objects;
+
+public class StudyReducer implements LinkedHashMapRowReducer<Integer, Study>, RowMapperHelper {
+
+  @Override
+  public void accumulate(Map<Integer, Study> map, RowView rowView) {
+    Study study =
+            map.computeIfAbsent(
+                    rowView.getColumn("study_id", Integer.class), id -> rowView.getRow(Study.class));
+
+    reduceStudy(study, rowView);
+  }
+
+
+  public void reduceStudy(Study study, RowView rowView) {
+    if (hasColumn(rowView, "sp_key", String.class)
+            && hasColumn(rowView, "sp_property_value", String.class)) {
+      String keyName = rowView.getColumn("sp_key", String.class);
+      String propVal = rowView.getColumn("sp_value", String.class);
+      PropertyType propType = PropertyType.String;
+      if (hasColumn(rowView, "sp_property_type", String.class)) {
+        propType = PropertyType.parse(rowView.getColumn("sp_property_type", String.class));
+      }
+
+      if (Objects.nonNull(keyName) && Objects.nonNull(propVal)) {
+        try {
+          StudyProperty prop = new StudyProperty();
+          prop.setStudyId(study.getStudyId());
+          prop.setValue(propType.coerce(propVal));
+          prop.setName(keyName);
+          prop.setType(propType);
+
+          study.addProperty(prop);
+        } catch (Exception e) {
+          // do nothing.
+        }
+      }
+    }
+
+    if (hasColumn(rowView, "fso_file_storage_object_id", Integer.class)
+            && Objects.nonNull(rowView.getColumn("fso_file_storage_object_id", Integer.class))
+    ) {
+      FileStorageObject fileStorageObject = rowView.getRow(FileStorageObject.class);
+
+      switch (fileStorageObject.getCategory()) {
+        case ALTERNATIVE_DATA_SHARING_PLAN -> {
+          if (isFileNewer(fileStorageObject, study.getAlternativeDataSharingPlan())) {
+            study.setAlternativeDataSharingPlan(fileStorageObject);
+          }
+        }
+        default -> {
+        }
+      }
+    }
+  }
+
+  private boolean isFileNewer(FileStorageObject incomingFile, FileStorageObject existingFile) {
+    return Objects.isNull(existingFile) || incomingFile.getLatestUpdateDate().isAfter(existingFile.getLatestUpdateDate());
+  }
+}

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/StudyReducer.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/StudyReducer.java
@@ -23,18 +23,26 @@ public class StudyReducer implements LinkedHashMapRowReducer<Integer, Study>, Ro
 
 
   public void reduceStudy(Study study, RowView rowView) {
-    if (hasColumn(rowView, "sp_key", String.class)
-            && hasColumn(rowView, "sp_property_value", String.class)) {
+
+    if (hasColumn(rowView, "s_dataset_id", Integer.class)) {
+      study.addDatasetId(rowView.getColumn("s_dataset_id", Integer.class));
+    }
+
+    if (hasColumn(rowView, "sp_study_property_id", Integer.class)) {
+      Integer studyPropertyId = rowView.getColumn("sp_study_property_id", Integer.class);
       String keyName = rowView.getColumn("sp_key", String.class);
       String propVal = rowView.getColumn("sp_value", String.class);
+      Integer studyId = rowView.getColumn("sp_study_id", Integer.class);
       PropertyType propType = PropertyType.String;
-      if (hasColumn(rowView, "sp_property_type", String.class)) {
-        propType = PropertyType.parse(rowView.getColumn("sp_property_type", String.class));
+      if (hasColumn(rowView, "sp_type", String.class)) {
+        propType = PropertyType.parse(rowView.getColumn("sp_type", String.class));
       }
 
       if (Objects.nonNull(keyName) && Objects.nonNull(propVal)) {
         try {
           StudyProperty prop = new StudyProperty();
+          prop.setStudyPropertyId(studyPropertyId);
+          prop.setStudyId(studyId);
           prop.setStudyId(study.getStudyId());
           prop.setValue(propType.coerce(propVal));
           prop.setName(keyName);

--- a/src/main/java/org/broadinstitute/consent/http/enumeration/PropertyType.java
+++ b/src/main/java/org/broadinstitute/consent/http/enumeration/PropertyType.java
@@ -7,7 +7,7 @@ import com.google.gson.JsonSyntaxException;
 import java.time.Instant;
 import java.time.format.DateTimeParseException;
 
-public enum DatasetPropertyType {
+public enum PropertyType {
     String("string"),
     Boolean("boolean"),
     Number("number"),
@@ -16,7 +16,7 @@ public enum DatasetPropertyType {
 
     private final String value;
 
-    DatasetPropertyType(String value) {
+    PropertyType(String value) {
         this.value = value;
     }
 
@@ -25,21 +25,21 @@ public enum DatasetPropertyType {
         return this.value;
     }
 
-    public static DatasetPropertyType parse(String type) {
+    public static PropertyType parse(String type) {
         if (type == null) {
-            return DatasetPropertyType.String;
+            return PropertyType.String;
         }
         switch (type) {
             case "boolean":
-                return DatasetPropertyType.Boolean;
+                return PropertyType.Boolean;
             case "json":
-                return DatasetPropertyType.Json;
+                return PropertyType.Json;
             case "date":
-                return DatasetPropertyType.Date;
+                return PropertyType.Date;
             case "number":
-                return DatasetPropertyType.Number;
+                return PropertyType.Number;
             default: // always default to string.
-                return DatasetPropertyType.String;
+                return PropertyType.String;
         }
     }
 

--- a/src/main/java/org/broadinstitute/consent/http/models/Dataset.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/Dataset.java
@@ -57,6 +57,7 @@ public class Dataset {
     private Boolean dacApproval;
 
     private User createUser;
+    private Study study;
 
     public Dataset() {
     }
@@ -343,6 +344,14 @@ public class Dataset {
                                 .anyMatch(
                                         (t) -> t.contains(q)
                                 ));
+    }
+
+    public Study getStudy() {
+        return study;
+    }
+
+    public void setStudy(Study study) {
+        this.study = study;
     }
 
     @Override

--- a/src/main/java/org/broadinstitute/consent/http/models/DatasetProperty.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DatasetProperty.java
@@ -1,7 +1,7 @@
 package org.broadinstitute.consent.http.models;
 
 import com.google.common.base.Objects;
-import org.broadinstitute.consent.http.enumeration.DatasetPropertyType;
+import org.broadinstitute.consent.http.enumeration.PropertyType;
 
 import java.util.Date;
 
@@ -14,7 +14,7 @@ public class DatasetProperty {
     private Object propertyValue;
     private Date createDate;
     private String schemaProperty;
-    private DatasetPropertyType propertyType;
+    private PropertyType propertyType;
 
     public DatasetProperty(){
     }
@@ -24,7 +24,7 @@ public class DatasetProperty {
                            Integer dataSetId,
                            Integer propertyKey,
                            String propertyValue,
-                           DatasetPropertyType type,
+                           PropertyType type,
                            Date createDate) {
         this(dataSetId, propertyKey, propertyValue, type, createDate);
         this.propertyId = propertyId;
@@ -34,7 +34,7 @@ public class DatasetProperty {
     public DatasetProperty(Integer dataSetId,
                            Integer propertyKey,
                            String propertyValue,
-                           DatasetPropertyType type,
+                           PropertyType type,
                            Date createDate){
         this.dataSetId = dataSetId;
         this.propertyKey = propertyKey;
@@ -48,7 +48,7 @@ public class DatasetProperty {
                            Integer propertyKey,
                            String schemaProperty,
                            String propertyValue,
-                           DatasetPropertyType type,
+                           PropertyType type,
                            Date createDate) {
         this(dataSetId, propertyKey, schemaProperty, propertyValue, type, createDate);
         this.propertyId = propertyId;
@@ -58,7 +58,7 @@ public class DatasetProperty {
                            Integer propertyKey,
                            String schemaProperty,
                            String propertyValue,
-                           DatasetPropertyType type,
+                           PropertyType type,
                            Date createDate){
         this.dataSetId = dataSetId;
         this.propertyKey = propertyKey;
@@ -132,9 +132,9 @@ public class DatasetProperty {
         this.createDate = createDate;
     }
 
-    public DatasetPropertyType getPropertyType() {
+    public PropertyType getPropertyType() {
         if (java.util.Objects.isNull(this.propertyType)) {
-            return DatasetPropertyType.String;
+            return PropertyType.String;
         }
 
         return this.propertyType;
@@ -143,7 +143,7 @@ public class DatasetProperty {
         return this.getPropertyType().toString();
     }
 
-    public void setPropertyType(DatasetPropertyType propertyType) {
+    public void setPropertyType(PropertyType propertyType) {
         this.propertyType = propertyType;
     }
 

--- a/src/main/java/org/broadinstitute/consent/http/models/Study.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/Study.java
@@ -1,10 +1,11 @@
 package org.broadinstitute.consent.http.models;
 
-import java.util.ArrayList;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.UUID;
 
 public class Study {
     private Integer studyId;
@@ -12,14 +13,15 @@ public class Study {
     private String description;
     private Boolean publicVisibility;
     private String piName;
-    private Set<String> dataTypes;
+    private List<String> dataTypes;
     private Set<Integer> datasetIds;
-    private List<StudyProperty> properties;
+    private Set<StudyProperty> properties;
     private FileStorageObject alternativeDataSharingPlan;
     private Date createDate;
     private Integer createUserId;
     private Date updateDate;
     private Integer updateUserId;
+    private UUID uuid;
 
 
     public Integer getStudyId() {
@@ -62,25 +64,25 @@ public class Study {
         this.piName = piName;
     }
 
-    public Set<String> getDataTypes() {
+    public List<String> getDataTypes() {
         return dataTypes;
     }
 
-    public void setDataTypes(Set<String> dataTypes) {
+    public void setDataTypes(List<String> dataTypes) {
         this.dataTypes = dataTypes;
     }
 
-    public List<StudyProperty> getProperties() {
+    public Set<StudyProperty> getProperties() {
         return properties;
     }
 
-    public void setProperties(List<StudyProperty> properties) {
+    public void setProperties(Set<StudyProperty> properties) {
         this.properties = properties;
     }
 
     public void addProperty(StudyProperty prop) {
         if (Objects.isNull(this.properties)) {
-            this.properties = new ArrayList<>();
+            this.properties = new HashSet<>();
         }
         this.properties.add(prop);
     }
@@ -98,6 +100,14 @@ public class Study {
 
     public void setDatasetIds(Set<Integer> datasetIds) {
         this.datasetIds = datasetIds;
+    }
+
+    public void addDatasetId(Integer datasetId) {
+        if (Objects.isNull(this.datasetIds)) {
+            this.datasetIds = new HashSet<>();
+        }
+
+        this.datasetIds.add(datasetId);
     }
 
     public Date getCreateDate() {
@@ -130,5 +140,13 @@ public class Study {
 
     public void setUpdateUserId(Integer updateUserId) {
         this.updateUserId = updateUserId;
+    }
+
+    public UUID getUuid() {
+        return uuid;
+    }
+
+    public void setUuid(UUID uuid) {
+        this.uuid = uuid;
     }
 }

--- a/src/main/java/org/broadinstitute/consent/http/models/Study.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/Study.java
@@ -1,0 +1,104 @@
+package org.broadinstitute.consent.http.models;
+
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+public class Study {
+    private Integer studyId;
+    private String studyName;
+    private String studyDescription;
+    private Boolean publicVisibility;
+    private String piName;
+    private Set<String> dataTypes;
+    private Set<Dataset> datasets;
+    private List<StudyProperty> properties;
+    private FileStorageObject alternativeDataSharingPlan;
+    private Date createDate;
+    private Integer createUserId;
+    private Date updateDate;
+    private Integer updateUserId;
+
+
+    public Integer getStudyId() {
+        return studyId;
+    }
+
+    public void setStudyId(Integer studyId) {
+        this.studyId = studyId;
+    }
+
+    public String getStudyName() {
+        return studyName;
+    }
+
+    public void setStudyName(String studyName) {
+        this.studyName = studyName;
+    }
+
+    public String getStudyDescription() {
+        return studyDescription;
+    }
+
+    public void setStudyDescription(String studyDescription) {
+        this.studyDescription = studyDescription;
+    }
+
+    public Boolean getPublicVisibility() {
+        return publicVisibility;
+    }
+
+    public void setPublicVisibility(Boolean publicVisibility) {
+        this.publicVisibility = publicVisibility;
+    }
+
+    public String getPiName() {
+        return piName;
+    }
+
+    public void setPiName(String piName) {
+        this.piName = piName;
+    }
+
+    public Set<Dataset> getDatasets() {
+        return datasets;
+    }
+
+    public void setDatasets(Set<Dataset> datasets) {
+        this.datasets = datasets;
+    }
+    public void addDataset(Dataset ds) {
+        if (Objects.isNull(this.datasets)) {
+            this.datasets = new HashSet<>();
+        }
+        this.datasets.add(ds);
+    }
+
+    public Set<String> getDataTypes() {
+        return dataTypes;
+    }
+
+    public void setDataTypes(Set<String> dataTypes) {
+        this.dataTypes = dataTypes;
+    }
+
+    public List<StudyProperty> getProperties() {
+        return properties;
+    }
+
+    public void setProperties(List<StudyProperty> properties) {
+        this.properties = properties;
+    }
+
+    public FileStorageObject getAlternativeDataSharingPlan() {
+        return alternativeDataSharingPlan;
+    }
+
+    public void setAlternativeDataSharingPlan(FileStorageObject alternativeDataSharingPlan) {
+        this.alternativeDataSharingPlan = alternativeDataSharingPlan;
+    }
+
+
+}

--- a/src/main/java/org/broadinstitute/consent/http/models/Study.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/Study.java
@@ -1,19 +1,19 @@
 package org.broadinstitute.consent.http.models;
 
+import java.util.ArrayList;
 import java.util.Date;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
 public class Study {
     private Integer studyId;
-    private String studyName;
-    private String studyDescription;
+    private String name;
+    private String description;
     private Boolean publicVisibility;
     private String piName;
     private Set<String> dataTypes;
-    private Set<Dataset> datasets;
+    private Set<Integer> datasetIds;
     private List<StudyProperty> properties;
     private FileStorageObject alternativeDataSharingPlan;
     private Date createDate;
@@ -30,20 +30,20 @@ public class Study {
         this.studyId = studyId;
     }
 
-    public String getStudyName() {
-        return studyName;
+    public String getName() {
+        return name;
     }
 
-    public void setStudyName(String studyName) {
-        this.studyName = studyName;
+    public void setName(String name) {
+        this.name = name;
     }
 
-    public String getStudyDescription() {
-        return studyDescription;
+    public String getDescription() {
+        return description;
     }
 
-    public void setStudyDescription(String studyDescription) {
-        this.studyDescription = studyDescription;
+    public void setDescription(String description) {
+        this.description = description;
     }
 
     public Boolean getPublicVisibility() {
@@ -62,20 +62,6 @@ public class Study {
         this.piName = piName;
     }
 
-    public Set<Dataset> getDatasets() {
-        return datasets;
-    }
-
-    public void setDatasets(Set<Dataset> datasets) {
-        this.datasets = datasets;
-    }
-    public void addDataset(Dataset ds) {
-        if (Objects.isNull(this.datasets)) {
-            this.datasets = new HashSet<>();
-        }
-        this.datasets.add(ds);
-    }
-
     public Set<String> getDataTypes() {
         return dataTypes;
     }
@@ -92,6 +78,13 @@ public class Study {
         this.properties = properties;
     }
 
+    public void addProperty(StudyProperty prop) {
+        if (Objects.isNull(this.properties)) {
+            this.properties = new ArrayList<>();
+        }
+        this.properties.add(prop);
+    }
+
     public FileStorageObject getAlternativeDataSharingPlan() {
         return alternativeDataSharingPlan;
     }
@@ -99,6 +92,43 @@ public class Study {
     public void setAlternativeDataSharingPlan(FileStorageObject alternativeDataSharingPlan) {
         this.alternativeDataSharingPlan = alternativeDataSharingPlan;
     }
+    public Set<Integer> getDatasetIds() {
+        return datasetIds;
+    }
 
+    public void setDatasetIds(Set<Integer> datasetIds) {
+        this.datasetIds = datasetIds;
+    }
 
+    public Date getCreateDate() {
+        return createDate;
+    }
+
+    public void setCreateDate(Date createDate) {
+        this.createDate = createDate;
+    }
+
+    public Integer getCreateUserId() {
+        return createUserId;
+    }
+
+    public void setCreateUserId(Integer createUserId) {
+        this.createUserId = createUserId;
+    }
+
+    public Date getUpdateDate() {
+        return updateDate;
+    }
+
+    public void setUpdateDate(Date updateDate) {
+        this.updateDate = updateDate;
+    }
+
+    public Integer getUpdateUserId() {
+        return updateUserId;
+    }
+
+    public void setUpdateUserId(Integer updateUserId) {
+        this.updateUserId = updateUserId;
+    }
 }

--- a/src/main/java/org/broadinstitute/consent/http/models/StudyProperty.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/StudyProperty.java
@@ -2,6 +2,8 @@ package org.broadinstitute.consent.http.models;
 
 import org.broadinstitute.consent.http.enumeration.PropertyType;
 
+import java.util.Objects;
+
 public class StudyProperty {
     private Integer studyPropertyId;
     private Integer studyId;
@@ -47,5 +49,18 @@ public class StudyProperty {
 
     public void setValue(Object value) {
         this.value = value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        StudyProperty that = (StudyProperty) o;
+        return Objects.equals(studyPropertyId, that.studyPropertyId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(studyPropertyId);
     }
 }

--- a/src/main/java/org/broadinstitute/consent/http/models/StudyProperty.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/StudyProperty.java
@@ -1,0 +1,51 @@
+package org.broadinstitute.consent.http.models;
+
+import org.broadinstitute.consent.http.enumeration.PropertyType;
+
+public class StudyProperty {
+    private Integer studyPropertyId;
+    private Integer studyId;
+    private String name;
+    private PropertyType type;
+    private Object value;
+
+    public Integer getStudyPropertyId() {
+        return studyPropertyId;
+    }
+
+    public void setStudyPropertyId(Integer studyPropertyId) {
+        this.studyPropertyId = studyPropertyId;
+    }
+
+    public Integer getStudyId() {
+        return studyId;
+    }
+
+    public void setStudyId(Integer studyId) {
+        this.studyId = studyId;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public PropertyType getType() {
+        return type;
+    }
+
+    public void setType(PropertyType type) {
+        this.type = type;
+    }
+
+    public Object getValue() {
+        return value;
+    }
+
+    public void setValue(Object value) {
+        this.value = value;
+    }
+}

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetRegistrationService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetRegistrationService.java
@@ -4,7 +4,7 @@ import com.google.cloud.storage.BlobId;
 import org.broadinstitute.consent.http.cloudstore.GCSService;
 import org.broadinstitute.consent.http.db.DacDAO;
 import org.broadinstitute.consent.http.db.DatasetDAO;
-import org.broadinstitute.consent.http.enumeration.DatasetPropertyType;
+import org.broadinstitute.consent.http.enumeration.PropertyType;
 import org.broadinstitute.consent.http.enumeration.FileCategory;
 import org.broadinstitute.consent.http.models.DataUse;
 import org.broadinstitute.consent.http.models.Dataset;
@@ -214,7 +214,7 @@ public class DatasetRegistrationService {
     public record DatasetPropertyExtractor(
             String name,
             String schemaProp,
-            DatasetPropertyType type,
+            PropertyType type,
             /*
              * Takes in: Dataset registration object and consent group
              * Produces: The value of the field, can be null if field not present.
@@ -249,13 +249,13 @@ public class DatasetRegistrationService {
     // TODO: is there some way to do this automatically from, e.g., the schema?
     private static final List<DatasetPropertyExtractor> DATASET_REGISTRATION_V1_PROPERTY_EXTRACTORS = List.of(
             new DatasetPropertyExtractor(
-                    "PI Name", "piName", DatasetPropertyType.String,
+                    "PI Name", "piName", PropertyType.String,
                     (registration, consentGroup) -> registration.getPiName()),
             new DatasetPropertyExtractor(
-                    "Study Name", "studyName", DatasetPropertyType.String,
+                    "Study Name", "studyName", PropertyType.String,
                     (registration, consentGroup) -> registration.getStudyName()),
             new DatasetPropertyExtractor(
-                    "Study Type", "studyType", DatasetPropertyType.String,
+                    "Study Type", "studyType", PropertyType.String,
                     (registration, consentGroup) -> {
                         if (Objects.nonNull(registration.getStudyType())) {
                             return registration.getStudyType().value();
@@ -263,7 +263,7 @@ public class DatasetRegistrationService {
                         return null;
                     }),
             new DatasetPropertyExtractor(
-                    "Data Types", "dataTypes", DatasetPropertyType.Json,
+                    "Data Types", "dataTypes", PropertyType.Json,
                     (registration, consentGroup) -> {
                         if (Objects.nonNull(registration.getDataTypes())) {
                             return GsonUtil.getInstance().toJson(registration.getDataTypes());
@@ -271,19 +271,19 @@ public class DatasetRegistrationService {
                         return null;
                     }),
             new DatasetPropertyExtractor(
-                    "Study Description", "studyDescription", DatasetPropertyType.String,
+                    "Study Description", "studyDescription", PropertyType.String,
                     (registration, consentGroup) -> registration.getStudyDescription()),
             new DatasetPropertyExtractor(
-                    "Phenotype Indication", "phenotypeIndication", DatasetPropertyType.String,
+                    "Phenotype Indication", "phenotypeIndication", PropertyType.String,
                     (registration, consentGroup) -> registration.getPhenotypeIndication()),
             new DatasetPropertyExtractor(
-                    "Species", "species", DatasetPropertyType.String,
+                    "Species", "species", PropertyType.String,
                     (registration, consentGroup) -> registration.getSpecies()),
             new DatasetPropertyExtractor(
-                    "Data Submitter User ID", "dataSubmitterUserId", DatasetPropertyType.Number,
+                    "Data Submitter User ID", "dataSubmitterUserId", PropertyType.Number,
                     (registration, consentGroup) -> registration.getDataSubmitterUserId()),
             new DatasetPropertyExtractor(
-                    "Data Custodian Email", "dataCustodianEmail", DatasetPropertyType.Json,
+                    "Data Custodian Email", "dataCustodianEmail", PropertyType.Json,
                     (registration, consentGroup) -> {
                         if (Objects.nonNull(registration.getDataCustodianEmail())) {
                             return GsonUtil.getInstance().toJson(registration.getDataCustodianEmail());
@@ -292,34 +292,34 @@ public class DatasetRegistrationService {
 
                     }),
             new DatasetPropertyExtractor(
-                    "Public Visibility", "publicVisibility", DatasetPropertyType.Boolean,
+                    "Public Visibility", "publicVisibility", PropertyType.Boolean,
                     (registration, consentGroup) -> registration.getPublicVisibility()),
             new DatasetPropertyExtractor(
-                    "NIH Anvil Use", "nihAnvilUse", DatasetPropertyType.String,
+                    "NIH Anvil Use", "nihAnvilUse", PropertyType.String,
                     (registration, consentGroup) -> registration.getNihAnvilUse()),
             new DatasetPropertyExtractor(
-                    "Submitting To Anvil", "submittingToAnvil", DatasetPropertyType.Boolean,
+                    "Submitting To Anvil", "submittingToAnvil", PropertyType.Boolean,
                     (registration, consentGroup) -> registration.getSubmittingToAnvil()),
             new DatasetPropertyExtractor(
-                    "dbGaP phs ID", "dbGaPPhsID", DatasetPropertyType.String,
+                    "dbGaP phs ID", "dbGaPPhsID", PropertyType.String,
                     (registration, consentGroup) -> registration.getDbGaPPhsID()),
             new DatasetPropertyExtractor(
-                    "dbGaP Study Registration Name", "dbGaPStudyRegistrationName", DatasetPropertyType.String,
+                    "dbGaP Study Registration Name", "dbGaPStudyRegistrationName", PropertyType.String,
                     (registration, consentGroup) -> registration.getDbGaPStudyRegistrationName()),
             new DatasetPropertyExtractor(
-                    "Embargo Release Date", "embargoReleaseDate", DatasetPropertyType.Date,
+                    "Embargo Release Date", "embargoReleaseDate", PropertyType.Date,
                     (registration, consentGroup) -> registration.getEmbargoReleaseDate()),
             new DatasetPropertyExtractor(
-                    "Sequencing Center", "sequencingCenter", DatasetPropertyType.String,
+                    "Sequencing Center", "sequencingCenter", PropertyType.String,
                     (registration, consentGroup) -> registration.getSequencingCenter()),
             new DatasetPropertyExtractor(
-                    "PI Institution", "piInstitution", DatasetPropertyType.Number,
+                    "PI Institution", "piInstitution", PropertyType.Number,
                     (registration, consentGroup) -> registration.getPiInstitution()),
             new DatasetPropertyExtractor(
-                    "NIH Grant Contract Number", "nihGrantContractNumber", DatasetPropertyType.String,
+                    "NIH Grant Contract Number", "nihGrantContractNumber", PropertyType.String,
                     (registration, consentGroup) -> registration.getNihGrantContractNumber()),
             new DatasetPropertyExtractor(
-                    "NIH ICs Supporting Study", "nihICsSupportingStudy", DatasetPropertyType.Json,
+                    "NIH ICs Supporting Study", "nihICsSupportingStudy", PropertyType.Json,
                     (registration, consentGroup) -> {
                         if (Objects.nonNull(registration.getNihICsSupportingStudy())) {
                             return GsonUtil.getInstance().toJson(registration.getNihICsSupportingStudy().stream().map(NihICsSupportingStudy::value).toList());
@@ -327,10 +327,10 @@ public class DatasetRegistrationService {
                         return null;
                     }),
             new DatasetPropertyExtractor(
-                    "NIH Program Officer Name", "nihProgramOfficerName", DatasetPropertyType.String,
+                    "NIH Program Officer Name", "nihProgramOfficerName", PropertyType.String,
                     (registration, consentGroup) -> registration.getNihProgramOfficerName()),
             new DatasetPropertyExtractor(
-                    "NIH Institution Center Submission", "nihInstitutionCenterSubmission", DatasetPropertyType.String,
+                    "NIH Institution Center Submission", "nihInstitutionCenterSubmission", PropertyType.String,
                     (registration, consentGroup) -> {
                         if (Objects.nonNull(registration.getNihInstitutionCenterSubmission())) {
                             return registration.getNihInstitutionCenterSubmission().value();
@@ -338,13 +338,13 @@ public class DatasetRegistrationService {
                         return null;
                     }),
             new DatasetPropertyExtractor(
-                    "NIH Genomic Program Administrator Name", "nihGenomicProgramAdministratorName", DatasetPropertyType.String,
+                    "NIH Genomic Program Administrator Name", "nihGenomicProgramAdministratorName", PropertyType.String,
                     (registration, consentGroup) -> registration.getNihGenomicProgramAdministratorName()),
             new DatasetPropertyExtractor(
-                    "Multi Center Study", "multiCenterStudy", DatasetPropertyType.Boolean,
+                    "Multi Center Study", "multiCenterStudy", PropertyType.Boolean,
                     (registration, consentGroup) -> registration.getMultiCenterStudy()),
             new DatasetPropertyExtractor(
-                    "Collaborating Sites", "collaboratingSites", DatasetPropertyType.Json,
+                    "Collaborating Sites", "collaboratingSites", PropertyType.Json,
                     (registration, consentGroup) -> {
                         if (Objects.nonNull(registration.getCollaboratingSites())) {
                             return GsonUtil.getInstance().toJson(registration.getCollaboratingSites());
@@ -352,16 +352,16 @@ public class DatasetRegistrationService {
                         return null;
                     }),
             new DatasetPropertyExtractor(
-                    "Controlled Access Required For Genomic Summary Results GSR", "controlledAccessRequiredForGenomicSummaryResultsGSR", DatasetPropertyType.Boolean,
+                    "Controlled Access Required For Genomic Summary Results GSR", "controlledAccessRequiredForGenomicSummaryResultsGSR", PropertyType.Boolean,
                     (registration, consentGroup) -> registration.getControlledAccessRequiredForGenomicSummaryResultsGSR()),
             new DatasetPropertyExtractor(
-                    "Controlled Access Required For Genomic Summary Results GSR Explanation", "controlledAccessRequiredForGenomicSummaryResultsGSRRequiredExplanation", DatasetPropertyType.String,
+                    "Controlled Access Required For Genomic Summary Results GSR Explanation", "controlledAccessRequiredForGenomicSummaryResultsGSRRequiredExplanation", PropertyType.String,
                     (registration, consentGroup) -> registration.getControlledAccessRequiredForGenomicSummaryResultsGSRRequiredExplanation()),
             new DatasetPropertyExtractor(
-                    "Alternative Data Sharing Plan", "alternativeDataSharingPlan", DatasetPropertyType.Boolean,
+                    "Alternative Data Sharing Plan", "alternativeDataSharingPlan", PropertyType.Boolean,
                     (registration, consentGroup) -> registration.getAlternativeDataSharingPlan()),
             new DatasetPropertyExtractor(
-                    "Alternative Data Sharing Plan Reasons", "alternativeDataSharingPlanReasons", DatasetPropertyType.Json,
+                    "Alternative Data Sharing Plan Reasons", "alternativeDataSharingPlanReasons", PropertyType.Json,
                     (registration, consentGroup) -> {
                         if (Objects.nonNull(registration.getAlternativeDataSharingPlanReasons())) {
                             return GsonUtil.getInstance().toJson(registration.getAlternativeDataSharingPlanReasons().stream().map(AlternativeDataSharingPlanReason::value).toList());
@@ -369,13 +369,13 @@ public class DatasetRegistrationService {
                         return null;
                     }),
             new DatasetPropertyExtractor(
-                    "Alternative Data Sharing Plan Explanation", "alternativeDataSharingPlanExplanation", DatasetPropertyType.String,
+                    "Alternative Data Sharing Plan Explanation", "alternativeDataSharingPlanExplanation", PropertyType.String,
                     (registration, consentGroup) -> registration.getAlternativeDataSharingPlanExplanation()),
             new DatasetPropertyExtractor(
-                    "Alternative Data Sharing Plan File Name", "alternativeDataSharingPlanFileName", DatasetPropertyType.String,
+                    "Alternative Data Sharing Plan File Name", "alternativeDataSharingPlanFileName", PropertyType.String,
                     (registration, consentGroup) -> registration.getAlternativeDataSharingPlanFileName()),
             new DatasetPropertyExtractor(
-                    "Alternative Data Sharing Plan Data Submitted", "alternativeDataSharingPlanDataSubmitted", DatasetPropertyType.String,
+                    "Alternative Data Sharing Plan Data Submitted", "alternativeDataSharingPlanDataSubmitted", PropertyType.String,
                     (registration, consentGroup) -> {
                         if (Objects.nonNull(registration.getAlternativeDataSharingPlanDataSubmitted())) {
                             return registration.getAlternativeDataSharingPlanDataSubmitted().value();
@@ -383,16 +383,16 @@ public class DatasetRegistrationService {
                         return null;
                     }),
             new DatasetPropertyExtractor(
-                    "Alternative Data Sharing Plan Data Released", "alternativeDataSharingPlanDataReleased", DatasetPropertyType.Boolean,
+                    "Alternative Data Sharing Plan Data Released", "alternativeDataSharingPlanDataReleased", PropertyType.Boolean,
                     (registration, consentGroup) -> registration.getAlternativeDataSharingPlanDataReleased()),
             new DatasetPropertyExtractor(
-                    "Alternative Data Sharing Plan Target Delivery Date", "alternativeDataSharingPlanTargetDeliveryDate", DatasetPropertyType.Date,
+                    "Alternative Data Sharing Plan Target Delivery Date", "alternativeDataSharingPlanTargetDeliveryDate", PropertyType.Date,
                     (registration, consentGroup) -> registration.getAlternativeDataSharingPlanTargetDeliveryDate()),
             new DatasetPropertyExtractor(
-                    "Alternative Data Sharing Plan Target Public Release Date", "alternativeDataSharingPlanTargetPublicReleaseDate", DatasetPropertyType.Date,
+                    "Alternative Data Sharing Plan Target Public Release Date", "alternativeDataSharingPlanTargetPublicReleaseDate", PropertyType.Date,
                     (registration, consentGroup) -> registration.getAlternativeDataSharingPlanTargetPublicReleaseDate()),
             new DatasetPropertyExtractor(
-                    "Alternative Data Sharing Plan Controlled Open Access", "alternativeDataSharingPlanControlledOpenAccess", DatasetPropertyType.String,
+                    "Alternative Data Sharing Plan Controlled Open Access", "alternativeDataSharingPlanControlledOpenAccess", PropertyType.String,
                     (registration, consentGroup) -> {
                         if (Objects.nonNull(registration.getAlternativeDataSharingPlanControlledOpenAccess())) {
                             return registration.getAlternativeDataSharingPlanControlledOpenAccess().value();
@@ -400,7 +400,7 @@ public class DatasetRegistrationService {
                         return null;
                     }),
             new DatasetPropertyExtractor(
-                    "Data Location", "consentGroup.dataLocation", DatasetPropertyType.String,
+                    "Data Location", "consentGroup.dataLocation", PropertyType.String,
                     (registration, consentGroup) -> {
                         if (Objects.nonNull(consentGroup.getDataLocation())) {
                             return consentGroup.getDataLocation().value();
@@ -408,7 +408,7 @@ public class DatasetRegistrationService {
                         return null;
                     }),
             new DatasetPropertyExtractor(
-                    "File Types", "consentGroup.fileTypes", DatasetPropertyType.Json,
+                    "File Types", "consentGroup.fileTypes", PropertyType.Json,
                     (registration, consentGroup) -> {
                         if (Objects.nonNull(consentGroup.getFileTypes())) {
                             return GsonUtil.getInstance().toJson(consentGroup.getFileTypes());
@@ -416,7 +416,7 @@ public class DatasetRegistrationService {
                         return null;
                     }),
             new DatasetPropertyExtractor(
-                    "URL", "consentGroup.url", DatasetPropertyType.String,
+                    "URL", "consentGroup.url", PropertyType.String,
                     (registration, consentGroup) -> {
                         if (Objects.nonNull(consentGroup.getUrl())) {
                             return consentGroup.getUrl().toString();
@@ -424,10 +424,10 @@ public class DatasetRegistrationService {
                         return null;
                     }),
             new DatasetPropertyExtractor(
-                    "Open Access", "consentGroup.openAccess", DatasetPropertyType.Boolean,
+                    "Open Access", "consentGroup.openAccess", PropertyType.Boolean,
                     (registration, consentGroup) -> consentGroup.getOpenAccess()),
             new DatasetPropertyExtractor(
-                    "DAC ID", "consentGroup.dataAccessCommitteeId", DatasetPropertyType.Number,
+                    "DAC ID", "consentGroup.dataAccessCommitteeId", PropertyType.Number,
                     (registration, consentGroup) -> consentGroup.getDataAccessCommitteeId())
     );
 

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -9,7 +9,7 @@ import org.broadinstitute.consent.http.db.UserRoleDAO;
 import org.broadinstitute.consent.http.enumeration.AssociationType;
 import org.broadinstitute.consent.http.enumeration.AuditActions;
 import org.broadinstitute.consent.http.enumeration.DataUseTranslationType;
-import org.broadinstitute.consent.http.enumeration.DatasetPropertyType;
+import org.broadinstitute.consent.http.enumeration.PropertyType;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.Consent;
 import org.broadinstitute.consent.http.models.Dac;
@@ -337,7 +337,7 @@ public class DatasetService {
                         new DatasetProperty(datasetId,
                                 dictionaries.get(keys.indexOf(p.getPropertyName())).getKeyId(),
                                 p.getPropertyValue(),
-                                DatasetPropertyType.String,
+                                PropertyType.String,
                                 now)
                 )
                 .collect(Collectors.toList());

--- a/src/main/resources/assets/schemas/Dataset.yaml
+++ b/src/main/resources/assets/schemas/Dataset.yaml
@@ -55,6 +55,9 @@ properties:
         propertyValue: NHLBI
       - propertyName: Sample Collection ID
         propertyValue: SC-000
+  study:
+    $ref: "./Study.yaml"
+    description: The study which produced this dataset.
   active:
     type: boolean
     description: The Dataset is active

--- a/src/main/resources/assets/schemas/Study.yaml
+++ b/src/main/resources/assets/schemas/Study.yaml
@@ -1,0 +1,52 @@
+type: object
+properties:
+  studyId:
+    type: integer
+    format: int32
+    description: The study's id.
+  name:
+    type: string
+    description: The name of the study.
+  description:
+    type: string
+    description: A human-readable description of the study.
+  dataTypes:
+    type: array
+    items:
+      type: string
+    description: The data types included in the study's dataset.
+  piName:
+    type: string
+    description: The name of the PI of the study.
+  publicVisibility:
+    type: boolean
+    description: Whether this study is publicly visible or not.
+  datasetIds:
+    type: array
+    items:
+      type: integer
+      format: int32
+    description: The ids of all of the datasets related to this study.
+  properties:
+    type: array
+    items:
+      $ref: './StudyProperty.yaml'
+    description: Optional properties describing the study.
+  alternativeDataSharingPlan:
+    $ref: './FileStorageObject.yaml'
+    description: Metadata about the study's alternative data sharing plan (if present).
+  createDate:
+    type: string
+    format: date-time
+    description: The timestamp of creation.
+  createUserId:
+    type: integer
+    format: int32
+    description: The id of the user which created this study.
+  updateDate:
+    type: string
+    format: date-time
+    description: The timestamp of last update.
+  updateUserId:
+    type: boolean
+    description: The id of the user which last updated this study.

--- a/src/main/resources/assets/schemas/StudyProperty.yaml
+++ b/src/main/resources/assets/schemas/StudyProperty.yaml
@@ -1,0 +1,11 @@
+type: object
+properties:
+  key:
+    type: string
+    description: Key of the Property.
+  value:
+    type: string
+    description: Value of the Property.
+  type:
+    type: string
+    description: Type of the property.

--- a/src/main/resources/changelog-master.xml
+++ b/src/main/resources/changelog-master.xml
@@ -114,4 +114,5 @@
     <include file="changesets/changelog-consent-2023-02-28-fix-dataset-audit.0.xml" relativeToChangelogFile="true"/>
     <include file="changesets/changelog-consent-2023-03-07-remove-use-restriction.0.xml" relativeToChangelogFile="true"/>
     <include file="changesets/changelog-consent-2023-03-16-rename-vote-userid.xml" relativeToChangelogFile="true"/>
+    <include file="changesets/changelog-consent-2023-04-20-create-study.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/changesets/changelog-consent-2023-04-20-create-study.xml
+++ b/src/main/resources/changesets/changelog-consent-2023-04-20-create-study.xml
@@ -7,10 +7,10 @@
       <column name="study_id" autoIncrement="true" type="int">
         <constraints primaryKey="true"/>
       </column>
-      <column name="study_name" type="text" >
+      <column name="name" type="text" >
         <constraints nullable="false" unique="true"/>
       </column>
-      <column name="study_description" type="text" >
+      <column name="description" type="text" >
         <constraints nullable="false"/>
       </column>
       <column name="data_types" type="text[]" >
@@ -31,7 +31,7 @@
       <column name="study_id" type="int">
         <constraints foreignKeyName="fk_study_id" nullable="false"/>
       </column>
-      <column name="name" type="text" >
+      <column name="key" type="text" >
         <constraints nullable="false"/>
       </column>
       <column name="type" type="text" >

--- a/src/main/resources/changesets/changelog-consent-2023-04-20-create-study.xml
+++ b/src/main/resources/changesets/changelog-consent-2023-04-20-create-study.xml
@@ -4,8 +4,8 @@
   <changeSet id="changelog-consent-2023-04-20-create-study" author="connorlbark">
 
     <createTable tableName="study">
-      <column name="study_id" autoIncrement="true" type="int">
-        <constraints primaryKey="true"/>
+      <column name="study_id" autoIncrement="true" type="bigint">
+        <constraints primaryKey="true" nullable="false"/>
       </column>
       <column name="name" type="text" >
         <constraints nullable="false" unique="true"/>
@@ -22,7 +22,33 @@
       <column name="public_visibility" type="boolean" >
         <constraints nullable="false"/>
       </column>
+      <column name="uuid" type="uuid" >
+        <constraints nullable="false"/>
+      </column>
+
+      <column name="create_user_id" type="bigint">
+        <constraints foreignKeyName="fk_create_user_id" nullable="false"/>
+      </column>
+      <column name="create_date" type="timestamp">
+        <constraints nullable="false"/>
+      </column>
+      <column name="update_user_id" type="bigint">
+        <constraints foreignKeyName="fk_update_user_id"/>
+      </column>
+      <column name="update_date" type="timestamp"/>
     </createTable>
+
+
+    <addForeignKeyConstraint baseColumnNames="create_user_id" baseTableName="study" constraintName="fk_create_user_id"
+                             deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION"
+                             referencedColumnNames="user_id" referencedTableName="users"
+                             referencesUniqueColumn="true"/>
+
+
+    <addForeignKeyConstraint baseColumnNames="update_user_id" baseTableName="study" constraintName="fk_update_user_id"
+                             deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION"
+                             referencedColumnNames="user_id" referencedTableName="users"
+                             referencesUniqueColumn="true"/>
 
     <createTable tableName="study_property">
       <column name="study_property_id" autoIncrement="true" type="int">

--- a/src/main/resources/changesets/changelog-consent-2023-04-20-create-study.xml
+++ b/src/main/resources/changesets/changelog-consent-2023-04-20-create-study.xml
@@ -1,0 +1,62 @@
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+  <changeSet id="changelog-consent-2023-04-20-create-study" author="connorlbark">
+
+    <createTable tableName="study">
+      <column name="study_id" autoIncrement="true" type="int">
+        <constraints primaryKey="true"/>
+      </column>
+      <column name="study_name" type="text" >
+        <constraints nullable="false" unique="true"/>
+      </column>
+      <column name="study_description" type="text" >
+        <constraints nullable="false"/>
+      </column>
+      <column name="data_types" type="text[]" >
+        <constraints nullable="false"/>
+      </column>
+      <column name="pi_name" type="text" >
+        <constraints nullable="false"/>
+      </column>
+      <column name="public_visibility" type="boolean" >
+        <constraints nullable="false"/>
+      </column>
+    </createTable>
+
+    <createTable tableName="study_property">
+      <column name="study_property_id" autoIncrement="true" type="int">
+        <constraints primaryKey="true"/>
+      </column>
+      <column name="study_id" type="int">
+        <constraints foreignKeyName="fk_study_id" nullable="false"/>
+      </column>
+      <column name="name" type="text" >
+        <constraints nullable="false"/>
+      </column>
+      <column name="type" type="text" >
+        <constraints nullable="false"/>
+      </column>
+      <column name="value" type="text" >
+        <constraints nullable="false"/>
+      </column>
+    </createTable>
+
+    <addForeignKeyConstraint baseColumnNames="study_id" baseTableName="study_property" constraintName="fk_study_id"
+                             deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION"
+                             referencedColumnNames="study_id" referencedTableName="study"
+                             referencesUniqueColumn="true"/>
+
+    <addColumn tableName="dataset">
+      <column name="study_id" type="int">
+        <constraints foreignKeyName="fk_study_id" />
+      </column>
+    </addColumn>
+
+    <addForeignKeyConstraint baseColumnNames="study_id" baseTableName="dataset" constraintName="fk_study_id"
+                             deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION"
+                             referencedColumnNames="study_id" referencedTableName="study"
+                             referencesUniqueColumn="true"/>
+
+  </changeSet>
+</databaseChangeLog>

--- a/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
@@ -178,8 +178,10 @@ public class DAOTestHelper {
         testingDAO.deleteAllDatasetProperties();
         testingDAO.deleteAllDictionaryTerms();
         testingDAO.deleteAllDatasetAssociations();
-        testingDAO.deleteAllDatasetAudits();;
+        testingDAO.deleteAllDatasetAudits();
         testingDAO.deleteAllDatasets();
+        testingDAO.deleteAllStudyProperties();
+        testingDAO.deleteAllStudies();
         testingDAO.deleteAllDacUserRoles();
         testingDAO.deleteAllDacs();
         testingDAO.deleteAllLibraryCards();

--- a/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
@@ -76,6 +76,7 @@ public class DAOTestHelper {
     protected static ElectionDAO electionDAO;
     protected static UserRoleDAO userRoleDAO;
     protected static VoteDAO voteDAO;
+    protected static StudyDAO studyDAO;
     protected static DataAccessRequestDAO dataAccessRequestDAO;
     protected static MatchDAO matchDAO;
     protected static MailMessageDAO mailMessageDAO;
@@ -140,6 +141,7 @@ public class DAOTestHelper {
         electionDAO = jdbi.onDemand(ElectionDAO.class);
         userRoleDAO = jdbi.onDemand(UserRoleDAO.class);
         voteDAO = jdbi.onDemand(VoteDAO.class);
+        studyDAO = jdbi.onDemand(StudyDAO.class);
         dataAccessRequestDAO = jdbi.onDemand(DataAccessRequestDAO.class);
         matchDAO = jdbi.onDemand(MatchDAO.class);
         mailMessageDAO = jdbi.onDemand(MailMessageDAO.class);

--- a/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
@@ -9,7 +9,6 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.RandomUtils;
 import org.broadinstitute.consent.http.ConsentApplication;
 import org.broadinstitute.consent.http.configurations.ConsentConfiguration;
-import org.broadinstitute.consent.http.enumeration.DatasetPropertyType;
 import org.broadinstitute.consent.http.enumeration.ElectionStatus;
 import org.broadinstitute.consent.http.enumeration.ElectionType;
 import org.broadinstitute.consent.http.enumeration.MatchAlgorithm;

--- a/src/test/java/org/broadinstitute/consent/http/db/DacDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DacDAOTest.java
@@ -12,7 +12,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Set;
 import org.apache.commons.lang3.RandomStringUtils;
-import org.broadinstitute.consent.http.enumeration.DatasetPropertyType;
+import org.broadinstitute.consent.http.enumeration.PropertyType;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.Consent;
 import org.broadinstitute.consent.http.models.Dac;
@@ -326,7 +326,7 @@ public class DacDAOTest extends DAOTestHelper {
                 1,
                 "dataAccessCommitteeId",
                 dac.getDacId().toString(),
-                DatasetPropertyType.Number,
+                PropertyType.Number,
                 Date.from(Instant.now()))));
 
         List<Dataset> results = datasetDAO.findDatasetsAssociatedWithDac(dac.getDacId());

--- a/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
@@ -990,7 +990,7 @@ public class DatasetDAOTest extends DAOTestHelper {
                 RandomStringUtils.randomAlphabetic(20),
                 RandomStringUtils.randomAlphabetic(20)
         );
-        String piName = org.testcontainers.shaded.org.apache.commons.lang3.RandomStringUtils.randomAlphabetic(20);
+        String piName = RandomStringUtils.randomAlphabetic(20);
         Boolean publicVisibility = true;
 
         Integer id = studyDAO.insertStudy(

--- a/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
@@ -3,7 +3,7 @@ package org.broadinstitute.consent.http.db;
 import com.google.gson.JsonObject;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.RandomUtils;
-import org.broadinstitute.consent.http.enumeration.DatasetPropertyType;
+import org.broadinstitute.consent.http.enumeration.PropertyType;
 import org.broadinstitute.consent.http.enumeration.FileCategory;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.Consent;
@@ -451,7 +451,7 @@ public class DatasetDAOTest extends DAOTestHelper {
         Dataset d = insertDataset();
         Set<DatasetProperty> properties = datasetDAO.findDatasetPropertiesByDatasetId(d.getDataSetId());
         DatasetProperty originalProperty = properties.stream().toList().get(0);
-        DatasetProperty newProperty = new DatasetProperty(d.getDataSetId(), 1, "Updated Value", DatasetPropertyType.String, new Date());
+        DatasetProperty newProperty = new DatasetProperty(d.getDataSetId(), 1, "Updated Value", PropertyType.String, new Date());
         List<DatasetProperty> updatedProperties = new ArrayList<>();
         updatedProperties.add(newProperty);
         datasetDAO.updateDatasetProperty(d.getDataSetId(), updatedProperties.get(0).getPropertyKey(), updatedProperties.get(0).getPropertyValue().toString());
@@ -475,7 +475,7 @@ public class DatasetDAOTest extends DAOTestHelper {
                         d.getDataSetId(),
                         1,
                         "10",
-                        DatasetPropertyType.Number,
+                        PropertyType.Number,
                         new Date())
         );
         datasetDAO.insertDatasetProperties(newProps);
@@ -484,7 +484,7 @@ public class DatasetDAOTest extends DAOTestHelper {
 
         assertEquals(1, dWithProps.getProperties().size());
         DatasetProperty prop = new ArrayList<>(dWithProps.getProperties()).get(0);
-        assertEquals(DatasetPropertyType.Number, prop.getPropertyType());
+        assertEquals(PropertyType.Number, prop.getPropertyType());
         assertEquals("10", prop.getPropertyValueAsString());
         assertEquals(10, prop.getPropertyValue());
     }
@@ -502,7 +502,7 @@ public class DatasetDAOTest extends DAOTestHelper {
                 d.getDataSetId(),
                 1,
                 date.toString(),
-                DatasetPropertyType.Date,
+                PropertyType.Date,
                 new Date());
 
         propToAdd.setSchemaProperty("date");
@@ -514,7 +514,7 @@ public class DatasetDAOTest extends DAOTestHelper {
         Set<DatasetProperty> props = datasetDAO.findDatasetPropertiesByDatasetId(d.getDataSetId());
         assertEquals(1, props.size());
         DatasetProperty prop = props.stream().findFirst().get();
-        assertEquals(DatasetPropertyType.Date, prop.getPropertyType());
+        assertEquals(PropertyType.Date, prop.getPropertyType());
         assertEquals(date.toString(), prop.getPropertyValueAsString());
     }
 
@@ -532,7 +532,7 @@ public class DatasetDAOTest extends DAOTestHelper {
                         d.getDataSetId(),
                         1,
                         bool.toString(),
-                        DatasetPropertyType.Boolean,
+                        PropertyType.Boolean,
                         new Date())
         );
         datasetDAO.insertDatasetProperties(newProps);
@@ -541,7 +541,7 @@ public class DatasetDAOTest extends DAOTestHelper {
 
         assertEquals(1, dWithProps.getProperties().size());
         DatasetProperty prop = new ArrayList<>(dWithProps.getProperties()).get(0);
-        assertEquals(DatasetPropertyType.Boolean, prop.getPropertyType());
+        assertEquals(PropertyType.Boolean, prop.getPropertyType());
         assertEquals(bool.toString(), prop.getPropertyValueAsString());
         assertEquals(Boolean.FALSE, prop.getPropertyValue());
     }
@@ -561,7 +561,7 @@ public class DatasetDAOTest extends DAOTestHelper {
                         d.getDataSetId(),
                         1,
                         jsonObject.toString(),
-                        DatasetPropertyType.Json,
+                        PropertyType.Json,
                         new Date())
         );
         datasetDAO.insertDatasetProperties(newProps);
@@ -570,7 +570,7 @@ public class DatasetDAOTest extends DAOTestHelper {
 
         assertEquals(1, dWithProps.getProperties().size());
         DatasetProperty prop = new ArrayList<>(dWithProps.getProperties()).get(0);
-        assertEquals(DatasetPropertyType.Json, prop.getPropertyType());
+        assertEquals(PropertyType.Json, prop.getPropertyType());
         assertEquals(jsonObject.toString(), prop.getPropertyValueAsString());
         assertEquals(jsonObject, prop.getPropertyValue());
     }
@@ -589,7 +589,7 @@ public class DatasetDAOTest extends DAOTestHelper {
                         d.getDataSetId(),
                         1,
                         value,
-                        DatasetPropertyType.String,
+                        PropertyType.String,
                         new Date())
         );
         datasetDAO.insertDatasetProperties(newProps);
@@ -598,7 +598,7 @@ public class DatasetDAOTest extends DAOTestHelper {
 
         assertEquals(1, dWithProps.getProperties().size());
         DatasetProperty prop = new ArrayList<>(dWithProps.getProperties()).get(0);
-        assertEquals(DatasetPropertyType.String, prop.getPropertyType());
+        assertEquals(PropertyType.String, prop.getPropertyType());
         assertEquals(value, prop.getPropertyValueAsString());
         assertEquals(value, prop.getPropertyValue());
     }
@@ -618,7 +618,7 @@ public class DatasetDAOTest extends DAOTestHelper {
                         1,
                         schemaValue,
                         "asdf",
-                        DatasetPropertyType.String,
+                        PropertyType.String,
                         new Date())
         );
         datasetDAO.insertDatasetProperties(newProps);
@@ -627,7 +627,7 @@ public class DatasetDAOTest extends DAOTestHelper {
 
         assertEquals(1, dWithProps.getProperties().size());
         DatasetProperty prop = new ArrayList<>(dWithProps.getProperties()).get(0);
-        assertEquals(DatasetPropertyType.String, prop.getPropertyType());
+        assertEquals(PropertyType.String, prop.getPropertyType());
         assertEquals(schemaValue, prop.getSchemaProperty());
     }
 
@@ -688,15 +688,15 @@ public class DatasetDAOTest extends DAOTestHelper {
     public void testFindAllActiveStudyNames() {
         Dataset ds1 = insertDataset();
         String ds1Name = RandomStringUtils.randomAlphabetic(20);
-        createDatasetProperty(ds1.getDataSetId(), "studyName", ds1Name, DatasetPropertyType.String);
+        createDatasetProperty(ds1.getDataSetId(), "studyName", ds1Name, PropertyType.String);
 
         Dataset ds2 = insertDataset();
         String ds2Name = RandomStringUtils.randomAlphabetic(25);
-        createDatasetProperty(ds2.getDataSetId(), "studyName", ds2Name, DatasetPropertyType.String);
+        createDatasetProperty(ds2.getDataSetId(), "studyName", ds2Name, PropertyType.String);
 
         Dataset ds3 = insertDataset();
         String ds3Name = RandomStringUtils.randomAlphabetic(15);
-        createDatasetProperty(ds3.getDataSetId(), "studyName", ds3Name, DatasetPropertyType.String);
+        createDatasetProperty(ds3.getDataSetId(), "studyName", ds3Name, PropertyType.String);
 
 
         Set<String> returned = datasetDAO.findAllActiveStudyNames();
@@ -709,11 +709,11 @@ public class DatasetDAOTest extends DAOTestHelper {
     public void testFindAllActiveStudyNames_inactive_dataset() {
         Dataset ds1 = insertDataset();
         String ds1Name = RandomStringUtils.randomAlphabetic(20);
-        createDatasetProperty(ds1.getDataSetId(), "studyName", ds1Name, DatasetPropertyType.String);
+        createDatasetProperty(ds1.getDataSetId(), "studyName", ds1Name, PropertyType.String);
 
         Dataset ds2 = insertDataset();
         String ds2Name = RandomStringUtils.randomAlphabetic(20);
-        createDatasetProperty(ds2.getDataSetId(), "studyName", ds2Name, DatasetPropertyType.String);
+        createDatasetProperty(ds2.getDataSetId(), "studyName", ds2Name, PropertyType.String);
 
         datasetDAO.updateDatasetActive(ds1.getDataSetId(), false);
 
@@ -909,7 +909,7 @@ public class DatasetDAOTest extends DAOTestHelper {
     }
 
 
-    protected void createDatasetProperty(Integer datasetId, String schemaProperty, String value, DatasetPropertyType type) {
+    protected void createDatasetProperty(Integer datasetId, String schemaProperty, String value, PropertyType type) {
         List<DatasetProperty> list = new ArrayList<>();
         DatasetProperty dsp = new DatasetProperty();
         dsp.setDataSetId(datasetId);

--- a/src/test/java/org/broadinstitute/consent/http/db/StudyDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/StudyDAOTest.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.consent.http.db;
 
+import org.apache.commons.lang3.RandomStringUtils;
 import org.broadinstitute.consent.http.enumeration.FileCategory;
 import org.broadinstitute.consent.http.enumeration.PropertyType;
 import org.broadinstitute.consent.http.models.DataUse;
@@ -9,7 +10,6 @@ import org.broadinstitute.consent.http.models.FileStorageObject;
 import org.broadinstitute.consent.http.models.Study;
 import org.broadinstitute.consent.http.models.User;
 import org.junit.Test;
-import org.testcontainers.shaded.org.apache.commons.lang3.RandomStringUtils;
 
 import java.sql.Timestamp;
 import java.time.Instant;
@@ -179,12 +179,12 @@ public class StudyDAOTest extends DAOTestHelper {
 
     @Test
     public void testIncludesDatasetIds() {
-        Study s = this.insertStudyWithProperties();
+        Study s = insertStudyWithProperties();
 
         insertDataset();
-        Dataset ds1 = this.insertDatasetForStudy(s.getStudyId());
+        Dataset ds1 = insertDatasetForStudy(s.getStudyId());
         insertDataset();
-        Dataset ds2 = this.insertDatasetForStudy(s.getStudyId());
+        Dataset ds2 = insertDatasetForStudy(s.getStudyId());
         insertDataset();
 
         s = studyDAO.findStudyById(s.getStudyId());
@@ -195,9 +195,9 @@ public class StudyDAOTest extends DAOTestHelper {
     }
 
     private FileStorageObject createFileStorageObject(String entityId, FileCategory category) {
-        String fileName = org.apache.commons.lang3.RandomStringUtils.randomAlphabetic(10);
-        String bucketName = org.apache.commons.lang3.RandomStringUtils.randomAlphabetic(10);
-        String gcsFileUri = org.apache.commons.lang3.RandomStringUtils.randomAlphabetic(10);
+        String fileName = RandomStringUtils.randomAlphabetic(10);
+        String bucketName = RandomStringUtils.randomAlphabetic(10);
+        String gcsFileUri = RandomStringUtils.randomAlphabetic(10);
         User createUser = createUser();
         Instant createDate = Instant.now();
 
@@ -216,13 +216,13 @@ public class StudyDAOTest extends DAOTestHelper {
     private Study insertStudyWithProperties() {
         User u = createUser();
 
-        String name = org.apache.commons.lang3.RandomStringUtils.randomAlphabetic(20);
-        String description = org.apache.commons.lang3.RandomStringUtils.randomAlphabetic(20);
+        String name = RandomStringUtils.randomAlphabetic(20);
+        String description = RandomStringUtils.randomAlphabetic(20);
         List<String> dataTypes = List.of(
-                org.apache.commons.lang3.RandomStringUtils.randomAlphabetic(20),
-                org.apache.commons.lang3.RandomStringUtils.randomAlphabetic(20)
+                RandomStringUtils.randomAlphabetic(20),
+                RandomStringUtils.randomAlphabetic(20)
         );
-        String piName = org.testcontainers.shaded.org.apache.commons.lang3.RandomStringUtils.randomAlphabetic(20);
+        String piName = RandomStringUtils.randomAlphabetic(20);
         Boolean publicVisibility = true;
 
         Integer id = studyDAO.insertStudy(
@@ -255,9 +255,9 @@ public class StudyDAOTest extends DAOTestHelper {
 
     private Dataset insertDatasetForStudy(Integer studyId) {
         User user = createUser();
-        String name = "Name_" + org.apache.commons.lang3.RandomStringUtils.random(20, true, true);
+        String name = "Name_" + RandomStringUtils.random(20, true, true);
         Timestamp now = new Timestamp(new Date().getTime());
-        String objectId = "Object ID_" + org.apache.commons.lang3.RandomStringUtils.random(20, true, true);
+        String objectId = "Object ID_" + RandomStringUtils.random(20, true, true);
         DataUse dataUse = new DataUseBuilder().setGeneralUse(true).build();
         Integer id = datasetDAO.insertDataset(name, now, user.getUserId(), objectId, true, dataUse.toString(), null);
 
@@ -268,9 +268,9 @@ public class StudyDAOTest extends DAOTestHelper {
 
     private Dataset insertDataset() {
         User user = createUser();
-        String name = "Name_" + org.apache.commons.lang3.RandomStringUtils.random(20, true, true);
+        String name = "Name_" + RandomStringUtils.random(20, true, true);
         Timestamp now = new Timestamp(new Date().getTime());
-        String objectId = "Object ID_" + org.apache.commons.lang3.RandomStringUtils.random(20, true, true);
+        String objectId = "Object ID_" + RandomStringUtils.random(20, true, true);
         DataUse dataUse = new DataUseBuilder().setGeneralUse(true).build();
         Integer id = datasetDAO.insertDataset(name, now, user.getUserId(), objectId, true, dataUse.toString(), null);
         return datasetDAO.findDatasetById(id);

--- a/src/test/java/org/broadinstitute/consent/http/db/StudyDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/StudyDAOTest.java
@@ -1,0 +1,279 @@
+package org.broadinstitute.consent.http.db;
+
+import org.broadinstitute.consent.http.enumeration.FileCategory;
+import org.broadinstitute.consent.http.enumeration.PropertyType;
+import org.broadinstitute.consent.http.models.DataUse;
+import org.broadinstitute.consent.http.models.DataUseBuilder;
+import org.broadinstitute.consent.http.models.Dataset;
+import org.broadinstitute.consent.http.models.FileStorageObject;
+import org.broadinstitute.consent.http.models.Study;
+import org.broadinstitute.consent.http.models.User;
+import org.junit.Test;
+import org.testcontainers.shaded.org.apache.commons.lang3.RandomStringUtils;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class StudyDAOTest extends DAOTestHelper {
+
+    @Test
+    public void testCreateAndFindStudy() {
+        User u = createUser();
+
+        String name = RandomStringUtils.randomAlphabetic(20);
+        String description = RandomStringUtils.randomAlphabetic(20);
+        List<String> dataTypes = List.of(
+                RandomStringUtils.randomAlphabetic(20),
+                RandomStringUtils.randomAlphabetic(20),
+                RandomStringUtils.randomAlphabetic(20)
+        );
+        String piName = RandomStringUtils.randomAlphabetic(20);
+        Boolean publicVisibility = true;
+        UUID uuid = UUID.randomUUID();
+
+        Integer id = studyDAO.insertStudy(
+                name,
+                description,
+                piName,
+                dataTypes,
+                publicVisibility,
+                u.getUserId(),
+                Instant.now(),
+                uuid
+        );
+
+        studyDAO.insertStudy(
+                RandomStringUtils.randomAlphabetic(20),
+                description,
+                piName,
+                dataTypes,
+                publicVisibility,
+                u.getUserId(),
+                Instant.now(),
+                UUID.randomUUID()
+        );
+
+        Study study = studyDAO.findStudyById(id);
+
+        assertEquals(id, study.getStudyId());
+        assertEquals(name, study.getName());
+        assertEquals(description, study.getDescription());
+        assertEquals(piName, study.getPiName());
+        assertEquals(dataTypes, study.getDataTypes());
+        assertEquals(publicVisibility, study.getPublicVisibility());
+        assertEquals(u.getUserId(), study.getCreateUserId());
+        assertEquals(uuid, study.getUuid());
+        assertNotNull(u.getCreateDate());
+    }
+
+    @Test
+    public void testStudyProps() {
+        User u = createUser();
+
+        String name = RandomStringUtils.randomAlphabetic(20);
+        String description = RandomStringUtils.randomAlphabetic(20);
+        List<String> dataTypes = List.of(
+                RandomStringUtils.randomAlphabetic(20),
+                RandomStringUtils.randomAlphabetic(20),
+                RandomStringUtils.randomAlphabetic(20)
+        );
+        String piName = RandomStringUtils.randomAlphabetic(20);
+        Boolean publicVisibility = true;
+
+        Integer id = studyDAO.insertStudy(
+                name,
+                description,
+                piName,
+                dataTypes,
+                publicVisibility,
+                u.getUserId(),
+                Instant.now(),
+                UUID.randomUUID()
+        );
+
+        Integer id2 = studyDAO.insertStudy(
+                RandomStringUtils.randomAlphabetic(20),
+                description,
+                piName,
+                dataTypes,
+                publicVisibility,
+                u.getUserId(),
+                Instant.now(),
+                UUID.randomUUID()
+        );
+
+        Integer prop1Id = studyDAO.insertStudyProperty(
+                id,
+                "prop1",
+                PropertyType.String.toString(),
+                "asdf"
+        );
+
+        Integer prop2Id = studyDAO.insertStudyProperty(
+                id,
+                "prop2",
+                PropertyType.Number.toString(),
+                "1"
+        );
+
+        // create some random, other property
+        studyDAO.insertStudyProperty(
+                id2,
+                "unrelated",
+                PropertyType.String.toString(),
+                "asdfasdfasdf"
+        );
+
+        Study study = studyDAO.findStudyById(id);
+
+        assertEquals(study.getProperties().size(), 2);
+
+        study.getProperties().forEach((prop) -> {
+            if (prop.getStudyPropertyId().equals(prop1Id)) {
+                assertEquals("prop1", prop.getName());
+                assertEquals(PropertyType.String, prop.getType());
+                assertEquals("asdf", prop.getValue());
+            } else if (prop.getStudyPropertyId().equals(prop2Id)) {
+                assertEquals("prop2", prop.getName());
+                assertEquals(PropertyType.Number, prop.getType());
+                assertEquals(1, prop.getValue());
+            } else {
+                fail("Unexpected property");
+            }
+        });
+    }
+
+
+    @Test
+    public void testAlternativeDataSharingPlan() {
+        User u = createUser();
+
+        UUID uuid = UUID.randomUUID();
+        Integer id = studyDAO.insertStudy(
+                "name",
+                "description",
+                "asdf",
+                List.of(),
+                true,
+                u.getUserId(),
+                Instant.now(),
+                uuid
+        );
+
+        FileStorageObject fso = createFileStorageObject(uuid.toString(), FileCategory.ALTERNATIVE_DATA_SHARING_PLAN);
+
+        Study study = studyDAO.findStudyById(id);
+
+        assertEquals(fso.getFileStorageObjectId(), study.getAlternativeDataSharingPlan().getFileStorageObjectId());
+        assertEquals(fso.getBlobId(), study.getAlternativeDataSharingPlan().getBlobId());
+
+    }
+
+    @Test
+    public void testIncludesDatasetIds() {
+        Study s = this.insertStudyWithProperties();
+
+        insertDataset();
+        Dataset ds1 = this.insertDatasetForStudy(s.getStudyId());
+        insertDataset();
+        Dataset ds2 = this.insertDatasetForStudy(s.getStudyId());
+        insertDataset();
+
+        s = studyDAO.findStudyById(s.getStudyId());
+
+        assertEquals(2, s.getDatasetIds().size());
+        assertTrue(s.getDatasetIds().contains(ds1.getDataSetId()));
+        assertTrue(s.getDatasetIds().contains(ds2.getDataSetId()));
+    }
+
+    private FileStorageObject createFileStorageObject(String entityId, FileCategory category) {
+        String fileName = org.apache.commons.lang3.RandomStringUtils.randomAlphabetic(10);
+        String bucketName = org.apache.commons.lang3.RandomStringUtils.randomAlphabetic(10);
+        String gcsFileUri = org.apache.commons.lang3.RandomStringUtils.randomAlphabetic(10);
+        User createUser = createUser();
+        Instant createDate = Instant.now();
+
+        Integer newFileStorageObjectId = fileStorageObjectDAO.insertNewFile(
+                fileName,
+                category.getValue(),
+                bucketName,
+                gcsFileUri,
+                entityId,
+                createUser.getUserId(),
+                createDate
+        );
+        return fileStorageObjectDAO.findFileById(newFileStorageObjectId);
+    }
+
+    private Study insertStudyWithProperties() {
+        User u = createUser();
+
+        String name = org.apache.commons.lang3.RandomStringUtils.randomAlphabetic(20);
+        String description = org.apache.commons.lang3.RandomStringUtils.randomAlphabetic(20);
+        List<String> dataTypes = List.of(
+                org.apache.commons.lang3.RandomStringUtils.randomAlphabetic(20),
+                org.apache.commons.lang3.RandomStringUtils.randomAlphabetic(20)
+        );
+        String piName = org.testcontainers.shaded.org.apache.commons.lang3.RandomStringUtils.randomAlphabetic(20);
+        Boolean publicVisibility = true;
+
+        Integer id = studyDAO.insertStudy(
+                name,
+                description,
+                piName,
+                dataTypes,
+                publicVisibility,
+                u.getUserId(),
+                Instant.now(),
+                UUID.randomUUID()
+        );
+
+        studyDAO.insertStudyProperty(
+                id,
+                "prop1",
+                PropertyType.String.toString(),
+                "asdf"
+        );
+
+        studyDAO.insertStudyProperty(
+                id,
+                "prop2",
+                PropertyType.Number.toString(),
+                "1"
+        );
+
+        return studyDAO.findStudyById(id);
+    }
+
+    private Dataset insertDatasetForStudy(Integer studyId) {
+        User user = createUser();
+        String name = "Name_" + org.apache.commons.lang3.RandomStringUtils.random(20, true, true);
+        Timestamp now = new Timestamp(new Date().getTime());
+        String objectId = "Object ID_" + org.apache.commons.lang3.RandomStringUtils.random(20, true, true);
+        DataUse dataUse = new DataUseBuilder().setGeneralUse(true).build();
+        Integer id = datasetDAO.insertDataset(name, now, user.getUserId(), objectId, true, dataUse.toString(), null);
+
+        datasetDAO.updateStudyId(id, studyId);
+
+        return datasetDAO.findDatasetById(id);
+    }
+
+    private Dataset insertDataset() {
+        User user = createUser();
+        String name = "Name_" + org.apache.commons.lang3.RandomStringUtils.random(20, true, true);
+        Timestamp now = new Timestamp(new Date().getTime());
+        String objectId = "Object ID_" + org.apache.commons.lang3.RandomStringUtils.random(20, true, true);
+        DataUse dataUse = new DataUseBuilder().setGeneralUse(true).build();
+        Integer id = datasetDAO.insertDataset(name, now, user.getUserId(), objectId, true, dataUse.toString(), null);
+        return datasetDAO.findDatasetById(id);
+    }
+
+}

--- a/src/test/java/org/broadinstitute/consent/http/db/TestingDAO.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/TestingDAO.java
@@ -52,6 +52,13 @@ public interface TestingDAO extends Transactional<TestingDAO> {
   @SqlUpdate("DELETE FROM dataset")
   void deleteAllDatasets();
 
+  @SqlUpdate("DELETE FROM study")
+  void deleteAllStudies();
+
+  @SqlUpdate("DELETE FROM study_property")
+  void deleteAllStudyProperties();
+
+
   @SqlUpdate("DELETE FROM user_role where dac_id is not null")
   void deleteAllDacUserRoles();
 

--- a/src/test/java/org/broadinstitute/consent/http/models/DatasetTests.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/DatasetTests.java
@@ -6,11 +6,10 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
-import org.broadinstitute.consent.http.enumeration.DatasetPropertyType;
+import org.broadinstitute.consent.http.enumeration.PropertyType;
 import org.junit.Test;
 import org.testcontainers.shaded.org.apache.commons.lang3.RandomStringUtils;
 
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -60,7 +59,7 @@ public class DatasetTests {
 
         DatasetProperty dsp = new DatasetProperty();
         dsp.setPropertyValue(value);
-        dsp.setPropertyType(DatasetPropertyType.String);
+        dsp.setPropertyType(PropertyType.String);
         ds.setProperties(Set.of(dsp));
 
         assertTrue(ds.isStringMatch(value));

--- a/src/test/java/org/broadinstitute/consent/http/service/DatasetRegistrationServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DatasetRegistrationServiceTest.java
@@ -4,7 +4,7 @@ import com.google.cloud.storage.BlobId;
 import org.broadinstitute.consent.http.cloudstore.GCSService;
 import org.broadinstitute.consent.http.db.DacDAO;
 import org.broadinstitute.consent.http.db.DatasetDAO;
-import org.broadinstitute.consent.http.enumeration.DatasetPropertyType;
+import org.broadinstitute.consent.http.enumeration.PropertyType;
 import org.broadinstitute.consent.http.enumeration.FileCategory;
 import org.broadinstitute.consent.http.models.Dac;
 import org.broadinstitute.consent.http.models.DataUse;
@@ -125,40 +125,40 @@ public class DatasetRegistrationServiceTest {
         assertContainsDatasetProperty(props, "piName", schema.getPiName());
         assertContainsDatasetProperty(props, "studyName", schema.getStudyName());
         assertContainsDatasetProperty(props, "studyType", schema.getStudyType().value());
-        assertContainsDatasetProperty(props, "dataTypes", DatasetPropertyType.coerceToJson(GsonUtil.getInstance().toJson(schema.getDataTypes())));
+        assertContainsDatasetProperty(props, "dataTypes", PropertyType.coerceToJson(GsonUtil.getInstance().toJson(schema.getDataTypes())));
         assertContainsDatasetProperty(props, "studyDescription", schema.getStudyDescription());
         assertContainsDatasetProperty(props, "phenotypeIndication", schema.getPhenotypeIndication());
         assertContainsDatasetProperty(props, "species", schema.getSpecies());
         assertContainsDatasetProperty(props, "dataSubmitterUserId", schema.getDataSubmitterUserId());
-        assertContainsDatasetProperty(props, "dataCustodianEmail", DatasetPropertyType.coerceToJson(GsonUtil.getInstance().toJson(schema.getDataCustodianEmail())));
+        assertContainsDatasetProperty(props, "dataCustodianEmail", PropertyType.coerceToJson(GsonUtil.getInstance().toJson(schema.getDataCustodianEmail())));
         assertContainsDatasetProperty(props, "publicVisibility", schema.getPublicVisibility());
         assertContainsDatasetProperty(props, "nihAnvilUse", schema.getNihAnvilUse().value());
         assertContainsDatasetProperty(props, "submittingToAnvil", schema.getSubmittingToAnvil());
         assertContainsDatasetProperty(props, "dbGaPPhsID", schema.getDbGaPPhsID());
         assertContainsDatasetProperty(props, "dbGaPStudyRegistrationName", schema.getDbGaPStudyRegistrationName());
-        assertContainsDatasetProperty(props, "embargoReleaseDate", DatasetPropertyType.coerceToDate(schema.getEmbargoReleaseDate()));
+        assertContainsDatasetProperty(props, "embargoReleaseDate", PropertyType.coerceToDate(schema.getEmbargoReleaseDate()));
         assertContainsDatasetProperty(props, "sequencingCenter", schema.getSequencingCenter());
         assertContainsDatasetProperty(props, "piInstitution", schema.getPiInstitution());
         assertContainsDatasetProperty(props, "nihGrantContractNumber", schema.getNihGrantContractNumber());
-        assertContainsDatasetProperty(props, "nihICsSupportingStudy", DatasetPropertyType.coerceToJson(GsonUtil.getInstance().toJson(schema.getNihICsSupportingStudy().stream().map(NihICsSupportingStudy::value).toList())));
+        assertContainsDatasetProperty(props, "nihICsSupportingStudy", PropertyType.coerceToJson(GsonUtil.getInstance().toJson(schema.getNihICsSupportingStudy().stream().map(NihICsSupportingStudy::value).toList())));
         assertContainsDatasetProperty(props, "nihProgramOfficerName", schema.getNihProgramOfficerName());
         assertContainsDatasetProperty(props, "nihInstitutionCenterSubmission", schema.getNihInstitutionCenterSubmission().value());
         assertContainsDatasetProperty(props, "nihGenomicProgramAdministratorName", schema.getNihGenomicProgramAdministratorName());
         assertContainsDatasetProperty(props, "multiCenterStudy", schema.getMultiCenterStudy());
-        assertContainsDatasetProperty(props, "collaboratingSites", DatasetPropertyType.coerceToJson(GsonUtil.getInstance().toJson(schema.getCollaboratingSites())));
+        assertContainsDatasetProperty(props, "collaboratingSites", PropertyType.coerceToJson(GsonUtil.getInstance().toJson(schema.getCollaboratingSites())));
         assertContainsDatasetProperty(props, "controlledAccessRequiredForGenomicSummaryResultsGSR", schema.getControlledAccessRequiredForGenomicSummaryResultsGSR());
         assertContainsDatasetProperty(props, "controlledAccessRequiredForGenomicSummaryResultsGSRRequiredExplanation", schema.getControlledAccessRequiredForGenomicSummaryResultsGSRRequiredExplanation());
         assertContainsDatasetProperty(props, "alternativeDataSharingPlan", schema.getAlternativeDataSharingPlan());
-        assertContainsDatasetProperty(props, "alternativeDataSharingPlanReasons", DatasetPropertyType.coerceToJson(GsonUtil.getInstance().toJson(schema.getAlternativeDataSharingPlanReasons().stream().map(AlternativeDataSharingPlanReason::value).toList())));
+        assertContainsDatasetProperty(props, "alternativeDataSharingPlanReasons", PropertyType.coerceToJson(GsonUtil.getInstance().toJson(schema.getAlternativeDataSharingPlanReasons().stream().map(AlternativeDataSharingPlanReason::value).toList())));
         assertContainsDatasetProperty(props, "alternativeDataSharingPlanExplanation", schema.getAlternativeDataSharingPlanExplanation());
         assertContainsDatasetProperty(props, "alternativeDataSharingPlanFileName", schema.getAlternativeDataSharingPlanFileName());
         assertContainsDatasetProperty(props, "alternativeDataSharingPlanDataSubmitted", schema.getAlternativeDataSharingPlanDataSubmitted().value());
         assertContainsDatasetProperty(props, "alternativeDataSharingPlanDataReleased", schema.getAlternativeDataSharingPlanDataReleased());
-        assertContainsDatasetProperty(props, "alternativeDataSharingPlanTargetDeliveryDate", DatasetPropertyType.Date.coerce(schema.getAlternativeDataSharingPlanTargetDeliveryDate()));
-        assertContainsDatasetProperty(props, "alternativeDataSharingPlanTargetPublicReleaseDate", DatasetPropertyType.Date.coerce(schema.getAlternativeDataSharingPlanTargetPublicReleaseDate()));
+        assertContainsDatasetProperty(props, "alternativeDataSharingPlanTargetDeliveryDate", PropertyType.Date.coerce(schema.getAlternativeDataSharingPlanTargetDeliveryDate()));
+        assertContainsDatasetProperty(props, "alternativeDataSharingPlanTargetPublicReleaseDate", PropertyType.Date.coerce(schema.getAlternativeDataSharingPlanTargetPublicReleaseDate()));
         assertContainsDatasetProperty(props, "alternativeDataSharingPlanControlledOpenAccess", schema.getAlternativeDataSharingPlanControlledOpenAccess().value());
         assertContainsDatasetProperty(props, "consentGroup.dataLocation", schema.getConsentGroups().get(0).getDataLocation().value());
-        assertContainsDatasetProperty(props, "consentGroup.fileTypes", DatasetPropertyType.coerceToJson(GsonUtil.getInstance().toJson(schema.getConsentGroups().get(0).getFileTypes())));
+        assertContainsDatasetProperty(props, "consentGroup.fileTypes", PropertyType.coerceToJson(GsonUtil.getInstance().toJson(schema.getConsentGroups().get(0).getFileTypes())));
         assertContainsDatasetProperty(props, "consentGroup.url", schema.getConsentGroups().get(0).getUrl().toString());
         assertContainsDatasetProperty(props, "consentGroup.dataAccessCommitteeId", schema.getConsentGroups().get(0).getDataAccessCommitteeId());
         assertContainsDatasetProperty(props, "consentGroup.openAccess", schema.getConsentGroups().get(0).getOpenAccess());
@@ -203,12 +203,12 @@ public class DatasetRegistrationServiceTest {
         List<DatasetProperty> props = inserts.get(0).props();
         assertContainsDatasetProperty(props, "piName", schema.getPiName());
         assertContainsDatasetProperty(props, "studyName", schema.getStudyName());
-        assertContainsDatasetProperty(props, "dataTypes", DatasetPropertyType.coerceToJson(GsonUtil.getInstance().toJson(schema.getDataTypes())));
+        assertContainsDatasetProperty(props, "dataTypes", PropertyType.coerceToJson(GsonUtil.getInstance().toJson(schema.getDataTypes())));
         assertContainsDatasetProperty(props, "studyDescription", schema.getStudyDescription());
         assertContainsDatasetProperty(props, "phenotypeIndication", schema.getPhenotypeIndication());
         assertContainsDatasetProperty(props, "species", schema.getSpecies());
         assertContainsDatasetProperty(props, "dataSubmitterUserId", schema.getDataSubmitterUserId());
-        assertContainsDatasetProperty(props, "consentGroup.fileTypes", DatasetPropertyType.coerceToJson(GsonUtil.getInstance().toJson(schema.getConsentGroups().get(0).getFileTypes())));
+        assertContainsDatasetProperty(props, "consentGroup.fileTypes", PropertyType.coerceToJson(GsonUtil.getInstance().toJson(schema.getConsentGroups().get(0).getFileTypes())));
     }
 
     @Test
@@ -278,12 +278,12 @@ public class DatasetRegistrationServiceTest {
         assertContainsDatasetProperty(props, "piName", schema.getPiName());
         assertContainsDatasetProperty(props, "studyName", schema.getStudyName());
         assertContainsDatasetProperty(props, "studyType", schema.getStudyType().value());
-        assertContainsDatasetProperty(props, "dataTypes", DatasetPropertyType.coerceToJson(GsonUtil.getInstance().toJson(schema.getDataTypes())));
+        assertContainsDatasetProperty(props, "dataTypes", PropertyType.coerceToJson(GsonUtil.getInstance().toJson(schema.getDataTypes())));
         assertContainsDatasetProperty(props, "studyDescription", schema.getStudyDescription());
         assertContainsDatasetProperty(props, "phenotypeIndication", schema.getPhenotypeIndication());
         assertContainsDatasetProperty(props, "species", schema.getSpecies());
         assertContainsDatasetProperty(props, "dataSubmitterUserId", schema.getDataSubmitterUserId());
-        assertContainsDatasetProperty(props, "consentGroup.fileTypes", DatasetPropertyType.coerceToJson(GsonUtil.getInstance().toJson(schema.getConsentGroups().get(0).getFileTypes())));
+        assertContainsDatasetProperty(props, "consentGroup.fileTypes", PropertyType.coerceToJson(GsonUtil.getInstance().toJson(schema.getConsentGroups().get(0).getFileTypes())));
         assertContainsDatasetProperty(props, "consentGroup.dataAccessCommitteeId", schema.getConsentGroups().get(0).getDataAccessCommitteeId());
         assertContainsDatasetProperty(props, "consentGroup.openAccess", schema.getConsentGroups().get(0).getOpenAccess());
 
@@ -306,12 +306,12 @@ public class DatasetRegistrationServiceTest {
         assertContainsDatasetProperty(props2, "piName", schema.getPiName());
         assertContainsDatasetProperty(props2, "studyName", schema.getStudyName());
         assertContainsDatasetProperty(props2, "studyType", schema.getStudyType().value());
-        assertContainsDatasetProperty(props2, "dataTypes", DatasetPropertyType.coerceToJson(GsonUtil.getInstance().toJson(schema.getDataTypes())));
+        assertContainsDatasetProperty(props2, "dataTypes", PropertyType.coerceToJson(GsonUtil.getInstance().toJson(schema.getDataTypes())));
         assertContainsDatasetProperty(props2, "studyDescription", schema.getStudyDescription());
         assertContainsDatasetProperty(props2, "phenotypeIndication", schema.getPhenotypeIndication());
         assertContainsDatasetProperty(props2, "species", schema.getSpecies());
         assertContainsDatasetProperty(props2, "dataSubmitterUserId", schema.getDataSubmitterUserId());
-        assertContainsDatasetProperty(props2, "consentGroup.fileTypes", DatasetPropertyType.coerceToJson(GsonUtil.getInstance().toJson(schema.getConsentGroups().get(1).getFileTypes())));
+        assertContainsDatasetProperty(props2, "consentGroup.fileTypes", PropertyType.coerceToJson(GsonUtil.getInstance().toJson(schema.getConsentGroups().get(1).getFileTypes())));
         assertContainsDatasetProperty(props2, "consentGroup.openAccess", schema.getConsentGroups().get(1).getOpenAccess());
 
     }
@@ -334,7 +334,7 @@ public class DatasetRegistrationServiceTest {
         DatasetRegistrationService.DatasetPropertyExtractor extractor = new DatasetRegistrationService.DatasetPropertyExtractor(
                 RandomStringUtils.randomAlphabetic(10),
                 RandomStringUtils.randomAlphabetic(10),
-                DatasetPropertyType.String,
+                PropertyType.String,
                 (registration, consentGroup) -> registration.getStudyName()
         );
 
@@ -362,7 +362,7 @@ public class DatasetRegistrationServiceTest {
         DatasetRegistrationService.DatasetPropertyExtractor extractor = new DatasetRegistrationService.DatasetPropertyExtractor(
                 RandomStringUtils.randomAlphabetic(10),
                 RandomStringUtils.randomAlphabetic(10),
-                DatasetPropertyType.Json,
+                PropertyType.Json,
                 (registration, consentGroup) -> GsonUtil.getInstance().toJson(registration.getDataTypes())
         );
 

--- a/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
@@ -6,7 +6,7 @@ import org.broadinstitute.consent.http.db.DacDAO;
 import org.broadinstitute.consent.http.db.DataAccessRequestDAO;
 import org.broadinstitute.consent.http.db.DatasetDAO;
 import org.broadinstitute.consent.http.db.UserRoleDAO;
-import org.broadinstitute.consent.http.enumeration.DatasetPropertyType;
+import org.broadinstitute.consent.http.enumeration.PropertyType;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.Consent;
 import org.broadinstitute.consent.http.models.Dac;
@@ -560,7 +560,7 @@ public class DatasetServiceTest {
         DatasetProperty ds1PI = new DatasetProperty();
         ds1PI.setPropertyName("Principal Investigator(PI)");
         ds1PI.setPropertyValue("John Doe");
-        ds1PI.setPropertyType(DatasetPropertyType.String);
+        ds1PI.setPropertyType(PropertyType.String);
         ds1.setProperties(Set.of(ds1PI));
 
         Dataset ds2 = new Dataset();
@@ -569,7 +569,7 @@ public class DatasetServiceTest {
         DatasetProperty ds2PI = new DatasetProperty();
         ds2PI.setPropertyName("Principal Investigator(PI)");
         ds2PI.setPropertyValue("Sally Doe");
-        ds2PI.setPropertyType(DatasetPropertyType.String);
+        ds2PI.setPropertyType(PropertyType.String);
         ds2.setProperties(Set.of(ds2PI));
 
         User u = new User();
@@ -867,7 +867,7 @@ public class DatasetServiceTest {
                 new DatasetProperty(1,
                         i,
                         "Test Value" + RandomStringUtils.randomAlphanumeric(25),
-                        DatasetPropertyType.String,
+                        PropertyType.String,
                         new Date())
             ).collect(Collectors.toSet());
     }

--- a/src/test/java/org/broadinstitute/consent/http/service/VoteServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/VoteServiceTest.java
@@ -32,7 +32,7 @@ import org.broadinstitute.consent.http.db.DatasetDAO;
 import org.broadinstitute.consent.http.db.ElectionDAO;
 import org.broadinstitute.consent.http.db.UserDAO;
 import org.broadinstitute.consent.http.db.VoteDAO;
-import org.broadinstitute.consent.http.enumeration.DatasetPropertyType;
+import org.broadinstitute.consent.http.enumeration.PropertyType;
 import org.broadinstitute.consent.http.enumeration.ElectionStatus;
 import org.broadinstitute.consent.http.enumeration.ElectionType;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
@@ -544,7 +544,7 @@ public class VoteServiceTest {
         DatasetProperty depositorProp = new DatasetProperty();
         depositorProp.setPropertyName("Data Depositor");
         depositorProp.setPropertyValue("depositor@test.com");
-        depositorProp.setPropertyType(DatasetPropertyType.String);
+        depositorProp.setPropertyType(PropertyType.String);
 
         DataAccessRequest dar1 = new DataAccessRequest();
         DataAccessRequestData data1 = new DataAccessRequestData();
@@ -606,7 +606,7 @@ public class VoteServiceTest {
         DatasetProperty depositorProp = new DatasetProperty();
         depositorProp.setPropertyName("Data Depositor");
         depositorProp.setPropertyValue("depositor@test.com");
-        depositorProp.setPropertyType(DatasetPropertyType.String);
+        depositorProp.setPropertyType(PropertyType.String);
 
         Dataset d1 = new Dataset();
         d1.setDataSetId(1);
@@ -788,7 +788,7 @@ public class VoteServiceTest {
         DatasetProperty depositorProp = new DatasetProperty();
         depositorProp.setPropertyName("Data Depositor");
         depositorProp.setPropertyValue("depositor@test.com");
-        depositorProp.setPropertyType(DatasetPropertyType.String);
+        depositorProp.setPropertyType(PropertyType.String);
 
         Dataset d1 = new Dataset();
         d1.setDataSetId(1);
@@ -852,7 +852,7 @@ public class VoteServiceTest {
         DatasetProperty depositorProp = new DatasetProperty();
         depositorProp.setPropertyName("Data Depositor");
         depositorProp.setPropertyValue("depositor@test.com");
-        depositorProp.setPropertyType(DatasetPropertyType.String);
+        depositorProp.setPropertyType(PropertyType.String);
 
         Dataset d1 = new Dataset();
         d1.setDataSetId(1);

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAOTest.java
@@ -3,7 +3,7 @@ package org.broadinstitute.consent.http.service.dao;
 import com.google.cloud.storage.BlobId;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.broadinstitute.consent.http.db.DAOTestHelper;
-import org.broadinstitute.consent.http.enumeration.DatasetPropertyType;
+import org.broadinstitute.consent.http.enumeration.PropertyType;
 import org.broadinstitute.consent.http.enumeration.FileCategory;
 import org.broadinstitute.consent.http.models.Dac;
 import org.broadinstitute.consent.http.models.DataUseBuilder;
@@ -41,13 +41,13 @@ public class DatasetServiceDAOTest extends DAOTestHelper {
         DatasetProperty prop1 = new DatasetProperty();
         prop1.setSchemaProperty(RandomStringUtils.randomAlphabetic(10));
         prop1.setPropertyName(RandomStringUtils.randomAlphabetic(10));
-        prop1.setPropertyType(DatasetPropertyType.Number);
+        prop1.setPropertyType(PropertyType.Number);
         prop1.setPropertyValue(new Random().nextInt());
 
         DatasetProperty prop2 = new DatasetProperty();
         prop2.setSchemaProperty(RandomStringUtils.randomAlphabetic(10));
         prop2.setPropertyName(RandomStringUtils.randomAlphabetic(10));
-        prop2.setPropertyType(DatasetPropertyType.Date);
+        prop2.setPropertyType(PropertyType.Date);
         prop2.setPropertyValueAsString("2000-10-20");
 
         FileStorageObject file1 = new FileStorageObject();
@@ -115,7 +115,7 @@ public class DatasetServiceDAOTest extends DAOTestHelper {
         prop1.setSchemaProperty(RandomStringUtils.randomAlphabetic(10));
         prop1.setPropertyName(RandomStringUtils.randomAlphabetic(10));
         prop1.setPropertyValue(new Random().nextInt());
-        prop1.setPropertyType(DatasetPropertyType.Number);
+        prop1.setPropertyType(PropertyType.Number);
 
 
         DatasetServiceDAO.DatasetInsert insert1 = new DatasetServiceDAO.DatasetInsert(


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DUOS-2446

This ended up being honestly a fair bit more complicated than I imagined.

Originally, I was hoping to have the study have a list of dataset objects:

```
{
   study_id: 2,
   datasets: [
      { dataset_id: 3, ... } 
   ]
}
```

But this proved to be pretty complicated with how datasets are currently represented, mapped, and reduced.

If we wanted to have datasets underneath studies, then we would have to: rewrite the dataset reducer to be more flexible, and probably change every single DAO call for datasets pretty significantly. At least, it seemed this way when I tried to do this.

Instead, I opted to have studies just have a list of dataset ids (not the full object), and datasets have the full study object (if present), like so:

```
{
   dataset_id: 3,
   study: {
      study_id: 1,
      ....
   }
}
```

Given that not all datasets are underneath a study right now, I think this approach makes more sense for now. E.g., in the new dataset catalog we're working on, I assume we want to be backwards compatible with datasets which don't have a study. This approach makes it easy - get all datasets, like we're doing now, and simply group them by study wherever possible.

However, long term, once all datasets have a study, I do think it makes sense to have datasets be returned underneath studies. In this scheme, the dataset catalog would do a call to get all studies (instead of all datasets). The studies themselves would contain the full dataset object. These datasets would already be properly grouped, and rendering them as such would be really straightforward.

Until then, though, this more complicated / less intuitive (imo) approach is necessary.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
