### PR TITLE
[DUOS-1740][risk=no] Bug Fix: revert swagger to latest working version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <pact.version>4.6.7</pact.version>
     <postgres.version>42.7.2</postgres.version>
     <surefire.version>3.2.5</surefire.version>
-    <swagger.ui.version>5.11.8</swagger.ui.version>
+    <swagger.ui.version>5.10.3</swagger.ui.version>
     <swagger.ui.path>META-INF/resources/webjars/swagger-ui/${swagger.ui.version}/</swagger.ui.path>
     <mockserver.version>5.15.0</mockserver.version>
     <junit.version>5.10.2</junit.version>


### PR DESCRIPTION
### Addresses
DUOS-1740

### Summary
Reverts the swagger part of https://github.com/DataBiosphere/consent/pull/2253 which introduced a bug where some tags are missing in the rendered interface.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
