### PR TITLE
DT-950: Handle NPE in delete study API

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/resources/StudyResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/StudyResource.java
@@ -148,7 +148,7 @@ public class StudyResource extends Resource {
         throw new NotFoundException("Study not found");
       }
 
-      boolean deletable = study.getDatasets()
+      boolean deletable = (study.getDatasets() == null || study.getDatasets().isEmpty()) || study.getDatasets()
           .stream()
           .allMatch(Dataset::getDeletable);
       if (!deletable) {

--- a/src/main/java/org/broadinstitute/consent/http/resources/StudyResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/StudyResource.java
@@ -157,13 +157,15 @@ public class StudyResource extends Resource {
       Set<Integer> studyDatasetIds = study.getDatasetIds();
       datasetService.deleteStudy(study, user);
       // Remove from ES index
-      studyDatasetIds.forEach(id -> {
-        try {
-          elasticSearchService.deleteIndex(id);
-        } catch (IOException e) {
-          logException(e);
-        }
-      });
+      if (studyDatasetIds != null) {
+        studyDatasetIds.forEach(id -> {
+          try {
+            elasticSearchService.deleteIndex(id);
+          } catch (IOException e) {
+            logException(e);
+          }
+        });
+      }
       return Response.ok().build();
     } catch (Exception e) {
       return createExceptionResponse(e);

--- a/src/test/java/org/broadinstitute/consent/http/resources/StudyResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/StudyResourceTest.java
@@ -277,6 +277,24 @@ class StudyResourceTest {
   }
 
   @Test
+  void testDeleteStudyByIdNullDatasets() throws Exception {
+    Study study = new Study();
+    study.setStudyId(1);
+    when(datasetService.getStudyWithDatasetsById(any())).thenReturn(study);
+    User admin = new User();
+    admin.setAdminRole();
+    admin.setUserId(study.getCreateUserId());
+    when(userService.findUserByEmail(any())).thenReturn(admin);
+    initResource();
+
+    try (Response response = resource.deleteStudyById(authUser, study.getStudyId())) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+      verify(elasticSearchService, never()).deleteIndex(any());
+    }
+  }
+
+
+  @Test
   void testDeleteStudyByIdNoDatasets() throws Exception {
     Study study = createMockStudy();
     study.setDatasetIds(Set.of());

--- a/src/test/java/org/broadinstitute/consent/http/resources/StudyResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/StudyResourceTest.java
@@ -18,7 +18,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.broadinstitute.consent.http.enumeration.PropertyType;
-import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.AuthUser;
 import org.broadinstitute.consent.http.models.DataUse;
 import org.broadinstitute.consent.http.models.Dataset;

--- a/src/test/java/org/broadinstitute/consent/http/resources/StudyResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/StudyResourceTest.java
@@ -2,18 +2,23 @@ package org.broadinstitute.consent.http.resources;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.api.client.http.HttpStatusCodes;
 import com.google.gson.Gson;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.core.Response;
+import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.broadinstitute.consent.http.enumeration.PropertyType;
+import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.AuthUser;
 import org.broadinstitute.consent.http.models.DataUse;
 import org.broadinstitute.consent.http.models.Dataset;
@@ -208,6 +213,105 @@ class StudyResourceTest {
     Response response = resource.updateStudyByRegistration(authUser, null, 1, input);
     assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
   }
+
+  @Test
+  void testDeleteStudyById() throws Exception {
+    Study study = createMockStudy();
+    study.getDatasets().forEach(d -> d.setDeletable(true));
+    when(datasetService.getStudyWithDatasetsById(any())).thenReturn(study);
+    User admin = new User();
+    admin.setAdminRole();
+    admin.setUserId(study.getCreateUserId());
+    when(userService.findUserByEmail(any())).thenReturn(admin);
+    initResource();
+
+    try (Response response = resource.deleteStudyById(authUser, study.getStudyId())) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+      verify(elasticSearchService, atLeastOnce()).deleteIndex(any());
+    }
+  }
+
+  @Test
+  void testDeleteStudyByIdNotFound() throws Exception {
+    Study study = createMockStudy();
+    initResource();
+
+    try (Response response = resource.deleteStudyById(authUser, study.getStudyId())) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
+      verify(elasticSearchService, never()).deleteIndex(any());
+    }
+  }
+
+  @Test
+  void testDeleteStudyByIdNonCreatorNonAdmin() throws Exception {
+    Study study = createMockStudy();
+    study.getDatasets().forEach(d -> d.setDeletable(true));
+    when(datasetService.getStudyWithDatasetsById(any())).thenReturn(study);
+    User chair = new User();
+    chair.setChairpersonRole();
+    chair.setUserId(study.getCreateUserId() + 1);
+    when(userService.findUserByEmail(any())).thenReturn(chair);
+    initResource();
+
+    try (Response response = resource.deleteStudyById(authUser, study.getStudyId())) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
+      verify(elasticSearchService, never()).deleteIndex(any());
+    }
+  }
+
+  @Test
+  void testDeleteStudyByIdNotDeletable() throws Exception {
+    Study study = createMockStudy();
+    study.getDatasets().forEach(d -> d.setDeletable(false));
+    when(datasetService.getStudyWithDatasetsById(any())).thenReturn(study);
+    User admin = new User();
+    admin.setAdminRole();
+    admin.setUserId(study.getCreateUserId());
+    when(userService.findUserByEmail(any())).thenReturn(admin);
+    initResource();
+
+    try (Response response = resource.deleteStudyById(authUser, study.getStudyId())) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
+      verify(elasticSearchService, never()).deleteIndex(any());
+    }
+  }
+
+  @Test
+  void testDeleteStudyByIdNoDatasets() throws Exception {
+    Study study = createMockStudy();
+    study.setDatasetIds(Set.of());
+    study.getDatasets().clear();
+    when(datasetService.getStudyWithDatasetsById(any())).thenReturn(study);
+    User admin = new User();
+    admin.setAdminRole();
+    admin.setUserId(study.getCreateUserId());
+    when(userService.findUserByEmail(any())).thenReturn(admin);
+    initResource();
+
+    try (Response response = resource.deleteStudyById(authUser, study.getStudyId())) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+      verify(elasticSearchService, never()).deleteIndex(any());
+    }
+  }
+
+  @Test
+  void testDeleteStudyByIdElasticSearchFailure() throws Exception {
+    Study study = createMockStudy();
+    study.getDatasets().forEach(d -> d.setDeletable(true));
+    when(datasetService.getStudyWithDatasetsById(any())).thenReturn(study);
+    User admin = new User();
+    admin.setAdminRole();
+    admin.setUserId(study.getCreateUserId());
+    when(userService.findUserByEmail(any())).thenReturn(admin);
+    when(elasticSearchService.deleteIndex(any())).thenThrow(new IOException());
+    initResource();
+
+    try (Response response = resource.deleteStudyById(authUser, study.getStudyId())) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+      verify(elasticSearchService, atLeastOnce()).deleteIndex(any());
+    }
+  }
+
 
   /*
    * Study mock


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-950

### Summary
The DELETE study api is expecting that all studies have datasets although this is not enforced in the code. This PR allows the delete to continue if there are no datasets in the study. It also adds tests to complete the coverage of this endpoint.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
