### PR TITLE
DCJ-688: Return default responses when Sam fails

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/SamDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/SamDAO.java
@@ -129,9 +129,10 @@ public class SamDAO implements ConsentLogger {
     GenericUrl genericUrl = new GenericUrl(configuration.postRegisterUserV2SelfUrl());
     HttpRequest request = clientUtil.buildPostRequest(genericUrl, new EmptyContent(), authUser);
     HttpResponse response;
+    String body;
     try {
       response = executeRequest(request);
-      String body = response.parseAsString();
+      body = response.parseAsString();
       if (!response.isSuccessStatusCode()) {
         if (HttpStatusCodes.STATUS_CODE_CONFLICT == response.getStatusCode()) {
           throw new ConsentConflictException("User exists in Sam: " + authUser.getEmail());
@@ -145,7 +146,6 @@ public class SamDAO implements ConsentLogger {
           throw e;
         }
       }
-      return new Gson().fromJson(body, UserStatus.class);
     } catch (ServerErrorException e) {
       logException(
           "Sam is down, returning mock UserStatus for user %s".formatted(authUser.getEmail()), e);
@@ -161,6 +161,7 @@ public class SamDAO implements ConsentLogger {
       userStatus.setUserInfo(userInfo);
       return userStatus;
     }
+    return new Gson().fromJson(body, UserStatus.class);
   }
 
   public void asyncPostRegistrationInfo(AuthUser authUser) {

--- a/src/main/java/org/broadinstitute/consent/http/db/SamDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/SamDAO.java
@@ -16,6 +16,7 @@ import jakarta.ws.rs.ServerErrorException;
 import jakarta.ws.rs.core.MediaType;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -58,6 +59,8 @@ public class SamDAO implements ConsentLogger {
     if (!response.isSuccessStatusCode()) {
       logException("Error getting resource types from Sam: " + response.getStatusMessage(),
           new ServerErrorException(response.getStatusMessage(), response.getStatusCode()));
+      logWarn("Sam is down, returning mock List<ResourceType> for user %s".formatted(authUser.getEmail()));
+      return List.of();
     }
     String body = response.parseAsString();
     Type resourceTypesListType = new TypeToken<ArrayList<ResourceType>>() {
@@ -73,6 +76,13 @@ public class SamDAO implements ConsentLogger {
       logException(
           "Error getting user registration information from Sam: " + response.getStatusMessage(),
           new ServerErrorException(response.getStatusMessage(), response.getStatusCode()));
+      logWarn("Sam is down, returning mock UserStatusInfo for user %s".formatted(authUser.getEmail()));
+      UserStatusInfo userStatusInfo = new UserStatusInfo();
+      userStatusInfo.setAdminEnabled(false);
+      userStatusInfo.setEnabled(true);
+      userStatusInfo.setUserEmail(authUser.getEmail());
+      userStatusInfo.setUserSubjectId("Mock subject id for user %s".formatted(authUser.getEmail()));
+      return userStatusInfo;
     }
     String body = response.parseAsString();
     return new Gson().fromJson(body, UserStatusInfo.class);
@@ -86,6 +96,14 @@ public class SamDAO implements ConsentLogger {
       logException(
           "Error getting enabled statuses of user from Sam: " + response.getStatusMessage(),
           new ServerErrorException(response.getStatusMessage(), response.getStatusCode()));
+      logWarn("Sam is down, returning mock UserStatusDiagnostics for user %s".formatted(authUser.getEmail()));
+      UserStatusDiagnostics userStatusDiagnostics = new UserStatusDiagnostics();
+      userStatusDiagnostics.setAdminEnabled(false);
+      userStatusDiagnostics.setEnabled(true);
+      userStatusDiagnostics.setTosAccepted(true);
+      userStatusDiagnostics.setInAllUsersGroup(true);
+      userStatusDiagnostics.setInGoogleProxyGroup(true);
+      return userStatusDiagnostics;
     }
     String body = response.parseAsString();
     return new Gson().fromJson(body, UserStatusDiagnostics.class);
@@ -141,6 +159,8 @@ public class SamDAO implements ConsentLogger {
     if (!response.isSuccessStatusCode()) {
       logException("Error getting Terms of Service text from Sam: " + response.getStatusMessage(),
           new ServerErrorException(response.getStatusMessage(), response.getStatusCode()));
+      logWarn("Sam is down, returning mock Terms of Service Text");
+      return "Terms of Service Text";
     }
     return response.parseAsString();
   }
@@ -152,6 +172,13 @@ public class SamDAO implements ConsentLogger {
     if (!response.isSuccessStatusCode()) {
       logException(String.format("Error getting Terms of Service: %s for user %s", response.getStatusMessage(), authUser.getEmail()),
           new ServerErrorException(response.getStatusMessage(), response.getStatusCode()));
+      logWarn("Sam is down, returning mock TosResponse for user: %s".formatted(authUser.getEmail()));
+      return new TosResponse(
+          new Date().toString(),
+          true,
+          "2023-11-15",
+          true
+      );
     }
     String body = response.parseAsString();
     return new Gson().fromJson(body, TosResponse.class);
@@ -164,6 +191,8 @@ public class SamDAO implements ConsentLogger {
     if (!response.isSuccessStatusCode()) {
       logException(String.format("Error accepting Terms of Service: %s for user %s", response.getStatusMessage(), authUser.getEmail()),
           new ServerErrorException(response.getStatusMessage(), response.getStatusCode()));
+      logWarn("Sam is down, returning mock ToS Acceptance Status for user: %s".formatted(authUser.getEmail()));
+      return 204;
     }
     return response.getStatusCode();
   }
@@ -176,6 +205,8 @@ public class SamDAO implements ConsentLogger {
       logException(
           String.format("Error removing Terms of Service: %s for user %s", response.getStatusMessage(), authUser.getEmail()),
           new ServerErrorException(response.getStatusMessage(), response.getStatusCode()));
+      logWarn("Sam is down, returning mock ToS Rejection Status for user: %s".formatted(authUser.getEmail()));
+      return 204;
     }
     return response.getStatusCode();
   }
@@ -188,6 +219,12 @@ public class SamDAO implements ConsentLogger {
       logException(
           "Error getting user by email from Sam: " + response.getStatusMessage(),
           new ServerErrorException(response.getStatusMessage(), response.getStatusCode()));
+      logWarn("Sam is down, returning mock EmailResponse for user: %s".formatted(authUser.getEmail()));
+      return new EmailResponse(
+          "Mock google subject id",
+          authUser.getEmail(),
+          "Mock user subject id"
+      );
     }
     String body = response.parseAsString();
     return new Gson().fromJson(body, EmailResponse.class);

--- a/src/main/java/org/broadinstitute/consent/http/db/SamDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/SamDAO.java
@@ -33,12 +33,13 @@ import org.broadinstitute.consent.http.util.HttpClientUtil;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-public class SamDAO implements ConsentLogger, SamDefaults {
+public class SamDAO implements ConsentLogger {
 
   private final ExecutorService executorService;
   private final HttpClientUtil clientUtil;
   private final ServicesConfiguration configuration;
   private final Integer connectTimeoutMilliseconds;
+  private final SamDefaults samDefaults = new SamDefaults();
   public final Integer readTimeoutMilliseconds;
 
   public SamDAO(HttpClientUtil clientUtil, ServicesConfiguration configuration) {
@@ -87,7 +88,7 @@ public class SamDAO implements ConsentLogger, SamDefaults {
       logException(
           "Sam is down, returning mock UserStatusInfo for user %s".formatted(authUser.getEmail()),
           e);
-      return getDefaultUserStatusInfo(authUser);
+      return samDefaults.getDefaultUserStatusInfo(authUser);
     }
     String body = response.parseAsString();
     return new Gson().fromJson(body, UserStatusInfo.class);
@@ -107,7 +108,7 @@ public class SamDAO implements ConsentLogger, SamDefaults {
     } catch (ServerErrorException e) {
       logException("Sam is down, returning mock UserStatusDiagnostics for user %s".formatted(
           authUser.getEmail()), e);
-      return getDefaultUserStatusDiagnostics();
+      return samDefaults.getDefaultUserStatusDiagnostics();
     }
     String body = response.parseAsString();
     return new Gson().fromJson(body, UserStatusDiagnostics.class);
@@ -137,7 +138,7 @@ public class SamDAO implements ConsentLogger, SamDefaults {
     } catch (ServerErrorException e) {
       logException(
           "Sam is down, returning mock UserStatus for user %s".formatted(authUser.getEmail()), e);
-      return getDefaultUserStatus(authUser);
+      return samDefaults.getDefaultUserStatus(authUser);
     }
     return new Gson().fromJson(body, UserStatus.class);
   }
@@ -175,11 +176,11 @@ public class SamDAO implements ConsentLogger, SamDefaults {
       if (!response.isSuccessStatusCode()) {
         logException("Error getting Terms of Service text from Sam: %s".formatted(response.getStatusMessage()),
             new ServerErrorException(response.getStatusMessage(), response.getStatusCode()));
-        return getDefaultToSText();
+        return samDefaults.getDefaultToSText();
       }
     } catch (ServerErrorException e) {
       logException("Sam is down, returning most recent Terms of Service Text: ", e);
-      return getDefaultToSText();
+      return samDefaults.getDefaultToSText();
     }
     return response.parseAsString();
   }
@@ -198,7 +199,7 @@ public class SamDAO implements ConsentLogger, SamDefaults {
     } catch (ServerErrorException e) {
       logException(
           "Sam is down, returning mock TosResponse for user: %s".formatted(authUser.getEmail()), e);
-      return getDefaultTosResponse();
+      return samDefaults.getDefaultTosResponse();
     }
     String body = response.parseAsString();
     return new Gson().fromJson(body, TosResponse.class);
@@ -218,7 +219,7 @@ public class SamDAO implements ConsentLogger, SamDefaults {
     } catch (ServerErrorException e) {
       logException("Sam is down, returning mock ToS Acceptance Status for user: %s".formatted(
           authUser.getEmail()), e);
-      return getDefaultTosStatusCode();
+      return samDefaults.getDefaultTosStatusCode();
     }
     return response.getStatusCode();
   }
@@ -238,7 +239,7 @@ public class SamDAO implements ConsentLogger, SamDefaults {
     } catch (ServerErrorException e) {
       logException("Sam is down, returning mock ToS Rejection Status for user: %s".formatted(
           authUser.getEmail()), e);
-      return getDefaultTosStatusCode();
+      return samDefaults.getDefaultTosStatusCode();
     }
     return response.getStatusCode();
   }
@@ -258,7 +259,7 @@ public class SamDAO implements ConsentLogger, SamDefaults {
       logException(
           "Sam is down, returning mock EmailResponse for user: %s".formatted(authUser.getEmail()),
           e);
-      return getDefaultEmailResponse(authUser);
+      return samDefaults.getDefaultEmailResponse(authUser);
     }
     String body = response.parseAsString();
     return new Gson().fromJson(body, EmailResponse.class);

--- a/src/main/java/org/broadinstitute/consent/http/db/SamDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/SamDAO.java
@@ -63,7 +63,8 @@ public class SamDAO implements ConsentLogger {
             new ServerErrorException(response.getStatusMessage(), response.getStatusCode()));
       }
     } catch (ServerErrorException e) {
-      logException("Sam is down, returning mock List<ResourceType> for user %s".formatted(authUser.getEmail()), e);
+      logException("Sam is down, returning mock List<ResourceType> for user %s".formatted(
+          authUser.getEmail()), e);
       return List.of();
     }
     String body = response.parseAsString();
@@ -84,7 +85,9 @@ public class SamDAO implements ConsentLogger {
             new ServerErrorException(response.getStatusMessage(), response.getStatusCode()));
       }
     } catch (ServerErrorException e) {
-      logException("Sam is down, returning mock UserStatusInfo for user %s".formatted(authUser.getEmail()), e);
+      logException(
+          "Sam is down, returning mock UserStatusInfo for user %s".formatted(authUser.getEmail()),
+          e);
       UserStatusInfo userStatusInfo = new UserStatusInfo();
       userStatusInfo.setAdminEnabled(false);
       userStatusInfo.setEnabled(true);
@@ -108,7 +111,8 @@ public class SamDAO implements ConsentLogger {
             new ServerErrorException(response.getStatusMessage(), response.getStatusCode()));
       }
     } catch (ServerErrorException e) {
-      logException("Sam is down, returning mock UserStatusDiagnostics for user %s".formatted(authUser.getEmail()), e);
+      logException("Sam is down, returning mock UserStatusDiagnostics for user %s".formatted(
+          authUser.getEmail()), e);
       UserStatusDiagnostics userStatusDiagnostics = new UserStatusDiagnostics();
       userStatusDiagnostics.setAdminEnabled(false);
       userStatusDiagnostics.setEnabled(true);
@@ -132,7 +136,7 @@ public class SamDAO implements ConsentLogger {
         if (HttpStatusCodes.STATUS_CODE_CONFLICT == response.getStatusCode()) {
           throw new ConsentConflictException("User exists in Sam: " + authUser.getEmail());
         } else {
-          String errorMsg = String.format("Error posting user registration information to Sam. Email [%s]. Status Code [%s]; Status Message [%s];  ",
+          String errorMsg = "Error posting user registration information to Sam. Email [%s]. Status Code [%s]; Status Message [%s];  ".formatted(
               authUser.getEmail(),
               response.getStatusCode(),
               response.getStatusMessage());
@@ -143,7 +147,8 @@ public class SamDAO implements ConsentLogger {
       }
       return new Gson().fromJson(body, UserStatus.class);
     } catch (ServerErrorException e) {
-      logException("Sam is down, returning mock UserStatus for user %s".formatted(authUser.getEmail()), e);
+      logException(
+          "Sam is down, returning mock UserStatus for user %s".formatted(authUser.getEmail()), e);
       UserStatus userStatus = new UserStatus();
       UserStatus.Enabled enabled = new UserStatus.Enabled();
       enabled.setLdap(true);
@@ -173,7 +178,9 @@ public class SamDAO implements ConsentLogger {
 
           @Override
           public void onFailure(@NonNull Throwable throwable) {
-            logException("Async Post Registration Failure for user: %s".formatted(authUser.getEmail()), new Exception(throwable));
+            logException(
+                "Async Post Registration Failure for user: %s".formatted(authUser.getEmail()),
+                new Exception(throwable));
           }
         },
         listeningExecutorService);
@@ -204,7 +211,7 @@ public class SamDAO implements ConsentLogger {
     try {
       response = executeRequest(request);
       if (!response.isSuccessStatusCode()) {
-        logException(String.format("Error getting Terms of Service: %s for user %s",
+        logException("Error getting Terms of Service: %s for user %s".formatted(
                 response.getStatusMessage(), authUser.getEmail()),
             new ServerErrorException(response.getStatusMessage(), response.getStatusCode()));
       }
@@ -228,11 +235,13 @@ public class SamDAO implements ConsentLogger {
     try {
       response = executeRequest(request);
       if (!response.isSuccessStatusCode()) {
-        logException(String.format("Error accepting Terms of Service: %s for user %s", response.getStatusMessage(), authUser.getEmail()),
+        logException("Error accepting Terms of Service: %s for user %s".formatted(
+                response.getStatusMessage(), authUser.getEmail()),
             new ServerErrorException(response.getStatusMessage(), response.getStatusCode()));
       }
     } catch (ServerErrorException e) {
-      logException("Sam is down, returning mock ToS Acceptance Status for user: %s".formatted(authUser.getEmail()), e);
+      logException("Sam is down, returning mock ToS Acceptance Status for user: %s".formatted(
+          authUser.getEmail()), e);
       return 204;
     }
     return response.getStatusCode();
@@ -246,11 +255,13 @@ public class SamDAO implements ConsentLogger {
       response = executeRequest(request);
       if (!response.isSuccessStatusCode()) {
         logException(
-            String.format("Error removing Terms of Service: %s for user %s", response.getStatusMessage(), authUser.getEmail()),
+            "Error removing Terms of Service: %s for user %s".formatted(response.getStatusMessage(),
+                authUser.getEmail()),
             new ServerErrorException(response.getStatusMessage(), response.getStatusCode()));
       }
     } catch (ServerErrorException e) {
-      logException("Sam is down, returning mock ToS Rejection Status for user: %s".formatted(authUser.getEmail()), e);
+      logException("Sam is down, returning mock ToS Rejection Status for user: %s".formatted(
+          authUser.getEmail()), e);
       return 204;
     }
     return response.getStatusCode();
@@ -268,7 +279,9 @@ public class SamDAO implements ConsentLogger {
             new ServerErrorException(response.getStatusMessage(), response.getStatusCode()));
       }
     } catch (ServerErrorException e) {
-      logException("Sam is down, returning mock EmailResponse for user: %s".formatted(authUser.getEmail()), e);
+      logException(
+          "Sam is down, returning mock EmailResponse for user: %s".formatted(authUser.getEmail()),
+          e);
       return new EmailResponse(
           "Mock google subject id",
           authUser.getEmail(),
@@ -280,9 +293,9 @@ public class SamDAO implements ConsentLogger {
   }
 
   /**
-   * Private method to handle the general case of sending requests to Sam.
-   * We inject timeouts here to prevent Sam from impacting API performance.
-   * The default is 10 seconds which should be more than enough for Sam calls.
+   * Private method to handle the general case of sending requests to Sam. We inject timeouts here
+   * to prevent Sam from impacting API performance. The default is 10 seconds which should be more
+   * than enough for Sam calls.
    *
    * @param request The HttpRequest
    * @return The HttpResponse

--- a/src/main/java/org/broadinstitute/consent/http/db/SamDefaults.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/SamDefaults.java
@@ -15,18 +15,18 @@ import org.broadinstitute.consent.http.models.sam.UserStatusInfo;
 /**
  * This class represents default/mock objects from Sam that can be used when Sam is unavailable
  */
-public interface SamDefaults {
+public class SamDefaults {
 
-  default UserStatusInfo getDefaultUserStatusInfo(AuthUser authUser) {
+  public UserStatusInfo getDefaultUserStatusInfo(AuthUser authUser) {
     UserStatusInfo userStatusInfo = new UserStatusInfo();
     userStatusInfo.setAdminEnabled(false);
     userStatusInfo.setEnabled(true);
     userStatusInfo.setUserEmail(authUser.getEmail());
-    userStatusInfo.setUserSubjectId("Default subject id for user %s".formatted(authUser.getEmail()));
+    userStatusInfo.setUserSubjectId(authUser.getEmail());
     return userStatusInfo;
   }
 
-  default UserStatusDiagnostics getDefaultUserStatusDiagnostics() {
+  public UserStatusDiagnostics getDefaultUserStatusDiagnostics() {
     UserStatusDiagnostics userStatusDiagnostics = new UserStatusDiagnostics();
     userStatusDiagnostics.setAdminEnabled(false);
     userStatusDiagnostics.setEnabled(true);
@@ -36,7 +36,7 @@ public interface SamDefaults {
     return userStatusDiagnostics;
   }
 
-  default UserStatus getDefaultUserStatus(AuthUser authUser) {
+  public UserStatus getDefaultUserStatus(AuthUser authUser) {
     UserStatus userStatus = new UserStatus();
     UserStatus.Enabled enabled = new UserStatus.Enabled();
     enabled.setLdap(true);
@@ -44,13 +44,13 @@ public interface SamDefaults {
     enabled.setGoogle(true);
     UserStatus.UserInfo userInfo = new UserStatus.UserInfo();
     userInfo.setUserEmail(authUser.getEmail());
-    userInfo.setUserSubjectId("Default user subject id");
+    userInfo.setUserSubjectId(authUser.getEmail());
     userStatus.setEnabled(enabled);
     userStatus.setUserInfo(userInfo);
     return userStatus;
   }
 
-  default String getDefaultToSText() throws Exception {
+  public String getDefaultToSText() throws Exception {
     try (InputStream is = this.getClass().getResourceAsStream("/tos.txt")) {
       if (is != null) {
         return IOUtils.toString(is, Charset.defaultCharset());
@@ -59,7 +59,7 @@ public interface SamDefaults {
     }
   }
 
-  default TosResponse getDefaultTosResponse() {
+  public TosResponse getDefaultTosResponse() {
     return new TosResponse(
         new Date().toString(),
         true,
@@ -67,15 +67,15 @@ public interface SamDefaults {
         true);
   }
 
-  default int getDefaultTosStatusCode() {
+  public int getDefaultTosStatusCode() {
     return HttpStatusCodes.STATUS_CODE_NO_CONTENT;
   }
 
-  default EmailResponse getDefaultEmailResponse(AuthUser authUser) {
+  public EmailResponse getDefaultEmailResponse(AuthUser authUser) {
     return new EmailResponse(
-        "Default google subject id",
         authUser.getEmail(),
-        "Default user subject id");
+        authUser.getEmail(),
+        authUser.getEmail());
   }
 
 }

--- a/src/main/java/org/broadinstitute/consent/http/db/SamDefaults.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/SamDefaults.java
@@ -13,7 +13,7 @@ import org.broadinstitute.consent.http.models.sam.UserStatusDiagnostics;
 import org.broadinstitute.consent.http.models.sam.UserStatusInfo;
 
 /**
- * This class represents default/mock objects from Sam that can be used when Sam is unavailable
+ * This class represents default Sam objects that can be used when Sam is unavailable
  */
 public class SamDefaults {
 

--- a/src/main/java/org/broadinstitute/consent/http/db/SamDefaults.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/SamDefaults.java
@@ -1,0 +1,81 @@
+package org.broadinstitute.consent.http.db;
+
+import com.google.api.client.http.HttpStatusCodes;
+import java.io.InputStream;
+import java.nio.charset.Charset;
+import java.util.Date;
+import org.apache.commons.io.IOUtils;
+import org.broadinstitute.consent.http.models.AuthUser;
+import org.broadinstitute.consent.http.models.sam.EmailResponse;
+import org.broadinstitute.consent.http.models.sam.TosResponse;
+import org.broadinstitute.consent.http.models.sam.UserStatus;
+import org.broadinstitute.consent.http.models.sam.UserStatusDiagnostics;
+import org.broadinstitute.consent.http.models.sam.UserStatusInfo;
+
+/**
+ * This class represents default/mock objects from Sam that can be used when Sam is unavailable
+ */
+public interface SamDefaults {
+
+  default UserStatusInfo getDefaultUserStatusInfo(AuthUser authUser) {
+    UserStatusInfo userStatusInfo = new UserStatusInfo();
+    userStatusInfo.setAdminEnabled(false);
+    userStatusInfo.setEnabled(true);
+    userStatusInfo.setUserEmail(authUser.getEmail());
+    userStatusInfo.setUserSubjectId("Default subject id for user %s".formatted(authUser.getEmail()));
+    return userStatusInfo;
+  }
+
+  default UserStatusDiagnostics getDefaultUserStatusDiagnostics() {
+    UserStatusDiagnostics userStatusDiagnostics = new UserStatusDiagnostics();
+    userStatusDiagnostics.setAdminEnabled(false);
+    userStatusDiagnostics.setEnabled(true);
+    userStatusDiagnostics.setTosAccepted(true);
+    userStatusDiagnostics.setInAllUsersGroup(true);
+    userStatusDiagnostics.setInGoogleProxyGroup(true);
+    return userStatusDiagnostics;
+  }
+
+  default UserStatus getDefaultUserStatus(AuthUser authUser) {
+    UserStatus userStatus = new UserStatus();
+    UserStatus.Enabled enabled = new UserStatus.Enabled();
+    enabled.setLdap(true);
+    enabled.setAllUsersGroup(true);
+    enabled.setGoogle(true);
+    UserStatus.UserInfo userInfo = new UserStatus.UserInfo();
+    userInfo.setUserEmail(authUser.getEmail());
+    userInfo.setUserSubjectId("Default user subject id");
+    userStatus.setEnabled(enabled);
+    userStatus.setUserInfo(userInfo);
+    return userStatus;
+  }
+
+  default String getDefaultToSText() throws Exception {
+    try (InputStream is = this.getClass().getResourceAsStream("/tos.txt")) {
+      if (is != null) {
+        return IOUtils.toString(is, Charset.defaultCharset());
+      }
+      return "Terms of Service";
+    }
+  }
+
+  default TosResponse getDefaultTosResponse() {
+    return new TosResponse(
+        new Date().toString(),
+        true,
+        "2023-11-15",
+        true);
+  }
+
+  default int getDefaultTosStatusCode() {
+    return HttpStatusCodes.STATUS_CODE_NO_CONTENT;
+  }
+
+  default EmailResponse getDefaultEmailResponse(AuthUser authUser) {
+    return new EmailResponse(
+        "Default google subject id",
+        authUser.getEmail(),
+        "Default user subject id");
+  }
+
+}

--- a/src/main/resources/tos.txt
+++ b/src/main/resources/tos.txt
@@ -1,0 +1,192 @@
+# Terra Platform Terms of Service
+
+Last Modified: November 15, 2023
+
+Effective Date: November 15, 2023
+
+Certain terms (including capitalized terms) are defined in Section 13 (Definitions).
+
+## 1. Introduction
+Thanks for using Terra! Terra is a platform developed by Verily, Microsoft and The Broad Institute that enables Users to curate and publish datasets, discover and access data, find and leverage tools, and collaborate with others. These Terms of Service (the “**Terms**”) apply to your use of Terra, as described in Section 2 and as operated by The Broad Institute.
+
+The mission of Terra is to enable the next generation of collaborative biomedical research by building an open platform that connects researchers to each other and to the datasets and tools they need to achieve scientific breakthroughs. The success of that mission depends on User contributions of Content, and so we encourage you to support this vibrant environment by making Content available for use and analysis by other Users.
+
+Your use of Terra requires that you agree to these Terms, which through reference incorporates our Acceptable Use Policy, Customer Security Requirements, and Terra Platform Privacy Policy. Please read these materials carefully. If you are accessing Terra on behalf of a company or entity, you represent that you have the legal authority to enter into these Terms on that entity’s behalf and agree that we may also contact such entity if you violate these Terms or the Acceptable Use Policy or Customer Security Requirements. If you do not understand these Terms, or do not accept any part of them, then do not use Terra.
+
+If you suspect or have confirmed you have identified a vulnerability in Terra, please report said vulnerability to us immediately at [infosec@broadinstitute.org](mailto:infosec@broadinstitute.org).
+
+## 2. Your Use of Terra
+Individual Use. Any individual may become a Terra User. Users may use Terra, either in an individual capacity or on behalf of a company or other entity, for data analysis, sharing reproducible research, developing scientific software tools, making data and scientific software tools available to the scientific community, teaching and educational activities, and/or sponsored research. Individual use of Terra is governed by the Terms.
+
+Enterprise Licensed Use. If your employer has reached an Enterprise License Agreement with The Broad Institute governing your Use of Terra, these Terms will apply in areas where they are additional to that agreement but will not amend or supervene the governing Enterprise License Agreement. We encourage Enterprise Licensed Users to contact us at [Terra-Enterprise@broadinstitute.org](mailto:Terra-Enterprise@broadinstitute.org) if any of the following service commitments are required by your organization, as they will require an Enterprise License Agreement with the Broad Institute, and may be subject to a license fee:
+- Data protections such as a HIPAA Business Associate Agreement, GDPR/UK GDPR Data Protection Addendum, or support for Breach notification
+- Guarantees around Service Levels (uptimes / response times)
+- Integration of Terra with your organization’s permissioning systems
+- Enterprise Licensed User-wide views of usage patterns within Terra
+- Specific data implementation support or other complex data management services beyond what Terra supports for Individual use. This includes large scale data curation efforts, complex metadata management, support for complex version control and redistribution of data, custom search / discovery software, and/or data access request support.
+
+Your Conduct. Don’t misuse Terra. You may use Terra only as permitted by Law, including applicable export and re-export control laws and regulations, and in accordance with the Acceptable Use Policy. You are responsible for your conduct and your Content Connected to Terra. By accessing Terra, you acknowledge and agree that we may monitor your conduct, your use of Terra, and your Content to filter spam, viruses, and other malware, ensure interoperability, fix bugs and resolve problems, ensure compliance with these Terms, the Acceptable Use Policy, Customer Security Requirements, and Law, provide you with help desk services and support, and that our understanding of the way Users interact with Terra may be used to improve Terra. This analysis may occur when you Connect Content to Terra or access Content Connected to Terra. We may Remove or refuse to display Content that we reasonably believe is spam, viruses, or other malware, not interoperable, not in compliance with these Terms, the Acceptable Use Policy, Customer Security Requirements, or Law, or is used outside of a restriction on its use. If you request technical support, we may also use eyes on monitoring to provide you with such technical support. When using or accessing Content other than your Content, you agree to comply with all restrictions and controls imposed by the owner of that Content. Within Terra workspaces and repositories, owners have the ability to allow other Users access, or remove and exclude Users entirely. Further, for those granted access to a workspace or repository, the owner can assign roles that limit access and use rights in a range of ways and revoke access previously granted. Note, though, that where you have previously granted access, and allowed others to acquire copies of your Content or related Metadata, your revocation of future access will not pull back or retrieve Content or Metadata in the hands of others through previously granted access. Finally an owner may impose terms or restrictions through separate agreements with Users. You may not access any data through Terra, or make any use of Terra functionality, other than access and use authorized by the owners, and may not try to defeat, disable, or otherwise avoid any technical mechanisms deployed within Terra to maintain or enforce any limitations on access or use.
+
+Your Terra Account. In order to use Terra, you will need to register for a Terra account using an account from a Compatible Cloud. You may not access Terra using group or shared accounts. The credentials used for authenticating to Terra must belong to a single individual and only that individual may use those credentials. To protect your Terra account, keep your password confidential. You are responsible for the activity that happens on or through your Terra account. Try not to reuse your Terra account password on third-party applications. If you learn of any unauthorized use of your password or Terra account, contact us immediately.
+
+Accessing a Government Website. To the extent you have selected research data from certain U.S. Government sources, you acknowledge that the following terms apply: (1) Users are accessing a U.S. Government information system; (2) Information system usage may be monitored, recorded and subject to audit; (3) Unauthorized use of the information system is prohibited and subject to criminal and civil penalties; and (4) Use of the information system indicates consent to monitoring and recording.
+
+Terra Security Requirements. To use Terra, you must comply with any and all customer and user security requirements, and use Terra in a manner consistent with any and all security requirements, that we make available at <https://terra.bio/resources/security/> or such other location as we may notify you of, including in the Customer Security Requirements. Users must ensure that your Web browsers use Transport Layer Security (TLS) 1.2 (or higher). SSL and TLS must use a minimum of 256-bit encryption.
+
+Announcements. In connection with your use of Terra, we may send you service announcements, administrative messages, and other information. You may opt out of some of these communications.
+
+Retained Rights. Using Terra does not give you ownership of any intellectual property rights in Terra or the Content you access. You may not use Content Connected to Terra unless you obtain permission from its owner or are otherwise permitted by Law. These Terms do not grant you the right to use any branding or logos used in Terra. Don’t remove, obscure, or alter any marks, designations, or legal notices displayed in or along with Terra.
+
+Age Restrictions. In order to use Terra you must be 18 years of age or older, unless you are accessing Terra in connection with your activities using your account authorized by a Non-Profit Entity, in which case you must be 16 years of age or older.
+
+No Medical Advice. Terra does not provide medical advice. All Content Connected to Terra is for informational purposes only and is not a substitute for professional medical advice or treatment. Always seek the advice of your physician or other qualified health provider with any questions you may have regarding your health. Never disregard professional medical advice or delay in seeking it because of something you have read on Terra. If you think you may have a medical emergency, call your doctor or 911 immediately. We do not recommend or endorse any specific tests, physicians, products, procedures, opinions, or other information that may be mentioned on Terra. Reliance on any information provided by us, available on Terra, or by other Users is solely at your own risk.
+
+## 3. Content
+Your Content. Terra enables you to Connect and access Content. You are never required to Connect Content to Terra. You retain ownership of any intellectual property rights that you hold in that Content. You control who can access your Content Connected to Terra. Your Content will never be shared through Terra with any other User in violation of the access restrictions and assigned roles you establish for your Content.
+
+Permitted Uses. When you Connect Content to Terra, you give us a non-exclusive, royalty-free, worldwide license to use that Content for the limited purposes of (a) providing Terra and the Content Connected to Terra to you, (b) providing support to you in connection with your use of and access to Terra, (c) making your Content available to other Users authorized by you via Terra’s functionality for such purpose and supporting such access and use, each in accordance with the restrictions and roles established by you, (d) using Metadata to maintain, test and improve Terra, and (e) to comply with any Law. The license to your Metadata (but not your Content itself) continues even if you stop using Terra or Remove your Content. Your revocation of access previously granted to one or more Users will cut off future access of those Users to your Content through the accounts you control. If, though, you have previously permitted other Users to copy Content to their own accounts, your revocation of access will not pull back the copied Content. Those Users may have ongoing access to the copies you have previously permitted, and this use will be permitted under this license. We will never let any third party (other than a third party we engage to exercise our rights under these Terms, including operating Terra) access your Content without your permission, and will never access or use your Content (including letting our employees and other representatives access your Content) for any purpose not allowed by these Terms without a separate agreement between you and us. You agree that we may engage third parties to exercise our rights under these Terms, including operating Terra.
+
+Terra provides certain functionality that will allow You to restrict access to workspaces and repositories, and, within a workspace or repository, assign Users roles that may have limited access to data or certain functionalities. You are solely responsible for the configuration, setting and use of these functionalities. Terra will not manage, review or otherwise correct any errors You may make in how these functionalities are configured, set or used. If you Connect Content to Terra, each such submission constitutes a representation and warranty to The Broad Institute that you have the rights to Connect your Content, grant any license described in these Terms of Service, share your Content with any Users, and allow Users to access or use your Content in accordance with any applicable regulation, any contractual or other legal duties you may have, and any such use as permitted by these Terms of Service will not infringe or misappropriate the intellectual property or moral rights that any person or third parties may have in your Content. Finally, You are responsible for keeping backups of your Content. We take no responsibility for your Content and do not and will not provide any back-up, archive, or restoration functionality.
+
+We have no obligation to review Content Connected to Terra, so please don’t assume that we do. We understand the importance of the confidentiality of your Content, including where applicable that your Content may be protected by law, such as by a Certificate of Confidentiality. If no exception at Law (for example, a Certificate of Confidentiality) applies, and we determine we are required by Law to do so, we may make any Content Connected to Terra available to a court, regulatory agency, or other government entity, including in connection with subpoenas, investigations, inquiries, examinations, or audits. Where the Law permits, we will use reasonable efforts to notify you before making any Content available to a court, agency or other government entity.
+
+Feedback. We welcome you to provide ideas, suggestions, and other feedback about Terra! There is no requirement that you provide us any feedback. If you do provide any ideas, suggestions, or other feedback about Terra, you grant us a perpetual, irrevocable, royalty-free, sublicensable, transferable, non-exclusive, worldwide right and license to use that feedback for any lawful purposes.
+
+Terra Community Forum. You may use your Terra account to access the Terra Community Forum. By accessing the Terra Community Forum you agree that the Terra Community Guidelines will cover your use of the Terra Community Forum
+
+External Links, Third Party Products and Services. Your use of Terra is possible using repositories and computing resources of third party services, including as may be offered by The Broad institute, Microsoft Verily or their respective affiliates. In addition, Terra may provide links that are maintained or controlled by external organizations. The listing of links are not an endorsement of information, products, or services, and do not imply a direct association between Terra and the operators of the outside resource links. Products and services that provide additional services or functions for use with Terra are made available under a separate agreement. Your use of such additional products and services is subject to those separate agreements.
+
+If you access Terra using your Azure account, you must enter into a separate agreement for Azure. Microsoft makes Azure available directly and through Microsoft Cloud Solution Providers. Your use of Azure is always subject to the Microsoft Universal License Terms for Online Services. Your agreements with Microsoft, and not these Terms, will apply to your use of Azure. Microsoft and Azure are registered trademarks of Microsoft Corporation. All rights reserved.
+
+If you access Terra using your Google Cloud Platform account, the terms of your separate agreement for Google Cloud Platform will apply to your use of Google Cloud Platform. Your agreements with Google or an authorized reseller of Google Cloud Platform services, and not these Terms, will apply to your use of GCP. Verily is a registered trademark of Verily Life Sciences LLC. All rights reserved.
+
+Additional Features relevant to Enterprise Licensed User Content.  Customers using Terra under Enterprise License Agreements may have additional features, user experiences, and data use restrictions in place around their Content Connected to Terra.  If you are an individual User, then as a condition of access to  features and/or Content Connected by Enterprise Licensed Users in Terra, you hereby agree to abide by the additional policies, responsibilities and terms stipulated by the applicable Enterprise Licensed Users pursuant to any additional data restrictions imposed by the Enterprise Licensed User who has Connected such Content to Terra.
+
+## 4. Privacy Protection
+Our Privacy Policy explains how we treat your personal data and protect your privacy when you use Terra. Any information submitted on Terra is subject to our Privacy Policy, the terms of which are incorporated herein by this reference. Please review our [Privacy Policy](https://app.terra.bio/#privacy) to understand our practices. By using Terra, you have read, understood, and agree to the terms of the Privacy Policy, and you agree that we may retrieve, use, and disclose your personal data in accordance with the Privacy Policy. If you are in the European Economic Area or the UK, this Privacy Policy is provided for informational purposes only.
+
+To the extent you access Terra using an Azure account, Microsoft processes your personal data in Azure as described in the Microsoft Universal License Terms for Online Services, including, as applicable, the Microsoft Privacy Statement.
+
+To the extent you access Terra using a Google Cloud Platform account, the terms of your separate agreement with Google will apply to the processing of your personal data in Google Cloud Platform.
+
+Compliance with Data Protection Laws. You may not use Terra to Connect Content that includes PHI or special category personal data, unless your organization has signed an Enterprise License Agreement with us that includes a Business Associate Agreement (BAA). Otherwise, you will Deidentify data prior to Connecting it to Terra. To the extent not prohibited by Law, you further agree to indemnify and hold harmless us, Microsoft, and Verily from any and all claims, demands, losses, causes of action, damage, lawsuits, judgments, including attorneys' fees and costs, arising out of or relating to your Connecting Content that includes PHI or special category personal data to Terra in violation of these Terms.
+
+To the extent you Connect Content in Terra that is protected under GDPR, UK GDPR or the Data Protection Act 2018, you and we agree that the Data Protection Addendum describes how we are processing any applicable personal data included in your Content. In absence of a DPA, you may not use Terra to Connect Content that includes PHI or special category personal data without Deidentifying such data prior to Connecting it to Terra.  To the extent not prohibited by Law, you further agree to indemnify and hold harmless us, Microsoft, and Verily from any and all claims, demands, losses, causes of action, damage, lawsuits, judgments, including attorneys' fees and costs, arising out of or relating to your Connecting Content that includes PHI or special category personal data to Terra in violation of these Terms.
+
+## 5. Copyright Protection
+We respond to notices of alleged copyright infringement and terminate accounts of repeat infringers according to the process set out in the U.S. Digital Millennium Copyright Act and related regulations, as updated from time to time.
+
+We provide information to help copyright holders manage their intellectual property online. If you think somebody is violating your copyrights and want to notify us, please review the Copyright Policies & Procedures.
+
+## 6. Software and Tools
+Terra has been developed and is available under an open source license and is intended to be interoperable with Compatible Clouds. In addition to the foundational open code, we may make various software and tools available through Terra. We may add, change, or remove such software and tools at any time in our sole discretion. Subject to any other applicable terms and conditions, we give you a personal, worldwide, royalty-free, non-assignable and non-exclusive license to use these tools. Third parties may also provide software and tools for use with Terra, and your use of such third party tools is subject to the terms on which they are made available.
+
+Some third party incorporated software used in Terra may be offered under open source licenses. We will make the terms of those licenses available to you. There may be provisions in the open source license that expressly override some of these Terms only with regard to the specific software associated with such provisions. To the extent not permitted under the applicable open source license, you may not copy, modify, distribute, sell, or lease any part of Terra or included tools, nor may you reverse engineer or attempt to extract the source code of those tools, unless Laws prohibit those restrictions or you have our written permission.
+
+## 7. Modifying and Terminating Use of Terra
+Changes to Terra. While we have no obligation to maintain or update Terra, we are constantly changing and improving Terra. We may make performance or security improvements, change functionalities or features, or make changes to comply with Law or to prevent illegal activities on, or abuse of, our systems. Your continued use of Terra constitutes acceptance of any updates to these Terms. There may be times when we will need to make changes to Terra without giving notice. These will be limited to instances where we need to take action to ensure the security and operability of the service, prevent abuse or where we must act to meet legal requirements.
+
+Suspension and Termination. You can stop using Terra at any time, although we’ll be sad to see you go. You may Remove your Content at any time. We may suspend or permanently disable your access to Terra without notice for any reason in our sole discretion, including if: (1) you materially or repeatedly violate these Terms or the Acceptable Use Policy or Customer Security Requirements; or (2) you are using Terra in a manner that could cause us legal liability.
+
+If we suspend or disable your access to Terra, we have no obligation to return your Content to you, and may Remove your Content in our sole discretion.
+
+Discontinuation of Terra. If we decide to discontinue Terra we will give you reasonable notice based on the circumstances, but may not be able to provide advance notice if we are required or advised to immediately discontinue Terra. During any advance notice period (if any), you will have the opportunity to Remove your Content from Terra. After the end of this advance notice (if any) period you will not be able to access your Content through Terra.
+
+## 8. Our Warranties and Disclaimers
+We operate Terra using a reasonable level of skill and care and we hope that you will enjoy using Terra. But there are certain things that we don’t promise about Terra, including that Terra will change in any way or not change in any way. Other than as expressly stated, we do not make any commitments about the specific form, features, or functionality available through Terra, its reliability, availability, or ability to meet your needs. We may change the form, features, or functionality of Terra at any time in our sole discretion.
+
+## 9. Liability for Terra; Disclaimers and Limitations
+You expressly understand and agree that your use of Terra, or any Content Connected to Terra, is at your own risk. We do not warrant that your access to Terra will be uninterrupted, problem-free, free of omissions, or error-free; nor make any warranty as to the results that may be obtained from Terra. We do not warrant that Terra or any Content Connected to Terra is safe to use or free from viruses or other malware. When you access Terra, your systems may be exposed to cybersecurity threats, including viruses and other malware. TO THE MAXIMUM EXTENT PERMITTED BY LAW, YOU ACKNOWLEDGE THAT ALL PRODUCTS AND SERVICES OFFERED THROUGH TERRA ARE MADE AVAILABLE “AS IS” AND WE MAKE NO REPRESENTATIONS OF ANY KIND AS TO THE OPERATION OR USE OF TERRA. IN ADDITION WE SPECIFICALLY DISCLAIM ANY REPRESENTATION OR WARRANTY THAT SUCH PRODUCTS OR SERVICES WILL BE OR OPERATE IN A FASHION THAT IS ERROR FREE, BE AVAILABLE OR ‘UP’ AT ANY TIME, OR WILL OPERATE IN A FASHION THAT IS FIT FOR ANY SPECIFIC RESEARCH OR COMMERCIAL APPLICATION.
+
+In no event will we be liable for the incidental, indirect, special, punitive, exemplary, or consequential damages, arising out of your use of or inability to use Terra, including loss of revenue or anticipated profits, loss of goodwill, loss of data, computer failure or malfunction, or any and all other damages.
+
+The total liability of us and our suppliers and distributors to you, for any claims arising from or related to your use of Terra, including claims for breach of any express or implied warranties, is limited to the amount (if any) you paid us to use Terra during the twelve-month period immediately preceding the time of the claim. If you did not pay us any amount for the use of Terra during the twelve month period immediately preceding the time of the claim, then the total liability of us and our suppliers and distributors to you for claims arising from or related to your use of Terra is limited to one hundred ($100) dollars.
+
+Nothing in these Terms is intended to exclude or limit our liability, or that of our suppliers and distributors, for death or personal injury, fraud, fraudulent misrepresentation or any liability that cannot be excluded by Law.
+
+Microsoft and Verily, who are development collaborators with the Broad Institute for Terra, and, in the case of Microsoft, a cloud service provider of one of the Compatible Clouds you may use with Terra, do not operate this version of Terra and do not make any warranties (whether express, implied or statutory) regarding Terra or Content Connected to Terra. In no event will Microsoft and/or Verily be responsible for any direct, incidental, indirect, special, punitive, exemplary, or consequential damages, arising out of your use of or inability to use Terra.
+
+## 10. Indemnification
+To the extent permitted by Law, you agree to fully defend, indemnify and hold us, Microsoft, and Verily harmless from any third party claims arising from your use of Terra, including any claim arising from the Connecting or accessing of Content. Neither we, nor Microsoft or Verily, agree to indemnify you.
+
+## 11. Laws Governing these Terms.
+The laws of the Commonwealth of Massachusetts, U.S.A., excluding Massachusetts’s conflict of laws rules, will apply to any disputes arising out of or relating to these Terms or Terra.
+
+We reserve the right to seek temporary or preliminary injunctive relief (or an equivalent type of urgent legal relief) in any jurisdiction. You waive the right to seek any equitable or legal remedies to restrain the operation of Terra. The Terra [website](https://terra.bio/) will provide contact information for our designated agent for notifications under these Terms or delivery of service of process.
+
+In the event of a dispute arising from your use of Terra, you and we agree that we will first contact each other in an attempt to informally resolve the dispute. If the dispute is not resolved, then either you or we may submit the dispute to binding arbitration. You and we will mutually agree on a qualified arbitrator who will conduct the arbitration solely by telephone, online, or based on written submissions without any personal appearances by any parties or witnesses unless mutually agreed. The arbitration shall be commenced and conducted under the Rules of Arbitration of the International Chamber of Commerce.
+
+Any judgment on the award rendered by the arbitrator will be binding on both you and us, final and unappealable and may be entered in any court of competent jurisdiction. The prevailing party will be entitled to recover its fees and costs incurred in connection with the arbitration, including reasonable attorneys’ fees. You acknowledge and accept these dispute resolution measures, and waive all right to litigate any disputes arising from these Terms in court, including waiver of any right to a jury trial or to participate in a class action suit against us.
+
+## 12. About these Terms
+We may modify these Terms, the Acceptable Use Policy, the Customer Security Requirements or any additional terms that apply to Terra or your use of Terra, for any reason, including to reflect changes to Terra or Laws or to enable us to meet our obligations. Any change to these Terms will be effective immediately upon our posting notice unless we state otherwise. You should look at the Terms regularly. We’ll post notice of modifications or additions to the Terms in Terra and will post prior notice of material changes to the Terms to you at <https://app.terra.bio/#terms-of-service> or such other location as we may notify you of.
+
+These Terms control the relationship between us and you. Microsoft, Verily, Google LLC, Alphabet Inc. and other entities that are or may become affiliates of the Broad Institute or the foregoing entities are not parties to these Terms, but are intended third party beneficiaries of these Terms, with a right to enforce these Terms directly against you. Otherwise, these Terms do not create any third party beneficiary rights.
+
+If you do not comply with these Terms, and we don’t take action right away, this doesn’t mean that we are waiving or giving up any rights that we may have (such as taking action in the future). If a particular term is not enforceable, this will not affect any other term.
+
+## 13. Definitions
+“Acceptable Use Policy” means our Acceptable Use Policy, available at <https://terra.bio/about/acceptable-use-policy/> or such other location as we may notify you of.
+
+“CCPA” means the California Consumer Protection Act, as amended, and its related regulations.
+
+“Cloud Identity” means a Microsoft Identity or Google Identity.
+
+“Compatible Cloud” means Microsoft Azure, Google Cloud Platform, or other cloud service providers as we may add to or remove from use with Terra at any time in our sole discretion.
+
+“Connect” means to connect, submit, share, send, create in or otherwise make Content available through Terra.
+
+“Content” means any data, information, material, documents, or other content, including any related Metadata. “your Content” means Content that you Connect to Terra. For clarity, Content will not include other copies of the same information that is not Connected to Terra.
+
+“Copyright Policies & Procedures” means our Copyright Policies & Procedures available at <https://support.terra.bio/hc/en-us/sections/4408251025563> or such other location as we may notify you of.
+
+“Customer Security Requirements” means our Customer Security Requirements available at <https://terra.bio/about/customer-security-requirements/> or such other location as we may notify you of.
+
+“Data Protection Addendum” means our Data Processing Terms available at <https://support.terra.bio/hc/en-us/articles/10860018891291> or such other location as we may notify you of.
+
+“Deidentify” means, with respect to any Content you Connect to Terra, the process of removing individual identifiers to the extent required in order to render the Content deidentified under 45 CFR § 164.514 of HIPAA; anonymized under GDPR Recital 26; or in accordance with other applicable law.
+
+“Enterprise License Agreement” means a separately executed, legally binding written agreement between you or the entity on whose behalf you are accessing and using Terra and Broad Institute, covering (among other things) your use of and access to Terra and your Content.
+
+“Enterprise Licensed User” means a User who has entered into an Enterprise License Agreement.
+
+“GDPR” means General Data Protection Regulation (EU) 2016/679 of the European Parliament and of the Council of 27 April 2016 on the protection of natural persons with regard to the processing of personal data and on the free movement of such data, and repealing Directive 95/46/EC, as may be amended, supplemented or replaced from time to time.
+
+“Google Identity” or “Google ID” means any of a gmail account, an organizationally-managed G Suite identity, or a Google Apps identity.
+
+“HIPAA” means the Health Insurance Portability and Accountability Act of 1996, as amended, and its related regulations.
+
+“including” means “including, without limitation and without limiting the foregoing.”
+
+“Law” means all laws, regulations, court orders, frameworks, guidelines and standards applicable to your use of Terra (including all Content Connected to Terra), including HIPAA, CCPA, the U.S. Computer Fraud and Abuse Act, GDPR, UK GDPR, Data Protection Act 2018, U.S. Digital Millennium Copyright Act, the National Institute of Standards and Technology Cybersecurity Framework, and any similar laws in any other jurisdictions, any applicable ethical standards, and any applicable informed consent documents. Something is “illegal” if it violates any Law.
+
+“Metadata” means information about a file or data object including the file size, number of rows, number of columns, column labels, and other descriptors that describe the format of the file or data object or about the behavior of a file or data object in a specific computer environment, such as the file’s level of compression or the latency to access, but does not include or mean the content of the file, including but not limited to any genotypic or phenotypic information contained in the Content.
+
+“Microsoft” means Microsoft Corporation, located at One Microsoft Way, Redmond, Washington 98052.
+
+“Microsoft Identity” means a Microsoft account or an Azure Active Directory account for Microsoft Azure users.
+
+“PHI” means protected health information, as defined in HIPAA.
+
+“Privacy Policy” means our Privacy Policy, available at <https://app.terra.bio/#privacy> or such other location as we may notify you of.
+
+“Remove” means to cause Content to not be Connected to Terra.
+
+“special category personal data” means, as defined in the GDPR, personal data revealing racial or ethnic origin, political opinions, religious or philosophical beliefs, or trade union membership, genetic data, biometric data for the purpose of uniquely identifying a natural person, data concerning health or data concerning a natural person’s sex life or sexual orientation.
+
+“Terms” means these legally binding Terms of Service, as may be amended by us from time to time.
+
+“Terra” means the Terra platform and all associated websites (including [terra.bio](https://terra.bio)).
+
+“The Broad Institute” means The Broad Institute, Inc., located at 415 Main St, Cambridge, MA 02142.
+
+“UK GDPR” means the GDPR as it forms part of the law of England and Wales, Scotland and Northern Ireland by virtue of section 3 of the European Union (Withdrawal) Act 2018 and as amended by the Data Protection, Privacy and Electronic Communications (Amendments etc.) (EU Exit) Regulations 2019 (SI 2019/419), as may be amended, supplemented or replaced from time to time.
+
+“User” means any person who has authorized access to Terra, under all applicable terms and requirements.
+
+“you” means the person who accesses Terra under these Terms. If you are accessing or using Terra in your individual capacity, all references to “you” reference you as an individual. If you are accessing or using Terra on behalf of a company or other entity all references to “you” reference both you as an individual and that entity.
+
+“Verily” means Verily Life Sciences LLC, located at 269 East Grand Avenue, South San Francisco, CA 94080.
+
+“we”, “us” and similar terms means The Broad Institute.
+

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/SamDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/SamDAOTest.java
@@ -24,6 +24,7 @@ import org.apache.commons.lang3.RandomUtils;
 import org.broadinstitute.consent.http.WithMockServer;
 import org.broadinstitute.consent.http.configurations.ServicesConfiguration;
 import org.broadinstitute.consent.http.db.SamDAO;
+import org.broadinstitute.consent.http.db.SamDefaults;
 import org.broadinstitute.consent.http.exceptions.ConsentConflictException;
 import org.broadinstitute.consent.http.models.AuthUser;
 import org.broadinstitute.consent.http.models.sam.EmailResponse;
@@ -50,6 +51,7 @@ import org.testcontainers.containers.MockServerContainer;
 class SamDAOTest implements WithMockServer {
 
   private SamDAO samDAO;
+  private final SamDefaults samDefaults = new SamDefaults();
 
   private MockServerClient mockServerClient;
 
@@ -348,7 +350,7 @@ class SamDAOTest implements WithMockServer {
           RandomStringUtils.randomAlphabetic(10));
       assertNotNull(response);
       // When Sam is down, we return a default EmailResponse
-      assertThat(samDAO.getDefaultEmailResponse(authUser), samePropertyValuesAs(response));
+      assertThat(samDefaults.getDefaultEmailResponse(authUser), samePropertyValuesAs(response));
     } catch (Exception e) {
       fail(e.getMessage());
     }

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/SamDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/SamDAOTest.java
@@ -121,9 +121,7 @@ class SamDAOTest implements WithMockServer {
         .respond(response()
             .withHeader(Header.header("Content-Type", "application/json"))
             .withStatusCode(HttpStatusCodes.STATUS_CODE_BAD_REQUEST));
-    assertThrows(BadRequestException.class, () -> {
-      samDAO.getRegistrationInfo(authUser);
-    });
+    assertThrows(BadRequestException.class, () -> samDAO.getRegistrationInfo(authUser));
   }
 
   @Test
@@ -132,9 +130,7 @@ class SamDAOTest implements WithMockServer {
         .respond(response()
             .withHeader(Header.header("Content-Type", "application/json"))
             .withStatusCode(HttpStatusCodes.STATUS_CODE_UNAUTHORIZED));
-    assertThrows(NotAuthorizedException.class, () -> {
-      samDAO.getRegistrationInfo(authUser);
-    });
+    assertThrows(NotAuthorizedException.class, () -> samDAO.getRegistrationInfo(authUser));
   }
 
   @Test
@@ -143,9 +139,7 @@ class SamDAOTest implements WithMockServer {
         .respond(response()
             .withHeader(Header.header("Content-Type", "application/json"))
             .withStatusCode(HttpStatusCodes.STATUS_CODE_FORBIDDEN));
-    assertThrows(ForbiddenException.class, () -> {
-      samDAO.getRegistrationInfo(authUser);
-    });
+    assertThrows(ForbiddenException.class, () -> samDAO.getRegistrationInfo(authUser));
   }
 
   @Test
@@ -155,9 +149,7 @@ class SamDAOTest implements WithMockServer {
         .respond(response()
             .withHeader(Header.header("Content-Type", "application/json"))
             .withStatusCode(HttpStatusCodes.STATUS_CODE_NOT_FOUND));
-    assertThrows(NotFoundException.class, () -> {
-      samDAO.getRegistrationInfo(authUser);
-    });
+    assertThrows(NotFoundException.class, () -> samDAO.getRegistrationInfo(authUser));
   }
 
   @Test
@@ -166,9 +158,7 @@ class SamDAOTest implements WithMockServer {
         .respond(response()
             .withHeader(Header.header("Content-Type", "application/json"))
             .withStatusCode(HttpStatusCodes.STATUS_CODE_CONFLICT));
-    assertThrows(ConsentConflictException.class, () -> {
-      samDAO.getRegistrationInfo(authUser);
-    });
+    assertThrows(ConsentConflictException.class, () -> samDAO.getRegistrationInfo(authUser));
   }
 
   @Test
@@ -224,9 +214,7 @@ class SamDAOTest implements WithMockServer {
             .withStatusCode(HttpStatusCodes.STATUS_CODE_CONFLICT)
             .withBody(status.toString()));
 
-    assertThrows(ConsentConflictException.class, () -> {
-      samDAO.postRegistrationInfo(authUser);
-    });
+    assertThrows(ConsentConflictException.class, () -> samDAO.postRegistrationInfo(authUser));
   }
 
   @Test
@@ -242,9 +230,7 @@ class SamDAOTest implements WithMockServer {
             .withStatusCode(HttpStatusCodes.STATUS_CODE_SERVER_ERROR)
             .withBody(status.toString()));
 
-    assertThrows(Exception.class, () -> {
-      samDAO.postRegistrationInfo(authUser);
-    });
+    assertThrows(Exception.class, () -> samDAO.postRegistrationInfo(authUser));
   }
 
   /**
@@ -353,7 +339,8 @@ class SamDAOTest implements WithMockServer {
   void testConnectTimeout() {
     mockServerClient.when(request()).error(HttpError.error().withDropConnection(true));
     try {
-      EmailResponse response = samDAO.getV1UserByEmail(authUser, RandomStringUtils.randomAlphabetic(10));
+      EmailResponse response = samDAO.getV1UserByEmail(authUser,
+          RandomStringUtils.randomAlphabetic(10));
       assertNotNull(response);
       // When Sam is down, we return a mocked EmailResponse
       assertTrue(response.toString().contains("Mock"));
@@ -372,7 +359,8 @@ class SamDAOTest implements WithMockServer {
             .withHeader(Header.header("Content-Type", "application/json"))
             .withStatusCode(HttpStatusCodes.STATUS_CODE_OK));
     try {
-      EmailResponse response = samDAO.getV1UserByEmail(authUser, RandomStringUtils.randomAlphabetic(10));
+      EmailResponse response = samDAO.getV1UserByEmail(authUser,
+          RandomStringUtils.randomAlphabetic(10));
       assertNotNull(response);
       // When Sam is down, we return a mocked EmailResponse
       assertTrue(response.toString().contains("Mock"));

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/SamDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/SamDAOTest.java
@@ -1,10 +1,11 @@
 package org.broadinstitute.consent.http.service.dao;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.samePropertyValuesAs;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
@@ -42,7 +43,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockserver.client.MockServerClient;
 import org.mockserver.model.Delay;
 import org.mockserver.model.Header;
-import org.mockserver.model.HttpError;
 import org.mockserver.model.MediaType;
 import org.testcontainers.containers.MockServerContainer;
 
@@ -335,20 +335,6 @@ class SamDAOTest implements WithMockServer {
   }
 
   @Test
-  void testConnectTimeout() {
-    mockServerClient.when(request()).error(HttpError.error().withDropConnection(true));
-    try {
-      EmailResponse response = samDAO.getV1UserByEmail(authUser,
-          RandomStringUtils.randomAlphabetic(10));
-      assertNotNull(response);
-      // When Sam is down, we return a mocked EmailResponse
-      assertTrue(response.toString().contains("Mock"));
-    } catch (Exception e) {
-      fail(e.getMessage());
-    }
-  }
-
-  @Test
   void testReadTimeout() {
     // Increase the delay to push the response beyond the read timeout value
     int delayMilliseconds = samDAO.readTimeoutMilliseconds + 10;
@@ -361,8 +347,8 @@ class SamDAOTest implements WithMockServer {
       EmailResponse response = samDAO.getV1UserByEmail(authUser,
           RandomStringUtils.randomAlphabetic(10));
       assertNotNull(response);
-      // When Sam is down, we return a mocked EmailResponse
-      assertTrue(response.toString().contains("Mock"));
+      // When Sam is down, we return a default EmailResponse
+      assertThat(samDAO.getDefaultEmailResponse(authUser), samePropertyValuesAs(response));
     } catch (Exception e) {
       fail(e.getMessage());
     }

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/SamDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/SamDAOTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
@@ -14,7 +15,6 @@ import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.ForbiddenException;
 import jakarta.ws.rs.NotAuthorizedException;
 import jakarta.ws.rs.NotFoundException;
-import jakarta.ws.rs.ServerErrorException;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -352,9 +352,14 @@ class SamDAOTest implements WithMockServer {
   @Test
   void testConnectTimeout() {
     mockServerClient.when(request()).error(HttpError.error().withDropConnection(true));
-    assertThrows(
-        ServerErrorException.class,
-        () -> samDAO.getV1UserByEmail(authUser, RandomStringUtils.randomAlphabetic(10)));
+    try {
+      EmailResponse response = samDAO.getV1UserByEmail(authUser, RandomStringUtils.randomAlphabetic(10));
+      assertNotNull(response);
+      // When Sam is down, we return a mocked EmailResponse
+      assertTrue(response.toString().contains("Mock"));
+    } catch (Exception e) {
+      fail(e.getMessage());
+    }
   }
 
   @Test
@@ -366,9 +371,14 @@ class SamDAOTest implements WithMockServer {
             .withDelay(new Delay(TimeUnit.MILLISECONDS, delayMilliseconds))
             .withHeader(Header.header("Content-Type", "application/json"))
             .withStatusCode(HttpStatusCodes.STATUS_CODE_OK));
-    assertThrows(
-        ServerErrorException.class,
-        () -> samDAO.getV1UserByEmail(authUser, RandomStringUtils.randomAlphabetic(10)));
+    try {
+      EmailResponse response = samDAO.getV1UserByEmail(authUser, RandomStringUtils.randomAlphabetic(10));
+      assertNotNull(response);
+      // When Sam is down, we return a mocked EmailResponse
+      assertTrue(response.toString().contains("Mock"));
+    } catch (Exception e) {
+      fail(e.getMessage());
+    }
   }
 
 }

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/SamDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/SamDAOTest.java
@@ -144,7 +144,6 @@ class SamDAOTest implements WithMockServer {
 
   @Test
   void testNotFound() {
-    setDebugLogging();
     mockServerClient.when(request())
         .respond(response()
             .withHeader(Header.header("Content-Type", "application/json"))

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/SamDownDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/SamDownDAOTest.java
@@ -1,0 +1,134 @@
+package org.broadinstitute.consent.http.service.dao;
+
+import static org.broadinstitute.consent.http.WithMockServer.IMAGE;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.samePropertyValuesAs;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockserver.model.HttpError.error;
+import static org.mockserver.model.HttpRequest.request;
+
+import com.google.api.client.http.HttpStatusCodes;
+import java.util.List;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.broadinstitute.consent.http.configurations.ServicesConfiguration;
+import org.broadinstitute.consent.http.db.SamDAO;
+import org.broadinstitute.consent.http.models.AuthUser;
+import org.broadinstitute.consent.http.models.sam.EmailResponse;
+import org.broadinstitute.consent.http.models.sam.ResourceType;
+import org.broadinstitute.consent.http.models.sam.TosResponse;
+import org.broadinstitute.consent.http.models.sam.UserStatus;
+import org.broadinstitute.consent.http.models.sam.UserStatusDiagnostics;
+import org.broadinstitute.consent.http.models.sam.UserStatusInfo;
+import org.broadinstitute.consent.http.util.HttpClientUtil;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockserver.client.MockServerClient;
+import org.testcontainers.containers.MockServerContainer;
+
+@ExtendWith(MockitoExtension.class)
+public class SamDownDAOTest {
+
+  private SamDAO samDAO;
+
+  private final AuthUser authUser = new AuthUser()
+      .setEmail(RandomStringUtils.randomAlphabetic(10));
+
+  private static final MockServerContainer container = new MockServerContainer(IMAGE);
+
+  @BeforeAll
+  public static void setUp() {
+    container.start();
+  }
+
+  @AfterAll
+  public static void tearDown() {
+    container.stop();
+  }
+
+  @BeforeEach
+  public void init() {
+    @SuppressWarnings("resource")
+    MockServerClient mockServerClient = new MockServerClient(container.getHost(),
+        container.getServerPort());
+    mockServerClient.reset();
+    ServicesConfiguration config = new ServicesConfiguration();
+    config.setTimeoutSeconds(1);
+    config.setSamUrl("http://" + container.getHost() + ":" + container.getServerPort() + "/");
+    samDAO = new SamDAO(new HttpClientUtil(config), config);
+    mockServerClient
+        .when(request())
+        .error(error().withDropConnection(true));
+  }
+
+  @Test
+  void testGetResourceTypes() throws Exception {
+    List<ResourceType> types = samDAO.getResourceTypes(authUser);
+    assertTrue(types.isEmpty());
+  }
+
+  @Test
+  void testGetRegistrationInfo() throws Exception {
+    UserStatusInfo info = samDAO.getRegistrationInfo(authUser);
+    UserStatusInfo def = samDAO.getDefaultUserStatusInfo(authUser);
+    assertNotNull(info);
+    assertThat(info, samePropertyValuesAs(def));
+  }
+
+  @Test
+  void testGetSelfDiagnostics() throws Exception {
+    UserStatusDiagnostics userStatus = samDAO.getSelfDiagnostics(authUser);
+    UserStatusDiagnostics def = samDAO.getDefaultUserStatusDiagnostics();
+    assertNotNull(userStatus);
+    assertThat(userStatus, samePropertyValuesAs(def));
+  }
+
+  @Test
+  void testPostRegistrationInfo() throws Exception {
+    UserStatus userStatus = samDAO.postRegistrationInfo(authUser);
+    UserStatus def = samDAO.getDefaultUserStatus(authUser);
+    assertNotNull(userStatus);
+    assertThat(userStatus.getEnabled(), samePropertyValuesAs(def.getEnabled()));
+    assertThat(userStatus.getUserInfo(), samePropertyValuesAs(def.getUserInfo()));
+  }
+
+  @Test
+  void testGetTosResponse() throws Exception {
+    TosResponse tos = samDAO.getTosResponse(authUser);
+    TosResponse def = samDAO.getDefaultTosResponse();
+    assertNotNull(tos);
+    assertThat(tos, samePropertyValuesAs(def));
+  }
+
+  @Test
+  void testGetToSText() throws Exception {
+    String text = samDAO.getToSText();
+    assertEquals(samDAO.getDefaultToSText(), text);
+  }
+
+  @Test
+  void testAcceptTosStatus() throws Exception {
+    int acceptStatus = samDAO.acceptTosStatus(authUser);
+    assertEquals(HttpStatusCodes.STATUS_CODE_NO_CONTENT, acceptStatus);
+  }
+
+  @Test
+  void testRejectTosStatus() throws Exception {
+    int rejectStatus = samDAO.rejectTosStatus(authUser);
+    assertEquals(HttpStatusCodes.STATUS_CODE_NO_CONTENT, rejectStatus);
+  }
+
+  @Test
+  void testGetV1UserByEmail() throws Exception {
+    EmailResponse userByEmail = samDAO.getV1UserByEmail(authUser, authUser.getEmail());
+    EmailResponse def = samDAO.getDefaultEmailResponse(authUser);
+    assertNotNull(userByEmail);
+    assertThat(userByEmail, samePropertyValuesAs(def));
+  }
+
+}

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/SamDownDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/SamDownDAOTest.java
@@ -13,6 +13,7 @@ import java.util.List;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.broadinstitute.consent.http.configurations.ServicesConfiguration;
 import org.broadinstitute.consent.http.db.SamDAO;
+import org.broadinstitute.consent.http.db.SamDefaults;
 import org.broadinstitute.consent.http.models.AuthUser;
 import org.broadinstitute.consent.http.models.sam.EmailResponse;
 import org.broadinstitute.consent.http.models.sam.ResourceType;
@@ -34,6 +35,7 @@ import org.testcontainers.containers.MockServerContainer;
 public class SamDownDAOTest {
 
   private SamDAO samDAO;
+  private final SamDefaults samDefaults = new SamDefaults();
 
   private final AuthUser authUser = new AuthUser()
       .setEmail(RandomStringUtils.randomAlphabetic(10));
@@ -74,7 +76,7 @@ public class SamDownDAOTest {
   @Test
   void testGetRegistrationInfo() throws Exception {
     UserStatusInfo info = samDAO.getRegistrationInfo(authUser);
-    UserStatusInfo def = samDAO.getDefaultUserStatusInfo(authUser);
+    UserStatusInfo def = samDefaults.getDefaultUserStatusInfo(authUser);
     assertNotNull(info);
     assertThat(info, samePropertyValuesAs(def));
   }
@@ -82,7 +84,7 @@ public class SamDownDAOTest {
   @Test
   void testGetSelfDiagnostics() throws Exception {
     UserStatusDiagnostics userStatus = samDAO.getSelfDiagnostics(authUser);
-    UserStatusDiagnostics def = samDAO.getDefaultUserStatusDiagnostics();
+    UserStatusDiagnostics def = samDefaults.getDefaultUserStatusDiagnostics();
     assertNotNull(userStatus);
     assertThat(userStatus, samePropertyValuesAs(def));
   }
@@ -90,7 +92,7 @@ public class SamDownDAOTest {
   @Test
   void testPostRegistrationInfo() throws Exception {
     UserStatus userStatus = samDAO.postRegistrationInfo(authUser);
-    UserStatus def = samDAO.getDefaultUserStatus(authUser);
+    UserStatus def = samDefaults.getDefaultUserStatus(authUser);
     assertNotNull(userStatus);
     assertThat(userStatus.getEnabled(), samePropertyValuesAs(def.getEnabled()));
     assertThat(userStatus.getUserInfo(), samePropertyValuesAs(def.getUserInfo()));
@@ -99,7 +101,7 @@ public class SamDownDAOTest {
   @Test
   void testGetTosResponse() throws Exception {
     TosResponse tos = samDAO.getTosResponse(authUser);
-    TosResponse def = samDAO.getDefaultTosResponse();
+    TosResponse def = samDefaults.getDefaultTosResponse();
     assertNotNull(tos);
     assertThat(tos, samePropertyValuesAs(def));
   }
@@ -107,25 +109,25 @@ public class SamDownDAOTest {
   @Test
   void testGetToSText() throws Exception {
     String text = samDAO.getToSText();
-    assertEquals(samDAO.getDefaultToSText(), text);
+    assertEquals(samDefaults.getDefaultToSText(), text);
   }
 
   @Test
   void testAcceptTosStatus() throws Exception {
     int acceptStatus = samDAO.acceptTosStatus(authUser);
-    assertEquals(samDAO.getDefaultTosStatusCode(), acceptStatus);
+    assertEquals(samDefaults.getDefaultTosStatusCode(), acceptStatus);
   }
 
   @Test
   void testRejectTosStatus() throws Exception {
     int rejectStatus = samDAO.rejectTosStatus(authUser);
-    assertEquals(samDAO.getDefaultTosStatusCode(), rejectStatus);
+    assertEquals(samDefaults.getDefaultTosStatusCode(), rejectStatus);
   }
 
   @Test
   void testGetV1UserByEmail() throws Exception {
     EmailResponse userByEmail = samDAO.getV1UserByEmail(authUser, authUser.getEmail());
-    EmailResponse def = samDAO.getDefaultEmailResponse(authUser);
+    EmailResponse def = samDefaults.getDefaultEmailResponse(authUser);
     assertNotNull(userByEmail);
     assertThat(userByEmail, samePropertyValuesAs(def));
   }

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/SamDownDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/SamDownDAOTest.java
@@ -9,7 +9,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockserver.model.HttpError.error;
 import static org.mockserver.model.HttpRequest.request;
 
-import com.google.api.client.http.HttpStatusCodes;
 import java.util.List;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.broadinstitute.consent.http.configurations.ServicesConfiguration;
@@ -114,13 +113,13 @@ public class SamDownDAOTest {
   @Test
   void testAcceptTosStatus() throws Exception {
     int acceptStatus = samDAO.acceptTosStatus(authUser);
-    assertEquals(HttpStatusCodes.STATUS_CODE_NO_CONTENT, acceptStatus);
+    assertEquals(samDAO.getDefaultTosStatusCode(), acceptStatus);
   }
 
   @Test
   void testRejectTosStatus() throws Exception {
     int rejectStatus = samDAO.rejectTosStatus(authUser);
-    assertEquals(HttpStatusCodes.STATUS_CODE_NO_CONTENT, rejectStatus);
+    assertEquals(samDAO.getDefaultTosStatusCode(), rejectStatus);
   }
 
   @Test


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DCJ-688

## Summary
When Sam fails, downstream systems that rely on Sam data can fail. In the case that we cannot communicate with Sam, we would now return generic default response objects instead of failing outright. This allows us to be less tightly coupled and enables continued DUOS operations when Sam is unavailable. When Sam recovers, we would then be able to respond with real Sam responses.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
