### PR TITLE
DT-945: Handle Update Study Registration Better

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/models/dataset_registration_v1/ConsentGroup.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/dataset_registration_v1/ConsentGroup.java
@@ -11,7 +11,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
@@ -849,25 +848,6 @@ public class ConsentGroup {
         return constant;
       }
     }
-  }
-
-  public boolean isInvalidForUpdate() {
-    return Objects.nonNull(this.accessManagement) ||
-        Objects.nonNull(this.generalResearchUse) ||
-        Objects.nonNull(this.hmb) ||
-        (Objects.nonNull(this.diseaseSpecificUse) && this.diseaseSpecificUse.size() > 0) ||
-        Objects.nonNull(this.poa) ||
-        Objects.nonNull(this.otherPrimary) ||
-        Objects.nonNull(this.nmds) ||
-        Objects.nonNull(this.gso) ||
-        Objects.nonNull(this.pub) ||
-        Objects.nonNull(this.col) ||
-        Objects.nonNull(this.irb) ||
-        Objects.nonNull(this.gs) ||
-        Objects.nonNull(this.mor) ||
-        Objects.nonNull(this.morDate) ||
-        Objects.nonNull(this.npu) ||
-        Objects.nonNull(this.otherSecondary);
   }
 
 }

--- a/src/main/java/org/broadinstitute/consent/http/models/dataset_registration_v1/DatasetRegistrationSchemaV1UpdateValidator.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/dataset_registration_v1/DatasetRegistrationSchemaV1UpdateValidator.java
@@ -1,5 +1,8 @@
 package org.broadinstitute.consent.http.models.dataset_registration_v1;
 
+import com.google.gson.ExclusionStrategy;
+import com.google.gson.FieldAttributes;
+import com.google.gson.Gson;
 import jakarta.ws.rs.BadRequestException;
 import java.util.HashSet;
 import java.util.List;
@@ -11,6 +14,7 @@ import org.broadinstitute.consent.http.models.Dataset;
 import org.broadinstitute.consent.http.models.Study;
 import org.broadinstitute.consent.http.models.dataset_registration_v1.DatasetRegistrationSchemaV1.NihAnvilUse;
 import org.broadinstitute.consent.http.service.DatasetService;
+import org.broadinstitute.consent.http.util.gson.GsonUtil;
 
 public class DatasetRegistrationSchemaV1UpdateValidator {
 
@@ -18,6 +22,51 @@ public class DatasetRegistrationSchemaV1UpdateValidator {
 
   public DatasetRegistrationSchemaV1UpdateValidator(DatasetService datasetService) {
     this.datasetService = datasetService;
+  }
+
+  /**
+   * Create a registration object suitable for the Update operation
+   *
+   * @param json DatasetRegistrationSchemaV1 in JSON format
+   * @return DatasetRegistrationSchemaV1
+   */
+  public DatasetRegistrationSchemaV1 deserializeRegistration(String json) {
+    ExclusionStrategy excludes = new ExclusionStrategy() {
+      final HashSet<String> exclusions = new HashSet<>(List.of(
+          "dataSubmitterUserId",
+          "accessManagement",
+          "col",
+          "dataAccessCommitteeId",
+          "datasetIdentifier",
+          "diseaseSpecificUse",
+          "generalResearchUse",
+          "gs",
+          "gso",
+          "hmb",
+          "irb",
+          "nmds",
+          "mor",
+          "morDate",
+          "npu",
+          "otherPrimary",
+          "otherSecondary",
+          "poa",
+          "pub"
+      ));
+
+      @Override
+      public boolean shouldSkipField(FieldAttributes fieldAttributes) {
+        return exclusions.contains(fieldAttributes.getName());
+      }
+
+      @Override
+      public boolean shouldSkipClass(Class<?> aClass) {
+        return false;
+      }
+    };
+    Gson gson = GsonUtil.gsonBuilderWithAdapters().addDeserializationExclusionStrategy(excludes)
+        .create();
+    return gson.fromJson(json, DatasetRegistrationSchemaV1.class);
   }
 
   public boolean validate(Study existingStudy, DatasetRegistrationSchemaV1 registration) {
@@ -29,8 +78,7 @@ public class DatasetRegistrationSchemaV1UpdateValidator {
       throw new BadRequestException("Invalid change to Study Name");
     }
 
-    // Not modifiable: Data Submitter Name/Email, Primary Data Use,
-    // Secondary Data Use
+    // Not modifiable: Data Submitter Name/Email
     if (registration.getDataSubmitterUserId() != null
         && !registration.getDataSubmitterUserId().equals(existingStudy.getCreateUserId())) {
       throw new BadRequestException("Invalid change to Data Submitter");
@@ -39,16 +87,6 @@ public class DatasetRegistrationSchemaV1UpdateValidator {
     // Minimum number of consent groups is 1
     if (registration.getConsentGroups().isEmpty()) {
       throw new BadRequestException("Invalid number of Consent Groups");
-    }
-
-    // Data use changes are not allowed for existing datasets
-    List<ConsentGroup> invalidConsentGroups = registration.getConsentGroups()
-        .stream()
-        .filter(cg -> Objects.nonNull(cg.getDatasetId()))
-        .filter(ConsentGroup::isInvalidForUpdate)
-        .toList();
-    if (!invalidConsentGroups.isEmpty()) {
-      throw new BadRequestException("Invalid Data Use changes to existing Consent Groups");
     }
 
     // Ensure that all consent group changes are for datasets in the current study
@@ -141,15 +179,8 @@ public class DatasetRegistrationSchemaV1UpdateValidator {
         throw new BadRequestException("NIH Grant of Contract Number is required");
       }
     }
-    if (Objects.isNull(registration.getPhenotypeIndication())) {
-      throw new BadRequestException("Phenotype Indication is required");
-    }
     if (Objects.isNull(registration.getPiName())) {
       throw new BadRequestException("Principal Investigator is required");
-    }
-    if (Objects.isNull(registration.getDataCustodianEmail()) || registration.getDataCustodianEmail()
-        .isEmpty()) {
-      throw new BadRequestException("Data Custodian Email is required");
     }
 
     return true;

--- a/src/main/java/org/broadinstitute/consent/http/models/dataset_registration_v1/DatasetRegistrationSchemaV1UpdateValidator.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/dataset_registration_v1/DatasetRegistrationSchemaV1UpdateValidator.java
@@ -3,7 +3,10 @@ package org.broadinstitute.consent.http.models.dataset_registration_v1;
 import com.google.gson.ExclusionStrategy;
 import com.google.gson.FieldAttributes;
 import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
 import jakarta.ws.rs.BadRequestException;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
@@ -24,16 +27,22 @@ public class DatasetRegistrationSchemaV1UpdateValidator {
     this.datasetService = datasetService;
   }
 
-  /**
-   * Create a registration object suitable for the Update operation
-   *
-   * @param json DatasetRegistrationSchemaV1 in JSON format
-   * @return DatasetRegistrationSchemaV1
-   */
-  public DatasetRegistrationSchemaV1 deserializeRegistration(String json) {
-    ExclusionStrategy exclusionStrategy = new ExclusionStrategy() {
+  private final ExclusionStrategy studyExclusionStrategy = new ExclusionStrategy() {
+    @Override
+    public boolean shouldSkipField(FieldAttributes fieldAttributes) {
+      return fieldAttributes.getName().equalsIgnoreCase("dataSubmitterUserId");
+    }
+
+    @Override
+    public boolean shouldSkipClass(Class<?> aClass) {
+      return aClass.getSimpleName().equalsIgnoreCase("ConsentGroup");
+    }
+  };
+
+  private final ExclusionStrategy consentGroupExclusionStrategy = new ExclusionStrategy() {
+    @Override
+    public boolean shouldSkipField(FieldAttributes fieldAttributes) {
       final HashSet<String> exclusions = new HashSet<>(List.of(
-          "dataSubmitterUserId",
           "accessManagement",
           "col",
           "dataAccessCommitteeId",
@@ -53,21 +62,50 @@ public class DatasetRegistrationSchemaV1UpdateValidator {
           "poa",
           "pub"
       ));
+      return exclusions.contains(fieldAttributes.getName());
+    }
 
-      @Override
-      public boolean shouldSkipField(FieldAttributes fieldAttributes) {
-        return exclusions.contains(fieldAttributes.getName());
-      }
+    @Override
+    public boolean shouldSkipClass(Class<?> aClass) {
+      return false;
+    }
+  };
 
-      @Override
-      public boolean shouldSkipClass(Class<?> aClass) {
-        return false;
-      }
-    };
-    Gson gson = GsonUtil.gsonBuilderWithAdapters()
-        .addDeserializationExclusionStrategy(exclusionStrategy)
+  /**
+   * Create a registration object suitable for the Update operation.
+   *
+   * @param json DatasetRegistrationSchemaV1 in JSON format
+   * @return DatasetRegistrationSchemaV1
+   */
+  public DatasetRegistrationSchemaV1 deserializeRegistration(String json) {
+    Gson studyGson = GsonUtil.gsonBuilderWithAdapters()
+        .addDeserializationExclusionStrategy(studyExclusionStrategy)
         .create();
-    return gson.fromJson(json, DatasetRegistrationSchemaV1.class);
+    // Create the registration without any ConsentGroups
+    DatasetRegistrationSchemaV1 registration = studyGson.fromJson(json,
+        DatasetRegistrationSchemaV1.class);
+    // Ensure that we have no null entries before parsing them.
+    registration.setConsentGroups(new ArrayList<>());
+
+    // Conditionally parse the consent groups
+    Gson gson = GsonUtil.getInstance();
+    Gson filteredCGGson = GsonUtil.gsonBuilderWithAdapters()
+        .addDeserializationExclusionStrategy(consentGroupExclusionStrategy).create();
+    JsonObject jsonObject = gson.fromJson(json, JsonObject.class);
+    JsonArray jsonArray = jsonObject.getAsJsonArray("consentGroups");
+    jsonArray.asList().forEach(jsonElement -> {
+      JsonObject cgJson = jsonElement.getAsJsonObject();
+      if (cgJson.has("datasetId")) {
+        // If we have a dataset id, we're updating. Filter out non-updatable fields
+        ConsentGroup cg = filteredCGGson.fromJson(cgJson, ConsentGroup.class);
+        registration.getConsentGroups().add(cg);
+      } else {
+        // If we have don't have a dataset id, we're trying to add a new one to the study.
+        ConsentGroup cg = gson.fromJson(cgJson, ConsentGroup.class);
+        registration.getConsentGroups().add(cg);
+      }
+    });
+    return registration;
   }
 
   public boolean validate(Study existingStudy, DatasetRegistrationSchemaV1 registration) {

--- a/src/main/java/org/broadinstitute/consent/http/models/dataset_registration_v1/DatasetRegistrationSchemaV1UpdateValidator.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/dataset_registration_v1/DatasetRegistrationSchemaV1UpdateValidator.java
@@ -93,18 +93,20 @@ public class DatasetRegistrationSchemaV1UpdateValidator {
         .addDeserializationExclusionStrategy(consentGroupExclusionStrategy).create();
     JsonObject jsonObject = gson.fromJson(json, JsonObject.class);
     JsonArray jsonArray = jsonObject.getAsJsonArray("consentGroups");
-    jsonArray.asList().forEach(jsonElement -> {
-      JsonObject cgJson = jsonElement.getAsJsonObject();
-      if (cgJson.has("datasetId")) {
-        // If we have a dataset id, we're updating. Filter out non-updatable fields
-        ConsentGroup cg = filteredCGGson.fromJson(cgJson, ConsentGroup.class);
-        registration.getConsentGroups().add(cg);
-      } else {
-        // If we have don't have a dataset id, we're trying to add a new one to the study.
-        ConsentGroup cg = gson.fromJson(cgJson, ConsentGroup.class);
-        registration.getConsentGroups().add(cg);
-      }
-    });
+    if (jsonArray != null) {
+      jsonArray.asList().forEach(jsonElement -> {
+        JsonObject cgJson = jsonElement.getAsJsonObject();
+        if (cgJson.has("datasetId")) {
+          // If we have a dataset id, we're updating. Filter out non-updatable fields
+          ConsentGroup cg = filteredCGGson.fromJson(cgJson, ConsentGroup.class);
+          registration.getConsentGroups().add(cg);
+        } else {
+          // If we have don't have a dataset id, we're trying to add a new one to the study.
+          ConsentGroup cg = gson.fromJson(cgJson, ConsentGroup.class);
+          registration.getConsentGroups().add(cg);
+        }
+      });
+    }
     return registration;
   }
 

--- a/src/main/java/org/broadinstitute/consent/http/models/dataset_registration_v1/DatasetRegistrationSchemaV1UpdateValidator.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/dataset_registration_v1/DatasetRegistrationSchemaV1UpdateValidator.java
@@ -31,7 +31,7 @@ public class DatasetRegistrationSchemaV1UpdateValidator {
    * @return DatasetRegistrationSchemaV1
    */
   public DatasetRegistrationSchemaV1 deserializeRegistration(String json) {
-    ExclusionStrategy excludes = new ExclusionStrategy() {
+    ExclusionStrategy exclusionStrategy = new ExclusionStrategy() {
       final HashSet<String> exclusions = new HashSet<>(List.of(
           "dataSubmitterUserId",
           "accessManagement",
@@ -64,7 +64,8 @@ public class DatasetRegistrationSchemaV1UpdateValidator {
         return false;
       }
     };
-    Gson gson = GsonUtil.gsonBuilderWithAdapters().addDeserializationExclusionStrategy(excludes)
+    Gson gson = GsonUtil.gsonBuilderWithAdapters()
+        .addDeserializationExclusionStrategy(exclusionStrategy)
         .create();
     return gson.fromJson(json, DatasetRegistrationSchemaV1.class);
   }

--- a/src/main/java/org/broadinstitute/consent/http/models/dataset_registration_v1/DatasetRegistrationSchemaV1UpdateValidator.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/dataset_registration_v1/DatasetRegistrationSchemaV1UpdateValidator.java
@@ -16,6 +16,7 @@ import org.apache.commons.collections4.SetUtils;
 import org.broadinstitute.consent.http.models.Dataset;
 import org.broadinstitute.consent.http.models.Study;
 import org.broadinstitute.consent.http.models.dataset_registration_v1.DatasetRegistrationSchemaV1.NihAnvilUse;
+import org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder;
 import org.broadinstitute.consent.http.service.DatasetService;
 import org.broadinstitute.consent.http.util.gson.GsonUtil;
 
@@ -43,24 +44,24 @@ public class DatasetRegistrationSchemaV1UpdateValidator {
     @Override
     public boolean shouldSkipField(FieldAttributes fieldAttributes) {
       final HashSet<String> exclusions = new HashSet<>(List.of(
-          "accessManagement",
-          "col",
-          "dataAccessCommitteeId",
-          "datasetIdentifier",
-          "diseaseSpecificUse",
-          "generalResearchUse",
-          "gs",
-          "gso",
-          "hmb",
-          "irb",
-          "nmds",
-          "mor",
-          "morDate",
-          "npu",
-          "otherPrimary",
-          "otherSecondary",
-          "poa",
-          "pub"
+          DatasetRegistrationSchemaV1Builder.accessManagement,
+          DatasetRegistrationSchemaV1Builder.col,
+          DatasetRegistrationSchemaV1Builder.dataAccessCommitteeId,
+          DatasetRegistrationSchemaV1Builder.datasetIdentifier,
+          DatasetRegistrationSchemaV1Builder.diseaseSpecificUse,
+          DatasetRegistrationSchemaV1Builder.generalResearchUse,
+          DatasetRegistrationSchemaV1Builder.gs,
+          DatasetRegistrationSchemaV1Builder.gso,
+          DatasetRegistrationSchemaV1Builder.hmb,
+          DatasetRegistrationSchemaV1Builder.irb,
+          DatasetRegistrationSchemaV1Builder.nmds,
+          DatasetRegistrationSchemaV1Builder.mor,
+          DatasetRegistrationSchemaV1Builder.morDate,
+          DatasetRegistrationSchemaV1Builder.npu,
+          DatasetRegistrationSchemaV1Builder.otherPrimary,
+          DatasetRegistrationSchemaV1Builder.otherSecondary,
+          DatasetRegistrationSchemaV1Builder.pub,
+          DatasetRegistrationSchemaV1Builder.poa
       ));
       return exclusions.contains(fieldAttributes.getName());
     }

--- a/src/main/java/org/broadinstitute/consent/http/models/dataset_registration_v1/builder/DatasetRegistrationSchemaV1Builder.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/dataset_registration_v1/builder/DatasetRegistrationSchemaV1Builder.java
@@ -54,6 +54,7 @@ public class DatasetRegistrationSchemaV1Builder {
   public static final String npu = "npu";
   public static final String otherSecondary = "otherSecondary";
   public static final String dataAccessCommitteeId = "dataAccessCommitteeId";
+  public static final String datasetIdentifier = "datasetIdentifier";
   public static final String dataLocation = "dataLocation";
   public static final String url = "url";
   public static final String numberOfParticipants = "numberOfParticipants";

--- a/src/main/java/org/broadinstitute/consent/http/resources/StudyResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/StudyResource.java
@@ -210,9 +210,7 @@ public class StudyResource extends Resource {
       // Manually validate the schema from an editing context. Validation with the schema tools
       // enforces it in a creation context but doesn't work for editing purposes.
       DatasetRegistrationSchemaV1UpdateValidator updateValidator = new DatasetRegistrationSchemaV1UpdateValidator(datasetService);
-      Gson gson = GsonUtil.gsonBuilderWithAdapters().create();
-      DatasetRegistrationSchemaV1 registration = gson.fromJson(json,
-          DatasetRegistrationSchemaV1.class);
+      DatasetRegistrationSchemaV1 registration = updateValidator.deserializeRegistration(json);
 
       if (updateValidator.validate(existingStudy, registration)) {
         // Update study from registration

--- a/src/main/resources/assets/paths/datasetByIdDataUse.yaml
+++ b/src/main/resources/assets/paths/datasetByIdDataUse.yaml
@@ -1,5 +1,6 @@
 put:
   summary: Admin Only API to update the Dataset's Data Use object from JSON
+  operationId: updateDatasetDataUse
   description: | 
     Admin Only API to update the Dataset's Data Use object from JSON.
     ## Note

--- a/src/main/resources/assets/paths/studyById.yaml
+++ b/src/main/resources/assets/paths/studyById.yaml
@@ -40,12 +40,15 @@ put:
       is also provided, then alternative data sharing information is required in the registration 
       schema. Study Names can be updated, but they must be unique in the system. 
       See [/api/dataset/studyNames](#/Study/findAllStudyNames) for a list of existing study names.
+      Data Use fields can only be modified using Admin permissions. See 
+      [/api/dataset/{id}/datause](#/Admin/updateDatasetDataUse) to update a dataset's Data Use.
       
       The following fields are not modifiable:
       * Data Submitter Name/Email
-      * Primary Data Use
-      * Secondary Data Use
+      * All Data Use fields (if any are provided, they will be ignored)
+      * Access Management (if provided, it will be ignored)
       * Consent Group Name
+      * Data Access Committee Id
       
       Additionally, existing Consent Groups cannot be removed from the study, but new ones can be
       added.

--- a/src/test/java/org/broadinstitute/consent/http/models/dataset_registration_v1/DatasetRegistrationSchemaV1UpdateValidatorTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/dataset_registration_v1/DatasetRegistrationSchemaV1UpdateValidatorTest.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.consent.http.models.dataset_registration_v1;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -109,6 +110,35 @@ class DatasetRegistrationSchemaV1UpdateValidatorTest {
                   "functionalEquivalence": null
                 }
               ]
+            },
+            {
+              "consentGroupName": "All of Us (Controlled+ Tier) - Set 2",
+              "accessManagement": "OPEN",
+              "generalResearchUse": true,
+              "hmb": false,
+              "diseaseSpecificUse": ["https://disease-ontology.org/term/DOID:162/"],
+              "poa": true,
+              "otherPrimary": "String",
+              "nmds": true,
+              "gso": false,
+              "pub": false,
+              "col": false,
+              "irb": false,
+              "gs": "GS",
+              "mor": true,
+              "morDate": "More Date",
+              "npu": false,
+              "otherSecondary": "String",
+              "dataAccessCommitteeId": 99,
+              "dataLocation": "TDR_LOCATION",
+              "url": "https://abcnews.com",
+              "numberOfParticipants": 2,
+              "fileTypes": [
+                {
+                  "fileType": null,
+                  "functionalEquivalence": null
+                }
+              ]
             }
           ]
         }
@@ -137,6 +167,27 @@ class DatasetRegistrationSchemaV1UpdateValidatorTest {
     assertNotNull(registration.getStudyName());
     assertNotNull(registration.getPublicVisibility());
     assertNotNull(registration.getConsentGroups().get(0).getDatasetId());
+    // Assert that the second consent group is populated with data use values
+    assertNotNull(registration.getConsentGroups().get(1).getAccessManagement());
+    assertNotNull(registration.getConsentGroups().get(1).getCol());
+    assertNotNull(registration.getConsentGroups().get(1).getDataAccessCommitteeId());
+    assertFalse(registration.getConsentGroups().get(1).getDiseaseSpecificUse().isEmpty());
+    assertNotNull(registration.getConsentGroups().get(1).getGeneralResearchUse());
+    assertNotNull(registration.getConsentGroups().get(1).getGso());
+    assertNotNull(registration.getConsentGroups().get(1).getGs());
+    assertNotNull(registration.getConsentGroups().get(1).getHmb());
+    assertNotNull(registration.getConsentGroups().get(1).getIrb());
+    assertNotNull(registration.getConsentGroups().get(1).getMor());
+    assertNotNull(registration.getConsentGroups().get(1).getMorDate());
+    assertNotNull(registration.getConsentGroups().get(1).getNmds());
+    assertNotNull(registration.getConsentGroups().get(1).getNpu());
+    assertNotNull(registration.getConsentGroups().get(1).getOtherPrimary());
+    assertNotNull(registration.getConsentGroups().get(1).getOtherSecondary());
+    assertNotNull(registration.getConsentGroups().get(1).getPoa());
+    assertNotNull(registration.getConsentGroups().get(1).getPub());
+    assertNotNull(registration.getConsentGroups().get(1).getDataLocation());
+    assertNotNull(registration.getConsentGroups().get(1).getUrl());
+    assertFalse(registration.getConsentGroups().get(1).getFileTypes().isEmpty());
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/models/dataset_registration_v1/DatasetRegistrationSchemaV1UpdateValidatorTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/dataset_registration_v1/DatasetRegistrationSchemaV1UpdateValidatorTest.java
@@ -1,5 +1,7 @@
 package org.broadinstitute.consent.http.models.dataset_registration_v1;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
@@ -13,7 +15,6 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.RandomUtils;
 import org.broadinstitute.consent.http.models.Dataset;
 import org.broadinstitute.consent.http.models.Study;
-import org.broadinstitute.consent.http.models.dataset_registration_v1.ConsentGroup.AccessManagement;
 import org.broadinstitute.consent.http.models.dataset_registration_v1.ConsentGroup.DataLocation;
 import org.broadinstitute.consent.http.models.dataset_registration_v1.DatasetRegistrationSchemaV1.NihAnvilUse;
 import org.broadinstitute.consent.http.service.DatasetService;
@@ -33,6 +34,109 @@ class DatasetRegistrationSchemaV1UpdateValidatorTest {
   @BeforeEach
   void setUp() {
     validator = new DatasetRegistrationSchemaV1UpdateValidator(datasetService);
+  }
+
+  @Test
+  void testValidation_knownFieldsExcluded() {
+    String json = """
+        {
+          "studyId": 6077,
+          "studyName": "All of Us (Controlled+ Tier)",
+          "studyType": null,
+          "studyDescription": "This study and dataset(s) represents the All of Us controlled+ tier data",
+          "dataTypes": [
+            "Whole Genome (WGS)"
+          ],
+          "phenotypeIndication": "NA",
+          "species": "Human",
+          "piName": "Paul Harris, Melissa Basford",
+          "dataSubmitterUserId": 3396,
+          "dataCustodianEmail": ["email@test.com"],
+          "publicVisibility": true,
+          "nihAnvilUse": "I_AM_NOT_NHGRI_FUNDED_AND_DO_NOT_PLAN_TO_STORE_DATA_IN_AN_VIL",
+          "submittingToAnvil": null,
+          "dbGaPPhsID": null,
+          "dbGaPStudyRegistrationName": null,
+          "embargoReleaseDate": null,
+          "sequencingCenter": null,
+          "piInstitution": null,
+          "nihGrantContractNumber": null,
+          "nihICsSupportingStudy": [],
+          "nihProgramOfficerName": null,
+          "nihInstitutionCenterSubmission": null,
+          "nihGenomicProgramAdministratorName": null,
+          "multiCenterStudy": null,
+          "collaboratingSites": [],
+          "controlledAccessRequiredForGenomicSummaryResultsGSR": null,
+          "controlledAccessRequiredForGenomicSummaryResultsGSRRequiredExplanation": null,
+          "alternativeDataSharingPlan": null,
+          "alternativeDataSharingPlanReasons": [],
+          "alternativeDataSharingPlanExplanation": null,
+          "alternativeDataSharingPlanFileName": null,
+          "alternativeDataSharingPlanDataSubmitted": null,
+          "alternativeDataSharingPlanDataReleased": null,
+          "alternativeDataSharingPlanTargetDeliveryDate": null,
+          "alternativeDataSharingPlanTargetPublicReleaseDate": null,
+          "alternativeDataSharingPlanAccessManagement": null,
+          "consentGroups": [
+            {
+              "datasetId": 2583,
+              "datasetIdentifier": "DUOS-001078",
+              "consentGroupName": "All of Us (Controlled+ Tier) - Set 1",
+              "accessManagement": "OPEN",
+              "generalResearchUse": true,
+              "hmb": false,
+              "diseaseSpecificUse": ["https://disease-ontology.org/term/DOID:162/"],
+              "poa": true,
+              "otherPrimary": "String",
+              "nmds": true,
+              "gso": false,
+              "pub": false,
+              "col": false,
+              "irb": false,
+              "gs": "GS",
+              "mor": true,
+              "morDate": "More Date",
+              "npu": false,
+              "otherSecondary": "String",
+              "dataAccessCommitteeId": 99,
+              "dataLocation": "TDR_LOCATION",
+              "url": "https://abcnews.com",
+              "numberOfParticipants": 2,
+              "fileTypes": [
+                {
+                  "fileType": null,
+                  "functionalEquivalence": null
+                }
+              ]
+            }
+          ]
+        }
+        """;
+    DatasetRegistrationSchemaV1 registration = validator.deserializeRegistration(json);
+    assertNull(registration.getDataSubmitterUserId());
+    assertNull(registration.getConsentGroups().get(0).getAccessManagement());
+    assertNull(registration.getConsentGroups().get(0).getCol());
+    assertNull(registration.getConsentGroups().get(0).getDataAccessCommitteeId());
+    assertNull(registration.getConsentGroups().get(0).getDatasetIdentifier());
+    assertTrue(registration.getConsentGroups().get(0).getDiseaseSpecificUse().isEmpty());
+    assertNull(registration.getConsentGroups().get(0).getGeneralResearchUse());
+    assertNull(registration.getConsentGroups().get(0).getGso());
+    assertNull(registration.getConsentGroups().get(0).getGs());
+    assertNull(registration.getConsentGroups().get(0).getHmb());
+    assertNull(registration.getConsentGroups().get(0).getIrb());
+    assertNull(registration.getConsentGroups().get(0).getMor());
+    assertNull(registration.getConsentGroups().get(0).getMorDate());
+    assertNull(registration.getConsentGroups().get(0).getNmds());
+    assertNull(registration.getConsentGroups().get(0).getNpu());
+    assertNull(registration.getConsentGroups().get(0).getOtherPrimary());
+    assertNull(registration.getConsentGroups().get(0).getOtherSecondary());
+    assertNull(registration.getConsentGroups().get(0).getPoa());
+    assertNull(registration.getConsentGroups().get(0).getPub());
+    // Spot check some of the non-null expectations
+    assertNotNull(registration.getStudyName());
+    assertNotNull(registration.getPublicVisibility());
+    assertNotNull(registration.getConsentGroups().get(0).getDatasetId());
   }
 
   @Test
@@ -80,17 +184,6 @@ class DatasetRegistrationSchemaV1UpdateValidatorTest {
   }
 
   @Test
-  void testValidation_invalid_data_use_changes() {
-    Study study = createMockStudy();
-    DatasetRegistrationSchemaV1 registration = createMockRegistration(study);
-    registration.getConsentGroups().get(0).setGeneralResearchUse(true);
-
-    assertThrows(BadRequestException.class, () -> {
-      validator.validate(study, registration);
-    });
-  }
-
-  @Test
   void testValidation_non_study_dataset() {
     Study study = createMockStudy();
     DatasetRegistrationSchemaV1 registration = createMockRegistration(study);
@@ -106,7 +199,9 @@ class DatasetRegistrationSchemaV1UpdateValidatorTest {
   void testValidation_consent_group_name_change_allowed() {
     Study study = createMockStudy();
     DatasetRegistrationSchemaV1 registration = createMockRegistration(study);
-    study.getDatasets().forEach(d -> { d.setName("");});
+    study.getDatasets().forEach(d -> {
+      d.setName("");
+    });
 
     boolean valid = validator.validate(study, registration);
     assertTrue(valid);
@@ -116,19 +211,8 @@ class DatasetRegistrationSchemaV1UpdateValidatorTest {
   void testValidation_consent_group_name_change_not_allowed() {
     Study study = createMockStudy();
     DatasetRegistrationSchemaV1 registration = createMockRegistration(study);
-    study.getDatasets().forEach(d -> { d.setName("Existing Name");});
-
-    assertThrows(BadRequestException.class, () -> {
-      validator.validate(study, registration);
-    });
-  }
-
-  @Test
-  void testValidation_consent_group_access_management_not_allowed() {
-    Study study = createMockStudy();
-    DatasetRegistrationSchemaV1 registration = createMockRegistration(study);
-    registration.getConsentGroups().forEach(cg -> {
-      cg.setAccessManagement(AccessManagement.CONTROLLED);
+    study.getDatasets().forEach(d -> {
+      d.setName("Existing Name");
     });
 
     assertThrows(BadRequestException.class, () -> {
@@ -255,7 +339,8 @@ class DatasetRegistrationSchemaV1UpdateValidatorTest {
   void testValidation_pi_institution() {
     Study study = createMockStudy();
     DatasetRegistrationSchemaV1 registration = createMockRegistration(study);
-    registration.setNihAnvilUse(NihAnvilUse.I_AM_NOT_NHGRI_FUNDED_BUT_I_AM_SEEKING_TO_SUBMIT_DATA_TO_AN_VIL);
+    registration.setNihAnvilUse(
+        NihAnvilUse.I_AM_NOT_NHGRI_FUNDED_BUT_I_AM_SEEKING_TO_SUBMIT_DATA_TO_AN_VIL);
     registration.setPiInstitution(null);
 
     assertThrows(BadRequestException.class, () -> {
@@ -267,20 +352,10 @@ class DatasetRegistrationSchemaV1UpdateValidatorTest {
   void testValidation_pi_institution_nih_grant_contract_number() {
     Study study = createMockStudy();
     DatasetRegistrationSchemaV1 registration = createMockRegistration(study);
-    registration.setNihAnvilUse(NihAnvilUse.I_AM_NOT_NHGRI_FUNDED_BUT_I_AM_SEEKING_TO_SUBMIT_DATA_TO_AN_VIL);
+    registration.setNihAnvilUse(
+        NihAnvilUse.I_AM_NOT_NHGRI_FUNDED_BUT_I_AM_SEEKING_TO_SUBMIT_DATA_TO_AN_VIL);
     registration.setPiInstitution(RandomUtils.nextInt(10, 100));
     registration.setNihGrantContractNumber(null);
-
-    assertThrows(BadRequestException.class, () -> {
-      validator.validate(study, registration);
-    });
-  }
-
-  @Test
-  void testValidation_phenotype_indication() {
-    Study study = createMockStudy();
-    DatasetRegistrationSchemaV1 registration = createMockRegistration(study);
-    registration.setPhenotypeIndication(null);
 
     assertThrows(BadRequestException.class, () -> {
       validator.validate(study, registration);
@@ -297,19 +372,6 @@ class DatasetRegistrationSchemaV1UpdateValidatorTest {
       validator.validate(study, registration);
     });
   }
-
-  @Test
-  void testValidation_data_custodian_email() {
-    Study study = createMockStudy();
-    DatasetRegistrationSchemaV1 registration = createMockRegistration(study);
-    registration.setDataCustodianEmail(List.of());
-
-    assertThrows(BadRequestException.class, () -> {
-      validator.validate(study, registration);
-    });
-  }
-
-
 
   private Study createMockStudy() {
     Study study = new Study();


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-945

### Summary
This PR makes some changes to the Update Study API to fix a few bugs. As a result of updating a production study (see [DT-941](https://broadworkbench.atlassian.net/browse/DT-941)), there was a non-trivial amount of hand-editing the JSON to get around incorrect validation rules. This PR fixes that to make updates a lot more smoother in the future.

* Phenotype is not a required field
* Data Custodian Email  is not a required field
* If the consent group (i.e. dataset) is being updated:
  * All data use related fields are ignored
  * Access management changes are ignored
* If the consent group (i.e. dataset) is a new entity, all data use and access management values are preserved.
* Everything else provided in the study is valid for update.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment


[DT-941]: https://broadworkbench.atlassian.net/browse/DT-941?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ