### PR TITLE
[DUOS-3007][risk=no] Log stack trace when retrieving Sam user info fails

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/authentication/OAuthAuthenticator.java
+++ b/src/main/java/org/broadinstitute/consent/http/authentication/OAuthAuthenticator.java
@@ -106,10 +106,7 @@ public class OAuthAuthenticator implements Authenticator<String, AuthUser>, Cons
         logException("AuthUser not able to be registered: '" + gson.toJson(authUser), exc);
       }
     } catch (Throwable e) {
-      logWarn(String.format(
-          "Exception retrieving Sam user info for '%s': Exception: %s",
-          authUser.getEmail(),
-          e.getMessage()));
+      logWarn(String.format("Exception retrieving Sam user info for '%s'", authUser.getEmail()), e);
     }
     return authUser;
   }

--- a/src/main/java/org/broadinstitute/consent/http/util/ConsentLogger.java
+++ b/src/main/java/org/broadinstitute/consent/http/util/ConsentLogger.java
@@ -53,6 +53,16 @@ public interface ConsentLogger {
   }
 
   /**
+   * Logs a warning message and throwable to the console
+   *
+   * @param message Error Message
+   * @param t       Exception
+   */
+  default void logWarn(String message, Throwable t) {
+    getLogger(this.getClass()).warn(message, t);
+  }
+
+  /**
    * Logs an info message to the console
    *
    * @param message Error Message


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DUOS-3007

### Summary

This may help us debug sporadic 'Forbidden' exceptions that Consent receives when calling Sam's [getUserStatusInfo](https://sam.dsde-prod.broadinstitute.org/#/Users/getUserStatusInfo) endpoint for the TDR SA `datarepo-jade-api@terra-datarepo-production.iam.gserviceaccount.com`.  Example logs: https://cloudlogging.app.goo.gl/GR6zPvk46ZNnmZnY8

I elected to keep Sentry behavior the same as it was -- that is, do not flag these exceptions in Sentry.

Note that this PR does *not* close out the ticket, but moves the ball forward to make debugging easier if / when we pick it back up.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
