### PR TITLE
[DUOS-2833][DUOS-2876] Remove the duplicate DAC ID dataset property

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetRegistrationService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetRegistrationService.java
@@ -700,10 +700,7 @@ public class DatasetRegistrationService implements ConsentLogger {
               return consentGroup.getAccessManagement().value();
             }
             return null;
-          }),
-      new DatasetPropertyExtractor(
-          "DAC ID", "dataAccessCommitteeId", PropertyType.Number,
-          ConsentGroup::getDataAccessCommitteeId)
+          })
   );
 
   private List<StudyProperty> convertRegistrationToStudyProperties(

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -469,12 +469,6 @@ public class DatasetService implements ConsentLogger {
     }
 
     List<Dictionary> dictionaries = datasetDAO.getDictionaryTerms();
-    // Dataset Property updates
-    if (studyConversion.getDacId() != null) {
-      newPropConversion(dictionaries, dataset, "DAC ID", "dataAccessCommitteeId",
-          PropertyType.Number, studyConversion.getDacId().toString());
-    }
-
     // Handle "Phenotype/Indication"
     if (studyConversion.getPhenotype() != null) {
       legacyPropConversion(dictionaries, dataset, "Phenotype/Indication", null, PropertyType.String,

--- a/src/main/resources/changelog-master.xml
+++ b/src/main/resources/changelog-master.xml
@@ -142,4 +142,6 @@
     relativeToChangelogFile="true"/>
   <include file="changesets/changelog-consent-2024-03-12-daa-lc.xml"
     relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-2024-03-28-dataset-dac-id-props.xml"
+    relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/changesets/changelog-consent-2024-03-28-dataset-dac-id-props.xml
+++ b/src/main/resources/changesets/changelog-consent-2024-03-28-dataset-dac-id-props.xml
@@ -1,0 +1,18 @@
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+  <changeSet id="changelog-consent-2024-03-28-dataset-dac-id-props.xml" author="grushton">
+    <sql>
+      -- Remove duplicate properties
+      DELETE
+      FROM dataset_property
+      WHERE property_key IN (SELECT key_id FROM "dictionary" d WHERE KEY = 'DAC ID')
+    </sql>
+    <sql>
+      -- Remove deprecated property key from dictionary
+      DELETE
+      FROM dictionary
+      WHERE key = 'DAC ID';
+    </sql>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/changesets/changelog-consent-2024-03-28-dataset-dac-id-props.xml
+++ b/src/main/resources/changesets/changelog-consent-2024-03-28-dataset-dac-id-props.xml
@@ -6,7 +6,7 @@
       -- Remove duplicate properties
       DELETE
       FROM dataset_property
-      WHERE property_key IN (SELECT key_id FROM "dictionary" d WHERE KEY = 'DAC ID')
+      WHERE property_key IN (SELECT key_id FROM dictionary d WHERE KEY = 'DAC ID')
     </sql>
     <sql>
       -- Remove deprecated property key from dictionary

--- a/src/test/java/org/broadinstitute/consent/http/service/DatasetRegistrationServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DatasetRegistrationServiceTest.java
@@ -229,8 +229,6 @@ public class DatasetRegistrationServiceTest {
         GsonUtil.getInstance().toJson(schema.getConsentGroups().get(0).getFileTypes())));
     assertContainsDatasetProperty(datasetProps, "url",
         schema.getConsentGroups().get(0).getUrl().toString());
-    assertContainsDatasetProperty(datasetProps, "dataAccessCommitteeId",
-        schema.getConsentGroups().get(0).getDataAccessCommitteeId());
     assertContainsDatasetProperty(datasetProps, "accessManagement",
         schema.getConsentGroups().get(0).getAccessManagement().value());
 
@@ -465,8 +463,6 @@ public class DatasetRegistrationServiceTest {
     List<DatasetProperty> props = inserts.get(0).props();
     assertContainsDatasetProperty(props, "fileTypes", PropertyType.coerceToJson(
         GsonUtil.getInstance().toJson(schema.getConsentGroups().get(0).getFileTypes())));
-    assertContainsDatasetProperty(props, "dataAccessCommitteeId",
-        schema.getConsentGroups().get(0).getDataAccessCommitteeId());
     assertContainsDatasetProperty(props, "accessManagement",
         schema.getConsentGroups().get(0).getAccessManagement().value());
     assertContainsDatasetProperty(props, "numberOfParticipants",


### PR DESCRIPTION
### Addresses
* https://broadworkbench.atlassian.net/browse/DUOS-2833
* https://broadworkbench.atlassian.net/browse/DUOS-2876

### Summary
* Stop creating dac id dataset props and instead, keep populating the dataset's dac id directly like we have been doing.
* Remove old dac id props and dictionary term

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
