### PR TITLE
[DCJ-274][risk=no] Update library vulnerabilty

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -424,11 +424,11 @@
       <version>1.4.1</version>
     </dependency>
 
-   <!--
-    See
-    https://broadworkbench.atlassian.net/browse/DCJ-274
-    org.bouncycastle:bcprov-jdk18on:jar:1.76 is vulnerable
-   -->
+    <!--
+     See
+     https://broadworkbench.atlassian.net/browse/DCJ-274
+     org.bouncycastle:bcprov-jdk18on:jar:1.76 is vulnerable
+    -->
     <dependency>
       <groupId>com.sendgrid</groupId>
       <artifactId>sendgrid-java</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -424,10 +424,32 @@
       <version>1.4.1</version>
     </dependency>
 
+   <!--
+    See
+    https://broadworkbench.atlassian.net/browse/DCJ-274
+    org.bouncycastle:bcprov-jdk18on:jar:1.76 is vulnerable
+   -->
     <dependency>
       <groupId>com.sendgrid</groupId>
       <artifactId>sendgrid-java</artifactId>
       <version>4.10.2</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>bcprov-jdk18on</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <!--
+     See
+     https://broadworkbench.atlassian.net/browse/DCJ-274
+     org.bouncycastle:bcprov-jdk18on:jar:1.76 is vulnerable
+    -->
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcprov-jdk18on</artifactId>
+      <version>1.78.1</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DCJ-274

### Summary
Minor library exclusion to address security concern. The concern is a dependency of Sendgrid so to test, we need to interact with email. I tested locally by enabling email for my user and in the app configuration (`consent.yaml`). Then look for a vote for which you have a user that can get email for. Hit the `/api/emailNotifier/reminderMessage/{voteId}` endpoint using a local instance. You should get an email from Sendgrid which shows that the library is unaffected by the newer dependency:

![Screenshot 2024-04-29 at 4 32 05 PM](https://github.com/DataBiosphere/consent/assets/116679/1a6a746b-9fab-4881-8d22-0f5a49766501)


----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
