### PR TITLE
[DUOS-2707][risk=no] Show null values in registration

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
@@ -180,9 +180,9 @@ public class DatasetResource extends Resource {
       Study study = datasets.get(0).getStudy();
       DatasetRegistrationSchemaV1Builder builder = new DatasetRegistrationSchemaV1Builder();
       DatasetRegistrationSchemaV1 createdRegistration = builder.build(study, datasets);
-      registration.setStudyId(study.getStudyId());
       URI uri = UriBuilder.fromPath(String.format("/api/dataset/study/%s", study.getStudyId())).build();
-      return Response.created(uri).entity(createdRegistration).build();
+      String entity = GsonUtil.buildGsonNullSerializer().toJson(createdRegistration);
+      return Response.created(uri).entity(entity).build();
     } catch (Exception e) {
       return createExceptionResponse(e);
     }
@@ -426,8 +426,8 @@ public class DatasetResource extends Resource {
       Study study = datasetService.getStudyWithDatasetsById(studyId);
       List<Dataset> datasets = Objects.nonNull(study.getDatasets()) ? study.getDatasets().stream().toList() : List.of();
       DatasetRegistrationSchemaV1 registration = new DatasetRegistrationSchemaV1Builder().build(study, datasets);
-      registration.setStudyId(study.getStudyId());
-      return Response.ok().entity(registration).build();
+      String entity = GsonUtil.buildGsonNullSerializer().toJson(registration);
+      return Response.ok().entity(entity).build();
     } catch (Exception e) {
       return createExceptionResponse(e);
     }
@@ -450,8 +450,8 @@ public class DatasetResource extends Resource {
         throw new NotFoundException("No study exists for dataset identifier: " + datasetIdentifier);
       }
       DatasetRegistrationSchemaV1 registration = new DatasetRegistrationSchemaV1Builder().build(study, List.of(dataset));
-      registration.setStudyId(study.getStudyId());
-      return Response.ok().entity(registration).build();
+      String entity = GsonUtil.buildGsonNullSerializer().toJson(registration);
+      return Response.ok().entity(entity).build();
     } catch (Exception e) {
       return createExceptionResponse(e);
     }

--- a/src/main/java/org/broadinstitute/consent/http/util/gson/GsonUtil.java
+++ b/src/main/java/org/broadinstitute/consent/http/util/gson/GsonUtil.java
@@ -23,6 +23,10 @@ public class GsonUtil {
     return gsonBuilderWithAdapters().create();
   }
 
+  public static Gson buildGsonNullSerializer() {
+    return gsonBuilderWithAdapters().serializeNulls().create();
+  }
+
   public static GsonBuilder gsonBuilderWithAdapters() {
     return new GsonBuilder()
         .registerTypeAdapter(


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DUOS-2707

### Summary
Ensure that null values are returned in APIs that return a registration schema

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
