### PR TITLE
[DUOS-2682][risk=no] Unicode fix for DAR Data queries

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
@@ -130,7 +130,7 @@ public interface DarCollectionDAO extends Transactional<DarCollectionDAO> {
           "dar.parent_id AS dar_parent_id, dar.draft AS dar_draft, dar.user_id AS dar_userId, " +
           "dar.create_date AS dar_create_date, dar.sort_date AS dar_sort_date, dar.submission_date AS dar_submission_date, "
           +
-          "dar.update_date AS dar_update_date, (dar.data #>> '{}')::jsonb AS data, dd.dataset_id " +
+          "dar.update_date AS dar_update_date, (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data, dd.dataset_id " +
           "FROM dar_collection c " +
           "INNER JOIN users u ON c.create_user_id = u.user_id " +
           "LEFT JOIN user_property up ON u.user_id = up.userid " +
@@ -167,7 +167,7 @@ public interface DarCollectionDAO extends Transactional<DarCollectionDAO> {
           + "dar.id AS dar_id, dar.reference_id AS dar_reference_id, dar.collection_id AS dar_collection_id, "
           + "dar.parent_id AS dar_parent_id, dar.draft AS dar_draft, dar.user_id AS dar_userId, "
           + "dar.create_date AS dar_create_date, dar.sort_date AS dar_sort_date, dar.submission_date AS dar_submission_date, "
-          + "dar.update_date AS dar_update_date, (dar.data #>> '{}')::jsonb AS data, "
+          + "dar.update_date AS dar_update_date, (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data, "
           + "e.election_id AS e_election_id, e.reference_id AS e_reference_id, e.status AS e_status, e.create_date AS e_create_date, "
           + "e.last_update AS e_last_update, e.dataset_id AS e_dataset_id, e.election_type AS e_election_type, e.latest, "
           + "v.voteid as v_vote_id, v.vote as v_vote, v.user_id as v_user_id, v.rationale as v_rationale, v.electionid as v_election_id, "

--- a/src/main/java/org/broadinstitute/consent/http/db/DarCollectionSummaryDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DarCollectionSummaryDAO.java
@@ -24,7 +24,7 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
       SELECT c.collection_id as dar_collection_id, c.dar_code, dar.submission_date, dar.reference_id as dar_reference_id, u.display_name as researcher_name,
         i.institution_name, e.election_id, e.status, e.dataset_id, e.reference_id, v.voteid as v_vote_id, dd.dataset_id as dd_datasetid,
         v.user_id as v_user_id, v.vote as v_vote, v.electionid as v_election_id, v.createdate as v_create_date, v.updatedate as v_update_date, v.type as v_type,
-        (dar.data #>> '{}')::jsonb ->> 'projectTitle' AS name
+        (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb ->> 'projectTitle' AS name
       FROM dar_collection c
       INNER JOIN users u
         ON u.user_id = c.create_user_id
@@ -61,7 +61,7 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
               +
               "i.institution_name, e.election_id, e.status, e.dataset_id, e.reference_id, dd.dataset_id as dd_datasetid, "
               +
-              "(dar.data #>> '{}')::jsonb ->> 'projectTitle' AS name " +
+              "(regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb ->> 'projectTitle' AS name " +
               "FROM dar_collection c " +
               "INNER JOIN users u " +
               "ON u.user_id = c.create_user_id " +
@@ -92,7 +92,7 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
   @SqlQuery("""
       SELECT c.collection_id as dar_collection_id, c.dar_code, dar.submission_date, dar.reference_id as dar_reference_id, u.display_name as researcher_name,
         i.institution_name, e.election_id, e.status, e.dataset_id, e.reference_id, dd.dataset_id as dd_datasetid,
-        (dar.data #>> '{}')::jsonb ->> 'projectTitle' AS name,
+        (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb ->> 'projectTitle' AS name,
         dac.name as dac_name
       FROM dar_collection c
       INNER JOIN users u ON u.user_id = c.create_user_id
@@ -121,8 +121,8 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
               +
               "i.institution_name, e.election_id, e.status, e.dataset_id, e.reference_id, dd.dataset_id as dd_datasetid, "
               +
-              "(dar.data #>> '{}')::jsonb ->> 'projectTitle' AS name, " +
-              "(dar.data #>> '{}')::jsonb ->> 'status' AS dar_status " +
+              "(regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb ->> 'projectTitle' AS name, " +
+              "(regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb ->> 'status' AS dar_status " +
               "FROM dar_collection c " +
               "INNER JOIN users u " +
               "ON u.user_id = c.create_user_id " +
@@ -157,7 +157,7 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
       SELECT c.collection_id as dar_collection_id, c.dar_code, dar.submission_date, u.display_name as researcher_name, u.user_id as researcher_id,
         i.institution_name, i.institution_id, e.election_id, e.status, e.dataset_id, e.reference_id, v.voteid as v_vote_id, dd.dataset_id as dd_datasetid,
         v.user_id as v_user_id, v.vote as v_vote, v.electionid as v_election_id, v.createdate as v_create_date, v.updatedate as v_update_date, v.type as v_type,
-        (dar.data #>> '{}')::jsonb ->> 'projectTitle' AS name
+        (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb ->> 'projectTitle' AS name
       FROM dar_collection c
       INNER JOIN users u
         ON u.user_id = c.create_user_id
@@ -197,8 +197,8 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
               +
               "u.user_id as researcher_id, i.institution_name, i.institution_id, e.election_id, e.status, e.dataset_id, e.reference_id, dd.dataset_id as dd_datasetid, "
               +
-              "(dar.data #>> '{}')::jsonb ->> 'projectTitle' AS name, " +
-              "(dar.data #>> '{}')::jsonb ->> 'status' AS dar_status " +
+              "(regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb ->> 'projectTitle' AS name, " +
+              "(regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb ->> 'status' AS dar_status " +
               "FROM dar_collection c " +
               "INNER JOIN users u " +
               "ON u.user_id = c.create_user_id " +

--- a/src/main/java/org/broadinstitute/consent/http/db/DataAccessRequestDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DataAccessRequestDAO.java
@@ -36,7 +36,7 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
   @UseRowReducer(DataAccessRequestReducer.class)
   @SqlQuery(
       "SELECT dd.dataset_id, dar.id, dar.reference_id, dar.collection_id, dar.parent_id, dar.draft, dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date, "
-          + "  (dar.data #>> '{}')::jsonb AS data FROM data_access_request dar"
+          + "  (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data FROM data_access_request dar"
           + "  LEFT JOIN dar_dataset dd on dd.reference_id = dar.reference_id "
           + "  WHERE dar.draft != true "
           + "  AND (LOWER(dar.data->>'status') != 'archived' OR dar.data->>'status' IS NULL)")
@@ -52,7 +52,7 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
   @SqlQuery(
       " SELECT distinct e.dataset_id, dar.id, dar.reference_id, dar.collection_id, dar.parent_id, dar.draft, "
           + " dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date, "
-          + " (dar.data #>> '{}')::jsonb AS data "
+          + " (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data "
           + " FROM data_access_request dar "
           + " INNER JOIN election e "
           + " ON e.reference_id = dar.reference_id "
@@ -110,7 +110,7 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
   @UseRowReducer(DataAccessRequestReducer.class)
   @SqlQuery(
       "SELECT dd.dataset_id, dar.id, dar.reference_id, dar.collection_id, dar.parent_id, dar.draft, dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date, "
-          + "  (dar.data #>> '{}')::jsonb AS data FROM data_access_request dar"
+          + "  (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data FROM data_access_request dar"
           + "  LEFT JOIN dar_dataset dd on dd.reference_id = dar.reference_id "
           + "  WHERE dar.draft = true "
           + "  AND (LOWER(dar.data->>'status') != 'archived' OR dar.data->>'status' IS NULL) "
@@ -125,7 +125,7 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
   @UseRowReducer(DataAccessRequestReducer.class)
   @SqlQuery(
       "SELECT dd.dataset_id, dar.id, dar.reference_id, dar.collection_id, dar.parent_id, dar.draft, dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date, "
-          + "  (dar.data #>> '{}')::jsonb AS data FROM data_access_request dar"
+          + "  (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data FROM data_access_request dar"
           + "  LEFT JOIN dar_dataset dd on dd.reference_id = dar.reference_id "
           + "  WHERE dar.draft = true "
           + "  AND (LOWER(dar.data->>'status') != 'archived' OR dar.data->>'status' IS NULL) "
@@ -142,7 +142,7 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
   @UseRowReducer(DataAccessRequestReducer.class)
   @SqlQuery(
       "SELECT dd.dataset_id, dar.id, dar.reference_id, dar.collection_id, dar.parent_id, dar.draft, dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date, "
-          + "  (dar.data #>> '{}')::jsonb AS data FROM data_access_request dar"
+          + "  (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data FROM data_access_request dar"
           + "  LEFT JOIN dar_dataset dd on dd.reference_id = dar.reference_id "
           + "  WHERE dar.draft = false "
           + "  AND dar.user_id = :userId "
@@ -159,7 +159,7 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
   @UseRowReducer(DataAccessRequestReducer.class)
   @SqlQuery(
       "SELECT dd.dataset_id, dar.id, dar.reference_id, dar.collection_id, dar.parent_id, dar.draft, dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date, "
-          + "  (dar.data #>> '{}')::jsonb AS data FROM data_access_request dar"
+          + "  (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data FROM data_access_request dar"
           + "  LEFT JOIN dar_dataset dd on dd.reference_id = dar.reference_id "
           + "  WHERE dar.reference_id = :referenceId "
           + "  AND (LOWER(dar.data->>'status') != 'archived' OR dar.data->>'status' IS NULL)")
@@ -174,7 +174,7 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
   @UseRowReducer(DataAccessRequestReducer.class)
   @SqlQuery(
       "SELECT dd.dataset_id, dar.id, dar.reference_id, dar.collection_id, dar.parent_id, dar.draft, dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date, "
-          + "  (dar.data #>> '{}')::jsonb AS data FROM data_access_request dar"
+          + "  (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data FROM data_access_request dar"
           + "  LEFT JOIN dar_dataset dd on dd.reference_id = dar.reference_id "
           + "  WHERE dar.reference_id IN (<referenceIds>) "
           + "  AND (LOWER(dar.data->>'status') != 'archived' OR dar.data->>'status' IS NULL)")

--- a/src/main/java/org/broadinstitute/consent/http/db/DataAccessRequestDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DataAccessRequestDAO.java
@@ -193,7 +193,7 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
   @RegisterArgumentFactory(JsonArgumentFactory.class)
   @SqlUpdate(
       "UPDATE data_access_request "
-          + "SET data = to_jsonb(:data), user_id = :userId, sort_date = :sortDate, "
+          + "SET data = to_jsonb(regexp_replace(:data, '\\\\u0000', '', 'g')), user_id = :userId, sort_date = :sortDate, "
           + "submission_date = :submissionDate, update_date = :updateDate "
           + "WHERE reference_id = :referenceId")
   void updateDataByReferenceId(
@@ -218,7 +218,7 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
 
   @SqlUpdate(
       "UPDATE data_access_request dar "
-          + "SET data=jsonb_set((dar.data #>> '{}')::jsonb, '{status}', '\"Canceled\"') "
+          + "SET data=jsonb_set((regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb, '{status}', '\"Canceled\"') "
           + "WHERE reference_id IN (<referenceIds>)")
   void cancelByReferenceIds(@BindList("referenceIds") List<String> referenceIds);
 

--- a/src/main/java/org/broadinstitute/consent/http/models/DarCollection.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DarCollection.java
@@ -22,8 +22,8 @@ public class DarCollection {
           "dar.parent_id AS dar_parent_id, dar.draft AS dar_draft, dar.user_id AS dar_userId, " +
           "dar.create_date AS dar_create_date, dar.sort_date AS dar_sort_date, dar.submission_date AS dar_submission_date, "
           +
-          "dar.update_date AS dar_update_date, (dar.data #>> '{}')::jsonb AS data, " +
-          "(dar.data #>> '{}')::jsonb ->> 'projectTitle' as projectTitle ";
+          "dar.update_date AS dar_update_date, (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data, " +
+          "(regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb ->> 'projectTitle' as projectTitle ";
 
   @JsonProperty
   private Integer darCollectionId;

--- a/src/main/java/org/broadinstitute/consent/http/service/dao/DataAccessRequestServiceDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/dao/DataAccessRequestServiceDAO.java
@@ -36,7 +36,7 @@ public class DataAccessRequestServiceDAO {
       handle.useTransaction(h -> {
 
         final String updateDataByReferenceId = "UPDATE data_access_request "
-            + "SET data = to_jsonb(:data), user_id = :userId, sort_date = :sortDate, "
+            + "SET data = to_jsonb(regexp_replace(:data, '\\\\u0000', '', 'g')), user_id = :userId, sort_date = :sortDate, "
             + "submission_date = :submissionDate, update_date = :updateDate "
             + "WHERE reference_id = :referenceId";
         final String deleteDarDatasetRelationByReferenceId = "DELETE FROM dar_dataset WHERE reference_id = :referenceId";

--- a/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
@@ -196,6 +196,66 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
   }
 
   @Test
+  void testUnsupportedUnicodeDarInsert() {
+    String unsupportedUnicode = "\u0000";
+    DarCollection collection = createDarCollection();
+    DataAccessRequestData data = new DataAccessRequestData();
+    data.setRus(String.format(" unsupported unicode characters: %s ", unsupportedUnicode));
+    String referenceId = UUID.randomUUID().toString();
+    Date now = new Date();
+    dataAccessRequestDAO.insertDataAccessRequest(
+        collection.getDarCollectionId(),
+        referenceId,
+        collection.getCreateUserId(),
+        now, now, now, now,
+        data);
+    DataAccessRequest dar = dataAccessRequestDAO.findByReferenceId(referenceId);
+    assertNotNull(dar);
+    assertFalse(dar.getData().getRus().contains(unsupportedUnicode));
+  }
+
+  @Test
+  void testUnsupportedUnicodeDarUpdate() {
+    String unsupportedUnicode = "\u0000";
+    DarCollection collection = createDarCollection();
+    DataAccessRequest dar = collection.getDars().values().stream().findFirst().orElse(null);
+    assertNotNull(dar);
+    Date now = new Date();
+
+    String rus = RandomStringUtils.random(10, true, false);
+    dar.getData().setRus(rus + String.format(" %s ", unsupportedUnicode));
+    dataAccessRequestDAO.updateDataByReferenceId(dar.getReferenceId(), collection.getCreateUserId(),
+        now, now,
+        now, dar.getData());
+
+    DataAccessRequest updatedDar = dataAccessRequestDAO.findByReferenceId(dar.getReferenceId());
+    assertNotNull(updatedDar);
+    assertFalse(updatedDar.getData().getRus().contains(unsupportedUnicode));
+  }
+
+  @Test
+  void testUnsupportedUnicodeDraftDar() {
+    String unsupportedUnicode = "\u0000";
+    User user = createUser();
+    DataAccessRequestData data = new DataAccessRequestData();
+    data.setRus(String.format(" unsupported unicode characters: %s ", unsupportedUnicode));
+    String referenceId = UUID.randomUUID().toString();
+    Date now = new Date();
+    dataAccessRequestDAO.insertDraftDataAccessRequest(
+        referenceId,
+        user.getUserId(),
+        now,
+        now,
+        now,
+        now,
+        data
+    );
+    DataAccessRequest dar = dataAccessRequestDAO.findByReferenceId(referenceId);
+    assertNotNull(dar);
+    assertFalse(dar.getData().getRus().contains(unsupportedUnicode));
+  }
+
+  @Test
   void testInsertDraftDataAccessRequest() {
     DataAccessRequest dar = createDraftDataAccessRequest();
     assertNotNull(dar);


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DUOS-2682

### Summary
The unicode `\u0000` is unsupported when selecting as a string in Postgres.
This PR replaces it with the empty string when trying to deserialize it into JSON.
Tested against copy of production db with existing invalid data.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
