### PR TITLE
[DUOS-2551][risk=no] Use maven job for OWASP reports

### DIFF
--- a/.github/workflows/owasp.yaml
+++ b/.github/workflows/owasp.yaml
@@ -23,6 +23,7 @@ jobs:
           mvn -v
           mvn dependency-check:check --batch-mode
       - name: Archive Report
+        if: always()
         uses: actions/upload-artifact@v3
         with:
           name: owasp-report

--- a/.github/workflows/owasp.yaml
+++ b/.github/workflows/owasp.yaml
@@ -16,33 +16,14 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 17
-      - name: Build project
+      - name: Run Report
         env:
           MAVEN_OPTS: -Dorg.slf4j.simpleLogger.defaultLogLevel=warn
         run: |
           mvn -v
-          mvn clean compile --batch-mode
-      - name: Depcheck
-        uses: dependency-check/Dependency-Check_Action@main
-        id: Depcheck
+          mvn dependency-check:check --batch-mode
+      - name: Archive Report
+        uses: actions/upload-artifact@v3
         with:
-          project: 'Consent'
-          path: '.'
-          format: 'HTML'
-          out: 'reports' # this is the default, no need to specify unless you wish to override it
-          args: >
-            --failOnCVSS 1
-            --enableRetired
-            --suppression "./owaspSuppression.xml"
-            --exclude **/automation/**
-            --exclude **/docs/**
-            --exclude **/jenkins/**
-            --exclude **/migration/**
-        env:
-          JAVA_HOME: /opt/jdk
-      - name: Upload Test results
-        if: always()
-        uses: actions/upload-artifact@master
-        with:
-          name: Depcheck report
-          path: ${{github.workspace}}/reports
+          name: owasp-report
+          path: target/dependency-check-report.html

--- a/owaspSuppression.xml
+++ b/owaspSuppression.xml
@@ -3,14 +3,6 @@
   <!-- Test Library -->
   <suppress>
     <notes><![CDATA[
-   file name: mockserver-client-java-5.15.0.jar
-   ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.mock\-server/mockserver\-client\-java@.*$</packageUrl>
-    <cve>CVE-2021-32827</cve>
-  </suppress>
-  <!-- Test Library -->
-  <suppress>
-    <notes><![CDATA[
    file name: metrics-httpclient5-4.2.18.jar
    ]]></notes>
     <packageUrl regex="true">^pkg:maven/io\.dropwizard\.metrics/metrics\-httpclient5@.*$

--- a/owaspSuppression.xml
+++ b/owaspSuppression.xml
@@ -11,14 +11,6 @@
   <!-- Test Library -->
   <suppress>
     <notes><![CDATA[
-   file name: mockserver-core-5.15.0.jar
-   ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.mock\-server/mockserver\-core@.*$</packageUrl>
-    <cve>CVE-2021-32827</cve>
-  </suppress>
-  <!-- Test Library -->
-  <suppress>
-    <notes><![CDATA[
    file name: metrics-httpclient5-4.2.18.jar
    ]]></notes>
     <packageUrl regex="true">^pkg:maven/io\.dropwizard\.metrics/metrics\-httpclient5@.*$

--- a/owaspSuppression.xml
+++ b/owaspSuppression.xml
@@ -7,7 +7,6 @@
    ]]></notes>
     <packageUrl regex="true">^pkg:maven/io\.dropwizard\.metrics/metrics\-httpclient5@.*$
     </packageUrl>
-    <cve>CVE-2020-13956</cve>
-    <cve>CVE-2014-3577</cve>
+    <cpe>cpe:/a:apache:httpclient</cpe>
   </suppress>
 </suppressions>


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DUOS-2551

### Summary
Update the OWASP job to run using maven plugin instead of the remote action due to inconsistencies in reports.
See also how we do this in Ontology: https://github.com/DataBiosphere/consent-ontology/blob/develop/.github/workflows/owasp.yaml

### Testing
Run `mvn dependency-check:check` in a terminal window (or from intelli-j's maven tab). That will generate a report that can be reviewed.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
