### PR TITLE
[DCJ-481] Add "Broad DAA" flag to appropriate DAA

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
@@ -416,7 +416,8 @@ public class ConsentModule extends AbstractModule {
         providesGCSService(),
         providesEmailService(),
         providesUserService(),
-        providesInstitutionDAO());
+        providesInstitutionDAO(),
+        providesDacDAO());
   }
 
   @Provides
@@ -427,7 +428,9 @@ public class ConsentModule extends AbstractModule {
         providesDatasetDAO(),
         providesElectionDAO(),
         providesDataAccessRequestDAO(),
-        providesVoteService());
+        providesVoteService(),
+        providesDaaService(),
+        providesDaaDAO());
   }
 
   @Provides

--- a/src/main/java/org/broadinstitute/consent/http/models/DataAccessAgreement.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DataAccessAgreement.java
@@ -99,8 +99,4 @@ public class DataAccessAgreement {
       this.dacs.add(dac);
     }
   }
-
-
-
-
 }

--- a/src/main/java/org/broadinstitute/consent/http/models/DataAccessAgreement.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DataAccessAgreement.java
@@ -14,6 +14,7 @@ public class DataAccessAgreement {
   private Integer initialDacId;
   private FileStorageObject file;
   private List<Dac> dacs;
+  private Boolean broadDaa = false;
 
   public Integer getDaaId() {
     return daaId;
@@ -79,6 +80,14 @@ public class DataAccessAgreement {
     this.dacs = dacs;
   }
 
+  public Boolean getBroadDaa() {
+    return broadDaa;
+  }
+
+  public void setBroadDaa(Boolean broadDaa) {
+    this.broadDaa = broadDaa;
+  }
+
   public void addDac(Dac dac) {
     if (this.dacs == null) {
       this.dacs = new ArrayList<>();
@@ -90,4 +99,8 @@ public class DataAccessAgreement {
       this.dacs.add(dac);
     }
   }
+
+
+
+
 }

--- a/src/main/java/org/broadinstitute/consent/http/service/DaaService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DaaService.java
@@ -107,6 +107,8 @@ public class DaaService implements ConsentLogger {
     daaDAO.deleteDacDaaRelation(dacId, daaId);
   }
 
+  // Note: This method/implementation is not the permanent solution to identifying the Broad DAA.
+  // Work is ticketed to refactor this logic.
   public boolean isBroadDAA(int daaId, List<DataAccessAgreement> allDaas, List<Dac> allDacs) {
     // Artificially tag the Broad/DUOS DAA as a reference DAA.
     Optional<Dac> broadDac = allDacs.stream()

--- a/src/main/java/org/broadinstitute/consent/http/service/DaaService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DaaService.java
@@ -11,14 +11,18 @@ import jakarta.ws.rs.ServerErrorException;
 import jakarta.ws.rs.core.MediaType;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.consent.http.cloudstore.GCSService;
 import org.broadinstitute.consent.http.db.DaaDAO;
+import org.broadinstitute.consent.http.db.DacDAO;
 import org.broadinstitute.consent.http.db.InstitutionDAO;
 import org.broadinstitute.consent.http.enumeration.FileCategory;
+import org.broadinstitute.consent.http.models.Dac;
 import org.broadinstitute.consent.http.models.DataAccessAgreement;
 import org.broadinstitute.consent.http.models.FileStorageObject;
 import org.broadinstitute.consent.http.models.Institution;
@@ -36,15 +40,17 @@ public class DaaService implements ConsentLogger {
   private final EmailService emailService;
   private final UserService userService;
   private final InstitutionDAO institutionDAO;
+  private final DacDAO dacDAO;
 
   @Inject
-  public DaaService(DaaServiceDAO daaServiceDAO, DaaDAO daaDAO, GCSService gcsService, EmailService emailService, UserService userService, InstitutionDAO institutionDAO) {
+  public DaaService(DaaServiceDAO daaServiceDAO, DaaDAO daaDAO, GCSService gcsService, EmailService emailService, UserService userService, InstitutionDAO institutionDAO, DacDAO dacDAO) {
     this.daaServiceDAO = daaServiceDAO;
     this.daaDAO = daaDAO;
     this.gcsService = gcsService;
     this.emailService = emailService;
     this.userService = userService;
     this.institutionDAO = institutionDAO;
+    this.dacDAO = dacDAO;
   }
 
   /**
@@ -101,11 +107,38 @@ public class DaaService implements ConsentLogger {
     daaDAO.deleteDacDaaRelation(dacId, daaId);
   }
 
-  public List<DataAccessAgreement> findAll() {
-    List<DataAccessAgreement> daas = daaDAO.findAll();
-    if (daas != null) {
-      return daas;
+  public boolean isBroadDAA(int daaId, List<DataAccessAgreement> allDaas, List<Dac> allDacs) {
+    // Artificially tag the Broad/DUOS DAA as a reference DAA.
+    Optional<Dac> broadDac = allDacs.stream()
+        .filter(dac -> dac.getName().toLowerCase().contains("broad")).findFirst();
+    if (broadDac.isPresent()) {
+      Optional<DataAccessAgreement> broadDAA = allDaas.stream()
+          .filter(daa -> daa.getInitialDacId().equals(broadDac.get().getDacId())).findFirst();
+      broadDAA.ifPresent(daa -> daa.setBroadDaa(true));
+    } else {
+      // In this case, we want the first created DAA to be the Broad default DAA.
+      allDaas.stream().min(Comparator.comparing(DataAccessAgreement::getDaaId))
+          .ifPresent(daa -> daa.setBroadDaa(true));
     }
+    Optional<DataAccessAgreement> broadDaa = allDaas.stream().filter(daa -> daa.getDaaId().equals(daaId)).findFirst();
+    if (broadDaa.isPresent()) {
+      return broadDaa.get().getBroadDaa();
+    } else {
+      return false;
+    }
+  }
+
+  public List<DataAccessAgreement> findAll() {
+      List<DataAccessAgreement> daas = daaDAO.findAll();
+      List<Dac> allDacs = dacDAO.findAll();
+      if (daas != null) {
+        daas.forEach(daa -> {
+          daa.setBroadDaa(
+              isBroadDAA(daa.getDaaId(), daas, allDacs)
+          );
+        });
+        return daas;
+      }
     return List.of();
   }
 

--- a/src/main/java/org/broadinstitute/consent/http/service/DacService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DacService.java
@@ -63,7 +63,7 @@ public class DacService {
     List<DataAccessAgreement> allDaas = daaDAO.findAll();
     for (Dac dac : dacs) {
       DataAccessAgreement associatedDaa = dac.getAssociatedDaa();
-      associatedDaa.setBroadDaa(daaService.isBroadDAA(associatedDaa.getDaaId(), allDaas, dacs));
+      associatedDaa.setBroadDaa(daaService.isBroadDAA(associatedDaa.getDaaId(), List.of(associatedDaa), List.of(dac)));
       dac.setAssociatedDaa(associatedDaa);
     }
     return dacs;

--- a/src/main/java/org/broadinstitute/consent/http/service/DacService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DacService.java
@@ -60,7 +60,6 @@ public class DacService {
 
   public List<Dac> findAll() {
     List<Dac> dacs = dacDAO.findAll();
-    List<DataAccessAgreement> allDaas = daaDAO.findAll();
     for (Dac dac : dacs) {
       DataAccessAgreement associatedDaa = dac.getAssociatedDaa();
       associatedDaa.setBroadDaa(daaService.isBroadDAA(associatedDaa.getDaaId(), List.of(associatedDaa), List.of(dac)));

--- a/src/main/java/org/broadinstitute/consent/http/service/DacService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DacService.java
@@ -150,9 +150,11 @@ public class DacService {
     if (Objects.nonNull(dac)) {
       dac.setChairpersons(chairs);
       dac.setMembers(members);
-      DataAccessAgreement associatedDaa = dac.getAssociatedDaa();
-      associatedDaa.setBroadDaa(daaService.isBroadDAA(associatedDaa.getDaaId(), List.of(associatedDaa), List.of(dac)));
-      dac.setAssociatedDaa(associatedDaa);
+      if (dac.getAssociatedDaa() != null) {
+        DataAccessAgreement associatedDaa = dac.getAssociatedDaa();
+        associatedDaa.setBroadDaa(daaService.isBroadDAA(associatedDaa.getDaaId(), List.of(associatedDaa), List.of(dac)));
+        dac.setAssociatedDaa(associatedDaa);
+      }
       return dac;
     }
     throw new NotFoundException("Could not find DAC with the provided id: " + dacId);

--- a/src/test/java/org/broadinstitute/consent/http/service/DaaServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DaaServiceTest.java
@@ -25,6 +25,7 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.RandomUtils;
 import org.broadinstitute.consent.http.cloudstore.GCSService;
 import org.broadinstitute.consent.http.db.DaaDAO;
+import org.broadinstitute.consent.http.db.DacDAO;
 import org.broadinstitute.consent.http.db.InstitutionDAO;
 import org.broadinstitute.consent.http.models.DataAccessAgreement;
 import org.broadinstitute.consent.http.models.FileStorageObject;
@@ -59,6 +60,9 @@ class DaaServiceTest {
   @Mock
   private InstitutionDAO institutionDAO;
 
+  @Mock
+  private DacDAO dacDAO;
+
   private final InputStream inputStream = mock(InputStream.class);
 
   private final FormDataContentDisposition contentDisposition = mock(
@@ -68,7 +72,7 @@ class DaaServiceTest {
   private DaaService service;
 
   private void initService() {
-    service = new DaaService(daaServiceDAO, daaDAO, gcsService, emailService, userService, institutionDAO);
+    service = new DaaService(daaServiceDAO, daaDAO, gcsService, emailService, userService, institutionDAO, dacDAO);
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/DaaServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DaaServiceTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
@@ -27,6 +28,7 @@ import org.broadinstitute.consent.http.cloudstore.GCSService;
 import org.broadinstitute.consent.http.db.DaaDAO;
 import org.broadinstitute.consent.http.db.DacDAO;
 import org.broadinstitute.consent.http.db.InstitutionDAO;
+import org.broadinstitute.consent.http.models.Dac;
 import org.broadinstitute.consent.http.models.DataAccessAgreement;
 import org.broadinstitute.consent.http.models.FileStorageObject;
 import org.broadinstitute.consent.http.models.Institution;
@@ -125,6 +127,48 @@ class DaaServiceTest {
 
     initService();
     service.removeDacFromDaa(1, 1);
+  }
+
+  @Test
+  void testFindAllNoDaas() {
+    when(daaDAO.findAll()).thenReturn(List.of());
+
+    initService();
+    assertEquals(List.of(), service.findAll());
+  }
+
+  @Test
+  void testFindAllWithBroadDaa() {
+    Dac broadDac = new Dac();
+    int broadDacId = RandomUtils.nextInt(3,50);
+    broadDac.setName("broadDac");
+    broadDac.setDacId(broadDacId);
+
+    Dac dac2 = new Dac();
+    int dac2Id = RandomUtils.nextInt(3,50);
+    dac2.setName("dac2");
+    dac2.setDacId(dac2Id);
+
+    DataAccessAgreement daa1 = new DataAccessAgreement();
+    daa1.setDaaId(1);
+    daa1.setInitialDacId(dac2Id);
+    DataAccessAgreement daa2 = new DataAccessAgreement();
+    daa2.setDaaId(2);
+    daa2.setInitialDacId(broadDacId);
+    DataAccessAgreement daa3 = new DataAccessAgreement();
+    daa3.setDaaId(3);
+    daa3.setInitialDacId(dac2Id);
+
+    when(daaDAO.findAll()).thenReturn(List.of(daa1, daa2, daa3));
+    when(dacDAO.findAll()).thenReturn(List.of(broadDac, dac2));
+
+    initService();
+    List<DataAccessAgreement> foundDaas = service.findAll();
+    assertEquals(List.of(daa1, daa2, daa3), foundDaas);
+    assertFalse(foundDaas.get(0).getBroadDaa());
+    assertTrue(foundDaas.get(1).getBroadDaa());
+    assertFalse(foundDaas.get(2).getBroadDaa());
+
   }
 
   @Test
@@ -488,5 +532,89 @@ class DaaServiceTest {
   void testDeleteDaaDaaNotFound() {
     initService();
     assertThrows(NotFoundException.class, () -> service.deleteDaa(1));
+  }
+
+  @Test
+  void testIsBroadDAANoDaasNoDacs() {
+    initService();
+    assertFalse(service.isBroadDAA(RandomUtils.nextInt(0,50), List.of(), List.of()));
+  }
+
+  @Test
+  void testIsBroadDAANoDacs() {
+    initService();
+
+    DataAccessAgreement daa1 = new DataAccessAgreement();
+    DataAccessAgreement daa2 = new DataAccessAgreement();
+    daa1.setDaaId(1);
+    daa2.setDaaId(2);
+
+    assertTrue(service.isBroadDAA(1, List.of(daa1, daa2), List.of()));
+    assertFalse(service.isBroadDAA(2, List.of(daa1, daa2), List.of()));
+  }
+
+  @Test
+  void testIsBroadDAANoBroadDacs() {
+    initService();
+
+    Dac dac = new Dac();
+    dac.setName("dacName");
+
+    Dac dac2= new Dac();
+    dac2.setName("dacName2");
+
+    DataAccessAgreement daa1 = new DataAccessAgreement();
+    DataAccessAgreement daa2 = new DataAccessAgreement();
+    daa1.setDaaId(1);
+    daa2.setDaaId(2);
+
+    assertTrue(service.isBroadDAA(1, List.of(daa1, daa2), List.of(dac, dac2)));
+    assertFalse(service.isBroadDAA(2, List.of(daa1, daa2), List.of(dac, dac2)));
+  }
+
+  @Test
+  void testIsBroadDAANoMatchingDaa() {
+    initService();
+
+    Dac dac = new Dac();
+    dac.setName("dacName");
+    dac.setDacId(1);
+
+    Dac dac2= new Dac();
+    dac2.setName("broadDac");
+    dac2.setDacId(2);
+
+    DataAccessAgreement daa1 = new DataAccessAgreement();
+    DataAccessAgreement daa2 = new DataAccessAgreement();
+    daa1.setDaaId(1);
+    daa1.setInitialDacId(RandomUtils.nextInt(3,50));
+    daa2.setDaaId(2);
+    daa2.setInitialDacId(RandomUtils.nextInt(3,50));
+
+    assertFalse(service.isBroadDAA(1, List.of(daa1, daa2), List.of(dac, dac2)));
+    assertFalse(service.isBroadDAA(2, List.of(daa1, daa2), List.of(dac, dac2)));
+  }
+
+  @Test
+  void testIsBroadDAAMatching() {
+    initService();
+
+    Dac dac = new Dac();
+    dac.setName("dacName");
+    dac.setDacId(1);
+
+    Dac dac2= new Dac();
+    dac2.setName("broadDac");
+    dac2.setDacId(2);
+
+    DataAccessAgreement daa1 = new DataAccessAgreement();
+    DataAccessAgreement daa2 = new DataAccessAgreement();
+    daa1.setDaaId(1);
+    daa1.setInitialDacId(RandomUtils.nextInt(3,50));
+    daa2.setDaaId(2);
+    daa2.setInitialDacId(2);
+
+    assertFalse(service.isBroadDAA(1, List.of(daa1, daa2), List.of(dac, dac2)));
+    assertTrue(service.isBroadDAA(2, List.of(daa1, daa2), List.of(dac, dac2)));
   }
 }

--- a/src/test/java/org/broadinstitute/consent/http/service/DacServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DacServiceTest.java
@@ -27,6 +27,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
+import org.broadinstitute.consent.http.db.DaaDAO;
 import org.broadinstitute.consent.http.db.DacDAO;
 import org.broadinstitute.consent.http.db.DataAccessRequestDAO;
 import org.broadinstitute.consent.http.db.DatasetDAO;
@@ -73,9 +74,15 @@ class DacServiceTest {
   @Mock
   private VoteService voteService;
 
+  @Mock
+  private DaaService daaService;
+
+  @Mock
+  private DaaDAO daaDAO;
+
   private void initService() {
     service = new DacService(dacDAO, userDAO, dataSetDAO, electionDAO, dataAccessRequestDAO,
-        voteService);
+        voteService, daaService, daaDAO);
   }
 
   @Test


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DCJ-481

### Summary
Adds a flag to a DataAccessAgreement saying it is the `broadDaa` if it was created by the broad DAC. This is to be used in the UI so that a `daaId` that may vary among environments does not have to be used to help match the Broad DAA. Additionally, makes sure that the DAAs are getting flagged appropriately when queried by DAA or by DAC, along with appropriate tests.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
