### PR TITLE
DCJ-483: Add some basic timer metrics for further analysis

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
@@ -1,5 +1,7 @@
 package org.broadinstitute.consent.http;
 
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.jersey3.InstrumentedResourceMethodApplicationListener;
 import com.google.common.util.concurrent.UncaughtExceptionHandlers;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
@@ -193,6 +195,10 @@ public class ConsentApplication extends Application<ConsentConfiguration> {
     System.setProperty("sun.net.http.allowRestrictedHeaders", "true");
 
     env.jersey().register(JerseyGsonProvider.class);
+
+    // Metric Registry
+    MetricRegistry metricRegistry = new MetricRegistry();
+    env.jersey().register(new InstrumentedResourceMethodApplicationListener(metricRegistry));
 
     // Health Checks
     env.healthChecks().register(GCS_CHECK, new GCSHealthCheck(gcsService));

--- a/src/main/java/org/broadinstitute/consent/http/resources/DarCollectionResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DarCollectionResource.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.consent.http.resources;
 
+import com.codahale.metrics.annotation.Timed;
 import com.google.inject.Inject;
 import io.dropwizard.auth.Auth;
 import jakarta.annotation.security.PermitAll;
@@ -46,6 +47,7 @@ public class DarCollectionResource extends Resource {
   @Path("role/{roleName}/summary")
   @Produces("application/json")
   @RolesAllowed({ADMIN, CHAIRPERSON, MEMBER, SIGNINGOFFICIAL, RESEARCHER})
+  @Timed
   public Response getCollectionSummariesForUserByRole(@Auth AuthUser authUser,
       @PathParam("roleName") String roleName) {
     try {

--- a/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.consent.http.resources;
 
+import com.codahale.metrics.annotation.Timed;
 import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
 import com.google.inject.Inject;
@@ -609,6 +610,7 @@ public class DatasetResource extends Resource {
   @Produces("application/json")
   @Path("/autocomplete")
   @PermitAll
+  @Timed
   public Response autocompleteDatasets(
       @Auth AuthUser authUser,
       @QueryParam("query") String query) {
@@ -626,6 +628,7 @@ public class DatasetResource extends Resource {
   @Consumes("application/json")
   @Produces("application/json")
   @PermitAll
+  @Timed
   public Response searchDatasetIndex(@Auth AuthUser authUser, String query) {
     try {
       User user = userService.findUserByEmail(authUser.getEmail());

--- a/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
@@ -1,6 +1,7 @@
 package org.broadinstitute.consent.http.resources;
 
 
+import com.codahale.metrics.annotation.Timed;
 import com.google.api.client.http.HttpStatusCodes;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.gson.Gson;
@@ -101,6 +102,7 @@ public class UserResource extends Resource {
   @Path("/me")
   @Produces("application/json")
   @PermitAll
+  @Timed
   public Response getUser(@Auth AuthUser authUser) {
     try {
       User user = userService.findUserByEmail(authUser.getEmail());

--- a/src/main/java/org/broadinstitute/consent/http/util/HttpClientUtil.java
+++ b/src/main/java/org/broadinstitute/consent/http/util/HttpClientUtil.java
@@ -140,7 +140,7 @@ public class HttpClientUtil implements ConsentLogger {
     String timerName = String.format("org.broadinstitute.consent.http.util.HttpClientUtil-%s-%s",
         request.getRequestMethod(), request.getUrl().toString());
     if (SharedMetricRegistries.tryGetDefault() == null) {
-      logWarn("This should only happen in testing conditions");
+      logWarn("Default SharedMetricRegistries is null, setting default");
       SharedMetricRegistries.setDefault("org.broadinstitute.consent", new MetricRegistry());
     }
     Timer timer = SharedMetricRegistries.getDefault().timer(timerName);

--- a/src/main/java/org/broadinstitute/consent/http/util/HttpClientUtil.java
+++ b/src/main/java/org/broadinstitute/consent/http/util/HttpClientUtil.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.consent.http.util;
 
+import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.SharedMetricRegistries;
 import com.codahale.metrics.Timer;
 import com.google.api.client.http.GenericUrl;
@@ -138,6 +139,10 @@ public class HttpClientUtil implements ConsentLogger {
   public HttpResponse handleHttpRequest(HttpRequest request) {
     String timerName = String.format("org.broadinstitute.consent.http.util.HttpClientUtil-%s-%s",
         request.getRequestMethod(), request.getUrl().toString());
+    if (SharedMetricRegistries.tryGetDefault() == null) {
+      logWarn("This should only happen in testing conditions");
+      SharedMetricRegistries.setDefault("org.broadinstitute.consent", new MetricRegistry());
+    }
     Timer timer = SharedMetricRegistries.getDefault().timer(timerName);
     try {
       request.setThrowExceptionOnExecuteError(false);

--- a/src/test/java/org/broadinstitute/consent/pact/sam/SamPactTests.java
+++ b/src/test/java/org/broadinstitute/consent/pact/sam/SamPactTests.java
@@ -97,7 +97,6 @@ class SamPactTests {
   public static void beforeClass() {
     System.setProperty("pact_do_not_track", "true");
     System.setProperty("pact.writer.overwrite", "true");
-    SharedMetricRegistries.setDefault("default", new MetricRegistry());
   }
 
   private void initSamDAO(MockServer mockServer) {

--- a/src/test/java/org/broadinstitute/consent/pact/sam/SamPactTests.java
+++ b/src/test/java/org/broadinstitute/consent/pact/sam/SamPactTests.java
@@ -12,6 +12,8 @@ import au.com.dius.pact.consumer.junit5.PactTestFor;
 import au.com.dius.pact.core.model.PactSpecVersion;
 import au.com.dius.pact.core.model.RequestResponsePact;
 import au.com.dius.pact.core.model.annotations.Pact;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.SharedMetricRegistries;
 import com.google.api.client.http.HttpStatusCodes;
 import com.google.gson.Gson;
 import jakarta.ws.rs.core.HttpHeaders;
@@ -95,6 +97,7 @@ class SamPactTests {
   public static void beforeClass() {
     System.setProperty("pact_do_not_track", "true");
     System.setProperty("pact.writer.overwrite", "true");
+    SharedMetricRegistries.setDefault("default", new MetricRegistry());
   }
 
   private void initSamDAO(MockServer mockServer) {

--- a/src/test/java/org/broadinstitute/consent/pact/sam/SamPactTests.java
+++ b/src/test/java/org/broadinstitute/consent/pact/sam/SamPactTests.java
@@ -12,8 +12,6 @@ import au.com.dius.pact.consumer.junit5.PactTestFor;
 import au.com.dius.pact.core.model.PactSpecVersion;
 import au.com.dius.pact.core.model.RequestResponsePact;
 import au.com.dius.pact.core.model.annotations.Pact;
-import com.codahale.metrics.MetricRegistry;
-import com.codahale.metrics.SharedMetricRegistries;
 import com.google.api.client.http.HttpStatusCodes;
 import com.google.gson.Gson;
 import jakarta.ws.rs.core.HttpHeaders;


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DCJ-483

### Summary
Adds a variety of timers that are collected up via our Prometheus deployment:
* GET /api/user/me
* GET /api/collections/role/{roleName}/summary
* POST /api/dataset/search/index 
* GET /api/dataset/autocomplete
* HttpClientUtil
  * This class is now instrumented to time all outgoing http calls with method and url

Future work will include charting these results in Grafana

### Local Testing
1. Spin up a local instance
2. Hit a variety of endpoints
3. Visit http://localhost:8081/admin/metrics to see the timers accrue values

### Example reports
Results of hitting the GET /api/user/me endpoint:
```
org.broadinstitute.consent.http.resources.UserResource.getUser.total": {
	"count": 3,
	"max": 0.151839042,
	"mean": 0.061330523006126916,
	"min": 0.012001416,
	"p50": 0.020896625000000002,
	"p75": 0.151839042,
	"p95": 0.151839042,
	"p98": 0.151839042,
	"p99": 0.151839042,
	"p999": 0.151839042,
	"stddev": 0.06386232947036796,
	"m15_rate": 0.0011080303990206543,
	"m1_rate": 0.015991117074135343,
	"m5_rate": 0.0033057092356765017,
	"mean_rate": 0.04006283916791666,
	"duration_units": "seconds",
	"rate_units": "calls/second"
},
```
Results of external calls to Sam:
```
"org.broadinstitute.consent.http.util.HttpClientUtil-GET-https://sam.dsde-dev.broadinstitute.org/register/user/v2/self/diagnostics": {
	"count": 6,
	"max": 0.219860084,
	"mean": 0.19634815674303197,
	"min": 0.177016,
	"p50": 0.193332375,
	"p75": 0.219353875,
	"p95": 0.219860084,
	"p98": 0.219860084,
	"p99": 0.219860084,
	"p999": 0.219860084,
	"stddev": 0.01743163514621687,
	"m15_rate": 1.180165744585941,
	"m1_rate": 0.934560939685686,
	"m5_rate": 1.1414753094008565,
	"mean_rate": 0.24498124102652444,
	"duration_units": "seconds",
	"rate_units": "calls/second"
},
"org.broadinstitute.consent.http.util.HttpClientUtil-GET-https://sam.dsde-dev.broadinstitute.org/register/user/v2/self/info": {
	"count": 2,
	"max": 0.10551183300000001,
	"mean": 0.10547495800000001,
	"min": 0.105438083,
	"p50": 0.10551183300000001,
	"p75": 0.10551183300000001,
	"p95": 0.10551183300000001,
	"p98": 0.10551183300000001,
	"p99": 0.10551183300000001,
	"p999": 0.10551183300000001,
	"stddev": 0.000036875,
	"m15_rate": 0.39120914899384024,
	"m1_rate": 0.2866125242295158,
	"m5_rate": 0.37420279401264706,
	"mean_rate": 0.07886614662771757,
	"duration_units": "seconds",
	"rate_units": "calls/second"
},
```


----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
