### PR TITLE
[DUOS-2513][risk=no] Move Number of Participants

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/models/dataset_registration_v1/ConsentGroup.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/dataset_registration_v1/ConsentGroup.java
@@ -159,6 +159,12 @@ public class ConsentGroup {
   @JsonPropertyDescription("Free text field for entering URL of data")
   private URI url;
   /**
+   * # of Participants (Required)
+   */
+  @JsonProperty("numberOfParticipants")
+  @JsonPropertyDescription("# of Participants")
+  private Integer numberOfParticipants;
+  /**
    * List of File Types
    */
   @JsonProperty("fileTypes")
@@ -485,6 +491,14 @@ public class ConsentGroup {
     this.url = url;
   }
 
+  public Integer getNumberOfParticipants() {
+    return numberOfParticipants;
+  }
+
+  public void setNumberOfParticipants(Integer numberOfParticipants) {
+    this.numberOfParticipants = numberOfParticipants;
+  }
+
   /**
    * List of File Types
    */
@@ -586,6 +600,10 @@ public class ConsentGroup {
     sb.append('=');
     sb.append(((this.url == null) ? "<null>" : this.url));
     sb.append(',');
+    sb.append("numberOfParticipants");
+    sb.append('=');
+    sb.append(((this.numberOfParticipants == null) ? "<null>" : this.numberOfParticipants));
+    sb.append(',');
     sb.append("fileTypes");
     sb.append('=');
     sb.append(((this.fileTypes == null) ? "<null>" : this.fileTypes));
@@ -612,6 +630,8 @@ public class ConsentGroup {
     result = ((result * 31) + ((this.otherPrimary == null) ? 0 : this.otherPrimary.hashCode()));
     result = ((result * 31) + ((this.gs == null) ? 0 : this.gs.hashCode()));
     result = ((result * 31) + ((this.url == null) ? 0 : this.url.hashCode()));
+    result = ((result * 31) + ((this.numberOfParticipants == null) ? 0
+        : this.numberOfParticipants.hashCode()));
     result = ((result * 31) + ((this.fileTypes == null) ? 0 : this.fileTypes.hashCode()));
     result = ((result * 31) + ((this.diseaseSpecificUse == null) ? 0
         : this.diseaseSpecificUse.hashCode()));

--- a/src/main/java/org/broadinstitute/consent/http/models/dataset_registration_v1/FileTypeObject.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/dataset_registration_v1/FileTypeObject.java
@@ -29,12 +29,6 @@ public class FileTypeObject {
   @JsonProperty("functionalEquivalence")
   @JsonPropertyDescription("Functional Equivalence")
   private String functionalEquivalence;
-  /**
-   * # of Participants (Required)
-   */
-  @JsonProperty("numberOfParticipants")
-  @JsonPropertyDescription("# of Participants")
-  private Integer numberOfParticipants;
 
   /**
    * File Type
@@ -68,22 +62,6 @@ public class FileTypeObject {
     this.functionalEquivalence = functionalEquivalence;
   }
 
-  /**
-   * # of Participants (Required)
-   */
-  @JsonProperty("numberOfParticipants")
-  public Integer getNumberOfParticipants() {
-    return numberOfParticipants;
-  }
-
-  /**
-   * # of Participants (Required)
-   */
-  @JsonProperty("numberOfParticipants")
-  public void setNumberOfParticipants(Integer numberOfParticipants) {
-    this.numberOfParticipants = numberOfParticipants;
-  }
-
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
@@ -97,10 +75,6 @@ public class FileTypeObject {
     sb.append('=');
     sb.append(((this.functionalEquivalence == null) ? "<null>" : this.functionalEquivalence));
     sb.append(',');
-    sb.append("numberOfParticipants");
-    sb.append('=');
-    sb.append(((this.numberOfParticipants == null) ? "<null>" : this.numberOfParticipants));
-    sb.append(',');
     if (sb.charAt((sb.length() - 1)) == ',') {
       sb.setCharAt((sb.length() - 1), ']');
     } else {
@@ -112,8 +86,6 @@ public class FileTypeObject {
   @Override
   public int hashCode() {
     int result = 1;
-    result = ((result * 31) + ((this.numberOfParticipants == null) ? 0
-        : this.numberOfParticipants.hashCode()));
     result = ((result * 31) + ((this.functionalEquivalence == null) ? 0
         : this.functionalEquivalence.hashCode()));
     result = ((result * 31) + ((this.fileType == null) ? 0 : this.fileType.hashCode()));
@@ -129,13 +101,10 @@ public class FileTypeObject {
       return false;
     }
     FileTypeObject rhs = ((FileTypeObject) other);
-    return ((((this.numberOfParticipants == rhs.numberOfParticipants) || (
-        (this.numberOfParticipants != null) && this.numberOfParticipants.equals(
-            rhs.numberOfParticipants))) && (
-        (this.functionalEquivalence == rhs.functionalEquivalence) || (
-            (this.functionalEquivalence != null) && this.functionalEquivalence.equals(
-                rhs.functionalEquivalence)))) && ((this.fileType == rhs.fileType) || (
-        (this.fileType != null) && this.fileType.equals(rhs.fileType))));
+    return (((this.functionalEquivalence == rhs.functionalEquivalence) || (
+        (this.functionalEquivalence != null) && this.functionalEquivalence.equals(
+            rhs.functionalEquivalence)))) && ((this.fileType == rhs.fileType) || (
+        (this.fileType != null) && this.fileType.equals(rhs.fileType)));
   }
 
 

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetRegistrationService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetRegistrationService.java
@@ -490,6 +490,9 @@ public class DatasetRegistrationService {
             return null;
           }),
       new DatasetPropertyExtractor(
+          "Number Of Participants", "numberOfParticipants", PropertyType.Number,
+          ConsentGroup::getNumberOfParticipants),
+      new DatasetPropertyExtractor(
           "File Types", "fileTypes", PropertyType.Json,
           (consentGroup) -> {
             if (Objects.nonNull(consentGroup.getFileTypes())) {

--- a/src/main/resources/assets/schemas/DatasetRegistrationSchemaV1.yaml
+++ b/src/main/resources/assets/schemas/DatasetRegistrationSchemaV1.yaml
@@ -243,16 +243,12 @@ required:
       functionalEquivalence:
         type: string
         description: Functional Equivalence
-      numberOfParticipants:
-        type: number
-        description: Number of Participants
     required:
       - fileType
       - functionalEquivalence
-      - numberOfParticipants
   consentGroup:
     type: object
-    description: | 
+    description: |
       Each Consent Group will be translated into a separate dataset
       Required fields include the `consentGroupName` and any one of 
       `generalResearchUse`, `hmb`, or `diseaseSpecificUse`.
@@ -260,6 +256,9 @@ required:
       consentGroupName:
         type: string
         description: Consent Group Name
+      numberOfParticipants:
+        type: number
+        description: Number of Participants
       generalResearchUse:
         type: boolean
         description: General Research Use
@@ -334,3 +333,4 @@ required:
     required:
       - consentGroupName
       - fileTypes
+      - numberOfParticipants

--- a/src/main/resources/dataset-registration-schema_v1.json
+++ b/src/main/resources/dataset-registration-schema_v1.json
@@ -18,17 +18,27 @@
     {
       "$comment": "require GSR explanation if the user selected yes",
       "if": {
-        "required": ["controlledAccessRequiredForGenomicSummaryResultsGSR"],
-        "properties": {"controlledAccessRequiredForGenomicSummaryResultsGSR": { "const": true }}
+        "required": [
+          "controlledAccessRequiredForGenomicSummaryResultsGSR"
+        ],
+        "properties": {
+          "controlledAccessRequiredForGenomicSummaryResultsGSR": {
+            "const": true
+          }
+        }
       },
       "then": {
-        "required": ["controlledAccessRequiredForGenomicSummaryResultsGSRRequiredExplanation"]
+        "required": [
+          "controlledAccessRequiredForGenomicSummaryResultsGSRRequiredExplanation"
+        ]
       }
     },
     {
       "$comment": "include dbGaP related fields if they have one",
       "if": {
-        "required": ["nihAnvilUse"],
+        "required": [
+          "nihAnvilUse"
+        ],
         "properties": {
           "nihAnvilUse": {
             "type": "string",
@@ -39,13 +49,15 @@
         }
       },
       "then": {
-        "$ref":  "#/$defs/dbGaPInfo"
+        "$ref": "#/$defs/dbGaPInfo"
       }
     },
     {
       "$comment": "include NIH related fields if using AnVil",
       "if": {
-        "required": ["nihAnvilUse"],
+        "required": [
+          "nihAnvilUse"
+        ],
         "properties": {
           "nihAnvilUse": {
             "type": "string",
@@ -58,17 +70,26 @@
         }
       },
       "then": {
-        "$ref":  "#/$defs/nihAdministrativeInformation"
+        "$ref": "#/$defs/nihAdministrativeInformation"
       }
     },
     {
       "$comment": "require alternative data sharing plan fields if the DS needs one",
       "if": {
-        "required": ["alternativeDataSharingPlan"],
-        "properties": {"alternativeDataSharingPlan": { "const": true }}
+        "required": [
+          "alternativeDataSharingPlan"
+        ],
+        "properties": {
+          "alternativeDataSharingPlan": {
+            "const": true
+          }
+        }
       },
       "then": {
-        "required": ["alternativeDataSharingPlanExplanation", "alternativeDataSharingPlanReasons"],
+        "required": [
+          "alternativeDataSharingPlanExplanation",
+          "alternativeDataSharingPlanReasons"
+        ],
         "properties": {
           "alternativeDataSharingPlanReasons": {
             "minItems": 1
@@ -86,7 +107,18 @@
     },
     "studyType": {
       "type": "string",
-      "enum": ["Observational", "Interventional", "Descriptive", "Analytical", "Prospective", "Retrospective", "Case report", "Case series", "Cross-sectional", "Cohort study"],
+      "enum": [
+        "Observational",
+        "Interventional",
+        "Descriptive",
+        "Analytical",
+        "Prospective",
+        "Retrospective",
+        "Case report",
+        "Case series",
+        "Cross-sectional",
+        "Cohort study"
+      ],
       "label": "Study Type",
       "description": "The study type"
     },
@@ -168,31 +200,36 @@
       "minItems": 1,
       "label": "Consent Groups",
       "description": "Consent Groups",
-      "items": { "$ref":  "#/$defs/consentGroup"}
+      "items": {
+        "$ref": "#/$defs/consentGroup"
+      }
     }
   },
   "$defs": {
     "fileTypeObject": {
-      "required": ["numberOfParticipants"],
       "type": "object",
       "properties": {
         "fileType": {
           "type": "string",
           "description": "File Type",
-          "enum": ["Arrays", "Genome", "Exome", "Survey", "Phenotype"]
+          "enum": [
+            "Arrays",
+            "Genome",
+            "Exome",
+            "Survey",
+            "Phenotype"
+          ]
         },
         "functionalEquivalence": {
           "type": "string",
           "description": "Functional Equivalence"
-        },
-        "numberOfParticipants": {
-          "type": "integer",
-          "description": "# of Participants"
         }
       }
     },
     "dbGaPInfo": {
-      "required": ["dbGaPPhsID"],
+      "required": [
+        "dbGaPPhsID"
+      ],
       "properties": {
         "dbGaPPhsID": {
           "type": "string",
@@ -219,7 +256,10 @@
       }
     },
     "nihAdministrativeInformation": {
-      "required": ["piInstitution", "nihGrantContractNumber"],
+      "required": [
+        "piInstitution",
+        "nihGrantContractNumber"
+      ],
       "properties": {
         "piInstitution": {
           "type": "integer",
@@ -238,7 +278,35 @@
           "description": "NIH ICs Supporting the Study",
           "items": {
             "type": "string",
-            "enum": ["NCI", "NEI", "NHLBI", "NHGRI", "NIA", "NIAAA", "NIAID", "NIAMS", "NIBIB", "NICHD", "NIDCD", "NIDCR", "NIDDK", "NIDA", "NIEHS", "NIGMS", "NIMH", "NIMHD", "NINDS", "NINR", "NLM", "CC", "CIT", "CSR", "FIC", "NCATS", "NCCIH"]
+            "enum": [
+              "NCI",
+              "NEI",
+              "NHLBI",
+              "NHGRI",
+              "NIA",
+              "NIAAA",
+              "NIAID",
+              "NIAMS",
+              "NIBIB",
+              "NICHD",
+              "NIDCD",
+              "NIDCR",
+              "NIDDK",
+              "NIDA",
+              "NIEHS",
+              "NIGMS",
+              "NIMH",
+              "NIMHD",
+              "NINDS",
+              "NINR",
+              "NLM",
+              "CC",
+              "CIT",
+              "CSR",
+              "FIC",
+              "NCATS",
+              "NCCIH"
+            ]
           }
         },
         "nihProgramOfficerName": {
@@ -250,7 +318,35 @@
           "type": "string",
           "label": "NIH Institution/Center for Submission",
           "description": "NIH Institution/Center for Submission",
-          "enum": ["NCI", "NEI", "NHLBI", "NHGRI", "NIA", "NIAAA", "NIAID", "NIAMS", "NIBIB", "NICHD", "NIDCD", "NIDCR", "NIDDK", "NIDA", "NIEHS", "NIGMS", "NIMH", "NIMHD", "NINDS", "NINR", "NLM", "CC", "CIT", "CSR", "FIC", "NCATS", "NCCIH"]
+          "enum": [
+            "NCI",
+            "NEI",
+            "NHLBI",
+            "NHGRI",
+            "NIA",
+            "NIAAA",
+            "NIAID",
+            "NIAMS",
+            "NIBIB",
+            "NICHD",
+            "NIDCD",
+            "NIDCR",
+            "NIDDK",
+            "NIDA",
+            "NIEHS",
+            "NIGMS",
+            "NIMH",
+            "NIMHD",
+            "NINDS",
+            "NINR",
+            "NLM",
+            "CC",
+            "CIT",
+            "CSR",
+            "FIC",
+            "NCATS",
+            "NCCIH"
+          ]
         },
         "nihGenomicProgramAdministratorName": {
           "type": "string",
@@ -338,7 +434,10 @@
           "type": "string",
           "label": "Does the data need to be managed under Controlled or Open Access?",
           "description": "Does the data need to be managed under Controlled or Open Access?",
-          "enum": ["Controlled Access", "Open Access"]
+          "enum": [
+            "Controlled Access",
+            "Open Access"
+          ]
         }
       }
     },
@@ -346,25 +445,38 @@
       "type": "object",
       "required": [
         "consentGroupName",
-        "fileTypes"
+        "fileTypes",
+        "numberOfParticipants"
       ],
       "allOf": [
         {
           "if": {
-            "properties": {"dataLocation":  { "const": "Not Determined" }}
+            "properties": {
+              "dataLocation": {
+                "const": "Not Determined"
+              }
+            }
           },
           "then": {},
           "else": {
-            "required": ["url"]
+            "required": [
+              "url"
+            ]
           }
         },
         {
           "$comment": "if openAccess is false OR not present, then require dac id & add secondary consent fields",
           "if": {
-            "properties": {"openAccess":  {"const":  false}}
+            "properties": {
+              "openAccess": {
+                "const": false
+              }
+            }
           },
           "then": {
-            "required": ["dataAccessCommitteeId"],
+            "required": [
+              "dataAccessCommitteeId"
+            ],
             "properties": {
               "nmds": {
                 "type": "boolean",
@@ -429,28 +541,64 @@
           "$comment": "ensure one (and only one) primary consent is selected",
           "oneOf": [
             {
-              "properties": {"openAccess": { "const": true }},
-              "required": ["openAccess"]
+              "properties": {
+                "openAccess": {
+                  "const": true
+                }
+              },
+              "required": [
+                "openAccess"
+              ]
             },
             {
-              "properties": {"generalResearchUse": { "const": true }},
-              "required": ["generalResearchUse"]
+              "properties": {
+                "generalResearchUse": {
+                  "const": true
+                }
+              },
+              "required": [
+                "generalResearchUse"
+              ]
             },
             {
-              "properties": {"hmb": { "const": true }},
-              "required": ["hmb"]
+              "properties": {
+                "hmb": {
+                  "const": true
+                }
+              },
+              "required": [
+                "hmb"
+              ]
             },
             {
-              "properties": {"poa": { "const": true }},
-              "required": ["poa"]
+              "properties": {
+                "poa": {
+                  "const": true
+                }
+              },
+              "required": [
+                "poa"
+              ]
             },
             {
-              "properties": {"diseaseSpecificUse": { "minItems": 1 }},
-              "required": ["diseaseSpecificUse"]
+              "properties": {
+                "diseaseSpecificUse": {
+                  "minItems": 1
+                }
+              },
+              "required": [
+                "diseaseSpecificUse"
+              ]
             },
             {
-              "properties": {"otherPrimary": { "minLength": 1 }},
-              "required": ["otherPrimary"]
+              "properties": {
+                "otherPrimary": {
+                  "minLength": 1
+                }
+              },
+              "required": [
+                "otherPrimary"
+              ]
             }
           ]
         }
@@ -497,7 +645,12 @@
         },
         "dataLocation": {
           "type": "string",
-          "enum": ["AnVIL Workspace", "Terra Workspace", "TDR Location", "Not Determined"],
+          "enum": [
+            "AnVIL Workspace",
+            "Terra Workspace",
+            "TDR Location",
+            "Not Determined"
+          ],
           "label": "Please provide the location of your data resource for this consent group",
           "description": "Data Location"
         },
@@ -508,10 +661,16 @@
           "description": "Free text field for entering URL of data",
           "minLength": 1
         },
+        "numberOfParticipants": {
+          "type": "integer",
+          "description": "# of Participants"
+        },
         "fileTypes": {
           "type": "array",
           "minItems": 1,
-          "items": { "$ref":  "#/$defs/fileTypeObject"},
+          "items": {
+            "$ref": "#/$defs/fileTypeObject"
+          },
           "description": "List of File Types"
         }
       }

--- a/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
@@ -1066,9 +1066,9 @@ public class DatasetResourceTest {
           "consentGroups": [{
             "fileTypes": [{
               "fileType": "Arrays",
-              "functionalEquivalence": "equivalence",
-              "numberOfParticipants": 2
+              "functionalEquivalence": "equivalence"
             }],
+            "numberOfParticipants": 2,
             "consentGroupName": "name",
             "generalResearchUse": true,
             "dataAccessCommitteeId": 1,

--- a/src/test/java/org/broadinstitute/consent/http/service/DatasetRegistrationServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DatasetRegistrationServiceTest.java
@@ -205,6 +205,8 @@ public class DatasetRegistrationServiceTest {
     List<DatasetProperty> datasetProps = inserts.get(0).props();
     assertContainsDatasetProperty(datasetProps, "dataLocation",
         schema.getConsentGroups().get(0).getDataLocation().value());
+    assertContainsDatasetProperty(datasetProps, "numberOfParticipants",
+        schema.getConsentGroups().get(0).getNumberOfParticipants());
     assertContainsDatasetProperty(datasetProps, "fileTypes", PropertyType.coerceToJson(
         GsonUtil.getInstance().toJson(schema.getConsentGroups().get(0).getFileTypes())));
     assertContainsDatasetProperty(datasetProps, "url",
@@ -265,6 +267,8 @@ public class DatasetRegistrationServiceTest {
     assertContainsStudyProperty(studyProps, "phenotypeIndication", schema.getPhenotypeIndication());
     assertContainsStudyProperty(studyProps, "species", schema.getSpecies());
     assertContainsStudyProperty(studyProps, "dataSubmitterUserId", schema.getDataSubmitterUserId());
+    assertContainsDatasetProperty(datasetProps, "numberOfParticipants",
+        schema.getConsentGroups().get(0).getNumberOfParticipants());
     assertContainsDatasetProperty(datasetProps, "fileTypes", PropertyType.coerceToJson(
         GsonUtil.getInstance().toJson(schema.getConsentGroups().get(0).getFileTypes())));
   }
@@ -358,6 +362,8 @@ public class DatasetRegistrationServiceTest {
         schema.getConsentGroups().get(0).getDataAccessCommitteeId());
     assertContainsDatasetProperty(props, "openAccess",
         schema.getConsentGroups().get(0).getOpenAccess());
+    assertContainsDatasetProperty(props, "numberOfParticipants",
+        schema.getConsentGroups().get(0).getNumberOfParticipants());
 
     // assert on all the same properties, but for the second dataset
 
@@ -378,6 +384,9 @@ public class DatasetRegistrationServiceTest {
         GsonUtil.getInstance().toJson(schema.getConsentGroups().get(1).getFileTypes())));
     assertContainsDatasetProperty(props2, "openAccess",
         schema.getConsentGroups().get(1).getOpenAccess());
+    assertContainsDatasetProperty(props2, "numberOfParticipants",
+        schema.getConsentGroups().get(1).getNumberOfParticipants());
+
 
   }
 
@@ -566,7 +575,7 @@ public class DatasetRegistrationServiceTest {
     FileTypeObject fileType = new FileTypeObject();
     fileType.setFileType(FileTypeObject.FileType.ARRAYS);
     fileType.setFunctionalEquivalence(RandomStringUtils.randomAlphabetic(10));
-    fileType.setNumberOfParticipants(new Random().nextInt());
+    consentGroup.setNumberOfParticipants(new Random().nextInt());
     consentGroup.setFileTypes(List.of(fileType));
     consentGroup.setDataAccessCommitteeId(new Random().nextInt());
 
@@ -594,7 +603,7 @@ public class DatasetRegistrationServiceTest {
     FileTypeObject fileType = new FileTypeObject();
     fileType.setFileType(FileTypeObject.FileType.ARRAYS);
     fileType.setFunctionalEquivalence(RandomStringUtils.randomAlphabetic(10));
-    fileType.setNumberOfParticipants(new Random().nextInt());
+    consentGroup.setNumberOfParticipants(new Random().nextInt());
     consentGroup.setFileTypes(List.of(fileType));
 
     schemaV1.setConsentGroups(List.of(consentGroup));
@@ -621,7 +630,7 @@ public class DatasetRegistrationServiceTest {
     FileTypeObject fileType1 = new FileTypeObject();
     fileType1.setFileType(FileTypeObject.FileType.ARRAYS);
     fileType1.setFunctionalEquivalence(RandomStringUtils.randomAlphabetic(10));
-    fileType1.setNumberOfParticipants(new Random().nextInt());
+    consentGroup1.setNumberOfParticipants(new Random().nextInt());
     consentGroup1.setFileTypes(List.of(fileType1));
     consentGroup1.setDataAccessCommitteeId(new Random().nextInt());
     consentGroup1.setOpenAccess(false);
@@ -632,7 +641,7 @@ public class DatasetRegistrationServiceTest {
     FileTypeObject fileType2 = new FileTypeObject();
     fileType2.setFileType(FileTypeObject.FileType.ARRAYS);
     fileType2.setFunctionalEquivalence(RandomStringUtils.randomAlphabetic(10));
-    fileType2.setNumberOfParticipants(new Random().nextInt());
+    consentGroup2.setNumberOfParticipants(new Random().nextInt());
     consentGroup2.setFileTypes(List.of(fileType2));
     consentGroup2.setOpenAccess(true);
 
@@ -691,14 +700,13 @@ public class DatasetRegistrationServiceTest {
     ConsentGroup consentGroup = new ConsentGroup();
     consentGroup.setConsentGroupName(RandomStringUtils.randomAlphabetic(10));
     consentGroup.setGeneralResearchUse(true);
+    consentGroup.setNumberOfParticipants(new Random().nextInt());
     FileTypeObject fileType1 = new FileTypeObject();
     fileType1.setFileType(FileTypeObject.FileType.ARRAYS);
     fileType1.setFunctionalEquivalence(RandomStringUtils.randomAlphabetic(10));
-    fileType1.setNumberOfParticipants(new Random().nextInt());
     FileTypeObject fileType2 = new FileTypeObject();
     fileType2.setFileType(FileTypeObject.FileType.PHENOTYPE);
     fileType2.setFunctionalEquivalence(RandomStringUtils.randomAlphabetic(10));
-    fileType2.setNumberOfParticipants(new Random().nextInt());
     consentGroup.setFileTypes(List.of(fileType1, fileType2));
     consentGroup.setUrl(URI.create("https://asdf.gov"));
     consentGroup.setMor(false);

--- a/src/test/java/org/broadinstitute/consent/http/util/JsonSchemaUtilTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/util/JsonSchemaUtilTest.java
@@ -30,9 +30,9 @@ public class JsonSchemaUtilTest {
         "consentGroups": [{
           "fileTypes": [{
             "fileType": "Arrays",
-            "functionalEquivalence": "equivalence",
-            "numberOfParticipants": 2
+            "functionalEquivalence": "equivalence"
           }],
+          "numberOfParticipants": 2,
           "consentGroupName": "name",
           "generalResearchUse": true,
           "dataAccessCommitteeId": 1,
@@ -104,9 +104,9 @@ public class JsonSchemaUtilTest {
           "consentGroups": [{
             "fileTypes": [{
               "fileType": "Arrays",
-              "functionalEquivalence": "equivalence",
-              "numberOfParticipants": 2
+              "functionalEquivalence": "equivalence"
             }],
+            "numberOfParticipants": 2,
             "consentGroupName": "name",
             "generalResearchUse": true,
             "dataAccessCommitteeId": 1,
@@ -142,9 +142,9 @@ public class JsonSchemaUtilTest {
           "consentGroups": [{
             "fileTypes": [{
               "fileType": "Arrays",
-              "functionalEquivalence": "equivalence",
-              "numberOfParticipants": 2
+              "functionalEquivalence": "equivalence"
             }],
+            "numberOfParticipants": 2,
             "consentGroupName": "name",
             "generalResearchUse": true,
             "dataAccessCommitteeId": 1,
@@ -177,9 +177,9 @@ public class JsonSchemaUtilTest {
           "consentGroups": [{
             "fileTypes": [{
               "fileType": "Arrays",
-              "functionalEquivalence": "equivalence",
-              "numberOfParticipants": 2
+              "functionalEquivalence": "equivalence"
             }],
+            "numberOfParticipants": 2,
             "consentGroupName": "name",
             "generalResearchUse": true,
             "dataAccessCommitteeId": 1,
@@ -204,9 +204,9 @@ public class JsonSchemaUtilTest {
           "consentGroups": [{
             "fileTypes": [{
               "fileType": "Arrays",
-              "functionalEquivalence": "equivalence",
-              "numberOfParticipants": 2
+              "functionalEquivalence": "equivalence"
             }],
+            "numberOfParticipants": 2,
             "consentGroupName": "name",
             "generalResearchUse": true,
             "dataAccessCommitteeId": 1,
@@ -233,9 +233,9 @@ public class JsonSchemaUtilTest {
           "consentGroups": [{
             "fileTypes": [{
               "fileType": "Arrays",
-              "functionalEquivalence": "equivalence",
-              "numberOfParticipants": 2
+              "functionalEquivalence": "equivalence"
             }],
+            "numberOfParticipants": 2,
             "consentGroupName": "name",
             "generalResearchUse": true,
             "dataAccessCommitteeId": 1,
@@ -274,9 +274,9 @@ public class JsonSchemaUtilTest {
           "consentGroups": [{
             "fileTypes": [{
               "fileType": "Arrays",
-              "functionalEquivalence": "equivalence",
-              "numberOfParticipants": 2
+              "functionalEquivalence": "equivalence"
             }],
+            "numberOfParticipants": 2,
             "consentGroupName": "name",
             "generalResearchUse": true,
             "dataAccessCommitteeId": 1,
@@ -312,9 +312,9 @@ public class JsonSchemaUtilTest {
           "consentGroups": [{
             "fileTypes": [{
               "fileType": "Arrays",
-              "functionalEquivalence": "equivalence",
-              "numberOfParticipants": 2
+              "functionalEquivalence": "equivalence"
             }],
+            "numberOfParticipants": 2,
             "consentGroupName": "name",
             "generalResearchUse": true,
             "dataAccessCommitteeId": 1,
@@ -339,9 +339,9 @@ public class JsonSchemaUtilTest {
           "consentGroups": [{
             "fileTypes": [{
               "fileType": "Arrays",
-              "functionalEquivalence": "equivalence",
-              "numberOfParticipants": 2
+              "functionalEquivalence": "equivalence"
             }],
+            "numberOfParticipants": 2,
             "consentGroupName": "name",
             "generalResearchUse": true,
             "dataAccessCommitteeId": 1,
@@ -366,9 +366,9 @@ public class JsonSchemaUtilTest {
           "consentGroups": [{
             "fileTypes": [{
               "fileType": "Arrays",
-              "functionalEquivalence": "equivalence",
-              "numberOfParticipants": 2
+              "functionalEquivalence": "equivalence"
             }],
+            "numberOfParticipants": 2,
             "consentGroupName": "name",
             "generalResearchUse": true,
             "dataAccessCommitteeId": 1,
@@ -413,9 +413,9 @@ public class JsonSchemaUtilTest {
           "consentGroups": [{
             "fileTypes": [{
               "fileType": "Arrays",
-              "functionalEquivalence": "equivalence",
-              "numberOfParticipants": 2
+              "functionalEquivalence": "equivalence"
             }],
+            "numberOfParticipants": 2,
             "consentGroupName": "name",
             "openAccess": true,
             "url": "https://asdf.com"
@@ -439,9 +439,9 @@ public class JsonSchemaUtilTest {
           "consentGroups": [{
             "fileTypes": [{
               "fileType": "Arrays",
-              "functionalEquivalence": "equivalence",
-              "numberOfParticipants": 2
+              "functionalEquivalence": "equivalence"
             }],
+            "numberOfParticipants": 2,
             "consentGroupName": "name",
             "openAccess": false,
             "poa": true,
@@ -466,9 +466,9 @@ public class JsonSchemaUtilTest {
           "consentGroups": [{
             "fileTypes": [{
               "fileType": "Arrays",
-              "functionalEquivalence": "equivalence",
-              "numberOfParticipants": 2
+              "functionalEquivalence": "equivalence"
             }],
+            "numberOfParticipants": 2,
             "consentGroupName": "name",
             "hmb": true,
             "url": "https://asdf.com"
@@ -606,9 +606,9 @@ public class JsonSchemaUtilTest {
           "consentGroups": [{
             "fileTypes": [{
               "fileType": "Arrays",
-              "functionalEquivalence": "equivalence",
-              "numberOfParticipants": 2
+              "functionalEquivalence": "equivalence"
             }],
+            "numberOfParticipants": 2,
             "consentGroupName": "name",
             "diseaseSpecificUse": [],
             "dataAccessCommitteeId": 1,
@@ -633,9 +633,10 @@ public class JsonSchemaUtilTest {
           "consentGroups": [{
             "fileTypes": [{
               "fileType": "Arrays",
-              "functionalEquivalence": "equivalence",
-              "numberOfParticipants": 2
-            }],                "consentGroupName": "name",
+              "functionalEquivalence": "equivalence"
+            }],
+            "numberOfParticipants": 2,
+            "consentGroupName": "name",
             "diseaseSpecificUse": ["something!"],
             "dataAccessCommitteeId": 1,
             "url": "https://asdf.com"
@@ -668,9 +669,9 @@ public class JsonSchemaUtilTest {
           "consentGroups": [{
             "fileTypes": [{
               "fileType": "Arrays",
-              "functionalEquivalence": "equivalence",
-              "numberOfParticipants": 2
+              "functionalEquivalence": "equivalence"
             }],
+            "numberOfParticipants": 2,
             "consentGroupName": "name!",
             "generalResearchUse": true,
             "hmb": true,
@@ -696,9 +697,9 @@ public class JsonSchemaUtilTest {
           "consentGroups": [{
             "fileTypes": [{
               "fileType": "Arrays",
-              "functionalEquivalence": "equivalence",
-              "numberOfParticipants": 2
+              "functionalEquivalence": "equivalence"
             }],
+            "numberOfParticipants": 2,
             "consentGroupName": "name!",
             "diseaseSpecificUse": ["some disease"],
             "openAccess": true,
@@ -733,9 +734,9 @@ public class JsonSchemaUtilTest {
           "consentGroups": [{
             "fileTypes": [{
               "fileType": "Arrays",
-              "functionalEquivalence": "equivalence",
-              "numberOfParticipants": 2
+              "functionalEquivalence": "equivalence"
             }],
+            "numberOfParticipants": 2,
             "consentGroupName": "name",
             "generalResearchUse": true,
             "dataAccessCommitteeId": 1,
@@ -760,9 +761,9 @@ public class JsonSchemaUtilTest {
           "consentGroups": [{
             "fileTypes": [{
               "fileType": "Arrays",
-              "functionalEquivalence": "equivalence",
-              "numberOfParticipants": 2
+              "functionalEquivalence": "equivalence"
             }],
+            "numberOfParticipants": 2,
             "consentGroupName": "name",
             "generalResearchUse": true,
             "dataAccessCommitteeId": 1,
@@ -803,9 +804,9 @@ public class JsonSchemaUtilTest {
            "consentGroups": [{
              "fileTypes": [{
                "fileType": "Arrays",
-               "functionalEquivalence": "equivalence",
-               "numberOfParticipants": 2
+               "functionalEquivalence": "equivalence"
              }],
+             "numberOfParticipants": 2,
              "consentGroupName": "",
              "generalResearchUse": true,
              "dataAccessCommitteeId": 1,


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DUOS-2513

### Summary

Moves `numberOfParticipants` away from a sub property of `fileTypes` to a top-level property of `consentGroups`

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
