### PR TITLE
[DUOS-2655][risk=no] Remove create consent for old create dataset code path

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
@@ -153,7 +153,7 @@ public class DatasetResource extends Resource {
     User dacUser = userService.findUserByEmail(authUser.getGenericUser().getEmail());
     Integer userId = dacUser.getUserId();
     try {
-      DatasetDTO createdDatasetWithConsent = datasetService.createDatasetWithConsent(inputDataset,
+      DatasetDTO createdDatasetWithConsent = datasetService.createDatasetFromDatasetDTO(inputDataset,
           name, userId);
       URI uri = info.getRequestUriBuilder().replacePath("api/dataset/{datasetId}")
           .build(createdDatasetWithConsent.getDataSetId());

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -16,7 +16,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.commons.collections4.CollectionUtils;
@@ -26,13 +25,11 @@ import org.broadinstitute.consent.http.db.DataAccessRequestDAO;
 import org.broadinstitute.consent.http.db.DatasetDAO;
 import org.broadinstitute.consent.http.db.StudyDAO;
 import org.broadinstitute.consent.http.db.UserRoleDAO;
-import org.broadinstitute.consent.http.enumeration.AssociationType;
 import org.broadinstitute.consent.http.enumeration.AuditActions;
 import org.broadinstitute.consent.http.enumeration.DataUseTranslationType;
 import org.broadinstitute.consent.http.enumeration.PropertyType;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.ApprovedDataset;
-import org.broadinstitute.consent.http.models.Consent;
 import org.broadinstitute.consent.http.models.Dac;
 import org.broadinstitute.consent.http.models.DataUse;
 import org.broadinstitute.consent.http.models.Dataset;
@@ -147,73 +144,7 @@ public class DatasetService {
     return d;
   }
 
-  /**
-   * Create a minimal consent from the data provided in a Dataset.
-   *
-   * @param dataset The DataSetDTO
-   * @return The created Consent
-   */
-  public Consent createConsentForDataset(DatasetDTO dataset) {
-    String consentId = UUID.randomUUID().toString();
-    Optional<DatasetPropertyDTO> nameProp = dataset.getProperties()
-        .stream()
-        .filter(p -> p.getPropertyName().equalsIgnoreCase(DATASET_NAME_KEY))
-        .findFirst();
-    // Typically, this is a construct from ORSP consisting of dataset name and some form of investigator code.
-    // In our world, we'll use that dataset name if provided, or the alias.
-    String groupName =
-        nameProp.isPresent() ? nameProp.get().getPropertyValue() : dataset.getAlias();
-    String name = CONSENT_NAME_PREFIX + dataset.getDataSetId();
-    Date createDate = new Date();
-    if (Objects.nonNull(dataset.getDataUse())) {
-      boolean manualReview = isConsentDataUseManualReview(dataset.getDataUse());
-      /*
-       * Consents created for a dataset do not need the following properties:
-       * data user letter
-       * data user letter name
-       */
-      consentDAO.useTransaction(h -> {
-        try {
-          h.insertConsent(consentId, manualReview, dataset.getDataUse().toString(), null, name,
-              null, createDate, createDate, groupName);
-          String associationType = AssociationType.SAMPLE_SET.getValue();
-          h.insertConsentAssociation(consentId, associationType, dataset.getDataSetId());
-        } catch (Exception e) {
-          h.rollback();
-          logger.error("Exception creating consent: " + e.getMessage());
-          throw e;
-        }
-      });
-      return consentDAO.findConsentById(consentId);
-    } else {
-      throw new IllegalArgumentException(
-          "Dataset is missing Data Use information. Consent could not be created.");
-    }
-  }
-
-  private boolean isConsentDataUseManualReview(DataUse dataUse) {
-    return Objects.nonNull(dataUse.getOther()) ||
-        (Objects.nonNull(dataUse.getPopulationRestrictions()) && !dataUse
-            .getPopulationRestrictions().isEmpty()) ||
-        (Objects.nonNull(dataUse.getAddiction()) && dataUse.getAddiction()) ||
-        (Objects.nonNull(dataUse.getEthicsApprovalRequired()) && dataUse
-            .getEthicsApprovalRequired()) ||
-        (Objects.nonNull(dataUse.getIllegalBehavior()) && dataUse.getIllegalBehavior()) ||
-        (Objects.nonNull(dataUse.getManualReview()) && dataUse.getManualReview()) ||
-        (Objects.nonNull(dataUse.getOtherRestrictions()) && dataUse.getOtherRestrictions()) ||
-        (Objects.nonNull(dataUse.getPopulationOriginsAncestry()) && dataUse
-            .getPopulationOriginsAncestry()) ||
-        (Objects.nonNull(dataUse.getPsychologicalTraits()) && dataUse
-            .getPsychologicalTraits()) ||
-        (Objects.nonNull(dataUse.getSexualDiseases()) && dataUse.getSexualDiseases()) ||
-        (Objects.nonNull(dataUse.getStigmatizeDiseases()) && dataUse.getStigmatizeDiseases())
-        ||
-        (Objects.nonNull(dataUse.getVulnerablePopulations()) && dataUse
-            .getVulnerablePopulations());
-  }
-
-  public DatasetDTO createDatasetWithConsent(DatasetDTO dataset, String name, Integer userId)
-      throws Exception {
+  public DatasetDTO createDatasetFromDatasetDTO(DatasetDTO dataset, String name, Integer userId) {
     if (Objects.nonNull(getDatasetByName(name))) {
       throw new IllegalArgumentException("Dataset name: " + name + " is already in use");
     }
@@ -235,13 +166,6 @@ public class DatasetService {
       }
     });
     dataset.setDataSetId(createdDatasetId);
-    try {
-      createConsentForDataset(dataset);
-    } catch (Exception e) {
-      logger.error("Exception creating consent for dataset: " + e.getMessage());
-      deleteDataset(createdDatasetId, userId);
-      throw e;
-    }
     return getDatasetDTO(createdDatasetId);
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
@@ -42,7 +42,6 @@ import org.broadinstitute.consent.http.db.StudyDAO;
 import org.broadinstitute.consent.http.enumeration.PropertyType;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.AuthUser;
-import org.broadinstitute.consent.http.models.Consent;
 import org.broadinstitute.consent.http.models.DataUse;
 import org.broadinstitute.consent.http.models.DataUseBuilder;
 import org.broadinstitute.consent.http.models.Dataset;
@@ -144,12 +143,10 @@ public class DatasetResourceTest {
   @Test
   public void testCreateDatasetSuccess() throws Exception {
     DatasetDTO result = createMockDatasetDTO();
-    Consent consent = new Consent();
     String json = createPropertiesJson("Dataset Name", "test");
 
     when(datasetService.getDatasetByName("test")).thenReturn(null);
-    when(datasetService.createDatasetWithConsent(any(), any(), anyInt())).thenReturn(result);
-    when(datasetService.createConsentForDataset(any())).thenReturn(consent);
+    when(datasetService.createDatasetFromDatasetDTO(any(), any(), anyInt())).thenReturn(result);
     when(datasetService.getDatasetDTO(any())).thenReturn(result);
     when(authUser.getGenericUser()).thenReturn(genericUser);
     when(genericUser.getEmail()).thenReturn("email@email.com");
@@ -258,13 +255,11 @@ public class DatasetResourceTest {
 
   @Test
   public void testCreateDatasetError() throws Exception {
-    Consent consent = new Consent();
     String json = createPropertiesJson("Dataset Name", "test");
 
     when(datasetService.getDatasetByName("test")).thenReturn(null);
     doThrow(new RuntimeException()).when(datasetService)
-        .createDatasetWithConsent(any(), any(), anyInt());
-    when(datasetService.createConsentForDataset(any())).thenReturn(consent);
+        .createDatasetFromDatasetDTO(any(), any(), anyInt());
     when(authUser.getGenericUser()).thenReturn(genericUser);
     when(genericUser.getEmail()).thenReturn("email@email.com");
     when(userService.findUserByEmail(any())).thenReturn(user);

--- a/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
@@ -20,9 +20,6 @@ import static org.mockito.Mockito.when;
 
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.NotFoundException;
-import jakarta.ws.rs.core.Response;
-import jakarta.ws.rs.core.Response.Status;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -46,10 +43,7 @@ import org.broadinstitute.consent.http.enumeration.DataUseTranslationType;
 import org.broadinstitute.consent.http.enumeration.PropertyType;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.ApprovedDataset;
-import org.broadinstitute.consent.http.models.Consent;
 import org.broadinstitute.consent.http.models.Dac;
-import org.broadinstitute.consent.http.models.DarCollection;
-import org.broadinstitute.consent.http.models.DataAccessRequest;
 import org.broadinstitute.consent.http.models.DataUse;
 import org.broadinstitute.consent.http.models.DataUseBuilder;
 import org.broadinstitute.consent.http.models.Dataset;
@@ -117,7 +111,7 @@ public class DatasetServiceTest {
         Collections.singleton(test));
     initService();
 
-    DatasetDTO result = datasetService.createDatasetWithConsent(getDatasetDTO(), "Test Dataset 1",
+    DatasetDTO result = datasetService.createDatasetFromDatasetDTO(getDatasetDTO(), "Test Dataset 1",
         1);
 
     assertNotNull(result);
@@ -541,35 +535,6 @@ public class DatasetServiceTest {
     assertNotNull(updated);
     assertTrue(updated.isPresent());
     verify(datasetDAO, times(1)).updateDataset(eq(datasetId), eq(name), any(), any(), any(), any());
-  }
-
-  @Test
-  public void testCreateConsentForDataset() throws IOException {
-    DatasetDTO dataSetDTO = getDatasetDTO();
-    DataUse dataUse = new DataUseBuilder().build();
-    dataSetDTO.setDataUse(dataUse);
-    Consent consent = new Consent();
-    when(consentDAO.findConsentById(anyString())).thenReturn(consent);
-    doNothing().when(consentDAO)
-        .insertConsent(any(), any(), any(), any(), any(), any(), any(), any(), any());
-    doNothing().when(consentDAO).insertConsentAssociation(any(), any(), any());
-    initService();
-
-    Consent result = datasetService.createConsentForDataset(dataSetDTO);
-    assertNotNull(result);
-  }
-
-  @Test
-  public void testCreateConsentForDatasetNullDataUse() {
-    DatasetDTO dataSetDTO = getDatasetDTO();
-    dataSetDTO.setDataUse(null);
-    Consent consent = new Consent();
-    when(consentDAO.findConsentById(anyString())).thenReturn(consent);
-    initService();
-
-    assertThrows(IllegalArgumentException.class, () -> {
-      datasetService.createConsentForDataset(dataSetDTO);
-    });
   }
 
   @Test


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DUOS-2655

### Summary
Remove the create consent part of creating older dataset objects.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
