### PR TITLE
DCJ-364: Return all DAAs for a DAR reference id

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
@@ -215,9 +215,7 @@ public class ConsentApplication extends Application<ConsentConfiguration> {
 
     // Register standard application resources.
     env.jersey().register(injector.getInstance(DaaResource.class));
-    env.jersey().register(
-        new DataAccessRequestResource(dataAccessRequestService, emailService, gcsService,
-            userService, datasetService, matchService));
+    env.jersey().register(injector.getInstance(DataAccessRequestResource.class));
     env.jersey().register(new DatasetResource(datasetService, userService, dataAccessRequestService,
         datasetRegistrationService, elasticSearchService));
     env.jersey().register(injector.getInstance(DatasetAssociationsResource.class));

--- a/src/main/java/org/broadinstitute/consent/http/service/DaaService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DaaService.java
@@ -232,4 +232,8 @@ public class DaaService implements ConsentLogger {
       throw new NotFoundException("Could not find DAA with the provided ID: " + daaId);
     }
   }
+
+  public List<DataAccessAgreement> findByDarReferenceId(String referenceId) {
+    return daaDAO.findByDarReferenceId(referenceId);
+  }
 }

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -289,6 +289,9 @@ paths:
   /api/dar/v2/{referenceId}:
     $ref: './paths/darV2ByReferenceId.yaml'
 
+  /api/dar/v2/{referenceId}/daas:
+    $ref: './paths/darV2DAAsByReferenceId.yaml'
+
   /api/dar/v2/draft:
     post:
       deprecated: true

--- a/src/main/resources/assets/paths/darV2DAAsByReferenceId.yaml
+++ b/src/main/resources/assets/paths/darV2DAAsByReferenceId.yaml
@@ -1,0 +1,28 @@
+get:
+  summary: Get all Data Access Agreements for Data Access Request by DAR Reference Id
+  description: Returns the Data Access Agreements for Data Access Request by DAR Reference.
+  parameters:
+    - name: referenceId
+      in: path
+      description: The referenceId of the Data Access Request
+      required: true
+      schema:
+        type: string
+  tags:
+    - DAA
+    - Data Access Request
+  responses:
+    200:
+      description: Returns a list of Data Access Agreements
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: '../schemas/DataAccessAgreement.yaml'
+    400:
+      description: The provided Reference Id is not a valid DAR identifier
+    404:
+      description: No DAR can be found with the provided identifier
+    500:
+      description: Server Error

--- a/src/test/java/org/broadinstitute/consent/http/service/DaaServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DaaServiceTest.java
@@ -617,4 +617,25 @@ class DaaServiceTest {
     assertFalse(service.isBroadDAA(1, List.of(daa1, daa2), List.of(dac, dac2)));
     assertTrue(service.isBroadDAA(2, List.of(daa1, daa2), List.of(dac, dac2)));
   }
+
+  @Test
+  void testFindByDarReferenceId() {
+    initService();
+    DataAccessAgreement daa1 = new DataAccessAgreement();
+    when(daaDAO.findByDarReferenceId(any())).thenReturn(List.of(daa1));
+
+    List<DataAccessAgreement> daas = service.findByDarReferenceId(RandomStringUtils.randomAlphabetic(5));
+    assertFalse(daas.isEmpty());
+    assertTrue(daas.stream().map(DataAccessAgreement::getDaaId).toList().contains(daa1.getDaaId()));
+  }
+
+  @Test
+  void testFindByDarReferenceIdNoResults() {
+    initService();
+    when(daaDAO.findByDarReferenceId(any())).thenReturn(List.of());
+
+    List<DataAccessAgreement> daas = service.findByDarReferenceId(RandomStringUtils.randomAlphabetic(5));
+    assertTrue(daas.isEmpty());
+  }
+
 }


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DCJ-364

### Summary
New endpoint to get all DAAs for a DAR reference id.

### Testing
It will be helpful to test as an admin. Spin up a local instance and look at a variety of DARs to ensure correctness and completeness. For example, `1b0ae6d6-4657-47f2-87e8-bd58db69eec3` is a good DAR id to query for. There are a number of datasets for that DAR, but only two of the datasets are associated to DACs with data access agreements.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
