### PR TITLE
[DUOS-750][risk=no] Fix POST /api/dacuser Swagger Doc

### DIFF
--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -302,26 +302,7 @@ paths:
         500:
           description: Internal Server Error
   /api/dacuser:
-    post:
-      summary: Create User
-      description: Creates a User
-      parameters:
-        - name: dac
-          in: body
-          required: true
-          schema:
-            $ref: '#/components/schemas/User'
-      tags:
-        - User
-      responses:
-        200:
-          description: Returns the created user.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/User'
-        400:
-          description: Malformed user entity.
+    $ref: './paths/dacuser.yaml'
   /api/dar/v2:
     $ref: './paths/darV2.yaml'
   /api/dar/v2/{referenceId}:

--- a/src/main/resources/assets/paths/dacuser.yaml
+++ b/src/main/resources/assets/paths/dacuser.yaml
@@ -1,0 +1,31 @@
+post:
+  summary: Create User
+  requestBody:
+    description: Creates a User
+    required: true
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            displayName:
+              type: string
+            email:
+              type: string
+            emailPreference:
+              type: boolean
+            roles:
+              type: array
+              items:
+                $ref: '../schemas/UserRole.yaml'
+  tags:
+    - User
+  responses:
+    200:
+      description: Returns the created user.
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/User.yaml'
+    400:
+      description: Malformed user entity.


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DUOS-750

### Summary
This PR fixes the swagger endpoint for `POST /api/dacuser` which is an admin endpoint used to manually create users. The swagger definition was syntactically incorrect.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
