### PR TITLE
[DCJ-445] Remove extraneous print statements

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DacReducer.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DacReducer.java
@@ -1,6 +1,5 @@
 package org.broadinstitute.consent.http.db.mapper;
 
-import java.sql.Date;
 import java.sql.Timestamp;
 import java.util.Map;
 import org.broadinstitute.consent.http.models.Dac;
@@ -51,7 +50,6 @@ public class DacReducer implements LinkedHashMapRowReducer<Integer, Dac>,
 
         //aliased columns must be set directly
         String dsAlias = rowView.getColumn("dataset_alias", String.class);
-        System.out.println("dsAlias: " + dsAlias);
         if (dsAlias != null) {
           try {
             dataset.setAlias(Integer.parseInt(dsAlias));
@@ -71,7 +69,6 @@ public class DacReducer implements LinkedHashMapRowReducer<Integer, Dac>,
         }
 
         String duStr = rowView.getColumn("dataset_data_use", String.class);
-        System.out.println("duStr: " + duStr);
         if (duStr != null) {
           dataset.setDataUse(dataUseParser.parseDataUse(duStr));
         }


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DCJ-445

### Summary
Removes extraneous print statements left in the DacReducer as fallout from PR https://broadworkbench.atlassian.net/browse/DCJ-445 testing. Additionally, removes unused import.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
