### PR TITLE
DT-400, DT-989: Update Liquibase to latest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <java.version>21</java.version>
     <maven.compiler.source>21</maven.compiler.source>
     <maven.compiler.target>21</maven.compiler.target>
-    <liquibase.version>4.29.2</liquibase.version>
+    <liquibase.version>4.30.0</liquibase.version>
     <dropwizard.version>4.0.7</dropwizard.version>
     <logback.version>1.5.7</logback.version>
     <pact.version>4.6.15</pact.version>
@@ -732,6 +732,12 @@
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-collections4</artifactId>
       <version>4.4</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.17.0</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-400
https://broadworkbench.atlassian.net/browse/DT-989

### Summary
The latest liquibase update required the addition of apache commons lang3 to get tests to run (see [this previously failing dependabot PR](https://github.com/DataBiosphere/consent/pull/2425)). I suspect this is a timing issue with test containers and liquibase. The new metrics collection feature is disabled in https://github.com/broadinstitute/terra-helmfile/pull/5954

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
