### PR TITLE
[DUOS-2481][risk=no] Remove excludes from Semgrep action

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -8,7 +8,4 @@ jobs:
     name: Check
     steps:
       - uses: actions/checkout@v3
-      - run: |
-          semgrep ci --config=p/findsecbugs \
-            --exclude-rule=gitlab.find_sec_bugs.CUSTOM_INJECTION-2 \
-            --exclude-rule=gitlab.find_sec_bugs.JAXRS_ENDPOINT-1
+      - run: semgrep ci --config=p/findsecbugs


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DUOS-2481

### Summary

Follow up to #2006, remove excludes in Github action.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
