### PR TITLE
[DUOS-2747][risk=no] Remove SO from create user functionality

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/resources/DACUserResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DACUserResource.java
@@ -31,7 +31,7 @@ public class DACUserResource extends Resource {
 
   @POST
   @Consumes("application/json")
-  @RolesAllowed({ADMIN, SIGNINGOFFICIAL})
+  @RolesAllowed({ADMIN})
   public Response createDACUser(@Context UriInfo info, String json) {
     try {
       User user = userService.createUser(new User(json));


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DUOS-2747

### Summary
Removes the SO from roles allowed to create users so this is fully restricted to Admins.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
