### PR TITLE
[DUOS-1740][risk=no] Revert http client version update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -426,7 +426,7 @@
     <dependency>
       <groupId>org.apache.httpcomponents.client5</groupId>
       <artifactId>httpclient5</artifactId>
-      <version>5.2.2</version>
+      <version>5.2.1</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DUOS-1740

### Summary
Reverts http5 library update which introduced `java.lang.IllegalArgumentException: Invalid Proxy` errors in status checks.

Will look at an update with potential code fixes separately.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
