### PR TITLE
[DUOS-2656][risk=no] Remove consent association for datasets

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/DacDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DacDAO.java
@@ -38,14 +38,15 @@ public interface DacDAO extends Transactional<DacDAO> {
   @RegisterBeanMapper(value = Dac.class)
   @RegisterBeanMapper(value = Dataset.class)
   @UseRowReducer(DacWithDatasetsReducer.class)
-  @SqlQuery(
-      "SELECT dac.dac_id, dac.email, dac.name, dac.description, d.dataset_id, d.name AS dataset_name, DATE(d.create_date) AS dataset_create_date, "
-          + " d.object_id, d.active, d.needs_approval, d.alias AS dataset_alias, d.create_user_id, d.update_date AS dataset_update_date, "
-          + " d.update_user_id, d.data_use AS dataset_data_use, d.sharing_plan_document, d.sharing_plan_document_name, ca.consent_id, c.translated_use_restriction "
-          + " FROM dac "
-          + " LEFT OUTER JOIN dataset d ON dac.dac_id = d.dac_id"
-          + " LEFT OUTER JOIN consent_associations ca ON ca.dataset_id = d.dataset_id "
-          + " LEFT OUTER JOIN consents c ON c.consent_id = ca.consent_id ")
+  @SqlQuery("""
+      SELECT dac.dac_id, dac.email, dac.name, dac.description, d.dataset_id, d.name AS dataset_name,
+        DATE(d.create_date) AS dataset_create_date, d.object_id, d.active, d.needs_approval,
+        d.alias AS dataset_alias, d.create_user_id, d.update_date AS dataset_update_date,
+        d.update_user_id, d.data_use AS dataset_data_use, d.sharing_plan_document,
+        d.sharing_plan_document_name
+      FROM dac
+      LEFT OUTER JOIN dataset d ON dac.dac_id = d.dac_id
+      """)
   List<Dac> findAll();
 
   /**

--- a/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
@@ -93,7 +93,6 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
               u.create_date AS u_create_date, u.email_preference AS u_email_preference,
               u.institution_id AS u_institution_id, u.era_commons_id AS u_era_commons_id,
               k.key, dp.property_value, dp.property_key, dp.property_type, dp.schema_property, dp.property_id,
-              ca.consent_id, c.translated_use_restriction,
               fso.file_storage_object_id AS fso_file_storage_object_id,
               s.study_id AS s_study_id,
               s.name AS s_name,
@@ -127,12 +126,10 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
           LEFT JOIN (SELECT DISTINCT dataset_id AS id FROM dar_dataset) dar_ds_ids ON dar_ds_ids.id = d.dataset_id
           LEFT JOIN dataset_property dp ON dp.dataset_id = d.dataset_id
           LEFT JOIN dictionary k ON k.key_id = dp.property_key
-          LEFT JOIN consent_associations ca ON ca.dataset_id = d.dataset_id
           LEFT JOIN study s ON s.study_id = d.study_id
           LEFT JOIN study_property sp ON sp.study_id = s.study_id
           LEFT JOIN dataset s_dataset ON s_dataset.study_id = s.study_id
           LEFT JOIN file_storage_object fso ON (fso.entity_id = d.dataset_id::text OR fso.entity_id = s.uuid::text) AND fso.deleted = false
-          LEFT JOIN consents c ON c.consent_id = ca.consent_id
           WHERE d.dataset_id = :datasetId
       """)
   Dataset findDatasetById(@Bind("datasetId") Integer datasetId);
@@ -146,7 +143,6 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
               u.create_date AS u_create_date, u.email_preference AS u_email_preference,
               u.institution_id AS u_institution_id, u.era_commons_id AS u_era_commons_id,
               k.key, dp.property_value, dp.property_key, dp.property_type, dp.schema_property, dp.property_id,
-              ca.consent_id, c.translated_use_restriction,
               s.study_id AS s_study_id,
               s.name AS s_name,
               s.description AS s_description,
@@ -180,12 +176,10 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
           LEFT JOIN (SELECT DISTINCT dataset_id AS id FROM dar_dataset) dar_ds_ids ON dar_ds_ids.id = d.dataset_id
           LEFT JOIN dataset_property dp ON dp.dataset_id = d.dataset_id
           LEFT JOIN dictionary k ON k.key_id = dp.property_key
-          LEFT JOIN consent_associations ca ON ca.dataset_id = d.dataset_id
           LEFT JOIN study s ON s.study_id = d.study_id
           LEFT JOIN study_property sp ON sp.study_id = s.study_id
           LEFT JOIN dataset s_dataset ON s_dataset.study_id = s.study_id
           LEFT JOIN file_storage_object fso ON (fso.entity_id = d.dataset_id::text OR fso.entity_id = s.uuid::text) AND fso.deleted = false
-          LEFT JOIN consents c ON c.consent_id = ca.consent_id
           WHERE d.dataset_id in (<datasetIds>)
       """)
   List<Dataset> findDatasetsByIdList(@BindList("datasetIds") List<Integer> datasetIds);
@@ -199,7 +193,6 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
               u.create_date AS u_create_date, u.email_preference AS u_email_preference,
               u.institution_id AS u_institution_id, u.era_commons_id AS u_era_commons_id,
               k.key, dp.property_value, dp.property_key, dp.property_type, dp.schema_property, dp.property_id,
-              ca.consent_id, c.translated_use_restriction,
               s.study_id AS s_study_id,
               s.name AS s_name,
               s.description AS s_description,
@@ -233,12 +226,10 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
           LEFT JOIN (SELECT DISTINCT dataset_id AS id FROM dar_dataset) dar_ds_ids ON dar_ds_ids.id = d.dataset_id
           LEFT JOIN dataset_property dp ON dp.dataset_id = d.dataset_id
           LEFT JOIN dictionary k ON k.key_id = dp.property_key
-          LEFT JOIN consent_associations ca ON ca.dataset_id = d.dataset_id
           LEFT JOIN study s ON s.study_id = d.study_id
           LEFT JOIN study_property sp ON sp.study_id = s.study_id
           LEFT JOIN dataset s_dataset ON s_dataset.study_id = s.study_id
           LEFT JOIN file_storage_object fso ON (fso.entity_id = d.dataset_id::text OR fso.entity_id = s.uuid::text) AND fso.deleted = false
-          LEFT JOIN consents c ON c.consent_id = ca.consent_id
       """)
   List<Dataset> findAllDatasets();
 
@@ -297,7 +288,6 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
               u.create_date AS u_create_date, u.email_preference AS u_email_preference,
               u.institution_id AS u_institution_id, u.era_commons_id AS u_era_commons_id,
               k.key, dp.property_value, dp.property_key, dp.property_type, dp.schema_property, dp.property_id,
-              ca.consent_id, c.translated_use_restriction,
               s.study_id AS s_study_id,
               s.name AS s_name,
               s.description AS s_description,
@@ -331,12 +321,10 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
           LEFT JOIN (SELECT DISTINCT dataset_id AS id FROM dar_dataset) dar_ds_ids ON dar_ds_ids.id = d.dataset_id
           LEFT JOIN dataset_property dp ON dp.dataset_id = d.dataset_id
           LEFT JOIN dictionary k ON k.key_id = dp.property_key
-          LEFT JOIN consent_associations ca ON ca.dataset_id = d.dataset_id
           LEFT JOIN study s ON s.study_id = d.study_id
           LEFT JOIN study_property sp ON sp.study_id = s.study_id
           LEFT JOIN dataset s_dataset ON s_dataset.study_id = s.study_id
           LEFT JOIN file_storage_object fso ON (fso.entity_id = d.dataset_id::text OR fso.entity_id = s.uuid::text) AND fso.deleted = false
-          LEFT JOIN consents c ON c.consent_id = ca.consent_id
           INNER JOIN user_role dac_role ON dac_role.dac_id = d.dac_id
           INNER JOIN users dac_user ON dac_role.user_id = dac_user.user_id AND dac_user.email = :email
       """)
@@ -357,7 +345,6 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
               u.create_date AS u_create_date, u.email_preference AS u_email_preference,
               u.institution_id AS u_institution_id, u.era_commons_id AS u_era_commons_id,
               k.key, dp.property_value, dp.property_key, dp.property_type, dp.schema_property, dp.property_id,
-              ca.consent_id, c.translated_use_restriction,
               s.study_id AS s_study_id,
               s.name AS s_name,
               s.description AS s_description,
@@ -391,12 +378,10 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
           LEFT JOIN (SELECT DISTINCT dataset_id AS id FROM dar_dataset) dar_ds_ids ON dar_ds_ids.id = d.dataset_id
           LEFT JOIN dataset_property dp ON dp.dataset_id = d.dataset_id
           LEFT JOIN dictionary k ON k.key_id = dp.property_key
-          LEFT JOIN consent_associations ca ON ca.dataset_id = d.dataset_id
           LEFT JOIN study s ON s.study_id = d.study_id
           LEFT JOIN study_property sp ON sp.study_id = s.study_id
           LEFT JOIN dataset s_dataset ON s_dataset.study_id = s.study_id
           LEFT JOIN file_storage_object fso ON (fso.entity_id = d.dataset_id::text OR fso.entity_id = s.uuid::text) AND fso.deleted = false
-          LEFT JOIN consents c ON c.consent_id = ca.consent_id
           WHERE d.dac_id = :dacId
           OR (dp.schema_property = 'dataAccessCommitteeId' AND dp.property_value = :dacId::text)
       """)
@@ -411,7 +396,6 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
               u.create_date AS u_create_date, u.email_preference AS u_email_preference,
               u.institution_id AS u_institution_id, u.era_commons_id AS u_era_commons_id,
               k.key, dp.property_value, dp.property_key, dp.property_type, dp.schema_property, dp.property_id,
-              ca.consent_id, c.translated_use_restriction,
               s.study_id AS s_study_id,
               s.name AS s_name,
               s.description AS s_description,
@@ -445,12 +429,10 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
           LEFT JOIN (SELECT DISTINCT dataset_id AS id FROM dar_dataset) dar_ds_ids ON dar_ds_ids.id = d.dataset_id
           LEFT JOIN dataset_property dp ON dp.dataset_id = d.dataset_id
           LEFT JOIN dictionary k ON k.key_id = dp.property_key
-          LEFT JOIN consent_associations ca ON ca.dataset_id = d.dataset_id
           LEFT JOIN study s ON s.study_id = d.study_id
           LEFT JOIN study_property sp ON sp.study_id = s.study_id
           LEFT JOIN dataset s_dataset ON s_dataset.study_id = s.study_id
           LEFT JOIN file_storage_object fso ON (fso.entity_id = d.dataset_id::text OR fso.entity_id = s.uuid::text) AND fso.deleted = false
-          LEFT JOIN consents c ON c.consent_id = ca.consent_id
           WHERE d.name IS NOT NULL
       """)
   List<Dataset> getDatasets();
@@ -472,7 +454,6 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
               u.create_date AS u_create_date, u.email_preference AS u_email_preference,
               u.institution_id AS u_institution_id, u.era_commons_id AS u_era_commons_id,
               k.key, dp.property_value, dp.property_key, dp.property_type, dp.schema_property, dp.property_id,
-              ca.consent_id, c.translated_use_restriction,
               s.study_id AS s_study_id,
               s.name AS s_name,
               s.description AS s_description,
@@ -506,12 +487,10 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
           LEFT JOIN (SELECT DISTINCT dataset_id AS id FROM dar_dataset) dar_ds_ids ON dar_ds_ids.id = d.dataset_id
           LEFT JOIN dataset_property dp ON dp.dataset_id = d.dataset_id
           LEFT JOIN dictionary k ON k.key_id = dp.property_key
-          LEFT JOIN consent_associations ca ON ca.dataset_id = d.dataset_id
           LEFT JOIN study s ON s.study_id = d.study_id
           LEFT JOIN study_property sp ON sp.study_id = s.study_id
           LEFT JOIN dataset s_dataset ON s_dataset.study_id = s.study_id
           LEFT JOIN file_storage_object fso ON (fso.entity_id = d.dataset_id::text OR fso.entity_id = s.uuid::text) AND fso.deleted = false
-          LEFT JOIN consents c ON c.consent_id = ca.consent_id
           WHERE d.alias = :alias
       """)
   Dataset findDatasetByAlias(@Bind("alias") Integer alias);
@@ -519,7 +498,7 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
   @UseRowReducer(DatasetReducer.class)
   @SqlQuery(
       """
-          SELECT d.*, k.key, dp.property_value, dp.property_key, dp.property_id, ca.consent_id, d.dac_id, c.translated_use_restriction, dar_ds_ids.id as in_use,
+          SELECT d.*, k.key, dp.property_value, dp.property_key, dp.property_id, d.dac_id, dar_ds_ids.id as in_use,
               s.study_id AS s_study_id,
               s.name AS s_name,
               s.description AS s_description,
@@ -543,12 +522,10 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
                    LEFT JOIN (SELECT DISTINCT dataset_id AS id FROM dar_dataset) dar_ds_ids ON dar_ds_ids.id = d.dataset_id
                    LEFT JOIN dataset_property dp ON dp.dataset_id = d.dataset_id
                    LEFT JOIN dictionary k ON k.key_id = dp.property_key
-                   LEFT JOIN consent_associations ca ON ca.dataset_id = d.dataset_id
                    LEFT JOIN study s ON s.study_id = d.study_id
                    LEFT JOIN study_property sp ON sp.study_id = s.study_id
                    LEFT JOIN dataset s_dataset ON s_dataset.study_id = s.study_id
                    LEFT JOIN file_storage_object fso ON (fso.entity_id = d.dataset_id::text OR fso.entity_id = s.uuid::text) AND fso.deleted = false
-                   LEFT JOIN consents c ON c.consent_id = ca.consent_id
                    WHERE d.alias IN (<aliases>)
               """)
   List<Dataset> findDatasetsByAlias(@BindList("aliases") List<Integer> aliases);
@@ -651,7 +628,7 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
   @UseRowReducer(DatasetReducer.class)
   @SqlQuery(
       """
-          SELECT d.*, k.key, dp.property_value, dp.property_key, dp.property_type, dp.schema_property, dp.property_id, ca.consent_id, d.dac_id, c.translated_use_restriction, dar_ds_ids.id as in_use,
+          SELECT d.*, k.key, dp.property_value, dp.property_key, dp.property_type, dp.schema_property, dp.property_id, d.dac_id, dar_ds_ids.id as in_use,
               s.study_id AS s_study_id,
               s.name AS s_name,
               s.description AS s_description,
@@ -675,12 +652,10 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
                   LEFT JOIN (SELECT DISTINCT dataset_id AS id FROM dar_dataset) dar_ds_ids ON dar_ds_ids.id = d.dataset_id
                   LEFT JOIN dataset_property dp ON dp.dataset_id = d.dataset_id
                   LEFT JOIN dictionary k ON k.key_id = dp.property_key
-                  LEFT JOIN consent_associations ca ON ca.dataset_id = d.dataset_id
                   LEFT JOIN study s ON s.study_id = d.study_id
                   LEFT JOIN study_property sp ON sp.study_id = s.study_id
                   LEFT JOIN dataset s_dataset ON s_dataset.study_id = s.study_id
                   LEFT JOIN file_storage_object fso ON (fso.entity_id = d.dataset_id::text OR fso.entity_id = s.uuid::text) AND fso.deleted = false
-                  LEFT JOIN consents c ON c.consent_id = ca.consent_id
                   WHERE d.dataset_id IN (<datasetIds>)
                   ORDER BY d.dataset_id, k.display_order
               """)
@@ -688,28 +663,25 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
 
   @Deprecated
   @UseRowMapper(DatasetDTOWithPropertiesMapper.class)
-  @SqlQuery(
-      "SELECT d.*, k.key, dp.property_value, ca.consent_id, d.dac_id, c.translated_use_restriction "
-          + " FROM dataset d "
-          + " LEFT OUTER JOIN dataset_property dp ON dp.dataset_id = d.dataset_id "
-          + " LEFT OUTER JOIN dictionary k ON k.key_id = dp.property_key "
-          + " INNER JOIN consent_associations ca ON ca.dataset_id = d.dataset_id "
-          + " INNER JOIN consents c ON c.consent_id = ca.consent_id "
-          + " INNER JOIN user_role ur ON ur.dac_id = d.dac_id "
-          + " WHERE ur.user_id = :userId "
-          + " AND d.name IS NOT NULL "
-          + " ORDER BY d.dataset_id ")
+  @SqlQuery("""
+      SELECT d.*, k.key, dp.property_value, d.dac_id
+      FROM dataset d
+      LEFT OUTER JOIN dataset_property dp ON dp.dataset_id = d.dataset_id
+      LEFT OUTER JOIN dictionary k ON k.key_id = dp.property_key
+      INNER JOIN user_role ur ON ur.dac_id = d.dac_id
+      WHERE ur.user_id = :userId
+      AND d.name IS NOT NULL
+      ORDER BY d.dataset_id
+      """)
   Set<DatasetDTO> findDatasetDTOsByUserId(@Bind("userId") Integer userId);
 
   @Deprecated
   @UseRowMapper(DatasetDTOWithPropertiesMapper.class)
   @SqlQuery("""
-      SELECT d.*, k.key, dp.property_value, ca.consent_id, d.dac_id, c.translated_use_restriction
+      SELECT d.*, k.key, dp.property_value, d.dac_id
       FROM dataset d
       LEFT OUTER JOIN dataset_property dp ON dp.dataset_id = d.dataset_id
       LEFT OUTER JOIN dictionary k ON k.key_id = dp.property_key
-      LEFT OUTER JOIN consent_associations ca ON ca.dataset_id = d.dataset_id
-      LEFT OUTER JOIN consents c ON c.consent_id = ca.consent_id
       WHERE d.name IS NOT NULL
       ORDER BY d.dataset_id
       """)
@@ -717,27 +689,24 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
 
   @Deprecated
   @UseRowMapper(DatasetDTOWithPropertiesMapper.class)
-  @SqlQuery(
-      "SELECT d.*, k.key, dp.property_value, ca.consent_id, d.dac_id, c.translated_use_restriction "
-          + " FROM dataset d "
-          + " LEFT OUTER JOIN dataset_property dp ON dp.dataset_id = d.dataset_id "
-          + " LEFT OUTER JOIN dictionary k ON k.key_id = dp.property_key "
-          + " LEFT OUTER JOIN consent_associations ca ON ca.dataset_id = d.dataset_id "
-          + " LEFT OUTER JOIN consents c ON c.consent_id = ca.consent_id "
-          + " ORDER BY d.dataset_id ")
+  @SqlQuery("""
+      SELECT d.*, k.key, dp.property_value, d.dac_id
+      FROM dataset d
+      LEFT OUTER JOIN dataset_property dp ON dp.dataset_id = d.dataset_id
+      LEFT OUTER JOIN dictionary k ON k.key_id = dp.property_key
+      ORDER BY d.dataset_id
+      """)
   Set<DatasetDTO> findAllDatasetDTOs();
 
   @Deprecated
   @UseRowMapper(DatasetDTOWithPropertiesMapper.class)
-  @SqlQuery(
-      "SELECT d.*, k.key, dp.property_value, ca.consent_id, d.dac_id, c.translated_use_restriction "
-          +
-          "FROM dataset d " +
-          "LEFT OUTER JOIN dataset_property dp ON dp.dataset_id = d.dataset_id " +
-          "LEFT OUTER JOIN dictionary k ON k.key_id = dp.property_key " +
-          "LEFT OUTER JOIN consent_associations ca ON ca.dataset_id = d.dataset_id " +
-          "LEFT OUTER JOIN consents c ON c.consent_id = ca.consent_id " +
-          "WHERE d.dataset_id = :datasetId ORDER BY d.dataset_id, k.display_order")
+  @SqlQuery("""
+      SELECT d.*, k.key, dp.property_value, d.dac_id
+      FROM dataset d
+      LEFT OUTER JOIN dataset_property dp ON dp.dataset_id = d.dataset_id
+      LEFT OUTER JOIN dictionary k ON k.key_id = dp.property_key
+      WHERE d.dataset_id = :datasetId ORDER BY d.dataset_id, k.display_order
+      """)
   Set<DatasetDTO> findDatasetDTOWithPropertiesByDatasetId(@Bind("datasetId") Integer datasetId);
 
   @UseRowMapper(DatasetPropertyMapper.class)
@@ -749,14 +718,13 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
 
   @Deprecated
   @UseRowMapper(DatasetDTOWithPropertiesMapper.class)
-  @SqlQuery(
-      "SELECT d.*, k.key, dp.property_value, ca.consent_id, d.dac_id, c.translated_use_restriction "
-          +
-          " FROM dataset d INNER JOIN dataset_property dp ON dp.dataset_id = d.dataset_id " +
-          " INNER JOIN dictionary k ON k.key_id = dp.property_key " +
-          " INNER JOIN consent_associations ca ON ca.dataset_id = d.dataset_id " +
-          " INNER JOIN consents c ON c.consent_id = ca.consent_id " +
-          " WHERE d.dataset_id IN (<dataSetIdList>) ORDER BY d.dataset_id, k.receive_order ")
+  @SqlQuery("""
+      SELECT d.*, k.key, dp.property_value, d.dac_id
+      FROM dataset d
+      LEFT OUTER JOIN dataset_property dp ON dp.dataset_id = d.dataset_id
+      LEFT OUTER JOIN dictionary k ON k.key_id = dp.property_key
+      WHERE d.dataset_id IN (<dataSetIdList>) ORDER BY d.dataset_id, k.receive_order
+      """)
   Set<DatasetDTO> findDatasetsByReceiveOrder(
       @BindList("dataSetIdList") List<Integer> dataSetIdList);
 
@@ -805,25 +773,22 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
    */
   @Deprecated
   @UseRowMapper(DatasetDTOWithPropertiesMapper.class)
-  @SqlQuery(
-      "SELECT d.*, k.key, p.property_value, c.consent_id, d.dac_id, c.translated_use_restriction " +
-          " FROM dataset d " +
-          " LEFT OUTER JOIN dataset_property p ON p.dataset_id = d.dataset_id " +
-          " LEFT OUTER JOIN dictionary k ON k.key_id = p.property_key " +
-          " INNER JOIN consent_associations a ON a.dataset_id = d.dataset_id " +
-          " INNER JOIN consents c ON c.consent_id = a.consent_id " +
-          " WHERE d.dac_id IN (<dacIds>) ")
+  @SqlQuery("""
+      SELECT d.*, k.key, p.property_value, d.dac_id
+      FROM dataset d
+      LEFT OUTER JOIN dataset_property p ON p.dataset_id = d.dataset_id
+      LEFT OUTER JOIN dictionary k ON k.key_id = p.property_key
+      WHERE d.dac_id IN (<dacIds>)
+      """)
   Set<DatasetDTO> findDatasetsByDacIds(@BindList("dacIds") List<Integer> dacIds);
 
   @UseRowReducer(DatasetReducer.class)
   @SqlQuery("""
-          SELECT distinct d.*, k.key, p.property_value, c.consent_id, d.dac_id, c.translated_use_restriction
-          FROM dataset d
-          LEFT JOIN dataset_property p ON p.dataset_id = d.dataset_id
-          LEFT JOIN dictionary k ON k.key_id = p.property_key
-          LEFT JOIN consent_associations a ON a.dataset_id = d.dataset_id
-          LEFT JOIN consents c ON c.consent_id = a.consent_id
-          WHERE d.dac_id IN (<dacIds>)
+      SELECT distinct d.*, k.key, p.property_value, d.dac_id
+      FROM dataset d
+      LEFT JOIN dataset_property p ON p.dataset_id = d.dataset_id
+      LEFT JOIN dictionary k ON k.key_id = p.property_key
+      WHERE d.dac_id IN (<dacIds>)
       """)
   List<Dataset> findDatasetListByDacIds(@BindList("dacIds") List<Integer> dacIds);
 
@@ -835,14 +800,13 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
    */
   @Deprecated
   @UseRowMapper(DatasetDTOWithPropertiesMapper.class)
-  @SqlQuery(
-      "SELECT d.*, k.key, p.property_value, c.consent_id, d.dac_id, c.translated_use_restriction " +
-          " FROM dataset d " +
-          " LEFT OUTER JOIN dataset_property p ON p.dataset_id = d.dataset_id " +
-          " LEFT OUTER JOIN dictionary k ON k.key_id = p.property_key " +
-          " INNER JOIN consent_associations a ON a.dataset_id = d.dataset_id " +
-          " INNER JOIN consents c ON c.consent_id = a.consent_id " +
-          " WHERE d.dac_id IS NOT NULL ")
+  @SqlQuery("""
+      SELECT distinct d.*, k.key, p.property_value, d.dac_id
+      FROM dataset d
+      LEFT JOIN dataset_property p ON p.dataset_id = d.dataset_id
+      LEFT JOIN dictionary k ON k.key_id = p.property_key
+      WHERE d.dac_id IS NOT NULL
+      """)
   Set<DatasetDTO> findDatasetsWithDacs();
 
   @SqlUpdate(

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DatasetDTOWithPropertiesMapper.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DatasetDTOWithPropertiesMapper.java
@@ -21,7 +21,6 @@ public class DatasetDTOWithPropertiesMapper implements RowMapper<DatasetDTO>, Ro
 
     DatasetDTO datasetDTO;
     Integer dataSetId = r.getInt("dataset_id");
-    String consentId = r.getString("consent_id");
     Integer alias = r.getInt("alias");
     if (!datasetDTOs.containsKey(dataSetId)) {
       datasetDTO = new DatasetDTO(new ArrayList<>());
@@ -31,7 +30,6 @@ public class DatasetDTOWithPropertiesMapper implements RowMapper<DatasetDTO>, Ro
           datasetDTO.setDacId(dacId);
         }
       }
-      datasetDTO.setConsentId(consentId);
       datasetDTO.setAlias(alias);
       datasetDTO.setDataSetId(dataSetId);
       datasetDTO.setActive(r.getBoolean("active"));

--- a/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
@@ -54,15 +54,11 @@ class DatasetDAOTest extends DAOTestHelper {
   void testFindDatasetByIdWithDacAndConsent() {
     Dataset dataset = insertDataset();
     Dac dac = insertDac();
-    Consent consent = insertConsent();
     datasetDAO.updateDatasetDacId(dataset.getDataSetId(), dac.getDacId());
-    consentDAO.insertConsentAssociation(consent.getConsentId(), ASSOCIATION_TYPE_TEST,
-        dataset.getDataSetId());
 
     Dataset foundDataset = datasetDAO.findDatasetById(dataset.getDataSetId());
     assertNotNull(foundDataset);
     assertEquals(dac.getDacId(), foundDataset.getDacId());
-    assertEquals(consent.getConsentId(), foundDataset.getConsentId());
     assertFalse(foundDataset.getProperties().isEmpty());
     assertTrue(foundDataset.getDeletable());
     assertNotNull(foundDataset.getCreateUser());
@@ -580,16 +576,12 @@ class DatasetDAOTest extends DAOTestHelper {
   void testFindDatasetsByIdList() {
     Dataset dataset = insertDataset();
     Dac dac = insertDac();
-    Consent consent = insertConsent();
     datasetDAO.updateDatasetDacId(dataset.getDataSetId(), dac.getDacId());
-    consentDAO.insertConsentAssociation(consent.getConsentId(), ASSOCIATION_TYPE_TEST,
-        dataset.getDataSetId());
 
     List<Dataset> datasets = datasetDAO.findDatasetsByIdList(List.of(dataset.getDataSetId()));
     assertFalse(datasets.isEmpty());
     assertEquals(1, datasets.size());
     assertEquals(dac.getDacId(), datasets.get(0).getDacId());
-    assertEquals(consent.getConsentId(), datasets.get(0).getConsentId());
     assertFalse(datasets.get(0).getProperties().isEmpty());
     assertNotNull(datasets.get(0).getCreateUser());
   }
@@ -599,10 +591,7 @@ class DatasetDAOTest extends DAOTestHelper {
   void testFindDataSetsByAuthUserEmail() {
     Dataset dataset = insertDataset();
     Dac dac = insertDac();
-    Consent consent = insertConsent();
     datasetDAO.updateDatasetDacId(dataset.getDataSetId(), dac.getDacId());
-    consentDAO.insertConsentAssociation(consent.getConsentId(), ASSOCIATION_TYPE_TEST,
-        dataset.getDataSetId());
     User user = createUser();
     createUserRole(UserRoles.CHAIRPERSON.getRoleId(), user.getUserId(), dac.getDacId());
 
@@ -847,9 +836,6 @@ class DatasetDAOTest extends DAOTestHelper {
   void testFindAllDatasets() {
     List<Dataset> datasetList = IntStream.range(1, 5).mapToObj(i -> {
       Dataset dataset = insertDataset();
-      Consent consent = insertConsent();
-      consentDAO.insertConsentAssociation(consent.getConsentId(), ASSOCIATION_TYPE_TEST,
-          dataset.getDataSetId());
       return dataset;
     }).toList();
 
@@ -865,9 +851,6 @@ class DatasetDAOTest extends DAOTestHelper {
   @Test
   void testFindAllDatasetDTOs() {
     Dataset dataset = insertDataset();
-    Consent consent = insertConsent();
-    consentDAO.insertConsentAssociation(consent.getConsentId(), ASSOCIATION_TYPE_TEST,
-        dataset.getDataSetId());
 
     Set<DatasetDTO> datasets = datasetDAO.findAllDatasetDTOs();
     assertFalse(datasets.isEmpty());
@@ -878,10 +861,6 @@ class DatasetDAOTest extends DAOTestHelper {
   @Test
   void testFindActiveDatasets() {
     Dataset dataset = insertDataset();
-    Consent consent = insertConsent();
-
-    consentDAO.insertConsentAssociation(consent.getConsentId(), ASSOCIATION_TYPE_TEST,
-        dataset.getDataSetId());
 
     Set<DatasetDTO> datasets = datasetDAO.getDatasetDTOs();
     assertFalse(datasets.isEmpty());
@@ -930,10 +909,7 @@ class DatasetDAOTest extends DAOTestHelper {
   void testFindDatasetsByUser() {
     Dataset dataset = insertDataset();
     Dac dac = insertDac();
-    Consent consent = insertConsent();
     datasetDAO.updateDatasetDacId(dataset.getDataSetId(), dac.getDacId());
-    consentDAO.insertConsentAssociation(consent.getConsentId(), ASSOCIATION_TYPE_TEST,
-        dataset.getDataSetId());
     User user = createUser();
     createUserRole(UserRoles.CHAIRPERSON.getRoleId(), user.getUserId(), dac.getDacId());
 
@@ -998,10 +974,7 @@ class DatasetDAOTest extends DAOTestHelper {
   void testFindDatasetWithDataUseByIdList() {
     Dataset dataset = insertDataset();
     Dac dac = insertDac();
-    Consent consent = insertConsent();
     datasetDAO.updateDatasetDacId(dataset.getDataSetId(), dac.getDacId());
-    consentDAO.insertConsentAssociation(consent.getConsentId(), ASSOCIATION_TYPE_TEST,
-        dataset.getDataSetId());
 
     Set<Dataset> datasets = datasetDAO.findDatasetWithDataUseByIdList(
         Collections.singletonList(dataset.getDataSetId()));


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DUOS-2656

### Summary
The original need for joining datasets with consents was for the translated use restriction property. That is no longer necessary since we have a data use translation as a top level field on dataset. This PR removes the unnecessary joins when populating datasets.


----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
