### PR TITLE
[DUOS-3021][risk=no] Handle null roles better

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/util/InstitutionUtil.java
+++ b/src/main/java/org/broadinstitute/consent/http/util/InstitutionUtil.java
@@ -5,11 +5,12 @@ import com.google.gson.FieldAttributes;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import java.util.List;
+import java.util.Objects;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.UserRole;
 
-public class InstitutionUtil {
+public class InstitutionUtil implements ConsentLogger {
 
   private final GsonBuilder gson;
 
@@ -28,8 +29,12 @@ public class InstitutionUtil {
 
   public Boolean checkIfAdmin(User user) {
     List<UserRole> roles = user.getRoles();
+    if (roles == null || roles.isEmpty()) {
+      logWarn("User has no roles: " + user.getEmail());
+      return false;
+    }
     return roles.stream()
-        .anyMatch((userRole) -> userRole.getRoleId() == UserRoles.ADMIN.getRoleId());
+        .anyMatch((userRole) -> Objects.equals(userRole.getRoleId(), UserRoles.ADMIN.getRoleId()));
   }
 
   private ExclusionStrategy getSerializationExclusionStrategy(Boolean isAdmin) {

--- a/src/test/java/org/broadinstitute/consent/http/util/InstitutionUtilTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/util/InstitutionUtilTest.java
@@ -44,11 +44,10 @@ class InstitutionUtilTest {
   }
 
   @Test
-  void testCheckIfAdmin() {
-    Boolean adminResult = util.checkIfAdmin(adminUser);
-    Boolean researcherResult = util.checkIfAdmin(researcherUser);
-    assertTrue(adminResult);
-    assertFalse(researcherResult);
+  void testCheckIfAdminAdmin() {
+    assertTrue(util.checkIfAdmin(adminUser));
+    assertFalse(util.checkIfAdmin(researcherUser));
+    assertFalse(util.checkIfAdmin(new User()));
   }
 
   @Test


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DUOS-3021

### Summary
Minor fix for handling the case where an existing user does not have any roles assigned.
See also this front end PR: https://github.com/DataBiosphere/duos-ui/pull/2523

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
