### PR TITLE
[DUOS-2649][risk=no] Bug Fix: Use correct content type for ES bulk indexing

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
@@ -73,7 +73,7 @@ public class ElasticSearchService implements ConsentLogger {
   public Response indexDatasetTerms(List<DatasetTerm> datasets) throws IOException {
     List<String> bulkApiCall = new ArrayList<>();
 
-    datasets.forEach((dsTerm) -> {
+    datasets.forEach(dsTerm -> {
       bulkApiCall.add(bulkHeader.formatted(dsTerm.getDatasetId()));
       bulkApiCall.add(GsonUtil.getInstance().toJson(dsTerm) + "\n");
     });
@@ -84,7 +84,7 @@ public class ElasticSearchService implements ConsentLogger {
 
     bulkRequest.setEntity(new NStringEntity(
         String.join("", bulkApiCall) + "\n",
-        ContentType.DEFAULT_BINARY));
+        ContentType.APPLICATION_JSON));
 
     return performRequest(bulkRequest);
   }
@@ -168,7 +168,7 @@ public class ElasticSearchService implements ConsentLogger {
         prop -> {
           JsonArray jsonArray = (JsonArray) prop.getValue();
           List<String> dataCustodianEmail = new ArrayList<>();
-          jsonArray.forEach((email) -> dataCustodianEmail.add(email.getAsString()));
+          jsonArray.forEach(email -> dataCustodianEmail.add(email.getAsString()));
           term.setDataCustodianEmail(dataCustodianEmail);
         }
     );
@@ -257,8 +257,8 @@ public class ElasticSearchService implements ConsentLogger {
     return
         props
             .stream()
-            .filter((p) -> Objects.nonNull(p.getSchemaProperty()))
-            .filter((p) -> p.getSchemaProperty().equals(schemaProp))
+            .filter(p -> Objects.nonNull(p.getSchemaProperty()))
+            .filter(p -> p.getSchemaProperty().equals(schemaProp))
             .findFirst();
   }
 
@@ -270,7 +270,7 @@ public class ElasticSearchService implements ConsentLogger {
     return
         props
             .stream()
-            .filter((p) -> p.getKey().equals(key))
+            .filter(p -> p.getKey().equals(key))
             .findFirst();
   }
 


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DUOS-2649

### Summary
* Bug fix for incorrect header type. [Docs](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html) specify `application/json`:

> The final line of data must end with a newline character \n. Each newline character may be preceded by a carriage return \r. When sending NDJSON data to the _bulk endpoint, use a Content-Type header of application/json or application/x-ndjson.


----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
