### PR TITLE
DCJ-504 Bug fix for null alias in queries

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DatasetMapper.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DatasetMapper.java
@@ -44,7 +44,7 @@ public class DatasetMapper implements RowMapper<Dataset>, RowMapperHelper {
     if (hasColumn(r, "translated_data_use")) {
       dataset.setTranslatedDataUse(r.getString("translated_data_use"));
     }
-    if (hasNonZeroColumn(r, "alias")) {
+    if (hasColumn(r, "alias")) {
       dataset.setAlias(r.getInt("alias"));
     }
 


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DCJ-504

### Summary
Fixes fallout from https://github.com/DataBiosphere/consent/pull/2347 where we explicitly did not map zero-value aliases. There are several in staging/prod so we need to maintain this functionality.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
