### PR TITLE
DT-1284: Improve dataset query performance

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
@@ -141,6 +141,13 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
       """)
   Dataset findDatasetById(@Bind("datasetId") Integer datasetId);
 
+  /**
+   * Return a list of Dataset objects from a list of dataset ids. This explicitly does NOT populate
+   * study information due to performance issues.
+   *
+   * @param datasetIds List of dataset ids
+   * @return List of datasets
+   */
   @UseRowReducer(DatasetReducer.class)
   @SqlQuery("""
           SELECT d.dataset_id, d.name, d.create_date, d.create_user_id, d.update_date,
@@ -150,22 +157,6 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
               u.create_date AS u_create_date, u.email_preference AS u_email_preference,
               u.institution_id AS u_institution_id, u.era_commons_id AS u_era_commons_id,
               k.key, dp.property_value, dp.property_key, dp.property_type, dp.schema_property, dp.property_id,
-              s.study_id AS s_study_id,
-              s.name AS s_name,
-              s.description AS s_description,
-              s.data_types AS s_data_types,
-              s.pi_name AS s_pi_name,
-              s.create_user_id AS s_create_user_id,
-              s.create_date AS s_create_date,
-              s.update_user_id AS s_user_id,
-              s.update_date AS s_update_date,
-              s.public_visibility AS s_public_visibility,
-              s_dataset.dataset_id AS s_dataset_id,
-              sp.study_property_id AS sp_study_property_id,
-              sp.study_id AS sp_study_id,
-              sp.key AS sp_key,
-              sp.value AS sp_value,
-              sp.type AS sp_type,
               fso.file_storage_object_id AS fso_file_storage_object_id,
               fso.entity_id AS fso_entity_id,
               fso.file_name AS fso_file_name,
@@ -179,68 +170,15 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
               fso.deleted AS fso_deleted,
               fso.delete_user_id AS fso_delete_user_id
           FROM dataset d
-          LEFT JOIN users u on d.create_user_id = u.user_id
+          INNER JOIN users u on d.create_user_id = u.user_id
           LEFT JOIN (SELECT DISTINCT dataset_id AS id FROM dar_dataset) dar_ds_ids ON dar_ds_ids.id = d.dataset_id
-          LEFT JOIN dataset_property dp ON dp.dataset_id = d.dataset_id
-          LEFT JOIN dictionary k ON k.key_id = dp.property_key
-          LEFT JOIN study s ON s.study_id = d.study_id
-          LEFT JOIN study_property sp ON sp.study_id = s.study_id
-          LEFT JOIN dataset s_dataset ON s_dataset.study_id = s.study_id
-          LEFT JOIN file_storage_object fso ON (fso.entity_id = d.dataset_id::text OR fso.entity_id = s.uuid::text) AND fso.deleted = false
+          INNER JOIN dataset_property dp ON dp.dataset_id = d.dataset_id
+          INNER JOIN dictionary k ON k.key_id = dp.property_key
+          LEFT JOIN file_storage_object fso ON fso.entity_id = d.dataset_id::text AND fso.deleted = false
           WHERE d.dataset_id in (<datasetIds>)
           ORDER BY d.dataset_id
       """)
   List<Dataset> findDatasetsByIdList(@BindList("datasetIds") Collection<Integer> datasetIds);
-
-  @Deprecated
-  @UseRowReducer(DatasetReducer.class)
-  @SqlQuery("""
-          SELECT d.dataset_id, d.name, d.create_date, d.create_user_id, d.update_date,
-              d.update_user_id, d.object_id, d.dac_id, d.alias, d.data_use, d.translated_data_use, d.dac_approval,
-              dar_ds_ids.id AS in_use,
-              u.user_id AS u_user_id, u.email AS u_email, u.display_name AS u_display_name,
-              u.create_date AS u_create_date, u.email_preference AS u_email_preference,
-              u.institution_id AS u_institution_id, u.era_commons_id AS u_era_commons_id,
-              k.key, dp.property_value, dp.property_key, dp.property_type, dp.schema_property, dp.property_id,
-              s.study_id AS s_study_id,
-              s.name AS s_name,
-              s.description AS s_description,
-              s.data_types AS s_data_types,
-              s.pi_name AS s_pi_name,
-              s.create_user_id AS s_create_user_id,
-              s.create_date AS s_create_date,
-              s.update_user_id AS s_user_id,
-              s.update_date AS s_update_date,
-              s.public_visibility AS s_public_visibility,
-              s_dataset.dataset_id AS s_dataset_id,
-              sp.study_property_id AS sp_study_property_id,
-              sp.study_id AS sp_study_id,
-              sp.key AS sp_key,
-              sp.value AS sp_value,
-              sp.type AS sp_type,
-              fso.file_storage_object_id AS fso_file_storage_object_id,
-              fso.entity_id AS fso_entity_id,
-              fso.file_name AS fso_file_name,
-              fso.category AS fso_category,
-              fso.gcs_file_uri AS fso_gcs_file_uri,
-              fso.media_type AS fso_media_type,
-              fso.create_date AS fso_create_date,
-              fso.create_user_id AS fso_create_user_id,
-              fso.update_date AS fso_update_date,
-              fso.update_user_id AS fso_update_user_id,
-              fso.deleted AS fso_deleted,
-              fso.delete_user_id AS fso_delete_user_id
-          FROM dataset d
-          LEFT JOIN users u on d.create_user_id = u.user_id
-          LEFT JOIN (SELECT DISTINCT dataset_id AS id FROM dar_dataset) dar_ds_ids ON dar_ds_ids.id = d.dataset_id
-          LEFT JOIN dataset_property dp ON dp.dataset_id = d.dataset_id
-          LEFT JOIN dictionary k ON k.key_id = dp.property_key
-          LEFT JOIN study s ON s.study_id = d.study_id
-          LEFT JOIN study_property sp ON sp.study_id = s.study_id
-          LEFT JOIN dataset s_dataset ON s_dataset.study_id = s.study_id
-          LEFT JOIN file_storage_object fso ON (fso.entity_id = d.dataset_id::text OR fso.entity_id = s.uuid::text) AND fso.deleted = false
-      """)
-  List<Dataset> findAllDatasets();
 
   @SqlQuery("""
         SELECT dataset_id FROM dataset ORDER BY dataset_id
@@ -262,8 +200,9 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
   List<Integer> findDatasetIdsByDACUserId(@Bind("userId") Integer userId);
 
   /**
-   * Finds all minimal dataset/study  information for datasets assigned to this DAC and which have
-   * been requested for this DAC.
+   * Finds all minimal dataset information for datasets assigned to this DAC and which have
+   * been requested for this DAC. This explicitly does NOT populate study information due to
+   * performance issues.
    *
    * @param dacId id
    * @return all datasets associated with DAC
@@ -277,84 +216,15 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
               u.create_date AS u_create_date, u.email_preference AS u_email_preference,
               u.institution_id AS u_institution_id, u.era_commons_id AS u_era_commons_id,
               k.key, dp.property_value, dp.property_key, dp.property_type, dp.schema_property, dp.property_id,
-              s.study_id AS s_study_id,
-              s.name AS s_name,
-              s.description AS s_description,
-              s.data_types AS s_data_types,
-              s.pi_name AS s_pi_name,
-              s.create_user_id AS s_create_user_id,
-              s.create_date AS s_create_date,
-              s.update_user_id AS s_user_id,
-              s.update_date AS s_update_date,
-              s.public_visibility AS s_public_visibility,
-              s_dataset.dataset_id AS s_dataset_id,
-              sp.study_property_id AS sp_study_property_id,
-              sp.study_id AS sp_study_id,
-              sp.key AS sp_key,
-              sp.value AS sp_value,
-              sp.type AS sp_type
           FROM dataset d
-          LEFT JOIN users u on d.create_user_id = u.user_id
+          INNER JOIN users u on d.create_user_id = u.user_id
           LEFT JOIN (SELECT DISTINCT dataset_id AS id FROM dar_dataset) dar_ds_ids ON dar_ds_ids.id = d.dataset_id
-          LEFT JOIN dataset_property dp ON dp.dataset_id = d.dataset_id
-          LEFT JOIN dictionary k ON k.key_id = dp.property_key
-          LEFT JOIN study s ON s.study_id = d.study_id
-          LEFT JOIN study_property sp ON sp.study_id = s.study_id
-          LEFT JOIN dataset s_dataset ON s_dataset.study_id = s.study_id
+          INNER JOIN dataset_property dp ON dp.dataset_id = d.dataset_id
+          INNER JOIN dictionary k ON k.key_id = dp.property_key
           WHERE d.dac_id = :dacId
           OR (dp.schema_property = 'dataAccessCommitteeId' AND dp.property_value = :dacId::text)
       """)
   List<Dataset> findDatasetsAssociatedWithDac(@Bind("dacId") Integer dacId);
-
-  @UseRowReducer(DatasetReducer.class)
-  @SqlQuery("""
-          SELECT d.dataset_id, d.name, d.create_date, d.create_user_id, d.update_date,
-              d.update_user_id, d.object_id, d.dac_id, d.alias, d.data_use, d.translated_data_use, d.dac_approval,
-              dar_ds_ids.id AS in_use,
-              u.user_id AS u_user_id, u.email AS u_email, u.display_name AS u_display_name,
-              u.create_date AS u_create_date, u.email_preference AS u_email_preference,
-              u.institution_id AS u_institution_id, u.era_commons_id AS u_era_commons_id,
-              k.key, dp.property_value, dp.property_key, dp.property_type, dp.schema_property, dp.property_id,
-              s.study_id AS s_study_id,
-              s.name AS s_name,
-              s.description AS s_description,
-              s.data_types AS s_data_types,
-              s.pi_name AS s_pi_name,
-              s.create_user_id AS s_create_user_id,
-              s.create_date AS s_create_date,
-              s.update_user_id AS s_user_id,
-              s.update_date AS s_update_date,
-              s.public_visibility AS s_public_visibility,
-              s_dataset.dataset_id AS s_dataset_id,
-              sp.study_property_id AS sp_study_property_id,
-              sp.study_id AS sp_study_id,
-              sp.key AS sp_key,
-              sp.value AS sp_value,
-              sp.type AS sp_type,
-              fso.file_storage_object_id AS fso_file_storage_object_id,
-              fso.entity_id AS fso_entity_id,
-              fso.file_name AS fso_file_name,
-              fso.category AS fso_category,
-              fso.gcs_file_uri AS fso_gcs_file_uri,
-              fso.media_type AS fso_media_type,
-              fso.create_date AS fso_create_date,
-              fso.create_user_id AS fso_create_user_id,
-              fso.update_date AS fso_update_date,
-              fso.update_user_id AS fso_update_user_id,
-              fso.deleted AS fso_deleted,
-              fso.delete_user_id AS fso_delete_user_id
-          FROM dataset d
-          LEFT JOIN users u on d.create_user_id = u.user_id
-          LEFT JOIN (SELECT DISTINCT dataset_id AS id FROM dar_dataset) dar_ds_ids ON dar_ds_ids.id = d.dataset_id
-          LEFT JOIN dataset_property dp ON dp.dataset_id = d.dataset_id
-          LEFT JOIN dictionary k ON k.key_id = dp.property_key
-          LEFT JOIN study s ON s.study_id = d.study_id
-          LEFT JOIN study_property sp ON sp.study_id = s.study_id
-          LEFT JOIN dataset s_dataset ON s_dataset.study_id = s.study_id
-          LEFT JOIN file_storage_object fso ON (fso.entity_id = d.dataset_id::text OR fso.entity_id = s.uuid::text) AND fso.deleted = false
-          WHERE d.name IS NOT NULL
-      """)
-  List<Dataset> getDatasets();
 
   @SqlQuery("""
           SELECT DISTINCT dp.property_value as name
@@ -412,10 +282,10 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
               fso.deleted AS fso_deleted,
               fso.delete_user_id AS fso_delete_user_id
           FROM dataset d
-          LEFT JOIN users u on d.create_user_id = u.user_id
+          INNER JOIN users u on d.create_user_id = u.user_id
           LEFT JOIN (SELECT DISTINCT dataset_id AS id FROM dar_dataset) dar_ds_ids ON dar_ds_ids.id = d.dataset_id
-          LEFT JOIN dataset_property dp ON dp.dataset_id = d.dataset_id
-          LEFT JOIN dictionary k ON k.key_id = dp.property_key
+          INNER JOIN dataset_property dp ON dp.dataset_id = d.dataset_id
+          INNER JOIN dictionary k ON k.key_id = dp.property_key
           LEFT JOIN study s ON s.study_id = d.study_id
           LEFT JOIN study_property sp ON sp.study_id = s.study_id
           LEFT JOIN dataset s_dataset ON s_dataset.study_id = s.study_id
@@ -424,39 +294,42 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
       """)
   Dataset findDatasetByAlias(@Bind("alias") Integer alias);
 
+  /**
+   * Return a list of Dataset objects from a list of dataset aliases. This explicitly does NOT
+   * populate study information due to performance issues.
+   *
+   * @param aliases List of dataset aliases
+   * @return List of datasets
+   */
   @UseRowReducer(DatasetReducer.class)
-  @SqlQuery(
-      """
-          SELECT d.*, k.key, dp.property_value, dp.property_key, dp.property_id, d.dac_id, dar_ds_ids.id as in_use,
-              s.study_id AS s_study_id,
-              s.name AS s_name,
-              s.description AS s_description,
-              s.data_types AS s_data_types,
-              s.pi_name AS s_pi_name,
-              s.create_user_id AS s_create_user_id,
-              s.create_date AS s_create_date,
-              s.update_user_id AS s_user_id,
-              s.update_date AS s_update_date,
-              s.public_visibility AS s_public_visibility,
-              s_dataset.dataset_id AS s_dataset_id,
-              sp.study_property_id AS sp_study_property_id,
-              sp.study_id AS sp_study_id,
-              sp.key AS sp_key,
-              sp.value AS sp_value,
-              sp.type AS sp_type,
-          """
-          + FileStorageObject.QUERY_FIELDS_WITH_FSO_PREFIX + " " +
-          """
-                   FROM dataset d
-                   LEFT JOIN (SELECT DISTINCT dataset_id AS id FROM dar_dataset) dar_ds_ids ON dar_ds_ids.id = d.dataset_id
-                   LEFT JOIN dataset_property dp ON dp.dataset_id = d.dataset_id
-                   LEFT JOIN dictionary k ON k.key_id = dp.property_key
-                   LEFT JOIN study s ON s.study_id = d.study_id
-                   LEFT JOIN study_property sp ON sp.study_id = s.study_id
-                   LEFT JOIN dataset s_dataset ON s_dataset.study_id = s.study_id
-                   LEFT JOIN file_storage_object fso ON (fso.entity_id = d.dataset_id::text OR fso.entity_id = s.uuid::text) AND fso.deleted = false
-                   WHERE d.alias IN (<aliases>)
-              """)
+  @SqlQuery("""
+          SELECT d.dataset_id, d.name, d.create_date, d.create_user_id, d.update_date,
+              d.update_user_id, d.object_id, d.dac_id, d.alias, d.data_use, d.translated_data_use, 
+              d.dac_approval, dar_ds_ids.id AS in_use,
+              u.user_id AS u_user_id, u.email AS u_email, u.display_name AS u_display_name,
+              u.create_date AS u_create_date, u.email_preference AS u_email_preference,
+              u.institution_id AS u_institution_id, u.era_commons_id AS u_era_commons_id,
+              k.key, dp.property_value, dp.property_key, dp.property_type, dp.schema_property, dp.property_id,
+              fso.file_storage_object_id AS fso_file_storage_object_id,
+              fso.entity_id AS fso_entity_id,
+              fso.file_name AS fso_file_name,
+              fso.category AS fso_category,
+              fso.gcs_file_uri AS fso_gcs_file_uri,
+              fso.media_type AS fso_media_type,
+              fso.create_date AS fso_create_date,
+              fso.create_user_id AS fso_create_user_id,
+              fso.update_date AS fso_update_date,
+              fso.update_user_id AS fso_update_user_id,
+              fso.deleted AS fso_deleted,
+              fso.delete_user_id AS fso_delete_user_id
+          FROM dataset d
+          INNER JOIN users u on d.create_user_id = u.user_id
+          LEFT JOIN (SELECT DISTINCT dataset_id AS id FROM dar_dataset) dar_ds_ids ON dar_ds_ids.id = d.dataset_id
+          INNER JOIN dataset_property dp ON dp.dataset_id = d.dataset_id
+          INNER JOIN dictionary k ON k.key_id = dp.property_key
+          LEFT JOIN file_storage_object fso ON fso.entity_id = d.dataset_id::text AND fso.deleted = false
+          WHERE d.alias IN (<aliases>)
+      """)
   List<Dataset> findDatasetsByAlias(@BindList("aliases") List<Integer> aliases);
 
   @Deprecated
@@ -668,8 +541,7 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
   List<Dataset> findDatasetListByDacIds(@BindList("dacIds") List<Integer> dacIds);
 
   /**
-   * DACs -> Datasets Datasets -> DatasetProperties ->
-   * Dictionary
+   * DACs -> Datasets -> DatasetProperties -> Dictionary
    *
    * @return Set of datasets, with properties, that are associated to any Dac.
    */

--- a/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
@@ -172,8 +172,8 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
           FROM dataset d
           INNER JOIN users u on d.create_user_id = u.user_id
           LEFT JOIN (SELECT DISTINCT dataset_id AS id FROM dar_dataset) dar_ds_ids ON dar_ds_ids.id = d.dataset_id
-          INNER JOIN dataset_property dp ON dp.dataset_id = d.dataset_id
-          INNER JOIN dictionary k ON k.key_id = dp.property_key
+          LEFT JOIN dataset_property dp ON dp.dataset_id = d.dataset_id
+          LEFT JOIN dictionary k ON k.key_id = dp.property_key
           LEFT JOIN file_storage_object fso ON fso.entity_id = d.dataset_id::text AND fso.deleted = false
           WHERE d.dataset_id in (<datasetIds>)
           ORDER BY d.dataset_id
@@ -219,8 +219,8 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
           FROM dataset d
           INNER JOIN users u on d.create_user_id = u.user_id
           LEFT JOIN (SELECT DISTINCT dataset_id AS id FROM dar_dataset) dar_ds_ids ON dar_ds_ids.id = d.dataset_id
-          INNER JOIN dataset_property dp ON dp.dataset_id = d.dataset_id
-          INNER JOIN dictionary k ON k.key_id = dp.property_key
+          LEFT JOIN dataset_property dp ON dp.dataset_id = d.dataset_id
+          LEFT JOIN dictionary k ON k.key_id = dp.property_key
           WHERE d.dac_id = :dacId
           OR (dp.schema_property = 'dataAccessCommitteeId' AND dp.property_value = :dacId::text)
       """)
@@ -284,8 +284,8 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
           FROM dataset d
           INNER JOIN users u on d.create_user_id = u.user_id
           LEFT JOIN (SELECT DISTINCT dataset_id AS id FROM dar_dataset) dar_ds_ids ON dar_ds_ids.id = d.dataset_id
-          INNER JOIN dataset_property dp ON dp.dataset_id = d.dataset_id
-          INNER JOIN dictionary k ON k.key_id = dp.property_key
+          LEFT JOIN dataset_property dp ON dp.dataset_id = d.dataset_id
+          LEFT JOIN dictionary k ON k.key_id = dp.property_key
           LEFT JOIN study s ON s.study_id = d.study_id
           LEFT JOIN study_property sp ON sp.study_id = s.study_id
           LEFT JOIN dataset s_dataset ON s_dataset.study_id = s.study_id
@@ -325,8 +325,8 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
           FROM dataset d
           INNER JOIN users u on d.create_user_id = u.user_id
           LEFT JOIN (SELECT DISTINCT dataset_id AS id FROM dar_dataset) dar_ds_ids ON dar_ds_ids.id = d.dataset_id
-          INNER JOIN dataset_property dp ON dp.dataset_id = d.dataset_id
-          INNER JOIN dictionary k ON k.key_id = dp.property_key
+          LEFT JOIN dataset_property dp ON dp.dataset_id = d.dataset_id
+          LEFT JOIN dictionary k ON k.key_id = dp.property_key
           LEFT JOIN file_storage_object fso ON fso.entity_id = d.dataset_id::text AND fso.deleted = false
           WHERE d.alias IN (<aliases>)
       """)

--- a/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
@@ -94,7 +94,7 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
   @SqlQuery("""
           SELECT d.dataset_id, d.name, d.create_date, d.create_user_id, d.update_date,
               d.update_user_id, d.object_id, d.dac_id, d.alias, d.data_use, d.translated_data_use, d.dac_approval,
-              dar_ds_ids.id AS in_use,
+              dar_ds_ids.id AS in_use, d.study_id,
               u.user_id AS u_user_id, u.email AS u_email, u.display_name AS u_display_name,
               u.create_date AS u_create_date, u.email_preference AS u_email_preference,
               u.institution_id AS u_institution_id, u.era_commons_id AS u_era_commons_id,
@@ -151,7 +151,7 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
   @SqlQuery("""
           SELECT d.dataset_id, d.name, d.create_date, d.create_user_id, d.update_date,
               d.update_user_id, d.object_id, d.dac_id, d.alias, d.data_use, d.translated_data_use, d.dac_approval,
-              dar_ds_ids.id AS in_use,
+              dar_ds_ids.id AS in_use, d.study_id,
               u.user_id AS u_user_id, u.email AS u_email, u.display_name AS u_display_name,
               u.create_date AS u_create_date, u.email_preference AS u_email_preference,
               u.institution_id AS u_institution_id, u.era_commons_id AS u_era_commons_id,
@@ -210,7 +210,7 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
   @SqlQuery("""
           SELECT d.dataset_id, d.name, d.create_date, d.create_user_id, d.update_date,
               d.update_user_id, d.object_id, d.dac_id, d.alias, d.data_use, d.translated_data_use, d.dac_approval,
-              dar_ds_ids.id AS in_use,
+              dar_ds_ids.id AS in_use, d.study_id,
               u.user_id AS u_user_id, u.email AS u_email, u.display_name AS u_display_name,
               u.create_date AS u_create_date, u.email_preference AS u_email_preference,
               u.institution_id AS u_institution_id, u.era_commons_id AS u_era_commons_id,
@@ -247,7 +247,7 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
   @SqlQuery("""
           SELECT d.dataset_id, d.name, d.create_date, d.create_user_id, d.update_date,
               d.update_user_id, d.object_id, d.dac_id, d.alias, d.data_use, d.translated_data_use, d.dac_approval,
-              dar_ds_ids.id AS in_use,
+              dar_ds_ids.id AS in_use, d.study_id,
               u.user_id AS u_user_id, u.email AS u_email, u.display_name AS u_display_name,
               u.create_date AS u_create_date, u.email_preference AS u_email_preference,
               u.institution_id AS u_institution_id, u.era_commons_id AS u_era_commons_id,
@@ -304,7 +304,7 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
   @SqlQuery("""
           SELECT d.dataset_id, d.name, d.create_date, d.create_user_id, d.update_date,
               d.update_user_id, d.object_id, d.dac_id, d.alias, d.data_use, d.translated_data_use,
-              d.dac_approval, dar_ds_ids.id AS in_use,
+              d.dac_approval, dar_ds_ids.id AS in_use, d.study_id,
               u.user_id AS u_user_id, u.email AS u_email, u.display_name AS u_display_name,
               u.create_date AS u_create_date, u.email_preference AS u_email_preference,
               u.institution_id AS u_institution_id, u.era_commons_id AS u_era_commons_id,

--- a/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
@@ -536,20 +536,20 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
   @RegisterRowMapper(ApprovedDatasetMapper.class)
   @UseRowReducer(ApprovedDatasetReducer.class)
   @SqlQuery("""
-          SELECT DISTINCT c.dar_code, d.alias, d.name as dataset_name, dac.name as dac_name, vote_view.update_date
-          FROM data_access_request dar
-          INNER JOIN dar_collection c on dar.collection_id = c.collection_id
-          INNER JOIN dar_dataset dd ON dd.reference_id = dar.reference_id
-          INNER JOIN dataset d on d.dataset_id = dd.dataset_id
-          INNER JOIN dac dac on dac.dac_id = d.dac_id
-          INNER JOIN election e on dar.reference_id = e.reference_id AND e.dataset_id = d.dataset_id
-          INNER JOIN vote v ON e.election_id = v.electionid AND v.vote IS NOT NULL
-          INNER JOIN (
-            SELECT voteid, MAX(updatedate) update_date
-            FROM vote
-            GROUP BY voteid) vote_view ON v.voteid = vote_view.voteid
-          WHERE d.dac_approval = TRUE AND dar.user_id = :userId
-      """)
+        SELECT DISTINCT c.dar_code, d.alias, d.name as dataset_name, dac.name as dac_name, vote_view.update_date
+        FROM data_access_request dar
+        INNER JOIN dar_collection c on dar.collection_id = c.collection_id
+        INNER JOIN dar_dataset dd ON dd.reference_id = dar.reference_id
+        INNER JOIN dataset d on d.dataset_id = dd.dataset_id
+        INNER JOIN dac dac on dac.dac_id = d.dac_id
+        INNER JOIN election e on dar.reference_id = e.reference_id AND e.dataset_id = d.dataset_id
+        INNER JOIN vote v ON e.election_id = v.electionid AND v.vote IS NOT NULL
+        INNER JOIN (
+          SELECT voteid, MAX(updatedate) update_date
+          FROM vote
+          GROUP BY voteid) vote_view ON v.voteid = vote_view.voteid
+        WHERE d.dac_approval = TRUE AND dar.user_id = :userId
+  """)
   List<ApprovedDataset> getApprovedDatasets(@Bind("userId") Integer userId);
 
   @RegisterRowMapper(DatasetSummaryMapper.class)

--- a/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
@@ -215,7 +215,7 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
               u.user_id AS u_user_id, u.email AS u_email, u.display_name AS u_display_name,
               u.create_date AS u_create_date, u.email_preference AS u_email_preference,
               u.institution_id AS u_institution_id, u.era_commons_id AS u_era_commons_id,
-              k.key, dp.property_value, dp.property_key, dp.property_type, dp.schema_property, dp.property_id,
+              k.key, dp.property_value, dp.property_key, dp.property_type, dp.schema_property, dp.property_id
           FROM dataset d
           INNER JOIN users u on d.create_user_id = u.user_id
           LEFT JOIN (SELECT DISTINCT dataset_id AS id FROM dar_dataset) dar_ds_ids ON dar_ds_ids.id = d.dataset_id

--- a/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
@@ -536,19 +536,19 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
   @RegisterRowMapper(ApprovedDatasetMapper.class)
   @UseRowReducer(ApprovedDatasetReducer.class)
   @SqlQuery("""
-            SELECT DISTINCT c.dar_code, d.alias, d.name as dataset_name, dac.name as dac_name, vote_view.update_date
-            FROM data_access_request dar
-            INNER JOIN dar_collection c on dar.collection_id = c.collection_id
-            INNER JOIN dar_dataset dd ON dd.reference_id = dar.reference_id
-            INNER JOIN dataset d on d.dataset_id = dd.dataset_id
-            INNER JOIN dac dac on dac.dac_id = d.dac_id
-            INNER JOIN election e on dar.reference_id = e.reference_id AND e.dataset_id = d.dataset_id
-            INNER JOIN vote v ON e.election_id = v.electionid AND v.vote IS NOT NULL
-            INNER JOIN (
-              SELECT voteid, MAX(updatedate) update_date
-              FROM vote
-              GROUP BY voteid) vote_view ON v.voteid = vote_view.voteid
-            WHERE d.dac_approval = TRUE AND dar.user_id = :userId
+          SELECT DISTINCT c.dar_code, d.alias, d.name as dataset_name, dac.name as dac_name, vote_view.update_date
+          FROM data_access_request dar
+          INNER JOIN dar_collection c on dar.collection_id = c.collection_id
+          INNER JOIN dar_dataset dd ON dd.reference_id = dar.reference_id
+          INNER JOIN dataset d on d.dataset_id = dd.dataset_id
+          INNER JOIN dac dac on dac.dac_id = d.dac_id
+          INNER JOIN election e on dar.reference_id = e.reference_id AND e.dataset_id = d.dataset_id
+          INNER JOIN vote v ON e.election_id = v.electionid AND v.vote IS NOT NULL
+          INNER JOIN (
+            SELECT voteid, MAX(updatedate) update_date
+            FROM vote
+            GROUP BY voteid) vote_view ON v.voteid = vote_view.voteid
+          WHERE d.dac_approval = TRUE AND dar.user_id = :userId
       """)
   List<ApprovedDataset> getApprovedDatasets(@Bind("userId") Integer userId);
 

--- a/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
@@ -23,7 +23,6 @@ import org.broadinstitute.consent.http.models.DatasetProperty;
 import org.broadinstitute.consent.http.models.DatasetStudySummary;
 import org.broadinstitute.consent.http.models.DatasetSummary;
 import org.broadinstitute.consent.http.models.Dictionary;
-import org.broadinstitute.consent.http.models.FileStorageObject;
 import org.broadinstitute.consent.http.models.Study;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.dto.DatasetDTO;
@@ -181,8 +180,8 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
   List<Dataset> findDatasetsByIdList(@BindList("datasetIds") Collection<Integer> datasetIds);
 
   @SqlQuery("""
-        SELECT dataset_id FROM dataset ORDER BY dataset_id
-        """)
+      SELECT dataset_id FROM dataset ORDER BY dataset_id
+      """)
   List<Integer> findAllDatasetIds();
 
   /**
@@ -200,9 +199,9 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
   List<Integer> findDatasetIdsByDACUserId(@Bind("userId") Integer userId);
 
   /**
-   * Finds all minimal dataset information for datasets assigned to this DAC and which have
-   * been requested for this DAC. This explicitly does NOT populate study information due to
-   * performance issues.
+   * Finds all minimal dataset information for datasets assigned to this DAC and which have been
+   * requested for this DAC. This explicitly does NOT populate study information due to performance
+   * issues.
    *
    * @param dacId id
    * @return all datasets associated with DAC
@@ -304,7 +303,7 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
   @UseRowReducer(DatasetReducer.class)
   @SqlQuery("""
           SELECT d.dataset_id, d.name, d.create_date, d.create_user_id, d.update_date,
-              d.update_user_id, d.object_id, d.dac_id, d.alias, d.data_use, d.translated_data_use, 
+              d.update_user_id, d.object_id, d.dac_id, d.alias, d.data_use, d.translated_data_use,
               d.dac_approval, dar_ds_ids.id AS in_use,
               u.user_id AS u_user_id, u.email AS u_email, u.display_name AS u_display_name,
               u.create_date AS u_create_date, u.email_preference AS u_email_preference,
@@ -428,7 +427,8 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
       SET create_user_id = :createUserId
       WHERE dataset_id = :datasetId
       """)
-  void updateDatasetCreateUserId(@Bind("datasetId") Integer datasetId, @Bind("createUserId") Integer createUserId);
+  void updateDatasetCreateUserId(@Bind("datasetId") Integer datasetId,
+      @Bind("createUserId") Integer createUserId);
 
   @SqlUpdate("""
       UPDATE dataset
@@ -451,42 +451,6 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
   void updateDatasetUpdateUser(@Bind("datasetId") Integer datasetId,
       @Bind("updateDate") Timestamp updateDate,
       @Bind("updateUserId") Integer updateUserId);
-
-  @UseRowReducer(DatasetReducer.class)
-  @SqlQuery(
-      """
-          SELECT d.*, k.key, dp.property_value, dp.property_key, dp.property_type, dp.schema_property, dp.property_id, d.dac_id, dar_ds_ids.id as in_use,
-              s.study_id AS s_study_id,
-              s.name AS s_name,
-              s.description AS s_description,
-              s.data_types AS s_data_types,
-              s.pi_name AS s_pi_name,
-              s.create_user_id AS s_create_user_id,
-              s.create_date AS s_create_date,
-              s.update_user_id AS s_user_id,
-              s.update_date AS s_update_date,
-              s.public_visibility AS s_public_visibility,
-              s_dataset.dataset_id AS s_dataset_id,
-              sp.study_property_id AS sp_study_property_id,
-              sp.study_id AS sp_study_id,
-              sp.key AS sp_key,
-              sp.value AS sp_value,
-              sp.type AS sp_type,
-          """
-          + FileStorageObject.QUERY_FIELDS_WITH_FSO_PREFIX + " " +
-          """
-                  FROM dataset d
-                  LEFT JOIN (SELECT DISTINCT dataset_id AS id FROM dar_dataset) dar_ds_ids ON dar_ds_ids.id = d.dataset_id
-                  LEFT JOIN dataset_property dp ON dp.dataset_id = d.dataset_id
-                  LEFT JOIN dictionary k ON k.key_id = dp.property_key
-                  LEFT JOIN study s ON s.study_id = d.study_id
-                  LEFT JOIN study_property sp ON sp.study_id = s.study_id
-                  LEFT JOIN dataset s_dataset ON s_dataset.study_id = s.study_id
-                  LEFT JOIN file_storage_object fso ON (fso.entity_id = d.dataset_id::text OR fso.entity_id = s.uuid::text) AND fso.deleted = false
-                  WHERE d.dataset_id IN (<datasetIds>)
-                  ORDER BY d.dataset_id, k.display_order
-              """)
-  Set<Dataset> findDatasetWithDataUseByIdList(@BindList("datasetIds") List<Integer> datasetIds);
 
   @Deprecated
   @UseRowMapper(DatasetDTOWithPropertiesMapper.class)
@@ -514,8 +478,7 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
   Dataset getDatasetByName(@Bind("name") String name);
 
   /**
-   * DACs -> Datasets Datasets -> DatasetProperties ->
-   * Dictionary
+   * DACs -> Datasets Datasets -> DatasetProperties -> Dictionary
    *
    * @return Set of datasets, with properties, that are associated with the provided DAC IDs
    */
@@ -573,20 +536,20 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
   @RegisterRowMapper(ApprovedDatasetMapper.class)
   @UseRowReducer(ApprovedDatasetReducer.class)
   @SqlQuery("""
-        SELECT DISTINCT c.dar_code, d.alias, d.name as dataset_name, dac.name as dac_name, vote_view.update_date
-        FROM data_access_request dar
-        INNER JOIN dar_collection c on dar.collection_id = c.collection_id
-        INNER JOIN dar_dataset dd ON dd.reference_id = dar.reference_id
-        INNER JOIN dataset d on d.dataset_id = dd.dataset_id
-        INNER JOIN dac dac on dac.dac_id = d.dac_id
-        INNER JOIN election e on dar.reference_id = e.reference_id AND e.dataset_id = d.dataset_id
-        INNER JOIN vote v ON e.election_id = v.electionid AND v.vote IS NOT NULL
-        INNER JOIN (
-          SELECT voteid, MAX(updatedate) update_date
-          FROM vote
-          GROUP BY voteid) vote_view ON v.voteid = vote_view.voteid
-        WHERE d.dac_approval = TRUE AND dar.user_id = :userId
-  """)
+            SELECT DISTINCT c.dar_code, d.alias, d.name as dataset_name, dac.name as dac_name, vote_view.update_date
+            FROM data_access_request dar
+            INNER JOIN dar_collection c on dar.collection_id = c.collection_id
+            INNER JOIN dar_dataset dd ON dd.reference_id = dar.reference_id
+            INNER JOIN dataset d on d.dataset_id = dd.dataset_id
+            INNER JOIN dac dac on dac.dac_id = d.dac_id
+            INNER JOIN election e on dar.reference_id = e.reference_id AND e.dataset_id = d.dataset_id
+            INNER JOIN vote v ON e.election_id = v.electionid AND v.vote IS NOT NULL
+            INNER JOIN (
+              SELECT voteid, MAX(updatedate) update_date
+              FROM vote
+              GROUP BY voteid) vote_view ON v.voteid = vote_view.voteid
+            WHERE d.dac_approval = TRUE AND dar.user_id = :userId
+      """)
   List<ApprovedDataset> getApprovedDatasets(@Bind("userId") Integer userId);
 
   @RegisterRowMapper(DatasetSummaryMapper.class)

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DatasetMapper.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DatasetMapper.java
@@ -47,6 +47,9 @@ public class DatasetMapper implements RowMapper<Dataset>, RowMapperHelper {
     if (hasColumn(r, "alias")) {
       dataset.setAlias(r.getInt("alias"));
     }
+    if (hasNonZeroColumn(r, "study_id")) {
+      dataset.setStudyId(r.getInt("study_id"));
+    }
 
     return dataset;
   }

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DatasetReducer.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DatasetReducer.java
@@ -66,6 +66,10 @@ public class DatasetReducer implements LinkedHashMapRowReducer<Integer, Dataset>
       }
     }
 
+    if (hasNonZeroColumn(rowView, "study_id")) {
+      dataset.setStudyId(rowView.getColumn("study_id", Integer.class));
+    }
+
     if (hasNonZeroColumn(rowView, "s_study_id")) {
       if (Objects.isNull(dataset.getStudy())) {
         dataset.setStudy(rowView.getRow(Study.class));

--- a/src/main/java/org/broadinstitute/consent/http/models/Dataset.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/Dataset.java
@@ -53,6 +53,9 @@ public class Dataset implements ConsentLogger {
   private Boolean dacApproval;
 
   private User createUser;
+
+  private Integer studyId;
+
   private Study study;
 
   public Dataset() {
@@ -339,10 +342,18 @@ public class Dataset implements ConsentLogger {
     this.study = study;
   }
 
+  public Integer getStudyId() {
+    return studyId;
+  }
+
+  public void setStudyId(Integer studyId) {
+    this.studyId = studyId;
+  }
+
   /**
    * Determine if the user is a dataset/study creator
    *
-   * @param user    User
+   * @param user User
    * @return User is a creator of the dataset/study
    */
   public boolean isCustodian(User user) {
@@ -374,7 +385,7 @@ public class Dataset implements ConsentLogger {
         getStudy().getCreateUserId());
   }
 
-    @Override
+  @Override
   public boolean equals(Object o) {
     if (this == o) {
       return true;

--- a/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
@@ -14,6 +14,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -530,7 +531,7 @@ public class DarCollectionService implements ConsentLogger {
       if (!filterDatasetIds.isEmpty()) {
         datasetIds.retainAll(filterDatasetIds);
       }
-      Set<Dataset> datasets = datasetDAO.findDatasetWithDataUseByIdList(datasetIds);
+      Set<Dataset> datasets = new HashSet<>(datasetDAO.findDatasetsByIdList(datasetIds));
       Map<Integer, Dataset> datasetMap = datasets.stream()
           .collect(Collectors.toMap(Dataset::getDatasetId, Function.identity()));
 

--- a/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
@@ -14,7 +14,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -531,8 +530,9 @@ public class DarCollectionService implements ConsentLogger {
       if (!filterDatasetIds.isEmpty()) {
         datasetIds.retainAll(filterDatasetIds);
       }
-      Set<Dataset> datasets = new HashSet<>(datasetDAO.findDatasetsByIdList(datasetIds));
-      Map<Integer, Dataset> datasetMap = datasets.stream()
+      Map<Integer, Dataset> datasetMap = datasetDAO.findDatasetsByIdList(datasetIds)
+          .stream()
+          .distinct()
           .collect(Collectors.toMap(Dataset::getDatasetId, Function.identity()));
 
       return collections.stream().map(c -> {

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -228,11 +228,6 @@ public class DatasetService implements ConsentLogger {
     return datasetDAO.findDatasetsByIdList(datasetIds);
   }
 
-  @Deprecated
-  public List<Dataset> findAllDatasets() {
-    return datasetDAO.findAllDatasets();
-  }
-
   public List<Integer> findAllDatasetIds() {
     return datasetDAO.findAllDatasetIds();
   }

--- a/src/main/resources/assets/paths/datasetBatch.yaml
+++ b/src/main/resources/assets/paths/datasetBatch.yaml
@@ -1,6 +1,9 @@
 get:
   summary: Get Dataset by List of Ids
-  description: Finds Dataset and DatasetProperties of the Dataset specified by id.
+  description: |
+    Finds Dataset and DatasetProperties of the Dataset specified by id.
+    Note that study information is not included in dataset list endpoints but is provided in
+    individual dataset endpoints.
   parameters:
     - name: ids
       in: query

--- a/src/main/resources/assets/paths/datasetV2.yaml
+++ b/src/main/resources/assets/paths/datasetV2.yaml
@@ -1,7 +1,9 @@
 get:
   summary: Get Streamed Datasets
-  description: | 
+  description: |
     Returns all Datasets in a streamed format. This endpoint can be slow, but will eventually complete.
+    Note that study information is not included in dataset list endpoints but is provided in
+    individual dataset endpoints.
   tags:
     - Dataset
   responses:

--- a/src/main/resources/assets/paths/datasetV3.yaml
+++ b/src/main/resources/assets/paths/datasetV3.yaml
@@ -1,6 +1,7 @@
 get:
-  summary:
-  description:
+  summary: List of Dataset Study Summary objects
+  description: |
+    Provides a list of datasets and their associated study information in a very minimal format.
   tags:
     - Dataset
   responses:

--- a/src/main/resources/assets/paths/datasetsByDacId.yaml
+++ b/src/main/resources/assets/paths/datasetsByDacId.yaml
@@ -4,6 +4,8 @@
       description: |
         List all Datasets of a DAC. The datasets returned from this endpoint are limited in the 
         volume of data returned. To get the full dataset, use the `/datasets/{datasetId}` endpoint.
+        Note that study information is not included in dataset list endpoints but is provided in
+        individual dataset endpoints.
       parameters:
         - name: dacId
           in: path

--- a/src/main/resources/assets/paths/getDatasetsFromUserDacsV2.yaml
+++ b/src/main/resources/assets/paths/getDatasetsFromUserDacsV2.yaml
@@ -1,6 +1,9 @@
 get:
   summary: Get datasets from currently authenticated user's DACs
-  description: Get datasets from currently authenticated user's DACs
+  description: |
+    Get datasets from currently authenticated user's DACs.
+    Note that study information is not included in dataset list endpoints but is provided in
+    individual dataset endpoints.
   tags:
     - User
   responses:

--- a/src/main/resources/assets/schemas/Dataset.yaml
+++ b/src/main/resources/assets/schemas/Dataset.yaml
@@ -51,7 +51,7 @@ properties:
   studyId:
     type: integer
     format: int32
-    description: The study's id.
+    description: The dataset's study id.
   study:
     $ref: "./Study.yaml"
   alias:

--- a/src/main/resources/assets/schemas/Dataset.yaml
+++ b/src/main/resources/assets/schemas/Dataset.yaml
@@ -48,6 +48,10 @@ properties:
         propertyValue: http://...
       - propertyName: Sample Collection ID
         propertyValue: SC-000
+  studyId:
+    type: integer
+    format: int32
+    description: The study's id.
   study:
     $ref: "./Study.yaml"
   alias:

--- a/src/main/resources/assets/schemas/Dataset.yaml
+++ b/src/main/resources/assets/schemas/Dataset.yaml
@@ -16,7 +16,6 @@ properties:
     format: int32
     description: The create user id, if available
   createUser:
-    description: The create user, if available
     $ref: './User.yaml'
   dacId:
     type: string
@@ -51,7 +50,6 @@ properties:
         propertyValue: SC-000
   study:
     $ref: "./Study.yaml"
-    description: The study which produced this dataset.
   alias:
     type: string
     description: The dataset id, short format

--- a/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
@@ -14,7 +14,6 @@ import com.google.gson.JsonObject;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -723,19 +722,6 @@ class DatasetDAOTest extends DAOTestHelper {
     assertNotNull(foundDataset);
     assertEquals(user.getUserId(), foundDataset.getUpdateUserId());
     assertTrue(foundDataset.getUpdateDate().after(dataset.getUpdateDate()));
-  }
-
-  @Test
-  void testFindDatasetWithDataUseByIdList() {
-    Dataset dataset = insertDataset();
-    Dac dac = insertDac();
-    datasetDAO.updateDatasetDacId(dataset.getDatasetId(), dac.getDacId());
-
-    Set<Dataset> datasets = datasetDAO.findDatasetWithDataUseByIdList(
-        Collections.singletonList(dataset.getDatasetId()));
-    assertFalse(datasets.isEmpty());
-    List<Integer> datasetIds = datasets.stream().map(Dataset::getDatasetId).toList();
-    assertTrue(datasetIds.contains(dataset.getDatasetId()));
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
@@ -580,22 +580,6 @@ class DatasetDAOTest extends DAOTestHelper {
   }
 
   @Test
-  void testFindAllDatasets() {
-    List<Dataset> datasetList = IntStream.range(1, 5).mapToObj(i -> {
-      Dataset dataset = insertDataset();
-      return dataset;
-    }).toList();
-
-    List<Dataset> datasets = datasetDAO.findAllDatasets();
-    assertFalse(datasets.isEmpty());
-    assertEquals(datasetList.size(), datasets.size());
-    List<Integer> insertedDatasetIds = datasetList.stream().map(Dataset::getDatasetId).toList();
-    List<Integer> foundDatasetIds = datasets.stream().map(Dataset::getDatasetId).toList();
-    assertTrue(foundDatasetIds.containsAll(insertedDatasetIds));
-    assertTrue(insertedDatasetIds.containsAll(foundDatasetIds));
-  }
-
-  @Test
   void testFindAllDatasetIds() {
     List<Integer> insertedDatasetIds = IntStream.range(1, 5).mapToObj(i -> {
       Dataset dataset = insertDataset();

--- a/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
@@ -99,7 +99,7 @@ class DarCollectionServiceTest {
         .sorted()
         .collect(Collectors.toList());
 
-    when(datasetDAO.findDatasetWithDataUseByIdList(anyList())).thenReturn(datasets);
+    when(datasetDAO.findDatasetsByIdList(anyList())).thenReturn(new ArrayList<>(datasets));
     when(dataAccessRequestDAO.findAllDARDatasetRelations(any())).thenReturn(datasetIds);
 
     collections = service.addDatasetsToCollections(collections, List.of());
@@ -130,9 +130,8 @@ class DarCollectionServiceTest {
     Dataset dataset = new Dataset();
     dataset.setDatasetId(datasetIds.get(0));
 
-    // mocking out findDatasetWithDataUseByIdList to only return one of the datasets
-    when(datasetDAO.findDatasetWithDataUseByIdList(List.of(dataset.getDatasetId()))).thenReturn(
-        new HashSet<>(List.of(dataset)));
+    // mocking out findDatasetsByIdList to only return one of the datasets
+    when(datasetDAO.findDatasetsByIdList(List.of(dataset.getDatasetId()))).thenReturn(List.of(dataset));
     when(dataAccessRequestDAO.findAllDARDatasetRelations(any())).thenReturn(datasetIds);
 
     collections = service.addDatasetsToCollections(collections, List.of(dataset.getDatasetId()));

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DacServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DacServiceDAOTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.sql.Timestamp;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -47,6 +48,7 @@ class DacServiceDAOTest extends DAOTestHelper {
     //  * DAC Member and Chairperson
     //  * Dataset associated to the DAC
     List<Dac> dacs = createMockDACs();
+    List<Integer> createdDatasetIds = new ArrayList<>();
     dacs.forEach(dac -> {
       // DAC
       int dacId = dacDAO.createDac(
@@ -98,6 +100,7 @@ class DacServiceDAOTest extends DAOTestHelper {
           "object id: " + RandomStringUtils.randomAlphabetic(10),
           new DataUseBuilder().setGeneralUse(true).build().toString(),
           dacId);
+      createdDatasetIds.add(datasetId);
       datasetDAO.updateDatasetDacId(datasetId, dacId);
     });
     dacDAO.findAll().forEach(dac -> {
@@ -125,7 +128,8 @@ class DacServiceDAOTest extends DAOTestHelper {
         }
       });
     });
-    datasetDAO.findAllDatasets().forEach(ds -> {
+    createdDatasetIds.forEach(id -> {
+      Dataset ds = datasetDAO.findDatasetById(id);
       assertNull(ds.getDacId(), "Dataset should not have a DAC");
       assertNull(ds.getDacApproval(), "Dataset should not have a DAC approval");
     });

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAOTest.java
@@ -219,7 +219,7 @@ class DatasetServiceDAOTest extends DAOTestHelper {
 
     assertEquals(1, datasets.size());
 
-    Dataset dataset1 = datasets.get(0);
+    Dataset dataset1 = datasetDAO.findDatasetById(createdIds.get(0));
 
     assertNotNull(dataset1.getStudy());
     Study s = dataset1.getStudy();
@@ -275,7 +275,7 @@ class DatasetServiceDAOTest extends DAOTestHelper {
 
     assertEquals(1, datasets.size());
 
-    Dataset dataset1 = datasets.get(0);
+    Dataset dataset1 = datasetDAO.findDatasetById(createdIds.get(0));
 
     assertNotNull(dataset1.getStudy());
     Study s = dataset1.getStudy();
@@ -348,7 +348,7 @@ class DatasetServiceDAOTest extends DAOTestHelper {
 
     assertEquals(1, datasets.size());
 
-    Dataset dataset1 = datasets.get(0);
+    Dataset dataset1 = datasetDAO.findDatasetById(createdIds.get(0));
 
     assertNotNull(dataset1.getStudy());
     Study s = dataset1.getStudy();
@@ -1010,8 +1010,8 @@ class DatasetServiceDAOTest extends DAOTestHelper {
 
     List<Integer> createdIds = serviceDAO.insertDatasetRegistration(studyInsert,
         List.of(datasetInsert));
-    List<Dataset> createdDatasets = datasetDAO.findDatasetsByIdList(createdIds);
-    return createdDatasets.get(0).getStudy();
+    Dataset createdDataset = datasetDAO.findDatasetById(createdIds.get(0));
+    return createdDataset.getStudy();
   }
 
   private Dataset createDataset() {


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-1284

### Summary
The diff on this is confusing, I think, because there are large blocks of added/removed code. For example, I didn't make any changes to `findAllStudyNames` or `findAllDatasetNames`, but they show up as new additions and deletions in the diff.

This PR does several things
- Remove usages of unused/deprecated methods
  - Deprecated: `findAllDatasets()`
  - Unused: `getDatasets()`
  - Duplicative: `findDatasetWithDataUseByIdList()` -> `findDatasetsByIdList()`
- Remove study information from dataset collection queries
  - This allows for a simpler file storage object clause that reduces query time 10-fold
  - Still pull the study info when querying for a single dataset
- Since we're not populating study on dataset collections, populate the study id instead which should be enough for clients to follow up with.
- Add inner joins on create user as that is guaranteed to be non-null
- Update swagger docs to make it clear that study info is not returned with collection-based dataset endpoint.

### Testing Notes
APIs tested include:
* Get all datasets by ids: `GET /api/dataset/batch`
* Post all datasets to ES: `POST /api/dataset/index`
* Get registration: `GET /api/dataset/registration/{datasetIdentifier}`
* Get datasets v2: `GET /api/dataset/v2`
* Get datasets v3: `GET /api/dataset/v3`
* Get study: `GET /api/dataset/study/{studyId}`
  * For example, study id: 67  with 32 datasets: 
    * Prod: 42596 ms response
    * New: 1290 ms -> 33x better response
    * On prod, study id 62 has 66 datasets and crashes the running pod.
* Get study registration: `GET /api/dataset/study/registration/{studyId}`

### Explain Plans

Before
![Screenshot 2025-03-05 at 2 54 56 PM](https://github.com/user-attachments/assets/46d29cb9-a56d-454d-9a24-47a21f33ba23)

After
![Screenshot 2025-03-05 at 2 56 20 PM](https://github.com/user-attachments/assets/8cab2b96-2a4b-444d-9df3-19d9fcf9d046)

The thing to note between these two is the large removal of the Bitmap Heap Scan over the `file_storage_object` table. The original query was looking for FSOs associated to either the Dataset or the Study. When we processed the rows into objects, we never looked at the Study FSO results, just the Dataset FSO. By removing that OR condition, we significantly improve performance.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
