### PR TITLE
[DUOS-2724][risk=no] Make file types not required and other minor fixes

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/models/dataset_registration_v1/ConsentGroup.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/dataset_registration_v1/ConsentGroup.java
@@ -539,10 +539,18 @@ public class ConsentGroup {
     this.url = url;
   }
 
+  /**
+   * # of Participants (Required)
+   */
+  @JsonProperty("numberOfParticipants")
   public Integer getNumberOfParticipants() {
     return numberOfParticipants;
   }
 
+  /**
+   * # of Participants (Required)
+   */
+  @JsonProperty("numberOfParticipants")
   public void setNumberOfParticipants(Integer numberOfParticipants) {
     this.numberOfParticipants = numberOfParticipants;
   }

--- a/src/main/java/org/broadinstitute/consent/http/models/dataset_registration_v1/FileTypeObject.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/dataset_registration_v1/FileTypeObject.java
@@ -12,8 +12,7 @@ import java.util.Map;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
     "fileType",
-    "functionalEquivalence",
-    "numberOfParticipants"
+    "functionalEquivalence"
 })
 public class FileTypeObject {
 

--- a/src/main/resources/dataset-registration-schema_v1.json
+++ b/src/main/resources/dataset-registration-schema_v1.json
@@ -450,7 +450,6 @@
       "type": "object",
       "required": [
         "consentGroupName",
-        "fileTypes",
         "numberOfParticipants"
       ],
       "allOf": [
@@ -681,7 +680,6 @@
         },
         "fileTypes": {
           "type": "array",
-          "minItems": 1,
           "items": {
             "$ref": "#/$defs/fileTypeObject"
           },

--- a/src/test/java/org/broadinstitute/consent/http/util/JsonSchemaUtilTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/util/JsonSchemaUtilTest.java
@@ -530,7 +530,7 @@ class JsonSchemaUtilTest {
   }
 
   @Test
-  void testValidateDatasetRegistrationObject_v1_file_types_required() {
+  void testValidateDatasetRegistrationObject_v1_file_types_not_required() {
     String noFileTypes = """
         {
           "studyType": "Observational",
@@ -545,6 +545,7 @@ class JsonSchemaUtilTest {
           "dataSubmitterUserId": 1,
           "nihAnvilUse": "I am not NHGRI funded and do not plan to store data in AnVIL",
           "consentGroups": [{
+            "numberOfParticipants": 1,
             "consentGroupName": "name",
             "generalResearchUse": true,
             "dataAccessCommitteeId": 1,
@@ -568,6 +569,7 @@ class JsonSchemaUtilTest {
           "nihAnvilUse": "I am not NHGRI funded and do not plan to store data in AnVIL",
           "consentGroups": [{
             "fileTypes": [],
+            "numberOfParticipants": 1,
             "consentGroupName": "name",
             "generalResearchUse": true,
             "dataAccessCommitteeId": 1,
@@ -577,10 +579,10 @@ class JsonSchemaUtilTest {
         """;
 
     Set<ValidationMessage> errors = schemaUtil.validateSchema_v1(noFileTypes);
-    assertFieldHasError(errors, "fileTypes");
+    assertNoErrors(errors);
 
     errors = schemaUtil.validateSchema_v1(emptyFileTypes);
-    assertFieldHasError(errors, "fileTypes");
+    assertNoErrors(errors);
   }
 
 


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DUOS-2724

### Summary
* Make file types optional
* Minor cleanup from previously missed changes

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
