### PR TITLE
[DUOS-2737][risk=no] New api to get all dataset names

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
@@ -443,6 +443,13 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
       """)
   Set<String> findAllStudyNames();
 
+  @SqlQuery("""
+          SELECT DISTINCT d.name
+          FROM dataset d
+          WHERE d.name IS NOT NULL
+      """)
+  List<String> findAllDatasetNames();
+
   @UseRowReducer(DatasetReducer.class)
   @SqlQuery("""
           SELECT d.dataset_id, d.name, d.create_date, d.create_user_id, d.update_date,

--- a/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
@@ -511,6 +511,20 @@ public class DatasetResource extends Resource {
     }
   }
 
+  @GET
+  @Consumes("application/json")
+  @Produces("application/json")
+  @Path("/datasetNames")
+  @PermitAll
+  public Response findAllDatasetNames() {
+    try {
+      List<String> datasetNames = datasetService.findAllDatasetNames();
+      return Response.ok(datasetNames).build();
+    } catch (Exception e) {
+      return createExceptionResponse(e);
+    }
+  }
+
   @POST
   @Path("/download")
   @Consumes(MediaType.APPLICATION_JSON)

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -139,6 +139,10 @@ public class DatasetService {
   public Set<String> findAllStudyNames() {
     return datasetDAO.findAllStudyNames();
   }
+  public List<String> findAllDatasetNames() {
+    return datasetDAO.findAllDatasetNames();
+  }
+
   public Study findStudyById(Integer id) {
     return studyDAO.findStudyById(id);
   }

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -582,6 +582,8 @@ paths:
     $ref: './paths/datasetRegistrationByDatasetIdentifier.yaml'
   /api/dataset/studyNames:
     $ref: './paths/findAllStudyNames.yaml'
+  /api/dataset/datasetNames:
+    $ref: './paths/findAllDatasetNames.yaml'
   /api/dataset/study/{studyId}:
     $ref: './paths/studyById.yaml'
   /api/dataset/study/registration/{studyId}:

--- a/src/main/resources/assets/paths/findAllDatasetNames.yaml
+++ b/src/main/resources/assets/paths/findAllDatasetNames.yaml
@@ -1,12 +1,11 @@
 get:
-  summary: Find All Study Names
-  description: Returns a list of all the actively used dataset study names.
+  summary: Find All Dataset Names
+  description: Returns a list of all the actively used dataset names.
   tags:
     - Dataset
-    - Study
   responses:
     200:
-      description: All study names
+      description: All dataset names
       content:
         application/json:
           schema:

--- a/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
@@ -872,6 +872,16 @@ class DatasetDAOTest extends DAOTestHelper {
   }
 
   @Test
+  void testFindAllDatasetNames() {
+    Dataset ds1 = insertDataset();
+    Dataset ds2 = insertDataset();
+
+    List<String> dsNames = datasetDAO.findAllDatasetNames();
+    assertTrue(dsNames.contains(ds1.getDatasetName()));
+    assertTrue(dsNames.contains(ds2.getDatasetName()));
+  }
+
+  @Test
   void testFindDatasetsByDacIds() {
     Dataset dataset = insertDataset();
     Dac dac = insertDac();


### PR DESCRIPTION
### Addresses
Back end support for https://broadworkbench.atlassian.net/browse/DUOS-2737

### Summary
* New API to get all (non-filtered) dataset names
* Necessary for dataset registration form validation

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
