### PR TITLE
DT-1078: Fix Study Update bug that cleared out dataset name

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
@@ -190,7 +190,7 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
           WHERE d.dataset_id in (<datasetIds>)
           ORDER BY d.dataset_id
       """)
-  List<Dataset> findDatasetsByIdList(@BindList("datasetIds") List<Integer> datasetIds);
+  List<Dataset> findDatasetsByIdList(@BindList("datasetIds") Collection<Integer> datasetIds);
 
   @Deprecated
   @UseRowReducer(DatasetReducer.class)

--- a/src/main/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAO.java
@@ -368,23 +368,17 @@ public class DatasetServiceDAO implements ConsentLogger {
       boolean executeDeletes) {
 
     // Don't update the name if it isn't provided
-    if (StringUtils.isBlank(datasetName)) {
-      Dataset dataset = datasetDAO.findDatasetById(datasetId);
-      addAuditRecord(datasetId, dataset.getName(), userId, AuditActions.UPDATE);
-      datasetDAO.updateDatasetUpdateUser(datasetId, new Timestamp(new Date().getTime()),
-          userId
-      );
-    } else {
-      addAuditRecord(datasetId, datasetName, userId, AuditActions.UPDATE);
-      // update dataset
-      datasetDAO.updateDatasetByDatasetId(
-          datasetId,
-          datasetName,
-          new Timestamp(new Date().getTime()),
-          userId,
-          dacId
-      );
-    }
+    Dataset dataset = datasetDAO.findDatasetById(datasetId);
+    String updateName = StringUtils.isBlank(datasetName) ? dataset.getName() : datasetName;
+    addAuditRecord(datasetId, updateName, userId, AuditActions.UPDATE);
+    // update dataset
+    datasetDAO.updateDatasetByDatasetId(
+        datasetId,
+        updateName,
+        new Timestamp(new Date().getTime()),
+        userId,
+        dacId
+    );
 
     // insert properties
     executeSynchronizeDatasetProperties(handle, datasetId, properties, executeDeletes);

--- a/src/main/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAO.java
@@ -12,6 +12,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.consent.http.db.DatasetDAO;
 import org.broadinstitute.consent.http.db.FileStorageObjectDAO;
 import org.broadinstitute.consent.http.db.StudyDAO;
@@ -365,15 +366,25 @@ public class DatasetServiceDAO implements ConsentLogger {
       List<DatasetProperty> properties,
       List<FileStorageObject> uploadedFiles,
       boolean executeDeletes) {
-    addAuditRecord(datasetId, datasetName, userId, AuditActions.UPDATE);
-    // update dataset
-    datasetDAO.updateDatasetByDatasetId(
-        datasetId,
-        datasetName,
-        new Timestamp(new Date().getTime()),
-        userId,
-        dacId
-    );
+
+    // Don't update the name if it isn't provided
+    if (StringUtils.isBlank(datasetName)) {
+      Dataset dataset = datasetDAO.findDatasetById(datasetId);
+      addAuditRecord(datasetId, dataset.getName(), userId, AuditActions.UPDATE);
+      datasetDAO.updateDatasetUpdateUser(datasetId, new Timestamp(new Date().getTime()),
+          userId
+      );
+    } else {
+      addAuditRecord(datasetId, datasetName, userId, AuditActions.UPDATE);
+      // update dataset
+      datasetDAO.updateDatasetByDatasetId(
+          datasetId,
+          datasetName,
+          new Timestamp(new Date().getTime()),
+          userId,
+          dacId
+      );
+    }
 
     // insert properties
     executeSynchronizeDatasetProperties(handle, datasetId, properties, executeDeletes);

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAOTest.java
@@ -768,7 +768,6 @@ class DatasetServiceDAOTest extends DAOTestHelper {
         false)
     );
     Dataset updatedDataset = datasetDAO.findDatasetById(dataset.getDatasetId());
-    assertNotNull(updatedDataset);
     assertNotNull(updatedDataset.getName());
     List<DatasetAudit> audits = datasetDAO.findAuditsByDatasetId(dataset.getDatasetId());
     assertFalse(audits.isEmpty());
@@ -792,7 +791,6 @@ class DatasetServiceDAOTest extends DAOTestHelper {
         false)
     );
     Dataset updatedDataset = datasetDAO.findDatasetById(dataset.getDatasetId());
-    assertNotNull(updatedDataset);
     assertEquals(newName, updatedDataset.getName());
     List<DatasetAudit> audits = datasetDAO.findAuditsByDatasetId(dataset.getDatasetId());
     assertFalse(audits.isEmpty());

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAOTest.java
@@ -747,7 +747,6 @@ class DatasetServiceDAOTest extends DAOTestHelper {
         false)
     );
     Dataset updatedDataset = datasetDAO.findDatasetById(dataset.getDatasetId());
-    assertNotNull(updatedDataset);
     assertNotNull(updatedDataset.getName());
     List<DatasetAudit> audits = datasetDAO.findAuditsByDatasetId(dataset.getDatasetId());
     assertFalse(audits.isEmpty());

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAOTest.java
@@ -734,7 +734,7 @@ class DatasetServiceDAOTest extends DAOTestHelper {
   void testExecuteUpdateDatasetWithNullName() throws Exception {
     // This creates a study with a single dataset:
     Study study = createStudy(List.of());
-    List<Dataset> datasets = datasetDAO.findDatasetsByIdList(List.copyOf(study.getDatasetIds()));
+    List<Dataset> datasets = datasetDAO.findDatasetsByIdList(study.getDatasetIds());
     Dataset dataset = datasets.get(0);
     jdbi.useHandle(handle -> serviceDAO.executeUpdateDatasetWithFiles(
         handle,

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAOTest.java
@@ -15,6 +15,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.broadinstitute.consent.http.db.DAOTestHelper;
 import org.broadinstitute.consent.http.enumeration.AuditActions;
 import org.broadinstitute.consent.http.enumeration.FileCategory;
@@ -727,6 +728,76 @@ class DatasetServiceDAOTest extends DAOTestHelper {
               .anyMatch(a -> a.getAction().equalsIgnoreCase(AuditActions.DELETE.name())));
     });
 
+  }
+
+  @Test
+  void testExecuteUpdateDatasetWithNullName() throws Exception {
+    // This creates a study with a single dataset:
+    Study study = createStudy(List.of());
+    List<Dataset> datasets = datasetDAO.findDatasetsByIdList(study.getDatasetIds().stream().toList());
+    Dataset dataset = datasets.get(0);
+    jdbi.useHandle(handle -> serviceDAO.executeUpdateDatasetWithFiles(
+        handle,
+        dataset.getDatasetId(),
+        null,
+        study.getCreateUserId(),
+        dataset.getDacId(),
+        List.of(),
+        List.of(),
+        false)
+    );
+    Dataset updatedDataset = datasetDAO.findDatasetById(dataset.getDatasetId());
+    assertNotNull(updatedDataset);
+    assertNotNull(updatedDataset.getName());
+    List<DatasetAudit> audits = datasetDAO.findAuditsByDatasetId(dataset.getDatasetId());
+    assertFalse(audits.isEmpty());
+  }
+
+  @Test
+  void testExecuteUpdateDatasetWithEmptyName() throws Exception {
+    // This creates a study with a single dataset:
+    Study study = createStudy(List.of());
+    List<Dataset> datasets = datasetDAO.findDatasetsByIdList(study.getDatasetIds().stream().toList());
+    Dataset dataset = datasets.get(0);
+    jdbi.useHandle(handle -> serviceDAO.executeUpdateDatasetWithFiles(
+        handle,
+        dataset.getDatasetId(),
+        "",
+        study.getCreateUserId(),
+        dataset.getDacId(),
+        List.of(),
+        List.of(),
+        false)
+    );
+    Dataset updatedDataset = datasetDAO.findDatasetById(dataset.getDatasetId());
+    assertNotNull(updatedDataset);
+    assertNotNull(updatedDataset.getName());
+    List<DatasetAudit> audits = datasetDAO.findAuditsByDatasetId(dataset.getDatasetId());
+    assertFalse(audits.isEmpty());
+  }
+
+  @Test
+  void testExecuteUpdateDatasetWithNewName() throws Exception {
+    // This creates a study with a single dataset:
+    Study study = createStudy(List.of());
+    List<Dataset> datasets = datasetDAO.findDatasetsByIdList(study.getDatasetIds().stream().toList());
+    Dataset dataset = datasets.get(0);
+    String newName = RandomStringUtils.secureStrong().nextAlphabetic(dataset.getName().length() + 10);
+    jdbi.useHandle(handle -> serviceDAO.executeUpdateDatasetWithFiles(
+        handle,
+        dataset.getDatasetId(),
+        newName,
+        study.getCreateUserId(),
+        dataset.getDacId(),
+        List.of(),
+        List.of(),
+        false)
+    );
+    Dataset updatedDataset = datasetDAO.findDatasetById(dataset.getDatasetId());
+    assertNotNull(updatedDataset);
+    assertEquals(newName, updatedDataset.getName());
+    List<DatasetAudit> audits = datasetDAO.findAuditsByDatasetId(dataset.getDatasetId());
+    assertFalse(audits.isEmpty());
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAOTest.java
@@ -781,7 +781,7 @@ class DatasetServiceDAOTest extends DAOTestHelper {
     Study study = createStudy(List.of());
     List<Dataset> datasets = datasetDAO.findDatasetsByIdList(study.getDatasetIds().stream().toList());
     Dataset dataset = datasets.get(0);
-    String newName = RandomStringUtils.secureStrong().nextAlphabetic(dataset.getName().length() + 10);
+    String newName = randomAlphabetic(dataset.getName().length() + 10);
     jdbi.useHandle(handle -> serviceDAO.executeUpdateDatasetWithFiles(
         handle,
         dataset.getDatasetId(),

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAOTest.java
@@ -734,7 +734,7 @@ class DatasetServiceDAOTest extends DAOTestHelper {
   void testExecuteUpdateDatasetWithNullName() throws Exception {
     // This creates a study with a single dataset:
     Study study = createStudy(List.of());
-    List<Dataset> datasets = datasetDAO.findDatasetsByIdList(study.getDatasetIds().stream().toList());
+    List<Dataset> datasets = datasetDAO.findDatasetsByIdList(List.copyOf(study.getDatasetIds()));
     Dataset dataset = datasets.get(0);
     jdbi.useHandle(handle -> serviceDAO.executeUpdateDatasetWithFiles(
         handle,

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAOTest.java
@@ -15,7 +15,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.broadinstitute.consent.http.db.DAOTestHelper;
 import org.broadinstitute.consent.http.enumeration.AuditActions;
 import org.broadinstitute.consent.http.enumeration.FileCategory;


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DT-1078

## Summary
Add logic around the dataset update block to ensure we're not clearing out the dataset name. 

The existing Study Update code provides a dataset registration object that is conditionally populated with ConsentGroup objects. If the user creates a new consent group, the full data is provided. If the user edits an existing consent group, then only partial data is provided that may or may not include the consent group name. This update allows the API to function correctly in both cases where the name is or is not provided by the UI.

This could be handled in the UI as well. However, a significant amount of validation refactoring would be required AND this UI is being deprecated in favor of a new study registration process. For those reasons, it is easier and quicker to handle this edge case in server code.

## Testing Strategy
1. Run this code locally
2. Run a local UI against this instance
3. As a Chairperson, navigate to the My DAC's Datasets page
4. Choose a dataset that has a pencil icon which indicates that it is editable
5. That should direct you to the edit study page
6. Choose something to edit on the study and submit: there should be no errors
7. Repeat the process and choose to edit a consent group and submit: there should be no errors

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
