### PR TITLE
[DUOS-2627][risk=no] Always report to sherlock

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -69,7 +69,6 @@ jobs:
         channel: "#duos-notifications"
         fields: repo,commit,author,action,eventName,ref,workflow,job,took
   report-to-sherlock:
-    if: github.event_name == 'push'
     uses: broadinstitute/sherlock/.github/workflows/client-report-app-version.yaml@main
     needs: [ tag-build-push ]
     with:


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DUOS-2627

### Summary
Always report builds to sherlock

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
