### PR TITLE
DCJ-485: Handle empty dataset id cases

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/DarCollectionSummaryDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DarCollectionSummaryDAO.java
@@ -9,6 +9,7 @@ import org.broadinstitute.consent.http.models.Vote;
 import org.jdbi.v3.sqlobject.config.RegisterBeanMapper;
 import org.jdbi.v3.sqlobject.customizer.Bind;
 import org.jdbi.v3.sqlobject.customizer.BindList;
+import org.jdbi.v3.sqlobject.customizer.BindList.EmptyHandling;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.UseRowReducer;
 import org.jdbi.v3.sqlobject.transaction.Transactional;
@@ -49,7 +50,7 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
       """)
   List<DarCollectionSummary> getDarCollectionSummariesForDAC(
       @Bind("currentUserId") Integer currentUserId,
-      @BindList("datasetIds") List<Integer> datasetIds);
+      @BindList(value = "datasetIds", onEmpty = EmptyHandling.NULL_STRING) List<Integer> datasetIds);
 
   @RegisterBeanMapper(value = DarCollectionSummary.class)
   @RegisterBeanMapper(value = DarCollection.class)

--- a/src/main/java/org/broadinstitute/consent/http/models/User.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/User.java
@@ -217,7 +217,6 @@ public class User {
     this.roles = List.of(memberRole);
   }
 
-
   public void setResearcherRole() {
     this.roles = List.of(UserRoles.Researcher());
   }

--- a/src/main/java/org/broadinstitute/consent/http/models/User.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/User.java
@@ -211,6 +211,13 @@ public class User {
     this.roles = List.of(UserRoles.Member());
   }
 
+  public void setMemberRoleWithDAC(int dacId) {
+    UserRole memberRole = UserRoles.Member();
+    memberRole.setDacId(dacId);
+    this.roles = List.of(memberRole);
+  }
+
+
   public void setResearcherRole() {
     this.roles = List.of(UserRoles.Researcher());
   }

--- a/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
@@ -298,12 +298,12 @@ public class DarCollectionService {
         break;
       case CHAIRPERSON:
         datasetIds = getDatasetIdsForUserAndRoleId(user, UserRoles.CHAIRPERSON.getRoleId());
-        summaries = darCollectionSummaryDAO.getDarCollectionSummariesForDAC(userId, datasetIds);
+        summaries = datasetIds.isEmpty() ? List.of() : darCollectionSummaryDAO.getDarCollectionSummariesForDAC(userId, datasetIds);
         processDarCollectionSummariesForChair(summaries);
         break;
       case MEMBER:
         datasetIds = getDatasetIdsForUserAndRoleId(user, UserRoles.MEMBER.getRoleId());
-        summaries = darCollectionSummaryDAO.getDarCollectionSummariesForDAC(userId, datasetIds);
+        summaries = datasetIds.isEmpty() ? List.of() : darCollectionSummaryDAO.getDarCollectionSummariesForDAC(userId, datasetIds);
         processDarCollectionSummariesForMember(summaries, userId);
         break;
       case RESEARCHER:

--- a/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
@@ -298,12 +298,12 @@ public class DarCollectionService {
         break;
       case CHAIRPERSON:
         datasetIds = getDatasetIdsForUserAndRoleId(user, UserRoles.CHAIRPERSON.getRoleId());
-        summaries = datasetIds.isEmpty() ? List.of() : darCollectionSummaryDAO.getDarCollectionSummariesForDAC(userId, datasetIds);
+        summaries = darCollectionSummaryDAO.getDarCollectionSummariesForDAC(userId, datasetIds);
         processDarCollectionSummariesForChair(summaries);
         break;
       case MEMBER:
         datasetIds = getDatasetIdsForUserAndRoleId(user, UserRoles.MEMBER.getRoleId());
-        summaries = datasetIds.isEmpty() ? List.of() : darCollectionSummaryDAO.getDarCollectionSummariesForDAC(userId, datasetIds);
+        summaries = darCollectionSummaryDAO.getDarCollectionSummariesForDAC(userId, datasetIds);
         processDarCollectionSummariesForMember(summaries, userId);
         break;
       case RESEARCHER:

--- a/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
@@ -53,7 +53,6 @@ import org.broadinstitute.consent.http.models.DataAccessRequestData;
 import org.broadinstitute.consent.http.models.Dataset;
 import org.broadinstitute.consent.http.models.Election;
 import org.broadinstitute.consent.http.models.User;
-import org.broadinstitute.consent.http.models.UserRole;
 import org.broadinstitute.consent.http.models.Vote;
 import org.broadinstitute.consent.http.service.dao.DarCollectionServiceDAO;
 import org.junit.jupiter.api.BeforeEach;
@@ -713,7 +712,6 @@ class DarCollectionServiceTest {
     List<DarCollectionSummary> summaries = service.getSummariesForRoleName(user,
         UserRoles.MEMBER.getRoleName());
     assertTrue(summaries.isEmpty());
-    verify(darCollectionSummaryDAO, never()).getDarCollectionSummariesForDAC(any(), any());
   }
 
   @Test
@@ -726,7 +724,6 @@ class DarCollectionServiceTest {
     List<DarCollectionSummary> summaries = service.getSummariesForRoleName(user,
         UserRoles.CHAIRPERSON.getRoleName());
     assertTrue(summaries.isEmpty());
-    verify(darCollectionSummaryDAO, never()).getDarCollectionSummariesForDAC(any(), any());
   }
 
   @Test


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DCJ-485

### Summary
This PR adds a minor check to the list of dataset ids the user has access to. If it's empty, skip the lookup for datasets the user can see through this method. Includes additional tests and additional setup for existing tests that hit these code paths.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
