### PR TITLE
[DCJ-15][risk=no] Make DCJ team codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,4 @@
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
 # These owners will be the default owners for everything in the repo.
-*       @DataBiosphere/data-custodian-journeys @DataBiosphere/data-explorer-eng
+*       @DataBiosphere/data-custodian-journeys

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
+# Lines starting with '#' are comments.
 # Each line is a file pattern followed by one or more owners.
+# Documentation with syntax examples:
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
-# These owners will be the default owners for everything in
-# the repo. Unless a later match takes precedence,
-# the DUOS team will be requested for
-# review when someone opens a pull request.
-* @DataBiosphere/DUOS
+# These owners will be the default owners for everything in the repo.
+*       @DataBiosphere/data-custodian-journeys @DataBiosphere/data-explorer-eng

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,8 +6,6 @@ updates:
       # Check for updates to GitHub Actions every week
       interval: "weekly"
     target-branch: develop
-    reviewers:
-      - "@DataBiosphere/DUOS"
     commit-message:
       prefix: "[DUOS-1740-actions]"
     groups:
@@ -20,8 +18,6 @@ updates:
       interval: weekly
     open-pull-requests-limit: 10
     target-branch: develop
-    reviewers:
-      - "@DataBiosphere/DUOS"
     labels:
       - dependency
     commit-message:
@@ -36,8 +32,6 @@ updates:
       interval: weekly
     open-pull-requests-limit: 10
     target-branch: develop
-    reviewers:
-      - "@DataBiosphere/DUOS"
     labels:
       - dependency
     commit-message:


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DCJ-15

### Summary

- Make @DataBiosphere/data-custodian-journeys (new Github team) the default codeowners.  I have also made the team an admin of this repository.
- Remove explicit reviewer setting on Dependabot PRs: this will be handled by our Github team configuration.

Related PR with more context on team makeup, code review settings, and Slack scheduled reminders: https://github.com/DataBiosphere/jade-data-repo/pull/1665

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
