### PR TITLE
DCJ-708: Refactor query performance

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
@@ -255,8 +255,8 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
   @SqlQuery("""
           SELECT distinct d.dataset_id
           FROM dataset d
-          LEFT JOIN user_role dac_role ON dac_role.dac_id = d.dac_id
-          LEFT JOIN users dac_user ON dac_role.user_id = dac_user.user_id AND dac_user.email = :email
+          INNER JOIN user_role dac_role ON dac_role.dac_id = d.dac_id
+          INNER JOIN users dac_user ON dac_role.user_id = dac_user.user_id AND dac_user.email = :email
       """)
   List<Integer> findDatasetIdsByDACUserEmail(@Bind("email") String email);
 

--- a/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
@@ -249,16 +249,16 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
   /**
    * Find all dataset IDs that the user email has access to via their DAC association.
    *
-   * @param email User email
+   * @param userId User ID
    * @return List of Dataset IDs that are visible to the user via DACs.
    */
   @SqlQuery("""
           SELECT distinct d.dataset_id
           FROM dataset d
           INNER JOIN user_role dac_role ON dac_role.dac_id = d.dac_id
-          INNER JOIN users dac_user ON dac_role.user_id = dac_user.user_id AND dac_user.email = :email
+          INNER JOIN users dac_user ON dac_role.user_id = dac_user.user_id AND dac_user.user_id = :userId
       """)
-  List<Integer> findDatasetIdsByDACUserEmail(@Bind("email") String email);
+  List<Integer> findDatasetIdsByDACUserId(@Bind("userId") Integer userId);
 
   /**
    * Finds all minimal dataset/study  information for datasets assigned to this DAC and which have

--- a/src/main/java/org/broadinstitute/consent/http/resources/DarCollectionResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DarCollectionResource.java
@@ -82,7 +82,7 @@ public class DarCollectionResource extends Resource {
           break;
         case Resource.CHAIRPERSON:
         case Resource.MEMBER:
-          List<Integer> userDatasetIds = darCollectionService.findDatasetIdsByUser(user);
+          List<Integer> userDatasetIds = darCollectionService.findDatasetIdsByDACUser(user);
           allowedAccess = summary.getDatasetIds().stream().anyMatch(userDatasetIds::contains);
           break;
         case Resource.SIGNINGOFFICIAL:
@@ -147,7 +147,7 @@ public class DarCollectionResource extends Resource {
 
   private boolean checkDacPermissionsForCollection(User user, DarCollection collection) {
     // finds datasetIds for user based on the DACs they belong to
-    List<Integer> userDatasetIds = darCollectionService.findDatasetIdsByUser(user);
+    List<Integer> userDatasetIds = darCollectionService.findDatasetIdsByDACUser(user);
 
     return collection.getDatasets().stream()
         .map(Dataset::getDataSetId)

--- a/src/main/java/org/broadinstitute/consent/http/service/DacService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DacService.java
@@ -290,12 +290,7 @@ public class DacService implements ConsentLogger {
       }
       // Chair and Member users can see data access requests that they have DAC access to
       if (user.hasUserRole(UserRoles.MEMBER) || user.hasUserRole(UserRoles.CHAIRPERSON)) {
-        List<Integer> accessibleDatasetIds = dataSetDAO.findDatasetsByAuthUserEmail(
-                user.getEmail()).
-            stream().
-            map(Dataset::getDataSetId).
-            collect(Collectors.toList());
-
+        List<Integer> accessibleDatasetIds = dataSetDAO.findDatasetIdsByDACUserEmail(user.getEmail());
         return documents.
             stream().
             filter(d -> {

--- a/src/main/java/org/broadinstitute/consent/http/service/DacService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DacService.java
@@ -290,7 +290,7 @@ public class DacService implements ConsentLogger {
       }
       // Chair and Member users can see data access requests that they have DAC access to
       if (user.hasUserRole(UserRoles.MEMBER) || user.hasUserRole(UserRoles.CHAIRPERSON)) {
-        List<Integer> accessibleDatasetIds = dataSetDAO.findDatasetIdsByDACUserEmail(user.getEmail());
+        List<Integer> accessibleDatasetIds = dataSetDAO.findDatasetIdsByDACUserId(user.getUserId());
         return documents.
             stream().
             filter(d -> {

--- a/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
@@ -420,7 +420,7 @@ public class DarCollectionService implements ConsentLogger {
    * @return List of Dataset IDs
    */
   public List<Integer> findDatasetIdsByDACUser(User user) {
-    return datasetDAO.findDatasetIdsByDACUserEmail(user.getEmail());
+    return datasetDAO.findDatasetIdsByDACUserId(user.getUserId());
   }
 
   public void deleteByCollectionId(User user, Integer collectionId)
@@ -624,7 +624,7 @@ public class DarCollectionService implements ConsentLogger {
    */
   public DarCollection cancelDarCollectionElectionsAsChair(DarCollection collection, User user) {
     // Find dataset ids the chairperson has access to:
-    List<Integer> datasetIds = datasetDAO.findDatasetIdsByDACUserEmail(user.getEmail());
+    List<Integer> datasetIds = datasetDAO.findDatasetIdsByDACUserId(user.getUserId());
 
     // Filter the list of DARs we can operate on by the datasets accessible to this chairperson
     List<DataAccessRequest> dars = collection.getDars().values().stream()

--- a/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
@@ -414,11 +414,13 @@ public class DarCollectionService implements ConsentLogger {
     return this.processDraftAsSummary(new ArrayList<>(sourceCollection.getDars().values()).get(0));
   }
 
-  public List<Integer> findDatasetIdsByUser(User user) {
-    return datasetDAO.findDatasetsByAuthUserEmail(user.getEmail())
-        .stream()
-        .map(Dataset::getDataSetId)
-        .collect(Collectors.toList());
+  /**
+   * Find all dataset ids by the DAC User. Will return ids for Chairpersons or Members
+   * @param user The DAC User
+   * @return List of Dataset IDs
+   */
+  public List<Integer> findDatasetIdsByDACUser(User user) {
+    return datasetDAO.findDatasetIdsByDACUserEmail(user.getEmail());
   }
 
   public void deleteByCollectionId(User user, Integer collectionId)
@@ -622,10 +624,7 @@ public class DarCollectionService implements ConsentLogger {
    */
   public DarCollection cancelDarCollectionElectionsAsChair(DarCollection collection, User user) {
     // Find dataset ids the chairperson has access to:
-    List<Integer> datasetIds = datasetDAO.findDatasetsByAuthUserEmail(user.getEmail())
-        .stream()
-        .map(Dataset::getDataSetId)
-        .collect(Collectors.toList());
+    List<Integer> datasetIds = datasetDAO.findDatasetIdsByDACUserEmail(user.getEmail());
 
     // Filter the list of DARs we can operate on by the datasets accessible to this chairperson
     List<DataAccessRequest> dars = collection.getDars().values().stream()

--- a/src/main/java/org/broadinstitute/consent/http/service/dao/DarCollectionServiceDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/dao/DarCollectionServiceDAO.java
@@ -14,7 +14,6 @@ import org.broadinstitute.consent.http.enumeration.ElectionType;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.enumeration.VoteType;
 import org.broadinstitute.consent.http.models.DarCollection;
-import org.broadinstitute.consent.http.models.Dataset;
 import org.broadinstitute.consent.http.models.Election;
 import org.broadinstitute.consent.http.models.User;
 import org.jdbi.v3.core.Handle;
@@ -56,11 +55,7 @@ public class DarCollectionServiceDAO {
     // If the user is not an admin, we need to know what datasets they have access to.
     List<Integer> dacUserDatasetIds = isAdmin ?
         List.of() :
-        datasetDAO
-            .findDatasetsByAuthUserEmail(user.getEmail())
-            .stream()
-            .map(Dataset::getDataSetId)
-            .toList();
+        datasetDAO.findDatasetIdsByDACUserEmail(user.getEmail());
     jdbi.useHandle(
         handle -> {
           // By default, new connections are set to auto-commit which breaks our rollback strategy.

--- a/src/main/java/org/broadinstitute/consent/http/service/dao/DarCollectionServiceDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/dao/DarCollectionServiceDAO.java
@@ -55,7 +55,7 @@ public class DarCollectionServiceDAO {
     // If the user is not an admin, we need to know what datasets they have access to.
     List<Integer> dacUserDatasetIds = isAdmin ?
         List.of() :
-        datasetDAO.findDatasetIdsByDACUserEmail(user.getEmail());
+        datasetDAO.findDatasetIdsByDACUserId(user.getUserId());
     jdbi.useHandle(
         handle -> {
           // By default, new connections are set to auto-commit which breaks our rollback strategy.

--- a/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
@@ -343,7 +343,7 @@ class DatasetDAOTest extends DAOTestHelper {
     User user = createUser();
     createUserRole(UserRoles.CHAIRPERSON.getRoleId(), user.getUserId(), dac.getDacId());
 
-    List<Integer> datasetIds = datasetDAO.findDatasetIdsByDACUserEmail(user.getEmail());
+    List<Integer> datasetIds = datasetDAO.findDatasetIdsByDACUserId(user.getUserId());
     assertFalse(datasetIds.isEmpty());
     assertTrue(datasetIds.contains(dataset.getDataSetId()));
   }

--- a/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
@@ -343,9 +343,8 @@ class DatasetDAOTest extends DAOTestHelper {
     User user = createUser();
     createUserRole(UserRoles.CHAIRPERSON.getRoleId(), user.getUserId(), dac.getDacId());
 
-    List<Dataset> datasets = datasetDAO.findDatasetsByAuthUserEmail(user.getEmail());
-    assertFalse(datasets.isEmpty());
-    List<Integer> datasetIds = datasets.stream().map(Dataset::getDataSetId).toList();
+    List<Integer> datasetIds = datasetDAO.findDatasetIdsByDACUserEmail(user.getEmail());
+    assertFalse(datasetIds.isEmpty());
     assertTrue(datasetIds.contains(dataset.getDataSetId()));
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/resources/DarCollectionResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DarCollectionResourceTest.java
@@ -192,7 +192,7 @@ class DarCollectionResourceTest {
 
     when(darCollectionService.getByCollectionId(any())).thenReturn(collection);
     when(userService.findUserByEmail(anyString())).thenReturn(chair);
-    when(darCollectionService.findDatasetIdsByUser(any())).thenReturn(Arrays.asList(1, 2));
+    when(darCollectionService.findDatasetIdsByDACUser(any())).thenReturn(Arrays.asList(1, 2));
     initResource();
 
     Response response = resource.getCollectionById(authUser, collection.getDarCollectionId());
@@ -213,7 +213,7 @@ class DarCollectionResourceTest {
 
     when(darCollectionService.getByCollectionId(any())).thenReturn(collection);
     when(userService.findUserByEmail(anyString())).thenReturn(chair);
-    when(darCollectionService.findDatasetIdsByUser(any())).thenReturn(Arrays.asList(1, 2));
+    when(darCollectionService.findDatasetIdsByDACUser(any())).thenReturn(Arrays.asList(1, 2));
     initResource();
 
     Response response = resource.getCollectionById(authUser, collection.getDarCollectionId());
@@ -234,7 +234,7 @@ class DarCollectionResourceTest {
 
     when(darCollectionService.getByCollectionId(any())).thenReturn(collection);
     when(userService.findUserByEmail(anyString())).thenReturn(chair);
-    when(darCollectionService.findDatasetIdsByUser(any())).thenReturn(Arrays.asList(1, 2));
+    when(darCollectionService.findDatasetIdsByDACUser(any())).thenReturn(Arrays.asList(1, 2));
     initResource();
 
     Response response = resource.getCollectionById(authUser, collection.getDarCollectionId());
@@ -257,7 +257,7 @@ class DarCollectionResourceTest {
 
     when(darCollectionService.getByCollectionId(any())).thenReturn(collection);
     when(userService.findUserByEmail(anyString())).thenReturn(researcher);
-    when(darCollectionService.findDatasetIdsByUser(any())).thenReturn(Arrays.asList(1, 2));
+    when(darCollectionService.findDatasetIdsByDACUser(any())).thenReturn(Arrays.asList(1, 2));
     initResource();
 
     Response response = resource.getCollectionById(authUser, collection.getDarCollectionId());
@@ -612,7 +612,7 @@ class DarCollectionResourceTest {
     Integer collectionId = RandomUtils.nextInt(1, 100);
 
     when(userService.findUserByEmail(anyString())).thenReturn(user);
-    when(darCollectionService.findDatasetIdsByUser(user)).thenReturn(List.of(1, 2));
+    when(darCollectionService.findDatasetIdsByDACUser(user)).thenReturn(List.of(1, 2));
     when(darCollectionService.getSummaryForRoleNameByCollectionId(any(User.class), anyString(),
         anyInt()))
         .thenReturn(mockSummary);
@@ -633,7 +633,7 @@ class DarCollectionResourceTest {
     Integer collectionId = RandomUtils.nextInt(1, 100);
 
     when(userService.findUserByEmail(anyString())).thenReturn(user);
-    when(darCollectionService.findDatasetIdsByUser(user)).thenReturn(List.of(2));
+    when(darCollectionService.findDatasetIdsByDACUser(user)).thenReturn(List.of(2));
     when(darCollectionService.getSummaryForRoleNameByCollectionId(any(User.class), anyString(),
         anyInt()))
         .thenReturn(mockSummary);
@@ -654,7 +654,7 @@ class DarCollectionResourceTest {
     Integer collectionId = RandomUtils.nextInt(1, 100);
 
     when(userService.findUserByEmail(anyString())).thenReturn(user);
-    when(darCollectionService.findDatasetIdsByUser(user)).thenReturn(List.of(1, 2));
+    when(darCollectionService.findDatasetIdsByDACUser(user)).thenReturn(List.of(1, 2));
     when(darCollectionService.getSummaryForRoleNameByCollectionId(any(User.class), anyString(),
         anyInt()))
         .thenReturn(mockSummary);
@@ -675,7 +675,7 @@ class DarCollectionResourceTest {
     Integer collectionId = RandomUtils.nextInt(1, 100);
 
     when(userService.findUserByEmail(anyString())).thenReturn(user);
-    when(darCollectionService.findDatasetIdsByUser(user)).thenReturn(List.of(2));
+    when(darCollectionService.findDatasetIdsByDACUser(user)).thenReturn(List.of(2));
     when(darCollectionService.getSummaryForRoleNameByCollectionId(any(User.class), anyString(),
         anyInt()))
         .thenReturn(mockSummary);

--- a/src/test/java/org/broadinstitute/consent/http/service/DacServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DacServiceTest.java
@@ -23,13 +23,11 @@ import jakarta.ws.rs.BadRequestException;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import java.util.stream.Stream;
 import org.apache.commons.lang3.RandomUtils;
 import org.broadinstitute.consent.http.db.DacDAO;
 import org.broadinstitute.consent.http.db.DataAccessRequestDAO;
@@ -392,7 +390,7 @@ class DacServiceTest {
   void testFilterDataAccessRequestsByDAC_memberCase_1() {
     // Member has access to DataSet 1
     List<Dataset> memberDataSets = Collections.singletonList(getDatasets().get(0));
-    when(dataSetDAO.findDatasetsByAuthUserEmail(getMember().getEmail())).thenReturn(memberDataSets);
+    when(dataSetDAO.findDatasetIdsByDACUserEmail(getMember().getEmail())).thenReturn(List.of(memberDataSets.get(0).getDataSetId()));
 
     initService();
 
@@ -408,7 +406,7 @@ class DacServiceTest {
   void testFilterDataAccessRequestsByDAC_memberCase_2() {
     // Member has access to datasets
     List<Dataset> memberDataSets = Collections.singletonList(getDatasets().get(0));
-    when(dataSetDAO.findDatasetsByAuthUserEmail(getMember().getEmail())).thenReturn(memberDataSets);
+    when(dataSetDAO.findDatasetIdsByDACUserEmail(getMember().getEmail())).thenReturn(List.of(memberDataSets.get(0).getDataSetId()));
 
     initService();
 
@@ -424,7 +422,7 @@ class DacServiceTest {
   void testFilterDataAccessRequestsByDAC_memberCase_3() {
     // Member no direct access to datasets
     List<Dataset> memberDataSets = Collections.emptyList();
-    when(dataSetDAO.findDatasetsByAuthUserEmail(getMember().getEmail())).thenReturn(memberDataSets);
+    when(dataSetDAO.findDatasetIdsByDACUserEmail(getMember().getEmail())).thenReturn(List.of());
 
     initService();
 

--- a/src/test/java/org/broadinstitute/consent/http/service/DacServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DacServiceTest.java
@@ -390,7 +390,7 @@ class DacServiceTest {
   void testFilterDataAccessRequestsByDAC_memberCase_1() {
     // Member has access to DataSet 1
     List<Dataset> memberDataSets = Collections.singletonList(getDatasets().get(0));
-    when(dataSetDAO.findDatasetIdsByDACUserEmail(getMember().getEmail())).thenReturn(List.of(memberDataSets.get(0).getDataSetId()));
+    when(dataSetDAO.findDatasetIdsByDACUserId(getMember().getUserId())).thenReturn(List.of(memberDataSets.get(0).getDataSetId()));
 
     initService();
 
@@ -406,7 +406,7 @@ class DacServiceTest {
   void testFilterDataAccessRequestsByDAC_memberCase_2() {
     // Member has access to datasets
     List<Dataset> memberDataSets = Collections.singletonList(getDatasets().get(0));
-    when(dataSetDAO.findDatasetIdsByDACUserEmail(getMember().getEmail())).thenReturn(List.of(memberDataSets.get(0).getDataSetId()));
+    when(dataSetDAO.findDatasetIdsByDACUserId(getMember().getUserId())).thenReturn(List.of(memberDataSets.get(0).getDataSetId()));
 
     initService();
 
@@ -422,7 +422,7 @@ class DacServiceTest {
   void testFilterDataAccessRequestsByDAC_memberCase_3() {
     // Member no direct access to datasets
     List<Dataset> memberDataSets = Collections.emptyList();
-    when(dataSetDAO.findDatasetIdsByDACUserEmail(getMember().getEmail())).thenReturn(List.of());
+    when(dataSetDAO.findDatasetIdsByDACUserId(getMember().getUserId())).thenReturn(List.of());
 
     initService();
 

--- a/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
@@ -238,7 +238,7 @@ class DarCollectionServiceTest {
   @Test
   void testCancelDarCollectionAsChair_ChairHasDatasets() {
     User user = new User();
-    user.setEmail("email");
+    user.setUserId(RandomUtils.nextInt(1, 10));
     Dataset dataset = new Dataset();
     dataset.setDataSetId(1);
     DataAccessRequest dar = new DataAccessRequest();
@@ -266,7 +266,7 @@ class DarCollectionServiceTest {
   @Test
   void testCancelDarCollectionAsChair_ChairHasNoDatasets() {
     User user = new User();
-    user.setEmail("email");
+    user.setUserId(RandomUtils.nextInt(1, 10));
     Dataset dataset = new Dataset();
     dataset.setDataSetId(1);
     DataAccessRequest dar = new DataAccessRequest();

--- a/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
@@ -252,11 +252,11 @@ class DarCollectionServiceTest {
     election.setReferenceId(dar.getReferenceId());
     election.setStatus(ElectionStatus.OPEN.getValue());
     election.setElectionId(1);
-    when(datasetDAO.findDatasetIdsByDACUserEmail(anyString())).thenReturn(List.of(dataset.getDataSetId()));
+    when(datasetDAO.findDatasetIdsByDACUserId(anyInt())).thenReturn(List.of(dataset.getDataSetId()));
     when(electionDAO.findOpenElectionsByReferenceIds(anyList())).thenReturn(List.of(election));
 
     service.cancelDarCollectionElectionsAsChair(collection, user);
-    verify(datasetDAO, times(1)).findDatasetIdsByDACUserEmail(anyString());
+    verify(datasetDAO, times(1)).findDatasetIdsByDACUserId(anyInt());
     verify(electionDAO, times(1)).findOpenElectionsByReferenceIds(anyList());
     verify(electionDAO, times(1)).updateElectionById(anyInt(), anyString(), any());
     verify(dataAccessRequestDAO, times(0)).cancelByReferenceIds(anyList());
@@ -280,10 +280,10 @@ class DarCollectionServiceTest {
     election.setReferenceId(dar.getReferenceId());
     election.setStatus(ElectionStatus.OPEN.getValue());
     election.setElectionId(1);
-    when(datasetDAO.findDatasetIdsByDACUserEmail(anyString())).thenReturn(List.of());
+    when(datasetDAO.findDatasetIdsByDACUserId(anyInt())).thenReturn(List.of());
 
     service.cancelDarCollectionElectionsAsChair(collection, user);
-    verify(datasetDAO, times(1)).findDatasetIdsByDACUserEmail(anyString());
+    verify(datasetDAO, times(1)).findDatasetIdsByDACUserId(anyInt());
     verify(electionDAO, times(0)).findLastElectionsByReferenceIds(anyList());
     verify(electionDAO, times(0)).updateElectionById(anyInt(), anyString(), any());
     verify(dataAccessRequestDAO, times(0)).cancelByReferenceIds(anyList());

--- a/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
@@ -252,11 +252,11 @@ class DarCollectionServiceTest {
     election.setReferenceId(dar.getReferenceId());
     election.setStatus(ElectionStatus.OPEN.getValue());
     election.setElectionId(1);
-    when(datasetDAO.findDatasetsByAuthUserEmail(anyString())).thenReturn(List.of(dataset));
+    when(datasetDAO.findDatasetIdsByDACUserEmail(anyString())).thenReturn(List.of(dataset.getDataSetId()));
     when(electionDAO.findOpenElectionsByReferenceIds(anyList())).thenReturn(List.of(election));
 
     service.cancelDarCollectionElectionsAsChair(collection, user);
-    verify(datasetDAO, times(1)).findDatasetsByAuthUserEmail(anyString());
+    verify(datasetDAO, times(1)).findDatasetIdsByDACUserEmail(anyString());
     verify(electionDAO, times(1)).findOpenElectionsByReferenceIds(anyList());
     verify(electionDAO, times(1)).updateElectionById(anyInt(), anyString(), any());
     verify(dataAccessRequestDAO, times(0)).cancelByReferenceIds(anyList());
@@ -280,10 +280,10 @@ class DarCollectionServiceTest {
     election.setReferenceId(dar.getReferenceId());
     election.setStatus(ElectionStatus.OPEN.getValue());
     election.setElectionId(1);
-    when(datasetDAO.findDatasetsByAuthUserEmail(anyString())).thenReturn(List.of());
+    when(datasetDAO.findDatasetIdsByDACUserEmail(anyString())).thenReturn(List.of());
 
     service.cancelDarCollectionElectionsAsChair(collection, user);
-    verify(datasetDAO, times(1)).findDatasetsByAuthUserEmail(anyString());
+    verify(datasetDAO, times(1)).findDatasetIdsByDACUserEmail(anyString());
     verify(electionDAO, times(0)).findLastElectionsByReferenceIds(anyList());
     verify(electionDAO, times(0)).updateElectionById(anyInt(), anyString(), any());
     verify(dataAccessRequestDAO, times(0)).cancelByReferenceIds(anyList());


### PR DESCRIPTION
### Addresses
Ticket: https://broadworkbench.atlassian.net/browse/DCJ-708

### Summary
In this PR, we fix a long-running query bug that caused the instance to crash. This manifested in a never-ending loading screen for the user and an eventual redirect back to their console with an error message. The root of the problem is that it is very expensive to populate a large list of datasets which caused OOMs and the pod to crash/restart.

Fixes:
* Rename service/dao methods to be more reflective of what they are actually doing
* Query only for the Dataset ID instead of the full dataset object
  * This allows the server to complete the response instead of OOM-ing and crashing the instance
* Update tests to match new signatures.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
