### PR TITLE
[DUOS-2972][risk=no] Safer email filtering for TDR Approved User calls

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/service/TDRService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/TDRService.java
@@ -46,6 +46,7 @@ public class TDRService implements ConsentLogger {
         .flatMap(List::stream)
         .filter(Objects::nonNull)
         .map(Collaborator::getEmail)
+        .filter(email -> !email.isBlank())
         // Sam has an endpoint for validating a single email at a time
         .map(email -> {
           try {
@@ -62,8 +63,11 @@ public class TDRService implements ConsentLogger {
         .filter(Objects::nonNull)
         .toList();
     List<Integer> userIds = dars.stream().map(DataAccessRequest::getUserId).toList();
-    Collection<User> users = userDAO.findUsers(userIds);
-    List<String> userEmails = users.stream().map(User::getEmail).toList();
+    Collection<User> users = userIds.isEmpty() ? List.of() : userDAO.findUsers(userIds);
+    List<String> userEmails = users.stream()
+        .map(User::getEmail)
+        .filter(email -> !email.isBlank())
+        .toList();
 
     List<ApprovedUser> approvedUsers = Stream.of(labCollaborators, userEmails)
         .flatMap(List::stream)

--- a/src/test/java/org/broadinstitute/consent/http/service/TDRServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/TDRServiceTest.java
@@ -3,6 +3,8 @@ package org.broadinstitute.consent.http.service;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.openMocks;
 
@@ -79,6 +81,44 @@ class TDRServiceTest {
 
     assertTrue(
         approvedUsersEmails.containsAll(List.of(user1.getEmail(), user2.getEmail(), lab.getEmail())));
+  }
+
+  @Test
+  void testGetApprovedUsersForDatasetEmptyEmails() {
+    Dataset dataset = new Dataset();
+    User user1 = new User();
+    user1.setUserId(1);
+    user1.setEmail(" ");
+    DataAccessRequest dar1 = new DataAccessRequest();
+    dar1.setUserId(user1.getUserId());
+    DataAccessRequestData data = new DataAccessRequestData();
+    Collaborator lab = new Collaborator();
+    lab.setEmail(" ");
+    data.setLabCollaborators(List.of(lab));
+    dar1.setData(data);
+    User user2 = new User();
+    user2.setUserId(2);
+    user2.setEmail(" ");
+    DataAccessRequest dar2 = new DataAccessRequest();
+    dar2.setUserId(user2.getUserId());
+
+    when(darService.getApprovedDARsForDataset(dataset)).thenReturn(List.of(dar1, dar2));
+    when(userDAO.findUsers(any())).thenReturn(List.of(user1, user2));
+
+    initService();
+    ApprovedUsers approvedUsers = service.getApprovedUsersForDataset(authUser, dataset);
+    assertTrue(approvedUsers.approvedUsers().isEmpty());
+  }
+
+  @Test
+  void testGetApprovedUsersForDatasetNoUsers() {
+    Dataset dataset = new Dataset();
+    when(darService.getApprovedDARsForDataset(any())).thenReturn(List.of());
+
+    initService();
+    ApprovedUsers approvedUsers = service.getApprovedUsersForDataset(authUser, dataset);
+    assertTrue(approvedUsers.approvedUsers().isEmpty());
+    verify(userDAO, never()).findUsers(any());
   }
 
   @Test


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DUOS-2972

### Summary
Minor updates to the filtering logic to ensure we're not trying to query on invalid values.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
