### PR TITLE
[DCJ-293] Add LC to user if none for PUT DAA-LC relationship endpoint

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/resources/DaaResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DaaResource.java
@@ -121,14 +121,7 @@ public class DaaResource extends Resource implements ConsentLogger {
           .filter(card -> card.getInstitutionId() == authedUser.getInstitutionId().intValue())
           .findFirst();
       if (matchingCard.isEmpty()) {
-        LibraryCard lc = new LibraryCard();
-        lc.setUserId(user.getUserId());
-        lc.setInstitutionId(authedUser.getInstitutionId());
-        lc.setEraCommonsId(user.getEraCommonsId());
-        lc.setUserName(user.getDisplayName());
-        lc.setUserEmail(user.getEmail());
-        lc.setCreateUserId(authedUser.getUserId());
-        LibraryCard createdLc = libraryCardService.createLibraryCard(lc, user);
+        LibraryCard createdLc = libraryCardService.createLibraryCardForSigningOfficial(user, authedUser);
         matchingCard = Optional.of(createdLc);
       }
       int libraryCardId = matchingCard.get().getId();

--- a/src/main/java/org/broadinstitute/consent/http/resources/DaaResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DaaResource.java
@@ -121,7 +121,15 @@ public class DaaResource extends Resource implements ConsentLogger {
           .filter(card -> card.getInstitutionId() == authedUser.getInstitutionId().intValue())
           .findFirst();
       if (matchingCard.isEmpty()) {
-        return Response.status(Status.NOT_FOUND).build();
+        LibraryCard lc = new LibraryCard();
+        lc.setUserId(user.getUserId());
+        lc.setInstitutionId(authedUser.getInstitutionId());
+        lc.setEraCommonsId(user.getEraCommonsId());
+        lc.setUserName(user.getDisplayName());
+        lc.setUserEmail(user.getEmail());
+        lc.setCreateUserId(authedUser.getUserId());
+        LibraryCard createdLc = libraryCardService.createLibraryCard(lc, user);
+        matchingCard = Optional.of(createdLc);
       }
       int libraryCardId = matchingCard.get().getId();
       libraryCardService.addDaaToLibraryCard(libraryCardId, daaId);

--- a/src/main/java/org/broadinstitute/consent/http/service/LibraryCardService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/LibraryCardService.java
@@ -136,6 +136,18 @@ public class LibraryCardService {
     return matchingLibraryCards;
   }
 
+  public LibraryCard createLibraryCardForSigningOfficial(User user, User signingOfficial) {
+    LibraryCard lc = new LibraryCard();
+    lc.setUserId(user.getUserId());
+    lc.setInstitutionId(signingOfficial.getInstitutionId());
+    lc.setEraCommonsId(user.getEraCommonsId());
+    lc.setUserName(user.getDisplayName());
+    lc.setUserEmail(user.getEmail());
+    lc.setCreateUserId(signingOfficial.getUserId());
+    LibraryCard createdLc = createLibraryCard(lc, user);
+    return createdLc;
+  }
+
   private void checkForValidInstitution(Integer institutionId) {
     checkInstitutionId(institutionId);
     Institution institution = institutionDAO.findInstitutionById(institutionId);

--- a/src/test/java/org/broadinstitute/consent/http/resources/DaaResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DaaResourceTest.java
@@ -428,7 +428,7 @@ class DaaResourceTest {
     when(userService.findUserByEmail(any())).thenReturn(admin);
     when(userService.findUserById(any())).thenReturn(researcher);
     when(libraryCardService.findLibraryCardsByUserId(any())).thenReturn(Collections.singletonList(lc));
-    when(libraryCardService.createLibraryCard(any(), any())).thenReturn(newLc);
+    when(libraryCardService.createLibraryCardForSigningOfficial(any(), any())).thenReturn(newLc);
 
     resource = new DaaResource(daaService, dacService, userService, libraryCardService, emailService);
     Response response = resource.createLibraryCardDaaRelation(info, authUser, daa.getDaaId(),  admin.getUserId());
@@ -459,7 +459,7 @@ class DaaResourceTest {
     when(userService.findUserByEmail(any())).thenReturn(admin);
     when(userService.findUserById(any())).thenReturn(researcher);
     when(libraryCardService.findLibraryCardsByUserId(any())).thenReturn(List.of());
-    when(libraryCardService.createLibraryCard(any(), any())).thenReturn(newLc);
+    when(libraryCardService.createLibraryCardForSigningOfficial(any(), any())).thenReturn(newLc);
 
     resource = new DaaResource(daaService, dacService, userService, libraryCardService, emailService);
     Response response = resource.createLibraryCardDaaRelation(info, authUser, daa.getDaaId(),  admin.getUserId());

--- a/src/test/java/org/broadinstitute/consent/http/resources/DaaResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DaaResourceTest.java
@@ -405,6 +405,8 @@ class DaaResourceTest {
   void testCreateLibraryCardDaaRelation_NoMatchingLibraryCardsCase() {
     UriInfo info = mock(UriInfo.class);
     UriBuilder builder = mock(UriBuilder.class);
+    when(info.getBaseUriBuilder()).thenReturn(builder);
+    when(builder.replacePath(any())).thenReturn(builder);
     Dac dac = new Dac();
     dac.setDacId(RandomUtils.nextInt(10, 100));
     User admin = new User();
@@ -418,14 +420,50 @@ class DaaResourceTest {
     LibraryCard lc = new LibraryCard();
     lc.setId(1);
     lc.setInstitutionId(2);
+    LibraryCard newLc = new LibraryCard();
+    newLc.setId(2);
+    newLc.setInstitutionId(1);
+
 
     when(userService.findUserByEmail(any())).thenReturn(admin);
     when(userService.findUserById(any())).thenReturn(researcher);
     when(libraryCardService.findLibraryCardsByUserId(any())).thenReturn(Collections.singletonList(lc));
+    when(libraryCardService.createLibraryCard(any(), any())).thenReturn(newLc);
 
     resource = new DaaResource(daaService, dacService, userService, libraryCardService, emailService);
     Response response = resource.createLibraryCardDaaRelation(info, authUser, daa.getDaaId(),  admin.getUserId());
-    assert response.getStatus() == HttpStatus.SC_NOT_FOUND;
+    assert response.getStatus() == HttpStatus.SC_OK;
+  }
+
+  @Test
+  void testCreateLibraryCardDaaRelation_NoLibraryCardsCase() {
+    UriInfo info = mock(UriInfo.class);
+    UriBuilder builder = mock(UriBuilder.class);
+    when(info.getBaseUriBuilder()).thenReturn(builder);
+    when(builder.replacePath(any())).thenReturn(builder);
+    Dac dac = new Dac();
+    dac.setDacId(RandomUtils.nextInt(10, 100));
+    User admin = new User();
+    admin.setSigningOfficialRole();
+    admin.setInstitutionId(1);
+    User researcher = new User();
+    researcher.setResearcherRole();
+    researcher.setInstitutionId(1);
+    DataAccessAgreement daa = new DataAccessAgreement();
+    daa.setDaaId(1);
+    LibraryCard newLc = new LibraryCard();
+    newLc.setId(1);
+    newLc.setInstitutionId(1);
+
+
+    when(userService.findUserByEmail(any())).thenReturn(admin);
+    when(userService.findUserById(any())).thenReturn(researcher);
+    when(libraryCardService.findLibraryCardsByUserId(any())).thenReturn(List.of());
+    when(libraryCardService.createLibraryCard(any(), any())).thenReturn(newLc);
+
+    resource = new DaaResource(daaService, dacService, userService, libraryCardService, emailService);
+    Response response = resource.createLibraryCardDaaRelation(info, authUser, daa.getDaaId(),  admin.getUserId());
+    assert response.getStatus() == HttpStatus.SC_OK;
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/LibraryCardServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/LibraryCardServiceTest.java
@@ -467,6 +467,33 @@ public class LibraryCardServiceTest {
   }
 
   @Test
+  void testCreateLibraryCardForSigningOfficial() {
+    Institution institution = testInstitution();
+    User user = createUserWithRole(UserRoles.RESEARCHER.getRoleId(), UserRoles.RESEARCHER.getRoleName());
+    user.setInstitutionId(institution.getId());
+    User signingOfficial = createUserWithRole(UserRoles.ADMIN.getRoleId(), UserRoles.ADMIN.getRoleName());
+    signingOfficial.setInstitutionId(institution.getId());
+    user.setEmail("testemail");
+    LibraryCard newLc = new LibraryCard();
+    newLc.setId(1);
+    newLc.setInstitutionId(institution.getId());
+
+    when(userDAO.findUserById(anyInt())).thenReturn(user);
+    when(institutionDAO.findInstitutionById(anyInt())).thenReturn(institution);
+    when(libraryCardDAO.findLibraryCardsByUserId(anyInt())).thenReturn(Collections.emptyList());
+
+    when(libraryCardDAO.insertLibraryCard(anyInt(), anyInt(), any(), any(), any(), anyInt(),
+        any())).thenReturn(1);
+    when(libraryCardDAO.findLibraryCardById(anyInt())).thenReturn(newLc);
+
+    initService();
+    LibraryCard card = service.createLibraryCardForSigningOfficial(user, signingOfficial);
+    assertNotNull(card);
+    assertEquals(card.getId(), newLc.getId());
+    assertEquals(card.getInstitutionId(), newLc.getInstitutionId());
+  }
+
+  @Test
   void testRemoveDaaFromUserLibraryCardByInstitutionNoLibraryCards() {
     User user = testUser(1);
     Integer userId = user.getUserId();


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DCJ-293

### Summary
Updates the PUT DAA-LC relationship endpoint to now create a LC for the user if no matching library cards are found. This change adds that functionality along with appropriate tests. 

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
