### PR TITLE
[DUOS-2546][risk=no] Fix OWASP Job Upload

### DIFF
--- a/.github/workflows/owasp.yaml
+++ b/.github/workflows/owasp.yaml
@@ -41,6 +41,7 @@ jobs:
         env:
           JAVA_HOME: /opt/jdk
       - name: Upload Test results
+        if: ${{ always() }}
         uses: actions/upload-artifact@master
         with:
           name: Depcheck report

--- a/.github/workflows/owasp.yaml
+++ b/.github/workflows/owasp.yaml
@@ -41,7 +41,7 @@ jobs:
         env:
           JAVA_HOME: /opt/jdk
       - name: Upload Test results
-        if: ${{ always() }}
+        if: always()
         uses: actions/upload-artifact@master
         with:
           name: Depcheck report

--- a/pom.xml
+++ b/pom.xml
@@ -108,11 +108,6 @@
       <plugin>
         <groupId>org.owasp</groupId>
         <artifactId>dependency-check-maven</artifactId>
-        <configuration>
-          <suppressionFiles>
-            <suppressionFile>owaspSuppression.xml</suppressionFile>
-          </suppressionFiles>
-        </configuration>
         <version>8.2.1</version>
         <executions>
           <execution>
@@ -173,8 +168,7 @@
           <prefix>git</prefix>
           <verbose>false</verbose>
           <generateGitPropertiesFile>true</generateGitPropertiesFile>
-          <generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties
-          </generateGitPropertiesFilename>
+          <generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties</generateGitPropertiesFilename>
           <format>json</format>
           <gitDescribe>
             <skip>true</skip>
@@ -314,11 +308,11 @@
             <configuration>
               <transformers>
                 <transformer
-                  implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                        implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                   <mainClass>org.broadinstitute.consent.http.ConsentApplication</mainClass>
                 </transformer>
                 <transformer
-                  implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                        implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
               </transformers>
             </configuration>
           </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,11 @@
       <plugin>
         <groupId>org.owasp</groupId>
         <artifactId>dependency-check-maven</artifactId>
+        <configuration>
+          <suppressionFiles>
+            <suppressionFile>owaspSuppression.xml</suppressionFile>
+          </suppressionFiles>
+        </configuration>
         <version>8.2.1</version>
         <executions>
           <execution>
@@ -168,7 +173,8 @@
           <prefix>git</prefix>
           <verbose>false</verbose>
           <generateGitPropertiesFile>true</generateGitPropertiesFile>
-          <generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties</generateGitPropertiesFilename>
+          <generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties
+          </generateGitPropertiesFilename>
           <format>json</format>
           <gitDescribe>
             <skip>true</skip>
@@ -308,11 +314,11 @@
             <configuration>
               <transformers>
                 <transformer
-                        implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                   <mainClass>org.broadinstitute.consent.http.ConsentApplication</mainClass>
                 </transformer>
                 <transformer
-                        implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                  implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
               </transformers>
             </configuration>
           </execution>


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DUOS-2546

### Summary
Minor fix to the OWASP job so that it always uploads the report, even on failures.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
