### PR TITLE
[DUOS-2626] Allow size and from parameters in query

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
@@ -95,10 +95,15 @@ public class ElasticSearchService implements ConsentLogger {
   }
 
   public boolean validateQuery(String query) throws IOException {
+    // Remove `size` and `from` parameters from query, otherwise validation will fail
+    var modifiedQuery = query
+        .replaceAll("\"size\": ?\\d+,?", "")
+        .replaceAll("\"from\": ?\\d+,?", "");
+
     Request validateRequest = new Request(
         HttpMethod.GET,
         "/" + esConfig.getDatasetIndexName() + "/_validate/query");
-    validateRequest.setEntity(new NStringEntity(query, ContentType.APPLICATION_JSON));
+    validateRequest.setEntity(new NStringEntity(modifiedQuery, ContentType.APPLICATION_JSON));
     Response response = performRequest(validateRequest);
 
     var entity = response.getEntity().toString();

--- a/src/main/resources/assets/paths/datasetSearchIndex.yaml
+++ b/src/main/resources/assets/paths/datasetSearchIndex.yaml
@@ -8,6 +8,17 @@ post:
       application/json:
         schema:
           type: object
+        examples:
+          example1:
+            summary: Search request 1
+            value:
+              query:
+                bool:
+                  must:
+                    - match:
+                        _type: dataset
+                    - match:
+                        _id: 1440
   tags:
     - Dataset
   responses:
@@ -21,12 +32,40 @@ post:
               $ref: '../schemas/DatasetSearch.yaml'
           examples:
             example1:
-              summary: Example search request 1
+              summary: Search response 1
               value:
-                query:
-                  bool:
-                    must:
-                      - match:
-                          _type: dataset
-                      - match:
-                          _id: 1403
+                - datasetId: 1440
+                  datasetIdentifier: DUOS-000636
+                  participantCount: 45
+                  dataUse:
+                    primary:
+                      - code: NPOA
+                        description: Future use for population origins or ancestry research is prohibited.
+                    secondary:
+                      - code: NCU
+                        description: Commercial use is not prohibited.
+                      - code: NMDS
+                        description: Data use for methods development research irrespective of the specified data use limitations is not prohibited.
+                      - code: NCTRL
+                        description: Restrictions for use as a control set for diseases other than those defined were not specified.
+                      - code: IRB
+                        description: Local ethics committee approval is required.
+                  dataLocation: Not Determined
+                  dacId: 3
+                  openAccess: false
+                  approvedUserIds:
+                    - 1
+                    - 2
+                    - 3
+                  study:
+                    description: Test study details
+                    studyName: Test Dataset
+                    studyId: 22
+                    phenotype: cancer
+                    species: human
+                    piName: FB
+                    dataSubmitterId: 5101
+                    dataCustodian:
+                    publicVisibility: true
+                    dataTypes:
+                      - genome

--- a/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
@@ -255,6 +255,16 @@ public class ElasticSearchServiceTest {
   }
 
   @Test
+  public void testValidateQueryWithFromAndSize() throws IOException {
+    String query = "{ \"from\": 0, \"size\": 100, \"query\": { \"query_string\": { \"query\": \"(GRU) AND (HMB)\" } } }";
+
+    mockElasticSearchResponse(200, "{\"valid\":true}");
+
+    initService();
+    assertTrue(service.validateQuery(query));
+  }
+
+  @Test
   public void testValidateQueryEmpty() throws IOException {
     String query = "{}";
 


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DUOS-2626

### Summary

Validation fails when the `size` and `from` parameter are specified, but these are needed to extract more than 10 results.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
