### PR TITLE
[DCJ-347][risk=no] Delete Library Card DAA relationships when deleting the Library Card

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/LibraryCardDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/LibraryCardDAO.java
@@ -49,7 +49,10 @@ public interface LibraryCardDAO extends Transactional<LibraryCardDAO> {
       @Bind("updateUserId") Integer updateUserId,
       @Bind("updateDate") Date updateDate);
 
-  @SqlUpdate("DELETE FROM library_card WHERE id = :libraryCardId")
+  @SqlUpdate("""
+      WITH daa_deletes AS (DELETE FROM lc_daa lc_daa WHERE lc_daa.lc_id = :libraryCardId)
+      DELETE FROM library_card lc WHERE lc.id = :libraryCardId
+      """)
   void deleteLibraryCardById(@Bind("libraryCardId") Integer libraryCardId);
 
   @RegisterBeanMapper(value = LibraryCard.class)

--- a/src/test/java/org/broadinstitute/consent/http/db/LibraryCardDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/LibraryCardDAOTest.java
@@ -115,7 +115,7 @@ class LibraryCardDAOTest extends DAOTestHelper {
     // 1. Library Card for a user as a top level object that will be deleted
     // 2. Dac so we can create a DAA
     // 3. DAA so we can link it to a user's Library Card
-    // 4. Library Card <-> DAA relationship that represents a user's acceptance of a DAA
+    // 4. Library Card <-> DAA relationship that represents a Signing Official's acceptance of a DAA for the user
     LibraryCard card = createLibraryCard();
     int dacId = dacDAO.createDac(RandomStringUtils.randomAlphabetic(10), RandomStringUtils.randomAlphabetic(10), new Date());
     int daaId = daaDAO.createDaa(card.getCreateUserId(), Instant.now(), card.getCreateUserId(), Instant.now(), dacId);

--- a/src/test/java/org/broadinstitute/consent/http/db/LibraryCardDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/LibraryCardDAOTest.java
@@ -114,8 +114,8 @@ class LibraryCardDAOTest extends DAOTestHelper {
     // This test creates several relationships:
     // 1. Library Card for a user as a top level object that will be deleted
     // 2. Dac so we can create a DAA
-    // 3. DAA so we can associate link it to a user's Library Card
-    // 4. Library Card - DAA relationship that represents a user's acceptance of a DAA
+    // 3. DAA so we can link it to a user's Library Card
+    // 4. Library Card <-> DAA relationship that represents a user's acceptance of a DAA
     LibraryCard card = createLibraryCard();
     int dacId = dacDAO.createDac(RandomStringUtils.randomAlphabetic(10), RandomStringUtils.randomAlphabetic(10), new Date());
     int daaId = daaDAO.createDaa(card.getCreateUserId(), Instant.now(), card.getCreateUserId(), Instant.now(), dacId);


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DCJ-347

### Summary
When deleting a library card, ensure that any DAA relationships to that library card are also deleted. Uses a [Common Table Expression](https://www.postgresql.org/docs/current/queries-with.html) to do so.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
