### PR TITLE
[DCJ-302][risk=no] Remove duplicate data submitter property

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/models/StudyConversion.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/StudyConversion.java
@@ -154,7 +154,7 @@ public class StudyConversion {
     return study;
   }
 
-  public Collection<StudyProperty> getStudyProperties(User submitter) {
+  public Collection<StudyProperty> getStudyProperties() {
     List<StudyProperty> props = new ArrayList<>();
     if (getPhenotype() != null) {
       props.add(new StudyProperty("phenotypeIndication", getPhenotype(), PropertyType.String));
@@ -164,9 +164,6 @@ public class StudyConversion {
     }
     if (getNihAnvilUse() != null) {
       props.add(new StudyProperty("nihAnvilUse", getNihAnvilUse(), PropertyType.String));
-    }
-    if (submitter != null) {
-      props.add(new StudyProperty("dataSubmitterUserId", submitter.getUserId(), PropertyType.Number));
     }
     return props;
   }

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetRegistrationService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetRegistrationService.java
@@ -554,9 +554,6 @@ public class DatasetRegistrationService implements ConsentLogger {
           "species", PropertyType.String,
           DatasetRegistrationSchemaV1::getSpecies),
       new StudyPropertyExtractor(
-          "dataSubmitterUserId", PropertyType.Number,
-          DatasetRegistrationSchemaV1::getDataSubmitterUserId),
-      new StudyPropertyExtractor(
           "dataCustodianEmail", PropertyType.Json,
           (registration) -> {
             if (Objects.nonNull(registration.getDataCustodianEmail())) {

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -505,8 +505,6 @@ public class DatasetService implements ConsentLogger {
     if (studyConversion.getDataSubmitterEmail() != null) {
       User submitter = userDAO.findUserByEmail(studyConversion.getDataSubmitterEmail());
       if (submitter != null) {
-        newPropConversion(dictionaries, dataset, "Data Submitter User ID", "dataSubmitterUserId",
-            PropertyType.Number, user.getUserId().toString());
         datasetDAO.updateDatasetCreateUserId(dataset.getDataSetId(), user.getUserId());
       }
     }

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -636,22 +636,21 @@ public class DatasetService implements ConsentLogger {
 
     // Create or update study properties:
     Set<StudyProperty> existingProps = studyDAO.findStudyById(studyId).getProperties();
-    User submitter = userDAO.findUserByEmail(studyConversion.getDataSubmitterEmail());
     // If we don't have any props, we need to add all of the new ones
     if (existingProps == null || existingProps.isEmpty()) {
-      studyConversion.getStudyProperties(submitter).stream()
+      studyConversion.getStudyProperties().stream()
           .filter(Objects::nonNull)
           .forEach(p -> studyDAO.insertStudyProperty(studyId, p.getKey(), p.getType().toString(),
               p.getValue().toString()));
     } else {
       // Study props to add:
-      studyConversion.getStudyProperties(submitter).stream()
+      studyConversion.getStudyProperties().stream()
           .filter(Objects::nonNull)
           .filter(p -> existingProps.stream().noneMatch(ep -> ep.getKey().equals(p.getKey())))
           .forEach(p -> studyDAO.insertStudyProperty(studyId, p.getKey(), p.getType().toString(),
               p.getValue().toString()));
       // Study props to update:
-      studyConversion.getStudyProperties(submitter).stream()
+      studyConversion.getStudyProperties().stream()
           .filter(Objects::nonNull)
           .filter(p -> existingProps.stream().anyMatch(ep -> ep.equals(p)))
           .forEach(p -> studyDAO.updateStudyProperty(studyId, p.getKey(), p.getType().toString(),

--- a/src/main/resources/changelog-master.xml
+++ b/src/main/resources/changelog-master.xml
@@ -150,4 +150,6 @@
     relativeToChangelogFile="true"/>
   <include file="changesets/changelog-consent-2024-04-23-standardize-dataset-association.xml"
     relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-2024-05-03-rm-submitter-prop.xml"
+    relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/changesets/changelog-consent-2024-05-03-rm-submitter-prop.xml
+++ b/src/main/resources/changesets/changelog-consent-2024-05-03-rm-submitter-prop.xml
@@ -1,0 +1,18 @@
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+  <changeSet id="changelog-consent-2024-04-01-rm-piname.xml" author="grushton">
+    <sql>
+      -- Remove duplicated properties
+      DELETE
+      FROM dataset_property
+      WHERE property_key IN (SELECT key_id FROM dictionary d WHERE KEY = 'Data Submitter User ID')
+    </sql>
+    <sql>
+      -- Remove deprecated property key from dictionary
+      DELETE
+      FROM dictionary
+      WHERE key = 'Data Submitter User ID';
+    </sql>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/changesets/changelog-consent-2024-05-03-rm-submitter-prop.xml
+++ b/src/main/resources/changesets/changelog-consent-2024-05-03-rm-submitter-prop.xml
@@ -7,6 +7,8 @@
       DELETE
       FROM dataset_property
       WHERE property_key IN (SELECT key_id FROM dictionary d WHERE KEY = 'Data Submitter User ID')
+    </sql>
+    <sql>
       -- Remove duplicated study properties
       DELETE
       FROM study_property

--- a/src/main/resources/changesets/changelog-consent-2024-05-03-rm-submitter-prop.xml
+++ b/src/main/resources/changesets/changelog-consent-2024-05-03-rm-submitter-prop.xml
@@ -3,10 +3,14 @@
          http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
   <changeSet id="changelog-consent-2024-04-01-rm-piname.xml" author="grushton">
     <sql>
-      -- Remove duplicated properties
+      -- Remove duplicated dataset properties
       DELETE
       FROM dataset_property
       WHERE property_key IN (SELECT key_id FROM dictionary d WHERE KEY = 'Data Submitter User ID')
+      -- Remove duplicated study properties
+      DELETE
+      FROM study_property
+      WHERE key = 'dataSubmitterUserId'
     </sql>
     <sql>
       -- Remove deprecated property key from dictionary

--- a/src/test/java/org/broadinstitute/consent/http/service/DatasetRegistrationServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DatasetRegistrationServiceTest.java
@@ -39,7 +39,6 @@ import org.broadinstitute.consent.http.db.DatasetDAO;
 import org.broadinstitute.consent.http.db.StudyDAO;
 import org.broadinstitute.consent.http.enumeration.FileCategory;
 import org.broadinstitute.consent.http.enumeration.PropertyType;
-import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.Dac;
 import org.broadinstitute.consent.http.models.DataUse;
 import org.broadinstitute.consent.http.models.Dataset;
@@ -47,7 +46,6 @@ import org.broadinstitute.consent.http.models.DatasetProperty;
 import org.broadinstitute.consent.http.models.Study;
 import org.broadinstitute.consent.http.models.StudyProperty;
 import org.broadinstitute.consent.http.models.User;
-import org.broadinstitute.consent.http.models.UserRole;
 import org.broadinstitute.consent.http.models.dataset_registration_v1.AlternativeDataSharingPlanReason;
 import org.broadinstitute.consent.http.models.dataset_registration_v1.ConsentGroup;
 import org.broadinstitute.consent.http.models.dataset_registration_v1.ConsentGroup.AccessManagement;
@@ -177,7 +175,6 @@ class DatasetRegistrationServiceTest {
     assertContainsStudyProperty(studyProps, "studyType", schema.getStudyType().value());
     assertContainsStudyProperty(studyProps, "phenotypeIndication", schema.getPhenotypeIndication());
     assertContainsStudyProperty(studyProps, "species", schema.getSpecies());
-    assertContainsStudyProperty(studyProps, "dataSubmitterUserId", schema.getDataSubmitterUserId());
     assertContainsStudyProperty(studyProps, "dataCustodianEmail",
         PropertyType.coerceToJson(GsonUtil.getInstance().toJson(schema.getDataCustodianEmail())));
     assertContainsStudyProperty(studyProps, "nihAnvilUse", schema.getNihAnvilUse().value());
@@ -290,7 +287,6 @@ class DatasetRegistrationServiceTest {
     List<StudyProperty> studyProps = capturedStudyInsert.props();
     assertContainsStudyProperty(studyProps, "phenotypeIndication", schema.getPhenotypeIndication());
     assertContainsStudyProperty(studyProps, "species", schema.getSpecies());
-    assertContainsStudyProperty(studyProps, "dataSubmitterUserId", schema.getDataSubmitterUserId());
     assertContainsDatasetProperty(datasetProps, "numberOfParticipants",
         schema.getConsentGroups().get(0).getNumberOfParticipants());
     assertContainsDatasetProperty(datasetProps, "fileTypes", PropertyType.coerceToJson(
@@ -479,7 +475,6 @@ class DatasetRegistrationServiceTest {
     assertContainsStudyProperty(studyProps, "studyType", schema.getStudyType().value());
     assertContainsStudyProperty(studyProps, "phenotypeIndication", schema.getPhenotypeIndication());
     assertContainsStudyProperty(studyProps, "species", schema.getSpecies());
-    assertContainsStudyProperty(studyProps, "dataSubmitterUserId", schema.getDataSubmitterUserId());
 
     List<DatasetProperty> props = inserts.get(0).props();
     assertContainsDatasetProperty(props, "fileTypes", PropertyType.coerceToJson(


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DCJ-302

### Summary
Minor update to remove the duplicate data submitter properties. The data submitter is the create user for both the dataset and the study. Current code creates both a dataset and a study property with the same values as the create user, which is redundant.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
