### PR TITLE
[DUOS-2617][risk=no] Update DAR -> DataUse conversion

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/models/DataUse.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DataUse.java
@@ -27,8 +27,10 @@ public class DataUse {
   private Boolean methodsResearch;
   private String aggregateResearch;
   private String controlSetOption;
+  private boolean controls;
   private String gender;
   private Boolean pediatric;
+  private boolean population;
   private List<String> populationRestrictions;
   private Boolean otherRestrictions;
   private String dateRestriction;
@@ -48,6 +50,7 @@ public class DataUse {
   private Boolean stigmatizeDiseases;
   private Boolean vulnerablePopulations;
   private Boolean psychologicalTraits;
+  private Boolean notHealth;
   private Boolean nonBiomedical;
   private Boolean manualReview;
   private Boolean geneticStudiesOnly;
@@ -361,6 +364,30 @@ public class DataUse {
     this.publicationMoratorium = publicationMoratorium;
   }
 
+  public boolean getControls() {
+    return controls;
+  }
+
+  public void setControls(boolean controls) {
+    this.controls = controls;
+  }
+
+  public boolean getPopulation() {
+    return population;
+  }
+
+  public void setPopulation(boolean population) {
+    this.population = population;
+  }
+
+  public Boolean getNotHealth() {
+    return notHealth;
+  }
+
+  public void setNotHealth(Boolean notHealth) {
+    this.notHealth = notHealth;
+  }
+
   @Override
   public String toString() {
     return new GsonBuilder().create().toJson(this);
@@ -427,7 +454,10 @@ public class DataUse {
         && Objects.equal(getGenomicResults(), dataUse.getGenomicResults())
         && Objects.equal(getGenomicSummaryResults(), dataUse.getGenomicSummaryResults())
         && Objects.equal(getCollaborationInvestigators(), dataUse.getCollaborationInvestigators())
-        && Objects.equal(getPublicationMoratorium(), dataUse.getPublicationMoratorium());
+        && Objects.equal(getPublicationMoratorium(), dataUse.getPublicationMoratorium())
+        && Objects.equal(getControls(), dataUse.getControls())
+        && Objects.equal(getPopulation(), dataUse.getPopulation())
+        && Objects.equal(getNotHealth(), dataUse.getNotHealth());
   }
 
   @Override
@@ -446,6 +476,6 @@ public class DataUse {
         getManualReview(),
         getGeneticStudiesOnly(), getPublicationResults(), getGenomicResults(),
         getGenomicSummaryResults(), getCollaborationInvestigators(),
-        getPublicationMoratorium());
+        getPublicationMoratorium(), getControls(), getPopulation(), getNotHealth());
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/service/UseRestrictionConverter.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/UseRestrictionConverter.java
@@ -125,13 +125,15 @@ public class UseRestrictionConverter {
       //    Research related entries
       //
       if (Objects.nonNull(dar.getData().getMethods())) {
-        dataUse.setMethodsResearch(true);
+        dataUse.setMethodsResearch(dar.getData().getMethods());
       }
       if (Objects.nonNull(dar.getData().getPopulation())) {
-        dataUse.setPopulationStructure(true);
+        dataUse.setPopulationStructure(dar.getData().getPopulation());
+        dataUse.setPopulation(dar.getData().getPopulation());
       }
       if (Objects.nonNull(dar.getData().getControls())) {
         dataUse.setControlSetOption("Yes");
+        dataUse.setControls(dar.getData().getControls());
       }
 
       //
@@ -188,6 +190,11 @@ public class UseRestrictionConverter {
       }
       if (Objects.nonNull(dar.getData().getOtherText())) {
         dataUse.setOther(dar.getData().getOtherText());
+      }
+
+      if (Objects.nonNull(dar.getData().getNotHealth())) {
+        dataUse.setNotHealth(dar.getData().getNotHealth());
+        dataUse.setNonBiomedical(dar.getData().getNotHealth());
       }
 
     }

--- a/src/main/java/org/broadinstitute/consent/http/service/UseRestrictionConverter.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/UseRestrictionConverter.java
@@ -181,6 +181,15 @@ public class UseRestrictionConverter {
           dataUse.setHmbResearch(true);
         }
       }
+
+      // Other Conditions
+      if (Objects.nonNull(dar.getData().getOther())) {
+        dataUse.setOtherRestrictions(dar.getData().getOther());
+      }
+      if (Objects.nonNull(dar.getData().getOtherText())) {
+        dataUse.setOther(dar.getData().getOtherText());
+      }
+
     }
     return dataUse;
   }

--- a/src/test/java/org/broadinstitute/consent/http/service/UseRestrictionConverterTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/UseRestrictionConverterTest.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.consent.http.service;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -372,6 +373,39 @@ public class UseRestrictionConverterTest implements WithMockServer {
     dar.getData().setOtherText("other");
     DataUse dataUse = converter.parseDataUsePurpose(dar);
     assertNotNull(dataUse.getOther());
+  }
+
+  @Test
+  public void testParseDataUseControl() {
+    Client client = ClientBuilder.newClient();
+    UseRestrictionConverter converter = new UseRestrictionConverter(client, config());
+    DataAccessRequest dar = createDataAccessRequest();
+    dar.getData().setControls(true);
+    DataUse dataUse = converter.parseDataUsePurpose(dar);
+    assertTrue(dataUse.getControls());
+    assertEquals("Yes", dataUse.getControlSetOption());
+  }
+
+  @Test
+  public void testParseDataUsePopulation() {
+    Client client = ClientBuilder.newClient();
+    UseRestrictionConverter converter = new UseRestrictionConverter(client, config());
+    DataAccessRequest dar = createDataAccessRequest();
+    dar.getData().setPopulation(true);
+    DataUse dataUse = converter.parseDataUsePurpose(dar);
+    assertTrue(dataUse.getPopulationStructure());
+    assertTrue(dataUse.getPopulation());
+  }
+
+  @Test
+  public void testParseDataUseNotHealth() {
+    Client client = ClientBuilder.newClient();
+    UseRestrictionConverter converter = new UseRestrictionConverter(client, config());
+    DataAccessRequest dar = createDataAccessRequest();
+    dar.getData().setNotHealth(true);
+    DataUse dataUse = converter.parseDataUsePurpose(dar);
+    assertTrue(dataUse.getNotHealth());
+    assertTrue(dataUse.getNonBiomedical());
   }
 
   private DataAccessRequest createDataAccessRequest() {

--- a/src/test/java/org/broadinstitute/consent/http/service/UseRestrictionConverterTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/UseRestrictionConverterTest.java
@@ -9,11 +9,16 @@ import static org.mockserver.model.HttpResponse.response;
 import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.client.ClientBuilder;
 import jakarta.ws.rs.core.MediaType;
+import java.util.List;
+import java.util.UUID;
 import org.broadinstitute.consent.http.WithMockServer;
 import org.broadinstitute.consent.http.configurations.ServicesConfiguration;
 import org.broadinstitute.consent.http.enumeration.DataUseTranslationType;
+import org.broadinstitute.consent.http.models.DataAccessRequest;
+import org.broadinstitute.consent.http.models.DataAccessRequestData;
 import org.broadinstitute.consent.http.models.DataUse;
 import org.broadinstitute.consent.http.models.DataUseBuilder;
+import org.broadinstitute.consent.http.models.OntologyEntry;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -232,6 +237,150 @@ public class UseRestrictionConverterTest implements WithMockServer {
     assertTrue(dataUse.getControlSetOption().equalsIgnoreCase("Yes"));
     assertTrue(dataUse.getPopulationOriginsAncestry());
     assertTrue(dataUse.getHmbResearch());
+  }
+
+  @Test
+  public void testParseDataUsePurposeEmpty() {
+    Client client = ClientBuilder.newClient();
+    UseRestrictionConverter converter = new UseRestrictionConverter(client, config());
+    DataAccessRequest dar = createDataAccessRequest();
+    DataUse dataUse = converter.parseDataUsePurpose(dar);
+    assertNull(dataUse.getGeneralUse());
+    assertNull(dataUse.getMethodsResearch());
+    assertNull(dataUse.getControlSetOption());
+    assertNull(dataUse.getDiseaseRestrictions());
+    assertNull(dataUse.getCommercialUse());
+    assertNull(dataUse.getGender());
+    assertNull(dataUse.getPediatric());
+    assertNull(dataUse.getPopulationOriginsAncestry());
+    assertNull(dataUse.getHmbResearch());
+    assertNull(dataUse.getOther());
+    assertNull(dataUse.getOtherRestrictions());
+    assertNull(dataUse.getSecondaryOther());
+  }
+
+  @Test
+  public void testParseDataUsePurposeMethods() {
+    Client client = ClientBuilder.newClient();
+    UseRestrictionConverter converter = new UseRestrictionConverter(client, config());
+    DataAccessRequest dar = createDataAccessRequest();
+    dar.getData().setMethods(true);
+    DataUse dataUse = converter.parseDataUsePurpose(dar);
+    assertTrue(dataUse.getMethodsResearch());
+  }
+
+  @Test
+  public void testParseDataUsePurposePopulation() {
+    Client client = ClientBuilder.newClient();
+    UseRestrictionConverter converter = new UseRestrictionConverter(client, config());
+    DataAccessRequest dar = createDataAccessRequest();
+    dar.getData().setPopulation(true);
+    DataUse dataUse = converter.parseDataUsePurpose(dar);
+    assertTrue(dataUse.getPopulationStructure());
+  }
+
+  @Test
+  public void testParseDataUsePurposeControls() {
+    Client client = ClientBuilder.newClient();
+    UseRestrictionConverter converter = new UseRestrictionConverter(client, config());
+    DataAccessRequest dar = createDataAccessRequest();
+    dar.getData().setControls(true);
+    DataUse dataUse = converter.parseDataUsePurpose(dar);
+    assertNotNull(dataUse.getControlSetOption());
+  }
+
+  @Test
+  public void testParseDataUsePurposeDisease() {
+    Client client = ClientBuilder.newClient();
+    UseRestrictionConverter converter = new UseRestrictionConverter(client, config());
+    DataAccessRequest dar = createDataAccessRequest();
+    OntologyEntry entry = new OntologyEntry();
+    entry.setId("id");
+    entry.setDefinition("description");
+    entry.setLabel("label");
+    dar.getData().setOntologies(List.of(entry));
+    DataUse dataUse = converter.parseDataUsePurpose(dar);
+    assertNotNull(dataUse.getDiseaseRestrictions());
+  }
+
+  @Test
+  public void testParseDataUsePurposeCommercial() {
+    Client client = ClientBuilder.newClient();
+    UseRestrictionConverter converter = new UseRestrictionConverter(client, config());
+    DataAccessRequest dar = createDataAccessRequest();
+    dar.getData().setForProfit(true);
+    DataUse dataUse = converter.parseDataUsePurpose(dar);
+    assertTrue(dataUse.getCommercialUse());
+  }
+
+  @Test
+  public void testParseDataUsePurposeGender() {
+    Client client = ClientBuilder.newClient();
+    UseRestrictionConverter converter = new UseRestrictionConverter(client, config());
+    DataAccessRequest dar = createDataAccessRequest();
+    dar.getData().setOneGender(true);
+    dar.getData().setGender("F");
+    DataUse dataUse = converter.parseDataUsePurpose(dar);
+    assertNotNull(dataUse.getGender());
+  }
+
+  @Test
+  public void testParseDataUsePurposePediatric() {
+    Client client = ClientBuilder.newClient();
+    UseRestrictionConverter converter = new UseRestrictionConverter(client, config());
+    DataAccessRequest dar = createDataAccessRequest();
+    dar.getData().setPediatric(true);
+    DataUse dataUse = converter.parseDataUsePurpose(dar);
+    assertTrue(dataUse.getPediatric());
+  }
+
+  @Test
+  public void testParseDataUsePurposePOA() {
+    Client client = ClientBuilder.newClient();
+    UseRestrictionConverter converter = new UseRestrictionConverter(client, config());
+    DataAccessRequest dar = createDataAccessRequest();
+    dar.getData().setPoa(true);
+    DataUse dataUse = converter.parseDataUsePurpose(dar);
+    assertTrue(dataUse.getPopulationOriginsAncestry());
+  }
+
+  @Test
+  public void testParseDataUsePurposeHMB() {
+    Client client = ClientBuilder.newClient();
+    UseRestrictionConverter converter = new UseRestrictionConverter(client, config());
+    DataAccessRequest dar = createDataAccessRequest();
+    dar.getData().setHmb(true);
+    DataUse dataUse = converter.parseDataUsePurpose(dar);
+    assertTrue(dataUse.getHmbResearch());
+  }
+
+  @Test
+  public void testParseDataUsePurposeOther1() {
+    Client client = ClientBuilder.newClient();
+    UseRestrictionConverter converter = new UseRestrictionConverter(client, config());
+    DataAccessRequest dar = createDataAccessRequest();
+    dar.getData().setOther(true);
+    DataUse dataUse = converter.parseDataUsePurpose(dar);
+    assertTrue(dataUse.getOtherRestrictions());
+  }
+
+  @Test
+  public void testParseDataUsePurposeOther2() {
+    Client client = ClientBuilder.newClient();
+    UseRestrictionConverter converter = new UseRestrictionConverter(client, config());
+    DataAccessRequest dar = createDataAccessRequest();
+    dar.getData().setOtherText("other");
+    DataUse dataUse = converter.parseDataUsePurpose(dar);
+    assertNotNull(dataUse.getOther());
+  }
+
+  private DataAccessRequest createDataAccessRequest() {
+    DataAccessRequest dar = new DataAccessRequest();
+    dar.setReferenceId(UUID.randomUUID().toString());
+    DataAccessRequestData data = new DataAccessRequestData();
+    data.setReferenceId(dar.getReferenceId());
+    dar.setData(data);
+    return dar;
   }
 
 }


### PR DESCRIPTION
### Addresses
Consent side of https://broadworkbench.atlassian.net/browse/DUOS-2617

### Summary
* See also: https://github.com/DataBiosphere/consent-ontology/pull/879
* Minor update to add `other` and unhandled _abstain_ cases to the data use translation for DARs
* More tests to ensure condition coverage

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
