### PR TITLE
[DUOS-2651] Additional dataset index terms

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
@@ -445,7 +445,8 @@ public class ConsentModule extends AbstractModule {
         providesDacDAO(),
         providesDataAccessRequestDAO(),
         providesUserDAO(),
-        providesOntologyService()
+        providesOntologyService(),
+        providesInstitutionDAO()
     );
   }
 

--- a/src/main/java/org/broadinstitute/consent/http/models/elastic_search/DacTerm.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/elastic_search/DacTerm.java
@@ -1,24 +1,3 @@
 package org.broadinstitute.consent.http.models.elastic_search;
 
-public class DacTerm {
-
-  private Integer dacId;
-
-  private String dacName;
-
-  public Integer getDacId() {
-    return dacId;
-  }
-
-  public void setDacId(Integer dacId) {
-    this.dacId = dacId;
-  }
-
-  public String getDacName() {
-    return dacName;
-  }
-
-  public void setDacName(String dacName) {
-    this.dacName = dacName;
-  }
-}
+public record DacTerm (Integer dacId, String dacName) {}

--- a/src/main/java/org/broadinstitute/consent/http/models/elastic_search/DacTerm.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/elastic_search/DacTerm.java
@@ -1,0 +1,24 @@
+package org.broadinstitute.consent.http.models.elastic_search;
+
+public class DacTerm {
+
+  private Integer dacId;
+
+  private String dacName;
+
+  public Integer getDacId() {
+    return dacId;
+  }
+
+  public void setDacId(Integer dacId) {
+    this.dacId = dacId;
+  }
+
+  public String getDacName() {
+    return dacName;
+  }
+
+  public void setDacName(String dacName) {
+    this.dacName = dacName;
+  }
+}

--- a/src/main/java/org/broadinstitute/consent/http/models/elastic_search/DatasetTerm.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/elastic_search/DatasetTerm.java
@@ -7,6 +7,7 @@ public class DatasetTerm {
 
   private Integer datasetId;
   private Integer createUserId;
+  @Deprecated // Use submitter.displayName instead
   private String createUserDisplayName;
   private String datasetIdentifier;
   private String datasetName;
@@ -15,11 +16,14 @@ public class DatasetTerm {
   private String dataLocation;
   private String url;
   private Integer dacId;
+  @Deprecated // Use dac.name instead
   private String dacName;
   private Boolean dacApproval;
   private Boolean openAccess;
   private List<Integer> approvedUserIds;
   private StudyTerm study;
+  private UserTerm submitter;
+  private DacTerm dac;
 
   public Integer getDatasetId() {
     return datasetId;
@@ -68,7 +72,6 @@ public class DatasetTerm {
   public void setParticipantCount(Integer participantCount) {
     this.participantCount = participantCount;
   }
-
 
   public DataUseSummary getDataUse() {
     return dataUse;
@@ -140,5 +143,21 @@ public class DatasetTerm {
 
   public void setStudy(StudyTerm study) {
     this.study = study;
+  }
+
+  public UserTerm getSubmitter() {
+    return submitter;
+  }
+
+  public void setSubmitter(UserTerm submitter) {
+    this.submitter = submitter;
+  }
+
+  public DacTerm getDac() {
+    return dac;
+  }
+
+  public void setDac(DacTerm dac) {
+    this.dac = dac;
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/models/elastic_search/DatasetTerm.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/elastic_search/DatasetTerm.java
@@ -23,6 +23,7 @@ public class DatasetTerm {
   private List<Integer> approvedUserIds;
   private StudyTerm study;
   private UserTerm submitter;
+  private UserTerm updateUser;
   private DacTerm dac;
 
   public Integer getDatasetId() {
@@ -151,6 +152,14 @@ public class DatasetTerm {
 
   public void setSubmitter(UserTerm submitter) {
     this.submitter = submitter;
+  }
+
+  public UserTerm getUpdateUser() {
+    return updateUser;
+  }
+
+  public void setUpdateUser(UserTerm updateUser) {
+    this.updateUser = updateUser;
   }
 
   public DacTerm getDac() {

--- a/src/main/java/org/broadinstitute/consent/http/models/elastic_search/InstitutionTerm.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/elastic_search/InstitutionTerm.java
@@ -1,24 +1,3 @@
 package org.broadinstitute.consent.http.models.elastic_search;
 
-public class InstitutionTerm {
-
-  private Integer id;
-
-  private String name;
-
-  public Integer getId() {
-    return id;
-  }
-
-  public void setId(Integer id) {
-    this.id = id;
-  }
-
-  public String getName() {
-    return name;
-  }
-
-  public void setName(String name) {
-    this.name = name;
-  }
-}
+public record InstitutionTerm(Integer id, String name) {}

--- a/src/main/java/org/broadinstitute/consent/http/models/elastic_search/InstitutionTerm.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/elastic_search/InstitutionTerm.java
@@ -1,0 +1,24 @@
+package org.broadinstitute.consent.http.models.elastic_search;
+
+public class InstitutionTerm {
+
+  private Integer id;
+
+  private String name;
+
+  public Integer getId() {
+    return id;
+  }
+
+  public void setId(Integer id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+}

--- a/src/main/java/org/broadinstitute/consent/http/models/elastic_search/UserTerm.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/elastic_search/UserTerm.java
@@ -1,33 +1,3 @@
 package org.broadinstitute.consent.http.models.elastic_search;
 
-public class UserTerm {
-
-  private Integer userId;
-  private String displayName;
-  private InstitutionTerm institution;
-
-  public Integer getUserId() {
-    return userId;
-  }
-
-  public void setUserId(Integer userId) {
-    this.userId = userId;
-  }
-
-  public String getDisplayName() {
-    return displayName;
-  }
-
-  public void setDisplayName(String displayName) {
-    this.displayName = displayName;
-  }
-
-  public InstitutionTerm getInstitution() {
-    return institution;
-  }
-
-  public void setInstitution(
-      InstitutionTerm institution) {
-    this.institution = institution;
-  }
-}
+public record UserTerm(Integer userId, String displayName, InstitutionTerm institution) {}

--- a/src/main/java/org/broadinstitute/consent/http/models/elastic_search/UserTerm.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/elastic_search/UserTerm.java
@@ -3,6 +3,8 @@ package org.broadinstitute.consent.http.models.elastic_search;
 public class UserTerm {
 
   private Integer userId;
+  private String displayName;
+  private InstitutionTerm institution;
 
   public Integer getUserId() {
     return userId;
@@ -10,5 +12,22 @@ public class UserTerm {
 
   public void setUserId(Integer userId) {
     this.userId = userId;
+  }
+
+  public String getDisplayName() {
+    return displayName;
+  }
+
+  public void setDisplayName(String displayName) {
+    this.displayName = displayName;
+  }
+
+  public InstitutionTerm getInstitution() {
+    return institution;
+  }
+
+  public void setInstitution(
+      InstitutionTerm institution) {
+    this.institution = institution;
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
@@ -205,30 +205,24 @@ public class ElasticSearchService implements ConsentLogger {
     if (Objects.isNull(user)) {
       return null;
     }
-    UserTerm term = new UserTerm();
-    term.setUserId(user.getUserId());
-    term.setDisplayName(user.getDisplayName());
-    return term;
+    InstitutionTerm institution = (Objects.nonNull(user.getInstitutionId())) ?
+      toInstitutionTerm(institutionDAO.findInstitutionById(user.getInstitutionId())) :
+      null;
+    return new UserTerm(user.getUserId(), user.getDisplayName(), institution);
   }
 
   public DacTerm toDacTerm(Dac dac) {
     if (Objects.isNull(dac)) {
       return null;
     }
-    DacTerm term = new DacTerm();
-    term.setDacId(dac.getDacId());
-    term.setDacName(dac.getName());
-    return term;
+    return new DacTerm(dac.getDacId(), dac.getName());
   }
 
   public InstitutionTerm toInstitutionTerm(Institution institution) {
     if (Objects.isNull(institution)) {
       return null;
     }
-    InstitutionTerm term = new InstitutionTerm();
-    term.setId(institution.getId());
-    term.setName(institution.getName());
-    return term;
+    return new InstitutionTerm(institution.getId(), institution.getName());
   }
 
   public Response indexDataset(Dataset dataset) throws IOException {
@@ -253,10 +247,10 @@ public class ElasticSearchService implements ConsentLogger {
       term.setCreateUserId(dataset.getCreateUserId());
       term.setCreateUserDisplayName(user.getDisplayName());
       term.setSubmitter(toUserTerm(user));
-      if (Objects.nonNull(user.getInstitutionId())) {
-        Institution institution = institutionDAO.findInstitutionById(user.getInstitutionId());
-        term.getSubmitter().setInstitution(toInstitutionTerm(institution));
-      }
+    });
+    Optional.ofNullable(dataset.getUpdateUserId()).ifPresent(userId -> {
+      User user = userDAO.findUserById(dataset.getUpdateUserId());
+      term.setUpdateUser(toUserTerm(user));
     });
     term.setDatasetIdentifier(dataset.getDatasetIdentifier());
     term.setDatasetName(dataset.getName());

--- a/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
@@ -16,16 +16,21 @@ import org.apache.http.nio.entity.NStringEntity;
 import org.broadinstitute.consent.http.configurations.ElasticSearchConfiguration;
 import org.broadinstitute.consent.http.db.DacDAO;
 import org.broadinstitute.consent.http.db.DataAccessRequestDAO;
+import org.broadinstitute.consent.http.db.InstitutionDAO;
 import org.broadinstitute.consent.http.db.UserDAO;
 import org.broadinstitute.consent.http.models.Dac;
 import org.broadinstitute.consent.http.models.Dataset;
 import org.broadinstitute.consent.http.models.DatasetProperty;
+import org.broadinstitute.consent.http.models.Institution;
 import org.broadinstitute.consent.http.models.Study;
 import org.broadinstitute.consent.http.models.StudyProperty;
 import org.broadinstitute.consent.http.models.User;
+import org.broadinstitute.consent.http.models.elastic_search.DacTerm;
 import org.broadinstitute.consent.http.models.elastic_search.DatasetTerm;
 import org.broadinstitute.consent.http.models.elastic_search.ElasticSearchHits;
+import org.broadinstitute.consent.http.models.elastic_search.InstitutionTerm;
 import org.broadinstitute.consent.http.models.elastic_search.StudyTerm;
+import org.broadinstitute.consent.http.models.elastic_search.UserTerm;
 import org.broadinstitute.consent.http.util.ConsentLogger;
 import org.broadinstitute.consent.http.util.gson.GsonUtil;
 import org.elasticsearch.client.Request;
@@ -39,6 +44,7 @@ public class ElasticSearchService implements ConsentLogger {
   private final DataAccessRequestDAO dataAccessRequestDAO;
   private final UserDAO userDAO;
   private final OntologyService ontologyService;
+  private final InstitutionDAO institutionDAO;
 
   public ElasticSearchService(
       RestClient esClient,
@@ -46,13 +52,15 @@ public class ElasticSearchService implements ConsentLogger {
       DacDAO dacDAO,
       DataAccessRequestDAO dataAccessRequestDAO,
       UserDAO userDao,
-      OntologyService ontologyService) {
+      OntologyService ontologyService,
+      InstitutionDAO institutionDAO) {
     this.esClient = esClient;
     this.esConfig = esConfig;
     this.dacDAO = dacDAO;
     this.dataAccessRequestDAO = dataAccessRequestDAO;
     this.userDAO = userDao;
     this.ontologyService = ontologyService;
+    this.institutionDAO = institutionDAO;
   }
 
 
@@ -193,6 +201,36 @@ public class ElasticSearchService implements ConsentLogger {
     return term;
   }
 
+  public UserTerm toUserTerm(User user) {
+    if (Objects.isNull(user)) {
+      return null;
+    }
+    UserTerm term = new UserTerm();
+    term.setUserId(user.getUserId());
+    term.setDisplayName(user.getDisplayName());
+    return term;
+  }
+
+  public DacTerm toDacTerm(Dac dac) {
+    if (Objects.isNull(dac)) {
+      return null;
+    }
+    DacTerm term = new DacTerm();
+    term.setDacId(dac.getDacId());
+    term.setDacName(dac.getName());
+    return term;
+  }
+
+  public InstitutionTerm toInstitutionTerm(Institution institution) {
+    if (Objects.isNull(institution)) {
+      return null;
+    }
+    InstitutionTerm term = new InstitutionTerm();
+    term.setId(institution.getId());
+    term.setName(institution.getName());
+    return term;
+  }
+
   public Response indexDataset(Dataset dataset) throws IOException {
     return indexDatasetTerms(List.of(toDatasetTerm(dataset)));
   }
@@ -214,6 +252,11 @@ public class ElasticSearchService implements ConsentLogger {
       User user = userDAO.findUserById(dataset.getCreateUserId());
       term.setCreateUserId(dataset.getCreateUserId());
       term.setCreateUserDisplayName(user.getDisplayName());
+      term.setSubmitter(toUserTerm(user));
+      if (Objects.nonNull(user.getInstitutionId())) {
+        Institution institution = institutionDAO.findInstitutionById(user.getInstitutionId());
+        term.getSubmitter().setInstitution(toInstitutionTerm(institution));
+      }
     });
     term.setDatasetIdentifier(dataset.getDatasetIdentifier());
     term.setDatasetName(dataset.getName());
@@ -229,6 +272,7 @@ public class ElasticSearchService implements ConsentLogger {
       if (Objects.nonNull(dataset.getDacApproval())) {
         term.setDacApproval(dataset.getDacApproval());
       }
+      term.setDac(toDacTerm(dac));
     });
 
     List<Integer> approvedUserIds =

--- a/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
@@ -248,10 +248,10 @@ public class ElasticSearchService implements ConsentLogger {
       term.setCreateUserDisplayName(user.getDisplayName());
       term.setSubmitter(toUserTerm(user));
     });
-    Optional.ofNullable(dataset.getUpdateUserId()).ifPresent(userId -> {
-      User user = userDAO.findUserById(dataset.getUpdateUserId());
-      term.setUpdateUser(toUserTerm(user));
-    });
+    Optional.ofNullable(dataset.getUpdateUserId())
+        .map(userDAO::findUserById)
+        .map(this::toUserTerm)
+        .ifPresent(term::setUpdateUser);
     term.setDatasetIdentifier(dataset.getDatasetIdentifier());
     term.setDatasetName(dataset.getName());
 

--- a/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
@@ -25,6 +25,7 @@ import org.apache.http.nio.entity.NStringEntity;
 import org.broadinstitute.consent.http.configurations.ElasticSearchConfiguration;
 import org.broadinstitute.consent.http.db.DacDAO;
 import org.broadinstitute.consent.http.db.DataAccessRequestDAO;
+import org.broadinstitute.consent.http.db.InstitutionDAO;
 import org.broadinstitute.consent.http.db.UserDAO;
 import org.broadinstitute.consent.http.enumeration.PropertyType;
 import org.broadinstitute.consent.http.models.Dac;
@@ -71,6 +72,9 @@ class ElasticSearchServiceTest {
   @Mock
   private UserDAO userDao;
 
+  @Mock
+  private InstitutionDAO institutionDAO;
+
   private void initService() {
     service = new ElasticSearchService(
         esClient,
@@ -78,7 +82,8 @@ class ElasticSearchServiceTest {
         dacDAO,
         dataAccessRequestDAO,
         userDao,
-        ontologyService);
+        ontologyService,
+        institutionDAO);
   }
 
   private void mockElasticSearchResponse(int statusCode, String body) throws IOException {


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DUOS-2651

### Summary
Add new terms to dataset index:
* submitter
  * submitter.institution
* updateUser
  * updateUser.institution
* dac

Updated the ES test to break up the assertions into more manageable sections.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
