### PR TITLE
[DUOS-2527][risk=no] Add dataset id to schema

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/models/dataset_registration_v1/ConsentGroup.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/dataset_registration_v1/ConsentGroup.java
@@ -14,6 +14,7 @@ import java.util.Map;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
+    "datasetId",
     "consentGroupName",
     "openAccess",
     "generalResearchUse",
@@ -38,6 +39,12 @@ import java.util.Map;
 })
 public class ConsentGroup {
 
+  /**
+   * Dataset Id
+   */
+  @JsonProperty("datasetId")
+  @JsonPropertyDescription("Dataset Id")
+  private Integer datasetId;
   /**
    * Consent Group Name
    */
@@ -170,6 +177,20 @@ public class ConsentGroup {
   @JsonProperty("fileTypes")
   @JsonPropertyDescription("List of File Types")
   private List<FileTypeObject> fileTypes = new ArrayList<FileTypeObject>();
+
+  /**
+   * Dataset Id
+   */
+  public Integer getDatasetId() {
+    return datasetId;
+  }
+
+  /**
+   * Dataset Id
+   */
+  public void setDatasetId(Integer datasetId) {
+    this.datasetId = datasetId;
+  }
 
   /**
    * Consent Group Name
@@ -520,6 +541,10 @@ public class ConsentGroup {
     StringBuilder sb = new StringBuilder();
     sb.append(ConsentGroup.class.getName()).append('@')
         .append(Integer.toHexString(System.identityHashCode(this))).append('[');
+    sb.append("datasetId");
+    sb.append('=');
+    sb.append(((this.datasetId == null) ? "<null>" : this.datasetId));
+    sb.append(',');
     sb.append("consentGroupName");
     sb.append('=');
     sb.append(((this.consentGroupName == null) ? "<null>" : this.consentGroupName));
@@ -635,6 +660,7 @@ public class ConsentGroup {
     result = ((result * 31) + ((this.fileTypes == null) ? 0 : this.fileTypes.hashCode()));
     result = ((result * 31) + ((this.diseaseSpecificUse == null) ? 0
         : this.diseaseSpecificUse.hashCode()));
+    result = ((result * 31) + ((this.datasetId == null) ? 0 : this.datasetId.hashCode()));
     result = ((result * 31) + ((this.consentGroupName == null) ? 0
         : this.consentGroupName.hashCode()));
     result = ((result * 31) + ((this.mor == null) ? 0 : this.mor.hashCode()));
@@ -675,8 +701,10 @@ public class ConsentGroup {
         (this.fileTypes == rhs.fileTypes) || ((this.fileTypes != null) && this.fileTypes.equals(
             rhs.fileTypes)))) && ((this.diseaseSpecificUse == rhs.diseaseSpecificUse) || (
         (this.diseaseSpecificUse != null) && this.diseaseSpecificUse.equals(
-            rhs.diseaseSpecificUse)))) && ((this.consentGroupName == rhs.consentGroupName) || (
-        (this.consentGroupName != null) && this.consentGroupName.equals(rhs.consentGroupName))))
+            rhs.diseaseSpecificUse)))) && ((this.datasetId == rhs.datasetId) || (
+        (this.datasetId != null) && this.datasetId.equals(rhs.datasetId))) && (
+        (this.consentGroupName == rhs.consentGroupName) || (
+            (this.consentGroupName != null) && this.consentGroupName.equals(rhs.consentGroupName))))
         && ((this.mor == rhs.mor) || ((this.mor != null) && this.mor.equals(rhs.mor)))) && (
         (this.npu == rhs.npu) || ((this.npu != null) && this.npu.equals(rhs.npu)))) && (
         (this.dataLocation == rhs.dataLocation) || ((this.dataLocation != null)

--- a/src/main/resources/assets/schemas/DatasetRegistrationSchemaV1.yaml
+++ b/src/main/resources/assets/schemas/DatasetRegistrationSchemaV1.yaml
@@ -253,6 +253,9 @@ required:
       Required fields include the `consentGroupName` and any one of 
       `generalResearchUse`, `hmb`, or `diseaseSpecificUse`.
     properties:
+      datasetId:
+        type: number
+        description: Dataset Id corresponding to this Consent Group. Required only for updates.
       consentGroupName:
         type: string
         description: Consent Group Name

--- a/src/main/resources/dataset-registration-schema_v1.json
+++ b/src/main/resources/dataset-registration-schema_v1.json
@@ -604,6 +604,10 @@
         }
       ],
       "properties": {
+        "datasetId": {
+          "type": "integer",
+          "description": "Dataset Id"
+        },
         "consentGroupName": {
           "type": "string",
           "label": "Consent Group Name",


### PR DESCRIPTION
### Addresses
Small update for https://broadworkbench.atlassian.net/browse/DUOS-2527

### Summary
Add an optional dataset id to the consent group schema so that consent group updates can refer to an existing dataset.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
