### PR TITLE
[DCJ-350] Modify bulk DAA endpoints to create LC if none on user(s)

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/LibraryCardDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/LibraryCardDAO.java
@@ -10,6 +10,7 @@ import org.broadinstitute.consent.http.models.LibraryCard;
 import org.jdbi.v3.sqlobject.config.RegisterBeanMapper;
 import org.jdbi.v3.sqlobject.customizer.Bind;
 import org.jdbi.v3.sqlobject.statement.GetGeneratedKeys;
+import org.jdbi.v3.sqlobject.statement.SqlBatch;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 import org.jdbi.v3.sqlobject.statement.UseRowReducer;
@@ -117,6 +118,29 @@ public interface LibraryCardDAO extends Transactional<LibraryCardDAO> {
       WHERE library_card.institution_id = :institutionId
       """)
   List<LibraryCard> findLibraryCardsByInstitutionId(@Bind("institutionId") Integer institutionId);
+
+  @RegisterBeanMapper(value = LibraryCard.class)
+  @RegisterBeanMapper(value = Institution.class, prefix = "i")
+  @UseRowReducer(LibraryCardReducer.class)
+  @SqlQuery("""
+      SELECT lc.*,
+      institution.institution_id AS i_institution_id,
+      institution.institution_name AS i_name,
+      institution.it_director_name AS i_it_director_name,
+      institution.it_director_email AS i_it_director_email,
+      institution.create_user AS i_create_user_id,
+      institution.create_date AS i_create_date,
+      institution.update_date AS i_update_date,
+      institution.update_user AS i_update_user_id,
+      ld.daa_id
+      FROM library_card AS lc
+      LEFT JOIN institution
+      ON lc.institution_id = :institutionId
+      LEFT JOIN lc_daa ld ON lc.id = ld.lc_id
+      WHERE lc.user_id = :userId
+      """)
+  List<LibraryCard> findLibraryCardsByUserIdInstitutionId(@Bind("userId") Integer userId,
+      @Bind("institutionId") Integer institutionId);
 
   @RegisterBeanMapper(value = LibraryCard.class)
   @RegisterBeanMapper(value = Institution.class, prefix = "i")

--- a/src/main/java/org/broadinstitute/consent/http/resources/DaaResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DaaResource.java
@@ -244,7 +244,7 @@ public class DaaResource extends Resource implements ConsentLogger {
       }
       daaService.findById(daaId);
       for (User user : users) {
-        libraryCardService.addDaaToUserLibraryCardByInstitution(user, authedUser.getInstitutionId(), daaId);
+        libraryCardService.addDaaToUserLibraryCardByInstitution(user, authedUser, daaId);
       }
       return Response.ok().build();
     } catch (Exception e) {
@@ -296,7 +296,7 @@ public class DaaResource extends Resource implements ConsentLogger {
       }
       List<DataAccessAgreement> daaList = daaService.findDAAsInJsonArray(json, "daaList");
       for (DataAccessAgreement daa : daaList) {
-        libraryCardService.addDaaToUserLibraryCardByInstitution(user, authedUser.getInstitutionId(), daa.getDaaId());
+        libraryCardService.addDaaToUserLibraryCardByInstitution(user, authedUser, daa.getDaaId());
       }
       return Response.ok().build();
     } catch (Exception e) {

--- a/src/main/java/org/broadinstitute/consent/http/service/LibraryCardService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/LibraryCardService.java
@@ -115,6 +115,9 @@ public class LibraryCardService {
   }
 
   public List<LibraryCard> addDaaToUserLibraryCardByInstitution(User user, User signingOfficial, Integer daaId) {
+    if (signingOfficial.getInstitutionId() == null) {
+      throw new BadRequestException("This signing official does not have an institution.");
+    }
     List<LibraryCard> libraryCards = findLibraryCardsByUserId(user.getUserId());
     List<LibraryCard> matchingLibraryCards = libraryCards.stream()
         .filter(card -> Objects.equals(card.getInstitutionId(), signingOfficial.getInstitutionId()))

--- a/src/main/java/org/broadinstitute/consent/http/service/LibraryCardService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/LibraryCardService.java
@@ -118,19 +118,16 @@ public class LibraryCardService {
     if (signingOfficial.getInstitutionId() == null) {
       throw new BadRequestException("This signing official does not have an institution.");
     }
-    List<LibraryCard> libraryCards = findLibraryCardsByUserId(user.getUserId());
-    List<LibraryCard> matchingLibraryCards = libraryCards.stream()
-        .filter(card -> Objects.equals(card.getInstitutionId(), signingOfficial.getInstitutionId()))
-        .collect(Collectors.toCollection(ArrayList::new));
-    if (matchingLibraryCards.isEmpty()) {
+    List<LibraryCard> libraryCards = new ArrayList<>(libraryCardDAO.findLibraryCardsByUserIdInstitutionId(user.getUserId(), signingOfficial.getInstitutionId()));
+    if (libraryCards.isEmpty()) {
       LibraryCard lc = createLibraryCardForSigningOfficial(user, signingOfficial);
-      matchingLibraryCards.add(lc);
+      libraryCards.add(lc);
     }
     // typically there should be one library card per user per institution
-    for (LibraryCard libraryCard : matchingLibraryCards) {
+    for (LibraryCard libraryCard : libraryCards) {
       addDaaToLibraryCard(libraryCard.getId(), daaId);
     }
-    return matchingLibraryCards;
+    return libraryCardDAO.findLibraryCardsByUserIdInstitutionId(user.getUserId(), signingOfficial.getInstitutionId());
   }
 
   public List<LibraryCard> removeDaaFromUserLibraryCardByInstitution(User user, Integer institutionId, Integer daaId) {

--- a/src/test/java/org/broadinstitute/consent/http/db/LibraryCardDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/LibraryCardDAOTest.java
@@ -4,6 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
 
 import java.time.Instant;
 import java.util.Date;
@@ -222,15 +224,19 @@ class LibraryCardDAOTest extends DAOTestHelper {
   @Test
   void testFindLibraryCardByUserIdInstitutionId() {
     LibraryCard libraryCard = createLibraryCard();
+    int dacId = dacDAO.createDac(RandomStringUtils.randomAlphabetic(5), RandomStringUtils.randomAlphabetic(5), RandomStringUtils.randomAlphabetic(5), new Date());
+    Instant now = Instant.now();
+    int daaId = daaDAO.createDaa(libraryCard.getUserId(), now, libraryCard.getUserId(), now, dacId);
+    daaDAO.createDacDaaRelation(dacId, daaId);
+    libraryCardDAO.createLibraryCardDaaRelation(libraryCard.getId(), daaId);
     List<LibraryCard> cardsFromDAO = libraryCardDAO.findLibraryCardsByUserIdInstitutionId(
         libraryCard.getUserId(),
         libraryCard.getInstitutionId());
-
     assertNotNull(cardsFromDAO);
     assertEquals(cardsFromDAO.size(), 1);
     assertEquals(cardsFromDAO.get(0).getId(), libraryCard.getId());
     assertEquals(cardsFromDAO.get(0).getUserId(), libraryCard.getUserId());
-    assertTrue(cardsFromDAO.get(0).getDaaIds().isEmpty());
+    assertFalse(cardsFromDAO.get(0).getDaaIds().isEmpty());
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/db/LibraryCardDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/LibraryCardDAOTest.java
@@ -220,6 +220,20 @@ class LibraryCardDAOTest extends DAOTestHelper {
   }
 
   @Test
+  void testFindLibraryCardByUserIdInstitutionId() {
+    LibraryCard libraryCard = createLibraryCard();
+    List<LibraryCard> cardsFromDAO = libraryCardDAO.findLibraryCardsByUserIdInstitutionId(
+        libraryCard.getUserId(),
+        libraryCard.getInstitutionId());
+
+    assertNotNull(cardsFromDAO);
+    assertEquals(cardsFromDAO.size(), 1);
+    assertEquals(cardsFromDAO.get(0).getId(), libraryCard.getId());
+    assertEquals(cardsFromDAO.get(0).getUserId(), libraryCard.getUserId());
+    assertTrue(cardsFromDAO.get(0).getDaaIds().isEmpty());
+  }
+
+  @Test
   void testFindAllLibraryCards() {
     List<LibraryCard> cardList = libraryCardDAO.findAllLibraryCards();
     assertEquals(0, cardList.size());

--- a/src/test/java/org/broadinstitute/consent/http/service/LibraryCardServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/LibraryCardServiceTest.java
@@ -386,6 +386,7 @@ public class LibraryCardServiceTest {
   @Test
   void testAddDaaToUserLibraryCardByInstitution() {
     User user = testUser(1);
+    User signingOfficial = testUser(1);
     Integer userId = user.getUserId();
     List<LibraryCard> libraryCards = List.of(
         testLibraryCard(1, userId),
@@ -397,13 +398,16 @@ public class LibraryCardServiceTest {
         .thenReturn(libraryCards);
     doNothing().when(libraryCardDAO).createLibraryCardDaaRelation(any(), any());
     initService();
-    List<LibraryCard> cards = service.addDaaToUserLibraryCardByInstitution(user, 1, 1);
+    List<LibraryCard> cards = service.addDaaToUserLibraryCardByInstitution(user, signingOfficial, 1);
     assertEquals(2, cards.size());
   }
 
   @Test
   void testAddDaaToUserLibraryCardByInstitutionNoMatchingInstitutions() {
     User user = testUser(1);
+    user.setRoles(List.of(new UserRole(UserRoles.RESEARCHER.getRoleId(), UserRoles.RESEARCHER.getRoleName())));
+    User signingOfficial = createUserWithRole(UserRoles.SIGNINGOFFICIAL.getRoleId(), UserRoles.SIGNINGOFFICIAL.getRoleName());
+    signingOfficial.setInstitutionId(4);
     Integer userId = user.getUserId();
     List<LibraryCard> libraryCards = List.of(
         testLibraryCard(1, userId),
@@ -415,19 +419,32 @@ public class LibraryCardServiceTest {
         .thenReturn(libraryCards);
     doNothing().when(libraryCardDAO).createLibraryCardDaaRelation(any(), any());
     initService();
-    List<LibraryCard> cards = service.addDaaToUserLibraryCardByInstitution(user, 4, 1);
-    assertEquals(0, cards.size());
+    assertThrows(BadRequestException.class, () -> {
+      service.addDaaToUserLibraryCardByInstitution(user, signingOfficial, 1);
+    });
   }
 
   @Test
   void testAddDaaToUserLibraryCardByInstitutionNoLibraryCards() {
-    User user = testUser(1);
+    initService();
+    Institution institution = testInstitution();
+    User user = testUser(institution.getId());
+    user.setRoles(List.of(new UserRole(UserRoles.RESEARCHER.getRoleId(), UserRoles.RESEARCHER.getRoleName())));
+    User signingOfficial = createUserWithRole(UserRoles.SIGNINGOFFICIAL.getRoleId(), UserRoles.SIGNINGOFFICIAL.getRoleName());
+    signingOfficial.setInstitutionId(institution.getId());
     Integer userId = user.getUserId();
+    LibraryCard payload = testLibraryCard(institution.getId(), signingOfficial.getUserId());
+    payload.setUserEmail("testemail");
     when(libraryCardDAO.findLibraryCardsByUserId(userId))
         .thenReturn(Collections.emptyList());
-    initService();
-    List<LibraryCard> cards = service.addDaaToUserLibraryCardByInstitution(user, 1, 1);
-    assertEquals(0, cards.size());
+    when(institutionDAO.findInstitutionById(anyInt())).thenReturn(institution);
+    when(userDAO.findUserById(anyInt())).thenReturn(signingOfficial);
+    when(service.createLibraryCard(payload, signingOfficial)).thenReturn(payload);
+    when(libraryCardDAO.insertLibraryCard(anyInt(), anyInt(), any(), any(), any(), anyInt(), any()))
+        .thenReturn(1);
+    when(libraryCardDAO.findLibraryCardById(anyInt())).thenReturn(new LibraryCard());
+    List<LibraryCard> cards = service.addDaaToUserLibraryCardByInstitution(user, signingOfficial, 1);
+    assertEquals(1, cards.size());
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/LibraryCardServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/LibraryCardServiceTest.java
@@ -386,15 +386,15 @@ public class LibraryCardServiceTest {
   @Test
   void testAddDaaToUserLibraryCardByInstitution() {
     User user = testUser(1);
-    User signingOfficial = testUser(1);
+    user.setRoles(List.of(new UserRole(UserRoles.RESEARCHER.getRoleId(), UserRoles.RESEARCHER.getRoleName())));
+    User signingOfficial = createUserWithRole(UserRoles.SIGNINGOFFICIAL.getRoleId(), UserRoles.SIGNINGOFFICIAL.getRoleName());
+    signingOfficial.setInstitutionId(1);
     Integer userId = user.getUserId();
     List<LibraryCard> libraryCards = List.of(
         testLibraryCard(1, userId),
-        testLibraryCard(2, userId),
-        testLibraryCard(1, userId),
-        testLibraryCard(3, userId)
+        testLibraryCard(1, userId)
     );
-    when(libraryCardDAO.findLibraryCardsByUserId(user.getUserId()))
+    when(libraryCardDAO.findLibraryCardsByUserIdInstitutionId(user.getUserId(), user.getInstitutionId()))
         .thenReturn(libraryCards);
     doNothing().when(libraryCardDAO).createLibraryCardDaaRelation(any(), any());
     initService();
@@ -437,11 +437,15 @@ public class LibraryCardServiceTest {
     payload.setUserEmail("testemail");
     when(libraryCardDAO.findLibraryCardsByUserId(userId))
         .thenReturn(Collections.emptyList());
+    when(libraryCardDAO.findLibraryCardsByUserIdInstitutionId(userId, institution.getId()))
+        .thenReturn(Collections.emptyList(),Collections.singletonList(payload));
     when(institutionDAO.findInstitutionById(anyInt())).thenReturn(institution);
     when(userDAO.findUserById(anyInt())).thenReturn(signingOfficial);
+    when(service.createLibraryCardForSigningOfficial(user, signingOfficial)).thenReturn(payload);
     when(service.createLibraryCard(payload, signingOfficial)).thenReturn(payload);
     when(libraryCardDAO.insertLibraryCard(anyInt(), anyInt(), any(), any(), any(), anyInt(), any()))
         .thenReturn(1);
+    when(libraryCardDAO.findLibraryCardById(anyInt())).thenReturn(new LibraryCard());
     when(libraryCardDAO.findLibraryCardById(anyInt())).thenReturn(new LibraryCard());
     List<LibraryCard> cards = service.addDaaToUserLibraryCardByInstitution(user, signingOfficial, 1);
     assertEquals(1, cards.size());

--- a/src/test/java/org/broadinstitute/consent/http/service/LibraryCardServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/LibraryCardServiceTest.java
@@ -448,6 +448,27 @@ public class LibraryCardServiceTest {
   }
 
   @Test
+  void testAddDaaToUserLibraryCardByInstitutionSigningOfficialNoInstitution() {
+    User user = testUser(1);
+    user.setRoles(List.of(new UserRole(UserRoles.RESEARCHER.getRoleId(), UserRoles.RESEARCHER.getRoleName())));
+    User signingOfficial = createUserWithRole(UserRoles.SIGNINGOFFICIAL.getRoleId(), UserRoles.SIGNINGOFFICIAL.getRoleName());
+    Integer userId = user.getUserId();
+    List<LibraryCard> libraryCards = List.of(
+        testLibraryCard(1, userId),
+        testLibraryCard(2, userId),
+        testLibraryCard(1, userId),
+        testLibraryCard(3, userId)
+    );
+    when(libraryCardDAO.findLibraryCardsByUserId(user.getUserId()))
+        .thenReturn(libraryCards);
+    doNothing().when(libraryCardDAO).createLibraryCardDaaRelation(any(), any());
+    initService();
+    assertThrows(BadRequestException.class, () -> {
+      service.addDaaToUserLibraryCardByInstitution(user, signingOfficial, 1);
+    });
+  }
+
+  @Test
   void testRemoveDaaFromUserLibraryCardByInstitution() {
     User user = testUser(1);
     Integer userId = user.getUserId();

--- a/src/test/java/org/broadinstitute/consent/http/service/LibraryCardServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/LibraryCardServiceTest.java
@@ -455,7 +455,8 @@ public class LibraryCardServiceTest {
   void testAddDaaToUserLibraryCardByInstitutionSigningOfficialNoInstitution() {
     User user = testUser(1);
     user.setRoles(List.of(new UserRole(UserRoles.RESEARCHER.getRoleId(), UserRoles.RESEARCHER.getRoleName())));
-    User signingOfficial = createUserWithRole(UserRoles.SIGNINGOFFICIAL.getRoleId(), UserRoles.SIGNINGOFFICIAL.getRoleName());
+    User signingOfficial = new User();
+    signingOfficial.setRoles(List.of(new UserRole(UserRoles.SIGNINGOFFICIAL.getRoleId(), UserRoles.SIGNINGOFFICIAL.getRoleName())));
     Integer userId = user.getUserId();
     List<LibraryCard> libraryCards = List.of(
         testLibraryCard(1, userId),


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DCJ-350

### Summary
Modifies service level methods for the bulk DAA-LC endpoints to now create a library card for a user/users if they don't have one before creating a DAA-LC relationship. This change was similarly done for the non-bulk endpoints. These changes also modify the corresponding tests.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
