### PR TITLE
[DT-1253] Check for empty and null arguments for `findVoteUsersByElectionReferenceIdList`

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
@@ -416,6 +416,7 @@ public class DarCollectionService implements ConsentLogger {
 
   /**
    * Find all dataset ids by the DAC User. Will return ids for Chairpersons or Members
+   *
    * @param user The DAC User
    * @return List of Dataset IDs
    */
@@ -657,13 +658,21 @@ public class DarCollectionService implements ConsentLogger {
    * @param collection The DarCollection
    * @return The updated DarCollection
    */
-  public DarCollection createElectionsForDarCollection(User user, DarCollection collection) {
+  public DarCollection createElectionsForDarCollection(User user, DarCollection collection)
+      throws Exception {
     try {
       List<String> createdElectionReferenceIds = collectionServiceDAO.createElectionsForDarCollection(
           user, collection);
-      List<User> voteUsers = voteDAO.findVoteUsersByElectionReferenceIdList(
-          createdElectionReferenceIds);
+      if (createdElectionReferenceIds == null || createdElectionReferenceIds.isEmpty()) {
+        var e = new IllegalStateException(
+            "No elections were created for DAR Collection: %s".formatted(
+                collection.getDarCode()));
+        logException(e);
+        throw e;
+      }
       try {
+        List<User> voteUsers = voteDAO.findVoteUsersByElectionReferenceIdList(
+            createdElectionReferenceIds);
         emailService.sendDarNewCollectionElectionMessage(voteUsers, collection);
       } catch (Exception e) {
         logException(
@@ -673,6 +682,7 @@ public class DarCollectionService implements ConsentLogger {
     } catch (Exception e) {
       logException("Exception creating elections and votes for collection: %s".formatted(
           collection.getDarCollectionId()), e);
+      throw e;
     }
     return darCollectionDAO.findDARCollectionByCollectionId(collection.getDarCollectionId());
   }

--- a/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
@@ -663,7 +663,7 @@ public class DarCollectionService implements ConsentLogger {
     try {
       List<String> createdElectionReferenceIds = collectionServiceDAO.createElectionsForDarCollection(
           user, collection);
-      if (createdElectionReferenceIds == null || createdElectionReferenceIds.isEmpty()) {
+      if (createdElectionReferenceIds.isEmpty()) {
         var e = new IllegalStateException(
             "No elections were created for DAR Collection: %s".formatted(
                 collection.getDarCode()));

--- a/src/test/java/org/broadinstitute/consent/http/db/VoteDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/VoteDAOTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.sql.Timestamp;
@@ -411,11 +412,25 @@ class VoteDAOTest extends DAOTestHelper {
   }
 
   @Test
-  void testFindVoteUsersByElectionReferenceIdList_Empty() {
+  void testFindVoteUsersByElectionReferenceIdList_Invalid() {
     // Empty case
     List<User> voteUsers = voteDAO.findVoteUsersByElectionReferenceIdList(
         List.of("invalid reference id"));
     assertTrue(voteUsers.isEmpty());
+  }
+
+  @Test
+  void testFindVoteUsersByElectionReferenceIdList_Empty() {
+    assertThrows(IllegalArgumentException.class, () -> {
+      voteDAO.findVoteUsersByElectionReferenceIdList(List.of());
+    });
+  }
+
+  @Test
+  void testFindVoteUsersByElectionReferenceIdList_Null() {
+    assertThrows(IllegalArgumentException.class, () -> {
+      voteDAO.findVoteUsersByElectionReferenceIdList(null);
+    });
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
@@ -324,22 +324,6 @@ class DarCollectionServiceTest {
   }
 
   @Test
-  void testCreateElectionsForDarCollectionNull() throws Exception {
-    User user = new User();
-    user.setEmail("email");
-    DataAccessRequest dar = new DataAccessRequest();
-    dar.setReferenceId(UUID.randomUUID().toString());
-    DarCollection collection = createMockCollections(1).get(0);
-    collection.setDars(Map.of(dar.getReferenceId(), dar));
-    when(darCollectionServiceDAO.createElectionsForDarCollection(user, collection)).thenReturn(
-        null);
-
-    assertThrows(IllegalStateException.class, () -> {
-      service.createElectionsForDarCollection(user, collection);
-    });
-  }
-
-  @Test
   void testCreateElectionsForDarCollectionVoteUsersException() throws Exception {
     User user = new User();
     user.setEmail("email");

--- a/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
@@ -10,6 +10,7 @@ import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import jakarta.ws.rs.BadRequestException;
@@ -330,7 +331,8 @@ class DarCollectionServiceTest {
     dar.setReferenceId(UUID.randomUUID().toString());
     DarCollection collection = createMockCollections(1).get(0);
     collection.setDars(Map.of(dar.getReferenceId(), dar));
-    when(darCollectionServiceDAO.createElectionsForDarCollection(any(), any())).thenReturn(null);
+    when(darCollectionServiceDAO.createElectionsForDarCollection(user, collection)).thenReturn(
+        null);
 
     assertThrows(IllegalStateException.class, () -> {
       service.createElectionsForDarCollection(user, collection);
@@ -345,16 +347,17 @@ class DarCollectionServiceTest {
     dar.setReferenceId(UUID.randomUUID().toString());
     DarCollection collection = createMockCollections(1).get(0);
     collection.setDars(Map.of(dar.getReferenceId(), dar));
-    when(darCollectionServiceDAO.createElectionsForDarCollection(any(), any())).thenReturn(
-        List.of("electionId"));
-    when(voteDAO.findVoteUsersByElectionReferenceIdList(any())).thenThrow(
+    List<String> electionIds = List.of("electionId");
+    when(darCollectionServiceDAO.createElectionsForDarCollection(user, collection)).thenReturn(
+        electionIds);
+    when(voteDAO.findVoteUsersByElectionReferenceIdList(electionIds)).thenThrow(
         IllegalArgumentException.class);
 
     service.createElectionsForDarCollection(user, collection);
-    verify(darCollectionServiceDAO, times(1)).createElectionsForDarCollection(any(), any());
-    verify(voteDAO, times(1)).findVoteUsersByElectionReferenceIdList(any());
-    verify(emailService, times(0)).sendDarNewCollectionElectionMessage(any(), any());
-    verify(darCollectionDAO, times(1)).findDARCollectionByCollectionId(any());
+    verify(darCollectionServiceDAO).createElectionsForDarCollection(user, collection);
+    verify(voteDAO).findVoteUsersByElectionReferenceIdList(electionIds);
+    verifyNoInteractions(emailService);
+    verify(darCollectionDAO).findDARCollectionByCollectionId(collection.getDarCollectionId());
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
@@ -41,7 +41,6 @@ import org.broadinstitute.consent.http.enumeration.DarCollectionActions;
 import org.broadinstitute.consent.http.enumeration.DarCollectionStatus;
 import org.broadinstitute.consent.http.enumeration.DarStatus;
 import org.broadinstitute.consent.http.enumeration.ElectionStatus;
-import org.broadinstitute.consent.http.enumeration.ElectionType;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.enumeration.VoteType;
 import org.broadinstitute.consent.http.models.Dac;
@@ -135,7 +134,6 @@ class DarCollectionServiceTest {
         new HashSet<>(List.of(dataset)));
     when(dataAccessRequestDAO.findAllDARDatasetRelations(any())).thenReturn(datasetIds);
 
-
     collections = service.addDatasetsToCollections(collections, List.of(dataset.getDatasetId()));
     assertEquals(1, collections.size());
 
@@ -186,7 +184,7 @@ class DarCollectionServiceTest {
     collection.setDars(Map.of(dar.getReferenceId(), dar));
     when(electionDAO.findLastElectionsByReferenceIds(anyList())).thenReturn(List.of());
     when(darCollectionDAO.findDARCollectionByCollectionId(any())).thenReturn(collection);
-   initService();
+    initService();
 
     service.cancelDarCollectionAsResearcher(collection);
     verify(electionDAO, times(1)).findLastElectionsByReferenceIds(anyList());
@@ -252,7 +250,8 @@ class DarCollectionServiceTest {
     election.setReferenceId(dar.getReferenceId());
     election.setStatus(ElectionStatus.OPEN.getValue());
     election.setElectionId(1);
-    when(datasetDAO.findDatasetIdsByDACUserId(anyInt())).thenReturn(List.of(dataset.getDatasetId()));
+    when(datasetDAO.findDatasetIdsByDACUserId(anyInt())).thenReturn(
+        List.of(dataset.getDatasetId()));
     when(electionDAO.findOpenElectionsByReferenceIds(anyList())).thenReturn(List.of(election));
 
     service.cancelDarCollectionElectionsAsChair(collection, user);
@@ -298,17 +297,63 @@ class DarCollectionServiceTest {
     dar.setReferenceId(UUID.randomUUID().toString());
     DarCollection collection = createMockCollections(1).get(0);
     collection.setDars(Map.of(dar.getReferenceId(), dar));
-    Election election = createMockElection();
-    election.setReferenceId(dar.getReferenceId());
-    election.setStatus(ElectionStatus.CANCELED.getValue());
-    election.setElectionType(ElectionType.DATA_ACCESS.getValue());
-    election.setElectionId(1);
+    when(darCollectionServiceDAO.createElectionsForDarCollection(any(), any())).thenReturn(
+        List.of("electionId"));
     when(voteDAO.findVoteUsersByElectionReferenceIdList(any())).thenReturn(List.of(new User()));
 
     service.createElectionsForDarCollection(user, collection);
     verify(darCollectionServiceDAO, times(1)).createElectionsForDarCollection(any(), any());
     verify(voteDAO, times(1)).findVoteUsersByElectionReferenceIdList(any());
     verify(emailService, times(1)).sendDarNewCollectionElectionMessage(any(), any());
+    verify(darCollectionDAO, times(1)).findDARCollectionByCollectionId(any());
+  }
+
+  @Test
+  void testCreateElectionsForDarCollectionEmpty() {
+    User user = new User();
+    user.setEmail("email");
+    DataAccessRequest dar = new DataAccessRequest();
+    dar.setReferenceId(UUID.randomUUID().toString());
+    DarCollection collection = createMockCollections(1).get(0);
+    collection.setDars(Map.of(dar.getReferenceId(), dar));
+
+    assertThrows(IllegalStateException.class, () -> {
+      service.createElectionsForDarCollection(user, collection);
+    });
+  }
+
+  @Test
+  void testCreateElectionsForDarCollectionNull() throws Exception {
+    User user = new User();
+    user.setEmail("email");
+    DataAccessRequest dar = new DataAccessRequest();
+    dar.setReferenceId(UUID.randomUUID().toString());
+    DarCollection collection = createMockCollections(1).get(0);
+    collection.setDars(Map.of(dar.getReferenceId(), dar));
+    when(darCollectionServiceDAO.createElectionsForDarCollection(any(), any())).thenReturn(null);
+
+    assertThrows(IllegalStateException.class, () -> {
+      service.createElectionsForDarCollection(user, collection);
+    });
+  }
+
+  @Test
+  void testCreateElectionsForDarCollectionVoteUsersException() throws Exception {
+    User user = new User();
+    user.setEmail("email");
+    DataAccessRequest dar = new DataAccessRequest();
+    dar.setReferenceId(UUID.randomUUID().toString());
+    DarCollection collection = createMockCollections(1).get(0);
+    collection.setDars(Map.of(dar.getReferenceId(), dar));
+    when(darCollectionServiceDAO.createElectionsForDarCollection(any(), any())).thenReturn(
+        List.of("electionId"));
+    when(voteDAO.findVoteUsersByElectionReferenceIdList(any())).thenThrow(
+        IllegalArgumentException.class);
+
+    service.createElectionsForDarCollection(user, collection);
+    verify(darCollectionServiceDAO, times(1)).createElectionsForDarCollection(any(), any());
+    verify(voteDAO, times(1)).findVoteUsersByElectionReferenceIdList(any());
+    verify(emailService, times(0)).sendDarNewCollectionElectionMessage(any(), any());
     verify(darCollectionDAO, times(1)).findDARCollectionByCollectionId(any());
   }
 
@@ -563,7 +608,6 @@ class DarCollectionServiceTest {
     when(darCollectionSummaryDAO.getDarCollectionSummariesForResearcher(any())).thenReturn(
         mockSummaries);
 
-
     List<DarCollectionSummary> summaries = service.getSummariesForRoleName(user,
         UserRoles.RESEARCHER.getRoleName());
     assertNotNull(summaries);
@@ -664,7 +708,6 @@ class DarCollectionServiceTest {
 
     when(darCollectionSummaryDAO.getDarCollectionSummariesForAdmin())
         .thenReturn(List.of(summaryOne, summaryTwo, summaryThree, summaryFour));
-
 
     List<DarCollectionSummary> summaries = service.getSummariesForRoleName(user,
         UserRoles.ADMIN.getRoleName());
@@ -791,7 +834,6 @@ class DarCollectionServiceTest {
     when(datasetDAO.findDatasetListByDacIds(any())).thenReturn(datasets);
     when(darCollectionSummaryDAO.getDarCollectionSummariesForDAC(any(), any()))
         .thenReturn(List.of(summary, summaryTwo, summaryThree, summaryFour));
-
 
     List<DarCollectionSummary> summaries = service.getSummariesForRoleName(user,
         UserRoles.MEMBER.getRoleName());
@@ -1114,7 +1156,6 @@ class DarCollectionServiceTest {
         .thenReturn(summary);
     when(datasetDAO.findDatasetListByDacIds(any())).thenReturn(List.of());
 
-
     DarCollectionSummary summaryResult = service.getSummaryForRoleNameByCollectionId(user,
         UserRoles.CHAIRPERSON.getRoleName(), collectionId);
     assertNotNull(summaryResult);
@@ -1160,7 +1201,6 @@ class DarCollectionServiceTest {
     when(darCollectionSummaryDAO.getDarCollectionSummaryForDACByCollectionId(user.getUserId(),
         List.of(), collectionId))
         .thenReturn(summary);
-
 
     DarCollectionSummary summaryResult = service.getSummaryForRoleNameByCollectionId(user,
         UserRoles.MEMBER.getRoleName(), collectionId);


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-1253

### Summary

Add tests and fix for when `findVoteUsersByElectionReferenceIdList` is empty or null

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
