### PR TITLE
[DUOS-2579][risk=no] Deprecate Dataset Name Property

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DatasetReducer.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DatasetReducer.java
@@ -2,7 +2,6 @@ package org.broadinstitute.consent.http.db.mapper;
 
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import org.broadinstitute.consent.http.enumeration.PropertyType;
 import org.broadinstitute.consent.http.models.DataUse;
 import org.broadinstitute.consent.http.models.Dataset;
@@ -10,7 +9,6 @@ import org.broadinstitute.consent.http.models.DatasetProperty;
 import org.broadinstitute.consent.http.models.FileStorageObject;
 import org.broadinstitute.consent.http.models.Study;
 import org.broadinstitute.consent.http.models.User;
-import org.broadinstitute.consent.http.service.DatasetService;
 import org.jdbi.v3.core.result.LinkedHashMapRowReducer;
 import org.jdbi.v3.core.result.RowView;
 
@@ -103,23 +101,6 @@ public class DatasetReducer implements LinkedHashMapRowReducer<Integer, Dataset>
       dataset.setCreateUser(user);
     }
 
-    // The name property doesn't always come through, add it manually:
-    Optional<DatasetProperty> nameProp =
-        Objects.isNull(dataset.getProperties()) ?
-            Optional.empty() :
-            dataset.getProperties()
-                .stream()
-                .filter(p -> Objects.nonNull(p.getPropertyName()))
-                .filter(p -> p.getPropertyName().equals(DatasetService.DATASET_NAME_KEY))
-                .findFirst();
-    if (nameProp.isEmpty()) {
-      DatasetProperty name = new DatasetProperty();
-      name.setPropertyName(DatasetService.DATASET_NAME_KEY);
-      name.setPropertyValue(dataset.getName());
-      name.setDataSetId(dataset.getDataSetId());
-      name.setPropertyType(PropertyType.String);
-      dataset.addProperty(name);
-    }
     dataset.setDatasetName(dataset.getName());
     dataset.setDatasetIdentifier();
   }

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAOTest.java
@@ -7,7 +7,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.cloud.storage.BlobId;
-import com.google.gson.Gson;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Date;
@@ -32,7 +31,6 @@ import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.service.dao.DatasetServiceDAO.DatasetInsert;
 import org.broadinstitute.consent.http.service.dao.DatasetServiceDAO.DatasetUpdate;
 import org.broadinstitute.consent.http.service.dao.DatasetServiceDAO.StudyUpdate;
-import org.broadinstitute.consent.http.util.gson.GsonUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -87,15 +85,12 @@ public class DatasetServiceDAOTest extends DAOTestHelper {
     assertEquals(insert.name(), created.getName());
     assertEquals(insert.dacId(), created.getDacId());
 
-    assertEquals(3, created.getProperties().size());
+    assertEquals(2, created.getProperties().size());
 
     DatasetProperty createdProp1 = created.getProperties().stream()
         .filter((p) -> p.getPropertyName().equals(prop1.getPropertyName())).findFirst().get();
     DatasetProperty createdProp2 = created.getProperties().stream()
         .filter((p) -> p.getPropertyName().equals(prop2.getPropertyName())).findFirst().get();
-    DatasetProperty datasetNameProp = created.getProperties().stream()
-        .filter((p) -> p.getPropertyName().equals("Dataset Name")).findFirst().get();
-    assertNotNull(datasetNameProp);
 
     assertEquals(created.getDataSetId(), createdProp1.getDataSetId());
     assertEquals(prop1.getPropertyValue(), createdProp1.getPropertyValue());
@@ -157,7 +152,7 @@ public class DatasetServiceDAOTest extends DAOTestHelper {
     assertEquals(insert1.name(), dataset1.getName());
     assertEquals(insert1.dacId(), dataset1.getDacId());
     assertEquals(true, dataset1.getDataUse().getGeneralUse());
-    assertEquals(1, dataset1.getProperties().size()); // dataset name property auto created
+    assertNull(dataset1.getProperties());
     assertNull(dataset1.getNihInstitutionalCertificationFile());
 
     Optional<Dataset> ds2Optional = datasets.stream()
@@ -168,7 +163,7 @@ public class DatasetServiceDAOTest extends DAOTestHelper {
     assertEquals(insert2.name(), dataset2.getName());
     assertEquals(insert2.dacId(), dataset2.getDacId());
     assertEquals(true, dataset2.getDataUse().getIllegalBehavior());
-    assertEquals(2, dataset2.getProperties().size());
+    assertEquals(1, dataset2.getProperties().size());
     assertNull(dataset2.getNihInstitutionalCertificationFile());
   }
 
@@ -643,12 +638,20 @@ public class DatasetServiceDAOTest extends DAOTestHelper {
         List.of(prop1, prop2),
         Objects.isNull(fso) ? List.of() : fso);
 
+    DatasetProperty datasetProperty = new DatasetProperty();
+    datasetProperty.setSchemaProperty(RandomStringUtils.randomAlphabetic(10));
+    datasetProperty.setPropertyName(RandomStringUtils.randomAlphabetic(10));
+    datasetProperty.setPropertyType(PropertyType.Number);
+    datasetProperty.setPropertyKey(1);
+    datasetProperty.setPropertyValue(new Random().nextInt());
+    datasetProperty.setCreateDate(new Date());
+
     DatasetServiceDAO.DatasetInsert datasetInsert = new DatasetServiceDAO.DatasetInsert(
         RandomStringUtils.randomAlphabetic(20),
         dac.getDacId(),
         new DataUseBuilder().setGeneralUse(true).build(),
         user.getUserId(),
-        List.of(),
+        List.of(datasetProperty),
         List.of());
 
     List<Integer> createdIds = serviceDAO.insertDatasetRegistration(studyInsert,


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DUOS-2579

### Summary
Deprecate the usages of dataset name as a property

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
