### PR TITLE
DT-1424: Add new indexed_date field to dataset

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
@@ -94,7 +94,7 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
   @SqlQuery("""
           SELECT d.dataset_id, d.name, d.create_date, d.create_user_id, d.update_date,
               d.update_user_id, d.object_id, d.dac_id, d.alias, d.data_use, d.translated_data_use, d.dac_approval,
-              dar_ds_ids.id AS in_use, d.study_id,
+              dar_ds_ids.id AS in_use, d.study_id, d.indexed_date,
               u.user_id AS u_user_id, u.email AS u_email, u.display_name AS u_display_name,
               u.create_date AS u_create_date, u.email_preference AS u_email_preference,
               u.institution_id AS u_institution_id, u.era_commons_id AS u_era_commons_id,
@@ -151,7 +151,7 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
   @SqlQuery("""
           SELECT d.dataset_id, d.name, d.create_date, d.create_user_id, d.update_date,
               d.update_user_id, d.object_id, d.dac_id, d.alias, d.data_use, d.translated_data_use, d.dac_approval,
-              dar_ds_ids.id AS in_use, d.study_id,
+              dar_ds_ids.id AS in_use, d.study_id, d.indexed_date,
               u.user_id AS u_user_id, u.email AS u_email, u.display_name AS u_display_name,
               u.create_date AS u_create_date, u.email_preference AS u_email_preference,
               u.institution_id AS u_institution_id, u.era_commons_id AS u_era_commons_id,
@@ -210,7 +210,7 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
   @SqlQuery("""
           SELECT d.dataset_id, d.name, d.create_date, d.create_user_id, d.update_date,
               d.update_user_id, d.object_id, d.dac_id, d.alias, d.data_use, d.translated_data_use, d.dac_approval,
-              dar_ds_ids.id AS in_use, d.study_id,
+              dar_ds_ids.id AS in_use, d.study_id, d.indexed_date,
               u.user_id AS u_user_id, u.email AS u_email, u.display_name AS u_display_name,
               u.create_date AS u_create_date, u.email_preference AS u_email_preference,
               u.institution_id AS u_institution_id, u.era_commons_id AS u_era_commons_id,
@@ -247,7 +247,7 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
   @SqlQuery("""
           SELECT d.dataset_id, d.name, d.create_date, d.create_user_id, d.update_date,
               d.update_user_id, d.object_id, d.dac_id, d.alias, d.data_use, d.translated_data_use, d.dac_approval,
-              dar_ds_ids.id AS in_use, d.study_id,
+              dar_ds_ids.id AS in_use, d.study_id, d.indexed_date,
               u.user_id AS u_user_id, u.email AS u_email, u.display_name AS u_display_name,
               u.create_date AS u_create_date, u.email_preference AS u_email_preference,
               u.institution_id AS u_institution_id, u.era_commons_id AS u_era_commons_id,
@@ -304,7 +304,7 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
   @SqlQuery("""
           SELECT d.dataset_id, d.name, d.create_date, d.create_user_id, d.update_date,
               d.update_user_id, d.object_id, d.dac_id, d.alias, d.data_use, d.translated_data_use,
-              d.dac_approval, dar_ds_ids.id AS in_use, d.study_id,
+              d.dac_approval, dar_ds_ids.id AS in_use, d.study_id, d.indexed_date,
               u.user_id AS u_user_id, u.email AS u_email, u.display_name AS u_display_name,
               u.create_date AS u_create_date, u.email_preference AS u_email_preference,
               u.institution_id AS u_institution_id, u.era_commons_id AS u_era_commons_id,
@@ -532,6 +532,13 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
       @Bind("updateUserId") Integer updateUserId,
       @Bind("datasetId") Integer datasetId
   );
+
+  @SqlUpdate("""
+      UPDATE dataset
+      SET indexed_date = :indexedDate
+      WHERE dataset_id = :datasetId
+      """)
+  void updateDatasetIndexedDate(@Bind("datasetId") Integer datasetId, @Bind("indexedDate") Instant indexedDate);
 
   @RegisterRowMapper(ApprovedDatasetMapper.class)
   @UseRowReducer(ApprovedDatasetReducer.class)

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DatasetMapper.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DatasetMapper.java
@@ -30,6 +30,9 @@ public class DatasetMapper implements RowMapper<Dataset>, RowMapperHelper {
     if (hasColumn(r, "update_date")) {
       dataset.setUpdateDate(r.getTimestamp("update_date"));
     }
+    if (hasColumn(r, "indexed_date")) {
+      dataset.setIndexedDate(r.getTimestamp("indexed_date"));
+    }
     if (hasColumn(r, "dac_approval")) {
       String boolString = r.getString("dac_approval");
       Boolean value = Objects.isNull(boolString) ? null : r.getBoolean("dac_approval");

--- a/src/main/java/org/broadinstitute/consent/http/enumeration/AuditActions.java
+++ b/src/main/java/org/broadinstitute/consent/http/enumeration/AuditActions.java
@@ -6,7 +6,9 @@ public enum AuditActions {
   DELETE("delete"),
   REMOVE("remove"),
   REPLACE("replace"),
-  UPDATE("update");
+  UPDATE("update"),
+  INDEXED("indexed"),
+  UN_INDEXED("un_indexed");
 
   private final String value;
 

--- a/src/main/java/org/broadinstitute/consent/http/enumeration/AuditActions.java
+++ b/src/main/java/org/broadinstitute/consent/http/enumeration/AuditActions.java
@@ -8,7 +8,7 @@ public enum AuditActions {
   REPLACE("replace"),
   UPDATE("update"),
   INDEXED("indexed"),
-  UN_INDEXED("un_indexed");
+  DEINDEXED("deindexed");
 
   private final String value;
 

--- a/src/main/java/org/broadinstitute/consent/http/models/Dataset.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/Dataset.java
@@ -58,6 +58,8 @@ public class Dataset implements ConsentLogger {
 
   private Study study;
 
+  private Date indexedDate;
+
   public Dataset() {
   }
 
@@ -348,6 +350,14 @@ public class Dataset implements ConsentLogger {
 
   public void setStudyId(Integer studyId) {
     this.studyId = studyId;
+  }
+
+  public Date getIndexedDate() {
+    return indexedDate;
+  }
+
+  public void setIndexedDate(Date indexedDate) {
+    this.indexedDate = indexedDate;
   }
 
   /**

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -10,6 +10,7 @@ import jakarta.ws.rs.NotAuthorizedException;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.core.StreamingOutput;
 import java.io.IOException;
+import java.sql.SQLException;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Date;
@@ -523,6 +524,12 @@ public class DatasetService implements ConsentLogger {
 
   public void setDatasetBatchSize(Integer datasetBatchSize) {
     this.datasetBatchSize = datasetBatchSize;
+  }
+
+  public Dataset updateDatasetIndex(Integer datasetId, Integer userId, Instant indexDate)
+      throws SQLException {
+    datasetServiceDAO.updateDatasetIndex(datasetId, userId, indexDate);
+    return datasetDAO.findDatasetById(datasetId);
   }
 
 }

--- a/src/main/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAO.java
@@ -218,7 +218,7 @@ public class DatasetServiceDAO implements ConsentLogger {
     jdbi.useHandle(handle -> {
       handle.getConnection().setAutoCommit(false);
       Dataset dataset = datasetDAO.findDatasetById(datasetId);
-      AuditActions action = indexDate == null ? AuditActions.UN_INDEXED : AuditActions.INDEXED;
+      AuditActions action = indexDate == null ? AuditActions.DEINDEXED : AuditActions.INDEXED;
       String dsAuditName = dataset.getName() == null ? dataset.getDatasetIdentifier() : dataset.getName();
       try {
         datasetDAO.updateDatasetIndexedDate(dataset.getDatasetId(), indexDate);

--- a/src/main/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAO.java
@@ -206,6 +206,32 @@ public class DatasetServiceDAO implements ConsentLogger {
     return datasetId;
   }
 
+  /**
+   * Updates the dataset index date and adds an audit record.
+   *
+   * @param datasetId The ID of the dataset to update.
+   * @param userId    The ID of the user performing the update.
+   * @param indexDate The new index date, or null to un-index the dataset.
+   * @throws SQLException if DB transaction fails.
+   */
+  public void updateDatasetIndex(Integer datasetId, Integer userId, Instant indexDate) throws SQLException {
+    jdbi.useHandle(handle -> {
+      handle.getConnection().setAutoCommit(false);
+      Dataset dataset = datasetDAO.findDatasetById(datasetId);
+      AuditActions action = indexDate == null ? AuditActions.UN_INDEXED : AuditActions.INDEXED;
+      String dsAuditName = dataset.getName() == null ? dataset.getDatasetIdentifier() : dataset.getName();
+      try {
+        datasetDAO.updateDatasetIndexedDate(dataset.getDatasetId(), indexDate);
+        addAuditRecord(dataset.getDatasetId(), dsAuditName, userId, action);
+      } catch (Exception e) {
+        handle.rollback();
+        logException(e);
+        throw e;
+      }
+      handle.commit();
+    });
+  }
+
   private Integer executeInsertStudy(Handle handle, StudyInsert insert) {
     StudyDAO studyDAO = handle.attach(StudyDAO.class);
     UUID uuid = UUID.randomUUID();

--- a/src/main/resources/assets/schemas/Dataset.yaml
+++ b/src/main/resources/assets/schemas/Dataset.yaml
@@ -17,6 +17,10 @@ properties:
     description: The create user id, if available
   createUser:
     $ref: './User.yaml'
+  createDate:
+    type: string
+    format: date-time
+    description: The dataset creation date
   dacId:
     type: string
     description: The id of the DAC this dataset belongs to, if defined.
@@ -69,7 +73,17 @@ properties:
   dacApproval:
     type: boolean
     description: DAC approval/disapproval for this dataset
-  nihCertificationFile:
+  nihInstitutionalCertificationFile:
     $ref: './FileStorageObject.yaml'
-  alternativeDataSharingPlanFile:
-    $ref: './FileStorageObject.yaml'
+  updateUserId:
+    type: integer
+    format: int32
+    description: The update user id, if available
+  updateDate:
+    type: string
+    format: date-time
+    description: The dataset update date
+  indexedDate:
+    type: string
+    format: date-time
+    description: The dataset index date

--- a/src/main/resources/changelog-master.xml
+++ b/src/main/resources/changelog-master.xml
@@ -166,6 +166,6 @@
     relativeToChangelogFile="true"/>
   <include file="changesets/changelog-consent-2024-09-17-draft.xml"
     relativeToChangelogFile="true"/>
-  <include file="changesets/changelog-consent-2025-05-19-indexed.xml"
+  <include file="changesets/changelog-consent-2025-03-19-indexed.xml"
     relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/changelog-master.xml
+++ b/src/main/resources/changelog-master.xml
@@ -166,4 +166,6 @@
     relativeToChangelogFile="true"/>
   <include file="changesets/changelog-consent-2024-09-17-draft.xml"
     relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-2025-05-19-indexed.xml"
+    relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/changesets/changelog-consent-2025-03-19-indexed.xml
+++ b/src/main/resources/changesets/changelog-consent-2025-03-19-indexed.xml
@@ -1,7 +1,7 @@
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
          https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
-  <changeSet id="changelog-consent-2025-05-19-indexed.xml" author="grushton">
+  <changeSet id="changelog-consent-2025-03-19-indexed.xml" author="grushton">
       <addColumn tableName="dataset">
         <column name="indexed_date" type="timestamp with timezone"/>
       </addColumn>

--- a/src/main/resources/changesets/changelog-consent-2025-05-19-indexed.xml
+++ b/src/main/resources/changesets/changelog-consent-2025-05-19-indexed.xml
@@ -1,0 +1,9 @@
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+  <changeSet id="changelog-consent-2025-05-19-indexed.xml" author="grushton">
+      <addColumn tableName="dataset">
+        <column name="indexed_date" type="timestamp with timezone"/>
+      </addColumn>
+  </changeSet>
+</databaseChangeLog>

--- a/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
@@ -934,6 +934,17 @@ class DatasetDAOTest extends DAOTestHelper {
   }
 
   @Test
+  void testUpdateDatasetIndexedDate() {
+    Dataset dataset = createDataset();
+    datasetDAO.updateDatasetIndexedDate(dataset.getDatasetId(), Instant.now());
+    Dataset updatedDataset = datasetDAO.findDatasetById(dataset.getDatasetId());
+    assertNotNull(updatedDataset.getIndexedDate());
+    datasetDAO.updateDatasetIndexedDate(dataset.getDatasetId(), null);
+    Dataset updatedDataset2 = datasetDAO.findDatasetById(dataset.getDatasetId());
+    assertNull(updatedDataset2.getIndexedDate());
+  }
+
+  @Test
   void testFindDatasetSummariesByQuery_NotApproved() {
     Dataset dataset = createDataset();
 

--- a/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
@@ -24,6 +24,8 @@ import com.google.gson.reflect.TypeToken;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.NotFoundException;
 import java.io.ByteArrayOutputStream;
+import java.sql.SQLException;
+import java.time.Instant;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -514,6 +516,15 @@ class DatasetServiceTest {
     assertDoesNotThrow(() -> datasetService.enforceDAARestrictions(user, List.of(1, 2, 3)));
     assertThrows(BadRequestException.class, () -> datasetService.enforceDAARestrictions(user, List.of(1, 2, 3, 4)));
     assertThrows(BadRequestException.class, () -> datasetService.enforceDAARestrictions(user, List.of(2, 3, 4, 5)));
+  }
+
+  @Test
+  void testUpdateDatasetIndex() throws SQLException {
+    doNothing().when(datasetServiceDAO).updateDatasetIndex(any(), any(), any());
+    when(datasetDAO.findDatasetById(any())).thenReturn(new Dataset());
+    initService();
+    assertDoesNotThrow(() -> datasetService.updateDatasetIndex(1, 1, Instant.now()));
+    assertDoesNotThrow(() -> datasetService.updateDatasetIndex(1, 1, null));
   }
 
   /* Helper functions */

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAOTest.java
@@ -987,11 +987,11 @@ class DatasetServiceDAOTest extends DAOTestHelper {
     // Validate that the indexed date is null
     assertNull(updatedDataset.getIndexedDate());
 
-    // Validate that a UN_INDEXED audit record was added:
+    // Validate that a DEINDEXED audit record was added:
     List<DatasetAudit> audits = datasetDAO.findAuditsByDatasetId(updatedDataset.getDatasetId());
     assertFalse(audits.isEmpty());
     assertTrue(
-        audits.stream().anyMatch(a -> a.getAction().equalsIgnoreCase(AuditActions.UN_INDEXED.name())));
+        audits.stream().anyMatch(a -> a.getAction().equalsIgnoreCase(AuditActions.DEINDEXED.name())));
   }
 
   /**

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAOTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.cloud.storage.BlobId;
 import java.sql.Timestamp;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -959,6 +960,38 @@ class DatasetServiceDAOTest extends DAOTestHelper {
     assertFalse(audits.isEmpty());
     assertTrue(
         audits.stream().anyMatch(a -> a.getAction().equalsIgnoreCase(AuditActions.UPDATE.name())));
+  }
+
+  @Test
+  void testUpdateDatasetIndexWithDate() throws Exception {
+    Dataset dataset = createDataset();
+    serviceDAO.updateDatasetIndex(dataset.getDatasetId(), dataset.getCreateUserId(), Instant.now());
+    Dataset updatedDataset = datasetDAO.findDatasetById(dataset.getDatasetId());
+
+    // Validate that the indexed date is updated
+    assertNotNull(updatedDataset.getIndexedDate());
+
+    // Validate that an INDEXED audit record was added:
+    List<DatasetAudit> audits = datasetDAO.findAuditsByDatasetId(updatedDataset.getDatasetId());
+    assertFalse(audits.isEmpty());
+    assertTrue(
+        audits.stream().anyMatch(a -> a.getAction().equalsIgnoreCase(AuditActions.INDEXED.name())));
+  }
+
+  @Test
+  void testUpdateDatasetIndexWithNull() throws Exception {
+    Dataset dataset = createDataset();
+    serviceDAO.updateDatasetIndex(dataset.getDatasetId(), dataset.getCreateUserId(), null);
+    Dataset updatedDataset = datasetDAO.findDatasetById(dataset.getDatasetId());
+
+    // Validate that the indexed date is null
+    assertNull(updatedDataset.getIndexedDate());
+
+    // Validate that a UN_INDEXED audit record was added:
+    List<DatasetAudit> audits = datasetDAO.findAuditsByDatasetId(updatedDataset.getDatasetId());
+    assertFalse(audits.isEmpty());
+    assertTrue(
+        audits.stream().anyMatch(a -> a.getAction().equalsIgnoreCase(AuditActions.UN_INDEXED.name())));
   }
 
   /**


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-1424

### Summary
This PR adds a new `indexed_date` field to `Dataset`. This will be used to indicate if a dataset has been indexed in ElasticSearch (currently). A future PR will make further use of the service method to ensure the updates are recorded when we both index and un-index a dataset.

Features:
* Liquibase addition
* Model updates
  * Note that this includes some drive-by fixes to `Dataset.yaml` - there were several missing fields and one incorrectly named field.
* New audit actions so we can track the history of un/indexing a dataset
* Query and mapper updates to ensure we're populating this field across all usages

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
