### PR TITLE
[DUOS-3066][risk=no] Handle CCE bug when trying to notify data custodians of approved datasets

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/service/VoteService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/VoteService.java
@@ -1,7 +1,10 @@
 package org.broadinstitute.consent.http.service;
 
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
 import com.google.inject.Inject;
 import jakarta.ws.rs.NotFoundException;
+import java.lang.reflect.Type;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -36,6 +39,7 @@ import org.broadinstitute.consent.http.models.Study;
 import org.broadinstitute.consent.http.models.StudyProperty;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.Vote;
+import org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder;
 import org.broadinstitute.consent.http.models.dto.DatasetMailDTO;
 import org.broadinstitute.consent.http.service.dao.VoteServiceDAO;
 import org.broadinstitute.consent.http.util.ConsentLogger;
@@ -354,15 +358,23 @@ public class VoteService implements ConsentLogger {
 
         // Data Custodian (study)
         if (Objects.nonNull(study.getProperties())) {
+          Type listOfStringType = new TypeToken<ArrayList<String>>() {}.getType();
+          Gson gson = GsonUtil.gsonBuilderWithAdapters().create();
           Set<StudyProperty> props = study.getProperties();
-          List<User> submitters = props.stream()
-              .filter(p -> p.getKey().equals("dataCustodianEmail"))
-              .map(p -> {
-                List<String> emailList = List.of(GsonUtil.getInstance().fromJson((String)p.getValue(), String[].class));
-                return userDAO.findUsersByEmailList(emailList);
-              }).flatMap(List::stream).toList();
-          if (!submitters.isEmpty()) {
-            submitters.forEach(s -> {
+          List<String> custodianEmails = new ArrayList<>();
+          props.stream()
+              .filter(p -> p.getKey().equals(DatasetRegistrationSchemaV1Builder.dataCustodianEmail))
+              .forEach(p -> {
+                String propValue = p.getValue().toString();
+                try {
+                  custodianEmails.addAll(gson.fromJson(propValue, listOfStringType));
+                } catch (Exception e) {
+                  logException("Error finding data custodians for study: " + study.getStudyId(), e);
+                }
+              });
+          if (!custodianEmails.isEmpty()) {
+            List<User> custodianUsers = userDAO.findUsersByEmailList(custodianEmails);
+            custodianUsers.forEach(s -> {
               custodianMap.putIfAbsent(s, new HashSet<>());
               custodianMap.get(s).add(d);
             });

--- a/src/test/java/org/broadinstitute/consent/http/service/VoteServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/VoteServiceTest.java
@@ -749,49 +749,6 @@ public class VoteServiceTest {
   }
 
   @Test
-  public void testNotifyCustodiansOfApprovedDatasetsWithCustodianProps() {
-    User submitter = new User();
-    submitter.setEmail("submitter@test.com");
-    submitter.setDisplayName("submitter");
-    submitter.setUserId(4);
-
-    Dataset d1 = new Dataset();
-    d1.setDataSetId(1);
-    d1.setName(RandomStringUtils.random(50, true, false));
-    d1.setAlias(1);
-    d1.setDataUse(new DataUseBuilder().setGeneralUse(false).setNonProfitUse(true).build());
-    d1.setCreateUserId(submitter.getUserId());
-
-    Dataset d2 = new Dataset();
-    d2.setDataSetId(2);
-    d2.setName(RandomStringUtils.random(50, true, false));
-    d2.setAlias(2);
-    d2.setDataUse(new DataUseBuilder().setGeneralUse(false).setHmbResearch(true).build());
-    d2.setCreateUserId(submitter.getUserId());
-
-    User researcher = new User();
-    researcher.setEmail("researcher@test.com");
-    researcher.setDisplayName("Researcher");
-    researcher.setUserId(1);
-
-    when(userDAO.findUserById(submitter.getUserId())).thenReturn(submitter);
-
-    initService();
-    try {
-      service.notifyCustodiansOfApprovedDatasets(List.of(d1, d2), researcher, "Dar Code");
-      verify(emailService, times(1)).sendDataCustodianApprovalMessage(
-          any(),
-          any(),
-          any(),
-          any(),
-          any()
-      );
-    } catch (Exception e) {
-      fail(e.getMessage());
-    }
-  }
-
-  @Test
   public void testNotifyCustodiansOfApprovedDatasetsNoSubmitterOrDepositorOrCustodians() throws Exception {
     User submitterNotFound = new User();
     submitterNotFound.setEmail("submitter@test.com");

--- a/src/test/java/org/broadinstitute/consent/http/service/VoteServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/VoteServiceTest.java
@@ -106,9 +106,7 @@ public class VoteServiceTest {
     Vote v = setUpTestVote(false, false);
     initService();
 
-    assertThrows(NotFoundException.class, () -> {
-      service.updateVote(v, 11, "test");
-    });
+    assertThrows(NotFoundException.class, () -> service.updateVote(v, 11, "test"));
   }
 
   @Test
@@ -120,8 +118,7 @@ public class VoteServiceTest {
     v.setIsReminderSent(false);
     v.setVote(false);
     when(voteDAO.findVoteById(anyInt())).thenReturn(v);
-    when(voteDAO.checkVoteById("test", v.getVoteId()))
-        .thenReturn(v.getVoteId());
+    when(voteDAO.checkVoteById("test", v.getVoteId())).thenReturn(v.getVoteId());
     initService();
 
     Vote vote = service.updateVote(v, v.getVoteId(), "test");
@@ -129,7 +126,7 @@ public class VoteServiceTest {
   }
 
   @Test
-  public void testUpdateVotesWithValue() throws Exception {
+  public void testUpdateVotesWithValue() {
     initService();
 
     List<Vote> votes = service.updateVotesWithValue(List.of(), true, "rationale");
@@ -286,7 +283,7 @@ public class VoteServiceTest {
   }
 
   @Test
-  public void testUpdateVotesWithValue_ClosedElection() throws Exception {
+  public void testUpdateVotesWithValue_ClosedElection() {
     when(electionDAO.findElectionsByIds(any())).thenReturn(List.of());
     Vote v = setUpTestVote(true, true);
 
@@ -296,15 +293,12 @@ public class VoteServiceTest {
     when(electionDAO.findElectionsByIds(any())).thenReturn(List.of(closedAccessElection));
 
     initService();
-
-    assertThrows(IllegalArgumentException.class, () -> {
-      service.updateVotesWithValue(List.of(v), true, "rationale");
-    });
+    assertThrows(IllegalArgumentException.class, () -> service.updateVotesWithValue(List.of(v), true, "rationale"));
   }
 
 
   @Test
-  public void testUpdateVotesWithValue_MultipleElectionsDifferentStatuses() throws Exception {
+  public void testUpdateVotesWithValue_MultipleElectionsDifferentStatuses() {
     when(electionDAO.findElectionsByIds(any())).thenReturn(List.of());
     Vote v = setUpTestVote(true, true);
 
@@ -322,9 +316,7 @@ public class VoteServiceTest {
 
     initService();
 
-    assertThrows(IllegalArgumentException.class, () -> {
-      service.updateVotesWithValue(List.of(v), true, "rationale");
-    });
+    assertThrows(IllegalArgumentException.class, () -> service.updateVotesWithValue(List.of(v), true, "rationale"));
   }
 
   @Test
@@ -439,9 +431,7 @@ public class VoteServiceTest {
     when(electionDAO.findElectionsByIds(any())).thenReturn(List.of(election));
     initService();
 
-    assertThrows(IllegalArgumentException.class, () -> {
-      service.updateRationaleByVoteIds(List.of(1), "rationale");
-    });
+    assertThrows(IllegalArgumentException.class, () -> service.updateRationaleByVoteIds(List.of(1), "rationale"));
   }
 
   @Test
@@ -452,9 +442,7 @@ public class VoteServiceTest {
     when(electionDAO.findElectionsByIds(any())).thenReturn(List.of(election));
     initService();
 
-    assertThrows(IllegalArgumentException.class, () -> {
-      service.updateRationaleByVoteIds(List.of(1), "rationale");
-    });
+    assertThrows(IllegalArgumentException.class, () -> service.updateRationaleByVoteIds(List.of(1), "rationale"));
   }
 
   @Test
@@ -839,9 +827,7 @@ public class VoteServiceTest {
     when(userDAO.findUserById(submitterNotFound.getUserId())).thenReturn(null);
 
     initService();
-    assertThrows(IllegalArgumentException.class, () -> {
-      service.notifyCustodiansOfApprovedDatasets(List.of(d1, d2), researcher, "Dar Code");
-    });
+    assertThrows(IllegalArgumentException.class, () -> service.notifyCustodiansOfApprovedDatasets(List.of(d1, d2), researcher, "Dar Code"));
     verify(emailService, times(0)).sendDataCustodianApprovalMessage(
         any(),
         any(),


### PR DESCRIPTION
### Addresses
Fix for https://broadworkbench.atlassian.net/browse/DUOS-3066

### Summary
* Handle potential CCEs better when finding custodians for a study
* Significant service class test clearnup related to updating the test to use `@ExtendWith(MockitoExtension.class)`

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
