### PR TITLE
DT-1060: Add auditing to DatasetServiceDAO

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
@@ -498,8 +498,8 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
   @UseRowMapper(DatasetAuditMapper.class)
   @SqlQuery("""
           SELECT *
-          FROM dataset_audit a
-          WHERE a.dataset_id = :datasetId
+          FROM dataset_audit
+          WHERE dataset_id = :datasetId
       """)
   List<DatasetAudit> findAuditsByDatasetId(@Bind("datasetId") Integer datasetId);
 

--- a/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Set;
 import org.broadinstitute.consent.http.db.mapper.ApprovedDatasetMapper;
 import org.broadinstitute.consent.http.db.mapper.ApprovedDatasetReducer;
+import org.broadinstitute.consent.http.db.mapper.DatasetAuditMapper;
 import org.broadinstitute.consent.http.db.mapper.DatasetDTOWithPropertiesMapper;
 import org.broadinstitute.consent.http.db.mapper.DatasetMapper;
 import org.broadinstitute.consent.http.db.mapper.DatasetPropertyMapper;
@@ -493,6 +494,14 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
       """)
   @GetGeneratedKeys
   Integer insertDatasetAudit(@BindBean DatasetAudit dataSets);
+
+  @UseRowMapper(DatasetAuditMapper.class)
+  @SqlQuery("""
+          SELECT *
+          FROM dataset_audit a
+          WHERE a.dataset_id = :datasetId
+      """)
+  List<DatasetAudit> findAuditsByDatasetId(@Bind("datasetId") Integer datasetId);
 
   @SqlUpdate(
       "UPDATE dataset_property "

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DatasetAuditMapper.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DatasetAuditMapper.java
@@ -1,0 +1,37 @@
+package org.broadinstitute.consent.http.db.mapper;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import org.broadinstitute.consent.http.models.DatasetAudit;
+import org.jdbi.v3.core.mapper.RowMapper;
+import org.jdbi.v3.core.statement.StatementContext;
+
+public class DatasetAuditMapper implements RowMapper<DatasetAudit>, RowMapperHelper {
+
+  @Override
+  public DatasetAudit map(ResultSet rs, StatementContext ctx) throws SQLException {
+    DatasetAudit datasetAudit = new DatasetAudit();
+    if (hasNonZeroColumn(rs, "dataset_audit_id")) {
+      datasetAudit.setDataSetAuditId(rs.getInt("dataset_audit_id"));
+    }
+    if (hasNonZeroColumn(rs, "dataset_id")) {
+      datasetAudit.setDatasetId(rs.getInt("dataset_id"));
+    }
+    if (hasColumn(rs, "change_action")) {
+      datasetAudit.setAction(rs.getString("change_action"));
+    }
+    if (hasNonZeroColumn(rs, "modified_by_user")) {
+      datasetAudit.setUser(rs.getInt("modified_by_user"));
+    }
+    if (hasColumn(rs, "modification_date")) {
+      datasetAudit.setDate(rs.getDate("modification_date"));
+    }
+    if (hasColumn(rs, "object_id")) {
+      datasetAudit.setObjectId(rs.getString("object_id"));
+    }
+    if (hasColumn(rs, "name")) {
+      datasetAudit.setName(rs.getString("name"));
+    }
+    return datasetAudit;
+  }
+}

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DatasetAuditMapper.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DatasetAuditMapper.java
@@ -34,4 +34,5 @@ public class DatasetAuditMapper implements RowMapper<DatasetAudit>, RowMapperHel
     }
     return datasetAudit;
   }
+
 }

--- a/src/main/java/org/broadinstitute/consent/http/enumeration/AuditActions.java
+++ b/src/main/java/org/broadinstitute/consent/http/enumeration/AuditActions.java
@@ -5,7 +5,8 @@ public enum AuditActions {
   CREATE("create"),
   DELETE("delete"),
   REMOVE("remove"),
-  REPLACE("replace");
+  REPLACE("replace"),
+  UPDATE("update");
 
   private final String value;
 

--- a/src/main/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAO.java
@@ -190,7 +190,6 @@ public class DatasetServiceDAO implements ConsentLogger {
         dacId
     );
 
-    // add entry to audit table
     addAuditRecord(datasetId, name, userId, AuditActions.CREATE);
 
     if (Objects.nonNull(studyId)) {
@@ -366,7 +365,6 @@ public class DatasetServiceDAO implements ConsentLogger {
       List<DatasetProperty> properties,
       List<FileStorageObject> uploadedFiles,
       boolean executeDeletes) {
-    // add entry to audit table
     addAuditRecord(datasetId, datasetName, userId, AuditActions.UPDATE);
     // update dataset
     datasetDAO.updateDatasetByDatasetId(
@@ -416,14 +414,12 @@ public class DatasetServiceDAO implements ConsentLogger {
           "Attempt to update dataset name with null or blank value: dataset id: %s; user id: %s".formatted(
               datasetId, userId));
       Dataset dataset = datasetDAO.findDatasetById(datasetId);
-      // add entry to audit table
       addAuditRecord(datasetId, dataset.getDatasetName(), userId, AuditActions.UPDATE);
       datasetDAO.updateDatasetUpdateUser(
           datasetId,
           new Timestamp(new Date().getTime()),
           userId);
     } else {
-      // add entry to audit table
       addAuditRecord(datasetId, datasetName, userId, AuditActions.UPDATE);
       datasetDAO.updateDatasetNameWithUpdateUser(
           datasetId,

--- a/src/main/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAO.java
@@ -50,11 +50,8 @@ public class DatasetServiceDAO implements ConsentLogger {
       // Some legacy dataset names can be null
       String dsAuditName =
           Objects.nonNull(dataset.getName()) ? dataset.getName() : dataset.getDatasetIdentifier();
-      DatasetAudit dsAudit = new DatasetAudit(dataset.getDatasetId(), dataset.getObjectId(),
-          dsAuditName,
-          new Date(), userId, AuditActions.DELETE.getValue().toUpperCase());
       try {
-        datasetDAO.insertDatasetAudit(dsAudit);
+        addAuditRecord(dataset.getDatasetId(), dsAuditName, userId, AuditActions.DELETE);
         datasetDAO.deleteDatasetPropertiesByDatasetId(dataset.getDatasetId());
         datasetDAO.deleteDatasetById(dataset.getDatasetId());
       } catch (Exception e) {
@@ -194,15 +191,7 @@ public class DatasetServiceDAO implements ConsentLogger {
     );
 
     // add entry to audit table
-    DatasetAudit audit = new DatasetAudit(
-        datasetId,
-        null,
-        name,
-        new Date(),
-        userId,
-        AuditActions.CREATE.getValue().toUpperCase()
-    );
-    datasetDAO.insertDatasetAudit(audit);
+    addAuditRecord(datasetId, name, userId, AuditActions.CREATE);
 
     if (Objects.nonNull(studyId)) {
       datasetDAO.updateStudyId(datasetId, studyId);
@@ -378,15 +367,7 @@ public class DatasetServiceDAO implements ConsentLogger {
       List<FileStorageObject> uploadedFiles,
       boolean executeDeletes) {
     // add entry to audit table
-    DatasetAudit audit = new DatasetAudit(
-        datasetId,
-        null,
-        datasetName,
-        new Date(),
-        userId,
-        AuditActions.UPDATE.getValue().toUpperCase()
-    );
-    datasetDAO.insertDatasetAudit(audit);
+    addAuditRecord(datasetId, datasetName, userId, AuditActions.UPDATE);
     // update dataset
     datasetDAO.updateDatasetByDatasetId(
         datasetId,
@@ -436,30 +417,14 @@ public class DatasetServiceDAO implements ConsentLogger {
               datasetId, userId));
       Dataset dataset = datasetDAO.findDatasetById(datasetId);
       // add entry to audit table
-      DatasetAudit audit = new DatasetAudit(
-          datasetId,
-          null,
-          dataset.getDatasetName(),
-          new Date(),
-          userId,
-          AuditActions.UPDATE.getValue().toUpperCase()
-      );
-      datasetDAO.insertDatasetAudit(audit);
+      addAuditRecord(datasetId, dataset.getDatasetName(), userId, AuditActions.UPDATE);
       datasetDAO.updateDatasetUpdateUser(
           datasetId,
           new Timestamp(new Date().getTime()),
           userId);
     } else {
       // add entry to audit table
-      DatasetAudit audit = new DatasetAudit(
-          datasetId,
-          null,
-          datasetName,
-          new Date(),
-          userId,
-          AuditActions.UPDATE.getValue().toUpperCase()
-      );
-      datasetDAO.insertDatasetAudit(audit);
+      addAuditRecord(datasetId, datasetName, userId, AuditActions.UPDATE);
       datasetDAO.updateDatasetNameWithUpdateUser(
           datasetId,
           datasetName,
@@ -469,6 +434,18 @@ public class DatasetServiceDAO implements ConsentLogger {
     // insert properties
     executeSynchronizeDatasetProperties(handle, datasetId, properties, false);
 
+  }
+
+  private void addAuditRecord(Integer datasetId, String name, Integer userId, AuditActions action) {
+    DatasetAudit audit = new DatasetAudit(
+        datasetId,
+        null,
+        name,
+        new Date(),
+        userId,
+        action.getValue().toUpperCase()
+    );
+    datasetDAO.insertDatasetAudit(audit);
   }
 
   // Helper methods to generate Dictionary inserts

--- a/src/main/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAO.java
@@ -50,8 +50,9 @@ public class DatasetServiceDAO implements ConsentLogger {
       // Some legacy dataset names can be null
       String dsAuditName =
           Objects.nonNull(dataset.getName()) ? dataset.getName() : dataset.getDatasetIdentifier();
-      DatasetAudit dsAudit = new DatasetAudit(dataset.getDatasetId(), dataset.getObjectId(), dsAuditName,
-        new Date(), userId, AuditActions.DELETE.getValue().toUpperCase());
+      DatasetAudit dsAudit = new DatasetAudit(dataset.getDatasetId(), dataset.getObjectId(),
+          dsAuditName,
+          new Date(), userId, AuditActions.DELETE.getValue().toUpperCase());
       try {
         datasetDAO.insertDatasetAudit(dsAudit);
         datasetDAO.deleteDatasetPropertiesByDatasetId(dataset.getDatasetId());
@@ -191,6 +192,17 @@ public class DatasetServiceDAO implements ConsentLogger {
         dataUse.toString(),
         dacId
     );
+
+    // add entry to audit table
+    DatasetAudit audit = new DatasetAudit(
+        datasetId,
+        null,
+        name,
+        new Date(),
+        userId,
+        AuditActions.CREATE.getValue().toUpperCase()
+    );
+    datasetDAO.insertDatasetAudit(audit);
 
     if (Objects.nonNull(studyId)) {
       datasetDAO.updateStudyId(datasetId, studyId);
@@ -337,17 +349,21 @@ public class DatasetServiceDAO implements ConsentLogger {
           // Turn that off for this connection. This will not affect existing or new connections and
           // only applies to the current one in this handle.
           handle.getConnection().setAutoCommit(false);
-
-          executeUpdateDatasetWithFiles(
-              handle,
-              updates.datasetId(),
-              updates.name(),
-              updates.userId(),
-              updates.dacId(),
-              updates.props(),
-              updates.files(),
-              true);
-
+          try {
+            executeUpdateDatasetWithFiles(
+                handle,
+                updates.datasetId(),
+                updates.name(),
+                updates.userId(),
+                updates.dacId(),
+                updates.props(),
+                updates.files(),
+                true);
+          } catch (Exception e) {
+            handle.rollback();
+            logException(e);
+            throw e;
+          }
           handle.commit();
         }
     );
@@ -361,6 +377,16 @@ public class DatasetServiceDAO implements ConsentLogger {
       List<DatasetProperty> properties,
       List<FileStorageObject> uploadedFiles,
       boolean executeDeletes) {
+    // add entry to audit table
+    DatasetAudit audit = new DatasetAudit(
+        datasetId,
+        null,
+        datasetName,
+        new Date(),
+        userId,
+        AuditActions.UPDATE.getValue().toUpperCase()
+    );
+    datasetDAO.insertDatasetAudit(audit);
     // update dataset
     datasetDAO.updateDatasetByDatasetId(
         datasetId,
@@ -381,12 +407,18 @@ public class DatasetServiceDAO implements ConsentLogger {
     jdbi.useHandle(
         handle -> {
           handle.getConnection().setAutoCommit(false);
-          executePatchDataset(
-              handle,
-              datasetId,
-              patch.name(),
-              user.getUserId(),
-              patch.properties());
+          try {
+            executePatchDataset(
+                handle,
+                datasetId,
+                patch.name(),
+                user.getUserId(),
+                patch.properties());
+          } catch (Exception e) {
+            handle.rollback();
+            logException(e);
+            throw e;
+          }
           handle.commit();
         }
     );
@@ -399,11 +431,35 @@ public class DatasetServiceDAO implements ConsentLogger {
       List<DatasetProperty> properties) {
     // update dataset
     if (datasetName == null || datasetName.isBlank()) {
+      logWarn(
+          "Attempt to update dataset name with null or blank value: dataset id: %s; user id: %s".formatted(
+              datasetId, userId));
+      Dataset dataset = datasetDAO.findDatasetById(datasetId);
+      // add entry to audit table
+      DatasetAudit audit = new DatasetAudit(
+          datasetId,
+          null,
+          dataset.getDatasetName(),
+          new Date(),
+          userId,
+          AuditActions.UPDATE.getValue().toUpperCase()
+      );
+      datasetDAO.insertDatasetAudit(audit);
       datasetDAO.updateDatasetUpdateUser(
           datasetId,
           new Timestamp(new Date().getTime()),
           userId);
     } else {
+      // add entry to audit table
+      DatasetAudit audit = new DatasetAudit(
+          datasetId,
+          null,
+          datasetName,
+          new Date(),
+          userId,
+          AuditActions.UPDATE.getValue().toUpperCase()
+      );
+      datasetDAO.insertDatasetAudit(audit);
       datasetDAO.updateDatasetNameWithUpdateUser(
           datasetId,
           datasetName,

--- a/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
@@ -188,6 +188,14 @@ public class DAOTestHelper {
        dao methods directly to do any manipulation.
      */
 
+  protected String randomAlphabetic(int length) {
+    return RandomStringUtils.secure().nextAlphabetic(length);
+  }
+
+  protected String randomAlphanumeric(int length) {
+    return RandomStringUtils.secure().nextAlphanumeric(length);
+  }
+
   /**
    * Creates a user with default role of Researcher and random user properties
    *

--- a/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
@@ -180,15 +180,15 @@ public class DAOTestHelper {
      */
 
   protected String randomAlphabetic(int length) {
-    return RandomStringUtils.secure().nextAlphabetic(length);
+    return RandomStringUtils.secureStrong().nextAlphabetic(length);
   }
 
   protected String randomAlphanumeric(int length) {
-    return RandomStringUtils.secure().nextAlphanumeric(length);
+    return RandomStringUtils.secureStrong().nextAlphanumeric(length);
   }
 
   protected int randomInt(int startInclusive, int endExclusive) {
-    return RandomUtils.secure().randomInt(startInclusive, endExclusive);
+    return RandomUtils.secureStrong().randomInt(startInclusive, endExclusive);
   }
 
   /**

--- a/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
@@ -1,24 +1,16 @@
 package org.broadinstitute.consent.http.db;
 
 import static org.broadinstitute.consent.http.ConsentModule.DB_ENV;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import io.dropwizard.core.setup.Environment;
 import io.dropwizard.jdbi3.JdbiFactory;
 import io.dropwizard.testing.ConfigOverride;
 import io.dropwizard.testing.DropwizardTestSupport;
 import io.dropwizard.testing.ResourceHelpers;
-import jakarta.ws.rs.core.MediaType;
-import java.io.ByteArrayInputStream;
-import java.io.InputStream;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Random;
 import java.util.UUID;
-import java.util.stream.IntStream;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.RandomUtils;
 import org.broadinstitute.consent.http.ConsentApplication;
@@ -32,7 +24,6 @@ import org.broadinstitute.consent.http.models.DatasetEntry;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.UserProperty;
 import org.broadinstitute.consent.http.util.gson.GsonUtil;
-import org.glassfish.jersey.media.multipart.FormDataBodyPart;
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.gson2.Gson2Config;
 import org.jdbi.v3.gson2.Gson2Plugin;
@@ -196,20 +187,24 @@ public class DAOTestHelper {
     return RandomStringUtils.secure().nextAlphanumeric(length);
   }
 
+  protected int randomInt(int startInclusive, int endExclusive) {
+    return RandomUtils.secure().randomInt(startInclusive, endExclusive);
+  }
+
   /**
    * Creates a user with default role of Researcher and random user properties
    *
    * @return Created User
    */
   protected User createUser() {
-    int i1 = RandomUtils.nextInt(5, 10);
-    int i2 = RandomUtils.nextInt(5, 10);
-    int i3 = RandomUtils.nextInt(3, 5);
-    String email = RandomStringUtils.randomAlphabetic(i1) +
+    int i1 = randomInt(5, 10);
+    int i2 = randomInt(5, 10);
+    int i3 = randomInt(3, 5);
+    String email = randomAlphabetic(i1) +
         "@" +
-        RandomStringUtils.randomAlphabetic(i2) +
+        randomAlphabetic(i2) +
         "." +
-        RandomStringUtils.randomAlphabetic(i3);
+        randomAlphabetic(i3);
     Integer userId = userDAO.insertUser(email, "display name", new Date());
     userRoleDAO.insertSingleUserRole(UserRoles.RESEARCHER.getRoleId(), userId);
     UserProperty prop = new UserProperty();
@@ -227,25 +222,25 @@ public class DAOTestHelper {
    * @return Last DataAccessRequest of a DarCollection
    */
   protected DataAccessRequest createDataAccessRequestV3() {
-    int i1 = RandomUtils.nextInt(5, 10);
-    String email = RandomStringUtils.randomAlphabetic(i1);
-    String name = RandomStringUtils.randomAlphabetic(10);
+    int i1 = RandomUtils.secure().randomInt(5, 10);
+    String email = randomAlphabetic(i1);
+    String name = randomAlphabetic(10);
     Integer userId = userDAO.insertUser(email, name, new Date());
-    Integer institutionId = institutionDAO.insertInstitution(RandomStringUtils.randomAlphabetic(20),
+    Integer institutionId = institutionDAO.insertInstitution(randomAlphabetic(20),
         "itDirectorName",
         "itDirectorEmail",
-        RandomStringUtils.randomAlphabetic(10),
+        randomAlphabetic(10),
         new Random().nextInt(),
-        RandomStringUtils.randomAlphabetic(10),
-        RandomStringUtils.randomAlphabetic(10),
-        RandomStringUtils.randomAlphabetic(10),
+        randomAlphabetic(10),
+        randomAlphabetic(10),
+        randomAlphabetic(10),
         OrganizationType.NON_PROFIT.getValue(),
         userId,
         new Date());
     userDAO.updateUser(name, userId, institutionId);
     userRoleDAO.insertSingleUserRole(7, userId);
     User user = userDAO.findUserById(userId);
-    String darCode = "DAR-" + RandomUtils.nextInt(1, 999999999);
+    String darCode = "DAR-" + randomInt(1, 999999999);
     Integer collection_id = darCollectionDAO.insertDarCollection(darCode, user.getUserId(),
         new Date());
     for (int i = 0; i < 4; i++) {
@@ -262,7 +257,7 @@ public class DAOTestHelper {
   private DataAccessRequest createDataAccessRequest(Integer userId, Integer collectionId,
       String darCode) {
     DataAccessRequestData data = new DataAccessRequestData();
-    data.setProjectTitle("Project Title: " + RandomStringUtils.random(50, true, false));
+    data.setProjectTitle("Project Title: " + randomAlphabetic(50));
     data.setDarCode(darCode);
     DatasetEntry entry = new DatasetEntry();
     entry.setKey("key");

--- a/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
@@ -98,7 +98,7 @@ public class DAOTestHelper {
     testApp.before();
 
     // Initialize DAOs
-    String dbiExtension = "_" + RandomStringUtils.random(10, true, false);
+    String dbiExtension = "_" + RandomStringUtils.secureStrong().nextAlphabetic(10);
     ConsentConfiguration configuration = testApp.getConfiguration();
     Environment environment = testApp.getEnvironment();
     jdbi = new JdbiFactory().build(environment, configuration.getDataSourceFactory(),
@@ -222,7 +222,7 @@ public class DAOTestHelper {
    * @return Last DataAccessRequest of a DarCollection
    */
   protected DataAccessRequest createDataAccessRequestV3() {
-    int i1 = RandomUtils.secure().randomInt(5, 10);
+    int i1 = randomInt(5, 10);
     String email = randomAlphabetic(i1);
     String name = randomAlphabetic(10);
     Integer userId = userDAO.insertUser(email, name, new Date());

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAOTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.cloud.storage.BlobId;
@@ -36,7 +35,6 @@ import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.service.dao.DatasetServiceDAO.DatasetInsert;
 import org.broadinstitute.consent.http.service.dao.DatasetServiceDAO.DatasetUpdate;
 import org.broadinstitute.consent.http.service.dao.DatasetServiceDAO.StudyUpdate;
-import org.jdbi.v3.core.statement.UnableToExecuteStatementException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -513,7 +511,8 @@ class DatasetServiceDAOTest extends DAOTestHelper {
       List<DatasetAudit> audits = datasetDAO.findAuditsByDatasetId(id);
       assertFalse(audits.isEmpty());
       assertFalse(
-          audits.stream().anyMatch(a -> a.getAction().equalsIgnoreCase(AuditActions.UPDATE.name())));
+          audits.stream()
+              .anyMatch(a -> a.getAction().equalsIgnoreCase(AuditActions.UPDATE.name())));
     });
   }
 
@@ -560,7 +559,8 @@ class DatasetServiceDAOTest extends DAOTestHelper {
       List<DatasetAudit> audits = datasetDAO.findAuditsByDatasetId(id);
       assertFalse(audits.isEmpty());
       assertFalse(
-          audits.stream().anyMatch(a -> a.getAction().equalsIgnoreCase(AuditActions.UPDATE.name())));
+          audits.stream()
+              .anyMatch(a -> a.getAction().equalsIgnoreCase(AuditActions.UPDATE.name())));
     });
   }
 
@@ -615,7 +615,8 @@ class DatasetServiceDAOTest extends DAOTestHelper {
       List<DatasetAudit> audits = datasetDAO.findAuditsByDatasetId(id);
       assertFalse(audits.isEmpty());
       assertTrue(
-          audits.stream().anyMatch(a -> a.getAction().equalsIgnoreCase(AuditActions.CREATE.name())));
+          audits.stream()
+              .anyMatch(a -> a.getAction().equalsIgnoreCase(AuditActions.CREATE.name())));
     });
   }
 
@@ -682,7 +683,8 @@ class DatasetServiceDAOTest extends DAOTestHelper {
       List<DatasetAudit> audits = datasetDAO.findAuditsByDatasetId(id);
       assertFalse(audits.isEmpty());
       assertFalse(
-          audits.stream().anyMatch(a -> a.getAction().equalsIgnoreCase(AuditActions.UPDATE.name())));
+          audits.stream()
+              .anyMatch(a -> a.getAction().equalsIgnoreCase(AuditActions.UPDATE.name())));
     });
   }
 
@@ -719,9 +721,11 @@ class DatasetServiceDAOTest extends DAOTestHelper {
       List<DatasetAudit> audits = datasetDAO.findAuditsByDatasetId(id);
       assertFalse(audits.isEmpty());
       assertTrue(
-          audits.stream().anyMatch(a -> a.getAction().equalsIgnoreCase(AuditActions.CREATE.name())));
+          audits.stream()
+              .anyMatch(a -> a.getAction().equalsIgnoreCase(AuditActions.CREATE.name())));
       assertTrue(
-          audits.stream().anyMatch(a -> a.getAction().equalsIgnoreCase(AuditActions.DELETE.name())));
+          audits.stream()
+              .anyMatch(a -> a.getAction().equalsIgnoreCase(AuditActions.DELETE.name())));
     });
 
   }

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAOTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.cloud.storage.BlobId;
@@ -17,12 +18,14 @@ import java.util.Random;
 import java.util.Set;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.broadinstitute.consent.http.db.DAOTestHelper;
+import org.broadinstitute.consent.http.enumeration.AuditActions;
 import org.broadinstitute.consent.http.enumeration.FileCategory;
 import org.broadinstitute.consent.http.enumeration.PropertyType;
 import org.broadinstitute.consent.http.models.Dac;
 import org.broadinstitute.consent.http.models.DataUse;
 import org.broadinstitute.consent.http.models.DataUseBuilder;
 import org.broadinstitute.consent.http.models.Dataset;
+import org.broadinstitute.consent.http.models.DatasetAudit;
 import org.broadinstitute.consent.http.models.DatasetPatch;
 import org.broadinstitute.consent.http.models.DatasetProperty;
 import org.broadinstitute.consent.http.models.Dictionary;
@@ -33,6 +36,7 @@ import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.service.dao.DatasetServiceDAO.DatasetInsert;
 import org.broadinstitute.consent.http.service.dao.DatasetServiceDAO.DatasetUpdate;
 import org.broadinstitute.consent.http.service.dao.DatasetServiceDAO.StudyUpdate;
+import org.jdbi.v3.core.statement.UnableToExecuteStatementException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -57,6 +61,10 @@ class DatasetServiceDAOTest extends DAOTestHelper {
     Dataset deleted = datasetDAO.findDatasetById(dataset.getDatasetId());
     assertNull(deleted);
 
+    // Validate that an audit record was added:
+    List<DatasetAudit> audits = datasetDAO.findAuditsByDatasetId(dataset.getDatasetId());
+    assertEquals(1, audits.size());
+    assertEquals(AuditActions.DELETE.name(), audits.get(0).getAction());
   }
 
   @Test
@@ -66,26 +74,27 @@ class DatasetServiceDAOTest extends DAOTestHelper {
     User user = createUser();
 
     DatasetProperty prop1 = new DatasetProperty();
-    prop1.setSchemaProperty(RandomStringUtils.randomAlphabetic(10));
-    prop1.setPropertyName(RandomStringUtils.randomAlphabetic(10));
+    prop1.setSchemaProperty(RandomStringUtils.secure().nextAlphabetic(10));
+    prop1.setPropertyName(RandomStringUtils.secure().nextAlphabetic(10));
     prop1.setPropertyType(PropertyType.Number);
     prop1.setPropertyValue(new Random().nextInt());
 
     DatasetProperty prop2 = new DatasetProperty();
-    prop2.setSchemaProperty(RandomStringUtils.randomAlphabetic(10));
-    prop2.setPropertyName(RandomStringUtils.randomAlphabetic(10));
+    prop2.setSchemaProperty(RandomStringUtils.secure().nextAlphabetic(10));
+    prop2.setPropertyName(RandomStringUtils.secure().nextAlphabetic(10));
     prop2.setPropertyType(PropertyType.Date);
     prop2.setPropertyValueAsString("2000-10-20");
 
     FileStorageObject file1 = new FileStorageObject();
-    file1.setMediaType(RandomStringUtils.randomAlphabetic(20));
+    file1.setMediaType(RandomStringUtils.secure().nextAlphabetic(20));
     file1.setCategory(FileCategory.NIH_INSTITUTIONAL_CERTIFICATION);
     file1.setBlobId(
-        BlobId.of(RandomStringUtils.randomAlphabetic(10), RandomStringUtils.randomAlphabetic(10)));
-    file1.setFileName(RandomStringUtils.randomAlphabetic(10));
+        BlobId.of(RandomStringUtils.secure().nextAlphabetic(10),
+            RandomStringUtils.secure().nextAlphabetic(10)));
+    file1.setFileName(RandomStringUtils.secure().nextAlphabetic(10));
 
     DatasetServiceDAO.DatasetInsert insert = new DatasetServiceDAO.DatasetInsert(
-        RandomStringUtils.randomAlphabetic(20),
+        RandomStringUtils.secure().nextAlphabetic(20),
         dac.getDacId(),
         new DataUseBuilder().setStigmatizeDiseases(true).setGeneralUse(true).build(),
         user.getUserId(),
@@ -132,13 +141,13 @@ class DatasetServiceDAOTest extends DAOTestHelper {
     User user = createUser();
 
     DatasetProperty prop1 = new DatasetProperty();
-    prop1.setSchemaProperty(RandomStringUtils.randomAlphabetic(10));
-    prop1.setPropertyName(RandomStringUtils.randomAlphabetic(10));
+    prop1.setSchemaProperty(RandomStringUtils.secure().nextAlphabetic(10));
+    prop1.setPropertyName(RandomStringUtils.secure().nextAlphabetic(10));
     prop1.setPropertyValue(new Random().nextInt());
     prop1.setPropertyType(PropertyType.Number);
 
     DatasetServiceDAO.DatasetInsert insert1 = new DatasetServiceDAO.DatasetInsert(
-        RandomStringUtils.randomAlphabetic(20),
+        RandomStringUtils.secure().nextAlphabetic(20),
         dac.getDacId(),
         new DataUseBuilder().setGeneralUse(true).build(),
         user.getUserId(),
@@ -146,7 +155,7 @@ class DatasetServiceDAOTest extends DAOTestHelper {
         List.of());
 
     DatasetServiceDAO.DatasetInsert insert2 = new DatasetServiceDAO.DatasetInsert(
-        RandomStringUtils.randomAlphabetic(20),
+        RandomStringUtils.secure().nextAlphabetic(20),
         dac.getDacId(),
         new DataUseBuilder().setIllegalBehavior(true).build(),
         user.getUserId(),
@@ -189,17 +198,17 @@ class DatasetServiceDAOTest extends DAOTestHelper {
     User user = createUser();
 
     DatasetServiceDAO.StudyInsert studyInsert = new DatasetServiceDAO.StudyInsert(
-        RandomStringUtils.randomAlphabetic(10),
-        RandomStringUtils.randomAlphabetic(10),
-        List.of(RandomStringUtils.randomAlphabetic(10)),
-        RandomStringUtils.randomAlphabetic(10),
+        RandomStringUtils.secure().nextAlphabetic(10),
+        RandomStringUtils.secure().nextAlphabetic(10),
+        List.of(RandomStringUtils.secure().nextAlphabetic(10)),
+        RandomStringUtils.secure().nextAlphabetic(10),
         true,
         user.getUserId(),
         List.of(),
         List.of());
 
     DatasetServiceDAO.DatasetInsert datasetInsert = new DatasetServiceDAO.DatasetInsert(
-        RandomStringUtils.randomAlphabetic(20),
+        RandomStringUtils.secure().nextAlphabetic(20),
         dac.getDacId(),
         new DataUseBuilder().setGeneralUse(true).build(),
         user.getUserId(),
@@ -235,27 +244,27 @@ class DatasetServiceDAOTest extends DAOTestHelper {
     User user = createUser();
 
     StudyProperty prop1 = new StudyProperty();
-    prop1.setKey(RandomStringUtils.randomAlphabetic(10));
+    prop1.setKey(RandomStringUtils.secure().nextAlphabetic(10));
     prop1.setType(PropertyType.String);
-    prop1.setValue(RandomStringUtils.randomAlphabetic(10));
+    prop1.setValue(RandomStringUtils.secure().nextAlphabetic(10));
 
     StudyProperty prop2 = new StudyProperty();
-    prop2.setKey(RandomStringUtils.randomAlphabetic(10));
+    prop2.setKey(RandomStringUtils.secure().nextAlphabetic(10));
     prop2.setType(PropertyType.Number);
     prop2.setValue(new Random().nextInt());
 
     DatasetServiceDAO.StudyInsert studyInsert = new DatasetServiceDAO.StudyInsert(
-        RandomStringUtils.randomAlphabetic(10),
-        RandomStringUtils.randomAlphabetic(10),
-        List.of(RandomStringUtils.randomAlphabetic(10)),
-        RandomStringUtils.randomAlphabetic(10),
+        RandomStringUtils.secure().nextAlphabetic(10),
+        RandomStringUtils.secure().nextAlphabetic(10),
+        List.of(RandomStringUtils.secure().nextAlphabetic(10)),
+        RandomStringUtils.secure().nextAlphabetic(10),
         true,
         user.getUserId(),
         List.of(prop1, prop2),
         List.of());
 
     DatasetServiceDAO.DatasetInsert datasetInsert = new DatasetServiceDAO.DatasetInsert(
-        RandomStringUtils.randomAlphabetic(20),
+        RandomStringUtils.secure().nextAlphabetic(20),
         dac.getDacId(),
         new DataUseBuilder().setGeneralUse(true).build(),
         user.getUserId(),
@@ -300,34 +309,35 @@ class DatasetServiceDAOTest extends DAOTestHelper {
     User user = createUser();
 
     StudyProperty prop1 = new StudyProperty();
-    prop1.setKey(RandomStringUtils.randomAlphabetic(10));
+    prop1.setKey(RandomStringUtils.secure().nextAlphabetic(10));
     prop1.setType(PropertyType.String);
-    prop1.setValue(RandomStringUtils.randomAlphabetic(10));
+    prop1.setValue(RandomStringUtils.secure().nextAlphabetic(10));
 
     StudyProperty prop2 = new StudyProperty();
-    prop2.setKey(RandomStringUtils.randomAlphabetic(10));
+    prop2.setKey(RandomStringUtils.secure().nextAlphabetic(10));
     prop2.setType(PropertyType.Number);
     prop2.setValue(new Random().nextInt());
 
     FileStorageObject file = new FileStorageObject();
-    file.setMediaType(RandomStringUtils.randomAlphabetic(20));
+    file.setMediaType(RandomStringUtils.secure().nextAlphabetic(20));
     file.setCategory(FileCategory.ALTERNATIVE_DATA_SHARING_PLAN);
     file.setBlobId(
-        BlobId.of(RandomStringUtils.randomAlphabetic(10), RandomStringUtils.randomAlphabetic(10)));
-    file.setFileName(RandomStringUtils.randomAlphabetic(10));
+        BlobId.of(RandomStringUtils.secure().nextAlphabetic(10),
+            RandomStringUtils.secure().nextAlphabetic(10)));
+    file.setFileName(RandomStringUtils.secure().nextAlphabetic(10));
 
     DatasetServiceDAO.StudyInsert studyInsert = new DatasetServiceDAO.StudyInsert(
-        RandomStringUtils.randomAlphabetic(10),
-        RandomStringUtils.randomAlphabetic(10),
-        List.of(RandomStringUtils.randomAlphabetic(10)),
-        RandomStringUtils.randomAlphabetic(10),
+        RandomStringUtils.secure().nextAlphabetic(10),
+        RandomStringUtils.secure().nextAlphabetic(10),
+        List.of(RandomStringUtils.secure().nextAlphabetic(10)),
+        RandomStringUtils.secure().nextAlphabetic(10),
         true,
         user.getUserId(),
         List.of(prop1, prop2),
         List.of(file));
 
     DatasetServiceDAO.DatasetInsert datasetInsert = new DatasetServiceDAO.DatasetInsert(
-        RandomStringUtils.randomAlphabetic(20),
+        RandomStringUtils.secure().nextAlphabetic(20),
         dac.getDacId(),
         new DataUseBuilder().setGeneralUse(true).build(),
         user.getUserId(),
@@ -370,6 +380,13 @@ class DatasetServiceDAOTest extends DAOTestHelper {
         s.getAlternativeDataSharingPlan().getFileName());
     assertEquals(file.getCategory(),
         s.getAlternativeDataSharingPlan().getCategory());
+
+    // Validate that an audit record was added for each dataset
+    datasets.forEach(d -> {
+      List<DatasetAudit> audits = datasetDAO.findAuditsByDatasetId(d.getDatasetId());
+      assertEquals(1, audits.size());
+      assertEquals(AuditActions.CREATE.name(), audits.get(0).getAction());
+    });
   }
 
   @Test
@@ -378,8 +395,8 @@ class DatasetServiceDAOTest extends DAOTestHelper {
 
     // Set up two existing props for updating
     DatasetProperty prop1 = new DatasetProperty();
-    prop1.setSchemaProperty(RandomStringUtils.randomAlphabetic(10));
-    prop1.setPropertyName(RandomStringUtils.randomAlphabetic(10));
+    prop1.setSchemaProperty(RandomStringUtils.secure().nextAlphabetic(10));
+    prop1.setPropertyName(RandomStringUtils.secure().nextAlphabetic(10));
     prop1.setPropertyType(PropertyType.Number);
     prop1.setPropertyKey(1);
     prop1.setPropertyValue(new Random().nextInt());
@@ -387,8 +404,8 @@ class DatasetServiceDAOTest extends DAOTestHelper {
     prop1.setCreateDate(new Date());
 
     DatasetProperty prop2 = new DatasetProperty();
-    prop2.setSchemaProperty(RandomStringUtils.randomAlphabetic(10));
-    prop2.setPropertyName(RandomStringUtils.randomAlphabetic(10));
+    prop2.setSchemaProperty(RandomStringUtils.secure().nextAlphabetic(10));
+    prop2.setPropertyName(RandomStringUtils.secure().nextAlphabetic(10));
     prop2.setPropertyType(PropertyType.Date);
     prop2.setPropertyKey(2);
     prop2.setPropertyValue("2000-10-20");
@@ -397,11 +414,11 @@ class DatasetServiceDAOTest extends DAOTestHelper {
 
     // Prop for deletion
     DatasetProperty prop3 = new DatasetProperty();
-    prop3.setSchemaProperty(RandomStringUtils.randomAlphabetic(10));
-    prop3.setPropertyName(RandomStringUtils.randomAlphabetic(10));
+    prop3.setSchemaProperty(RandomStringUtils.secure().nextAlphabetic(10));
+    prop3.setPropertyName(RandomStringUtils.secure().nextAlphabetic(10));
     prop3.setPropertyType(PropertyType.String);
     prop3.setPropertyKey(3);
-    prop3.setPropertyValue(RandomStringUtils.randomAlphabetic(10));
+    prop3.setPropertyValue(RandomStringUtils.secure().nextAlphabetic(10));
     prop3.setDatasetId(dataset.getDatasetId());
     prop3.setCreateDate(new Date());
 
@@ -418,8 +435,8 @@ class DatasetServiceDAOTest extends DAOTestHelper {
 
     // New prop to add as part of the update
     DatasetProperty prop4 = new DatasetProperty();
-    prop4.setSchemaProperty(RandomStringUtils.randomAlphabetic(10));
-    prop4.setPropertyName(RandomStringUtils.randomAlphabetic(10));
+    prop4.setSchemaProperty(RandomStringUtils.secure().nextAlphabetic(10));
+    prop4.setPropertyName(RandomStringUtils.secure().nextAlphabetic(10));
     prop4.setPropertyType(PropertyType.String);
     prop4.setPropertyKey(4);
     prop4.setPropertyValue("new prop4 value");
@@ -438,11 +455,16 @@ class DatasetServiceDAOTest extends DAOTestHelper {
     serviceDAO.updateDataset(updates);
 
     // Validate that the dataset props have been updated, deleted, or added:
-    Set<DatasetProperty> updatedProps = datasetDAO.findDatasetPropertiesByDatasetId(dataset.getDatasetId());
-    Optional<DatasetProperty> updated1 = updatedProps.stream().filter(p -> p.getPropertyName().equals(prop1.getPropertyName())).findFirst();
-    Optional<DatasetProperty> updated2 = updatedProps.stream().filter(p -> p.getPropertyName().equals(prop2.getPropertyName())).findFirst();
-    Optional<DatasetProperty> deleted3 = updatedProps.stream().filter(p -> p.getPropertyName().equals(prop3.getPropertyName())).findFirst();
-    Optional<DatasetProperty> added4 = updatedProps.stream().filter(p -> p.getPropertyName().equals(prop4.getPropertyName())).findFirst();
+    Set<DatasetProperty> updatedProps = datasetDAO.findDatasetPropertiesByDatasetId(
+        dataset.getDatasetId());
+    Optional<DatasetProperty> updated1 = updatedProps.stream()
+        .filter(p -> p.getPropertyName().equals(prop1.getPropertyName())).findFirst();
+    Optional<DatasetProperty> updated2 = updatedProps.stream()
+        .filter(p -> p.getPropertyName().equals(prop2.getPropertyName())).findFirst();
+    Optional<DatasetProperty> deleted3 = updatedProps.stream()
+        .filter(p -> p.getPropertyName().equals(prop3.getPropertyName())).findFirst();
+    Optional<DatasetProperty> added4 = updatedProps.stream()
+        .filter(p -> p.getPropertyName().equals(prop4.getPropertyName())).findFirst();
     assertTrue(updated1.isPresent());
     assertEquals(updateProp1.getPropertyValueAsString(), updated1.get().getPropertyValueAsString());
     assertTrue(updated2.isPresent());
@@ -453,6 +475,11 @@ class DatasetServiceDAOTest extends DAOTestHelper {
 
     Dataset updatedDataset = datasetDAO.findDatasetById(dataset.getDatasetId());
     assertEquals(newName, updatedDataset.getDatasetName());
+
+    // Validate that an audit record was added:
+    List<DatasetAudit> audits = datasetDAO.findAuditsByDatasetId(dataset.getDatasetId());
+    assertEquals(1, audits.size());
+    assertEquals(AuditActions.UPDATE.name(), audits.get(0).getAction());
   }
 
   @Test
@@ -480,6 +507,14 @@ class DatasetServiceDAOTest extends DAOTestHelper {
     assertEquals(newStudyDescription, updatedStudy.getDescription());
     assertEquals(newPIName, updatedStudy.getPiName());
     assertEquals(newDataTypes, updatedStudy.getDataTypes());
+
+    // Validate that NO update records were added for each dataset
+    updatedStudy.getDatasetIds().forEach(id -> {
+      List<DatasetAudit> audits = datasetDAO.findAuditsByDatasetId(id);
+      assertFalse(audits.isEmpty());
+      assertFalse(
+          audits.stream().anyMatch(a -> a.getAction().equalsIgnoreCase(AuditActions.UPDATE.name())));
+    });
   }
 
   @Test
@@ -488,9 +523,9 @@ class DatasetServiceDAOTest extends DAOTestHelper {
     List<StudyProperty> props = List.copyOf(study.getProperties());
 
     StudyProperty newProp = new StudyProperty();
-    newProp.setKey(RandomStringUtils.randomAlphabetic(10));
+    newProp.setKey(RandomStringUtils.secure().nextAlphabetic(10));
     newProp.setType(PropertyType.String);
-    newProp.setValue(RandomStringUtils.randomAlphabetic(10));
+    newProp.setValue(RandomStringUtils.secure().nextAlphabetic(10));
 
     String newPropValue = "New Study Prop Value";
     StudyProperty prop1 = props.get(0);
@@ -511,12 +546,22 @@ class DatasetServiceDAOTest extends DAOTestHelper {
 
     Study updatedStudy = serviceDAO.updateStudy(studyUpdate, List.of(), List.of());
     // Updated prop
-    Optional<StudyProperty> updatedProp1 = updatedStudy.getProperties().stream().filter(p -> p.getStudyPropertyId().equals(prop1.getStudyPropertyId())).findFirst();
+    Optional<StudyProperty> updatedProp1 = updatedStudy.getProperties().stream()
+        .filter(p -> p.getStudyPropertyId().equals(prop1.getStudyPropertyId())).findFirst();
     assertTrue(updatedProp1.isPresent());
     assertEquals(newPropValue, updatedProp1.get().getValue());
     // Added prop
-    Optional<StudyProperty> addedNewProp = updatedStudy.getProperties().stream().filter(p -> newProp.getValue().equals(p.getValue())).findFirst();
+    Optional<StudyProperty> addedNewProp = updatedStudy.getProperties().stream()
+        .filter(p -> newProp.getValue().equals(p.getValue())).findFirst();
     assertTrue(addedNewProp.isPresent());
+
+    // Validate that NO update records were added for each dataset
+    updatedStudy.getDatasetIds().forEach(id -> {
+      List<DatasetAudit> audits = datasetDAO.findAuditsByDatasetId(id);
+      assertFalse(audits.isEmpty());
+      assertFalse(
+          audits.stream().anyMatch(a -> a.getAction().equalsIgnoreCase(AuditActions.UPDATE.name())));
+    });
   }
 
   @Test
@@ -556,44 +601,58 @@ class DatasetServiceDAOTest extends DAOTestHelper {
         List.of()
     );
 
-    Study updatedStudy = serviceDAO.updateStudy(studyUpdate, List.of(datasetUpdate), List.of(datasetInsert));
-    List<Dataset> updatedDatasets = datasetDAO.findDatasetsByIdList(new ArrayList<>(updatedStudy.getDatasetIds()));
+    Study updatedStudy = serviceDAO.updateStudy(studyUpdate, List.of(datasetUpdate),
+        List.of(datasetInsert));
+    List<Dataset> updatedDatasets = datasetDAO.findDatasetsByIdList(
+        new ArrayList<>(updatedStudy.getDatasetIds()));
     assertTrue(updatedDatasets.contains(dataset));
     assertEquals(updatedStudy.getDatasetIds().size(), updatedDatasets.size());
     assertTrue(updatedDatasets.stream().anyMatch(d -> d.getDatasetName().equals(newDatasetName)));
     assertTrue(updatedDatasets.stream().anyMatch(d -> d.getDatasetName().equals(newInsertName)));
+
+    // Validate that update records were added for each dataset
+    updatedStudy.getDatasetIds().forEach(id -> {
+      List<DatasetAudit> audits = datasetDAO.findAuditsByDatasetId(id);
+      assertFalse(audits.isEmpty());
+      assertTrue(
+          audits.stream().anyMatch(a -> a.getAction().equalsIgnoreCase(AuditActions.CREATE.name())));
+    });
   }
 
   @Test
   void testUpdateStudyWithFileUpdates() throws Exception {
     FileStorageObject fso1 = new FileStorageObject();
-    fso1.setMediaType(RandomStringUtils.randomAlphabetic(20));
+    fso1.setMediaType(RandomStringUtils.secure().nextAlphabetic(20));
     fso1.setCategory(FileCategory.ALTERNATIVE_DATA_SHARING_PLAN);
     fso1.setBlobId(
-        BlobId.of(RandomStringUtils.randomAlphabetic(10), RandomStringUtils.randomAlphabetic(10)));
-    fso1.setFileName(RandomStringUtils.randomAlphabetic(10));
+        BlobId.of(RandomStringUtils.secure().nextAlphabetic(10),
+            RandomStringUtils.secure().nextAlphabetic(10)));
+    fso1.setFileName(RandomStringUtils.secure().nextAlphabetic(10));
 
     FileStorageObject fso2 = new FileStorageObject();
-    fso2.setMediaType(RandomStringUtils.randomAlphabetic(20));
+    fso2.setMediaType(RandomStringUtils.secure().nextAlphabetic(20));
     fso2.setCategory(FileCategory.NIH_INSTITUTIONAL_CERTIFICATION);
     fso2.setBlobId(
-        BlobId.of(RandomStringUtils.randomAlphabetic(10), RandomStringUtils.randomAlphabetic(10)));
-    fso2.setFileName(RandomStringUtils.randomAlphabetic(10));
+        BlobId.of(RandomStringUtils.secure().nextAlphabetic(10),
+            RandomStringUtils.secure().nextAlphabetic(10)));
+    fso2.setFileName(RandomStringUtils.secure().nextAlphabetic(10));
     Study study = createStudy(List.of(fso1, fso2));
 
     FileStorageObject updatedFso1 = new FileStorageObject();
-    updatedFso1.setMediaType(RandomStringUtils.randomAlphabetic(20));
+    updatedFso1.setMediaType(RandomStringUtils.secure().nextAlphabetic(20));
     updatedFso1.setCategory(FileCategory.ALTERNATIVE_DATA_SHARING_PLAN);
     updatedFso1.setBlobId(
-        BlobId.of(RandomStringUtils.randomAlphabetic(10), RandomStringUtils.randomAlphabetic(10)));
-    updatedFso1.setFileName(RandomStringUtils.randomAlphabetic(10));
+        BlobId.of(RandomStringUtils.secure().nextAlphabetic(10),
+            RandomStringUtils.secure().nextAlphabetic(10)));
+    updatedFso1.setFileName(RandomStringUtils.secure().nextAlphabetic(10));
 
     FileStorageObject updatedFso2 = new FileStorageObject();
-    updatedFso2.setMediaType(RandomStringUtils.randomAlphabetic(20));
+    updatedFso2.setMediaType(RandomStringUtils.secure().nextAlphabetic(20));
     updatedFso2.setCategory(FileCategory.NIH_INSTITUTIONAL_CERTIFICATION);
     updatedFso2.setBlobId(
-        BlobId.of(RandomStringUtils.randomAlphabetic(10), RandomStringUtils.randomAlphabetic(10)));
-    updatedFso2.setFileName(RandomStringUtils.randomAlphabetic(10));
+        BlobId.of(RandomStringUtils.secure().nextAlphabetic(10),
+            RandomStringUtils.secure().nextAlphabetic(10)));
+    updatedFso2.setFileName(RandomStringUtils.secure().nextAlphabetic(10));
 
     StudyUpdate studyUpdate = new StudyUpdate(
         study.getName(),
@@ -609,45 +668,73 @@ class DatasetServiceDAOTest extends DAOTestHelper {
 
     Study updatedStudy = serviceDAO.updateStudy(studyUpdate, List.of(), List.of());
     assertNotNull(updatedStudy.getAlternativeDataSharingPlan());
-    assertEquals(updatedFso1.getFileName(), updatedStudy.getAlternativeDataSharingPlan().getFileName());
+    assertEquals(updatedFso1.getFileName(),
+        updatedStudy.getAlternativeDataSharingPlan().getFileName());
     assertTrue(updatedStudy.getDatasetIds().stream().findFirst().isPresent());
-    Dataset dataset = datasetDAO.findDatasetById(updatedStudy.getDatasetIds().stream().findFirst().get());
+    Dataset dataset = datasetDAO.findDatasetById(
+        updatedStudy.getDatasetIds().stream().findFirst().get());
     assertNotNull(dataset.getNihInstitutionalCertificationFile());
-    assertEquals(updatedFso2.getFileName(), dataset.getNihInstitutionalCertificationFile().getFileName());
+    assertEquals(updatedFso2.getFileName(),
+        dataset.getNihInstitutionalCertificationFile().getFileName());
+
+    // Validate that NO update records were added for each dataset
+    updatedStudy.getDatasetIds().forEach(id -> {
+      List<DatasetAudit> audits = datasetDAO.findAuditsByDatasetId(id);
+      assertFalse(audits.isEmpty());
+      assertFalse(
+          audits.stream().anyMatch(a -> a.getAction().equalsIgnoreCase(AuditActions.UPDATE.name())));
+    });
   }
 
 
   @Test
   void testDeleteStudy() throws Exception {
     FileStorageObject fso1 = new FileStorageObject();
-    fso1.setMediaType(RandomStringUtils.randomAlphabetic(20));
+    fso1.setMediaType(RandomStringUtils.secure().nextAlphabetic(20));
     fso1.setCategory(FileCategory.ALTERNATIVE_DATA_SHARING_PLAN);
     fso1.setBlobId(
-        BlobId.of(RandomStringUtils.randomAlphabetic(10), RandomStringUtils.randomAlphabetic(10)));
-    fso1.setFileName(RandomStringUtils.randomAlphabetic(10));
+        BlobId.of(RandomStringUtils.secure().nextAlphabetic(10),
+            RandomStringUtils.secure().nextAlphabetic(10)));
+    fso1.setFileName(RandomStringUtils.secure().nextAlphabetic(10));
 
     FileStorageObject fso2 = new FileStorageObject();
-    fso2.setMediaType(RandomStringUtils.randomAlphabetic(20));
+    fso2.setMediaType(RandomStringUtils.secure().nextAlphabetic(20));
     fso2.setCategory(FileCategory.NIH_INSTITUTIONAL_CERTIFICATION);
     fso2.setBlobId(
-        BlobId.of(RandomStringUtils.randomAlphabetic(10), RandomStringUtils.randomAlphabetic(10)));
-    fso2.setFileName(RandomStringUtils.randomAlphabetic(10));
+        BlobId.of(RandomStringUtils.secure().nextAlphabetic(10),
+            RandomStringUtils.secure().nextAlphabetic(10)));
+    fso2.setFileName(RandomStringUtils.secure().nextAlphabetic(10));
     Study study = createStudy(List.of(fso1, fso2));
 
-    List<Dataset> datasets = datasetDAO.findDatasetsByIdList(new ArrayList<>(study.getDatasetIds()));
+    List<Dataset> datasets = datasetDAO.findDatasetsByIdList(
+        new ArrayList<>(study.getDatasetIds()));
     study.addDatasets(datasets);
 
     serviceDAO.deleteStudy(study, createUser());
     Study deletedStudy = studyDAO.findStudyById(study.getStudyId());
     assertNull(deletedStudy);
+
+    // Validate that audit records are added for each dataset:
+    study.getDatasetIds().forEach(id -> {
+      List<DatasetAudit> audits = datasetDAO.findAuditsByDatasetId(id);
+      assertFalse(audits.isEmpty());
+      assertTrue(
+          audits.stream().anyMatch(a -> a.getAction().equalsIgnoreCase(AuditActions.CREATE.name())));
+      assertTrue(
+          audits.stream().anyMatch(a -> a.getAction().equalsIgnoreCase(AuditActions.DELETE.name())));
+    });
+
   }
 
   @Test
   void testPatchDataset() throws Exception {
     List<Dictionary> dictionaries = datasetDAO.getDictionaryTerms();
-    Dictionary one = dictionaries.stream().filter(d -> d.getKeyId().equals(1)).findFirst().orElse(null);
-    Dictionary two = dictionaries.stream().filter(d -> d.getKeyId().equals(2)).findFirst().orElse(null);
-    Dictionary three = dictionaries.stream().filter(d -> d.getKeyId().equals(3)).findFirst().orElse(null);
+    Dictionary one = dictionaries.stream().filter(d -> d.getKeyId().equals(1)).findFirst()
+        .orElse(null);
+    Dictionary two = dictionaries.stream().filter(d -> d.getKeyId().equals(2)).findFirst()
+        .orElse(null);
+    Dictionary three = dictionaries.stream().filter(d -> d.getKeyId().equals(3)).findFirst()
+        .orElse(null);
     assertNotNull(one);
     assertNotNull(two);
     assertNotNull(three);
@@ -662,7 +749,7 @@ class DatasetServiceDAOTest extends DAOTestHelper {
     prop1.setPropertyName(one.getKey());
     prop1.setPropertyType(PropertyType.String);
     prop1.setPropertyKey(one.getKeyId());
-    prop1.setPropertyValue(RandomStringUtils.randomAlphabetic(10));
+    prop1.setPropertyValue(RandomStringUtils.secure().nextAlphabetic(10));
     prop1.setDatasetId(dataset.getDatasetId());
     prop1.setCreateDate(new Date());
 
@@ -672,7 +759,7 @@ class DatasetServiceDAOTest extends DAOTestHelper {
     prop2.setPropertyName(two.getKey());
     prop2.setPropertyType(PropertyType.String);
     prop2.setPropertyKey(two.getKeyId());
-    prop2.setPropertyValue(RandomStringUtils.randomAlphabetic(10));
+    prop2.setPropertyValue(RandomStringUtils.secure().nextAlphabetic(10));
     prop2.setDatasetId(dataset.getDatasetId());
     prop2.setCreateDate(new Date());
 
@@ -684,7 +771,7 @@ class DatasetServiceDAOTest extends DAOTestHelper {
     patchProp.setPropertyName(prop2.getPropertyName());
     patchProp.setPropertyType(prop2.getPropertyType());
     patchProp.setPropertyKey(prop2.getPropertyKey());
-    patchProp.setPropertyValue(RandomStringUtils.randomAlphabetic(10));
+    patchProp.setPropertyValue(RandomStringUtils.secure().nextAlphabetic(10));
 
     // New, added prop
     DatasetProperty prop3 = new DatasetProperty();
@@ -692,10 +779,10 @@ class DatasetServiceDAOTest extends DAOTestHelper {
     prop3.setPropertyName(three.getKey());
     prop3.setPropertyType(PropertyType.String);
     prop3.setPropertyKey(three.getKeyId());
-    prop3.setPropertyValue(RandomStringUtils.randomAlphabetic(10));
+    prop3.setPropertyValue(RandomStringUtils.secure().nextAlphabetic(10));
     prop3.setCreateDate(new Date());
 
-    String newName = RandomStringUtils.randomAlphabetic(10);
+    String newName = RandomStringUtils.secure().nextAlphabetic(10);
     DatasetPatch patch = new DatasetPatch(newName, List.of(patchProp, prop3));
 
     serviceDAO.patchDataset(dataset.getDatasetId(), user, patch);
@@ -704,25 +791,35 @@ class DatasetServiceDAOTest extends DAOTestHelper {
     // Validate that the name is updated
     assertEquals(newName, patched.getDatasetName());
 
-    Set<DatasetProperty> updatedProps = datasetDAO.findDatasetPropertiesByDatasetId(dataset.getDatasetId());
+    Set<DatasetProperty> updatedProps = datasetDAO.findDatasetPropertiesByDatasetId(
+        dataset.getDatasetId());
 
     // Validate that the first prop was not changed
-    Optional<DatasetProperty> original = updatedProps.stream().filter(p -> p.getPropertyName().equals(prop1.getPropertyName())).findFirst();
+    Optional<DatasetProperty> original = updatedProps.stream()
+        .filter(p -> p.getPropertyName().equals(prop1.getPropertyName())).findFirst();
     assertTrue(original.isPresent());
     assertEquals(prop1.getPropertyValue(), original.get().getPropertyValue());
 
     // Validate that the new value was updated
-    Optional<DatasetProperty> updated = updatedProps.stream().filter(p -> p.getPropertyName().equals(prop2.getPropertyName())).findFirst();
+    Optional<DatasetProperty> updated = updatedProps.stream()
+        .filter(p -> p.getPropertyName().equals(prop2.getPropertyName())).findFirst();
     assertTrue(updated.isPresent());
     assertEquals(patchProp.getPropertyValue(), updated.get().getPropertyValue());
 
     // Validate that the new prop was added
-    Optional<DatasetProperty> added = updatedProps.stream().filter(p -> p.getPropertyName().equals(prop3.getPropertyName())).findFirst();
+    Optional<DatasetProperty> added = updatedProps.stream()
+        .filter(p -> p.getPropertyName().equals(prop3.getPropertyName())).findFirst();
     assertTrue(added.isPresent());
     assertEquals(prop3.getPropertyValue(), added.get().getPropertyValue());
 
     // Validate that no props were deleted
     assertEquals(3, patched.getProperties().size());
+
+    // Validate that an audit record was added:
+    List<DatasetAudit> audits = datasetDAO.findAuditsByDatasetId(dataset.getDatasetId());
+    assertFalse(audits.isEmpty());
+    assertTrue(
+        audits.stream().anyMatch(a -> a.getAction().equalsIgnoreCase(AuditActions.UPDATE.name())));
   }
 
   @Test
@@ -735,6 +832,12 @@ class DatasetServiceDAOTest extends DAOTestHelper {
 
     // Validate that the name is NOT updated to a null value
     assertEquals(dataset.getName(), patched.getDatasetName());
+
+    // Validate that an update audit record was added:
+    List<DatasetAudit> audits = datasetDAO.findAuditsByDatasetId(dataset.getDatasetId());
+    assertFalse(audits.isEmpty());
+    assertTrue(
+        audits.stream().anyMatch(a -> a.getAction().equalsIgnoreCase(AuditActions.UPDATE.name())));
   }
 
   @Test
@@ -747,6 +850,12 @@ class DatasetServiceDAOTest extends DAOTestHelper {
 
     // Validate that the name is NOT updated with an empty value
     assertEquals(dataset.getName(), patched.getDatasetName());
+
+    // Validate that an update audit record was added:
+    List<DatasetAudit> audits = datasetDAO.findAuditsByDatasetId(dataset.getDatasetId());
+    assertFalse(audits.isEmpty());
+    assertTrue(
+        audits.stream().anyMatch(a -> a.getAction().equalsIgnoreCase(AuditActions.UPDATE.name())));
   }
 
   @Test
@@ -759,10 +868,17 @@ class DatasetServiceDAOTest extends DAOTestHelper {
 
     // Validate that the name is NOT updated with an empty value
     assertEquals(dataset.getName(), patched.getDatasetName());
+
+    // Validate that an update audit record was added:
+    List<DatasetAudit> audits = datasetDAO.findAuditsByDatasetId(dataset.getDatasetId());
+    assertFalse(audits.isEmpty());
+    assertTrue(
+        audits.stream().anyMatch(a -> a.getAction().equalsIgnoreCase(AuditActions.UPDATE.name())));
   }
 
   /**
    * Helper method to create a study with two props and one dataset
+   *
    * @param fso Optional FSO to use as part of the study insert
    * @return Study
    * @throws Exception The exception
@@ -772,35 +888,35 @@ class DatasetServiceDAOTest extends DAOTestHelper {
     User user = createUser();
 
     StudyProperty prop1 = new StudyProperty();
-    prop1.setKey(RandomStringUtils.randomAlphabetic(10));
+    prop1.setKey(RandomStringUtils.secure().nextAlphabetic(10));
     prop1.setType(PropertyType.String);
-    prop1.setValue(RandomStringUtils.randomAlphabetic(10));
+    prop1.setValue(RandomStringUtils.secure().nextAlphabetic(10));
 
     StudyProperty prop2 = new StudyProperty();
-    prop2.setKey(RandomStringUtils.randomAlphabetic(10));
+    prop2.setKey(RandomStringUtils.secure().nextAlphabetic(10));
     prop2.setType(PropertyType.String);
-    prop2.setValue(RandomStringUtils.randomAlphabetic(10));
+    prop2.setValue(RandomStringUtils.secure().nextAlphabetic(10));
 
     DatasetServiceDAO.StudyInsert studyInsert = new DatasetServiceDAO.StudyInsert(
-        RandomStringUtils.randomAlphabetic(10),
-        RandomStringUtils.randomAlphabetic(10),
-        List.of(RandomStringUtils.randomAlphabetic(10)),
-        RandomStringUtils.randomAlphabetic(10),
+        RandomStringUtils.secure().nextAlphabetic(10),
+        RandomStringUtils.secure().nextAlphabetic(10),
+        List.of(RandomStringUtils.secure().nextAlphabetic(10)),
+        RandomStringUtils.secure().nextAlphabetic(10),
         true,
         user.getUserId(),
         List.of(prop1, prop2),
         Objects.isNull(fso) ? List.of() : fso);
 
     DatasetProperty datasetProperty = new DatasetProperty();
-    datasetProperty.setSchemaProperty(RandomStringUtils.randomAlphabetic(10));
-    datasetProperty.setPropertyName(RandomStringUtils.randomAlphabetic(10));
+    datasetProperty.setSchemaProperty(RandomStringUtils.secure().nextAlphabetic(10));
+    datasetProperty.setPropertyName(RandomStringUtils.secure().nextAlphabetic(10));
     datasetProperty.setPropertyType(PropertyType.Number);
     datasetProperty.setPropertyKey(1);
     datasetProperty.setPropertyValue(new Random().nextInt());
     datasetProperty.setCreateDate(new Date());
 
     DatasetServiceDAO.DatasetInsert datasetInsert = new DatasetServiceDAO.DatasetInsert(
-        RandomStringUtils.randomAlphabetic(20),
+        RandomStringUtils.secure().nextAlphabetic(20),
         dac.getDacId(),
         new DataUseBuilder().setGeneralUse(true).build(),
         user.getUserId(),
@@ -815,9 +931,9 @@ class DatasetServiceDAOTest extends DAOTestHelper {
 
   private Dataset createDataset() {
     User user = createUser();
-    String name = "Name_" + RandomStringUtils.random(20, true, true);
+    String name = "Name_" + RandomStringUtils.secure().nextAlphanumeric(20);
     Timestamp now = new Timestamp(new Date().getTime());
-    String objectId = "Object ID_" + RandomStringUtils.random(20, true, true);
+    String objectId = "Object ID_" + RandomStringUtils.secure().nextAlphanumeric(20);
     DataUse dataUse = new DataUseBuilder().setGeneralUse(true).build();
     Integer id = datasetDAO.insertDataset(name, now, user.getUserId(), objectId,
         dataUse.toString(), null);
@@ -826,8 +942,8 @@ class DatasetServiceDAOTest extends DAOTestHelper {
 
   private Dac createDac() {
     Integer id = dacDAO.createDac(
-        "Test_" + RandomStringUtils.random(20, true, true),
-        "Test_" + RandomStringUtils.random(20, true, true),
+        "Test_" + RandomStringUtils.secure().nextAlphanumeric(20),
+        "Test_" + RandomStringUtils.secure().nextAlphanumeric(20),
         new Date());
     return dacDAO.findById(id);
   }

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAOTest.java
@@ -15,7 +15,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.broadinstitute.consent.http.db.DAOTestHelper;
 import org.broadinstitute.consent.http.enumeration.AuditActions;
 import org.broadinstitute.consent.http.enumeration.FileCategory;
@@ -72,27 +71,27 @@ class DatasetServiceDAOTest extends DAOTestHelper {
     User user = createUser();
 
     DatasetProperty prop1 = new DatasetProperty();
-    prop1.setSchemaProperty(RandomStringUtils.secure().nextAlphabetic(10));
-    prop1.setPropertyName(RandomStringUtils.secure().nextAlphabetic(10));
+    prop1.setSchemaProperty(randomAlphabetic(10));
+    prop1.setPropertyName(randomAlphabetic(10));
     prop1.setPropertyType(PropertyType.Number);
     prop1.setPropertyValue(new Random().nextInt());
 
     DatasetProperty prop2 = new DatasetProperty();
-    prop2.setSchemaProperty(RandomStringUtils.secure().nextAlphabetic(10));
-    prop2.setPropertyName(RandomStringUtils.secure().nextAlphabetic(10));
+    prop2.setSchemaProperty(randomAlphabetic(10));
+    prop2.setPropertyName(randomAlphabetic(10));
     prop2.setPropertyType(PropertyType.Date);
     prop2.setPropertyValueAsString("2000-10-20");
 
     FileStorageObject file1 = new FileStorageObject();
-    file1.setMediaType(RandomStringUtils.secure().nextAlphabetic(20));
+    file1.setMediaType(randomAlphabetic(20));
     file1.setCategory(FileCategory.NIH_INSTITUTIONAL_CERTIFICATION);
     file1.setBlobId(
-        BlobId.of(RandomStringUtils.secure().nextAlphabetic(10),
-            RandomStringUtils.secure().nextAlphabetic(10)));
-    file1.setFileName(RandomStringUtils.secure().nextAlphabetic(10));
+        BlobId.of(randomAlphabetic(10),
+            randomAlphabetic(10)));
+    file1.setFileName(randomAlphabetic(10));
 
     DatasetServiceDAO.DatasetInsert insert = new DatasetServiceDAO.DatasetInsert(
-        RandomStringUtils.secure().nextAlphabetic(20),
+        randomAlphabetic(20),
         dac.getDacId(),
         new DataUseBuilder().setStigmatizeDiseases(true).setGeneralUse(true).build(),
         user.getUserId(),
@@ -139,13 +138,13 @@ class DatasetServiceDAOTest extends DAOTestHelper {
     User user = createUser();
 
     DatasetProperty prop1 = new DatasetProperty();
-    prop1.setSchemaProperty(RandomStringUtils.secure().nextAlphabetic(10));
-    prop1.setPropertyName(RandomStringUtils.secure().nextAlphabetic(10));
+    prop1.setSchemaProperty(randomAlphabetic(10));
+    prop1.setPropertyName(randomAlphabetic(10));
     prop1.setPropertyValue(new Random().nextInt());
     prop1.setPropertyType(PropertyType.Number);
 
     DatasetServiceDAO.DatasetInsert insert1 = new DatasetServiceDAO.DatasetInsert(
-        RandomStringUtils.secure().nextAlphabetic(20),
+        randomAlphabetic(20),
         dac.getDacId(),
         new DataUseBuilder().setGeneralUse(true).build(),
         user.getUserId(),
@@ -153,7 +152,7 @@ class DatasetServiceDAOTest extends DAOTestHelper {
         List.of());
 
     DatasetServiceDAO.DatasetInsert insert2 = new DatasetServiceDAO.DatasetInsert(
-        RandomStringUtils.secure().nextAlphabetic(20),
+        randomAlphabetic(20),
         dac.getDacId(),
         new DataUseBuilder().setIllegalBehavior(true).build(),
         user.getUserId(),
@@ -196,17 +195,17 @@ class DatasetServiceDAOTest extends DAOTestHelper {
     User user = createUser();
 
     DatasetServiceDAO.StudyInsert studyInsert = new DatasetServiceDAO.StudyInsert(
-        RandomStringUtils.secure().nextAlphabetic(10),
-        RandomStringUtils.secure().nextAlphabetic(10),
-        List.of(RandomStringUtils.secure().nextAlphabetic(10)),
-        RandomStringUtils.secure().nextAlphabetic(10),
+        randomAlphabetic(10),
+        randomAlphabetic(10),
+        List.of(randomAlphabetic(10)),
+        randomAlphabetic(10),
         true,
         user.getUserId(),
         List.of(),
         List.of());
 
     DatasetServiceDAO.DatasetInsert datasetInsert = new DatasetServiceDAO.DatasetInsert(
-        RandomStringUtils.secure().nextAlphabetic(20),
+        randomAlphabetic(20),
         dac.getDacId(),
         new DataUseBuilder().setGeneralUse(true).build(),
         user.getUserId(),
@@ -242,27 +241,27 @@ class DatasetServiceDAOTest extends DAOTestHelper {
     User user = createUser();
 
     StudyProperty prop1 = new StudyProperty();
-    prop1.setKey(RandomStringUtils.secure().nextAlphabetic(10));
+    prop1.setKey(randomAlphabetic(10));
     prop1.setType(PropertyType.String);
-    prop1.setValue(RandomStringUtils.secure().nextAlphabetic(10));
+    prop1.setValue(randomAlphabetic(10));
 
     StudyProperty prop2 = new StudyProperty();
-    prop2.setKey(RandomStringUtils.secure().nextAlphabetic(10));
+    prop2.setKey(randomAlphabetic(10));
     prop2.setType(PropertyType.Number);
     prop2.setValue(new Random().nextInt());
 
     DatasetServiceDAO.StudyInsert studyInsert = new DatasetServiceDAO.StudyInsert(
-        RandomStringUtils.secure().nextAlphabetic(10),
-        RandomStringUtils.secure().nextAlphabetic(10),
-        List.of(RandomStringUtils.secure().nextAlphabetic(10)),
-        RandomStringUtils.secure().nextAlphabetic(10),
+        randomAlphabetic(10),
+        randomAlphabetic(10),
+        List.of(randomAlphabetic(10)),
+        randomAlphabetic(10),
         true,
         user.getUserId(),
         List.of(prop1, prop2),
         List.of());
 
     DatasetServiceDAO.DatasetInsert datasetInsert = new DatasetServiceDAO.DatasetInsert(
-        RandomStringUtils.secure().nextAlphabetic(20),
+        randomAlphabetic(20),
         dac.getDacId(),
         new DataUseBuilder().setGeneralUse(true).build(),
         user.getUserId(),
@@ -307,35 +306,35 @@ class DatasetServiceDAOTest extends DAOTestHelper {
     User user = createUser();
 
     StudyProperty prop1 = new StudyProperty();
-    prop1.setKey(RandomStringUtils.secure().nextAlphabetic(10));
+    prop1.setKey(randomAlphabetic(10));
     prop1.setType(PropertyType.String);
-    prop1.setValue(RandomStringUtils.secure().nextAlphabetic(10));
+    prop1.setValue(randomAlphabetic(10));
 
     StudyProperty prop2 = new StudyProperty();
-    prop2.setKey(RandomStringUtils.secure().nextAlphabetic(10));
+    prop2.setKey(randomAlphabetic(10));
     prop2.setType(PropertyType.Number);
     prop2.setValue(new Random().nextInt());
 
     FileStorageObject file = new FileStorageObject();
-    file.setMediaType(RandomStringUtils.secure().nextAlphabetic(20));
+    file.setMediaType(randomAlphabetic(20));
     file.setCategory(FileCategory.ALTERNATIVE_DATA_SHARING_PLAN);
     file.setBlobId(
-        BlobId.of(RandomStringUtils.secure().nextAlphabetic(10),
-            RandomStringUtils.secure().nextAlphabetic(10)));
-    file.setFileName(RandomStringUtils.secure().nextAlphabetic(10));
+        BlobId.of(randomAlphabetic(10),
+            randomAlphabetic(10)));
+    file.setFileName(randomAlphabetic(10));
 
     DatasetServiceDAO.StudyInsert studyInsert = new DatasetServiceDAO.StudyInsert(
-        RandomStringUtils.secure().nextAlphabetic(10),
-        RandomStringUtils.secure().nextAlphabetic(10),
-        List.of(RandomStringUtils.secure().nextAlphabetic(10)),
-        RandomStringUtils.secure().nextAlphabetic(10),
+        randomAlphabetic(10),
+        randomAlphabetic(10),
+        List.of(randomAlphabetic(10)),
+        randomAlphabetic(10),
         true,
         user.getUserId(),
         List.of(prop1, prop2),
         List.of(file));
 
     DatasetServiceDAO.DatasetInsert datasetInsert = new DatasetServiceDAO.DatasetInsert(
-        RandomStringUtils.secure().nextAlphabetic(20),
+        randomAlphabetic(20),
         dac.getDacId(),
         new DataUseBuilder().setGeneralUse(true).build(),
         user.getUserId(),
@@ -393,8 +392,8 @@ class DatasetServiceDAOTest extends DAOTestHelper {
 
     // Set up two existing props for updating
     DatasetProperty prop1 = new DatasetProperty();
-    prop1.setSchemaProperty(RandomStringUtils.secure().nextAlphabetic(10));
-    prop1.setPropertyName(RandomStringUtils.secure().nextAlphabetic(10));
+    prop1.setSchemaProperty(randomAlphabetic(10));
+    prop1.setPropertyName(randomAlphabetic(10));
     prop1.setPropertyType(PropertyType.Number);
     prop1.setPropertyKey(1);
     prop1.setPropertyValue(new Random().nextInt());
@@ -402,8 +401,8 @@ class DatasetServiceDAOTest extends DAOTestHelper {
     prop1.setCreateDate(new Date());
 
     DatasetProperty prop2 = new DatasetProperty();
-    prop2.setSchemaProperty(RandomStringUtils.secure().nextAlphabetic(10));
-    prop2.setPropertyName(RandomStringUtils.secure().nextAlphabetic(10));
+    prop2.setSchemaProperty(randomAlphabetic(10));
+    prop2.setPropertyName(randomAlphabetic(10));
     prop2.setPropertyType(PropertyType.Date);
     prop2.setPropertyKey(2);
     prop2.setPropertyValue("2000-10-20");
@@ -412,11 +411,11 @@ class DatasetServiceDAOTest extends DAOTestHelper {
 
     // Prop for deletion
     DatasetProperty prop3 = new DatasetProperty();
-    prop3.setSchemaProperty(RandomStringUtils.secure().nextAlphabetic(10));
-    prop3.setPropertyName(RandomStringUtils.secure().nextAlphabetic(10));
+    prop3.setSchemaProperty(randomAlphabetic(10));
+    prop3.setPropertyName(randomAlphabetic(10));
     prop3.setPropertyType(PropertyType.String);
     prop3.setPropertyKey(3);
-    prop3.setPropertyValue(RandomStringUtils.secure().nextAlphabetic(10));
+    prop3.setPropertyValue(randomAlphabetic(10));
     prop3.setDatasetId(dataset.getDatasetId());
     prop3.setCreateDate(new Date());
 
@@ -433,8 +432,8 @@ class DatasetServiceDAOTest extends DAOTestHelper {
 
     // New prop to add as part of the update
     DatasetProperty prop4 = new DatasetProperty();
-    prop4.setSchemaProperty(RandomStringUtils.secure().nextAlphabetic(10));
-    prop4.setPropertyName(RandomStringUtils.secure().nextAlphabetic(10));
+    prop4.setSchemaProperty(randomAlphabetic(10));
+    prop4.setPropertyName(randomAlphabetic(10));
     prop4.setPropertyType(PropertyType.String);
     prop4.setPropertyKey(4);
     prop4.setPropertyValue("new prop4 value");
@@ -522,9 +521,9 @@ class DatasetServiceDAOTest extends DAOTestHelper {
     List<StudyProperty> props = List.copyOf(study.getProperties());
 
     StudyProperty newProp = new StudyProperty();
-    newProp.setKey(RandomStringUtils.secure().nextAlphabetic(10));
+    newProp.setKey(randomAlphabetic(10));
     newProp.setType(PropertyType.String);
-    newProp.setValue(RandomStringUtils.secure().nextAlphabetic(10));
+    newProp.setValue(randomAlphabetic(10));
 
     String newPropValue = "New Study Prop Value";
     StudyProperty prop1 = props.get(0);
@@ -623,37 +622,37 @@ class DatasetServiceDAOTest extends DAOTestHelper {
   @Test
   void testUpdateStudyWithFileUpdates() throws Exception {
     FileStorageObject fso1 = new FileStorageObject();
-    fso1.setMediaType(RandomStringUtils.secure().nextAlphabetic(20));
+    fso1.setMediaType(randomAlphabetic(20));
     fso1.setCategory(FileCategory.ALTERNATIVE_DATA_SHARING_PLAN);
     fso1.setBlobId(
-        BlobId.of(RandomStringUtils.secure().nextAlphabetic(10),
-            RandomStringUtils.secure().nextAlphabetic(10)));
-    fso1.setFileName(RandomStringUtils.secure().nextAlphabetic(10));
+        BlobId.of(randomAlphabetic(10),
+            randomAlphabetic(10)));
+    fso1.setFileName(randomAlphabetic(10));
 
     FileStorageObject fso2 = new FileStorageObject();
-    fso2.setMediaType(RandomStringUtils.secure().nextAlphabetic(20));
+    fso2.setMediaType(randomAlphabetic(20));
     fso2.setCategory(FileCategory.NIH_INSTITUTIONAL_CERTIFICATION);
     fso2.setBlobId(
-        BlobId.of(RandomStringUtils.secure().nextAlphabetic(10),
-            RandomStringUtils.secure().nextAlphabetic(10)));
-    fso2.setFileName(RandomStringUtils.secure().nextAlphabetic(10));
+        BlobId.of(randomAlphabetic(10),
+            randomAlphabetic(10)));
+    fso2.setFileName(randomAlphabetic(10));
     Study study = createStudy(List.of(fso1, fso2));
 
     FileStorageObject updatedFso1 = new FileStorageObject();
-    updatedFso1.setMediaType(RandomStringUtils.secure().nextAlphabetic(20));
+    updatedFso1.setMediaType(randomAlphabetic(20));
     updatedFso1.setCategory(FileCategory.ALTERNATIVE_DATA_SHARING_PLAN);
     updatedFso1.setBlobId(
-        BlobId.of(RandomStringUtils.secure().nextAlphabetic(10),
-            RandomStringUtils.secure().nextAlphabetic(10)));
-    updatedFso1.setFileName(RandomStringUtils.secure().nextAlphabetic(10));
+        BlobId.of(randomAlphabetic(10),
+            randomAlphabetic(10)));
+    updatedFso1.setFileName(randomAlphabetic(10));
 
     FileStorageObject updatedFso2 = new FileStorageObject();
-    updatedFso2.setMediaType(RandomStringUtils.secure().nextAlphabetic(20));
+    updatedFso2.setMediaType(randomAlphabetic(20));
     updatedFso2.setCategory(FileCategory.NIH_INSTITUTIONAL_CERTIFICATION);
     updatedFso2.setBlobId(
-        BlobId.of(RandomStringUtils.secure().nextAlphabetic(10),
-            RandomStringUtils.secure().nextAlphabetic(10)));
-    updatedFso2.setFileName(RandomStringUtils.secure().nextAlphabetic(10));
+        BlobId.of(randomAlphabetic(10),
+            randomAlphabetic(10)));
+    updatedFso2.setFileName(randomAlphabetic(10));
 
     StudyUpdate studyUpdate = new StudyUpdate(
         study.getName(),
@@ -692,20 +691,20 @@ class DatasetServiceDAOTest extends DAOTestHelper {
   @Test
   void testDeleteStudy() throws Exception {
     FileStorageObject fso1 = new FileStorageObject();
-    fso1.setMediaType(RandomStringUtils.secure().nextAlphabetic(20));
+    fso1.setMediaType(randomAlphabetic(20));
     fso1.setCategory(FileCategory.ALTERNATIVE_DATA_SHARING_PLAN);
     fso1.setBlobId(
-        BlobId.of(RandomStringUtils.secure().nextAlphabetic(10),
-            RandomStringUtils.secure().nextAlphabetic(10)));
-    fso1.setFileName(RandomStringUtils.secure().nextAlphabetic(10));
+        BlobId.of(randomAlphabetic(10),
+            randomAlphabetic(10)));
+    fso1.setFileName(randomAlphabetic(10));
 
     FileStorageObject fso2 = new FileStorageObject();
-    fso2.setMediaType(RandomStringUtils.secure().nextAlphabetic(20));
+    fso2.setMediaType(randomAlphabetic(20));
     fso2.setCategory(FileCategory.NIH_INSTITUTIONAL_CERTIFICATION);
     fso2.setBlobId(
-        BlobId.of(RandomStringUtils.secure().nextAlphabetic(10),
-            RandomStringUtils.secure().nextAlphabetic(10)));
-    fso2.setFileName(RandomStringUtils.secure().nextAlphabetic(10));
+        BlobId.of(randomAlphabetic(10),
+            randomAlphabetic(10)));
+    fso2.setFileName(randomAlphabetic(10));
     Study study = createStudy(List.of(fso1, fso2));
 
     List<Dataset> datasets = datasetDAO.findDatasetsByIdList(
@@ -753,7 +752,7 @@ class DatasetServiceDAOTest extends DAOTestHelper {
     prop1.setPropertyName(one.getKey());
     prop1.setPropertyType(PropertyType.String);
     prop1.setPropertyKey(one.getKeyId());
-    prop1.setPropertyValue(RandomStringUtils.secure().nextAlphabetic(10));
+    prop1.setPropertyValue(randomAlphabetic(10));
     prop1.setDatasetId(dataset.getDatasetId());
     prop1.setCreateDate(new Date());
 
@@ -763,7 +762,7 @@ class DatasetServiceDAOTest extends DAOTestHelper {
     prop2.setPropertyName(two.getKey());
     prop2.setPropertyType(PropertyType.String);
     prop2.setPropertyKey(two.getKeyId());
-    prop2.setPropertyValue(RandomStringUtils.secure().nextAlphabetic(10));
+    prop2.setPropertyValue(randomAlphabetic(10));
     prop2.setDatasetId(dataset.getDatasetId());
     prop2.setCreateDate(new Date());
 
@@ -775,7 +774,7 @@ class DatasetServiceDAOTest extends DAOTestHelper {
     patchProp.setPropertyName(prop2.getPropertyName());
     patchProp.setPropertyType(prop2.getPropertyType());
     patchProp.setPropertyKey(prop2.getPropertyKey());
-    patchProp.setPropertyValue(RandomStringUtils.secure().nextAlphabetic(10));
+    patchProp.setPropertyValue(randomAlphabetic(10));
 
     // New, added prop
     DatasetProperty prop3 = new DatasetProperty();
@@ -783,10 +782,10 @@ class DatasetServiceDAOTest extends DAOTestHelper {
     prop3.setPropertyName(three.getKey());
     prop3.setPropertyType(PropertyType.String);
     prop3.setPropertyKey(three.getKeyId());
-    prop3.setPropertyValue(RandomStringUtils.secure().nextAlphabetic(10));
+    prop3.setPropertyValue(randomAlphabetic(10));
     prop3.setCreateDate(new Date());
 
-    String newName = RandomStringUtils.secure().nextAlphabetic(10);
+    String newName = randomAlphabetic(10);
     DatasetPatch patch = new DatasetPatch(newName, List.of(patchProp, prop3));
 
     serviceDAO.patchDataset(dataset.getDatasetId(), user, patch);
@@ -892,35 +891,35 @@ class DatasetServiceDAOTest extends DAOTestHelper {
     User user = createUser();
 
     StudyProperty prop1 = new StudyProperty();
-    prop1.setKey(RandomStringUtils.secure().nextAlphabetic(10));
+    prop1.setKey(randomAlphabetic(10));
     prop1.setType(PropertyType.String);
-    prop1.setValue(RandomStringUtils.secure().nextAlphabetic(10));
+    prop1.setValue(randomAlphabetic(10));
 
     StudyProperty prop2 = new StudyProperty();
-    prop2.setKey(RandomStringUtils.secure().nextAlphabetic(10));
+    prop2.setKey(randomAlphabetic(10));
     prop2.setType(PropertyType.String);
-    prop2.setValue(RandomStringUtils.secure().nextAlphabetic(10));
+    prop2.setValue(randomAlphabetic(10));
 
     DatasetServiceDAO.StudyInsert studyInsert = new DatasetServiceDAO.StudyInsert(
-        RandomStringUtils.secure().nextAlphabetic(10),
-        RandomStringUtils.secure().nextAlphabetic(10),
-        List.of(RandomStringUtils.secure().nextAlphabetic(10)),
-        RandomStringUtils.secure().nextAlphabetic(10),
+        randomAlphabetic(10),
+        randomAlphabetic(10),
+        List.of(randomAlphabetic(10)),
+        randomAlphabetic(10),
         true,
         user.getUserId(),
         List.of(prop1, prop2),
         Objects.isNull(fso) ? List.of() : fso);
 
     DatasetProperty datasetProperty = new DatasetProperty();
-    datasetProperty.setSchemaProperty(RandomStringUtils.secure().nextAlphabetic(10));
-    datasetProperty.setPropertyName(RandomStringUtils.secure().nextAlphabetic(10));
+    datasetProperty.setSchemaProperty(randomAlphabetic(10));
+    datasetProperty.setPropertyName(randomAlphabetic(10));
     datasetProperty.setPropertyType(PropertyType.Number);
     datasetProperty.setPropertyKey(1);
     datasetProperty.setPropertyValue(new Random().nextInt());
     datasetProperty.setCreateDate(new Date());
 
     DatasetServiceDAO.DatasetInsert datasetInsert = new DatasetServiceDAO.DatasetInsert(
-        RandomStringUtils.secure().nextAlphabetic(20),
+        randomAlphabetic(20),
         dac.getDacId(),
         new DataUseBuilder().setGeneralUse(true).build(),
         user.getUserId(),
@@ -935,9 +934,9 @@ class DatasetServiceDAOTest extends DAOTestHelper {
 
   private Dataset createDataset() {
     User user = createUser();
-    String name = "Name_" + RandomStringUtils.secure().nextAlphanumeric(20);
+    String name = "Name_" + randomAlphanumeric(20);
     Timestamp now = new Timestamp(new Date().getTime());
-    String objectId = "Object ID_" + RandomStringUtils.secure().nextAlphanumeric(20);
+    String objectId = "Object ID_" + randomAlphanumeric(20);
     DataUse dataUse = new DataUseBuilder().setGeneralUse(true).build();
     Integer id = datasetDAO.insertDataset(name, now, user.getUserId(), objectId,
         dataUse.toString(), null);
@@ -946,8 +945,8 @@ class DatasetServiceDAOTest extends DAOTestHelper {
 
   private Dac createDac() {
     Integer id = dacDAO.createDac(
-        "Test_" + RandomStringUtils.secure().nextAlphanumeric(20),
-        "Test_" + RandomStringUtils.secure().nextAlphanumeric(20),
+        "Test_" + randomAlphanumeric(20),
+        "Test_" + randomAlphanumeric(20),
         new Date());
     return dacDAO.findById(id);
   }


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-1060

### Summary

- Adds dataset audits to the insert, update, and patch operations.
- Significant test updates to ensure the audits happen where appropriate
- Test updates to move from the deprecated random string utility methods we used for random values

Note to reviewers, there are a lot of formatting changes so I recommend hiding white space

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
