### PR TITLE
DT-978: Fix patch name bug

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
@@ -560,6 +560,16 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
       @Bind("updateDate") Timestamp updateDate,
       @Bind("updateUserId") Integer updateUserId);
 
+  @SqlUpdate("""
+      UPDATE dataset
+      SET update_date = :updateDate,
+          update_user_id = :updateUserId
+      WHERE dataset_id = :datasetId
+      """)
+  void updateDatasetUpdateUser(@Bind("datasetId") Integer datasetId,
+      @Bind("updateDate") Timestamp updateDate,
+      @Bind("updateUserId") Integer updateUserId);
+
   @UseRowReducer(DatasetReducer.class)
   @SqlQuery(
       """

--- a/src/main/java/org/broadinstitute/consent/http/models/DatasetPatch.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DatasetPatch.java
@@ -22,7 +22,7 @@ public record DatasetPatch(String name, List<DatasetProperty> properties) {
    * @return True if any patch values are different, false otherwise.
    */
   public boolean isPatchable(Dataset dataset) {
-    if (name() != null && !name().equals(dataset.getName())) {
+    if (name() != null && !name().equals(dataset.getName()) && !name().isBlank()) {
       return true;
     }
     // Find any cases where the new property value is different from the existing one

--- a/src/main/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAO.java
@@ -397,16 +397,19 @@ public class DatasetServiceDAO implements ConsentLogger {
       String datasetName,
       Integer userId,
       List<DatasetProperty> properties) {
-    if (datasetName == null || datasetName.isBlank()) {
-      Dataset d = datasetDAO.findDatasetById(datasetId);
-      datasetName = d.getDatasetName();
-    }
     // update dataset
-    datasetDAO.updateDatasetNameWithUpdateUser(
-        datasetId,
-        datasetName,
-        new Timestamp(new Date().getTime()),
-        userId);
+    if (datasetName == null || datasetName.isBlank()) {
+      datasetDAO.updateDatasetUpdateUser(
+          datasetId,
+          new Timestamp(new Date().getTime()),
+          userId);
+    } else {
+      datasetDAO.updateDatasetNameWithUpdateUser(
+          datasetId,
+          datasetName,
+          new Timestamp(new Date().getTime()),
+          userId);
+    }
     // insert properties
     executeSynchronizeDatasetProperties(handle, datasetId, properties, false);
 

--- a/src/main/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAO.java
@@ -397,6 +397,10 @@ public class DatasetServiceDAO implements ConsentLogger {
       String datasetName,
       Integer userId,
       List<DatasetProperty> properties) {
+    if (datasetName == null || datasetName.isBlank()) {
+      Dataset d = datasetDAO.findDatasetById(datasetId);
+      datasetName = d.getDatasetName();
+    }
     // update dataset
     datasetDAO.updateDatasetNameWithUpdateUser(
         datasetId,

--- a/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
@@ -8,7 +8,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.gson.JsonObject;

--- a/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.gson.JsonObject;
@@ -725,6 +726,20 @@ class DatasetDAOTest extends DAOTestHelper {
     Dataset foundDataset = datasetDAO.findDatasetById(dataset.getDatasetId());
     assertNotNull(foundDataset);
     assertEquals(newName, foundDataset.getName());
+  }
+
+  @Test
+  void testUpdateDatasetUpdateUser() {
+    Dataset dataset = insertDataset();
+    User user = createUser();
+    datasetDAO.updateDatasetUpdateUser(
+        dataset.getDatasetId(),
+        new Timestamp(new Date().getTime()),
+        user.getUserId());
+    Dataset foundDataset = datasetDAO.findDatasetById(dataset.getDatasetId());
+    assertNotNull(foundDataset);
+    assertEquals(user.getUserId(), foundDataset.getUpdateUserId());
+    assertTrue(foundDataset.getUpdateDate().after(dataset.getUpdateDate()));
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/models/DatasetPatchTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/DatasetPatchTest.java
@@ -16,6 +16,38 @@ import org.junit.jupiter.params.provider.EnumSource;
 public class DatasetPatchTest {
 
   @Test
+  void testIsPatchableName() {
+    Dataset dataset = new Dataset();
+    dataset.setName(RandomStringUtils.randomAlphabetic(10));
+    DatasetPatch patch = new DatasetPatch("Name", List.of());
+    assertTrue(patch.isPatchable(dataset));
+  }
+
+  @Test
+  void testIsPatchableNullNameEmptyProps() {
+    Dataset dataset = new Dataset();
+    dataset.setName(RandomStringUtils.randomAlphabetic(10));
+    DatasetPatch patch = new DatasetPatch(null, List.of());
+    assertFalse(patch.isPatchable(dataset));
+  }
+
+  @Test
+  void testIsPatchableEmptyNameEmptyProps() {
+    Dataset dataset = new Dataset();
+    dataset.setName(RandomStringUtils.randomAlphabetic(10));
+    DatasetPatch patch = new DatasetPatch("", List.of());
+    assertFalse(patch.isPatchable(dataset));
+  }
+
+  @Test
+  void testIsPatchableBlankNameEmptyProps() {
+    Dataset dataset = new Dataset();
+    dataset.setName(RandomStringUtils.randomAlphabetic(10));
+    DatasetPatch patch = new DatasetPatch("   ", List.of());
+    assertFalse(patch.isPatchable(dataset));
+  }
+
+  @Test
   void testInvalidPropertyKeys() {
     DatasetProperty invalidProp = new DatasetProperty();
     invalidProp.setPropertyName(RandomStringUtils.randomAlphanumeric(25));

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAOTest.java
@@ -749,6 +749,18 @@ class DatasetServiceDAOTest extends DAOTestHelper {
     assertEquals(dataset.getName(), patched.getDatasetName());
   }
 
+  @Test
+  void testPatchDatasetWithBlankName() throws Exception {
+    Dataset dataset = createDataset();
+    User user = userDAO.findUserById(dataset.getCreateUserId());
+    DatasetPatch patch = new DatasetPatch("   ", List.of());
+    serviceDAO.patchDataset(dataset.getDatasetId(), user, patch);
+    Dataset patched = datasetDAO.findDatasetById(dataset.getDatasetId());
+
+    // Validate that the name is NOT updated with an empty value
+    assertEquals(dataset.getName(), patched.getDatasetName());
+  }
+
   /**
    * Helper method to create a study with two props and one dataset
    * @param fso Optional FSO to use as part of the study insert

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAOTest.java
@@ -725,6 +725,30 @@ class DatasetServiceDAOTest extends DAOTestHelper {
     assertEquals(3, patched.getProperties().size());
   }
 
+  @Test
+  void testPatchDatasetWithNullName() throws Exception {
+    Dataset dataset = createDataset();
+    User user = userDAO.findUserById(dataset.getCreateUserId());
+    DatasetPatch patch = new DatasetPatch(null, List.of());
+    serviceDAO.patchDataset(dataset.getDatasetId(), user, patch);
+    Dataset patched = datasetDAO.findDatasetById(dataset.getDatasetId());
+
+    // Validate that the name is NOT updated to a null value
+    assertEquals(dataset.getName(), patched.getDatasetName());
+  }
+
+  @Test
+  void testPatchDatasetWithEmptyName() throws Exception {
+    Dataset dataset = createDataset();
+    User user = userDAO.findUserById(dataset.getCreateUserId());
+    DatasetPatch patch = new DatasetPatch("", List.of());
+    serviceDAO.patchDataset(dataset.getDatasetId(), user, patch);
+    Dataset patched = datasetDAO.findDatasetById(dataset.getDatasetId());
+
+    // Validate that the name is NOT updated with an empty value
+    assertEquals(dataset.getName(), patched.getDatasetName());
+  }
+
   /**
    * Helper method to create a study with two props and one dataset
    * @param fso Optional FSO to use as part of the study insert


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-978

### Summary
Previous patch functionality would clear out the dataset name if not provided. This PR fixes it to make it truly optional.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
