### PR TITLE
[DT-1122] Apply `zizmor` suggestions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,6 +22,8 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - name: Get Short Sha
       id: short-sha
       run: echo "sha=$(git rev-parse --short=12 HEAD)" >> $GITHUB_OUTPUT
@@ -30,23 +32,23 @@ jobs:
     - name: Construct tags
       id: construct-tags
       run: |
-        SHA_TAG="${REGISTRY_HOST}/${GOOGLE_PROJECT}/${SERVICE_NAME}:${{ steps.short-sha.outputs.sha }}"
+        SHA_TAG="${REGISTRY_HOST}/${GOOGLE_PROJECT}/${SERVICE_NAME}:${SHORT_SHA}"
         ENVIRONMENT_TAG=""
         if ${{ github.event_name == 'pull_request'}}; then
-          ENVIRONMENT_TAG="${REGISTRY_HOST}/${GOOGLE_PROJECT}/${SERVICE_NAME}:pr-${{ steps.short-sha.outputs.sha }}"
+          ENVIRONMENT_TAG="${REGISTRY_HOST}/${GOOGLE_PROJECT}/${SERVICE_NAME}:pr-${SHORT_SHA}"
         elif ${{github.event_name == 'push' }}; then
           ENVIRONMENT_TAG="${REGISTRY_HOST}/${GOOGLE_PROJECT}/${SERVICE_NAME}:dev"
         fi
         echo "sha-tag=$SHA_TAG" >> $GITHUB_OUTPUT
         echo "environment-tag=$ENVIRONMENT_TAG" >> $GITHUB_OUTPUT
+      env:
+        SHORT_SHA: ${{ steps.short-sha.outputs.sha }}
     - name: Build Image
       run: |
-        docker build \
-        -t ${{ steps.construct-tags.outputs.sha-tag }} \
-        -t ${{ steps.construct-tags.outputs.environment-tag }} \
-        .
-    - name: Log Github Actor
-      run: echo "${{ github.actor }}"
+        docker build -t "${SHA_TAG}" -t "${ENVIRONMENT_TAG}" .
+      env:
+        SHA_TAG: ${{ steps.construct-tags.outputs.sha-tag }}
+        ENVIRONMENT_TAG: ${{ steps.construct-tags.outputs.environment-tag }}
     - id: 'auth'
       if: github.actor != 'dependabot[bot]'
       name: 'Authenticate to Google Cloud'
@@ -59,8 +61,11 @@ jobs:
       if: github.actor != 'dependabot[bot]'
       run: |
         gcloud auth configure-docker --quiet
-        docker push ${{ steps.construct-tags.outputs.sha-tag }}
-        docker push ${{ steps.construct-tags.outputs.environment-tag }}
+        docker push "${SHA_TAG}"
+        docker push "${ENVIRONMENT_TAG}"
+      env:
+        SHA_TAG: ${{ steps.construct-tags.outputs.sha-tag }}
+        ENVIRONMENT_TAG: ${{ steps.construct-tags.outputs.environment-tag }}
   report-to-sherlock:
     uses: broadinstitute/sherlock/.github/workflows/client-report-app-version.yaml@main
     needs: [ tag-build-push ]

--- a/.github/workflows/consumer_contract_tests.yaml
+++ b/.github/workflows/consumer_contract_tests.yaml
@@ -26,10 +26,11 @@ jobs:
     outputs:
       sha-short: ${{ steps.extract-branch.outputs.sha-short }}
       pact-b64: ${{ steps.encode-pact.outputs.pact-b64 }}
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
@@ -39,11 +40,11 @@ jobs:
         run: |
           GITHUB_EVENT_NAME=${{ github.event_name }}
           if [[ "$GITHUB_EVENT_NAME" == "push" ]]; then
-            GITHUB_REF=${{ github.ref }}
-            GITHUB_SHA=${{ github.sha }}
+            GITHUB_REF="${GITHUB_DEFAULT_REF}"
+            GITHUB_SHA="${GITHUB_DEFAULT_SHA}"
           elif [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
-            GITHUB_REF=refs/heads/${{ github.head_ref }}
-            GITHUB_SHA=${{ github.event.pull_request.head.sha }}
+            GITHUB_REF="refs/heads/${GITHUB_HEAD_REF}"
+            GITHUB_SHA="${GITHUB_HEAD_SHA}"
           else
             echo "Failed to extract branch information"
             exit 1
@@ -52,13 +53,23 @@ jobs:
           echo "sha=$GITHUB_SHA" >> $GITHUB_OUTPUT
           echo "sha-short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
           echo "branch=${GITHUB_REF/refs\/heads\//""}" >> $GITHUB_OUTPUT
+        env:
+          GITHUB_DEFAULT_SHA: ${{ github.sha }}
+          GITHUB_DEFAULT_REF: ${{ github.ref }}
+          GITHUB_HEAD_REF: ${{ github.head_ref }}
+          GITHUB_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
 
       - name: Echo branch information
         run: |
-          echo ${{ steps.extract-branch.outputs.ref }}
-          echo ${{ steps.extract-branch.outputs.sha }}
-          echo ${{ steps.extract-branch.outputs.sha-short }}
-          echo ${{ steps.extract-branch.outputs.branch }}
+          echo "${BRANCH_REF}"
+          echo "${BRANCH_SHA}"
+          echo "${BRANCH_SHA_SHORT}"
+          echo "${BRANCH_NAME}"
+        env:
+          BRANCH_REF: ${{ steps.extract-branch.outputs.ref }}
+          BRANCH_SHA: ${{ steps.extract-branch.outputs.sha }}
+          BRANCH_SHA_SHORT: ${{ steps.extract-branch.outputs.sha-short }}
+          BRANCH_NAME: ${{ steps.extract-branch.outputs.branch }}
 
       - name: Run consumer tests
         run: mvn clean test -Ppact-tests

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'

--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -7,6 +7,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -8,4 +8,6 @@ jobs:
     name: Check
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - run: semgrep ci --config=p/findsecbugs

--- a/.github/workflows/smoke-tests.yaml
+++ b/.github/workflows/smoke-tests.yaml
@@ -18,9 +18,14 @@ jobs:
       - name: setup
         id: setup
         run:
-          echo "bee-name=${{ github.event.repository.name }}-${{ github.run_id }}-dev" >> $GITHUB_OUTPUT
+          echo "bee-name=${REPO_NAME}-${RUN_ID}-dev" >> $GITHUB_OUTPUT
+        env:
+          REPO_NAME: ${{ github.event.repository.name }}
+          RUN_ID: ${{ github.run_id }}
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
@@ -36,7 +41,9 @@ jobs:
           inputs: '{ "bee-name": "${{ steps.setup.outputs.bee-name }}", "bee-template-name": "duos", "version-template": "dev" }'
       - name: Run Smoke Tests
         run: |
-          mvn clean test -P integration-tests -DbaseUrl=https://consent.${{ steps.setup.outputs.bee-name }}.bee.envs-terra.bio/
+          mvn clean test -P integration-tests -DbaseUrl="https://consent.${BEE_NAME}.bee.envs-terra.bio/"
+        env:
+          BEE_NAME: ${{ steps.setup.outputs.bee-name }}
       - name: Store Test Result Artifact
         uses: actions/upload-artifact@v4
         if: always()

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -8,4 +8,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: broadinstitute/dsp-appsec-trivy-action@v1


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-1122

### Summary

- The Github actor is already logged on the action run page
- Do not persist credentials if not needed
- Use shell variable expansion instead of [template expansion](https://woodruffw.github.io/zizmor/audits/#template-injection)

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
