### PR TITLE
[DCJ-235] Fully populate LC on users for  /api/user/role/{roleName} User endpoint

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/UserDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/UserDAO.java
@@ -145,22 +145,41 @@ public interface UserDAO extends Transactional<UserDAO> {
   @SqlQuery(
       //This will pull in users tied to the institution
       //Users will come with LCs issued by SOs institution (if any)
-      " SELECT DISTINCT " +
-          User.QUERY_FIELDS_WITH_U_PREFIX + QUERY_FIELD_SEPARATOR +
-          " r.name, ur.role_id, ur.user_role_id, ur.dac_id, ur.user_id, " +
-          " lc.id AS lc_id , lc.user_id AS lc_user_id, lc.institution_id AS lc_institution_id, " +
-          " lc.era_commons_id AS lc_era_commons_id, lc.user_name AS lc_user_name, lc.user_email AS lc_user_email, "
-          +
-          " lc.create_user_id AS lc_create_user_id, lc.create_date AS lc_create_date, " +
-          " lc.update_user_id AS lc_update_user_id, " +
-          Institution.QUERY_FIELDS_WITH_LCI_PREFIX + QUERY_FIELD_SEPARATOR +
-          Institution.QUERY_FIELDS_WITH_I_PREFIX +
-          " FROM users u " +
-          " LEFT JOIN user_role ur ON ur.user_id = u.user_id " +
-          " LEFT JOIN roles r ON r.role_id = ur.role_id " +
-          " LEFT JOIN library_card lc ON lc.user_id = u.user_id " +
-          " LEFT JOIN institution lci ON lc.institution_id = lci.institution_id" +
-          " LEFT JOIN institution i ON u.institution_id = i.institution_id")
+      """
+          SELECT DISTINCT
+          u.user_id as u_user_id,
+          u.email as u_email,
+          u.display_name as u_display_name,
+          u.create_date as u_create_date,
+          u.email_preference as u_email_preference,
+          u.institution_id as u_institution_id,
+          u.era_commons_id as u_era_commons_id,
+          r.name, ur.role_id, ur.user_role_id, ur.dac_id, ur.user_id,
+          lc.id AS lc_id , lc.user_id AS lc_user_id, lc.institution_id AS lc_institution_id,
+          lc.era_commons_id AS lc_era_commons_id, lc.user_name AS lc_user_name, lc.user_email AS lc_user_email,
+          lc.create_user_id AS lc_create_user_id, lc.create_date AS lc_create_date,
+          lc.update_user_id AS lc_update_user_id,
+          ld.daa_id as lc_daa_id,
+          lci.institution_id as lci_id,
+          lci.institution_name as lci_name,
+          lci.it_director_name as lci_it_director_name,
+          lci.it_director_email as lci_it_director_email,
+          lci.create_date as lci_create_date,
+          lci.update_date as lci_update_date,
+          i.institution_id as i_id,
+          i.institution_name as i_name,
+          i.it_director_name as i_it_director_name,
+          i.it_director_email as i_it_director_email,
+          i.create_date as i_create_date,
+          i.update_date as i_update_date
+          FROM users u
+          LEFT JOIN user_role ur ON ur.user_id = u.user_id
+          LEFT JOIN roles r ON r.role_id = ur.role_id
+          LEFT JOIN library_card lc ON lc.user_id = u.user_id
+          LEFT JOIN lc_daa ld ON lc.id = ld.lc_id
+          LEFT JOIN institution lci ON lc.institution_id = lci.institution_id
+          LEFT JOIN institution i ON u.institution_id = i.institution_id
+        """)
   List<User> findUsersWithLCsAndInstitution();
 
   @UseRowMapper(UserWithRolesMapper.class)
@@ -213,24 +232,42 @@ public interface UserDAO extends Transactional<UserDAO> {
   @SqlQuery(
       //This will pull in users tied to the institution
       //Users will come with LCs issued by SOs institution (if any)
-      " SELECT " +
-          User.QUERY_FIELDS_WITH_U_PREFIX + QUERY_FIELD_SEPARATOR +
-          " r.name, ur.role_id, ur.user_role_id, ur.dac_id, ur.user_id, " +
-          " lc.id AS lc_id , lc.user_id AS lc_user_id, lc.institution_id AS lc_institution_id, " +
-          " lc.era_commons_id AS lc_era_commons_id, lc.user_name AS lc_user_name, lc.user_email AS lc_user_email, "
-          +
-          " lc.create_user_id AS lc_create_user_id, lc.create_date AS lc_create_date, " +
-          " lc.update_user_id AS lc_update_user_id, " +
-          Institution.QUERY_FIELDS_WITH_LCI_PREFIX + ", " +
-          Institution.QUERY_FIELDS_WITH_I_PREFIX +
-          " FROM users u " +
-          " LEFT JOIN user_role ur ON ur.user_id = u.user_id " +
-          " LEFT JOIN roles r ON r.role_id = ur.role_id " +
-          " LEFT JOIN library_card lc ON lc.user_id = u.user_id AND lc.institution_id = :institutionId "
-          +
-          " LEFT JOIN institution lci ON lc.institution_id = lci.institution_id" +
-          " LEFT JOIN institution i ON u.institution_id = i.institution_id" +
-          " WHERE u.institution_id = :institutionId")
+      """
+          SELECT
+          u.user_id as u_user_id,
+          u.email as u_email,
+          u.display_name as u_display_name,
+          u.create_date as u_create_date,
+          u.email_preference as u_email_preference,
+          u.institution_id as u_institution_id,
+          u.era_commons_id as u_era_commons_id,
+          r.name, ur.role_id, ur.user_role_id, ur.dac_id, ur.user_id,
+          lc.id AS lc_id , lc.user_id AS lc_user_id, lc.institution_id AS lc_institution_id,
+          lc.era_commons_id AS lc_era_commons_id, lc.user_name AS lc_user_name, lc.user_email AS lc_user_email,
+          lc.create_user_id AS lc_create_user_id, lc.create_date AS lc_create_date,
+          lc.update_user_id AS lc_update_user_id,
+          ld.daa_id as lc_daa_id,
+          lci.institution_id as lci_id,
+          lci.institution_name as lci_name,
+          lci.it_director_name as lci_it_director_name,
+          lci.it_director_email as lci_it_director_email,
+          lci.create_date as lci_create_date,
+          lci.update_date as lci_update_date,
+          i.institution_id as i_id,
+          i.institution_name as i_name,
+          i.it_director_name as i_it_director_name,
+          i.it_director_email as i_it_director_email,
+          i.create_date as i_create_date,
+          i.update_date as i_update_date
+          FROM users u
+          LEFT JOIN user_role ur ON ur.user_id = u.user_id
+          LEFT JOIN roles r ON r.role_id = ur.role_id
+          LEFT JOIN library_card lc ON lc.user_id = u.user_id AND lc.institution_id = :institutionId
+          LEFT JOIN lc_daa ld ON lc.id = ld.lc_id
+          LEFT JOIN institution lci ON lc.institution_id = lci.institution_id
+          LEFT JOIN institution i ON u.institution_id = i.institution_id
+          WHERE u.institution_id = :institutionId
+        """)
   List<User> getUsersFromInstitutionWithCards(@Bind("institutionId") Integer institutionId);
 
   //SO only endpoint (so far)

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/UserWithRolesReducer.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/UserWithRolesReducer.java
@@ -74,6 +74,9 @@ public class UserWithRolesReducer implements LinkedHashMapRowReducer<Integer, Us
         } catch (MappingException e) {
           // Ignore institution mapping errors
         }
+        if (rowView.getColumn("lc_daa_id", Integer.class) != null) {
+          lc.addDaa(rowView.getColumn("lc_daa_id", Integer.class));
+        }
         if (Objects.isNull(user.getLibraryCards()) || user.getLibraryCards().stream()
             .noneMatch(card -> card.getId().equals(lc.getId()))) {
           user.addLibraryCard(lc);

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/UserWithRolesReducer.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/UserWithRolesReducer.java
@@ -2,6 +2,7 @@ package org.broadinstitute.consent.http.db.mapper;
 
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import org.broadinstitute.consent.http.models.Institution;
 import org.broadinstitute.consent.http.models.LibraryCard;
 import org.broadinstitute.consent.http.models.User;
@@ -61,8 +62,15 @@ public class UserWithRolesReducer implements LinkedHashMapRowReducer<Integer, Us
     //ex) The same LC can end up being repeated multiple times
     //Below only adds LC if not currently saved on the array
     try {
-      if (Objects.nonNull(rowView.getColumn("lc_id", Integer.class))) {
-        LibraryCard lc = rowView.getRow(LibraryCard.class);
+      if (rowView.getColumn("lc_id", Integer.class) != null) {
+        int lcId = rowView.getColumn("lc_id", Integer.class);
+        LibraryCard lc;
+        Optional<LibraryCard> existingLibraryCard = user.getLibraryCards() == null ?
+            Optional.empty() :
+            user.getLibraryCards().stream()
+            .filter(card -> card.getId().equals(lcId))
+            .findFirst();
+        lc = existingLibraryCard.orElseGet(() -> rowView.getRow(LibraryCard.class));
         try {
           if (Objects.nonNull(rowView.getColumn("lci_id", Integer.class))) {
             Institution institution = rowView.getRow(Institution.class);
@@ -77,10 +85,7 @@ public class UserWithRolesReducer implements LinkedHashMapRowReducer<Integer, Us
         if (rowView.getColumn("lc_daa_id", Integer.class) != null) {
           lc.addDaa(rowView.getColumn("lc_daa_id", Integer.class));
         }
-        if (Objects.isNull(user.getLibraryCards()) || user.getLibraryCards().stream()
-            .noneMatch(card -> card.getId().equals(lc.getId()))) {
-          user.addLibraryCard(lc);
-        }
+        user.addLibraryCard(lc);
       }
     } catch (MappingException e) {
       //Ignore exceptions here, user may not have a library card issued under this instiution

--- a/src/main/java/org/broadinstitute/consent/http/service/UserService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/UserService.java
@@ -269,17 +269,15 @@ public class UserService {
       case Resource.SIGNINGOFFICIAL:
         Integer institutionId = user.getInstitutionId();
         if (Objects.nonNull(user.getInstitutionId())) {
-          List<User> users = userDAO.getUsersFromInstitutionWithCards(institutionId);
-          populateLibraryCardsOnUsers(users);
-          return users;
+          return userDAO.getUsersFromInstitutionWithCards(institutionId);
         } else {
           throw new NotFoundException("Signing Official (user: " + user.getDisplayName()
               + ") is not associated with an Institution.");
         }
       case Resource.ADMIN:
-        List<User> users = userDAO.findUsersWithLCsAndInstitution();
-        populateLibraryCardsOnUsers(users);
-        return users;
+        return userDAO.findUsersWithLCsAndInstitution();
+      default:
+        // do nothing
     }
     return Collections.emptyList();
   }
@@ -458,15 +456,6 @@ public class UserService {
         });
 
     userDAO.updateUser(user.getDisplayName(), user.getUserId(), user.getInstitutionId());
-  }
-
-  private void populateLibraryCardsOnUsers(List<User> users) {
-    for (User user: users) {
-      List<LibraryCard> cards = libraryCardDAO.findLibraryCardsByUserId(user.getUserId());
-      if (Objects.nonNull(cards) && !cards.isEmpty()) {
-        user.setLibraryCards(cards);
-      }
-    }
   }
 
   public User findOrCreateUser(AuthUser authUser) throws Exception {

--- a/src/main/java/org/broadinstitute/consent/http/service/UserService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/UserService.java
@@ -270,12 +270,7 @@ public class UserService {
         Integer institutionId = user.getInstitutionId();
         if (Objects.nonNull(user.getInstitutionId())) {
           List<User> users = userDAO.getUsersFromInstitutionWithCards(institutionId);
-          for (User u: users) {
-            List<LibraryCard> cards = libraryCardDAO.findLibraryCardsByUserId(u.getUserId());
-            if (Objects.nonNull(cards) && !cards.isEmpty()) {
-              u.setLibraryCards(cards);
-            }
-          }
+          populateLibraryCardsOnUsers(users);
           return users;
         } else {
           throw new NotFoundException("Signing Official (user: " + user.getDisplayName()
@@ -283,12 +278,7 @@ public class UserService {
         }
       case Resource.ADMIN:
         List<User> users = userDAO.findUsersWithLCsAndInstitution();
-        for (User u: users) {
-          List<LibraryCard> cards = libraryCardDAO.findLibraryCardsByUserId(u.getUserId());
-          if (Objects.nonNull(cards) && !cards.isEmpty()) {
-            u.setLibraryCards(cards);
-          }
-        }
+        populateLibraryCardsOnUsers(users);
         return users;
     }
     return Collections.emptyList();
@@ -468,6 +458,15 @@ public class UserService {
         });
 
     userDAO.updateUser(user.getDisplayName(), user.getUserId(), user.getInstitutionId());
+  }
+
+  private void populateLibraryCardsOnUsers(List<User> users) {
+    for (User user: users) {
+      List<LibraryCard> cards = libraryCardDAO.findLibraryCardsByUserId(user.getUserId());
+      if (Objects.nonNull(cards) && !cards.isEmpty()) {
+        user.setLibraryCards(cards);
+      }
+    }
   }
 
   public User findOrCreateUser(AuthUser authUser) throws Exception {

--- a/src/main/java/org/broadinstitute/consent/http/service/UserService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/UserService.java
@@ -269,13 +269,27 @@ public class UserService {
       case Resource.SIGNINGOFFICIAL:
         Integer institutionId = user.getInstitutionId();
         if (Objects.nonNull(user.getInstitutionId())) {
-          return userDAO.getUsersFromInstitutionWithCards(institutionId);
+          List<User> users = userDAO.getUsersFromInstitutionWithCards(institutionId);
+          for (User u: users) {
+            List<LibraryCard> cards = libraryCardDAO.findLibraryCardsByUserId(u.getUserId());
+            if (Objects.nonNull(cards) && !cards.isEmpty()) {
+              u.setLibraryCards(cards);
+            }
+          }
+          return users;
         } else {
           throw new NotFoundException("Signing Official (user: " + user.getDisplayName()
               + ") is not associated with an Institution.");
         }
       case Resource.ADMIN:
-        return userDAO.findUsersWithLCsAndInstitution();
+        List<User> users = userDAO.findUsersWithLCsAndInstitution();
+        for (User u: users) {
+          List<LibraryCard> cards = libraryCardDAO.findLibraryCardsByUserId(u.getUserId());
+          if (Objects.nonNull(cards) && !cards.isEmpty()) {
+            u.setLibraryCards(cards);
+          }
+        }
+        return users;
     }
     return Collections.emptyList();
   }

--- a/src/test/java/org/broadinstitute/consent/http/db/UserDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/UserDAOTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.sql.Timestamp;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -205,12 +206,17 @@ class UserDAOTest extends DAOTestHelper {
   @Test
   void testFindUsersWithLCsAndInstitution() {
     User user = createUserWithInstitution();
-    libraryCardDAO.insertLibraryCard(user.getUserId(), user.getInstitutionId(), "asdf",
+    int dacId = dacDAO.createDac(RandomStringUtils.randomAlphabetic(5), RandomStringUtils.randomAlphabetic(5), new Date());
+    Instant now = Instant.now();
+    int daaId = daaDAO.createDaa(user.getUserId(), now, user.getUserId(), now, dacId);
+    int lcId1 = libraryCardDAO.insertLibraryCard(user.getUserId(), user.getInstitutionId(), "asdf",
         user.getDisplayName(), user.getEmail(), user.getUserId(), new Date());
+    libraryCardDAO.createLibraryCardDaaRelation(lcId1, daaId);
 
     User user2 = createUserWithInstitution();
-    libraryCardDAO.insertLibraryCard(user2.getUserId(), user.getInstitutionId(), "asdf",
+    int lcId2 = libraryCardDAO.insertLibraryCard(user2.getUserId(), user.getInstitutionId(), "asdf",
         user.getDisplayName(), user.getEmail(), user.getUserId(), new Date());
+    libraryCardDAO.createLibraryCardDaaRelation(lcId2, daaId);
 
     List<User> users = userDAO.findUsersWithLCsAndInstitution();
     assertNotNull(users);
@@ -222,7 +228,6 @@ class UserDAOTest extends DAOTestHelper {
     assertNotNull(users.get(1).getInstitution());
     assertNotNull(users.get(1).getLibraryCards());
     assertEquals(1, users.get(1).getLibraryCards().size());
-
   }
 
   @Test
@@ -336,7 +341,11 @@ class UserDAOTest extends DAOTestHelper {
 
   @Test
   void testGetUsersFromInstitutionWithCards() {
+    int dacId = dacDAO.createDac(RandomStringUtils.randomAlphabetic(5), RandomStringUtils.randomAlphabetic(5), new Date());
+    Instant now = Instant.now();
     LibraryCard card = createLibraryCard();
+    int daaId = daaDAO.createDaa(card.getUserId(), now, card.getUserId(), now, dacId);
+    libraryCardDAO.createLibraryCardDaaRelation(card.getId(), daaId);
     Integer institutionId = card.getInstitutionId();
     Integer userId = card.getUserId();
     List<User> users = userDAO.getUsersFromInstitutionWithCards(institutionId);

--- a/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
@@ -581,6 +581,16 @@ class UserServiceTest {
   }
 
   @Test
+  void testGetUsersAsRoleInvalidRole() {
+    User u1 = generateUser();
+    initService();
+    List<User> users = service.getUsersAsRole(u1, UserRoles.ADMIN.getRoleName());
+    assertNotNull(users);
+    assertEquals(0, users.size());
+    assertEquals(Collections.emptyList(), users);
+  }
+
+  @Test
   void testFindUsersWithNoInstitution() {
     User user = generateUser();
     when(userDAO.getUsersWithNoInstitution()).thenReturn(List.of(user));

--- a/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
@@ -535,8 +535,7 @@ class UserServiceTest {
     LibraryCard lc = generateLibraryCard(u);
     u.setLibraryCards(List.of(lc));
     when(userDAO.getUsersFromInstitutionWithCards(anyInt())).thenReturn(
-        List.of(new User(), new User()));
-    when(libraryCardDAO.findLibraryCardsByUserId(any())).thenReturn(List.of(lc));
+        List.of(u, new User()));
     initService();
 
     List<User> users = service.getUsersAsRole(u, UserRoles.SIGNINGOFFICIAL.getRoleName());
@@ -571,7 +570,6 @@ class UserServiceTest {
     LibraryCard lc = generateLibraryCard(u1);
     u1.setLibraryCards(List.of(lc));
     when(userDAO.findUsersWithLCsAndInstitution()).thenReturn(returnedUsers);
-    when(libraryCardDAO.findLibraryCardsByUserId(u1.getUserId())).thenReturn(List.of(lc));
     initService();
     List<User> users = service.getUsersAsRole(u1, UserRoles.ADMIN.getRoleName());
     assertNotNull(users);

--- a/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
@@ -532,13 +532,17 @@ class UserServiceTest {
   void testGetUsersByUserRole_SO() {
     User u = generateUser();
     u.setInstitutionId(1);
+    LibraryCard lc = generateLibraryCard(u);
+    u.setLibraryCards(List.of(lc));
     when(userDAO.getUsersFromInstitutionWithCards(anyInt())).thenReturn(
         List.of(new User(), new User()));
+    when(libraryCardDAO.findLibraryCardsByUserId(any())).thenReturn(List.of(lc));
     initService();
 
     List<User> users = service.getUsersAsRole(u, UserRoles.SIGNINGOFFICIAL.getRoleName());
     assertNotNull(users);
     assertEquals(2, users.size());
+    assertEquals(List.of(lc), users.get(0).getLibraryCards());
   }
 
   @Test
@@ -564,11 +568,16 @@ class UserServiceTest {
     if (!returnedUsers.contains(u3)) {
       returnedUsers.add(u3);
     }
+    LibraryCard lc = generateLibraryCard(u1);
+    u1.setLibraryCards(List.of(lc));
     when(userDAO.findUsersWithLCsAndInstitution()).thenReturn(returnedUsers);
+    when(libraryCardDAO.findLibraryCardsByUserId(u1.getUserId())).thenReturn(List.of(lc));
     initService();
     List<User> users = service.getUsersAsRole(u1, UserRoles.ADMIN.getRoleName());
     assertNotNull(users);
     assertEquals(returnedUsers.size(), users.size());
+    assertEquals(List.of(lc), users.get(0).getLibraryCards());
+    assertNull(users.get(1).getLibraryCards());
   }
 
   @Test


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DCJ-235

### Summary
Fully populates the library card object & associated properties on a user now in the `getUsersAsRole` method exposed through the `/api/user/role/{roleName}` endpoint. Modifies existing tests to check for Library Cards.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
