### PR TITLE
[DUOS-2414][risk=no] Use match v3 for all match results

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/configurations/ServicesConfiguration.java
+++ b/src/main/java/org/broadinstitute/consent/http/configurations/ServicesConfiguration.java
@@ -62,8 +62,8 @@ public class ServicesConfiguration {
     this.localURL = localURL;
   }
 
-  public String getMatchURL_v2() {
-    return getOntologyURL() + "match/v2";
+  public String getMatchURL_v3() {
+    return getOntologyURL() + "match/v3";
   }
 
   public String getSamUrl() {

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/MatchMapper.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/MatchMapper.java
@@ -15,6 +15,7 @@ public class MatchMapper implements RowMapper<Match> {
         r.getString("consent"),
         r.getString("purpose"),
         r.getBoolean("matchEntity"),
+        r.getBoolean("abstain"),
         r.getBoolean("failed"),
         r.getDate("createDate"),
         r.getString("algorithm_version"));

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/MatchReducer.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/MatchReducer.java
@@ -25,6 +25,9 @@ public class MatchReducer implements LinkedHashMapRowReducer<Integer, Match>, Ro
         if (hasColumn(rowView, "matchentity", Boolean.class)) {
             match.setMatch(rowView.getColumn("matchentity", Boolean.class));
         }
+        if (hasColumn(rowView, "abstain", Boolean.class)) {
+            match.setAbstain(rowView.getColumn("abstain", Boolean.class));
+        }
         if (hasColumn(rowView, "failed", Boolean.class)) {
             match.setFailed(rowView.getColumn("failed", Boolean.class));
         }

--- a/src/main/java/org/broadinstitute/consent/http/enumeration/MatchAlgorithm.java
+++ b/src/main/java/org/broadinstitute/consent/http/enumeration/MatchAlgorithm.java
@@ -2,7 +2,8 @@ package org.broadinstitute.consent.http.enumeration;
 
 public enum MatchAlgorithm {
     V1("v1"),
-    V2("v2");
+    V2("v2"),
+    V3("v3");
 
     String version;
 

--- a/src/main/java/org/broadinstitute/consent/http/models/Match.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/Match.java
@@ -2,11 +2,15 @@ package org.broadinstitute.consent.http.models;
 
 
 import org.broadinstitute.consent.http.enumeration.MatchAlgorithm;
+import org.broadinstitute.consent.http.models.matching.DataUseMatchResultType;
 
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Objects;
+
+import static org.broadinstitute.consent.http.models.matching.DataUseMatchResultType.Abstain;
+import static org.broadinstitute.consent.http.models.matching.DataUseMatchResultType.Approve;
 
 public class Match {
 
@@ -18,6 +22,8 @@ public class Match {
 
     private Boolean match;
 
+    private Boolean abstain;
+
     private Boolean failed;
 
     private Date createDate;
@@ -26,32 +32,23 @@ public class Match {
 
     private List<String> failureReasons;
 
-    @Deprecated
-    public Match(Integer id, String consent, String purpose, Boolean match, Boolean failed, Date createDate){
+    public Match(Integer id, String consent, String purpose, Boolean match, Boolean abstain, Boolean failed, Date createDate, String algorithmVersion){
         this.id = id;
         this.consent = consent;
         this.purpose = purpose;
         this.match = match;
-        this.failed = failed;
-        this.createDate = createDate;
-        this.algorithmVersion = MatchAlgorithm.V1.getVersion();
-    }
-
-    public Match(Integer id, String consent, String purpose, Boolean match, Boolean failed, Date createDate, String algorithmVersion){
-        this.id = id;
-        this.consent = consent;
-        this.purpose = purpose;
-        this.match = match;
+        this.abstain = abstain;
         this.failed = failed;
         this.createDate = createDate;
         this.algorithmVersion = algorithmVersion;
     }
 
-    public Match(String consentId, String purposeId, boolean failed, boolean isMatch, MatchAlgorithm algorithm, List<String> failureReasons) {
+    public Match(String consentId, String purposeId, boolean match, boolean abstain, boolean failed, MatchAlgorithm algorithm, List<String> failureReasons) {
         this.setConsent(consentId);
         this.setPurpose(purposeId);
+        this.setMatch(match);
+        this.setAbstain(abstain);
         this.setFailed(failed);
-        this.setMatch(isMatch);
         this.setCreateDate(new Date());
         this.setAlgorithmVersion(algorithm.getVersion());
         this.setFailureReasons(failureReasons);
@@ -90,6 +87,14 @@ public class Match {
 
     public void setMatch(Boolean match) {
         this.match = match;
+    }
+
+    public Boolean getAbstain() {
+        return abstain;
+    }
+
+    public void setAbstain(Boolean abstain) {
+        this.abstain = abstain;
     }
 
     public Boolean getFailed() {
@@ -134,5 +139,13 @@ public class Match {
         if (!this.failureReasons.contains(reason) && !reason.isBlank()) {
             this.failureReasons.add(reason);
         }
+    }
+
+    public static Match matchFailure(String consentId, String purposeId, List<String> failureReasons) {
+        return new Match(consentId, purposeId, false, false, true, MatchAlgorithm.V3, failureReasons);
+    }
+
+    public static Match matchSuccess(String consentId, String purposeId, DataUseMatchResultType match, List<String> failureReasons) {
+        return new Match(consentId, purposeId, Approve(match), Abstain(match), false, MatchAlgorithm.V3, failureReasons);
     }
 }

--- a/src/main/java/org/broadinstitute/consent/http/models/matching/DataUseMatchResultType.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/matching/DataUseMatchResultType.java
@@ -1,0 +1,19 @@
+package org.broadinstitute.consent.http.models.matching;
+
+public enum DataUseMatchResultType {
+    APPROVE,
+    DENY,
+    ABSTAIN;
+
+    public static Boolean Approve(DataUseMatchResultType x) {
+        return x == APPROVE;
+    }
+
+    public static Boolean Deny(DataUseMatchResultType x) {
+        return x == DENY;
+    }
+
+    public static Boolean Abstain(DataUseMatchResultType x) {
+        return x == ABSTAIN;
+    }
+}

--- a/src/main/java/org/broadinstitute/consent/http/models/matching/DataUseMatchResultType.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/matching/DataUseMatchResultType.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.consent.http.models.matching;
 
+// Copied from MatchResultPair in consent-ontology
 public enum DataUseMatchResultType {
     APPROVE,
     DENY,

--- a/src/main/java/org/broadinstitute/consent/http/models/matching/DataUseMatchResultType.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/matching/DataUseMatchResultType.java
@@ -2,8 +2,8 @@ package org.broadinstitute.consent.http.models.matching;
 
 // Copied from MatchResultPair in consent-ontology
 public enum DataUseMatchResultType {
-    APPROVE,
-    DENY,
+    APPROVE,    // true
+    DENY,       // false
     ABSTAIN;
 
     public static Boolean Approve(DataUseMatchResultType x) {

--- a/src/main/java/org/broadinstitute/consent/http/models/matching/DataUseRequestMatchingObject.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/matching/DataUseRequestMatchingObject.java
@@ -2,6 +2,7 @@ package org.broadinstitute.consent.http.models.matching;
 
 import org.broadinstitute.consent.http.models.DataUse;
 
+// Copied from DataUseMatchPair in consent-ontology
 public class DataUseRequestMatchingObject {
 
     public DataUse consent;

--- a/src/main/java/org/broadinstitute/consent/http/models/matching/DataUseResponseMatchingObject.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/matching/DataUseResponseMatchingObject.java
@@ -2,25 +2,29 @@ package org.broadinstitute.consent.http.models.matching;
 
 import java.util.List;
 
+import static org.broadinstitute.consent.http.models.matching.DataUseMatchResultType.Approve;
+
 public class DataUseResponseMatchingObject {
 
-    public boolean result;
+    public DataUseMatchResultType result;
 
     public DataUseRequestMatchingObject matchPair;
 
     public List<String> failureReasons;
 
-    public DataUseResponseMatchingObject(boolean result, DataUseRequestMatchingObject matchPair, List<String> failureReasons) {
+    public DataUseResponseMatchingObject(DataUseMatchResultType result, DataUseRequestMatchingObject matchPair, List<String> failureReasons) {
         this.result = result;
         this.matchPair = matchPair;
         this.failureReasons = failureReasons;
     }
 
+    public DataUseMatchResultType getResult() { return result; }
+
     public boolean isResult() {
-        return result;
+        return Approve(result);
     }
 
-    public void setResult(boolean result) {
+    public void setResult(DataUseMatchResultType result) {
         this.result = result;
     }
 

--- a/src/main/java/org/broadinstitute/consent/http/service/MatchService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/MatchService.java
@@ -154,7 +154,7 @@ public class MatchService implements ConsentLogger {
         return matches;
     }
 
-    private Match singleEntitiesMatchV3(Dataset dataset, DataAccessRequest dar) {
+    public Match singleEntitiesMatchV3(Dataset dataset, DataAccessRequest dar) {
         if (Objects.isNull(dataset)) {
             logWarn("Dataset is null");
             throw new IllegalArgumentException("Consent cannot be null");

--- a/src/main/resources/changelog-master.xml
+++ b/src/main/resources/changelog-master.xml
@@ -115,4 +115,5 @@
     <include file="changesets/changelog-consent-2023-03-07-remove-use-restriction.0.xml" relativeToChangelogFile="true"/>
     <include file="changesets/changelog-consent-2023-03-16-rename-vote-userid.xml" relativeToChangelogFile="true"/>
     <include file="changesets/changelog-consent-2023-04-20-create-study.xml" relativeToChangelogFile="true"/>
+    <include file="changesets/changelog-consent-2023-05-03-add-abstain.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/changesets/changelog-consent-2023-05-03-add-abstain.xml
+++ b/src/main/resources/changesets/changelog-consent-2023-05-03-add-abstain.xml
@@ -1,0 +1,9 @@
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+    <changeSet id="2023-05-03-add-abstain" author="fboulnois">
+        <addColumn tableName="match_entity">
+            <column name="abstain" type="boolean"/>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
@@ -291,7 +291,7 @@ public class DAOTestHelper {
             RandomUtils.nextBoolean(),
             false,
             new Date(),
-            MatchAlgorithm.V2.getVersion());
+            MatchAlgorithm.V3.getVersion());
         return matchDAO.findMatchById(matchId);
     }
 

--- a/src/test/java/org/broadinstitute/consent/http/db/MatchDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/MatchDAOTest.java
@@ -187,7 +187,7 @@ public class MatchDAOTest extends DAOTestHelper {
   public void testInsertFailureReason() {
     Match match = makeMockMatch(UUID.randomUUID().toString());
     match.setMatch(false);
-    match.setAlgorithmVersion(MatchAlgorithm.V2.getVersion());
+    match.setAlgorithmVersion(MatchAlgorithm.V3.getVersion());
     match.addFailureReason(RandomStringUtils.randomAlphabetic(100));
     match.addFailureReason(RandomStringUtils.randomAlphabetic(100));
     Integer matchId = matchDAO.insertMatch(
@@ -207,7 +207,7 @@ public class MatchDAOTest extends DAOTestHelper {
   public void testDeleteFailureReasonsByConsentIds() {
     Match match = makeMockMatch(UUID.randomUUID().toString());
     match.setMatch(false);
-    match.setAlgorithmVersion(MatchAlgorithm.V2.getVersion());
+    match.setAlgorithmVersion(MatchAlgorithm.V3.getVersion());
     match.addFailureReason(RandomStringUtils.randomAlphabetic(100));
     match.addFailureReason(RandomStringUtils.randomAlphabetic(100));
     Integer matchId = matchDAO.insertMatch(
@@ -228,7 +228,7 @@ public class MatchDAOTest extends DAOTestHelper {
   public void testDeleteFailureReasonsByPurposeIds() {
     Match match = makeMockMatch(UUID.randomUUID().toString());
     match.setMatch(false);
-    match.setAlgorithmVersion(MatchAlgorithm.V2.getVersion());
+    match.setAlgorithmVersion(MatchAlgorithm.V3.getVersion());
     match.addFailureReason(RandomStringUtils.randomAlphabetic(100));
     match.addFailureReason(RandomStringUtils.randomAlphabetic(100));
     Integer matchId = matchDAO.insertMatch(

--- a/src/test/java/org/broadinstitute/consent/http/service/MatchServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/MatchServiceTest.java
@@ -262,6 +262,6 @@ public class MatchServiceTest {
     }
 
     private Match createMatchObject() {
-        return new Match(1, UUID.randomUUID().toString(), UUID.randomUUID().toString(), true, false, new Date(), MatchAlgorithm.V3.getVersion());
+        return new Match(1, UUID.randomUUID().toString(), UUID.randomUUID().toString(), true, true, false, new Date(), MatchAlgorithm.V3.getVersion());
     }
 }

--- a/src/test/java/org/broadinstitute/consent/http/service/MatchServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/MatchServiceTest.java
@@ -180,6 +180,113 @@ public class MatchServiceTest {
         verify(dataAccessRequestDAO, atLeastOnce()).findAllDataAccessRequests();
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void testSingleEntitiesMatchV3EmptyDataset() {
+       DataAccessRequest dar = new DataAccessRequest();
+       initService();
+       service.singleEntitiesMatchV3(null, dar);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testSingleEntitiesMatchV3EmptyDar() {
+        Dataset dataset = new Dataset();
+        initService();
+        service.singleEntitiesMatchV3(dataset, null);
+    }
+
+    @Test
+    public void testSingleEntitiesMatchV3Failure() {
+        Dataset dataset = new Dataset();
+        dataset.setDataSetId(1);
+        dataset.setAlias(2);
+        dataset.setDatasetIdentifier();
+        DataAccessRequest dar = getSampleDataAccessRequest("DAR-2");
+        dar.setDatasetIds(List.of(1, 2, 3));
+
+        Response response = Mockito.mock(Response.class);
+        when(datasetDAO.getDatasetsForConsent(any())).thenReturn(List.of(dataset));
+        when(dataAccessRequestDAO.findAllDataAccessRequests()).thenReturn(List.of(dar));
+        when(response.getStatus()).thenReturn(500);
+        when(builder.post(any())).thenReturn(response);
+        when(target.request(MediaType.APPLICATION_JSON)).thenReturn(builder);
+        when(clientMock.target(config.getMatchURL_v3())).thenReturn(target);
+
+        initService();
+        Match match = service.singleEntitiesMatchV3(dataset, dar);
+        assertFalse(match.getMatch());
+        assertFalse(match.getAbstain());
+        assertTrue(match.getFailed());
+    }
+
+    @Test
+    public void testSingleEntitiesMatchV3Approve() {
+        Dataset dataset = new Dataset();
+        dataset.setDataSetId(1);
+        DataAccessRequest dar = getSampleDataAccessRequest("DAR-2");
+        dar.setDatasetIds(List.of(1, 2, 3));
+        String stringEntity = "{\"result\": \"APPROVE\", \"matchPair\": {}, \"failureReasons\": []}";
+
+        when(datasetDAO.getDatasetsForConsent(any())).thenReturn(List.of(dataset));
+        when(dataAccessRequestDAO.findAllDataAccessRequests()).thenReturn(List.of(dar));
+        when(response.readEntity(any(Class.class))).thenReturn(stringEntity);
+        when(response.getStatus()).thenReturn(200);
+        when(builder.post(any())).thenReturn(response);
+        when(target.request(MediaType.APPLICATION_JSON)).thenReturn(builder);
+        when(clientMock.target(config.getMatchURL_v3())).thenReturn(target);
+
+        initService();
+        Match match = service.singleEntitiesMatchV3(dataset, dar);
+        assertTrue(match.getMatch());
+        assertFalse(match.getAbstain());
+        assertFalse(match.getFailed());
+    }
+
+    @Test
+    public void testSingleEntitiesMatchV3Deny() {
+        Dataset dataset = new Dataset();
+        dataset.setDataSetId(1);
+        DataAccessRequest dar = getSampleDataAccessRequest("DAR-2");
+        dar.setDatasetIds(List.of(1, 2, 3));
+        String stringEntity = "{\"result\": \"DENY\", \"matchPair\": {}, \"failureReasons\": []}";
+
+        when(datasetDAO.getDatasetsForConsent(any())).thenReturn(List.of(dataset));
+        when(dataAccessRequestDAO.findAllDataAccessRequests()).thenReturn(List.of(dar));
+        when(response.readEntity(any(Class.class))).thenReturn(stringEntity);
+        when(response.getStatus()).thenReturn(200);
+        when(builder.post(any())).thenReturn(response);
+        when(target.request(MediaType.APPLICATION_JSON)).thenReturn(builder);
+        when(clientMock.target(config.getMatchURL_v3())).thenReturn(target);
+
+        initService();
+        Match match = service.singleEntitiesMatchV3(dataset, dar);
+        assertFalse(match.getMatch());
+        assertFalse(match.getAbstain());
+        assertFalse(match.getFailed());
+    }
+
+    @Test
+    public void testSingleEntitiesMatchV3Abstain() {
+        Dataset dataset = new Dataset();
+        dataset.setDataSetId(1);
+        DataAccessRequest dar = getSampleDataAccessRequest("DAR-2");
+        dar.setDatasetIds(List.of(1, 2, 3));
+        String stringEntity = "{\"result\": \"ABSTAIN\", \"matchPair\": {}, \"failureReasons\": []}";
+
+        when(datasetDAO.getDatasetsForConsent(any())).thenReturn(List.of(dataset));
+        when(dataAccessRequestDAO.findAllDataAccessRequests()).thenReturn(List.of(dar));
+        when(response.readEntity(any(Class.class))).thenReturn(stringEntity);
+        when(response.getStatus()).thenReturn(200);
+        when(builder.post(any())).thenReturn(response);
+        when(target.request(MediaType.APPLICATION_JSON)).thenReturn(builder);
+        when(clientMock.target(config.getMatchURL_v3())).thenReturn(target);
+
+        initService();
+        Match match = service.singleEntitiesMatchV3(dataset, dar);
+        assertFalse(match.getMatch());
+        assertTrue(match.getAbstain());
+        assertFalse(match.getFailed());
+    }
+
     @Test
     public void testFindMatchesByPurposeId() {
         Match m = createMatchObject();

--- a/src/test/java/org/broadinstitute/consent/http/service/MatchServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/MatchServiceTest.java
@@ -154,7 +154,7 @@ public class MatchServiceTest {
         when(response.getStatus()).thenReturn(200);
         when(builder.post(any())).thenReturn(response);
         when(target.request(MediaType.APPLICATION_JSON)).thenReturn(builder);
-        when(clientMock.target(config.getMatchURL_v2())).thenReturn(target);
+        when(clientMock.target(config.getMatchURL_v3())).thenReturn(target);
         spy(datasetDAO);
         initService();
 
@@ -262,6 +262,6 @@ public class MatchServiceTest {
     }
 
     private Match createMatchObject() {
-        return new Match(1, UUID.randomUUID().toString(), UUID.randomUUID().toString(), true, false, new Date(), MatchAlgorithm.V2.getVersion());
+        return new Match(1, UUID.randomUUID().toString(), UUID.randomUUID().toString(), true, false, new Date(), MatchAlgorithm.V3.getVersion());
     }
 }


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DUOS-2414

### Summary

Use V3 match for all match results.

### Notes

I originally tried to propagate the `APPROVE`, `DENY`, and `ABSTAIN` case across the codebase, but this added much more code to the codebase and importantly required me to change the `matchentity` column in the database from a boolean to an enum. This had additional consequences including requiring us to migrate all the current matches which made the problem more challenging.

As a result I picked a simpler approach which instead adds a boolean `abstain` column in the database and use the `APPROVE`, `DENY`, `ABSTAIN` where it makes sense, without propagating it to the whole codebase.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
