### PR TITLE
[DCJ-627][risk=low] Remove deprecated Dataset needsApproval and active state attributes from consent service and database

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/DacDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DacDAO.java
@@ -44,7 +44,7 @@ public interface DacDAO extends Transactional<DacDAO> {
   @UseRowReducer(DacReducer.class)
   @SqlQuery("""
       SELECT dac.dac_id, dac.email, dac.name, dac.description, d.dataset_id, d.name AS dataset_name,
-        DATE(d.create_date) AS dataset_create_date, d.object_id, d.active, d.needs_approval,
+        DATE(d.create_date) AS dataset_create_date, d.object_id,
         d.alias AS dataset_alias, d.create_user_id, d.update_date AS dataset_update_date,
         d.update_user_id, d.data_use AS dataset_data_use, d.sharing_plan_document,
         d.sharing_plan_document_name

--- a/src/main/java/org/broadinstitute/consent/http/db/DacDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DacDAO.java
@@ -54,8 +54,6 @@ public interface DacDAO extends Transactional<DacDAO> {
         d.name AS dataset_name,
         DATE(d.create_date) AS dataset_create_date,
         d.object_id,
-        d.active,
-        d.needs_approval,
         d.alias AS dataset_alias,
         d.create_user_id,
         d.update_date AS dataset_update_date,

--- a/src/main/java/org/broadinstitute/consent/http/models/Dataset.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/Dataset.java
@@ -30,20 +30,6 @@ public class Dataset {
 
   private Integer updateUserId;
 
-  /**
-   * Active is a deprecated property. The visibility of a dataset is calculated from DAC approval
-   * and the public visibility dataset property
-   */
-  @Deprecated(forRemoval = true)
-  private Boolean active;
-
-  /**
-   * Needs Approval is a deprecated property. The visibility of a dataset is calculated from DAC
-   * approval and the public visibility dataset property
-   */
-  @Deprecated(forRemoval = true)
-  private Boolean needsApproval;
-
   private Integer alias;
 
   private String datasetIdentifier;
@@ -186,22 +172,6 @@ public class Dataset {
       this.properties = new HashSet<>();
     }
     this.properties.add(property);
-  }
-
-  public Boolean getActive() {
-    return active;
-  }
-
-  public void setActive(Boolean active) {
-    this.active = active;
-  }
-
-  public Boolean getNeedsApproval() {
-    return needsApproval;
-  }
-
-  public void setNeedsApproval(Boolean needsApproval) {
-    this.needsApproval = needsApproval;
   }
 
   public Boolean getDacApproval() {

--- a/src/main/java/org/broadinstitute/consent/http/models/dto/DatasetDTO.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/dto/DatasetDTO.java
@@ -31,12 +31,6 @@ public class DatasetDTO {
   private List<DatasetPropertyDTO> properties;
 
   @JsonProperty
-  private Boolean active;
-
-  @JsonProperty
-  private Boolean needsApproval;
-
-  @JsonProperty
   private Boolean isAssociatedToDataOwners;
 
   @JsonProperty
@@ -113,22 +107,6 @@ public class DatasetDTO {
 
   public void setProperties(List<DatasetPropertyDTO> properties) {
     this.properties = properties;
-  }
-
-  public Boolean getActive() {
-    return active;
-  }
-
-  public void setActive(Boolean active) {
-    this.active = active;
-  }
-
-  public Boolean getNeedsApproval() {
-    return needsApproval;
-  }
-
-  public void setNeedsApproval(Boolean needsApproval) {
-    this.needsApproval = needsApproval;
   }
 
   public Boolean getIsAssociatedToDataOwners() {

--- a/src/main/resources/assets/schemas/Dataset.yaml
+++ b/src/main/resources/assets/schemas/Dataset.yaml
@@ -52,14 +52,6 @@ properties:
   study:
     $ref: "./Study.yaml"
     description: The study which produced this dataset.
-  active:
-    type: boolean
-    description: The Dataset is active
-    deprecated: true
-  needsApproval:
-    type: boolean
-    description: The Dataset need Data Owners approval
-    deprecated: true
   alias:
     type: string
     description: The dataset id, short format

--- a/src/main/resources/changelog-master.xml
+++ b/src/main/resources/changelog-master.xml
@@ -162,4 +162,6 @@
     relativeToChangelogFile="true"/>
   <include file="changesets/changelog-consent-2024-08-28-rm-consents.xml"
     relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-2024-09-04-drop-deprecated-dataset-columns-.xml"
+    relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/changesets/changelog-consent-2024-09-04-drop-deprecated-dataset-columns-.xml
+++ b/src/main/resources/changesets/changelog-consent-2024-09-04-drop-deprecated-dataset-columns-.xml
@@ -1,0 +1,8 @@
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+  <changeSet id="changelog-consent-2024-09-04-drop-deprecated-dataset-columns" author="otchet-broad">
+    <dropColumn tableName="dataset" columnName="needs_approval"/>
+    <dropColumn tableName="dataset" columnName="active"/>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/test-data.xml
+++ b/src/main/resources/test-data.xml
@@ -136,11 +136,9 @@
     <!--insert researcher user-->
     <changeSet author="rfricke" id="test-dataset">
         <sql>
-            INSERT INTO dataset (name, active, needs_approval)
+            INSERT INTO dataset (name)
             SELECT
-                dac.name,
-                't',
-                'f'
+                dac.name
             FROM dac
         </sql>
     </changeSet>


### PR DESCRIPTION
### Addresses

Addresses the consent and database portion of [removing deprecated Dataset properties](https://broadworkbench.atlassian.net/browse/DCJ-627?atlOrigin=eyJpIjoiMjYxZTkxODc0MWFiNDBmMTg0ZDBiODA5Y2FmNDEzMjAiLCJwIjoiaiJ9)

### Summary
Removes properties and related getters/setters from Dataset class, DTOs
Removes columns from SQL queries
Adds liquidbase script to drop the columns from the dataset table

### See Also:
https://github.com/DataBiosphere/duos-ui/pull/2663

