### PR TITLE
DT-1191: Migrate to DSP GAR

### DIFF
--- a/.github/workflows/dsp_ar_build.yaml
+++ b/.github/workflows/dsp_ar_build.yaml
@@ -1,0 +1,101 @@
+name: DSP GAR - Tag, Build and Push Image
+
+on:
+  push:
+    branches:
+    - develop
+  pull_request:
+    branches:
+    - develop
+env:
+  REGISTRY_HOST: us-central1-docker.pkg.dev
+  GOOGLE_PROJECT: dsp-artifact-registry
+  SERVICE_NAME: ${{ github.event.repository.name }}
+jobs:
+  tag-build-push:
+    runs-on: ubuntu-latest
+    outputs:
+      sherlock-version: ${{ steps.short-sha.outputs.sha }}
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        persist-credentials: false
+    - name: Get Short Sha
+      id: short-sha
+      run: echo "sha=$(git rev-parse --short=12 HEAD)" >> $GITHUB_OUTPUT
+    - name: 'Set up Cloud SDK'
+      uses: 'google-github-actions/setup-gcloud@v2'
+    - name: Construct tags
+      id: construct-tags
+      run: |
+        SHA_TAG="${REGISTRY_HOST}/${GOOGLE_PROJECT}/${SERVICE_NAME}/${SERVICE_NAME}:${SHORT_SHA}"
+        ENVIRONMENT_TAG=""
+        if [ "$GITHUB_EVENT" = "pull_request" ]; then
+          ENVIRONMENT_TAG="${REGISTRY_HOST}/${GOOGLE_PROJECT}/${SERVICE_NAME}/${SERVICE_NAME}:pr-${SHORT_SHA}"
+        elif [ "$GITHUB_EVENT" = "push" ]; then
+          ENVIRONMENT_TAG="${REGISTRY_HOST}/${GOOGLE_PROJECT}/${SERVICE_NAME}/${SERVICE_NAME}:dev"
+        fi
+        echo "sha-tag=$SHA_TAG" >> $GITHUB_OUTPUT
+        echo "environment-tag=$ENVIRONMENT_TAG" >> $GITHUB_OUTPUT
+      env:
+        SHORT_SHA: ${{ steps.short-sha.outputs.sha }}
+        GITHUB_EVENT: ${{ github.event_name }}
+    - name: Build Image
+      run: |
+        docker build -t "${SHA_TAG}" -t "${ENVIRONMENT_TAG}" .
+      env:
+        SHA_TAG: ${{ steps.construct-tags.outputs.sha-tag }}
+        ENVIRONMENT_TAG: ${{ steps.construct-tags.outputs.environment-tag }}
+    - id: 'auth'
+      if: github.actor != 'dependabot[bot]'
+      name: 'Authenticate to Google Cloud'
+      uses: 'google-github-actions/auth@v2'
+      with:
+        # Centralized in dsp-tools-k8s; ask in #dsp-devops-champions for help troubleshooting
+        token_format: 'access_token'
+        workload_identity_provider: 'projects/1038484894585/locations/global/workloadIdentityPools/github-wi-pool/providers/github-wi-provider'
+        service_account: 'dsp-artifact-registry-push@dsp-artifact-registry.iam.gserviceaccount.com'
+    # authenticate to GAR docker repo
+    - name: Docker Login
+      uses: 'docker/login-action@v3'
+      with:
+        registry: 'us-central1-docker.pkg.dev'
+        username: 'oauth2accesstoken'
+        password: '${{ steps.auth.outputs.access_token }}'
+    - name: Push Image to DSP GAR
+      if: github.actor != 'dependabot[bot]'
+      run: |
+        gcloud auth configure-docker "$GOOGLE_PROJECT" --quiet
+        docker push "${SHA_TAG}"
+        docker push "${ENVIRONMENT_TAG}"
+      env:
+        SHA_TAG: ${{ steps.construct-tags.outputs.sha-tag }}
+        ENVIRONMENT_TAG: ${{ steps.construct-tags.outputs.environment-tag }}
+  report-to-sherlock:
+    # When we have cut over the deployment to point to DSP GAR, we can enable this
+    if: false
+    uses: broadinstitute/sherlock/.github/workflows/client-report-app-version.yaml@main
+    needs: [ tag-build-push ]
+    with:
+      new-version: ${{ needs.tag-build-push.outputs.sherlock-version }}
+      chart-name: 'consent'
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+  set-version-in-dev:
+    # When we have cut over the deployment to point to DSP GAR, we can enable this
+    if: false # if: github.event_name == 'push'
+    uses: broadinstitute/sherlock/.github/workflows/client-set-environment-app-version.yaml@main
+    needs: [ tag-build-push, report-to-sherlock ]
+    with:
+      new-version: ${{ needs.tag-build-push.outputs.sherlock-version }}
+      chart-name: 'consent'
+      environment-name: 'dev'
+    secrets:
+      sync-git-token: ${{ secrets.BROADBOT_TOKEN }}
+    permissions:
+      id-token: 'write'

--- a/.github/workflows/dsp_ar_build.yaml
+++ b/.github/workflows/dsp_ar_build.yaml
@@ -51,7 +51,6 @@ jobs:
         SHA_TAG: ${{ steps.construct-tags.outputs.sha-tag }}
         ENVIRONMENT_TAG: ${{ steps.construct-tags.outputs.environment-tag }}
     - id: 'auth'
-      if: github.actor != 'dependabot[bot]'
       name: 'Authenticate to Google Cloud'
       uses: 'google-github-actions/auth@v2'
       with:
@@ -67,7 +66,6 @@ jobs:
         username: 'oauth2accesstoken'
         password: '${{ steps.auth.outputs.access_token }}'
     - name: Push Image to DSP GAR
-      if: github.actor != 'dependabot[bot]'
       run: |
         gcloud auth configure-docker "$GOOGLE_PROJECT" --quiet
         docker push "${SHA_TAG}"


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DT-1191

## Summary
There are three phases to migrating to DSP's Artifact Registry

* This PR: Push images to new GAR
* Update deployments to look at new GAR: https://github.com/broadinstitute/terra-helmfile/pull/6038
* Remove old image pushes to GCR AND report versions to Sherlock from the new action in this PR: https://github.com/DataBiosphere/consent/pull/2460

It is verified that images are being pushed to the new project:
![Screenshot 2025-02-18 at 9 03 02 AM](https://github.com/user-attachments/assets/1d20f678-d92d-4e95-b8fe-e6f0ad353360)

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
