### PR TITLE
[DUOS-2683][risk=no] Return all study names

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
@@ -433,10 +433,13 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
   List<Dataset> getDatasets();
 
   @SqlQuery("""
-          SELECT DISTINCT dp.property_value
+          SELECT DISTINCT dp.property_value as name
           FROM dataset_property dp
           INNER JOIN dataset d ON dp.dataset_id = d.dataset_id
           WHERE (dp.schema_property = 'studyName')
+          UNION DISTINCT
+          SELECT DISTINCT s.name as name
+          FROM study s
       """)
   Set<String> findAllStudyNames();
 

--- a/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
@@ -862,10 +862,13 @@ class DatasetDAOTest extends DAOTestHelper {
     String ds3Name = RandomStringUtils.randomAlphabetic(15);
     createDatasetProperty(ds3.getDataSetId(), "studyName", ds3Name, PropertyType.String);
 
+    Study study = insertStudyWithProperties();
+
     Set<String> returned = datasetDAO.findAllStudyNames();
 
-    assertEquals(3, returned.size());
-    assertTrue(returned.containsAll(Set.of(ds1Name, ds2Name, ds3Name)));
+    Set<String> names = Set.of(ds1Name, ds2Name, ds3Name, study.getName());
+    assertEquals(names.size(), returned.size());
+    assertTrue(returned.containsAll(names));
   }
 
   @Test


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DUOS-2683

### Summary
Minor query fix to get study names that are stored in both dataset properties and the study table.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
