### PR TITLE
[DUOS-3018][risk=no] Remove User-Institution Emails

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
@@ -239,8 +239,7 @@ public class ConsentApplication extends Application<ConsentConfiguration> {
     env.jersey().register(new SwaggerResource(config.getGoogleAuthentication()));
     env.jersey().register(new StatusResource(env.healthChecks()));
     env.jersey().register(
-        new UserResource(samService, userService, datasetService, supportRequestService,
-            acknowledgementService));
+        new UserResource(samService, userService, datasetService, acknowledgementService));
     env.jersey().register(new TosResource(samService));
     env.jersey().register(injector.getInstance(VersionResource.class));
     env.jersey().register(new VoteResource(userService, voteService, electionService));

--- a/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
@@ -47,7 +47,6 @@ import org.broadinstitute.consent.http.models.UserUpdateFields;
 import org.broadinstitute.consent.http.models.dto.DatasetDTO;
 import org.broadinstitute.consent.http.service.AcknowledgementService;
 import org.broadinstitute.consent.http.service.DatasetService;
-import org.broadinstitute.consent.http.service.SupportRequestService;
 import org.broadinstitute.consent.http.service.UserService;
 import org.broadinstitute.consent.http.service.UserService.SimplifiedUser;
 import org.broadinstitute.consent.http.service.sam.SamService;
@@ -59,17 +58,14 @@ public class UserResource extends Resource {
   private final Gson gson = new Gson();
   private final SamService samService;
   private final DatasetService datasetService;
-  private final SupportRequestService supportRequestService;
   private final AcknowledgementService acknowledgementService;
 
   @Inject
   public UserResource(SamService samService, UserService userService,
-      DatasetService datasetService, SupportRequestService supportRequestService,
-      AcknowledgementService acknowledgementService) {
+      DatasetService datasetService, AcknowledgementService acknowledgementService) {
     this.samService = samService;
     this.userService = userService;
     this.datasetService = datasetService;
-    this.supportRequestService = supportRequestService;
     this.acknowledgementService = acknowledgementService;
   }
 
@@ -241,7 +237,6 @@ public class UserResource extends Resource {
       }
 
       user = userService.updateUserFieldsById(userUpdateFields, user.getUserId());
-      supportRequestService.handleInstitutionSOSupportRequest(userUpdateFields, user);
       Gson gson = new Gson();
       JsonObject jsonUser = userService.findUserWithPropertiesByIdAsJsonObject(authUser,
           user.getUserId());


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DUOS-3018

### Summary
* Removes the case where we would send emails for institution updates on user info updates
* Note that this leaves in place unused code in `SupportRequestService` - we have tickets in place to expand this feature out so that all support emails are sent via the back end instead of via the UI, so I wanted to keep this code for that future use.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
