### PR TITLE
DT-1206: Bug fixes for support requests

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/exceptions/UnprocessableEntityException.java
+++ b/src/main/java/org/broadinstitute/consent/http/exceptions/UnprocessableEntityException.java
@@ -9,6 +9,4 @@ public class UnprocessableEntityException extends ClientErrorException {
     super(message, HttpStatusCodes.STATUS_CODE_UNPROCESSABLE_ENTITY);
   }
 
-
-
 }

--- a/src/main/java/org/broadinstitute/consent/http/exceptions/UnprocessableEntityException.java
+++ b/src/main/java/org/broadinstitute/consent/http/exceptions/UnprocessableEntityException.java
@@ -1,0 +1,14 @@
+package org.broadinstitute.consent.http.exceptions;
+
+import com.google.api.client.http.HttpStatusCodes;
+import jakarta.ws.rs.ClientErrorException;
+
+public class UnprocessableEntityException extends ClientErrorException {
+
+  public UnprocessableEntityException(String message) {
+    super(message, HttpStatusCodes.STATUS_CODE_UNPROCESSABLE_ENTITY);
+  }
+
+
+
+}

--- a/src/main/java/org/broadinstitute/consent/http/resources/Resource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/Resource.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.consent.http.resources;
 
+import com.google.api.client.http.HttpStatusCodes;
 import com.google.gson.JsonSyntaxException;
 import com.google.gson.stream.MalformedJsonException;
 import io.sentry.Sentry;
@@ -24,6 +25,7 @@ import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.exceptions.ConsentConflictException;
 import org.broadinstitute.consent.http.exceptions.UnknownIdentifierException;
+import org.broadinstitute.consent.http.exceptions.UnprocessableEntityException;
 import org.broadinstitute.consent.http.models.Error;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.util.ConsentLogger;
@@ -124,6 +126,9 @@ abstract public class Resource implements ConsentLogger {
     dispatch.put(ConsentConflictException.class, e ->
         Response.status(Response.Status.CONFLICT).type(MediaType.APPLICATION_JSON)
             .entity(new Error(e.getMessage(), Response.Status.CONFLICT.getStatusCode())).build());
+    dispatch.put(UnprocessableEntityException.class, e ->
+        Response.status(HttpStatusCodes.STATUS_CODE_UNPROCESSABLE_ENTITY).type(MediaType.APPLICATION_JSON)
+            .entity(new Error(e.getMessage(), HttpStatusCodes.STATUS_CODE_UNPROCESSABLE_ENTITY)).build());
     dispatch.put(UnsupportedOperationException.class, e ->
         Response.status(Response.Status.CONFLICT).type(MediaType.APPLICATION_JSON)
             .entity(new Error(e.getMessage(), Response.Status.CONFLICT.getStatusCode())).build());

--- a/src/main/java/org/broadinstitute/consent/http/service/SupportRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/SupportRequestService.java
@@ -56,10 +56,13 @@ public class SupportRequestService implements ConsentLogger {
       String responseContent = IOUtils.toString(response.getContent(), Charset.defaultCharset());
       JsonObject obj = GsonUtil.getInstance().fromJson(responseContent, JsonObject.class);
       if (obj != null && obj.get("upload") != null) {
-        JsonObject uploadObj = obj.get("upload").getAsJsonObject();
-        if (uploadObj != null && uploadObj.get("token") != null) {
-          return uploadObj.get("token").getAsJsonObject();
-        }
+        return obj.get("upload").getAsJsonObject();
+      } else {
+        var errorException = new ServerErrorException(response.getStatusMessage(),
+            HttpStatusCodes.STATUS_CODE_SERVER_ERROR);
+        String errorMessage = "Error reading attachment response content: " + responseContent;
+        logException(errorMessage, errorException);
+        throw errorException;
       }
     }
     throw new BadRequestException("Not configured to send support attachments");

--- a/src/main/java/org/broadinstitute/consent/http/service/SupportRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/SupportRequestService.java
@@ -13,6 +13,7 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import org.apache.commons.io.IOUtils;
 import org.broadinstitute.consent.http.configurations.ServicesConfiguration;
+import org.broadinstitute.consent.http.exceptions.UnprocessableEntityException;
 import org.broadinstitute.consent.http.models.support.DuosTicket;
 import org.broadinstitute.consent.http.models.support.TicketFactory;
 import org.broadinstitute.consent.http.util.ConsentLogger;
@@ -48,8 +49,10 @@ public class SupportRequestService implements ConsentLogger {
 
       if (!response.isSuccessStatusCode()) {
         String errorMessage = "Error sending attachment to support: " + response.getStatusMessage();
-        var errorException = new ServerErrorException(response.getStatusMessage(),
-            HttpStatusCodes.STATUS_CODE_SERVER_ERROR);
+        var errorException =
+            response.getStatusCode() == HttpStatusCodes.STATUS_CODE_UNPROCESSABLE_ENTITY ?
+                new UnprocessableEntityException(errorMessage) :
+                new ServerErrorException(response.getStatusMessage(), response.getStatusCode());
         logException(errorMessage, errorException);
         throw errorException;
       }
@@ -85,8 +88,10 @@ public class SupportRequestService implements ConsentLogger {
 
       if (!response.isSuccessStatusCode()) {
         String errorMessage = "Error posting ticket to support: " + response.getStatusMessage();
-        var errorException = new ServerErrorException(response.getStatusMessage(),
-            HttpStatusCodes.STATUS_CODE_SERVER_ERROR);
+        var errorException =
+            response.getStatusCode() == HttpStatusCodes.STATUS_CODE_UNPROCESSABLE_ENTITY ?
+                new UnprocessableEntityException(errorMessage) :
+                new ServerErrorException(response.getStatusMessage(), response.getStatusCode());
         logException(errorMessage, errorException);
         throw errorException;
       }

--- a/src/main/resources/assets/paths/supportRequest.yaml
+++ b/src/main/resources/assets/paths/supportRequest.yaml
@@ -18,5 +18,8 @@ post:
     400:
       description: |
         Bad Request: not configured for support requests
+    422:
+      description: |
+        Unprocessable Entity: provided content is not processable
     500:
       description: Internal Server Error

--- a/src/main/resources/assets/paths/supportUpload.yaml
+++ b/src/main/resources/assets/paths/supportUpload.yaml
@@ -23,5 +23,8 @@ post:
     400:
       description: | 
         Bad Request: max file upload size is 5 MB or server not configured for uploads
+    422:
+      description: |
+        Unprocessable Entity: provided content is not processable
     500:
       description: Internal Server Error

--- a/src/test/java/org/broadinstitute/consent/http/resources/SupportResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/SupportResourceTest.java
@@ -2,6 +2,7 @@ package org.broadinstitute.consent.http.resources;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 
 import com.google.api.client.http.HttpStatusCodes;
@@ -10,6 +11,7 @@ import com.google.gson.JsonPrimitive;
 import jakarta.ws.rs.core.Response;
 import java.util.stream.Stream;
 import org.broadinstitute.consent.http.enumeration.SupportRequestType;
+import org.broadinstitute.consent.http.exceptions.UnprocessableEntityException;
 import org.broadinstitute.consent.http.service.SupportRequestService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -132,12 +134,40 @@ public class SupportResourceTest extends ResourceTest {
   }
 
   @Test
+  void testUnprocessableTicket() throws Exception {
+    doThrow(new UnprocessableEntityException("Unprocessable")).when(supportRequestService)
+        .postTicketToSupport(any());
+    try (Response response = supportResource.postRequest("""
+        {
+          "name": "Test User",
+          "email": "test.user@example.com",
+          "subject": "Test Subject",
+          "description": "Test Description",
+          "type": "QUESTION",
+          "url": "https://example.com",
+          "uploads": ["token1", "token2"]
+        }
+        """)) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_UNPROCESSABLE_ENTITY, response.getStatus());
+    }
+  }
+
+  @Test
   void testPostUpload() throws Exception {
     JsonObject obj = new JsonObject();
     obj.add("token", new JsonPrimitive("token value"));
     when(supportRequestService.postAttachmentToSupport(any())).thenReturn(obj);
     try (Response response = supportResource.postUpload("test".getBytes())) {
       assertEquals(HttpStatusCodes.STATUS_CODE_CREATED, response.getStatus());
+    }
+  }
+
+  @Test
+  void testUnprocessableUpload() throws Exception {
+    doThrow(new UnprocessableEntityException("Unprocessable")).when(supportRequestService)
+        .postAttachmentToSupport(any());
+    try (Response response = supportResource.postUpload("test".getBytes())) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_UNPROCESSABLE_ENTITY, response.getStatus());
     }
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/service/SupportRequestServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/SupportRequestServiceTest.java
@@ -109,7 +109,7 @@ class SupportRequestServiceTest extends AbstractTestHelper {
   @Test
   void testPostAttachmentToSupport() throws Exception {
     String expectedBody = """
-        { "upload": { "token": { "token": "token string" } } }
+        { "upload": { "token": "token string" } }
         """;
     when(config.isActivateSupportNotifications()).thenReturn(true);
     when(config.postSupportUploadUrl()).thenReturn(
@@ -124,6 +124,25 @@ class SupportRequestServiceTest extends AbstractTestHelper {
     service.postAttachmentToSupport("Test".getBytes());
     HttpRequest[] requests = mockServerClient.retrieveRecordedRequests(null);
     assertEquals(1, requests.length);
+  }
+
+  @Test
+  void testPostTicketToSupportServerError_UnableToParseResponse() {
+    // This case should never happen, but we do inspect the response for a valid "upload" object.
+    // We need to ensure that the service handles invalid response formats correctly.
+    String expectedBody = """
+        { "invalid": { "missing_token": "token string" } }
+        """;
+    when(config.isActivateSupportNotifications()).thenReturn(true);
+    when(config.postSupportUploadUrl()).thenReturn(
+        "http://" + container.getHost() + ":" + container.getServerPort() + "/");
+    mockServerClient.when(request().withMethod("POST"))
+        .respond(response()
+            .withHeader(Header.header("Content-Type", "application/json"))
+            .withStatusCode(HttpStatusCodes.STATUS_CODE_CREATED)
+            .withBody(expectedBody)
+        );
+    assertThrows(ServerErrorException.class, () -> service.postAttachmentToSupport("Test".getBytes()));
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/SupportRequestServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/SupportRequestServiceTest.java
@@ -10,6 +10,7 @@ import static org.mockserver.model.HttpResponse.response;
 import com.google.api.client.http.HttpStatusCodes;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.ServerErrorException;
+import jakarta.ws.rs.WebApplicationException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
@@ -17,6 +18,7 @@ import java.util.List;
 import org.broadinstitute.consent.http.AbstractTestHelper;
 import org.broadinstitute.consent.http.configurations.ServicesConfiguration;
 import org.broadinstitute.consent.http.enumeration.SupportRequestType;
+import org.broadinstitute.consent.http.exceptions.UnprocessableEntityException;
 import org.broadinstitute.consent.http.models.support.DuosTicket;
 import org.broadinstitute.consent.http.models.support.TicketFactory;
 import org.broadinstitute.consent.http.models.support.TicketFields;
@@ -94,6 +96,19 @@ class SupportRequestServiceTest extends AbstractTestHelper {
   }
 
   @Test
+  void testPostTicketToSupportNotificationsUnprocessableEntity() {
+    DuosTicket ticket = generateTicket();
+    when(config.isActivateSupportNotifications()).thenReturn(true);
+    when(config.postSupportRequestUrl()).thenReturn(
+        "http://" + container.getHost() + ":" + container.getServerPort() + "/");
+    mockServerClient.when(request())
+        .respond(response()
+            .withHeader(Header.header("Content-Type", "application/json"))
+            .withStatusCode(HttpStatusCodes.STATUS_CODE_UNPROCESSABLE_ENTITY));
+    assertThrows(UnprocessableEntityException.class, () -> service.postTicketToSupport(ticket));
+  }
+
+  @Test
   void testPostTicketToSupportServerError() {
     DuosTicket ticket = generateTicket();
     when(config.isActivateSupportNotifications()).thenReturn(true);
@@ -127,7 +142,7 @@ class SupportRequestServiceTest extends AbstractTestHelper {
   }
 
   @Test
-  void testPostTicketToSupportServerError_UnableToParseResponse() {
+  void testPostTicketToSupportUnableToParseResponse() {
     // This case should never happen, but we do inspect the response for a valid "upload" object.
     // We need to ensure that the service handles invalid response formats correctly.
     String expectedBody = """
@@ -163,6 +178,18 @@ class SupportRequestServiceTest extends AbstractTestHelper {
             .withHeader(Header.header("Content-Type", "application/json"))
             .withStatusCode(HttpStatusCodes.STATUS_CODE_SERVER_ERROR));
     assertThrows(ServerErrorException.class, () -> service.postAttachmentToSupport("Test".getBytes()));
+  }
+
+  @Test
+  void testPostAttachmentToSupportUnprocessableEntity() {
+    when(config.isActivateSupportNotifications()).thenReturn(true);
+    when(config.postSupportUploadUrl()).thenReturn(
+        "http://" + container.getHost() + ":" + container.getServerPort() + "/");
+    mockServerClient.when(request())
+        .respond(response()
+            .withHeader(Header.header("Content-Type", "application/json"))
+            .withStatusCode(HttpStatusCodes.STATUS_CODE_UNPROCESSABLE_ENTITY));
+    assertThrows(UnprocessableEntityException.class, () -> service.postAttachmentToSupport("Test".getBytes()));
   }
 
   // Creates support ticket with random values


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-1206

### Summary
This PR handles a couple of overlooked bugs
* Fix the return format the upload token to be a valid json object instead of a plain string
* Handle the Zendesk error case of `UnprocessableEntityException` when a normally well-formed ticket object cannot be processed by Zendesk due to invalid data

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
