### PR TITLE
[DUOS-2532][risk=no] Populate the property id for downstream processing

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DatasetReducer.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DatasetReducer.java
@@ -58,6 +58,9 @@ public class DatasetReducer implements LinkedHashMapRowReducer<Integer, Dataset>
       if (Objects.nonNull(keyName) && Objects.nonNull(propVal)) {
         try {
           DatasetProperty prop = new DatasetProperty();
+          if (hasColumn(rowView, "property_id", Integer.class)) {
+            prop.setPropertyId(rowView.getColumn("property_id", Integer.class));
+          }
           prop.setDataSetId(dataset.getDataSetId());
           prop.setPropertyValue(propType.coerce(propVal));
           prop.setPropertyName(keyName);


### PR DESCRIPTION
### Addresses
Small fix for future dataset updating
https://broadworkbench.atlassian.net/browse/DUOS-2532

### Summary
Ensure that the property ids are populated when a dataset is being updated.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
