### PR TITLE
[DCJ-535] Ensure that admins that are also SOs can bulk add/remove users

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/resources/DaaResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DaaResource.java
@@ -250,7 +250,7 @@ public class DaaResource extends Resource implements ConsentLogger {
     try {
       User authedUser = userService.findUserByEmail(authUser.getEmail());
       List<User> users = userService.findUsersInJsonArray(json, "users");
-      if (authedUser.hasUserRole(UserRoles.SIGNINGOFFICIAL)) {
+      if (authedUser.hasUserRole(UserRoles.SIGNINGOFFICIAL) && !authedUser.hasUserRole(UserRoles.ADMIN)) {
         for (User user : users) {
           if (!Objects.equals(authedUser.getInstitutionId(), user.getInstitutionId())) {
             return Response.status(Status.FORBIDDEN).build();
@@ -278,7 +278,7 @@ public class DaaResource extends Resource implements ConsentLogger {
     try {
       User authedUser = userService.findUserByEmail(authUser.getEmail());
       List<User> users = userService.findUsersInJsonArray(json, "users");
-      if (authedUser.hasUserRole(UserRoles.SIGNINGOFFICIAL)) {
+      if (authedUser.hasUserRole(UserRoles.SIGNINGOFFICIAL) && !authedUser.hasUserRole(UserRoles.ADMIN)) {
         for (User user : users) {
           if (!Objects.equals(authedUser.getInstitutionId(), user.getInstitutionId())) {
             return Response.status(Status.FORBIDDEN).build();


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DCJ-535

### Summary

Ensure that admins that are also SOs can bulk add/remove users. Also adds unit tests for this situation.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
