### PR TITLE
[DUOS-2515]Update Dataset Search Feature

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/models/DataUse.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DataUse.java
@@ -56,6 +56,7 @@ public class DataUse {
   private String genomicSummaryResults;
   private Boolean collaborationInvestigators;
   private String publicationMoratorium;
+  private Boolean openAccess;
 
   public Boolean getGeneralUse() {
     return generalUse;
@@ -360,6 +361,10 @@ public class DataUse {
   public void setPublicationMoratorium(String publicationMoratorium) {
     this.publicationMoratorium = publicationMoratorium;
   }
+
+  public Boolean getOpenAccess() { return openAccess; }
+
+  public void setOpenAccess(Boolean openAccess) { this.openAccess = openAccess; }
 
   @Override
   public String toString() {

--- a/src/main/java/org/broadinstitute/consent/http/models/DataUse.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DataUse.java
@@ -56,7 +56,6 @@ public class DataUse {
   private String genomicSummaryResults;
   private Boolean collaborationInvestigators;
   private String publicationMoratorium;
-  private Boolean openAccess;
 
   public Boolean getGeneralUse() {
     return generalUse;
@@ -361,10 +360,6 @@ public class DataUse {
   public void setPublicationMoratorium(String publicationMoratorium) {
     this.publicationMoratorium = publicationMoratorium;
   }
-
-  public Boolean getOpenAccess() { return openAccess; }
-
-  public void setOpenAccess(Boolean openAccess) { this.openAccess = openAccess; }
 
   @Override
   public String toString() {

--- a/src/main/java/org/broadinstitute/consent/http/models/Dataset.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/Dataset.java
@@ -313,7 +313,7 @@ public class Dataset {
    * @return if the Dataset matched query
    *
    */
-  public boolean isStringMatch(@NonNull String query, @NonNull Boolean openAccess) {
+  public boolean isDatasetMatch(@NonNull String query, @NonNull Boolean openAccess) {
     String lowerCaseQuery = query.toLowerCase();
     List<String> queryTerms = List.of(lowerCaseQuery.split("\\s+"));
 

--- a/src/main/java/org/broadinstitute/consent/http/models/Dataset.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/Dataset.java
@@ -309,7 +309,7 @@ public class Dataset {
    * the raw search query and open access.
    *
    * @param query       Raw string query
-   * @param openAccess  Nullable Boolean for open access
+   * @param openAccess  Boolean for open access
    * @return if the Dataset matched query
    *
    */

--- a/src/main/java/org/broadinstitute/consent/http/models/Dataset.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/Dataset.java
@@ -313,7 +313,7 @@ public class Dataset {
    * @return if the Dataset matched query
    *
    */
-  public boolean isDatasetMatch(@NonNull String query, @NonNull Boolean openAccess) {
+  public boolean isDatasetMatch(@NonNull String query, boolean openAccess) {
     String lowerCaseQuery = query.toLowerCase();
     List<String> queryTerms = List.of(lowerCaseQuery.split("\\s+"));
 
@@ -333,7 +333,7 @@ public class Dataset {
           return false;
         }
       }
-      else if (!Objects.equals(openAccessProp.get().getPropertyValue().toString(), openAccess.toString()))
+      else if (!Objects.equals(openAccessProp.get().getPropertyValue().toString(), Boolean.toString(openAccess)))
       {
         return false;
       }

--- a/src/main/java/org/broadinstitute/consent/http/models/Dataset.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/Dataset.java
@@ -313,6 +313,8 @@ public class Dataset {
    * @return if the Dataset matched query
    *
    */
+
+  // TODO: investigate whether we can try to coerce getPropertyValue to a boolean instead of comparing strings
   public boolean isDatasetMatch(@NonNull String query, boolean openAccess) {
     String lowerCaseQuery = query.toLowerCase();
     List<String> queryTerms = List.of(lowerCaseQuery.split("\\s+"));

--- a/src/main/java/org/broadinstitute/consent/http/models/Dataset.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/Dataset.java
@@ -303,19 +303,6 @@ public class Dataset {
     this.deletable = deletable;
   }
 
-  // helper methods for open access string matching
-  public Optional<DatasetProperty> getPropertyByName(String name) {
-    if (Objects.isNull(getProperties()) || getProperties().isEmpty()){
-      return Optional.empty();
-    }
-    return getProperties()
-        .stream()
-        .filter((dp) -> Objects.nonNull(dp.getPropertyValue()))
-        .filter((dp) -> Objects.equals(dp.getPropertyName(), name))
-        .findFirst();
-  }
-
-
   /**
    * Checks if the Dataset matches a raw search query. Searches on all dataset properties and some
    * data use properties. Has optional parameter "Open Access" which will search datasets on both
@@ -326,7 +313,7 @@ public class Dataset {
    * @return if the Dataset matched query
    *
    */
-  public boolean isStringMatch(@NonNull String query, Boolean openAccess) {
+  public boolean isStringMatch(@NonNull String query, @NonNull Boolean openAccess) {
     String lowerCaseQuery = query.toLowerCase();
     List<String> queryTerms = List.of(lowerCaseQuery.split("\\s+"));
 
@@ -334,8 +321,12 @@ public class Dataset {
     matchTerms.add(this.getName());
     matchTerms.add(this.getDatasetIdentifier());
 
-    if (Objects.nonNull(openAccess)) {
-      Optional<DatasetProperty> openAccessProp = getPropertyByName(OPEN_ACCESS.toString());
+    if (Objects.nonNull(getProperties()) && !getProperties().isEmpty()) {
+      Optional<DatasetProperty> openAccessProp = getProperties()
+          .stream()
+          .filter((dp) -> Objects.nonNull(dp.getPropertyValue()))
+          .filter((dp) -> Objects.equals(dp.getPropertyName(), OPEN_ACCESS.toString()))
+          .findFirst();
 
       if (openAccessProp.isEmpty()){
         if (openAccess) {
@@ -346,9 +337,7 @@ public class Dataset {
       {
         return false;
       }
-    }
 
-    if (Objects.nonNull(getProperties()) && !getProperties().isEmpty()) {
       List<String> propVals = getProperties()
           .stream()
           .filter((dp) -> Objects.nonNull(dp.getPropertyValue()))

--- a/src/main/java/org/broadinstitute/consent/http/models/Dataset.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/Dataset.java
@@ -330,11 +330,6 @@ public class Dataset {
       if (Objects.nonNull(dataUse.getDiseaseRestrictions())) {
         matchTerms.addAll(dataUse.getDiseaseRestrictions());
       }
-
-      if(Objects.nonNull(dataUse.getOpenAccess())
-      && dataUse.getOpenAccess()){
-        matchTerms.add("openAccess");
-      }
     }
 
     return queryTerms
@@ -382,6 +377,13 @@ public class Dataset {
 
       if (Objects.nonNull(dataUse.getDiseaseRestrictions())) {
         matchTerms.addAll(dataUse.getDiseaseRestrictions());
+      }
+
+      if (openAccess){
+        if(Objects.nonNull(dataUse.getOpenAccess())
+            && dataUse.getOpenAccess()){
+          matchTerms.add("openAccess");
+        }
       }
     }
 

--- a/src/main/java/org/broadinstitute/consent/http/models/Dataset.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/Dataset.java
@@ -330,6 +330,59 @@ public class Dataset {
       if (Objects.nonNull(dataUse.getDiseaseRestrictions())) {
         matchTerms.addAll(dataUse.getDiseaseRestrictions());
       }
+
+      if(Objects.nonNull(dataUse.getOpenAccess())
+      && dataUse.getOpenAccess()){
+        matchTerms.add("openAccess");
+      }
+    }
+
+    return queryTerms
+        .stream()
+        .filter(Objects::nonNull)
+        // all terms must match at least one thing
+        .allMatch((q) ->
+            matchTerms
+                .stream()
+                .filter(Objects::nonNull)
+                .map(String::toLowerCase)
+                .anyMatch(
+                    (t) -> t.contains(q)
+                ));
+  }
+
+  public boolean isStringMatchWithOpenAccess(@NonNull String query, @NonNull Boolean openAccess) {
+    String lowerCaseQuery = query.toLowerCase();
+    List<String> queryTerms = List.of(lowerCaseQuery.split("\\s+"));
+
+    List<String> matchTerms = new ArrayList<>();
+    matchTerms.add(this.getName());
+    matchTerms.add(this.getDatasetIdentifier());
+
+    if (Objects.nonNull(getProperties()) && !getProperties().isEmpty()) {
+      List<String> propVals = getProperties()
+          .stream()
+          .filter((dp) -> Objects.nonNull(dp.getPropertyValue()))
+          .map(DatasetProperty::getPropertyValueAsString)
+          .map(String::toLowerCase)
+          .toList();
+      matchTerms.addAll(propVals);
+    }
+
+    if (Objects.nonNull(dataUse)) {
+      if (Objects.nonNull(dataUse.getEthicsApprovalRequired())
+          && dataUse.getEthicsApprovalRequired()) {
+        matchTerms.add("irb");
+      }
+
+      if (Objects.nonNull(dataUse.getCollaboratorRequired())
+          && dataUse.getCollaboratorRequired()) {
+        matchTerms.add("collaborator");
+      }
+
+      if (Objects.nonNull(dataUse.getDiseaseRestrictions())) {
+        matchTerms.addAll(dataUse.getDiseaseRestrictions());
+      }
     }
 
     return queryTerms

--- a/src/main/java/org/broadinstitute/consent/http/models/Dataset.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/Dataset.java
@@ -8,6 +8,7 @@ import java.util.Objects;
 import java.util.Set;
 import org.apache.commons.lang3.StringUtils;
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.broadinstitute.consent.http.models.dataset_registration_v1.ConsentGroup;
 
 public class Dataset {
 
@@ -56,6 +57,8 @@ public class Dataset {
 
   private User createUser;
   private Study study;
+
+  private ConsentGroup consentGroup;
 
   public Dataset() {
   }
@@ -380,8 +383,8 @@ public class Dataset {
       }
 
       if (openAccess){
-        if(Objects.nonNull(dataUse.getOpenAccess())
-            && dataUse.getOpenAccess()){
+        if(Objects.nonNull(consentGroup.getOpenAccess())
+            && consentGroup.getOpenAccess()){
           matchTerms.add("openAccess");
         }
       }

--- a/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
@@ -529,7 +529,7 @@ public class DatasetResource extends Resource {
   public Response searchDatasets(
       @Auth AuthUser authUser,
       @QueryParam("query") String query,
-      @QueryParam("open") @DefaultValue("false") Boolean openAccess) {
+      @QueryParam("open") @DefaultValue("false") boolean openAccess) {
     try {
       User user = userService.findUserByEmail(authUser.getEmail());
       List<Dataset> datasets = datasetService.searchDatasets(query, openAccess, user);

--- a/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
@@ -9,6 +9,7 @@ import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.ClientErrorException;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.DefaultValue;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.POST;
@@ -525,10 +526,13 @@ public class DatasetResource extends Resource {
   @Path("/search")
   @Produces("application/json")
   @PermitAll
-  public Response searchDatasets(@Auth AuthUser authUser, @QueryParam("query") String query) {
+  public Response searchDatasets(
+      @Auth AuthUser authUser,
+      @QueryParam("query") String query,
+      @QueryParam("open") @DefaultValue("false") Boolean openAccess) {
     try {
       User user = userService.findUserByEmail(authUser.getEmail());
-      List<Dataset> datasets = datasetService.searchDatasets(query, user);
+      List<Dataset> datasets = datasetService.searchDatasets(query, openAccess, user);
       return Response.ok().entity(unmarshal(datasets)).build();
     } catch (Exception e) {
       return createExceptionResponse(e);

--- a/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
@@ -529,7 +529,7 @@ public class DatasetResource extends Resource {
   public Response searchDatasets(
       @Auth AuthUser authUser,
       @QueryParam("query") String query,
-      @QueryParam("open") Boolean openAccess) {
+      @QueryParam("open") @DefaultValue("false") Boolean openAccess) {
     try {
       User user = userService.findUserByEmail(authUser.getEmail());
       List<Dataset> datasets = datasetService.searchDatasets(query, openAccess, user);

--- a/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
@@ -529,7 +529,7 @@ public class DatasetResource extends Resource {
   public Response searchDatasets(
       @Auth AuthUser authUser,
       @QueryParam("query") String query,
-      @QueryParam("open") @DefaultValue("false") Boolean openAccess) {
+      @QueryParam("open") Boolean openAccess) {
     try {
       User user = userService.findUserByEmail(authUser.getEmail());
       List<Dataset> datasets = datasetService.searchDatasets(query, openAccess, user);

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -430,7 +430,7 @@ public class DatasetService {
 
   public List<Dataset> searchDatasets(String query, Boolean openAccess, User user) {
     List<Dataset> datasets = findAllDatasetsByUser(user);
-    return datasets.stream().filter(ds -> ds.isStringMatchWithOpenAccess(query, openAccess)).toList();
+    return datasets.stream().filter(ds -> ds.isStringMatch(query, openAccess)).toList();
   }
 
   @Deprecated

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -430,7 +430,7 @@ public class DatasetService {
 
   public List<Dataset> searchDatasets(String query, Boolean openAccess, User user) {
     List<Dataset> datasets = findAllDatasetsByUser(user);
-    return datasets.stream().filter(ds -> ds.isStringMatch(query, openAccess)).toList();
+    return datasets.stream().filter(ds -> ds.isDatasetMatch(query, openAccess)).toList();
   }
 
   @Deprecated

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -428,9 +428,14 @@ public class DatasetService {
   }
 
 
-  public List<Dataset> searchDatasets(String query, User user) {
+  public List<Dataset> searchDatasets(String query, Boolean openAccess, User user) {
     List<Dataset> datasets = findAllDatasetsByUser(user);
-    return datasets.stream().filter(ds -> ds.isStringMatch(query)).toList();
+    if (Objects.isNull(openAccess) || (openAccess.equals(false))){
+      return datasets.stream().filter(ds -> ds.isStringMatch(query)).toList();
+    } else {
+      return datasets.stream().filter(ds -> ds.isStringMatchWithOpenAccess(query, openAccess)).toList();
+    }
+
   }
 
   @Deprecated

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -428,7 +428,7 @@ public class DatasetService {
   }
 
 
-  public List<Dataset> searchDatasets(String query, Boolean openAccess, User user) {
+  public List<Dataset> searchDatasets(String query, boolean openAccess, User user) {
     List<Dataset> datasets = findAllDatasetsByUser(user);
     return datasets.stream().filter(ds -> ds.isDatasetMatch(query, openAccess)).toList();
   }

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -430,12 +430,7 @@ public class DatasetService {
 
   public List<Dataset> searchDatasets(String query, Boolean openAccess, User user) {
     List<Dataset> datasets = findAllDatasetsByUser(user);
-    if (Objects.isNull(openAccess) || (openAccess.equals(false))){
-      return datasets.stream().filter(ds -> ds.isStringMatch(query)).toList();
-    } else {
-      return datasets.stream().filter(ds -> ds.isStringMatchWithOpenAccess(query, openAccess)).toList();
-    }
-
+    return datasets.stream().filter(ds -> ds.isStringMatchWithOpenAccess(query, openAccess)).toList();
   }
 
   @Deprecated

--- a/src/main/resources/assets/paths/datasetSearch.yaml
+++ b/src/main/resources/assets/paths/datasetSearch.yaml
@@ -13,9 +13,9 @@ get:
       description: Open Access
       required: false
       schema:
-        type:
-          type: boolean
-          enum: [true, false]
+        type: boolean
+        required: false
+        default: false
   tags:
     - Dataset
   responses:

--- a/src/main/resources/assets/paths/datasetSearch.yaml
+++ b/src/main/resources/assets/paths/datasetSearch.yaml
@@ -8,6 +8,14 @@ get:
       required: true
       schema:
         type: string
+    - name: open
+      in: query
+      description: Open Access
+      required: false
+      schema:
+        type:
+          type: boolean
+          enum: [true, false]
   tags:
     - Dataset
   responses:

--- a/src/test/java/org/broadinstitute/consent/http/models/DatasetTests.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/DatasetTests.java
@@ -29,32 +29,32 @@ public class DatasetTests {
   }
 
   @Test
-  public void testIsStringMatchName() {
+  public void testIsDatasetMatchName() {
     String name = RandomStringUtils.randomAlphanumeric(20);
 
     Dataset ds = new Dataset();
     ds.setName(name);
 
-    assertTrue(ds.isStringMatch(name, false));
-    assertTrue(ds.isStringMatch(name.substring(5, 10), false));
-    assertTrue(ds.isStringMatch(name.substring(10, 15), false));
+    assertTrue(ds.isDatasetMatch(name, false));
+    assertTrue(ds.isDatasetMatch(name.substring(5, 10), false));
+    assertTrue(ds.isDatasetMatch(name.substring(10, 15), false));
 
-    assertFalse(ds.isStringMatch(RandomStringUtils.randomAlphanumeric(30), false));
+    assertFalse(ds.isDatasetMatch(RandomStringUtils.randomAlphanumeric(30), false));
   }
 
   @Test
-  public void testIsStringMatchNameCaseIndependent() {
+  public void testIsDatasetMatchNameCaseIndependent() {
     String name = RandomStringUtils.randomAlphabetic(20);
 
     Dataset ds = new Dataset();
     ds.setName(name.toLowerCase());
 
-    assertTrue(ds.isStringMatch(name.toUpperCase(), false));
-    assertTrue(ds.isStringMatch(name.toUpperCase().substring(7, 14), false));
+    assertTrue(ds.isDatasetMatch(name.toUpperCase(), false));
+    assertTrue(ds.isDatasetMatch(name.toUpperCase().substring(7, 14), false));
   }
 
   @Test
-  public void testIsStringMatchDatasetProperty() {
+  public void testIsDatasetMatchDatasetProperty() {
     Dataset ds = new Dataset();
 
     String value = RandomStringUtils.randomAlphanumeric(20);
@@ -64,84 +64,84 @@ public class DatasetTests {
     dsp.setPropertyType(PropertyType.String);
     ds.setProperties(Set.of(dsp));
 
-    assertTrue(ds.isStringMatch(value, false));
-    assertFalse(ds.isStringMatch(RandomStringUtils.randomAlphanumeric(25), false));
+    assertTrue(ds.isDatasetMatch(value, false));
+    assertFalse(ds.isDatasetMatch(RandomStringUtils.randomAlphanumeric(25), false));
   }
 
   @Test
-  public void testIsStringMatchIdentifier() {
+  public void testIsDatasetMatchIdentifier() {
     Dataset ds = new Dataset();
     ds.setAlias(1235);
 
-    assertTrue(ds.isStringMatch("DUOS-001235", false));
-    assertTrue(ds.isStringMatch("DUOS", false));
-    assertTrue(ds.isStringMatch("123", false));
-    assertTrue(ds.isStringMatch("001235", false));
-    assertFalse(ds.isStringMatch("DUOS-123456", false));
+    assertTrue(ds.isDatasetMatch("DUOS-001235", false));
+    assertTrue(ds.isDatasetMatch("DUOS", false));
+    assertTrue(ds.isDatasetMatch("123", false));
+    assertTrue(ds.isDatasetMatch("001235", false));
+    assertFalse(ds.isDatasetMatch("DUOS-123456", false));
   }
 
   @Test
-  public void testIsStringMatchDataUseCommercial() {
+  public void testIsDatasetMatchDataUseCommercial() {
     Dataset ds = new Dataset();
 
-    assertFalse(ds.isStringMatch("collaborator", false));
+    assertFalse(ds.isDatasetMatch("collaborator", false));
 
     DataUse du = new DataUseBuilder().setCollaboratorRequired(true).build();
 
     ds.setDataUse(du);
 
-    assertTrue(ds.isStringMatch("collaborator", false));
-    assertTrue(ds.isStringMatch("collab", false));
+    assertTrue(ds.isDatasetMatch("collaborator", false));
+    assertTrue(ds.isDatasetMatch("collab", false));
   }
 
   @Test
-  public void testIsStringMatchDataUseIrb() {
+  public void testIsDatasetMatchDataUseIrb() {
     Dataset ds = new Dataset();
 
-    assertFalse(ds.isStringMatch("irb", false));
+    assertFalse(ds.isDatasetMatch("irb", false));
 
     DataUse du = new DataUse();
     du.setEthicsApprovalRequired(true);
 
     ds.setDataUse(du);
 
-    assertTrue(ds.isStringMatch("irb", false));
-    assertTrue(ds.isStringMatch("irb", false));
+    assertTrue(ds.isDatasetMatch("irb", false));
+    assertTrue(ds.isDatasetMatch("irb", false));
   }
 
   @Test
-  public void testIsStringMatchDataUseDiseases() {
+  public void testIsDatasetMatchDataUseDiseases() {
     Dataset ds = new Dataset();
 
-    assertFalse(ds.isStringMatch("cancer", false));
-    assertFalse(ds.isStringMatch("alzheimers", false));
+    assertFalse(ds.isDatasetMatch("cancer", false));
+    assertFalse(ds.isDatasetMatch("alzheimers", false));
 
     DataUse du = new DataUse();
     du.setDiseaseRestrictions(List.of("cancer", "alzheimers"));
 
     ds.setDataUse(du);
 
-    assertTrue(ds.isStringMatch("cancer", false));
-    assertTrue(ds.isStringMatch("alzheimers", false));
+    assertTrue(ds.isDatasetMatch("cancer", false));
+    assertTrue(ds.isDatasetMatch("alzheimers", false));
   }
 
   @Test
-  public void testIsStringMatchMultipleTerms() {
+  public void testIsDatasetMatchMultipleTerms() {
     Dataset ds = new Dataset();
 
     ds.setName("asdf");
     ds.setAlias(1234);
 
-    assertTrue(ds.isStringMatch("ASD DUOS-001234", false));
-    assertTrue(ds.isStringMatch("asdf 123", false));
+    assertTrue(ds.isDatasetMatch("ASD DUOS-001234", false));
+    assertTrue(ds.isDatasetMatch("asdf 123", false));
 
-    assertFalse(ds.isStringMatch("asf DUOS-001234", false));
-    assertFalse(ds.isStringMatch("asd 122", false));
+    assertFalse(ds.isDatasetMatch("asf DUOS-001234", false));
+    assertFalse(ds.isDatasetMatch("asd 122", false));
 
   }
 
   @Test
-  public void testIsStringMatchOpenAccessTrue() {
+  public void testIsDatasetMatchOpenAccessTrue() {
     Dataset ds = new Dataset();
 
     String value = "true";
@@ -153,12 +153,12 @@ public class DatasetTests {
     dsp.setSchemaProperty("consentGroup.openAccess");
     ds.setProperties(Set.of(dsp));
 
-    assertTrue(ds.isStringMatch(value, true));
-    assertFalse(ds.isStringMatch(RandomStringUtils.randomAlphanumeric(25), true));
+    assertTrue(ds.isDatasetMatch(value, true));
+    assertFalse(ds.isDatasetMatch(RandomStringUtils.randomAlphanumeric(25), true));
   }
 
   @Test
-  public void testIsStringMatchOpenAccessFalse() {
+  public void testIsDatasetMatchOpenAccessFalse() {
     Dataset ds = new Dataset();
 
     String value = "false";
@@ -170,7 +170,7 @@ public class DatasetTests {
     dsp.setSchemaProperty("consentGroup.openAccess");
     ds.setProperties(Set.of(dsp));
 
-    assertTrue(ds.isStringMatch(value, false));
-    assertFalse(ds.isStringMatch(RandomStringUtils.randomAlphanumeric(25), true));
+    assertTrue(ds.isDatasetMatch(value, false));
+    assertFalse(ds.isDatasetMatch(RandomStringUtils.randomAlphanumeric(25), true));
   }
 }

--- a/src/test/java/org/broadinstitute/consent/http/models/DatasetTests.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/DatasetTests.java
@@ -35,11 +35,11 @@ public class DatasetTests {
     Dataset ds = new Dataset();
     ds.setName(name);
 
-    assertTrue(ds.isStringMatch(name));
-    assertTrue(ds.isStringMatch(name.substring(5, 10)));
-    assertTrue(ds.isStringMatch(name.substring(10, 15)));
+    assertTrue(ds.isStringMatch(name, null));
+    assertTrue(ds.isStringMatch(name.substring(5, 10), null));
+    assertTrue(ds.isStringMatch(name.substring(10, 15), null));
 
-    assertFalse(ds.isStringMatch(RandomStringUtils.randomAlphanumeric(30)));
+    assertFalse(ds.isStringMatch(RandomStringUtils.randomAlphanumeric(30), null));
   }
 
   @Test
@@ -49,8 +49,8 @@ public class DatasetTests {
     Dataset ds = new Dataset();
     ds.setName(name.toLowerCase());
 
-    assertTrue(ds.isStringMatch(name.toUpperCase()));
-    assertTrue(ds.isStringMatch(name.toUpperCase().substring(7, 14)));
+    assertTrue(ds.isStringMatch(name.toUpperCase(), null));
+    assertTrue(ds.isStringMatch(name.toUpperCase().substring(7, 14), null));
   }
 
   @Test
@@ -64,8 +64,8 @@ public class DatasetTests {
     dsp.setPropertyType(PropertyType.String);
     ds.setProperties(Set.of(dsp));
 
-    assertTrue(ds.isStringMatch(value));
-    assertFalse(ds.isStringMatch(RandomStringUtils.randomAlphanumeric(25)));
+    assertTrue(ds.isStringMatch(value, null));
+    assertFalse(ds.isStringMatch(RandomStringUtils.randomAlphanumeric(25), null));
   }
 
   @Test
@@ -73,56 +73,56 @@ public class DatasetTests {
     Dataset ds = new Dataset();
     ds.setAlias(1235);
 
-    assertTrue(ds.isStringMatch("DUOS-001235"));
-    assertTrue(ds.isStringMatch("DUOS"));
-    assertTrue(ds.isStringMatch("123"));
-    assertTrue(ds.isStringMatch("001235"));
-    assertFalse(ds.isStringMatch("DUOS-123456"));
+    assertTrue(ds.isStringMatch("DUOS-001235", null));
+    assertTrue(ds.isStringMatch("DUOS", null));
+    assertTrue(ds.isStringMatch("123", null));
+    assertTrue(ds.isStringMatch("001235", null));
+    assertFalse(ds.isStringMatch("DUOS-123456", null));
   }
 
   @Test
   public void testIsStringMatchDataUseCommercial() {
     Dataset ds = new Dataset();
 
-    assertFalse(ds.isStringMatch("collaborator"));
+    assertFalse(ds.isStringMatch("collaborator", null));
 
     DataUse du = new DataUseBuilder().setCollaboratorRequired(true).build();
 
     ds.setDataUse(du);
 
-    assertTrue(ds.isStringMatch("collaborator"));
-    assertTrue(ds.isStringMatch("collab"));
+    assertTrue(ds.isStringMatch("collaborator", null));
+    assertTrue(ds.isStringMatch("collab", null));
   }
 
   @Test
   public void testIsStringMatchDataUseIrb() {
     Dataset ds = new Dataset();
 
-    assertFalse(ds.isStringMatch("irb"));
+    assertFalse(ds.isStringMatch("irb", null));
 
     DataUse du = new DataUse();
     du.setEthicsApprovalRequired(true);
 
     ds.setDataUse(du);
 
-    assertTrue(ds.isStringMatch("irb"));
-    assertTrue(ds.isStringMatch("irb"));
+    assertTrue(ds.isStringMatch("irb", null));
+    assertTrue(ds.isStringMatch("irb", null));
   }
 
   @Test
   public void testIsStringMatchDataUseDiseases() {
     Dataset ds = new Dataset();
 
-    assertFalse(ds.isStringMatch("cancer"));
-    assertFalse(ds.isStringMatch("alzheimers"));
+    assertFalse(ds.isStringMatch("cancer", null));
+    assertFalse(ds.isStringMatch("alzheimers", null));
 
     DataUse du = new DataUse();
     du.setDiseaseRestrictions(List.of("cancer", "alzheimers"));
 
     ds.setDataUse(du);
 
-    assertTrue(ds.isStringMatch("cancer"));
-    assertTrue(ds.isStringMatch("alzheimers"));
+    assertTrue(ds.isStringMatch("cancer", null));
+    assertTrue(ds.isStringMatch("alzheimers", null));
   }
 
   @Test
@@ -132,11 +132,11 @@ public class DatasetTests {
     ds.setName("asdf");
     ds.setAlias(1234);
 
-    assertTrue(ds.isStringMatch("ASD DUOS-001234"));
-    assertTrue(ds.isStringMatch("asdf 123"));
+    assertTrue(ds.isStringMatch("ASD DUOS-001234", null));
+    assertTrue(ds.isStringMatch("asdf 123", null));
 
-    assertFalse(ds.isStringMatch("asf DUOS-001234"));
-    assertFalse(ds.isStringMatch("asd 122"));
+    assertFalse(ds.isStringMatch("asf DUOS-001234", null));
+    assertFalse(ds.isStringMatch("asd 122", null));
 
   }
 }

--- a/src/test/java/org/broadinstitute/consent/http/models/DatasetTests.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/DatasetTests.java
@@ -35,11 +35,11 @@ public class DatasetTests {
     Dataset ds = new Dataset();
     ds.setName(name);
 
-    assertTrue(ds.isStringMatch(name, null));
-    assertTrue(ds.isStringMatch(name.substring(5, 10), null));
-    assertTrue(ds.isStringMatch(name.substring(10, 15), null));
+    assertTrue(ds.isStringMatch(name, false));
+    assertTrue(ds.isStringMatch(name.substring(5, 10), false));
+    assertTrue(ds.isStringMatch(name.substring(10, 15), false));
 
-    assertFalse(ds.isStringMatch(RandomStringUtils.randomAlphanumeric(30), null));
+    assertFalse(ds.isStringMatch(RandomStringUtils.randomAlphanumeric(30), false));
   }
 
   @Test
@@ -49,8 +49,8 @@ public class DatasetTests {
     Dataset ds = new Dataset();
     ds.setName(name.toLowerCase());
 
-    assertTrue(ds.isStringMatch(name.toUpperCase(), null));
-    assertTrue(ds.isStringMatch(name.toUpperCase().substring(7, 14), null));
+    assertTrue(ds.isStringMatch(name.toUpperCase(), false));
+    assertTrue(ds.isStringMatch(name.toUpperCase().substring(7, 14), false));
   }
 
   @Test
@@ -64,8 +64,8 @@ public class DatasetTests {
     dsp.setPropertyType(PropertyType.String);
     ds.setProperties(Set.of(dsp));
 
-    assertTrue(ds.isStringMatch(value, null));
-    assertFalse(ds.isStringMatch(RandomStringUtils.randomAlphanumeric(25), null));
+    assertTrue(ds.isStringMatch(value, false));
+    assertFalse(ds.isStringMatch(RandomStringUtils.randomAlphanumeric(25), false));
   }
 
   @Test
@@ -73,56 +73,56 @@ public class DatasetTests {
     Dataset ds = new Dataset();
     ds.setAlias(1235);
 
-    assertTrue(ds.isStringMatch("DUOS-001235", null));
-    assertTrue(ds.isStringMatch("DUOS", null));
-    assertTrue(ds.isStringMatch("123", null));
-    assertTrue(ds.isStringMatch("001235", null));
-    assertFalse(ds.isStringMatch("DUOS-123456", null));
+    assertTrue(ds.isStringMatch("DUOS-001235", false));
+    assertTrue(ds.isStringMatch("DUOS", false));
+    assertTrue(ds.isStringMatch("123", false));
+    assertTrue(ds.isStringMatch("001235", false));
+    assertFalse(ds.isStringMatch("DUOS-123456", false));
   }
 
   @Test
   public void testIsStringMatchDataUseCommercial() {
     Dataset ds = new Dataset();
 
-    assertFalse(ds.isStringMatch("collaborator", null));
+    assertFalse(ds.isStringMatch("collaborator", false));
 
     DataUse du = new DataUseBuilder().setCollaboratorRequired(true).build();
 
     ds.setDataUse(du);
 
-    assertTrue(ds.isStringMatch("collaborator", null));
-    assertTrue(ds.isStringMatch("collab", null));
+    assertTrue(ds.isStringMatch("collaborator", false));
+    assertTrue(ds.isStringMatch("collab", false));
   }
 
   @Test
   public void testIsStringMatchDataUseIrb() {
     Dataset ds = new Dataset();
 
-    assertFalse(ds.isStringMatch("irb", null));
+    assertFalse(ds.isStringMatch("irb", false));
 
     DataUse du = new DataUse();
     du.setEthicsApprovalRequired(true);
 
     ds.setDataUse(du);
 
-    assertTrue(ds.isStringMatch("irb", null));
-    assertTrue(ds.isStringMatch("irb", null));
+    assertTrue(ds.isStringMatch("irb", false));
+    assertTrue(ds.isStringMatch("irb", false));
   }
 
   @Test
   public void testIsStringMatchDataUseDiseases() {
     Dataset ds = new Dataset();
 
-    assertFalse(ds.isStringMatch("cancer", null));
-    assertFalse(ds.isStringMatch("alzheimers", null));
+    assertFalse(ds.isStringMatch("cancer", false));
+    assertFalse(ds.isStringMatch("alzheimers", false));
 
     DataUse du = new DataUse();
     du.setDiseaseRestrictions(List.of("cancer", "alzheimers"));
 
     ds.setDataUse(du);
 
-    assertTrue(ds.isStringMatch("cancer", null));
-    assertTrue(ds.isStringMatch("alzheimers", null));
+    assertTrue(ds.isStringMatch("cancer", false));
+    assertTrue(ds.isStringMatch("alzheimers", false));
   }
 
   @Test
@@ -132,11 +132,11 @@ public class DatasetTests {
     ds.setName("asdf");
     ds.setAlias(1234);
 
-    assertTrue(ds.isStringMatch("ASD DUOS-001234", null));
-    assertTrue(ds.isStringMatch("asdf 123", null));
+    assertTrue(ds.isStringMatch("ASD DUOS-001234", false));
+    assertTrue(ds.isStringMatch("asdf 123", false));
 
-    assertFalse(ds.isStringMatch("asf DUOS-001234", null));
-    assertFalse(ds.isStringMatch("asd 122", null));
+    assertFalse(ds.isStringMatch("asf DUOS-001234", false));
+    assertFalse(ds.isStringMatch("asd 122", false));
 
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/models/DatasetTests.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/DatasetTests.java
@@ -139,4 +139,38 @@ public class DatasetTests {
     assertFalse(ds.isStringMatch("asd 122", null));
 
   }
+
+  @Test
+  public void testIsStringMatchOpenAccessTrue() {
+    Dataset ds = new Dataset();
+
+    String value = "true";
+
+    DatasetProperty dsp = new DatasetProperty();
+    dsp.setPropertyName("Open Access");
+    dsp.setPropertyValue(value);
+    dsp.setPropertyType(PropertyType.String);
+    dsp.setSchemaProperty("consentGroup.openAccess");
+    ds.setProperties(Set.of(dsp));
+
+    assertTrue(ds.isStringMatch(value, true));
+    assertFalse(ds.isStringMatch(RandomStringUtils.randomAlphanumeric(25), true));
+  }
+
+  @Test
+  public void testIsStringMatchOpenAccessFalse() {
+    Dataset ds = new Dataset();
+
+    String value = "false";
+
+    DatasetProperty dsp = new DatasetProperty();
+    dsp.setPropertyName("Open Access");
+    dsp.setPropertyValue(value);
+    dsp.setPropertyType(PropertyType.String);
+    dsp.setSchemaProperty("consentGroup.openAccess");
+    ds.setProperties(Set.of(dsp));
+
+    assertTrue(ds.isStringMatch(value, false));
+    assertFalse(ds.isStringMatch(RandomStringUtils.randomAlphanumeric(25), true));
+  }
 }

--- a/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
@@ -689,21 +689,39 @@ public class DatasetResourceTest {
     assertEquals(500, response.getStatus());
   }
 
-//  @Test
-//  public void testSearchDatasets() {
-//    Dataset ds = new Dataset();
-//    ds.setDataSetId(1);
-//    when(authUser.getEmail()).thenReturn("testauthuser@test.com");
-//    when(userService.findUserByEmail("testauthuser@test.com")).thenReturn(user);
-//    when(user.getUserId()).thenReturn(0);
-//    when(datasetService.searchDatasets("search query", user)).thenReturn(List.of(ds));
-//
-//    initResource();
-//    Response response = resource.searchDatasets(authUser, "search query");
-//
-//    assertEquals(200, response.getStatus());
-//    assertEquals(GsonUtil.buildGson().toJson(List.of(ds)), response.getEntity());
-//  }
+  @Test
+  public void testSearchDatasetsOpenAccessFalse() {
+    Dataset ds = new Dataset();
+    ds.setDataSetId(1);
+    Boolean openAccess = false;
+    when(authUser.getEmail()).thenReturn("testauthuser@test.com");
+    when(userService.findUserByEmail("testauthuser@test.com")).thenReturn(user);
+    when(user.getUserId()).thenReturn(0);
+    when(datasetService.searchDatasets("search query", openAccess, user)).thenReturn(List.of(ds));
+
+    initResource();
+    Response response = resource.searchDatasets(authUser, "search query", openAccess);
+
+    assertEquals(200, response.getStatus());
+    assertEquals(GsonUtil.buildGson().toJson(List.of(ds)), response.getEntity());
+  }
+
+  @Test
+  public void testSearchDatasetsOpenAccessTrue() {
+    Dataset ds = new Dataset();
+    ds.setDataSetId(1);
+    Boolean openAccess = true;
+    when(authUser.getEmail()).thenReturn("testauthuser@test.com");
+    when(userService.findUserByEmail("testauthuser@test.com")).thenReturn(user);
+    when(user.getUserId()).thenReturn(0);
+    when(datasetService.searchDatasets("search query", openAccess, user)).thenReturn(List.of(ds));
+
+    initResource();
+    Response response = resource.searchDatasets(authUser, "search query", openAccess);
+
+    assertEquals(200, response.getStatus());
+    assertEquals(GsonUtil.buildGson().toJson(List.of(ds)), response.getEntity());
+  }
 
   @Test
   public void testUpdateNeedsReviewDataSetsSuccess() {

--- a/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
@@ -689,21 +689,21 @@ public class DatasetResourceTest {
     assertEquals(500, response.getStatus());
   }
 
-  @Test
-  public void testSearchDatasets() {
-    Dataset ds = new Dataset();
-    ds.setDataSetId(1);
-    when(authUser.getEmail()).thenReturn("testauthuser@test.com");
-    when(userService.findUserByEmail("testauthuser@test.com")).thenReturn(user);
-    when(user.getUserId()).thenReturn(0);
-    when(datasetService.searchDatasets("search query", user)).thenReturn(List.of(ds));
-
-    initResource();
-    Response response = resource.searchDatasets(authUser, "search query");
-
-    assertEquals(200, response.getStatus());
-    assertEquals(GsonUtil.buildGson().toJson(List.of(ds)), response.getEntity());
-  }
+//  @Test
+//  public void testSearchDatasets() {
+//    Dataset ds = new Dataset();
+//    ds.setDataSetId(1);
+//    when(authUser.getEmail()).thenReturn("testauthuser@test.com");
+//    when(userService.findUserByEmail("testauthuser@test.com")).thenReturn(user);
+//    when(user.getUserId()).thenReturn(0);
+//    when(datasetService.searchDatasets("search query", user)).thenReturn(List.of(ds));
+//
+//    initResource();
+//    Response response = resource.searchDatasets(authUser, "search query");
+//
+//    assertEquals(200, response.getStatus());
+//    assertEquals(GsonUtil.buildGson().toJson(List.of(ds)), response.getEntity());
+//  }
 
   @Test
   public void testUpdateNeedsReviewDataSetsSuccess() {

--- a/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
@@ -575,68 +575,68 @@ public class DatasetServiceTest {
     assertEquals(result.size(), dtos.size());
   }
 
-  @Test
-  public void testSearchDatasets() {
-    Dataset ds1 = new Dataset();
-    ds1.setName("asdf1234");
-    ds1.setAlias(3);
-    DatasetProperty ds1PI = new DatasetProperty();
-    ds1PI.setPropertyName("Principal Investigator(PI)");
-    ds1PI.setPropertyValue("John Doe");
-    ds1PI.setPropertyType(PropertyType.String);
-    ds1.setProperties(Set.of(ds1PI));
-
-    Dataset ds2 = new Dataset();
-    ds2.setName("ghjk5678");
-    ds2.setAlias(280);
-    DatasetProperty ds2PI = new DatasetProperty();
-    ds2PI.setPropertyName("Principal Investigator(PI)");
-    ds2PI.setPropertyValue("Sally Doe");
-    ds2PI.setPropertyType(PropertyType.String);
-    ds2.setProperties(Set.of(ds2PI));
-
-    User u = new User();
-    u.addRole(new UserRole(UserRoles.ADMIN.getRoleId(), UserRoles.ADMIN.getRoleName()));
-
-    when(datasetDAO.findAllDatasets()).thenReturn(List.of(ds1, ds2));
-
-    initService();
-
-    // query dataset name
-    List<Dataset> results = datasetService.searchDatasets("asdf", u);
-
-    assertEquals(1, results.size());
-    assertTrue(results.contains(ds1));
-
-    // query pi name
-    results = datasetService.searchDatasets("John", u);
-
-    assertEquals(1, results.size());
-    assertTrue(results.contains(ds1));
-
-    // query ds identifier
-    results = datasetService.searchDatasets("DUOS-000280", u);
-
-    assertEquals(1, results.size());
-    assertTrue(results.contains(ds2));
-
-    // query pi name for all of them
-    results = datasetService.searchDatasets("Doe", u);
-
-    assertEquals(2, results.size());
-    assertTrue(results.contains(ds2));
-    assertTrue(results.contains(ds1));
-
-    // search on two things at once
-    results = datasetService.searchDatasets("Doe asdf", u);
-
-    assertEquals(1, results.size());
-    assertTrue(results.contains(ds1));
-
-    // query nonexistent phrase
-    results = datasetService.searchDatasets("asdflasdfasdfasdfhalskdjf", u);
-    assertEquals(0, results.size());
-  }
+//  @Test
+//  public void testSearchDatasets() {
+//    Dataset ds1 = new Dataset();
+//    ds1.setName("asdf1234");
+//    ds1.setAlias(3);
+//    DatasetProperty ds1PI = new DatasetProperty();
+//    ds1PI.setPropertyName("Principal Investigator(PI)");
+//    ds1PI.setPropertyValue("John Doe");
+//    ds1PI.setPropertyType(PropertyType.String);
+//    ds1.setProperties(Set.of(ds1PI));
+//
+//    Dataset ds2 = new Dataset();
+//    ds2.setName("ghjk5678");
+//    ds2.setAlias(280);
+//    DatasetProperty ds2PI = new DatasetProperty();
+//    ds2PI.setPropertyName("Principal Investigator(PI)");
+//    ds2PI.setPropertyValue("Sally Doe");
+//    ds2PI.setPropertyType(PropertyType.String);
+//    ds2.setProperties(Set.of(ds2PI));
+//
+//    User u = new User();
+//    u.addRole(new UserRole(UserRoles.ADMIN.getRoleId(), UserRoles.ADMIN.getRoleName()));
+//
+//    when(datasetDAO.findAllDatasets()).thenReturn(List.of(ds1, ds2));
+//
+//    initService();
+//
+//    // query dataset name
+//    List<Dataset> results = datasetService.searchDatasets("asdf", u);
+//
+//    assertEquals(1, results.size());
+//    assertTrue(results.contains(ds1));
+//
+//    // query pi name
+//    results = datasetService.searchDatasets("John", u);
+//
+//    assertEquals(1, results.size());
+//    assertTrue(results.contains(ds1));
+//
+//    // query ds identifier
+//    results = datasetService.searchDatasets("DUOS-000280", u);
+//
+//    assertEquals(1, results.size());
+//    assertTrue(results.contains(ds2));
+//
+//    // query pi name for all of them
+//    results = datasetService.searchDatasets("Doe", u);
+//
+//    assertEquals(2, results.size());
+//    assertTrue(results.contains(ds2));
+//    assertTrue(results.contains(ds1));
+//
+//    // search on two things at once
+//    results = datasetService.searchDatasets("Doe asdf", u);
+//
+//    assertEquals(1, results.size());
+//    assertTrue(results.contains(ds1));
+//
+//    // query nonexistent phrase
+//    results = datasetService.searchDatasets("asdflasdfasdfasdfhalskdjf", u);
+//    assertEquals(0, results.size());
+//  }
 
   @Test
   public void testDescribeDatasets() {

--- a/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
@@ -575,68 +575,113 @@ public class DatasetServiceTest {
     assertEquals(result.size(), dtos.size());
   }
 
-//  @Test
-//  public void testSearchDatasets() {
-//    Dataset ds1 = new Dataset();
-//    ds1.setName("asdf1234");
-//    ds1.setAlias(3);
-//    DatasetProperty ds1PI = new DatasetProperty();
-//    ds1PI.setPropertyName("Principal Investigator(PI)");
-//    ds1PI.setPropertyValue("John Doe");
-//    ds1PI.setPropertyType(PropertyType.String);
-//    ds1.setProperties(Set.of(ds1PI));
-//
-//    Dataset ds2 = new Dataset();
-//    ds2.setName("ghjk5678");
-//    ds2.setAlias(280);
-//    DatasetProperty ds2PI = new DatasetProperty();
-//    ds2PI.setPropertyName("Principal Investigator(PI)");
-//    ds2PI.setPropertyValue("Sally Doe");
-//    ds2PI.setPropertyType(PropertyType.String);
-//    ds2.setProperties(Set.of(ds2PI));
-//
-//    User u = new User();
-//    u.addRole(new UserRole(UserRoles.ADMIN.getRoleId(), UserRoles.ADMIN.getRoleName()));
-//
-//    when(datasetDAO.findAllDatasets()).thenReturn(List.of(ds1, ds2));
-//
-//    initService();
-//
-//    // query dataset name
-//    List<Dataset> results = datasetService.searchDatasets("asdf", u);
-//
-//    assertEquals(1, results.size());
-//    assertTrue(results.contains(ds1));
-//
-//    // query pi name
-//    results = datasetService.searchDatasets("John", u);
-//
-//    assertEquals(1, results.size());
-//    assertTrue(results.contains(ds1));
-//
-//    // query ds identifier
-//    results = datasetService.searchDatasets("DUOS-000280", u);
-//
-//    assertEquals(1, results.size());
-//    assertTrue(results.contains(ds2));
-//
-//    // query pi name for all of them
-//    results = datasetService.searchDatasets("Doe", u);
-//
-//    assertEquals(2, results.size());
-//    assertTrue(results.contains(ds2));
-//    assertTrue(results.contains(ds1));
-//
-//    // search on two things at once
-//    results = datasetService.searchDatasets("Doe asdf", u);
-//
-//    assertEquals(1, results.size());
-//    assertTrue(results.contains(ds1));
-//
-//    // query nonexistent phrase
-//    results = datasetService.searchDatasets("asdflasdfasdfasdfhalskdjf", u);
-//    assertEquals(0, results.size());
-//  }
+  @Test
+  public void testSearchDatasetsOpenAccessFalse() {
+    Dataset ds1 = new Dataset();
+    ds1.setName("asdf1234");
+    ds1.setAlias(3);
+    DatasetProperty ds1PI = new DatasetProperty();
+    ds1PI.setPropertyName("Principal Investigator(PI)");
+    ds1PI.setPropertyValue("John Doe");
+    ds1PI.setPropertyType(PropertyType.String);
+    ds1.setProperties(Set.of(ds1PI));
+
+    Dataset ds2 = new Dataset();
+    ds2.setName("ghjk5678");
+    ds2.setAlias(280);
+    DatasetProperty ds2PI = new DatasetProperty();
+    ds2PI.setPropertyName("Principal Investigator(PI)");
+    ds2PI.setPropertyValue("Sally Doe");
+    ds2PI.setPropertyType(PropertyType.String);
+    ds2.setProperties(Set.of(ds2PI));
+
+    User u = new User();
+    u.addRole(new UserRole(UserRoles.ADMIN.getRoleId(), UserRoles.ADMIN.getRoleName()));
+
+    when(datasetDAO.findAllDatasets()).thenReturn(List.of(ds1, ds2));
+
+    initService();
+
+    // query dataset name
+    List<Dataset> results = datasetService.searchDatasets("asdf", false, u);
+
+    assertEquals(1, results.size());
+    assertTrue(results.contains(ds1));
+
+    // query pi name
+    results = datasetService.searchDatasets("John", false, u);
+
+    assertEquals(1, results.size());
+    assertTrue(results.contains(ds1));
+
+    // query ds identifier
+    results = datasetService.searchDatasets("DUOS-000280", false, u);
+
+    assertEquals(1, results.size());
+    assertTrue(results.contains(ds2));
+
+    // query pi name for all of them
+    results = datasetService.searchDatasets("Doe", false, u);
+
+    assertEquals(2, results.size());
+    assertTrue(results.contains(ds2));
+    assertTrue(results.contains(ds1));
+
+    // search on two things at once
+    results = datasetService.searchDatasets("Doe asdf",false, u);
+
+    assertEquals(1, results.size());
+    assertTrue(results.contains(ds1));
+
+    // query nonexistent phrase
+    results = datasetService.searchDatasets("asdflasdfasdfasdfhalskdjf",false, u);
+    assertEquals(0, results.size());
+  }
+
+  @Test
+  public void testSearchDatasetsOpenAccessTrue() {
+    Dataset ds1 = new Dataset();
+    ds1.setName("string");
+    ds1.setAlias(622);
+    DatasetProperty ds1PI = new DatasetProperty();
+    ds1PI.setPropertyName("Open Access");
+    ds1PI.setPropertyValue("true");
+    ds1PI.setPropertyType(PropertyType.String);
+    ds1.setProperties(Set.of(ds1PI));
+
+    Dataset ds2 = new Dataset();
+    ds2.setName("TESTING NAME");
+    ds2.setAlias(623);
+    DatasetProperty ds2PI = new DatasetProperty();
+    ds2PI.setPropertyName("Open Access");
+    ds2PI.setPropertyValue("true");
+    ds2PI.setPropertyType(PropertyType.String);
+    ds2.setProperties(Set.of(ds2PI));
+
+    User u = new User();
+    u.addRole(new UserRole(UserRoles.ADMIN.getRoleId(), UserRoles.ADMIN.getRoleName()));
+
+    when(datasetDAO.findAllDatasets()).thenReturn(List.of(ds1, ds2));
+
+    initService();
+
+    // query dataset name
+    List<Dataset> results = datasetService.searchDatasets("string", true, u);
+
+    assertEquals(1, results.size());
+    assertTrue(results.contains(ds1));
+
+
+    // query ds identifier
+    results = datasetService.searchDatasets("DUOS-000623", true, u);
+
+    assertEquals(1, results.size());
+    assertTrue(results.contains(ds2));
+
+    // query nonexistent phrase
+    results = datasetService.searchDatasets("asdflasdfasdfasdfhalskdjf",true, u);
+    assertEquals(0, results.size());
+  }
 
   @Test
   public void testDescribeDatasets() {


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/jira/software/c/projects/DUOS/boards/123?modal=detail&selectedIssue=DUOS-2515

### Summary
After this update: `GET /api/dataset/search?query={term}&open=true|false`
The open parameter will have a default value of false in the case that it is not passed in as a value.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
