### PR TITLE
[DUOS-2856][risk=no] Add dataset, study, property and fso indexes

### DIFF
--- a/src/main/resources/changelog-master.xml
+++ b/src/main/resources/changelog-master.xml
@@ -130,4 +130,6 @@
     relativeToChangelogFile="true"/>
   <include file="changesets/changelog-consent-2023-09-20-rename-role-id-column-in-roles.xml"
     relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-2023-12-18-dataset-study-indexes.xml"
+    relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/changesets/changelog-consent-2023-12-18-dataset-study-indexes.xml
+++ b/src/main/resources/changesets/changelog-consent-2023-12-18-dataset-study-indexes.xml
@@ -1,0 +1,33 @@
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+  <changeSet id="changelog-consent-2023-12-18-dataset-study-indexes.xml" author="grushton">
+    <createIndex indexName="idx_dataset_study_id" tableName="dataset">
+      <column name="study_id"/>
+    </createIndex>
+    <createIndex indexName="idx_dataset_prop_schema" tableName="dataset_property">
+      <column name="schema_property"/>
+    </createIndex>
+    <createIndex indexName="idx_study_uuid" tableName="study">
+      <column name="uuid"/>
+    </createIndex>
+    <createIndex indexName="idx_study_prop_study_id" tableName="study_property">
+      <column name="study_id"/>
+    </createIndex>
+    <createIndex indexName="idx_study_prop_key" tableName="study_property">
+      <column name="key"/>
+    </createIndex>
+    <createIndex indexName="idx_study_prop_type" tableName="study_property">
+      <column name="type"/>
+    </createIndex>
+    <createIndex indexName="idx_fso_entity" tableName="file_storage_object">
+      <column name="entity_id"/>
+    </createIndex>
+    <createIndex indexName="idx_fso_category" tableName="file_storage_object">
+      <column name="category"/>
+    </createIndex>
+    <createIndex indexName="idx_fso_deleted" tableName="file_storage_object">
+      <column name="deleted"/>
+    </createIndex>
+  </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DUOS-2856

### Summary
Indexes intended to speed up query execution plans.

#### Before Plan:
Run time is 19121.064
![Screenshot 2023-12-18 at 11 29 25 AM](https://github.com/DataBiosphere/consent/assets/116679/6eab7760-f9ef-43d7-862f-cd4a6334e35a)

#### After Plan:
Run time is 1113.526, roughly a 20-fold increase
![Screenshot 2023-12-18 at 11 27 14 AM](https://github.com/DataBiosphere/consent/assets/116679/a6ca1018-34be-41e5-8392-eeecc840412a)

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
