### PR TITLE
[DUOS-2641][risk=no] Remove active check on get datasets

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
@@ -712,7 +712,7 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
           + " LEFT OUTER JOIN consents c ON c.consent_id = ca.consent_id "
           + " WHERE d.name IS NOT NULL "
           + " ORDER BY d.dataset_id ")
-  Set<DatasetDTO> findActiveDatasetDTOs();
+  Set<DatasetDTO> getDatasetDTOs();
 
   @Deprecated
   @UseRowMapper(DatasetDTOWithPropertiesMapper.class)

--- a/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
@@ -246,7 +246,6 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
   @SqlQuery(
       Dataset.BASE_QUERY + """
               WHERE (s.public_visibility IS NULL OR s.public_visibility = TRUE)
-                AND d.active = TRUE
                 AND d.dac_approval = TRUE
           """)
   List<Dataset> findPublicDatasets();
@@ -257,7 +256,6 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
               WHERE
                 (
                   (s.public_visibility IS NULL OR s.public_visibility = TRUE)
-                  AND d.active = TRUE
                   AND d.dac_approval = TRUE
                 )
                 OR d.dac_id IN (<dacIds>)
@@ -270,7 +268,6 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
               WHERE
                 (
                   (s.public_visibility IS NULL OR s.public_visibility = TRUE)
-                  AND d.active = TRUE
                   AND d.dac_approval = TRUE
                 )
                 OR
@@ -454,9 +451,9 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
           LEFT JOIN dataset s_dataset ON s_dataset.study_id = s.study_id
           LEFT JOIN file_storage_object fso ON (fso.entity_id = d.dataset_id::text OR fso.entity_id = s.uuid::text) AND fso.deleted = false
           LEFT JOIN consents c ON c.consent_id = ca.consent_id
-          WHERE d.name IS NOT NULL AND d.active = true
+          WHERE d.name IS NOT NULL
       """)
-  List<Dataset> getActiveDatasets();
+  List<Dataset> getDatasets();
 
   @SqlQuery("""
           SELECT DISTINCT dp.property_value
@@ -713,7 +710,7 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
           + " LEFT OUTER JOIN dictionary k ON k.key_id = dp.property_key "
           + " LEFT OUTER JOIN consent_associations ca ON ca.dataset_id = d.dataset_id "
           + " LEFT OUTER JOIN consents c ON c.consent_id = ca.consent_id "
-          + " WHERE d.name IS NOT NULL AND d.active = true "
+          + " WHERE d.name IS NOT NULL "
           + " ORDER BY d.dataset_id ")
   Set<DatasetDTO> findActiveDatasetDTOs();
 

--- a/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
@@ -703,15 +703,16 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
 
   @Deprecated
   @UseRowMapper(DatasetDTOWithPropertiesMapper.class)
-  @SqlQuery(
-      "SELECT d.*, k.key, dp.property_value, ca.consent_id, d.dac_id, c.translated_use_restriction "
-          + " FROM dataset d "
-          + " LEFT OUTER JOIN dataset_property dp ON dp.dataset_id = d.dataset_id "
-          + " LEFT OUTER JOIN dictionary k ON k.key_id = dp.property_key "
-          + " LEFT OUTER JOIN consent_associations ca ON ca.dataset_id = d.dataset_id "
-          + " LEFT OUTER JOIN consents c ON c.consent_id = ca.consent_id "
-          + " WHERE d.name IS NOT NULL "
-          + " ORDER BY d.dataset_id ")
+  @SqlQuery("""
+      SELECT d.*, k.key, dp.property_value, ca.consent_id, d.dac_id, c.translated_use_restriction
+      FROM dataset d
+      LEFT OUTER JOIN dataset_property dp ON dp.dataset_id = d.dataset_id
+      LEFT OUTER JOIN dictionary k ON k.key_id = dp.property_key
+      LEFT OUTER JOIN consent_associations ca ON ca.dataset_id = d.dataset_id
+      LEFT OUTER JOIN consents c ON c.consent_id = ca.consent_id
+      WHERE d.name IS NOT NULL
+      ORDER BY d.dataset_id
+      """)
   Set<DatasetDTO> getDatasetDTOs();
 
   @Deprecated

--- a/src/main/java/org/broadinstitute/consent/http/models/Dataset.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/Dataset.java
@@ -82,6 +82,11 @@ public class Dataset {
 
   private Integer updateUserId;
 
+  /**
+   * Active is a deprecated property. The visibility of a dataset is
+   * calculated from DAC approval and the public visibility dataset property
+   */
+  @Deprecated(forRemoval = true)
   private Boolean active;
 
   private String consentName;

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -438,7 +438,7 @@ public class DatasetService {
     if (userHasRole(UserRoles.ADMIN.getRoleName(), userId)) {
       datasets.addAll(datasetDAO.findAllDatasetDTOs());
     } else {
-      datasets.addAll(datasetDAO.findActiveDatasetDTOs());
+      datasets.addAll(datasetDAO.getDatasetDTOs());
       if (userHasRole(UserRoles.CHAIRPERSON.getRoleName(), userId)) {
         Collection<DatasetDTO> chairSpecificDatasets = datasetDAO.findDatasetDTOsByUserId(userId);
         datasets.addAll(chairSpecificDatasets);

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -546,7 +546,7 @@ public class DatasetService {
     if (user.hasUserRole(UserRoles.ADMIN)) {
       return datasetDAO.findAllDatasets();
     } else {
-      List<Dataset> datasets = datasetDAO.getActiveDatasets();
+      List<Dataset> datasets = datasetDAO.getDatasets();
       if (user.hasUserRole(UserRoles.CHAIRPERSON)) {
         List<Dataset> chairDatasets = datasetDAO.findDatasetsByAuthUserEmail(user.getEmail());
         return Stream

--- a/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import com.google.gson.JsonObject;
 import java.sql.Timestamp;
 import java.time.Instant;
@@ -43,16 +44,14 @@ import org.broadinstitute.consent.http.models.Election;
 import org.broadinstitute.consent.http.models.FileStorageObject;
 import org.broadinstitute.consent.http.models.Study;
 import org.broadinstitute.consent.http.models.User;
-import org.broadinstitute.consent.http.models.UserRole;
-import org.broadinstitute.consent.http.models.Vote;
 import org.broadinstitute.consent.http.models.dto.DatasetDTO;
 import org.broadinstitute.consent.http.util.gson.GsonUtil;
 import org.junit.jupiter.api.Test;
 
-public class DatasetDAOTest extends DAOTestHelper {
+class DatasetDAOTest extends DAOTestHelper {
 
   @Test
-  public void testFindDatasetByIdWithDacAndConsent() {
+  void testFindDatasetByIdWithDacAndConsent() {
     Dataset dataset = insertDataset();
     Dac dac = insertDac();
     Consent consent = insertConsent();
@@ -70,39 +69,7 @@ public class DatasetDAOTest extends DAOTestHelper {
   }
 
   @Test
-  public void testGetActiveDatasets_positive_case() {
-    // This inserts a dataset with the active property set to true
-    Dataset ds = insertDataset();
-    Dac dac = insertDac();
-    Consent consent = insertConsent();
-    datasetDAO.updateDatasetDacId(ds.getDataSetId(), dac.getDacId());
-    consentDAO.insertConsentAssociation(consent.getConsentId(), ASSOCIATION_TYPE_TEST,
-        ds.getDataSetId());
-
-    List<Dataset> activeDatasets = datasetDAO.getActiveDatasets();
-    assertFalse(activeDatasets.isEmpty());
-    assertEquals(1, activeDatasets.size());
-    assertTrue(activeDatasets.get(0).getActive());
-  }
-
-  @Test
-  public void testGetActiveDatasets_negative_case() {
-    // This inserts a dataset with the active property set to true
-    Dataset ds = insertDataset();
-    // Update so it is inactive
-    datasetDAO.updateDatasetActive(ds.getDataSetId(), false);
-    Dac dac = insertDac();
-    Consent consent = insertConsent();
-    datasetDAO.updateDatasetDacId(ds.getDataSetId(), dac.getDacId());
-    consentDAO.insertConsentAssociation(consent.getConsentId(), ASSOCIATION_TYPE_TEST,
-        ds.getDataSetId());
-
-    List<Dataset> activeDatasets = datasetDAO.getActiveDatasets();
-    assertTrue(activeDatasets.isEmpty());
-  }
-
-  @Test
-  public void testFindPublicDatasets_positive() {
+  void testFindPublicDatasets_positive() {
     User user = createUser();
 
     Dataset ds1 = insertDataset();
@@ -138,7 +105,7 @@ public class DatasetDAOTest extends DAOTestHelper {
   }
 
   @Test
-  public void testFindPublicDatasets_negative() {
+  void testFindPublicDatasets_negative() {
     User user = createUser();
 
     Dataset ds1 = insertDataset();
@@ -162,7 +129,7 @@ public class DatasetDAOTest extends DAOTestHelper {
   }
 
   @Test
-  public void testFindPublicDatasets_no_study() {
+  void testFindPublicDatasets_no_study() {
     User user = createUser();
 
     Dataset ds1 = insertDataset();
@@ -190,7 +157,7 @@ public class DatasetDAOTest extends DAOTestHelper {
   }
 
   @Test
-  public void testFindPublicDatasets_not_approved() {
+  void testFindPublicDatasets_not_approved() {
     insertDataset();
     insertDataset();
 
@@ -200,7 +167,7 @@ public class DatasetDAOTest extends DAOTestHelper {
   }
 
   @Test
-  public void testFindDatasetsForDataSubmitter_email() {
+  void testFindDatasetsForDataSubmitter_email() {
     User user = createUser();
 
     Dataset ds1 = insertDataset();
@@ -223,7 +190,7 @@ public class DatasetDAOTest extends DAOTestHelper {
   }
 
   @Test
-  public void testFindDatasetsForDataSubmitter_create_user() {
+  void testFindDatasetsForDataSubmitter_create_user() {
     User user = createUser();
 
     Dataset ds1 = insertDataset();
@@ -240,7 +207,7 @@ public class DatasetDAOTest extends DAOTestHelper {
   }
 
   @Test
-  public void testFindDatasetsForDataSubmitter_public() {
+  void testFindDatasetsForDataSubmitter_public() {
     User user = createUser();
 
     Dataset ds1 = insertDataset();
@@ -275,7 +242,7 @@ public class DatasetDAOTest extends DAOTestHelper {
   }
 
   @Test
-  public void testFindDatasetsForDataSubmitter_negative() {
+  void testFindDatasetsForDataSubmitter_negative() {
     User user = createUser();
 
     Dataset ds1 = insertDataset();
@@ -300,7 +267,7 @@ public class DatasetDAOTest extends DAOTestHelper {
   }
 
   @Test
-  public void testFindDatasetsForDataSubmitter_no_study() {
+  void testFindDatasetsForDataSubmitter_no_study() {
     User user = createUser();
 
     Dataset ds1 = insertDataset();
@@ -329,7 +296,7 @@ public class DatasetDAOTest extends DAOTestHelper {
   }
 
   @Test
-  public void testFindDatasetsForDataSubmitter_not_approved() {
+  void testFindDatasetsForDataSubmitter_not_approved() {
     User user = createUser();
 
     insertDataset();
@@ -342,7 +309,7 @@ public class DatasetDAOTest extends DAOTestHelper {
   }
 
   @Test
-  public void testFindDatasetsForChairperson_positive() {
+  void testFindDatasetsForChairperson_positive() {
     Dac dac = insertDac();
 
     User chairperson = createUser();
@@ -394,7 +361,7 @@ public class DatasetDAOTest extends DAOTestHelper {
   }
 
   @Test
-  public void testFindDatasetByIdWithDacAndConsentNotDeletable() {
+  void testFindDatasetByIdWithDacAndConsentNotDeletable() {
     User user = createUser();
     Dataset d1 = insertDataset();
     Dataset d2 = insertDataset();
@@ -416,7 +383,7 @@ public class DatasetDAOTest extends DAOTestHelper {
   }
 
   @Test
-  public void testTranslatedDataUse() {
+  void testTranslatedDataUse() {
     Dataset d1 = insertDataset();
 
     String tdu = RandomStringUtils.randomAlphabetic(10);
@@ -428,7 +395,7 @@ public class DatasetDAOTest extends DAOTestHelper {
   }
 
   @Test
-  public void testFindDatasetByAlias() {
+  void testFindDatasetByAlias() {
     Dataset dataset = insertDataset();
 
     Dataset foundDataset = datasetDAO.findDatasetByAlias(dataset.getAlias());
@@ -438,7 +405,7 @@ public class DatasetDAOTest extends DAOTestHelper {
   }
 
   @Test
-  public void testFindDatasetsByAlias() {
+  void testFindDatasetsByAlias() {
     Dataset dataset1 = insertDataset();
     Dataset dataset2 = insertDataset();
 
@@ -451,7 +418,7 @@ public class DatasetDAOTest extends DAOTestHelper {
   }
 
   @Test
-  public void testGetNIHInstitutionalFile() {
+  void testGetNIHInstitutionalFile() {
     Dataset dataset = insertDataset();
 
     // create unrelated file with the same id as dataset id but different category, timestamp before
@@ -481,7 +448,7 @@ public class DatasetDAOTest extends DAOTestHelper {
   }
 
   @Test
-  public void testGetNIHInstitutionalFile_AlwaysLatestUpdated() throws InterruptedException {
+  void testGetNIHInstitutionalFile_AlwaysLatestUpdated() throws InterruptedException {
     Dataset dataset = insertDataset();
 
     String fileName = RandomStringUtils.randomAlphabetic(10);
@@ -533,7 +500,7 @@ public class DatasetDAOTest extends DAOTestHelper {
   }
 
   @Test
-  public void testGetNIHInstitutionalFile_AlwaysLatestCreated() throws InterruptedException {
+  void testGetNIHInstitutionalFile_AlwaysLatestCreated() throws InterruptedException {
     Dataset dataset = insertDataset();
 
     String fileName = RandomStringUtils.randomAlphabetic(10);
@@ -578,7 +545,7 @@ public class DatasetDAOTest extends DAOTestHelper {
   }
 
   @Test
-  public void testGetNIHInstitutionalFile_NotDeleted() {
+  void testGetNIHInstitutionalFile_NotDeleted() {
     Dataset dataset = insertDataset();
 
     FileStorageObject nihFile = createFileStorageObject(
@@ -600,7 +567,7 @@ public class DatasetDAOTest extends DAOTestHelper {
   }
 
   @Test
-  public void testGetDictionaryTerms() {
+  void testGetDictionaryTerms() {
     List<Dictionary> terms = datasetDAO.getDictionaryTerms();
     assertFalse(terms.isEmpty());
     terms.forEach(t -> {
@@ -610,7 +577,7 @@ public class DatasetDAOTest extends DAOTestHelper {
   }
 
   @Test
-  public void testFindDatasetsByIdList() {
+  void testFindDatasetsByIdList() {
     Dataset dataset = insertDataset();
     Dac dac = insertDac();
     Consent consent = insertConsent();
@@ -629,7 +596,7 @@ public class DatasetDAOTest extends DAOTestHelper {
 
   // User -> UserRoles -> DACs -> Consents -> Consent Associations -> DataSets
   @Test
-  public void testFindDataSetsByAuthUserEmail() {
+  void testFindDataSetsByAuthUserEmail() {
     Dataset dataset = insertDataset();
     Dac dac = insertDac();
     Consent consent = insertConsent();
@@ -646,14 +613,14 @@ public class DatasetDAOTest extends DAOTestHelper {
   }
 
   @Test
-  public void testFindDatasetPropertiesByDatasetId() {
+  void testFindDatasetPropertiesByDatasetId() {
     Dataset d = insertDataset();
     Set<DatasetProperty> properties = datasetDAO.findDatasetPropertiesByDatasetId(d.getDataSetId());
     assertEquals(properties.size(), 1);
   }
 
   @Test
-  public void testUpdateDataset() {
+  void testUpdateDataset() {
     Dataset d = insertDataset();
     Dac dac = insertDac();
     String name = RandomStringUtils.random(20, true, true);
@@ -670,7 +637,7 @@ public class DatasetDAOTest extends DAOTestHelper {
   }
 
   @Test
-  public void testUpdateDatasetProperty() {
+  void testUpdateDatasetProperty() {
     Dataset d = insertDataset();
     Set<DatasetProperty> properties = datasetDAO.findDatasetPropertiesByDatasetId(d.getDataSetId());
     DatasetProperty originalProperty = properties.stream().toList().get(0);
@@ -691,7 +658,7 @@ public class DatasetDAOTest extends DAOTestHelper {
   }
 
   @Test
-  public void testCreateNumberTypedDatasetProperty() {
+  void testCreateNumberTypedDatasetProperty() {
     Dataset d = insertDataset();
 
     Set<DatasetProperty> oldProperties = datasetDAO.findDatasetPropertiesByDatasetId(
@@ -719,7 +686,7 @@ public class DatasetDAOTest extends DAOTestHelper {
   }
 
   @Test
-  public void testCreateDateTypedDatasetProperty() {
+  void testCreateDateTypedDatasetProperty() {
     Dataset d = insertDataset();
     Instant date = Instant.now();
 
@@ -749,7 +716,7 @@ public class DatasetDAOTest extends DAOTestHelper {
   }
 
   @Test
-  public void testCreateBooleanTypedDatasetProperty() {
+  void testCreateBooleanTypedDatasetProperty() {
     Dataset d = insertDataset();
     Boolean bool = Boolean.FALSE;
 
@@ -778,7 +745,7 @@ public class DatasetDAOTest extends DAOTestHelper {
   }
 
   @Test
-  public void testCreateJsonTypedDatasetProperty() {
+  void testCreateJsonTypedDatasetProperty() {
     Dataset d = insertDataset();
     JsonObject jsonObject = new JsonObject();
     jsonObject.add("test", new JsonObject());
@@ -808,7 +775,7 @@ public class DatasetDAOTest extends DAOTestHelper {
   }
 
   @Test
-  public void testCreateStringTypedDatasetProperty() {
+  void testCreateStringTypedDatasetProperty() {
     Dataset d = insertDataset();
     String value = "hi";
 
@@ -837,7 +804,7 @@ public class DatasetDAOTest extends DAOTestHelper {
   }
 
   @Test
-  public void testCreateTypedDatasetPropertyWithSchema() {
+  void testCreateTypedDatasetPropertyWithSchema() {
     Dataset d = insertDataset();
     String schemaValue = "test test test test";
 
@@ -866,7 +833,7 @@ public class DatasetDAOTest extends DAOTestHelper {
   }
 
   @Test
-  public void testDeleteDatasetPropertyByKey() {
+  void testDeleteDatasetPropertyByKey() {
     Dataset d = insertDataset();
     Set<DatasetProperty> properties = datasetDAO.findDatasetPropertiesByDatasetId(d.getDataSetId());
     DatasetProperty propertyToDelete = properties.stream().toList().get(0);
@@ -877,7 +844,7 @@ public class DatasetDAOTest extends DAOTestHelper {
   }
 
   @Test
-  public void testFindAllDatasets() {
+  void testFindAllDatasets() {
     List<Dataset> datasetList = IntStream.range(1, 5).mapToObj(i -> {
       Dataset dataset = insertDataset();
       Consent consent = insertConsent();
@@ -896,7 +863,7 @@ public class DatasetDAOTest extends DAOTestHelper {
   }
 
   @Test
-  public void testFindAllDatasetDTOs() {
+  void testFindAllDatasetDTOs() {
     Dataset dataset = insertDataset();
     Consent consent = insertConsent();
     consentDAO.insertConsentAssociation(consent.getConsentId(), ASSOCIATION_TYPE_TEST,
@@ -909,7 +876,7 @@ public class DatasetDAOTest extends DAOTestHelper {
   }
 
   @Test
-  public void testFindActiveDatasets() {
+  void testFindActiveDatasets() {
     Dataset dataset = insertDataset();
     Consent consent = insertConsent();
 
@@ -923,7 +890,7 @@ public class DatasetDAOTest extends DAOTestHelper {
   }
 
   @Test
-  public void testFindAllStudyNames() {
+  void testFindAllStudyNames() {
     Dataset ds1 = insertDataset();
     String ds1Name = RandomStringUtils.randomAlphabetic(20);
     createDatasetProperty(ds1.getDataSetId(), "studyName", ds1Name, PropertyType.String);
@@ -943,7 +910,7 @@ public class DatasetDAOTest extends DAOTestHelper {
   }
 
   @Test
-  public void testFindAllStudyNamesWithInactiveDataset() {
+  void testFindAllStudyNamesWithInactiveDataset() {
     Dataset ds1 = insertDataset();
     String ds1Name = RandomStringUtils.randomAlphabetic(20);
     createDatasetProperty(ds1.getDataSetId(), "studyName", ds1Name, PropertyType.String);
@@ -960,7 +927,7 @@ public class DatasetDAOTest extends DAOTestHelper {
   }
 
   @Test
-  public void testFindDatasetsByUser() {
+  void testFindDatasetsByUser() {
     Dataset dataset = insertDataset();
     Dac dac = insertDac();
     Consent consent = insertConsent();
@@ -977,7 +944,7 @@ public class DatasetDAOTest extends DAOTestHelper {
   }
 
   @Test
-  public void testFindDatasetsByDacIds() {
+  void testFindDatasetsByDacIds() {
     Dataset dataset = insertDataset();
     Dac dac = insertDac();
 
@@ -994,7 +961,7 @@ public class DatasetDAOTest extends DAOTestHelper {
   }
 
   @Test
-  public void testFindDatasetListByDacIds() {
+  void testFindDatasetListByDacIds() {
     Dataset dataset = insertDataset();
     Dac dac = insertDac();
 
@@ -1011,7 +978,7 @@ public class DatasetDAOTest extends DAOTestHelper {
   }
 
   @Test
-  public void testUpdateDatasetDataUse() {
+  void testUpdateDatasetDataUse() {
     Dataset dataset = insertDataset();
     DataUse oldDataUse = dataset.getDataUse();
     DataUse newDataUse = new DataUseBuilder()
@@ -1028,7 +995,7 @@ public class DatasetDAOTest extends DAOTestHelper {
   }
 
   @Test
-  public void testFindDatasetWithDataUseByIdList() {
+  void testFindDatasetWithDataUseByIdList() {
     Dataset dataset = insertDataset();
     Dac dac = insertDac();
     Consent consent = insertConsent();
@@ -1044,7 +1011,7 @@ public class DatasetDAOTest extends DAOTestHelper {
   }
 
   @Test
-  public void testGetDatasetsForConsent() {
+  void testGetDatasetsForConsent() {
     Integer datasetId = datasetDAO.insertDataset(RandomStringUtils.randomAlphabetic(10), null,
         null, RandomStringUtils.randomAlphabetic(10), true, null, null);
     //negative record, make sure this isn't pulled in
@@ -1065,7 +1032,7 @@ public class DatasetDAOTest extends DAOTestHelper {
   }
 
   @Test
-  public void testUpdateDatasetApproval() {
+  void testUpdateDatasetApproval() {
     User updateUser = createUser();
     Dataset dataset = insertDataset();
     datasetDAO.updateDatasetApproval(true, Instant.now(), updateUser.getUserId(),
@@ -1084,7 +1051,7 @@ public class DatasetDAOTest extends DAOTestHelper {
   }
 
   @Test
-  public void testInsertDatasetAudit() {
+  void testInsertDatasetAudit() {
     Dataset d = createDataset();
     DatasetAudit audit = new DatasetAudit(
         d.getDataSetId(),
@@ -1097,7 +1064,7 @@ public class DatasetDAOTest extends DAOTestHelper {
   }
 
   @Test
-  public void testDatasetWithStudy() {
+  void testDatasetWithStudy() {
     Study study = insertStudyWithProperties();
 
     Dataset ds = createDataset();
@@ -1131,7 +1098,7 @@ public class DatasetDAOTest extends DAOTestHelper {
   }
 
   @Test
-  public void testGetApprovedDatasets() throws Exception {
+  void testGetApprovedDatasets() throws Exception {
 
     // user with a mix of approved and unapproved datasets
     User user = createUser();
@@ -1196,7 +1163,7 @@ public class DatasetDAOTest extends DAOTestHelper {
   }
 
   @Test
-  public void testGetApprovedDatasetsWhenNone() throws Exception {
+  void testGetApprovedDatasetsWhenNone() throws Exception {
 
     // user with only unapproved datasets
     User user = createUser();
@@ -1221,16 +1188,16 @@ public class DatasetDAOTest extends DAOTestHelper {
     }
 
     List<ApprovedDataset> approvedDatasets = datasetDAO.getApprovedDatasets(user.getUserId());
-    assertTrue(approvedDatasets.size() == 0);
+    assertEquals(0, approvedDatasets.size());
   }
 
   @Test
-  public void testGetApprovedDatasetsWhenEmpty() throws Exception {
+  void testGetApprovedDatasetsWhenEmpty() throws Exception {
 
     // user with no datasets
     User user = createUser();
     List<ApprovedDataset> approvedDatasets = datasetDAO.getApprovedDatasets(user.getUserId());
-    assertTrue(approvedDatasets.size() == 0);
+    assertEquals(0, approvedDatasets.size());
 
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
@@ -883,7 +883,7 @@ class DatasetDAOTest extends DAOTestHelper {
     consentDAO.insertConsentAssociation(consent.getConsentId(), ASSOCIATION_TYPE_TEST,
         dataset.getDataSetId());
 
-    Set<DatasetDTO> datasets = datasetDAO.findActiveDatasetDTOs();
+    Set<DatasetDTO> datasets = datasetDAO.getDatasetDTOs();
     assertFalse(datasets.isEmpty());
     List<Integer> datasetIds = datasets.stream().map(DatasetDTO::getDataSetId).toList();
     assertTrue(datasetIds.contains(dataset.getDataSetId()));

--- a/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
@@ -701,7 +701,7 @@ public class DatasetServiceTest {
         null);
     when(userRoleDAO.findRoleByNameAndUser(UserRoles.CHAIRPERSON.getRoleName(), 2)).thenReturn(2);
     when(datasetDAO.findAllDatasetDTOs()).thenReturn(setOfDtos);
-    when(datasetDAO.findActiveDatasetDTOs()).thenReturn(emptyActiveDtoSet);
+    when(datasetDAO.getDatasetDTOs()).thenReturn(emptyActiveDtoSet);
     when(datasetDAO.findDatasetDTOsByUserId(2)).thenReturn(singleDtoSet);
     initService();
 

--- a/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
@@ -111,7 +111,7 @@ public class DatasetServiceTest {
         Collections.singleton(test));
     initService();
 
-    DatasetDTO result = datasetService.createDatasetWithConsent(getDatasetDTO(), "Test Dataset 1",
+    DatasetDTO result = datasetService.createDatasetFromDatasetDTO(getDatasetDTO(), "Test Dataset 1",
         1);
 
     assertNotNull(result);

--- a/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
@@ -20,8 +20,6 @@ import static org.mockito.Mockito.when;
 
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.NotFoundException;
-import jakarta.ws.rs.core.Response;
-import jakarta.ws.rs.core.Response.Status;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -48,8 +46,6 @@ import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.ApprovedDataset;
 import org.broadinstitute.consent.http.models.Consent;
 import org.broadinstitute.consent.http.models.Dac;
-import org.broadinstitute.consent.http.models.DarCollection;
-import org.broadinstitute.consent.http.models.DataAccessRequest;
 import org.broadinstitute.consent.http.models.DataUse;
 import org.broadinstitute.consent.http.models.DataUseBuilder;
 import org.broadinstitute.consent.http.models.Dataset;
@@ -735,7 +731,7 @@ public class DatasetServiceTest {
     assertEquals(1, datasets.size());
     assertEquals(dataset.getDataSetId(), datasets.get(0).getDataSetId());
     verify(datasetDAO, times(1)).findAllDatasets();
-    verify(datasetDAO, times(0)).getActiveDatasets();
+    verify(datasetDAO, times(0)).getDatasets();
     verify(datasetDAO, times(0)).findDatasetsByAuthUserEmail(any());
   }
 
@@ -751,7 +747,7 @@ public class DatasetServiceTest {
     d2.setDataSetId(2);
     Dataset d3 = new Dataset();
     d2.setDataSetId(3);
-    when(datasetDAO.getActiveDatasets()).thenReturn(List.of(d1, d2));
+    when(datasetDAO.getDatasets()).thenReturn(List.of(d1, d2));
     when(datasetDAO.findDatasetsByAuthUserEmail(any())).thenReturn(List.of(d2, d3));
     initService();
 
@@ -763,7 +759,7 @@ public class DatasetServiceTest {
     assertTrue(datasets.contains(d2));
     assertTrue(datasets.contains(d3));
     verify(datasetDAO, times(0)).findAllDatasets();
-    verify(datasetDAO, times(1)).getActiveDatasets();
+    verify(datasetDAO, times(1)).getDatasets();
     verify(datasetDAO, times(1)).findDatasetsByAuthUserEmail(any());
   }
 
@@ -777,7 +773,7 @@ public class DatasetServiceTest {
     d1.setDataSetId(1);
     Dataset d2 = new Dataset();
     d2.setDataSetId(2);
-    when(datasetDAO.getActiveDatasets()).thenReturn(List.of(d1, d2));
+    when(datasetDAO.getDatasets()).thenReturn(List.of(d1, d2));
     initService();
 
     List<Dataset> datasets = datasetService.findAllDatasetsByUser(user);
@@ -786,7 +782,7 @@ public class DatasetServiceTest {
     assertTrue(datasets.contains(d1));
     assertTrue(datasets.contains(d2));
     verify(datasetDAO, times(0)).findAllDatasets();
-    verify(datasetDAO, times(1)).getActiveDatasets();
+    verify(datasetDAO, times(1)).getDatasets();
     verify(datasetDAO, times(0)).findDatasetsByAuthUserEmail(any());
   }
 


### PR DESCRIPTION
### Addresses
Back end support for https://broadworkbench.atlassian.net/browse/DUOS-2641

### Summary
* Removes the `active` check on filtering datasets for Data Submitters (and other users as well). Visibility of a dataset is no longer dependent on whether an admin marks a dataset as `active` or not. Instead, visibility depends on two factors: the DAC Approval and Public Visibility properties.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
