### PR TITLE
DCJ-685: Fix bugs in the conversion of study datasets to registration schema consent groups.

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/models/dataset_registration_v1/builder/ConsentGroupFromDataset.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/dataset_registration_v1/builder/ConsentGroupFromDataset.java
@@ -1,34 +1,19 @@
 package org.broadinstitute.consent.http.models.dataset_registration_v1.builder;
 
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.accessManagement;
-import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.col;
-import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.dataAccessCommitteeId;
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.dataLocation;
-import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.diseaseSpecificUse;
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.fileTypes;
-import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.generalResearchUse;
-import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.gs;
-import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.gso;
-import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.hmb;
-import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.irb;
-import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.mor;
-import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.morDate;
-import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.nmds;
-import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.npu;
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.numberOfParticipants;
-import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.otherPrimary;
-import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.otherSecondary;
-import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.poa;
-import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.pub;
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.url;
 
 import com.google.gson.JsonArray;
-import com.google.gson.JsonElement;
 import java.net.URI;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import javax.annotation.Nullable;
+import org.apache.commons.lang3.StringUtils;
+import org.broadinstitute.consent.http.models.DataUse;
 import org.broadinstitute.consent.http.models.Dataset;
 import org.broadinstitute.consent.http.models.DatasetProperty;
 import org.broadinstitute.consent.http.models.dataset_registration_v1.ConsentGroup;
@@ -40,7 +25,7 @@ import org.broadinstitute.consent.http.util.gson.GsonUtil;
 public class ConsentGroupFromDataset {
 
   public ConsentGroup build(Dataset dataset) {
-    if (Objects.nonNull(dataset)) {
+    if (dataset != null) {
       ConsentGroup consentGroup = new ConsentGroup();
       consentGroup.setDatasetId(dataset.getDataSetId());
       consentGroup.setDatasetIdentifier(dataset.getDatasetIdentifier());
@@ -49,25 +34,29 @@ public class ConsentGroupFromDataset {
       if (Objects.nonNull(accessManagementVal)) {
         consentGroup.setAccessManagement(AccessManagement.fromValue(accessManagementVal));
       }
-      consentGroup.setGeneralResearchUse(
-          findBooleanDSPropValue(dataset.getProperties(), generalResearchUse));
-      consentGroup.setHmb(findBooleanDSPropValue(dataset.getProperties(), hmb));
-      consentGroup.setDiseaseSpecificUse(findListStringDSPropValue(dataset.getProperties()));
-      consentGroup.setPoa(findBooleanDSPropValue(dataset.getProperties(), poa));
-      consentGroup.setOtherPrimary(findStringDSPropValue(dataset.getProperties(), otherPrimary));
-      consentGroup.setNmds(findBooleanDSPropValue(dataset.getProperties(), nmds));
-      consentGroup.setGso(findBooleanDSPropValue(dataset.getProperties(), gso));
-      consentGroup.setPub(findBooleanDSPropValue(dataset.getProperties(), pub));
-      consentGroup.setCol(findBooleanDSPropValue(dataset.getProperties(), col));
-      consentGroup.setIrb(findBooleanDSPropValue(dataset.getProperties(), irb));
-      consentGroup.setGs(findStringDSPropValue(dataset.getProperties(), gs));
-      consentGroup.setMor(findBooleanDSPropValue(dataset.getProperties(), mor));
-      consentGroup.setMorDate(findStringDSPropValue(dataset.getProperties(), morDate));
-      consentGroup.setNpu(findBooleanDSPropValue(dataset.getProperties(), npu));
-      consentGroup.setOtherSecondary(
-          findStringDSPropValue(dataset.getProperties(), otherSecondary));
-      consentGroup.setDataAccessCommitteeId(
-          findIntegerDSPropValue(dataset.getProperties(), dataAccessCommitteeId));
+      if (dataset.getDataUse() != null) {
+        DataUse dataUse = dataset.getDataUse();
+        consentGroup.setGeneralResearchUse(dataUse.getGeneralUse());
+        consentGroup.setHmb(dataUse.getHmbResearch());
+        consentGroup.setDiseaseSpecificUse(dataUse.getDiseaseRestrictions());
+        consentGroup.setPoa(dataUse.getPopulationOriginsAncestry());
+        consentGroup.setOtherPrimary(dataUse.getOther());
+        consentGroup.setNmds(dataUse.getMethodsResearch());
+        consentGroup.setGso(dataUse.getGeneticStudiesOnly());
+        consentGroup.setPub(dataUse.getPublicationResults());
+        consentGroup.setCol(dataUse.getCollaboratorRequired());
+        consentGroup.setIrb(dataUse.getEthicsApprovalRequired());
+        consentGroup.setGs(dataUse.getGeographicalRestrictions());
+        if (!StringUtils.isBlank(dataUse.getPublicationMoratorium())) {
+          consentGroup.setMor(true);
+          consentGroup.setMorDate(dataUse.getPublicationMoratorium());
+        }
+        consentGroup.setNpu(dataUse.getNonProfitUse());
+        consentGroup.setOtherSecondary(dataUse.getSecondaryOther());
+      }
+      if (dataset.getDacId() != null) {
+        consentGroup.setDataAccessCommitteeId(dataset.getDacId());
+      }
       String dataLocationVal = findStringDSPropValue(dataset.getProperties(), dataLocation);
       if (Objects.nonNull(dataLocationVal)) {
         consentGroup.setDataLocation(DataLocation.fromValue(dataLocationVal));
@@ -94,38 +83,6 @@ public class ConsentGroupFromDataset {
           .map(DatasetProperty::getPropertyValueAsString)
           .findFirst()
           .orElse(null);
-    }
-    return null;
-  }
-
-  @Nullable
-  private Boolean findBooleanDSPropValue(Set<DatasetProperty> props, String propName) {
-    if (Objects.nonNull(props) && !props.isEmpty()) {
-      return props
-          .stream()
-          .filter(p -> p.getSchemaProperty() != null && p.getSchemaProperty().equalsIgnoreCase(propName))
-          .map(DatasetProperty::getPropertyValue)
-          .map(Object::toString)
-          .map(Boolean::valueOf)
-          .findFirst()
-          .orElse(null);
-    }
-    return null;
-  }
-
-  @Nullable
-  private List<String> findListStringDSPropValue(Set<DatasetProperty> props) {
-    if (Objects.nonNull(props) && !props.isEmpty()) {
-      return props
-          .stream()
-          .filter(p -> p.getSchemaProperty() != null && p.getSchemaProperty().equalsIgnoreCase(diseaseSpecificUse))
-          .map(DatasetProperty::getPropertyValue)
-          .map(p -> GsonUtil.getInstance().fromJson(p.toString(), JsonElement.class))
-          .map(JsonElement::getAsJsonArray)
-          .map(JsonArray::asList)
-          .flatMap(List::stream)
-          .map(JsonElement::getAsString)
-          .toList();
     }
     return null;
   }

--- a/src/test/java/org/broadinstitute/consent/http/models/DatasetRegistrationSchemaV1BuilderTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/DatasetRegistrationSchemaV1BuilderTest.java
@@ -9,25 +9,16 @@ import static org.broadinstitute.consent.http.models.dataset_registration_v1.bui
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.alternativeDataSharingPlanReasons;
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.alternativeDataSharingPlanTargetDeliveryDate;
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.alternativeDataSharingPlanTargetPublicReleaseDate;
-import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.col;
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.collaboratingSites;
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.controlledAccessRequiredForGenomicSummaryResultsGSR;
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.controlledAccessRequiredForGenomicSummaryResultsGSRRequiredExplanation;
-import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.dataAccessCommitteeId;
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.dataCustodianEmail;
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.dataLocation;
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.dbGaPPhsID;
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.dbGaPStudyRegistrationName;
-import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.diseaseSpecificUse;
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.embargoReleaseDate;
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.fileTypes;
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.generalResearchUse;
-import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.gs;
-import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.gso;
-import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.hmb;
-import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.irb;
-import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.mor;
-import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.morDate;
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.multiCenterStudy;
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.nihAnvilUse;
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.nihGenomicProgramAdministratorName;
@@ -35,21 +26,16 @@ import static org.broadinstitute.consent.http.models.dataset_registration_v1.bui
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.nihICsSupportingStudy;
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.nihInstitutionCenterSubmission;
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.nihProgramOfficerName;
-import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.nmds;
-import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.npu;
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.numberOfParticipants;
-import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.otherPrimary;
-import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.otherSecondary;
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.phenotypeIndication;
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.piInstitution;
-import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.poa;
-import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.pub;
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.sequencingCenter;
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.species;
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.studyType;
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.submittingToAnvil;
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.url;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -149,30 +135,53 @@ class DatasetRegistrationSchemaV1BuilderTest {
     assertNotNull(consentGroup);
     assertNotNull(consentGroup.getDatasetId());
     assertNotNull(consentGroup.getDatasetIdentifier());
-    assertNotNull(consentGroup.getConsentGroupName());
-    assertNotNull(consentGroup.getAccessManagement());
-    assertNotNull(consentGroup.getGeneralResearchUse());
-    assertNotNull(consentGroup.getHmb());
-    assertNotNull(consentGroup.getDiseaseSpecificUse());
-    assertFalse(consentGroup.getDiseaseSpecificUse().isEmpty());
-    assertNotNull(consentGroup.getPoa());
-    assertNotNull(consentGroup.getOtherPrimary());
-    assertNotNull(consentGroup.getNmds());
-    assertNotNull(consentGroup.getGso());
-    assertNotNull(consentGroup.getPub());
-    assertNotNull(consentGroup.getCol());
-    assertNotNull(consentGroup.getIrb());
-    assertNotNull(consentGroup.getGs());
-    assertNotNull(consentGroup.getMor());
-    assertNotNull(consentGroup.getMorDate());
-    assertNotNull(consentGroup.getNpu());
-    assertNotNull(consentGroup.getOtherSecondary());
-    assertNotNull(consentGroup.getDataAccessCommitteeId());
     assertNotNull(consentGroup.getDataLocation());
     assertNotNull(consentGroup.getUrl());
     assertNotNull(consentGroup.getNumberOfParticipants());
     assertNotNull(consentGroup.getFileTypes());
     assertFalse(consentGroup.getFileTypes().isEmpty());
+  }
+
+  @Test
+  void testBuildSchemaWithDataUse() {
+    DatasetRegistrationSchemaV1Builder builder = new DatasetRegistrationSchemaV1Builder();
+    Study study = createMockStudy();
+    Dataset dataset = createMockDataset();
+    DataUse dataUse = new DataUseBuilder()
+        .setGeneralUse(RandomUtils.nextBoolean())
+        .setHmbResearch(RandomUtils.nextBoolean())
+        .setDiseaseRestrictions(List.of(RandomStringUtils.randomAlphabetic(10)))
+        .setPopulationOriginsAncestry(RandomUtils.nextBoolean())
+        .setOther(RandomStringUtils.randomAlphabetic(10))
+        .setMethodsResearch(RandomUtils.nextBoolean())
+        .setGeneticStudiesOnly(RandomUtils.nextBoolean())
+        .setPublicationResults(RandomUtils.nextBoolean())
+        .setCollaboratorRequired(RandomUtils.nextBoolean())
+        .setEthicsApprovalRequired(RandomUtils.nextBoolean())
+        .setGeographicalRestrictions(RandomStringUtils.randomAlphabetic(10))
+        .setPublicationMoratorium(new Date().toString())
+        .setNonProfitUse(RandomUtils.nextBoolean())
+        .setSecondaryOther(RandomStringUtils.randomAlphabetic(10))
+        .build();
+    dataset.setDataUse(dataUse);
+    DatasetRegistrationSchemaV1 schemaV1 = builder.build(study, List.of(dataset));
+    ConsentGroup consentGroup = schemaV1.getConsentGroups().get(0);
+    assertEquals(dataUse.getGeneralUse(), consentGroup.getGeneralResearchUse());
+    assertEquals(dataUse.getHmbResearch(), consentGroup.getHmb());
+    assertEquals(dataUse.getDiseaseRestrictions(), consentGroup.getDiseaseSpecificUse());
+    assertEquals(dataUse.getPopulationOriginsAncestry(), consentGroup.getPoa());
+    assertEquals(dataUse.getOther(), consentGroup.getOtherPrimary());
+    assertEquals(dataUse.getMethodsResearch(), consentGroup.getNmds());
+    assertEquals(dataUse.getGeneticStudiesOnly(), consentGroup.getGso());
+    assertEquals(dataUse.getPublicationResults(), consentGroup.getPub());
+    assertEquals(dataUse.getCollaboratorRequired(), consentGroup.getCol());
+    assertEquals(dataUse.getEthicsApprovalRequired(), consentGroup.getIrb());
+    assertEquals(dataUse.getGeographicalRestrictions(), consentGroup.getGs());
+    // ConsentGroup.morDate is a string value that is meant to represent a date
+    assertEquals(true, consentGroup.getMor());
+    assertEquals(dataUse.getPublicationMoratorium(), consentGroup.getMorDate());
+    assertEquals(dataUse.getNonProfitUse(), consentGroup.getNpu());
+    assertEquals(dataUse.getSecondaryOther(), consentGroup.getOtherSecondary());
   }
 
   @Test
@@ -329,25 +338,8 @@ class DatasetRegistrationSchemaV1BuilderTest {
     dataset.addProperty(
         createDatasetProperty(dataset, accessManagement, PropertyType.String,
             AccessManagement.CONTROLLED.value()));
-    dataset.addProperty(
-        createDatasetProperty(dataset, generalResearchUse, PropertyType.Boolean, null));
-    dataset.addProperty(createDatasetProperty(dataset, hmb, PropertyType.Boolean, null));
-    dataset.addProperty(
-        createDatasetProperty(dataset, diseaseSpecificUse, PropertyType.Json, null));
-    dataset.addProperty(createDatasetProperty(dataset, poa, PropertyType.Boolean, null));
-    dataset.addProperty(createDatasetProperty(dataset, otherPrimary, PropertyType.String, null));
-    dataset.addProperty(createDatasetProperty(dataset, nmds, PropertyType.Boolean, null));
-    dataset.addProperty(createDatasetProperty(dataset, gso, PropertyType.Boolean, null));
-    dataset.addProperty(createDatasetProperty(dataset, pub, PropertyType.Boolean, null));
-    dataset.addProperty(createDatasetProperty(dataset, col, PropertyType.Boolean, null));
-    dataset.addProperty(createDatasetProperty(dataset, irb, PropertyType.Boolean, null));
-    dataset.addProperty(createDatasetProperty(dataset, gs, PropertyType.String, null));
-    dataset.addProperty(createDatasetProperty(dataset, mor, PropertyType.Boolean, null));
-    dataset.addProperty(createDatasetProperty(dataset, morDate, PropertyType.String, null));
-    dataset.addProperty(createDatasetProperty(dataset, npu, PropertyType.Boolean, null));
-    dataset.addProperty(createDatasetProperty(dataset, otherSecondary, PropertyType.String, null));
-    dataset.addProperty(
-        createDatasetProperty(dataset, dataAccessCommitteeId, PropertyType.Number, null));
+    // Controlled access datasets require a DAC ID
+    dataset.setDacId(RandomUtils.nextInt(10, 100));
     dataset.addProperty(createDatasetProperty(dataset, dataLocation, PropertyType.String,
         DataLocation.NOT_DETERMINED.value()));
     dataset.addProperty(


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DCJ-685

### Summary
This fixes an issue where we were trying to get the DAC ID and `DataUse` values from non-existent `DatasetProperties` instead of from the `Dataset` directly.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
