### PR TITLE
DCJ-705: Patch Dataset

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
@@ -591,6 +591,18 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
       """)
   void updateDatasetCreateUserId(@Bind("datasetId") Integer datasetId, @Bind("createUserId") Integer createUserId);
 
+  @SqlUpdate("""
+      UPDATE dataset
+      SET name = :datasetName,
+          update_date = :updateDate,
+          update_user_id = :updateUserId
+      WHERE dataset_id = :datasetId
+      """)
+  void updateDatasetNameWithUpdateUser(@Bind("datasetId") Integer datasetId,
+      @Bind("datasetName") String datasetName,
+      @Bind("updateDate") Timestamp updateDate,
+      @Bind("updateUserId") Integer updateUserId);
+
   @UseRowReducer(DatasetReducer.class)
   @SqlQuery(
       """

--- a/src/main/java/org/broadinstitute/consent/http/models/Dataset.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/Dataset.java
@@ -1,5 +1,7 @@
 package org.broadinstitute.consent.http.models;
 
+import com.google.gson.JsonArray;
+import com.google.gson.JsonPrimitive;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashSet;
@@ -9,9 +11,11 @@ import java.util.Optional;
 import java.util.Set;
 import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.consent.http.models.dataset_registration_v1.ConsentGroup.AccessManagement;
+import org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder;
+import org.broadinstitute.consent.http.util.ConsentLogger;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
-public class Dataset {
+public class Dataset implements ConsentLogger {
 
   private Integer datasetId;
 
@@ -335,7 +339,42 @@ public class Dataset {
     this.study = study;
   }
 
-  @Override
+  /**
+   * Determine if the user is a dataset/study creator
+   *
+   * @param user    User
+   * @return User is a creator of the dataset/study
+   */
+  public boolean isCustodian(User user) {
+    if (getStudy() != null && getStudy().getProperties() != null) {
+      Optional<StudyProperty> dataCustodians = getStudy()
+          .getProperties()
+          .stream()
+          .filter(p -> p.getKey().equals(DatasetRegistrationSchemaV1Builder.dataCustodianEmail))
+          .findFirst();
+      if (dataCustodians.isPresent()) {
+        JsonArray jsonArray = (JsonArray) dataCustodians.get().getValue();
+        return jsonArray.contains(new JsonPrimitive(user.getEmail()));
+      } else {
+        logWarn(
+            "No data custodians found for dataset: %s".formatted(getDatasetIdentifier()));
+      }
+    } else {
+      logWarn(
+          "No study properties found for dataset: %s".formatted(getDatasetIdentifier()));
+    }
+    return false;
+  }
+
+  public boolean isCreator(User user) {
+    if (Objects.equals(user.getUserId(), getCreateUserId())) {
+      return true;
+    }
+    return getStudy() != null && Objects.equals(user.getUserId(),
+        getStudy().getCreateUserId());
+  }
+
+    @Override
   public boolean equals(Object o) {
     if (this == o) {
       return true;

--- a/src/main/java/org/broadinstitute/consent/http/models/DatasetPatch.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DatasetPatch.java
@@ -1,0 +1,33 @@
+package org.broadinstitute.consent.http.models;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * This model represents the values of a dataset that are modifiable via the PATCH operation
+ *
+ * @param name       Dataset name
+ * @param properties List of DatasetProperties
+ */
+public record DatasetPatch(String name, List<DatasetProperty> properties) {
+
+  /**
+   * Determine if this patch object contains different values from the provided Dataset entity
+   * @param dataset Dataset
+   * @return True if any patch values are different, false otherwise.
+   */
+  public boolean isPatchable(Dataset dataset) {
+    if (name() != null && !name().equals(dataset.getName())) {
+      return true;
+    }
+    // Find any cases where the new property value is different from the existing one
+    return properties().stream().anyMatch(p -> {
+      Optional<DatasetProperty> existingProp = dataset.getProperties()
+          .stream()
+          .filter(eProp -> eProp.getPropertyName().equals(p.getPropertyName()))
+          .findFirst();
+      return (existingProp.isPresent() && !existingProp.get().getPropertyValueAsString().equals(p.getPropertyValueAsString()));
+    });
+  }
+
+}

--- a/src/main/java/org/broadinstitute/consent/http/models/DatasetPatch.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DatasetPatch.java
@@ -48,6 +48,7 @@ public record DatasetPatch(String name, List<DatasetProperty> properties) {
     });
   }
 
+  // The following properties are Patch-able:
   public static List<String> validPropertyNames = List.of(
       "# of participants",
       "url",
@@ -55,7 +56,6 @@ public record DatasetPatch(String name, List<DatasetProperty> properties) {
       "data location"
       );
 
-  // The following properties are Patch-able:
   public boolean validateProperties() {
     List<Boolean> validPropValues = properties.stream().map(p -> {
       if (!validPropertyNames.contains(p.getPropertyName().toLowerCase())) {

--- a/src/main/java/org/broadinstitute/consent/http/models/DatasetPatch.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DatasetPatch.java
@@ -24,7 +24,17 @@ public record DatasetPatch(String name, List<DatasetProperty> properties) {
     return properties().stream().anyMatch(p -> {
       Optional<DatasetProperty> existingProp = dataset.getProperties()
           .stream()
-          .filter(eProp -> eProp.getPropertyName().equals(p.getPropertyName()))
+          .filter(eProp -> {
+            // Favor the property name as the primary comparator
+            if (eProp.getPropertyName() != null) {
+              return eProp.getPropertyName().equals(p.getPropertyName());
+            } else if (eProp.getPropertyKey() != null) {
+              return eProp.getPropertyKey().equals(p.getPropertyKey());
+            } else if (eProp.getSchemaProperty() != null) {
+              return eProp.getSchemaProperty().equals(p.getSchemaProperty());
+            }
+            return false;
+          })
           .findFirst();
       return (existingProp.isPresent() && !existingProp.get().getPropertyValueAsString().equals(p.getPropertyValueAsString()));
     });

--- a/src/main/java/org/broadinstitute/consent/http/models/DatasetPatch.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DatasetPatch.java
@@ -1,7 +1,13 @@
 package org.broadinstitute.consent.http.models;
 
+import com.google.gson.Gson;
+import java.net.URI;
 import java.util.List;
 import java.util.Optional;
+import org.broadinstitute.consent.http.models.dataset_registration_v1.ConsentGroup.DataLocation;
+import org.broadinstitute.consent.http.models.dataset_registration_v1.FileTypeObject;
+import org.broadinstitute.consent.http.models.dataset_registration_v1.FileTypeObject.FileType;
+import org.broadinstitute.consent.http.util.gson.GsonUtil;
 
 /**
  * This model represents the values of a dataset that are modifiable via the PATCH operation
@@ -13,6 +19,7 @@ public record DatasetPatch(String name, List<DatasetProperty> properties) {
 
   /**
    * Determine if this patch object contains different values from the provided Dataset entity
+   *
    * @param dataset Dataset
    * @return True if any patch values are different, false otherwise.
    */
@@ -36,8 +43,71 @@ public record DatasetPatch(String name, List<DatasetProperty> properties) {
             return false;
           })
           .findFirst();
-      return (existingProp.isPresent() && !existingProp.get().getPropertyValueAsString().equals(p.getPropertyValueAsString()));
+      return (existingProp.isPresent() && !existingProp.get().getPropertyValueAsString()
+          .equals(p.getPropertyValueAsString()));
     });
+  }
+
+  public static List<String> validPropertyNames = List.of(
+      "# of participants",
+      "url",
+      "file types",
+      "data location"
+      );
+
+  // The following properties are Patch-able:
+  public boolean validateProperties() {
+    List<Boolean> validPropValues = properties.stream().map(p -> {
+      if (!validPropertyNames.contains(p.getPropertyName().toLowerCase())) {
+        return false;
+      }
+      return switch (p.getPropertyName().toLowerCase()) {
+        case "# of participants" -> isNumeric(p.getPropertyTypeAsString());
+        case "url" -> isUrl(p.getPropertyTypeAsString());
+        case "file types" -> isFileTypes(p.getPropertyValueAsString());
+        case "data location" -> isDataLocation(p.getPropertyValueAsString());
+        default -> false;
+      };
+    }).distinct().toList();
+    return validPropValues.stream().allMatch(p -> p);
+  }
+
+  private boolean isNumeric(String str) {
+    try {
+      Integer.valueOf(str);
+      return true;
+    } catch (Exception e) {
+      return false;
+    }
+  }
+
+  private boolean isUrl(String str) {
+    try {
+      URI.create(str);
+      return true;
+    } catch (Exception e) {
+      return false;
+    }
+  }
+
+  private boolean isFileTypes(String str) {
+    try {
+      Gson gson = GsonUtil.buildGson();
+      gson.fromJson(str, FileTypeObject.class);
+      return true;
+    } catch (Exception e) {
+      return false;
+    }
+  }
+
+  private boolean isDataLocation(String str) {
+    try {
+      Gson gson = GsonUtil.buildGson();
+      gson.fromJson(str, DataLocation.class);
+      return true;
+    } catch (Exception e) {
+      return false;
+    }
   }
 
 }

--- a/src/main/java/org/broadinstitute/consent/http/models/DatasetPatch.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DatasetPatch.java
@@ -35,17 +35,21 @@ public record DatasetPatch(String name, List<DatasetProperty> properties) {
           .filter(eProp -> {
             // Favor the property name as the primary comparator
             if (eProp.getPropertyName() != null) {
-              return eProp.getPropertyName().equals(p.getPropertyName());
+              return eProp.getPropertyName().equalsIgnoreCase(p.getPropertyName());
             } else if (eProp.getPropertyKey() != null) {
               return eProp.getPropertyKey().equals(p.getPropertyKey());
             } else if (eProp.getSchemaProperty() != null) {
-              return eProp.getSchemaProperty().equals(p.getSchemaProperty());
+              return eProp.getSchemaProperty().equalsIgnoreCase(p.getSchemaProperty());
             }
             return false;
           })
           .findFirst();
-      return (existingProp.isPresent() && !existingProp.get().getPropertyValueAsString()
-          .equals(p.getPropertyValueAsString()));
+      return existingProp.map(
+          eProp ->
+              // If the existing prop value is different from the new one, this is patchable
+              (!eProp.getPropertyValueAsString().equals(p.getPropertyValueAsString())))
+              // If no existing prop, we're adding a new prop, and therefore patchable.
+              .orElse(true);
     });
   }
 

--- a/src/main/java/org/broadinstitute/consent/http/models/DatasetPatch.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DatasetPatch.java
@@ -57,15 +57,17 @@ public record DatasetPatch(String name, List<DatasetProperty> properties) {
         "file types", this::isFileTypes,
         "data location", this::isDataLocation
     );
-    List<Boolean> validPropValues = properties.stream().map(p -> {
-      if (!validators.containsKey(p.getPropertyName().toLowerCase())) {
-        return false;
-      }
-      return validators
-          .get(p.getPropertyName().toLowerCase())
-          .apply(p.getPropertyValueAsString());
-    }).distinct().toList();
-    return validPropValues.stream().allMatch(p -> p);
+    return properties.stream()
+        .map(p -> {
+          if (!validators.containsKey(p.getPropertyName().toLowerCase())) {
+            return false;
+          }
+          return validators
+              .get(p.getPropertyName().toLowerCase())
+              .apply(p.getPropertyValueAsString());
+        })
+        .distinct()
+        .allMatch(valid -> valid);
   }
 
   private boolean isNumeric(String str) {

--- a/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
@@ -250,8 +250,8 @@ public class DatasetResource extends Resource {
                 HttpStatusCodes.STATUS_CODE_BAD_REQUEST))
             .build();
       }
-      Dataset patched = datasetRegistrationService.patchDataset(datasetId, user, patch);
-      return Response.noContent().entity(patched).build();
+      datasetRegistrationService.patchDataset(datasetId, user, patch);
+      return Response.noContent().build();
     } catch (Exception e) {
       return createExceptionResponse(e);
     }

--- a/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
@@ -233,12 +233,20 @@ public class DatasetResource extends Resource {
       if (!patch.isPatchable(existingDataset)) {
         return Response.notModified().entity(existingDataset).build();
       }
-      // Is new name unique?
+      // Validate DatasetPatch values
       List<String> existingNames = datasetService.findAllDatasetNames();
-      if (patch.name() != null && !patch.name().equals(existingDataset.getName()) && existingNames.contains(patch.name())) {
+      if (patch.name() != null && !patch.name().equals(existingDataset.getName())
+          && existingNames.contains(patch.name())) {
         return Response.status(HttpStatusCodes.STATUS_CODE_BAD_REQUEST)
             .entity(new Error(
                 "The new name for this dataset already exists: " + patch.name(),
+                HttpStatusCodes.STATUS_CODE_BAD_REQUEST))
+            .build();
+      }
+      if (!patch.validateProperties()) {
+        return Response.status(HttpStatusCodes.STATUS_CODE_BAD_REQUEST)
+            .entity(new Error(
+                "Properties are invalid",
                 HttpStatusCodes.STATUS_CODE_BAD_REQUEST))
             .build();
       }

--- a/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
@@ -212,7 +212,7 @@ public class DatasetResource extends Resource {
       if (json == null || json.isEmpty()) {
         throw new BadRequestException("Dataset Patch is required");
       }
-      Gson gson = GsonUtil.buildGson();
+      Gson gson = GsonUtil.getInstance();
       DatasetPatch patch;
       try {
         patch = gson.fromJson(json, DatasetPatch.class);

--- a/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
@@ -1,6 +1,7 @@
 package org.broadinstitute.consent.http.resources;
 
 import com.codahale.metrics.annotation.Timed;
+import com.google.api.client.http.HttpStatusCodes;
 import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
 import com.google.inject.Inject;
@@ -222,6 +223,13 @@ public class DatasetResource extends Resource {
       }
       if (!patch.isPatchable(existingDataset)) {
         return Response.notModified().entity(existingDataset).build();
+      }
+      // Is new name unique?
+      List<String> existingNames = datasetService.findAllDatasetNames();
+      if (!patch.name().equals(existingDataset.getName()) && existingNames.contains(patch.name())) {
+        return Response.status(HttpStatusCodes.STATUS_CODE_BAD_REQUEST)
+            .entity("The new name for this dataset already exists: " + patch.name())
+            .build();
       }
       User user = userService.findUserByEmail(authUser.getEmail());
       Dataset patched = datasetRegistrationService.patchDataset(datasetId, user, patch);

--- a/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
@@ -625,11 +625,11 @@ public class DatasetResource extends Resource {
    * @param dataset Dataset
    * @return User is a creator or custodian of the dataset.
    */
-  private boolean isCreatorOrCustodian(User user, Dataset dataset) {
+  public boolean isCreatorOrCustodian(User user, Dataset dataset) {
     if (Objects.equals(user.getUserId(), dataset.getCreateUserId())) {
       return true;
     }
-    if (Objects.equals(user.getUserId(), dataset.getStudy().getCreateUserId())) {
+    if (dataset.getStudy() != null && Objects.equals(user.getUserId(), dataset.getStudy().getCreateUserId())) {
       return true;
     }
     if (dataset.getStudy() != null && dataset.getStudy().getProperties() != null) {

--- a/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
@@ -212,7 +212,7 @@ public class DatasetResource extends Resource {
       if (json == null || json.isEmpty()) {
         throw new BadRequestException("Dataset Patch is required");
       }
-      Gson gson = GsonUtil.gsonBuilderWithAdapters().create();
+      Gson gson = GsonUtil.buildGson();
       DatasetPatch patch;
       try {
         patch = gson.fromJson(json, DatasetPatch.class);

--- a/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
@@ -3,8 +3,6 @@ package org.broadinstitute.consent.http.resources;
 import com.codahale.metrics.annotation.Timed;
 import com.google.api.client.http.HttpStatusCodes;
 import com.google.gson.Gson;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonPrimitive;
 import com.google.gson.JsonSyntaxException;
 import com.google.inject.Inject;
 import com.networknt.schema.ValidationMessage;
@@ -51,7 +49,6 @@ import org.broadinstitute.consent.http.models.DatasetSummary;
 import org.broadinstitute.consent.http.models.DatasetUpdate;
 import org.broadinstitute.consent.http.models.Error;
 import org.broadinstitute.consent.http.models.Study;
-import org.broadinstitute.consent.http.models.StudyProperty;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.UserRole;
 import org.broadinstitute.consent.http.models.dataset_registration_v1.DatasetRegistrationSchemaV1;
@@ -209,6 +206,17 @@ public class DatasetResource extends Resource {
   public Response patchByDatasetUpdate(@Auth AuthUser authUser,
       @PathParam("datasetId") Integer datasetId, String json) {
     try {
+      Dataset existingDataset = datasetService.findDatasetById(datasetId);
+      if (existingDataset == null) {
+        throw new NotFoundException("Could not find the dataset with id: " + datasetId);
+      }
+      // Check permissions for non-admin roles.
+      User user = userService.findUserByEmail(authUser.getEmail());
+      if (!user.hasUserRole(UserRoles.ADMIN)) {
+        if (!existingDataset.isCreator(user) && !existingDataset.isCustodian(user)) {
+          throw new ForbiddenException("User does not have permission to update this dataset");
+        }
+      }
       if (json == null || json.isEmpty()) {
         throw new BadRequestException("Dataset Patch is required");
       }
@@ -218,17 +226,6 @@ public class DatasetResource extends Resource {
         patch = gson.fromJson(json, DatasetPatch.class);
       } catch (Exception e) {
         throw new BadRequestException("Unable to parse dataset patch: " + json);
-      }
-      Dataset existingDataset = datasetService.findDatasetById(datasetId);
-      if (existingDataset == null) {
-        throw new NotFoundException("Could not find the dataset with id: " + datasetId);
-      }
-      // Check permissions for non-admin roles.
-      User user = userService.findUserByEmail(authUser.getEmail());
-      if (!user.hasUserRole(UserRoles.ADMIN)) {
-        if (!isCreatorOrCustodian(user, existingDataset)) {
-          throw new ForbiddenException("User does not have permission to update this dataset");
-        }
       }
       if (!patch.isPatchable(existingDataset)) {
         return Response.notModified().entity(existingDataset).build();
@@ -625,42 +622,6 @@ public class DatasetResource extends Resource {
         }
       }
     }
-  }
-
-  /**
-   * Determine if the user is a dataset/study creator, or if they are listed as a data custodian.
-   *
-   * @param user    User
-   * @param dataset Dataset
-   * @return User is a creator or custodian of the dataset.
-   */
-  protected boolean isCreatorOrCustodian(User user, Dataset dataset) {
-    if (Objects.equals(user.getUserId(), dataset.getCreateUserId())) {
-      return true;
-    }
-    if (dataset.getStudy() != null && Objects.equals(user.getUserId(),
-        dataset.getStudy().getCreateUserId())) {
-      return true;
-    }
-    if (dataset.getStudy() != null && dataset.getStudy().getProperties() != null) {
-      Optional<StudyProperty> dataCustodians = dataset
-          .getStudy()
-          .getProperties()
-          .stream()
-          .filter(p -> p.getKey().equals(DatasetRegistrationSchemaV1Builder.dataCustodianEmail))
-          .findFirst();
-      if (dataCustodians.isPresent()) {
-        JsonArray jsonArray = (JsonArray) dataCustodians.get().getValue();
-        return jsonArray.contains(new JsonPrimitive(user.getEmail()));
-      } else {
-        logWarn(
-            "No data custodians found for dataset: %s".formatted(dataset.getDatasetIdentifier()));
-      }
-    } else {
-      logWarn(
-          "No study properties found for dataset: %s".formatted(dataset.getDatasetIdentifier()));
-    }
-    return false;
   }
 
 }

--- a/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
@@ -247,8 +247,8 @@ public class DatasetResource extends Resource {
                 HttpStatusCodes.STATUS_CODE_BAD_REQUEST))
             .build();
       }
-      datasetRegistrationService.patchDataset(datasetId, user, patch);
-      return Response.noContent().build();
+      Dataset patched = datasetRegistrationService.patchDataset(datasetId, user, patch);
+      return Response.ok(patched).build();
     } catch (Exception e) {
       return createExceptionResponse(e);
     }

--- a/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
@@ -234,18 +234,10 @@ public class DatasetResource extends Resource {
       List<String> existingNames = datasetService.findAllDatasetNames();
       if (patch.name() != null && !patch.name().equals(existingDataset.getName())
           && existingNames.contains(patch.name())) {
-        return Response.status(HttpStatusCodes.STATUS_CODE_BAD_REQUEST)
-            .entity(new Error(
-                "The new name for this dataset already exists: " + patch.name(),
-                HttpStatusCodes.STATUS_CODE_BAD_REQUEST))
-            .build();
+        throw new BadRequestException("The new name for this dataset already exists: " + patch.name());
       }
       if (!patch.validateProperties()) {
-        return Response.status(HttpStatusCodes.STATUS_CODE_BAD_REQUEST)
-            .entity(new Error(
-                "Properties are invalid",
-                HttpStatusCodes.STATUS_CODE_BAD_REQUEST))
-            .build();
+        throw new BadRequestException("Properties are invalid");
       }
       Dataset patched = datasetRegistrationService.patchDataset(datasetId, user, patch);
       return Response.ok(patched).build();

--- a/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
@@ -1,7 +1,6 @@
 package org.broadinstitute.consent.http.resources;
 
 import com.codahale.metrics.annotation.Timed;
-import com.google.api.client.http.HttpStatusCodes;
 import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
 import com.google.inject.Inject;
@@ -47,7 +46,6 @@ import org.broadinstitute.consent.http.models.DatasetPatch;
 import org.broadinstitute.consent.http.models.DatasetStudySummary;
 import org.broadinstitute.consent.http.models.DatasetSummary;
 import org.broadinstitute.consent.http.models.DatasetUpdate;
-import org.broadinstitute.consent.http.models.Error;
 import org.broadinstitute.consent.http.models.Study;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.UserRole;

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetRegistrationService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetRegistrationService.java
@@ -26,6 +26,7 @@ import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.Dac;
 import org.broadinstitute.consent.http.models.DataUse;
 import org.broadinstitute.consent.http.models.Dataset;
+import org.broadinstitute.consent.http.models.DatasetPatch;
 import org.broadinstitute.consent.http.models.DatasetProperty;
 import org.broadinstitute.consent.http.models.DatasetUpdate;
 import org.broadinstitute.consent.http.models.FileStorageObject;
@@ -66,6 +67,11 @@ public class DatasetRegistrationService implements ConsentLogger {
     this.elasticSearchService = elasticSearchService;
     this.studyDAO = studyDAO;
     this.emailService = emailService;
+  }
+
+  public Dataset patchDataset(Integer datasetId, User user, DatasetPatch patch) {
+    // TODO: Flesh out stub
+    return datasetDAO.findDatasetById(datasetId);
   }
 
   public Study findStudyById(Integer studyId) {

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetRegistrationService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetRegistrationService.java
@@ -2,6 +2,7 @@ package org.broadinstitute.consent.http.service;
 
 import com.google.cloud.storage.BlobId;
 import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.InternalServerErrorException;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.core.Response;
 import java.io.IOException;
@@ -69,9 +70,14 @@ public class DatasetRegistrationService implements ConsentLogger {
     this.emailService = emailService;
   }
 
-  public Dataset patchDataset(Integer datasetId, User user, DatasetPatch patch) throws Exception {
-    datasetServiceDAO.patchDataset(datasetId, user, patch);
-    return datasetDAO.findDatasetById(datasetId);
+  public Dataset patchDataset(Integer datasetId, User user, DatasetPatch patch) {
+    try {
+      datasetServiceDAO.patchDataset(datasetId, user, patch);
+      return datasetDAO.findDatasetById(datasetId);
+    } catch (SQLException ex) {
+      logException(ex);
+      throw new InternalServerErrorException("An error occurred while patching the dataset.");
+    }
   }
 
   public Study findStudyById(Integer studyId) {

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetRegistrationService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetRegistrationService.java
@@ -69,8 +69,8 @@ public class DatasetRegistrationService implements ConsentLogger {
     this.emailService = emailService;
   }
 
-  public Dataset patchDataset(Integer datasetId, User user, DatasetPatch patch) {
-    // TODO: Flesh out stub
+  public Dataset patchDataset(Integer datasetId, User user, DatasetPatch patch) throws Exception {
+    datasetServiceDAO.patchDataset(datasetId, user, patch);
     return datasetDAO.findDatasetById(datasetId);
   }
 

--- a/src/main/resources/assets/paths/datasetById.yaml
+++ b/src/main/resources/assets/paths/datasetById.yaml
@@ -10,6 +10,18 @@ patch:
         type: integer
   tags:
     - Dataset
+  requestBody:
+    description: DatasetPatch object
+    required: true
+    content:
+      multipart/form-data:
+        schema:
+          type: object
+          properties:
+            dataset:
+      application/json:
+        schema:
+          $ref: '../schemas/DatasetPatch.yaml'
   responses:
     204:
       description: Dataset Patch applied successfully

--- a/src/main/resources/assets/paths/datasetById.yaml
+++ b/src/main/resources/assets/paths/datasetById.yaml
@@ -1,3 +1,34 @@
+patch:
+  summary: Patch Dataset
+  description: Patch the dataset with provided values. Anything not provided is ignored
+  parameters:
+    - name: id
+      in: path
+      description: ID of the Dataset
+      required: true
+      schema:
+        type: integer
+  tags:
+    - Dataset
+  responses:
+    204:
+      description: Dataset Patch applied successfully
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/Dataset.yaml'
+    304:
+      description: Dataset not modified
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/Dataset.yaml'
+    400:
+      description: Dataset Patch is not formatted correctly
+    404:
+      description: Not Found
+    500:
+      description: Server error.
 delete:
   summary: Delete Dataset
   description: Deletes Dataset and DatasetProperties of the Dataset specified by id.
@@ -20,6 +51,7 @@ delete:
     500:
       description: Server error.
 put:
+  deprecated: true
   summary: Updates the Dataset from JSON
   description: Updates the Dataset from JSON
   parameters:

--- a/src/main/resources/assets/paths/datasetById.yaml
+++ b/src/main/resources/assets/paths/datasetById.yaml
@@ -1,6 +1,24 @@
 patch:
   summary: Patch Dataset
-  description: Patch the dataset with provided values. Anything not provided is ignored
+  description: |
+    This API allows Admins, Chairpersons, and Data Submitters to patch a limited set of dataset
+    properties. File Types and Data Location must conform to the schema defined in
+    [/schemas/dataset-registration/v1](#/Schema/getDatasetRegistrationSchemaV1)
+      * The dataset name. This is an optional field
+      * List of optional properties to update
+        * \# of participants must be an integer value greater than zero
+        * URL must be a valid url
+        * File Types must be a list of valid file types
+          * Arrays
+          * Genome
+          * Exome
+          * Survey
+          * Phenotype
+        * Data Location must be a valid data location:
+          * AnVIL Workspace
+          * Terra Workspace
+          * TDR Location
+          * Not Determined
   parameters:
     - name: id
       in: path
@@ -14,11 +32,6 @@ patch:
     description: DatasetPatch object
     required: true
     content:
-      multipart/form-data:
-        schema:
-          type: object
-          properties:
-            dataset:
       application/json:
         schema:
           $ref: '../schemas/DatasetPatch.yaml'

--- a/src/main/resources/assets/paths/datasetById.yaml
+++ b/src/main/resources/assets/paths/datasetById.yaml
@@ -24,7 +24,10 @@ patch:
           schema:
             $ref: '../schemas/Dataset.yaml'
     400:
-      description: Dataset Patch is not formatted correctly
+      description: |
+        Dataset Patch is not formatted correctly OR the new dataset name is not unique in the
+        system. See [/api/dataset/datasetNames](#/Dataset/findAllDatasetNames) for a list of
+        existing dataset names.
     404:
       description: Not Found
     500:

--- a/src/main/resources/assets/paths/datasetById.yaml
+++ b/src/main/resources/assets/paths/datasetById.yaml
@@ -2,18 +2,12 @@ patch:
   summary: Patch Dataset
   description: |
     This API allows Admins, Chairpersons, and Data Submitters to patch a limited set of dataset
-    properties. File Types and Data Location must conform to the schema defined in
+    properties. Data Location must conform to the schema defined in
     [/schemas/dataset-registration/v1](#/Schema/getDatasetRegistrationSchemaV1)
       * The dataset name. This is an optional field
       * List of optional properties to update
         * \# of participants must be an integer value greater than zero
         * URL must be a valid url
-        * File Types must be a list of valid file types
-          * Arrays
-          * Genome
-          * Exome
-          * Survey
-          * Phenotype
         * Data Location must be a valid data location:
           * AnVIL Workspace
           * Terra Workspace

--- a/src/main/resources/assets/paths/datasetById.yaml
+++ b/src/main/resources/assets/paths/datasetById.yaml
@@ -30,7 +30,7 @@ patch:
         schema:
           $ref: '../schemas/DatasetPatch.yaml'
   responses:
-    204:
+    200:
       description: Dataset Patch applied successfully
       content:
         application/json:

--- a/src/main/resources/assets/paths/datasetById.yaml
+++ b/src/main/resources/assets/paths/datasetById.yaml
@@ -1,8 +1,8 @@
 patch:
   summary: Patch Dataset
   description: |
-    This API allows Admins, Chairpersons, and Data Submitters to patch a limited set of dataset
-    properties. Data Location must conform to the schema defined in
+    This API allows Admins, Chairpersons, and Data Submitters to patch the dataset name and a 
+    limited set of dataset properties. Data Location must conform to the schema defined in
     [/schemas/dataset-registration/v1](#/Schema/getDatasetRegistrationSchemaV1)
       * The dataset name. This is an optional field
       * List of optional properties to update

--- a/src/main/resources/assets/paths/findAllDatasetNames.yaml
+++ b/src/main/resources/assets/paths/findAllDatasetNames.yaml
@@ -1,5 +1,6 @@
 get:
   summary: Find All Dataset Names
+  operationId: findAllDatasetNames
   description: Returns a list of all the actively used dataset names.
   tags:
     - Dataset

--- a/src/main/resources/assets/paths/schemaDatasetRegistrationV1.yaml
+++ b/src/main/resources/assets/paths/schemaDatasetRegistrationV1.yaml
@@ -1,6 +1,7 @@
 get:
   summary: Dataset Registration Schema V1
   description: Dataset Registration Schema V1
+  operationId: getDatasetRegistrationSchemaV1
   tags:
     - Schema
   responses:

--- a/src/main/resources/assets/schemas/DatasetPatch.yaml
+++ b/src/main/resources/assets/schemas/DatasetPatch.yaml
@@ -8,17 +8,11 @@ properties:
     items:
       $ref: './DatasetProperty.yaml'
     example:
-      - propertyName: Data Type
-        propertyValue: Whole Genome
-      - propertyName: Species
-        propertyValue: Human
-      - propertyName: Phenotype/Indication
-        propertyValue: Cardiovascular System Disease
       - propertyName: "# of participants"
         propertyValue: 20
       - propertyName: URL
         propertyValue: http://...
       - propertyName: File Types
-        propertyValue: [{"fileType":"ARRAYS"}]
+        propertyValue: [{"fileType":"ARRAYS", "functionalEquivalence": "Free Text"}]
       - propertyName: Data Location
         propertyValue: Terra Workspace

--- a/src/main/resources/assets/schemas/DatasetPatch.yaml
+++ b/src/main/resources/assets/schemas/DatasetPatch.yaml
@@ -10,9 +10,17 @@ properties:
     example:
       - propertyName: "# of participants"
         propertyValue: 20
+        schemaProperty: numberOfParticipants
+        propertyType: Number
       - propertyName: URL
         propertyValue: https://duos.org
+        schemaProperty: url
+        propertyType: String
       - propertyName: File Types
-        propertyValue: [{"fileType":"Arrays", "functionalEquivalence": "Free Text"}]
+        propertyValue: [{"fileType":"ARRAYS", "functionalEquivalence": "Free Text"}]
+        schemaProperty: fileTypes
+        propertyType: Json
       - propertyName: Data Location
         propertyValue: Terra Workspace
+        schemaProperty: dataLocation
+        propertyType: String

--- a/src/main/resources/assets/schemas/DatasetPatch.yaml
+++ b/src/main/resources/assets/schemas/DatasetPatch.yaml
@@ -16,10 +16,6 @@ properties:
         propertyValue: https://duos.org
         schemaProperty: url
         propertyType: String
-      - propertyName: File Types
-        propertyValue: [{"fileType":"ARRAYS", "functionalEquivalence": "Free Text"}]
-        schemaProperty: fileTypes
-        propertyType: Json
       - propertyName: Data Location
         propertyValue: Terra Workspace
         schemaProperty: dataLocation

--- a/src/main/resources/assets/schemas/DatasetPatch.yaml
+++ b/src/main/resources/assets/schemas/DatasetPatch.yaml
@@ -11,8 +11,8 @@ properties:
       - propertyName: "# of participants"
         propertyValue: 20
       - propertyName: URL
-        propertyValue: http://...
+        propertyValue: https://duos.org
       - propertyName: File Types
-        propertyValue: [{"fileType":"ARRAYS", "functionalEquivalence": "Free Text"}]
+        propertyValue: [{"fileType":"Arrays", "functionalEquivalence": "Free Text"}]
       - propertyName: Data Location
         propertyValue: Terra Workspace

--- a/src/main/resources/assets/schemas/DatasetPatch.yaml
+++ b/src/main/resources/assets/schemas/DatasetPatch.yaml
@@ -1,0 +1,24 @@
+type: object
+properties:
+  name:
+    type: string
+    description: The dataset name. This is an optional field
+  properties:
+    type: array
+    items:
+      $ref: './DatasetProperty.yaml'
+    example:
+      - propertyName: Data Type
+        propertyValue: Whole Genome
+      - propertyName: Species
+        propertyValue: Human
+      - propertyName: Phenotype/Indication
+        propertyValue: Cardiovascular System Disease
+      - propertyName: "# of participants"
+        propertyValue: 20
+      - propertyName: URL
+        propertyValue: http://...
+      - propertyName: File Types
+        propertyValue: [{"fileType":"ARRAYS"}]
+      - propertyName: Data Location
+        propertyValue: Terra Workspace

--- a/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
@@ -725,7 +725,6 @@ class DatasetDAOTest extends DAOTestHelper {
     Dataset foundDataset = datasetDAO.findDatasetById(dataset.getDatasetId());
     assertNotNull(foundDataset);
     assertEquals(newName, foundDataset.getName());
-
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
@@ -715,6 +715,21 @@ class DatasetDAOTest extends DAOTestHelper {
   }
 
   @Test
+  void testUpdateDatasetNameWithUpdateUser() {
+    Dataset dataset = insertDataset();
+    String newName = RandomStringUtils.randomAlphabetic(dataset.getName().length() + 5);
+    datasetDAO.updateDatasetNameWithUpdateUser(
+        dataset.getDataSetId(),
+        newName,
+        new Timestamp(new Date().getTime()),
+        dataset.getCreateUserId());
+    Dataset foundDataset = datasetDAO.findDatasetById(dataset.getDataSetId());
+    assertNotNull(foundDataset);
+    assertEquals(newName, foundDataset.getName());
+
+  }
+
+  @Test
   void testFindDatasetWithDataUseByIdList() {
     Dataset dataset = insertDataset();
     Dac dac = insertDac();

--- a/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
@@ -718,11 +718,11 @@ class DatasetDAOTest extends DAOTestHelper {
     Dataset dataset = insertDataset();
     String newName = RandomStringUtils.randomAlphabetic(dataset.getName().length() + 5);
     datasetDAO.updateDatasetNameWithUpdateUser(
-        dataset.getDataSetId(),
+        dataset.getDatasetId(),
         newName,
         new Timestamp(new Date().getTime()),
         dataset.getCreateUserId());
-    Dataset foundDataset = datasetDAO.findDatasetById(dataset.getDataSetId());
+    Dataset foundDataset = datasetDAO.findDatasetById(dataset.getDatasetId());
     assertNotNull(foundDataset);
     assertEquals(newName, foundDataset.getName());
 

--- a/src/test/java/org/broadinstitute/consent/http/models/DatasetPatchTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/DatasetPatchTest.java
@@ -3,15 +3,12 @@ package org.broadinstitute.consent.http.models;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.google.gson.Gson;
 import java.util.List;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.RandomUtils;
 import org.broadinstitute.consent.http.enumeration.PropertyType;
 import org.broadinstitute.consent.http.models.dataset_registration_v1.ConsentGroup.DataLocation;
-import org.broadinstitute.consent.http.models.dataset_registration_v1.FileTypeObject.FileType;
 import org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder;
-import org.broadinstitute.consent.http.util.gson.GsonUtil;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -65,55 +62,6 @@ public class DatasetPatchTest {
     urlProp.setPropertyValue("");
     urlProp.setPropertyType(PropertyType.String);
     DatasetPatch patch = new DatasetPatch(null, List.of(urlProp));
-    assertFalse(patch.validateProperties());
-  }
-
-  private final String fileTypeInput = """
-      {
-        "name": "name",
-        "properties": [
-          {
-            "propertyName": "File Types",
-            "propertyValue": [
-              {
-                "fileType": "%s",
-                "functionalEquivalence": "%s"
-              }
-            ]
-          }
-        ]
-      }
-      """;
-
-  @ParameterizedTest
-  @EnumSource(FileType.class)
-  void testValidateFileType(FileType fileType) {
-    String json = fileTypeInput.formatted(fileType.value(), RandomStringUtils.randomAlphanumeric(5));
-    Gson gson = GsonUtil.buildGson();
-    DatasetPatch patch = gson.fromJson(json, DatasetPatch.class);
-    assertTrue(patch.validateProperties());
-  }
-
-  @Test
-  void testValidateFileTypeFailure() {
-    String json = fileTypeInput.formatted(RandomStringUtils.randomAlphanumeric(5),
-        RandomStringUtils.randomAlphanumeric(5));
-    Gson gson = GsonUtil.buildGson();
-    DatasetPatch patch = gson.fromJson(json, DatasetPatch.class);
-    assertFalse(patch.validateProperties());
-  }
-
-  @Test
-  void testValidateFileTypeMissingFileTypeFailure() {
-    String invalidFileType = """
-        [{"invalidFileType": "invalid", "functionalEquivalence": "random"}]
-        """;
-    DatasetProperty fileTypeProp = new DatasetProperty();
-    fileTypeProp.setPropertyName("file types");
-    fileTypeProp.setSchemaProperty(DatasetRegistrationSchemaV1Builder.fileTypes);
-    fileTypeProp.setPropertyType(PropertyType.Json);
-    fileTypeProp.setPropertyValue(invalidFileType);
-    DatasetPatch patch = new DatasetPatch(null, List.of(fileTypeProp));
     assertFalse(patch.validateProperties());
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/models/DatasetPatchTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/DatasetPatchTest.java
@@ -1,0 +1,157 @@
+package org.broadinstitute.consent.http.models;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.google.gson.Gson;
+import com.google.gson.internal.LinkedTreeMap;
+import java.util.List;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.RandomUtils;
+import org.broadinstitute.consent.http.enumeration.PropertyType;
+import org.broadinstitute.consent.http.models.dataset_registration_v1.ConsentGroup.DataLocation;
+import org.broadinstitute.consent.http.models.dataset_registration_v1.FileTypeObject;
+import org.broadinstitute.consent.http.models.dataset_registration_v1.FileTypeObject.FileType;
+import org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder;
+import org.broadinstitute.consent.http.util.gson.GsonUtil;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+public class DatasetPatchTest {
+
+  @Test
+  void testInvalidPropertyKeys() {
+    DatasetProperty invalidProp = new DatasetProperty();
+    invalidProp.setPropertyName(RandomStringUtils.randomAlphabetic(25));
+    invalidProp.setPropertyValue(RandomUtils.nextInt(1, 10));
+    invalidProp.setPropertyType(PropertyType.Number);
+    DatasetPatch patch = new DatasetPatch(null, List.of(invalidProp));
+    assertFalse(patch.validateProperties());
+  }
+
+  @Test
+  void testValidateNumberOfParticipants() {
+    DatasetProperty participantsProp = new DatasetProperty();
+    participantsProp.setPropertyName("# of participants");
+    participantsProp.setPropertyValue(RandomUtils.nextInt(1, 10));
+    participantsProp.setPropertyType(PropertyType.Number);
+    DatasetPatch patch = new DatasetPatch(null, List.of(participantsProp));
+    assertTrue(patch.validateProperties());
+  }
+
+  @Test
+  void testValidateNumberOfParticipantsFailure() {
+    DatasetProperty participantsProp = new DatasetProperty();
+    participantsProp.setPropertyName("# of participants");
+    participantsProp.setPropertyValue(RandomStringUtils.randomAlphabetic(10));
+    participantsProp.setPropertyType(PropertyType.Number);
+    DatasetPatch patch = new DatasetPatch(null, List.of(participantsProp));
+    assertFalse(patch.validateProperties());
+  }
+
+  @Test
+  void testValidateUrl() {
+    DatasetProperty urlProp = new DatasetProperty();
+    urlProp.setPropertyName("url");
+    urlProp.setPropertyValue("https://duos.org");
+    urlProp.setPropertyType(PropertyType.String);
+    DatasetPatch patch = new DatasetPatch(null, List.of(urlProp));
+    assertTrue(patch.validateProperties());
+  }
+
+  @Test
+  void testValidateUrlFailure() {
+    DatasetProperty urlProp = new DatasetProperty();
+    urlProp.setPropertyName("url");
+    urlProp.setPropertyValue("");
+    urlProp.setPropertyType(PropertyType.String);
+    DatasetPatch patch = new DatasetPatch(null, List.of(urlProp));
+    assertFalse(patch.validateProperties());
+  }
+
+  @ParameterizedTest
+  @EnumSource(FileType.class)
+  void testValidateFileType(FileType fileType) {
+    Gson gson = GsonUtil.buildGson();
+    DatasetProperty fileTypeProp = new DatasetProperty();
+    fileTypeProp.setPropertyName("file types");
+    fileTypeProp.setSchemaProperty(DatasetRegistrationSchemaV1Builder.fileTypes);
+    fileTypeProp.setPropertyType(PropertyType.Json);
+    FileTypeObject fileTypeObj = new FileTypeObject();
+    fileTypeObj.setFileType(fileType);
+    fileTypeObj.setFunctionalEquivalence(
+        RandomStringUtils.randomAlphabetic(5) + " " + RandomStringUtils.randomAlphabetic(5));
+    fileTypeProp.setPropertyValue(gson.toJson(List.of(fileTypeObj)));
+    DatasetPatch patch = new DatasetPatch(null, List.of(fileTypeProp));
+    assertTrue(patch.validateProperties());
+  }
+
+  // We need this version of the FileType test due to Gson serialization. When a correctly formed
+  // List of FileTypeObject is passed in as a property in a DatasetPatch at the resource level,
+  // Gson cannot infer the nested types based on the property name. Therefore, it comes through as
+  // an ArrayList of LinkedTreeMap objects. The validateProperties method handles both cases.
+  @ParameterizedTest
+  @EnumSource(FileType.class)
+  void testValidateFileTypeAsLinkedTreeMaps(FileType fileType) {
+    DatasetProperty fileTypeProp = new DatasetProperty();
+    fileTypeProp.setPropertyName("file types");
+    fileTypeProp.setSchemaProperty(DatasetRegistrationSchemaV1Builder.fileTypes);
+    fileTypeProp.setPropertyType(PropertyType.Json);
+    LinkedTreeMap<String, String> treeMap = new LinkedTreeMap<>();
+    treeMap.put("fileType", fileType.value());
+    treeMap.put("functionalEquivalence", RandomStringUtils.randomAlphabetic(5));
+    fileTypeProp.setPropertyValue(List.of(treeMap));
+    DatasetPatch patch = new DatasetPatch(null, List.of(fileTypeProp));
+    assertTrue(patch.validateProperties());
+  }
+
+  @Test
+  void testValidateFileTypeFailure() {
+    DatasetProperty fileTypeProp = new DatasetProperty();
+    fileTypeProp.setPropertyName("file types");
+    fileTypeProp.setSchemaProperty(DatasetRegistrationSchemaV1Builder.fileTypes);
+    fileTypeProp.setPropertyType(PropertyType.Json);
+    fileTypeProp.setPropertyValue(RandomStringUtils.randomAlphabetic(10));
+    DatasetPatch patch = new DatasetPatch(null, List.of(fileTypeProp));
+    assertFalse(patch.validateProperties());
+  }
+
+  @Test
+  void testValidateFileTypeMissingFileTypeFailure() {
+    String invalidFileType = """
+        [{"invalidFileType": "invalid", "functionalEquivalence": "random"}]
+        """;
+    DatasetProperty fileTypeProp = new DatasetProperty();
+    fileTypeProp.setPropertyName("file types");
+    fileTypeProp.setSchemaProperty(DatasetRegistrationSchemaV1Builder.fileTypes);
+    fileTypeProp.setPropertyType(PropertyType.Json);
+    fileTypeProp.setPropertyValue(invalidFileType);
+    DatasetPatch patch = new DatasetPatch(null, List.of(fileTypeProp));
+    assertFalse(patch.validateProperties());
+  }
+
+  @ParameterizedTest
+  @EnumSource(DataLocation.class)
+  void testValidateDataLocation(DataLocation location) {
+    DatasetProperty dataLocationProp = new DatasetProperty();
+    dataLocationProp.setPropertyName("data location");
+    dataLocationProp.setSchemaProperty(DatasetRegistrationSchemaV1Builder.dataLocation);
+    dataLocationProp.setPropertyType(PropertyType.Json);
+    dataLocationProp.setPropertyValue(location.value());
+    DatasetPatch patch = new DatasetPatch(null, List.of(dataLocationProp));
+    assertTrue(patch.validateProperties());
+  }
+
+  @Test
+  void testValidateDataLocationFailure() {
+    DatasetProperty dataLocationProp = new DatasetProperty();
+    dataLocationProp.setPropertyName("data location");
+    dataLocationProp.setSchemaProperty(DatasetRegistrationSchemaV1Builder.dataLocation);
+    dataLocationProp.setPropertyType(PropertyType.Json);
+    dataLocationProp.setPropertyValue(RandomStringUtils.randomAlphabetic(10));
+    DatasetPatch patch = new DatasetPatch(null, List.of(dataLocationProp));
+    assertFalse(patch.validateProperties());
+  }
+
+}

--- a/src/test/java/org/broadinstitute/consent/http/models/DatasetTests.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/DatasetTests.java
@@ -6,17 +6,84 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.google.gson.JsonArray;
 import java.util.List;
 import java.util.Set;
 import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.RandomUtils;
 import org.broadinstitute.consent.http.enumeration.PropertyType;
 import org.broadinstitute.consent.http.models.dataset_registration_v1.ConsentGroup.AccessManagement;
+import org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class DatasetTests {
+
+  @Test
+  void testIsCreatorOrCustodian_datasetCreator() {
+    User user = new User();
+    user.setUserId(RandomUtils.nextInt(1, 100));
+    Dataset dataset = new Dataset();
+    dataset.setDatasetId(RandomUtils.nextInt(1, 100));
+    dataset.setCreateUserId(user.getUserId());
+
+    assertTrue(dataset.isCreator(user));
+  }
+
+  @Test
+  void testIsCreatorOrCustodian_studyCreator() {
+    User user = new User();
+    user.setUserId(RandomUtils.nextInt(1, 100));
+    Dataset dataset = new Dataset();
+    dataset.setDatasetId(RandomUtils.nextInt(1, 100));
+    Study study = new Study();
+    study.setCreateUserId(user.getUserId());
+    dataset.setStudy(study);
+
+    assertTrue(dataset.isCreator(user));
+  }
+
+  @Test
+  void testIsCreatorOrCustodian_dataCustodian() {
+    User user = new User();
+    user.setUserId(RandomUtils.nextInt(1, 100));
+    user.setEmail("test@test.com");
+    Dataset dataset = new Dataset();
+    dataset.setDatasetId(RandomUtils.nextInt(1, 100));
+    Study study = new Study();
+    dataset.setStudy(study);
+    StudyProperty p = new StudyProperty();
+    p.setKey(DatasetRegistrationSchemaV1Builder.dataCustodianEmail);
+    p.setType(PropertyType.Json);
+    JsonArray a = new JsonArray();
+    a.add(user.getEmail());
+    p.setValue(a);
+    study.setProperties(Set.of(p));
+
+    assertTrue(dataset.isCustodian(user));
+  }
+
+  @Test
+  void testIsCreatorOrCustodian_notCustodian() {
+    User user = new User();
+    user.setUserId(RandomUtils.nextInt(1, 100));
+    user.setEmail("test@test.com");
+    Dataset dataset = new Dataset();
+    dataset.setDatasetId(RandomUtils.nextInt(1, 100));
+    Study study = new Study();
+    dataset.setStudy(study);
+    StudyProperty p = new StudyProperty();
+    p.setKey(DatasetRegistrationSchemaV1Builder.dataCustodianEmail);
+    p.setType(PropertyType.Json);
+    JsonArray a = new JsonArray();
+    a.add("different_user@test.com");
+    p.setValue(a);
+    study.setProperties(Set.of(p));
+
+    assertFalse(dataset.isCustodian(user));
+  }
 
   @Test
   void testParseIdentifierToAlias() {

--- a/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
@@ -118,7 +118,7 @@ class DatasetResourceTest {
   //       Maybe a case for parameterized tests
   // TODO: Add non-patchable case
   @Test
-  void testPatchByDatasetUpdate_patchable() {
+  void testPatchByDatasetUpdate_patchable() throws Exception {
     Gson gson = GsonUtil.buildGson();
 
     Dataset dataset = new Dataset();

--- a/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
@@ -142,6 +142,10 @@ class DatasetResourceTest {
 
     // TODO: Update the response to match what we patched
     when(datasetRegistrationService.patchDataset(any(), any(), any())).thenReturn(dataset);
+    when(authUser.getEmail()).thenReturn("test@test.com");
+    when(userService.findUserByEmail("test@test.com")).thenReturn(user);
+    when(user.getUserId()).thenReturn(RandomUtils.nextInt(1, 100));
+    dataset.setCreateUserId(user.getUserId());
 
     initResource();
     try (Response response = resource.patchByDatasetUpdate(authUser, dataset.getDataSetId(),

--- a/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
@@ -152,7 +152,7 @@ class DatasetResourceTest {
   @Test
   void testPatchByDatasetUpdate_userForbiddenException() {
     Dataset dataset = new Dataset();
-    dataset.setDataSetId(RandomUtils.nextInt(1, 10));
+    dataset.setDatasetId(RandomUtils.nextInt(1, 10));
 
     when(datasetService.findDatasetById(any())).thenReturn(dataset);
     when(authUser.getEmail()).thenReturn("test@test.com");
@@ -172,7 +172,7 @@ class DatasetResourceTest {
     Gson gson = GsonUtil.buildGson();
 
     Dataset dataset = new Dataset();
-    dataset.setDataSetId(RandomUtils.nextInt(1, 100));
+    dataset.setDatasetId(RandomUtils.nextInt(1, 100));
     dataset.setName(RandomStringUtils.randomAlphabetic(10));
 
     DatasetProperty dataLocationProp = new DatasetProperty();
@@ -191,7 +191,7 @@ class DatasetResourceTest {
     dataset.setCreateUserId(user.getUserId());
 
     initResource();
-    try (Response response = resource.patchByDatasetUpdate(authUser, dataset.getDataSetId(),
+    try (Response response = resource.patchByDatasetUpdate(authUser, dataset.getDatasetId(),
         gson.toJson(patch))) {
       assertEquals(HttpStatusCodes.STATUS_CODE_NOT_MODIFIED, response.getStatus());
     }
@@ -202,7 +202,7 @@ class DatasetResourceTest {
     Gson gson = GsonUtil.buildGson();
 
     Dataset dataset = new Dataset();
-    dataset.setDataSetId(RandomUtils.nextInt(1, 100));
+    dataset.setDatasetId(RandomUtils.nextInt(1, 100));
     dataset.setName(RandomStringUtils.randomAlphabetic(10));
 
     DatasetProperty dataLocationProp = new DatasetProperty();
@@ -229,7 +229,7 @@ class DatasetResourceTest {
     when(datasetService.findAllDatasetNames()).thenReturn(List.of(dataset.getName(), patch.name()));
 
     initResource();
-    try (Response response = resource.patchByDatasetUpdate(authUser, dataset.getDataSetId(),
+    try (Response response = resource.patchByDatasetUpdate(authUser, dataset.getDatasetId(),
         gson.toJson(patch))) {
       assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
     }
@@ -240,7 +240,7 @@ class DatasetResourceTest {
     Gson gson = GsonUtil.buildGson();
 
     Dataset dataset = new Dataset();
-    dataset.setDataSetId(RandomUtils.nextInt(1, 100));
+    dataset.setDatasetId(RandomUtils.nextInt(1, 100));
     dataset.setName(RandomStringUtils.randomAlphabetic(10));
 
     DatasetProperty dataLocationProp = new DatasetProperty();
@@ -266,7 +266,7 @@ class DatasetResourceTest {
     dataset.setCreateUserId(user.getUserId());
 
     initResource();
-    try (Response response = resource.patchByDatasetUpdate(authUser, dataset.getDataSetId(),
+    try (Response response = resource.patchByDatasetUpdate(authUser, dataset.getDatasetId(),
         gson.toJson(patch))) {
       assertEquals(HttpStatusCodes.STATUS_CODE_NO_CONTENT, response.getStatus());
     }
@@ -277,7 +277,7 @@ class DatasetResourceTest {
     User user = new User();
     user.setUserId(RandomUtils.nextInt(1, 100));
     Dataset dataset = new Dataset();
-    dataset.setDataSetId(RandomUtils.nextInt(1, 100));
+    dataset.setDatasetId(RandomUtils.nextInt(1, 100));
     dataset.setCreateUserId(user.getUserId());
 
     initResource();
@@ -289,7 +289,7 @@ class DatasetResourceTest {
     User user = new User();
     user.setUserId(RandomUtils.nextInt(1, 100));
     Dataset dataset = new Dataset();
-    dataset.setDataSetId(RandomUtils.nextInt(1, 100));
+    dataset.setDatasetId(RandomUtils.nextInt(1, 100));
     Study study = new Study();
     study.setCreateUserId(user.getUserId());
     dataset.setStudy(study);
@@ -304,7 +304,7 @@ class DatasetResourceTest {
     user.setUserId(RandomUtils.nextInt(1, 100));
     user.setEmail("test@test.com");
     Dataset dataset = new Dataset();
-    dataset.setDataSetId(RandomUtils.nextInt(1, 100));
+    dataset.setDatasetId(RandomUtils.nextInt(1, 100));
     Study study = new Study();
     dataset.setStudy(study);
     StudyProperty p = new StudyProperty();
@@ -325,7 +325,7 @@ class DatasetResourceTest {
     user.setUserId(RandomUtils.nextInt(1, 100));
     user.setEmail("test@test.com");
     Dataset dataset = new Dataset();
-    dataset.setDataSetId(RandomUtils.nextInt(1, 100));
+    dataset.setDatasetId(RandomUtils.nextInt(1, 100));
     Study study = new Study();
     dataset.setStudy(study);
     StudyProperty p = new StudyProperty();
@@ -346,7 +346,7 @@ class DatasetResourceTest {
     user.setUserId(RandomUtils.nextInt(1, 100));
     user.setEmail("test@test.com");
     Dataset dataset = new Dataset();
-    dataset.setDataSetId(RandomUtils.nextInt(1, 100));
+    dataset.setDatasetId(RandomUtils.nextInt(1, 100));
     Study study = new Study();
     dataset.setStudy(study);
     StudyProperty p = new StudyProperty();
@@ -531,7 +531,7 @@ class DatasetResourceTest {
   @Test
   void testDeleteErrorNullConsent() {
     Dataset dataSet = new Dataset();
-    dataSet.setDataSetId(1);
+    dataSet.setDatasetId(1);
 
     when(user.hasUserRole(UserRoles.ADMIN)).thenReturn(false);
     UserRole role = UserRoles.Chairperson();

--- a/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
@@ -176,7 +176,7 @@ class DatasetResourceTest {
     dataset.setName(RandomStringUtils.randomAlphabetic(10));
 
     DatasetProperty dataLocationProp = new DatasetProperty();
-    dataLocationProp.setPropertyName(DatasetRegistrationSchemaV1Builder.dataLocation);
+    dataLocationProp.setPropertyName("data location");
     dataLocationProp.setSchemaProperty(DatasetRegistrationSchemaV1Builder.dataLocation);
     dataLocationProp.setPropertyType(PropertyType.String);
     dataLocationProp.setPropertyValue(DataLocation.NOT_DETERMINED.value());
@@ -206,7 +206,7 @@ class DatasetResourceTest {
     dataset.setName(RandomStringUtils.randomAlphabetic(10));
 
     DatasetProperty dataLocationProp = new DatasetProperty();
-    dataLocationProp.setPropertyName(DatasetRegistrationSchemaV1Builder.dataLocation);
+    dataLocationProp.setPropertyName("data location");
     dataLocationProp.setSchemaProperty(DatasetRegistrationSchemaV1Builder.dataLocation);
     dataLocationProp.setPropertyType(PropertyType.String);
     dataLocationProp.setPropertyValue(DataLocation.NOT_DETERMINED.value());
@@ -215,6 +215,7 @@ class DatasetResourceTest {
     when(datasetService.findDatasetById(any())).thenReturn(dataset);
 
     DatasetProperty patchProp = new DatasetProperty();
+    patchProp.setPropertyName("data location");
     patchProp.setSchemaProperty(DatasetRegistrationSchemaV1Builder.dataLocation);
     patchProp.setPropertyType(PropertyType.String);
     patchProp.setPropertyValue(DataLocation.TDR_LOCATION.value());
@@ -244,7 +245,7 @@ class DatasetResourceTest {
     dataset.setName(RandomStringUtils.randomAlphabetic(10));
 
     DatasetProperty dataLocationProp = new DatasetProperty();
-    dataLocationProp.setPropertyName(DatasetRegistrationSchemaV1Builder.dataLocation);
+    dataLocationProp.setPropertyName("data location");
     dataLocationProp.setSchemaProperty(DatasetRegistrationSchemaV1Builder.dataLocation);
     dataLocationProp.setPropertyType(PropertyType.String);
     dataLocationProp.setPropertyValue(DataLocation.NOT_DETERMINED.value());
@@ -253,6 +254,7 @@ class DatasetResourceTest {
     when(datasetService.findDatasetById(any())).thenReturn(dataset);
 
     DatasetProperty patchProp = new DatasetProperty();
+    patchProp.setPropertyName("data location");
     patchProp.setSchemaProperty(DatasetRegistrationSchemaV1Builder.dataLocation);
     patchProp.setPropertyType(PropertyType.String);
     patchProp.setPropertyValue(DataLocation.TDR_LOCATION.value());
@@ -281,7 +283,7 @@ class DatasetResourceTest {
     dataset.setName(RandomStringUtils.randomAlphabetic(10));
 
     DatasetProperty dataLocationProp = new DatasetProperty();
-    dataLocationProp.setPropertyName(DatasetRegistrationSchemaV1Builder.dataLocation);
+    dataLocationProp.setPropertyName("data location");
     dataLocationProp.setSchemaProperty(DatasetRegistrationSchemaV1Builder.dataLocation);
     dataLocationProp.setPropertyType(PropertyType.String);
     dataLocationProp.setPropertyValue(DataLocation.NOT_DETERMINED.value());
@@ -290,8 +292,8 @@ class DatasetResourceTest {
     when(datasetService.findDatasetById(any())).thenReturn(dataset);
 
     DatasetProperty patchProp = new DatasetProperty();
+    patchProp.setPropertyName("data location");
     patchProp.setSchemaProperty(DatasetRegistrationSchemaV1Builder.dataLocation);
-    patchProp.setPropertyName(DatasetRegistrationSchemaV1Builder.dataLocation);
     patchProp.setPropertyType(PropertyType.String);
     patchProp.setPropertyValue(DataLocation.TDR_LOCATION.value());
 
@@ -310,6 +312,44 @@ class DatasetResourceTest {
       assertEquals(HttpStatusCodes.STATUS_CODE_NO_CONTENT, response.getStatus());
     }
   }
+
+  @Test
+  void testPatchByDatasetUpdate_invalidPatchProperties() {
+    Gson gson = GsonUtil.buildGson();
+
+    Dataset dataset = new Dataset();
+    dataset.setDatasetId(RandomUtils.nextInt(1, 100));
+    dataset.setName(RandomStringUtils.randomAlphabetic(10));
+
+    DatasetProperty invalidProp = new DatasetProperty();
+    invalidProp.setPropertyName("invalid");
+    invalidProp.setSchemaProperty(DatasetRegistrationSchemaV1Builder.accessManagement);
+    invalidProp.setPropertyType(PropertyType.String);
+    invalidProp.setPropertyValue(AccessManagement.OPEN.value());
+    dataset.setProperties(Set.of(invalidProp));
+
+    when(datasetService.findDatasetById(any())).thenReturn(dataset);
+
+    DatasetProperty patchProp = new DatasetProperty();
+    patchProp.setPropertyName("invalid");
+    patchProp.setSchemaProperty(DatasetRegistrationSchemaV1Builder.accessManagement);
+    patchProp.setPropertyType(PropertyType.String);
+    patchProp.setPropertyValue(AccessManagement.CONTROLLED.value());
+
+    DatasetPatch patch = new DatasetPatch(RandomStringUtils.randomAlphabetic(20), List.of(patchProp));
+
+    when(authUser.getEmail()).thenReturn("test@test.com");
+    when(userService.findUserByEmail("test@test.com")).thenReturn(user);
+    when(user.getUserId()).thenReturn(RandomUtils.nextInt(1, 100));
+    dataset.setCreateUserId(user.getUserId());
+
+    initResource();
+    try (Response response = resource.patchByDatasetUpdate(authUser, dataset.getDatasetId(),
+        gson.toJson(patch))) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
+    }
+  }
+
 
   @Test
   void testIsCreatorOrCustodian_datasetCreator() {

--- a/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
@@ -290,7 +290,7 @@ class DatasetResourceTest {
     initResource();
     try (Response response = resource.patchByDatasetUpdate(authUser, dataset.getDatasetId(),
         gson.toJson(patch))) {
-      assertEquals(HttpStatusCodes.STATUS_CODE_NO_CONTENT, response.getStatus());
+      assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
     }
   }
 
@@ -329,7 +329,7 @@ class DatasetResourceTest {
     initResource();
     try (Response response = resource.patchByDatasetUpdate(authUser, dataset.getDatasetId(),
         gson.toJson(patch))) {
-      assertEquals(HttpStatusCodes.STATUS_CODE_NO_CONTENT, response.getStatus());
+      assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
     }
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
@@ -117,6 +117,16 @@ class DatasetResourceTest {
 
   @Test
   void testPatchByDatasetUpdate_emptyInput() {
+    when(authUser.getEmail()).thenReturn("test@test.com");
+    when(userService.findUserByEmail("test@test.com")).thenReturn(user);
+    when(user.getUserId()).thenReturn(RandomUtils.nextInt(1, 100));
+
+    Dataset dataset = new Dataset();
+    dataset.setDatasetId(RandomUtils.nextInt(1, 100));
+    dataset.setName(RandomStringUtils.randomAlphabetic(10));
+    dataset.setCreateUserId(user.getUserId());
+    when(datasetService.findDatasetById(any())).thenReturn(dataset);
+
     initResource();
     try (Response response = resource.patchByDatasetUpdate(authUser, 1, "")) {
       assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
@@ -125,6 +135,16 @@ class DatasetResourceTest {
 
   @Test
   void testPatchByDatasetUpdate_malformedInput() {
+    when(authUser.getEmail()).thenReturn("test@test.com");
+    when(userService.findUserByEmail("test@test.com")).thenReturn(user);
+    when(user.getUserId()).thenReturn(RandomUtils.nextInt(1, 100));
+
+    Dataset dataset = new Dataset();
+    dataset.setDatasetId(RandomUtils.nextInt(1, 100));
+    dataset.setName(RandomStringUtils.randomAlphabetic(10));
+    dataset.setCreateUserId(user.getUserId());
+    when(datasetService.findDatasetById(any())).thenReturn(dataset);
+
     initResource();
     try (Response response = resource.patchByDatasetUpdate(authUser, 1, "}{")) {
       assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
@@ -348,94 +368,6 @@ class DatasetResourceTest {
         gson.toJson(patch))) {
       assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
     }
-  }
-
-
-  @Test
-  void testIsCreatorOrCustodian_datasetCreator() {
-    User user = new User();
-    user.setUserId(RandomUtils.nextInt(1, 100));
-    Dataset dataset = new Dataset();
-    dataset.setDatasetId(RandomUtils.nextInt(1, 100));
-    dataset.setCreateUserId(user.getUserId());
-
-    initResource();
-    assertTrue(resource.isCreatorOrCustodian(user, dataset));
-  }
-
-  @Test
-  void testIsCreatorOrCustodian_studyCreator() {
-    User user = new User();
-    user.setUserId(RandomUtils.nextInt(1, 100));
-    Dataset dataset = new Dataset();
-    dataset.setDatasetId(RandomUtils.nextInt(1, 100));
-    Study study = new Study();
-    study.setCreateUserId(user.getUserId());
-    dataset.setStudy(study);
-
-    initResource();
-    assertTrue(resource.isCreatorOrCustodian(user, dataset));
-  }
-
-  @Test
-  void testIsCreatorOrCustodian_dataCustodian() {
-    User user = new User();
-    user.setUserId(RandomUtils.nextInt(1, 100));
-    user.setEmail("test@test.com");
-    Dataset dataset = new Dataset();
-    dataset.setDatasetId(RandomUtils.nextInt(1, 100));
-    Study study = new Study();
-    dataset.setStudy(study);
-    StudyProperty p = new StudyProperty();
-    p.setKey(DatasetRegistrationSchemaV1Builder.dataCustodianEmail);
-    p.setType(PropertyType.Json);
-    JsonArray a = new JsonArray();
-    a.add(user.getEmail());
-    p.setValue(a);
-    study.setProperties(Set.of(p));
-
-    initResource();
-    assertTrue(resource.isCreatorOrCustodian(user, dataset));
-  }
-
-  @Test
-  void testIsCreatorOrCustodian_notCustodian() {
-    User user = new User();
-    user.setUserId(RandomUtils.nextInt(1, 100));
-    user.setEmail("test@test.com");
-    Dataset dataset = new Dataset();
-    dataset.setDatasetId(RandomUtils.nextInt(1, 100));
-    Study study = new Study();
-    dataset.setStudy(study);
-    StudyProperty p = new StudyProperty();
-    p.setKey(DatasetRegistrationSchemaV1Builder.dataCustodianEmail);
-    p.setType(PropertyType.Json);
-    JsonArray a = new JsonArray();
-    a.add("different_user@test.com");
-    p.setValue(a);
-    study.setProperties(Set.of(p));
-
-    initResource();
-    assertFalse(resource.isCreatorOrCustodian(user, dataset));
-  }
-
-  @Test
-  void testIsCreatorOrCustodian_notCreatorOrCustodian() {
-    User user = new User();
-    user.setUserId(RandomUtils.nextInt(1, 100));
-    user.setEmail("test@test.com");
-    Dataset dataset = new Dataset();
-    dataset.setDatasetId(RandomUtils.nextInt(1, 100));
-    Study study = new Study();
-    dataset.setStudy(study);
-    StudyProperty p = new StudyProperty();
-    p.setKey(DatasetRegistrationSchemaV1Builder.dataLocation);
-    p.setType(PropertyType.String);
-    p.setValue(DataLocation.NOT_DETERMINED.value());
-    study.setProperties(Set.of(p));
-
-    initResource();
-    assertFalse(resource.isCreatorOrCustodian(user, dataset));
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAOTest.java
@@ -682,8 +682,8 @@ class DatasetServiceDAOTest extends DAOTestHelper {
     DatasetProperty patchProp = new DatasetProperty();
     patchProp.setSchemaProperty(prop2.getSchemaProperty());
     patchProp.setPropertyName(prop2.getPropertyName());
-    prop2.setPropertyType(prop2.getPropertyType());
-    prop2.setPropertyKey(prop2.getPropertyKey());
+    patchProp.setPropertyType(prop2.getPropertyType());
+    patchProp.setPropertyKey(prop2.getPropertyKey());
     patchProp.setPropertyValue(RandomStringUtils.randomAlphabetic(10));
 
     // New, added prop


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DCJ-705

### Summary
This PR adds a new PATCH endpoint that allows for Admins, Chairpersons, and Data Submitters to make updates to dataset objects in a very limited fashion. Updatable fields include the name, and the following dataset property fields:

* \# of participants
* URL
* Data Location

#### Validation Rules

1. \# of participants must be an integer value > 0
2. URL must be a valid URL
3. Data Location MUST be one of these values: AnVIL Workspace, Terra Workspace, TDR Location, or Not Determined

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
