### PR TITLE
DCJ-242: Standardize user properties columns and DAO calls

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
@@ -34,7 +34,7 @@ public interface DarCollectionDAO extends Transactional<DarCollectionDAO> {
           DarCollection.DAR_FILTER_QUERY_COLUMNS +
           " FROM dar_collection c " +
           " INNER JOIN users u ON u.user_id = c.create_user_id " +
-          " LEFT JOIN user_property up ON u.user_id = up.userid AND up.propertykey in ('isThePI', 'piName', 'havePI', 'piERACommonsID') "
+          " LEFT JOIN user_property up ON u.user_id = up.user_id AND up.property_key in ('isThePI', 'piName', 'havePI', 'piERACommonsID') "
           +
           " LEFT JOIN institution i ON i.institution_id = u.institution_id " +
           " INNER JOIN data_access_request dar ON c.collection_id = dar.collection_id " +
@@ -92,7 +92,7 @@ public interface DarCollectionDAO extends Transactional<DarCollectionDAO> {
           "dar.update_date AS dar_update_date, (dar.data #>> '{}')::jsonb AS data " +
           "FROM dar_collection c " +
           "INNER JOIN users u ON c.create_user_id = u.user_id " +
-          "LEFT JOIN user_property up ON u.user_id = up.userid " +
+          "LEFT JOIN user_property up ON u.user_id = up.user_id " +
           "INNER JOIN data_access_request dar on c.collection_id = dar.collection_id " +
           "LEFT JOIN dar_dataset dd on dd.reference_id = dar.reference_id " +
           "LEFT JOIN institution i ON i.institution_id = u.institution_id " +
@@ -133,7 +133,7 @@ public interface DarCollectionDAO extends Transactional<DarCollectionDAO> {
           "dar.update_date AS dar_update_date, (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data, dd.dataset_id " +
           "FROM dar_collection c " +
           "INNER JOIN users u ON c.create_user_id = u.user_id " +
-          "LEFT JOIN user_property up ON u.user_id = up.userid " +
+          "LEFT JOIN user_property up ON u.user_id = up.user_id " +
           "LEFT JOIN institution i ON i.institution_id = u.institution_id " +
           "INNER JOIN data_access_request dar ON c.collection_id = dar.collection_id " +
           "LEFT JOIN dar_dataset dd on dd.reference_id = dar.reference_id " +
@@ -174,7 +174,7 @@ public interface DarCollectionDAO extends Transactional<DarCollectionDAO> {
           + "v.createdate as v_create_date, v.updatedate as v_update_date, v.type as v_type, du.display_name as v_display_name "
           + "FROM dar_collection c "
           + "INNER JOIN users u ON c.create_user_id = u.user_id "
-          + "LEFT JOIN user_property up ON u.user_id = up.userid "
+          + "LEFT JOIN user_property up ON u.user_id = up.user_id "
           + "LEFT JOIN institution i ON i.institution_id = u.institution_id "
           + "LEFT JOIN library_card lc ON u.user_id = lc.user_id "
           + "INNER JOIN data_access_request dar ON c.collection_id = dar.collection_id "

--- a/src/main/java/org/broadinstitute/consent/http/db/UserPropertyDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/UserPropertyDAO.java
@@ -16,21 +16,27 @@ import org.jdbi.v3.sqlobject.transaction.Transactional;
 @RegisterRowMapper(UserPropertyMapper.class)
 public interface UserPropertyDAO extends Transactional<UserPropertyDAO> {
 
-  @SqlQuery("SELECT * FROM user_property WHERE userid = :userId AND propertykey IN (<keys>)")
+  @SqlQuery("""
+    SELECT * FROM user_property WHERE user_id = :userId AND property_key IN (<keys>)
+    """)
   List<UserProperty> findUserPropertiesByUserIdAndPropertyKeys(@Bind("userId") Integer userId,
       @BindList("keys") List<String> keys);
 
   @SqlBatch("""
-          INSERT INTO user_property (userid, propertykey, propertyvalue)
+          INSERT INTO user_property (user_id, property_key, property_value)
           VALUES (:userId, :propertyKey, :propertyValue)
-          ON CONFLICT (userid, propertykey)
-          DO UPDATE SET propertyvalue = :propertyValue
+          ON CONFLICT (user_id, property_key)
+          DO UPDATE SET property_value = :propertyValue
       """)
   void insertAll(@BindBean Collection<UserProperty> researcherProperties);
 
-  @SqlUpdate("DELETE FROM user_property WHERE userid = :userId")
+  @SqlUpdate("""
+    DELETE FROM user_property WHERE user_id = :userId
+    """)
   void deleteAllPropertiesByUser(@Bind("userId") Integer userId);
 
-  @SqlBatch("DELETE FROM user_property WHERE userid = :userId AND propertykey = :propertyKey")
+  @SqlBatch("""
+    DELETE FROM user_property WHERE user_id = :userId AND property_key = :propertyKey
+    """)
   void deletePropertiesByUserAndKey(@BindBean Collection<UserProperty> researcherProperties);
 }

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/UserPropertyMapper.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/UserPropertyMapper.java
@@ -12,9 +12,9 @@ public class UserPropertyMapper implements RowMapper<UserProperty> {
   public UserProperty map(ResultSet r, StatementContext statementContext)
       throws SQLException {
     return new UserProperty(
-        r.getInt("propertyId"),
-        r.getInt("userId"),
-        r.getString("propertyKey"),
-        r.getString("propertyValue"));
+        r.getInt("property_id"),
+        r.getInt("user_id"),
+        r.getString("property_key"),
+        r.getString("property_value"));
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/models/UserProperty.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/UserProperty.java
@@ -7,10 +7,10 @@ import com.google.common.base.Objects;
 public class UserProperty {
 
   public static final String QUERY_FIELDS_WITH_UP_PREFIX =
-      " up.propertyid AS up_property_id, " +
-          " up.userid AS up_user_id, " +
-          " up.propertykey AS up_property_key, " +
-          " up.propertyvalue AS up_property_value ";
+      " up.property_id AS up_property_id, " +
+          " up.user_id AS up_user_id, " +
+          " up.property_key AS up_property_key, " +
+          " up.property_value AS up_property_value ";
 
   @JsonProperty
   private Integer propertyId;

--- a/src/main/resources/changelog-master.xml
+++ b/src/main/resources/changelog-master.xml
@@ -154,4 +154,6 @@
     relativeToChangelogFile="true"/>
   <include file="changesets/changelog-consent-2024-06-04-unique-dac-id-daa.xml"
     relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-2024-07-01-user-property-dao-fixes.xml"
+    relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/changesets/changelog-consent-2024-07-01-user-property-dao-fixes.xml
+++ b/src/main/resources/changesets/changelog-consent-2024-07-01-user-property-dao-fixes.xml
@@ -1,0 +1,18 @@
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+  <changeSet id="changelog-consent-2024-07-01-user-property-dao-fixes" author="grushton">
+    <renameColumn tableName="user_property"
+      oldColumnName="propertyid"
+      newColumnName="property_id"/>
+    <renameColumn tableName="user_property"
+      oldColumnName="userid"
+      newColumnName="user_id"/>
+    <renameColumn tableName="user_property"
+      oldColumnName="propertykey"
+      newColumnName="property_key"/>
+    <renameColumn tableName="user_property"
+      oldColumnName="propertyvalue"
+      newColumnName="property_value"/>
+  </changeSet>
+</databaseChangeLog>

--- a/src/test/java/org/broadinstitute/consent/http/db/UserPropertyDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/UserPropertyDAOTest.java
@@ -19,7 +19,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 public class UserPropertyDAOTest extends DAOTestHelper {
 
   @Test
-  public void testFindResearcherProperties() {
+  public void testFindUserProperties() {
     User user = createUserWithRole(UserRoles.RESEARCHER.getRoleId());
 
     UserProperty suggestedInstitution = new UserProperty();


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DCJ-242

### Summary
Standardize the column names in the `user_properties` table and sql statements in DAO calls.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
