### PR TITLE
[DCJ-400-actions]: Bump aurelien-baudet/workflow-dispatch from 2.1.1 to 4.0.0 in the action-dependencies group

### DIFF
--- a/.github/workflows/consumer_contract_tests.yaml
+++ b/.github/workflows/consumer_contract_tests.yaml
@@ -78,7 +78,7 @@ jobs:
     if: github.actor != 'dependabot[bot]'
     steps:
       - name: Dispatch to terra-github-workflows
-        uses: aurelien-baudet/workflow-dispatch@93e95b157d791ae7f42aef8f8a0d3d723eba1c31 #commit sha for v2.1.1
+        uses: aurelien-baudet/workflow-dispatch@3133c5d135c7dbe4be4f9793872b6ef331b53bc7 #commit sha for v4.0.0
         with:
           workflow: publish-pacts.yaml
           repo: broadinstitute/terra-github-workflows

--- a/.github/workflows/consumer_contract_tests.yaml
+++ b/.github/workflows/consumer_contract_tests.yaml
@@ -75,7 +75,6 @@ jobs:
     permissions:
       contents: 'read'
       id-token: 'write'
-    if: github.actor != 'dependabot[bot]'
     steps:
       - name: Dispatch to terra-github-workflows
         uses: aurelien-baudet/workflow-dispatch@3133c5d135c7dbe4be4f9793872b6ef331b53bc7 #commit sha for v4.0.0


### PR DESCRIPTION
Testing the removal of the dependabot exclusion for https://github.com/DataBiosphere/consent/pull/2343