### PR TITLE
[DUOS-2075][risk=no] Part 1: Add translated data use to dataset

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
@@ -84,7 +84,7 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
   @UseRowReducer(DatasetReducer.class)
   @SqlQuery("""
           SELECT d.dataset_id, d.name, d.create_date, d.create_user_id, d.update_date,
-              d.update_user_id, d.object_id, d.active, d.dac_id, d.alias, d.data_use, d.dac_approval,
+              d.update_user_id, d.object_id, d.active, d.dac_id, d.alias, d.data_use, d.translated_data_use, d.dac_approval,
               dar_ds_ids.id AS in_use,
               u.user_id AS u_user_id, u.email AS u_email, u.display_name AS u_display_name,
               u.create_date AS u_create_date, u.email_preference AS u_email_preference,
@@ -137,7 +137,7 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
   @UseRowReducer(DatasetReducer.class)
   @SqlQuery("""
           SELECT d.dataset_id, d.name, d.create_date, d.create_user_id, d.update_date,
-              d.update_user_id, d.object_id, d.active, d.dac_id, d.alias, d.data_use, d.dac_approval,
+              d.update_user_id, d.object_id, d.active, d.dac_id, d.alias, d.data_use, d.translated_data_use, d.dac_approval,
               dar_ds_ids.id AS in_use,
               u.user_id AS u_user_id, u.email AS u_email, u.display_name AS u_display_name,
               u.create_date AS u_create_date, u.email_preference AS u_email_preference,
@@ -190,7 +190,7 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
   @UseRowReducer(DatasetReducer.class)
   @SqlQuery("""
           SELECT d.dataset_id, d.name, d.create_date, d.create_user_id, d.update_date,
-              d.update_user_id, d.object_id, d.active, d.dac_id, d.alias, d.data_use, d.dac_approval,
+              d.update_user_id, d.object_id, d.active, d.dac_id, d.alias, d.data_use, d.translated_data_use, d.dac_approval,
               dar_ds_ids.id AS in_use,
               u.user_id AS u_user_id, u.email AS u_email, u.display_name AS u_display_name,
               u.create_date AS u_create_date, u.email_preference AS u_email_preference,
@@ -250,7 +250,7 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
   @UseRowReducer(DatasetReducer.class)
   @SqlQuery("""
           SELECT d.dataset_id, d.name, d.create_date, d.create_user_id, d.update_date,
-              d.update_user_id, d.object_id, d.active, d.dac_id, d.alias, d.data_use, d.dac_approval,
+              d.update_user_id, d.object_id, d.active, d.dac_id, d.alias, d.data_use, d.translated_data_use, d.dac_approval,
               dar_ds_ids.id AS in_use,
               u.user_id AS u_user_id, u.email AS u_email, u.display_name AS u_display_name,
               u.create_date AS u_create_date, u.email_preference AS u_email_preference,
@@ -310,7 +310,7 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
   @UseRowReducer(DatasetReducer.class)
   @SqlQuery("""
           SELECT d.dataset_id, d.name, d.create_date, d.create_user_id, d.update_date,
-              d.update_user_id, d.object_id, d.active, d.dac_id, d.alias, d.data_use, d.dac_approval,
+              d.update_user_id, d.object_id, d.active, d.dac_id, d.alias, d.data_use, d.translated_data_use, d.dac_approval,
               dar_ds_ids.id AS in_use,
               u.user_id AS u_user_id, u.email AS u_email, u.display_name AS u_display_name,
               u.create_date AS u_create_date, u.email_preference AS u_email_preference,
@@ -364,7 +364,7 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
   @UseRowReducer(DatasetReducer.class)
   @SqlQuery("""
           SELECT d.dataset_id, d.name, d.create_date, d.create_user_id, d.update_date,
-              d.update_user_id, d.object_id, d.active, d.dac_id, d.alias, d.data_use, d.dac_approval,
+              d.update_user_id, d.object_id, d.active, d.dac_id, d.alias, d.data_use, d.translated_data_use, d.dac_approval,
               dar_ds_ids.id AS in_use,
               u.user_id AS u_user_id, u.email AS u_email, u.display_name AS u_display_name,
               u.create_date AS u_create_date, u.email_preference AS u_email_preference,
@@ -425,7 +425,7 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
   @UseRowReducer(DatasetReducer.class)
   @SqlQuery("""
           SELECT d.dataset_id, d.name, d.create_date, d.create_user_id, d.update_date,
-              d.update_user_id, d.object_id, d.active, d.dac_id, d.alias, d.data_use, d.dac_approval,
+              d.update_user_id, d.object_id, d.active, d.dac_id, d.alias, d.data_use, d.translated_data_use, d.dac_approval,
               dar_ds_ids.id AS in_use,
               u.user_id AS u_user_id, u.email AS u_email, u.display_name AS u_display_name,
               u.create_date AS u_create_date, u.email_preference AS u_email_preference,
@@ -518,6 +518,11 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
 
   @SqlUpdate("UPDATE dataset SET dac_id = :dacId WHERE dataset_id = :datasetId")
   void updateDatasetDacId(@Bind("datasetId") Integer datasetId, @Bind("dacId") Integer dacId);
+
+
+  @SqlUpdate("UPDATE dataset SET translated_data_use = :translatedDataUse WHERE dataset_id = :datasetId")
+  void updateDatasetTranslatedDataUse(@Bind("datasetId") Integer datasetId,
+      @Bind("translatedDataUse") String translatedDataUse);
 
   @SqlBatch(
       "INSERT INTO dataset_property (dataset_id, property_key, schema_property, property_value, property_type, create_date )"

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DatasetMapper.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DatasetMapper.java
@@ -46,6 +46,9 @@ public class DatasetMapper implements RowMapper<Dataset>, RowMapperHelper {
     if (hasColumn(r, "data_use")) {
       dataset.setDataUse(DataUse.parseDataUse(r.getString("data_use")).orElse(null));
     }
+    if (hasColumn(r, "translated_data_use")) {
+      dataset.setTranslatedDataUse(r.getString("translated_data_use"));
+    }
     dataset.setActive(r.getBoolean("active"));
     dataset.setAlias(r.getInt("alias"));
 

--- a/src/main/java/org/broadinstitute/consent/http/models/Dataset.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/Dataset.java
@@ -9,10 +9,9 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.broadinstitute.consent.http.models.dataset_registration_v1.ConsentGroup;
+import org.checkerframework.checker.nullness.qual.NonNull;
 
 public class Dataset {
 
@@ -45,6 +44,7 @@ public class Dataset {
 
   public DataUse dataUse;
 
+  private String translatedDataUse;
   private Integer dacId;
 
   private String consentId;
@@ -295,6 +295,14 @@ public class Dataset {
     this.translatedUseRestriction = translatedUseRestriction;
   }
 
+  public String getTranslatedDataUse() {
+    return translatedDataUse;
+  }
+
+  public void setTranslatedDataUse(String translatedDataUse) {
+    this.translatedDataUse = translatedDataUse;
+  }
+
   public Boolean getDeletable() {
     return deletable;
   }
@@ -308,10 +316,9 @@ public class Dataset {
    * data use properties. Has optional parameter "Open Access" which will search datasets on both
    * the raw search query and open access.
    *
-   * @param query       Raw string query
-   * @param openAccess  Boolean for open access
+   * @param query      Raw string query
+   * @param openAccess Boolean for open access
    * @return if the Dataset matched query
-   *
    */
 
   // TODO: investigate whether we can try to coerce getPropertyValue to a boolean instead of comparing strings
@@ -330,13 +337,12 @@ public class Dataset {
           .filter((dp) -> Objects.equals(dp.getPropertyName(), OPEN_ACCESS.toString()))
           .findFirst();
 
-      if (openAccessProp.isEmpty()){
+      if (openAccessProp.isEmpty()) {
         if (openAccess) {
           return false;
         }
-      }
-      else if (!Objects.equals(openAccessProp.get().getPropertyValue().toString(), Boolean.toString(openAccess)))
-      {
+      } else if (!Objects.equals(openAccessProp.get().getPropertyValue().toString(),
+          Boolean.toString(openAccess))) {
         return false;
       }
 
@@ -420,5 +426,4 @@ public class Dataset {
   public void setCreateUser(User createUser) {
     this.createUser = createUser;
   }
-
 }

--- a/src/main/resources/changelog-master.xml
+++ b/src/main/resources/changelog-master.xml
@@ -1,119 +1,129 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
-                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
-    <include file="migrations.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-1.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-2.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-3.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-4.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-5.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-6.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-7.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-8.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-9.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-10.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-11.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-12.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-13.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-14.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-15.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-16.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-17.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-18.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-19.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-20.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-21.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-22.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-23.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-24.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-25.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-26.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-27.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-28.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-29.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-30.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-31.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-32.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-33.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-34.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-35.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-36.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-37.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-38.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-39.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-40.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-41.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-42.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-43.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-44.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-45.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-46.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-47.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-48.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-49.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-50.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-51.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-52.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-53.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-54.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-55.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-56.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-57.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-58.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-59.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-60.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-61.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-62.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-63.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-64.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-65.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-66.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-67.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-68.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-69.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-70.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-71.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-72.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-73.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-74.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-75.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-76.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-77.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-78.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-79.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-80.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-81.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-82.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-83.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-84.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-85.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-86.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-87.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-88.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-89.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-90.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-91.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-92.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-93.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-94.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-95.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-96.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-97.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-98.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-99.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-100.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-101.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-102.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-103.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-104.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-105.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-2022-12-29-email.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-2023-01-08-election-archive.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-2023-01-09-dac-email.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-2023-02-28-fix-dataset-audit.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-2023-03-07-remove-use-restriction.0.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-2023-03-16-rename-vote-userid.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-2023-04-20-create-study.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/changelog-consent-2023-05-03-add-abstain.xml" relativeToChangelogFile="true"/>
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+  <include file="migrations.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-1.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-2.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-3.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-4.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-5.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-6.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-7.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-8.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-9.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-10.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-11.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-12.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-13.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-14.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-15.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-16.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-17.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-18.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-19.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-20.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-21.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-22.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-23.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-24.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-25.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-26.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-27.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-28.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-29.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-30.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-31.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-32.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-33.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-34.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-35.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-36.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-37.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-38.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-39.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-40.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-41.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-42.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-43.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-44.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-45.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-46.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-47.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-48.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-49.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-50.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-51.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-52.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-53.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-54.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-55.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-56.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-57.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-58.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-59.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-60.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-61.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-62.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-63.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-64.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-65.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-66.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-67.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-68.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-69.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-70.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-71.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-72.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-73.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-74.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-75.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-76.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-77.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-78.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-79.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-80.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-81.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-82.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-83.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-84.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-85.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-86.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-87.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-88.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-89.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-90.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-91.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-92.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-93.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-94.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-95.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-96.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-97.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-98.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-99.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-100.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-101.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-102.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-103.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-104.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-105.0.xml" relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-2022-12-29-email.0.xml"
+    relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-2023-01-08-election-archive.0.xml"
+    relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-2023-01-09-dac-email.0.xml"
+    relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-2023-02-28-fix-dataset-audit.0.xml"
+    relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-2023-03-07-remove-use-restriction.0.xml"
+    relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-2023-03-16-rename-vote-userid.xml"
+    relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-2023-04-20-create-study.xml"
+    relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-2023-05-03-add-abstain.xml"
+    relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-2023-06-08-add-translated-data-use.xml"
+    relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/changesets/changelog-consent-2023-06-08-add-translated-data-use.xml
+++ b/src/main/resources/changesets/changelog-consent-2023-06-08-add-translated-data-use.xml
@@ -1,0 +1,16 @@
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+  <changeSet id="2023-06-08-add-translated-data-use" author="connorlbark">
+    <addColumn tableName="dataset">
+      <column name="translated_data_use" type="text"/>
+    </addColumn>
+    <sql>
+      UPDATE dataset
+      SET translated_data_use = (SELECT c.translated_use_restriction AS translated_data_use
+                                 FROM consents c
+                                        INNER JOIN consent_associations ca ON ca.consent_id = c.consent_id
+                                 WHERE ca.dataset_id = dataset_id)
+    </sql>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/changesets/changelog-consent-2023-06-08-add-translated-data-use.xml
+++ b/src/main/resources/changesets/changelog-consent-2023-06-08-add-translated-data-use.xml
@@ -10,7 +10,8 @@
       SET translated_data_use = (SELECT c.translated_use_restriction AS translated_data_use
                                  FROM consents c
                                         INNER JOIN consent_associations ca ON ca.consent_id = c.consent_id
-                                 WHERE ca.dataset_id = dataset_id)
+                                 WHERE ca.dataset_id = dataset_id
+                                 ORDER BY c.create_date DESC LIMIT 1)
     </sql>
   </changeSet>
 </databaseChangeLog>

--- a/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
@@ -117,6 +117,18 @@ public class DatasetDAOTest extends DAOTestHelper {
   }
 
   @Test
+  public void testTranslatedDataUse() {
+    Dataset d1 = insertDataset();
+
+    String tdu = RandomStringUtils.randomAlphabetic(10);
+    datasetDAO.updateDatasetTranslatedDataUse(d1.getDataSetId(), tdu);
+
+    d1 = datasetDAO.findDatasetById(d1.getDataSetId());
+
+    assertEquals(tdu, d1.getTranslatedDataUse());
+  }
+
+  @Test
   public void testFindDatasetByAlias() {
     Dataset dataset = insertDataset();
 


### PR DESCRIPTION
### Addresses

PARTIALLY ADDRESSES https://broadworkbench.atlassian.net/browse/DUOS-2075

### Summary

Adds translated data use to the dataset, and prepopulates it with the already existing `translated_use_restriction` from consents.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
