### PR TITLE
[DUOS-2460][risk=low] Refactor google token validation to be non-fatal

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
@@ -258,7 +258,7 @@ public class ConsentApplication extends Application<ConsentConfiguration> {
                 .setAuthenticator(new DefaultAuthenticator())
                 .setRealm(" ")
                 .buildAuthFilter();
-        List<AuthFilter> filters = Lists.newArrayList(
+        List<AuthFilter> filters = List.of(
                 defaultAuthFilter,
                 new OAuthCustomAuthFilter(authenticator, userRoleDAO));
         env.jersey().register(new AuthDynamicFeature(new ChainedAuthFilter(filters)));

--- a/src/main/java/org/broadinstitute/consent/http/authentication/DefaultAuthenticator.java
+++ b/src/main/java/org/broadinstitute/consent/http/authentication/DefaultAuthenticator.java
@@ -1,15 +1,13 @@
 package org.broadinstitute.consent.http.authentication;
 
-import io.dropwizard.auth.AuthenticationException;
 import io.dropwizard.auth.Authenticator;
-import org.broadinstitute.consent.http.models.AuthUser;
-
 import java.util.Optional;
+import org.broadinstitute.consent.http.models.AuthUser;
 
 public class DefaultAuthenticator implements Authenticator<String, AuthUser> {
 
     @Override
-    public Optional<AuthUser> authenticate(String s) throws AuthenticationException {
+    public Optional<AuthUser> authenticate(String s) {
         return Optional.of(new AuthUser(s));
     }
 }

--- a/src/main/java/org/broadinstitute/consent/http/authentication/GenericUser.java
+++ b/src/main/java/org/broadinstitute/consent/http/authentication/GenericUser.java
@@ -4,7 +4,7 @@ import com.google.gson.FieldNamingPolicy;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
-public class GoogleUser {
+public class GenericUser {
 
     private String sub;
     private String name;
@@ -17,7 +17,7 @@ public class GoogleUser {
     private String locale;
     private String hd;
 
-    public GoogleUser() {}
+    public GenericUser() {}
 
     /**
      * Convenience method to deserialize from Google's userinfo API, e.g.:
@@ -36,11 +36,11 @@ public class GoogleUser {
      *
      * @param json The JSON string to deserialize
      */
-    GoogleUser(String json) {
+    GenericUser(String json) {
         Gson gson = new GsonBuilder()
                 .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
                 .create();
-        GoogleUser u = gson.fromJson(json, GoogleUser.class);
+        GenericUser u = gson.fromJson(json, GenericUser.class);
         this.setSub(u.getSub());
         this.setName(u.getName());
         this.setGivenName(u.getGivenName());

--- a/src/main/java/org/broadinstitute/consent/http/authentication/OAuthAuthenticator.java
+++ b/src/main/java/org/broadinstitute/consent/http/authentication/OAuthAuthenticator.java
@@ -5,18 +5,17 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.Inject;
 import io.dropwizard.auth.AuthenticationException;
 import io.dropwizard.auth.Authenticator;
+import java.util.HashMap;
+import java.util.Optional;
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 import org.broadinstitute.consent.http.models.AuthUser;
 import org.broadinstitute.consent.http.models.sam.UserStatusInfo;
 import org.broadinstitute.consent.http.service.sam.SamService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.ws.rs.NotFoundException;
-import javax.ws.rs.client.Client;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import java.util.HashMap;
-import java.util.Optional;
 
 
 public class OAuthAuthenticator implements Authenticator<String, AuthUser> {
@@ -37,8 +36,8 @@ public class OAuthAuthenticator implements Authenticator<String, AuthUser> {
     public Optional<AuthUser> authenticate(String bearer) {
         try {
             validateAudience(bearer);
-            GoogleUser googleUser = getUserInfo(bearer);
-            AuthUser user = new AuthUser(googleUser).setAuthToken(bearer);
+            GenericUser genericUser = getUserInfo(bearer);
+            AuthUser user = new AuthUser(genericUser).setAuthToken(bearer);
             AuthUser userWithStatus = getUserWithStatusInfo(user);
             return Optional.of(userWithStatus);
         } catch (Exception e) {
@@ -94,15 +93,15 @@ public class OAuthAuthenticator implements Authenticator<String, AuthUser> {
         return tokenInfo;
     }
 
-    private GoogleUser getUserInfo(String bearer) throws AuthenticationException {
-        GoogleUser u = null;
+    private GenericUser getUserInfo(String bearer) throws AuthenticationException {
+        GenericUser u = null;
         try {
             Response response = this.client.
                     target(USER_INFO_URL + bearer).
                     request(MediaType.APPLICATION_JSON_TYPE).
                     get(Response.class);
             String result = response.readEntity(String.class);
-            u = new GoogleUser(result);
+            u = new GenericUser(result);
         } catch (Exception e) {
             logger.error("Error getting user info from token: " + e.getMessage());
             unauthorized(bearer);

--- a/src/main/java/org/broadinstitute/consent/http/authentication/OAuthAuthenticator.java
+++ b/src/main/java/org/broadinstitute/consent/http/authentication/OAuthAuthenticator.java
@@ -1,11 +1,8 @@
 package org.broadinstitute.consent.http.authentication;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.Inject;
-import io.dropwizard.auth.AuthenticationException;
 import io.dropwizard.auth.Authenticator;
-import java.util.HashMap;
+import java.util.Objects;
 import java.util.Optional;
 import javax.ws.rs.NotFoundException;
 import javax.ws.rs.client.Client;
@@ -14,15 +11,12 @@ import javax.ws.rs.core.Response;
 import org.broadinstitute.consent.http.models.AuthUser;
 import org.broadinstitute.consent.http.models.sam.UserStatusInfo;
 import org.broadinstitute.consent.http.service.sam.SamService;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.broadinstitute.consent.http.util.ConsentLogger;
 
 
-public class OAuthAuthenticator implements Authenticator<String, AuthUser> {
+public class OAuthAuthenticator implements Authenticator<String, AuthUser>, ConsentLogger {
 
-    private static final String TOKEN_INFO_URL = "https://www.googleapis.com/oauth2/v3/tokeninfo?access_token=";
     private static final String USER_INFO_URL = "https://www.googleapis.com/oauth2/v3/userinfo?access_token=";
-    private static final Logger logger = LoggerFactory.getLogger(OAuthAuthenticator.class);
     private final Client client;
     private final SamService samService;
 
@@ -35,13 +29,14 @@ public class OAuthAuthenticator implements Authenticator<String, AuthUser> {
     @Override
     public Optional<AuthUser> authenticate(String bearer) {
         try {
-            validateAudience(bearer);
-            GenericUser genericUser = getUserInfo(bearer);
-            AuthUser user = new AuthUser(genericUser).setAuthToken(bearer);
+            GenericUser genericUser = getUserProfileInfo(bearer);
+            AuthUser user = Objects.nonNull(genericUser) ?
+                new AuthUser(genericUser).setAuthToken(bearer) :
+                new AuthUser().setAuthToken(bearer);
             AuthUser userWithStatus = getUserWithStatusInfo(user);
             return Optional.of(userWithStatus);
         } catch (Exception e) {
-            logger.error("Error authenticating credentials: " + e.getMessage());
+            logException("Error authenticating credentials", e);
             return Optional.empty();
         }
     }
@@ -55,45 +50,29 @@ public class OAuthAuthenticator implements Authenticator<String, AuthUser> {
     private AuthUser getUserWithStatusInfo(AuthUser authUser) {
         try {
             UserStatusInfo userStatusInfo = samService.getRegistrationInfo(authUser);
+            // safety check in case the call to generic user (i.e. Google) failed.
+            if (Objects.isNull(authUser.getEmail())) {
+                authUser.setEmail(userStatusInfo.getUserEmail());
+            }
+            if (Objects.isNull(authUser.getName())) {
+                authUser.setName(userStatusInfo.getUserEmail());
+            }
             return authUser.deepCopy().setUserStatusInfo(userStatusInfo);
         } catch (NotFoundException e) {
-            logger.warn("User not found: '" + authUser.getEmail());
+            logWarn("User not found: '" + authUser.getEmail());
         } catch (Throwable e) {
-            logger.error("Exception retrieving Sam user info for '" + authUser.getEmail() + "': " + e.getMessage());
+            logException("Exception retrieving Sam user info for '" + authUser.getEmail() + "'", new Exception(e.getMessage()));
         }
         return authUser;
     }
 
-    private void validateAudience(String bearer) throws AuthenticationException {
-        HashMap<String, Object> tokenInfo = validateToken(bearer);
-        try {
-            String clientId = tokenInfo.containsKey("aud") ? tokenInfo.get("aud").toString() : tokenInfo.get("audience").toString();
-            if (clientId == null) {
-                unauthorized(bearer);
-            }
-        } catch (AuthenticationException e) {
-            logger.error("Error validating audience: " + e.getMessage());
-            unauthorized(bearer);
-        }
-    }
-
-    private HashMap<String, Object> validateToken(String accessToken) throws AuthenticationException {
-        HashMap<String, Object> tokenInfo = null;
-        try {
-            Response response = this.client.
-                    target(TOKEN_INFO_URL + accessToken).
-                    request(MediaType.APPLICATION_JSON_TYPE).
-                    get(Response.class);
-            String result = response.readEntity(String.class);
-            tokenInfo = new ObjectMapper().readValue(result, new TypeReference<>() {});
-        } catch (Exception e) {
-            logger.error("Error validating access token: " + e.getMessage());
-            unauthorized(accessToken);
-        }
-        return tokenInfo;
-    }
-
-    private GenericUser getUserInfo(String bearer) throws AuthenticationException {
+    /**
+     * This method is currently google-centric. When we fully support B2C authentication,
+     * we should ensure that we can look up user info from a MS service.
+     * @param bearer Bearer Token
+     * @return GenericUser
+     */
+    private GenericUser getUserProfileInfo(String bearer) {
         GenericUser u = null;
         try {
             Response response = this.client.
@@ -103,14 +82,9 @@ public class OAuthAuthenticator implements Authenticator<String, AuthUser> {
             String result = response.readEntity(String.class);
             u = new GenericUser(result);
         } catch (Exception e) {
-            logger.error("Error getting user info from token: " + e.getMessage());
-            unauthorized(bearer);
+            logWarn("Error getting Google user info from token: " + e.getMessage());
         }
         return u;
-    }
-
-    private void unauthorized(String accessToken) throws AuthenticationException {
-        throw new AuthenticationException("Provided access token or user credential is either null or empty or does not have permissions to access this resource." + accessToken);
     }
 
 }

--- a/src/main/java/org/broadinstitute/consent/http/models/AuthUser.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/AuthUser.java
@@ -2,6 +2,7 @@ package org.broadinstitute.consent.http.models;
 
 import com.google.gson.Gson;
 import java.security.Principal;
+import java.util.Objects;
 import org.broadinstitute.consent.http.authentication.GenericUser;
 import org.broadinstitute.consent.http.models.sam.UserStatusInfo;
 
@@ -25,8 +26,12 @@ public class AuthUser implements Principal {
   }
 
   public AuthUser(GenericUser genericUser) {
-    this.name = genericUser.getName();
-    this.email = genericUser.getEmail();
+    if (Objects.nonNull(genericUser) && Objects.nonNull(genericUser.getName())) {
+      this.name = genericUser.getName();
+    }
+    if (Objects.nonNull(genericUser) && Objects.nonNull(genericUser.getEmail())) {
+      this.email = genericUser.getEmail();
+    }
     this.genericUser = genericUser;
   }
 
@@ -48,13 +53,8 @@ public class AuthUser implements Principal {
     return this;
   }
 
-  public GenericUser getGoogleUser() {
+  public GenericUser getGenericUser() {
     return genericUser;
-  }
-
-  public AuthUser setGoogleUser(GenericUser genericUser) {
-    this.genericUser = genericUser;
-    return this;
   }
 
   @Override

--- a/src/main/java/org/broadinstitute/consent/http/models/AuthUser.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/AuthUser.java
@@ -1,16 +1,15 @@
 package org.broadinstitute.consent.http.models;
 
 import com.google.gson.Gson;
-import org.broadinstitute.consent.http.authentication.GoogleUser;
-import org.broadinstitute.consent.http.models.sam.UserStatusInfo;
-
 import java.security.Principal;
+import org.broadinstitute.consent.http.authentication.GenericUser;
+import org.broadinstitute.consent.http.models.sam.UserStatusInfo;
 
 public class AuthUser implements Principal {
 
   private String authToken;
   private String email;
-  private GoogleUser googleUser;
+  private GenericUser genericUser;
   private String name;
   private UserStatusInfo userStatusInfo;
 
@@ -25,10 +24,10 @@ public class AuthUser implements Principal {
     return gson.fromJson(gson.toJson(this), AuthUser.class);
   }
 
-  public AuthUser(GoogleUser googleUser) {
-    this.name = googleUser.getName();
-    this.email = googleUser.getEmail();
-    this.googleUser = googleUser;
+  public AuthUser(GenericUser genericUser) {
+    this.name = genericUser.getName();
+    this.email = genericUser.getEmail();
+    this.genericUser = genericUser;
   }
 
   public String getAuthToken() {
@@ -49,12 +48,12 @@ public class AuthUser implements Principal {
     return this;
   }
 
-  public GoogleUser getGoogleUser() {
-    return googleUser;
+  public GenericUser getGoogleUser() {
+    return genericUser;
   }
 
-  public AuthUser setGoogleUser(GoogleUser googleUser) {
-    this.googleUser = googleUser;
+  public AuthUser setGoogleUser(GenericUser genericUser) {
+    this.genericUser = genericUser;
     return this;
   }
 

--- a/src/main/java/org/broadinstitute/consent/http/models/User.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/User.java
@@ -15,7 +15,7 @@ import net.gcardone.junidecode.Junidecode;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.broadinstitute.consent.http.authentication.GoogleUser;
+import org.broadinstitute.consent.http.authentication.GenericUser;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
 
 public class User {
@@ -87,9 +87,9 @@ public class User {
         this.roles = roles;
     }
 
-    public User(GoogleUser googleUser) {
-        this.displayName = googleUser.getName();
-        this.email = googleUser.getEmail();
+    public User(GenericUser genericUser) {
+        this.displayName = genericUser.getName();
+        this.email = genericUser.getEmail();
     }
 
     /**

--- a/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
@@ -136,7 +136,7 @@ public class DatasetResource extends Resource {
         if (Objects.nonNull(datasetNameAlreadyUsed)) {
             throw new ClientErrorException("Dataset name: " + name + " is already in use", Status.CONFLICT);
         }
-        User dacUser = userService.findUserByEmail(authUser.getGoogleUser().getEmail());
+        User dacUser = userService.findUserByEmail(authUser.getGenericUser().getEmail());
         Integer userId = dacUser.getUserId();
         try {
             DatasetDTO createdDatasetWithConsent = datasetService.createDatasetWithConsent(inputDataset, name, userId);
@@ -242,7 +242,7 @@ public class DatasetResource extends Resource {
             if (duplicateProperties.size() > 0) {
                 throw new BadRequestException("Dataset contains multiple values for the same property.");
             }
-            User user = userService.findUserByEmail(authUser.getGoogleUser().getEmail());
+            User user = userService.findUserByEmail(authUser.getGenericUser().getEmail());
             // Validate that the admin/chairperson has edit access to this dataset
             validateDatasetDacAccess(user, datasetExists);
             Integer userId = user.getUserId();

--- a/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
@@ -35,7 +35,7 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
-import org.broadinstitute.consent.http.authentication.GoogleUser;
+import org.broadinstitute.consent.http.authentication.GenericUser;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.Acknowledgement;
 import org.broadinstitute.consent.http.models.AuthUser;
@@ -372,15 +372,15 @@ public class UserResource extends Resource {
     @Produces("application/json")
     @PermitAll
     public Response createResearcher(@Context UriInfo info, @Auth AuthUser user) {
-        GoogleUser googleUser = user.getGoogleUser();
-        if (googleUser == null || googleUser.getEmail() == null || googleUser.getName() == null) {
+        GenericUser genericUser = user.getGoogleUser();
+        if (genericUser == null || genericUser.getEmail() == null || genericUser.getName() == null) {
             return Response.
                     status(Response.Status.BAD_REQUEST).
                     entity(new Error("Unable to verify google identity", Response.Status.BAD_REQUEST.getStatusCode())).
                     build();
         }
         try {
-            if (userService.findUserByEmail(googleUser.getEmail()) != null) {
+            if (userService.findUserByEmail(genericUser.getEmail()) != null) {
                 return Response.
                         status(Response.Status.CONFLICT).
                         entity(new Error("Registered user exists", Response.Status.CONFLICT.getStatusCode())).
@@ -389,7 +389,7 @@ public class UserResource extends Resource {
         } catch (NotFoundException nfe) {
             // no-op, we expect to not find the new user in this case.
         }
-        User dacUser = new User(googleUser);
+        User dacUser = new User(genericUser);
         UserRole researcher = new UserRole(UserRoles.RESEARCHER.getRoleId(), UserRoles.RESEARCHER.getRoleName());
         dacUser.setRoles(Collections.singletonList(researcher));
         try {

--- a/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
@@ -372,7 +372,7 @@ public class UserResource extends Resource {
     @Produces("application/json")
     @PermitAll
     public Response createResearcher(@Context UriInfo info, @Auth AuthUser user) {
-        GenericUser genericUser = user.getGoogleUser();
+        GenericUser genericUser = user.getGenericUser();
         if (genericUser == null || genericUser.getEmail() == null || genericUser.getName() == null) {
             return Response.
                     status(Response.Status.BAD_REQUEST).

--- a/src/test/java/org/broadinstitute/consent/http/authentication/OAuthAuthenticatorTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/authentication/OAuthAuthenticatorTest.java
@@ -1,0 +1,93 @@
+package org.broadinstitute.consent.http.authentication;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.openMocks;
+
+import com.google.gson.Gson;
+import java.util.Optional;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.Invocation;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import org.broadinstitute.consent.http.models.AuthUser;
+import org.broadinstitute.consent.http.service.sam.SamService;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+public class OAuthAuthenticatorTest {
+
+  @Mock
+  private Client client;
+
+  @Mock
+  private SamService samService;
+
+  @Mock
+  private WebTarget target;
+
+  @Mock
+  private Invocation.Builder builder;
+
+  @Mock
+  private Response response;
+
+  private OAuthAuthenticator oAuthAuthenticator;
+
+  @Before
+  public void setUp() {
+    openMocks(this);
+  }
+
+  @Test
+  public void testAuthenticateWithToken() {
+    oAuthAuthenticator = new OAuthAuthenticator(client, samService);
+    Optional<AuthUser> authUser = oAuthAuthenticator.authenticate("bearer-token");
+    assertTrue(authUser.isPresent());
+  }
+
+  @Test
+  public void testAuthenticateGetUserInfoSuccess() {
+    String bearerToken = "bearer-token";
+    Gson gson = new Gson();
+    GenericUser user = new GenericUser();
+    user.setEmail("email");
+    user.setName("name");
+    when(client.target(anyString())).thenReturn(target);
+    when(target.request(MediaType.APPLICATION_JSON_TYPE)).thenReturn(builder);
+    when(builder.get(Response.class)).thenReturn(response);
+    when(response.readEntity(String.class)).thenReturn(gson.toJson(user));
+    when(response.getStatus()).thenReturn(200);
+    oAuthAuthenticator = new OAuthAuthenticator(client, samService);
+
+    Optional<AuthUser> authUser = oAuthAuthenticator.authenticate(bearerToken);
+    assertTrue(authUser.isPresent());
+    assertEquals(user.getEmail(), authUser.get().getEmail());
+    assertEquals(user.getName(), authUser.get().getName());
+    assertEquals(authUser.get().getAuthToken(), bearerToken);
+  }
+
+  /**
+   * Test that in the case of a token lookup failure, we don't fail the overall
+   * request.
+   */
+  @Test
+  public void testAuthenticateGetUserInfoFailure() {
+    String bearerToken = "bearer-token";
+    when(client.target(anyString())).thenReturn(target);
+    when(target.request(MediaType.APPLICATION_JSON_TYPE)).thenReturn(builder);
+    when(builder.get(Response.class)).thenReturn(response);
+    when(response.readEntity(String.class)).thenReturn("Bad Request");
+    when(response.getStatus()).thenReturn(400);
+    oAuthAuthenticator = new OAuthAuthenticator(client, samService);
+
+    Optional<AuthUser> authUser = oAuthAuthenticator.authenticate(bearerToken);
+    assertTrue(authUser.isPresent());
+    assertEquals(authUser.get().getAuthToken(), bearerToken);
+  }
+
+}

--- a/src/test/java/org/broadinstitute/consent/http/authentication/OAuthCustomAuthFilterTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/authentication/OAuthCustomAuthFilterTest.java
@@ -1,6 +1,14 @@
 package org.broadinstitute.consent.http.authentication;
 
+import static org.mockito.ArgumentMatchers.notNull;
+import static org.mockito.Mockito.when;
+
 import io.dropwizard.auth.AuthFilter;
+import java.util.Optional;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.UriInfo;
 import org.broadinstitute.consent.http.db.UserRoleDAO;
 import org.broadinstitute.consent.http.models.AuthUser;
 import org.junit.Before;
@@ -10,16 +18,6 @@ import org.junit.rules.ExpectedException;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
-
-import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.container.ContainerRequestContext;
-import javax.ws.rs.core.MultivaluedMap;
-import javax.ws.rs.core.UriInfo;
-
-import java.util.Optional;
-
-import static org.mockito.ArgumentMatchers.notNull;
-import static org.mockito.Mockito.when;
 
 public class OAuthCustomAuthFilterTest {
 
@@ -42,7 +40,7 @@ public class OAuthCustomAuthFilterTest {
 
     AuthUser user;
 
-    GoogleUser googleUser;
+    GenericUser genericUser;
 
     @Before
     public void setUp(){
@@ -52,10 +50,10 @@ public class OAuthCustomAuthFilterTest {
         when(headers.getFirst("Authorization")).thenReturn("Bearer 0cx2G9gKm4XZdK8BFxoWy7AE025tvq");
         when(authenticator.authenticate(notNull())).thenReturn(principal);
         filter = Mockito.spy(new OAuthCustomAuthFilter(authenticator, userRoleDAO));
-        googleUser = new GoogleUser();
-        googleUser.setName("Test User");
-        googleUser.setEmail("test@gmail.com");
-        user = new AuthUser(googleUser);
+        genericUser = new GenericUser();
+        genericUser.setName("Test User");
+        genericUser.setEmail("test@gmail.com");
+        user = new AuthUser(genericUser);
     }
 
     @Test

--- a/src/test/java/org/broadinstitute/consent/http/authentication/OAuthCustomAuthFilterTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/authentication/OAuthCustomAuthFilterTest.java
@@ -1,7 +1,10 @@
 package org.broadinstitute.consent.http.authentication;
 
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.notNull;
 import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import io.dropwizard.auth.AuthFilter;
 import java.util.Optional;
@@ -12,17 +15,12 @@ import javax.ws.rs.core.UriInfo;
 import org.broadinstitute.consent.http.db.UserRoleDAO;
 import org.broadinstitute.consent.http.models.AuthUser;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
 
 public class OAuthCustomAuthFilterTest {
 
-    @Rule
-    public ExpectedException expectedEx = ExpectedException.none();
     @Mock
     ContainerRequestContext requestContext;
     @Mock
@@ -44,7 +42,7 @@ public class OAuthCustomAuthFilterTest {
 
     @Before
     public void setUp(){
-        MockitoAnnotations.initMocks(this);
+        openMocks(this);
         when(requestContext.getHeaders()).thenReturn(headers);
         when(requestContext.getUriInfo()).thenReturn(uriInfo);
         when(headers.getFirst("Authorization")).thenReturn("Bearer 0cx2G9gKm4XZdK8BFxoWy7AE025tvq");
@@ -66,12 +64,15 @@ public class OAuthCustomAuthFilterTest {
 
 
     @Test
-    public void testFilterExceptionBadCredentials() throws Exception {
+    public void testFilterExceptionBadCredentials() {
         principal = Optional.empty();
         when(uriInfo.getPath()).thenReturn("api/something");
         when(authenticator.authenticate("0cx2G9gKm4XZdK8BFxoWy7AE025tvq")).thenReturn(principal);
-        expectedEx.expect(WebApplicationException.class);
-        expectedEx.expectMessage("HTTP 401 Unauthorized");
-        filter.filter(requestContext);
+        try {
+            filter.filter(requestContext);
+            fail("Filter should have failed");
+        } catch (Exception e) {
+            assertTrue(e instanceof WebApplicationException);
+        }
     }
 }

--- a/src/test/java/org/broadinstitute/consent/http/authentication/TestOAuthAuthenticator.java
+++ b/src/test/java/org/broadinstitute/consent/http/authentication/TestOAuthAuthenticator.java
@@ -2,10 +2,9 @@ package org.broadinstitute.consent.http.authentication;
 
 import io.dropwizard.auth.AuthenticationException;
 import io.dropwizard.auth.Authenticator;
-import org.broadinstitute.consent.http.models.AuthUser;
-
 import java.util.List;
 import java.util.Optional;
+import org.broadinstitute.consent.http.models.AuthUser;
 
 public class TestOAuthAuthenticator implements Authenticator<String, AuthUser> {
 
@@ -18,10 +17,10 @@ public class TestOAuthAuthenticator implements Authenticator<String, AuthUser> {
     @Override
     public Optional<AuthUser> authenticate(String credentials) throws AuthenticationException {
         if (acceptableCredentials.contains(credentials)) {
-            GoogleUser googleUser = new GoogleUser();
-            googleUser.setEmail(credentials);
-            googleUser.setName(credentials);
-            AuthUser user = new AuthUser(googleUser);
+            GenericUser genericUser = new GenericUser();
+            genericUser.setEmail(credentials);
+            genericUser.setName(credentials);
+            AuthUser user = new AuthUser(genericUser);
             return Optional.of(user);
         }
         return Optional.empty();

--- a/src/test/java/org/broadinstitute/consent/http/authentication/TestOAuthAuthenticator.java
+++ b/src/test/java/org/broadinstitute/consent/http/authentication/TestOAuthAuthenticator.java
@@ -1,6 +1,5 @@
 package org.broadinstitute.consent.http.authentication;
 
-import io.dropwizard.auth.AuthenticationException;
 import io.dropwizard.auth.Authenticator;
 import java.util.List;
 import java.util.Optional;
@@ -8,14 +7,14 @@ import org.broadinstitute.consent.http.models.AuthUser;
 
 public class TestOAuthAuthenticator implements Authenticator<String, AuthUser> {
 
-    private List<String> acceptableCredentials;
+    private final List<String> acceptableCredentials;
 
     public TestOAuthAuthenticator(List<String> acceptableCredentials) {
         this.acceptableCredentials = acceptableCredentials;
     }
 
     @Override
-    public Optional<AuthUser> authenticate(String credentials) throws AuthenticationException {
+    public Optional<AuthUser> authenticate(String credentials) {
         if (acceptableCredentials.contains(credentials)) {
             GenericUser genericUser = new GenericUser();
             genericUser.setEmail(credentials);

--- a/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
@@ -1,9 +1,40 @@
 package org.broadinstitute.consent.http.resources;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.openMocks;
+
 import com.google.api.client.http.HttpStatusCodes;
 import com.google.gson.Gson;
+import java.io.IOException;
+import java.net.URI;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.ClientErrorException;
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriBuilder;
+import javax.ws.rs.core.UriInfo;
 import org.apache.commons.lang3.RandomUtils;
-import org.broadinstitute.consent.http.authentication.GoogleUser;
+import org.broadinstitute.consent.http.authentication.GenericUser;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.AuthUser;
 import org.broadinstitute.consent.http.models.Consent;
@@ -29,38 +60,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 
-import javax.ws.rs.BadRequestException;
-import javax.ws.rs.ClientErrorException;
-import javax.ws.rs.NotFoundException;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.UriBuilder;
-import javax.ws.rs.core.UriInfo;
-import java.io.IOException;
-import java.net.URI;
-import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.openMocks;
-
 public class DatasetResourceTest {
 
     @Mock
@@ -78,7 +77,7 @@ public class DatasetResourceTest {
     private AuthUser authUser;
 
     @Mock
-    private GoogleUser googleUser;
+    private GenericUser genericUser;
 
     @Mock
     private User user;
@@ -134,8 +133,8 @@ public class DatasetResourceTest {
         when(datasetService.createDatasetWithConsent(any(), any(), anyInt())).thenReturn(result);
         when(datasetService.createConsentForDataset(any())).thenReturn(consent);
         when(datasetService.getDatasetDTO(any())).thenReturn(result);
-        when(authUser.getGoogleUser()).thenReturn(googleUser);
-        when(googleUser.getEmail()).thenReturn("email@email.com");
+        when(authUser.getGoogleUser()).thenReturn(genericUser);
+        when(genericUser.getEmail()).thenReturn("email@email.com");
         when(userService.findUserByEmail(any())).thenReturn(user);
         when(user.getUserId()).thenReturn(1);
         when(uriInfo.getRequestUriBuilder()).thenReturn(uriBuilder);
@@ -228,8 +227,8 @@ public class DatasetResourceTest {
         when(datasetService.getDatasetByName("test")).thenReturn(null);
         doThrow(new RuntimeException()).when(datasetService).createDatasetWithConsent(any(), any(), anyInt());
         when(datasetService.createConsentForDataset(any())).thenReturn(consent);
-        when(authUser.getGoogleUser()).thenReturn(googleUser);
-        when(googleUser.getEmail()).thenReturn("email@email.com");
+        when(authUser.getGoogleUser()).thenReturn(genericUser);
+        when(genericUser.getEmail()).thenReturn("email@email.com");
         when(userService.findUserByEmail(any())).thenReturn(user);
         when(user.getUserId()).thenReturn(1);
         initResource();
@@ -244,8 +243,8 @@ public class DatasetResourceTest {
         String json = createPropertiesJson("Dataset Name", "test");
         when(datasetService.findDatasetById(anyInt())).thenReturn(preexistingDataset);
         when(datasetService.updateDataset(any(), any(), any())).thenReturn(Optional.of(preexistingDataset));
-        when(authUser.getGoogleUser()).thenReturn(googleUser);
-        when(googleUser.getEmail()).thenReturn("email@email.com");
+        when(authUser.getGoogleUser()).thenReturn(genericUser);
+        when(genericUser.getEmail()).thenReturn("email@email.com");
         when(userService.findUserByEmail(any())).thenReturn(user);
         when(user.getUserId()).thenReturn(1);
         when(user.hasUserRole(any())).thenReturn(true);
@@ -318,8 +317,8 @@ public class DatasetResourceTest {
         String json = createPropertiesJson("Dataset Name", "test");
         when(datasetService.findDatasetById(anyInt())).thenReturn(preexistingDataset);
         when(datasetService.updateDataset(any(), any(), any())).thenReturn(Optional.empty());
-        when(authUser.getGoogleUser()).thenReturn(googleUser);
-        when(googleUser.getEmail()).thenReturn("email@email.com");
+        when(authUser.getGoogleUser()).thenReturn(genericUser);
+        when(genericUser.getEmail()).thenReturn("email@email.com");
         when(userService.findUserByEmail(any())).thenReturn(user);
         when(user.getUserId()).thenReturn(1);
         when(user.hasUserRole(any())).thenReturn(true);

--- a/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
@@ -133,7 +133,7 @@ public class DatasetResourceTest {
         when(datasetService.createDatasetWithConsent(any(), any(), anyInt())).thenReturn(result);
         when(datasetService.createConsentForDataset(any())).thenReturn(consent);
         when(datasetService.getDatasetDTO(any())).thenReturn(result);
-        when(authUser.getGoogleUser()).thenReturn(genericUser);
+        when(authUser.getGenericUser()).thenReturn(genericUser);
         when(genericUser.getEmail()).thenReturn("email@email.com");
         when(userService.findUserByEmail(any())).thenReturn(user);
         when(user.getUserId()).thenReturn(1);
@@ -227,7 +227,7 @@ public class DatasetResourceTest {
         when(datasetService.getDatasetByName("test")).thenReturn(null);
         doThrow(new RuntimeException()).when(datasetService).createDatasetWithConsent(any(), any(), anyInt());
         when(datasetService.createConsentForDataset(any())).thenReturn(consent);
-        when(authUser.getGoogleUser()).thenReturn(genericUser);
+        when(authUser.getGenericUser()).thenReturn(genericUser);
         when(genericUser.getEmail()).thenReturn("email@email.com");
         when(userService.findUserByEmail(any())).thenReturn(user);
         when(user.getUserId()).thenReturn(1);
@@ -243,7 +243,7 @@ public class DatasetResourceTest {
         String json = createPropertiesJson("Dataset Name", "test");
         when(datasetService.findDatasetById(anyInt())).thenReturn(preexistingDataset);
         when(datasetService.updateDataset(any(), any(), any())).thenReturn(Optional.of(preexistingDataset));
-        when(authUser.getGoogleUser()).thenReturn(genericUser);
+        when(authUser.getGenericUser()).thenReturn(genericUser);
         when(genericUser.getEmail()).thenReturn("email@email.com");
         when(userService.findUserByEmail(any())).thenReturn(user);
         when(user.getUserId()).thenReturn(1);
@@ -317,7 +317,7 @@ public class DatasetResourceTest {
         String json = createPropertiesJson("Dataset Name", "test");
         when(datasetService.findDatasetById(anyInt())).thenReturn(preexistingDataset);
         when(datasetService.updateDataset(any(), any(), any())).thenReturn(Optional.empty());
-        when(authUser.getGoogleUser()).thenReturn(genericUser);
+        when(authUser.getGenericUser()).thenReturn(genericUser);
         when(genericUser.getEmail()).thenReturn("email@email.com");
         when(userService.findUserByEmail(any())).thenReturn(user);
         when(user.getUserId()).thenReturn(1);

--- a/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
@@ -1,11 +1,44 @@
 package org.broadinstitute.consent.http.resources;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.openMocks;
+import static org.mockito.internal.verification.VerificationModeFactory.times;
+
 import com.google.api.client.http.HttpStatusCodes;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.stream.Collectors;
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.ServerErrorException;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import javax.ws.rs.core.UriBuilder;
+import javax.ws.rs.core.UriInfo;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.RandomUtils;
-import org.broadinstitute.consent.http.authentication.GoogleUser;
+import org.broadinstitute.consent.http.authentication.GenericUser;
 import org.broadinstitute.consent.http.enumeration.UserFields;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.Acknowledgement;
@@ -27,40 +60,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
-
-import javax.ws.rs.NotFoundException;
-import javax.ws.rs.ServerErrorException;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.Status;
-import javax.ws.rs.core.UriBuilder;
-import javax.ws.rs.core.UriInfo;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.sql.Timestamp;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Random;
-import java.util.stream.Collectors;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.openMocks;
-import static org.mockito.internal.verification.VerificationModeFactory.times;
 
 public class UserResourceTest {
 
@@ -90,10 +89,10 @@ public class UserResourceTest {
 
   @Before
   public void setUp() throws URISyntaxException {
-    GoogleUser googleUser = new GoogleUser();
-    googleUser.setName("Test User");
-    googleUser.setEmail(TEST_EMAIL);
-    authUser = new AuthUser(googleUser)
+    GenericUser genericUser = new GenericUser();
+    genericUser.setName("Test User");
+    genericUser.setEmail(TEST_EMAIL);
+    authUser = new AuthUser(genericUser)
             .setAuthToken("auth-token")
             .setUserStatusInfo(userStatusInfo);
     openMocks(this);

--- a/src/test/java/org/broadinstitute/consent/http/service/ResearcherServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/ResearcherServiceTest.java
@@ -1,8 +1,18 @@
 package org.broadinstitute.consent.http.service;
 
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.openMocks;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.RandomUtils;
-import org.broadinstitute.consent.http.authentication.GoogleUser;
+import org.broadinstitute.consent.http.authentication.GenericUser;
 import org.broadinstitute.consent.http.db.UserDAO;
 import org.broadinstitute.consent.http.db.UserPropertyDAO;
 import org.broadinstitute.consent.http.enumeration.UserFields;
@@ -12,17 +22,6 @@ import org.broadinstitute.consent.http.models.UserProperty;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
-
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.openMocks;
 
 public class ResearcherServiceTest {
 
@@ -40,10 +39,10 @@ public class ResearcherServiceTest {
 
     @Before
     public void setUp() {
-        GoogleUser googleUser = new GoogleUser();
-        googleUser.setName("Test User");
-        googleUser.setEmail("test@gmail.com");
-        authUser = new AuthUser(googleUser);
+        GenericUser genericUser = new GenericUser();
+        genericUser.setName("Test User");
+        genericUser.setEmail("test@gmail.com");
+        authUser = new AuthUser(genericUser);
         user = new User();
         user.setEmail(authUser.getEmail());
         user.setUserId(RandomUtils.nextInt(1, 10));


### PR DESCRIPTION
## Addresses
Partially addresses https://broadworkbench.atlassian.net/browse/DUOS-2460

This PR removes the failure case when we cannot validate a bearer token against google. This code path no longer necessary as our proxy does this for us. Additionally, it only supports google tokens and we need to be able to accept authenticated calls from B2C tokens which will fail when queried against Google's token endpoint.

Future tasks/PRs will address support for B2C tokens in our proxy and B2C authentication via the UI.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
