### PR TITLE
[DUOS-3030] Create new method to flesh out DAA on LC

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/LibraryCardDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/LibraryCardDAO.java
@@ -64,7 +64,7 @@ public interface LibraryCardDAO extends Transactional<LibraryCardDAO> {
   LibraryCard findLibraryCardById(@Bind("libraryCardId") Integer libraryCardId);
 
   @RegisterBeanMapper(value = LibraryCard.class)
-  @RegisterBeanMapper(value = DataAccessAgreement.class)
+  @RegisterBeanMapper(value = DataAccessAgreement.class, prefix = "daa")
   @UseRowReducer(LibraryCardWithDaaReducer.class)
   @SqlQuery("""
       SELECT lc.*,
@@ -75,7 +75,7 @@ public interface LibraryCardDAO extends Transactional<LibraryCardDAO> {
       daa.update_user_id as daa_update_user_id,
       daa.update_date as daa_update_date,
       daa.initial_dac_id as daa_initial_dac_id
-      FROM library_card AS lc
+      FROM library_card lc
       LEFT JOIN lc_daa ld ON lc.id = ld.lc_id
       LEFT JOIN data_access_agreement daa ON ld.daa_id = daa.daa_id
       WHERE lc.id = :libraryCardId

--- a/src/main/java/org/broadinstitute/consent/http/db/LibraryCardDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/LibraryCardDAO.java
@@ -63,6 +63,24 @@ public interface LibraryCardDAO extends Transactional<LibraryCardDAO> {
   LibraryCard findLibraryCardById(@Bind("libraryCardId") Integer libraryCardId);
 
   @RegisterBeanMapper(value = LibraryCard.class)
+  @UseRowReducer(LibraryCardReducer.class)
+  @SqlQuery("""
+      SELECT lc.*,
+      ld.daa_id,
+      daa.daa_id as daa_daa_id,
+      daa.create_user_id as daa_create_user_id,
+      daa.create_date as daa_create_date,
+      daa.update_user_id as daa_update_user_id,
+      daa.update_date as daa_update_date,
+      daa.initial_dac_id as daa_initial_dac_id
+      FROM library_card AS lc
+      LEFT JOIN lc_daa ld ON lc.id = ld.lc_id
+      LEFT JOIN data_access_agreement daa ON ld.daa_id = daa.daa_id
+      WHERE lc.id = :libraryCardId
+      """)
+  LibraryCard findLibraryCardDaaById(@Bind("libraryCardId") Integer libraryCardId);
+
+  @RegisterBeanMapper(value = LibraryCard.class)
   @RegisterBeanMapper(value = Institution.class, prefix = "i")
   @UseRowReducer(LibraryCardReducer.class)
   @SqlQuery("""

--- a/src/main/java/org/broadinstitute/consent/http/db/LibraryCardDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/LibraryCardDAO.java
@@ -3,6 +3,7 @@ package org.broadinstitute.consent.http.db;
 import java.util.Date;
 import java.util.List;
 import org.broadinstitute.consent.http.db.mapper.LibraryCardReducer;
+import org.broadinstitute.consent.http.db.mapper.LibraryCardWithDaaReducer;
 import org.broadinstitute.consent.http.models.DataAccessAgreement;
 import org.broadinstitute.consent.http.models.Institution;
 import org.broadinstitute.consent.http.models.LibraryCard;
@@ -63,7 +64,8 @@ public interface LibraryCardDAO extends Transactional<LibraryCardDAO> {
   LibraryCard findLibraryCardById(@Bind("libraryCardId") Integer libraryCardId);
 
   @RegisterBeanMapper(value = LibraryCard.class)
-  @UseRowReducer(LibraryCardReducer.class)
+  @RegisterBeanMapper(value = DataAccessAgreement.class)
+  @UseRowReducer(LibraryCardWithDaaReducer.class)
   @SqlQuery("""
       SELECT lc.*,
       ld.daa_id,

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/LibraryCardReducer.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/LibraryCardReducer.java
@@ -18,7 +18,6 @@ public class LibraryCardReducer implements LinkedHashMapRowReducer<Integer, Libr
     LibraryCard card = map.computeIfAbsent(
         rowView.getColumn("id", Integer.class),
         id -> rowView.getRow(LibraryCard.class));
-    DataAccessAgreement daa = null;
 
     try {
       if (Objects.nonNull(card) && Objects.nonNull(
@@ -37,53 +36,8 @@ public class LibraryCardReducer implements LinkedHashMapRowReducer<Integer, Libr
       if (Objects.nonNull(card) && Objects.nonNull(
           rowView.getColumn("daa_id", Integer.class))) {
         card.addDaa(rowView.getColumn("daa_id", Integer.class));
-        daa.setDaaId(rowView.getColumn("daa_id", Integer.class));
       }
     } catch (MappingException e) {
-    }
-
-    try {
-      if (Objects.nonNull(card) && Objects.nonNull(
-          rowView.getColumn("create_user_id", Integer.class))) {
-        daa.setCreateUserId(rowView.getColumn("create_user_id", Integer.class));
-      }
-    } catch (MappingException e) {
-    }
-
-    try {
-      if (Objects.nonNull(card) && Objects.nonNull(
-          rowView.getColumn("create_date", Instant.class))) {
-        daa.setCreateDate(rowView.getColumn("create_date", Instant.class));
-      }
-    } catch (MappingException e) {
-    }
-
-    try {
-      if (Objects.nonNull(card) && Objects.nonNull(
-          rowView.getColumn("update_user_id", Integer.class))) {
-        daa.setUpdateUserId(rowView.getColumn("update_user_id", Integer.class));
-      }
-    } catch (MappingException e) {
-    }
-
-    try {
-      if (Objects.nonNull(card) && Objects.nonNull(
-          rowView.getColumn("create_date", Instant.class))) {
-        daa.setCreateDate(rowView.getColumn("create_date", Instant.class));
-      }
-    } catch (MappingException e) {
-    }
-
-    try {
-      if (Objects.nonNull(card) && Objects.nonNull(
-          rowView.getColumn("initial_dac_id", Integer.class))) {
-        daa.setInitialDacId(rowView.getColumn("initial_dac_id", Integer.class));
-      }
-    } catch (MappingException e) {
-    }
-
-    if (daa != null) {
-      card.addDaaObject(daa);
     }
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/LibraryCardReducer.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/LibraryCardReducer.java
@@ -1,9 +1,7 @@
 package org.broadinstitute.consent.http.db.mapper;
 
-import java.time.Instant;
 import java.util.Map;
 import java.util.Objects;
-import org.broadinstitute.consent.http.models.DataAccessAgreement;
 import org.broadinstitute.consent.http.models.Institution;
 import org.broadinstitute.consent.http.models.LibraryCard;
 import org.jdbi.v3.core.mapper.MappingException;

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/LibraryCardReducer.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/LibraryCardReducer.java
@@ -77,7 +77,7 @@ public class LibraryCardReducer implements LinkedHashMapRowReducer<Integer, Libr
     try {
       if (Objects.nonNull(card) && Objects.nonNull(
           rowView.getColumn("initial_dac_id", Integer.class))) {
-        daa.setInitialDacId(rowView.getColumn("initial_dac_id", Integer.class);
+        daa.setInitialDacId(rowView.getColumn("initial_dac_id", Integer.class));
       }
     } catch (MappingException e) {
     }

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/LibraryCardReducer.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/LibraryCardReducer.java
@@ -1,7 +1,9 @@
 package org.broadinstitute.consent.http.db.mapper;
 
+import java.time.Instant;
 import java.util.Map;
 import java.util.Objects;
+import org.broadinstitute.consent.http.models.DataAccessAgreement;
 import org.broadinstitute.consent.http.models.Institution;
 import org.broadinstitute.consent.http.models.LibraryCard;
 import org.jdbi.v3.core.mapper.MappingException;
@@ -16,6 +18,7 @@ public class LibraryCardReducer implements LinkedHashMapRowReducer<Integer, Libr
     LibraryCard card = map.computeIfAbsent(
         rowView.getColumn("id", Integer.class),
         id -> rowView.getRow(LibraryCard.class));
+    DataAccessAgreement daa = null;
 
     try {
       if (Objects.nonNull(card) && Objects.nonNull(
@@ -34,8 +37,53 @@ public class LibraryCardReducer implements LinkedHashMapRowReducer<Integer, Libr
       if (Objects.nonNull(card) && Objects.nonNull(
           rowView.getColumn("daa_id", Integer.class))) {
         card.addDaa(rowView.getColumn("daa_id", Integer.class));
+        daa.setDaaId(rowView.getColumn("daa_id", Integer.class));
       }
     } catch (MappingException e) {
+    }
+
+    try {
+      if (Objects.nonNull(card) && Objects.nonNull(
+          rowView.getColumn("create_user_id", Integer.class))) {
+        daa.setCreateUserId(rowView.getColumn("create_user_id", Integer.class));
+      }
+    } catch (MappingException e) {
+    }
+
+    try {
+      if (Objects.nonNull(card) && Objects.nonNull(
+          rowView.getColumn("create_date", Instant.class))) {
+        daa.setCreateDate(rowView.getColumn("create_date", Instant.class));
+      }
+    } catch (MappingException e) {
+    }
+
+    try {
+      if (Objects.nonNull(card) && Objects.nonNull(
+          rowView.getColumn("update_user_id", Integer.class))) {
+        daa.setUpdateUserId(rowView.getColumn("update_user_id", Integer.class));
+      }
+    } catch (MappingException e) {
+    }
+
+    try {
+      if (Objects.nonNull(card) && Objects.nonNull(
+          rowView.getColumn("create_date", Instant.class))) {
+        daa.setCreateDate(rowView.getColumn("create_date", Instant.class));
+      }
+    } catch (MappingException e) {
+    }
+
+    try {
+      if (Objects.nonNull(card) && Objects.nonNull(
+          rowView.getColumn("initial_dac_id", Integer.class))) {
+        daa.setInitialDacId(rowView.getColumn("initial_dac_id", Integer.class);
+      }
+    } catch (MappingException e) {
+    }
+
+    if (daa != null) {
+      card.addDaaObject(daa);
     }
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/LibraryCardWithDaaReducer.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/LibraryCardWithDaaReducer.java
@@ -1,8 +1,6 @@
 package org.broadinstitute.consent.http.db.mapper;
 
-import java.time.Instant;
 import java.util.Map;
-import java.util.Objects;
 import org.broadinstitute.consent.http.models.DataAccessAgreement;
 import org.broadinstitute.consent.http.models.Institution;
 import org.broadinstitute.consent.http.models.LibraryCard;
@@ -21,21 +19,19 @@ public class LibraryCardWithDaaReducer implements LinkedHashMapRowReducer<Intege
     DataAccessAgreement daa = new DataAccessAgreement();
 
     try {
-      if (Objects.nonNull(card) && Objects.nonNull(
-          rowView.getColumn("i_institution_id", Integer.class))) {
+      if (card != null && rowView.getColumn("i_institution_id", Integer.class) != null) {
         institution = rowView.getRow(Institution.class);
         institution.setId(rowView.getColumn("i_institution_id", Integer.class));
       }
     } catch (MappingException e) {
     }
 
-    if (Objects.nonNull(institution)) {
+    if (institution != null) {
       card.setInstitution(institution);
     }
 
     try {
-      if (Objects.nonNull(card) && Objects.nonNull(
-          rowView.getColumn("daa_id", Integer.class))) {
+      if (card != null && rowView.getColumn("daa_id", Integer.class) != null) {
         daa = rowView.getRow(DataAccessAgreement.class);
         card.addDaa(rowView.getColumn("daa_id", Integer.class));
       }

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/LibraryCardWithDaaReducer.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/LibraryCardWithDaaReducer.java
@@ -43,54 +43,7 @@ public class LibraryCardWithDaaReducer implements LinkedHashMapRowReducer<Intege
     } catch (MappingException e) {
     }
 
-//    try {
-//      if (Objects.nonNull(card) && Objects.nonNull(
-//          rowView.getColumn("create_user_id", Integer.class))) {
-//        daa.setCreateUserId(rowView.getColumn("create_user_id", Integer.class));
-//      }
-//    } catch (MappingException e) {
-//    }
-//
-//    try {
-//      if (Objects.nonNull(card) && Objects.nonNull(
-//          rowView.getColumn("create_date", Instant.class))) {
-//        daa.setCreateDate(rowView.getColumn("create_date", Instant.class));
-//      }
-//    } catch (MappingException e) {
-//    }
-//
-//    try {
-//      if (Objects.nonNull(card) && Objects.nonNull(
-//          rowView.getColumn("update_user_id", Integer.class))) {
-//        daa.setUpdateUserId(rowView.getColumn("update_user_id", Integer.class));
-//      }
-//    } catch (MappingException e) {
-//    }
-//
-//    try {
-//      if (Objects.nonNull(card) && Objects.nonNull(
-//          rowView.getColumn("update_date", Instant.class))) {
-//        daa.setUpdateDate(rowView.getColumn("update_date", Instant.class));
-//      }
-//    } catch (MappingException e) {
-//    }
-//
-//    try {
-//      if (Objects.nonNull(card) && Objects.nonNull(
-//          rowView.getColumn("initial_dac_id", Integer.class))) {
-//        System.out.println("hit1");
-//        daa.setInitialDacId(rowView.getColumn("initial_dac_id", Integer.class));
-//      }
-//    } catch (MappingException e) {
-//    }
-
-    if (daa != null) {
-      System.out.println("dao id: " + daa.getDaaId());
-      System.out.println("dao create user id: " + daa.getCreateUserId());
-      System.out.println("dao crate date: " + daa.getCreateDate());
-      System.out.println("dao update id: " + daa.getUpdateUserId());
-      System.out.println("dao update date: " + daa.getUpdateDate());
-      System.out.println("dao initial dac id: " + daa.getInitialDacId());
+    if (daa.getDaaId() != null) {
       card.addDaaObject(daa);
     }
   }

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/LibraryCardWithDaaReducer.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/LibraryCardWithDaaReducer.java
@@ -38,7 +38,6 @@ public class LibraryCardWithDaaReducer implements LinkedHashMapRowReducer<Intege
           rowView.getColumn("daa_id", Integer.class))) {
         daa = rowView.getRow(DataAccessAgreement.class);
         card.addDaa(rowView.getColumn("daa_id", Integer.class));
-//        daa.setDaaId(rowView.getColumn("daa_id", Integer.class));
       }
     } catch (MappingException e) {
     }

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/LibraryCardWithDaaReducer.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/LibraryCardWithDaaReducer.java
@@ -36,53 +36,61 @@ public class LibraryCardWithDaaReducer implements LinkedHashMapRowReducer<Intege
     try {
       if (Objects.nonNull(card) && Objects.nonNull(
           rowView.getColumn("daa_id", Integer.class))) {
+        daa = rowView.getRow(DataAccessAgreement.class);
         card.addDaa(rowView.getColumn("daa_id", Integer.class));
-        daa.setDaaId(rowView.getColumn("daa_id", Integer.class));
+//        daa.setDaaId(rowView.getColumn("daa_id", Integer.class));
       }
     } catch (MappingException e) {
     }
 
-    try {
-      if (Objects.nonNull(card) && Objects.nonNull(
-          rowView.getColumn("create_user_id", Integer.class))) {
-        daa.setCreateUserId(rowView.getColumn("create_user_id", Integer.class));
-      }
-    } catch (MappingException e) {
-    }
-
-    try {
-      if (Objects.nonNull(card) && Objects.nonNull(
-          rowView.getColumn("create_date", Instant.class))) {
-        daa.setCreateDate(rowView.getColumn("create_date", Instant.class));
-      }
-    } catch (MappingException e) {
-    }
-
-    try {
-      if (Objects.nonNull(card) && Objects.nonNull(
-          rowView.getColumn("update_user_id", Integer.class))) {
-        daa.setUpdateUserId(rowView.getColumn("update_user_id", Integer.class));
-      }
-    } catch (MappingException e) {
-    }
-
-    try {
-      if (Objects.nonNull(card) && Objects.nonNull(
-          rowView.getColumn("create_date", Instant.class))) {
-        daa.setCreateDate(rowView.getColumn("create_date", Instant.class));
-      }
-    } catch (MappingException e) {
-    }
-
-    try {
-      if (Objects.nonNull(card) && Objects.nonNull(
-          rowView.getColumn("initial_dac_id", Integer.class))) {
-        daa.setInitialDacId(rowView.getColumn("initial_dac_id", Integer.class));
-      }
-    } catch (MappingException e) {
-    }
+//    try {
+//      if (Objects.nonNull(card) && Objects.nonNull(
+//          rowView.getColumn("create_user_id", Integer.class))) {
+//        daa.setCreateUserId(rowView.getColumn("create_user_id", Integer.class));
+//      }
+//    } catch (MappingException e) {
+//    }
+//
+//    try {
+//      if (Objects.nonNull(card) && Objects.nonNull(
+//          rowView.getColumn("create_date", Instant.class))) {
+//        daa.setCreateDate(rowView.getColumn("create_date", Instant.class));
+//      }
+//    } catch (MappingException e) {
+//    }
+//
+//    try {
+//      if (Objects.nonNull(card) && Objects.nonNull(
+//          rowView.getColumn("update_user_id", Integer.class))) {
+//        daa.setUpdateUserId(rowView.getColumn("update_user_id", Integer.class));
+//      }
+//    } catch (MappingException e) {
+//    }
+//
+//    try {
+//      if (Objects.nonNull(card) && Objects.nonNull(
+//          rowView.getColumn("update_date", Instant.class))) {
+//        daa.setUpdateDate(rowView.getColumn("update_date", Instant.class));
+//      }
+//    } catch (MappingException e) {
+//    }
+//
+//    try {
+//      if (Objects.nonNull(card) && Objects.nonNull(
+//          rowView.getColumn("initial_dac_id", Integer.class))) {
+//        System.out.println("hit1");
+//        daa.setInitialDacId(rowView.getColumn("initial_dac_id", Integer.class));
+//      }
+//    } catch (MappingException e) {
+//    }
 
     if (daa != null) {
+      System.out.println("dao id: " + daa.getDaaId());
+      System.out.println("dao create user id: " + daa.getCreateUserId());
+      System.out.println("dao crate date: " + daa.getCreateDate());
+      System.out.println("dao update id: " + daa.getUpdateUserId());
+      System.out.println("dao update date: " + daa.getUpdateDate());
+      System.out.println("dao initial dac id: " + daa.getInitialDacId());
       card.addDaaObject(daa);
     }
   }

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/LibraryCardWithDaaReducer.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/LibraryCardWithDaaReducer.java
@@ -1,0 +1,89 @@
+package org.broadinstitute.consent.http.db.mapper;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.Objects;
+import org.broadinstitute.consent.http.models.DataAccessAgreement;
+import org.broadinstitute.consent.http.models.Institution;
+import org.broadinstitute.consent.http.models.LibraryCard;
+import org.jdbi.v3.core.mapper.MappingException;
+import org.jdbi.v3.core.result.LinkedHashMapRowReducer;
+import org.jdbi.v3.core.result.RowView;
+
+public class LibraryCardWithDaaReducer implements LinkedHashMapRowReducer<Integer, LibraryCard> {
+
+  @Override
+  public void accumulate(Map<Integer, LibraryCard> map, RowView rowView) {
+    Institution institution = null;
+    LibraryCard card = map.computeIfAbsent(
+        rowView.getColumn("id", Integer.class),
+        id -> rowView.getRow(LibraryCard.class));
+    DataAccessAgreement daa = new DataAccessAgreement();
+
+    try {
+      if (Objects.nonNull(card) && Objects.nonNull(
+          rowView.getColumn("i_institution_id", Integer.class))) {
+        institution = rowView.getRow(Institution.class);
+        institution.setId(rowView.getColumn("i_institution_id", Integer.class));
+      }
+    } catch (MappingException e) {
+    }
+
+    if (Objects.nonNull(institution)) {
+      card.setInstitution(institution);
+    }
+
+    try {
+      if (Objects.nonNull(card) && Objects.nonNull(
+          rowView.getColumn("daa_id", Integer.class))) {
+        card.addDaa(rowView.getColumn("daa_id", Integer.class));
+        daa.setDaaId(rowView.getColumn("daa_id", Integer.class));
+      }
+    } catch (MappingException e) {
+    }
+
+    try {
+      if (Objects.nonNull(card) && Objects.nonNull(
+          rowView.getColumn("create_user_id", Integer.class))) {
+        daa.setCreateUserId(rowView.getColumn("create_user_id", Integer.class));
+      }
+    } catch (MappingException e) {
+    }
+
+    try {
+      if (Objects.nonNull(card) && Objects.nonNull(
+          rowView.getColumn("create_date", Instant.class))) {
+        daa.setCreateDate(rowView.getColumn("create_date", Instant.class));
+      }
+    } catch (MappingException e) {
+    }
+
+    try {
+      if (Objects.nonNull(card) && Objects.nonNull(
+          rowView.getColumn("update_user_id", Integer.class))) {
+        daa.setUpdateUserId(rowView.getColumn("update_user_id", Integer.class));
+      }
+    } catch (MappingException e) {
+    }
+
+    try {
+      if (Objects.nonNull(card) && Objects.nonNull(
+          rowView.getColumn("create_date", Instant.class))) {
+        daa.setCreateDate(rowView.getColumn("create_date", Instant.class));
+      }
+    } catch (MappingException e) {
+    }
+
+    try {
+      if (Objects.nonNull(card) && Objects.nonNull(
+          rowView.getColumn("initial_dac_id", Integer.class))) {
+        daa.setInitialDacId(rowView.getColumn("initial_dac_id", Integer.class));
+      }
+    } catch (MappingException e) {
+    }
+
+    if (daa != null) {
+      card.addDaaObject(daa);
+    }
+  }
+}

--- a/src/main/java/org/broadinstitute/consent/http/models/LibraryCard.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/LibraryCard.java
@@ -3,6 +3,7 @@ package org.broadinstitute.consent.http.models;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import javax.xml.crypto.Data;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 
 public class LibraryCard {
@@ -32,6 +33,8 @@ public class LibraryCard {
   private Institution institution;
 
   private List<Integer> daaIds;
+
+  private List<DataAccessAgreement> daas;
 
   public LibraryCard() {
     this.createDate = new Date();
@@ -127,6 +130,10 @@ public class LibraryCard {
 
   public void setDaaIds(List<Integer> daaIds) {this.daaIds = daaIds;}
 
+  public List<DataAccessAgreement> getDaas() {return daas;}
+
+  public void setDaas(List<DataAccessAgreement> daas) {this.daas = daas;}
+
   @Override
   public boolean equals(Object libraryCard) {
     if (libraryCard == this) {
@@ -158,6 +165,28 @@ public class LibraryCard {
         .stream()
         .anyMatch(d -> d.equals(daaId))) {
       this.daaIds.remove(daaId);
+    }
+  }
+
+  public void addDaaObject(DataAccessAgreement daa) {
+    if (this.daas == null) {
+      this.daas = new ArrayList<>();
+    }
+    if (this.daas
+        .stream()
+        .noneMatch(d -> d.equals(daa))) {
+      this.daas.add(daa);
+    }
+  }
+
+  public void removeDaaObject(DataAccessAgreement daa) {
+    if (this.daas == null) {
+      return;
+    }
+    if (this.daas
+        .stream()
+        .anyMatch(d -> d.equals(daas))) {
+      this.daas.remove(daas);
     }
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/models/LibraryCard.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/LibraryCard.java
@@ -38,6 +38,7 @@ public class LibraryCard {
 
   public LibraryCard() {
     this.createDate = new Date();
+    this.daaIds = new ArrayList<>();
   }
 
   public Integer getId() {

--- a/src/main/java/org/broadinstitute/consent/http/models/LibraryCard.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/LibraryCard.java
@@ -178,15 +178,4 @@ public class LibraryCard {
       this.daas.add(daa);
     }
   }
-
-  public void removeDaaObject(DataAccessAgreement daa) {
-    if (this.daas == null) {
-      return;
-    }
-    if (this.daas
-        .stream()
-        .anyMatch(d -> d.equals(daas))) {
-      this.daas.remove(daas);
-    }
-  }
 }

--- a/src/main/java/org/broadinstitute/consent/http/models/LibraryCard.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/LibraryCard.java
@@ -3,7 +3,6 @@ package org.broadinstitute.consent.http.models;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-import javax.xml.crypto.Data;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 
 public class LibraryCard {

--- a/src/main/java/org/broadinstitute/consent/http/models/User.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/User.java
@@ -16,6 +16,7 @@ import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
+import org.broadinstitute.consent.http.util.gson.GsonUtil;
 
 public class User {
 
@@ -95,7 +96,7 @@ public class User {
    * @param json A json string that may or may not be correctly structured as a DACUser
    */
   public User(String json) {
-    Gson gson = new Gson();
+    Gson gson = GsonUtil.gsonBuilderWithAdapters().create();
     JsonObject userJsonObject = gson.fromJson(json, JsonObject.class);
     // There are no cases where we want to pull the create date/update date from user-provided data.
     // Nor do we need to retrieve the full institution object from user-provided data.

--- a/src/main/java/org/broadinstitute/consent/http/models/User.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/User.java
@@ -96,7 +96,7 @@ public class User {
    * @param json A json string that may or may not be correctly structured as a DACUser
    */
   public User(String json) {
-    Gson gson = GsonUtil.gsonBuilderWithAdapters().create();
+    Gson gson = GsonUtil.getInstance();
     JsonObject userJsonObject = gson.fromJson(json, JsonObject.class);
     // There are no cases where we want to pull the create date/update date from user-provided data.
     // Nor do we need to retrieve the full institution object from user-provided data.

--- a/src/main/java/org/broadinstitute/consent/http/resources/InstitutionResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/InstitutionResource.java
@@ -81,7 +81,7 @@ public class InstitutionResource extends Resource {
   public Response createInstitution(@Auth AuthUser authUser, String institution) {
     try {
       User user = userService.findUserByEmail(authUser.getEmail());
-      Institution payload = GsonUtil.gsonBuilderWithAdapters().create().fromJson(institution, Institution.class);
+      Institution payload = GsonUtil.getInstance().fromJson(institution, Institution.class);
       List<Institution> conflicts = institutionService.findAllInstitutionsByName(payload.getName());
       if (!conflicts.isEmpty()) {
         throw new ConsentConflictException(
@@ -103,7 +103,7 @@ public class InstitutionResource extends Resource {
       String institution) {
     try {
       User user = userService.findUserByEmail(authUser.getEmail());
-      Institution payload = GsonUtil.gsonBuilderWithAdapters().create().fromJson(institution, Institution.class);
+      Institution payload = GsonUtil.getInstance().fromJson(institution, Institution.class);
       Institution updatedInstitution = institutionService.updateInstitutionById(payload, id,
           user.getUserId());
       return Response.ok().entity(updatedInstitution).build();

--- a/src/main/java/org/broadinstitute/consent/http/resources/InstitutionResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/InstitutionResource.java
@@ -22,6 +22,7 @@ import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.service.InstitutionService;
 import org.broadinstitute.consent.http.service.UserService;
 import org.broadinstitute.consent.http.util.InstitutionUtil;
+import org.broadinstitute.consent.http.util.gson.GsonUtil;
 
 @Path("api/institutions")
 public class InstitutionResource extends Resource {
@@ -80,7 +81,7 @@ public class InstitutionResource extends Resource {
   public Response createInstitution(@Auth AuthUser authUser, String institution) {
     try {
       User user = userService.findUserByEmail(authUser.getEmail());
-      Institution payload = new Gson().fromJson(institution, Institution.class);
+      Institution payload = GsonUtil.gsonBuilderWithAdapters().create().fromJson(institution, Institution.class);
       List<Institution> conflicts = institutionService.findAllInstitutionsByName(payload.getName());
       if (!conflicts.isEmpty()) {
         throw new ConsentConflictException(
@@ -102,7 +103,7 @@ public class InstitutionResource extends Resource {
       String institution) {
     try {
       User user = userService.findUserByEmail(authUser.getEmail());
-      Institution payload = new Gson().fromJson(institution, Institution.class);
+      Institution payload = GsonUtil.gsonBuilderWithAdapters().create().fromJson(institution, Institution.class);
       Institution updatedInstitution = institutionService.updateInstitutionById(payload, id,
           user.getUserId());
       return Response.ok().entity(updatedInstitution).build();

--- a/src/main/java/org/broadinstitute/consent/http/resources/LibraryCardResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/LibraryCardResource.java
@@ -22,6 +22,7 @@ import org.broadinstitute.consent.http.models.LibraryCard;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.service.LibraryCardService;
 import org.broadinstitute.consent.http.service.UserService;
+import org.broadinstitute.consent.http.util.gson.GsonUtil;
 
 @Path("api/libraryCards")
 public class LibraryCardResource extends Resource {
@@ -84,7 +85,7 @@ public class LibraryCardResource extends Resource {
   public Response createLibraryCard(@Auth AuthUser authUser, String libraryCard) {
     try {
       User user = userService.findUserByEmail(authUser.getEmail());
-      LibraryCard payload = new Gson().fromJson(libraryCard, LibraryCard.class);
+      LibraryCard payload = GsonUtil.gsonBuilderWithAdapters().create().fromJson(libraryCard, LibraryCard.class);
       payload.setCreateUserId(user.getUserId());
       LibraryCard newLibraryCard = libraryCardService.createLibraryCard(payload, user);
       return Response.status(HttpStatusCodes.STATUS_CODE_CREATED).entity(newLibraryCard).build();
@@ -102,7 +103,7 @@ public class LibraryCardResource extends Resource {
       String libraryCard) {
     try {
       User user = userService.findUserByEmail(authUser.getEmail());
-      LibraryCard payload = new Gson().fromJson(libraryCard, LibraryCard.class);
+      LibraryCard payload = GsonUtil.gsonBuilderWithAdapters().create().fromJson(libraryCard, LibraryCard.class);
       LibraryCard updatedLibraryCard = libraryCardService.updateLibraryCard(payload, id,
           user.getUserId());
       return Response.ok().entity(updatedLibraryCard).build();

--- a/src/main/java/org/broadinstitute/consent/http/resources/LibraryCardResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/LibraryCardResource.java
@@ -1,7 +1,6 @@
 package org.broadinstitute.consent.http.resources;
 
 import com.google.api.client.http.HttpStatusCodes;
-import com.google.gson.Gson;
 import com.google.inject.Inject;
 import io.dropwizard.auth.Auth;
 import jakarta.annotation.security.RolesAllowed;
@@ -85,7 +84,7 @@ public class LibraryCardResource extends Resource {
   public Response createLibraryCard(@Auth AuthUser authUser, String libraryCard) {
     try {
       User user = userService.findUserByEmail(authUser.getEmail());
-      LibraryCard payload = GsonUtil.gsonBuilderWithAdapters().create().fromJson(libraryCard, LibraryCard.class);
+      LibraryCard payload = GsonUtil.getInstance().fromJson(libraryCard, LibraryCard.class);
       payload.setCreateUserId(user.getUserId());
       LibraryCard newLibraryCard = libraryCardService.createLibraryCard(payload, user);
       return Response.status(HttpStatusCodes.STATUS_CODE_CREATED).entity(newLibraryCard).build();
@@ -103,7 +102,7 @@ public class LibraryCardResource extends Resource {
       String libraryCard) {
     try {
       User user = userService.findUserByEmail(authUser.getEmail());
-      LibraryCard payload = GsonUtil.gsonBuilderWithAdapters().create().fromJson(libraryCard, LibraryCard.class);
+      LibraryCard payload = GsonUtil.getInstance().fromJson(libraryCard, LibraryCard.class);
       LibraryCard updatedLibraryCard = libraryCardService.updateLibraryCard(payload, id,
           user.getUserId());
       return Response.ok().entity(updatedLibraryCard).build();

--- a/src/main/java/org/broadinstitute/consent/http/service/LibraryCardService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/LibraryCardService.java
@@ -98,6 +98,12 @@ public class LibraryCardService {
     return libraryCard;
   }
 
+  public LibraryCard findLibraryCardWithDaasById(Integer libraryCardId) {
+    LibraryCard libraryCard = libraryCardDAO.findLibraryCardDaaById(libraryCardId);
+    throwIfNull(libraryCard);
+    return libraryCard;
+  }
+
   public void addDaaToLibraryCard(Integer libraryCardId, Integer daaId) {
     libraryCardDAO.createLibraryCardDaaRelation(libraryCardId, daaId);
   }

--- a/src/main/java/org/broadinstitute/consent/http/service/UserService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/UserService.java
@@ -355,7 +355,7 @@ public class UserService {
    * @return JsonObject.
    */
   public JsonObject findUserWithPropertiesByIdAsJsonObject(AuthUser authUser, Integer userId) {
-    Gson gson = GsonUtil.gsonBuilderWithAdapters().create();
+    Gson gson = GsonUtil.getInstance();
     User user = findUserById(userId);
     List<UserProperty> props = findAllUserProperties(user.getUserId());
     List<LibraryCard> entries =

--- a/src/main/java/org/broadinstitute/consent/http/service/UserService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/UserService.java
@@ -38,6 +38,7 @@ import org.broadinstitute.consent.http.models.UserUpdateFields;
 import org.broadinstitute.consent.http.models.Vote;
 import org.broadinstitute.consent.http.resources.Resource;
 import org.broadinstitute.consent.http.service.dao.UserServiceDAO;
+import org.broadinstitute.consent.http.util.gson.GsonUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -356,7 +357,7 @@ public class UserService {
    * @return JsonObject.
    */
   public JsonObject findUserWithPropertiesByIdAsJsonObject(AuthUser authUser, Integer userId) {
-    Gson gson = new Gson();
+    Gson gson = GsonUtil.gsonBuilderWithAdapters().create();
     User user = findUserById(userId);
     List<UserProperty> props = findAllUserProperties(user.getUserId());
     List<LibraryCard> entries =

--- a/src/main/java/org/broadinstitute/consent/http/util/InstitutionUtil.java
+++ b/src/main/java/org/broadinstitute/consent/http/util/InstitutionUtil.java
@@ -4,20 +4,19 @@ import com.google.gson.ExclusionStrategy;
 import com.google.gson.FieldAttributes;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import java.time.Instant;
 import java.util.List;
 import java.util.Objects;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.UserRole;
-import org.broadinstitute.consent.http.util.gson.InstantTypeAdapter;
+import org.broadinstitute.consent.http.util.gson.GsonUtil;
 
 public class InstitutionUtil implements ConsentLogger {
 
   private final GsonBuilder gson;
 
   public InstitutionUtil() {
-    this.gson = new GsonBuilder().registerTypeAdapter(Instant.class, new InstantTypeAdapter());
+    this.gson = GsonUtil.gsonBuilderWithAdapters();
   }
 
   // Gson builder and exclusion strategy helpers

--- a/src/main/java/org/broadinstitute/consent/http/util/InstitutionUtil.java
+++ b/src/main/java/org/broadinstitute/consent/http/util/InstitutionUtil.java
@@ -4,18 +4,20 @@ import com.google.gson.ExclusionStrategy;
 import com.google.gson.FieldAttributes;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import java.time.Instant;
 import java.util.List;
 import java.util.Objects;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.UserRole;
+import org.broadinstitute.consent.http.util.gson.InstantTypeAdapter;
 
 public class InstitutionUtil implements ConsentLogger {
 
   private final GsonBuilder gson;
 
   public InstitutionUtil() {
-    this.gson = new GsonBuilder();
+    this.gson = new GsonBuilder().registerTypeAdapter(Instant.class, new InstantTypeAdapter());
   }
 
   // Gson builder and exclusion strategy helpers

--- a/src/main/java/org/broadinstitute/consent/http/util/gson/DateTypeAdapter.java
+++ b/src/main/java/org/broadinstitute/consent/http/util/gson/DateTypeAdapter.java
@@ -24,8 +24,12 @@ public class DateTypeAdapter
       throws JsonParseException {
     try {
       return new Date(json.getAsLong());
-    } catch (DateTimeParseException e) {
-      throw new JsonParseException(e.getMessage());
+    } catch (NumberFormatException e) {
+      try {
+        return new Date(json.getAsString());
+      } catch (DateTimeParseException e1) {
+        throw new JsonParseException(e1.getMessage());
+      }
     }
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/util/gson/DateTypeAdapter.java
+++ b/src/main/java/org/broadinstitute/consent/http/util/gson/DateTypeAdapter.java
@@ -8,7 +8,8 @@ import com.google.gson.JsonPrimitive;
 import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
 import java.lang.reflect.Type;
-import java.time.format.DateTimeParseException;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.util.Date;
 
 public class DateTypeAdapter
@@ -26,8 +27,8 @@ public class DateTypeAdapter
       return new Date(json.getAsLong());
     } catch (NumberFormatException e) {
       try {
-        return new Date(json.getAsString());
-      } catch (DateTimeParseException e1) {
+        return new SimpleDateFormat("LLL dd, yyyy, hh:mm:ss a").parse(json.getAsString());
+      } catch (ParseException e1) {
         throw new JsonParseException(e1.getMessage());
       }
     }

--- a/src/test/java/org/broadinstitute/consent/http/db/LibraryCardDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/LibraryCardDAOTest.java
@@ -130,23 +130,14 @@ class LibraryCardDAOTest extends DAOTestHelper {
   void testFindLibraryCardDaaById() {
     LibraryCard card = createLibraryCard();
     Integer dacId = dacDAO.createDac(RandomStringUtils.randomAlphabetic(5), RandomStringUtils.randomAlphabetic(5), "",  new Date());
-    System.out.println("dacId: " + dacId);
     Integer daaId = daaDAO.createDaa(card.getUserId(), new Date().toInstant(), card.getUserId(), new Date().toInstant(), dacId);
     DataAccessAgreement daa = daaDAO.findById(daaId);
-    System.out.println("daaId: " + daa.getDaaId());
-    System.out.println("create user id: " + daa.getCreateUserId());
-    System.out.println("create date: " + daa.getCreateDate());
-    System.out.println("update user id: " + daa.getUpdateUserId());
-    System.out.println("update date: " + daa.getUpdateDate());
-    System.out.println("initial dac id: " + daa.getInitialDacId());
     card.addDaa(daa.getDaaId());
     card.addDaaObject(daa);
-
     libraryCardDAO.createLibraryCardDaaRelation(card.getId(), daaId);
-
     Integer id = card.getId();
     LibraryCard cardFromDAO = libraryCardDAO.findLibraryCardDaaById(id);
-//    cardFromDAO.addDaa(daa.getDaaId());
+
     assertEquals(cardFromDAO.getUserId(), card.getUserId());
     assertEquals(cardFromDAO.getUserName(), card.getUserName());
     assertEquals(cardFromDAO.getUserEmail(), card.getUserEmail());
@@ -156,10 +147,67 @@ class LibraryCardDAOTest extends DAOTestHelper {
     DataAccessAgreement daaFromDAO = cardFromDAO.getDaas().get(0);
     assertEquals(daaFromDAO.getDaaId(), daa.getDaaId());
     assertEquals(daaFromDAO.getCreateUserId(), daa.getCreateUserId());
-    assertEquals(daaFromDAO.getCreateDate(), daa.getCreateDate()); //fails
-    assertEquals(daaFromDAO.getUpdateUserId(), daa.getUpdateUserId()); // fails
-    assertEquals(daaFromDAO.getUpdateDate(), daa.getUpdateDate()); // fails
-    assertEquals(daaFromDAO.getInitialDacId(), daa.getInitialDacId()); // fails
+    assertEquals(daaFromDAO.getCreateDate(), daa.getCreateDate());
+    assertEquals(daaFromDAO.getUpdateUserId(), daa.getUpdateUserId());
+    assertEquals(daaFromDAO.getUpdateDate(), daa.getUpdateDate());
+    assertEquals(daaFromDAO.getInitialDacId(), daa.getInitialDacId());
+  }
+
+  @Test
+  void testFindLibraryCardDaaByIdMultipleDaas() {
+    LibraryCard card = createLibraryCard();
+    Integer userId = userDAO.insertUser(RandomStringUtils.randomAlphabetic(5), RandomStringUtils.randomAlphabetic(5), new Date());
+    Integer dacId = dacDAO.createDac(RandomStringUtils.randomAlphabetic(5), RandomStringUtils.randomAlphabetic(5), "",  new Date());
+    Integer daaId1 = daaDAO.createDaa(userId, new Date().toInstant(), userId, new Date().toInstant(), dacId);
+    Integer daaId2 = daaDAO.createDaa(userId, new Date().toInstant(), userId, new Date().toInstant(), dacId);
+    DataAccessAgreement daa1 = daaDAO.findById(daaId1);
+    DataAccessAgreement daa2 = daaDAO.findById(daaId2);
+    card.addDaa(daa1.getDaaId());
+    card.addDaa(daa2.getDaaId());
+    card.addDaaObject(daa1);
+    card.addDaaObject(daa2);
+    libraryCardDAO.createLibraryCardDaaRelation(card.getId(), daaId1);
+    libraryCardDAO.createLibraryCardDaaRelation(card.getId(), daaId2);
+    Integer id = card.getId();
+    LibraryCard cardFromDAO = libraryCardDAO.findLibraryCardDaaById(id);
+
+    assertEquals(cardFromDAO.getUserId(), card.getUserId());
+    assertEquals(cardFromDAO.getUserName(), card.getUserName());
+    assertEquals(cardFromDAO.getUserEmail(), card.getUserEmail());
+    assertEquals(cardFromDAO.getCreateUserId(), card.getCreateUserId());
+    assertEquals(cardFromDAO.getCreateDate(), card.getCreateDate());
+    assertEquals(cardFromDAO.getDaaIds(), card.getDaaIds());
+
+    DataAccessAgreement daaFromDAO1 = cardFromDAO.getDaas().get(0);
+    assertEquals(daaFromDAO1.getDaaId(), daa1.getDaaId());
+    assertEquals(daaFromDAO1.getCreateUserId(), daa1.getCreateUserId());
+    assertEquals(daaFromDAO1.getCreateDate(), daa1.getCreateDate());
+    assertEquals(daaFromDAO1.getUpdateUserId(), daa1.getUpdateUserId());
+    assertEquals(daaFromDAO1.getUpdateDate(), daa1.getUpdateDate());
+    assertEquals(daaFromDAO1.getInitialDacId(), daa1.getInitialDacId());
+
+    DataAccessAgreement daaFromDAO2 = cardFromDAO.getDaas().get(1);
+    assertEquals(daaFromDAO2.getDaaId(), daa2.getDaaId());
+    assertEquals(daaFromDAO2.getCreateUserId(), daa2.getCreateUserId());
+    assertEquals(daaFromDAO2.getCreateDate(), daa2.getCreateDate());
+    assertEquals(daaFromDAO2.getUpdateUserId(), daa2.getUpdateUserId());
+    assertEquals(daaFromDAO2.getUpdateDate(), daa2.getUpdateDate());
+    assertEquals(daaFromDAO2.getInitialDacId(), daa2.getInitialDacId());
+  }
+
+  @Test
+  void testFindLibraryCardDaaByIdNoDaas() {
+    LibraryCard card = createLibraryCard();
+    Integer id = card.getId();
+    LibraryCard cardFromDAO = libraryCardDAO.findLibraryCardDaaById(id);
+
+    assertEquals(cardFromDAO.getUserId(), card.getUserId());
+    assertEquals(cardFromDAO.getUserName(), card.getUserName());
+    assertEquals(cardFromDAO.getUserEmail(), card.getUserEmail());
+    assertEquals(cardFromDAO.getCreateUserId(), card.getCreateUserId());
+    assertEquals(cardFromDAO.getCreateDate(), card.getCreateDate());
+    assertEquals(cardFromDAO.getDaaIds(), card.getDaaIds());
+    assertNull(cardFromDAO.getDaas());
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/db/LibraryCardDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/LibraryCardDAOTest.java
@@ -11,6 +11,7 @@ import java.util.Random;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.RandomUtils;
 import org.broadinstitute.consent.http.enumeration.OrganizationType;
+import org.broadinstitute.consent.http.models.DataAccessAgreement;
 import org.broadinstitute.consent.http.models.Institution;
 import org.broadinstitute.consent.http.models.LibraryCard;
 import org.broadinstitute.consent.http.models.User;
@@ -128,15 +129,37 @@ class LibraryCardDAOTest extends DAOTestHelper {
   @Test
   void testFindLibraryCardDaaById() {
     LibraryCard card = createLibraryCard();
+    Integer dacId = dacDAO.createDac(RandomStringUtils.randomAlphabetic(5), RandomStringUtils.randomAlphabetic(5), "",  new Date());
+    System.out.println("dacId: " + dacId);
+    Integer daaId = daaDAO.createDaa(card.getUserId(), new Date().toInstant(), card.getUserId(), new Date().toInstant(), dacId);
+    DataAccessAgreement daa = daaDAO.findById(daaId);
+    System.out.println("daaId: " + daa.getDaaId());
+    System.out.println("create user id: " + daa.getCreateUserId());
+    System.out.println("create date: " + daa.getCreateDate());
+    System.out.println("update user id: " + daa.getUpdateUserId());
+    System.out.println("update date: " + daa.getUpdateDate());
+    System.out.println("initial dac id: " + daa.getInitialDacId());
+    card.addDaa(daa.getDaaId());
+    card.addDaaObject(daa);
+
+    libraryCardDAO.createLibraryCardDaaRelation(card.getId(), daaId);
+
     Integer id = card.getId();
     LibraryCard cardFromDAO = libraryCardDAO.findLibraryCardDaaById(id);
+//    cardFromDAO.addDaa(daa.getDaaId());
     assertEquals(cardFromDAO.getUserId(), card.getUserId());
     assertEquals(cardFromDAO.getUserName(), card.getUserName());
     assertEquals(cardFromDAO.getUserEmail(), card.getUserEmail());
     assertEquals(cardFromDAO.getCreateUserId(), card.getCreateUserId());
     assertEquals(cardFromDAO.getCreateDate(), card.getCreateDate());
     assertEquals(cardFromDAO.getDaaIds(), card.getDaaIds());
-    // this needs to be fixed!
+    DataAccessAgreement daaFromDAO = cardFromDAO.getDaas().get(0);
+    assertEquals(daaFromDAO.getDaaId(), daa.getDaaId());
+    assertEquals(daaFromDAO.getCreateUserId(), daa.getCreateUserId());
+    assertEquals(daaFromDAO.getCreateDate(), daa.getCreateDate()); //fails
+    assertEquals(daaFromDAO.getUpdateUserId(), daa.getUpdateUserId()); // fails
+    assertEquals(daaFromDAO.getUpdateDate(), daa.getUpdateDate()); // fails
+    assertEquals(daaFromDAO.getInitialDacId(), daa.getInitialDacId()); // fails
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/db/LibraryCardDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/LibraryCardDAOTest.java
@@ -126,6 +126,26 @@ class LibraryCardDAOTest extends DAOTestHelper {
   }
 
   @Test
+  void testFindLibraryCardDaaById() {
+    LibraryCard card = createLibraryCard();
+    Integer id = card.getId();
+    LibraryCard cardFromDAO = libraryCardDAO.findLibraryCardDaaById(id);
+    assertEquals(cardFromDAO.getUserId(), card.getUserId());
+    assertEquals(cardFromDAO.getUserName(), card.getUserName());
+    assertEquals(cardFromDAO.getUserEmail(), card.getUserEmail());
+    assertEquals(cardFromDAO.getCreateUserId(), card.getCreateUserId());
+    assertEquals(cardFromDAO.getCreateDate(), card.getCreateDate());
+    assertEquals(cardFromDAO.getDaaIds(), card.getDaaIds());
+    // this needs to be fixed!
+  }
+
+  @Test
+  void testFindLibraryCardDaaByIdNegative() {
+    LibraryCard cardFromDAO = libraryCardDAO.findLibraryCardDaaById(RandomUtils.nextInt(100, 200));
+    assertNull(cardFromDAO);
+  }
+
+  @Test
   void testFindLibraryCardByInstitutionId() {
     LibraryCard libraryCard = createLibraryCard();
     List<LibraryCard> cardsFromDAO = libraryCardDAO.findLibraryCardsByInstitutionId(

--- a/src/test/java/org/broadinstitute/consent/http/db/LibraryCardDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/LibraryCardDAOTest.java
@@ -177,7 +177,7 @@ class LibraryCardDAOTest extends DAOTestHelper {
     assertNotNull(cardsFromDAO);
     assertEquals(cardsFromDAO.size(), 1);
     assertEquals(cardsFromDAO.get(0).getId(), libraryCard.getId());
-    assertNull(cardsFromDAO.get(0).getDaaIds());
+    assertEquals(cardsFromDAO.get(0).getDaaIds().size(),0);
   }
 
   @Test
@@ -192,7 +192,7 @@ class LibraryCardDAOTest extends DAOTestHelper {
     Institution cardInstitution = card.getInstitution();
     assertEquals(institution.getId(), cardInstitution.getId());
     assertEquals(institution.getName(), cardInstitution.getName());
-    assertNull(card.getDaaIds());
+    assertEquals(card.getDaaIds().size(),0);
   }
 
   @Test
@@ -216,8 +216,8 @@ class LibraryCardDAOTest extends DAOTestHelper {
     assertEquals(2, libraryCards.size());
     assertEquals(one.getId(), libraryCards.get(0).getId());
     assertEquals(two.getId(), libraryCards.get(1).getId());
-    assertNull(one.getDaaIds());
-    assertNull(two.getDaaIds());
+    assertEquals(one.getDaaIds().size(),0);
+    assertEquals(two.getDaaIds().size(),0);
   }
 
   @Test
@@ -287,7 +287,7 @@ class LibraryCardDAOTest extends DAOTestHelper {
 
     List<LibraryCard> lcs = libraryCardDAO.findAllLibraryCards();
     LibraryCard lc1 = lcs.get(0);
-    assertNull(lc1.getDaaIds());
+    assertEquals(lc1.getDaaIds().size(),0);
   }
 
   @Test
@@ -314,7 +314,7 @@ class LibraryCardDAOTest extends DAOTestHelper {
 
     libraryCardDAO.deleteLibraryCardDaaRelation(card.getId(), daaId2);lcs = libraryCardDAO.findAllLibraryCards();
     lc1 = lcs.get(0);
-    assertNull(lc1.getDaaIds());
+    assertEquals(lc1.getDaaIds().size(),0);
   }
 
 

--- a/src/test/java/org/broadinstitute/consent/http/db/LibraryCardDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/LibraryCardDAOTest.java
@@ -127,33 +127,6 @@ class LibraryCardDAOTest extends DAOTestHelper {
   }
 
   @Test
-  void testFindLibraryCardDaaById() {
-    LibraryCard card = createLibraryCard();
-    Integer dacId = dacDAO.createDac(RandomStringUtils.randomAlphabetic(5), RandomStringUtils.randomAlphabetic(5), "",  new Date());
-    Integer daaId = daaDAO.createDaa(card.getUserId(), new Date().toInstant(), card.getUserId(), new Date().toInstant(), dacId);
-    DataAccessAgreement daa = daaDAO.findById(daaId);
-    card.addDaa(daa.getDaaId());
-    card.addDaaObject(daa);
-    libraryCardDAO.createLibraryCardDaaRelation(card.getId(), daaId);
-    Integer id = card.getId();
-    LibraryCard cardFromDAO = libraryCardDAO.findLibraryCardDaaById(id);
-
-    assertEquals(cardFromDAO.getUserId(), card.getUserId());
-    assertEquals(cardFromDAO.getUserName(), card.getUserName());
-    assertEquals(cardFromDAO.getUserEmail(), card.getUserEmail());
-    assertEquals(cardFromDAO.getCreateUserId(), card.getCreateUserId());
-    assertEquals(cardFromDAO.getCreateDate(), card.getCreateDate());
-    assertEquals(cardFromDAO.getDaaIds(), card.getDaaIds());
-    DataAccessAgreement daaFromDAO = cardFromDAO.getDaas().get(0);
-    assertEquals(daaFromDAO.getDaaId(), daa.getDaaId());
-    assertEquals(daaFromDAO.getCreateUserId(), daa.getCreateUserId());
-    assertEquals(daaFromDAO.getCreateDate(), daa.getCreateDate());
-    assertEquals(daaFromDAO.getUpdateUserId(), daa.getUpdateUserId());
-    assertEquals(daaFromDAO.getUpdateDate(), daa.getUpdateDate());
-    assertEquals(daaFromDAO.getInitialDacId(), daa.getInitialDacId());
-  }
-
-  @Test
   void testFindLibraryCardDaaByIdMultipleDaas() {
     LibraryCard card = createLibraryCard();
     Integer userId = userDAO.insertUser(RandomStringUtils.randomAlphabetic(5), RandomStringUtils.randomAlphabetic(5), new Date());
@@ -225,7 +198,7 @@ class LibraryCardDAOTest extends DAOTestHelper {
     assertNotNull(cardsFromDAO);
     assertEquals(cardsFromDAO.size(), 1);
     assertEquals(cardsFromDAO.get(0).getId(), libraryCard.getId());
-    assertEquals(cardsFromDAO.get(0).getDaaIds().size(),0);
+    assertTrue(cardsFromDAO.get(0).getDaaIds().isEmpty());
   }
 
   @Test
@@ -240,7 +213,7 @@ class LibraryCardDAOTest extends DAOTestHelper {
     Institution cardInstitution = card.getInstitution();
     assertEquals(institution.getId(), cardInstitution.getId());
     assertEquals(institution.getName(), cardInstitution.getName());
-    assertEquals(card.getDaaIds().size(),0);
+    assertTrue(card.getDaaIds().isEmpty());
   }
 
   @Test
@@ -264,8 +237,8 @@ class LibraryCardDAOTest extends DAOTestHelper {
     assertEquals(2, libraryCards.size());
     assertEquals(one.getId(), libraryCards.get(0).getId());
     assertEquals(two.getId(), libraryCards.get(1).getId());
-    assertEquals(one.getDaaIds().size(),0);
-    assertEquals(two.getDaaIds().size(),0);
+    assertTrue(one.getDaaIds().isEmpty());
+    assertTrue(two.getDaaIds().isEmpty());
   }
 
   @Test
@@ -335,7 +308,7 @@ class LibraryCardDAOTest extends DAOTestHelper {
 
     List<LibraryCard> lcs = libraryCardDAO.findAllLibraryCards();
     LibraryCard lc1 = lcs.get(0);
-    assertEquals(lc1.getDaaIds().size(),0);
+    assertTrue(lc1.getDaaIds().isEmpty());
   }
 
   @Test
@@ -362,7 +335,7 @@ class LibraryCardDAOTest extends DAOTestHelper {
 
     libraryCardDAO.deleteLibraryCardDaaRelation(card.getId(), daaId2);lcs = libraryCardDAO.findAllLibraryCards();
     lc1 = lcs.get(0);
-    assertEquals(lc1.getDaaIds().size(),0);
+    assertTrue(lc1.getDaaIds().isEmpty());
   }
 
 

--- a/src/test/java/org/broadinstitute/consent/http/resources/InstitutionResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/InstitutionResourceTest.java
@@ -25,7 +25,6 @@ import org.broadinstitute.consent.http.models.UserRole;
 import org.broadinstitute.consent.http.service.InstitutionService;
 import org.broadinstitute.consent.http.service.UserService;
 import org.broadinstitute.consent.http.util.gson.GsonUtil;
-import org.broadinstitute.consent.http.util.gson.TimestampTypeAdapter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -134,7 +133,7 @@ public class InstitutionResourceTest {
     when(userService.findUserByEmail(anyString())).thenReturn(adminUser);
     when(institutionService.createInstitution(any(), anyInt())).thenReturn(mockInstitution);
     initResource();
-    String requestJson = GsonUtil.buildGson().toJson(mockInstitution, Institution.class);
+    String requestJson = GsonUtil.gsonBuilderWithAdapters().create().toJson(mockInstitution, Institution.class);
     Response response = resource.createInstitution(authUser, requestJson);
     String json = response.getEntity().toString();
     assertEquals(200, response.getStatus());
@@ -148,7 +147,8 @@ public class InstitutionResourceTest {
     when(userService.findUserByEmail(anyString())).thenReturn(adminUser);
     when(institutionService.createInstitution(any(), anyInt())).thenThrow(error);
     initResource();
-    Response response = resource.createInstitution(authUser, new Gson().toJson(mockInstitution));
+    Response response = resource.createInstitution(authUser,
+        GsonUtil.gsonBuilderWithAdapters().create().toJson(mockInstitution));
     assertEquals(400, response.getStatus());
   }
 
@@ -159,7 +159,8 @@ public class InstitutionResourceTest {
     when(userService.findUserByEmail(anyString())).thenReturn(adminUser);
     when(institutionService.createInstitution(any(), anyInt())).thenThrow(error);
     initResource();
-    Response response = resource.createInstitution(authUser, new Gson().toJson(mockInstitution));
+    Response response = resource.createInstitution(authUser,
+        GsonUtil.gsonBuilderWithAdapters().create().toJson(mockInstitution));
     assertEquals(400, response.getStatus());
   }
 
@@ -169,7 +170,8 @@ public class InstitutionResourceTest {
     when(userService.findUserByEmail(anyString())).thenReturn(adminUser);
     when(institutionService.findAllInstitutionsByName(any())).thenReturn(List.of(mockInstitution));
     initResource();
-    Response response = resource.createInstitution(authUser, new Gson().toJson(mockInstitution));
+    Response response = resource.createInstitution(authUser,
+        GsonUtil.gsonBuilderWithAdapters().create().toJson(mockInstitution));
     assertEquals(409, response.getStatus());
   }
 
@@ -180,7 +182,8 @@ public class InstitutionResourceTest {
     when(institutionService.updateInstitutionById(any(), anyInt(), anyInt())).thenReturn(
         mockInstitution);
     initResource();
-    Response response = resource.updateInstitution(authUser, 1, new Gson().toJson(mockInstitution));
+    Response response = resource.updateInstitution(authUser, 1,
+        GsonUtil.gsonBuilderWithAdapters().create().toJson(mockInstitution));
     assertEquals(200, response.getStatus());
     assertNotNull(response.getEntity().toString());
   }
@@ -192,7 +195,8 @@ public class InstitutionResourceTest {
     when(userService.findUserByEmail(anyString())).thenReturn(adminUser);
     when(institutionService.updateInstitutionById(any(), anyInt(), anyInt())).thenThrow(error);
     initResource();
-    Response response = resource.updateInstitution(authUser, 1, new Gson().toJson(mockInstitution));
+    Response response = resource.updateInstitution(authUser, 1,
+        GsonUtil.gsonBuilderWithAdapters().create().toJson(mockInstitution));
     assertEquals(404, response.getStatus());
   }
 
@@ -204,7 +208,8 @@ public class InstitutionResourceTest {
     when(userService.findUserByEmail(anyString())).thenReturn(adminUser);
     when(institutionService.updateInstitutionById(any(), anyInt(), anyInt())).thenThrow(error);
     initResource();
-    Response response = resource.updateInstitution(authUser, 1, new Gson().toJson(mockInstitution));
+    Response response = resource.updateInstitution(authUser, 1,
+        GsonUtil.gsonBuilderWithAdapters().create().toJson(mockInstitution));
     assertEquals(400, response.getStatus());
   }
 
@@ -216,9 +221,8 @@ public class InstitutionResourceTest {
     when(userService.findUserByEmail(anyString())).thenReturn(adminUser);
     when(institutionService.updateInstitutionById(any(), anyInt(), anyInt())).thenThrow(error);
     initResource();
-    Response response = resource.updateInstitution(authUser, 1, new GsonBuilder()
-        .registerTypeAdapter(Timestamp.class, new TimestampTypeAdapter())
-        .create().toJson(mockInstitution));
+    Response response = resource.updateInstitution(authUser, 1,
+        GsonUtil.gsonBuilderWithAdapters().create().toJson(mockInstitution));
     assertEquals(400, response.getStatus());
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/resources/InstitutionResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/InstitutionResourceTest.java
@@ -10,8 +10,10 @@ import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.openMocks;
 
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.core.Response;
+import java.sql.Timestamp;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -22,6 +24,8 @@ import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.UserRole;
 import org.broadinstitute.consent.http.service.InstitutionService;
 import org.broadinstitute.consent.http.service.UserService;
+import org.broadinstitute.consent.http.util.gson.GsonUtil;
+import org.broadinstitute.consent.http.util.gson.TimestampTypeAdapter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -130,7 +134,7 @@ public class InstitutionResourceTest {
     when(userService.findUserByEmail(anyString())).thenReturn(adminUser);
     when(institutionService.createInstitution(any(), anyInt())).thenReturn(mockInstitution);
     initResource();
-    String requestJson = new Gson().toJson(mockInstitution, Institution.class);
+    String requestJson = GsonUtil.buildGson().toJson(mockInstitution, Institution.class);
     Response response = resource.createInstitution(authUser, requestJson);
     String json = response.getEntity().toString();
     assertEquals(200, response.getStatus());
@@ -212,7 +216,9 @@ public class InstitutionResourceTest {
     when(userService.findUserByEmail(anyString())).thenReturn(adminUser);
     when(institutionService.updateInstitutionById(any(), anyInt(), anyInt())).thenThrow(error);
     initResource();
-    Response response = resource.updateInstitution(authUser, 1, new Gson().toJson(mockInstitution));
+    Response response = resource.updateInstitution(authUser, 1, new GsonBuilder()
+        .registerTypeAdapter(Timestamp.class, new TimestampTypeAdapter())
+        .create().toJson(mockInstitution));
     assertEquals(400, response.getStatus());
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/resources/InstitutionResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/InstitutionResourceTest.java
@@ -124,7 +124,7 @@ public class InstitutionResourceTest {
     when(userService.findUserByEmail(anyString())).thenReturn(adminUser);
     when(institutionService.createInstitution(any(), anyInt())).thenReturn(mockInstitution);
     initResource();
-    String requestJson = GsonUtil.gsonBuilderWithAdapters().create().toJson(mockInstitution, Institution.class);
+    String requestJson = GsonUtil.getInstance().toJson(mockInstitution, Institution.class);
     Response response = resource.createInstitution(authUser, requestJson);
     String json = response.getEntity().toString();
     assertEquals(200, response.getStatus());
@@ -139,7 +139,7 @@ public class InstitutionResourceTest {
     when(institutionService.createInstitution(any(), anyInt())).thenThrow(error);
     initResource();
     Response response = resource.createInstitution(authUser,
-        GsonUtil.gsonBuilderWithAdapters().create().toJson(mockInstitution));
+        GsonUtil.getInstance().toJson(mockInstitution));
     assertEquals(400, response.getStatus());
   }
 
@@ -151,7 +151,7 @@ public class InstitutionResourceTest {
     when(institutionService.createInstitution(any(), anyInt())).thenThrow(error);
     initResource();
     Response response = resource.createInstitution(authUser,
-        GsonUtil.gsonBuilderWithAdapters().create().toJson(mockInstitution));
+        GsonUtil.getInstance().toJson(mockInstitution));
     assertEquals(400, response.getStatus());
   }
 
@@ -162,7 +162,7 @@ public class InstitutionResourceTest {
     when(institutionService.findAllInstitutionsByName(any())).thenReturn(List.of(mockInstitution));
     initResource();
     Response response = resource.createInstitution(authUser,
-        GsonUtil.gsonBuilderWithAdapters().create().toJson(mockInstitution));
+        GsonUtil.getInstance().toJson(mockInstitution));
     assertEquals(409, response.getStatus());
   }
 
@@ -174,7 +174,7 @@ public class InstitutionResourceTest {
         mockInstitution);
     initResource();
     Response response = resource.updateInstitution(authUser, 1,
-        GsonUtil.gsonBuilderWithAdapters().create().toJson(mockInstitution));
+        GsonUtil.getInstance().toJson(mockInstitution));
     assertEquals(200, response.getStatus());
     assertNotNull(response.getEntity().toString());
   }
@@ -187,7 +187,7 @@ public class InstitutionResourceTest {
     when(institutionService.updateInstitutionById(any(), anyInt(), anyInt())).thenThrow(error);
     initResource();
     Response response = resource.updateInstitution(authUser, 1,
-        GsonUtil.gsonBuilderWithAdapters().create().toJson(mockInstitution));
+        GsonUtil.getInstance().toJson(mockInstitution));
     assertEquals(404, response.getStatus());
   }
 
@@ -200,7 +200,7 @@ public class InstitutionResourceTest {
     when(institutionService.updateInstitutionById(any(), anyInt(), anyInt())).thenThrow(error);
     initResource();
     Response response = resource.updateInstitution(authUser, 1,
-        GsonUtil.gsonBuilderWithAdapters().create().toJson(mockInstitution));
+        GsonUtil.getInstance().toJson(mockInstitution));
     assertEquals(400, response.getStatus());
   }
 
@@ -213,7 +213,7 @@ public class InstitutionResourceTest {
     when(institutionService.updateInstitutionById(any(), anyInt(), anyInt())).thenThrow(error);
     initResource();
     Response response = resource.updateInstitution(authUser, 1,
-        GsonUtil.gsonBuilderWithAdapters().create().toJson(mockInstitution));
+        GsonUtil.getInstance().toJson(mockInstitution));
     assertEquals(400, response.getStatus());
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/resources/LibraryCardResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/LibraryCardResourceTest.java
@@ -9,12 +9,9 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 
 import com.google.api.client.http.HttpStatusCodes;
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.core.Response;
-import java.time.Instant;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -26,7 +23,6 @@ import org.broadinstitute.consent.http.models.UserRole;
 import org.broadinstitute.consent.http.service.LibraryCardService;
 import org.broadinstitute.consent.http.service.UserService;
 import org.broadinstitute.consent.http.util.gson.GsonUtil;
-import org.broadinstitute.consent.http.util.gson.InstantTypeAdapter;
 import org.jdbi.v3.core.statement.UnableToExecuteStatementException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -129,7 +125,7 @@ public class LibraryCardResourceTest {
   @Test
   void testCreateLibraryCard() throws Exception {
     LibraryCard mockCard = mockLibraryCardSetup();
-    String payload = GsonUtil.gsonBuilderWithAdapters().create().toJson(mockCard);
+    String payload = GsonUtil.getInstance().toJson(mockCard);
     when(userService.findUserByEmail(authUser.getEmail())).thenReturn(user);
     when(libraryCardService.createLibraryCard(any(LibraryCard.class), any(User.class))).thenReturn(
         mockCard);
@@ -191,7 +187,7 @@ public class LibraryCardResourceTest {
   @Test
   void testUpdateLibraryCard() {
     LibraryCard mockCard = mockLibraryCardSetup();
-    String payload = GsonUtil.gsonBuilderWithAdapters().create().toJson(mockCard);
+    String payload = GsonUtil.getInstance().toJson(mockCard);
     when(userService.findUserByEmail(anyString())).thenReturn(user);
     when(libraryCardService.updateLibraryCard(any(LibraryCard.class), anyInt(), anyInt()))
         .thenReturn(mockCard);

--- a/src/test/java/org/broadinstitute/consent/http/resources/LibraryCardResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/LibraryCardResourceTest.java
@@ -11,9 +11,11 @@ import static org.mockito.MockitoAnnotations.openMocks;
 
 import com.google.api.client.http.HttpStatusCodes;
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.core.Response;
+import java.time.Instant;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -24,6 +26,8 @@ import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.UserRole;
 import org.broadinstitute.consent.http.service.LibraryCardService;
 import org.broadinstitute.consent.http.service.UserService;
+import org.broadinstitute.consent.http.util.gson.GsonUtil;
+import org.broadinstitute.consent.http.util.gson.InstantTypeAdapter;
 import org.jdbi.v3.core.statement.UnableToExecuteStatementException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -137,7 +141,9 @@ public class LibraryCardResourceTest {
   @Test
   public void testCreateLibraryCard() throws Exception {
     LibraryCard mockCard = mockLibraryCardSetup();
-    String payload = new Gson().toJson(mockCard);
+    String payload = new GsonBuilder()
+        .registerTypeAdapter(Instant.class, new InstantTypeAdapter())
+        .create().toJson(mockCard);
     when(userService.findUserByEmail(authUser.getEmail())).thenReturn(user);
     when(libraryCardService.createLibraryCard(any(LibraryCard.class), any(User.class))).thenReturn(
         mockCard);
@@ -151,7 +157,7 @@ public class LibraryCardResourceTest {
   @Test
   public void testCreateLibraryCardThrowsIllegalArgumentException() throws Exception {
     LibraryCard mockCard = mockLibraryCardSetup();
-    String payload = new Gson().toJson(mockCard);
+    String payload = GsonUtil.getInstance().toJson(mockCard);
     when(userService.findUserByEmail(anyString())).thenReturn(user);
     when(libraryCardService.createLibraryCard(any(LibraryCard.class), any(User.class))).thenThrow(
         new IllegalArgumentException());
@@ -163,7 +169,7 @@ public class LibraryCardResourceTest {
   @Test
   public void testCreateLibraryCardThrowsConflictException() throws Exception {
     UnableToExecuteStatementException exception = generateUniqueViolationException();
-    String json = new Gson().toJson(mockLibraryCardSetup());
+    String json = GsonUtil.getInstance().toJson(mockLibraryCardSetup());
     when(userService.findUserByEmail(anyString())).thenReturn(user);
     when(libraryCardService.createLibraryCard(any(LibraryCard.class), any(User.class))).thenThrow(
         exception);
@@ -175,7 +181,7 @@ public class LibraryCardResourceTest {
   @Test
   public void testCreateLibraryCardThrowsBadRequestException() throws Exception {
     BadRequestException exception = new BadRequestException();
-    String json = new Gson().toJson(mockLibraryCardSetup());
+    String json = GsonUtil.getInstance().toJson(mockLibraryCardSetup());
     when(userService.findUserByEmail(anyString())).thenReturn(user);
     when(libraryCardService.createLibraryCard(any(LibraryCard.class), any(User.class))).thenThrow(
         exception);
@@ -187,7 +193,7 @@ public class LibraryCardResourceTest {
   @Test
   public void testCreateLibraruCardThrowsNotFoundException() throws Exception {
     NotFoundException exception = new NotFoundException();
-    String json = new Gson().toJson(mockLibraryCardSetup());
+    String json = GsonUtil.getInstance().toJson(mockLibraryCardSetup());
     when(userService.findUserByEmail(anyString())).thenReturn(user);
     when(libraryCardService.createLibraryCard(any(LibraryCard.class), any(User.class))).thenThrow(
         exception);
@@ -199,7 +205,7 @@ public class LibraryCardResourceTest {
   @Test
   public void testUpdateLibraryCard() {
     LibraryCard mockCard = mockLibraryCardSetup();
-    String payload = new Gson().toJson(mockCard);
+    String payload = GsonUtil.getInstance().toJson(mockCard);
     when(userService.findUserByEmail(anyString())).thenReturn(user);
     when(libraryCardService.updateLibraryCard(any(LibraryCard.class), anyInt(), anyInt()))
         .thenReturn(mockCard);
@@ -213,7 +219,7 @@ public class LibraryCardResourceTest {
   @Test
   public void testUpdateLibraryCardThrowsIllegalArgumentException() {
     LibraryCard mockCard = mockLibraryCardSetup();
-    String payload = new Gson().toJson(mockCard);
+    String payload = GsonUtil.getInstance().toJson(mockCard);
     when(userService.findUserByEmail(anyString())).thenReturn(user);
     when(libraryCardService.updateLibraryCard(any(LibraryCard.class), anyInt(), anyInt()))
         .thenThrow(new IllegalArgumentException());
@@ -227,7 +233,7 @@ public class LibraryCardResourceTest {
     when(userService.findUserByEmail(anyString())).thenReturn(user);
     when(libraryCardService.updateLibraryCard(any(LibraryCard.class), anyInt(), anyInt()))
         .thenThrow(new NotFoundException());
-    String payload = new Gson().toJson(mockLibraryCardSetup());
+    String payload = GsonUtil.getInstance().toJson(mockLibraryCardSetup());
     initResource();
     Response response = resource.updateLibraryCard(authUser, 1, payload);
     assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
@@ -239,7 +245,7 @@ public class LibraryCardResourceTest {
     when(userService.findUserByEmail(anyString())).thenReturn(user);
     when(libraryCardService.updateLibraryCard(any(LibraryCard.class), anyInt(), anyInt()))
         .thenThrow(exception);
-    String payload = new Gson().toJson(mockLibraryCardSetup());
+    String payload = GsonUtil.getInstance().toJson(mockLibraryCardSetup());
     initResource();
     Response response = resource.updateLibraryCard(authUser, 1, payload);
     assertEquals(HttpStatusCodes.STATUS_CODE_CONFLICT, response.getStatus());

--- a/src/test/java/org/broadinstitute/consent/http/resources/LibraryCardResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/LibraryCardResourceTest.java
@@ -141,9 +141,7 @@ public class LibraryCardResourceTest {
   @Test
   public void testCreateLibraryCard() throws Exception {
     LibraryCard mockCard = mockLibraryCardSetup();
-    String payload = new GsonBuilder()
-        .registerTypeAdapter(Instant.class, new InstantTypeAdapter())
-        .create().toJson(mockCard);
+    String payload = GsonUtil.gsonBuilderWithAdapters().create().toJson(mockCard);
     when(userService.findUserByEmail(authUser.getEmail())).thenReturn(user);
     when(libraryCardService.createLibraryCard(any(LibraryCard.class), any(User.class))).thenReturn(
         mockCard);
@@ -205,7 +203,7 @@ public class LibraryCardResourceTest {
   @Test
   public void testUpdateLibraryCard() {
     LibraryCard mockCard = mockLibraryCardSetup();
-    String payload = GsonUtil.getInstance().toJson(mockCard);
+    String payload = GsonUtil.gsonBuilderWithAdapters().create().toJson(mockCard);
     when(userService.findUserByEmail(anyString())).thenReturn(user);
     when(libraryCardService.updateLibraryCard(any(LibraryCard.class), anyInt(), anyInt()))
         .thenReturn(mockCard);

--- a/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
@@ -86,6 +86,8 @@ public class UserResourceTest {
 
   private final String TEST_EMAIL = "test@gmail.com";
 
+  private final Gson gson = GsonUtil.gsonBuilderWithAdapters().create();
+
   private AuthUser authUser;
 
   @BeforeEach
@@ -519,7 +521,6 @@ public class UserResourceTest {
   public void testUpdateSelf() {
     User user = createUserWithRole();
     UserUpdateFields userUpdateFields = new UserUpdateFields();
-    Gson gson = GsonUtil.gsonBuilderWithAdapters().create();
     when(userService.findUserById(any())).thenReturn(user);
     when(userService.findUserByEmail(any())).thenReturn(user);
     when(userService.updateUserFieldsById(any(), any())).thenReturn(user);
@@ -535,7 +536,6 @@ public class UserResourceTest {
     User user = createUserWithRole();
     UserUpdateFields userUpdateFields = new UserUpdateFields();
     userUpdateFields.setUserRoleIds(List.of(1)); // any roles
-    Gson gson = GsonUtil.gsonBuilderWithAdapters().create();
     when(userService.findUserById(any())).thenReturn(user);
     when(userService.findUserByEmail(any())).thenReturn(user);
     when(userService.updateUserFieldsById(any(), any())).thenReturn(user);
@@ -554,7 +554,6 @@ public class UserResourceTest {
     user.addRole(so);
     UserUpdateFields userUpdateFields = new UserUpdateFields();
     userUpdateFields.setInstitutionId(10);
-    Gson gson = GsonUtil.gsonBuilderWithAdapters().create();
     when(userService.findUserById(any())).thenReturn(user);
     when(userService.findUserByEmail(any())).thenReturn(user);
     when(userService.updateUserFieldsById(any(), any())).thenReturn(user);
@@ -574,7 +573,6 @@ public class UserResourceTest {
     user.setInstitutionId(10);
     UserUpdateFields userUpdateFields = new UserUpdateFields();
     userUpdateFields.setInstitutionId(20);
-    Gson gson = GsonUtil.gsonBuilderWithAdapters().create();
     when(userService.findUserById(any())).thenReturn(user);
     when(userService.findUserByEmail(any())).thenReturn(user);
     when(userService.updateUserFieldsById(any(), any())).thenReturn(user);
@@ -594,7 +592,6 @@ public class UserResourceTest {
     user.setInstitutionId(10);
     UserUpdateFields userUpdateFields = new UserUpdateFields();
     userUpdateFields.setInstitutionId(10);
-    Gson gson = GsonUtil.gsonBuilderWithAdapters().create();
     when(userService.findUserById(any())).thenReturn(user);
     when(userService.findUserByEmail(any())).thenReturn(user);
     when(userService.updateUserFieldsById(any(), any())).thenReturn(user);
@@ -613,7 +610,6 @@ public class UserResourceTest {
     user.addRole(itd);
     UserUpdateFields userUpdateFields = new UserUpdateFields();
     userUpdateFields.setInstitutionId(10);
-    Gson gson = GsonUtil.gsonBuilderWithAdapters().create();
     when(userService.findUserById(any())).thenReturn(user);
     when(userService.findUserByEmail(any())).thenReturn(user);
     when(userService.updateUserFieldsById(any(), any())).thenReturn(user);
@@ -633,7 +629,6 @@ public class UserResourceTest {
     user.setInstitutionId(10);
     UserUpdateFields userUpdateFields = new UserUpdateFields();
     userUpdateFields.setInstitutionId(20);
-    Gson gson = GsonUtil.gsonBuilderWithAdapters().create();
     when(userService.findUserById(any())).thenReturn(user);
     when(userService.findUserByEmail(any())).thenReturn(user);
     when(userService.updateUserFieldsById(any(), any())).thenReturn(user);
@@ -653,7 +648,6 @@ public class UserResourceTest {
     user.setInstitutionId(10);
     UserUpdateFields userUpdateFields = new UserUpdateFields();
     userUpdateFields.setInstitutionId(null);
-    Gson gson = GsonUtil.gsonBuilderWithAdapters().create();
     when(userService.findUserById(any())).thenReturn(user);
     when(userService.findUserByEmail(any())).thenReturn(user);
     when(userService.updateUserFieldsById(any(), any())).thenReturn(user);
@@ -737,7 +731,6 @@ public class UserResourceTest {
   public void testUpdate() {
     User user = createUserWithRole();
     UserUpdateFields userUpdateFields = new UserUpdateFields();
-    Gson gson = GsonUtil.gsonBuilderWithAdapters().create();
     when(userService.findUserById(any())).thenReturn(user);
     when(userService.updateUserFieldsById(any(), any())).thenReturn(user);
     when(userService.findUserWithPropertiesByIdAsJsonObject(any(), any())).thenReturn(
@@ -776,7 +769,6 @@ public class UserResourceTest {
     activeUser.addRole(admin);
     when(userService.findUserById(any())).thenReturn(user);
     when(userService.findUserByEmail(any())).thenReturn(activeUser);
-    Gson gson = GsonUtil.gsonBuilderWithAdapters().create();
     JsonElement userJson = gson.toJsonTree(user);
     when(userService.findUserWithPropertiesByIdAsJsonObject(any(), any())).thenReturn(
         userJson.getAsJsonObject());
@@ -945,7 +937,6 @@ public class UserResourceTest {
     activeUser.addRole(admin);
     when(userService.findUserById(any())).thenReturn(user);
     when(userService.findUserByEmail(any())).thenReturn(activeUser);
-    Gson gson = GsonUtil.gsonBuilderWithAdapters().create();
     JsonElement userJson = gson.toJsonTree(user);
     when(userService.findUserWithPropertiesByIdAsJsonObject(any(), any())).thenReturn(
         userJson.getAsJsonObject());

--- a/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
@@ -47,7 +47,6 @@ import org.broadinstitute.consent.http.service.DatasetService;
 import org.broadinstitute.consent.http.service.UserService;
 import org.broadinstitute.consent.http.service.sam.SamService;
 import org.broadinstitute.consent.http.util.gson.GsonUtil;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -81,7 +80,7 @@ class UserResourceTest {
 
   private final String TEST_EMAIL = "test@gmail.com";
 
-  private final Gson gson = GsonUtil.gsonBuilderWithAdapters().create();
+  private final Gson gson = GsonUtil.getInstance();
 
   private final AuthUser authUser = new AuthUser()
       .setAuthToken("auth-token")

--- a/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
@@ -51,6 +51,7 @@ import org.broadinstitute.consent.http.service.DatasetService;
 import org.broadinstitute.consent.http.service.LibraryCardService;
 import org.broadinstitute.consent.http.service.UserService;
 import org.broadinstitute.consent.http.service.sam.SamService;
+import org.broadinstitute.consent.http.util.gson.GsonUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -518,7 +519,7 @@ public class UserResourceTest {
   public void testUpdateSelf() {
     User user = createUserWithRole();
     UserUpdateFields userUpdateFields = new UserUpdateFields();
-    Gson gson = new Gson();
+    Gson gson = GsonUtil.gsonBuilderWithAdapters().create();
     when(userService.findUserById(any())).thenReturn(user);
     when(userService.findUserByEmail(any())).thenReturn(user);
     when(userService.updateUserFieldsById(any(), any())).thenReturn(user);
@@ -534,7 +535,7 @@ public class UserResourceTest {
     User user = createUserWithRole();
     UserUpdateFields userUpdateFields = new UserUpdateFields();
     userUpdateFields.setUserRoleIds(List.of(1)); // any roles
-    Gson gson = new Gson();
+    Gson gson = GsonUtil.gsonBuilderWithAdapters().create();
     when(userService.findUserById(any())).thenReturn(user);
     when(userService.findUserByEmail(any())).thenReturn(user);
     when(userService.updateUserFieldsById(any(), any())).thenReturn(user);
@@ -553,7 +554,7 @@ public class UserResourceTest {
     user.addRole(so);
     UserUpdateFields userUpdateFields = new UserUpdateFields();
     userUpdateFields.setInstitutionId(10);
-    Gson gson = new Gson();
+    Gson gson = GsonUtil.gsonBuilderWithAdapters().create();
     when(userService.findUserById(any())).thenReturn(user);
     when(userService.findUserByEmail(any())).thenReturn(user);
     when(userService.updateUserFieldsById(any(), any())).thenReturn(user);
@@ -573,7 +574,7 @@ public class UserResourceTest {
     user.setInstitutionId(10);
     UserUpdateFields userUpdateFields = new UserUpdateFields();
     userUpdateFields.setInstitutionId(20);
-    Gson gson = new Gson();
+    Gson gson = GsonUtil.gsonBuilderWithAdapters().create();
     when(userService.findUserById(any())).thenReturn(user);
     when(userService.findUserByEmail(any())).thenReturn(user);
     when(userService.updateUserFieldsById(any(), any())).thenReturn(user);
@@ -593,7 +594,7 @@ public class UserResourceTest {
     user.setInstitutionId(10);
     UserUpdateFields userUpdateFields = new UserUpdateFields();
     userUpdateFields.setInstitutionId(10);
-    Gson gson = new Gson();
+    Gson gson = GsonUtil.gsonBuilderWithAdapters().create();
     when(userService.findUserById(any())).thenReturn(user);
     when(userService.findUserByEmail(any())).thenReturn(user);
     when(userService.updateUserFieldsById(any(), any())).thenReturn(user);
@@ -612,7 +613,7 @@ public class UserResourceTest {
     user.addRole(itd);
     UserUpdateFields userUpdateFields = new UserUpdateFields();
     userUpdateFields.setInstitutionId(10);
-    Gson gson = new Gson();
+    Gson gson = GsonUtil.gsonBuilderWithAdapters().create();
     when(userService.findUserById(any())).thenReturn(user);
     when(userService.findUserByEmail(any())).thenReturn(user);
     when(userService.updateUserFieldsById(any(), any())).thenReturn(user);
@@ -632,7 +633,7 @@ public class UserResourceTest {
     user.setInstitutionId(10);
     UserUpdateFields userUpdateFields = new UserUpdateFields();
     userUpdateFields.setInstitutionId(20);
-    Gson gson = new Gson();
+    Gson gson = GsonUtil.gsonBuilderWithAdapters().create();
     when(userService.findUserById(any())).thenReturn(user);
     when(userService.findUserByEmail(any())).thenReturn(user);
     when(userService.updateUserFieldsById(any(), any())).thenReturn(user);
@@ -652,7 +653,7 @@ public class UserResourceTest {
     user.setInstitutionId(10);
     UserUpdateFields userUpdateFields = new UserUpdateFields();
     userUpdateFields.setInstitutionId(null);
-    Gson gson = new Gson();
+    Gson gson = GsonUtil.gsonBuilderWithAdapters().create();
     when(userService.findUserById(any())).thenReturn(user);
     when(userService.findUserByEmail(any())).thenReturn(user);
     when(userService.updateUserFieldsById(any(), any())).thenReturn(user);
@@ -736,7 +737,7 @@ public class UserResourceTest {
   public void testUpdate() {
     User user = createUserWithRole();
     UserUpdateFields userUpdateFields = new UserUpdateFields();
-    Gson gson = new Gson();
+    Gson gson = GsonUtil.gsonBuilderWithAdapters().create();
     when(userService.findUserById(any())).thenReturn(user);
     when(userService.updateUserFieldsById(any(), any())).thenReturn(user);
     when(userService.findUserWithPropertiesByIdAsJsonObject(any(), any())).thenReturn(
@@ -775,7 +776,7 @@ public class UserResourceTest {
     activeUser.addRole(admin);
     when(userService.findUserById(any())).thenReturn(user);
     when(userService.findUserByEmail(any())).thenReturn(activeUser);
-    Gson gson = new Gson();
+    Gson gson = GsonUtil.gsonBuilderWithAdapters().create();
     JsonElement userJson = gson.toJsonTree(user);
     when(userService.findUserWithPropertiesByIdAsJsonObject(any(), any())).thenReturn(
         userJson.getAsJsonObject());
@@ -944,7 +945,7 @@ public class UserResourceTest {
     activeUser.addRole(admin);
     when(userService.findUserById(any())).thenReturn(user);
     when(userService.findUserByEmail(any())).thenReturn(activeUser);
-    Gson gson = new Gson();
+    Gson gson = GsonUtil.gsonBuilderWithAdapters().create();
     JsonElement userJson = gson.toJsonTree(user);
     when(userService.findUserWithPropertiesByIdAsJsonObject(any(), any())).thenReturn(
         userJson.getAsJsonObject());

--- a/src/test/java/org/broadinstitute/consent/http/service/LibraryCardServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/LibraryCardServiceTest.java
@@ -13,12 +13,14 @@ import static org.mockito.MockitoAnnotations.openMocks;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.NotFoundException;
 import java.util.Collections;
+import java.util.List;
 import org.apache.commons.lang3.RandomUtils;
 import org.broadinstitute.consent.http.db.InstitutionDAO;
 import org.broadinstitute.consent.http.db.LibraryCardDAO;
 import org.broadinstitute.consent.http.db.UserDAO;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.exceptions.ConsentConflictException;
+import org.broadinstitute.consent.http.models.DataAccessAgreement;
 import org.broadinstitute.consent.http.models.Institution;
 import org.broadinstitute.consent.http.models.LibraryCard;
 import org.broadinstitute.consent.http.models.User;
@@ -349,6 +351,32 @@ public class LibraryCardServiceTest {
     LibraryCard result = service.findLibraryCardById(libraryCard.getId());
     assertNotNull(result);
     assertEquals(result.getId(), libraryCard.getId());
+  }
+
+  @Test
+  public void testFindLibraryCardDaaById_NotFound() {
+    when(libraryCardDAO.findLibraryCardDaaById(any()))
+        .thenReturn(null);
+    initService();
+    assertThrows(NotFoundException.class, () -> {
+      service.findLibraryCardWithDaasById(1);
+    });
+  }
+
+  @Test
+  public void testFindLibraryCardByIdDaa() {
+    LibraryCard libraryCard = testLibraryCard(1, 1);
+    DataAccessAgreement daa = new DataAccessAgreement();
+    daa.setDaaId(1);
+    libraryCard.addDaaObject(daa);
+    when(libraryCardDAO.findLibraryCardDaaById(libraryCard.getId()))
+        .thenReturn(libraryCard);
+    initService();
+    LibraryCard result = service.findLibraryCardWithDaasById(libraryCard.getId());
+    assertNotNull(result);
+    assertEquals(result.getId(), libraryCard.getId());
+    assertEquals(result.getDaas(), List.of(daa));
+    assertEquals(result.getDaas().get(0).getDaaId(), 1);
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/LibraryCardServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/LibraryCardServiceTest.java
@@ -366,17 +366,23 @@ public class LibraryCardServiceTest {
   @Test
   public void testFindLibraryCardByIdDaa() {
     LibraryCard libraryCard = testLibraryCard(1, 1);
-    DataAccessAgreement daa = new DataAccessAgreement();
-    daa.setDaaId(1);
-    libraryCard.addDaaObject(daa);
+    DataAccessAgreement daa1 = new DataAccessAgreement();
+    int daaId1 = RandomUtils.nextInt(1, 10);
+    int daaId2 = RandomUtils.nextInt(1, 10);;
+    daa1.setDaaId(daaId1);
+    DataAccessAgreement daa2 = new DataAccessAgreement();
+    daa2.setDaaId(daaId2);
+    libraryCard.addDaaObject(daa1);
+    libraryCard.addDaaObject(daa2);
     when(libraryCardDAO.findLibraryCardDaaById(libraryCard.getId()))
         .thenReturn(libraryCard);
     initService();
     LibraryCard result = service.findLibraryCardWithDaasById(libraryCard.getId());
     assertNotNull(result);
     assertEquals(result.getId(), libraryCard.getId());
-    assertEquals(result.getDaas(), List.of(daa));
-    assertEquals(result.getDaas().get(0).getDaaId(), 1);
+    assertEquals(result.getDaas(), List.of(daa1, daa2));
+    assertEquals(result.getDaas().get(0).getDaaId(), daaId1);
+    assertEquals(result.getDaas().get(1).getDaaId(), daaId2);
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/util/InstitutionUtilTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/util/InstitutionUtilTest.java
@@ -12,6 +12,7 @@ import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.Institution;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.UserRole;
+import org.broadinstitute.consent.http.util.gson.GsonUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -55,7 +56,7 @@ class InstitutionUtilTest {
     Institution mockInstitution = initMockInstitution();
     Gson builder = util.getGsonBuilder(true);
     String json = builder.toJson(mockInstitution);
-    Institution deserialized = new Gson().fromJson(json, Institution.class);
+    Institution deserialized = GsonUtil.gsonBuilderWithAdapters().create().fromJson(json, Institution.class);
     assertEquals(mockInstitution.getName(), deserialized.getName());
     assertEquals(mockInstitution.getCreateUserId(), deserialized.getCreateUserId());
     assertEquals(mockInstitution.getUpdateUserId(), deserialized.getUpdateUserId());

--- a/src/test/java/org/broadinstitute/consent/http/util/InstitutionUtilTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/util/InstitutionUtilTest.java
@@ -57,7 +57,7 @@ class InstitutionUtilTest {
     Institution mockInstitution = initMockInstitution();
     Gson builder = util.getGsonBuilder(true);
     String json = builder.toJson(mockInstitution);
-    Institution deserialized = GsonUtil.gsonBuilderWithAdapters().create().fromJson(json, Institution.class);
+    Institution deserialized = GsonUtil.getInstance().fromJson(json, Institution.class);
     assertEquals(mockInstitution.getName(), deserialized.getName());
     assertEquals(mockInstitution.getCreateUserId(), deserialized.getCreateUserId());
     assertEquals(mockInstitution.getUpdateUserId(), deserialized.getUpdateUserId());


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DUOS-3030

### Summary
Adds new DAO and service level methods to get a Library Card with its DAAs & corresponding tests.

Note: there are numerous `Gson` changes to many classes that seem untouched by the relevant changes in this PR. These changes were necessary to account for us now pulling DAAs when we pull for LCs that are queried with our Users. A User can no longer be deserialized with standard `Gson`, so we needed `Gson` with adapters.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
