### PR TITLE
DCJ-515: Fix json parsing for dataset updates

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/models/DatasetUpdate.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DatasetUpdate.java
@@ -1,7 +1,6 @@
 package org.broadinstitute.consent.http.models;
 
 import com.google.gson.Gson;
-import com.google.gson.ToNumberPolicy;
 import java.util.List;
 import org.broadinstitute.consent.http.util.gson.GsonUtil;
 
@@ -11,8 +10,7 @@ public record DatasetUpdate(
     List<DatasetProperty> properties
 ) {
 
-  private static final Gson GSON = GsonUtil.gsonBuilderWithAdapters().setObjectToNumberStrategy(
-      ToNumberPolicy.LONG_OR_DOUBLE).create();
+  private static final Gson GSON = GsonUtil.gsonBuilderWithAdapters().create();
 
   public DatasetUpdate(String json) {
     this(GSON.fromJson(json, DatasetUpdate.class).getName(),

--- a/src/main/java/org/broadinstitute/consent/http/models/DatasetUpdate.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DatasetUpdate.java
@@ -1,12 +1,24 @@
 package org.broadinstitute.consent.http.models;
 
+import com.google.gson.Gson;
+import com.google.gson.ToNumberPolicy;
 import java.util.List;
+import org.broadinstitute.consent.http.util.gson.GsonUtil;
 
-public record DatasetUpdate (
+public record DatasetUpdate(
     String name,
     Integer dacId,
     List<DatasetProperty> properties
-){
+) {
+
+  private static final Gson GSON = GsonUtil.gsonBuilderWithAdapters().setObjectToNumberStrategy(
+      ToNumberPolicy.LONG_OR_DOUBLE).create();
+
+  public DatasetUpdate(String json) {
+    this(GSON.fromJson(json, DatasetUpdate.class).getName(),
+        GSON.fromJson(json, DatasetUpdate.class).getDacId(),
+        GSON.fromJson(json, DatasetUpdate.class).getDatasetProperties());
+  }
 
   public String getName() {
     return this.name;

--- a/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
@@ -233,12 +233,10 @@ public class DatasetResource extends Resource {
       @FormDataParam("dataset") String json) {
 
     try {
-
-      DatasetUpdate update = new Gson().fromJson(json, DatasetUpdate.class);
-
-      if (Objects.isNull(update)) {
+      if (json == null || json.isEmpty()) {
         throw new BadRequestException("Dataset is required");
       }
+      DatasetUpdate update = new DatasetUpdate(json);
 
       Dataset datasetExists = datasetService.findDatasetById(datasetId);
       if (Objects.isNull(datasetExists)) {

--- a/src/main/java/org/broadinstitute/consent/http/util/gson/GsonUtil.java
+++ b/src/main/java/org/broadinstitute/consent/http/util/gson/GsonUtil.java
@@ -3,6 +3,7 @@ package org.broadinstitute.consent.http.util.gson;
 import com.google.cloud.storage.BlobId;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.ToNumberPolicy;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.Date;
@@ -29,6 +30,7 @@ public class GsonUtil {
 
   public static GsonBuilder gsonBuilderWithAdapters() {
     return new GsonBuilder()
+        .setObjectToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE)
         .registerTypeAdapter(
             Instant.class,
             new InstantTypeAdapter())

--- a/src/test/java/org/broadinstitute/consent/http/models/DatasetUpdateTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/DatasetUpdateTest.java
@@ -2,6 +2,7 @@ package org.broadinstitute.consent.http.models;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
@@ -15,42 +16,40 @@ public class DatasetUpdateTest {
 
   @Test
   void testDatasetUpdate() {
-    // Ensure each property type is correctly handled. See dataset-registration-schema_v1.json
-    // for full list of properties datasets can have.
-    String location = "TDR Location";
-    Long participants = 12L;
-    Boolean nmds = true;
     String json = """
         {
           "name": "Test Dataset Update",
           "dacId": 1,
           "properties": [
             {
-              "propertyName": "Data Location",
-              "propertyValue": "%s"
+              "propertyName": "string value",
+              "propertyValue": "TDR Location"
             },
             {
-              "propertyName": "# of participants",
-              "propertyValue": %d
+              "propertyName": "long value",
+              "propertyValue": 12
             },
             {
-              "propertyName": "nmds",
-              "propertyValue": %s
+              "propertyName": "boolean value",
+              "propertyValue": true
+            },
+            {
+              "propertyName": "double value",
+              "propertyValue": 10.001
             },
             {
               "propertyName": "File Types",
               "propertyValue": [{"fileType":"ARRAYS","functionalEquivalence":"testing"}]
             }
           ]
-        }""".formatted(location, participants, nmds);
+        }""";
     DatasetUpdate update = new DatasetUpdate(json);
+
     List<DatasetProperty> props = update.getDatasetProperties();
-
-    assertEquals(location, getPropByName("Data Location", props).getPropertyValue());
-
-    assertEquals(participants, getPropByName("# of participants", props).getPropertyValue());
-
-    assertEquals(nmds, getPropByName("nmds", props).getPropertyValue());
+    assertEquals("TDR Location", getPropByName("string value", props).getPropertyValue());
+    assertEquals(12L, getPropByName("long value", props).getPropertyValue());
+    assertEquals(true, getPropByName("boolean value", props).getPropertyValue());
+    assertEquals(10.001D, getPropByName("double value", props).getPropertyValue());
 
     // Parsing the object value of this prop is a little complicated due to JSON serialization
     DatasetProperty fileTypeProp = getPropByName("File Types", props);
@@ -60,11 +59,29 @@ public class DatasetUpdateTest {
     assertFalse(fileTypes.isEmpty());
     FileTypeObject type = fileTypes.get(0);
     assertEquals(FileType.ARRAYS, type.getFileType());
-
   }
 
   private DatasetProperty getPropByName(String name, List<DatasetProperty> props ) {
     return props.stream().filter(p -> p.getPropertyName().equals(name)).findFirst().orElse(null);
+  }
+
+  @Test
+  void testDatasetUpdateNullValues() {
+    String json = """
+        {
+          "not_a_name": "Test Dataset Update",
+          "not_a_dac_id": 1,
+          "no_properties": [
+            {
+              "propertyName": "string value",
+              "propertyValue": "TDR Location"
+            }
+          ]
+        }""";
+    DatasetUpdate update = new DatasetUpdate(json);
+    assertNull(update.getName());
+    assertNull(update.getDacId());
+    assertNull(update.getDatasetProperties());
   }
 
 }

--- a/src/test/java/org/broadinstitute/consent/http/models/DatasetUpdateTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/DatasetUpdateTest.java
@@ -1,0 +1,70 @@
+package org.broadinstitute.consent.http.models;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import java.util.ArrayList;
+import java.util.List;
+import org.broadinstitute.consent.http.models.dataset_registration_v1.FileTypeObject;
+import org.broadinstitute.consent.http.models.dataset_registration_v1.FileTypeObject.FileType;
+import org.junit.jupiter.api.Test;
+
+public class DatasetUpdateTest {
+
+  @Test
+  void testDatasetUpdate() {
+    // Ensure each property type is correctly handled. See dataset-registration-schema_v1.json
+    // for full list of properties datasets can have.
+    String location = "TDR Location";
+    Long participants = 12L;
+    Boolean nmds = true;
+    String json = """
+        {
+          "name": "Test Dataset Update",
+          "dacId": 1,
+          "properties": [
+            {
+              "propertyName": "Data Location",
+              "propertyValue": "%s"
+            },
+            {
+              "propertyName": "# of participants",
+              "propertyValue": %d
+            },
+            {
+              "propertyName": "nmds",
+              "propertyValue": %s
+            },
+            {
+              "propertyName": "File Types",
+              "propertyValue": [{"fileType":"ARRAYS","functionalEquivalence":"testing"}]
+            }
+          ]
+        }""".formatted(location, participants, nmds);
+    DatasetUpdate update = new DatasetUpdate(json);
+    List<DatasetProperty> props = update.getDatasetProperties();
+
+    assertEquals(location, getPropByName("Data Location", props).getPropertyValue());
+
+    assertEquals(participants, getPropByName("# of participants", props).getPropertyValue());
+
+    assertEquals(nmds, getPropByName("nmds", props).getPropertyValue());
+
+    // Parsing the object value of this prop is a little complicated due to JSON serialization
+    DatasetProperty fileTypeProp = getPropByName("File Types", props);
+    java.lang.reflect.Type listOfFileTypes = new TypeToken<ArrayList<FileTypeObject>>() {}.getType();
+    Gson gson = new Gson();
+    List<FileTypeObject> fileTypes = gson.fromJson(fileTypeProp.getPropertyValueAsString(), listOfFileTypes);
+    assertFalse(fileTypes.isEmpty());
+    FileTypeObject type = fileTypes.get(0);
+    assertEquals(FileType.ARRAYS, type.getFileType());
+
+  }
+
+  private DatasetProperty getPropByName(String name, List<DatasetProperty> props ) {
+    return props.stream().filter(p -> p.getPropertyName().equals(name)).findFirst().orElse(null);
+  }
+
+}


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DCJ-515

### Summary
This PR updates the `Gson` parsing for dataset update json objects to ensure that integer values in json are not converted to floats.

### Testing Strategy
With a recent database update, I tested updating `DUOS-000866` (ID: `2368`) in the following way:

Visit [local swagger v3 PUT endpoint](https://local.dsde-dev.broadinstitute.org:27443/#/Dataset/put_api_dataset_v3__datasetId_) with the dataset id of 2368 and this payload: 
```
{
  "name": "AJ test controlled access dataset (GRU)",
  "dacId": 3,
  "properties": [
    {
      "propertyName": "Data Location",
      "propertyValue": "TDR Location"
    },
    {
      "propertyName": "File Types",
      "propertyValue": [
        {}
      ]
    },
    {
      "propertyName": "Access Management",
      "propertyValue": "controlled"
    },
    {
      "propertyName": "# of participants",
      "propertyValue": 12
    }
  ]
}
```
Repeated calls to the same endpoint should work (previously, subsequent updates would fail due to integer conversion problems). The response should include all properties as defined in the above payload. Calls to the [local GET endpoint](https://local.dsde-dev.broadinstitute.org:27443/#/Dataset/get_api_dataset_v2__id_) should now also return the updated values correctly.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
