### PR TITLE
DT-942: Remove deprecated/unused update dataset api

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
@@ -614,11 +614,6 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
           " WHERE p.dataset_id = :datasetId ")
   Set<DatasetProperty> findDatasetPropertiesByDatasetId(@Bind("datasetId") Integer datasetId);
 
-  @Deprecated // Use getDictionaryTerms()
-  @RegisterRowMapper(DictionaryMapper.class)
-  @SqlQuery("SELECT * FROM dictionary d ORDER BY receive_order")
-  List<Dictionary> getMappedFieldsOrderByReceiveOrder();
-
   @RegisterRowMapper(DictionaryMapper.class)
   @SqlQuery("SELECT * FROM dictionary ORDER BY key_id")
   List<Dictionary> getDictionaryTerms();

--- a/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
@@ -34,7 +34,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -51,8 +50,6 @@ import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.UserRole;
 import org.broadinstitute.consent.http.models.dataset_registration_v1.DatasetRegistrationSchemaV1;
 import org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder;
-import org.broadinstitute.consent.http.models.dto.DatasetDTO;
-import org.broadinstitute.consent.http.models.dto.DatasetPropertyDTO;
 import org.broadinstitute.consent.http.service.DatasetRegistrationService;
 import org.broadinstitute.consent.http.service.DatasetService;
 import org.broadinstitute.consent.http.service.ElasticSearchService;
@@ -239,59 +236,6 @@ public class DatasetResource extends Resource {
       }
       Dataset patched = datasetRegistrationService.patchDataset(datasetId, user, patch);
       return Response.ok(patched).build();
-    } catch (Exception e) {
-      return createExceptionResponse(e);
-    }
-  }
-
-  @Deprecated
-  @PUT
-  @Consumes("application/json")
-  @Produces("application/json")
-  @Path("/{datasetId}")
-  @RolesAllowed({ADMIN, CHAIRPERSON})
-  public Response updateDataset(@Auth AuthUser authUser, @Context UriInfo info,
-      @PathParam("datasetId") Integer datasetId, String json) {
-    try {
-      DatasetDTO inputDataset = new Gson().fromJson(json, DatasetDTO.class);
-      if (Objects.isNull(inputDataset)) {
-        throw new BadRequestException("Dataset is required");
-      }
-      if (Objects.isNull(inputDataset.getProperties()) || inputDataset.getProperties().isEmpty()) {
-        throw new BadRequestException("Dataset must contain required properties");
-      }
-      Dataset datasetExists = datasetService.findDatasetById(datasetId);
-      if (Objects.isNull(datasetExists)) {
-        throw new NotFoundException("Could not find the dataset with id: " + datasetId);
-      }
-      List<DatasetPropertyDTO> invalidProperties = datasetService.findInvalidProperties(
-          inputDataset.getProperties());
-      if (invalidProperties.size() > 0) {
-        List<String> invalidKeys = invalidProperties.stream()
-            .map(DatasetPropertyDTO::getPropertyName)
-            .collect(Collectors.toList());
-        throw new BadRequestException(
-            "Dataset contains invalid properties that could not be recognized or associated with a key: "
-                + invalidKeys.toString());
-      }
-      List<DatasetPropertyDTO> duplicateProperties = datasetService.findDuplicateProperties(
-          inputDataset.getProperties());
-      if (duplicateProperties.size() > 0) {
-        throw new BadRequestException("Dataset contains multiple values for the same property.");
-      }
-      User user = userService.findUserByEmail(authUser.getEmail());
-      // Validate that the admin/chairperson has edit access to this dataset
-      validateDatasetDacAccess(user, datasetExists);
-      Integer userId = user.getUserId();
-      Optional<Dataset> updatedDataset = datasetService.updateDataset(inputDataset, datasetId,
-          userId);
-      if (updatedDataset.isPresent()) {
-        URI uri = info.getRequestUriBuilder().replacePath("api/dataset/{datasetId}")
-            .build(updatedDataset.get().getDatasetId());
-        return Response.ok(uri).entity(updatedDataset.get()).build();
-      } else {
-        return Response.noContent().build();
-      }
     } catch (Exception e) {
       return createExceptionResponse(e);
     }

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -10,10 +10,8 @@ import jakarta.ws.rs.NotAuthorizedException;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.core.StreamingOutput;
 import java.io.IOException;
-import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
@@ -21,7 +19,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
-import java.util.stream.Collectors;
 import org.apache.commons.collections4.CollectionUtils;
 import org.broadinstitute.consent.http.db.DaaDAO;
 import org.broadinstitute.consent.http.db.DacDAO;
@@ -44,7 +41,6 @@ import org.broadinstitute.consent.http.models.StudyConversion;
 import org.broadinstitute.consent.http.models.StudyProperty;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.dto.DatasetDTO;
-import org.broadinstitute.consent.http.models.dto.DatasetPropertyDTO;
 import org.broadinstitute.consent.http.service.dao.DatasetServiceDAO;
 import org.broadinstitute.consent.http.util.ConsentLogger;
 import org.broadinstitute.consent.http.util.gson.GsonUtil;
@@ -52,7 +48,6 @@ import org.broadinstitute.consent.http.util.gson.GsonUtil;
 
 public class DatasetService implements ConsentLogger {
 
-  public static final String DATASET_NAME_KEY = "Dataset Name";
   private final DatasetDAO datasetDAO;
   private final DaaDAO daaDAO;
   private final DacDAO dacDAO;
@@ -135,42 +130,6 @@ public class DatasetService implements ConsentLogger {
     return datasetDAO.findDatasetById(id);
   }
 
-  public Optional<Dataset> updateDataset(DatasetDTO dataset, Integer datasetId, Integer userId) {
-    Timestamp now = new Timestamp(new Date().getTime());
-
-    if (dataset.getDatasetName() == null) {
-      throw new IllegalArgumentException("Dataset 'Name' cannot be null");
-    }
-
-    Dataset old = findDatasetById(datasetId);
-    Set<DatasetProperty> oldProperties = old.getProperties();
-
-    List<DatasetPropertyDTO> updateDatasetPropertyDTOs = dataset.getProperties();
-    List<DatasetProperty> updateDatasetProperties = processDatasetProperties(datasetId,
-        updateDatasetPropertyDTOs);
-
-    List<DatasetProperty> propertiesToAdd = updateDatasetProperties.stream()
-        .filter(p -> oldProperties.stream()
-            .noneMatch(op -> op.getPropertyName().equals(p.getPropertyName())))
-        .toList();
-
-    List<DatasetProperty> propertiesToUpdate = updateDatasetProperties.stream()
-        .filter(p -> oldProperties.stream()
-            .noneMatch(p::equals))
-        .toList();
-
-    if (propertiesToAdd.isEmpty() && propertiesToUpdate.isEmpty() &&
-        dataset.getDatasetName().equals(old.getName())) {
-      return Optional.empty();
-    }
-
-    updateDatasetProperties(propertiesToUpdate, List.of(), propertiesToAdd);
-    datasetDAO.updateDataset(datasetId, dataset.getDatasetName(), now, userId,
-        dataset.getDacId());
-    Dataset updatedDataset = findDatasetById(datasetId);
-    return Optional.of(updatedDataset);
-  }
-
   public Dataset updateDatasetDataUse(User user, Integer datasetId, DataUse dataUse) {
     Dataset d = datasetDAO.findDatasetById(datasetId);
     if (d == null) {
@@ -194,66 +153,6 @@ public class DatasetService implements ConsentLogger {
     datasetDAO.updateDatasetTranslatedDataUse(datasetId, translation);
 
     return datasetDAO.findDatasetById(datasetId);
-  }
-
-  private void updateDatasetProperties(List<DatasetProperty> updateProperties,
-      List<DatasetProperty> deleteProperties, List<DatasetProperty> addProperties) {
-    updateProperties.forEach(p -> datasetDAO
-        .updateDatasetProperty(p.getDatasetId(), p.getPropertyKey(),
-            p.getPropertyValue().toString()));
-    deleteProperties.forEach(
-        p -> datasetDAO.deleteDatasetPropertyByKey(p.getDatasetId(), p.getPropertyKey()));
-    datasetDAO.insertDatasetProperties(addProperties);
-  }
-
-  @Deprecated // Use synchronizeDatasetProperties() instead
-  public List<DatasetProperty> processDatasetProperties(Integer datasetId,
-      List<DatasetPropertyDTO> properties) {
-    Date now = new Date();
-    List<Dictionary> dictionaries = datasetDAO.getMappedFieldsOrderByReceiveOrder();
-    List<String> keys = dictionaries.stream().map(Dictionary::getKey)
-        .collect(Collectors.toList());
-
-    return properties.stream()
-        .filter(p -> keys.contains(p.getPropertyName()) && !p.getPropertyName()
-            .equals(DATASET_NAME_KEY))
-        .map(p ->
-            new DatasetProperty(datasetId,
-                dictionaries.get(keys.indexOf(p.getPropertyName())).getKeyId(),
-                p.getPropertyValue(),
-                PropertyType.String,
-                now)
-        )
-        .collect(Collectors.toList());
-  }
-
-  public List<DatasetPropertyDTO> findInvalidProperties(List<DatasetPropertyDTO> properties) {
-    List<Dictionary> dictionaries = datasetDAO.getMappedFieldsOrderByReceiveOrder();
-    List<String> keys = dictionaries.stream().map(Dictionary::getKey)
-        .collect(Collectors.toList());
-
-    return properties.stream()
-        .filter(p -> !keys.contains(p.getPropertyName()))
-        .collect(Collectors.toList());
-  }
-
-  public List<DatasetPropertyDTO> findDuplicateProperties(List<DatasetPropertyDTO> properties) {
-    Set<String> uniqueKeys = properties.stream()
-        .map(DatasetPropertyDTO::getPropertyName)
-        .collect(Collectors.toSet());
-    if (uniqueKeys.size() != properties.size()) {
-      List<DatasetPropertyDTO> allDuplicateProperties = new ArrayList<>();
-      uniqueKeys.forEach(key -> {
-        List<DatasetPropertyDTO> propertiesPerKey = properties.stream()
-            .filter(property -> property.getPropertyName().equals(key))
-            .collect(Collectors.toList());
-        if (propertiesPerKey.size() > 1) {
-          allDuplicateProperties.addAll(propertiesPerKey);
-        }
-      });
-      return allDuplicateProperties;
-    }
-    return Collections.emptyList();
   }
 
   public void deleteDataset(Integer datasetId, Integer userId) throws Exception {

--- a/src/main/resources/assets/paths/datasetById.yaml
+++ b/src/main/resources/assets/paths/datasetById.yaml
@@ -72,34 +72,3 @@ delete:
       description: Not Found
     500:
       description: Server error.
-put:
-  deprecated: true
-  summary: Updates the Dataset from JSON
-  description: Updates the Dataset from JSON
-  parameters:
-    - name: datasetId
-      in: path
-      description: ID of the Dataset
-      required: true
-      schema:
-        type: integer
-  requestBody:
-    description: Dataset with properties
-    required: true
-    content:
-      application/json:
-        schema:
-          $ref: '../schemas/Dataset.yaml'
-  tags:
-    - Dataset
-  responses:
-    200:
-      description: Successfully updated Dataset
-    204:
-      description: Not modified
-    400:
-      description: Bad Request (invalid input)
-    404:
-      description: Not Found
-    500:
-      description: Internal Error

--- a/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
@@ -9,7 +9,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -24,8 +23,6 @@ import com.google.gson.reflect.TypeToken;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.StreamingOutput;
-import jakarta.ws.rs.core.UriBuilder;
-import jakarta.ws.rs.core.UriInfo;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.lang.reflect.Type;
@@ -89,12 +86,6 @@ class DatasetResourceTest {
 
   @Mock
   private User user;
-
-  @Mock
-  private UriInfo uriInfo;
-
-  @Mock
-  private UriBuilder uriBuilder;
 
   private DatasetResource resource;
 
@@ -368,93 +359,6 @@ class DatasetResourceTest {
         gson.toJson(patch))) {
       assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
     }
-  }
-
-  @Test
-  void testUpdateDatasetSuccess() {
-    Dataset preexistingDataset = new Dataset();
-    String json = createPropertiesJson("Dataset Name", "test");
-    when(datasetService.findDatasetById(anyInt())).thenReturn(preexistingDataset);
-    when(datasetService.updateDataset(any(), any(), any())).thenReturn(
-        Optional.of(preexistingDataset));
-    when(userService.findUserByEmail(any())).thenReturn(user);
-    when(user.getUserId()).thenReturn(1);
-    when(user.hasUserRole(any())).thenReturn(true);
-    when(uriInfo.getRequestUriBuilder()).thenReturn(uriBuilder);
-    when(uriBuilder.replacePath(anyString())).thenReturn(uriBuilder);
-    initResource();
-    Response response = resource.updateDataset(authUser, uriInfo, 1, json);
-    assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
-    assertEquals(Optional.of(preexistingDataset).get(), response.getEntity());
-  }
-
-  @Test
-  void testUpdateDatasetNoJson() {
-    initResource();
-    Response response = resource.updateDataset(authUser, uriInfo, 1, "");
-    assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
-  }
-
-  @Test
-  void testUpdateDatasetNoProperties() {
-    initResource();
-    Response response = resource.updateDataset(authUser, uriInfo, 1, "{\"properties\":[]}");
-    assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
-  }
-
-  @Test
-  void testUpdateDatasetIdNotFound() {
-    String json = createPropertiesJson("Dataset Name", "test");
-    when(datasetService.findDatasetById(anyInt())).thenReturn(null);
-
-    initResource();
-    Response response = resource.updateDataset(authUser, uriInfo, 1, json);
-    assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
-  }
-
-  @Test
-  void testUpdateDatasetInvalidProperty() {
-    List<DatasetPropertyDTO> invalidProperties = new ArrayList<>();
-    invalidProperties.add(new DatasetPropertyDTO("Invalid Property", "test"));
-    when(datasetService.findInvalidProperties(any())).thenReturn(invalidProperties);
-
-    Dataset preexistingDataset = new Dataset();
-    when(datasetService.findDatasetById(anyInt())).thenReturn(preexistingDataset);
-    String json = createPropertiesJson(invalidProperties);
-
-    initResource();
-    Response response = resource.updateDataset(authUser, uriInfo, 1, json);
-    assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
-  }
-
-  @Test
-  void testUpdateDatasetDuplicateProperties() {
-    List<DatasetPropertyDTO> duplicateProperties = new ArrayList<>();
-    duplicateProperties.add(new DatasetPropertyDTO("Dataset Name", "test"));
-    duplicateProperties.add(new DatasetPropertyDTO("Dataset Name", "test"));
-    when(datasetService.findDuplicateProperties(any())).thenReturn(duplicateProperties);
-
-    Dataset preexistingDataset = new Dataset();
-    when(datasetService.findDatasetById(anyInt())).thenReturn(preexistingDataset);
-    String json = createPropertiesJson(duplicateProperties);
-
-    initResource();
-    Response response = resource.updateDataset(authUser, uriInfo, 1, json);
-    assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
-  }
-
-  @Test
-  void testUpdateDatasetNoContent() {
-    Dataset preexistingDataset = new Dataset();
-    String json = createPropertiesJson("Dataset Name", "test");
-    when(datasetService.findDatasetById(anyInt())).thenReturn(preexistingDataset);
-    when(datasetService.updateDataset(any(), any(), any())).thenReturn(Optional.empty());
-    when(userService.findUserByEmail(any())).thenReturn(user);
-    when(user.getUserId()).thenReturn(1);
-    when(user.hasUserRole(any())).thenReturn(true);
-    initResource();
-    Response responseNoContent = resource.updateDataset(authUser, uriInfo, 1, json);
-    assertEquals(204, responseNoContent.getStatus());
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
@@ -189,27 +189,6 @@ class DatasetServiceTest {
     assertNull(datasetService.findDatasetByIdentifier("DUOS-00003"));
   }
 
-//  @Test
-//  void testUpdateDatasetNotModified() {
-//    int datasetId = 1;
-//    DatasetDTO dataSetDTO = getDatasetDTO();
-//    Dataset dataset = getDatasets().get(0);
-//    dataSetDTO.setDatasetName(dataset.getName());
-//    Set<DatasetProperty> datasetProps = getDatasetProperties();
-//    List<DatasetPropertyDTO> dtoProps = datasetProps.stream().map(p ->
-//        new DatasetPropertyDTO(p.getPropertyName(), p.getPropertyValue().toString())
-//    ).collect(Collectors.toList());
-//    dataSetDTO.setProperties(dtoProps);
-//    dataset.setProperties(datasetProps);
-//    when(datasetDAO.findDatasetById(datasetId)).thenReturn(dataset);
-//    when(datasetDAO.getMappedFieldsOrderByReceiveOrder()).thenReturn(getDictionaries());
-//    initService();
-//
-//    Optional<Dataset> notModified = datasetService.updateDataset(dataSetDTO, datasetId, 1);
-//    assertEquals(Optional.empty(), notModified);
-//  }
-
-
   @Test
   void testUpdateDatasetDataUseAdmin() {
     doNothing().when(datasetDAO).updateDatasetDataUse(any(), any());

--- a/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
@@ -14,7 +14,6 @@ import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -25,17 +24,13 @@ import com.google.gson.reflect.TypeToken;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.NotFoundException;
 import java.io.ByteArrayOutputStream;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.RandomUtils;
 import org.broadinstitute.consent.http.db.DaaDAO;
 import org.broadinstitute.consent.http.db.DacDAO;
@@ -50,14 +45,10 @@ import org.broadinstitute.consent.http.models.Dac;
 import org.broadinstitute.consent.http.models.DataUse;
 import org.broadinstitute.consent.http.models.DataUseBuilder;
 import org.broadinstitute.consent.http.models.Dataset;
-import org.broadinstitute.consent.http.models.DatasetProperty;
-import org.broadinstitute.consent.http.models.Dictionary;
 import org.broadinstitute.consent.http.models.Study;
 import org.broadinstitute.consent.http.models.StudyProperty;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.UserRole;
-import org.broadinstitute.consent.http.models.dto.DatasetDTO;
-import org.broadinstitute.consent.http.models.dto.DatasetPropertyDTO;
 import org.broadinstitute.consent.http.service.dao.DatasetServiceDAO;
 import org.broadinstitute.consent.http.util.gson.GsonUtil;
 import org.junit.jupiter.api.Test;
@@ -169,45 +160,6 @@ class DatasetServiceTest {
   }
 
   @Test
-  void testProcessDatasetProperties() {
-    when(datasetDAO.getMappedFieldsOrderByReceiveOrder()).thenReturn(getDictionaries());
-    initService();
-
-    List<DatasetProperty> properties = datasetService
-        .processDatasetProperties(1, getDatasetPropertiesDTO());
-
-    assertEquals(properties.size(), getDatasetPropertiesDTO().size());
-  }
-
-  @Test
-  void testFindInvalidProperties() {
-    when(datasetDAO.getMappedFieldsOrderByReceiveOrder()).thenReturn(getDictionaries());
-    initService();
-
-    List<DatasetPropertyDTO> input = getDatasetPropertiesDTO().stream()
-        .peek(p -> p.setPropertyKey("Invalid Key"))
-        .collect(Collectors.toList());
-
-    List<DatasetPropertyDTO> properties = datasetService.findInvalidProperties(input);
-
-    assertFalse(properties.isEmpty());
-  }
-
-  @Test
-  void testFindDuplicateProperties() {
-    initService();
-
-    List<DatasetPropertyDTO> input = getDatasetPropertiesDTO();
-    DatasetPropertyDTO duplicateProperty = input.get(0);
-    input.add(duplicateProperty);
-
-    List<DatasetPropertyDTO> properties = datasetService.findDuplicateProperties(input);
-
-    assertFalse(properties.isEmpty());
-    assertEquals(properties.get(0), duplicateProperty);
-  }
-
-  @Test
   void testFindDatasetByIdentifier() {
     Dataset d = new Dataset();
     d.setAlias(3);
@@ -237,25 +189,25 @@ class DatasetServiceTest {
     assertNull(datasetService.findDatasetByIdentifier("DUOS-00003"));
   }
 
-  @Test
-  void testUpdateDatasetNotModified() {
-    int datasetId = 1;
-    DatasetDTO dataSetDTO = getDatasetDTO();
-    Dataset dataset = getDatasets().get(0);
-    dataSetDTO.setDatasetName(dataset.getName());
-    Set<DatasetProperty> datasetProps = getDatasetProperties();
-    List<DatasetPropertyDTO> dtoProps = datasetProps.stream().map(p ->
-        new DatasetPropertyDTO(p.getPropertyName(), p.getPropertyValue().toString())
-    ).collect(Collectors.toList());
-    dataSetDTO.setProperties(dtoProps);
-    dataset.setProperties(datasetProps);
-    when(datasetDAO.findDatasetById(datasetId)).thenReturn(dataset);
-    when(datasetDAO.getMappedFieldsOrderByReceiveOrder()).thenReturn(getDictionaries());
-    initService();
-
-    Optional<Dataset> notModified = datasetService.updateDataset(dataSetDTO, datasetId, 1);
-    assertEquals(Optional.empty(), notModified);
-  }
+//  @Test
+//  void testUpdateDatasetNotModified() {
+//    int datasetId = 1;
+//    DatasetDTO dataSetDTO = getDatasetDTO();
+//    Dataset dataset = getDatasets().get(0);
+//    dataSetDTO.setDatasetName(dataset.getName());
+//    Set<DatasetProperty> datasetProps = getDatasetProperties();
+//    List<DatasetPropertyDTO> dtoProps = datasetProps.stream().map(p ->
+//        new DatasetPropertyDTO(p.getPropertyName(), p.getPropertyValue().toString())
+//    ).collect(Collectors.toList());
+//    dataSetDTO.setProperties(dtoProps);
+//    dataset.setProperties(datasetProps);
+//    when(datasetDAO.findDatasetById(datasetId)).thenReturn(dataset);
+//    when(datasetDAO.getMappedFieldsOrderByReceiveOrder()).thenReturn(getDictionaries());
+//    initService();
+//
+//    Optional<Dataset> notModified = datasetService.updateDataset(dataSetDTO, datasetId, 1);
+//    assertEquals(Optional.empty(), notModified);
+//  }
 
 
   @Test
@@ -295,103 +247,6 @@ class DatasetServiceTest {
     } catch (IllegalArgumentException e) {
       assertTrue(true);
     }
-  }
-
-  @Test
-  void testUpdateDatasetMultiFieldUpdateOnly() {
-    int datasetId = 1;
-    DatasetDTO dataSetDTO = getDatasetDTO();
-    Dataset dataset = getDatasets().get(0);
-    dataset.setProperties(getDatasetProperties());
-    dataSetDTO.setDatasetName(dataset.getName());
-
-    List<DatasetPropertyDTO> updatedProperties = getDatasetPropertiesDTO();
-    updatedProperties.get(2).setPropertyValue("updated value");
-    updatedProperties.get(3).setPropertyValue("updated value");
-    dataSetDTO.setProperties(updatedProperties);
-
-    when(datasetDAO.findDatasetById(datasetId)).thenReturn(dataset);
-    when(datasetDAO.getMappedFieldsOrderByReceiveOrder()).thenReturn(getDictionaries());
-    initService();
-
-    Optional<Dataset> updated = datasetService.updateDataset(dataSetDTO, datasetId, 1);
-    assertNotNull(updated);
-    assertTrue(updated.isPresent());
-  }
-
-  @Test
-  void testUpdateDatasetMultiFieldAddOnly() {
-    int datasetId = 1;
-    DatasetDTO dataSetDTO = getDatasetDTO();
-    Dataset dataset = getDatasets().get(0);
-    dataSetDTO.setDatasetName(dataset.getName());
-    List<DatasetProperty> properties = new ArrayList<>(getDatasetProperties());
-    properties.remove(2);
-    properties.remove(2);
-    dataset.setProperties(new HashSet<>(properties));
-
-    List<DatasetPropertyDTO> updatedProperties = getDatasetPropertiesDTO();
-    updatedProperties.get(2).setPropertyValue("added value");
-    updatedProperties.get(3).setPropertyValue("added value");
-    dataSetDTO.setProperties(updatedProperties);
-
-    when(datasetDAO.findDatasetById(datasetId)).thenReturn(dataset);
-    when(datasetDAO.getMappedFieldsOrderByReceiveOrder()).thenReturn(getDictionaries());
-    initService();
-
-    Optional<Dataset> updated = datasetService.updateDataset(dataSetDTO, datasetId, 1);
-    assertNotNull(updated);
-    assertTrue(updated.isPresent());
-  }
-
-  @Test
-  void testUpdateDatasetMultiFieldDeleteOnly() {
-    int datasetId = 1;
-    DatasetDTO dataSetDTO = getDatasetDTO();
-    Dataset dataset = getDatasets().get(0);
-    dataset.setProperties(getDatasetProperties());
-    dataSetDTO.setDatasetName(dataset.getName());
-
-    List<DatasetPropertyDTO> updatedProperties = getDatasetPropertiesDTO();
-    updatedProperties.remove(2);
-    updatedProperties.remove(2);
-    dataSetDTO.setProperties(updatedProperties);
-
-    when(datasetDAO.findDatasetById(datasetId)).thenReturn(dataset);
-    when(datasetDAO.getMappedFieldsOrderByReceiveOrder()).thenReturn(getDictionaries());
-    initService();
-
-    Optional<Dataset> updated = datasetService.updateDataset(dataSetDTO, datasetId, 1);
-    assertNotNull(updated);
-    assertTrue(updated.isPresent());
-  }
-
-  @Test
-  void testUpdateDatasetNameModified() {
-    int datasetId = 1;
-    DatasetDTO datasetDTO = getDatasetDTO();
-    Dataset dataset = getDatasets().get(0);
-
-    //dataset properties are the same between the existing dataset and the update datasetDTO - no modification
-    Set<DatasetProperty> datasetProps = getDatasetProperties();
-    List<DatasetPropertyDTO> dtoProps = datasetProps.stream().map(p ->
-        new DatasetPropertyDTO(p.getPropertyKey().toString(), p.getPropertyValue().toString())
-    ).collect(Collectors.toList());
-    datasetDTO.setProperties(dtoProps);
-    dataset.setProperties(datasetProps);
-
-    //datasetDTO given the updated name - existing dataset requires name to be modified
-    String name = RandomStringUtils.randomAlphabetic(10);
-    datasetDTO.setDatasetName(name);
-
-    when(datasetDAO.findDatasetById(datasetId)).thenReturn(dataset);
-    when(datasetDAO.getMappedFieldsOrderByReceiveOrder()).thenReturn(getDictionaries());
-    initService();
-
-    Optional<Dataset> updated = datasetService.updateDataset(datasetDTO, datasetId, 1);
-    assertNotNull(updated);
-    assertTrue(updated.isPresent());
-    verify(datasetDAO, times(1)).updateDataset(eq(datasetId), eq(name), any(), any(), any());
   }
 
   @Test
@@ -690,58 +545,4 @@ class DatasetServiceTest {
           return dataset;
         }).collect(Collectors.toList());
   }
-
-  private List<DatasetDTO> getDatasetDTOs() {
-    return IntStream.range(1, 3)
-        .mapToObj(i -> {
-          DatasetDTO dataset = new DatasetDTO();
-          dataset.setDatasetId(i);
-          DatasetPropertyDTO nameProperty = new DatasetPropertyDTO("Dataset Name",
-              "Test Dataset " + i);
-          dataset.setProperties(Collections.singletonList(nameProperty));
-          return dataset;
-        }).collect(Collectors.toList());
-  }
-
-  private Set<DatasetProperty> getDatasetProperties() {
-    return IntStream.range(1, 11)
-        .mapToObj(i -> {
-              DatasetProperty prop = new DatasetProperty(1,
-                  i,
-                  "Test Value" + RandomStringUtils.randomAlphanumeric(25),
-                  PropertyType.String,
-                  new Date());
-              prop.setPropertyName(RandomStringUtils.randomAlphanumeric(15));
-              prop.setPropertyId(i);
-              return prop;
-            }
-        ).collect(Collectors.toSet());
-  }
-
-  private List<DatasetPropertyDTO> getDatasetPropertiesDTO() {
-    List<Dictionary> dictionaries = getDictionaries();
-    return dictionaries.stream()
-        .map(d ->
-            new DatasetPropertyDTO(d.getKey(), "Test Value")
-        ).collect(Collectors.toList());
-  }
-
-  private DatasetDTO getDatasetDTO() {
-    DatasetDTO datasetDTO = new DatasetDTO();
-    datasetDTO.setDatasetId(1);
-    datasetDTO.setObjectId("Test ObjectId");
-    datasetDTO.setProperties(getDatasetPropertiesDTO());
-    DataUse dataUse = new DataUse();
-    dataUse.setGeneralUse(true);
-    datasetDTO.setDataUse(dataUse);
-    return datasetDTO;
-  }
-
-  private List<Dictionary> getDictionaries() {
-    return IntStream.range(1, 11)
-        .mapToObj(i ->
-            new Dictionary(i, String.valueOf(i), true, i, i)
-        ).collect(Collectors.toList());
-  }
-
 }


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-942

### Summary
This PR removes an unused, deprecated API for updating dataset entities along with a ton of associated supporting code.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
