### PR TITLE
[DUOS-2906][risk=no] Bug Fix: Handle DAR Document Errors Better

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceVersion2.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceVersion2.java
@@ -31,6 +31,7 @@ import java.util.Objects;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.consent.http.cloudstore.GCSService;
 import org.broadinstitute.consent.http.enumeration.DarDocumentType;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
@@ -257,8 +258,10 @@ public class DataAccessRequestResourceVersion2 extends Resource {
           Stream.of(UserRoles.ADMIN, UserRoles.CHAIRPERSON, UserRoles.MEMBER)
               .collect(Collectors.toList()),
           authUser, referenceId);
-      if (Objects.nonNull(dar.getData().getIrbDocumentLocation()) &&
-          Objects.nonNull(dar.getData().getIrbDocumentName())) {
+      if (dar.getData() != null &&
+          StringUtils.isNotEmpty(dar.getData().getIrbDocumentLocation()) &&
+          StringUtils.isNotEmpty(dar.getData().getIrbDocumentName())
+      ) {
         String blobIdName = dar.getData().getIrbDocumentLocation();
         String fileName = dar.getData().getIrbDocumentName();
         InputStream is = gcsService.getDocument(blobIdName);
@@ -368,8 +371,10 @@ public class DataAccessRequestResourceVersion2 extends Resource {
           Stream.of(UserRoles.ADMIN, UserRoles.CHAIRPERSON, UserRoles.MEMBER)
               .collect(Collectors.toList()),
           authUser, referenceId);
-      if (Objects.nonNull(dar.getData().getCollaborationLetterLocation()) &&
-          Objects.nonNull(dar.getData().getCollaborationLetterName())) {
+      if (dar.getData() != null &&
+          StringUtils.isNotEmpty(dar.getData().getCollaborationLetterLocation()) &&
+          StringUtils.isNotEmpty(dar.getData().getCollaborationLetterName())
+      ) {
         String blobIdName = dar.getData().getCollaborationLetterLocation();
         String fileName = dar.getData().getCollaborationLetterName();
         InputStream is = gcsService.getDocument(blobIdName);

--- a/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceVersion2Test.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceVersion2Test.java
@@ -54,6 +54,7 @@ import org.glassfish.jersey.media.multipart.FormDataContentDisposition;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 
 public class DataAccessRequestResourceVersion2Test {
 
@@ -292,6 +293,34 @@ public class DataAccessRequestResourceVersion2Test {
   public void testGetIrbDocumentDARNotFound() {
     when(userService.findUserByEmail(any())).thenReturn(user);
     when(dataAccessRequestService.findByReferenceId(any())).thenReturn(null);
+    initResource();
+
+    Response response = resource.getIrbDocument(authUser, "");
+    assertEquals(404, response.getStatus());
+  }
+
+  @Test
+  public void testGetIrbDocumentNullValues() {
+    when(userService.findUserByEmail(any())).thenReturn(user);
+    DataAccessRequest dar = Mockito.mock(DataAccessRequest.class);
+    DataAccessRequestData data = Mockito.mock(DataAccessRequestData.class);
+    when(dar.getData()).thenReturn(data);
+    when(data.getIrbDocumentLocation()).thenReturn(null);
+    when(data.getIrbDocumentName()).thenReturn(null);
+    initResource();
+
+    Response response = resource.getIrbDocument(authUser, "");
+    assertEquals(404, response.getStatus());
+  }
+
+  @Test
+  public void testGetIrbDocumentEmptyValues() {
+    when(userService.findUserByEmail(any())).thenReturn(user);
+    DataAccessRequest dar = Mockito.mock(DataAccessRequest.class);
+    DataAccessRequestData data = Mockito.mock(DataAccessRequestData.class);
+    when(dar.getData()).thenReturn(data);
+    when(data.getIrbDocumentLocation()).thenReturn("");
+    when(data.getIrbDocumentName()).thenReturn("");
     initResource();
 
     Response response = resource.getIrbDocument(authUser, "");
@@ -618,6 +647,34 @@ public class DataAccessRequestResourceVersion2Test {
     initResource();
 
     Response response = resource.getCollaborationDocument(authUser, "");
+    assertEquals(404, response.getStatus());
+  }
+
+  @Test
+  public void testGetCollaborationDocumentNullValues() {
+    when(userService.findUserByEmail(any())).thenReturn(user);
+    DataAccessRequest dar = Mockito.mock(DataAccessRequest.class);
+    DataAccessRequestData data = Mockito.mock(DataAccessRequestData.class);
+    when(dar.getData()).thenReturn(data);
+    when(data.getCollaborationLetterLocation()).thenReturn(null);
+    when(data.getCollaborationLetterName()).thenReturn(null);
+    initResource();
+
+    Response response = resource.getIrbDocument(authUser, "");
+    assertEquals(404, response.getStatus());
+  }
+
+  @Test
+  public void testGetCollaborationDocumentEmptyValues() {
+    when(userService.findUserByEmail(any())).thenReturn(user);
+    DataAccessRequest dar = Mockito.mock(DataAccessRequest.class);
+    DataAccessRequestData data = Mockito.mock(DataAccessRequestData.class);
+    when(dar.getData()).thenReturn(data);
+    when(data.getCollaborationLetterLocation()).thenReturn("");
+    when(data.getCollaborationLetterName()).thenReturn("");
+    initResource();
+
+    Response response = resource.getIrbDocument(authUser, "");
     assertEquals(404, response.getStatus());
   }
 


### PR DESCRIPTION
### Addresses
Partially addresses https://broadworkbench.atlassian.net/browse/DUOS-2906

### Summary
* Back end updates to make the document retrieval APIs safer
* See also this front-end update: https://github.com/DataBiosphere/duos-ui/pull/2453

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
