### PR TITLE
[DUOS-2617][risk=no] Add abstain and rationales to match inserts

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -37,7 +37,7 @@
         </value>
       </option>
     </AndroidXmlCodeStyleSettings>
-    <JSCodeStyleSettings>
+    <JSCodeStyleSettings version="0">
       <option name="INDENT_CHAINED_CALLS" value="false" />
     </JSCodeStyleSettings>
     <JavaCodeStyleSettings>
@@ -100,7 +100,7 @@
     <Python>
       <option name="USE_CONTINUATION_INDENT_FOR_ARGUMENTS" value="true" />
     </Python>
-    <TypeScriptCodeStyleSettings>
+    <TypeScriptCodeStyleSettings version="0">
       <option name="INDENT_CHAINED_CALLS" value="false" />
     </TypeScriptCodeStyleSettings>
     <XML>
@@ -191,7 +191,6 @@
       <option name="DOWHILE_BRACE_FORCE" value="3" />
       <option name="WHILE_BRACE_FORCE" value="3" />
       <option name="FOR_BRACE_FORCE" value="3" />
-      <option name="PARENT_SETTINGS_INSTALLED" value="true" />
       <indentOptions>
         <option name="INDENT_SIZE" value="2" />
         <option name="TAB_SIZE" value="2" />
@@ -223,10 +222,8 @@
       </indentOptions>
     </codeStyleSettings>
     <codeStyleSettings language="Python">
-      <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
       <option name="RIGHT_MARGIN" value="80" />
       <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
-      <option name="PARENT_SETTINGS_INSTALLED" value="true" />
       <indentOptions>
         <option name="INDENT_SIZE" value="2" />
         <option name="CONTINUATION_INDENT_SIZE" value="4" />
@@ -577,9 +574,7 @@
     <codeStyleSettings language="protobuf">
       <option name="RIGHT_MARGIN" value="80" />
       <indentOptions>
-        <option name="INDENT_SIZE" value="2" />
         <option name="CONTINUATION_INDENT_SIZE" value="2" />
-        <option name="TAB_SIZE" value="2" />
       </indentOptions>
     </codeStyleSettings>
   </code_scheme>

--- a/src/main/java/org/broadinstitute/consent/http/db/MatchDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/MatchDAO.java
@@ -7,10 +7,8 @@ import org.broadinstitute.consent.http.db.mapper.MatchReducer;
 import org.broadinstitute.consent.http.models.Match;
 import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
 import org.jdbi.v3.sqlobject.customizer.Bind;
-import org.jdbi.v3.sqlobject.customizer.BindBean;
 import org.jdbi.v3.sqlobject.customizer.BindList;
 import org.jdbi.v3.sqlobject.statement.GetGeneratedKeys;
-import org.jdbi.v3.sqlobject.statement.SqlBatch;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 import org.jdbi.v3.sqlobject.statement.UseRowReducer;
@@ -70,31 +68,20 @@ public interface MatchDAO extends Transactional<MatchDAO> {
       " WHERE m.purpose IN (<purposeId>) ")
   List<Match> findMatchesForPurposeIds(@BindList("purposeId") List<String> purposeId);
 
-  @SqlUpdate(
-      " INSERT INTO match_entity " +
-          " (consent, purpose, matchentity, failed, createdate, algorithm_version) VALUES " +
-          " (:consentId, :purposeId, :match, :failed, :createDate, 'v1')")
-  @GetGeneratedKeys
-  Integer insertMatch(@Bind("consentId") String consentId,
-      @Bind("purposeId") String purposeId,
-      @Bind("match") Boolean match,
-      @Bind("failed") Boolean failed,
-      @Bind("createDate") Date date);
-
-  @SqlUpdate(
-      " INSERT INTO match_entity " +
-          " (consent, purpose, matchentity, failed, createdate, algorithm_version) VALUES " +
-          " (:consentId, :purposeId, :match, :failed, :createDate, :algorithmVersion)")
+  @SqlUpdate("""
+        INSERT INTO match_entity
+          (consent, purpose, matchentity, failed, createdate, algorithm_version, abstain)
+        VALUES
+          (:consentId, :purposeId, :match, :failed, :createDate, :algorithmVersion, :abstain)
+      """)
   @GetGeneratedKeys
   Integer insertMatch(@Bind("consentId") String consentId,
       @Bind("purposeId") String purposeId,
       @Bind("match") Boolean match,
       @Bind("failed") Boolean failed,
       @Bind("createDate") Date date,
-      @Bind("algorithmVersion") String algorithmVersion);
-
-  @SqlBatch("INSERT INTO match_entity (consent, purpose, matchentity, failed, createdate, algorithm_version) VALUES (:consent, :purpose, :match, :failed, :createDate, :algorithmVersion)")
-  void insertAll(@BindBean List<Match> matches);
+      @Bind("algorithmVersion") String algorithmVersion,
+      @Bind("abstain") Boolean abstain);
 
   @SqlUpdate("INSERT INTO match_failure_reason (match_entity_id, failure_reason) VALUES (:matchId, :reason) ")
   void insertFailureReason(@Bind("matchId") Integer matchId, @Bind("reason") String reason);

--- a/src/main/java/org/broadinstitute/consent/http/db/MatchDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/MatchDAO.java
@@ -20,21 +20,21 @@ public interface MatchDAO extends Transactional<MatchDAO> {
   @UseRowReducer(MatchReducer.class)
   @SqlQuery("SELECT m.*, r.* " +
       " FROM match_entity m " +
-      " LEFT JOIN match_failure_reason r on r.match_entity_id = m.matchid " +
+      " LEFT JOIN match_rationale r on r.match_entity_id = m.matchid " +
       " WHERE m.consent = :consentId ")
   List<Match> findMatchesByConsentId(@Bind("consentId") String consentId);
 
   @UseRowReducer(MatchReducer.class)
   @SqlQuery("SELECT m.*, r.* " +
       " FROM match_entity m " +
-      " LEFT JOIN match_failure_reason r on r.match_entity_id = m.matchid " +
+      " LEFT JOIN match_rationale r on r.match_entity_id = m.matchid " +
       " WHERE m.purpose = :purposeId ")
   List<Match> findMatchesByPurposeId(@Bind("purposeId") String purposeId);
 
   @UseRowReducer(MatchReducer.class)
   @SqlQuery("SELECT m.*, r.* " +
       " FROM match_entity m " +
-      " LEFT JOIN match_failure_reason r on r.match_entity_id = m.matchid " +
+      " LEFT JOIN match_rationale r on r.match_entity_id = m.matchid " +
       " WHERE m.purpose = :purposeId AND m.consent = :consentId ")
   Match findMatchByPurposeIdAndConsentId(@Bind("purposeId") String purposeId,
       @Bind("consentId") String consentId);
@@ -42,14 +42,14 @@ public interface MatchDAO extends Transactional<MatchDAO> {
   @UseRowReducer(MatchReducer.class)
   @SqlQuery("SELECT m.*, r.* " +
       " FROM match_entity m " +
-      " LEFT JOIN match_failure_reason r on r.match_entity_id = m.matchid " +
+      " LEFT JOIN match_rationale r on r.match_entity_id = m.matchid " +
       " WHERE m.matchid = :id ")
   Match findMatchById(@Bind("id") Integer id);
 
   @UseRowReducer(MatchReducer.class)
   @SqlQuery(
       " SELECT match_entity.*, r.* FROM match_entity " +
-          " LEFT JOIN match_failure_reason r on r.match_entity_id = match_entity.matchid " +
+          " LEFT JOIN match_rationale r on r.match_entity_id = match_entity.matchid " +
           " INNER JOIN (" +
           "   SELECT election.*, MAX(election.election_id) OVER (PARTITION BY election.reference_id, election.dataset_id) AS latest "
           +
@@ -64,7 +64,7 @@ public interface MatchDAO extends Transactional<MatchDAO> {
   @UseRowReducer(MatchReducer.class)
   @SqlQuery("SELECT m.*, r.* " +
       " FROM match_entity m " +
-      " LEFT JOIN match_failure_reason r on r.match_entity_id = m.matchid " +
+      " LEFT JOIN match_rationale r on r.match_entity_id = m.matchid " +
       " WHERE m.purpose IN (<purposeId>) ")
   List<Match> findMatchesForPurposeIds(@BindList("purposeId") List<String> purposeId);
 
@@ -83,8 +83,8 @@ public interface MatchDAO extends Transactional<MatchDAO> {
       @Bind("algorithmVersion") String algorithmVersion,
       @Bind("abstain") Boolean abstain);
 
-  @SqlUpdate("INSERT INTO match_failure_reason (match_entity_id, failure_reason) VALUES (:matchId, :reason) ")
-  void insertFailureReason(@Bind("matchId") Integer matchId, @Bind("reason") String reason);
+  @SqlUpdate("INSERT INTO match_rationale (match_entity_id, rationale) VALUES (:matchId, :rationale) ")
+  void insertRationale(@Bind("matchId") Integer matchId, @Bind("rationale") String rationale);
 
   @SqlUpdate("DELETE FROM match_entity WHERE consent = :consentId")
   void deleteMatchesByConsentId(@Bind("consentId") String consentId);
@@ -95,11 +95,11 @@ public interface MatchDAO extends Transactional<MatchDAO> {
   @SqlUpdate("DELETE FROM match_entity WHERE purpose IN (<purposeIds>)")
   void deleteMatchesByPurposeIds(@BindList("purposeIds") List<String> purposeIds);
 
-  @SqlUpdate("DELETE FROM match_failure_reason WHERE match_entity_id in (SELECT matchid FROM match_entity WHERE consent IN (<consentIds>)) ")
-  void deleteFailureReasonsByConsentIds(@BindList("consentIds") List<String> consentIds);
+  @SqlUpdate("DELETE FROM match_rationale WHERE match_entity_id in (SELECT matchid FROM match_entity WHERE consent IN (<consentIds>)) ")
+  void deleteRationalesByConsentIds(@BindList("consentIds") List<String> consentIds);
 
-  @SqlUpdate("DELETE FROM match_failure_reason WHERE match_entity_id in (SELECT matchid FROM match_entity WHERE purpose IN (<purposeIds>)) ")
-  void deleteFailureReasonsByPurposeIds(@BindList("purposeIds") List<String> purposeIds);
+  @SqlUpdate("DELETE FROM match_rationale WHERE match_entity_id in (SELECT matchid FROM match_entity WHERE purpose IN (<purposeIds>)) ")
+  void deleteRationalesByPurposeIds(@BindList("purposeIds") List<String> purposeIds);
 
   @SqlQuery("SELECT COUNT(*) FROM match_entity WHERE matchentity = :matchEntity AND failed = 'FALSE' ")
   Integer countMatchesByResult(@Bind("matchEntity") Boolean matchEntity);

--- a/src/main/java/org/broadinstitute/consent/http/db/MatchDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/MatchDAO.java
@@ -18,32 +18,40 @@ import org.jdbi.v3.sqlobject.transaction.Transactional;
 public interface MatchDAO extends Transactional<MatchDAO> {
 
   @UseRowReducer(MatchReducer.class)
-  @SqlQuery("SELECT m.*, r.* " +
-      " FROM match_entity m " +
-      " LEFT JOIN match_rationale r on r.match_entity_id = m.matchid " +
-      " WHERE m.consent = :consentId ")
+  @SqlQuery("""
+      SELECT m.*, r.*
+        FROM match_entity m
+        LEFT JOIN match_rationale r on r.match_entity_id = m.matchid
+        WHERE m.consent = :consentId
+      """)
   List<Match> findMatchesByConsentId(@Bind("consentId") String consentId);
 
   @UseRowReducer(MatchReducer.class)
-  @SqlQuery("SELECT m.*, r.* " +
-      " FROM match_entity m " +
-      " LEFT JOIN match_rationale r on r.match_entity_id = m.matchid " +
-      " WHERE m.purpose = :purposeId ")
+  @SqlQuery("""
+      SELECT m.*, r.*
+        FROM match_entity m
+        LEFT JOIN match_rationale r on r.match_entity_id = m.matchid
+        WHERE m.purpose = :purposeId
+      """)
   List<Match> findMatchesByPurposeId(@Bind("purposeId") String purposeId);
 
   @UseRowReducer(MatchReducer.class)
-  @SqlQuery("SELECT m.*, r.* " +
-      " FROM match_entity m " +
-      " LEFT JOIN match_rationale r on r.match_entity_id = m.matchid " +
-      " WHERE m.purpose = :purposeId AND m.consent = :consentId ")
+  @SqlQuery("""
+      SELECT m.*, r.*
+        FROM match_entity m
+        LEFT JOIN match_rationale r on r.match_entity_id = m.matchid
+        WHERE m.purpose = :purposeId AND m.consent = :consentId
+      """)
   Match findMatchByPurposeIdAndConsentId(@Bind("purposeId") String purposeId,
       @Bind("consentId") String consentId);
 
   @UseRowReducer(MatchReducer.class)
-  @SqlQuery("SELECT m.*, r.* " +
-      " FROM match_entity m " +
-      " LEFT JOIN match_rationale r on r.match_entity_id = m.matchid " +
-      " WHERE m.matchid = :id ")
+  @SqlQuery("""
+      SELECT m.*, r.*
+        FROM match_entity m
+        LEFT JOIN match_rationale r on r.match_entity_id = m.matchid
+        WHERE m.matchid = :id
+      """)
   Match findMatchById(@Bind("id") Integer id);
 
   @UseRowReducer(MatchReducer.class)
@@ -62,10 +70,12 @@ public interface MatchDAO extends Transactional<MatchDAO> {
       @BindList("purposeIds") List<String> purposeIds);
 
   @UseRowReducer(MatchReducer.class)
-  @SqlQuery("SELECT m.*, r.* " +
-      " FROM match_entity m " +
-      " LEFT JOIN match_rationale r on r.match_entity_id = m.matchid " +
-      " WHERE m.purpose IN (<purposeId>) ")
+  @SqlQuery("""
+      SELECT m.*, r.*
+            FROM match_entity m
+            LEFT JOIN match_rationale r on r.match_entity_id = m.matchid
+            WHERE m.purpose IN (<purposeId>)
+      """)
   List<Match> findMatchesForPurposeIds(@BindList("purposeId") List<String> purposeId);
 
   @SqlUpdate("""

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/MatchReducer.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/MatchReducer.java
@@ -34,10 +34,10 @@ public class MatchReducer implements LinkedHashMapRowReducer<Integer, Match>, Ro
     if (hasColumn(rowView, "createdate", Date.class)) {
       match.setCreateDate(rowView.getColumn("createdate", Date.class));
     }
-    if (hasColumn(rowView, "failure_reason", String.class)) {
-      String failure = rowView.getColumn("failure_reason", String.class);
-      if (Objects.nonNull(failure) && !failure.isBlank()) {
-        match.addFailureReason(rowView.getColumn("failure_reason", String.class));
+    if (hasColumn(rowView, "rationale", String.class)) {
+      String rationale = rowView.getColumn("rationale", String.class);
+      if (Objects.nonNull(rationale) && !rationale.isBlank()) {
+        match.addRationale(rowView.getColumn("rationale", String.class));
       }
     }
   }

--- a/src/main/java/org/broadinstitute/consent/http/models/Match.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/Match.java
@@ -29,7 +29,7 @@ public class Match {
 
   private String algorithmVersion;
 
-  private List<String> failureReasons;
+  private List<String> rationales;
 
   public Match(Integer id, String consent, String purpose, Boolean match, Boolean abstain,
       Boolean failed, Date createDate, String algorithmVersion) {
@@ -44,7 +44,7 @@ public class Match {
   }
 
   public Match(String consentId, String purposeId, boolean match, boolean abstain, boolean failed,
-      MatchAlgorithm algorithm, List<String> failureReasons) {
+      MatchAlgorithm algorithm, List<String> rationales) {
     this.setConsent(consentId);
     this.setPurpose(purposeId);
     this.setMatch(match);
@@ -52,7 +52,7 @@ public class Match {
     this.setFailed(failed);
     this.setCreateDate(new Date());
     this.setAlgorithmVersion(algorithm.getVersion());
-    this.setFailureReasons(failureReasons);
+    this.setRationales(rationales);
   }
 
   public Match() {
@@ -122,34 +122,34 @@ public class Match {
     this.algorithmVersion = algorithmVersion;
   }
 
-  public List<String> getFailureReasons() {
-    if (Objects.isNull(this.failureReasons)) {
+  public List<String> getRationales() {
+    if (Objects.isNull(this.rationales)) {
       return List.of();
     }
-    return failureReasons;
+    return rationales;
   }
 
-  public void setFailureReasons(List<String> failureReasons) {
-    this.failureReasons = failureReasons;
+  public void setRationales(List<String> rationales) {
+    this.rationales = rationales;
   }
 
-  public void addFailureReason(String reason) {
-    if (Objects.isNull(this.failureReasons)) {
-      this.failureReasons = new ArrayList<>();
+  public void addRationale(String reason) {
+    if (Objects.isNull(this.rationales)) {
+      this.rationales = new ArrayList<>();
     }
-    if (!this.failureReasons.contains(reason) && !reason.isBlank()) {
-      this.failureReasons.add(reason);
+    if (!this.rationales.contains(reason) && !reason.isBlank()) {
+      this.rationales.add(reason);
     }
   }
 
   public static Match matchFailure(String consentId, String purposeId,
-      List<String> failureReasons) {
-    return new Match(consentId, purposeId, false, false, true, MatchAlgorithm.V3, failureReasons);
+      List<String> rationales) {
+    return new Match(consentId, purposeId, false, false, true, MatchAlgorithm.V3, rationales);
   }
 
   public static Match matchSuccess(String consentId, String purposeId, DataUseMatchResultType match,
-      List<String> failureReasons) {
+      List<String> rationales) {
     return new Match(consentId, purposeId, Approve(match), Abstain(match), false, MatchAlgorithm.V3,
-        failureReasons);
+        rationales);
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/models/matching/DataUseResponseMatchingObject.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/matching/DataUseResponseMatchingObject.java
@@ -10,13 +10,13 @@ public class DataUseResponseMatchingObject {
 
   public DataUseRequestMatchingObject matchPair;
 
-  public List<String> failureReasons;
+  public List<String> rationale;
 
   public DataUseResponseMatchingObject(DataUseMatchResultType result,
-      DataUseRequestMatchingObject matchPair, List<String> failureReasons) {
+      DataUseRequestMatchingObject matchPair, List<String> rationale) {
     this.result = result;
     this.matchPair = matchPair;
-    this.failureReasons = failureReasons;
+    this.rationale = rationale;
   }
 
   public DataUseMatchResultType getResult() {
@@ -39,11 +39,11 @@ public class DataUseResponseMatchingObject {
     this.matchPair = matchPair;
   }
 
-  public List<String> getFailureReasons() {
-    return failureReasons;
+  public List<String> getRationale() {
+    return rationale;
   }
 
-  public void setFailureReasons(List<String> failureReasons) {
-    this.failureReasons = failureReasons;
+  public void setRationale(List<String> rationale) {
+    this.rationale = rationale;
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
@@ -437,7 +437,7 @@ public class DarCollectionService {
     // no elections left & user has perms => safe to delete collection
 
     // delete DARs
-    matchDAO.deleteFailureReasonsByPurposeIds(referenceIds);
+    matchDAO.deleteRationalesByPurposeIds(referenceIds);
     matchDAO.deleteMatchesByPurposeIds(referenceIds);
     dataAccessRequestDAO.deleteDARDatasetRelationByReferenceIds(referenceIds);
     dataAccessRequestDAO.deleteByReferenceIds(referenceIds);

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
@@ -111,7 +111,7 @@ public class DataAccessRequestService {
         throw new NotAcceptableException(message);
       }
     }
-    matchDAO.deleteFailureReasonsByPurposeIds(List.of(referenceId));
+    matchDAO.deleteRationalesByPurposeIds(List.of(referenceId));
     matchDAO.deleteMatchesByPurposeId(referenceId);
     dataAccessRequestDAO.deleteDARDatasetRelationByReferenceId(referenceId);
     dataAccessRequestDAO.deleteByReferenceId(referenceId);

--- a/src/main/java/org/broadinstitute/consent/http/service/MatchService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/MatchService.java
@@ -65,7 +65,8 @@ public class MatchService implements ConsentLogger {
           m.getMatch(),
           m.getFailed(),
           new Date(),
-          m.getAlgorithmVersion()
+          m.getAlgorithmVersion(),
+          m.getAbstain()
       );
       if (!m.getFailureReasons().isEmpty()) {
         m.getFailureReasons().forEach(f -> {

--- a/src/main/java/org/broadinstitute/consent/http/service/MatchService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/MatchService.java
@@ -68,9 +68,9 @@ public class MatchService implements ConsentLogger {
           m.getAlgorithmVersion(),
           m.getAbstain()
       );
-      if (!m.getFailureReasons().isEmpty()) {
-        m.getFailureReasons().forEach(f -> {
-          matchDAO.insertFailureReason(id, f);
+      if (!m.getRationales().isEmpty()) {
+        m.getRationales().forEach(f -> {
+          matchDAO.insertRationale(id, f);
         });
       }
     });
@@ -110,12 +110,12 @@ public class MatchService implements ConsentLogger {
   }
 
   public void removeMatchesForPurpose(String purposeId) {
-    matchDAO.deleteFailureReasonsByPurposeIds(List.of(purposeId));
+    matchDAO.deleteRationalesByPurposeIds(List.of(purposeId));
     matchDAO.deleteMatchesByPurposeId(purposeId);
   }
 
   public void removeMatchesForConsent(String consentId) {
-    matchDAO.deleteFailureReasonsByConsentIds(List.of(consentId));
+    matchDAO.deleteRationalesByConsentIds(List.of(consentId));
     matchDAO.deleteMatchesByConsentId(consentId);
   }
 
@@ -178,7 +178,7 @@ public class MatchService implements ConsentLogger {
       DataUseResponseMatchingObject entity = new Gson().fromJson(stringEntity,
           DataUseResponseMatchingObject.class);
       match = matchSuccess(datasetId, darReferenceId, entity.getResult(),
-          entity.getFailureReasons());
+          entity.getRationale());
     } else {
       match = matchFailure(datasetId, darReferenceId, List.of());
     }

--- a/src/main/resources/assets/schemas/MatchResult.yaml
+++ b/src/main/resources/assets/schemas/MatchResult.yaml
@@ -25,3 +25,8 @@ properties:
   algorithmVersion:
     type: string
     description: The version of the algorithm used to generate the match.
+  rationales:
+    type: array
+    items:
+      type: string
+      description: Rationales for match results

--- a/src/main/resources/changelog-master.xml
+++ b/src/main/resources/changelog-master.xml
@@ -126,4 +126,6 @@
     relativeToChangelogFile="true"/>
   <include file="changesets/changelog-consent-2023-06-08-add-translated-data-use.xml"
     relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-2023-07-27-match-rationale.xml"
+    relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/changesets/changelog-consent-2023-07-27-match-rationale.xml
+++ b/src/main/resources/changesets/changelog-consent-2023-07-27-match-rationale.xml
@@ -1,0 +1,9 @@
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+  <changeSet id="2023-07-27-match-rationale" author="grushton">
+    <renameTable newTableName="match_rationale" oldTableName="match_failure_reason"/>
+    <renameColumn tableName="match_rationale" oldColumnName="failure_reason"
+      newColumnName="rationale"/>
+  </changeSet>
+</databaseChangeLog>

--- a/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
@@ -154,7 +154,7 @@ public class DAOTestHelper {
     testingDAO.deleteAllApprovalTimes();
     testingDAO.deleteAllVotes();
     testingDAO.deleteAllConsentAudits();
-    testingDAO.deleteAllMatchEntityFailureReasons();
+    testingDAO.deleteAllMatchEntityRationales();
     testingDAO.deleteAllMatchEntities();
     testingDAO.deleteAllConsentAssociations();
     testingDAO.deleteAllConsents();

--- a/src/test/java/org/broadinstitute/consent/http/db/MatchDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/MatchDAOTest.java
@@ -196,8 +196,8 @@ public class MatchDAOTest extends DAOTestHelper {
     Match match = makeMockMatch(UUID.randomUUID().toString());
     match.setMatch(false);
     match.setAlgorithmVersion(MatchAlgorithm.V3.getVersion());
-    match.addFailureReason(RandomStringUtils.randomAlphabetic(100));
-    match.addFailureReason(RandomStringUtils.randomAlphabetic(100));
+    match.addRationale(RandomStringUtils.randomAlphabetic(100));
+    match.addRationale(RandomStringUtils.randomAlphabetic(100));
     Integer matchId = matchDAO.insertMatch(
         match.getConsent(),
         match.getPurpose(),
@@ -206,11 +206,11 @@ public class MatchDAOTest extends DAOTestHelper {
         match.getCreateDate(),
         match.getAlgorithmVersion(),
         match.getAbstain());
-    match.getFailureReasons().forEach(f -> matchDAO.insertFailureReason(matchId, f));
+    match.getRationales().forEach(f -> matchDAO.insertRationale(matchId, f));
     Match foundMatch = matchDAO.findMatchById(matchId);
     assertNotNull(foundMatch);
-    assertEquals(match.getFailureReasons().size(),
-        foundMatch.getFailureReasons().size());
+    assertEquals(match.getRationales().size(),
+        foundMatch.getRationales().size());
   }
 
   @Test
@@ -218,8 +218,8 @@ public class MatchDAOTest extends DAOTestHelper {
     Match match = makeMockMatch(UUID.randomUUID().toString());
     match.setMatch(false);
     match.setAlgorithmVersion(MatchAlgorithm.V3.getVersion());
-    match.addFailureReason(RandomStringUtils.randomAlphabetic(100));
-    match.addFailureReason(RandomStringUtils.randomAlphabetic(100));
+    match.addRationale(RandomStringUtils.randomAlphabetic(100));
+    match.addRationale(RandomStringUtils.randomAlphabetic(100));
     Integer matchId = matchDAO.insertMatch(
         match.getConsent(),
         match.getPurpose(),
@@ -228,11 +228,11 @@ public class MatchDAOTest extends DAOTestHelper {
         match.getCreateDate(),
         match.getAlgorithmVersion(),
         match.getAbstain());
-    match.getFailureReasons().forEach(f -> matchDAO.insertFailureReason(matchId, f));
-    matchDAO.deleteFailureReasonsByConsentIds(List.of(match.getConsent()));
+    match.getRationales().forEach(f -> matchDAO.insertRationale(matchId, f));
+    matchDAO.deleteRationalesByConsentIds(List.of(match.getConsent()));
     Match foundMatch = matchDAO.findMatchById(matchId);
     assertNotNull(foundMatch);
-    assertEquals(0, foundMatch.getFailureReasons().size());
+    assertEquals(0, foundMatch.getRationales().size());
   }
 
   @Test
@@ -240,8 +240,8 @@ public class MatchDAOTest extends DAOTestHelper {
     Match match = makeMockMatch(UUID.randomUUID().toString());
     match.setMatch(false);
     match.setAlgorithmVersion(MatchAlgorithm.V3.getVersion());
-    match.addFailureReason(RandomStringUtils.randomAlphabetic(100));
-    match.addFailureReason(RandomStringUtils.randomAlphabetic(100));
+    match.addRationale(RandomStringUtils.randomAlphabetic(100));
+    match.addRationale(RandomStringUtils.randomAlphabetic(100));
     Integer matchId = matchDAO.insertMatch(
         match.getConsent(),
         match.getPurpose(),
@@ -250,11 +250,11 @@ public class MatchDAOTest extends DAOTestHelper {
         match.getCreateDate(),
         match.getAlgorithmVersion(),
         match.getAbstain());
-    match.getFailureReasons().forEach(f -> matchDAO.insertFailureReason(matchId, f));
-    matchDAO.deleteFailureReasonsByPurposeIds(List.of(match.getPurpose()));
+    match.getRationales().forEach(f -> matchDAO.insertRationale(matchId, f));
+    matchDAO.deleteRationalesByPurposeIds(List.of(match.getPurpose()));
     Match foundMatch = matchDAO.findMatchById(matchId);
     assertNotNull(foundMatch);
-    assertEquals(0, foundMatch.getFailureReasons().size());
+    assertEquals(0, foundMatch.getRationales().size());
   }
 
   private Match createMatch() {

--- a/src/test/java/org/broadinstitute/consent/http/db/MatchDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/MatchDAOTest.java
@@ -10,7 +10,6 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.UUID;
-import java.util.stream.IntStream;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.RandomUtils;
 import org.broadinstitute.consent.http.enumeration.ElectionStatus;
@@ -58,20 +57,6 @@ public class MatchDAOTest extends DAOTestHelper {
     assertEquals(found.getMatch(), m.getMatch());
   }
 
-  @Test
-  public void testInsertAll() {
-    String consentId = createConsent().getConsentId();
-    List<Match> matches = new ArrayList<>();
-    IntStream
-        .range(1, RandomUtils.nextInt(5, 10))
-        .forEach(i -> matches.add(makeMockMatch(consentId)));
-
-    matchDAO.insertAll(matches);
-    List<Match> foundMatches = matchDAO.findMatchesByConsentId(consentId);
-    assertFalse(foundMatches.isEmpty());
-    assertEquals(matches.size(), foundMatches.size());
-  }
-
   private Match makeMockMatch(String consentId) {
     Match match = new Match();
     match.setConsent(consentId);
@@ -80,6 +65,7 @@ public class MatchDAOTest extends DAOTestHelper {
     match.setCreateDate(new Date());
     match.setMatch(RandomUtils.nextBoolean());
     match.setAlgorithmVersion(MatchAlgorithm.V1.getVersion());
+    match.setAbstain(false);
     return match;
   }
 
@@ -130,15 +116,15 @@ public class MatchDAOTest extends DAOTestHelper {
     String consentId = createConsent().getConsentId();
 
     //This match represents the match record generated for the target election
-    matchDAO.insertMatch(consentId, darReferenceId, true, false, new Date());
+    matchDAO.insertMatch(consentId, darReferenceId, true, false, new Date(), MatchAlgorithm.V3.getVersion(), false);
 
     // This match represents the match record generated for the ignored access election
     matchDAO.insertMatch(consentId, ignoredAccessElection.getReferenceId(), false, false,
-        new Date());
+        new Date(), MatchAlgorithm.V3.getVersion(), false);
 
     // This match is never created under consent's workflow (unless the cause is a bug)
     // This is included simply to test the DataAccess conditional on the INNER JOIN statement
-    matchDAO.insertMatch(consentId, rpElection.getReferenceId(), false, false, new Date());
+    matchDAO.insertMatch(consentId, rpElection.getReferenceId(), false, false, new Date(), MatchAlgorithm.V3.getVersion(), true);
 
     List<Match> matchResults = matchDAO.findMatchesForLatestDataAccessElectionsByPurposeIds(
         List.of(darReferenceId));
@@ -161,11 +147,11 @@ public class MatchDAOTest extends DAOTestHelper {
     String consentId = createConsent().getConsentId();
 
     // This match represents the match record generated for the access election
-    matchDAO.insertMatch(consentId, accessElection.getReferenceId(), true, false, new Date());
+    matchDAO.insertMatch(consentId, accessElection.getReferenceId(), true, false, new Date(), MatchAlgorithm.V3.getVersion(), false);
 
     // This match is never created under consent's workflow (unless the cause is a bug)
     // This is included simply to test the DataAccess conditional on the INNER JOIN statement
-    matchDAO.insertMatch(consentId, rpElection.getReferenceId(), false, false, new Date());
+    matchDAO.insertMatch(consentId, rpElection.getReferenceId(), false, false, new Date(), MatchAlgorithm.V3.getVersion(), false);
 
     //Negative testing means we'll feed the query a reference id that isn't tied to a DataAccess election
     //Again, a match like this usually isn't generated in a normal workflow unless bug occurs, but having the 'DataAccess' condition is a nice safety net
@@ -177,7 +163,14 @@ public class MatchDAOTest extends DAOTestHelper {
   @Test
   public void testFindMatchByPurposeIdAndConsentId() {
     Match match = makeMockMatch(UUID.randomUUID().toString());
-    matchDAO.insertAll(List.of(match));
+    matchDAO.insertMatch(
+      match.getConsent(),
+      match.getPurpose(),
+      match.getMatch(),
+      match.getFailed(),
+      new Date(),
+      match.getAlgorithmVersion(),
+      match.getAbstain());
     Match foundMatch = matchDAO.findMatchByPurposeIdAndConsentId(match.getPurpose(),
         match.getConsent());
     assertNotNull(foundMatch);
@@ -192,7 +185,8 @@ public class MatchDAOTest extends DAOTestHelper {
         match.getMatch(),
         match.getFailed(),
         match.getCreateDate(),
-        match.getAlgorithmVersion());
+        match.getAlgorithmVersion(),
+        match.getAbstain());
     Match foundMatch = matchDAO.findMatchById(matchId);
     assertNotNull(foundMatch);
   }
@@ -210,7 +204,8 @@ public class MatchDAOTest extends DAOTestHelper {
         match.getMatch(),
         match.getFailed(),
         match.getCreateDate(),
-        match.getAlgorithmVersion());
+        match.getAlgorithmVersion(),
+        match.getAbstain());
     match.getFailureReasons().forEach(f -> matchDAO.insertFailureReason(matchId, f));
     Match foundMatch = matchDAO.findMatchById(matchId);
     assertNotNull(foundMatch);
@@ -231,7 +226,8 @@ public class MatchDAOTest extends DAOTestHelper {
         match.getMatch(),
         match.getFailed(),
         match.getCreateDate(),
-        match.getAlgorithmVersion());
+        match.getAlgorithmVersion(),
+        match.getAbstain());
     match.getFailureReasons().forEach(f -> matchDAO.insertFailureReason(matchId, f));
     matchDAO.deleteFailureReasonsByConsentIds(List.of(match.getConsent()));
     Match foundMatch = matchDAO.findMatchById(matchId);
@@ -252,7 +248,8 @@ public class MatchDAOTest extends DAOTestHelper {
         match.getMatch(),
         match.getFailed(),
         match.getCreateDate(),
-        match.getAlgorithmVersion());
+        match.getAlgorithmVersion(),
+        match.getAbstain());
     match.getFailureReasons().forEach(f -> matchDAO.insertFailureReason(matchId, f));
     matchDAO.deleteFailureReasonsByPurposeIds(List.of(match.getPurpose()));
     Match foundMatch = matchDAO.findMatchById(matchId);
@@ -271,7 +268,8 @@ public class MatchDAOTest extends DAOTestHelper {
             RandomUtils.nextBoolean(),
             false,
             new Date(),
-            MatchAlgorithm.V3.getVersion());
+            MatchAlgorithm.V3.getVersion(),
+            false);
     return matchDAO.findMatchById(matchId);
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/db/TestingDAO.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/TestingDAO.java
@@ -15,8 +15,8 @@ public interface TestingDAO extends Transactional<TestingDAO> {
   @SqlUpdate("DELETE FROM consent_audit")
   void deleteAllConsentAudits();
 
-  @SqlUpdate("DELETE FROM match_failure_reason")
-  void deleteAllMatchEntityFailureReasons();
+  @SqlUpdate("DELETE FROM match_rationale")
+  void deleteAllMatchEntityRationales();
 
   @SqlUpdate("DELETE FROM match_entity")
   void deleteAllMatchEntities();

--- a/src/test/java/org/broadinstitute/consent/http/service/MatchServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/MatchServiceTest.java
@@ -89,7 +89,7 @@ public class MatchServiceTest {
   @Test
   public void testInsertMatches() {
     when(matchDAO.insertMatch(any(), any(), any(), any(), any(), any(), any())).thenReturn(1);
-    doNothing().when(matchDAO).insertFailureReason(any(), any());
+    doNothing().when(matchDAO).insertRationale(any(), any());
     initService();
 
     service.insertMatches(List.of(new Match()));
@@ -326,7 +326,7 @@ public class MatchServiceTest {
     initService();
 
     service.removeMatchesForPurpose("DAR-2");
-    verify(matchDAO, atLeastOnce()).deleteFailureReasonsByPurposeIds(anyList());
+    verify(matchDAO, atLeastOnce()).deleteRationalesByPurposeIds(anyList());
     verify(matchDAO, atLeastOnce()).deleteMatchesByPurposeId(any());
   }
 
@@ -336,7 +336,7 @@ public class MatchServiceTest {
     initService();
 
     service.removeMatchesForConsent(m.getConsent());
-    verify(matchDAO, atLeastOnce()).deleteFailureReasonsByConsentIds(anyList());
+    verify(matchDAO, atLeastOnce()).deleteRationalesByConsentIds(anyList());
     verify(matchDAO, atLeastOnce()).deleteMatchesByConsentId(any());
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/service/MatchServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/MatchServiceTest.java
@@ -88,12 +88,12 @@ public class MatchServiceTest {
 
   @Test
   public void testInsertMatches() {
-    when(matchDAO.insertMatch(any(), any(), any(), any(), any(), any())).thenReturn(1);
+    when(matchDAO.insertMatch(any(), any(), any(), any(), any(), any(), any())).thenReturn(1);
     doNothing().when(matchDAO).insertFailureReason(any(), any());
     initService();
 
     service.insertMatches(List.of(new Match()));
-    verify(matchDAO, atLeastOnce()).insertMatch(any(), any(), any(), any(), any(), any());
+    verify(matchDAO, atLeastOnce()).insertMatch(any(), any(), any(), any(), any(), any(), any());
   }
 
   @Test


### PR DESCRIPTION
### Addresses
Partially addresses https://broadworkbench.atlassian.net/browse/DUOS-2617

### Summary
Existing code was not saving the `abstain` value returned from Ontology when a V3 match was made so when queried from the UI, they were always null. This PR ensures that we save that value when we get it back from Ontology. It also renames failure reasons to rationales to capture all returned match explanations.

See also: https://github.com/DataBiosphere/duos-ui/pull/2296

Example response:
```
  {
    "id": 1355,
    "consent": "DUOS-000013",
    "purpose": "7ca0f5a9-afdd-41e7-b226-2aad825f8079",
    "match": false,
    "abstain": true,
    "failed": false,
    "createDate": "Jul 27, 2023",
    "algorithmVersion": "v3",
    "rationales": [
      "The proposed population, origins, and/or ancestry research is within the bounds of the population, origins, and/or ancestry use permissions of the dataset(s)",
      "Methods research is permitted on controlled-access data so long as it is not expressly prohibited",
      "The Commercial Use Research Purpose does not match the No Commercial Use data use limitation.",
      "The Research Purpose does not result in DUOS Decision."
    ]
  },
```

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
