### PR TITLE
[DUOS-2527][risk=no] Make CG Name non-modifiable in PUT

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/models/dataset_registration_v1/ConsentGroup.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/dataset_registration_v1/ConsentGroup.java
@@ -766,6 +766,7 @@ public class ConsentGroup {
 
   public boolean isInvalidForUpdate() {
     return Objects.nonNull(this.openAccess) ||
+        Objects.nonNull(this.consentGroupName) ||
         Objects.nonNull(this.generalResearchUse) ||
         Objects.nonNull(this.hmb) ||
         (Objects.nonNull(this.diseaseSpecificUse) && this.diseaseSpecificUse.size() > 0) ||

--- a/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
@@ -236,7 +236,7 @@ public class DatasetResource extends Resource {
       if (Objects.nonNull(registration.getDataSubmitterUserId()) &&!registration.getDataSubmitterUserId().equals(existingStudy.getCreateUserId())) {
         throw new BadRequestException("Invalid change to Data Submitter");
       }
-      // Data use changes are not allowed for existing datasets
+      // Data use and name changes are not allowed for existing datasets
       List<ConsentGroup> invalidConsentGroups = registration.getConsentGroups()
           .stream()
           .filter(cg -> Objects.nonNull(cg.getDatasetId()))

--- a/src/main/resources/assets/paths/studyById.yaml
+++ b/src/main/resources/assets/paths/studyById.yaml
@@ -41,6 +41,16 @@ put:
       and institutional certification files. The registration schema is always required. If a file 
       is also provided, then alternative data sharing information is required in the registration 
       schema.
+      
+      The following fields are not modifiable:
+      * Study Name
+      * Data Submitter Name/Email
+      * Primary Data Use
+      * Secondary Data Use
+      * Consent Group Name
+      
+      Additionally, existing Consent Groups cannot be removed from the study, but new ones can be
+      added.
     content:
       multipart/form-data:
         schema:

--- a/src/test/java/org/broadinstitute/consent/http/resources/DataResourceTestData.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DataResourceTestData.java
@@ -136,7 +136,6 @@ public class DataResourceTestData {
             }],
             "hmb": true,
             "numberOfParticipants": 2,
-            "consentGroupName": "name 1",
             "dataAccessCommitteeId": 1,
             "dataLocation": "location",
             "url": "https://asdf.com"
@@ -148,7 +147,6 @@ public class DataResourceTestData {
               "functionalEquivalence": "equivalence"
             }],
             "numberOfParticipants": 2,
-            "consentGroupName": "name 1",
             "dataAccessCommitteeId": 1,
             "dataLocation": "location",
             "url": "https://asdf.com"


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DUOS-2527

### Summary
* Make consent group name non-modifiable
* Update api doc

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
