### PR TITLE
[DUOS-2862] Stop sending ZenDesk Support emails when users select existing institution

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/models/support/SupportTicketCreator.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/support/SupportTicketCreator.java
@@ -86,11 +86,11 @@ public class SupportTicketCreator {
       List<String> descriptionItems, Integer selectedInstitutionId) {
     Institution selectedInstitution = institutionDAO.findInstitutionById(selectedInstitutionId);
     subjectItems.add("Institution Selection");
-    descriptionItems.add(
-        Objects.nonNull(selectedInstitution)
-            ? "- selected an existing institution: " + selectedInstitution.getName()
-            : "- attempted to select institution with id " + selectedInstitutionId + " (not found)"
-    );
+    if (Objects.isNull(selectedInstitution)) {
+      descriptionItems.add(
+          "- attempted to select institution with id " + selectedInstitutionId + " (not found)"
+      );
+    }
   }
 
   private void addSuggestedSigningOfficialMessages(List<String> subjectItems,

--- a/src/test/java/org/broadinstitute/consent/http/models/SupportTicketCreatorTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/SupportTicketCreatorTest.java
@@ -113,39 +113,6 @@ class SupportTicketCreatorTest {
   }
 
   @Test
-  void testCreateInstitutionSOSupportTicket_SelectedInstitution() {
-    String displayName = RandomStringUtils.randomAlphabetic(10);
-    String email = RandomStringUtils.randomAlphabetic(10);
-    User user = new User();
-    user.setDisplayName(displayName);
-    user.setEmail(email);
-
-    UserUpdateFields updateFields = new UserUpdateFields();
-    updateFields.setInstitutionId(1);
-    Institution institution = new Institution();
-    String institutionName = RandomStringUtils.randomAlphabetic(10);
-    institution.setName(institutionName);
-
-    when(institutionDAO.findInstitutionById(1)).thenReturn(institution);
-
-    SupportTicket ticket = supportTicketCreator.createInstitutionSOSupportTicket(updateFields,
-        user);
-    SupportTicket.SupportRequest supportRequest = ticket.getRequest();
-    assertEquals(displayName + " user updates: Institution Selection",
-        supportRequest.getSubject());
-
-    String expectedDescription = String.format(
-        "User %s [%s] has:\n- selected an existing institution: %s",
-        user.getDisplayName(),
-        user.getEmail(),
-        institutionName);
-    List<CustomRequestField> customFields = supportRequest.getCustomFields();
-    assertEquals(5, customFields.size());
-    assertTrue(
-        customFields.contains(new CustomRequestField(360007369412L, expectedDescription)));
-  }
-
-  @Test
   void testCreateInstitutionSOSupportTicket_SelectedInstitutionNotFound() {
     String displayName = RandomStringUtils.randomAlphabetic(10);
     String email = RandomStringUtils.randomAlphabetic(10);


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DUOS-2862

### Summary
Only send email to ZenDesk Support regarding the selection of an institution if the selected institution is not found. Deprecates sending of email when users select existing institutions.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
