### PR TITLE
[DUOS-2641][risk=no] Bug fix and new fields for dataset index terms

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
@@ -442,6 +442,7 @@ public class ConsentModule extends AbstractModule {
     return new ElasticSearchService(
         ElasticSearchSupport.createRestClient(config.getElasticSearchConfiguration()),
         config.getElasticSearchConfiguration(),
+        providesDacDAO(),
         providesDataAccessRequestDAO(),
         providesUserDAO(),
         providesOntologyService()

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DatasetReducer.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DatasetReducer.java
@@ -29,6 +29,9 @@ public class DatasetReducer implements LinkedHashMapRowReducer<Integer, Dataset>
       dataset.setDataUse(
           DataUse.parseDataUse(rowView.getColumn("data_use", String.class)).orElse(null));
     }
+    if (hasColumn(rowView, "translated_data_use", String.class)) {
+      dataset.setTranslatedDataUse(rowView.getColumn("translated_data_use", String.class));
+    }
     if (hasColumn(rowView, "in_use", Integer.class)) {
       Integer dsIdInUse = rowView.getColumn("in_use", Integer.class);
       dataset.setDeletable(Objects.isNull(dsIdInUse));

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DatasetReducer.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DatasetReducer.java
@@ -29,9 +29,8 @@ public class DatasetReducer implements LinkedHashMapRowReducer<Integer, Dataset>
       dataset.setDataUse(
           DataUse.parseDataUse(rowView.getColumn("data_use", String.class)).orElse(null));
     }
-    if (hasColumn(rowView, "translated_data_use", String.class)) {
-      dataset.setTranslatedDataUse(rowView.getColumn("translated_data_use", String.class));
-    }
+    hasOptionalColumn(rowView, "translated_data_use", String.class)
+      .ifPresent(dataset::setTranslatedDataUse);
     if (hasColumn(rowView, "in_use", Integer.class)) {
       Integer dsIdInUse = rowView.getColumn("in_use", Integer.class);
       dataset.setDeletable(Objects.isNull(dsIdInUse));

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/RowMapperHelper.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/RowMapperHelper.java
@@ -5,6 +5,7 @@ import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.util.Objects;
+import java.util.Optional;
 import org.apache.commons.text.StringEscapeUtils;
 import org.broadinstitute.consent.http.models.DataAccessRequestData;
 import org.jdbi.v3.core.result.RowView;
@@ -31,6 +32,23 @@ public interface RowMapperHelper {
     } catch (Exception e) {
       log.debug("RowView does not contain column " + columnName);
       return false;
+    }
+  }
+
+  /*
+   * Utility method to check if a column exists in the row view or not.
+   *
+   * @param rowView The RowView
+   * @param columnName The column name
+   * @param clazz The class that corresponds to the column
+   * @return Optional of requested class if the column is in the results, empty otherwise
+   */
+  default <T> Optional<T> hasOptionalColumn(RowView rowView, String columnName, Class<T> clazz) {
+    try {
+      return Optional.of(rowView.getColumn(columnName, clazz));
+    } catch (Exception e) {
+      log.debug(String.format("RowView does not contain column %s", columnName));
+      return Optional.empty();
     }
   }
 

--- a/src/main/java/org/broadinstitute/consent/http/models/elastic_search/DatasetTerm.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/elastic_search/DatasetTerm.java
@@ -14,6 +14,7 @@ public class DatasetTerm {
   private String url;
   private Integer dacId;
   private String dacName;
+  private Boolean dacApproval;
   private Boolean openAccess;
   private List<Integer> approvedUserIds;
   private StudyTerm study;
@@ -90,6 +91,14 @@ public class DatasetTerm {
 
   public void setDacName(String dacName) {
     this.dacName = dacName;
+  }
+
+  public Boolean getDacApproval() {
+    return dacApproval;
+  }
+
+  public void setDacApproval(Boolean dacApproval) {
+    this.dacApproval = dacApproval;
   }
 
   public Boolean getOpenAccess() {

--- a/src/main/java/org/broadinstitute/consent/http/models/elastic_search/DatasetTerm.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/elastic_search/DatasetTerm.java
@@ -7,6 +7,7 @@ public class DatasetTerm {
 
   private Integer datasetId;
   private Integer createUserId;
+  private String createUserDisplayName;
   private String datasetIdentifier;
   private String datasetName;
   private Integer participantCount;
@@ -34,6 +35,14 @@ public class DatasetTerm {
 
   public void setCreateUserId(Integer createUserId) {
     this.createUserId = createUserId;
+  }
+
+  public String getCreateUserDisplayName() {
+    return createUserDisplayName;
+  }
+
+  public void setCreateUserDisplayName(String createUserDisplayName) {
+    this.createUserDisplayName = createUserDisplayName;
   }
 
   public String getDatasetIdentifier() {

--- a/src/main/java/org/broadinstitute/consent/http/models/elastic_search/DatasetTerm.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/elastic_search/DatasetTerm.java
@@ -8,6 +8,7 @@ public class DatasetTerm {
   private Integer datasetId;
   private Integer createUserId;
   private String datasetIdentifier;
+  private String datasetName;
   private Integer participantCount;
   private DataUseSummary dataUse;
   private String dataLocation;
@@ -43,6 +44,13 @@ public class DatasetTerm {
     this.datasetIdentifier = datasetIdentifier;
   }
 
+  public String getDatasetName() {
+    return datasetName;
+  }
+
+  public void setDatasetName(String datasetName) {
+    this.datasetName = datasetName;
+  }
 
   public Integer getParticipantCount() {
     return participantCount;

--- a/src/main/java/org/broadinstitute/consent/http/models/elastic_search/DatasetTerm.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/elastic_search/DatasetTerm.java
@@ -6,12 +6,14 @@ import org.broadinstitute.consent.http.models.ontology.DataUseSummary;
 public class DatasetTerm {
 
   private Integer datasetId;
+  private Integer createUserId;
   private String datasetIdentifier;
   private Integer participantCount;
   private DataUseSummary dataUse;
   private String dataLocation;
   private String url;
   private Integer dacId;
+  private String dacName;
   private Boolean openAccess;
   private List<Integer> approvedUserIds;
   private StudyTerm study;
@@ -22,6 +24,14 @@ public class DatasetTerm {
 
   public void setDatasetId(Integer datasetId) {
     this.datasetId = datasetId;
+  }
+
+  public Integer getCreateUserId() {
+    return createUserId;
+  }
+
+  public void setCreateUserId(Integer createUserId) {
+    this.createUserId = createUserId;
   }
 
   public String getDatasetIdentifier() {
@@ -72,6 +82,14 @@ public class DatasetTerm {
 
   public void setDacId(Integer dacId) {
     this.dacId = dacId;
+  }
+
+  public String getDacName() {
+    return dacName;
+  }
+
+  public void setDacName(String dacName) {
+    this.dacName = dacName;
   }
 
   public Boolean getOpenAccess() {

--- a/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
@@ -210,7 +210,11 @@ public class ElasticSearchService implements ConsentLogger {
     DatasetTerm term = new DatasetTerm();
 
     term.setDatasetId(dataset.getDataSetId());
-    term.setCreateUserId(dataset.getCreateUserId());
+    if (Objects.nonNull(dataset.getCreateUserId())) {
+      User user = userDAO.findUserById(dataset.getCreateUserId());
+      term.setCreateUserId(dataset.getCreateUserId());
+      term.setCreateUserDisplayName(user.getDisplayName());
+    }
     term.setDatasetIdentifier(dataset.getDatasetIdentifier());
     term.setDatasetName(dataset.getName());
 

--- a/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
@@ -212,6 +212,7 @@ public class ElasticSearchService implements ConsentLogger {
     term.setDatasetId(dataset.getDataSetId());
     term.setCreateUserId(dataset.getCreateUserId());
     term.setDatasetIdentifier(dataset.getDatasetIdentifier());
+    term.setDatasetName(dataset.getName());
 
     if (Objects.nonNull(dataset.getStudy())) {
       term.setStudy(toStudyTerm(dataset.getStudy()));

--- a/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
@@ -210,11 +210,11 @@ public class ElasticSearchService implements ConsentLogger {
     DatasetTerm term = new DatasetTerm();
 
     term.setDatasetId(dataset.getDataSetId());
-    if (Objects.nonNull(dataset.getCreateUserId())) {
+    Optional.ofNullable(dataset.getCreateUserId()).ifPresent(userId -> {
       User user = userDAO.findUserById(dataset.getCreateUserId());
       term.setCreateUserId(dataset.getCreateUserId());
       term.setCreateUserDisplayName(user.getDisplayName());
-    }
+    });
     term.setDatasetIdentifier(dataset.getDatasetIdentifier());
     term.setDatasetName(dataset.getName());
 
@@ -222,14 +222,14 @@ public class ElasticSearchService implements ConsentLogger {
       term.setStudy(toStudyTerm(dataset.getStudy()));
     }
 
-    if (Objects.nonNull(dataset.getDacId())) {
+    Optional.ofNullable(dataset.getDacId()).ifPresent(dacId -> {
       Dac dac = dacDAO.findById(dataset.getDacId());
       term.setDacId(dataset.getDacId());
       term.setDacName(dac.getName());
       if (Objects.nonNull(dataset.getDacApproval())) {
         term.setDacApproval(dataset.getDacApproval());
       }
-    }
+    });
 
     List<Integer> approvedUserIds =
         dataAccessRequestDAO.findAllUserIdsWithApprovedDARsByDatasetId(

--- a/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
@@ -221,6 +221,9 @@ public class ElasticSearchService implements ConsentLogger {
       Dac dac = dacDAO.findById(dataset.getDacId());
       term.setDacId(dataset.getDacId());
       term.setDacName(dac.getName());
+      if (Objects.nonNull(dataset.getDacApproval())) {
+        term.setDacApproval(dataset.getDacApproval());
+      }
     }
 
     List<Integer> approvedUserIds =

--- a/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
@@ -101,6 +101,7 @@ public class ElasticSearchServiceTest {
     dataset.setDataSetId(100);
     dataset.setAlias(10);
     dataset.setDatasetIdentifier();
+    dataset.setName(RandomStringUtils.randomAlphabetic(10));
     dataset.setDacId(1);
     dataset.setDataUse(new DataUse());
 

--- a/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
@@ -24,6 +24,7 @@ import org.apache.http.entity.ContentType;
 import org.apache.http.message.BasicStatusLine;
 import org.apache.http.nio.entity.NStringEntity;
 import org.broadinstitute.consent.http.configurations.ElasticSearchConfiguration;
+import org.broadinstitute.consent.http.db.DacDAO;
 import org.broadinstitute.consent.http.db.DataAccessRequestDAO;
 import org.broadinstitute.consent.http.db.UserDAO;
 import org.broadinstitute.consent.http.enumeration.PropertyType;
@@ -59,6 +60,9 @@ public class ElasticSearchServiceTest {
   private ElasticSearchConfiguration esConfig;
 
   @Mock
+  private DacDAO dacDAO;
+
+  @Mock
   private DataAccessRequestDAO dataAccessRequestDAO;
 
   @Mock
@@ -73,6 +77,7 @@ public class ElasticSearchServiceTest {
     service = new ElasticSearchService(
         esClient,
         esConfig,
+        dacDAO,
         dataAccessRequestDAO,
         userDao,
         ontologyService);

--- a/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
@@ -186,6 +186,7 @@ public class ElasticSearchServiceTest {
     assertEquals(study.getDataTypes(), term.getStudy().getDataTypes());
     assertEquals(dataLocationProp.getPropertyValue(), term.getDataLocation());
     assertEquals(dataset.getDacId(), term.getDacId());
+    assertEquals(dac.getName(), term.getDacName());
     assertEquals(openAccessProp.getPropertyValue(), term.getOpenAccess());
     assertEquals(study.getPublicVisibility(), term.getStudy().getPublicVisibility());
 

--- a/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
@@ -9,7 +9,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.openMocks;
 
 import com.google.gson.JsonArray;
 import java.io.IOException;
@@ -34,6 +33,7 @@ import org.broadinstitute.consent.http.models.Dataset;
 import org.broadinstitute.consent.http.models.DatasetProperty;
 import org.broadinstitute.consent.http.models.Study;
 import org.broadinstitute.consent.http.models.StudyProperty;
+import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.elastic_search.DatasetTerm;
 import org.broadinstitute.consent.http.models.ontology.DataUseSummary;
 import org.broadinstitute.consent.http.models.ontology.DataUseTerm;
@@ -41,13 +41,15 @@ import org.broadinstitute.consent.http.util.gson.GsonUtil;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.RestClient;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-public class ElasticSearchServiceTest {
+@ExtendWith(MockitoExtension.class)
+class ElasticSearchServiceTest {
 
   private ElasticSearchService service;
 
@@ -68,11 +70,6 @@ public class ElasticSearchServiceTest {
 
   @Mock
   private UserDAO userDao;
-
-  @BeforeEach
-  public void setUp() {
-    openMocks(this);
-  }
 
   private void initService() {
     service = new ElasticSearchService(
@@ -96,14 +93,22 @@ public class ElasticSearchServiceTest {
   }
 
   @Test
-  public void testToDatasetTermComplete() {
+  void testToDatasetTermComplete() {
+    User user = new User();
+    user.setUserId(1);
+    user.setDisplayName(RandomStringUtils.randomAlphabetic(10));
+    user.setEmail(RandomStringUtils.randomAlphabetic(10));
+
     Dataset dataset = new Dataset();
     dataset.setDataSetId(100);
     dataset.setAlias(10);
     dataset.setDatasetIdentifier();
     dataset.setName(RandomStringUtils.randomAlphabetic(10));
     dataset.setDacId(1);
+    dataset.setDacApproval(true);
     dataset.setDataUse(new DataUse());
+    dataset.setCreateUser(user);
+    dataset.setCreateUserId(user.getUserId());
 
     Study study = new Study();
     study.setName(RandomStringUtils.randomAlphabetic(10));
@@ -114,6 +119,8 @@ public class ElasticSearchServiceTest {
     study.setCreateUserId(9);
     study.setCreateUserEmail(RandomStringUtils.randomAlphabetic(10));
     study.setPublicVisibility(true);
+    study.setCreateUserId(user.getUserId());
+    study.setCreateUserEmail(user.getEmail());
 
     StudyProperty phenotypeProperty = new StudyProperty();
     phenotypeProperty.setKey("phenotypeIndication");
@@ -161,6 +168,7 @@ public class ElasticSearchServiceTest {
     dac.setDacId(dataset.getDacId());
     dac.setName("Dac Name");
 
+    when(userDao.findUserById(any())).thenReturn(user);
     when(dacDAO.findById(any())).thenReturn(dac);
     when(dataAccessRequestDAO.findAllUserIdsWithApprovedDARsByDatasetId(any())).thenReturn(
         List.of(10, 11));
@@ -171,6 +179,8 @@ public class ElasticSearchServiceTest {
 
     assertEquals(dataset.getDataSetId(), term.getDatasetId());
     assertEquals(dataset.getDatasetIdentifier(), term.getDatasetIdentifier());
+    assertEquals(user.getUserId(), term.getCreateUserId());
+    assertEquals(user.getDisplayName(), term.getCreateUserDisplayName());
     assertEquals(study.getDescription(), term.getStudy().getDescription());
     assertEquals(study.getName(), term.getStudy().getStudyName());
     assertEquals(study.getStudyId(), term.getStudy().getStudyId());
@@ -188,6 +198,7 @@ public class ElasticSearchServiceTest {
     assertEquals(dataLocationProp.getPropertyValue(), term.getDataLocation());
     assertEquals(dataset.getDacId(), term.getDacId());
     assertEquals(dac.getName(), term.getDacName());
+    assertEquals(dataset.getDacApproval(), term.getDacApproval());
     assertEquals(openAccessProp.getPropertyValue(), term.getOpenAccess());
     assertEquals(study.getPublicVisibility(), term.getStudy().getPublicVisibility());
 
@@ -199,7 +210,7 @@ public class ElasticSearchServiceTest {
   }
 
   @Test
-  public void testToDatasetTermIncomplete() {
+  void testToDatasetTermIncomplete() {
     Dataset dataset = new Dataset();
     dataset.setDataSetId(100);
     dataset.setAlias(10);
@@ -220,7 +231,7 @@ public class ElasticSearchServiceTest {
   ArgumentCaptor<Request> request;
 
   @Test
-  public void testIndexDatasets() throws IOException {
+  void testIndexDatasets() throws IOException {
     DatasetTerm term1 = new DatasetTerm();
     term1.setDatasetId(1);
     DatasetTerm term2 = new DatasetTerm();
@@ -251,7 +262,7 @@ public class ElasticSearchServiceTest {
   }
 
   @Test
-  public void testSearchDatasets() throws IOException {
+  void testSearchDatasets() throws IOException {
     String query = "{ \"query\": { \"query_string\": { \"query\": \"(GRU) AND (HMB)\" } } }";
 
     /*
@@ -269,7 +280,7 @@ public class ElasticSearchServiceTest {
   }
 
   @Test
-  public void testValidateQuery() throws IOException {
+  void testValidateQuery() throws IOException {
     String query = "{ \"query\": { \"query_string\": { \"query\": \"(GRU) AND (HMB)\" } } }";
 
     mockElasticSearchResponse(200, "{\"valid\":true}");
@@ -279,7 +290,7 @@ public class ElasticSearchServiceTest {
   }
 
   @Test
-  public void testValidateQueryWithFromAndSize() throws IOException {
+  void testValidateQueryWithFromAndSize() throws IOException {
     String query = "{ \"from\": 0, \"size\": 100, \"query\": { \"query_string\": { \"query\": \"(GRU) AND (HMB)\" } } }";
 
     mockElasticSearchResponse(200, "{\"valid\":true}");
@@ -289,17 +300,21 @@ public class ElasticSearchServiceTest {
   }
 
   @Test
-  public void testValidateQueryEmpty() throws IOException {
+  void testValidateQueryEmpty() throws IOException {
     String query = "{}";
 
-    mockElasticSearchResponse(400, "Bad Request");
+    Response response = mock(Response.class);
+    String reasonPhrase = fromStatusCode(400).getReasonPhrase();
+    BasicStatusLine status = new BasicStatusLine(HttpVersion.HTTP_1_1, 400, reasonPhrase);
+    when(esClient.performRequest(any())).thenReturn(response);
+    when(response.getStatusLine()).thenReturn(status);
 
     initService();
     assertThrows(IOException.class, () -> service.validateQuery(query));
   }
 
   @Test
-  public void testValidateQueryInvalid() throws IOException {
+  void testValidateQueryInvalid() throws IOException {
     String query = "{ \"bad\": [\"and\", \"invalid\"] }";
 
     mockElasticSearchResponse(200, "{\"valid\":false}");

--- a/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
@@ -28,6 +28,7 @@ import org.broadinstitute.consent.http.db.DacDAO;
 import org.broadinstitute.consent.http.db.DataAccessRequestDAO;
 import org.broadinstitute.consent.http.db.UserDAO;
 import org.broadinstitute.consent.http.enumeration.PropertyType;
+import org.broadinstitute.consent.http.models.Dac;
 import org.broadinstitute.consent.http.models.DataUse;
 import org.broadinstitute.consent.http.models.Dataset;
 import org.broadinstitute.consent.http.models.DatasetProperty;
@@ -155,6 +156,11 @@ public class ElasticSearchServiceTest {
     dataUseSummary.setPrimary(List.of(new DataUseTerm("DS", "Description")));
     dataUseSummary.setPrimary(List.of(new DataUseTerm("NMDS", "Description")));
 
+    Dac dac = new Dac();
+    dac.setDacId(dataset.getDacId());
+    dac.setName("Dac Name");
+
+    when(dacDAO.findById(any())).thenReturn(dac);
     when(dataAccessRequestDAO.findAllUserIdsWithApprovedDARsByDatasetId(any())).thenReturn(
         List.of(10, 11));
     when(ontologyService.translateDataUseSummary(any())).thenReturn(dataUseSummary);


### PR DESCRIPTION
### Addresses
Support for https://broadworkbench.atlassian.net/browse/DUOS-2641

### Summary
* Add the translated data use to the reducer similar to what we do in the mapper. This was missed on a previous PR.
* Add the create user id to the dataset term index
* Add the dac name to the term index
* Add dac approval to the term index
* Add dac name to the term index


----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
