### PR TITLE
[DT-970] Draft renaming + returning draft type in summary list.

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/DraftDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DraftDAO.java
@@ -27,7 +27,7 @@ import org.jdbi.v3.sqlobject.transaction.Transactional;
 public interface DraftDAO extends Transactional<DraftDAO> {
 
   String DRAFT_SUMMARY = """
-      SELECT ds.name, ds.create_date, ds.uuid, ds.update_date
+      SELECT ds.name, ds.create_date, ds.uuid, ds.update_date, ds.draft_type
       FROM draft ds
       WHERE ds.create_user_id = :createdUserId
       ORDER BY ds.update_date DESC

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DraftSummaryMapper.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DraftSummaryMapper.java
@@ -5,6 +5,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Date;
 import java.util.UUID;
+import org.broadinstitute.consent.http.enumeration.DraftType;
 import org.broadinstitute.consent.http.models.DraftSummary;
 import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.core.statement.StatementContext;
@@ -18,7 +19,8 @@ public class DraftSummaryMapper implements RowMapper<DraftSummary>,
     UUID uuid = UUID.fromString(rs.getString("uuid"));
     Date createDate = rs.getTimestamp("create_date");
     Date updateDate = hasColumn(rs, "update_date") ? rs.getTimestamp("update_date") : null;
+    DraftType draftType = DraftType.fromValue(rs.getString("draft_type"));
 
-    return new DraftSummary(uuid, name, createDate, updateDate);
+    return new DraftSummary(uuid, name, createDate, updateDate, draftType);
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/models/DraftSummary.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DraftSummary.java
@@ -2,6 +2,7 @@ package org.broadinstitute.consent.http.models;
 
 import java.util.Date;
 import java.util.UUID;
+import org.broadinstitute.consent.http.enumeration.DraftType;
 
 public class DraftSummary {
 
@@ -9,12 +10,14 @@ public class DraftSummary {
   private String name;
   private Date createDate;
   private Date updateDate;
+  private DraftType draftType;
 
-  public DraftSummary(UUID id, String name, Date createDate, Date updateDate) {
+  public DraftSummary(UUID id, String name, Date createDate, Date updateDate, DraftType draftType) {
     this.setId(id);
     this.setName(name);
     this.setCreateDate(createDate);
     this.setUpdateDate(updateDate);
+    this.setDraftType(draftType);
   }
 
   public UUID getId() {
@@ -48,4 +51,8 @@ public class DraftSummary {
   public void setUpdateDate(Date updateDate) {
     this.updateDate = updateDate;
   }
+
+  public DraftType getDraftType() { return draftType; }
+
+  public void setDraftType(DraftType draftType) { this.draftType = draftType; }
 }

--- a/src/main/java/org/broadinstitute/consent/http/resources/DraftResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DraftResource.java
@@ -124,6 +124,7 @@ public class DraftResource extends Resource {
   @Produces({MediaType.APPLICATION_JSON})
   @Consumes({MediaType.TEXT_PLAIN})
   @Path("/v1/{draftUUID}")
+  @RolesAllowed({ADMIN, DATASUBMITTER})
   public Response patchDraftName(@Auth AuthUser authUser, @PathParam("draftUUID") String draftUUID, String name) {
     try {
       User user = userService.findUserByEmail(authUser.getEmail());

--- a/src/main/java/org/broadinstitute/consent/http/resources/DraftResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DraftResource.java
@@ -9,6 +9,7 @@ import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.InternalServerErrorException;
 import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.PATCH;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.PUT;
 import jakarta.ws.rs.Path;
@@ -112,6 +113,22 @@ public class DraftResource extends Resource {
       DraftInterface draft = draftService.getAuthorizedDraft(
           validateUUID(draftUUID), user);
       draft.setJson(json);
+      DraftInterface responseDraft = draftService.updateDraft(draft, user);
+      return Response.ok().entity(draftService.draftAsJson(responseDraft)).build();
+    } catch (Exception e) {
+      return createExceptionResponse(e);
+    }
+  }
+
+  @PATCH
+  @Produces({MediaType.APPLICATION_JSON})
+  @Consumes({MediaType.TEXT_PLAIN})
+  @Path("/v1/{draftUUID}")
+  public Response patchDraftName(@Auth AuthUser authUser, @PathParam("draftUUID") String draftUUID, String name) {
+    try {
+      User user = userService.findUserByEmail(authUser.getEmail());
+      DraftInterface draft = draftService.getAuthorizedDraft(validateUUID(draftUUID), user);
+      draft.setName(name);
       DraftInterface responseDraft = draftService.updateDraft(draft, user);
       return Response.ok().entity(draftService.draftAsJson(responseDraft)).build();
     } catch (Exception e) {

--- a/src/main/resources/assets/paths/draftDocumentIndex.yaml
+++ b/src/main/resources/assets/paths/draftDocumentIndex.yaml
@@ -96,8 +96,8 @@ patch:
           type: string
   responses:
     200:
-      description: The delete succeeded.
+      description: The rename succeeded.
     401:
-      description: User not authorized to delete draft
+      description: User not authorized to rename draft
     404:
       description: The draft cannot be found.

--- a/src/main/resources/assets/paths/draftDocumentIndex.yaml
+++ b/src/main/resources/assets/paths/draftDocumentIndex.yaml
@@ -74,3 +74,30 @@ delete:
       description: User not authorized to delete draft
     404:
       description: The draft cannot be found.
+patch:
+  summary: Renames a draft
+  description: Updates the name of a draft to the supplied value.
+  tags:
+    - Draft
+  parameters:
+    - name: draftUUID
+      in: path
+      description: The UUID identifying the draft.
+      required: true
+      schema:
+        type: string
+        format: uuid
+  requestBody:
+    description: |
+      The name of the draft.
+    content:
+      text/plain:
+        schema:
+          type: string
+  responses:
+    200:
+      description: The delete succeeded.
+    401:
+      description: User not authorized to delete draft
+    404:
+      description: The draft cannot be found.

--- a/src/main/resources/assets/paths/draftIndex.yaml
+++ b/src/main/resources/assets/paths/draftIndex.yaml
@@ -13,7 +13,7 @@ get:
             items:
               $ref: '../schemas/DraftSummary.yaml'
     401:
-      description: Not authorized.  Did you remember to authenticate?  You must be a data submitter to use this endpoint.
+      description: User not authorized to get draft summaries.
     500:
       description: Internal server error.  Something went wrong with the valid input provided.
 post:
@@ -38,6 +38,6 @@ post:
     400:
       description: Bad Request (invalid input)
     401:
-      description: Not authorized.  Did you remember to authenticate?  You must be a data submitter to use this endpoint.
+      description: User not authorized to create draft
     500:
       description: Internal Error (something went wrong processing valid input)

--- a/src/main/resources/assets/schemas/DraftSummary.yaml
+++ b/src/main/resources/assets/schemas/DraftSummary.yaml
@@ -15,3 +15,6 @@ properties:
     type: string
     format: date
     description: Describes the date the draft was last modified.
+  draftType:
+    type: string
+    enum: [StudyDatasetSubmissionV1]

--- a/src/test/java/org/broadinstitute/consent/http/db/DraftDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DraftDAOTest.java
@@ -222,5 +222,6 @@ class DraftDAOTest extends DAOTestHelper {
     assertEquals(draftSummary.getName(), draftInterface.getName());
     assertEquals(draftSummary.getCreateDate(), draftInterface.getCreateDate());
     assertEquals(draftSummary.getUpdateDate(), draftInterface.getUpdateDate());
+    assertEquals(draftSummary.getDraftType(), draftInterface.getType());
   }
 }

--- a/src/test/java/org/broadinstitute/consent/http/resources/DraftResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DraftResourceTest.java
@@ -25,6 +25,7 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
+import org.broadinstitute.consent.http.enumeration.DraftType;
 import org.broadinstitute.consent.http.models.AuthUser;
 import org.broadinstitute.consent.http.models.DraftStudyDataset;
 import org.broadinstitute.consent.http.models.DraftInterface;
@@ -84,7 +85,8 @@ class DraftResourceTest {
   void testGetDraftsWhenOneExistForUser() {
     Set<DraftSummary> draftSummaries = new HashSet<>();
     draftSummaries.add(
-        new DraftSummary(UUID.randomUUID(), "test", new Date(), new Date()));
+        new DraftSummary(UUID.randomUUID(), "test", new Date(), new Date(),
+            DraftType.STUDY_DATASET_SUBMISSION_V1));
     when(userService.findUserByEmail(any())).thenReturn(user);
     when(draftService.findDraftSummariesForUser(any())).thenReturn(draftSummaries);
     initResource();


### PR DESCRIPTION
### Addresses

[DT-970](https://broadworkbench.atlassian.net/browse/DT-970)

### Summary
Adds API to edit a draft name.
Returns draft type in DraftSummary entry


----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment


[DT-970]: https://broadworkbench.atlassian.net/browse/DT-970?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ