### PR TITLE
DCJ-539: New API for returning dataset + study summaries

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
@@ -268,7 +268,6 @@ public class ConsentModule extends AbstractModule {
         providesDaaDAO(),
         providesDacDAO(),
         providesEmailService(),
-        providesLibraryCardDAO(),
         providesOntologyService(),
         providesStudyDAO(),
         providesDatasetServiceDAO(),

--- a/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
@@ -556,9 +556,6 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
           " VALUES (:dataSetId, :propertyKey, :schemaProperty, :getPropertyValueAsString, :getPropertyTypeAsString, :createDate)")
   void insertDatasetProperties(@BindBean @BindMethods List<DatasetProperty> dataSetPropertiesList);
 
-  @SqlBatch("DELETE FROM dataset_property WHERE dataset_id = :dataSetId")
-  void deleteDatasetsProperties(@Bind("dataSetId") Collection<Integer> dataSetsIds);
-
   @SqlUpdate("DELETE FROM dataset_property WHERE dataset_id = :datasetId")
   void deleteDatasetPropertiesByDatasetId(@Bind("datasetId") Integer datasetId);
 

--- a/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
@@ -11,6 +11,7 @@ import org.broadinstitute.consent.http.db.mapper.DatasetDTOWithPropertiesMapper;
 import org.broadinstitute.consent.http.db.mapper.DatasetMapper;
 import org.broadinstitute.consent.http.db.mapper.DatasetPropertyMapper;
 import org.broadinstitute.consent.http.db.mapper.DatasetReducer;
+import org.broadinstitute.consent.http.db.mapper.DatasetStudySummaryMapper;
 import org.broadinstitute.consent.http.db.mapper.DatasetSummaryMapper;
 import org.broadinstitute.consent.http.db.mapper.DictionaryMapper;
 import org.broadinstitute.consent.http.db.mapper.FileStorageObjectMapperWithFSOPrefix;
@@ -18,6 +19,7 @@ import org.broadinstitute.consent.http.models.ApprovedDataset;
 import org.broadinstitute.consent.http.models.Dataset;
 import org.broadinstitute.consent.http.models.DatasetAudit;
 import org.broadinstitute.consent.http.models.DatasetProperty;
+import org.broadinstitute.consent.http.models.DatasetStudySummary;
 import org.broadinstitute.consent.http.models.DatasetSummary;
 import org.broadinstitute.consent.http.models.Dictionary;
 import org.broadinstitute.consent.http.models.FileStorageObject;
@@ -46,6 +48,15 @@ import org.jdbi.v3.sqlobject.transaction.Transactional;
 public interface DatasetDAO extends Transactional<DatasetDAO> {
 
   String CHAIRPERSON = Resource.CHAIRPERSON;
+
+  @UseRowMapper(DatasetStudySummaryMapper.class)
+  @SqlQuery("""
+      SELECT d.dataset_id, d.name AS dataset_name, d.alias, s.study_id, s.name AS study_name
+        FROM dataset d
+        LEFT JOIN study s ON s.study_id = d.study_id
+        ORDER BY dataset_id
+      """)
+  List<DatasetStudySummary> findAllDatasetStudySummaries();
 
   @SqlUpdate(
       """

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DatasetStudySummaryMapper.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DatasetStudySummaryMapper.java
@@ -1,0 +1,22 @@
+package org.broadinstitute.consent.http.db.mapper;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import org.broadinstitute.consent.http.models.Dataset;
+import org.broadinstitute.consent.http.models.DatasetStudySummary;
+import org.jdbi.v3.core.mapper.RowMapper;
+import org.jdbi.v3.core.statement.StatementContext;
+
+public class DatasetStudySummaryMapper implements RowMapper<DatasetStudySummary>, RowMapperHelper {
+
+  @Override
+  public DatasetStudySummary map(ResultSet rs, StatementContext ctx) throws SQLException {
+    Integer datasetId = hasNonZeroColumn(rs, "dataset_id") ? rs.getInt("dataset_id") : null;
+    String datasetName = rs.getString("dataset_name");
+    String studyName = rs.getString("study_name");
+    Integer studyId = hasNonZeroColumn(rs, "study_id") ? rs.getInt("study_id") : null;
+    Integer alias = hasNonZeroColumn(rs, "alias") ? rs.getInt("alias") : 0;
+    String identifier = Dataset.parseAliasToIdentifier(alias);
+    return new DatasetStudySummary(datasetId, datasetName, identifier, studyId, studyName);
+  }
+}

--- a/src/main/java/org/broadinstitute/consent/http/models/DatasetStudySummary.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DatasetStudySummary.java
@@ -1,0 +1,4 @@
+package org.broadinstitute.consent.http.models;
+
+public record DatasetStudySummary(Integer dataset_id, String dataset_name, String identifier, Integer study_id, String study_name) {
+}

--- a/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
@@ -314,6 +314,7 @@ public class DatasetResource extends Resource {
   @Produces("application/json")
   @PermitAll
   @Path("/v2")
+  @Deprecated
   public Response findAllDatasetsAvailableToUser(@Auth AuthUser authUser,
       @QueryParam("asCustodian") Boolean asCustodian) {
     try {
@@ -646,7 +647,7 @@ public class DatasetResource extends Resource {
   @Timed
   public Response searchDatasetIndex(@Auth AuthUser authUser, String query) {
     try {
-      User user = userService.findUserByEmail(authUser.getEmail());
+      userService.findUserByEmail(authUser.getEmail());
       return elasticSearchService.searchDatasets(query);
     } catch (Exception e) {
       return createExceptionResponse(e);

--- a/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
@@ -45,6 +45,7 @@ import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.AuthUser;
 import org.broadinstitute.consent.http.models.DataUse;
 import org.broadinstitute.consent.http.models.Dataset;
+import org.broadinstitute.consent.http.models.DatasetStudySummary;
 import org.broadinstitute.consent.http.models.DatasetSummary;
 import org.broadinstitute.consent.http.models.DatasetUpdate;
 import org.broadinstitute.consent.http.models.Dictionary;
@@ -321,6 +322,20 @@ public class DatasetResource extends Resource {
           datasetService.findDatasetsByCustodian(user) :
           datasetService.findAllDatasetsByUser(user);
       return Response.ok(datasets).build();
+    } catch (Exception e) {
+      return createExceptionResponse(e);
+    }
+  }
+
+  @GET
+  @Produces("application/json")
+  @PermitAll
+  @Path("/v3")
+  public Response findAllDatasetStudySummaries(@Auth AuthUser authUser) {
+    try {
+      userService.findUserByEmail(authUser.getEmail());
+      List<DatasetStudySummary> summaries = datasetService.findAllDatasetStudySummaries();
+      return Response.ok(summaries).build();
     } catch (Exception e) {
       return createExceptionResponse(e);
     }

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -24,7 +24,6 @@ import org.apache.commons.collections4.CollectionUtils;
 import org.broadinstitute.consent.http.db.DaaDAO;
 import org.broadinstitute.consent.http.db.DacDAO;
 import org.broadinstitute.consent.http.db.DatasetDAO;
-import org.broadinstitute.consent.http.db.LibraryCardDAO;
 import org.broadinstitute.consent.http.db.StudyDAO;
 import org.broadinstitute.consent.http.db.UserDAO;
 import org.broadinstitute.consent.http.enumeration.DataUseTranslationType;

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -35,6 +35,7 @@ import org.broadinstitute.consent.http.models.Dac;
 import org.broadinstitute.consent.http.models.DataUse;
 import org.broadinstitute.consent.http.models.Dataset;
 import org.broadinstitute.consent.http.models.DatasetProperty;
+import org.broadinstitute.consent.http.models.DatasetStudySummary;
 import org.broadinstitute.consent.http.models.DatasetSummary;
 import org.broadinstitute.consent.http.models.Dictionary;
 import org.broadinstitute.consent.http.models.Study;
@@ -58,7 +59,6 @@ public class DatasetService implements ConsentLogger {
   private final DaaDAO daaDAO;
   private final DacDAO dacDAO;
   private final EmailService emailService;
-  private final LibraryCardDAO libraryCardDAO;
   private final OntologyService ontologyService;
   private final StudyDAO studyDAO;
   private final DatasetServiceDAO datasetServiceDAO;
@@ -66,13 +66,12 @@ public class DatasetService implements ConsentLogger {
 
   @Inject
   public DatasetService(DatasetDAO dataSetDAO, DaaDAO daaDAO, DacDAO dacDAO, EmailService emailService,
-      LibraryCardDAO libraryCardDAO, OntologyService ontologyService, StudyDAO studyDAO,
+      OntologyService ontologyService, StudyDAO studyDAO,
       DatasetServiceDAO datasetServiceDAO, UserDAO userDAO) {
     this.datasetDAO = dataSetDAO;
     this.daaDAO = daaDAO;
     this.dacDAO = dacDAO;
     this.emailService = emailService;
-    this.libraryCardDAO = libraryCardDAO;
     this.ontologyService = ontologyService;
     this.studyDAO = studyDAO;
     this.datasetServiceDAO = datasetServiceDAO;
@@ -322,6 +321,10 @@ public class DatasetService implements ConsentLogger {
 
   public List<DatasetSummary> searchDatasetSummaries(String query) {
     return datasetDAO.findDatasetSummariesByQuery(query);
+  }
+
+  public List<DatasetStudySummary> findAllDatasetStudySummaries() {
+    return datasetDAO.findAllDatasetStudySummaries();
   }
 
   public Dataset approveDataset(Dataset dataset, User user, Boolean approval) {

--- a/src/main/resources/assets/paths/datasetV2.yaml
+++ b/src/main/resources/assets/paths/datasetV2.yaml
@@ -1,4 +1,5 @@
 get:
+  deprecated: true
   summary: Get Datasets
   description: | 
     Returns Dataset list filtered by authenticated user role.

--- a/src/main/resources/assets/paths/datasetV3.yaml
+++ b/src/main/resources/assets/paths/datasetV3.yaml
@@ -1,3 +1,17 @@
+get:
+  summary:
+  description:
+  tags:
+    - Dataset
+  responses:
+    200:
+      description: List of Dataset Study Summary objects
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: '../schemas/DatasetStudySummary.yaml'
 post:
   summary: Creates a set of Datasets from a valid dataset registration JsonSchema object
   description: Creates a set of Datasets from a valid dataset registration JsonSchema object

--- a/src/main/resources/assets/schemas/DatasetStudySummary.yaml
+++ b/src/main/resources/assets/schemas/DatasetStudySummary.yaml
@@ -1,0 +1,17 @@
+type: object
+properties:
+  dataset_id:
+    type: integer
+    description: The id for a dataset
+  dataset_name:
+    type: string
+    description: The dataset name
+  identifier:
+    type: string
+    description: The dataset identifier
+  study_id:
+    type: integer
+    description: The id for the dataset's study
+  study_name:
+    type: string
+    description: The study name

--- a/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import com.google.gson.JsonObject;
 import java.sql.Timestamp;
@@ -39,6 +38,7 @@ import org.broadinstitute.consent.http.models.DataUseBuilder;
 import org.broadinstitute.consent.http.models.Dataset;
 import org.broadinstitute.consent.http.models.DatasetAudit;
 import org.broadinstitute.consent.http.models.DatasetProperty;
+import org.broadinstitute.consent.http.models.DatasetStudySummary;
 import org.broadinstitute.consent.http.models.DatasetSummary;
 import org.broadinstitute.consent.http.models.Dictionary;
 import org.broadinstitute.consent.http.models.Election;
@@ -55,6 +55,30 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class DatasetDAOTest extends DAOTestHelper {
+
+  @Test
+  void testFindAllDatasetStudySummariesDatasetAndStudy() {
+    Dataset dataset = insertDataset();
+    Study study = insertStudyWithProperties();
+    datasetDAO.updateStudyId(dataset.getDataSetId(), study.getStudyId());
+
+    List<DatasetStudySummary> summaries = datasetDAO.findAllDatasetStudySummaries();
+    assertFalse(summaries.isEmpty());
+    assertEquals( 1, summaries.size());
+    assertEquals(dataset.getDataSetId(), summaries.get(0).dataset_id());
+    assertEquals(study.getStudyId(), summaries.get(0).study_id());
+  }
+
+  @Test
+  void testFindAllDatasetStudySummariesDatasetOnly() {
+    Dataset dataset = insertDataset();
+
+    List<DatasetStudySummary> summaries = datasetDAO.findAllDatasetStudySummaries();
+    assertFalse(summaries.isEmpty());
+    assertEquals( 1, summaries.size());
+    assertEquals(dataset.getDataSetId(), summaries.get(0).dataset_id());
+    assertNull(summaries.get(0).study_id());
+  }
 
   @Test
   void testFindDatasetByIdWithDacAndConsent() {

--- a/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
@@ -63,8 +63,7 @@ class DatasetDAOTest extends DAOTestHelper {
     datasetDAO.updateStudyId(dataset.getDataSetId(), study.getStudyId());
 
     List<DatasetStudySummary> summaries = datasetDAO.findAllDatasetStudySummaries();
-    assertFalse(summaries.isEmpty());
-    assertEquals( 1, summaries.size());
+    assertThat(summaries, hasSize(1));
     assertEquals(dataset.getDataSetId(), summaries.get(0).dataset_id());
     assertEquals(study.getStudyId(), summaries.get(0).study_id());
   }

--- a/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
@@ -1,5 +1,7 @@
 package org.broadinstitute.consent.http.db;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -73,8 +75,7 @@ class DatasetDAOTest extends DAOTestHelper {
     Dataset dataset = insertDataset();
 
     List<DatasetStudySummary> summaries = datasetDAO.findAllDatasetStudySummaries();
-    assertFalse(summaries.isEmpty());
-    assertEquals( 1, summaries.size());
+    assertThat(summaries, hasSize(1));
     assertEquals(dataset.getDataSetId(), summaries.get(0).dataset_id());
     assertNull(summaries.get(0).study_id());
   }

--- a/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
@@ -484,7 +484,7 @@ class DatasetDAOTest extends DAOTestHelper {
   }
 
   @Test
-  void testGetNIHInstitutionalFile_AlwaysLatestUpdated() throws InterruptedException {
+  void testGetNIHInstitutionalFile_AlwaysLatestUpdated() {
     Dataset dataset = insertDataset();
 
     String fileName = RandomStringUtils.randomAlphabetic(10);
@@ -536,7 +536,7 @@ class DatasetDAOTest extends DAOTestHelper {
   }
 
   @Test
-  void testGetNIHInstitutionalFile_AlwaysLatestCreated() throws InterruptedException {
+  void testGetNIHInstitutionalFile_AlwaysLatestCreated() {
     Dataset dataset = insertDataset();
 
     String fileName = RandomStringUtils.randomAlphabetic(10);
@@ -1087,7 +1087,7 @@ class DatasetDAOTest extends DAOTestHelper {
   }
 
   @Test
-  void testGetApprovedDatasets() throws Exception {
+  void testGetApprovedDatasets() {
 
     // user with a mix of approved and unapproved datasets
     User user = createUser();
@@ -1161,7 +1161,7 @@ class DatasetDAOTest extends DAOTestHelper {
   }
 
   @Test
-  void testGetApprovedDatasetsWhenNone() throws Exception {
+  void testGetApprovedDatasetsWhenNone() {
 
     // user with only unapproved datasets
     User user = createUser();
@@ -1191,7 +1191,7 @@ class DatasetDAOTest extends DAOTestHelper {
   }
 
   @Test
-  void testGetApprovedDatasetsWhenEmpty() throws Exception {
+  void testGetApprovedDatasetsWhenEmpty() {
 
     // user with no datasets
     User user = createUser();

--- a/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
@@ -809,6 +809,15 @@ class DatasetResourceTest {
   }
 
   @Test
+  void testFindAllDatasetStudySummaries() {
+    when(userService.findUserByEmail(any())).thenReturn(user);
+    when(datasetService.findAllDatasetStudySummaries()).thenReturn(List.of());
+    initResource();
+    Response response = resource.findAllDatasetStudySummaries(authUser);
+    assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+  }
+
+  @Test
   void testCreateDatasetRegistration_invalidSchema_case1() {
     initResource();
     Response response = resource.createDatasetRegistration(authUser, null, "");

--- a/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
@@ -37,7 +37,6 @@ import org.apache.commons.lang3.RandomUtils;
 import org.broadinstitute.consent.http.db.DaaDAO;
 import org.broadinstitute.consent.http.db.DacDAO;
 import org.broadinstitute.consent.http.db.DatasetDAO;
-import org.broadinstitute.consent.http.db.LibraryCardDAO;
 import org.broadinstitute.consent.http.db.StudyDAO;
 import org.broadinstitute.consent.http.db.UserDAO;
 import org.broadinstitute.consent.http.enumeration.DataUseTranslationType;
@@ -77,8 +76,6 @@ class DatasetServiceTest {
   @Mock
   private EmailService emailService;
   @Mock
-  private LibraryCardDAO libraryCardDAO;
-  @Mock
   private OntologyService ontologyService;
   @Mock
   private StudyDAO studyDAO;
@@ -89,7 +86,7 @@ class DatasetServiceTest {
 
   private void initService() {
     datasetService = new DatasetService(datasetDAO, daaDAO, dacDAO, emailService,
-      libraryCardDAO, ontologyService, studyDAO, datasetServiceDAO, userDAO);
+      ontologyService, studyDAO, datasetServiceDAO, userDAO);
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
@@ -90,7 +90,7 @@ class DatasetServiceTest {
   }
 
   @Test
-  void testCreateDataset() throws Exception {
+  void testCreateDataset() {
     DatasetDTO test = getDatasetDTO();
     Dataset mockDataset = getDatasets().get(0);
     when(datasetDAO.findDatasetDTOWithPropertiesByDatasetId(any())).thenReturn(


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DCJ-539

### Summary
This PR adds a v3 version of the get datasets API that is much more streamlined than the v2 version which is essentially unusable on dev. We don't use the v2 version any longer in the UI, so that should be deprecated.

#### Example Output
```
[
  {
    "dataset_id": 361,
    "dataset_name": "TOPMed Amish_HMB_IRB_MDS_phs000956.v2.p1.c2 V3",
    "identifier": "DUOS-000004"
  },
  ...
  {
    "dataset_id": 2582,
    "dataset_name": "All of Us (Controlled Tier) - Set 1",
    "identifier": "DUOS-001077",
    "study_id": 6076,
    "study_name": "All of Us (Controlled Tier)"
  },
  ...
]
```

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
