### PR TITLE
[DUOS-2544][risk=low] Update OWASP suppression file for metrics-httpclient5

### DIFF
--- a/owaspSuppression.xml
+++ b/owaspSuppression.xml
@@ -23,15 +23,7 @@
    ]]></notes>
     <packageUrl regex="true">^pkg:maven/io\.dropwizard\.metrics/metrics\-httpclient5@.*$
     </packageUrl>
-    <cpe>cpe:/a:apache:httpclient</cpe>
-  </suppress>
-  <!-- Test Library -->
-  <suppress>
-    <notes><![CDATA[
-   file name: metrics-httpclient5-4.2.18.jar
-   ]]></notes>
-    <packageUrl regex="true">^pkg:maven/io\.dropwizard\.metrics/metrics\-httpclient5@.*$
-    </packageUrl>
-    <cpe>cpe:/a:apache:httpclient</cpe>
+    <cve>CVE-2020-13956</cve>
+    <cve>CVE-2014-3577</cve>
   </suppress>
 </suppressions>

--- a/owaspSuppression.xml
+++ b/owaspSuppression.xml
@@ -1,22 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-  <!-- DW Testing Library -->
-  <suppress>
-    <notes><![CDATA[
-   file name: grizzly-http-client-1.16.jar
-   ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.glassfish\.grizzly/grizzly\-http\-client@.*$
-    </packageUrl>
-    <cve>CVE-2021-43138</cve>
-  </suppress>
-  <!-- Test Library -->
-  <suppress>
-    <notes><![CDATA[
-   file name: mockserver-1.17.6.jar
-   ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.testcontainers/mockserver@.*$</packageUrl>
-    <cve>CVE-2021-32827</cve>
-  </suppress>
   <!-- Test Library -->
   <suppress>
     <notes><![CDATA[
@@ -33,12 +16,22 @@
     <packageUrl regex="true">^pkg:maven/org\.mock\-server/mockserver\-core@.*$</packageUrl>
     <cve>CVE-2021-32827</cve>
   </suppress>
-  <!-- Dropwizard dependency, cannot address without a DW update -->
+  <!-- Test Library -->
   <suppress>
     <notes><![CDATA[
-   file name: snakeyaml-1.33.jar
+   file name: metrics-httpclient5-4.2.18.jar
    ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.yaml/snakeyaml@.*$</packageUrl>
-    <vulnerabilityName>CVE-2022-1471</vulnerabilityName>
+    <packageUrl regex="true">^pkg:maven/io\.dropwizard\.metrics/metrics\-httpclient5@.*$
+    </packageUrl>
+    <cpe>cpe:/a:apache:httpclient</cpe>
+  </suppress>
+  <!-- Test Library -->
+  <suppress>
+    <notes><![CDATA[
+   file name: metrics-httpclient5-4.2.18.jar
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/io\.dropwizard\.metrics/metrics\-httpclient5@.*$
+    </packageUrl>
+    <cpe>cpe:/a:apache:httpclient</cpe>
   </suppress>
 </suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -108,11 +108,6 @@
       <plugin>
         <groupId>org.owasp</groupId>
         <artifactId>dependency-check-maven</artifactId>
-        <configuration>
-          <suppressionFiles>
-            <suppressionFile>owaspSuppression.xml</suppressionFile>
-          </suppressionFiles>
-        </configuration>
         <version>8.2.1</version>
         <executions>
           <execution>
@@ -173,8 +168,7 @@
           <prefix>git</prefix>
           <verbose>false</verbose>
           <generateGitPropertiesFile>true</generateGitPropertiesFile>
-          <generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties
-          </generateGitPropertiesFilename>
+          <generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties</generateGitPropertiesFilename>
           <format>json</format>
           <gitDescribe>
             <skip>true</skip>
@@ -314,11 +308,11 @@
             <configuration>
               <transformers>
                 <transformer
-                  implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                        implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                   <mainClass>org.broadinstitute.consent.http.ConsentApplication</mainClass>
                 </transformer>
                 <transformer
-                  implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                        implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
               </transformers>
             </configuration>
           </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,11 @@
       <plugin>
         <groupId>org.owasp</groupId>
         <artifactId>dependency-check-maven</artifactId>
+        <configuration>
+          <suppressionFiles>
+            <suppressionFile>owaspSuppression.xml</suppressionFile>
+          </suppressionFiles>
+        </configuration>
         <version>8.2.1</version>
         <executions>
           <execution>
@@ -168,7 +173,8 @@
           <prefix>git</prefix>
           <verbose>false</verbose>
           <generateGitPropertiesFile>true</generateGitPropertiesFile>
-          <generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties</generateGitPropertiesFilename>
+          <generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties
+          </generateGitPropertiesFilename>
           <format>json</format>
           <gitDescribe>
             <skip>true</skip>
@@ -308,11 +314,11 @@
             <configuration>
               <transformers>
                 <transformer
-                        implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                   <mainClass>org.broadinstitute.consent.http.ConsentApplication</mainClass>
                 </transformer>
                 <transformer
-                        implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                  implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
               </transformers>
             </configuration>
           </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,11 @@
       <plugin>
         <groupId>org.owasp</groupId>
         <artifactId>dependency-check-maven</artifactId>
+        <configuration>
+          <suppressionFiles>
+            <suppressionFile>owaspSuppression.xml</suppressionFile>
+          </suppressionFiles>
+        </configuration>
         <version>8.2.1</version>
         <executions>
           <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,7 @@
         <groupId>org.owasp</groupId>
         <artifactId>dependency-check-maven</artifactId>
         <configuration>
+          <failBuildOnCVSS>1</failBuildOnCVSS>
           <suppressionFiles>
             <suppressionFile>owaspSuppression.xml</suppressionFile>
           </suppressionFiles>


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DUOS-2544

### Summary
Minor PR to update the suppression file. Old dependencies no longer used are removed and we add one for `metrics-httpclient5` since it is a test library.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
