### PR TITLE
[DUOS-3042][risk=no] NPE fixes for study by identifier API

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/models/dataset_registration_v1/builder/ConsentGroupFromDataset.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/dataset_registration_v1/builder/ConsentGroupFromDataset.java
@@ -90,7 +90,7 @@ public class ConsentGroupFromDataset {
     if (Objects.nonNull(props) && !props.isEmpty()) {
       return props
           .stream()
-          .filter(p -> p.getSchemaProperty().equalsIgnoreCase(propName))
+          .filter(p -> p.getSchemaProperty() != null && p.getSchemaProperty().equalsIgnoreCase(propName))
           .map(DatasetProperty::getPropertyValueAsString)
           .findFirst()
           .orElse(null);
@@ -103,7 +103,7 @@ public class ConsentGroupFromDataset {
     if (Objects.nonNull(props) && !props.isEmpty()) {
       return props
           .stream()
-          .filter(p -> p.getSchemaProperty().equalsIgnoreCase(propName))
+          .filter(p -> p.getSchemaProperty() != null && p.getSchemaProperty().equalsIgnoreCase(propName))
           .map(DatasetProperty::getPropertyValue)
           .map(Object::toString)
           .map(Boolean::valueOf)
@@ -118,8 +118,7 @@ public class ConsentGroupFromDataset {
     if (Objects.nonNull(props) && !props.isEmpty()) {
       return props
           .stream()
-          .filter(p -> p.getSchemaProperty()
-              .equalsIgnoreCase(diseaseSpecificUse))
+          .filter(p -> p.getSchemaProperty() != null && p.getSchemaProperty().equalsIgnoreCase(diseaseSpecificUse))
           .map(DatasetProperty::getPropertyValue)
           .map(p -> GsonUtil.getInstance().fromJson(p.toString(), JsonElement.class))
           .map(JsonElement::getAsJsonArray)
@@ -136,7 +135,7 @@ public class ConsentGroupFromDataset {
     if (Objects.nonNull(props) && !props.isEmpty()) {
       return props
           .stream()
-          .filter(p -> p.getSchemaProperty().equalsIgnoreCase(propName))
+          .filter(p -> p.getSchemaProperty() != null && p.getSchemaProperty().equalsIgnoreCase(propName))
           .map(DatasetProperty::getPropertyValue)
           .map(Object::toString)
           .map(Integer::valueOf)
@@ -151,7 +150,7 @@ public class ConsentGroupFromDataset {
     if (Objects.nonNull(props) && !props.isEmpty()) {
       return props
           .stream()
-          .filter(p -> p.getSchemaProperty().equalsIgnoreCase(fileTypes))
+          .filter(p -> p.getSchemaProperty() != null && p.getSchemaProperty().equalsIgnoreCase(fileTypes))
           .map(DatasetProperty::getPropertyValueAsString)
           .map(p -> GsonUtil.getInstance().fromJson(p, JsonArray.class))
           .map(JsonArray::asList)

--- a/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
@@ -382,7 +382,7 @@ public class DatasetResource extends Resource {
             "No dataset exists for dataset identifier: " + datasetIdentifier);
       }
       Study study;
-      if (Objects.nonNull(dataset.getStudy())) {
+      if (dataset.getStudy() != null && dataset.getStudy().getStudyId() != null) {
         study = datasetService.findStudyById(dataset.getStudy().getStudyId());
       } else {
         throw new NotFoundException("No study exists for dataset identifier: " + datasetIdentifier);

--- a/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
@@ -372,7 +372,7 @@ public class DatasetResource extends Resource {
   @GET
   @Path("/registration/{datasetIdentifier}")
   @Produces(MediaType.APPLICATION_JSON)
-  @RolesAllowed({ADMIN, CHAIRPERSON, DATASUBMITTER})
+  @PermitAll
   public Response getRegistrationFromDatasetIdentifier(@Auth AuthUser authUser,
       @PathParam("datasetIdentifier") String datasetIdentifier) {
     try {

--- a/src/main/java/org/broadinstitute/consent/http/resources/StudyResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/StudyResource.java
@@ -3,6 +3,7 @@ package org.broadinstitute.consent.http.resources;
 import com.google.gson.Gson;
 import com.google.inject.Inject;
 import io.dropwizard.auth.Auth;
+import jakarta.annotation.security.PermitAll;
 import jakarta.annotation.security.RolesAllowed;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.Consumes;
@@ -85,7 +86,7 @@ public class StudyResource extends Resource {
   @GET
   @Path("/{studyId}")
   @Produces(MediaType.APPLICATION_JSON)
-  @RolesAllowed({ADMIN, CHAIRPERSON, DATASUBMITTER})
+  @PermitAll
   public Response getStudyById(@PathParam("studyId") Integer studyId) {
     try {
       Study study = datasetService.getStudyWithDatasetsById(studyId);
@@ -139,7 +140,7 @@ public class StudyResource extends Resource {
   @GET
   @Path("/registration/{studyId}")
   @Produces(MediaType.APPLICATION_JSON)
-  @RolesAllowed({ADMIN, CHAIRPERSON, DATASUBMITTER})
+  @PermitAll
   public Response getRegistrationFromStudy(@Auth AuthUser authUser,
       @PathParam("studyId") Integer studyId) {
     try {

--- a/src/test/java/org/broadinstitute/consent/http/models/DatasetRegistrationSchemaV1BuilderTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/DatasetRegistrationSchemaV1BuilderTest.java
@@ -49,6 +49,7 @@ import static org.broadinstitute.consent.http.models.dataset_registration_v1.bui
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.studyType;
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.submittingToAnvil;
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.url;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -169,6 +170,20 @@ class DatasetRegistrationSchemaV1BuilderTest {
     assertNotNull(consentGroup.getNumberOfParticipants());
     assertNotNull(consentGroup.getFileTypes());
     assertFalse(consentGroup.getFileTypes().isEmpty());
+  }
+
+  @Test
+  void testBuildSchemaWithDatasetPropWithNullSchema() {
+    DatasetRegistrationSchemaV1Builder builder = new DatasetRegistrationSchemaV1Builder();
+    Study study = createMockStudy();
+    Dataset dataset = createMockDataset();
+    DatasetProperty prop = new DatasetProperty();
+    prop.setDataSetId(dataset.getDataSetId());
+    prop.setSchemaProperty(null);
+    prop.setPropertyName(generalResearchUse);
+    prop.setPropertyType(PropertyType.Boolean);
+    dataset.addProperty(prop);
+    assertDoesNotThrow(() -> builder.build(study, List.of(dataset)));
   }
 
   private Study createMockStudy() {


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DUOS-3042

### Summary
* Handle null schema property cases in translating datasets to consent groups
* Handle case where study object is not null and not populated
* Updated the roles allowed for the relevant `GET` endpoints related to getting studies by various criteria

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
