### PR TITLE
[DT-697] DUOS: B2C new MS login user display name is "unknown"

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/authentication/OAuthAuthenticator.java
+++ b/src/main/java/org/broadinstitute/consent/http/authentication/OAuthAuthenticator.java
@@ -54,7 +54,7 @@ public class OAuthAuthenticator implements Authenticator<String, AuthUser>, Cons
     String email = headers.get(ClaimsCache.OAUTH2_CLAIM_email);
     String name = headers.get(ClaimsCache.OAUTH2_CLAIM_name);
     // Name is not a guaranteed header
-    if (name == null) {
+    if (name == null || name.equals("unknown")) {
       name = email;
     }
     if (email == null) {

--- a/src/test/java/org/broadinstitute/consent/http/authentication/OAuthAuthenticatorTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/authentication/OAuthAuthenticatorTest.java
@@ -116,4 +116,22 @@ class OAuthAuthenticatorTest {
     verify(samService, never()).getRegistrationInfo(any());
   }
 
+  /**
+   * Test that if the name is "unknown" in the header, we use the email as the name
+   */
+  @Test
+  void testUnknownNameDefaultsToEmail() {
+    String bearerToken = RandomStringUtils.randomAlphabetic(100);
+    MultivaluedMap<String, String> headerMap = new MultivaluedHashMap<>();
+    headerMap.put(ClaimsCache.OAUTH2_CLAIM_access_token, List.of(bearerToken));
+    headerMap.put(ClaimsCache.OAUTH2_CLAIM_email, List.of("email"));
+    headerMap.put(ClaimsCache.OAUTH2_CLAIM_name, List.of("unknown"));
+    headerCache.loadCache(bearerToken, headerMap);
+    oAuthAuthenticator = new OAuthAuthenticator(samService);
+
+    Optional<AuthUser> authUser = oAuthAuthenticator.authenticate(bearerToken);
+    assertTrue(authUser.isPresent());
+    assertEquals(authUser.get().getName(), authUser.get().getEmail());
+  }
+
 }


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-697
### Summary
If `OAUTH2_CLAIM_name=unknown` default the display name to the auth claim's email instead.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
