### PR TITLE
[DUOS-2826][risk=low] Update logback, dropwizard versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,8 @@
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
     <liquibase.version>4.25.0</liquibase.version>
-    <dropwizard.version>4.0.2</dropwizard.version>
+    <dropwizard.version>4.0.4</dropwizard.version>
+    <logback.version>1.4.14</logback.version>
     <pact.version>4.6.3</pact.version>
     <postgres.version>42.7.0</postgres.version>
     <surefire.version>3.2.2</surefire.version>
@@ -452,6 +453,44 @@
       <groupId>io.dropwizard</groupId>
       <artifactId>dropwizard-json-logging</artifactId>
       <version>${dropwizard.version}</version>
+      <exclusions>
+        <!-- Security update. See https://broadworkbench.atlassian.net/browse/DUOS-2826 -->
+        <exclusion>
+          <groupId>ch.qos.logback</groupId>
+          <artifactId>logback-access</artifactId>
+        </exclusion>
+        <!-- Security update. See https://broadworkbench.atlassian.net/browse/DUOS-2826 -->
+        <exclusion>
+          <groupId>ch.qos.logback</groupId>
+          <artifactId>logback-classic</artifactId>
+        </exclusion>
+        <!-- Security update. See https://broadworkbench.atlassian.net/browse/DUOS-2826 -->
+        <exclusion>
+          <groupId>ch.qos.logback</groupId>
+          <artifactId>logback-core</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <!-- Security update. See https://broadworkbench.atlassian.net/browse/DUOS-2826 -->
+    <dependency>
+        <groupId>ch.qos.logback</groupId>
+        <artifactId>logback-access</artifactId>
+        <version>${logback.version}</version>
+        <scope>test</scope>
+    </dependency>
+    <!-- Security update. See https://broadworkbench.atlassian.net/browse/DUOS-2826 -->
+    <dependency>
+        <groupId>ch.qos.logback</groupId>
+        <artifactId>logback-classic</artifactId>
+        <version>${logback.version}</version>
+        <scope>test</scope>
+    </dependency>
+    <!-- Security update. See https://broadworkbench.atlassian.net/browse/DUOS-2826 -->
+    <dependency>
+        <groupId>ch.qos.logback</groupId>
+        <artifactId>logback-core</artifactId>
+        <version>${logback.version}</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
### Addresses
Consent side of https://broadworkbench.atlassian.net/browse/DUOS-2826

### Summary
Update logback libraries to the latest
Also updates dropwizard since logback is a secondary dependency of dropwizard logging libraries.
See also: https://github.com/DataBiosphere/consent-ontology/pull/911

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
