### PR TITLE
DT-1282: Handle null/empty datasets when deleting studies

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/models/Study.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/Study.java
@@ -119,7 +119,7 @@ public class Study {
   }
 
   public Set<Dataset> getDatasets() {
-    return datasets;
+    return datasets == null? Set.of() : datasets;
   }
 
   public Date getCreateDate() {

--- a/src/main/java/org/broadinstitute/consent/http/models/Study.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/Study.java
@@ -119,7 +119,7 @@ public class Study {
   }
 
   public Set<Dataset> getDatasets() {
-    return datasets == null? Set.of() : datasets;
+    return datasets == null ? Set.of() : datasets;
   }
 
   public Date getCreateDate() {

--- a/src/main/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAO.java
@@ -67,15 +67,17 @@ public class DatasetServiceDAO implements ConsentLogger {
   public void deleteStudy(Study study, User user) throws Exception {
     jdbi.useHandle(handle -> {
       handle.getConnection().setAutoCommit(false);
-      study.getDatasets().forEach(d -> {
-        try {
-          deleteDataset(d, user.getUserId());
-        } catch (Exception e) {
-          handle.rollback();
-          logException(e);
-          throw new DatasetDeletionException(e);
-        }
-      });
+      if (study.getDatasets() != null) {
+        study.getDatasets().forEach(d -> {
+          try {
+            deleteDataset(d, user.getUserId());
+          } catch (Exception e) {
+            handle.rollback();
+            logException(e);
+            throw new DatasetDeletionException(e);
+          }
+        });
+      }
       try {
         studyDAO.deleteStudyByStudyId(study.getStudyId());
       } catch (Exception e) {

--- a/src/main/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAO.java
@@ -67,17 +67,15 @@ public class DatasetServiceDAO implements ConsentLogger {
   public void deleteStudy(Study study, User user) throws Exception {
     jdbi.useHandle(handle -> {
       handle.getConnection().setAutoCommit(false);
-      if (study.getDatasets() != null) {
-        study.getDatasets().forEach(d -> {
-          try {
-            deleteDataset(d, user.getUserId());
-          } catch (Exception e) {
-            handle.rollback();
-            logException(e);
-            throw new DatasetDeletionException(e);
-          }
-        });
-      }
+      study.getDatasets().forEach(d -> {
+        try {
+          deleteDataset(d, user.getUserId());
+        } catch (Exception e) {
+          handle.rollback();
+          logException(e);
+          throw new DatasetDeletionException(e);
+        }
+      });
       try {
         studyDAO.deleteStudyByStudyId(study.getStudyId());
       } catch (Exception e) {

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAOTest.java
@@ -730,6 +730,21 @@ class DatasetServiceDAOTest extends DAOTestHelper {
   }
 
   @Test
+  void testDeleteStudyWithNoDatasets() throws Exception {
+    // Registration process creates a study and dataset with properties
+    Study study = createStudy(List.of());
+    // Delete any created datasets
+    study.getDatasetIds().forEach(id -> {
+      datasetDAO.deleteDatasetPropertiesByDatasetId(id);
+      datasetDAO.deleteDatasetById(id);
+    });
+    // Ensure that study deletion succeeds
+    serviceDAO.deleteStudy(study, createUser());
+    Study deletedStudy = studyDAO.findStudyById(study.getStudyId());
+    assertNull(deletedStudy);
+  }
+
+  @Test
   void testExecuteUpdateDatasetWithNullName() throws Exception {
     // This creates a study with a single dataset:
     Study study = createStudy(List.of());


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-1282

### Summary
Handle the case where there are no datasets in a study when deleting it. It is possible to delete datasets outside of the study context, so this code path needs to safely handle that case.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
