### PR TITLE
[DUOS-2811] Add deletable property for search index

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/models/elastic_search/DatasetTerm.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/elastic_search/DatasetTerm.java
@@ -10,6 +10,7 @@ public class DatasetTerm {
   @Deprecated // Use submitter.displayName instead
   private String createUserDisplayName;
   private String datasetIdentifier;
+  private Boolean deletable;
   private String datasetName;
   private Integer participantCount;
   private DataUseSummary dataUse;
@@ -54,6 +55,14 @@ public class DatasetTerm {
 
   public void setDatasetIdentifier(String datasetIdentifier) {
     this.datasetIdentifier = datasetIdentifier;
+  }
+
+  public Boolean getDeletable() {
+    return deletable;
+  }
+
+  public void setDeletable(Boolean deletable) {
+    this.deletable = deletable;
   }
 
   public String getDatasetName() {

--- a/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
@@ -254,6 +254,7 @@ public class ElasticSearchService implements ConsentLogger {
         .map(this::toUserTerm)
         .ifPresent(term::setUpdateUser);
     term.setDatasetIdentifier(dataset.getDatasetIdentifier());
+    term.setDeletable(dataset.getDeletable());
     term.setDatasetName(dataset.getName());
 
     if (Objects.nonNull(dataset.getStudy())) {

--- a/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
@@ -123,6 +123,7 @@ class ElasticSearchServiceTest {
     dataset.setDataSetId(RandomUtils.nextInt(1, 100));
     dataset.setAlias(dataset.getDataSetId());
     dataset.setDatasetIdentifier();
+    dataset.setDeletable(true);
     dataset.setName(RandomStringUtils.randomAlphabetic(10));
     dataset.setDatasetName(dataset.getName());
     dataset.setDacId(dac.getDacId());
@@ -309,6 +310,7 @@ class ElasticSearchServiceTest {
 
     assertEquals(datasetRecord.dataset.getDataSetId(), term.getDatasetId());
     assertEquals(datasetRecord.dataset.getDatasetIdentifier(), term.getDatasetIdentifier());
+    assertEquals(datasetRecord.dataset.getDeletable(), term.getDeletable());
     assertEquals(datasetRecord.dataset.getName(), term.getDatasetName());
     assertEquals(datasetRecord.dataset.getDatasetName(), term.getDatasetName());
 


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DUOS-2811

### Summary
Adds deletable property to the DatasetTerm for access in the Elastic Search index

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
