### PR TITLE
[DUOS-2957][risk=no] Bug Fix: Handle string values of # of participants better

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
@@ -293,7 +293,14 @@ public class ElasticSearchService implements ConsentLogger {
     findFirstDatasetPropertyByName(
         dataset.getProperties(), "# of participants"
     ).ifPresent(
-        datasetProperty -> term.setParticipantCount((Integer) datasetProperty.getPropertyValue())
+        datasetProperty -> {
+          String value = datasetProperty.getPropertyValueAsString();
+          try {
+            term.setParticipantCount(Integer.valueOf(value));
+          } catch (NumberFormatException e) {
+            logWarn(String.format("Unable to coerce participant count to integer: %s for dataset: %s", value, dataset.getDatasetIdentifier()));
+          }
+        }
     );
 
     findDatasetProperty(

--- a/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
@@ -355,6 +355,32 @@ class ElasticSearchServiceTest {
   }
 
   @Test
+  void testToDatasetTerm_StringNumberOfParticipants() {
+    User user = createUser(1, 100);
+    User updateUser = createUser(101, 200);
+    Dac dac = createDac();
+    Study study = createStudy(user);
+    study.setProperties(Set.of(
+        createStudyProperty("phenotypeIndication", PropertyType.String),
+        createStudyProperty("species", PropertyType.String),
+        createStudyProperty("dataCustodianEmail", PropertyType.Json)
+    ));
+    Dataset dataset = createDataset(user, updateUser, new DataUse(), dac);
+    dataset.setProperties(Set.of(
+        createDatasetProperty("numberOfParticipants", PropertyType.String, "# of participants"),
+        createDatasetProperty("url", PropertyType.String, "url")
+    ));
+    dataset.setStudy(study);
+    DatasetRecord record = new DatasetRecord(user, updateUser, dac, dataset, study);
+    when(dacDAO.findById(any())).thenReturn(dac);
+    when(userDao.findUserById(user.getUserId())).thenReturn(user);
+    when(dacDAO.findById(any())).thenReturn(record.dac);
+    when(userDao.findUserById(record.createUser.getUserId())).thenReturn(record.createUser);
+    initService();
+    assertDoesNotThrow(() -> service.toDatasetTerm(dataset));
+  }
+
+  @Test
   void testToDatasetTermIncomplete() {
     Dataset dataset = new Dataset();
     dataset.setDataSetId(100);


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DUOS-2957

### Summary
Minor error handling to ensure that non-numeric strings do not throw errors when exporting a dataset to ES.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
