### PR TITLE
[DUOS-2837] Unique dataset names

### DIFF
--- a/src/main/resources/changelog-master.xml
+++ b/src/main/resources/changelog-master.xml
@@ -134,4 +134,6 @@
     relativeToChangelogFile="true"/>
   <include file="changesets/changelog-consent-2023-12-20-dataset-study-indexes.xml"
     relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-2024-02-09-unique-dataset-names.xml"
+    relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/changesets/changelog-consent-2024-02-09-unique-dataset-names.xml
+++ b/src/main/resources/changesets/changelog-consent-2024-02-09-unique-dataset-names.xml
@@ -1,0 +1,7 @@
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+  <changeSet id="changelog-consent-2024-02-09-unique-dataset-names.xml" author="fboulnois">
+    <addUniqueConstraint columnNames="name" tableName="dataset"/>
+  </changeSet>
+</databaseChangeLog>

--- a/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
@@ -46,6 +46,7 @@ import org.broadinstitute.consent.http.models.Study;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.dto.DatasetDTO;
 import org.broadinstitute.consent.http.util.gson.GsonUtil;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 class DatasetDAOTest extends DAOTestHelper {
@@ -997,6 +998,17 @@ class DatasetDAOTest extends DAOTestHelper {
   }
 
   @Test
+  void testUniqueDatasetName() {
+    Dataset dataset0 = createStaticDataset();
+    try {
+      Dataset dataset1 = createStaticDataset();
+      Assertions.fail();
+    } catch (Exception e) {
+      assertTrue(e.getMessage().contains("duplicate key value violates unique constraint"));
+    }
+  }
+
+  @Test
   void testDatasetWithStudy() {
     Study study = insertStudyWithProperties();
 
@@ -1421,6 +1433,18 @@ class DatasetDAOTest extends DAOTestHelper {
     Integer id = datasetDAO.insertDataset(name, now, user.getUserId(), objectId,
         dataUse.toString(), null);
     datasetDAO.updateDatasetApproval(dacApproval, instant, user.getUserId(), id);
+    createDatasetProperties(id);
+    return datasetDAO.findDatasetById(id);
+  }
+
+  private Dataset createStaticDataset() {
+    User user = createUser();
+    String name = "test_unique_constraint_dataset_name";
+    Timestamp now = new Timestamp(new Date().getTime());
+    String objectId = "Object ID_" + RandomStringUtils.random(20, true, true);
+    DataUse dataUse = new DataUseBuilder().setGeneralUse(true).build();
+    Integer id = datasetDAO.insertDataset(name, now, user.getUserId(), objectId,
+        dataUse.toString(), null);
     createDatasetProperties(id);
     return datasetDAO.findDatasetById(id);
   }

--- a/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
@@ -1056,18 +1056,22 @@ class DatasetDAOTest extends DAOTestHelper {
         user.getUserId(), dac2.getDacId());
 
     DarCollection dar1 = createDarCollectionWithDatasets(dac1.getDacId(), user, List.of(dataset1));
-    DarCollection dar2 = createDarCollectionWithDatasets(dac2.getDacId(), user, List.of(dataset2, dataset3));
+    DarCollection dar2 = createDarCollectionWithDatasets(dac2.getDacId(), user,
+        List.of(dataset2, dataset3));
     DarCollection dar3 = createDarCollectionWithDatasets(dac2.getDacId(), user, List.of(dataset4));
     List<DarCollection> allDarCollections = List.of(dar1, dar2, dar3);
 
-    Map<Integer, Boolean> expectedFinalVotesForDatasets = Map.of(dataset1.getDataSetId(), false, dataset2.getDataSetId(), false, dataset3.getDataSetId(), true, dataset4.getDataSetId(), true);
+    Map<Integer, Boolean> expectedFinalVotesForDatasets = Map.of(dataset1.getDataSetId(), false,
+        dataset2.getDataSetId(), false, dataset3.getDataSetId(), true, dataset4.getDataSetId(),
+        true);
 
     Map<Integer, Election> elections = new HashMap<>();
 
     for (DarCollection dar : allDarCollections) {
       for (Map.Entry<String, DataAccessRequest> e : dar.getDars().entrySet()) {
         for (Integer id : e.getValue().getDatasetIds()) {
-          elections.put(id, createDataAccessElectionWithVotes(e.getKey(), id, user.getUserId(), expectedFinalVotesForDatasets.get(id)));
+          elections.put(id, createDataAccessElectionWithVotes(e.getKey(), id, user.getUserId(),
+              expectedFinalVotesForDatasets.get(id)));
         }
       }
     }
@@ -1080,9 +1084,14 @@ class DatasetDAOTest extends DAOTestHelper {
       assertTrue(datasetDAO.findDatasetByAlias(approvedDataset.getAlias()).getDacApproval());
     });
 
-    ApprovedDataset expectedApprovedDataset1 = new ApprovedDataset(dataset3.getAlias(), dar2.getDarCode(), dataset3.getDatasetName(), dac2.getName(), elections.get(dataset3.getDataSetId()).getLastUpdate());
-    ApprovedDataset expectedApprovedDataset2 = new ApprovedDataset(dataset4.getAlias(), dar3.getDarCode(), dataset4.getDatasetName(), dac2.getName(), elections.get(dataset4.getDataSetId()).getLastUpdate());
-    Map<Integer, ApprovedDataset> expectedDatasets = Map.of(dataset3.getAlias(), expectedApprovedDataset1, dataset4.getAlias(), expectedApprovedDataset2);
+    ApprovedDataset expectedApprovedDataset1 = new ApprovedDataset(dataset3.getAlias(),
+        dar2.getDarCode(), dataset3.getDatasetName(), dac2.getName(),
+        elections.get(dataset3.getDataSetId()).getLastUpdate());
+    ApprovedDataset expectedApprovedDataset2 = new ApprovedDataset(dataset4.getAlias(),
+        dar3.getDarCode(), dataset4.getDatasetName(), dac2.getName(),
+        elections.get(dataset4.getDataSetId()).getLastUpdate());
+    Map<Integer, ApprovedDataset> expectedDatasets = Map.of(dataset3.getAlias(),
+        expectedApprovedDataset1, dataset4.getAlias(), expectedApprovedDataset2);
 
     // checks that the expected result list size and contents match the observed result
     assertEquals(expectedDatasets.size(), approvedDatasets.size());
@@ -1112,7 +1121,8 @@ class DatasetDAOTest extends DAOTestHelper {
     datasetDAO.updateDataset(dataset2.getDataSetId(), dataset2.getDatasetName(), timestamp,
         user.getUserId(), dac1.getDacId());
 
-    DarCollection dar1 = createDarCollectionWithDatasets(dac1.getDacId(), user, List.of(dataset1, dataset2));
+    DarCollection dar1 = createDarCollectionWithDatasets(dac1.getDacId(), user,
+        List.of(dataset1, dataset2));
 
     for (Map.Entry<String, DataAccessRequest> e : dar1.getDars().entrySet()) {
       for (Integer id : e.getValue().getDatasetIds()) {
@@ -1139,14 +1149,17 @@ class DatasetDAOTest extends DAOTestHelper {
     Dataset dataset = createDataset();
     User user = dataset.getCreateUser();
     createDatasetProperty(dataset.getDataSetId(), "studyName", "Study Name", PropertyType.String);
-    createDatasetProperty(dataset.getDataSetId(), "dataCustodianEmail", user.getEmail(), PropertyType.String);
+    createDatasetProperty(dataset.getDataSetId(), "dataCustodianEmail", user.getEmail(),
+        PropertyType.String);
     Dataset dataset2 = createDataset();
 
     List<Dataset> datasets = datasetDAO.findDatasetsByCustodian(user.getUserId(), user.getEmail());
     assertNotNull(datasets);
     assertFalse(datasets.isEmpty());
-    assertEquals(dataset.getDataSetId(), datasets.stream().map(Dataset::getDataSetId).toList().get(0));
-    assertNotEquals(dataset2.getDataSetId(), datasets.stream().map(Dataset::getDataSetId).toList().get(0));
+    assertEquals(dataset.getDataSetId(),
+        datasets.stream().map(Dataset::getDataSetId).toList().get(0));
+    assertNotEquals(dataset2.getDataSetId(),
+        datasets.stream().map(Dataset::getDataSetId).toList().get(0));
   }
 
   @Test
@@ -1155,13 +1168,16 @@ class DatasetDAOTest extends DAOTestHelper {
     Dataset dataset2 = createDataset();
     User user = createUser();
     datasetDAO.updateDatasetApproval(true, Instant.now(), user.getUserId(), dataset.getDataSetId());
-    datasetDAO.updateDatasetApproval(true, Instant.now(), user.getUserId(), dataset2.getDataSetId());
+    datasetDAO.updateDatasetApproval(true, Instant.now(), user.getUserId(),
+        dataset2.getDataSetId());
 
     List<DatasetSummary> summaries = datasetDAO.findDatasetSummariesByQuery(dataset.getName());
     assertNotNull(summaries);
     assertFalse(summaries.isEmpty());
-    assertEquals(dataset.getDataSetId(), summaries.stream().map(DatasetSummary::id).toList().get(0));
-    assertNotEquals(dataset2.getDataSetId(), summaries.stream().map(DatasetSummary::id).toList().get(0));
+    assertEquals(dataset.getDataSetId(),
+        summaries.stream().map(DatasetSummary::id).toList().get(0));
+    assertNotEquals(dataset2.getDataSetId(),
+        summaries.stream().map(DatasetSummary::id).toList().get(0));
   }
 
   @Test
@@ -1409,7 +1425,8 @@ class DatasetDAOTest extends DAOTestHelper {
     return datasetDAO.findDatasetById(id);
   }
 
-  private Election createDataAccessElectionWithVotes(String referenceId, Integer datasetId, Integer userId, boolean finalVoteApproval) {
+  private Election createDataAccessElectionWithVotes(String referenceId, Integer datasetId,
+      Integer userId, boolean finalVoteApproval) {
     Integer electionId = electionDAO.insertElection(
         ElectionType.DATA_ACCESS.getValue(),
         ElectionStatus.OPEN.getValue(),
@@ -1418,7 +1435,8 @@ class DatasetDAOTest extends DAOTestHelper {
         datasetId
     );
     Integer voteId = voteDAO.insertVote(userId, electionId, VoteType.FINAL.getValue());
-    voteDAO.updateVote(finalVoteApproval, "rationale", new Date(), voteId, false, electionId, new Date(), false);
+    voteDAO.updateVote(finalVoteApproval, "rationale", new Date(), voteId, false, electionId,
+        new Date(), false);
     electionDAO.updateElectionById(electionId, ElectionStatus.CLOSED.getValue(), new Date());
     datasetDAO.updateDatasetApproval(finalVoteApproval, Instant.now(), userId, datasetId);
     return electionDAO.findElectionById(electionId);


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DUOS-2837

### Summary

> DO NOT MERGE before changes have been made to duplicate dataset names in dev and prod.

Adds a constraint to ensure dataset names are globally unique.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
