### PR TITLE
[DUOS-2870][risk=no] Fix NPE

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DataUseParser.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DataUseParser.java
@@ -13,6 +13,9 @@ public class DataUseParser implements ConsentLogger {
   private final ConcurrentMap<String, DataUse> dataUseCache = new ConcurrentHashMap<>();
 
   public DataUse parseDataUse(String dataUseString) {
+    if (null == dataUseString || dataUseString.isEmpty()) {
+      return null;
+    }
     return dataUseCache.computeIfAbsent(dataUseString, s -> {
       try {
         return gson.fromJson(dataUseString, DataUse.class);

--- a/src/test/java/org/broadinstitute/consent/http/db/DataUseParserTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DataUseParserTest.java
@@ -27,4 +27,18 @@ class DataUseParserTest {
     assertNull(dataUse);
   }
 
+  @Test
+  void testParseNullDataUse() {
+    DataUseParser dataUseParser = new DataUseParser();
+    DataUse dataUse = dataUseParser.parseDataUse(null);
+    assertNull(dataUse);
+  }
+
+  @Test
+  void testParseEmptyDataUse() {
+    DataUseParser dataUseParser = new DataUseParser();
+    DataUse dataUse = dataUseParser.parseDataUse("");
+    assertNull(dataUse);
+  }
+
 }


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DUOS-2870

### Summary
Root cause: null data use strings throw an NPE when used as a key in `ConcurrentMap`

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
