### PR TITLE
[DUOS-2841][DUOS-3058][risk=no] Set a timeout for Sam

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/authentication/OAuthAuthenticator.java
+++ b/src/main/java/org/broadinstitute/consent/http/authentication/OAuthAuthenticator.java
@@ -106,8 +106,10 @@ public class OAuthAuthenticator implements Authenticator<String, AuthUser>, Cons
         logException("AuthUser not able to be registered: '" + gson.toJson(authUser), exc);
       }
     } catch (Throwable e) {
-      logException("Exception retrieving Sam user info for '" + authUser.getEmail() + "'",
-          new Exception(e.getMessage()));
+      logWarn(String.format(
+          "Exception retrieving Sam user info for '%s': Exception: %s",
+          authUser.getEmail(),
+          e.getMessage()));
     }
     return authUser;
   }

--- a/src/main/java/org/broadinstitute/consent/http/db/SamDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/SamDAO.java
@@ -38,13 +38,17 @@ public class SamDAO implements ConsentLogger {
   private final ExecutorService executorService;
   private final HttpClientUtil clientUtil;
   private final ServicesConfiguration configuration;
-  private final Integer timeoutMilliseconds;
+  private final Integer connectTimeoutMilliseconds;
+  private final Integer readTimeoutMilliseconds;
 
   public SamDAO(HttpClientUtil clientUtil, ServicesConfiguration configuration) {
     this.executorService = Executors.newCachedThreadPool();
     this.clientUtil = clientUtil;
     this.configuration = configuration;
-    this.timeoutMilliseconds = configuration.getTimeoutSeconds() * 1000;
+    // Defaults to 10 seconds
+    this.connectTimeoutMilliseconds = configuration.getTimeoutSeconds() * 1000;
+    // Defaults to 60 seconds
+    this.readTimeoutMilliseconds = configuration.getTimeoutSeconds() * 6000;
   }
 
   public List<ResourceType> getResourceTypes(AuthUser authUser) throws Exception {
@@ -198,8 +202,8 @@ public class SamDAO implements ConsentLogger {
    * @return The HttpResponse
    */
   private HttpResponse executeRequest(HttpRequest request) {
-    request.setConnectTimeout(timeoutMilliseconds);
-    request.setReadTimeout(timeoutMilliseconds);
+    request.setConnectTimeout(connectTimeoutMilliseconds);
+    request.setReadTimeout(readTimeoutMilliseconds);
     return clientUtil.handleHttpRequest(request);
   }
 

--- a/src/main/java/org/broadinstitute/consent/http/db/SamDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/SamDAO.java
@@ -39,7 +39,7 @@ public class SamDAO implements ConsentLogger {
   private final HttpClientUtil clientUtil;
   private final ServicesConfiguration configuration;
   private final Integer connectTimeoutMilliseconds;
-  private final Integer readTimeoutMilliseconds;
+  public final Integer readTimeoutMilliseconds;
 
   public SamDAO(HttpClientUtil clientUtil, ServicesConfiguration configuration) {
     this.executorService = Executors.newCachedThreadPool();

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/SamDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/SamDAOTest.java
@@ -358,10 +358,10 @@ class SamDAOTest implements WithMockServer {
 
   @Test
   void testReadTimeout() {
-    int readTimeoutSeconds = samDAO.readTimeoutMilliseconds + 1;
+    int readTimeoutMilliseconds = samDAO.readTimeoutMilliseconds + 1;
     mockServerClient.when(request())
         .respond(response()
-            .withDelay(new Delay(TimeUnit.SECONDS, readTimeoutSeconds))
+            .withDelay(new Delay(TimeUnit.MILLISECONDS, readTimeoutMilliseconds))
             .withHeader(Header.header("Content-Type", "application/json"))
             .withStatusCode(HttpStatusCodes.STATUS_CODE_OK));
     assertThrows(

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/SamDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/SamDAOTest.java
@@ -73,6 +73,7 @@ class SamDAOTest implements WithMockServer {
     mockServerClient = new MockServerClient(container.getHost(), container.getServerPort());
     mockServerClient.reset();
     ServicesConfiguration config = new ServicesConfiguration();
+    config.setTimeoutSeconds(1);
     config.setSamUrl("http://" + container.getHost() + ":" + container.getServerPort() + "/");
     samDAO = new SamDAO(new HttpClientUtil(config), config);
   }
@@ -358,10 +359,11 @@ class SamDAOTest implements WithMockServer {
 
   @Test
   void testReadTimeout() {
-    int readTimeoutMilliseconds = samDAO.readTimeoutMilliseconds + 1;
+    // Increase the delay to push the response beyond the read timeout value
+    int delayMilliseconds = samDAO.readTimeoutMilliseconds + 10;
     mockServerClient.when(request())
         .respond(response()
-            .withDelay(new Delay(TimeUnit.MILLISECONDS, readTimeoutMilliseconds))
+            .withDelay(new Delay(TimeUnit.MILLISECONDS, delayMilliseconds))
             .withHeader(Header.header("Content-Type", "application/json"))
             .withStatusCode(HttpStatusCodes.STATUS_CODE_OK));
     assertThrows(

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/SamDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/SamDAOTest.java
@@ -14,8 +14,10 @@ import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.ForbiddenException;
 import jakarta.ws.rs.NotAuthorizedException;
 import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.ServerErrorException;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.RandomUtils;
 import org.broadinstitute.consent.http.WithMockServer;
@@ -38,7 +40,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockserver.client.MockServerClient;
+import org.mockserver.model.Delay;
 import org.mockserver.model.Header;
+import org.mockserver.model.HttpError;
 import org.mockserver.model.MediaType;
 import org.testcontainers.containers.MockServerContainer;
 
@@ -342,6 +346,14 @@ class SamDAOTest implements WithMockServer {
     } catch (Exception e) {
       fail(e.getMessage());
     }
+  }
+
+  @Test
+  void testConnectTimeout() {
+    mockServerClient.when(request()).error(HttpError.error().withDropConnection(true));
+    assertThrows(
+        ServerErrorException.class,
+        () -> samDAO.getV1UserByEmail(authUser, RandomStringUtils.randomAlphabetic(10)));
   }
 
 }

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/SamDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/SamDAOTest.java
@@ -356,4 +356,17 @@ class SamDAOTest implements WithMockServer {
         () -> samDAO.getV1UserByEmail(authUser, RandomStringUtils.randomAlphabetic(10)));
   }
 
+  @Test
+  void testReadTimeout() {
+    int readTimeoutSeconds = samDAO.readTimeoutMilliseconds + 1;
+    mockServerClient.when(request())
+        .respond(response()
+            .withDelay(new Delay(TimeUnit.SECONDS, readTimeoutSeconds))
+            .withHeader(Header.header("Content-Type", "application/json"))
+            .withStatusCode(HttpStatusCodes.STATUS_CODE_OK));
+    assertThrows(
+        ServerErrorException.class,
+        () -> samDAO.getV1UserByEmail(authUser, RandomStringUtils.randomAlphabetic(10)));
+  }
+
 }


### PR DESCRIPTION
### Addresses
* https://broadworkbench.atlassian.net/browse/DUOS-2841
* https://broadworkbench.atlassian.net/browse/DUOS-3058

### Summary
* Minor update to our Sam calls to timeout fast instead of holding up other API calls
* Reduce logging to warn in the general case

One thing we're seeing is that users are often blocked on slow-responding API calls when Sam is not responding. We see a lot of these kinds of errors in the logs:
```
jsonPayload: {
   logger: "org.broadinstitute.consent.http.authentication.OAuthAuthenticator".
   message: "Exception retrieving Sam user info for 'user@gmail.com'Server Error (Connect timed out)"
   service-name: "consent"
   thread: "pool-33-thread-195 - GET /api/dac"
   timestamp: 1710444777149
}
```
This PR should also reduce that logging down to a warning since it is so frequent.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
