### PR TITLE
[DUOS-2884][risk=no] Bug Fix: Ensure users exist for sending submitted dataset emails

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetRegistrationService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetRegistrationService.java
@@ -761,11 +761,15 @@ public class DatasetRegistrationService implements ConsentLogger {
             .stream()
             .filter(user -> user.hasUserRole(UserRoles.CHAIRPERSON))
             .toList();
-        for (User dacChair : chairPersons) {
-          emailService.sendDatasetSubmittedMessage(dacChair,
-              dataset.getCreateUser(),
-              dac.getName(),
-              dataset.getName());
+        if (chairPersons.isEmpty()) {
+          logWarn("No chairpersons found for DAC " + dac.getName());
+        } else {
+          for (User dacChair : chairPersons) {
+            emailService.sendDatasetSubmittedMessage(dacChair,
+                dataset.getCreateUser(),
+                dac.getName(),
+                dataset.getName());
+          }
         }
       }
     } catch (Exception e) {

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetRegistrationService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetRegistrationService.java
@@ -21,6 +21,7 @@ import org.broadinstitute.consent.http.db.DatasetDAO;
 import org.broadinstitute.consent.http.db.StudyDAO;
 import org.broadinstitute.consent.http.enumeration.FileCategory;
 import org.broadinstitute.consent.http.enumeration.PropertyType;
+import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.Dac;
 import org.broadinstitute.consent.http.models.DataUse;
 import org.broadinstitute.consent.http.models.Dataset;
@@ -755,7 +756,12 @@ public class DatasetRegistrationService implements ConsentLogger {
     try {
       for (Dataset dataset : datasets) {
         Dac dac = dacDAO.findById(dataset.getDacId());
-        for (User dacChair : dac.getChairpersons()) {
+        List<User> chairPersons = dacDAO
+            .findMembersByDacId(dac.getDacId())
+            .stream()
+            .filter(user -> user.hasUserRole(UserRoles.CHAIRPERSON))
+            .toList();
+        for (User dacChair : chairPersons) {
           emailService.sendDatasetSubmittedMessage(dacChair,
               dataset.getCreateUser(),
               dac.getName(),


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DUOS-2884

### Summary
* Minor bug fix to get chairs for each DAC when sending submitted dataset emails.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
