### PR TITLE
[DUOS-2887][risk=no] New api to search for dataset summaries

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
@@ -11,12 +11,14 @@ import org.broadinstitute.consent.http.db.mapper.DatasetDTOWithPropertiesMapper;
 import org.broadinstitute.consent.http.db.mapper.DatasetMapper;
 import org.broadinstitute.consent.http.db.mapper.DatasetPropertyMapper;
 import org.broadinstitute.consent.http.db.mapper.DatasetReducer;
+import org.broadinstitute.consent.http.db.mapper.DatasetSummaryMapper;
 import org.broadinstitute.consent.http.db.mapper.DictionaryMapper;
 import org.broadinstitute.consent.http.db.mapper.FileStorageObjectMapperWithFSOPrefix;
 import org.broadinstitute.consent.http.models.ApprovedDataset;
 import org.broadinstitute.consent.http.models.Dataset;
 import org.broadinstitute.consent.http.models.DatasetAudit;
 import org.broadinstitute.consent.http.models.DatasetProperty;
+import org.broadinstitute.consent.http.models.DatasetSummary;
 import org.broadinstitute.consent.http.models.Dictionary;
 import org.broadinstitute.consent.http.models.FileStorageObject;
 import org.broadinstitute.consent.http.models.Study;
@@ -780,4 +782,17 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
       OR (dp.schema_property = 'dataCustodianEmail' AND LOWER(dp.property_value) = LOWER(:email))
       """)
   List<Dataset> findDatasetsByCustodian(@Bind("userId") Integer userId, @Bind("email") String email);
+
+  @RegisterRowMapper(DatasetSummaryMapper.class)
+  @SqlQuery("""
+      SELECT DISTINCT d.dataset_id, d.alias, d.name
+      FROM dataset d
+      LEFT JOIN dataset_property p ON p.dataset_id = d.dataset_id
+      WHERE d.dac_approval = TRUE
+      AND (
+        LOWER(d.name) LIKE concat('%', LOWER(:query), '%') OR
+        LOWER(p.property_value) LIKE concat('%', LOWER(:query), '%')
+      )
+      """)
+  List<DatasetSummary> findDatasetSummariesByQuery(@Bind("query") String query);
 }

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DatasetSummaryMapper.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DatasetSummaryMapper.java
@@ -1,0 +1,20 @@
+package org.broadinstitute.consent.http.db.mapper;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import org.broadinstitute.consent.http.models.Dataset;
+import org.broadinstitute.consent.http.models.DatasetSummary;
+import org.jdbi.v3.core.mapper.RowMapper;
+import org.jdbi.v3.core.statement.StatementContext;
+
+public class DatasetSummaryMapper implements RowMapper<DatasetSummary>, RowMapperHelper {
+
+  @Override
+  public DatasetSummary map(ResultSet rs, StatementContext ctx) throws SQLException {
+    if (hasColumn(rs, "dataset_id") && hasColumn(rs, "name") && hasColumn(rs, "alias")) {
+      String identifier = Dataset.parseAliasToIdentifier(rs.getInt("alias"));
+      return new DatasetSummary(rs.getInt("dataset_id"), identifier, rs.getString("name"));
+    }
+    return null;
+  }
+}

--- a/src/main/java/org/broadinstitute/consent/http/models/DatasetSummary.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DatasetSummary.java
@@ -1,0 +1,4 @@
+package org.broadinstitute.consent.http.models;
+
+public record DatasetSummary(Integer id, String identifier, String name) {
+}

--- a/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
@@ -44,6 +44,7 @@ import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.AuthUser;
 import org.broadinstitute.consent.http.models.DataUse;
 import org.broadinstitute.consent.http.models.Dataset;
+import org.broadinstitute.consent.http.models.DatasetSummary;
 import org.broadinstitute.consent.http.models.DatasetUpdate;
 import org.broadinstitute.consent.http.models.Dictionary;
 import org.broadinstitute.consent.http.models.Study;
@@ -601,6 +602,22 @@ public class DatasetResource extends Resource {
       User user = userService.findUserByEmail(authUser.getEmail());
       List<Dataset> datasets = datasetService.searchDatasets(query, accessManagement, user);
       return Response.ok().entity(unmarshal(datasets)).build();
+    } catch (Exception e) {
+      return createExceptionResponse(e);
+    }
+  }
+
+  @GET
+  @Produces("application/json")
+  @Path("/autocomplete")
+  @PermitAll
+  public Response autocompleteDatasets(
+      @Auth AuthUser authUser,
+      @QueryParam("query") String query) {
+    try {
+      userService.findUserByEmail(authUser.getEmail());
+      List<DatasetSummary> datasets = datasetService.searchDatasetSummaries(query);
+      return Response.ok(datasets).build();
     } catch (Exception e) {
       return createExceptionResponse(e);
     }

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -30,6 +30,7 @@ import org.broadinstitute.consent.http.models.Dac;
 import org.broadinstitute.consent.http.models.DataUse;
 import org.broadinstitute.consent.http.models.Dataset;
 import org.broadinstitute.consent.http.models.DatasetProperty;
+import org.broadinstitute.consent.http.models.DatasetSummary;
 import org.broadinstitute.consent.http.models.Dictionary;
 import org.broadinstitute.consent.http.models.Study;
 import org.broadinstitute.consent.http.models.StudyConversion;
@@ -308,6 +309,10 @@ public class DatasetService implements ConsentLogger {
   public List<Dataset> searchDatasets(String query, AccessManagement accessManagement, User user) {
     List<Dataset> datasets = findAllDatasetsByUser(user);
     return datasets.stream().filter(ds -> ds.isDatasetMatch(query, accessManagement)).toList();
+  }
+
+  public List<DatasetSummary> searchDatasetSummaries(String query) {
+    return datasetDAO.findDatasetSummariesByQuery(query);
   }
 
   public Dataset approveDataset(Dataset dataset, User user, Boolean approval) {

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -612,6 +612,8 @@ paths:
     $ref: './paths/datasetIndexById.yaml'
   /api/dataset/search:
     $ref: './paths/datasetSearch.yaml'
+  /api/dataset/autocomplete:
+    $ref: './paths/datasetSummaryAutocomplete.yaml'
   /api/dataset/search/index:
     $ref: './paths/datasetSearchIndex.yaml'
   /api/datasetAssociation/{datasetId}:

--- a/src/main/resources/assets/paths/datasetSummaryAutocomplete.yaml
+++ b/src/main/resources/assets/paths/datasetSummaryAutocomplete.yaml
@@ -1,0 +1,21 @@
+get:
+  summary: Autocomplete Datasets
+  description: Returns all DAC approved dataset summaries matching a search query.
+  parameters:
+    - name: query
+      in: query
+      description: Search Query
+      required: true
+      schema:
+        type: string
+  tags:
+    - Dataset
+  responses:
+    200:
+      description: A list of Dataset Summary objects
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: '../schemas/DatasetSummary.yaml'

--- a/src/main/resources/assets/schemas/DatasetSummary.yaml
+++ b/src/main/resources/assets/schemas/DatasetSummary.yaml
@@ -1,0 +1,11 @@
+type: object
+properties:
+  id:
+    type: integer
+    description: The unique identifier for a dataset
+  identifier:
+    type: string
+    description: The public DUOS identifier for a dataset
+  name:
+    type: string
+    description: The dataset name

--- a/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
@@ -1173,6 +1173,24 @@ class DatasetDAOTest extends DAOTestHelper {
     assertTrue(summaries.isEmpty());
   }
 
+  @Test
+  void testFindDatasetSummariesByQuery_NullQuery() {
+    createDataset();
+
+    List<DatasetSummary> summaries = datasetDAO.findDatasetSummariesByQuery(null);
+    assertNotNull(summaries);
+    assertTrue(summaries.isEmpty());
+  }
+
+  @Test
+  void testFindDatasetSummariesByQuery_EmptyQuery() {
+    createDataset();
+
+    List<DatasetSummary> summaries = datasetDAO.findDatasetSummariesByQuery("");
+    assertNotNull(summaries);
+    assertTrue(summaries.isEmpty());
+  }
+
   private DarCollection createDarCollectionWithDatasets(int dacId, User user,
       List<Dataset> datasets) {
     String darCode = "DAR-" + RandomUtils.nextInt(1, 999999);

--- a/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
@@ -38,6 +38,7 @@ import org.broadinstitute.consent.http.models.DataUseBuilder;
 import org.broadinstitute.consent.http.models.Dataset;
 import org.broadinstitute.consent.http.models.DatasetAudit;
 import org.broadinstitute.consent.http.models.DatasetProperty;
+import org.broadinstitute.consent.http.models.DatasetSummary;
 import org.broadinstitute.consent.http.models.Dictionary;
 import org.broadinstitute.consent.http.models.Election;
 import org.broadinstitute.consent.http.models.FileStorageObject;
@@ -1146,6 +1147,30 @@ class DatasetDAOTest extends DAOTestHelper {
     assertFalse(datasets.isEmpty());
     assertEquals(dataset.getDataSetId(), datasets.stream().map(Dataset::getDataSetId).toList().get(0));
     assertNotEquals(dataset2.getDataSetId(), datasets.stream().map(Dataset::getDataSetId).toList().get(0));
+  }
+
+  @Test
+  void testFindDatasetSummariesByQuery() {
+    Dataset dataset = createDataset();
+    Dataset dataset2 = createDataset();
+    User user = createUser();
+    datasetDAO.updateDatasetApproval(true, Instant.now(), user.getUserId(), dataset.getDataSetId());
+    datasetDAO.updateDatasetApproval(true, Instant.now(), user.getUserId(), dataset2.getDataSetId());
+
+    List<DatasetSummary> summaries = datasetDAO.findDatasetSummariesByQuery(dataset.getName());
+    assertNotNull(summaries);
+    assertFalse(summaries.isEmpty());
+    assertEquals(dataset.getDataSetId(), summaries.stream().map(DatasetSummary::id).toList().get(0));
+    assertNotEquals(dataset2.getDataSetId(), summaries.stream().map(DatasetSummary::id).toList().get(0));
+  }
+
+  @Test
+  void testFindDatasetSummariesByQuery_NotApproved() {
+    Dataset dataset = createDataset();
+
+    List<DatasetSummary> summaries = datasetDAO.findDatasetSummariesByQuery(dataset.getName());
+    assertNotNull(summaries);
+    assertTrue(summaries.isEmpty());
   }
 
   private DarCollection createDarCollectionWithDatasets(int dacId, User user,

--- a/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
@@ -42,6 +42,7 @@ import org.broadinstitute.consent.http.models.DataUse;
 import org.broadinstitute.consent.http.models.DataUseBuilder;
 import org.broadinstitute.consent.http.models.Dataset;
 import org.broadinstitute.consent.http.models.DatasetProperty;
+import org.broadinstitute.consent.http.models.DatasetSummary;
 import org.broadinstitute.consent.http.models.Error;
 import org.broadinstitute.consent.http.models.Study;
 import org.broadinstitute.consent.http.models.StudyProperty;
@@ -584,6 +585,18 @@ class DatasetResourceTest {
 
     assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
     assertEquals(GsonUtil.buildGson().toJson(List.of(ds)), response.getEntity());
+  }
+
+  @Test
+  void testAutocompleteDatasets() {
+    when(authUser.getEmail()).thenReturn("testauthuser@test.com");
+    when(userService.findUserByEmail("testauthuser@test.com")).thenReturn(user);
+    when(datasetService.searchDatasetSummaries(any())).thenReturn(List.of(new DatasetSummary(1, "ID", "Name")));
+
+    initResource();
+    try (Response response = resource.autocompleteDatasets(authUser, "test")) {
+      assertTrue(HttpStatusCodes.isSuccess(response.getStatus()));
+    }
   }
 
   @Test


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DUOS-2887

### Summary
  * New api to search for DAC-approved dataset summary objects based on a query term
  * `GET /api/dataset/autocomplete?query=`
* Similar to the current `/api/dataset/search` endpoint but much more limited in search scope, faster, and has a smaller payload

Returns a list of summary objects:
```
[
  {
    "id": 1415,
    "identifier": "DUOS-000617",
    "name": "Test-05-01-23"
  },
  {
    "id": 1417,
    "identifier": "DUOS-000618",
    "name": "2-Test-05-01-23"
  }, ...
]
```

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
