### PR TITLE
[DUOS-2808][risk=no] Re-index datasets on study update

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
@@ -435,6 +435,7 @@ public class ConsentModule extends AbstractModule {
         providesUserDAO(),
         providesOntologyService(),
         providesInstitutionDAO(),
+        providesDatasetDAO(),
         providesStudyDAO()
     );
   }

--- a/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
@@ -434,7 +434,8 @@ public class ConsentModule extends AbstractModule {
         providesDataAccessRequestDAO(),
         providesUserDAO(),
         providesOntologyService(),
-        providesInstitutionDAO()
+        providesInstitutionDAO(),
+        providesStudyDAO()
     );
   }
 

--- a/src/main/java/org/broadinstitute/consent/http/resources/StudyResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/StudyResource.java
@@ -189,7 +189,7 @@ public class StudyResource extends Resource {
             user,
             files);
         try (Response indexResponse = elasticSearchService.indexStudy(studyId))  {
-          if (indexResponse.getStatus() >= 400) {
+          if (indexResponse.getStatus() >= Status.BAD_REQUEST.getStatusCode()) {
             logWarn("Non-OK response when reindexing study with id: " + studyId);
           }
         } catch (Exception e) {

--- a/src/main/java/org/broadinstitute/consent/http/resources/StudyResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/StudyResource.java
@@ -188,6 +188,13 @@ public class StudyResource extends Resource {
             registration,
             user,
             files);
+        try (Response indexResponse = elasticSearchService.indexStudy(studyId))  {
+          if (indexResponse.getStatus() >= 400) {
+            logWarn("Non-OK response when reindexing study with id: " + studyId);
+          }
+        } catch (Exception e) {
+          logException("Exception re-indexing datasets from study id: " + studyId, e);
+        }
         return Response.ok(updatedStudy).build();
       } else {
         return Response.status(Status.BAD_REQUEST).build();

--- a/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
@@ -243,7 +243,7 @@ public class ElasticSearchService implements ConsentLogger {
   public Response indexStudy(Integer studyId) {
     Study study = studyDAO.findStudyById(studyId);
     if (study != null && study.getDatasets() != null && !study.getDatasets().isEmpty()) {
-      final List<Dataset> datasets = study.getDatasets().stream().toList();
+      List<Dataset> datasets = study.getDatasets().stream().toList();
       try (Response response = indexDatasets(datasets)) {
         return response;
       } catch (Exception e) {

--- a/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
@@ -3,6 +3,7 @@ package org.broadinstitute.consent.http.service;
 import com.google.gson.JsonArray;
 import jakarta.ws.rs.HttpMethod;
 import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.Status;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -17,6 +18,7 @@ import org.broadinstitute.consent.http.configurations.ElasticSearchConfiguration
 import org.broadinstitute.consent.http.db.DacDAO;
 import org.broadinstitute.consent.http.db.DataAccessRequestDAO;
 import org.broadinstitute.consent.http.db.InstitutionDAO;
+import org.broadinstitute.consent.http.db.StudyDAO;
 import org.broadinstitute.consent.http.db.UserDAO;
 import org.broadinstitute.consent.http.models.Dac;
 import org.broadinstitute.consent.http.models.DataAccessRequest;
@@ -46,6 +48,7 @@ public class ElasticSearchService implements ConsentLogger {
   private final UserDAO userDAO;
   private final OntologyService ontologyService;
   private final InstitutionDAO institutionDAO;
+  private final StudyDAO studyDAO;
 
   public ElasticSearchService(
       RestClient esClient,
@@ -54,7 +57,8 @@ public class ElasticSearchService implements ConsentLogger {
       DataAccessRequestDAO dataAccessRequestDAO,
       UserDAO userDao,
       OntologyService ontologyService,
-      InstitutionDAO institutionDAO) {
+      InstitutionDAO institutionDAO,
+      StudyDAO studyDAO) {
     this.esClient = esClient;
     this.esConfig = esConfig;
     this.dacDAO = dacDAO;
@@ -62,6 +66,7 @@ public class ElasticSearchService implements ConsentLogger {
     this.userDAO = userDao;
     this.ontologyService = ontologyService;
     this.institutionDAO = institutionDAO;
+    this.studyDAO = studyDAO;
   }
 
 
@@ -233,6 +238,20 @@ public class ElasticSearchService implements ConsentLogger {
   public Response indexDatasets(List<Dataset> datasets) throws IOException {
     List<DatasetTerm> datasetTerms = datasets.stream().map(this::toDatasetTerm).toList();
     return indexDatasetTerms(datasetTerms);
+  }
+
+  public Response indexStudy(Integer studyId) {
+    Study study = studyDAO.findStudyById(studyId);
+    if (study != null && study.getDatasets() != null && !study.getDatasets().isEmpty()) {
+      final List<Dataset> datasets = study.getDatasets().stream().toList();
+      try (Response response = indexDatasets(datasets)) {
+        return response;
+      } catch (Exception e) {
+        logException(String.format("Failed to index datasets for study id: %d", studyId), e);
+        return Response.status(Status.INTERNAL_SERVER_ERROR).build();
+      }
+    }
+    return Response.status(Status.NOT_FOUND).build();
   }
 
   public DatasetTerm toDatasetTerm(Dataset dataset) {

--- a/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
@@ -29,6 +29,7 @@ import org.broadinstitute.consent.http.configurations.ElasticSearchConfiguration
 import org.broadinstitute.consent.http.db.DacDAO;
 import org.broadinstitute.consent.http.db.DataAccessRequestDAO;
 import org.broadinstitute.consent.http.db.InstitutionDAO;
+import org.broadinstitute.consent.http.db.StudyDAO;
 import org.broadinstitute.consent.http.db.UserDAO;
 import org.broadinstitute.consent.http.enumeration.PropertyType;
 import org.broadinstitute.consent.http.models.Dac;
@@ -80,6 +81,9 @@ class ElasticSearchServiceTest {
   @Mock
   private InstitutionDAO institutionDAO;
 
+  @Mock
+  private StudyDAO studyDAO;
+
   private void initService() {
     service = new ElasticSearchService(
         esClient,
@@ -88,7 +92,8 @@ class ElasticSearchServiceTest {
         dataAccessRequestDAO,
         userDao,
         ontologyService,
-        institutionDAO);
+        institutionDAO,
+        studyDAO);
   }
 
   private void mockElasticSearchResponse(int statusCode, String body) throws IOException {
@@ -511,5 +516,27 @@ class ElasticSearchServiceTest {
 
     initService();
     assertFalse(service.validateQuery(query));
+  }
+
+  @Test
+  void testIndexStudyWithDatasets() {
+    Study study = new Study();
+    study.setStudyId(1);
+    Dataset d = new Dataset();
+    study.addDatasets(List.of(d));
+    when(studyDAO.findStudyById(any())).thenReturn(study);
+
+    initService();
+    assertDoesNotThrow(() -> service.indexStudy(1));
+  }
+
+  @Test
+  void testIndexStudyWithNoDatasets() {
+    Study study = new Study();
+    study.setStudyId(1);
+    when(studyDAO.findStudyById(any())).thenReturn(study);
+
+    initService();
+    assertDoesNotThrow(() -> service.indexStudy(1));
   }
 }

--- a/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
@@ -28,6 +28,7 @@ import org.apache.http.nio.entity.NStringEntity;
 import org.broadinstitute.consent.http.configurations.ElasticSearchConfiguration;
 import org.broadinstitute.consent.http.db.DacDAO;
 import org.broadinstitute.consent.http.db.DataAccessRequestDAO;
+import org.broadinstitute.consent.http.db.DatasetDAO;
 import org.broadinstitute.consent.http.db.InstitutionDAO;
 import org.broadinstitute.consent.http.db.StudyDAO;
 import org.broadinstitute.consent.http.db.UserDAO;
@@ -82,6 +83,8 @@ class ElasticSearchServiceTest {
   private InstitutionDAO institutionDAO;
 
   @Mock
+  private DatasetDAO datasetDAO;
+  @Mock
   private StudyDAO studyDAO;
 
   private void initService() {
@@ -93,6 +96,7 @@ class ElasticSearchServiceTest {
         userDao,
         ontologyService,
         institutionDAO,
+        datasetDAO,
         studyDAO);
   }
 
@@ -523,8 +527,10 @@ class ElasticSearchServiceTest {
     Study study = new Study();
     study.setStudyId(1);
     Dataset d = new Dataset();
-    study.addDatasets(List.of(d));
+    d.setDataSetId(1);
+    study.addDatasetId(d.getDataSetId());
     when(studyDAO.findStudyById(any())).thenReturn(study);
+    when(datasetDAO.findDatasetsByIdList(any())).thenReturn(List.of(d));
 
     initService();
     assertDoesNotThrow(() -> service.indexStudy(1));


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DUOS-2808

### Summary
* Add a new method to re-index the datasets in a study and call on study update.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
