### PR TITLE
[DCJ-702] Switch to datasetId everywhere

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
@@ -474,10 +474,12 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
   void updateDatasetName(@Bind("datasetId") Integer datasetId, @Bind("name") String name);
 
 
-  @SqlBatch(
-      "INSERT INTO dataset_property (dataset_id, property_key, schema_property, property_value, property_type, create_date )"
-          +
-          " VALUES (:datasetId, :propertyKey, :schemaProperty, :getPropertyValueAsString, :getPropertyTypeAsString, :createDate)")
+  @SqlBatch("""
+      INSERT INTO dataset_property
+        (dataset_id, property_key, schema_property, property_value, property_type, create_date )
+      VALUES
+        (:datasetId, :propertyKey, :schemaProperty, :getPropertyValueAsString, :getPropertyTypeAsString, :createDate)
+      """)
   void insertDatasetProperties(@BindBean @BindMethods List<DatasetProperty> dataSetPropertiesList);
 
   @SqlUpdate("DELETE FROM dataset_property WHERE dataset_id = :datasetId")

--- a/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
@@ -477,7 +477,7 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
   @SqlBatch(
       "INSERT INTO dataset_property (dataset_id, property_key, schema_property, property_value, property_type, create_date )"
           +
-          " VALUES (:dataSetId, :propertyKey, :schemaProperty, :getPropertyValueAsString, :getPropertyTypeAsString, :createDate)")
+          " VALUES (:datasetId, :propertyKey, :schemaProperty, :getPropertyValueAsString, :getPropertyTypeAsString, :createDate)")
   void insertDatasetProperties(@BindBean @BindMethods List<DatasetProperty> dataSetPropertiesList);
 
   @SqlUpdate("DELETE FROM dataset_property WHERE dataset_id = :datasetId")
@@ -487,7 +487,7 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
       INSERT INTO dataset_audit
         (dataset_id, change_action, modified_by_user, modification_date, object_id, name)
       VALUES
-        (:dataSetId, :action, :user, :date, :objectId, :name)
+        (:datasetId, :action, :user, :date, :objectId, :name)
       """)
   @GetGeneratedKeys
   Integer insertDatasetAudit(@BindBean DatasetAudit dataSets);

--- a/src/main/java/org/broadinstitute/consent/http/db/ElectionDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/ElectionDAO.java
@@ -33,7 +33,7 @@ public interface ElectionDAO extends Transactional<ElectionDAO> {
       @Bind("status") String status,
       @Bind("createDate") Date createDate,
       @Bind("referenceId") String referenceId,
-      @Bind("datasetId") Integer dataSetId);
+      @Bind("datasetId") Integer datasetId);
 
   @SqlUpdate("DELETE FROM election WHERE election_id in (<electionIds>)")
   void deleteElectionsByIds(@BindList("electionIds") List<Integer> electionIds);

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DarCollectionSummaryReducer.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DarCollectionSummaryReducer.java
@@ -56,7 +56,7 @@ public class DarCollectionSummaryReducer implements
         election = rowView.getRow(Election.class);
         if (Objects.nonNull(election.getElectionId())) {
           summary.addElection(election);
-          summary.addDatasetId(election.getDataSetId());
+          summary.addDatasetId(election.getDatasetId());
         }
       } catch (MappingException e) {
         // Indicates that we do not have an election for this summary

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DatasetDTOWithPropertiesMapper.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DatasetDTOWithPropertiesMapper.java
@@ -20,15 +20,15 @@ public class DatasetDTOWithPropertiesMapper implements RowMapper<DatasetDTO>, Ro
   public DatasetDTO map(ResultSet r, StatementContext ctx) throws SQLException {
 
     DatasetDTO datasetDTO;
-    Integer dataSetId = r.getInt("dataset_id");
+    Integer datasetId = r.getInt("dataset_id");
     Integer alias = r.getInt("alias");
-    if (!datasetDTOs.containsKey(dataSetId)) {
+    if (!datasetDTOs.containsKey(datasetId)) {
       datasetDTO = new DatasetDTO(new ArrayList<>());
       if (hasNonZeroColumn(r, "dac_id")) {
         datasetDTO.setDacId(r.getInt("dac_id"));
       }
       datasetDTO.setAlias(alias);
-      datasetDTO.setDataSetId(dataSetId);
+      datasetDTO.setDatasetId(datasetId);
       if (hasColumn(r, "data_use")) {
         datasetDTO.setDataUse(dataUseParser.parseDataUse(r.getString("data_use")));
       }
@@ -52,9 +52,9 @@ public class DatasetDTOWithPropertiesMapper implements RowMapper<DatasetDTO>, Ro
         datasetDTO.addProperty(property);
       }
       datasetDTO.setObjectId(r.getString("object_id"));
-      datasetDTOs.put(dataSetId, datasetDTO);
+      datasetDTOs.put(datasetId, datasetDTO);
     } else {
-      datasetDTO = datasetDTOs.get(dataSetId);
+      datasetDTO = datasetDTOs.get(datasetId);
       DatasetPropertyDTO property =
           new DatasetPropertyDTO(r.getString(PROPERTY_KEY), r.getString(PROPERTY_PROPERTYVALUE));
       if (property.getPropertyName() != null) {

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DatasetMapper.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DatasetMapper.java
@@ -13,7 +13,7 @@ public class DatasetMapper implements RowMapper<Dataset>, RowMapperHelper {
 
   public Dataset map(ResultSet r, StatementContext ctx) throws SQLException {
     Dataset dataset = new Dataset();
-    dataset.setDataSetId(r.getInt("dataset_id"));
+    dataset.setDatasetId(r.getInt("dataset_id"));
 
     if (hasNonZeroColumn(r, "dac_id")) {
       dataset.setDacId(r.getInt("dac_id"));

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DatasetReducer.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DatasetReducer.java
@@ -52,7 +52,7 @@ public class DatasetReducer implements LinkedHashMapRowReducer<Integer, Dataset>
           if (hasNonZeroColumn(rowView, "property_id")) {
             prop.setPropertyId(rowView.getColumn("property_id", Integer.class));
           }
-          prop.setDataSetId(dataset.getDataSetId());
+          prop.setDatasetId(dataset.getDatasetId());
           prop.setPropertyValue(propType.coerce(propVal));
           prop.setPropertyName(keyName);
           prop.setPropertyType(propType);

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/ElectionMapper.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/ElectionMapper.java
@@ -60,7 +60,7 @@ public class ElectionMapper implements RowMapper<Election>, RowMapperHelper {
     }
     if (hasColumn(r, ElectionFields.DATASET_ID.getValue())
         && r.getObject(ElectionFields.DATASET_ID.getValue()) != null) {
-      election.setDataSetId(r.getInt(ElectionFields.DATASET_ID.getValue()));
+      election.setDatasetId(r.getInt(ElectionFields.DATASET_ID.getValue()));
     }
     if (hasColumn(r, ElectionFields.DATA_USE_LETTER.getValue())
         && r.getString(ElectionFields.DATA_USE_LETTER.getValue()) != null) {

--- a/src/main/java/org/broadinstitute/consent/http/models/Dac.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/Dac.java
@@ -131,8 +131,8 @@ public class Dac {
       datasets = new ArrayList<>();
     }
     datasets.add(dataset);
-    if (!datasetIds.contains(dataset.getDataSetId())) {
-      addDatasetId(dataset.getDataSetId());
+    if (!datasetIds.contains(dataset.getDatasetId())) {
+      addDatasetId(dataset.getDatasetId());
     }
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/models/DataRequest.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DataRequest.java
@@ -17,18 +17,18 @@ public class DataRequest {
   private String researcher;
 
   @JsonProperty
-  private Integer dataSetId;
+  private Integer datasetId;
 
   public DataRequest() {
   }
 
   public DataRequest(Integer requestId, Integer purposeId, String description, String researcher,
-      Integer dataSetId) {
+      Integer datasetId) {
     this.requestId = requestId;
     this.purposeId = purposeId;
     this.description = description;
     this.researcher = researcher;
-    this.dataSetId = dataSetId;
+    this.datasetId = datasetId;
   }
 
   public Integer getRequestId() {
@@ -63,12 +63,12 @@ public class DataRequest {
     this.researcher = researcher;
   }
 
-  public Integer getDataSetId() {
-    return dataSetId;
+  public Integer getDatasetId() {
+    return datasetId;
   }
 
-  public void setDataSetId(Integer dataSetId) {
-    this.dataSetId = dataSetId;
+  public void setDatasetId(Integer datasetId) {
+    this.datasetId = datasetId;
   }
 
 

--- a/src/main/java/org/broadinstitute/consent/http/models/Dataset.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/Dataset.java
@@ -13,7 +13,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 
 public class Dataset {
 
-  private Integer dataSetId;
+  private Integer datasetId;
 
   private String objectId;
 
@@ -54,9 +54,9 @@ public class Dataset {
   public Dataset() {
   }
 
-  public Dataset(Integer dataSetId, String objectId, String name, Date createDate,
+  public Dataset(Integer datasetId, String objectId, String name, Date createDate,
       Integer createUserId, Date updateDate, Integer updateUserId, Integer alias) {
-    this.dataSetId = dataSetId;
+    this.datasetId = datasetId;
     this.objectId = objectId;
     this.name = name;
     this.datasetName = name;
@@ -67,8 +67,8 @@ public class Dataset {
     this.alias = alias;
   }
 
-  public Dataset(Integer dataSetId, String objectId, String name, Date createDate, Integer alias) {
-    this.dataSetId = dataSetId;
+  public Dataset(Integer datasetId, String objectId, String name, Date createDate, Integer alias) {
+    this.datasetId = datasetId;
     this.objectId = objectId;
     this.name = name;
     this.datasetName = name;
@@ -76,8 +76,8 @@ public class Dataset {
     this.alias = alias;
   }
 
-  public Dataset(Integer dataSetId, String objectId, String name, Date createDate) {
-    this.dataSetId = dataSetId;
+  public Dataset(Integer datasetId, String objectId, String name, Date createDate) {
+    this.datasetId = datasetId;
     this.objectId = objectId;
     this.name = name;
     this.datasetName = name;
@@ -90,12 +90,12 @@ public class Dataset {
     this.objectId = objectId;
   }
 
-  public Integer getDataSetId() {
-    return dataSetId;
+  public Integer getDatasetId() {
+    return datasetId;
   }
 
-  public void setDataSetId(Integer dataSetId) {
-    this.dataSetId = dataSetId;
+  public void setDatasetId(Integer datasetId) {
+    this.datasetId = datasetId;
   }
 
   public String getObjectId() {
@@ -344,12 +344,12 @@ public class Dataset {
       return false;
     }
     Dataset dataset = (Dataset) o;
-    return com.google.common.base.Objects.equal(dataSetId, dataset.dataSetId);
+    return com.google.common.base.Objects.equal(datasetId, dataset.datasetId);
   }
 
   @Override
   public int hashCode() {
-    return com.google.common.base.Objects.hashCode(dataSetId);
+    return com.google.common.base.Objects.hashCode(datasetId);
   }
 
   public FileStorageObject getNihInstitutionalCertificationFile() {

--- a/src/main/java/org/broadinstitute/consent/http/models/DatasetAudit.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DatasetAudit.java
@@ -9,7 +9,7 @@ public class DatasetAudit {
   private Integer dataSetAuditId;
 
   @JsonProperty
-  private Integer dataSetId;
+  private Integer datasetId;
 
   @JsonProperty
   private String objectId;
@@ -34,13 +34,13 @@ public class DatasetAudit {
   }
 
   public DatasetAudit(
-      Integer dataSetId,
+      Integer datasetId,
       String objectId,
       String name,
       Date date,
       Integer user,
       String action) {
-    this.dataSetId = dataSetId;
+    this.datasetId = datasetId;
     this.objectId = objectId;
     this.name = name;
     this.date = date;
@@ -56,12 +56,12 @@ public class DatasetAudit {
     this.dataSetAuditId = dataSetAuditId;
   }
 
-  public Integer getDataSetId() {
-    return dataSetId;
+  public Integer getDatasetId() {
+    return datasetId;
   }
 
-  public void setDataSetId(Integer dataSetId) {
-    this.dataSetId = dataSetId;
+  public void setDatasetId(Integer datasetId) {
+    this.datasetId = datasetId;
   }
 
   public String getObjectId() {

--- a/src/main/java/org/broadinstitute/consent/http/models/DatasetProperty.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DatasetProperty.java
@@ -7,7 +7,7 @@ import org.broadinstitute.consent.http.enumeration.PropertyType;
 public class DatasetProperty {
 
   private Integer propertyId;
-  private Integer dataSetId;
+  private Integer datasetId;
   private Integer propertyKey;
   private String propertyName;
   private Object propertyValue;
@@ -20,22 +20,22 @@ public class DatasetProperty {
 
   @Deprecated
   public DatasetProperty(Integer propertyId,
-      Integer dataSetId,
+      Integer datasetId,
       Integer propertyKey,
       String propertyValue,
       PropertyType type,
       Date createDate) {
-    this(dataSetId, propertyKey, propertyValue, type, createDate);
+    this(datasetId, propertyKey, propertyValue, type, createDate);
     this.propertyId = propertyId;
   }
 
   @Deprecated
-  public DatasetProperty(Integer dataSetId,
+  public DatasetProperty(Integer datasetId,
       Integer propertyKey,
       String propertyValue,
       PropertyType type,
       Date createDate) {
-    this.dataSetId = dataSetId;
+    this.datasetId = datasetId;
     this.propertyKey = propertyKey;
     this.propertyValue = type.coerce(propertyValue);
     this.propertyType = type;
@@ -43,23 +43,23 @@ public class DatasetProperty {
   }
 
   public DatasetProperty(Integer propertyId,
-      Integer dataSetId,
+      Integer datasetId,
       Integer propertyKey,
       String schemaProperty,
       String propertyValue,
       PropertyType type,
       Date createDate) {
-    this(dataSetId, propertyKey, schemaProperty, propertyValue, type, createDate);
+    this(datasetId, propertyKey, schemaProperty, propertyValue, type, createDate);
     this.propertyId = propertyId;
   }
 
-  public DatasetProperty(Integer dataSetId,
+  public DatasetProperty(Integer datasetId,
       Integer propertyKey,
       String schemaProperty,
       String propertyValue,
       PropertyType type,
       Date createDate) {
-    this.dataSetId = dataSetId;
+    this.datasetId = datasetId;
     this.propertyKey = propertyKey;
     this.propertyValue = type.coerce(propertyValue);
     this.propertyType = type;
@@ -75,12 +75,12 @@ public class DatasetProperty {
     this.propertyId = propertyId;
   }
 
-  public Integer getDataSetId() {
-    return dataSetId;
+  public Integer getDatasetId() {
+    return datasetId;
   }
 
-  public void setDataSetId(Integer dataSetId) {
-    this.dataSetId = dataSetId;
+  public void setDatasetId(Integer datasetId) {
+    this.datasetId = datasetId;
   }
 
   public Integer getPropertyKey() {
@@ -156,12 +156,12 @@ public class DatasetProperty {
       return false;
     }
     DatasetProperty that = (DatasetProperty) o;
-    return Objects.equal(dataSetId, that.dataSetId) && Objects.equal(propertyName,
+    return Objects.equal(datasetId, that.datasetId) && Objects.equal(propertyName,
         that.propertyName) && Objects.equal(propertyValue, that.propertyValue);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(dataSetId, propertyName, propertyValue);
+    return Objects.hashCode(datasetId, propertyName, propertyValue);
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/models/Election.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/Election.java
@@ -53,7 +53,7 @@ public class Election {
   private Boolean finalAccessVote;
 
   @JsonProperty
-  private Integer dataSetId;
+  private Integer datasetId;
 
   @JsonProperty
   private String displayId;
@@ -84,7 +84,7 @@ public class Election {
 
   public Election(Integer electionId, String electionType,
       String status, Date createDate,
-      String referenceId, Date lastUpdate, Boolean finalAccessVote, Integer dataSetId) {
+      String referenceId, Date lastUpdate, Boolean finalAccessVote, Integer datasetId) {
     this.electionId = electionId;
     this.electionType = electionType;
     this.status = status;
@@ -92,13 +92,13 @@ public class Election {
     this.referenceId = referenceId;
     this.lastUpdate = lastUpdate;
     this.finalAccessVote = finalAccessVote;
-    this.dataSetId = dataSetId;
+    this.datasetId = datasetId;
     this.votes = new HashMap<>();
   }
 
   public Election(Integer electionId, String electionType,
       String status, Date createDate,
-      String referenceId, Date lastUpdate, Boolean finalAccessVote, Integer dataSetId,
+      String referenceId, Date lastUpdate, Boolean finalAccessVote, Integer datasetId,
       Boolean archived,
       String dulName, String dataUseLetter) {
     this.electionId = electionId;
@@ -108,7 +108,7 @@ public class Election {
     this.referenceId = referenceId;
     this.lastUpdate = lastUpdate;
     this.finalAccessVote = finalAccessVote;
-    this.dataSetId = dataSetId;
+    this.datasetId = datasetId;
     this.archived = archived;
     this.dulName = dulName;
     this.dataUseLetter = dataUseLetter;
@@ -194,12 +194,12 @@ public class Election {
     this.lastUpdate = lastUpdate;
   }
 
-  public Integer getDataSetId() {
-    return dataSetId;
+  public Integer getDatasetId() {
+    return datasetId;
   }
 
-  public void setDataSetId(Integer dataSetId) {
-    this.dataSetId = dataSetId;
+  public void setDatasetId(Integer datasetId) {
+    this.datasetId = datasetId;
   }
 
   public String getDisplayId() {

--- a/src/main/java/org/broadinstitute/consent/http/models/dataset_registration_v1/DatasetRegistrationSchemaV1UpdateValidator.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/dataset_registration_v1/DatasetRegistrationSchemaV1UpdateValidator.java
@@ -73,7 +73,7 @@ public class DatasetRegistrationSchemaV1UpdateValidator {
         .filter(cg -> {
           Optional<Dataset> dataset = SetUtils.emptyIfNull(existingStudy.getDatasets())
               .stream()
-              .filter(d -> d.getDataSetId().equals(cg.getDatasetId()))
+              .filter(d -> d.getDatasetId().equals(cg.getDatasetId()))
               .findFirst();
           return dataset.isPresent() && !dataset.get().getName().isBlank();
         })

--- a/src/main/java/org/broadinstitute/consent/http/models/dataset_registration_v1/builder/ConsentGroupFromDataset.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/dataset_registration_v1/builder/ConsentGroupFromDataset.java
@@ -27,7 +27,7 @@ public class ConsentGroupFromDataset {
   public ConsentGroup build(Dataset dataset) {
     if (dataset != null) {
       ConsentGroup consentGroup = new ConsentGroup();
-      consentGroup.setDatasetId(dataset.getDataSetId());
+      consentGroup.setDatasetId(dataset.getDatasetId());
       consentGroup.setDatasetIdentifier(dataset.getDatasetIdentifier());
       consentGroup.setConsentGroupName(dataset.getName());
       String accessManagementVal = findStringDSPropValue(dataset.getProperties(), accessManagement);

--- a/src/main/java/org/broadinstitute/consent/http/models/dto/DatasetDTO.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/dto/DatasetDTO.java
@@ -19,7 +19,7 @@ public class DatasetDTO {
   private Integer dacId;
 
   @JsonProperty
-  private Integer dataSetId;
+  private Integer datasetId;
 
   @JsonProperty
   private String consentId;
@@ -125,12 +125,12 @@ public class DatasetDTO {
     this.updateAssociationToDataOwnerAllowed = updateAssociationToDataOwnerAllowed;
   }
 
-  public void setDataSetId(Integer dataSetId) {
-    this.dataSetId = dataSetId;
+  public void setDatasetId(Integer datasetId) {
+    this.datasetId = datasetId;
   }
 
-  public Integer getDataSetId() {
-    return dataSetId;
+  public Integer getDatasetId() {
+    return datasetId;
   }
 
   public void setAlias(Integer alias) {
@@ -205,11 +205,11 @@ public class DatasetDTO {
       return false;
     }
     DatasetDTO that = (DatasetDTO) o;
-    return dataSetId.equals(that.dataSetId);
+    return datasetId.equals(that.datasetId);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(dataSetId);
+    return Objects.hash(datasetId);
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/resources/DarCollectionResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DarCollectionResource.java
@@ -150,7 +150,7 @@ public class DarCollectionResource extends Resource {
     List<Integer> userDatasetIds = darCollectionService.findDatasetIdsByDACUser(user);
 
     return collection.getDatasets().stream()
-        .map(Dataset::getDataSetId)
+        .map(Dataset::getDatasetId)
         .anyMatch(userDatasetIds::contains);
   }
 

--- a/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
@@ -232,7 +232,7 @@ public class DatasetResource extends Resource {
           userId);
       if (updatedDataset.isPresent()) {
         URI uri = info.getRequestUriBuilder().replacePath("api/dataset/{datasetId}")
-            .build(updatedDataset.get().getDataSetId());
+            .build(updatedDataset.get().getDatasetId());
         return Response.ok(uri).entity(updatedDataset.get()).build();
       } else {
         return Response.noContent().build();
@@ -321,7 +321,7 @@ public class DatasetResource extends Resource {
     try {
       List<Dataset> datasets = datasetService.findDatasetsByIds(datasetIds);
 
-      Set<Integer> foundIds = datasets.stream().map(Dataset::getDataSetId)
+      Set<Integer> foundIds = datasets.stream().map(Dataset::getDatasetId)
           .collect(Collectors.toSet());
       if (!foundIds.containsAll(datasetIds)) {
         // find the differences
@@ -350,7 +350,7 @@ public class DatasetResource extends Resource {
   public Response validateDatasetName(@QueryParam("name") String name) {
     try {
       Dataset datasetWithName = datasetService.getDatasetByName(name);
-      return Response.ok().entity(datasetWithName.getDataSetId()).build();
+      return Response.ok().entity(datasetWithName.getDatasetId()).build();
     } catch (Exception e) {
       throw new NotFoundException("Could not find the dataset with name: " + name);
     }
@@ -549,7 +549,7 @@ public class DatasetResource extends Resource {
       throw new NotFoundException();
     } else {
       if (Objects.isNull(dataset) || Objects.isNull(dataset.getDacId())) {
-        logWarn("Cannot find a valid dac id for dataset: " + dataset.getDataSetId());
+        logWarn("Cannot find a valid dac id for dataset: " + dataset.getDatasetId());
         throw new NotFoundException();
       } else {
         if (!dacIds.contains(dataset.getDacId())) {

--- a/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
@@ -332,7 +332,7 @@ public class DarCollectionService implements ConsentLogger {
         .filter(Predicate.not(List::isEmpty))
         .map(datasetDAO::findDatasetListByDacIds)
         .flatMap(List::stream)
-        .map(Dataset::getDataSetId)
+        .map(Dataset::getDatasetId)
         .toList();
   }
 
@@ -531,7 +531,7 @@ public class DarCollectionService implements ConsentLogger {
       }
       Set<Dataset> datasets = datasetDAO.findDatasetWithDataUseByIdList(datasetIds);
       Map<Integer, Dataset> datasetMap = datasets.stream()
-          .collect(Collectors.toMap(Dataset::getDataSetId, Function.identity()));
+          .collect(Collectors.toMap(Dataset::getDatasetId, Function.identity()));
 
       return collections.stream().map(c -> {
         Set<Dataset> collectionDatasets = c.getDars().values().stream()

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
@@ -315,7 +315,7 @@ public class DataAccessRequestService implements ConsentLogger {
   }
 
   public Collection<DataAccessRequest> getApprovedDARsForDataset(Dataset dataset) {
-    return dataAccessRequestDAO.findApprovedDARsByDatasetId(dataset.getDataSetId());
+    return dataAccessRequestDAO.findApprovedDARsByDatasetId(dataset.getDatasetId());
   }
 
 }

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetRegistrationService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetRegistrationService.java
@@ -751,7 +751,7 @@ public class DatasetRegistrationService implements ConsentLogger {
       return List.of();
     }
     return updatedStudy.getDatasets().stream().filter(
-        dataset -> !datasetUpdateIds.contains(dataset.getDataSetId())).toList();
+        dataset -> !datasetUpdateIds.contains(dataset.getDatasetId())).toList();
   }
 
   /**

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -199,10 +199,10 @@ public class DatasetService implements ConsentLogger {
   private void updateDatasetProperties(List<DatasetProperty> updateProperties,
       List<DatasetProperty> deleteProperties, List<DatasetProperty> addProperties) {
     updateProperties.forEach(p -> datasetDAO
-        .updateDatasetProperty(p.getDataSetId(), p.getPropertyKey(),
+        .updateDatasetProperty(p.getDatasetId(), p.getPropertyKey(),
             p.getPropertyValue().toString()));
     deleteProperties.forEach(
-        p -> datasetDAO.deleteDatasetPropertyByKey(p.getDataSetId(), p.getPropertyKey()));
+        p -> datasetDAO.deleteDatasetPropertyByKey(p.getDatasetId(), p.getPropertyKey()));
     datasetDAO.insertDatasetProperties(addProperties);
   }
 
@@ -277,7 +277,7 @@ public class DatasetService implements ConsentLogger {
 
   public Dataset approveDataset(Dataset dataset, User user, Boolean approval) {
     Boolean currentApprovalState = dataset.getDacApproval();
-    Integer datasetId = dataset.getDataSetId();
+    Integer datasetId = dataset.getDatasetId();
     Dataset datasetReturn = dataset;
     //Only update and fetch the dataset if it hasn't already been approved
     //If it has, simply returned the dataset in the argument (which was already queried for in the resource)
@@ -351,12 +351,12 @@ public class DatasetService implements ConsentLogger {
         datasets.forEach(d -> {
           try {
             output.write(gson.toJson(d).getBytes());
-            if (!Objects.equals(d.getDataSetId(), lastIndex)) {
+            if (!Objects.equals(d.getDatasetId(), lastIndex)) {
               output.write(",".getBytes());
             }
             output.write("\n".getBytes());
           } catch (IOException e) {
-            logException("Error writing dataset to streaming output, dataset id: " + d.getDataSetId(), e);
+            logException("Error writing dataset to streaming output, dataset id: " + d.getDatasetId(), e);
           }
         });
       });
@@ -409,19 +409,19 @@ public class DatasetService implements ConsentLogger {
 
     // Dataset updates
     if (studyConversion.getDacId() != null) {
-      datasetDAO.updateDatasetDacId(dataset.getDataSetId(), studyConversion.getDacId());
+      datasetDAO.updateDatasetDacId(dataset.getDatasetId(), studyConversion.getDacId());
     }
     if (studyConversion.getDataUse() != null) {
-      datasetDAO.updateDatasetDataUse(dataset.getDataSetId(),
+      datasetDAO.updateDatasetDataUse(dataset.getDatasetId(),
           studyConversion.getDataUse().toString());
     }
     if (studyConversion.getDataUse() != null) {
       String translation = ontologyService.translateDataUse(studyConversion.getDataUse(),
           DataUseTranslationType.DATASET);
-      datasetDAO.updateDatasetTranslatedDataUse(dataset.getDataSetId(), translation);
+      datasetDAO.updateDatasetTranslatedDataUse(dataset.getDatasetId(), translation);
     }
     if (studyConversion.getDatasetName() != null) {
-      datasetDAO.updateDatasetName(dataset.getDataSetId(), studyConversion.getDatasetName());
+      datasetDAO.updateDatasetName(dataset.getDatasetId(), studyConversion.getDatasetName());
     }
 
     List<Dictionary> dictionaries = datasetDAO.getDictionaryTerms();
@@ -459,7 +459,7 @@ public class DatasetService implements ConsentLogger {
     if (studyConversion.getDataSubmitterEmail() != null) {
       User submitter = userDAO.findUserByEmail(studyConversion.getDataSubmitterEmail());
       if (submitter != null) {
-        datasetDAO.updateDatasetCreateUserId(dataset.getDataSetId(), user.getUserId());
+        datasetDAO.updateDatasetCreateUserId(dataset.getDatasetId(), user.getUserId());
       }
     }
 
@@ -518,7 +518,7 @@ public class DatasetService implements ConsentLogger {
         .filter(p -> p.getSchemaProperty().equals(schemaProperty))
         .findFirst();
     if (maybeProp.isPresent()) {
-      datasetDAO.updateDatasetProperty(dataset.getDataSetId(), maybeProp.get().getPropertyKey(),
+      datasetDAO.updateDatasetProperty(dataset.getDatasetId(), maybeProp.get().getPropertyKey(),
           propValue);
     } else {
       dictionaries.stream()
@@ -526,7 +526,7 @@ public class DatasetService implements ConsentLogger {
           .findFirst()
           .ifPresent(dictionary -> {
             DatasetProperty prop = new DatasetProperty();
-            prop.setDataSetId(dataset.getDataSetId());
+            prop.setDatasetId(dataset.getDatasetId());
             prop.setPropertyKey(dictionary.getKeyId());
             prop.setSchemaProperty(schemaProperty);
             prop.setPropertyValue(propValue);
@@ -558,13 +558,13 @@ public class DatasetService implements ConsentLogger {
         .findFirst();
     // Legacy property exists, update it.
     if (dictionary.isPresent() && maybeProp.isPresent()) {
-      datasetDAO.updateDatasetProperty(dataset.getDataSetId(), dictionary.get().getKeyId(),
+      datasetDAO.updateDatasetProperty(dataset.getDatasetId(), dictionary.get().getKeyId(),
           propValue);
     }
     // Legacy property does not exist, but we have a valid dictionary term, so create it.
     else if (dictionary.isPresent()) {
       DatasetProperty prop = new DatasetProperty();
-      prop.setDataSetId(dataset.getDataSetId());
+      prop.setDatasetId(dataset.getDatasetId());
       prop.setPropertyKey(dictionary.get().getKeyId());
       prop.setSchemaProperty(schemaProperty);
       prop.setPropertyValue(propValue);
@@ -599,7 +599,7 @@ public class DatasetService implements ConsentLogger {
           studyConversion.getDataTypes(), studyConversion.getPublicVisibility(), userId,
           Instant.now());
     }
-    datasetDAO.updateStudyId(dataset.getDataSetId(), studyId);
+    datasetDAO.updateStudyId(dataset.getDatasetId(), studyId);
 
     // Create or update study properties:
     Set<StudyProperty> existingProps = studyDAO.findStudyById(studyId).getProperties();

--- a/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
@@ -273,7 +273,7 @@ public class ElasticSearchService implements ConsentLogger {
           }
           output.write("\n".getBytes());
         } catch (IOException e) {
-          logException("Error indexing dataset term for dataset id: %d ".formatted(dataset.getDataSetId()), e);
+          logException("Error indexing dataset term for dataset id: %d ".formatted(dataset.getDatasetId()), e);
         }
       });
       output.write("]".getBytes());
@@ -302,7 +302,7 @@ public class ElasticSearchService implements ConsentLogger {
 
     DatasetTerm term = new DatasetTerm();
 
-    term.setDatasetId(dataset.getDataSetId());
+    term.setDatasetId(dataset.getDatasetId());
     Optional.ofNullable(dataset.getCreateUserId()).ifPresent(userId -> {
       User user = userDAO.findUserById(dataset.getCreateUserId());
       term.setCreateUserId(dataset.getCreateUserId());
@@ -331,7 +331,7 @@ public class ElasticSearchService implements ConsentLogger {
     });
 
     List<Integer> approvedUserIds = dataAccessRequestDAO
-        .findApprovedDARsByDatasetId(dataset.getDataSetId())
+        .findApprovedDARsByDatasetId(dataset.getDatasetId())
         .stream()
         .map(DataAccessRequest::getUserId)
         .toList();
@@ -345,7 +345,7 @@ public class ElasticSearchService implements ConsentLogger {
       if (summary != null) {
         term.setDataUse(summary);
       } else {
-        logWarn("No data use summary for dataset id: %d".formatted(dataset.getDataSetId()));
+        logWarn("No data use summary for dataset id: %d".formatted(dataset.getDatasetId()));
       }
     }
 

--- a/src/main/java/org/broadinstitute/consent/http/service/EmailService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/EmailService.java
@@ -129,7 +129,7 @@ public class EmailService implements ConsentLogger {
     }
     String researcherName = researcher == null ? "Unknown" : researcher.getDisplayName();
     Collection<Dac> dacsInDAR = dacDAO.findDacsForCollectionId(collectionId);
-    List<Integer> datasetIds = collection.getDatasets().stream().map(Dataset::getDataSetId).toList();
+    List<Integer> datasetIds = collection.getDatasets().stream().map(Dataset::getDatasetId).toList();
     List<Dataset> datasetsInDAR = datasetIds.isEmpty() ? List.of() : datasetDAO.findDatasetsByIdList(datasetIds);
 
     Map<String, List<String>>  sendList = new HashMap<>();

--- a/src/main/java/org/broadinstitute/consent/http/service/MetricsService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/MetricsService.java
@@ -138,7 +138,7 @@ public class MetricsService {
 
               Dataset dataset =
                   datasets.stream()
-                      .filter(d -> d.getDataSetId().equals(datasetId))
+                      .filter(d -> d.getDatasetId().equals(datasetId))
                       .findFirst()
                       .orElse(null);
 

--- a/src/main/java/org/broadinstitute/consent/http/service/TDRService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/TDRService.java
@@ -70,7 +70,7 @@ public class TDRService implements ConsentLogger {
     }
     List<Integer> datasetIds = datasets
         .stream()
-        .map(Dataset::getDataSetId)
+        .map(Dataset::getDatasetId)
         .toList();
     DataAccessRequest newDar = new DataAccessRequest();
     newDar.setCreateDate(new Timestamp(new Date().getTime()));

--- a/src/main/java/org/broadinstitute/consent/http/service/VoteService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/VoteService.java
@@ -272,7 +272,7 @@ public class VoteService implements ConsentLogger {
         darCollectionDAO.findDARCollectionByCollectionIds(collectionIds);
 
     List<Integer> datasetIds = finalElections.stream()
-        .map(Election::getDataSetId)
+        .map(Election::getDatasetId)
         .collect(Collectors.toList());
     List<Dataset> datasets =
         datasetIds.isEmpty() ? List.of() : datasetDAO.findDatasetsByIdList(datasetIds);
@@ -292,7 +292,7 @@ public class VoteService implements ConsentLogger {
           .distinct()
           .toList();
       List<Dataset> approvedDatasetsInCollection = datasets.stream()
-          .filter(d -> collectionDatasetIds.contains(d.getDataSetId()))
+          .filter(d -> collectionDatasetIds.contains(d.getDatasetId()))
           .toList();
 
       if (!approvedDatasetsInCollection.isEmpty()) {

--- a/src/main/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAO.java
@@ -49,12 +49,12 @@ public class DatasetServiceDAO implements ConsentLogger {
       // Some legacy dataset names can be null
       String dsAuditName =
           Objects.nonNull(dataset.getName()) ? dataset.getName() : dataset.getDatasetIdentifier();
-      DatasetAudit dsAudit = new DatasetAudit(dataset.getDataSetId(), dataset.getObjectId(), dsAuditName,
+      DatasetAudit dsAudit = new DatasetAudit(dataset.getDatasetId(), dataset.getObjectId(), dsAuditName,
         new Date(), userId, AuditActions.DELETE.getValue().toUpperCase());
       try {
         datasetDAO.insertDatasetAudit(dsAudit);
-        datasetDAO.deleteDatasetPropertiesByDatasetId(dataset.getDataSetId());
-        datasetDAO.deleteDatasetById(dataset.getDataSetId());
+        datasetDAO.deleteDatasetPropertiesByDatasetId(dataset.getDatasetId());
+        datasetDAO.deleteDatasetById(dataset.getDatasetId());
       } catch (Exception e) {
         handle.rollback();
         logException(e);
@@ -433,7 +433,7 @@ public class DatasetServiceDAO implements ConsentLogger {
     // Generate new inserts for props we don't know about yet
     properties.forEach(prop -> {
       if (!existingPropNames.contains(prop.getPropertyName())) {
-        prop.setDataSetId(datasetId);
+        prop.setDatasetId(datasetId);
         prop.setCreateDate(now);
         updates.add(createPropertyInsert(handle, prop, now));
       }
@@ -449,7 +449,7 @@ public class DatasetServiceDAO implements ConsentLogger {
                     :schemaProperty, :propertyStringValue, :propertyTypeValue, :createDate
         """;
     Update insert = handle.createUpdate(sql);
-    insert.bind("datasetId", property.getDataSetId());
+    insert.bind("datasetId", property.getDatasetId());
     insert.bind("propertyKey", property.getPropertyKey());
     insert.bind("propertyName", property.getPropertyName());
     insert.bind("schemaProperty", property.getSchemaProperty());
@@ -527,7 +527,7 @@ public class DatasetServiceDAO implements ConsentLogger {
             AND property_id = :propertyId
         """;
     Update insert = handle.createUpdate(sql);
-    insert.bind("datasetId", property.getDataSetId());
+    insert.bind("datasetId", property.getDatasetId());
     insert.bind("propertyKey", property.getPropertyKey());
     insert.bind("propertyId", property.getPropertyId());
     return insert;

--- a/src/main/resources/assets/schemas/Dataset.yaml
+++ b/src/main/resources/assets/schemas/Dataset.yaml
@@ -7,7 +7,7 @@ properties:
     type: string
     deprecated: true
     description: Legacy value for backwards compatibility, same as the dataset name
-  dataSetId:
+  datasetId:
     type: integer
     format: int32
     description: The dataset id, integer format

--- a/src/main/resources/assets/schemas/Election.yaml
+++ b/src/main/resources/assets/schemas/Election.yaml
@@ -34,9 +34,9 @@ properties:
   finalAccessVote:
     type: boolean
     description: For Data Access Request only. Final vote that determines if the request is approved or denied.
-  dataSetId:
+  datasetId:
     type: integer
-    description: The dataSetId related to the election.
+    description: The datasetId related to the election.
   displayId:
     type: string
     description: The ID for display.

--- a/src/test/java/org/broadinstitute/consent/http/db/DaaDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DaaDAOTest.java
@@ -248,9 +248,9 @@ class DaaDAOTest extends DAOTestHelper {
     List<Integer> datasetIds = daaDAO.findDaaDatasetIdsByUserId(user.getUserId());
     assertFalse(datasetIds.isEmpty());
     assertEquals(2, datasetIds.size());
-    assertTrue(datasetIds.contains(dataset1.getDataSetId()));
-    assertTrue(datasetIds.contains(dataset2.getDataSetId()));
-    assertFalse(datasetIds.contains(dataset3.getDataSetId()));
+    assertTrue(datasetIds.contains(dataset1.getDatasetId()));
+    assertTrue(datasetIds.contains(dataset2.getDatasetId()));
+    assertFalse(datasetIds.contains(dataset3.getDatasetId()));
   }
 
   @Test
@@ -313,8 +313,8 @@ class DaaDAOTest extends DAOTestHelper {
 
     // DAR and associated datasets
     DataAccessRequest dar = createDataAccessRequestV3();
-    dataAccessRequestDAO.insertDARDatasetRelation(dar.getReferenceId(), d1.getDataSetId());
-    dataAccessRequestDAO.insertDARDatasetRelation(dar.getReferenceId(), d2.getDataSetId());
+    dataAccessRequestDAO.insertDARDatasetRelation(dar.getReferenceId(), d1.getDatasetId());
+    dataAccessRequestDAO.insertDARDatasetRelation(dar.getReferenceId(), d2.getDatasetId());
 
     List<DataAccessAgreement> daas = daaDAO.findByDarReferenceId(dar.getReferenceId());
     assertFalse(daas.isEmpty());

--- a/src/test/java/org/broadinstitute/consent/http/db/DacDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DacDAOTest.java
@@ -115,7 +115,7 @@ class DacDAOTest extends DAOTestHelper {
     Integer datasetId = datasetDAO.insertDataset(RandomStringUtils.random(20, true, true), new Timestamp(new Date().getTime()), user.getUserId(), RandomStringUtils.random(20, true, true), new DataUseBuilder().setGeneralUse(true).build().toString(), dacId1);
     List<DatasetProperty> list = new ArrayList<>();
     DatasetProperty dsp = new DatasetProperty();
-    dsp.setDataSetId(datasetId);
+    dsp.setDatasetId(datasetId);
     dsp.setPropertyKey(1);
     dsp.setPropertyValue("Test_PropertyValue");
     dsp.setCreateDate(new Date());
@@ -387,7 +387,7 @@ class DacDAOTest extends DAOTestHelper {
     Dataset datasetSuggestedDac = createDataset();
     datasetDAO.insertDatasetProperties(List.of(new DatasetProperty(
         1,
-        datasetSuggestedDac.getDataSetId(),
+        datasetSuggestedDac.getDatasetId(),
         1,
         "dataAccessCommitteeId",
         dac.getDacId().toString(),
@@ -454,7 +454,7 @@ class DacDAOTest extends DAOTestHelper {
         new Date());
     Dataset dataset = createDataset();
     DataAccessRequest dar = createDataAccessRequest(user.getUserId(), collection_id);
-    dataAccessRequestDAO.insertDARDatasetRelation(dar.getReferenceId(), dataset.getDataSetId());
+    dataAccessRequestDAO.insertDARDatasetRelation(dar.getReferenceId(), dataset.getDatasetId());
     createDataAccessRequest(user.getUserId(), collection_id);
     return darCollectionDAO.findDARCollectionByCollectionId(collection_id);
   }
@@ -496,7 +496,7 @@ class DacDAOTest extends DAOTestHelper {
         new Date(),
         new DataAccessRequestData()
     );
-    dataAccessRequestDAO.insertDARDatasetRelation(randomUUID, d.getDataSetId());
+    dataAccessRequestDAO.insertDARDatasetRelation(randomUUID, d.getDatasetId());
   }
 
   private Dataset createDataset() {
@@ -513,7 +513,7 @@ class DacDAOTest extends DAOTestHelper {
   private void createDatasetProperties(Integer datasetId) {
     List<DatasetProperty> list = new ArrayList<>();
     DatasetProperty dsp = new DatasetProperty();
-    dsp.setDataSetId(datasetId);
+    dsp.setDatasetId(datasetId);
     dsp.setPropertyKey(1);
     dsp.setPropertyValue("Test_PropertyValue");
     dsp.setCreateDate(new Date());

--- a/src/test/java/org/broadinstitute/consent/http/db/DarCollectionDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DarCollectionDAOTest.java
@@ -50,7 +50,7 @@ class DarCollectionDAOTest extends DAOTestHelper {
         .filter(d -> !d.getElections().isEmpty()).findFirst().orElse(null);
     String referenceId = dar.getReferenceId();
     Election election = dar.getElections().values().stream().findFirst().orElse(null);
-    Integer datasetId = election.getDataSetId();
+    Integer datasetId = election.getDatasetId();
     electionDAO.insertElection("DataSet", "Open", new Date(), referenceId, datasetId);
   }
 
@@ -295,7 +295,7 @@ class DarCollectionDAOTest extends DAOTestHelper {
         testDar.getUpdateDate(),
         testDar.getData()
     );
-    dataAccessRequestDAO.insertDARDatasetRelation(testDar.getReferenceId(), dataset.getDataSetId());
+    dataAccessRequestDAO.insertDARDatasetRelation(testDar.getReferenceId(), dataset.getDatasetId());
     return testDar;
   }
 
@@ -322,7 +322,7 @@ class DarCollectionDAOTest extends DAOTestHelper {
 
     // create a DAC
     Dac dac = createDAC();
-    datasetDAO.updateDatasetDacId(dataset.getDataSetId(), dac.getDacId());
+    datasetDAO.updateDatasetDacId(dataset.getDatasetId(), dac.getDacId());
     DarCollection testDarCollection = darCollectionDAO.findDARCollectionByCollectionId(
         collectionId);
 
@@ -457,7 +457,7 @@ class DarCollectionDAOTest extends DAOTestHelper {
   private void createDatasetProperties(Integer datasetId) {
     List<DatasetProperty> list = new ArrayList<>();
     DatasetProperty dsp = new DatasetProperty();
-    dsp.setDataSetId(datasetId);
+    dsp.setDatasetId(datasetId);
     dsp.setPropertyKey(1);
     dsp.setPropertyValue("Test_PropertyValue");
     dsp.setCreateDate(new Date());
@@ -516,10 +516,10 @@ class DarCollectionDAOTest extends DAOTestHelper {
         new Date());
     Dataset dataset = createDataset();
     DataAccessRequest dar = createDataAccessRequest(user.getUserId(), collection_id, darCode);
-    dataAccessRequestDAO.insertDARDatasetRelation(dar.getReferenceId(), dataset.getDataSetId());
+    dataAccessRequestDAO.insertDARDatasetRelation(dar.getReferenceId(), dataset.getDatasetId());
     Election cancelled = createCancelledAccessElection(dar.getReferenceId(),
-        dataset.getDataSetId());
-    Election access = createDataAccessElection(dar.getReferenceId(), dataset.getDataSetId());
+        dataset.getDatasetId());
+    Election access = createDataAccessElection(dar.getReferenceId(), dataset.getDatasetId());
     createFinalVote(user.getUserId(), cancelled.getElectionId());
     createFinalVote(user.getUserId(), access.getElectionId());
     createDataAccessRequest(user.getUserId(), collection_id, darCode);
@@ -553,10 +553,10 @@ class DarCollectionDAOTest extends DAOTestHelper {
         new Date());
     Dataset dataset = createDataset();
     DataAccessRequest dar = createDataAccessRequest(user.getUserId(), collection_id, darCode);
-    dataAccessRequestDAO.insertDARDatasetRelation(dar.getReferenceId(), dataset.getDataSetId());
+    dataAccessRequestDAO.insertDARDatasetRelation(dar.getReferenceId(), dataset.getDatasetId());
     Election cancelled = createCancelledAccessElection(dar.getReferenceId(),
-        dataset.getDataSetId());
-    Election access = createDataAccessElection(dar.getReferenceId(), dataset.getDataSetId());
+        dataset.getDatasetId());
+    Election access = createDataAccessElection(dar.getReferenceId(), dataset.getDatasetId());
     createFinalVote(user.getUserId(), cancelled.getElectionId());
     createFinalVote(user.getUserId(), access.getElectionId());
     createDataAccessRequest(user.getUserId(), collection_id, darCode);

--- a/src/test/java/org/broadinstitute/consent/http/db/DarCollectionSummaryDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DarCollectionSummaryDAOTest.java
@@ -130,26 +130,26 @@ class DarCollectionSummaryDAOTest extends DAOTestHelper {
     DataAccessRequest darOne = createDataAccessRequest(collectionOneId, userOneId);
     DataAccessRequest darTwo = createDataAccessRequest(collectionTwoId, userTwoId);
 
-    dataAccessRequestDAO.insertDARDatasetRelation(darOne.getReferenceId(), dataset.getDataSetId());
+    dataAccessRequestDAO.insertDARDatasetRelation(darOne.getReferenceId(), dataset.getDatasetId());
     dataAccessRequestDAO.insertDARDatasetRelation(darTwo.getReferenceId(),
-        datasetTwo.getDataSetId());
+        datasetTwo.getDatasetId());
     dataAccessRequestDAO.insertDARDatasetRelation(excludedDar.getReferenceId(),
-        excludedDataset.getDataSetId());
+        excludedDataset.getDatasetId());
 
     Election collectionOnePrevElection = createElection(ElectionType.DATA_ACCESS.getValue(),
         ElectionStatus.CLOSED.getValue(),
         darOne.getReferenceId(),
-        dataset.getDataSetId()); //non-latest dataset, need to make sure this isn't pulled into query results
+        dataset.getDatasetId()); //non-latest dataset, need to make sure this isn't pulled into query results
     Election collectionOneElection = createElection(ElectionType.DATA_ACCESS.getValue(),
-        ElectionStatus.OPEN.getValue(), darOne.getReferenceId(), dataset.getDataSetId());
+        ElectionStatus.OPEN.getValue(), darOne.getReferenceId(), dataset.getDatasetId());
     Integer collectionOneElectionId = collectionOneElection.getElectionId();
     Integer collectionOnePrevElectionId = collectionOnePrevElection.getElectionId();
     Election excludedElection = createElection(ElectionType.DATA_ACCESS.getValue(),
         ElectionStatus.CLOSED.getValue(), //tied to excluded dataset, it should not be pulled in
-        excludedDar.getReferenceId(), excludedDataset.getDataSetId());
+        excludedDar.getReferenceId(), excludedDataset.getDatasetId());
     Election collectionTwoElection = createElection(ElectionType.DATA_ACCESS.getValue(),
         ElectionStatus.OPEN.getValue(),
-        darTwo.getReferenceId(), datasetTwo.getDataSetId());
+        darTwo.getReferenceId(), datasetTwo.getDatasetId());
     Integer collectionTwoElectionId = collectionTwoElection.getElectionId();
     Integer excludedElectionId = excludedElection.getElectionId();
 
@@ -180,7 +180,7 @@ class DarCollectionSummaryDAOTest extends DAOTestHelper {
     Vote collectionTwoVoteChair = createVote(userChairId, collectionTwoElectionId,
         VoteType.CHAIRPERSON.getValue());
 
-    List<Integer> targetDatasets = List.of(dataset.getDataSetId(), datasetTwo.getDataSetId());
+    List<Integer> targetDatasets = List.of(dataset.getDatasetId(), datasetTwo.getDatasetId());
     List<DarCollectionSummary> summaries = darCollectionSummaryDAO.getDarCollectionSummariesForDAC(
         userChairId, targetDatasets);
 
@@ -228,19 +228,19 @@ class DarCollectionSummaryDAOTest extends DAOTestHelper {
     DataAccessRequest excludedDar = createDataAccessRequest(excludedDarCollectionId, userOneId);
     DataAccessRequest darOne = createDataAccessRequest(collectionOneId, userOneId);
 
-    dataAccessRequestDAO.insertDARDatasetRelation(darOne.getReferenceId(), dataset.getDataSetId());
+    dataAccessRequestDAO.insertDARDatasetRelation(darOne.getReferenceId(), dataset.getDatasetId());
     dataAccessRequestDAO.insertDARDatasetRelation(excludedDar.getReferenceId(),
-        excludedDataset.getDataSetId());
+        excludedDataset.getDatasetId());
 
     Election excludedElection = createElection(ElectionType.DATA_ACCESS.getValue(),
         ElectionStatus.CLOSED.getValue(),
-        excludedDar.getReferenceId(), excludedDataset.getDataSetId());
+        excludedDar.getReferenceId(), excludedDataset.getDatasetId());
     Integer excludedElectionId = excludedElection.getElectionId();
 
     // create votes for dataset that should NOT be pulled by the query
     createVote(userOneId, excludedElectionId, VoteType.DAC.getValue());
 
-    List<Integer> targetDatasets = List.of(dataset.getDataSetId());
+    List<Integer> targetDatasets = List.of(dataset.getDatasetId());
     List<DarCollectionSummary> summaries = darCollectionSummaryDAO.getDarCollectionSummariesForDAC(
         userChairId,
         targetDatasets);
@@ -270,11 +270,11 @@ class DarCollectionSummaryDAOTest extends DAOTestHelper {
     DataAccessRequest archivedDar = createDataAccessRequest(archivedCollectionId, userOneId);
     dataAccessRequestDAO.archiveByReferenceIds(List.of(archivedDar.getReferenceId()));
 
-    dataAccessRequestDAO.insertDARDatasetRelation(darOne.getReferenceId(), dataset.getDataSetId());
+    dataAccessRequestDAO.insertDARDatasetRelation(darOne.getReferenceId(), dataset.getDatasetId());
     dataAccessRequestDAO.insertDARDatasetRelation(archivedDar.getReferenceId(),
-        dataset.getDataSetId());
+        dataset.getDatasetId());
 
-    List<Integer> targetDatasets = List.of(dataset.getDataSetId());
+    List<Integer> targetDatasets = List.of(dataset.getDatasetId());
     List<DarCollectionSummary> summaries = darCollectionSummaryDAO.getDarCollectionSummariesForDAC(
         userOneId, targetDatasets);
 
@@ -304,24 +304,24 @@ class DarCollectionSummaryDAOTest extends DAOTestHelper {
     DataAccessRequest darOne = createDataAccessRequest(collectionOneId, userOneId);
     DataAccessRequest darTwo = createDataAccessRequest(collectionTwoId, userTwoId);
 
-    dataAccessRequestDAO.insertDARDatasetRelation(darOne.getReferenceId(), dataset.getDataSetId());
+    dataAccessRequestDAO.insertDARDatasetRelation(darOne.getReferenceId(), dataset.getDatasetId());
     dataAccessRequestDAO.insertDARDatasetRelation(darTwo.getReferenceId(),
-        datasetTwo.getDataSetId());
+        datasetTwo.getDatasetId());
 
     Election collectionOnePrevElection = createElection(ElectionType.DATA_ACCESS.getValue(),
         ElectionStatus.CLOSED.getValue(),
-        darOne.getReferenceId(), dataset.getDataSetId());
+        darOne.getReferenceId(), dataset.getDatasetId());
     Election collectionOneElection = createElection(ElectionType.DATA_ACCESS.getValue(),
         ElectionStatus.OPEN.getValue(),
-        darOne.getReferenceId(), dataset.getDataSetId());
+        darOne.getReferenceId(), dataset.getDatasetId());
     Integer collectionOneElectionId = collectionOneElection.getElectionId();
     Integer collectionOnePrevElectionId = collectionOnePrevElection.getElectionId();
     Election collectionTwoElection = createElection(ElectionType.DATA_ACCESS.getValue(),
         ElectionStatus.OPEN.getValue(),
-        darTwo.getReferenceId(), datasetTwo.getDataSetId());
+        darTwo.getReferenceId(), datasetTwo.getDatasetId());
     Integer collectionTwoElectionId = collectionTwoElection.getElectionId();
 
-    List<Integer> targetDatasets = List.of(dataset.getDataSetId());
+    List<Integer> targetDatasets = List.of(dataset.getDatasetId());
     List<DarCollectionSummary> summaries = darCollectionSummaryDAO.getDarCollectionSummariesForSO(
         institutionId);
 
@@ -356,9 +356,9 @@ class DarCollectionSummaryDAOTest extends DAOTestHelper {
     Dataset dataset = createDataset(userOneId);
     Integer collectionOneId = createDarCollection(userOneId);
     DataAccessRequest darOne = createDataAccessRequest(collectionOneId, userOneId);
-    dataAccessRequestDAO.insertDARDatasetRelation(darOne.getReferenceId(), dataset.getDataSetId());
+    dataAccessRequestDAO.insertDARDatasetRelation(darOne.getReferenceId(), dataset.getDatasetId());
 
-    List<Integer> targetDatasets = List.of(dataset.getDataSetId());
+    List<Integer> targetDatasets = List.of(dataset.getDatasetId());
     List<DarCollectionSummary> summaries = darCollectionSummaryDAO.getDarCollectionSummariesForSO(
         institutionId);
 
@@ -389,9 +389,9 @@ class DarCollectionSummaryDAOTest extends DAOTestHelper {
     DataAccessRequest archivedDar = createDataAccessRequest(archivedCollectionId, userOneId);
     dataAccessRequestDAO.archiveByReferenceIds(List.of(archivedDar.getReferenceId()));
 
-    dataAccessRequestDAO.insertDARDatasetRelation(darOne.getReferenceId(), dataset.getDataSetId());
+    dataAccessRequestDAO.insertDARDatasetRelation(darOne.getReferenceId(), dataset.getDatasetId());
     dataAccessRequestDAO.insertDARDatasetRelation(archivedDar.getReferenceId(),
-        dataset.getDataSetId());
+        dataset.getDatasetId());
 
     List<DarCollectionSummary> summaries = darCollectionSummaryDAO.getDarCollectionSummariesForSO(
         institutionId);
@@ -422,24 +422,24 @@ class DarCollectionSummaryDAOTest extends DAOTestHelper {
     DataAccessRequest darOne = createDataAccessRequest(collectionOneId, userOneId);
     DataAccessRequest darTwo = createDataAccessRequest(collectionTwoId, userTwoId);
 
-    dataAccessRequestDAO.insertDARDatasetRelation(darOne.getReferenceId(), dataset.getDataSetId());
+    dataAccessRequestDAO.insertDARDatasetRelation(darOne.getReferenceId(), dataset.getDatasetId());
     dataAccessRequestDAO.insertDARDatasetRelation(darTwo.getReferenceId(),
-        datasetTwo.getDataSetId());
+        datasetTwo.getDatasetId());
 
     Election collectionOnePrevElection = createElection(ElectionType.DATA_ACCESS.getValue(),
         ElectionStatus.CLOSED.getValue(),
-        darOne.getReferenceId(), dataset.getDataSetId());
+        darOne.getReferenceId(), dataset.getDatasetId());
     Election collectionOneElection = createElection(ElectionType.DATA_ACCESS.getValue(),
         ElectionStatus.OPEN.getValue(),
-        darOne.getReferenceId(), dataset.getDataSetId());
+        darOne.getReferenceId(), dataset.getDatasetId());
     Integer collectionOneElectionId = collectionOneElection.getElectionId();
     Integer collectionOnePrevElectionId = collectionOnePrevElection.getElectionId();
     Election collectionTwoElection = createElection(ElectionType.DATA_ACCESS.getValue(),
         ElectionStatus.OPEN.getValue(),
-        darTwo.getReferenceId(), datasetTwo.getDataSetId());
+        darTwo.getReferenceId(), datasetTwo.getDatasetId());
     Integer collectionTwoElectionId = collectionTwoElection.getElectionId();
 
-    List<Integer> targetDatasets = List.of(dataset.getDataSetId());
+    List<Integer> targetDatasets = List.of(dataset.getDatasetId());
     List<DarCollectionSummary> summaries = darCollectionSummaryDAO.getDarCollectionSummariesForResearcher(
         userOneId);
 
@@ -481,16 +481,16 @@ class DarCollectionSummaryDAOTest extends DAOTestHelper {
     DataAccessRequest darOne = createDataAccessRequest(collectionOneId, userOneId);
     DataAccessRequest darTwo = createDataAccessRequest(collectionTwoId, userTwoId);
 
-    dataAccessRequestDAO.insertDARDatasetRelation(darOne.getReferenceId(), dataset.getDataSetId());
+    dataAccessRequestDAO.insertDARDatasetRelation(darOne.getReferenceId(), dataset.getDatasetId());
     dataAccessRequestDAO.insertDARDatasetRelation(darTwo.getReferenceId(),
-        datasetTwo.getDataSetId());
+        datasetTwo.getDatasetId());
 
     Election collectionTwoElection = createElection(ElectionType.DATA_ACCESS.getValue(),
         ElectionStatus.OPEN.getValue(),
-        darTwo.getReferenceId(), datasetTwo.getDataSetId());
+        darTwo.getReferenceId(), datasetTwo.getDatasetId());
     Integer collectionTwoElectionId = collectionTwoElection.getElectionId();
 
-    List<Integer> targetDatasets = List.of(dataset.getDataSetId());
+    List<Integer> targetDatasets = List.of(dataset.getDatasetId());
     List<DarCollectionSummary> summaries = darCollectionSummaryDAO.getDarCollectionSummariesForResearcher(
         userOneId);
 
@@ -520,9 +520,9 @@ class DarCollectionSummaryDAOTest extends DAOTestHelper {
     DataAccessRequest archivedDar = createDataAccessRequest(archivedCollectionId, userOneId);
     dataAccessRequestDAO.archiveByReferenceIds(List.of(archivedDar.getReferenceId()));
 
-    dataAccessRequestDAO.insertDARDatasetRelation(darOne.getReferenceId(), dataset.getDataSetId());
+    dataAccessRequestDAO.insertDARDatasetRelation(darOne.getReferenceId(), dataset.getDatasetId());
     dataAccessRequestDAO.insertDARDatasetRelation(archivedDar.getReferenceId(),
-        dataset.getDataSetId());
+        dataset.getDatasetId());
 
     List<DarCollectionSummary> summaries = darCollectionSummaryDAO.getDarCollectionSummariesForResearcher(
         userOneId);
@@ -545,7 +545,7 @@ class DarCollectionSummaryDAOTest extends DAOTestHelper {
     Integer collectionId = createDarCollection(userId);
     DataAccessRequest dar = createDataAccessRequest(collectionId, userId);
 
-    dataAccessRequestDAO.insertDARDatasetRelation(dar.getReferenceId(), dataset.getDataSetId());
+    dataAccessRequestDAO.insertDARDatasetRelation(dar.getReferenceId(), dataset.getDatasetId());
     dataAccessRequestDAO.updateDraftByReferenceId(dar.getReferenceId(), true); // draft DAR
 
     List<DarCollectionSummary> summaries = darCollectionSummaryDAO.getDarCollectionSummariesForResearcher(
@@ -575,24 +575,24 @@ class DarCollectionSummaryDAOTest extends DAOTestHelper {
     DataAccessRequest darOne = createDataAccessRequest(collectionOneId, userOneId);
     DataAccessRequest darTwo = createDataAccessRequest(collectionTwoId, userTwoId);
 
-    dataAccessRequestDAO.insertDARDatasetRelation(darOne.getReferenceId(), dataset.getDataSetId());
+    dataAccessRequestDAO.insertDARDatasetRelation(darOne.getReferenceId(), dataset.getDatasetId());
     dataAccessRequestDAO.insertDARDatasetRelation(darTwo.getReferenceId(),
-        datasetTwo.getDataSetId());
+        datasetTwo.getDatasetId());
 
     Election collectionOnePrevElection = createElection(ElectionType.DATA_ACCESS.getValue(),
         ElectionStatus.CLOSED.getValue(),
-        darOne.getReferenceId(), dataset.getDataSetId());
+        darOne.getReferenceId(), dataset.getDatasetId());
     Election collectionOneElection = createElection(ElectionType.DATA_ACCESS.getValue(),
         ElectionStatus.OPEN.getValue(),
-        darOne.getReferenceId(), dataset.getDataSetId());
+        darOne.getReferenceId(), dataset.getDatasetId());
     Integer collectionOneElectionId = collectionOneElection.getElectionId();
     Integer collectionOnePrevElectionId = collectionOnePrevElection.getElectionId();
     Election collectionTwoElection = createElection(ElectionType.DATA_ACCESS.getValue(),
         ElectionStatus.OPEN.getValue(),
-        darTwo.getReferenceId(), datasetTwo.getDataSetId());
+        darTwo.getReferenceId(), datasetTwo.getDatasetId());
     Integer collectionTwoElectionId = collectionTwoElection.getElectionId();
 
-    List<Integer> targetDatasets = List.of(dataset.getDataSetId(), datasetTwo.getDataSetId());
+    List<Integer> targetDatasets = List.of(dataset.getDatasetId(), datasetTwo.getDatasetId());
     List<String> targetDatasetDacNames = List.of(dacOneName, dacTwoName);
     List<DarCollectionSummary> summaries = darCollectionSummaryDAO.getDarCollectionSummariesForAdmin();
     assertNotNull(summaries);
@@ -639,11 +639,11 @@ class DarCollectionSummaryDAOTest extends DAOTestHelper {
     DataAccessRequest darOne = createDataAccessRequest(collectionOneId, userOneId);
     DataAccessRequest darTwo = createDataAccessRequest(collectionTwoId, userTwoId);
 
-    dataAccessRequestDAO.insertDARDatasetRelation(darOne.getReferenceId(), dataset.getDataSetId());
+    dataAccessRequestDAO.insertDARDatasetRelation(darOne.getReferenceId(), dataset.getDatasetId());
     dataAccessRequestDAO.insertDARDatasetRelation(darTwo.getReferenceId(),
-        datasetTwo.getDataSetId());
+        datasetTwo.getDatasetId());
 
-    List<Integer> targetDatasets = List.of(dataset.getDataSetId(), datasetTwo.getDataSetId());
+    List<Integer> targetDatasets = List.of(dataset.getDatasetId(), datasetTwo.getDatasetId());
     List<String> targetDatasetDacNames = List.of(dacOneName, dacTwoName);
     List<DarCollectionSummary> summaries = darCollectionSummaryDAO.getDarCollectionSummariesForAdmin();
     assertNotNull(summaries);
@@ -676,9 +676,9 @@ class DarCollectionSummaryDAOTest extends DAOTestHelper {
     DataAccessRequest archivedDar = createDataAccessRequest(archivedCollectionId, userOneId);
     dataAccessRequestDAO.archiveByReferenceIds(List.of(archivedDar.getReferenceId()));
 
-    dataAccessRequestDAO.insertDARDatasetRelation(darOne.getReferenceId(), dataset.getDataSetId());
+    dataAccessRequestDAO.insertDARDatasetRelation(darOne.getReferenceId(), dataset.getDatasetId());
     dataAccessRequestDAO.insertDARDatasetRelation(archivedDar.getReferenceId(),
-        dataset.getDataSetId());
+        dataset.getDatasetId());
 
     List<DarCollectionSummary> summaries = darCollectionSummaryDAO.getDarCollectionSummariesForAdmin();
 
@@ -702,24 +702,24 @@ class DarCollectionSummaryDAOTest extends DAOTestHelper {
     DataAccessRequest darOne = createDataAccessRequest(collectionOneId, userOneId);
     DataAccessRequest darTwo = createDataAccessRequest(collectionTwoId, userTwoId);
 
-    dataAccessRequestDAO.insertDARDatasetRelation(darOne.getReferenceId(), dataset.getDataSetId());
+    dataAccessRequestDAO.insertDARDatasetRelation(darOne.getReferenceId(), dataset.getDatasetId());
     dataAccessRequestDAO.insertDARDatasetRelation(darTwo.getReferenceId(),
-        datasetTwo.getDataSetId());
+        datasetTwo.getDatasetId());
 
     Election collectionOnePrevElection = createElection(ElectionType.DATA_ACCESS.getValue(),
         ElectionStatus.CLOSED.getValue(),
-        darOne.getReferenceId(), dataset.getDataSetId());
+        darOne.getReferenceId(), dataset.getDatasetId());
     Election collectionOneElection = createElection(ElectionType.DATA_ACCESS.getValue(),
         ElectionStatus.OPEN.getValue(),
-        darOne.getReferenceId(), dataset.getDataSetId());
+        darOne.getReferenceId(), dataset.getDatasetId());
     Integer collectionOneElectionId = collectionOneElection.getElectionId();
     Integer collectionOnePrevElectionId = collectionOnePrevElection.getElectionId();
     Election collectionTwoElection = createElection(ElectionType.DATA_ACCESS.getValue(),
         ElectionStatus.OPEN.getValue(),
-        darTwo.getReferenceId(), datasetTwo.getDataSetId());
+        darTwo.getReferenceId(), datasetTwo.getDatasetId());
     Integer collectionTwoElectionId = collectionTwoElection.getElectionId();
 
-    List<Integer> targetDatasets = List.of(dataset.getDataSetId());
+    List<Integer> targetDatasets = List.of(dataset.getDatasetId());
     DarCollectionSummary summary = darCollectionSummaryDAO.getDarCollectionSummaryByCollectionId(
         collectionOneId);
 
@@ -751,16 +751,16 @@ class DarCollectionSummaryDAOTest extends DAOTestHelper {
     DataAccessRequest darOne = createDataAccessRequest(collectionOneId, userOneId);
     DataAccessRequest darTwo = createDataAccessRequest(collectionTwoId, userTwoId);
 
-    dataAccessRequestDAO.insertDARDatasetRelation(darOne.getReferenceId(), dataset.getDataSetId());
+    dataAccessRequestDAO.insertDARDatasetRelation(darOne.getReferenceId(), dataset.getDatasetId());
     dataAccessRequestDAO.insertDARDatasetRelation(darTwo.getReferenceId(),
-        datasetTwo.getDataSetId());
+        datasetTwo.getDatasetId());
 
     Election collectionTwoElection = createElection(ElectionType.DATA_ACCESS.getValue(),
         ElectionStatus.OPEN.getValue(),
-        darTwo.getReferenceId(), datasetTwo.getDataSetId());
+        darTwo.getReferenceId(), datasetTwo.getDatasetId());
     Integer collectionTwoElectionId = collectionTwoElection.getElectionId();
 
-    List<Integer> targetDatasets = List.of(dataset.getDataSetId());
+    List<Integer> targetDatasets = List.of(dataset.getDatasetId());
     DarCollectionSummary summary = darCollectionSummaryDAO.getDarCollectionSummaryByCollectionId(
         collectionOneId);
 
@@ -789,21 +789,21 @@ class DarCollectionSummaryDAOTest extends DAOTestHelper {
     DataAccessRequest darOne = createDataAccessRequest(collectionOneId, userOneId);
     DataAccessRequest excludedDar = createDataAccessRequest(excludedCollectionId, userTwoId);
 
-    dataAccessRequestDAO.insertDARDatasetRelation(darOne.getReferenceId(), dataset.getDataSetId());
+    dataAccessRequestDAO.insertDARDatasetRelation(darOne.getReferenceId(), dataset.getDatasetId());
     dataAccessRequestDAO.insertDARDatasetRelation(excludedDar.getReferenceId(),
-        datasetTwo.getDataSetId());
+        datasetTwo.getDatasetId());
 
     Election collectionOnePrevElection = createElection(ElectionType.DATA_ACCESS.getValue(),
         ElectionStatus.CLOSED.getValue(),
         darOne.getReferenceId(),
-        dataset.getDataSetId()); //non-latest dataset, need to make sure this isn't pulled into query results
+        dataset.getDatasetId()); //non-latest dataset, need to make sure this isn't pulled into query results
     Election collectionOneElection = createElection(ElectionType.DATA_ACCESS.getValue(),
-        ElectionStatus.OPEN.getValue(), darOne.getReferenceId(), dataset.getDataSetId());
+        ElectionStatus.OPEN.getValue(), darOne.getReferenceId(), dataset.getDatasetId());
     Integer collectionOneElectionId = collectionOneElection.getElectionId();
     Integer collectionOnePrevElectionId = collectionOnePrevElection.getElectionId();
     Election excludedCollectionElection = createElection(ElectionType.DATA_ACCESS.getValue(),
         ElectionStatus.OPEN.getValue(),
-        excludedDar.getReferenceId(), datasetTwo.getDataSetId());
+        excludedDar.getReferenceId(), datasetTwo.getDatasetId());
     Integer excludedCollectionElectionId = excludedCollectionElection.getElectionId();
 
     //create old votes to ensure that they don't get pulled in by the query
@@ -830,7 +830,7 @@ class DarCollectionSummaryDAOTest extends DAOTestHelper {
     Vote collectionTwoVoteChair = createVote(userChairId, excludedCollectionElectionId,
         VoteType.CHAIRPERSON.getValue());
 
-    List<Integer> targetDatasets = List.of(dataset.getDataSetId(), datasetTwo.getDataSetId());
+    List<Integer> targetDatasets = List.of(dataset.getDatasetId(), datasetTwo.getDatasetId());
     DarCollectionSummary summary = darCollectionSummaryDAO.getDarCollectionSummaryForDACByCollectionId(
         userChairId, targetDatasets, collectionOneId);
 
@@ -865,19 +865,19 @@ class DarCollectionSummaryDAOTest extends DAOTestHelper {
     DataAccessRequest excludedDar = createDataAccessRequest(excludedDarCollectionId, userOneId);
     DataAccessRequest darOne = createDataAccessRequest(collectionOneId, userOneId);
 
-    dataAccessRequestDAO.insertDARDatasetRelation(darOne.getReferenceId(), dataset.getDataSetId());
+    dataAccessRequestDAO.insertDARDatasetRelation(darOne.getReferenceId(), dataset.getDatasetId());
     dataAccessRequestDAO.insertDARDatasetRelation(excludedDar.getReferenceId(),
-        excludedDataset.getDataSetId());
+        excludedDataset.getDatasetId());
 
     Election excludedElection = createElection(ElectionType.DATA_ACCESS.getValue(),
         ElectionStatus.CLOSED.getValue(),
-        excludedDar.getReferenceId(), excludedDataset.getDataSetId());
+        excludedDar.getReferenceId(), excludedDataset.getDatasetId());
     Integer excludedElectionId = excludedElection.getElectionId();
 
     // create votes for dataset that should NOT be pulled by the query
     createVote(userOneId, excludedElectionId, VoteType.DAC.getValue());
 
-    List<Integer> targetDatasets = List.of(dataset.getDataSetId());
+    List<Integer> targetDatasets = List.of(dataset.getDatasetId());
     DarCollectionSummary summary = darCollectionSummaryDAO.getDarCollectionSummaryForDACByCollectionId(
         userChairId, targetDatasets, collectionOneId);
 
@@ -904,9 +904,9 @@ class DarCollectionSummaryDAOTest extends DAOTestHelper {
     DataAccessRequest archivedDar = createDataAccessRequest(archivedCollectionId, userOneId);
     dataAccessRequestDAO.archiveByReferenceIds(List.of(archivedDar.getReferenceId()));
     dataAccessRequestDAO.insertDARDatasetRelation(archivedDar.getReferenceId(),
-        dataset.getDataSetId());
+        dataset.getDatasetId());
 
-    List<Integer> targetDatasets = List.of(dataset.getDataSetId());
+    List<Integer> targetDatasets = List.of(dataset.getDatasetId());
     DarCollectionSummary summary = darCollectionSummaryDAO.getDarCollectionSummaryForDACByCollectionId(
         userChairId, targetDatasets, archivedCollectionId);
 
@@ -923,7 +923,7 @@ class DarCollectionSummaryDAOTest extends DAOTestHelper {
     DataAccessRequest archivedDar = createDataAccessRequest(archivedCollectionId, userOneId);
     dataAccessRequestDAO.archiveByReferenceIds(List.of(archivedDar.getReferenceId()));
     dataAccessRequestDAO.insertDARDatasetRelation(archivedDar.getReferenceId(),
-        dataset.getDataSetId());
+        dataset.getDatasetId());
 
     DarCollectionSummary summary = darCollectionSummaryDAO.getDarCollectionSummaryByCollectionId(
         archivedCollectionId);

--- a/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
@@ -60,8 +60,8 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
     DataAccessRequest draft = createDraftDataAccessRequest();
     Dataset d1 = createDARDAOTestDataset();
     Dataset d2 = createDARDAOTestDataset();
-    dataAccessRequestDAO.insertDARDatasetRelation(draft.getReferenceId(), d1.getDataSetId());
-    dataAccessRequestDAO.insertDARDatasetRelation(draft.getReferenceId(), d2.getDataSetId());
+    dataAccessRequestDAO.insertDARDatasetRelation(draft.getReferenceId(), d1.getDatasetId());
+    dataAccessRequestDAO.insertDARDatasetRelation(draft.getReferenceId(), d2.getDatasetId());
     List<DataAccessRequest> newDars = dataAccessRequestDAO.findAllDraftDataAccessRequests();
     assertFalse(newDars.isEmpty());
     assertEquals(1, newDars.size());
@@ -73,8 +73,8 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
     DataAccessRequest dar = createDraftDataAccessRequest();
     Dataset d1 = createDARDAOTestDataset();
     Dataset d2 = createDARDAOTestDataset();
-    dataAccessRequestDAO.insertDARDatasetRelation(dar.getReferenceId(), d1.getDataSetId());
-    dataAccessRequestDAO.insertDARDatasetRelation(dar.getReferenceId(), d2.getDataSetId());
+    dataAccessRequestDAO.insertDARDatasetRelation(dar.getReferenceId(), d1.getDatasetId());
+    dataAccessRequestDAO.insertDARDatasetRelation(dar.getReferenceId(), d2.getDatasetId());
 
     List<DataAccessRequest> newDars = dataAccessRequestDAO.findAllDraftsByUserId(dar.getUserId());
     assertFalse(newDars.isEmpty());
@@ -160,13 +160,13 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
     DataAccessRequest dar = createDataAccessRequest(user.getUserId(), collection_id, darCode);
     Dataset d1 = createDARDAOTestDataset();
     Dataset d2 = createDARDAOTestDataset();
-    dataAccessRequestDAO.insertDARDatasetRelation(dar.getReferenceId(), d1.getDataSetId());
-    dataAccessRequestDAO.insertDARDatasetRelation(dar.getReferenceId(), d2.getDataSetId());
+    dataAccessRequestDAO.insertDARDatasetRelation(dar.getReferenceId(), d1.getDatasetId());
+    dataAccessRequestDAO.insertDARDatasetRelation(dar.getReferenceId(), d2.getDatasetId());
     DataAccessRequest foundDar = dataAccessRequestDAO.findByReferenceId(dar.getReferenceId());
     assertNotNull(foundDar);
     assertNotNull(foundDar.getData());
-    assertTrue(foundDar.getDatasetIds().contains(d1.getDataSetId()));
-    assertTrue(foundDar.getDatasetIds().contains(d2.getDataSetId()));
+    assertTrue(foundDar.getDatasetIds().contains(d1.getDatasetId()));
+    assertTrue(foundDar.getDatasetIds().contains(d2.getDatasetId()));
   }
 
   @Test
@@ -366,7 +366,7 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
         testDar.getUpdateDate(),
         testDar.getData()
     );
-    dataAccessRequestDAO.insertDARDatasetRelation(testDar.getReferenceId(), dataset.getDataSetId());
+    dataAccessRequestDAO.insertDARDatasetRelation(testDar.getReferenceId(), dataset.getDatasetId());
     return dataAccessRequestDAO.findByReferenceId(testDar.getReferenceId());
   }
 
@@ -433,7 +433,7 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
     DataAccessRequest testDar1 = createDAR(user1, dataset1, darCode1);
     DataAccessRequest testDar2 = createDAR(user2, dataset2, darCode2);
 
-    Election e1 = createDataAccessElection(testDar1.getReferenceId(), dataset1.getDataSetId());
+    Election e1 = createDataAccessElection(testDar1.getReferenceId(), dataset1.getDatasetId());
     Vote v1 = createFinalVote(dataset1.getCreateUserId(), e1.getElectionId());
     Date now = new Date();
     voteDAO.updateVote(true,
@@ -445,7 +445,7 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
         now,
         false);
 
-    Election e2 = createDataAccessElection(testDar2.getReferenceId(), dataset2.getDataSetId());
+    Election e2 = createDataAccessElection(testDar2.getReferenceId(), dataset2.getDatasetId());
     Vote v2 = createFinalVote(dataset2.getCreateUserId(), e2.getElectionId());
     now = new Date();
     voteDAO.updateVote(true,
@@ -458,9 +458,9 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
         false);
 
     List<DataAccessRequest> dars = dataAccessRequestDAO.findApprovedDARsByDatasetId(
-        dataset1.getDataSetId());
+        dataset1.getDatasetId());
     assertEquals(1, dars.size());
-    assertTrue(dars.get(0).getDatasetIds().contains(dataset1.getDataSetId()));
+    assertTrue(dars.get(0).getDatasetIds().contains(dataset1.getDatasetId()));
   }
 
   @Test
@@ -472,10 +472,10 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
     Dataset dataset2 = createDARDAOTestDataset();
 
     assertTrue(
-        dataAccessRequestDAO.findApprovedDARsByDatasetId(dataset1.getDataSetId())
+        dataAccessRequestDAO.findApprovedDARsByDatasetId(dataset1.getDatasetId())
             .isEmpty());
     assertTrue(
-        dataAccessRequestDAO.findApprovedDARsByDatasetId(dataset2.getDataSetId())
+        dataAccessRequestDAO.findApprovedDARsByDatasetId(dataset2.getDatasetId())
             .isEmpty());
 
     User user1 = createUserWithInstitution();
@@ -485,17 +485,17 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
     DataAccessRequest testDar2 = createDAR(user2, dataset2, darCode2);
     DataAccessRequest testDar3 = createDAR(user3, dataset2, darCode3);
     assertTrue(
-        dataAccessRequestDAO.findApprovedDARsByDatasetId(dataset1.getDataSetId())
+        dataAccessRequestDAO.findApprovedDARsByDatasetId(dataset1.getDatasetId())
             .isEmpty());
     assertTrue(
-        dataAccessRequestDAO.findApprovedDARsByDatasetId(dataset2.getDataSetId())
+        dataAccessRequestDAO.findApprovedDARsByDatasetId(dataset2.getDatasetId())
             .isEmpty());
 
     assertEquals(0,
-        dataAccessRequestDAO.findApprovedDARsByDatasetId(dataset2.getDataSetId())
+        dataAccessRequestDAO.findApprovedDARsByDatasetId(dataset2.getDatasetId())
             .size());
 
-    Election e1 = createDataAccessElection(testDar1.getReferenceId(), dataset1.getDataSetId());
+    Election e1 = createDataAccessElection(testDar1.getReferenceId(), dataset1.getDatasetId());
     Vote v1 = createFinalVote(dataset1.getCreateUserId(), e1.getElectionId());
     Date now = new Date();
     voteDAO.updateVote(true,
@@ -507,7 +507,7 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
         now,
         false);
 
-    Election e2 = createDataAccessElection(testDar2.getReferenceId(), dataset2.getDataSetId());
+    Election e2 = createDataAccessElection(testDar2.getReferenceId(), dataset2.getDatasetId());
     Vote v2 = createFinalVote(dataset2.getCreateUserId(), e2.getElectionId());
     now = new Date();
     voteDAO.updateVote(true,
@@ -520,19 +520,19 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
         false);
 
     assertEquals(1,
-        dataAccessRequestDAO.findApprovedDARsByDatasetId(dataset1.getDataSetId())
+        dataAccessRequestDAO.findApprovedDARsByDatasetId(dataset1.getDatasetId())
             .size());
     assertEquals(testDar1.getUserId(),
-        dataAccessRequestDAO.findApprovedDARsByDatasetId(dataset1.getDataSetId())
+        dataAccessRequestDAO.findApprovedDARsByDatasetId(dataset1.getDatasetId())
             .get(0).getUserId());
     assertEquals(1,
-        dataAccessRequestDAO.findApprovedDARsByDatasetId(dataset2.getDataSetId())
+        dataAccessRequestDAO.findApprovedDARsByDatasetId(dataset2.getDatasetId())
             .size());
     assertEquals(testDar2.getUserId(),
-        dataAccessRequestDAO.findApprovedDARsByDatasetId(dataset2.getDataSetId())
+        dataAccessRequestDAO.findApprovedDARsByDatasetId(dataset2.getDatasetId())
             .get(0).getUserId());
 
-    Election e3 = createDataAccessElection(testDar3.getReferenceId(), dataset2.getDataSetId());
+    Election e3 = createDataAccessElection(testDar3.getReferenceId(), dataset2.getDatasetId());
     Vote v3 = createFinalVote(dataset2.getCreateUserId(), e3.getElectionId());
     now = new Date();
     voteDAO.updateVote(true,
@@ -544,7 +544,7 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
         now,
         false);
 
-    List<DataAccessRequest> approvedDars = dataAccessRequestDAO.findApprovedDARsByDatasetId(dataset2.getDataSetId());
+    List<DataAccessRequest> approvedDars = dataAccessRequestDAO.findApprovedDARsByDatasetId(dataset2.getDatasetId());
     List<Integer> approvedDarIds = approvedDars.stream().map(DataAccessRequest::getId).toList();
     assertEquals(2, approvedDarIds.size());
     assertTrue(approvedDarIds.contains(testDar3.getId()));
@@ -563,7 +563,7 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
     User user1 = createUserWithInstitution();
     DataAccessRequest testDar1 = createDAR(user1, dataset1, darCode1);
 
-    Election e1 = createDataAccessElection(testDar1.getReferenceId(), dataset1.getDataSetId());
+    Election e1 = createDataAccessElection(testDar1.getReferenceId(), dataset1.getDatasetId());
     Vote v1 = createFinalVote(dataset1.getCreateUserId(), e1.getElectionId());
     Date now = new Date();
     voteDAO.updateVote(true,
@@ -576,10 +576,10 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
         false);
 
     assertEquals(1,
-        dataAccessRequestDAO.findApprovedDARsByDatasetId(dataset1.getDataSetId())
+        dataAccessRequestDAO.findApprovedDARsByDatasetId(dataset1.getDatasetId())
             .size());
 
-    Election e2 = createDataAccessElection(testDar1.getReferenceId(), dataset1.getDataSetId());
+    Election e2 = createDataAccessElection(testDar1.getReferenceId(), dataset1.getDatasetId());
     Vote v2 = createFinalVote(dataset1.getCreateUserId(), e2.getElectionId());
     now = new Date();
     voteDAO.updateVote(false,
@@ -592,7 +592,7 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
         false);
 
     assertEquals(0,
-        dataAccessRequestDAO.findApprovedDARsByDatasetId(dataset1.getDataSetId())
+        dataAccessRequestDAO.findApprovedDARsByDatasetId(dataset1.getDatasetId())
             .size());
   }
 
@@ -713,7 +713,7 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
         dataUse.toString(), null);
     List<DatasetProperty> list = new ArrayList<>();
     DatasetProperty dsp = new DatasetProperty();
-    dsp.setDataSetId(id);
+    dsp.setDatasetId(id);
     dsp.setPropertyKey(1);
     dsp.setPropertyValue("Test_PropertyValue");
     dsp.setCreateDate(new Date());
@@ -757,10 +757,10 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
         new Date());
     Dataset dataset = createDataset();
     DataAccessRequest dar = createDataAccessRequest(user.getUserId(), collection_id, darCode);
-    dataAccessRequestDAO.insertDARDatasetRelation(dar.getReferenceId(), dataset.getDataSetId());
+    dataAccessRequestDAO.insertDARDatasetRelation(dar.getReferenceId(), dataset.getDatasetId());
     Election cancelled = createCancelledAccessElection(dar.getReferenceId(),
-        dataset.getDataSetId());
-    Election access = createDataAccessElection(dar.getReferenceId(), dataset.getDataSetId());
+        dataset.getDatasetId());
+    Election access = createDataAccessElection(dar.getReferenceId(), dataset.getDatasetId());
     createFinalVote(user.getUserId(), cancelled.getElectionId());
     createFinalVote(user.getUserId(), access.getElectionId());
     createDataAccessRequest(user.getUserId(), collection_id, darCode);
@@ -794,7 +794,7 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
   private void createDatasetProperties(Integer datasetId) {
     List<DatasetProperty> list = new ArrayList<>();
     DatasetProperty dsp = new DatasetProperty();
-    dsp.setDataSetId(datasetId);
+    dsp.setDatasetId(datasetId);
     dsp.setPropertyKey(1);
     dsp.setPropertyValue("Test_PropertyValue");
     dsp.setCreateDate(new Date());

--- a/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
@@ -62,11 +62,11 @@ class DatasetDAOTest extends DAOTestHelper {
   void testFindAllDatasetStudySummariesDatasetAndStudy() {
     Dataset dataset = insertDataset();
     Study study = insertStudyWithProperties();
-    datasetDAO.updateStudyId(dataset.getDataSetId(), study.getStudyId());
+    datasetDAO.updateStudyId(dataset.getDatasetId(), study.getStudyId());
 
     List<DatasetStudySummary> summaries = datasetDAO.findAllDatasetStudySummaries();
     assertThat(summaries, hasSize(1));
-    assertEquals(dataset.getDataSetId(), summaries.get(0).dataset_id());
+    assertEquals(dataset.getDatasetId(), summaries.get(0).dataset_id());
     assertEquals(study.getStudyId(), summaries.get(0).study_id());
   }
 
@@ -76,7 +76,7 @@ class DatasetDAOTest extends DAOTestHelper {
 
     List<DatasetStudySummary> summaries = datasetDAO.findAllDatasetStudySummaries();
     assertThat(summaries, hasSize(1));
-    assertEquals(dataset.getDataSetId(), summaries.get(0).dataset_id());
+    assertEquals(dataset.getDatasetId(), summaries.get(0).dataset_id());
     assertNull(summaries.get(0).study_id());
   }
 
@@ -84,9 +84,9 @@ class DatasetDAOTest extends DAOTestHelper {
   void testFindDatasetByIdWithDacAndConsent() {
     Dataset dataset = insertDataset();
     Dac dac = insertDac();
-    datasetDAO.updateDatasetDacId(dataset.getDataSetId(), dac.getDacId());
+    datasetDAO.updateDatasetDacId(dataset.getDatasetId(), dac.getDacId());
 
-    Dataset foundDataset = datasetDAO.findDatasetById(dataset.getDataSetId());
+    Dataset foundDataset = datasetDAO.findDatasetById(dataset.getDatasetId());
     assertNotNull(foundDataset);
     assertEquals(dac.getDacId(), foundDataset.getDacId());
     assertFalse(foundDataset.getProperties().isEmpty());
@@ -103,13 +103,13 @@ class DatasetDAOTest extends DAOTestHelper {
     // Create a collection that references the created datasets
     createDarCollectionWithDatasets(dac.getDacId(), user, List.of(d1, d2));
 
-    Dataset foundDataset = datasetDAO.findDatasetById(d1.getDataSetId());
+    Dataset foundDataset = datasetDAO.findDatasetById(d1.getDatasetId());
     assertNotNull(foundDataset);
     assertEquals(dac.getDacId(), foundDataset.getDacId());
     assertFalse(foundDataset.getProperties().isEmpty());
     assertFalse(foundDataset.getDeletable());
 
-    Dataset foundDataset2 = datasetDAO.findDatasetById(d2.getDataSetId());
+    Dataset foundDataset2 = datasetDAO.findDatasetById(d2.getDatasetId());
     assertNotNull(foundDataset2);
     assertEquals(dac.getDacId(), foundDataset2.getDacId());
     assertFalse(foundDataset2.getProperties().isEmpty());
@@ -121,9 +121,9 @@ class DatasetDAOTest extends DAOTestHelper {
     Dataset d1 = insertDataset();
 
     String tdu = RandomStringUtils.randomAlphabetic(10);
-    datasetDAO.updateDatasetTranslatedDataUse(d1.getDataSetId(), tdu);
+    datasetDAO.updateDatasetTranslatedDataUse(d1.getDatasetId(), tdu);
 
-    d1 = datasetDAO.findDatasetById(d1.getDataSetId());
+    d1 = datasetDAO.findDatasetById(d1.getDatasetId());
 
     assertEquals(tdu, d1.getTranslatedDataUse());
   }
@@ -132,8 +132,8 @@ class DatasetDAOTest extends DAOTestHelper {
   void testUpdateDatasetName() {
     Dataset dataset = insertDataset();
     String newName = RandomStringUtils.randomAlphabetic(25);
-    datasetDAO.updateDatasetName(dataset.getDataSetId(), newName);
-    Dataset foundDataset = datasetDAO.findDatasetById(dataset.getDataSetId());
+    datasetDAO.updateDatasetName(dataset.getDatasetId(), newName);
+    Dataset foundDataset = datasetDAO.findDatasetById(dataset.getDatasetId());
     assertNotNull(foundDataset);
     assertEquals(newName, foundDataset.getName());
   }
@@ -145,7 +145,7 @@ class DatasetDAOTest extends DAOTestHelper {
     Dataset foundDataset = datasetDAO.findDatasetByAlias(dataset.getAlias());
 
     assertNotNull(foundDataset);
-    assertEquals(dataset.getDataSetId(), foundDataset.getDataSetId());
+    assertEquals(dataset.getDatasetId(), foundDataset.getDatasetId());
   }
 
   @Test
@@ -155,10 +155,10 @@ class DatasetDAOTest extends DAOTestHelper {
 
     List<Dataset> foundDatasets = datasetDAO.findDatasetsByAlias(
         List.of(dataset1.getAlias(), dataset2.getAlias()));
-    List<Integer> foundDatasetIds = foundDatasets.stream().map(Dataset::getDataSetId).toList();
+    List<Integer> foundDatasetIds = foundDatasets.stream().map(Dataset::getDatasetId).toList();
     assertNotNull(foundDatasets);
     assertTrue(
-        foundDatasetIds.containsAll(List.of(dataset1.getDataSetId(), dataset2.getDataSetId())));
+        foundDatasetIds.containsAll(List.of(dataset1.getDatasetId(), dataset2.getDatasetId())));
   }
 
   @Test
@@ -167,12 +167,12 @@ class DatasetDAOTest extends DAOTestHelper {
 
     // create unrelated file with the same id as dataset id but different category, timestamp before
     createFileStorageObject(
-        dataset.getDataSetId().toString(),
+        dataset.getDatasetId().toString(),
         FileCategory.ALTERNATIVE_DATA_SHARING_PLAN
     );
 
     FileStorageObject nihFile = createFileStorageObject(
-        dataset.getDataSetId().toString(),
+        dataset.getDatasetId().toString(),
         FileCategory.NIH_INSTITUTIONAL_CERTIFICATION
     );
 
@@ -180,11 +180,11 @@ class DatasetDAOTest extends DAOTestHelper {
     // completely separate from the dataset. ensures that the Mapper is selecting only the NIH file.
     createFileStorageObject();
     createFileStorageObject(
-        dataset.getDataSetId().toString(),
+        dataset.getDatasetId().toString(),
         FileCategory.DATA_USE_LETTER
     );
 
-    Dataset found = datasetDAO.findDatasetById(dataset.getDataSetId());
+    Dataset found = datasetDAO.findDatasetById(dataset.getDatasetId());
 
     assertEquals(nihFile, found.getNihInstitutionalCertificationFile());
     assertEquals(nihFile.getBlobId(),
@@ -205,7 +205,7 @@ class DatasetDAOTest extends DAOTestHelper {
         FileCategory.NIH_INSTITUTIONAL_CERTIFICATION.getValue(),
         bucketName,
         gcsFileUri,
-        dataset.getDataSetId().toString(),
+        dataset.getDatasetId().toString(),
         createUser.getUserId(),
         Instant.ofEpochMilli(100)
     );
@@ -215,7 +215,7 @@ class DatasetDAOTest extends DAOTestHelper {
         FileCategory.NIH_INSTITUTIONAL_CERTIFICATION.getValue(),
         bucketName,
         gcsFileUri,
-        dataset.getDataSetId().toString(),
+        dataset.getDatasetId().toString(),
         createUser.getUserId(),
         Instant.ofEpochMilli(110)
     );
@@ -236,7 +236,7 @@ class DatasetDAOTest extends DAOTestHelper {
         updateUser.getUserId(),
         Instant.ofEpochMilli(130));
 
-    Dataset found = datasetDAO.findDatasetById(dataset.getDataSetId());
+    Dataset found = datasetDAO.findDatasetById(dataset.getDatasetId());
 
     // returns last updated file
     assertEquals(nihFileIdCreatedFirstUpdatedSecond,
@@ -257,7 +257,7 @@ class DatasetDAOTest extends DAOTestHelper {
         FileCategory.NIH_INSTITUTIONAL_CERTIFICATION.getValue(),
         bucketName,
         gcsFileUri,
-        dataset.getDataSetId().toString(),
+        dataset.getDatasetId().toString(),
         createUser.getUserId(),
         Instant.ofEpochMilli(100)
     );
@@ -276,12 +276,12 @@ class DatasetDAOTest extends DAOTestHelper {
         FileCategory.NIH_INSTITUTIONAL_CERTIFICATION.getValue(),
         bucketName,
         gcsFileUri,
-        dataset.getDataSetId().toString(),
+        dataset.getDatasetId().toString(),
         createUser.getUserId(),
         Instant.ofEpochMilli(130)
     );
 
-    Dataset found = datasetDAO.findDatasetById(dataset.getDataSetId());
+    Dataset found = datasetDAO.findDatasetById(dataset.getDatasetId());
 
     // returns last updated file
     assertEquals(nihFileIdCreatedSecond,
@@ -293,7 +293,7 @@ class DatasetDAOTest extends DAOTestHelper {
     Dataset dataset = insertDataset();
 
     FileStorageObject nihFile = createFileStorageObject(
-        dataset.getDataSetId().toString(),
+        dataset.getDatasetId().toString(),
         FileCategory.NIH_INSTITUTIONAL_CERTIFICATION
     );
 
@@ -305,7 +305,7 @@ class DatasetDAOTest extends DAOTestHelper {
         Instant.now()
     );
 
-    Dataset found = datasetDAO.findDatasetById(dataset.getDataSetId());
+    Dataset found = datasetDAO.findDatasetById(dataset.getDatasetId());
 
     assertNull(found.getNihInstitutionalCertificationFile());
   }
@@ -324,9 +324,9 @@ class DatasetDAOTest extends DAOTestHelper {
   void testFindDatasetsByIdList() {
     Dataset dataset = insertDataset();
     Dac dac = insertDac();
-    datasetDAO.updateDatasetDacId(dataset.getDataSetId(), dac.getDacId());
+    datasetDAO.updateDatasetDacId(dataset.getDatasetId(), dac.getDacId());
 
-    List<Dataset> datasets = datasetDAO.findDatasetsByIdList(List.of(dataset.getDataSetId()));
+    List<Dataset> datasets = datasetDAO.findDatasetsByIdList(List.of(dataset.getDatasetId()));
     assertFalse(datasets.isEmpty());
     assertEquals(1, datasets.size());
     assertEquals(dac.getDacId(), datasets.get(0).getDacId());
@@ -339,19 +339,19 @@ class DatasetDAOTest extends DAOTestHelper {
   void testFindDataSetsByAuthUserEmail() {
     Dataset dataset = insertDataset();
     Dac dac = insertDac();
-    datasetDAO.updateDatasetDacId(dataset.getDataSetId(), dac.getDacId());
+    datasetDAO.updateDatasetDacId(dataset.getDatasetId(), dac.getDacId());
     User user = createUser();
     createUserRole(UserRoles.CHAIRPERSON.getRoleId(), user.getUserId(), dac.getDacId());
 
     List<Integer> datasetIds = datasetDAO.findDatasetIdsByDACUserId(user.getUserId());
     assertFalse(datasetIds.isEmpty());
-    assertTrue(datasetIds.contains(dataset.getDataSetId()));
+    assertTrue(datasetIds.contains(dataset.getDatasetId()));
   }
 
   @Test
   void testFindDatasetPropertiesByDatasetId() {
     Dataset d = insertDataset();
-    Set<DatasetProperty> properties = datasetDAO.findDatasetPropertiesByDatasetId(d.getDataSetId());
+    Set<DatasetProperty> properties = datasetDAO.findDatasetPropertiesByDatasetId(d.getDatasetId());
     assertEquals(properties.size(), 1);
   }
 
@@ -363,8 +363,8 @@ class DatasetDAOTest extends DAOTestHelper {
     Timestamp now = new Timestamp(new Date().getTime());
     Integer userId = RandomUtils.nextInt(1, 1000);
 
-    datasetDAO.updateDataset(d.getDataSetId(), name, now, userId, dac.getDacId());
-    Dataset updated = datasetDAO.findDatasetById(d.getDataSetId());
+    datasetDAO.updateDataset(d.getDatasetId(), name, now, userId, dac.getDacId());
+    Dataset updated = datasetDAO.findDatasetById(d.getDatasetId());
 
     assertEquals(name, updated.getName());
     assertEquals(now, updated.getUpdateDate());
@@ -375,16 +375,16 @@ class DatasetDAOTest extends DAOTestHelper {
   @Test
   void testUpdateDatasetProperty() {
     Dataset d = insertDataset();
-    Set<DatasetProperty> properties = datasetDAO.findDatasetPropertiesByDatasetId(d.getDataSetId());
+    Set<DatasetProperty> properties = datasetDAO.findDatasetPropertiesByDatasetId(d.getDatasetId());
     DatasetProperty originalProperty = properties.stream().toList().get(0);
-    DatasetProperty newProperty = new DatasetProperty(d.getDataSetId(), 1, "Updated Value",
+    DatasetProperty newProperty = new DatasetProperty(d.getDatasetId(), 1, "Updated Value",
         PropertyType.String, new Date());
     List<DatasetProperty> updatedProperties = new ArrayList<>();
     updatedProperties.add(newProperty);
-    datasetDAO.updateDatasetProperty(d.getDataSetId(), updatedProperties.get(0).getPropertyKey(),
+    datasetDAO.updateDatasetProperty(d.getDatasetId(), updatedProperties.get(0).getPropertyKey(),
         updatedProperties.get(0).getPropertyValue().toString());
     Set<DatasetProperty> returnedProperties = datasetDAO.findDatasetPropertiesByDatasetId(
-        d.getDataSetId());
+        d.getDatasetId());
     DatasetProperty returnedProperty = returnedProperties.stream().toList().get(0);
     assertEquals(originalProperty.getPropertyKey(),
         returnedProperty.getPropertyKey());
@@ -398,13 +398,13 @@ class DatasetDAOTest extends DAOTestHelper {
     Dataset d = insertDataset();
 
     Set<DatasetProperty> oldProperties = datasetDAO.findDatasetPropertiesByDatasetId(
-        d.getDataSetId());
+        d.getDatasetId());
     DatasetProperty propertyToDelete = new ArrayList<>(oldProperties).get(0);
-    datasetDAO.deleteDatasetPropertyByKey(d.getDataSetId(), propertyToDelete.getPropertyKey());
+    datasetDAO.deleteDatasetPropertyByKey(d.getDatasetId(), propertyToDelete.getPropertyKey());
 
     List<DatasetProperty> newProps = List.of(
         new DatasetProperty(
-            d.getDataSetId(),
+            d.getDatasetId(),
             1,
             "10",
             PropertyType.Number,
@@ -412,7 +412,7 @@ class DatasetDAOTest extends DAOTestHelper {
     );
     datasetDAO.insertDatasetProperties(newProps);
 
-    Dataset dWithProps = datasetDAO.findDatasetById(d.getDataSetId());
+    Dataset dWithProps = datasetDAO.findDatasetById(d.getDatasetId());
 
     assertEquals(1, dWithProps.getProperties().size());
     DatasetProperty prop = new ArrayList<>(dWithProps.getProperties()).get(0);
@@ -427,12 +427,12 @@ class DatasetDAOTest extends DAOTestHelper {
     Instant date = Instant.now();
 
     Set<DatasetProperty> oldProperties = datasetDAO.findDatasetPropertiesByDatasetId(
-        d.getDataSetId());
+        d.getDatasetId());
     DatasetProperty propertyToDelete = new ArrayList<>(oldProperties).get(0);
-    datasetDAO.deleteDatasetPropertyByKey(d.getDataSetId(), propertyToDelete.getPropertyKey());
+    datasetDAO.deleteDatasetPropertyByKey(d.getDatasetId(), propertyToDelete.getPropertyKey());
 
     DatasetProperty propToAdd = new DatasetProperty(
-        d.getDataSetId(),
+        d.getDatasetId(),
         1,
         date.toString(),
         PropertyType.Date,
@@ -444,7 +444,7 @@ class DatasetDAOTest extends DAOTestHelper {
     );
     datasetDAO.insertDatasetProperties(newProps);
 
-    Set<DatasetProperty> props = datasetDAO.findDatasetPropertiesByDatasetId(d.getDataSetId());
+    Set<DatasetProperty> props = datasetDAO.findDatasetPropertiesByDatasetId(d.getDatasetId());
     assertEquals(1, props.size());
     DatasetProperty prop = props.stream().findFirst().get();
     assertEquals(PropertyType.Date, prop.getPropertyType());
@@ -457,13 +457,13 @@ class DatasetDAOTest extends DAOTestHelper {
     Boolean bool = Boolean.FALSE;
 
     Set<DatasetProperty> oldProperties = datasetDAO.findDatasetPropertiesByDatasetId(
-        d.getDataSetId());
+        d.getDatasetId());
     DatasetProperty propertyToDelete = new ArrayList<>(oldProperties).get(0);
-    datasetDAO.deleteDatasetPropertyByKey(d.getDataSetId(), propertyToDelete.getPropertyKey());
+    datasetDAO.deleteDatasetPropertyByKey(d.getDatasetId(), propertyToDelete.getPropertyKey());
 
     List<DatasetProperty> newProps = List.of(
         new DatasetProperty(
-            d.getDataSetId(),
+            d.getDatasetId(),
             1,
             bool.toString(),
             PropertyType.Boolean,
@@ -471,7 +471,7 @@ class DatasetDAOTest extends DAOTestHelper {
     );
     datasetDAO.insertDatasetProperties(newProps);
 
-    Dataset dWithProps = datasetDAO.findDatasetById(d.getDataSetId());
+    Dataset dWithProps = datasetDAO.findDatasetById(d.getDatasetId());
 
     assertEquals(1, dWithProps.getProperties().size());
     DatasetProperty prop = new ArrayList<>(dWithProps.getProperties()).get(0);
@@ -487,13 +487,13 @@ class DatasetDAOTest extends DAOTestHelper {
     jsonObject.add("test", new JsonObject());
 
     Set<DatasetProperty> oldProperties = datasetDAO.findDatasetPropertiesByDatasetId(
-        d.getDataSetId());
+        d.getDatasetId());
     DatasetProperty propertyToDelete = new ArrayList<>(oldProperties).get(0);
-    datasetDAO.deleteDatasetPropertyByKey(d.getDataSetId(), propertyToDelete.getPropertyKey());
+    datasetDAO.deleteDatasetPropertyByKey(d.getDatasetId(), propertyToDelete.getPropertyKey());
 
     List<DatasetProperty> newProps = List.of(
         new DatasetProperty(
-            d.getDataSetId(),
+            d.getDatasetId(),
             1,
             jsonObject.toString(),
             PropertyType.Json,
@@ -501,7 +501,7 @@ class DatasetDAOTest extends DAOTestHelper {
     );
     datasetDAO.insertDatasetProperties(newProps);
 
-    Dataset dWithProps = datasetDAO.findDatasetById(d.getDataSetId());
+    Dataset dWithProps = datasetDAO.findDatasetById(d.getDatasetId());
 
     assertEquals(1, dWithProps.getProperties().size());
     DatasetProperty prop = new ArrayList<>(dWithProps.getProperties()).get(0);
@@ -516,13 +516,13 @@ class DatasetDAOTest extends DAOTestHelper {
     String value = "hi";
 
     Set<DatasetProperty> oldProperties = datasetDAO.findDatasetPropertiesByDatasetId(
-        d.getDataSetId());
+        d.getDatasetId());
     DatasetProperty propertyToDelete = new ArrayList<>(oldProperties).get(0);
-    datasetDAO.deleteDatasetPropertyByKey(d.getDataSetId(), propertyToDelete.getPropertyKey());
+    datasetDAO.deleteDatasetPropertyByKey(d.getDatasetId(), propertyToDelete.getPropertyKey());
 
     List<DatasetProperty> newProps = List.of(
         new DatasetProperty(
-            d.getDataSetId(),
+            d.getDatasetId(),
             1,
             value,
             PropertyType.String,
@@ -530,7 +530,7 @@ class DatasetDAOTest extends DAOTestHelper {
     );
     datasetDAO.insertDatasetProperties(newProps);
 
-    Dataset dWithProps = datasetDAO.findDatasetById(d.getDataSetId());
+    Dataset dWithProps = datasetDAO.findDatasetById(d.getDatasetId());
 
     assertEquals(1, dWithProps.getProperties().size());
     DatasetProperty prop = new ArrayList<>(dWithProps.getProperties()).get(0);
@@ -545,13 +545,13 @@ class DatasetDAOTest extends DAOTestHelper {
     String schemaValue = "test test test test";
 
     Set<DatasetProperty> oldProperties = datasetDAO.findDatasetPropertiesByDatasetId(
-        d.getDataSetId());
+        d.getDatasetId());
     DatasetProperty propertyToDelete = new ArrayList<>(oldProperties).get(0);
-    datasetDAO.deleteDatasetPropertyByKey(d.getDataSetId(), propertyToDelete.getPropertyKey());
+    datasetDAO.deleteDatasetPropertyByKey(d.getDatasetId(), propertyToDelete.getPropertyKey());
 
     List<DatasetProperty> newProps = List.of(
         new DatasetProperty(
-            d.getDataSetId(),
+            d.getDatasetId(),
             1,
             schemaValue,
             "asdf",
@@ -560,7 +560,7 @@ class DatasetDAOTest extends DAOTestHelper {
     );
     datasetDAO.insertDatasetProperties(newProps);
 
-    Dataset dWithProps = datasetDAO.findDatasetById(d.getDataSetId());
+    Dataset dWithProps = datasetDAO.findDatasetById(d.getDatasetId());
 
     assertEquals(1, dWithProps.getProperties().size());
     DatasetProperty prop = new ArrayList<>(dWithProps.getProperties()).get(0);
@@ -571,11 +571,11 @@ class DatasetDAOTest extends DAOTestHelper {
   @Test
   void testDeleteDatasetPropertyByKey() {
     Dataset d = insertDataset();
-    Set<DatasetProperty> properties = datasetDAO.findDatasetPropertiesByDatasetId(d.getDataSetId());
+    Set<DatasetProperty> properties = datasetDAO.findDatasetPropertiesByDatasetId(d.getDatasetId());
     DatasetProperty propertyToDelete = properties.stream().toList().get(0);
-    datasetDAO.deleteDatasetPropertyByKey(d.getDataSetId(), propertyToDelete.getPropertyKey());
+    datasetDAO.deleteDatasetPropertyByKey(d.getDatasetId(), propertyToDelete.getPropertyKey());
     Set<DatasetProperty> returnedProperties = datasetDAO.findDatasetPropertiesByDatasetId(
-        d.getDataSetId());
+        d.getDatasetId());
     assertNotEquals(properties.size(), returnedProperties.size());
   }
 
@@ -589,8 +589,8 @@ class DatasetDAOTest extends DAOTestHelper {
     List<Dataset> datasets = datasetDAO.findAllDatasets();
     assertFalse(datasets.isEmpty());
     assertEquals(datasetList.size(), datasets.size());
-    List<Integer> insertedDatasetIds = datasetList.stream().map(Dataset::getDataSetId).toList();
-    List<Integer> foundDatasetIds = datasets.stream().map(Dataset::getDataSetId).toList();
+    List<Integer> insertedDatasetIds = datasetList.stream().map(Dataset::getDatasetId).toList();
+    List<Integer> foundDatasetIds = datasets.stream().map(Dataset::getDatasetId).toList();
     assertTrue(foundDatasetIds.containsAll(insertedDatasetIds));
     assertTrue(insertedDatasetIds.containsAll(foundDatasetIds));
   }
@@ -599,7 +599,7 @@ class DatasetDAOTest extends DAOTestHelper {
   void testFindAllDatasetIds() {
     List<Integer> insertedDatasetIds = IntStream.range(1, 5).mapToObj(i -> {
       Dataset dataset = insertDataset();
-      return dataset.getDataSetId();
+      return dataset.getDatasetId();
     }).toList();
     List<Integer> datasetIds = datasetDAO.findAllDatasetIds();
     assertThat(datasetIds, contains(insertedDatasetIds.toArray()));
@@ -610,11 +610,11 @@ class DatasetDAOTest extends DAOTestHelper {
     Dataset dataset = insertDataset();
     jdbi.useHandle(handle -> {
       Update update = handle.createUpdate(" UPDATE dataset SET alias = 0 WHERE dataset_id = :dataset_id ");
-      update.bind("dataset_id", dataset.getDataSetId());
+      update.bind("dataset_id", dataset.getDatasetId());
       update.execute();
       handle.commit();
     });
-    Dataset updatedDataset = datasetDAO.findDatasetById(dataset.getDataSetId());
+    Dataset updatedDataset = datasetDAO.findDatasetById(dataset.getDatasetId());
     assertEquals(0, updatedDataset.getAlias());
     updatedDataset.setDatasetIdentifier();
     assertNotNull(updatedDataset.getDatasetIdentifier());
@@ -624,15 +624,15 @@ class DatasetDAOTest extends DAOTestHelper {
   void testFindAllStudyNames() {
     Dataset ds1 = insertDataset();
     String ds1Name = RandomStringUtils.randomAlphabetic(20);
-    createDatasetProperty(ds1.getDataSetId(), "studyName", ds1Name, PropertyType.String);
+    createDatasetProperty(ds1.getDatasetId(), "studyName", ds1Name, PropertyType.String);
 
     Dataset ds2 = insertDataset();
     String ds2Name = RandomStringUtils.randomAlphabetic(25);
-    createDatasetProperty(ds2.getDataSetId(), "studyName", ds2Name, PropertyType.String);
+    createDatasetProperty(ds2.getDatasetId(), "studyName", ds2Name, PropertyType.String);
 
     Dataset ds3 = insertDataset();
     String ds3Name = RandomStringUtils.randomAlphabetic(15);
-    createDatasetProperty(ds3.getDataSetId(), "studyName", ds3Name, PropertyType.String);
+    createDatasetProperty(ds3.getDatasetId(), "studyName", ds3Name, PropertyType.String);
 
     Study study = insertStudyWithProperties();
 
@@ -661,13 +661,13 @@ class DatasetDAOTest extends DAOTestHelper {
     Dataset datasetTwo = insertDataset();
     Dac dacTwo = insertDac();
 
-    datasetDAO.updateDatasetDacId(dataset.getDataSetId(), dac.getDacId());
-    datasetDAO.updateDatasetDacId(datasetTwo.getDataSetId(), dacTwo.getDacId());
+    datasetDAO.updateDatasetDacId(dataset.getDatasetId(), dac.getDacId());
+    datasetDAO.updateDatasetDacId(datasetTwo.getDatasetId(), dacTwo.getDacId());
 
-    List<Integer> datasetIds = List.of(dataset.getDataSetId(), datasetTwo.getDataSetId());
+    List<Integer> datasetIds = List.of(dataset.getDatasetId(), datasetTwo.getDatasetId());
     Set<DatasetDTO> datasets = datasetDAO.findDatasetsByDacIds(
         List.of(dac.getDacId(), dacTwo.getDacId()));
-    datasets.forEach(d -> assertTrue(datasetIds.contains(d.getDataSetId())));
+    datasets.forEach(d -> assertTrue(datasetIds.contains(d.getDatasetId())));
   }
 
   @Test
@@ -678,13 +678,13 @@ class DatasetDAOTest extends DAOTestHelper {
     Dataset datasetTwo = insertDataset();
     Dac dacTwo = insertDac();
 
-    datasetDAO.updateDatasetDacId(dataset.getDataSetId(), dac.getDacId());
-    datasetDAO.updateDatasetDacId(datasetTwo.getDataSetId(), dacTwo.getDacId());
+    datasetDAO.updateDatasetDacId(dataset.getDatasetId(), dac.getDacId());
+    datasetDAO.updateDatasetDacId(datasetTwo.getDatasetId(), dacTwo.getDacId());
 
-    List<Integer> datasetIds = List.of(dataset.getDataSetId(), datasetTwo.getDataSetId());
+    List<Integer> datasetIds = List.of(dataset.getDatasetId(), datasetTwo.getDatasetId());
     List<Dataset> datasets = datasetDAO.findDatasetListByDacIds(
         List.of(dac.getDacId(), dacTwo.getDacId()));
-    datasets.forEach(d -> assertTrue(datasetIds.contains(d.getDataSetId())));
+    datasets.forEach(d -> assertTrue(datasetIds.contains(d.getDatasetId())));
   }
 
   @Test
@@ -698,8 +698,8 @@ class DatasetDAOTest extends DAOTestHelper {
         .setDiseaseRestrictions(List.of("DOID_1"))
         .build();
 
-    datasetDAO.updateDatasetDataUse(dataset.getDataSetId(), newDataUse.toString());
-    Dataset updated = datasetDAO.findDatasetById(dataset.getDataSetId());
+    datasetDAO.updateDatasetDataUse(dataset.getDatasetId(), newDataUse.toString());
+    Dataset updated = datasetDAO.findDatasetById(dataset.getDatasetId());
     assertEquals(newDataUse, updated.getDataUse());
     assertNotEquals(oldDataUse, updated.getDataUse());
   }
@@ -708,8 +708,8 @@ class DatasetDAOTest extends DAOTestHelper {
   void testUpdateDatasetCreateUserId() {
     Dataset dataset = insertDataset();
     User user = createUser();
-    datasetDAO.updateDatasetCreateUserId(dataset.getDataSetId(), user.getUserId());
-    Dataset updated = datasetDAO.findDatasetById(dataset.getDataSetId());
+    datasetDAO.updateDatasetCreateUserId(dataset.getDatasetId(), user.getUserId());
+    Dataset updated = datasetDAO.findDatasetById(dataset.getDatasetId());
     assertEquals(user.getUserId(), updated.getCreateUserId());
   }
 
@@ -717,13 +717,13 @@ class DatasetDAOTest extends DAOTestHelper {
   void testFindDatasetWithDataUseByIdList() {
     Dataset dataset = insertDataset();
     Dac dac = insertDac();
-    datasetDAO.updateDatasetDacId(dataset.getDataSetId(), dac.getDacId());
+    datasetDAO.updateDatasetDacId(dataset.getDatasetId(), dac.getDacId());
 
     Set<Dataset> datasets = datasetDAO.findDatasetWithDataUseByIdList(
-        Collections.singletonList(dataset.getDataSetId()));
+        Collections.singletonList(dataset.getDatasetId()));
     assertFalse(datasets.isEmpty());
-    List<Integer> datasetIds = datasets.stream().map(Dataset::getDataSetId).toList();
-    assertTrue(datasetIds.contains(dataset.getDataSetId()));
+    List<Integer> datasetIds = datasets.stream().map(Dataset::getDatasetId).toList();
+    assertTrue(datasetIds.contains(dataset.getDatasetId()));
   }
 
   @Test
@@ -731,16 +731,16 @@ class DatasetDAOTest extends DAOTestHelper {
     User updateUser = createUser();
     Dataset dataset = insertDataset();
     datasetDAO.updateDatasetApproval(true, Instant.now(), updateUser.getUserId(),
-        dataset.getDataSetId());
-    Dataset updatedDataset = datasetDAO.findDatasetById(dataset.getDataSetId());
+        dataset.getDatasetId());
+    Dataset updatedDataset = datasetDAO.findDatasetById(dataset.getDatasetId());
     assertNotNull(updatedDataset);
     assertTrue(updatedDataset.getDacApproval());
     datasetDAO.updateDatasetApproval(false, Instant.now(), updateUser.getUserId(),
-        dataset.getDataSetId());
-    Dataset updatedDatasetAfterApprovalFalse = datasetDAO.findDatasetById(dataset.getDataSetId());
+        dataset.getDatasetId());
+    Dataset updatedDatasetAfterApprovalFalse = datasetDAO.findDatasetById(dataset.getDatasetId());
     assertNotNull(updatedDatasetAfterApprovalFalse);
-    assertEquals(dataset.getDataSetId(),
-        updatedDatasetAfterApprovalFalse.getDataSetId());
+    assertEquals(dataset.getDatasetId(),
+        updatedDatasetAfterApprovalFalse.getDatasetId());
     assertFalse(updatedDatasetAfterApprovalFalse.getDacApproval());
 
   }
@@ -749,7 +749,7 @@ class DatasetDAOTest extends DAOTestHelper {
   void testInsertDatasetAudit() {
     Dataset d = createDataset();
     DatasetAudit audit = new DatasetAudit(
-        d.getDataSetId(),
+        d.getDatasetId(),
         "objectid",
         "name",
         new Date(),
@@ -777,15 +777,15 @@ class DatasetDAOTest extends DAOTestHelper {
     createDataset(); // create unrelated datasets (for testing study's dataset ids)
     Dataset otherDsOnStudy = createDataset();
 
-    datasetDAO.updateStudyId(ds.getDataSetId(), study.getStudyId());
-    datasetDAO.updateStudyId(otherDsOnStudy.getDataSetId(), study.getStudyId());
+    datasetDAO.updateStudyId(ds.getDatasetId(), study.getStudyId());
+    datasetDAO.updateStudyId(otherDsOnStudy.getDatasetId(), study.getStudyId());
 
     createDataset(); // create unrelated datasets (for testing study's dataset ids)
 
     FileStorageObject fso = createFileStorageObject(study.getUuid().toString(),
         FileCategory.ALTERNATIVE_DATA_SHARING_PLAN);
 
-    ds = datasetDAO.findDatasetById(ds.getDataSetId());
+    ds = datasetDAO.findDatasetById(ds.getDatasetId());
 
     assertNotNull(ds.getStudy());
 
@@ -798,9 +798,9 @@ class DatasetDAOTest extends DAOTestHelper {
     assertEquals(fso.getFileStorageObjectId(),
         ds.getStudy().getAlternativeDataSharingPlan().getFileStorageObjectId());
     assertEquals(2, ds.getStudy().getDatasetIds().size());
-    assertTrue(ds.getStudy().getDatasetIds().contains(ds.getDataSetId()));
+    assertTrue(ds.getStudy().getDatasetIds().contains(ds.getDatasetId()));
     assertTrue(
-        ds.getStudy().getDatasetIds().contains(otherDsOnStudy.getDataSetId()));
+        ds.getStudy().getDatasetIds().contains(otherDsOnStudy.getDatasetId()));
   }
 
   @Test
@@ -817,15 +817,15 @@ class DatasetDAOTest extends DAOTestHelper {
     Timestamp timestamp = new Timestamp(new Date().getTime());
 
     Dac dac1 = insertDac();
-    datasetDAO.updateDataset(dataset1.getDataSetId(), dataset1.getDatasetName(), timestamp,
+    datasetDAO.updateDataset(dataset1.getDatasetId(), dataset1.getDatasetName(), timestamp,
         user.getUserId(), dac1.getDacId());
-    datasetDAO.updateDataset(dataset2.getDataSetId(), dataset2.getDatasetName(), timestamp,
+    datasetDAO.updateDataset(dataset2.getDatasetId(), dataset2.getDatasetName(), timestamp,
         user.getUserId(), dac1.getDacId());
 
     Dac dac2 = insertDac();
-    datasetDAO.updateDataset(dataset3.getDataSetId(), dataset3.getDatasetName(), timestamp,
+    datasetDAO.updateDataset(dataset3.getDatasetId(), dataset3.getDatasetName(), timestamp,
         user.getUserId(), dac2.getDacId());
-    datasetDAO.updateDataset(dataset4.getDataSetId(), dataset4.getDatasetName(), timestamp,
+    datasetDAO.updateDataset(dataset4.getDatasetId(), dataset4.getDatasetName(), timestamp,
         user.getUserId(), dac2.getDacId());
 
     DarCollection dar1 = createDarCollectionWithDatasets(dac1.getDacId(), user, List.of(dataset1));
@@ -834,8 +834,8 @@ class DatasetDAOTest extends DAOTestHelper {
     DarCollection dar3 = createDarCollectionWithDatasets(dac2.getDacId(), user, List.of(dataset4));
     List<DarCollection> allDarCollections = List.of(dar1, dar2, dar3);
 
-    Map<Integer, Boolean> expectedFinalVotesForDatasets = Map.of(dataset1.getDataSetId(), false,
-        dataset2.getDataSetId(), false, dataset3.getDataSetId(), true, dataset4.getDataSetId(),
+    Map<Integer, Boolean> expectedFinalVotesForDatasets = Map.of(dataset1.getDatasetId(), false,
+        dataset2.getDatasetId(), false, dataset3.getDatasetId(), true, dataset4.getDatasetId(),
         true);
 
     Map<Integer, Election> elections = new HashMap<>();
@@ -859,10 +859,10 @@ class DatasetDAOTest extends DAOTestHelper {
 
     ApprovedDataset expectedApprovedDataset1 = new ApprovedDataset(dataset3.getAlias(),
         dar2.getDarCode(), dataset3.getDatasetName(), dac2.getName(),
-        elections.get(dataset3.getDataSetId()).getLastUpdate());
+        elections.get(dataset3.getDatasetId()).getLastUpdate());
     ApprovedDataset expectedApprovedDataset2 = new ApprovedDataset(dataset4.getAlias(),
         dar3.getDarCode(), dataset4.getDatasetName(), dac2.getName(),
-        elections.get(dataset4.getDataSetId()).getLastUpdate());
+        elections.get(dataset4.getDatasetId()).getLastUpdate());
     Map<Integer, ApprovedDataset> expectedDatasets = Map.of(dataset3.getAlias(),
         expectedApprovedDataset1, dataset4.getAlias(), expectedApprovedDataset2);
 
@@ -889,9 +889,9 @@ class DatasetDAOTest extends DAOTestHelper {
     Timestamp timestamp = new Timestamp(new Date().getTime());
 
     Dac dac1 = insertDac();
-    datasetDAO.updateDataset(dataset1.getDataSetId(), dataset1.getDatasetName(), timestamp,
+    datasetDAO.updateDataset(dataset1.getDatasetId(), dataset1.getDatasetName(), timestamp,
         user.getUserId(), dac1.getDacId());
-    datasetDAO.updateDataset(dataset2.getDataSetId(), dataset2.getDatasetName(), timestamp,
+    datasetDAO.updateDataset(dataset2.getDatasetId(), dataset2.getDatasetName(), timestamp,
         user.getUserId(), dac1.getDacId());
 
     DarCollection dar1 = createDarCollectionWithDatasets(dac1.getDacId(), user,
@@ -922,16 +922,16 @@ class DatasetDAOTest extends DAOTestHelper {
     Dataset dataset = createDataset();
     Dataset dataset2 = createDataset();
     User user = createUser();
-    datasetDAO.updateDatasetApproval(true, Instant.now(), user.getUserId(), dataset.getDataSetId());
+    datasetDAO.updateDatasetApproval(true, Instant.now(), user.getUserId(), dataset.getDatasetId());
     datasetDAO.updateDatasetApproval(true, Instant.now(), user.getUserId(),
-        dataset2.getDataSetId());
+        dataset2.getDatasetId());
 
     List<DatasetSummary> summaries = datasetDAO.findDatasetSummariesByQuery(dataset.getName());
     assertNotNull(summaries);
     assertFalse(summaries.isEmpty());
-    assertEquals(dataset.getDataSetId(),
+    assertEquals(dataset.getDatasetId(),
         summaries.stream().map(DatasetSummary::id).toList().get(0));
-    assertNotEquals(dataset2.getDataSetId(),
+    assertNotEquals(dataset2.getDatasetId(),
         summaries.stream().map(DatasetSummary::id).toList().get(0));
   }
 
@@ -969,8 +969,8 @@ class DatasetDAOTest extends DAOTestHelper {
         new Date());
     IntStream.range(0, datasets.size()).forEach(index -> {
       Dataset dataset = datasets.get(index);
-      datasetDAO.updateDatasetDacId(dataset.getDataSetId(), dacId);
-      createDataAccessRequestWithDatasetAndCollectionInfo(collectionId, dataset.getDataSetId(),
+      datasetDAO.updateDatasetDacId(dataset.getDatasetId(), dacId);
+      createDataAccessRequestWithDatasetAndCollectionInfo(collectionId, dataset.getDatasetId(),
           user.getUserId());
     });
     return darCollectionDAO.findDARCollectionByCollectionId(collectionId);
@@ -1024,7 +1024,7 @@ class DatasetDAOTest extends DAOTestHelper {
       PropertyType type) {
     List<DatasetProperty> list = new ArrayList<>();
     DatasetProperty dsp = new DatasetProperty();
-    dsp.setDataSetId(datasetId);
+    dsp.setDatasetId(datasetId);
     dsp.setPropertyKey(1);
     dsp.setSchemaProperty(schemaProperty);
     dsp.setPropertyValue(type.coerce(value));
@@ -1145,7 +1145,7 @@ class DatasetDAOTest extends DAOTestHelper {
   private void createDatasetProperties(Integer datasetId) {
     List<DatasetProperty> list = new ArrayList<>();
     DatasetProperty dsp = new DatasetProperty();
-    dsp.setDataSetId(datasetId);
+    dsp.setDatasetId(datasetId);
     dsp.setPropertyKey(1);
     dsp.setPropertyValue("Test_PropertyValue");
     dsp.setCreateDate(new Date());

--- a/src/test/java/org/broadinstitute/consent/http/db/ElectionDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/ElectionDAOTest.java
@@ -48,9 +48,9 @@ class ElectionDAOTest extends DAOTestHelper {
     Dataset dataset1 = createDataset();
     Dataset dataset2 = createDataset();
     Election accessElection1 = createDataAccessElection(accessReferenceId1,
-        dataset1.getDataSetId());
+        dataset1.getDatasetId());
     Election accessElection2 = createDataAccessElection(accessReferenceId2,
-        dataset2.getDataSetId());
+        dataset2.getDatasetId());
 
     List<Integer> electionIds = electionDAO.getElectionIdsByReferenceIds(
         List.of(accessReferenceId1, accessReferenceId2));
@@ -71,8 +71,8 @@ class ElectionDAOTest extends DAOTestHelper {
         new Date());
     DataAccessRequest dar = createDataAccessRequest(user.getUserId(), collection_id, darCode);
     Dataset dataset = createDataset();
-    datasetDAO.updateDatasetDacId(dataset.getDataSetId(), dac.getDacId());
-    Election election = createDataAccessElection(dar.getReferenceId(), dataset.getDataSetId());
+    datasetDAO.updateDatasetDacId(dataset.getDatasetId(), dac.getDacId());
+    Election election = createDataAccessElection(dar.getReferenceId(), dataset.getDatasetId());
 
     List<Election> foundElections = electionDAO.findOpenElectionsByDacId(dac.getDacId());
     assertNotNull(foundElections);
@@ -84,7 +84,7 @@ class ElectionDAOTest extends DAOTestHelper {
     Dataset dataset = createDataset();
     DataAccessRequest dar = createDataAccessRequestV3();
     String referenceId = dar.getReferenceId();
-    Integer datasetId = dataset.getDataSetId();
+    Integer datasetId = dataset.getDatasetId();
     Election election1 = createDataAccessElection(referenceId, datasetId);
     Election election2 = createDataAccessElection(referenceId, datasetId);
 
@@ -104,7 +104,7 @@ class ElectionDAOTest extends DAOTestHelper {
     String referenceId1 = dar1.getReferenceId();
     String referenceId2 = dar2.getReferenceId();
 
-    Integer datasetId = dataset.getDataSetId();
+    Integer datasetId = dataset.getDatasetId();
 
     Election election1 = createDataAccessElection(referenceId1, datasetId);
     Election election2 = createDataAccessElection(referenceId1, datasetId);
@@ -140,8 +140,8 @@ class ElectionDAOTest extends DAOTestHelper {
     DataAccessRequest dar = createDataAccessRequest(user.getUserId(), collection_id, darCode);
     Dataset d1 = createDataset();
     Dataset d2 = createDataset();
-    dataAccessRequestDAO.insertDARDatasetRelation(dar.getReferenceId(), d1.getDataSetId());
-    dataAccessRequestDAO.insertDARDatasetRelation(dar.getReferenceId(), d2.getDataSetId());
+    dataAccessRequestDAO.insertDARDatasetRelation(dar.getReferenceId(), d1.getDatasetId());
+    dataAccessRequestDAO.insertDARDatasetRelation(dar.getReferenceId(), d2.getDatasetId());
     // Create OPEN elections
     List<Integer> firstElectionIds = Stream
         .of(createElectionsForDarDataset(dar, d1), createElectionsForDarDataset(dar, d2))
@@ -156,25 +156,25 @@ class ElectionDAOTest extends DAOTestHelper {
         .flatMap(List::stream).toList();
 
     Election latestAccessForD1 = electionDAO.findLastElectionByReferenceIdDatasetIdAndType(
-        dar.getReferenceId(), d1.getDataSetId(), ElectionType.DATA_ACCESS.getValue());
+        dar.getReferenceId(), d1.getDatasetId(), ElectionType.DATA_ACCESS.getValue());
     assertNotNull(latestAccessForD1);
     assertFalse(firstElectionIds.contains(latestAccessForD1.getElectionId()));
     assertTrue(latestElectionIds.contains(latestAccessForD1.getElectionId()));
 
     Election latestRPForD1 = electionDAO.findLastElectionByReferenceIdDatasetIdAndType(
-        dar.getReferenceId(), d1.getDataSetId(), ElectionType.RP.getValue());
+        dar.getReferenceId(), d1.getDatasetId(), ElectionType.RP.getValue());
     assertNotNull(latestRPForD1);
     assertFalse(firstElectionIds.contains(latestRPForD1.getElectionId()));
     assertTrue(latestElectionIds.contains(latestRPForD1.getElectionId()));
 
     Election latestAccessForD2 = electionDAO.findLastElectionByReferenceIdDatasetIdAndType(
-        dar.getReferenceId(), d2.getDataSetId(), ElectionType.DATA_ACCESS.getValue());
+        dar.getReferenceId(), d2.getDatasetId(), ElectionType.DATA_ACCESS.getValue());
     assertNotNull(latestAccessForD2);
     assertFalse(firstElectionIds.contains(latestAccessForD2.getElectionId()));
     assertTrue(latestElectionIds.contains(latestAccessForD2.getElectionId()));
 
     Election latestRPForD2 = electionDAO.findLastElectionByReferenceIdDatasetIdAndType(
-        dar.getReferenceId(), d2.getDataSetId(), ElectionType.RP.getValue());
+        dar.getReferenceId(), d2.getDatasetId(), ElectionType.RP.getValue());
     assertNotNull(latestRPForD2);
     assertFalse(firstElectionIds.contains(latestRPForD2.getElectionId()));
     assertTrue(latestElectionIds.contains(latestRPForD2.getElectionId()));
@@ -189,8 +189,8 @@ class ElectionDAOTest extends DAOTestHelper {
    * @return List of created electionIds
    */
   private List<Integer> createElectionsForDarDataset(DataAccessRequest dar, Dataset d) {
-    Election accessElection = createDataAccessElection(dar.getReferenceId(), d.getDataSetId());
-    Election rpElection = createRPElection(dar.getReferenceId(), d.getDataSetId());
+    Election accessElection = createDataAccessElection(dar.getReferenceId(), d.getDatasetId());
+    Election rpElection = createRPElection(dar.getReferenceId(), d.getDatasetId());
     return List.of(accessElection.getElectionId(), rpElection.getElectionId());
   }
 
@@ -202,12 +202,12 @@ class ElectionDAOTest extends DAOTestHelper {
         new Date());
     DataAccessRequest dar = createDataAccessRequest(user.getUserId(), collection_id, darCode);
     Dataset d1 = createDataset();
-    dataAccessRequestDAO.insertDARDatasetRelation(dar.getReferenceId(), d1.getDataSetId());
-    createRPElection(dar.getReferenceId(), d1.getDataSetId());
-    createDataAccessElection(dar.getReferenceId(), d1.getDataSetId());
+    dataAccessRequestDAO.insertDARDatasetRelation(dar.getReferenceId(), d1.getDatasetId());
+    createRPElection(dar.getReferenceId(), d1.getDatasetId());
+    createDataAccessElection(dar.getReferenceId(), d1.getDatasetId());
 
     List<Election> elections = electionDAO.findElectionsByReferenceIdAndDatasetId(
-        dar.getReferenceId(), d1.getDataSetId());
+        dar.getReferenceId(), d1.getDatasetId());
     assertEquals(2, elections.size());
   }
 
@@ -220,9 +220,9 @@ class ElectionDAOTest extends DAOTestHelper {
         new Date());
     DataAccessRequest dar = createDataAccessRequest(user.getUserId(), collection_id, darCode);
     Dataset dataset = createDataset();
-    datasetDAO.updateDatasetDacId(dataset.getDataSetId(), dac.getDacId());
+    datasetDAO.updateDatasetDacId(dataset.getDatasetId(), dac.getDacId());
 
-    Election election = createDataAccessElection(dar.getReferenceId(), dataset.getDataSetId());
+    Election election = createDataAccessElection(dar.getReferenceId(), dataset.getDatasetId());
 
     List<Election> foundElections = electionDAO.findOpenElectionsByDacId(dac.getDacId());
     assertNotNull(foundElections);
@@ -238,7 +238,7 @@ class ElectionDAOTest extends DAOTestHelper {
     Integer collection_id = darCollectionDAO.insertDarCollection(darCode, user.getUserId(),
         new Date());
     DataAccessRequest dar = createDataAccessRequest(user.getUserId(), collection_id, darCode);
-    createDataAccessElection(dar.getReferenceId(), dataset.getDataSetId());
+    createDataAccessElection(dar.getReferenceId(), dataset.getDatasetId());
 
     List<Election> foundElections = electionDAO.findOpenElectionsByDacId(dac.getDacId());
     assertTrue(foundElections.isEmpty());
@@ -254,9 +254,9 @@ class ElectionDAOTest extends DAOTestHelper {
         new Date());
     DataAccessRequest dar = createDataAccessRequest(user.getUserId(), collection_id, darCode);
     Dataset d = createDataset();
-    datasetDAO.updateDatasetDacId(d.getDataSetId(), dac.getDacId());
+    datasetDAO.updateDatasetDacId(d.getDatasetId(), dac.getDacId());
 
-    Election e = createDataAccessElection(dar.getReferenceId(), d.getDataSetId());
+    Election e = createDataAccessElection(dar.getReferenceId(), d.getDatasetId());
     Integer voteId = voteDAO.insertVote(u.getUserId(), e.getElectionId(),
         VoteType.FINAL.getValue());
     voteDAO.updateVote(true, "rationale", new Date(), voteId, false, e.getElectionId(), new Date(),
@@ -279,9 +279,9 @@ class ElectionDAOTest extends DAOTestHelper {
         new Date());
     DataAccessRequest dar = createDataAccessRequest(user.getUserId(), collection_id, darCode);
     Dataset d = createDataset();
-    datasetDAO.updateDatasetDacId(d.getDataSetId(), dac.getDacId());
+    datasetDAO.updateDatasetDacId(d.getDatasetId(), dac.getDacId());
 
-    Election e = createRPElection(dar.getReferenceId(), d.getDataSetId());
+    Election e = createRPElection(dar.getReferenceId(), d.getDatasetId());
     Vote v = createPopulatedChairpersonVote(u.getUserId(), e.getElectionId());
 
     Election election = electionDAO.findElectionWithFinalVoteById(e.getElectionId());
@@ -300,14 +300,14 @@ class ElectionDAOTest extends DAOTestHelper {
         new Date());
     DataAccessRequest dar = createDataAccessRequest(user.getUserId(), collection_id, darCode);
     Dataset d = createDataset();
-    datasetDAO.updateDatasetDacId(d.getDataSetId(), dac.getDacId());
+    datasetDAO.updateDatasetDacId(d.getDatasetId(), dac.getDacId());
 
     Integer electionId = electionDAO.insertElection(
         ElectionType.TRANSLATE_DUL.getValue(),
         ElectionStatus.OPEN.getValue(),
         new Date(),
         dar.getReferenceId(),
-        d.getDataSetId());
+        d.getDatasetId());
     Election e = electionDAO.findElectionById(electionId);
     Vote v = createPopulatedChairpersonVote(u.getUserId(), e.getElectionId());
 
@@ -321,8 +321,8 @@ class ElectionDAOTest extends DAOTestHelper {
   void testFindElectionsByReferenceIdCase1() {
     DataAccessRequest dar = createDataAccessRequestV3();
     Dataset d = createDataset();
-    createDataAccessElection(dar.getReferenceId(), d.getDataSetId());
-    createRPElection(dar.getReferenceId(), d.getDataSetId());
+    createDataAccessElection(dar.getReferenceId(), d.getDatasetId());
+    createRPElection(dar.getReferenceId(), d.getDatasetId());
 
     List<Election> elections = electionDAO.findElectionsByReferenceId(dar.getReferenceId());
     assertNotNull(elections);
@@ -339,14 +339,14 @@ class ElectionDAOTest extends DAOTestHelper {
     DataAccessRequest dar = createDataAccessRequest(user.getUserId(), collection_id, darCode);
     Dataset d = createDataset();
     User u = createUserWithRoleInDac(UserRoles.CHAIRPERSON.getRoleId(), dac.getDacId());
-    datasetDAO.updateDatasetDacId(d.getDataSetId(), dac.getDacId());
+    datasetDAO.updateDatasetDacId(d.getDatasetId(), dac.getDacId());
 
     Integer electionId = electionDAO.insertElection(
         ElectionType.DATA_ACCESS.getValue(),
         ElectionStatus.OPEN.getValue(),
         new Date(),
         dar.getReferenceId(),
-        d.getDataSetId());
+        d.getDatasetId());
     Election e = electionDAO.findElectionById(electionId);
     createFinalVote(u.getUserId(), e.getElectionId());
     Election election = electionDAO.findElectionWithFinalVoteById(e.getElectionId());
@@ -363,7 +363,7 @@ class ElectionDAOTest extends DAOTestHelper {
         ElectionStatus.OPEN.getValue(),
         new Date(),
         dar.getReferenceId(),
-        d.getDataSetId());
+        d.getDatasetId());
     List<Election> elections =
         electionDAO.findLastElectionsByReferenceIdsAndType(
             Collections.singletonList(dar.getReferenceId()), ElectionType.DATA_ACCESS.getValue());
@@ -376,8 +376,8 @@ class ElectionDAOTest extends DAOTestHelper {
   void testFindAllDacsForElectionIds() {
     Dac dac = createDac();
     Dataset dataset = createDataset();
-    Integer datasetId = dataset.getDataSetId();
-    datasetDAO.updateDatasetDacId(dataset.getDataSetId(), dac.getDacId());
+    Integer datasetId = dataset.getDatasetId();
+    datasetDAO.updateDatasetDacId(dataset.getDatasetId(), dac.getDacId());
     Election accessElection = createDataAccessElection(UUID.randomUUID().toString(), datasetId);
 
     List<Integer> electionIds = Collections.singletonList(accessElection.getElectionId());
@@ -399,16 +399,16 @@ class ElectionDAOTest extends DAOTestHelper {
   void testFindLastElectionsByReferenceIds() {
     Dac dac = createDac();
     Dataset dataset = createDataset();
-    datasetDAO.updateDatasetDacId(dataset.getDataSetId(), dac.getDacId());
+    datasetDAO.updateDatasetDacId(dataset.getDatasetId(), dac.getDacId());
 
     DataAccessRequest dar = createDataAccessRequestV3();
 
     String darReferenceId = dar.getReferenceId();
-    Integer datasetId = dataset.getDataSetId();
+    Integer datasetId = dataset.getDatasetId();
     dataAccessRequestDAO.insertDARDatasetRelation(dar.getReferenceId(), datasetId);
 
     Election recentClosedAccessElection = createDataAccessElection(darReferenceId,
-        dataset.getDataSetId());
+        dataset.getDatasetId());
     Election recentClosedRPElection = createRPElection(darReferenceId, datasetId);
     List<Election> elections =
         electionDAO.findLastElectionsByReferenceIds(Collections.singletonList(dar.referenceId));
@@ -432,7 +432,7 @@ class ElectionDAOTest extends DAOTestHelper {
     DataAccessRequest dar = createDataAccessRequestV3();
     Dataset dataset = createDataset();
     String referenceId = dar.getReferenceId();
-    int datasetId = dataset.getDataSetId();
+    int datasetId = dataset.getDatasetId();
     Election accessElection = createDataAccessElection(referenceId, datasetId);
     Election rpElection = createRPElection(referenceId, datasetId);
     User user = createUserWithRole(UserRoles.CHAIRPERSON.getRoleId());
@@ -451,7 +451,7 @@ class ElectionDAOTest extends DAOTestHelper {
     DataAccessRequest dar = createDataAccessRequestV3();
     Dataset dataset = createDataset();
     String referenceId = dar.getReferenceId();
-    int datasetId = dataset.getDataSetId();
+    int datasetId = dataset.getDatasetId();
     Election accessElection = createDataAccessElection(referenceId, datasetId);
     Election rpElection = createRPElection(referenceId, datasetId);
     User user = createUserWithRole(UserRoles.CHAIRPERSON.getRoleId());
@@ -470,7 +470,7 @@ class ElectionDAOTest extends DAOTestHelper {
     User lcUser = createUser();
     User nonLCUser = createUser();
     Dataset dataset = createDataset();
-    int datasetId = dataset.getDataSetId();
+    int datasetId = dataset.getDatasetId();
     createLibraryCard(lcUser);
     DataAccessRequest lcDAR = createDataAccessRequestWithUserIdV3(lcUser.getUserId());
     DataAccessRequest nonLCDAR = createDataAccessRequestWithUserIdV3(nonLCUser.getUserId());
@@ -489,7 +489,7 @@ class ElectionDAOTest extends DAOTestHelper {
     Dataset dataset = createDataset();
     DataAccessRequest dar = createDataAccessRequestV3();
     String referenceId = dar.getReferenceId();
-    Integer datasetId = dataset.getDataSetId();
+    Integer datasetId = dataset.getDatasetId();
     Election accessElection = createDataAccessElection(referenceId, datasetId);
     Election rpElection = createRPElection(referenceId, datasetId);
 
@@ -511,7 +511,7 @@ class ElectionDAOTest extends DAOTestHelper {
     Dataset dataset = createDatasetWithDac(dac.getDacId());
     DataAccessRequest dar = createDataAccessRequestV3();
     String referenceId = dar.getReferenceId();
-    Integer datasetId = dataset.getDataSetId();
+    Integer datasetId = dataset.getDatasetId();
 
     Date d = new Date();
 
@@ -528,7 +528,7 @@ class ElectionDAOTest extends DAOTestHelper {
     assertEquals(ElectionStatus.OPEN.getValue(), e.getStatus());
     assertNotNull(e.getCreateDate());
     assertEquals(referenceId, e.getReferenceId());
-    assertEquals(datasetId, e.getDataSetId());
+    assertEquals(datasetId, e.getDatasetId());
 
   }
 
@@ -538,7 +538,7 @@ class ElectionDAOTest extends DAOTestHelper {
     Dataset dataset = createDatasetWithDac(dac.getDacId());
     DataAccessRequest dar = createDataAccessRequestV3();
     String referenceId = dar.getReferenceId();
-    Integer datasetId = dataset.getDataSetId();
+    Integer datasetId = dataset.getDatasetId();
 
     Election before = createDataAccessElection(referenceId, datasetId);
 
@@ -562,7 +562,7 @@ class ElectionDAOTest extends DAOTestHelper {
     Dataset dataset = createDatasetWithDac(dac.getDacId());
     DataAccessRequest dar = createDataAccessRequestV3();
     String referenceId = dar.getReferenceId();
-    Integer datasetId = dataset.getDataSetId();
+    Integer datasetId = dataset.getDatasetId();
 
     Election before = createDataAccessElection(referenceId, datasetId);
 
@@ -589,7 +589,7 @@ class ElectionDAOTest extends DAOTestHelper {
     Dataset dataset = createDatasetWithDac(dac.getDacId());
     DataAccessRequest dar = createDataAccessRequestV3();
     String referenceId = dar.getReferenceId();
-    Integer datasetId = dataset.getDataSetId();
+    Integer datasetId = dataset.getDatasetId();
 
     Election e = createDataAccessElection(referenceId, datasetId);
 
@@ -607,7 +607,7 @@ class ElectionDAOTest extends DAOTestHelper {
     User user = createUserWithRoleInDac(UserRoles.CHAIRPERSON.getRoleId(), dac.getDacId());
     DataAccessRequest dar = createDataAccessRequestV3();
     String referenceId = dar.getReferenceId();
-    Integer datasetId = dataset.getDataSetId();
+    Integer datasetId = dataset.getDatasetId();
 
     Election e = createDataAccessElection(referenceId, datasetId);
     createFinalVote(user.getUserId(), e.getElectionId());
@@ -626,7 +626,7 @@ class ElectionDAOTest extends DAOTestHelper {
 
     DataAccessRequest dar = createDataAccessRequestV3();
     String referenceId = dar.getReferenceId();
-    Integer datasetId = dataset.getDataSetId();
+    Integer datasetId = dataset.getDatasetId();
 
     Election datasetAccessElection = createDataAccessElection(referenceId, datasetId);
     Election rpElection = createRPElection(referenceId, datasetId);
@@ -647,7 +647,7 @@ class ElectionDAOTest extends DAOTestHelper {
 
     DataAccessRequest dar = createDataAccessRequestV3();
     String referenceId = dar.getReferenceId();
-    Integer datasetId = dataset.getDataSetId();
+    Integer datasetId = dataset.getDatasetId();
 
     Election e = createDataAccessElection(referenceId, datasetId);
 
@@ -664,11 +664,11 @@ class ElectionDAOTest extends DAOTestHelper {
         new Date());
     DataAccessRequest dar = createDataAccessRequest(user.getUserId(), collection_id, darCode);
     Dataset d1 = createDataset();
-    dataAccessRequestDAO.insertDARDatasetRelation(dar.getReferenceId(), d1.getDataSetId());
-    createRPElection(dar.getReferenceId(), d1.getDataSetId());
-    createDataAccessElection(dar.getReferenceId(), d1.getDataSetId());
+    dataAccessRequestDAO.insertDARDatasetRelation(dar.getReferenceId(), d1.getDatasetId());
+    createRPElection(dar.getReferenceId(), d1.getDatasetId());
+    createDataAccessElection(dar.getReferenceId(), d1.getDatasetId());
     List<Election> elections = electionDAO.findElectionsByReferenceIdAndDatasetId(
-        dar.getReferenceId(), d1.getDataSetId());
+        dar.getReferenceId(), d1.getDatasetId());
     List<Integer> electionIds = elections.stream().map(Election::getElectionId).toList();
 
     electionDAO.archiveElectionByIds(electionIds, new Date());
@@ -683,7 +683,7 @@ class ElectionDAOTest extends DAOTestHelper {
 
     DataAccessRequest dar = createDataAccessRequestV3();
     String referenceId = dar.getReferenceId();
-    Integer datasetId = dataset.getDataSetId();
+    Integer datasetId = dataset.getDatasetId();
 
     Election e = createDataAccessElection(referenceId, datasetId);
 
@@ -698,7 +698,7 @@ class ElectionDAOTest extends DAOTestHelper {
 
     DataAccessRequest dar = createDataAccessRequestV3();
     String referenceId = dar.getReferenceId();
-    Integer datasetId = dataset.getDataSetId();
+    Integer datasetId = dataset.getDatasetId();
 
     Election e1 = createDataAccessElection(referenceId, datasetId);
     Election e2 = createRPElection(referenceId, datasetId);
@@ -789,7 +789,7 @@ class ElectionDAOTest extends DAOTestHelper {
   private void createDatasetProperties(Integer datasetId) {
     List<DatasetProperty> list = new ArrayList<>();
     DatasetProperty dsp = new DatasetProperty();
-    dsp.setDataSetId(datasetId);
+    dsp.setDatasetId(datasetId);
     dsp.setPropertyKey(1);
     dsp.setPropertyValue("Test_PropertyValue");
     dsp.setCreateDate(new Date());

--- a/src/test/java/org/broadinstitute/consent/http/db/MatchDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/MatchDAOTest.java
@@ -84,14 +84,14 @@ class MatchDAOTest extends DAOTestHelper {
     //creating two access elections with the same reference id and datasetid to test that condition
     String darReferenceId = UUID.randomUUID().toString();
     Election targetElection = createDataAccessElection(
-        darReferenceId, dataset.getDataSetId()
+        darReferenceId, dataset.getDatasetId()
     );
     Election ignoredAccessElection = createDataAccessElection(
-        UUID.randomUUID().toString(), dataset.getDataSetId()
+        UUID.randomUUID().toString(), dataset.getDatasetId()
     );
 
     //Generate RP election to test that the query only references DataAccess elections
-    Election rpElection = createRPElection(UUID.randomUUID().toString(), dataset.getDataSetId());
+    Election rpElection = createRPElection(UUID.randomUUID().toString(), dataset.getDatasetId());
     String datasetIdentifier = dataset.getDatasetIdentifier();
 
     //This match represents the match record generated for the target election
@@ -119,10 +119,10 @@ class MatchDAOTest extends DAOTestHelper {
 
     //Generate access election for test
     Election accessElection = createDataAccessElection(
-        UUID.randomUUID().toString(), dataset.getDataSetId());
+        UUID.randomUUID().toString(), dataset.getDatasetId());
 
     //Generate RP election for test
-    Election rpElection = createRPElection(darReferenceId, dataset.getDataSetId());
+    Election rpElection = createRPElection(darReferenceId, dataset.getDatasetId());
     String datasetIdentifier = dataset.getDatasetIdentifier();
 
     // This match represents the match record generated for the access election
@@ -237,7 +237,7 @@ class MatchDAOTest extends DAOTestHelper {
   private void createDatasetProperties(Integer datasetId) {
     List<DatasetProperty> list = new ArrayList<>();
     DatasetProperty dsp = new DatasetProperty();
-    dsp.setDataSetId(datasetId);
+    dsp.setDatasetId(datasetId);
     dsp.setPropertyKey(1);
     dsp.setPropertyValue("Test_PropertyValue");
     dsp.setCreateDate(new Date());

--- a/src/test/java/org/broadinstitute/consent/http/db/StudyDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/StudyDAOTest.java
@@ -295,8 +295,8 @@ class StudyDAOTest extends DAOTestHelper {
     s = studyDAO.findStudyById(s.getStudyId());
 
     assertEquals(2, s.getDatasetIds().size());
-    assertTrue(s.getDatasetIds().contains(ds1.getDataSetId()));
-    assertTrue(s.getDatasetIds().contains(ds2.getDataSetId()));
+    assertTrue(s.getDatasetIds().contains(ds1.getDatasetId()));
+    assertTrue(s.getDatasetIds().contains(ds2.getDatasetId()));
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/db/UserDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/UserDAOTest.java
@@ -285,10 +285,10 @@ class UserDAOTest extends DAOTestHelper {
     Dataset dataset = createDataset();
     Dac dac = createDac();
     User user = createUserWithRoleInDac(UserRoles.CHAIRPERSON.getRoleId(), dac.getDacId());
-    datasetDAO.updateDatasetDacId(dataset.getDataSetId(), dac.getDacId());
+    datasetDAO.updateDatasetDacId(dataset.getDatasetId(), dac.getDacId());
 
     Set<User> users = userDAO.findUsersForDatasetsByRole(
-        Collections.singletonList(dataset.getDataSetId()),
+        Collections.singletonList(dataset.getDatasetId()),
         Collections.singletonList(UserRoles.CHAIRPERSON.getRoleName()));
     Optional<User> foundUser = users.stream().findFirst();
     assertNotNull(users);
@@ -302,10 +302,10 @@ class UserDAOTest extends DAOTestHelper {
     Dataset dataset = createDataset();
     Dac dac = createDac();
     createUserWithRoleInDac(UserRoles.MEMBER.getRoleId(), dac.getDacId());
-    datasetDAO.updateDatasetDacId(dataset.getDataSetId(), dac.getDacId());
+    datasetDAO.updateDatasetDacId(dataset.getDatasetId(), dac.getDacId());
 
     Set<User> users = userDAO.findUsersForDatasetsByRole(
-        Collections.singletonList(dataset.getDataSetId()),
+        Collections.singletonList(dataset.getDatasetId()),
         Collections.singletonList(UserRoles.CHAIRPERSON.getRoleName()));
     assertNotNull(users);
     assertTrue(users.isEmpty());
@@ -478,7 +478,7 @@ class UserDAOTest extends DAOTestHelper {
   private void createDatasetProperties(Integer datasetId) {
     List<DatasetProperty> list = new ArrayList<>();
     DatasetProperty dsp = new DatasetProperty();
-    dsp.setDataSetId(datasetId);
+    dsp.setDatasetId(datasetId);
     dsp.setPropertyKey(1);
     dsp.setPropertyValue("Test_PropertyValue");
     dsp.setCreateDate(new Date());

--- a/src/test/java/org/broadinstitute/consent/http/db/VoteDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/VoteDAOTest.java
@@ -46,8 +46,8 @@ class VoteDAOTest extends DAOTestHelper {
     Integer collection_id = darCollectionDAO.insertDarCollection(darCode, user.getUserId(),
         new Date());
     DataAccessRequest dar = createDataAccessRequestWithDatasetAndCollectionInfo(collection_id,
-        dataset.getDataSetId(), user.getUserId());
-    Election election = createDataAccessElection(dar.getReferenceId(), dataset.getDataSetId());
+        dataset.getDatasetId(), user.getUserId());
+    Election election = createDataAccessElection(dar.getReferenceId(), dataset.getDatasetId());
     Vote vote = createDacVote(user.getUserId(), election.getElectionId());
 
     Vote foundVote = voteDAO.findVoteById(vote.getVoteId());
@@ -65,8 +65,8 @@ class VoteDAOTest extends DAOTestHelper {
     Integer collection_id = darCollectionDAO.insertDarCollection(darCode, user.getUserId(),
         new Date());
     DataAccessRequest dar = createDataAccessRequestWithDatasetAndCollectionInfo(collection_id,
-        dataset.getDataSetId(), user.getUserId());
-    Election election = createDataAccessElection(dar.getReferenceId(), dataset.getDataSetId());
+        dataset.getDatasetId(), user.getUserId());
+    Election election = createDataAccessElection(dar.getReferenceId(), dataset.getDatasetId());
     Vote vote = createDacVote(user.getUserId(), election.getElectionId());
     Vote vote2 = createDacVote(user2.getUserId(), election.getElectionId());
     Vote vote3 = createDacVote(user3.getUserId(), election.getElectionId());
@@ -89,8 +89,8 @@ class VoteDAOTest extends DAOTestHelper {
     Integer collection_id = darCollectionDAO.insertDarCollection(darCode, user.getUserId(),
         new Date());
     DataAccessRequest dar = createDataAccessRequestWithDatasetAndCollectionInfo(collection_id,
-        dataset.getDataSetId(), user.getUserId());
-    Election election = createDataAccessElection(dar.getReferenceId(), dataset.getDataSetId());
+        dataset.getDatasetId(), user.getUserId());
+    Election election = createDataAccessElection(dar.getReferenceId(), dataset.getDatasetId());
     createDacVote(user.getUserId(), election.getElectionId());
 
     Dataset dataset2 = createDataset();
@@ -98,8 +98,8 @@ class VoteDAOTest extends DAOTestHelper {
     Integer collection_id2 = darCollectionDAO.insertDarCollection(darCode2, user.getUserId(),
         new Date());
     DataAccessRequest dar2 = createDataAccessRequestWithDatasetAndCollectionInfo(collection_id2,
-        dataset.getDataSetId(), user.getUserId());
-    Election election2 = createDataAccessElection(dar2.getReferenceId(), dataset2.getDataSetId());
+        dataset.getDatasetId(), user.getUserId());
+    Election election2 = createDataAccessElection(dar2.getReferenceId(), dataset2.getDatasetId());
     createDacVote(user.getUserId(), election2.getElectionId());
     List<Integer> electionIds = Arrays.asList(election.getElectionId(), election2.getElectionId());
 
@@ -117,8 +117,8 @@ class VoteDAOTest extends DAOTestHelper {
     Integer collection_id = darCollectionDAO.insertDarCollection(darCode, user.getUserId(),
         new Date());
     DataAccessRequest dar = createDataAccessRequestWithDatasetAndCollectionInfo(collection_id,
-        dataset.getDataSetId(), user.getUserId());
-    Election election = createDataAccessElection(dar.getReferenceId(), dataset.getDataSetId());
+        dataset.getDatasetId(), user.getUserId());
+    Election election = createDataAccessElection(dar.getReferenceId(), dataset.getDatasetId());
     Vote vote = createDacVote(user.getUserId(), election.getElectionId());
 
     List<Vote> foundVotes = voteDAO.findVotesByElectionIdAndType(election.getElectionId(),
@@ -148,8 +148,8 @@ class VoteDAOTest extends DAOTestHelper {
     Integer collection_id = darCollectionDAO.insertDarCollection(darCode, user.getUserId(),
         new Date());
     DataAccessRequest dar = createDataAccessRequestWithDatasetAndCollectionInfo(collection_id,
-        dataset.getDataSetId(), user.getUserId());
-    Election election = createDataAccessElection(dar.getReferenceId(), dataset.getDataSetId());
+        dataset.getDatasetId(), user.getUserId());
+    Election election = createDataAccessElection(dar.getReferenceId(), dataset.getDatasetId());
     Vote vote = createDacVote(user.getUserId(), election.getElectionId());
 
     Vote foundVote = voteDAO.findVoteByElectionIdAndUserId(election.getElectionId(),
@@ -166,8 +166,8 @@ class VoteDAOTest extends DAOTestHelper {
     Integer collection_id = darCollectionDAO.insertDarCollection(darCode, user.getUserId(),
         new Date());
     DataAccessRequest dar = createDataAccessRequestWithDatasetAndCollectionInfo(collection_id,
-        dataset.getDataSetId(), user.getUserId());
-    Election election = createDataAccessElection(dar.getReferenceId(), dataset.getDataSetId());
+        dataset.getDatasetId(), user.getUserId());
+    Election election = createDataAccessElection(dar.getReferenceId(), dataset.getDatasetId());
     Vote vote = createDacVote(user.getUserId(), election.getElectionId());
 
     Integer voteId = voteDAO.checkVoteById(election.getReferenceId(), vote.getVoteId());
@@ -185,13 +185,13 @@ class VoteDAOTest extends DAOTestHelper {
     User user = createUser();
     Dataset dataset = createDataset();
     Dac dac = createDac();
-    datasetDAO.updateDatasetDacId(dataset.getDataSetId(), dac.getDacId());
+    datasetDAO.updateDatasetDacId(dataset.getDatasetId(), dac.getDacId());
     String darCode = "DAR-1234567890";
     Integer collection_id = darCollectionDAO.insertDarCollection(darCode, user.getUserId(),
         new Date());
     DataAccessRequest dar = createDataAccessRequestWithDatasetAndCollectionInfo(collection_id,
-        dataset.getDataSetId(), user.getUserId());
-    Election election = createDataAccessElection(dar.getReferenceId(), dataset.getDataSetId());
+        dataset.getDatasetId(), user.getUserId());
+    Election election = createDataAccessElection(dar.getReferenceId(), dataset.getDatasetId());
     Vote v = createDacVote(user.getUserId(), election.getElectionId());
 
     Vote vote = voteDAO.findVoteById(v.getVoteId());
@@ -204,13 +204,13 @@ class VoteDAOTest extends DAOTestHelper {
     User user = createUser();
     Dataset dataset = createDataset();
     Dac dac = createDac();
-    datasetDAO.updateDatasetDacId(dataset.getDataSetId(), dac.getDacId());
+    datasetDAO.updateDatasetDacId(dataset.getDatasetId(), dac.getDacId());
     String darCode = "DAR-1234567890";
     Integer collection_id = darCollectionDAO.insertDarCollection(darCode, user.getUserId(),
         new Date());
     DataAccessRequest dar = createDataAccessRequestWithDatasetAndCollectionInfo(collection_id,
-        dataset.getDataSetId(), user.getUserId());
-    Election election = createDataAccessElection(dar.getReferenceId(), dataset.getDataSetId());
+        dataset.getDatasetId(), user.getUserId());
+    Election election = createDataAccessElection(dar.getReferenceId(), dataset.getDatasetId());
     Vote v = createDacVote(user.getUserId(), election.getElectionId());
 
     String rationale = "rationale";
@@ -237,13 +237,13 @@ class VoteDAOTest extends DAOTestHelper {
     User user = createUser();
     Dataset dataset = createDataset();
     Dac dac = createDac();
-    datasetDAO.updateDatasetDacId(dataset.getDataSetId(), dac.getDacId());
+    datasetDAO.updateDatasetDacId(dataset.getDatasetId(), dac.getDacId());
     String darCode = "DAR-1234567890";
     Integer collection_id = darCollectionDAO.insertDarCollection(darCode, user.getUserId(),
         new Date());
     DataAccessRequest dar = createDataAccessRequestWithDatasetAndCollectionInfo(collection_id,
-        dataset.getDataSetId(), user.getUserId());
-    Election election = createDataAccessElection(dar.getReferenceId(), dataset.getDataSetId());
+        dataset.getDatasetId(), user.getUserId());
+    Election election = createDataAccessElection(dar.getReferenceId(), dataset.getDatasetId());
     Vote v = createDacVote(user.getUserId(), election.getElectionId());
 
     voteDAO.updateVoteReminderFlag(v.getVoteId(), true);
@@ -264,8 +264,8 @@ class VoteDAOTest extends DAOTestHelper {
     Integer collection_id = darCollectionDAO.insertDarCollection(darCode, user.getUserId(),
         new Date());
     DataAccessRequest dar = createDataAccessRequestWithDatasetAndCollectionInfo(collection_id,
-        dataset.getDataSetId(), user.getUserId());
-    Election election = createDataAccessElection(dar.getReferenceId(), dataset.getDataSetId());
+        dataset.getDatasetId(), user.getUserId());
+    Election election = createDataAccessElection(dar.getReferenceId(), dataset.getDatasetId());
     electionDAO.updateElectionById(
         election.getElectionId(),
         ElectionStatus.CLOSED.getValue(),
@@ -301,13 +301,13 @@ class VoteDAOTest extends DAOTestHelper {
     User user = createUser();
     Dataset dataset = createDataset();
     Dac dac = createDac();
-    datasetDAO.updateDatasetDacId(dataset.getDataSetId(), dac.getDacId());
+    datasetDAO.updateDatasetDacId(dataset.getDatasetId(), dac.getDacId());
     String darCode = "DAR-1234567890";
     Integer collection_id = darCollectionDAO.insertDarCollection(darCode, user.getUserId(),
         new Date());
     DataAccessRequest dar = createDataAccessRequestWithDatasetAndCollectionInfo(collection_id,
-        dataset.getDataSetId(), user.getUserId());
-    Election election = createDataAccessElection(dar.getReferenceId(), dataset.getDataSetId());
+        dataset.getDatasetId(), user.getUserId());
+    Election election = createDataAccessElection(dar.getReferenceId(), dataset.getDatasetId());
     electionDAO.updateElectionById(
         election.getElectionId(),
         ElectionStatus.CLOSED.getValue(),
@@ -337,14 +337,14 @@ class VoteDAOTest extends DAOTestHelper {
     User user3 = createUserWithRole(UserRoles.MEMBER.getRoleId());
     Dataset dataset = createDataset();
     Dac dac = createDac();
-    datasetDAO.updateDatasetDacId(dataset.getDataSetId(), dac.getDacId());
+    datasetDAO.updateDatasetDacId(dataset.getDatasetId(), dac.getDacId());
     User user4 = createUserWithRole(UserRoles.RESEARCHER.getRoleId());
     String darCode = "DAR-1234567890";
     Integer collection_id = darCollectionDAO.insertDarCollection(darCode, user4.getUserId(),
         new Date());
     DataAccessRequest dar = createDataAccessRequestWithDatasetAndCollectionInfo(collection_id,
-        dataset.getDataSetId(), user4.getUserId());
-    Election election = createDataAccessElection(dar.getReferenceId(), dataset.getDataSetId());
+        dataset.getDatasetId(), user4.getUserId());
+    Election election = createDataAccessElection(dar.getReferenceId(), dataset.getDatasetId());
     List<Integer> userIds = Arrays.asList(user1.getUserId(), user2.getUserId(), user3.getUserId());
 
     voteDAO.insertVotes(userIds, election.getElectionId(), VoteType.DAC.getValue());
@@ -360,13 +360,13 @@ class VoteDAOTest extends DAOTestHelper {
     User user = createUserWithRole(UserRoles.CHAIRPERSON.getRoleId());
     Dataset dataset = createDataset();
     Dac dac = createDac();
-    datasetDAO.updateDatasetDacId(dataset.getDataSetId(), dac.getDacId());
+    datasetDAO.updateDatasetDacId(dataset.getDatasetId(), dac.getDacId());
     String darCode = "DAR-1234567890";
     Integer collection_id = darCollectionDAO.insertDarCollection(darCode, user.getUserId(),
         new Date());
     DataAccessRequest dar = createDataAccessRequestWithDatasetAndCollectionInfo(collection_id,
-        dataset.getDataSetId(), user.getUserId());
-    Election election = createDataAccessElection(dar.getReferenceId(), dataset.getDataSetId());
+        dataset.getDatasetId(), user.getUserId());
+    Election election = createDataAccessElection(dar.getReferenceId(), dataset.getDatasetId());
     Vote vote = createDacVote(user.getUserId(), election.getElectionId());
 
     voteDAO.removeVotesByIds(Collections.singletonList(vote.getVoteId()));
@@ -379,13 +379,13 @@ class VoteDAOTest extends DAOTestHelper {
     User user = createUserWithRole(UserRoles.CHAIRPERSON.getRoleId());
     Dataset dataset = createDataset();
     Dac dac = createDac();
-    datasetDAO.updateDatasetDacId(dataset.getDataSetId(), dac.getDacId());
+    datasetDAO.updateDatasetDacId(dataset.getDatasetId(), dac.getDacId());
     String darCode = "DAR-1234567890";
     Integer collection_id = darCollectionDAO.insertDarCollection(darCode, user.getUserId(),
         new Date());
     DataAccessRequest dar = createDataAccessRequestWithDatasetAndCollectionInfo(collection_id,
-        dataset.getDataSetId(), user.getUserId());
-    Election election = createDataAccessElection(dar.getReferenceId(), dataset.getDataSetId());
+        dataset.getDatasetId(), user.getUserId());
+    Election election = createDataAccessElection(dar.getReferenceId(), dataset.getDatasetId());
     createChairpersonVote(user.getUserId(), election.getElectionId());
 
     List<Vote> userVotes = voteDAO.findVotesByUserId(user.getUserId());
@@ -399,7 +399,7 @@ class VoteDAOTest extends DAOTestHelper {
     Dac dac = createDac();
     User user = createUserWithRoleInDac(UserRoles.MEMBER.getRoleId(), dac.getDacId());
     DataAccessRequest dar = createDataAccessRequestV3();
-    Election election = createDataAccessElection(dar.getReferenceId(), dataset.getDataSetId());
+    Election election = createDataAccessElection(dar.getReferenceId(), dataset.getDatasetId());
     Vote dacVote = createDacVote(user.getUserId(), election.getElectionId());
     assertNull(dacVote.getRationale());
 
@@ -455,10 +455,10 @@ class VoteDAOTest extends DAOTestHelper {
     datasets
         .forEach(dataset -> {
           DataAccessRequest dar = createDataAccessRequestWithDatasetAndCollectionInfo(collectionId,
-              dataset.getDataSetId(), user.getUserId());
+              dataset.getDatasetId(), user.getUserId());
           Election cancelled = createCanceledAccessElection(dar.getReferenceId(),
-              dataset.getDataSetId());
-          Election access = createDataAccessElection(dar.getReferenceId(), dataset.getDataSetId());
+              dataset.getDatasetId());
+          Election access = createDataAccessElection(dar.getReferenceId(), dataset.getDatasetId());
           createFinalVote(user.getUserId(), cancelled.getElectionId());
           createFinalVote(user.getUserId(), access.getElectionId());
         });
@@ -510,7 +510,7 @@ class VoteDAOTest extends DAOTestHelper {
   private void createDatasetProperties(Integer datasetId) {
     List<DatasetProperty> list = new ArrayList<>();
     DatasetProperty dsp = new DatasetProperty();
-    dsp.setDataSetId(datasetId);
+    dsp.setDatasetId(datasetId);
     dsp.setPropertyKey(1);
     dsp.setPropertyValue("Test_PropertyValue");
     dsp.setCreateDate(new Date());

--- a/src/test/java/org/broadinstitute/consent/http/mail/freemarker/FreeMarkerTemplateHelperTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mail/freemarker/FreeMarkerTemplateHelperTest.java
@@ -73,7 +73,7 @@ class FreeMarkerTemplateHelperTest {
     Dataset d1 = new Dataset();
     d1.setDacId(1);
     d1.setDatasetName("Dataset-01");
-    d1.setDataSetId(1);
+    d1.setDatasetId(1);
     d1.setAlias(1);
     d1.setDatasetIdentifier();
 

--- a/src/test/java/org/broadinstitute/consent/http/models/DatasetRegistrationSchemaV1BuilderTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/DatasetRegistrationSchemaV1BuilderTest.java
@@ -190,7 +190,7 @@ class DatasetRegistrationSchemaV1BuilderTest {
     Study study = createMockStudy();
     Dataset dataset = createMockDataset();
     DatasetProperty prop = new DatasetProperty();
-    prop.setDataSetId(dataset.getDataSetId());
+    prop.setDatasetId(dataset.getDatasetId());
     prop.setSchemaProperty(null);
     prop.setPropertyName(generalResearchUse);
     prop.setPropertyType(PropertyType.Boolean);
@@ -318,7 +318,7 @@ class DatasetRegistrationSchemaV1BuilderTest {
     Date now = new Date();
     Dataset dataset = new Dataset();
     dataset.setName(randomString());
-    dataset.setDataSetId(randomInt());
+    dataset.setDatasetId(randomInt());
     dataset.setAlias(randomInt());
     // datasetIdentifier is derived from `alias`
     dataset.setDatasetIdentifier();
@@ -353,7 +353,7 @@ class DatasetRegistrationSchemaV1BuilderTest {
   private DatasetProperty createDatasetProperty(Dataset dataset, String schemaProp,
       PropertyType type, Object propValue) {
     DatasetProperty prop = new DatasetProperty();
-    prop.setDataSetId(dataset.getDataSetId());
+    prop.setDatasetId(dataset.getDatasetId());
     prop.setSchemaProperty(schemaProp);
     prop.setPropertyName(schemaProp);
     prop.setPropertyType(type);

--- a/src/test/java/org/broadinstitute/consent/http/models/dataset_registration_v1/DatasetRegistrationSchemaV1UpdateValidatorTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/dataset_registration_v1/DatasetRegistrationSchemaV1UpdateValidatorTest.java
@@ -156,11 +156,11 @@ class DatasetRegistrationSchemaV1UpdateValidatorTest {
     Dataset dataset = new Dataset();
     dataset.setName(RandomStringUtils.randomAlphabetic(10));
     // mock data is limited to 10->100
-    dataset.setDataSetId(10000);
+    dataset.setDatasetId(10000);
     dataset.setDacId(RandomUtils.nextInt(10, 100));
     study.getDatasets().add(dataset);
     ArrayList<Integer> datasetIds = new ArrayList<>(study.getDatasetIds().stream().toList());
-    datasetIds.add(dataset.getDataSetId());
+    datasetIds.add(dataset.getDatasetId());
     study.setDatasetIds(new HashSet<>(datasetIds));
 
     assertThrows(BadRequestException.class, () -> {
@@ -316,10 +316,10 @@ class DatasetRegistrationSchemaV1UpdateValidatorTest {
     study.setName(RandomStringUtils.randomAlphabetic(10));
     Dataset dataset = new Dataset();
     dataset.setName("");
-    dataset.setDataSetId(RandomUtils.nextInt(10, 100));
+    dataset.setDatasetId(RandomUtils.nextInt(10, 100));
     dataset.setDacId(RandomUtils.nextInt(10, 100));
     study.addDatasets(List.of(dataset));
-    study.setDatasetIds(Set.of(dataset.getDataSetId()));
+    study.setDatasetIds(Set.of(dataset.getDatasetId()));
     return study;
   }
 
@@ -341,7 +341,7 @@ class DatasetRegistrationSchemaV1UpdateValidatorTest {
       cg.setDataLocation(DataLocation.NOT_DETERMINED);
       cg.setNumberOfParticipants(RandomUtils.nextInt(10, 100));
       cg.setConsentGroupName(RandomStringUtils.randomAlphabetic(10));
-      cg.setDatasetId(d.getDataSetId());
+      cg.setDatasetId(d.getDatasetId());
       cg.setDataAccessCommitteeId(d.getDacId());
       return cg;
     }).toList();

--- a/src/test/java/org/broadinstitute/consent/http/resources/DarCollectionResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DarCollectionResourceTest.java
@@ -187,7 +187,7 @@ class DarCollectionResourceTest {
     collection.setCreateUserId(researcher.getUserId());
 
     Dataset dataSet = new Dataset();
-    dataSet.setDataSetId(2);
+    dataSet.setDatasetId(2);
     collection.addDataset(dataSet);
 
     when(darCollectionService.getByCollectionId(any())).thenReturn(collection);
@@ -208,7 +208,7 @@ class DarCollectionResourceTest {
     collection.setCreateUserId(researcher.getUserId());
 
     Dataset dataSet = new Dataset();
-    dataSet.setDataSetId(2);
+    dataSet.setDatasetId(2);
     collection.addDataset(dataSet);
 
     when(darCollectionService.getByCollectionId(any())).thenReturn(collection);
@@ -229,7 +229,7 @@ class DarCollectionResourceTest {
     collection.setCreateUserId(researcher.getUserId());
 
     Dataset dataSet = new Dataset();
-    dataSet.setDataSetId(3);
+    dataSet.setDatasetId(3);
     collection.addDataset(dataSet);
 
     when(darCollectionService.getByCollectionId(any())).thenReturn(collection);
@@ -252,7 +252,7 @@ class DarCollectionResourceTest {
     collection.setCreateUserId(user.getUserId());
 
     Dataset dataSet = new Dataset();
-    dataSet.setDataSetId(3);
+    dataSet.setDatasetId(3);
     collection.addDataset(dataSet);
 
     when(darCollectionService.getByCollectionId(any())).thenReturn(collection);

--- a/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
@@ -116,7 +116,7 @@ class DatasetResourceTest {
 
   private DatasetDTO createMockDatasetDTO() {
     DatasetDTO mockDTO = new DatasetDTO();
-    mockDTO.setDataSetId(RandomUtils.nextInt(100, 1000));
+    mockDTO.setDatasetId(RandomUtils.nextInt(100, 1000));
     mockDTO.setDatasetName("test");
     mockDTO.addProperty(new DatasetPropertyDTO("Property", "test"));
 
@@ -260,7 +260,7 @@ class DatasetResourceTest {
   @Test
   void testDeleteSuccessChairperson() {
     Dataset dataSet = new Dataset();
-    dataSet.setDataSetId(1);
+    dataSet.setDatasetId(1);
     dataSet.setDacId(1);
 
     when(user.hasUserRole(UserRoles.ADMIN)).thenReturn(false);
@@ -295,7 +295,7 @@ class DatasetResourceTest {
   @Test
   void testDeleteErrorNullConsent() {
     Dataset dataSet = new Dataset();
-    dataSet.setDataSetId(1);
+    dataSet.setDatasetId(1);
 
     when(user.hasUserRole(UserRoles.ADMIN)).thenReturn(false);
     UserRole role = UserRoles.Chairperson();
@@ -313,7 +313,7 @@ class DatasetResourceTest {
   @Test
   void testDeleteErrorMismatch() {
     Dataset dataSet = new Dataset();
-    dataSet.setDataSetId(1);
+    dataSet.setDatasetId(1);
     dataSet.setDacId(2);
 
     when(user.hasUserRole(UserRoles.ADMIN)).thenReturn(false);
@@ -332,7 +332,7 @@ class DatasetResourceTest {
   @Test
   void testIndexAllDatasets() throws Exception {
     Dataset dataset = new Dataset();
-    dataset.setDataSetId(RandomUtils.nextInt(10, 100));
+    dataset.setDatasetId(RandomUtils.nextInt(10, 100));
     Gson gson = GsonUtil.buildGson();
     String esResponseArray = """
         [
@@ -361,9 +361,9 @@ class DatasetResourceTest {
         ]
         """;
     StreamingOutput output = out -> out.write(
-        esResponseArray.formatted(dataset.getDataSetId()).getBytes());
-    when(datasetService.findAllDatasetIds()).thenReturn(List.of(dataset.getDataSetId()));
-    when(elasticSearchService.indexDatasetIds(List.of(dataset.getDataSetId()))).thenReturn(output);
+        esResponseArray.formatted(dataset.getDatasetId()).getBytes());
+    when(datasetService.findAllDatasetIds()).thenReturn(List.of(dataset.getDatasetId()));
+    when(elasticSearchService.indexDatasetIds(List.of(dataset.getDatasetId()))).thenReturn(output);
 
     initResource();
     try (Response response = resource.indexDatasets()) {
@@ -378,7 +378,7 @@ class DatasetResourceTest {
       JsonArray items = responseList.get(0).getAsJsonArray("items");
       assertEquals(1, items.size());
       assertEquals(
-          dataset.getDataSetId(),
+          dataset.getDatasetId(),
           items.get(0)
               .getAsJsonObject()
               .getAsJsonObject("index")
@@ -444,7 +444,7 @@ class DatasetResourceTest {
   @Test
   void testGetDataset() {
     Dataset ds = new Dataset();
-    ds.setDataSetId(1);
+    ds.setDatasetId(1);
     ds.setName("asdfasdfasdfasdfasdfasdf");
     when(datasetService.findDatasetById(1)).thenReturn(ds);
     initResource();
@@ -465,11 +465,11 @@ class DatasetResourceTest {
   @Test
   void testGetDatasets() {
     Dataset ds1 = new Dataset();
-    ds1.setDataSetId(1);
+    ds1.setDatasetId(1);
     Dataset ds2 = new Dataset();
-    ds2.setDataSetId(2);
+    ds2.setDatasetId(2);
     Dataset ds3 = new Dataset();
-    ds3.setDataSetId(3);
+    ds3.setDatasetId(3);
     List<Dataset> datasets = List.of(ds1, ds2, ds3);
 
     when(datasetService.findDatasetsByIds(List.of(1, 2, 3))).thenReturn(datasets);
@@ -483,11 +483,11 @@ class DatasetResourceTest {
   @Test
   void testGetDatasetsDuplicates() {
     Dataset ds1 = new Dataset();
-    ds1.setDataSetId(1);
+    ds1.setDatasetId(1);
     Dataset ds2 = new Dataset();
-    ds2.setDataSetId(2);
+    ds2.setDatasetId(2);
     Dataset ds3 = new Dataset();
-    ds3.setDataSetId(3);
+    ds3.setDatasetId(3);
     List<Dataset> datasets = List.of(ds1, ds2, ds3);
 
     when(datasetService.findDatasetsByIds(List.of(1, 1, 2, 2, 3, 3))).thenReturn(datasets);
@@ -501,9 +501,9 @@ class DatasetResourceTest {
   @Test
   void testGetDatasetsDuplicatesNotFound() {
     Dataset ds1 = new Dataset();
-    ds1.setDataSetId(1);
+    ds1.setDatasetId(1);
     Dataset ds2 = new Dataset();
-    ds2.setDataSetId(2);
+    ds2.setDatasetId(2);
 
     when(datasetService.findDatasetsByIds(List.of(1, 1, 2, 2, 3, 3))).thenReturn(List.of(
         ds1,
@@ -522,9 +522,9 @@ class DatasetResourceTest {
   @Test
   void testGetDatasetsNotFound() {
     Dataset ds1 = new Dataset();
-    ds1.setDataSetId(1);
+    ds1.setDatasetId(1);
     Dataset ds3 = new Dataset();
-    ds3.setDataSetId(3);
+    ds3.setDatasetId(3);
 
     when(datasetService.findDatasetsByIds(List.of(1, 2, 3, 4))).thenReturn(List.of(
         ds1,
@@ -543,9 +543,9 @@ class DatasetResourceTest {
   @Test
   void testGetDatasetsNotFoundNullValues() {
     Dataset ds1 = new Dataset();
-    ds1.setDataSetId(1);
+    ds1.setDatasetId(1);
     Dataset ds3 = new Dataset();
-    ds3.setDataSetId(3);
+    ds3.setDatasetId(3);
 
     when(datasetService.findDatasetsByIds(any())).thenReturn(List.of(
         ds1,
@@ -627,7 +627,7 @@ class DatasetResourceTest {
   @Test
   void testFindAllDatasetsStreaming() throws Exception {
     var dataset = new Dataset();
-    dataset.setDataSetId(RandomUtils.nextInt(100, 1000));
+    dataset.setDatasetId(RandomUtils.nextInt(100, 1000));
     when(userService.findUserByEmail(any())).thenReturn(user);
     final Gson gson = GsonUtil.buildGson();
     StreamingOutput output = out -> out.write(gson.toJson(List.of(dataset)).getBytes());
@@ -644,7 +644,7 @@ class DatasetResourceTest {
     }.getType();
     List<Dataset> returnedDatasets = gson.fromJson(entityString, listOfDatasetsType);
     assertThat(returnedDatasets, hasSize(1));
-    assertEquals(dataset.getDataSetId(), returnedDatasets.get(0).getDataSetId());
+    assertEquals(dataset.getDatasetId(), returnedDatasets.get(0).getDatasetId());
   }
 
   @Test
@@ -1013,7 +1013,7 @@ class DatasetResourceTest {
   private String createDataset(User user) {
     String format = """
         {
-          "dataSetId": 2,
+          "datasetId": 2,
           "objectId": "SC-10985",
           "name": "Herman Taylor (U. Miss Med Center) - Jackson Heart Study",
           "createDate": "Mar 21, 2019",
@@ -1036,7 +1036,7 @@ class DatasetResourceTest {
           "deletable": false,
           "properties": [
             {
-              "dataSetId": 2,
+              "datasetId": 2,
               "propertyName": "test",
               "propertyValue": "John Doe",
               "propertyType": "String"
@@ -1064,7 +1064,7 @@ class DatasetResourceTest {
   private String createInvalidDataset(User user) {
     String format = """
         {
-          "dataSetId": 2,
+          "datasetId": 2,
         }
         """;
 
@@ -1076,7 +1076,7 @@ class DatasetResourceTest {
    */
   private Study createMockStudy() {
     Dataset dataset = new Dataset();
-    dataset.setDataSetId(100);
+    dataset.setDatasetId(100);
     dataset.setAlias(10);
     dataset.setDatasetIdentifier();
     dataset.setDacId(1);
@@ -1091,7 +1091,7 @@ class DatasetResourceTest {
     study.setCreateUserId(9);
     study.setCreateUserEmail(RandomStringUtils.randomAlphabetic(10));
     study.setPublicVisibility(true);
-    study.setDatasetIds(Set.of(dataset.getDataSetId()));
+    study.setDatasetIds(Set.of(dataset.getDatasetId()));
 
     StudyProperty phenotypeProperty = new StudyProperty();
     phenotypeProperty.setKey("phenotypeIndication");

--- a/src/test/java/org/broadinstitute/consent/http/resources/StudyResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/StudyResourceTest.java
@@ -100,11 +100,11 @@ class StudyResourceTest {
   @Test
   void testGetStudyByIdWithDatasets() {
     Dataset ds1 = new Dataset();
-    ds1.setDataSetId(1);
+    ds1.setDatasetId(1);
     Dataset ds2 = new Dataset();
-    ds2.setDataSetId(2);
+    ds2.setDatasetId(2);
     Dataset ds3 = new Dataset();
-    ds3.setDataSetId(3);
+    ds3.setDatasetId(3);
     List<Dataset> datasets = List.of(ds1, ds2, ds3);
 
     Study study = new Study();
@@ -214,7 +214,7 @@ class StudyResourceTest {
    */
   private Study createMockStudy() {
     Dataset dataset = new Dataset();
-    dataset.setDataSetId(100);
+    dataset.setDatasetId(100);
     dataset.setAlias(10);
     dataset.setDatasetIdentifier();
     dataset.setDacId(1);
@@ -229,7 +229,7 @@ class StudyResourceTest {
     study.setCreateUserId(9);
     study.setCreateUserEmail(RandomStringUtils.randomAlphabetic(10));
     study.setPublicVisibility(true);
-    study.setDatasetIds(Set.of(dataset.getDataSetId()));
+    study.setDatasetIds(Set.of(dataset.getDatasetId()));
 
     StudyProperty phenotypeProperty = new StudyProperty();
     phenotypeProperty.setKey("phenotypeIndication");

--- a/src/test/java/org/broadinstitute/consent/http/service/DacServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DacServiceTest.java
@@ -390,7 +390,7 @@ class DacServiceTest {
   void testFilterDataAccessRequestsByDAC_memberCase_1() {
     // Member has access to DataSet 1
     List<Dataset> memberDataSets = Collections.singletonList(getDatasets().get(0));
-    when(dataSetDAO.findDatasetIdsByDACUserId(getMember().getUserId())).thenReturn(List.of(memberDataSets.get(0).getDataSetId()));
+    when(dataSetDAO.findDatasetIdsByDACUserId(getMember().getUserId())).thenReturn(List.of(memberDataSets.get(0).getDatasetId()));
 
     initService();
 
@@ -406,7 +406,7 @@ class DacServiceTest {
   void testFilterDataAccessRequestsByDAC_memberCase_2() {
     // Member has access to datasets
     List<Dataset> memberDataSets = Collections.singletonList(getDatasets().get(0));
-    when(dataSetDAO.findDatasetIdsByDACUserId(getMember().getUserId())).thenReturn(List.of(memberDataSets.get(0).getDataSetId()));
+    when(dataSetDAO.findDatasetIdsByDACUserId(getMember().getUserId())).thenReturn(List.of(memberDataSets.get(0).getDatasetId()));
 
     initService();
 
@@ -469,7 +469,7 @@ class DacServiceTest {
     return IntStream.range(1, 5).
         mapToObj(i -> {
           Election election = new Election();
-          election.setDataSetId(i);
+          election.setDatasetId(i);
           return election;
         }).collect(Collectors.toList());
   }
@@ -481,11 +481,11 @@ class DacServiceTest {
     return IntStream.range(1, 5).
         mapToObj(i -> {
           String referenceId = UUID.randomUUID().toString();
-          List<Integer> dataSetIds = Collections.singletonList(i);
+          List<Integer> datasetIds = Collections.singletonList(i);
           DataAccessRequest dar = new DataAccessRequest();
           dar.setReferenceId(referenceId);
           DataAccessRequestData data = new DataAccessRequestData();
-          dar.setDatasetIds(dataSetIds);
+          dar.setDatasetIds(datasetIds);
           data.setReferenceId(referenceId);
           dar.setData(data);
           return dar;
@@ -499,7 +499,7 @@ class DacServiceTest {
     return IntStream.range(1, 5).
         mapToObj(i -> {
           Dataset dataSet = new Dataset();
-          dataSet.setDataSetId(i);
+          dataSet.setDatasetId(i);
           return dataSet;
         }).collect(Collectors.toList());
   }

--- a/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
@@ -95,7 +95,7 @@ class DarCollectionServiceTest {
     Set<Dataset> datasets = new HashSet<>();
     collections.add(generateMockDarCollection(datasets));
     List<Integer> datasetIds = datasets.stream()
-        .map(Dataset::getDataSetId)
+        .map(Dataset::getDatasetId)
         .sorted()
         .collect(Collectors.toList());
 
@@ -110,7 +110,7 @@ class DarCollectionServiceTest {
     assertEquals(datasetIds.size(), datasetsFromCollection.size());
 
     List<Integer> collectionDatasetIds = datasetsFromCollection.stream()
-        .map(Dataset::getDataSetId)
+        .map(Dataset::getDatasetId)
         .sorted()
         .collect(Collectors.toList());
     assertEquals(datasetIds, collectionDatasetIds);
@@ -123,20 +123,20 @@ class DarCollectionServiceTest {
     // need a minimal version of a collection with an array of datasetIds
     collections.add(generateMockDarCollection(datasets));
     List<Integer> datasetIds = datasets.stream()
-        .map(Dataset::getDataSetId)
+        .map(Dataset::getDatasetId)
         .sorted()
         .collect(Collectors.toList());
 
     Dataset dataset = new Dataset();
-    dataset.setDataSetId(datasetIds.get(0));
+    dataset.setDatasetId(datasetIds.get(0));
 
     // mocking out findDatasetWithDataUseByIdList to only return one of the datasets
-    when(datasetDAO.findDatasetWithDataUseByIdList(List.of(dataset.getDataSetId()))).thenReturn(
+    when(datasetDAO.findDatasetWithDataUseByIdList(List.of(dataset.getDatasetId()))).thenReturn(
         new HashSet<>(List.of(dataset)));
     when(dataAccessRequestDAO.findAllDARDatasetRelations(any())).thenReturn(datasetIds);
 
 
-    collections = service.addDatasetsToCollections(collections, List.of(dataset.getDataSetId()));
+    collections = service.addDatasetsToCollections(collections, List.of(dataset.getDatasetId()));
     assertEquals(1, collections.size());
 
     DarCollection collection = collections.get(0);
@@ -144,10 +144,10 @@ class DarCollectionServiceTest {
     assertEquals(1, datasetsFromCollection.size());
 
     List<Integer> collectionDatasetIds = datasetsFromCollection.stream()
-        .map(Dataset::getDataSetId)
+        .map(Dataset::getDatasetId)
         .sorted()
         .toList();
-    assertEquals(dataset.getDataSetId(), collectionDatasetIds.get(0));
+    assertEquals(dataset.getDatasetId(), collectionDatasetIds.get(0));
   }
 
   @Test
@@ -240,11 +240,11 @@ class DarCollectionServiceTest {
     User user = new User();
     user.setUserId(RandomUtils.nextInt(1, 10));
     Dataset dataset = new Dataset();
-    dataset.setDataSetId(1);
+    dataset.setDatasetId(1);
     DataAccessRequest dar = new DataAccessRequest();
     dar.setReferenceId(UUID.randomUUID().toString());
     DataAccessRequestData data = new DataAccessRequestData();
-    dar.addDatasetId(dataset.getDataSetId());
+    dar.addDatasetId(dataset.getDatasetId());
     dar.setData(data);
     DarCollection collection = createMockCollections(1).get(0);
     collection.setDars(Map.of(dar.getReferenceId(), dar));
@@ -252,7 +252,7 @@ class DarCollectionServiceTest {
     election.setReferenceId(dar.getReferenceId());
     election.setStatus(ElectionStatus.OPEN.getValue());
     election.setElectionId(1);
-    when(datasetDAO.findDatasetIdsByDACUserId(anyInt())).thenReturn(List.of(dataset.getDataSetId()));
+    when(datasetDAO.findDatasetIdsByDACUserId(anyInt())).thenReturn(List.of(dataset.getDatasetId()));
     when(electionDAO.findOpenElectionsByReferenceIds(anyList())).thenReturn(List.of(election));
 
     service.cancelDarCollectionElectionsAsChair(collection, user);
@@ -268,11 +268,11 @@ class DarCollectionServiceTest {
     User user = new User();
     user.setUserId(RandomUtils.nextInt(1, 10));
     Dataset dataset = new Dataset();
-    dataset.setDataSetId(1);
+    dataset.setDatasetId(1);
     DataAccessRequest dar = new DataAccessRequest();
     dar.setReferenceId(UUID.randomUUID().toString());
     DataAccessRequestData data = new DataAccessRequestData();
-    dar.addDatasetId(dataset.getDataSetId());
+    dar.addDatasetId(dataset.getDatasetId());
     dar.setData(data);
     DarCollection collection = createMockCollections(1).get(0);
     collection.setDars(Map.of(dar.getReferenceId(), dar));
@@ -442,9 +442,9 @@ class DarCollectionServiceTest {
     electionOne.setElectionId(1);
     electionOne.setStatus(ElectionStatus.OPEN.getValue());
     Dataset datasetOne = new Dataset();
-    datasetOne.setDataSetId(1);
+    datasetOne.setDatasetId(1);
     summary.addElection(electionOne);
-    summary.addDatasetId(datasetOne.getDataSetId());
+    summary.addDatasetId(datasetOne.getDatasetId());
     when(darCollectionSummaryDAO.getDarCollectionSummariesForSO(any())).thenReturn(
         List.of(summary));
 
@@ -469,13 +469,13 @@ class DarCollectionServiceTest {
     electionTwo.setElectionId(2);
     electionTwo.setStatus((ElectionStatus.CANCELED.getValue()));
     Dataset datasetOne = new Dataset();
-    datasetOne.setDataSetId(1);
+    datasetOne.setDatasetId(1);
     Dataset datasetTwo = new Dataset();
-    datasetTwo.setDataSetId(2);
+    datasetTwo.setDatasetId(2);
     summary.addElection(electionOne);
     summary.addElection(electionTwo);
-    summary.addDatasetId(datasetOne.getDataSetId());
-    summary.addDatasetId(datasetTwo.getDataSetId());
+    summary.addDatasetId(datasetOne.getDatasetId());
+    summary.addDatasetId(datasetTwo.getDatasetId());
     when(darCollectionSummaryDAO.getDarCollectionSummariesForSO(any())).thenReturn(
         List.of(summary));
 
@@ -494,11 +494,11 @@ class DarCollectionServiceTest {
     user.setUserId(1);
     DarCollectionSummary summary = new DarCollectionSummary();
     Dataset datasetOne = new Dataset();
-    datasetOne.setDataSetId(1);
+    datasetOne.setDatasetId(1);
     Dataset datasetTwo = new Dataset();
-    datasetTwo.setDataSetId(2);
-    summary.addDatasetId(datasetOne.getDataSetId());
-    summary.addDatasetId(datasetTwo.getDataSetId());
+    datasetTwo.setDatasetId(2);
+    summary.addDatasetId(datasetOne.getDatasetId());
+    summary.addDatasetId(datasetTwo.getDatasetId());
     when(darCollectionSummaryDAO.getDarCollectionSummariesForSO(any())).thenReturn(
         List.of(summary));
 
@@ -524,28 +524,28 @@ class DarCollectionServiceTest {
 
     DarCollectionSummary summaryOne = new DarCollectionSummary();
     Dataset datasetOne = new Dataset();
-    datasetOne.setDataSetId(1);
+    datasetOne.setDatasetId(1);
     Dataset datasetTwo = new Dataset();
-    datasetTwo.setDataSetId(2);
+    datasetTwo.setDatasetId(2);
     Election electionOne = new Election();
     electionOne.setElectionId(1);
     electionOne.setStatus(ElectionStatus.OPEN.getValue());
     summaryOne.addElection(electionOne);
-    summaryOne.addDatasetId(datasetOne.getDataSetId());
-    summaryOne.addDatasetId(datasetTwo.getDataSetId());
+    summaryOne.addDatasetId(datasetOne.getDatasetId());
+    summaryOne.addDatasetId(datasetTwo.getDatasetId());
 
     DarCollectionSummary summaryTwo = new DarCollectionSummary();
     Dataset datasetThree = new Dataset();
-    datasetThree.setDataSetId(3);
+    datasetThree.setDatasetId(3);
     Dataset datasetFour = new Dataset();
-    datasetFour.setDataSetId(4);
-    summaryTwo.addDatasetId(datasetThree.getDataSetId());
-    summaryTwo.addDatasetId(datasetFour.getDataSetId());
+    datasetFour.setDatasetId(4);
+    summaryTwo.addDatasetId(datasetThree.getDatasetId());
+    summaryTwo.addDatasetId(datasetFour.getDatasetId());
 
     DarCollectionSummary summaryThree = new DarCollectionSummary();
     Dataset datasetFive = new Dataset();
-    datasetFive.setDataSetId(5);
-    summaryThree.addDatasetId(datasetFive.getDataSetId());
+    datasetFive.setDatasetId(5);
+    summaryThree.addDatasetId(datasetFive.getDatasetId());
     summaryThree.addStatus(DarStatus.CANCELED.getValue(), RandomStringUtils.randomAlphabetic(3));
 
     DataAccessRequest draft = new DataAccessRequest();
@@ -615,9 +615,9 @@ class DarCollectionServiceTest {
 
     DarCollectionSummary summaryOne = new DarCollectionSummary();
     Dataset datasetOne = new Dataset();
-    datasetOne.setDataSetId(1);
+    datasetOne.setDatasetId(1);
     Dataset datasetTwo = new Dataset();
-    datasetTwo.setDataSetId(2);
+    datasetTwo.setDatasetId(2);
     Election electionOne = new Election();
     electionOne.setElectionId(1);
     electionOne.setStatus(ElectionStatus.OPEN.getValue());
@@ -626,16 +626,16 @@ class DarCollectionServiceTest {
     electionTwo.setStatus(ElectionStatus.OPEN.getValue());
     summaryOne.addElection(electionOne);
     summaryOne.addElection(electionTwo);
-    summaryOne.addDatasetId(datasetOne.getDataSetId());
-    summaryOne.addDatasetId(datasetTwo.getDataSetId());
+    summaryOne.addDatasetId(datasetOne.getDatasetId());
+    summaryOne.addDatasetId(datasetTwo.getDatasetId());
 
     DarCollectionSummary summaryTwo = new DarCollectionSummary();
     Dataset datasetThree = new Dataset();
-    datasetThree.setDataSetId(3);
+    datasetThree.setDatasetId(3);
     Dataset datasetFour = new Dataset();
-    datasetFour.setDataSetId(4);
+    datasetFour.setDatasetId(4);
     Dataset datasetFive = new Dataset();
-    datasetFive.setDataSetId(5);
+    datasetFive.setDatasetId(5);
     Election electionThree = new Election();
     electionThree.setElectionId(3);
     electionThree.setStatus(ElectionStatus.OPEN.getValue());
@@ -644,23 +644,23 @@ class DarCollectionServiceTest {
     electionFour.setStatus(ElectionStatus.CANCELED.getValue());
     summaryTwo.addElection(electionThree);
     summaryTwo.addElection(electionFour);
-    summaryTwo.addDatasetId(datasetThree.getDataSetId());
-    summaryTwo.addDatasetId(datasetFour.getDataSetId());
-    summaryTwo.addDatasetId(datasetFive.getDataSetId());
+    summaryTwo.addDatasetId(datasetThree.getDatasetId());
+    summaryTwo.addDatasetId(datasetFour.getDatasetId());
+    summaryTwo.addDatasetId(datasetFive.getDatasetId());
 
     DarCollectionSummary summaryThree = new DarCollectionSummary();
     Dataset datasetSix = new Dataset();
-    datasetSix.setDataSetId(6);
+    datasetSix.setDatasetId(6);
     Election electionFive = new Election();
     electionFive.setElectionId(5);
     electionFive.setStatus(ElectionStatus.CANCELED.getValue());
     summaryThree.addElection(electionFive);
-    summaryThree.addDatasetId(datasetSix.getDataSetId());
+    summaryThree.addDatasetId(datasetSix.getDatasetId());
 
     DarCollectionSummary summaryFour = new DarCollectionSummary();
     Dataset datasetSeven = new Dataset();
-    datasetSeven.setDataSetId(7);
-    summaryFour.addDatasetId(datasetSeven.getDataSetId());
+    datasetSeven.setDatasetId(7);
+    summaryFour.addDatasetId(datasetSeven.getDatasetId());
 
     when(darCollectionSummaryDAO.getDarCollectionSummariesForAdmin())
         .thenReturn(List.of(summaryOne, summaryTwo, summaryThree, summaryFour));
@@ -784,7 +784,7 @@ class DarCollectionServiceTest {
         .distinct()
         .map(id -> {
           Dataset d = new Dataset();
-          d.setDataSetId(id);
+          d.setDatasetId(id);
           return d;
         })
         .toList();
@@ -837,9 +837,9 @@ class DarCollectionServiceTest {
 
     DarCollectionSummary summaryOne = new DarCollectionSummary();
     Dataset datasetOne = new Dataset();
-    datasetOne.setDataSetId(1);
+    datasetOne.setDatasetId(1);
     Dataset datasetTwo = new Dataset();
-    datasetTwo.setDataSetId(2);
+    datasetTwo.setDatasetId(2);
     Election electionOne = new Election();
     electionOne.setElectionId(1);
     electionOne.setStatus(ElectionStatus.OPEN.getValue());
@@ -848,16 +848,16 @@ class DarCollectionServiceTest {
     electionTwo.setStatus(ElectionStatus.OPEN.getValue());
     summaryOne.addElection(electionOne);
     summaryOne.addElection(electionTwo);
-    summaryOne.addDatasetId(datasetOne.getDataSetId());
-    summaryOne.addDatasetId(datasetTwo.getDataSetId());
+    summaryOne.addDatasetId(datasetOne.getDatasetId());
+    summaryOne.addDatasetId(datasetTwo.getDatasetId());
 
     DarCollectionSummary summaryTwo = new DarCollectionSummary();
     Dataset datasetThree = new Dataset();
-    datasetThree.setDataSetId(3);
+    datasetThree.setDatasetId(3);
     Dataset datasetFour = new Dataset();
-    datasetFour.setDataSetId(4);
+    datasetFour.setDatasetId(4);
     Dataset datasetFive = new Dataset();
-    datasetFive.setDataSetId(5);
+    datasetFive.setDatasetId(5);
     Election electionThree = new Election();
     electionThree.setElectionId(3);
     electionThree.setStatus(ElectionStatus.OPEN.getValue());
@@ -866,23 +866,23 @@ class DarCollectionServiceTest {
     electionFour.setStatus(ElectionStatus.CANCELED.getValue());
     summaryTwo.addElection(electionThree);
     summaryTwo.addElection(electionFour);
-    summaryTwo.addDatasetId(datasetThree.getDataSetId());
-    summaryTwo.addDatasetId(datasetFour.getDataSetId());
-    summaryTwo.addDatasetId(datasetFive.getDataSetId());
+    summaryTwo.addDatasetId(datasetThree.getDatasetId());
+    summaryTwo.addDatasetId(datasetFour.getDatasetId());
+    summaryTwo.addDatasetId(datasetFive.getDatasetId());
 
     DarCollectionSummary summaryThree = new DarCollectionSummary();
     Dataset datasetSix = new Dataset();
-    datasetSix.setDataSetId(6);
+    datasetSix.setDatasetId(6);
     Election electionFive = new Election();
     electionFive.setElectionId(5);
     electionFive.setStatus(ElectionStatus.CANCELED.getValue());
     summaryThree.addElection(electionFive);
-    summaryThree.addDatasetId(datasetSix.getDataSetId());
+    summaryThree.addDatasetId(datasetSix.getDatasetId());
 
     DarCollectionSummary summaryFour = new DarCollectionSummary();
     Dataset datasetSeven = new Dataset();
-    datasetSeven.setDataSetId(7);
-    summaryFour.addDatasetId(datasetSeven.getDataSetId());
+    datasetSeven.setDatasetId(7);
+    summaryFour.addDatasetId(datasetSeven.getDatasetId());
 
     DarCollectionSummary summaryFive = new DarCollectionSummary();
     Election electionSix = new Election();
@@ -983,9 +983,9 @@ class DarCollectionServiceTest {
     Integer collectionId = RandomUtils.nextInt(1, 100);
     summary.setDarCollectionId(collectionId);
     Dataset datasetOne = new Dataset();
-    datasetOne.setDataSetId(1);
+    datasetOne.setDatasetId(1);
     Dataset datasetTwo = new Dataset();
-    datasetTwo.setDataSetId(2);
+    datasetTwo.setDatasetId(2);
     Election electionOne = new Election();
     electionOne.setElectionId(1);
     electionOne.setStatus(ElectionStatus.OPEN.getValue());
@@ -994,8 +994,8 @@ class DarCollectionServiceTest {
     electionTwo.setStatus(ElectionStatus.CLOSED.getValue());
     summary.addElection(electionOne);
     summary.addElection(electionTwo);
-    summary.addDatasetId(datasetOne.getDataSetId());
-    summary.addDatasetId(datasetTwo.getDataSetId());
+    summary.addDatasetId(datasetOne.getDatasetId());
+    summary.addDatasetId(datasetTwo.getDatasetId());
 
     when(darCollectionSummaryDAO.getDarCollectionSummaryByCollectionId(collectionId))
         .thenReturn(summary);
@@ -1018,9 +1018,9 @@ class DarCollectionServiceTest {
     Integer collectionId = RandomUtils.nextInt(1, 100);
     summary.setDarCollectionId(collectionId);
     Dataset datasetOne = new Dataset();
-    datasetOne.setDataSetId(1);
+    datasetOne.setDatasetId(1);
     Dataset datasetTwo = new Dataset();
-    datasetTwo.setDataSetId(2);
+    datasetTwo.setDatasetId(2);
     Election electionOne = new Election();
     electionOne.setElectionId(1);
     electionOne.setStatus(ElectionStatus.OPEN.getValue());
@@ -1029,8 +1029,8 @@ class DarCollectionServiceTest {
     electionTwo.setStatus(ElectionStatus.CLOSED.getValue());
     summary.addElection(electionOne);
     summary.addElection(electionTwo);
-    summary.addDatasetId(datasetOne.getDataSetId());
-    summary.addDatasetId(datasetTwo.getDataSetId());
+    summary.addDatasetId(datasetOne.getDatasetId());
+    summary.addDatasetId(datasetTwo.getDatasetId());
 
     when(darCollectionSummaryDAO.getDarCollectionSummaryByCollectionId(collectionId))
         .thenReturn(summary);
@@ -1055,9 +1055,9 @@ class DarCollectionServiceTest {
     Integer collectionId = RandomUtils.nextInt(1, 100);
     summary.setDarCollectionId(collectionId);
     Dataset datasetOne = new Dataset();
-    datasetOne.setDataSetId(1);
+    datasetOne.setDatasetId(1);
     Dataset datasetTwo = new Dataset();
-    datasetTwo.setDataSetId(2);
+    datasetTwo.setDatasetId(2);
     Election electionOne = new Election();
     electionOne.setElectionId(1);
     electionOne.setStatus(ElectionStatus.OPEN.getValue());
@@ -1066,8 +1066,8 @@ class DarCollectionServiceTest {
     electionTwo.setStatus(ElectionStatus.CLOSED.getValue());
     summary.addElection(electionOne);
     summary.addElection(electionTwo);
-    summary.addDatasetId(datasetOne.getDataSetId());
-    summary.addDatasetId(datasetTwo.getDataSetId());
+    summary.addDatasetId(datasetOne.getDatasetId());
+    summary.addDatasetId(datasetTwo.getDatasetId());
 
     when(darCollectionSummaryDAO.getDarCollectionSummaryByCollectionId(collectionId))
         .thenReturn(summary);
@@ -1095,9 +1095,9 @@ class DarCollectionServiceTest {
     Integer collectionId = RandomUtils.nextInt(1, 100);
     summary.setDarCollectionId(collectionId);
     Dataset datasetOne = new Dataset();
-    datasetOne.setDataSetId(1);
+    datasetOne.setDatasetId(1);
     Dataset datasetTwo = new Dataset();
-    datasetTwo.setDataSetId(2);
+    datasetTwo.setDatasetId(2);
     Election electionOne = new Election();
     electionOne.setElectionId(1);
     electionOne.setStatus(ElectionStatus.OPEN.getValue());
@@ -1106,8 +1106,8 @@ class DarCollectionServiceTest {
     electionTwo.setStatus(ElectionStatus.CANCELED.getValue());
     summary.addElection(electionOne);
     summary.addElection(electionTwo);
-    summary.addDatasetId(datasetOne.getDataSetId());
-    summary.addDatasetId(datasetTwo.getDataSetId());
+    summary.addDatasetId(datasetOne.getDatasetId());
+    summary.addDatasetId(datasetTwo.getDatasetId());
 
     when(darCollectionSummaryDAO.getDarCollectionSummaryForDACByCollectionId(user.getUserId(),
         List.of(), collectionId))
@@ -1140,9 +1140,9 @@ class DarCollectionServiceTest {
     Integer collectionId = RandomUtils.nextInt(1, 100);
     summary.setDarCollectionId(collectionId);
     Dataset datasetOne = new Dataset();
-    datasetOne.setDataSetId(1);
+    datasetOne.setDatasetId(1);
     Dataset datasetTwo = new Dataset();
-    datasetTwo.setDataSetId(2);
+    datasetTwo.setDatasetId(2);
     Election electionOne = new Election();
     electionOne.setElectionId(1);
     electionOne.setStatus(ElectionStatus.OPEN.getValue());
@@ -1153,8 +1153,8 @@ class DarCollectionServiceTest {
         null, null);
     summary.addElection(electionOne);
     summary.addElection(electionTwo);
-    summary.addDatasetId(datasetOne.getDataSetId());
-    summary.addDatasetId(datasetTwo.getDataSetId());
+    summary.addDatasetId(datasetOne.getDatasetId());
+    summary.addDatasetId(datasetTwo.getDatasetId());
     summary.setVotes(List.of(vote));
 
     when(darCollectionSummaryDAO.getDarCollectionSummaryForDACByCollectionId(user.getUserId(),
@@ -1215,7 +1215,7 @@ class DarCollectionServiceTest {
 
   private Dataset generateMockDatasetWithDataUse(Integer datasetId) {
     Dataset dataset = new Dataset();
-    dataset.setDataSetId(datasetId);
+    dataset.setDatasetId(datasetId);
     return dataset;
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/service/DataAccessReportsParserTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DataAccessReportsParserTest.java
@@ -51,7 +51,7 @@ class DataAccessReportsParserTest {
   @BeforeEach
   public void setUp() {
     Dataset d = new Dataset();
-    d.setDataSetId(1); // This translates to an identifier of "DUOS-000001"
+    d.setDatasetId(1); // This translates to an identifier of "DUOS-000001"
     d.setAlias(1);
     d.setName(NAME);
     List<Dataset> datasets = List.of(d);

--- a/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
@@ -172,7 +172,7 @@ class DataAccessRequestServiceTest {
   @Test
   void testGetUsersApprovedForDataset() {
     Dataset d = new Dataset();
-    d.setDataSetId(10);
+    d.setDatasetId(10);
 
     User user1 = new User();
     user1.setUserId(10);
@@ -184,7 +184,7 @@ class DataAccessRequestServiceTest {
     DataAccessRequest dar2 = new DataAccessRequest();
     dar2.setUserId(20);
     when(dataAccessRequestDAO
-        .findApprovedDARsByDatasetId(d.getDataSetId()))
+        .findApprovedDARsByDatasetId(d.getDatasetId()))
         .thenReturn(List.of(dar1, dar2));
     initService();
 

--- a/src/test/java/org/broadinstitute/consent/http/service/DatasetRegistrationServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DatasetRegistrationServiceTest.java
@@ -368,7 +368,7 @@ class DatasetRegistrationServiceTest {
     Study study = mock();
     Set<Dataset> allDatasets = Stream.of(1, 2, 3, 4, 5).map((i) -> {
       Dataset dataset = new Dataset();
-      dataset.setDataSetId(i);
+      dataset.setDatasetId(i);
       return dataset;
     }).collect(Collectors.toSet());
     List<DatasetUpdate> updatedDatasets = Stream.of(3, 4)
@@ -383,7 +383,7 @@ class DatasetRegistrationServiceTest {
     assertEquals(3, datasets.size());
 
     List<Integer> expectedIds = List.of(1, 2, 5);
-    List<Integer> actualIds = datasets.stream().map(Dataset::getDataSetId).toList();
+    List<Integer> actualIds = datasets.stream().map(Dataset::getDatasetId).toList();
 
     assertEquals(expectedIds, actualIds);
   }
@@ -552,7 +552,7 @@ class DatasetRegistrationServiceTest {
     Dac dac = new Dac();
     dac.setDacId(RandomUtils.nextInt(1, 100));
     Dataset dataset = new Dataset();
-    dataset.setDataSetId(RandomUtils.nextInt(1, 100));
+    dataset.setDatasetId(RandomUtils.nextInt(1, 100));
     dataset.setDacId(dac.getDacId());
     String name = RandomStringUtils.randomAlphabetic(10);
     org.broadinstitute.consent.http.models.DatasetUpdate update = new org.broadinstitute.consent.http.models.DatasetUpdate(
@@ -563,7 +563,7 @@ class DatasetRegistrationServiceTest {
 
     initService();
     assertDoesNotThrow(() -> {
-      datasetRegistrationService.updateDataset(dataset.getDataSetId(), user, update, Map.of());
+      datasetRegistrationService.updateDataset(dataset.getDatasetId(), user, update, Map.of());
     }, "Update Error");
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
@@ -141,7 +141,7 @@ class DatasetServiceTest {
     Dataset dataset = datasetService.getDatasetByName("Test Dataset 1");
 
     assertNotNull(dataset);
-    assertEquals(dataset.getDataSetId(), getDatasets().get(0).getDataSetId());
+    assertEquals(dataset.getDatasetId(), getDatasets().get(0).getDatasetId());
   }
 
   @Test
@@ -158,7 +158,7 @@ class DatasetServiceTest {
 
   @Test
   void testFindDatasetById() {
-    when(datasetDAO.findDatasetById(getDatasets().get(0).getDataSetId()))
+    when(datasetDAO.findDatasetById(getDatasets().get(0).getDatasetId()))
         .thenReturn(getDatasets().get(0));
     initService();
 
@@ -397,8 +397,8 @@ class DatasetServiceTest {
   @Test
   void testFindAllDatasetsAsStreamingOutput() throws Exception {
     var datasets = getDatasets(RandomUtils.nextInt(10, 20));
-    when(datasetDAO.findAllDatasetIds()).thenReturn(datasets.stream().map(Dataset::getDataSetId).toList());
-    datasets.forEach(d -> when(datasetDAO.findDatasetsByIdList(List.of(d.getDataSetId()))).thenReturn(List.of(d)));
+    when(datasetDAO.findAllDatasetIds()).thenReturn(datasets.stream().map(Dataset::getDatasetId).toList());
+    datasets.forEach(d -> when(datasetDAO.findDatasetsByIdList(List.of(d.getDatasetId()))).thenReturn(List.of(d)));
     initService();
     // The following forces the number of calls to datasetDAO.findDatasetsByIdList to be the same as
     // the number of datasets generated in the test.
@@ -425,7 +425,7 @@ class DatasetServiceTest {
     user.setEmail("asdf@gmail.com");
     user.setDisplayName("John Doe");
     dataset.setDacApproval(true);
-    dataset.setDataSetId(1);
+    dataset.setDatasetId(1);
     dataset.setUpdateDate(new Date());
     dataset.setUpdateUserId(4);
     dataset.setAlias(1);
@@ -436,7 +436,7 @@ class DatasetServiceTest {
 
     Dataset datasetResult = datasetService.approveDataset(dataset, user, true);
     assertNotNull(datasetResult);
-    assertEquals(dataset.getDataSetId(), datasetResult.getDataSetId());
+    assertEquals(dataset.getDatasetId(), datasetResult.getDatasetId());
     assertEquals(dataset.getUpdateUserId(), datasetResult.getUpdateUserId());
     assertEquals(dataset.getDacApproval(), datasetResult.getDacApproval());
     assertEquals(dataset.getUpdateDate(), datasetResult.getUpdateDate());
@@ -470,14 +470,14 @@ class DatasetServiceTest {
   @Test
   void testApproveDataset() throws Exception {
     Dataset dataset = new Dataset();
-    dataset.setDataSetId(1);
+    dataset.setDatasetId(1);
     User user = new User();
     user.setUserId(1);
     user.setEmail("asdf@gmail.com");
     user.setDisplayName("John Doe");
     Boolean payloadBool = true;
     Dataset updatedDataset = new Dataset();
-    updatedDataset.setDataSetId(1);
+    updatedDataset.setDatasetId(1);
     updatedDataset.setDacApproval(payloadBool);
 
     when(datasetDAO.findDatasetById(any())).thenReturn(updatedDataset);
@@ -489,7 +489,7 @@ class DatasetServiceTest {
     when(dacDAO.findById(3)).thenReturn(dac);
 
     Dataset returnedDataset = datasetService.approveDataset(dataset, user, payloadBool);
-    assertEquals(dataset.getDataSetId(), returnedDataset.getDataSetId());
+    assertEquals(dataset.getDatasetId(), returnedDataset.getDatasetId());
     assertTrue(returnedDataset.getDacApproval());
 
     // send approved email
@@ -503,14 +503,14 @@ class DatasetServiceTest {
   @Test
   void testApproveDataset_DenyDataset() throws Exception {
     Dataset dataset = new Dataset();
-    dataset.setDataSetId(1);
+    dataset.setDatasetId(1);
     User user = new User();
     user.setUserId(1);
     user.setEmail("asdf@gmail.com");
     user.setDisplayName("John Doe");
     Boolean payloadBool = false;
     Dataset updatedDataset = new Dataset();
-    updatedDataset.setDataSetId(1);
+    updatedDataset.setDatasetId(1);
     updatedDataset.setDacApproval(payloadBool);
 
     when(datasetDAO.findDatasetById(any())).thenReturn(updatedDataset);
@@ -523,7 +523,7 @@ class DatasetServiceTest {
     when(dacDAO.findById(3)).thenReturn(dac);
 
     Dataset returnedDataset = datasetService.approveDataset(dataset, user, payloadBool);
-    assertEquals(dataset.getDataSetId(), returnedDataset.getDataSetId());
+    assertEquals(dataset.getDatasetId(), returnedDataset.getDatasetId());
     assertFalse(returnedDataset.getDacApproval());
 
     // send denied email
@@ -538,14 +538,14 @@ class DatasetServiceTest {
   @Test
   void testApproveDataset_DenyDataset_WithNoDACEmail() throws Exception {
     Dataset dataset = new Dataset();
-    dataset.setDataSetId(1);
+    dataset.setDatasetId(1);
     User user = new User();
     user.setUserId(1);
     user.setEmail("asdf@gmail.com");
     user.setDisplayName("John Doe");
     Boolean payloadBool = false;
     Dataset updatedDataset = new Dataset();
-    updatedDataset.setDataSetId(1);
+    updatedDataset.setDatasetId(1);
     updatedDataset.setDacApproval(payloadBool);
 
     when(datasetDAO.findDatasetById(any())).thenReturn(updatedDataset);
@@ -557,7 +557,7 @@ class DatasetServiceTest {
     when(dacDAO.findById(3)).thenReturn(dac);
 
     Dataset returnedDataset = datasetService.approveDataset(dataset, user, payloadBool);
-    assertEquals(dataset.getDataSetId(), returnedDataset.getDataSetId());
+    assertEquals(dataset.getDatasetId(), returnedDataset.getDatasetId());
     assertFalse(returnedDataset.getDacApproval());
 
     // do not send denied email
@@ -667,7 +667,7 @@ class DatasetServiceTest {
     return IntStream.range(1, 3)
         .mapToObj(i -> {
           Dataset dataset = new Dataset();
-          dataset.setDataSetId(i);
+          dataset.setDatasetId(i);
           dataset.setName("Test Dataset " + i);
           dataset.setProperties(Collections.emptySet());
           return dataset;
@@ -684,7 +684,7 @@ class DatasetServiceTest {
     return IntStream.range(1, count + 1)
         .mapToObj(i -> {
           Dataset dataset = new Dataset();
-          dataset.setDataSetId(i);
+          dataset.setDatasetId(i);
           dataset.setName("Test Dataset " + i);
           dataset.setProperties(Collections.emptySet());
           return dataset;
@@ -695,7 +695,7 @@ class DatasetServiceTest {
     return IntStream.range(1, 3)
         .mapToObj(i -> {
           DatasetDTO dataset = new DatasetDTO();
-          dataset.setDataSetId(i);
+          dataset.setDatasetId(i);
           DatasetPropertyDTO nameProperty = new DatasetPropertyDTO("Dataset Name",
               "Test Dataset " + i);
           dataset.setProperties(Collections.singletonList(nameProperty));
@@ -728,7 +728,7 @@ class DatasetServiceTest {
 
   private DatasetDTO getDatasetDTO() {
     DatasetDTO datasetDTO = new DatasetDTO();
-    datasetDTO.setDataSetId(1);
+    datasetDTO.setDatasetId(1);
     datasetDTO.setObjectId("Test ObjectId");
     datasetDTO.setProperties(getDatasetPropertiesDTO());
     DataUse dataUse = new DataUse();

--- a/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
@@ -138,8 +138,8 @@ class ElasticSearchServiceTest {
 
   private Dataset createDataset(User user, User updateUser, DataUse dataUse, Dac dac) {
     Dataset dataset = new Dataset();
-    dataset.setDataSetId(RandomUtils.nextInt(1, 100));
-    dataset.setAlias(dataset.getDataSetId());
+    dataset.setDatasetId(RandomUtils.nextInt(1, 100));
+    dataset.setAlias(dataset.getDatasetId());
     dataset.setDatasetIdentifier();
     dataset.setDeletable(true);
     dataset.setName(RandomStringUtils.randomAlphabetic(10));
@@ -333,7 +333,7 @@ class ElasticSearchServiceTest {
     initService();
     DatasetTerm term = service.toDatasetTerm(datasetRecord.dataset);
 
-    assertEquals(datasetRecord.dataset.getDataSetId(), term.getDatasetId());
+    assertEquals(datasetRecord.dataset.getDatasetId(), term.getDatasetId());
     assertEquals(datasetRecord.dataset.getDatasetIdentifier(), term.getDatasetIdentifier());
     assertEquals(datasetRecord.dataset.getDeletable(), term.getDeletable());
     assertEquals(datasetRecord.dataset.getName(), term.getDatasetName());
@@ -406,7 +406,7 @@ class ElasticSearchServiceTest {
   @Test
   void testToDatasetTermIncomplete() {
     Dataset dataset = new Dataset();
-    dataset.setDataSetId(100);
+    dataset.setDatasetId(100);
     dataset.setAlias(10);
     dataset.setDatasetIdentifier();
     dataset.setProperties(Set.of());
@@ -417,7 +417,7 @@ class ElasticSearchServiceTest {
     initService();
     DatasetTerm term = service.toDatasetTerm(dataset);
 
-    assertEquals(dataset.getDataSetId(), term.getDatasetId());
+    assertEquals(dataset.getDatasetId(), term.getDatasetId());
     assertEquals(dataset.getDatasetIdentifier(), term.getDatasetIdentifier());
   }
 
@@ -540,7 +540,7 @@ class ElasticSearchServiceTest {
   void testIndexDatasetIds() throws Exception {
     Gson gson = GsonUtil.buildGson();
     Dataset dataset = new Dataset();
-    dataset.setDataSetId(RandomUtils.nextInt(10, 100));
+    dataset.setDatasetId(RandomUtils.nextInt(10, 100));
     String esResponseBody = """
           {
             "took": 2,
@@ -568,9 +568,9 @@ class ElasticSearchServiceTest {
 
     initService();
 
-    when(datasetDAO.findDatasetById(dataset.getDataSetId())).thenReturn(dataset);
-    mockESClientResponse(200, esResponseBody.formatted(dataset.getDataSetId()));
-    StreamingOutput output = service.indexDatasetIds(List.of(dataset.getDataSetId()));
+    when(datasetDAO.findDatasetById(dataset.getDatasetId())).thenReturn(dataset);
+    mockESClientResponse(200, esResponseBody.formatted(dataset.getDatasetId()));
+    StreamingOutput output = service.indexDatasetIds(List.of(dataset.getDatasetId()));
     var baos = new ByteArrayOutputStream();
     output.write(baos);
     var entityString = baos.toString();
@@ -581,7 +581,7 @@ class ElasticSearchServiceTest {
     JsonArray items = responseList.get(0).getAsJsonArray("items");
     assertEquals(1, items.size());
     assertEquals(
-        dataset.getDataSetId(),
+        dataset.getDatasetId(),
         items.get(0)
             .getAsJsonObject()
             .getAsJsonObject("index")
@@ -593,12 +593,12 @@ class ElasticSearchServiceTest {
   void testIndexDatasetIdsErrors() throws Exception {
     Gson gson = GsonUtil.buildGson();
     Dataset dataset = new Dataset();
-    dataset.setDataSetId(RandomUtils.nextInt(10, 100));
-    when(datasetDAO.findDatasetById(dataset.getDataSetId())).thenReturn(dataset);
+    dataset.setDatasetId(RandomUtils.nextInt(10, 100));
+    when(datasetDAO.findDatasetById(dataset.getDatasetId())).thenReturn(dataset);
     mockESClientResponse(500, "error condition");
     initService();
 
-    StreamingOutput output = service.indexDatasetIds(List.of(dataset.getDataSetId()));
+    StreamingOutput output = service.indexDatasetIds(List.of(dataset.getDatasetId()));
     var baos = new ByteArrayOutputStream();
     output.write(baos);
     JsonArray jsonArray = gson.fromJson(baos.toString(), JsonArray.class);
@@ -626,8 +626,8 @@ class ElasticSearchServiceTest {
     Study study = new Study();
     study.setStudyId(1);
     Dataset d = new Dataset();
-    d.setDataSetId(1);
-    study.addDatasetId(d.getDataSetId());
+    d.setDatasetId(1);
+    study.addDatasetId(d.getDatasetId());
     when(studyDAO.findStudyById(any())).thenReturn(study);
     when(datasetDAO.findDatasetsByIdList(any())).thenReturn(List.of(d));
 

--- a/src/test/java/org/broadinstitute/consent/http/service/EmailServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/EmailServiceTest.java
@@ -212,11 +212,11 @@ class EmailServiceTest {
 
   private Dataset createDataset(Integer dacId) {
     Dataset dataset = new Dataset();
-    dataset.setDataSetId(RandomUtils.nextInt(1, 100000));
-    dataset.setAlias(dataset.getDataSetId());
+    dataset.setDatasetId(RandomUtils.nextInt(1, 100000));
+    dataset.setAlias(dataset.getDatasetId());
     dataset.setDatasetIdentifier();
     dataset.setDacId(dacId);
-    dataset.setName(String.format("Dataset %s-%s", RandomStringUtils.randomAlphabetic(10), dataset.getDataSetId()));
+    dataset.setName(String.format("Dataset %s-%s", RandomStringUtils.randomAlphabetic(10), dataset.getDatasetId()));
     return dataset;
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/service/MatchServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/MatchServiceTest.java
@@ -139,7 +139,7 @@ class MatchServiceTest {
   @Test
   void testSingleEntitiesMatchV3Failure() {
     Dataset dataset = new Dataset();
-    dataset.setDataSetId(1);
+    dataset.setDatasetId(1);
     dataset.setAlias(2);
     dataset.setDatasetIdentifier();
     DataAccessRequest dar = getSampleDataAccessRequest("DAR-2");
@@ -161,7 +161,7 @@ class MatchServiceTest {
   @Test
   void testSingleEntitiesMatchV3Approve() {
     Dataset dataset = new Dataset();
-    dataset.setDataSetId(1);
+    dataset.setDatasetId(1);
     DataAccessRequest dar = getSampleDataAccessRequest("DAR-2");
     dar.setDatasetIds(List.of(1, 2, 3));
     String stringEntity = "{\"result\": \"APPROVE\", \"matchPair\": {}, \"failureReasons\": []}";
@@ -182,7 +182,7 @@ class MatchServiceTest {
   @Test
   void testSingleEntitiesMatchV3Deny() {
     Dataset dataset = new Dataset();
-    dataset.setDataSetId(1);
+    dataset.setDatasetId(1);
     DataAccessRequest dar = getSampleDataAccessRequest("DAR-2");
     dar.setDatasetIds(List.of(1, 2, 3));
     String stringEntity = "{\"result\": \"DENY\", \"matchPair\": {}, \"failureReasons\": []}";
@@ -203,7 +203,7 @@ class MatchServiceTest {
   @Test
   void testSingleEntitiesMatchV3Abstain() {
     Dataset dataset = new Dataset();
-    dataset.setDataSetId(1);
+    dataset.setDatasetId(1);
     DataAccessRequest dar = getSampleDataAccessRequest("DAR-2");
     dar.setDatasetIds(List.of(1, 2, 3));
     String stringEntity = "{\"result\": \"ABSTAIN\", \"matchPair\": {}, \"failureReasons\": []}";

--- a/src/test/java/org/broadinstitute/consent/http/service/MetricsServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/MetricsServiceTest.java
@@ -166,7 +166,7 @@ class MetricsServiceTest {
               DatasetDTO dto = new DatasetDTO();
               dto.setDacId(dac.getDacId());
               dto.setAlias(ds.getAlias());
-              dto.setDataSetId(ds.getDataSetId());
+              dto.setDatasetId(ds.getDatasetId());
               DatasetPropertyDTO name = new DatasetPropertyDTO("Dataset Name", ds.getName());
               DatasetPropertyDTO consent = new DatasetPropertyDTO("Consent ID", ds.getName());
               dto.setProperties(Arrays.asList(name, consent));
@@ -180,12 +180,12 @@ class MetricsServiceTest {
         .mapToObj(
             i -> {
               String referenceId = UUID.randomUUID().toString();
-              List<Integer> dataSetIds = Collections.singletonList(i);
+              List<Integer> datasetIds = Collections.singletonList(i);
               DataAccessRequest dar = new DataAccessRequest();
               dar.setId(count);
               dar.setReferenceId(referenceId);
               DataAccessRequestData data = new DataAccessRequestData();
-              dar.setDatasetIds(dataSetIds);
+              dar.setDatasetIds(datasetIds);
               data.setReferenceId(referenceId);
               data.setProjectTitle(UUID.randomUUID().toString());
               dar.setData(data);
@@ -200,7 +200,7 @@ class MetricsServiceTest {
             i -> {
               Dataset d = new Dataset();
               d.setAlias(count);
-              d.setDataSetId(count);
+              d.setDatasetId(count);
               d.setName(UUID.randomUUID().toString());
               return d;
             })

--- a/src/test/java/org/broadinstitute/consent/http/service/TDRServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/TDRServiceTest.java
@@ -131,11 +131,11 @@ class TDRServiceTest {
         .toList();
 
     Dataset dataset1 = new Dataset();
-    dataset1.setDataSetId(1);
+    dataset1.setDatasetId(1);
     dataset1.setAlias(00001);
 
     Dataset dataset2 = new Dataset();
-    dataset2.setDataSetId(2);
+    dataset2.setDatasetId(2);
     dataset2.setAlias(00002);
 
     when(datasetDAO.findDatasetsByAlias(identifierList)).thenReturn(List.of(dataset1, dataset2));
@@ -152,11 +152,11 @@ class TDRServiceTest {
     String identifiers = "DUOS-00001, DUOS-00002";
     String title = "New Project";
     Dataset dataset1 = new Dataset();
-    dataset1.setDataSetId(1);
+    dataset1.setDatasetId(1);
     dataset1.setAlias(00001);
 
     Dataset dataset2 = new Dataset();
-    dataset2.setDataSetId(2);
+    dataset2.setDatasetId(2);
     dataset2.setAlias(00002);
 
     when(datasetDAO.findDatasetsByAlias(any())).thenReturn(List.of(dataset1, dataset2));
@@ -165,8 +165,8 @@ class TDRServiceTest {
     assertDoesNotThrow(() -> {
       DataAccessRequest dar = service.populateDraftDarStubFromDatasetIdentifiers(identifiers, "New Project");
       assertNotNull(dar);
-      assertTrue(dar.getDatasetIds().contains(dataset1.getDataSetId()));
-      assertTrue(dar.getDatasetIds().contains(dataset2.getDataSetId()));
+      assertTrue(dar.getDatasetIds().contains(dataset1.getDatasetId()));
+      assertTrue(dar.getDatasetIds().contains(dataset2.getDatasetId()));
       assertEquals(title, dar.getData().getProjectTitle());
       assertNotNull(dar.getReferenceId());
       assertNotNull(dar.getCreateDate());

--- a/src/test/java/org/broadinstitute/consent/http/service/VoteServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/VoteServiceTest.java
@@ -465,13 +465,13 @@ class VoteServiceTest {
     v2.setUserId(1);
 
     Dataset d1 = new Dataset();
-    d1.setDataSetId(1);
+    d1.setDatasetId(1);
     d1.setName(RandomStringUtils.random(50, true, false));
     d1.setAlias(1);
     d1.setDataUse(new DataUseBuilder().setGeneralUse(false).setNonProfitUse(true).build());
 
     Dataset d2 = new Dataset();
-    d2.setDataSetId(2);
+    d2.setDatasetId(2);
     d2.setName(RandomStringUtils.random(50, true, false));
     d2.setAlias(2);
     d2.setDataUse(new DataUseBuilder().setGeneralUse(false).setHmbResearch(true).build());
@@ -480,13 +480,13 @@ class VoteServiceTest {
     e1.setElectionId(1);
     e1.setReferenceId(referenceId1);
     e1.setElectionType(ElectionType.DATA_ACCESS.getValue());
-    e1.setDataSetId(1);
+    e1.setDatasetId(1);
 
     Election e2 = new Election();
     e2.setElectionId(2);
     e2.setReferenceId(referenceId2);
     e2.setElectionType(ElectionType.DATA_ACCESS.getValue());
-    e2.setDataSetId(2);
+    e2.setDatasetId(2);
 
     DatasetProperty depositorProp = new DatasetProperty();
     depositorProp.setPropertyName("Data Depositor");
@@ -495,7 +495,7 @@ class VoteServiceTest {
 
     DataAccessRequest dar1 = new DataAccessRequest();
     DataAccessRequestData data1 = new DataAccessRequestData();
-    dar1.addDatasetId(d1.getDataSetId());
+    dar1.addDatasetId(d1.getDatasetId());
     dar1.setCollectionId(1);
     dar1.setData(data1);
     dar1.setReferenceId(referenceId1);
@@ -503,7 +503,7 @@ class VoteServiceTest {
 
     DataAccessRequest dar2 = new DataAccessRequest();
     DataAccessRequestData data2 = new DataAccessRequestData();
-    dar2.addDatasetId(d2.getDataSetId());
+    dar2.addDatasetId(d2.getDatasetId());
     dar2.setCollectionId(1);
     dar2.setData(data2);
     dar2.setReferenceId(referenceId2);
@@ -555,14 +555,14 @@ class VoteServiceTest {
     depositorProp.setPropertyType(PropertyType.String);
 
     Dataset d1 = new Dataset();
-    d1.setDataSetId(1);
+    d1.setDatasetId(1);
     d1.setName(RandomStringUtils.random(50, true, false));
     d1.setAlias(1);
     d1.setDataUse(new DataUseBuilder().setGeneralUse(false).setNonProfitUse(true).build());
     d1.setProperties(Set.of(depositorProp));
 
     Dataset d2 = new Dataset();
-    d2.setDataSetId(2);
+    d2.setDatasetId(2);
     d2.setName(RandomStringUtils.random(50, true, false));
     d2.setAlias(2);
     d2.setDataUse(new DataUseBuilder().setGeneralUse(false).setHmbResearch(true).build());
@@ -572,24 +572,24 @@ class VoteServiceTest {
     e1.setElectionId(1);
     e1.setReferenceId(referenceId1);
     e1.setElectionType(ElectionType.DATA_ACCESS.getValue());
-    e1.setDataSetId(1);
+    e1.setDatasetId(1);
 
     Election e2 = new Election();
     e2.setElectionId(2);
     e2.setReferenceId(referenceId2);
     e2.setElectionType(ElectionType.DATA_ACCESS.getValue());
-    e2.setDataSetId(2);
+    e2.setDatasetId(2);
 
     DataAccessRequest dar1 = new DataAccessRequest();
     DataAccessRequestData data1 = new DataAccessRequestData();
-    dar1.addDatasetId(d1.getDataSetId());
+    dar1.addDatasetId(d1.getDatasetId());
     dar1.setCollectionId(1);
     dar1.setData(data1);
     dar1.setReferenceId(referenceId1);
 
     DataAccessRequest dar2 = new DataAccessRequest();
     DataAccessRequestData data2 = new DataAccessRequestData();
-    dar2.addDatasetId(d2.getDataSetId());
+    dar2.addDatasetId(d2.getDatasetId());
     dar2.setCollectionId(2);
     dar2.setData(data2);
     dar2.setReferenceId(referenceId2);
@@ -632,14 +632,14 @@ class VoteServiceTest {
     v1.setUserId(1);
 
     Dataset d1 = new Dataset();
-    d1.setDataSetId(1);
+    d1.setDatasetId(1);
     d1.setName(RandomStringUtils.random(50, true, false));
     d1.setAlias(1);
     d1.setDataUse(new DataUseBuilder().setGeneralUse(false).setNonProfitUse(true).build());
 
     DataAccessRequest dar1 = new DataAccessRequest();
     DataAccessRequestData data1 = new DataAccessRequestData();
-    dar1.addDatasetId(d1.getDataSetId());
+    dar1.addDatasetId(d1.getDatasetId());
     dar1.setCollectionId(1);
     dar1.setData(data1);
     dar1.setReferenceId(referenceId1);
@@ -671,14 +671,14 @@ class VoteServiceTest {
     v1.setUserId(1);
 
     Dataset d1 = new Dataset();
-    d1.setDataSetId(1);
+    d1.setDatasetId(1);
     d1.setName(RandomStringUtils.random(50, true, false));
     d1.setAlias(1);
     d1.setDataUse(new DataUseBuilder().setGeneralUse(false).setNonProfitUse(true).build());
 
     DataAccessRequest dar1 = new DataAccessRequest();
     DataAccessRequestData data1 = new DataAccessRequestData();
-    dar1.addDatasetId(d1.getDataSetId());
+    dar1.addDatasetId(d1.getDatasetId());
     dar1.setCollectionId(1);
     dar1.setData(data1);
     dar1.setReferenceId(referenceId1);
@@ -713,7 +713,7 @@ class VoteServiceTest {
     depositorProp.setPropertyType(PropertyType.String);
 
     Dataset d1 = new Dataset();
-    d1.setDataSetId(1);
+    d1.setDatasetId(1);
     d1.setName(RandomStringUtils.random(50, true, false));
     d1.setAlias(1);
     d1.setDataUse(new DataUseBuilder().setGeneralUse(false).setNonProfitUse(true).build());
@@ -721,7 +721,7 @@ class VoteServiceTest {
     d1.setCreateUserId(submitter.getUserId());
 
     Dataset d2 = new Dataset();
-    d2.setDataSetId(2);
+    d2.setDatasetId(2);
     d2.setName(RandomStringUtils.random(50, true, false));
     d2.setAlias(2);
     d2.setDataUse(new DataUseBuilder().setGeneralUse(false).setHmbResearch(true).build());
@@ -763,7 +763,7 @@ class VoteServiceTest {
     depositorProp.setPropertyType(PropertyType.String);
 
     Dataset d1 = new Dataset();
-    d1.setDataSetId(1);
+    d1.setDatasetId(1);
     d1.setName(RandomStringUtils.random(50, true, false));
     d1.setAlias(1);
     d1.setDataUse(new DataUseBuilder().setGeneralUse(false).setNonProfitUse(true).build());
@@ -771,7 +771,7 @@ class VoteServiceTest {
     d1.setCreateUserId(submitterNotFound.getUserId());
 
     Dataset d2 = new Dataset();
-    d2.setDataSetId(2);
+    d2.setDatasetId(2);
     d2.setName(RandomStringUtils.random(50, true, false));
     d2.setAlias(2);
     d2.setDataUse(new DataUseBuilder().setGeneralUse(false).setHmbResearch(true).build());
@@ -826,7 +826,7 @@ class VoteServiceTest {
     study.setCreateUserId(studySubmitter.getUserId());
 
     Dataset d1 = new Dataset();
-    d1.setDataSetId(1);
+    d1.setDatasetId(1);
     d1.setName(RandomStringUtils.random(50, true, false));
     d1.setAlias(1);
     d1.setDataUse(new DataUseBuilder().setGeneralUse(false).setNonProfitUse(true).build());
@@ -894,7 +894,7 @@ class VoteServiceTest {
     study.setCreateUserId(studySubmitter.getUserId());
 
     Dataset d1 = new Dataset();
-    d1.setDataSetId(1);
+    d1.setDatasetId(1);
     d1.setName(RandomStringUtils.random(50, true, false));
     d1.setAlias(1);
     d1.setDataUse(new DataUseBuilder().setGeneralUse(false).setNonProfitUse(true).build());

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DarCollectionServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DarCollectionServiceDAOTest.java
@@ -396,7 +396,7 @@ class DarCollectionServiceDAOTest extends DAOTestHelper {
     DataAccessRequest dar = collection.getDars().values().stream().findFirst().orElse(null);
     assertNotNull(dar);
     assertNotNull(dar.getData());
-    dataAccessRequestDAO.insertDARDatasetRelation(dar.getReferenceId(), dataset.getDataSetId());
+    dataAccessRequestDAO.insertDARDatasetRelation(dar.getReferenceId(), dataset.getDatasetId());
     Date now = new Date();
     dataAccessRequestDAO.updateDataByReferenceId(
         dar.getReferenceId(), dar.getUserId(), now, now, now, dar.getData());
@@ -442,7 +442,7 @@ class DarCollectionServiceDAOTest extends DAOTestHelper {
   private void createDatasetProperties(Integer datasetId) {
     List<DatasetProperty> list = new ArrayList<>();
     DatasetProperty dsp = new DatasetProperty();
-    dsp.setDataSetId(datasetId);
+    dsp.setDatasetId(datasetId);
     dsp.setPropertyKey(1);
     dsp.setPropertyValue("Test_PropertyValue");
     dsp.setCreateDate(new Date());
@@ -461,7 +461,7 @@ class DarCollectionServiceDAOTest extends DAOTestHelper {
         now, now, now, data);
     dataAccessRequestDAO.updateDraftForCollection(collectionId, dar.getReferenceId());
     dataAccessRequestDAO.updateDraftByReferenceId(dar.getReferenceId(), false);
-    dataAccessRequestDAO.insertDARDatasetRelation(dar.getReferenceId(), dataset.getDataSetId());
+    dataAccessRequestDAO.insertDARDatasetRelation(dar.getReferenceId(), dataset.getDatasetId());
     return dataAccessRequestDAO.findByReferenceId(dar.getReferenceId());
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DataAccessRequestServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DataAccessRequestServiceDAOTest.java
@@ -58,8 +58,8 @@ class DataAccessRequestServiceDAOTest extends DAOTestHelper {
     Date old = cal.getTime();
 
     String referenceId = RandomStringUtils.randomAlphanumeric(10);
-    DarDataset oldDarDataset = new DarDataset(referenceId, datasetOne.getDataSetId());
-    DarDataset oldDarDatasetTwo = new DarDataset(referenceId, datasetTwo.getDataSetId());
+    DarDataset oldDarDataset = new DarDataset(referenceId, datasetOne.getDatasetId());
+    DarDataset oldDarDatasetTwo = new DarDataset(referenceId, datasetTwo.getDatasetId());
     DarCollection collection = createDarCollection();
     Integer collectionId = collection.getDarCollectionId();
     dataAccessRequestDAO.insertDataAccessRequest(collectionId, referenceId, user.getUserId(), old,
@@ -71,7 +71,7 @@ class DataAccessRequestServiceDAOTest extends DAOTestHelper {
     dar.setCollectionId(collectionId);
     DataAccessRequestData data = new DataAccessRequestData();
     data.setOtherText("This is a test value");
-    List<Integer> newDatasetIds = List.of(datasetThree.getDataSetId());
+    List<Integer> newDatasetIds = List.of(datasetThree.getDatasetId());
     dar.setDatasetIds(newDatasetIds);
     dar.setData(data);
 
@@ -108,7 +108,7 @@ class DataAccessRequestServiceDAOTest extends DAOTestHelper {
   private void createDatasetProperties(Integer datasetId) {
     List<DatasetProperty> list = new ArrayList<>();
     DatasetProperty dsp = new DatasetProperty();
-    dsp.setDataSetId(datasetId);
+    dsp.setDatasetId(datasetId);
     dsp.setPropertyKey(1);
     dsp.setPropertyValue("Test_PropertyValue");
     dsp.setCreateDate(new Date());
@@ -123,10 +123,10 @@ class DataAccessRequestServiceDAOTest extends DAOTestHelper {
         new Date());
     Dataset dataset = createDataset();
     DataAccessRequest dar = createDataAccessRequest(user.getUserId(), collection_id, darCode);
-    dataAccessRequestDAO.insertDARDatasetRelation(dar.getReferenceId(), dataset.getDataSetId());
+    dataAccessRequestDAO.insertDARDatasetRelation(dar.getReferenceId(), dataset.getDatasetId());
     Election cancelled = createCancelledAccessElection(dar.getReferenceId(),
-        dataset.getDataSetId());
-    Election access = createDataAccessElection(dar.getReferenceId(), dataset.getDataSetId());
+        dataset.getDatasetId());
+    Election access = createDataAccessElection(dar.getReferenceId(), dataset.getDatasetId());
     createFinalVote(user.getUserId(), cancelled.getElectionId());
     createFinalVote(user.getUserId(), access.getElectionId());
     createDataAccessRequest(user.getUserId(), collection_id, darCode);

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAOTest.java
@@ -52,7 +52,7 @@ class DatasetServiceDAOTest extends DAOTestHelper {
 
     serviceDAO.deleteDataset(dataset, dataset.getCreateUserId());
     // Assert that the dataset is deleted:
-    Dataset deleted = datasetDAO.findDatasetById(dataset.getDataSetId());
+    Dataset deleted = datasetDAO.findDatasetById(dataset.getDatasetId());
     assertNull(deleted);
 
   }
@@ -106,11 +106,11 @@ class DatasetServiceDAOTest extends DAOTestHelper {
     DatasetProperty createdProp2 = created.getProperties().stream()
         .filter((p) -> p.getPropertyName().equals(prop2.getPropertyName())).findFirst().get();
 
-    assertEquals(created.getDataSetId(), createdProp1.getDataSetId());
+    assertEquals(created.getDatasetId(), createdProp1.getDatasetId());
     assertEquals(prop1.getPropertyValue(), createdProp1.getPropertyValue());
     assertEquals(prop1.getPropertyType(), createdProp1.getPropertyType());
 
-    assertEquals(created.getDataSetId(), createdProp2.getDataSetId());
+    assertEquals(created.getDatasetId(), createdProp2.getDatasetId());
     assertEquals(prop2.getPropertyValue(), createdProp2.getPropertyValue());
     assertEquals(prop2.getPropertyType(), createdProp2.getPropertyType());
 
@@ -381,7 +381,7 @@ class DatasetServiceDAOTest extends DAOTestHelper {
     prop1.setPropertyType(PropertyType.Number);
     prop1.setPropertyKey(1);
     prop1.setPropertyValue(new Random().nextInt());
-    prop1.setDataSetId(dataset.getDataSetId());
+    prop1.setDatasetId(dataset.getDatasetId());
     prop1.setCreateDate(new Date());
 
     DatasetProperty prop2 = new DatasetProperty();
@@ -390,7 +390,7 @@ class DatasetServiceDAOTest extends DAOTestHelper {
     prop2.setPropertyType(PropertyType.Date);
     prop2.setPropertyKey(2);
     prop2.setPropertyValue("2000-10-20");
-    prop2.setDataSetId(dataset.getDataSetId());
+    prop2.setDatasetId(dataset.getDatasetId());
     prop2.setCreateDate(new Date());
 
     // Prop for deletion
@@ -400,7 +400,7 @@ class DatasetServiceDAOTest extends DAOTestHelper {
     prop3.setPropertyType(PropertyType.String);
     prop3.setPropertyKey(3);
     prop3.setPropertyValue(RandomStringUtils.randomAlphabetic(10));
-    prop3.setDataSetId(dataset.getDataSetId());
+    prop3.setDatasetId(dataset.getDatasetId());
     prop3.setCreateDate(new Date());
 
     datasetDAO.insertDatasetProperties(List.of(prop1, prop2, prop3));
@@ -421,12 +421,12 @@ class DatasetServiceDAOTest extends DAOTestHelper {
     prop4.setPropertyType(PropertyType.String);
     prop4.setPropertyKey(4);
     prop4.setPropertyValue("new prop4 value");
-    prop4.setDataSetId(dataset.getDataSetId());
+    prop4.setDatasetId(dataset.getDatasetId());
     prop4.setCreateDate(new Date());
 
     String newName = "New Name";
     DatasetUpdate updates = new DatasetUpdate(
-        dataset.getDataSetId(),
+        dataset.getDatasetId(),
         newName,
         dataset.getCreateUserId(),
         dataset.getDacId(),
@@ -436,7 +436,7 @@ class DatasetServiceDAOTest extends DAOTestHelper {
     serviceDAO.updateDataset(updates);
 
     // Validate that the dataset props have been updated, deleted, or added:
-    Set<DatasetProperty> updatedProps = datasetDAO.findDatasetPropertiesByDatasetId(dataset.getDataSetId());
+    Set<DatasetProperty> updatedProps = datasetDAO.findDatasetPropertiesByDatasetId(dataset.getDatasetId());
     Optional<DatasetProperty> updated1 = updatedProps.stream().filter(p -> p.getPropertyName().equals(prop1.getPropertyName())).findFirst();
     Optional<DatasetProperty> updated2 = updatedProps.stream().filter(p -> p.getPropertyName().equals(prop2.getPropertyName())).findFirst();
     Optional<DatasetProperty> deleted3 = updatedProps.stream().filter(p -> p.getPropertyName().equals(prop3.getPropertyName())).findFirst();
@@ -449,7 +449,7 @@ class DatasetServiceDAOTest extends DAOTestHelper {
     assertTrue(added4.isPresent());
     assertEquals(prop4.getPropertyValueAsString(), added4.get().getPropertyValueAsString());
 
-    Dataset updatedDataset = datasetDAO.findDatasetById(dataset.getDataSetId());
+    Dataset updatedDataset = datasetDAO.findDatasetById(dataset.getDatasetId());
     assertEquals(newName, updatedDataset.getDatasetName());
   }
 
@@ -536,7 +536,7 @@ class DatasetServiceDAOTest extends DAOTestHelper {
 
     String newDatasetName = "New Dataset Name";
     DatasetUpdate datasetUpdate = new DatasetUpdate(
-        dataset.getDataSetId(),
+        dataset.getDatasetId(),
         newDatasetName,
         study.getCreateUserId(),
         dataset.getDacId(),

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/VoteServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/VoteServiceDAOTest.java
@@ -46,7 +46,7 @@ class VoteServiceDAOTest extends DAOTestHelper {
     User user = createUser();
     DataAccessRequest dar = createDataAccessRequestV3();
     Dataset dataset = createDataset();
-    Election election = createDataAccessElection(dar.getReferenceId(), dataset.getDataSetId());
+    Election election = createDataAccessElection(dar.getReferenceId(), dataset.getDatasetId());
     Vote vote = createFinalVote(user.getUserId(), election.getElectionId());
     String rationale = "rationale";
 
@@ -65,7 +65,7 @@ class VoteServiceDAOTest extends DAOTestHelper {
     User user = createUser();
     DataAccessRequest dar = createDataAccessRequestV3();
     Dataset dataset = createDataset();
-    Election election = createDataAccessElection(dar.getReferenceId(), dataset.getDataSetId());
+    Election election = createDataAccessElection(dar.getReferenceId(), dataset.getDatasetId());
     Vote vote = createFinalVote(user.getUserId(), election.getElectionId());
 
     List<Vote> votes = serviceDAO.updateVotesWithValue(List.of(vote), true, null);
@@ -81,7 +81,7 @@ class VoteServiceDAOTest extends DAOTestHelper {
     User user = createUser();
     DataAccessRequest dar = createDataAccessRequestV3();
     Dataset dataset = createDataset();
-    Election election = createDataAccessElection(dar.getReferenceId(), dataset.getDataSetId());
+    Election election = createDataAccessElection(dar.getReferenceId(), dataset.getDatasetId());
     Vote vote = createDacVote(user.getUserId(), election.getElectionId());
     String rationale = "rationale";
 
@@ -100,7 +100,7 @@ class VoteServiceDAOTest extends DAOTestHelper {
     User user = createUser();
     DataAccessRequest dar = createDataAccessRequestV3();
     Dataset dataset = createDataset();
-    Election election = createDataAccessElection(dar.getReferenceId(), dataset.getDataSetId());
+    Election election = createDataAccessElection(dar.getReferenceId(), dataset.getDatasetId());
     Vote vote1 = createDacVote(user.getUserId(), election.getElectionId());
     Vote vote2 = createDacVote(user.getUserId(), election.getElectionId());
     Vote vote3 = createDacVote(user.getUserId(), election.getElectionId());
@@ -127,10 +127,10 @@ class VoteServiceDAOTest extends DAOTestHelper {
     User user = createUser();
     DataAccessRequest dar = createDataAccessRequestV3();
     Dataset dataset = createDataset();
-    Election rpElection1 = createRPElection(dar.getReferenceId(), dataset.getDataSetId());
-    Election rpElection2 = createRPElection(dar.getReferenceId(), dataset.getDataSetId());
+    Election rpElection1 = createRPElection(dar.getReferenceId(), dataset.getDatasetId());
+    Election rpElection2 = createRPElection(dar.getReferenceId(), dataset.getDatasetId());
     Election accessElection = createDataAccessElection(dar.getReferenceId(),
-        dataset.getDataSetId());
+        dataset.getDatasetId());
     electionDAO.updateElectionById(
         rpElection1.getElectionId(),
         ElectionStatus.CLOSED.getValue(),
@@ -171,7 +171,7 @@ class VoteServiceDAOTest extends DAOTestHelper {
   private void createDatasetProperties(Integer datasetId) {
     List<DatasetProperty> list = new ArrayList<>();
     DatasetProperty dsp = new DatasetProperty();
-    dsp.setDataSetId(datasetId);
+    dsp.setDatasetId(datasetId);
     dsp.setPropertyKey(1);
     dsp.setPropertyValue("Test_PropertyValue");
     dsp.setCreateDate(new Date());


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DCJ-702

### Summary

Needs to go in with https://github.com/DataBiosphere/duos-ui/pull/2690 . Consolidates use of `dataSetId` and `datasetId`.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
