### PR TITLE
DT-1424: Mark datasets as indexed/deindexed when indexing operations are called

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
@@ -266,6 +266,7 @@ public class ConsentModule extends AbstractModule {
         providesDatasetDAO(),
         providesDaaDAO(),
         providesDacDAO(),
+        providesElasticSearchService(),
         providesEmailService(),
         providesOntologyService(),
         providesStudyDAO(),

--- a/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
@@ -443,6 +443,7 @@ public class ConsentModule extends AbstractModule {
         providesOntologyService(),
         providesInstitutionDAO(),
         providesDatasetDAO(),
+        providesDatasetServiceDAO(),
         providesStudyDAO()
     );
   }

--- a/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
@@ -32,6 +32,7 @@ import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
 import org.jdbi.v3.sqlobject.customizer.Bind;
 import org.jdbi.v3.sqlobject.customizer.BindBean;
 import org.jdbi.v3.sqlobject.customizer.BindList;
+import org.jdbi.v3.sqlobject.customizer.BindList.EmptyHandling;
 import org.jdbi.v3.sqlobject.customizer.BindMethods;
 import org.jdbi.v3.sqlobject.statement.GetGeneratedKeys;
 import org.jdbi.v3.sqlobject.statement.SqlBatch;
@@ -177,7 +178,7 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
           WHERE d.dataset_id in (<datasetIds>)
           ORDER BY d.dataset_id
       """)
-  List<Dataset> findDatasetsByIdList(@BindList("datasetIds") Collection<Integer> datasetIds);
+  List<Dataset> findDatasetsByIdList(@BindList(value = "datasetIds", onEmpty = EmptyHandling.NULL_STRING) Collection<Integer> datasetIds);
 
   @SqlQuery("""
       SELECT dataset_id FROM dataset ORDER BY dataset_id

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/StudyReducer.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/StudyReducer.java
@@ -1,6 +1,5 @@
 package org.broadinstitute.consent.http.db.mapper;
 
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
 import org.broadinstitute.consent.http.enumeration.PropertyType;
@@ -51,8 +50,6 @@ public class StudyReducer implements LinkedHashMapRowReducer<Integer, Study>, Ro
           // do nothing.
         }
       }
-    } else if (Objects.isNull(study.getProperties())) {
-      study.setProperties(new HashSet<>());
     }
 
     if (hasNonZeroColumn(rowView, "fso_file_storage_object_id")

--- a/src/main/java/org/broadinstitute/consent/http/models/Study.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/Study.java
@@ -78,8 +78,8 @@ public class Study {
     return properties;
   }
 
-  public void addProperties(Set<StudyProperty> properties) {
-    this.properties.addAll(properties);
+  public void addProperties(StudyProperty... properties) {
+    this.properties.addAll(Set.of(properties));
   }
 
   public void addProperty(StudyProperty prop) {

--- a/src/main/java/org/broadinstitute/consent/http/models/Study.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/Study.java
@@ -3,7 +3,6 @@ package org.broadinstitute.consent.http.models;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 
@@ -15,9 +14,9 @@ public class Study {
   private Boolean publicVisibility;
   private String piName;
   private List<String> dataTypes;
-  private Set<Integer> datasetIds = new HashSet<>();
+  private final Set<Integer> datasetIds = new HashSet<>();
   private Set<Dataset> datasets;
-  private Set<StudyProperty> properties = new HashSet<>();
+  private final Set<StudyProperty> properties = new HashSet<>();
   private FileStorageObject alternativeDataSharingPlan;
   private Date createDate;
   private String createUserEmail;
@@ -80,13 +79,10 @@ public class Study {
   }
 
   public void setProperties(Set<StudyProperty> properties) {
-    this.properties = properties;
+    this.properties.addAll(properties);
   }
 
   public void addProperty(StudyProperty prop) {
-    if (Objects.isNull(this.properties)) {
-      this.properties = new HashSet<>();
-    }
     this.properties.add(prop);
   }
 
@@ -103,14 +99,10 @@ public class Study {
   }
 
   public void setDatasetIds(Set<Integer> datasetIds) {
-    this.datasetIds = datasetIds;
+    this.datasetIds.addAll(datasetIds);
   }
 
   public void addDatasetId(Integer datasetId) {
-    if (Objects.isNull(this.datasetIds)) {
-      this.datasetIds = new HashSet<>();
-    }
-
     this.datasetIds.add(datasetId);
   }
 

--- a/src/main/java/org/broadinstitute/consent/http/models/Study.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/Study.java
@@ -78,7 +78,7 @@ public class Study {
     return properties;
   }
 
-  public void setProperties(Set<StudyProperty> properties) {
+  public void addProperties(Set<StudyProperty> properties) {
     this.properties.addAll(properties);
   }
 
@@ -98,7 +98,7 @@ public class Study {
     return datasetIds;
   }
 
-  public void setDatasetIds(Set<Integer> datasetIds) {
+  public void addDatasetIds(Set<Integer> datasetIds) {
     this.datasetIds.addAll(datasetIds);
   }
 

--- a/src/main/java/org/broadinstitute/consent/http/models/Study.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/Study.java
@@ -17,7 +17,7 @@ public class Study {
   private List<String> dataTypes;
   private Set<Integer> datasetIds = new HashSet<>();
   private Set<Dataset> datasets;
-  private Set<StudyProperty> properties;
+  private Set<StudyProperty> properties = new HashSet<>();
   private FileStorageObject alternativeDataSharingPlan;
   private Date createDate;
   private String createUserEmail;

--- a/src/main/java/org/broadinstitute/consent/http/models/Study.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/Study.java
@@ -15,7 +15,7 @@ public class Study {
   private Boolean publicVisibility;
   private String piName;
   private List<String> dataTypes;
-  private Set<Integer> datasetIds;
+  private Set<Integer> datasetIds = new HashSet<>();
   private Set<Dataset> datasets;
   private Set<StudyProperty> properties;
   private FileStorageObject alternativeDataSharingPlan;

--- a/src/main/java/org/broadinstitute/consent/http/resources/DacResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DacResource.java
@@ -270,7 +270,7 @@ public class DacResource extends Resource {
         throw new BadRequestException("Invalid request payload");
       }
       Dataset updatedDataset = datasetService.approveDataset(dataset, user, payload.getApproval());
-      try (Response indexResponse = elasticSearchService.indexDataset(updatedDataset))  {
+      try (Response indexResponse = elasticSearchService.indexDataset(updatedDataset, user))  {
         if (indexResponse.getStatus() >= Status.BAD_REQUEST.getStatusCode()) {
           logWarn("Non-OK response when reindexing dataset with id: " + datasetId);
         }

--- a/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
@@ -1,6 +1,7 @@
 package org.broadinstitute.consent.http.resources;
 
 import com.codahale.metrics.annotation.Timed;
+import com.google.api.client.http.HttpStatusCodes;
 import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
 import com.google.inject.Inject;
@@ -27,10 +28,8 @@ import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.StreamingOutput;
 import jakarta.ws.rs.core.UriBuilder;
 import jakarta.ws.rs.core.UriInfo;
-import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -378,11 +377,10 @@ public class DatasetResource extends Resource {
         logException(e);
         return createExceptionResponse(e);
       }
-      try {
-        elasticSearchService.deleteIndex(datasetId, user.getUserId());
-      } catch (IOException e) {
-        logException(e);
-        return createExceptionResponse(e);
+      try (var deleteResponse = elasticSearchService.deleteIndex(datasetId, user.getUserId())) {
+        if (!HttpStatusCodes.isSuccess(deleteResponse.getStatus())) {
+          logWarn("Unable to delete index for dataset: " + datasetId);
+        }
       }
       return Response.ok().build();
     } catch (Exception e) {

--- a/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
@@ -379,7 +379,7 @@ public class DatasetResource extends Resource {
         return createExceptionResponse(e);
       }
       try {
-        elasticSearchService.deleteIndex(datasetId);
+        elasticSearchService.deleteIndex(datasetId, user);
       } catch (IOException e) {
         logException(e);
         return createExceptionResponse(e);
@@ -393,10 +393,11 @@ public class DatasetResource extends Resource {
   @POST
   @Path("/index")
   @RolesAllowed(ADMIN)
-  public Response indexDatasets() {
+  public Response indexDatasets(@Auth AuthUser authUser) {
     try {
+      User user = userService.findUserByEmail(authUser.getEmail());
       var datasetIds = datasetService.findAllDatasetIds();
-      StreamingOutput indexResponse = elasticSearchService.indexDatasetIds(datasetIds);
+      StreamingOutput indexResponse = elasticSearchService.indexDatasetIds(datasetIds, user);
       return Response.ok(indexResponse, MediaType.APPLICATION_JSON).build();
     } catch (Exception e) {
       return createExceptionResponse(e);
@@ -406,10 +407,11 @@ public class DatasetResource extends Resource {
   @POST
   @Path("/index/{datasetId}")
   @RolesAllowed(ADMIN)
-  public Response indexDataset(@PathParam("datasetId") Integer datasetId) {
+  public Response indexDataset(@Auth AuthUser authUser, @PathParam("datasetId") Integer datasetId) {
     try {
+      User user = userService.findUserByEmail(authUser.getEmail());
       var dataset = datasetService.findDatasetById(datasetId);
-      return elasticSearchService.indexDataset(dataset);
+      return elasticSearchService.indexDataset(dataset, user);
     } catch (Exception e) {
       return createExceptionResponse(e);
     }
@@ -418,9 +420,10 @@ public class DatasetResource extends Resource {
   @DELETE
   @Path("/index/{datasetId}")
   @RolesAllowed(ADMIN)
-  public Response deleteDatasetIndex(@PathParam("datasetId") Integer datasetId) {
+  public Response deleteDatasetIndex(@Auth AuthUser authUser, @PathParam("datasetId") Integer datasetId) {
     try {
-      return elasticSearchService.deleteIndex(datasetId);
+      User user = userService.findUserByEmail(authUser.getEmail());
+      return elasticSearchService.deleteIndex(datasetId, user);
     } catch (Exception e) {
       return createExceptionResponse(e);
     }

--- a/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
@@ -379,7 +379,7 @@ public class DatasetResource extends Resource {
         return createExceptionResponse(e);
       }
       try {
-        elasticSearchService.deleteIndex(datasetId, user);
+        elasticSearchService.deleteIndex(datasetId, user.getUserId());
       } catch (IOException e) {
         logException(e);
         return createExceptionResponse(e);
@@ -423,7 +423,7 @@ public class DatasetResource extends Resource {
   public Response deleteDatasetIndex(@Auth AuthUser authUser, @PathParam("datasetId") Integer datasetId) {
     try {
       User user = userService.findUserByEmail(authUser.getEmail());
-      return elasticSearchService.deleteIndex(datasetId, user);
+      return elasticSearchService.deleteIndex(datasetId, user.getUserId());
     } catch (Exception e) {
       return createExceptionResponse(e);
     }

--- a/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
@@ -209,14 +209,7 @@ public class DatasetResource extends Resource {
         throw new BadRequestException("Properties are invalid");
       }
       Dataset patched = datasetRegistrationService.patchDataset(datasetId, user, patch);
-      if (patched != null && patched.getIndexedDate() != null) {
-        // If the dataset was indexed, we need to re-index it
-        try (var indexResponse = elasticSearchService.indexDataset(patched, user)) {
-          if (!HttpStatusCodes.isSuccess(indexResponse.getStatus())) {
-            logWarn("Unable to index patched dataset: " + patched.getDatasetId());
-          }
-        }
-      }
+      elasticSearchService.synchronizeDatasetInESIndex(patched, user, false);
       return Response.ok(patched).build();
     } catch (Exception e) {
       return createExceptionResponse(e);

--- a/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
@@ -209,6 +209,14 @@ public class DatasetResource extends Resource {
         throw new BadRequestException("Properties are invalid");
       }
       Dataset patched = datasetRegistrationService.patchDataset(datasetId, user, patch);
+      if (patched != null && patched.getIndexedDate() != null) {
+        // If the dataset was indexed, we need to re-index it
+        try (var indexResponse = elasticSearchService.indexDataset(patched, user)) {
+          if (!HttpStatusCodes.isSuccess(indexResponse.getStatus())) {
+            logWarn("Unable to index patched dataset: " + patched.getDatasetId());
+          }
+        }
+      }
       return Response.ok(patched).build();
     } catch (Exception e) {
       return createExceptionResponse(e);

--- a/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
@@ -159,6 +159,9 @@ public class DatasetResource extends Resource {
 
       Dataset updatedDataset = datasetRegistrationService.updateDataset(datasetId, user, update,
           files);
+      if (updatedDataset.getIndexedDate() != null) {
+        elasticSearchService.indexDataset(updatedDataset, user);
+      }
       return Response.ok().entity(updatedDataset).build();
     } catch (Exception e) {
       return createExceptionResponse(e);
@@ -479,6 +482,10 @@ public class DatasetResource extends Resource {
         return Response.notModified().entity(originalDataset).build();
       }
       Dataset dataset = datasetService.updateDatasetDataUse(user, id, dataUse);
+      // Re-index if the dataset is already indexed
+      if (dataset.getIndexedDate() != null) {
+        elasticSearchService.indexDataset(dataset, user);
+      }
       return Response.ok().entity(dataset).build();
     } catch (JsonSyntaxException jse) {
       return createExceptionResponse(
@@ -494,7 +501,8 @@ public class DatasetResource extends Resource {
   @Path("/{id}/reprocess/datause")
   public Response syncDataUseTranslation(@Auth AuthUser authUser, @PathParam("id") Integer id) {
     try {
-      Dataset ds = datasetService.syncDatasetDataUseTranslation(id);
+      User user = userService.findUserByEmail(authUser.getEmail());
+      Dataset ds = datasetService.syncDatasetDataUseTranslation(id, user);
       return Response.ok(ds).build();
     } catch (Exception e) {
       return createExceptionResponse(e);

--- a/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
@@ -159,9 +159,6 @@ public class DatasetResource extends Resource {
 
       Dataset updatedDataset = datasetRegistrationService.updateDataset(datasetId, user, update,
           files);
-      if (updatedDataset.getIndexedDate() != null) {
-        elasticSearchService.indexDataset(updatedDataset, user);
-      }
       return Response.ok().entity(updatedDataset).build();
     } catch (Exception e) {
       return createExceptionResponse(e);
@@ -482,10 +479,6 @@ public class DatasetResource extends Resource {
         return Response.notModified().entity(originalDataset).build();
       }
       Dataset dataset = datasetService.updateDatasetDataUse(user, id, dataUse);
-      // Re-index if the dataset is already indexed
-      if (dataset.getIndexedDate() != null) {
-        elasticSearchService.indexDataset(dataset, user);
-      }
       return Response.ok().entity(dataset).build();
     } catch (JsonSyntaxException jse) {
       return createExceptionResponse(

--- a/src/main/java/org/broadinstitute/consent/http/resources/StudyResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/StudyResource.java
@@ -20,7 +20,6 @@ import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.Response.Status;
 import java.io.IOException;
 import java.lang.reflect.Type;
-import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/org/broadinstitute/consent/http/resources/StudyResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/StudyResource.java
@@ -159,7 +159,7 @@ public class StudyResource extends Resource {
       // Remove from ES index
       if (studyDatasetIds != null) {
         studyDatasetIds.forEach(id -> {
-          try (Response indexResponse = elasticSearchService.deleteIndex(id, user)) {
+          try (Response indexResponse = elasticSearchService.deleteIndex(id, user.getUserId())) {
             if (indexResponse.getStatus() >= Status.BAD_REQUEST.getStatusCode()) {
               logWarn("Non-OK response when deleting index for dataset with id: " + id);
             }

--- a/src/main/java/org/broadinstitute/consent/http/resources/StudyResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/StudyResource.java
@@ -20,8 +20,8 @@ import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.Response.Status;
 import java.io.IOException;
 import java.lang.reflect.Type;
+import java.sql.SQLException;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -160,8 +160,8 @@ public class StudyResource extends Resource {
       if (studyDatasetIds != null) {
         studyDatasetIds.forEach(id -> {
           try {
-            elasticSearchService.deleteIndex(id);
-          } catch (IOException e) {
+            elasticSearchService.deleteIndex(id, user);
+          } catch (IOException | SQLException e) {
             logException(e);
           }
         });
@@ -222,7 +222,7 @@ public class StudyResource extends Resource {
             registration,
             user,
             files);
-        try (Response indexResponse = elasticSearchService.indexStudy(studyId))  {
+        try (Response indexResponse = elasticSearchService.indexStudy(studyId, user))  {
           if (indexResponse.getStatus() >= Status.BAD_REQUEST.getStatusCode()) {
             logWarn("Non-OK response when reindexing study with id: " + studyId);
           }

--- a/src/main/java/org/broadinstitute/consent/http/resources/StudyResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/StudyResource.java
@@ -157,17 +157,15 @@ public class StudyResource extends Resource {
       Set<Integer> studyDatasetIds = study.getDatasetIds();
       datasetService.deleteStudy(study, user);
       // Remove from ES index
-      if (studyDatasetIds != null) {
-        studyDatasetIds.forEach(id -> {
-          try (Response indexResponse = elasticSearchService.deleteIndex(id, user.getUserId())) {
-            if (indexResponse.getStatus() >= Status.BAD_REQUEST.getStatusCode()) {
-              logWarn("Non-OK response when deleting index for dataset with id: " + id);
-            }
-          } catch (IOException | SQLException e) {
-            logException(e);
+      studyDatasetIds.forEach(id -> {
+        try (Response indexResponse = elasticSearchService.deleteIndex(id, user.getUserId())) {
+          if (indexResponse.getStatus() >= Status.BAD_REQUEST.getStatusCode()) {
+            logWarn("Non-OK response when deleting index for dataset with id: " + id);
           }
-        });
-      }
+        } catch (IOException | SQLException e) {
+          logException(e);
+        }
+      });
       return Response.ok().build();
     } catch (Exception e) {
       return createExceptionResponse(e);

--- a/src/main/java/org/broadinstitute/consent/http/resources/StudyResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/StudyResource.java
@@ -135,7 +135,7 @@ public class StudyResource extends Resource {
   @RolesAllowed({ADMIN, CHAIRPERSON, DATASUBMITTER})
   public Response deleteStudyById(@Auth AuthUser authUser, @PathParam("studyId") Integer studyId) {
     try {
-      User user = userService.findUserByEmail(authUser.getEmail());
+      final User user = userService.findUserByEmail(authUser.getEmail());
       Study study = datasetService.getStudyWithDatasetsById(studyId);
 
       if (Objects.isNull(study)) {
@@ -159,8 +159,10 @@ public class StudyResource extends Resource {
       // Remove from ES index
       if (studyDatasetIds != null) {
         studyDatasetIds.forEach(id -> {
-          try {
-            elasticSearchService.deleteIndex(id, user);
+          try (Response indexResponse = elasticSearchService.deleteIndex(id, user)) {
+            if (indexResponse.getStatus() >= Status.BAD_REQUEST.getStatusCode()) {
+              logWarn("Non-OK response when deleting index for dataset with id: " + id);
+            }
           } catch (IOException | SQLException e) {
             logException(e);
           }

--- a/src/main/java/org/broadinstitute/consent/http/resources/StudyResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/StudyResource.java
@@ -162,7 +162,7 @@ public class StudyResource extends Resource {
           if (indexResponse.getStatus() >= Status.BAD_REQUEST.getStatusCode()) {
             logWarn("Non-OK response when deleting index for dataset with id: " + id);
           }
-        } catch (IOException | SQLException e) {
+        } catch (IOException e) {
           logException(e);
         }
       });

--- a/src/main/java/org/broadinstitute/consent/http/resources/VoteResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/VoteResource.java
@@ -96,7 +96,7 @@ public class VoteResource extends Resource {
       }
 
       List<Vote> updatedVotes = voteService.updateVotesWithValue(votes, voteUpdate.getVote(),
-          voteUpdate.getRationale());
+          voteUpdate.getRationale(), user);
       return Response.ok().entity(updatedVotes).build();
     } catch (Exception e) {
       return createExceptionResponse(e);

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetRegistrationService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetRegistrationService.java
@@ -285,15 +285,7 @@ public class DatasetRegistrationService implements ConsentLogger {
     }
 
     Dataset updatedDataset = datasetDAO.findDatasetById(datasetId);
-    if (updatedDataset.getIndexedDate() != null) {
-      try (Response response = elasticSearchService.indexDataset(dataset, user)) {
-        if (response.getStatus() >= 400) {
-          logWarn(String.format("Error indexing dataset update: %s", dataset.getName()));
-        }
-      } catch (Exception e) {
-        logException(e);
-      }
-    }
+    elasticSearchService.synchronizeDatasetInESIndex(updatedDataset, user, false);
     return updatedDataset;
   }
 

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetRegistrationService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetRegistrationService.java
@@ -207,7 +207,7 @@ public class DatasetRegistrationService implements ConsentLogger {
 
     List<Dataset> datasets = datasetDAO.findDatasetsByIdList(createdDatasetIds);
     sendDatasetSubmittedEmails(datasets);
-    try (Response response = elasticSearchService.indexDatasets(datasets)) {
+    try (Response response = elasticSearchService.indexDatasets(datasets, user)) {
       if (response.getStatus() >= 400) {
         logWarn(String.format("Error indexing datasets from registration: %s", registration.getStudyName()));
       }
@@ -285,7 +285,7 @@ public class DatasetRegistrationService implements ConsentLogger {
     }
 
     Dataset updatedDataset = datasetDAO.findDatasetById(datasetId);
-    try (Response response = elasticSearchService.indexDataset(dataset)) {
+    try (Response response = elasticSearchService.indexDataset(dataset, user)) {
       if (response.getStatus() >= 400) {
         logWarn(String.format("Error indexing dataset update: %s", dataset.getName()));
       }

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetRegistrationService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetRegistrationService.java
@@ -285,12 +285,14 @@ public class DatasetRegistrationService implements ConsentLogger {
     }
 
     Dataset updatedDataset = datasetDAO.findDatasetById(datasetId);
-    try (Response response = elasticSearchService.indexDataset(dataset, user)) {
-      if (response.getStatus() >= 400) {
-        logWarn(String.format("Error indexing dataset update: %s", dataset.getName()));
+    if (updatedDataset.getIndexedDate() != null) {
+      try (Response response = elasticSearchService.indexDataset(dataset, user)) {
+        if (response.getStatus() >= 400) {
+          logWarn(String.format("Error indexing dataset update: %s", dataset.getName()));
+        }
+      } catch (Exception e) {
+        logException(e);
       }
-    } catch (Exception e) {
-      logException(e);
     }
     return updatedDataset;
   }

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -11,7 +11,6 @@ import jakarta.ws.rs.NotAuthorizedException;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.core.StreamingOutput;
 import java.io.IOException;
-import java.sql.SQLException;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Date;

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -59,7 +59,7 @@ public class DatasetService implements ConsentLogger {
   private final StudyDAO studyDAO;
   private final DatasetServiceDAO datasetServiceDAO;
   private final UserDAO userDAO;
-  public static final Integer DATASET_BATCH_SIZE = 50;
+  public Integer datasetBatchSize = 50;
 
   @Inject
   public DatasetService(DatasetDAO dataSetDAO, DaaDAO daaDAO, DacDAO dacDAO, ElasticSearchService
@@ -254,7 +254,7 @@ public class DatasetService implements ConsentLogger {
 
   public StreamingOutput findAllDatasetsAsStreamingOutput() {
     List<Integer> datasetIds = datasetDAO.findAllDatasetIds();
-    final List<List<Integer>> datasetIdSubLists = Lists.partition(datasetIds, DATASET_BATCH_SIZE);
+    final List<List<Integer>> datasetIdSubLists = Lists.partition(datasetIds, datasetBatchSize);
     final List<Integer> lastSubList = datasetIdSubLists.get(datasetIdSubLists.size() - 1);
     final Integer lastIndex = lastSubList.get(lastSubList.size() - 1);
     Gson gson = GsonUtil.buildGson();
@@ -543,7 +543,7 @@ public class DatasetService implements ConsentLogger {
   }
 
   public void setDatasetBatchSize(Integer datasetBatchSize) {
-    this.DATASET_BATCH_SIZE = datasetBatchSize;
+    this.datasetBatchSize = datasetBatchSize;
   }
 
   private void synchronizeDatasetInESIndex(Dataset dataset, User user, boolean force) {

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -140,10 +140,7 @@ public class DatasetService implements ConsentLogger {
       throw new IllegalArgumentException("Admin use only");
     }
     datasetDAO.updateDatasetDataUse(datasetId, dataUse.toString());
-    // Re-index if the dataset is already indexed
-    if (d.getIndexedDate() != null) {
-      updateDatasetIndex(d.getDatasetId(), user.getUserId(), Instant.now());
-    }
+    updateIfIndexed(d, user.getUserId(), Instant.now());
     return datasetDAO.findDatasetById(datasetId);
   }
 
@@ -156,16 +153,12 @@ public class DatasetService implements ConsentLogger {
     String translation = ontologyService.translateDataUse(dataset.getDataUse(),
         DataUseTranslationType.DATASET);
     datasetDAO.updateDatasetTranslatedDataUse(datasetId, translation);
-
-    // Re-index if the dataset is already indexed
-    if (dataset.getIndexedDate() != null) {
-      updateDatasetIndex(datasetId, user.getUserId(), Instant.now());
-    }
-
+    updateIfIndexed(dataset, user.getUserId(), Instant.now());
     return datasetDAO.findDatasetById(datasetId);
   }
 
   public void deleteDataset(Integer datasetId, Integer userId) throws Exception {
+    // TODO: Figure out how to remove from index
     Dataset dataset = datasetDAO.findDatasetById(datasetId);
     if (dataset != null) {
       datasetServiceDAO.deleteDataset(dataset, userId);
@@ -173,6 +166,7 @@ public class DatasetService implements ConsentLogger {
   }
 
   public void deleteStudy(Study study, User user) throws Exception {
+    // TODO: Figure out how to remove from index
     datasetServiceDAO.deleteStudy(study, user);
   }
 
@@ -192,6 +186,7 @@ public class DatasetService implements ConsentLogger {
     //If it has, simply returned the dataset in the argument (which was already queried for in the resource)
     if (currentApprovalState == null || !currentApprovalState) {
       datasetDAO.updateDatasetApproval(approval, Instant.now(), user.getUserId(), datasetId);
+      updateIfIndexed(dataset, user.getUserId(), Instant.now());
       datasetReturn = datasetDAO.findDatasetById(datasetId);
     } else {
       if (approval == null || !approval) {
@@ -328,12 +323,7 @@ public class DatasetService implements ConsentLogger {
     if (studyConversion.getDatasetName() != null) {
       datasetDAO.updateDatasetName(dataset.getDatasetId(), studyConversion.getDatasetName());
     }
-
-    // Re-index if the dataset is already indexed
-    if (dataset.getIndexedDate() != null) {
-      updateDatasetIndex(dataset.getDatasetId(), user.getUserId(), Instant.now());
-    }
-
+    updateIfIndexed(dataset, user.getUserId(), Instant.now());
     List<Dictionary> dictionaries = datasetDAO.getDictionaryTerms();
     // Handle "Phenotype/Indication"
     if (studyConversion.getPhenotype() != null) {
@@ -396,9 +386,7 @@ public class DatasetService implements ConsentLogger {
     }
     study.getDatasetIds().forEach(datasetId -> {
       Dataset updatedDataset = findDatasetById(datasetId);
-      if (updatedDataset.getIndexedDate() != null) {
-        updateDatasetIndex(datasetId, user.getUserId(), Instant.now());
-      }
+      updateIfIndexed(updatedDataset, user.getUserId(), Instant.now());
     });
     return studyDAO.findStudyById(studyId);
   }
@@ -546,11 +534,13 @@ public class DatasetService implements ConsentLogger {
     this.datasetBatchSize = datasetBatchSize;
   }
 
-  public void updateDatasetIndex(Integer datasetId, Integer userId, Instant indexDate) {
-    try {
-      datasetServiceDAO.updateDatasetIndex(datasetId, userId, indexDate);
-    } catch (SQLException e) {
-      logWarn("Unable to update index date for dataset %s".formatted(datasetId), e);
+  protected void updateIfIndexed(Dataset dataset, Integer userId, Instant indexDate) {
+    if (dataset.getIndexedDate() != null) {
+      try {
+        datasetServiceDAO.updateDatasetIndex(dataset.getDatasetId(), userId, indexDate);
+      } catch (SQLException e) {
+        logWarn("Unable to update index date for dataset %s".formatted(dataset.getDatasetId()), e);
+      }
     }
   }
 

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -219,10 +219,10 @@ public class DatasetService implements ConsentLogger {
     return datasetReturn;
   }
 
-  private void sendDatasetApprovalNotificationEmail(Dataset dataset, User user, Boolean approval)
+  private void sendDatasetApprovalNotificationEmail(Dataset dataset, User user, boolean approval)
       throws Exception {
     Dac dac = dacDAO.findById(dataset.getDacId());
-    if (Boolean.TRUE.equals(approval)) {
+    if (approval) {
       emailService.sendDatasetApprovedMessage(
           user,
           dac.getName(),
@@ -396,8 +396,7 @@ public class DatasetService implements ConsentLogger {
       studyDAO.insertStudyProperty(studyId, dataCustodianEmail, PropertyType.Json.toString(),
           custodians);
     }
-    List<Dataset> datasets = study.getDatasetIds().isEmpty() ? List.of()
-        : datasetDAO.findDatasetsByIdList(study.getDatasetIds());
+    List<Dataset> datasets = datasetDAO.findDatasetsByIdList(study.getDatasetIds());
     datasets.forEach(dataset -> elasticSearchService.synchronizeDatasetInESIndex(dataset, user, false));
     return studyDAO.findStudyById(studyId);
   }

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -140,6 +140,10 @@ public class DatasetService implements ConsentLogger {
       throw new IllegalArgumentException("Admin use only");
     }
     datasetDAO.updateDatasetDataUse(datasetId, dataUse.toString());
+    // Re-index if the dataset is already indexed
+    if (d.getIndexedDate() != null) {
+      updateDatasetIndex(d.getDatasetId(), user.getUserId(), Instant.now());
+    }
     return datasetDAO.findDatasetById(datasetId);
   }
 

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -178,7 +178,7 @@ public class DatasetService implements ConsentLogger {
         if (!HttpStatusCodes.isSuccess(response.getStatus())) {
           logWarn("Response error, unable to delete dataset from index: %s".formatted(datasetId));
         }
-      } catch (SQLException| IOException e) {
+      } catch (IOException e) {
         throw new RuntimeException(e);
       }
     });

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -10,6 +10,7 @@ import jakarta.ws.rs.NotAuthorizedException;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.core.StreamingOutput;
 import java.io.IOException;
+import java.sql.SQLException;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Date;
@@ -142,7 +143,7 @@ public class DatasetService implements ConsentLogger {
     return datasetDAO.findDatasetById(datasetId);
   }
 
-  public Dataset syncDatasetDataUseTranslation(Integer datasetId) {
+  public Dataset syncDatasetDataUseTranslation(Integer datasetId, User user) {
     Dataset dataset = datasetDAO.findDatasetById(datasetId);
     if (dataset == null) {
       throw new NotFoundException("Dataset not found");
@@ -151,6 +152,11 @@ public class DatasetService implements ConsentLogger {
     String translation = ontologyService.translateDataUse(dataset.getDataUse(),
         DataUseTranslationType.DATASET);
     datasetDAO.updateDatasetTranslatedDataUse(datasetId, translation);
+
+    // Re-index if the dataset is already indexed
+    if (dataset.getIndexedDate() != null) {
+      updateDatasetIndex(datasetId, user.getUserId(), Instant.now());
+    }
 
     return datasetDAO.findDatasetById(datasetId);
   }
@@ -319,6 +325,11 @@ public class DatasetService implements ConsentLogger {
       datasetDAO.updateDatasetName(dataset.getDatasetId(), studyConversion.getDatasetName());
     }
 
+    // Re-index if the dataset is already indexed
+    if (dataset.getIndexedDate() != null) {
+      updateDatasetIndex(dataset.getDatasetId(), user.getUserId(), Instant.now());
+    }
+
     List<Dictionary> dictionaries = datasetDAO.getDictionaryTerms();
     // Handle "Phenotype/Indication"
     if (studyConversion.getPhenotype() != null) {
@@ -379,6 +390,12 @@ public class DatasetService implements ConsentLogger {
     } else {
       studyDAO.insertStudyProperty(studyId, dataCustodianEmail, PropertyType.Json.toString(), custodians);
     }
+    study.getDatasetIds().forEach(datasetId -> {
+      Dataset updatedDataset = findDatasetById(datasetId);
+      if (updatedDataset.getIndexedDate() != null) {
+        updateDatasetIndex(datasetId, user.getUserId(), Instant.now());
+      }
+    });
     return studyDAO.findStudyById(studyId);
   }
 
@@ -523,6 +540,14 @@ public class DatasetService implements ConsentLogger {
 
   public void setDatasetBatchSize(Integer datasetBatchSize) {
     this.datasetBatchSize = datasetBatchSize;
+  }
+
+  public void updateDatasetIndex(Integer datasetId, Integer userId, Instant indexDate) {
+    try {
+      datasetServiceDAO.updateDatasetIndex(datasetId, userId, indexDate);
+    } catch (SQLException e) {
+      logWarn("Unable to update index date for dataset %s".formatted(datasetId), e);
+    }
   }
 
 }

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -59,7 +59,7 @@ public class DatasetService implements ConsentLogger {
   private final StudyDAO studyDAO;
   private final DatasetServiceDAO datasetServiceDAO;
   private final UserDAO userDAO;
-  public Integer datasetBatchSize = 50;
+  public static final Integer DATASET_BATCH_SIZE = 50;
 
   @Inject
   public DatasetService(DatasetDAO dataSetDAO, DaaDAO daaDAO, DacDAO dacDAO, ElasticSearchService
@@ -143,7 +143,7 @@ public class DatasetService implements ConsentLogger {
       throw new IllegalArgumentException("Admin use only");
     }
     datasetDAO.updateDatasetDataUse(datasetId, dataUse.toString());
-    synchronizeDatasetInESIndex(d, user);
+    synchronizeDatasetInESIndex(d, user, false);
     return datasetDAO.findDatasetById(datasetId);
   }
 
@@ -156,7 +156,7 @@ public class DatasetService implements ConsentLogger {
     String translation = ontologyService.translateDataUse(dataset.getDataUse(),
         DataUseTranslationType.DATASET);
     datasetDAO.updateDatasetTranslatedDataUse(datasetId, translation);
-    synchronizeDatasetInESIndex(dataset, user);
+    synchronizeDatasetInESIndex(dataset, user, false);
     return datasetDAO.findDatasetById(datasetId);
   }
 
@@ -201,7 +201,7 @@ public class DatasetService implements ConsentLogger {
     //If it has, simply returned the dataset in the argument (which was already queried for in the resource)
     if (currentApprovalState == null || !currentApprovalState) {
       datasetDAO.updateDatasetApproval(approval, Instant.now(), user.getUserId(), datasetId);
-      synchronizeDatasetInESIndex(dataset, user);
+      synchronizeDatasetInESIndex(dataset, user, true);
       datasetReturn = datasetDAO.findDatasetById(datasetId);
     } else {
       if (approval == null || !approval) {
@@ -223,7 +223,7 @@ public class DatasetService implements ConsentLogger {
   private void sendDatasetApprovalNotificationEmail(Dataset dataset, User user, Boolean approval)
       throws Exception {
     Dac dac = dacDAO.findById(dataset.getDacId());
-    if (approval) {
+    if (Boolean.TRUE.equals(approval)) {
       emailService.sendDatasetApprovedMessage(
           user,
           dac.getName(),
@@ -254,7 +254,7 @@ public class DatasetService implements ConsentLogger {
 
   public StreamingOutput findAllDatasetsAsStreamingOutput() {
     List<Integer> datasetIds = datasetDAO.findAllDatasetIds();
-    final List<List<Integer>> datasetIdSubLists = Lists.partition(datasetIds, datasetBatchSize);
+    final List<List<Integer>> datasetIdSubLists = Lists.partition(datasetIds, DATASET_BATCH_SIZE);
     final List<Integer> lastSubList = datasetIdSubLists.get(datasetIdSubLists.size() - 1);
     final Integer lastIndex = lastSubList.get(lastSubList.size() - 1);
     Gson gson = GsonUtil.buildGson();
@@ -338,7 +338,7 @@ public class DatasetService implements ConsentLogger {
     if (studyConversion.getDatasetName() != null) {
       datasetDAO.updateDatasetName(dataset.getDatasetId(), studyConversion.getDatasetName());
     }
-    synchronizeDatasetInESIndex(dataset, user);
+    synchronizeDatasetInESIndex(dataset, user, false);
     List<Dictionary> dictionaries = datasetDAO.getDictionaryTerms();
     // Handle "Phenotype/Indication"
     if (studyConversion.getPhenotype() != null) {
@@ -399,7 +399,7 @@ public class DatasetService implements ConsentLogger {
     }
     List<Dataset> datasets = study.getDatasetIds().isEmpty() ? List.of()
         : datasetDAO.findDatasetsByIdList(study.getDatasetIds());
-    datasets.forEach(dataset -> synchronizeDatasetInESIndex(dataset, user));
+    datasets.forEach(dataset -> synchronizeDatasetInESIndex(dataset, user, false));
     return studyDAO.findStudyById(studyId);
   }
 
@@ -543,16 +543,18 @@ public class DatasetService implements ConsentLogger {
   }
 
   public void setDatasetBatchSize(Integer datasetBatchSize) {
-    this.datasetBatchSize = datasetBatchSize;
+    this.DATASET_BATCH_SIZE = datasetBatchSize;
   }
 
-  private void synchronizeDatasetInESIndex(Dataset dataset, User user) {
-    try (var response = elasticSearchService.indexDataset(dataset, user)) {
-      if (!HttpStatusCodes.isSuccess(response.getStatus())) {
-        logWarn("Response error, unable to index dataset: %s".formatted(dataset.getDatasetId()));
+  private void synchronizeDatasetInESIndex(Dataset dataset, User user, boolean force) {
+    if (force || dataset.getIndexedDate() != null) {
+      try (var response = elasticSearchService.indexDataset(dataset, user)) {
+        if (!HttpStatusCodes.isSuccess(response.getStatus())) {
+          logWarn("Response error, unable to index dataset: %s".formatted(dataset.getDatasetId()));
+        }
+      } catch (IOException e) {
+        logWarn("Exception, unable to index dataset: %s".formatted(dataset.getDatasetId()));
       }
-    } catch (IOException e) {
-      logWarn("Exception, unable to index dataset: %s".formatted(dataset.getDatasetId()));
     }
   }
 

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -143,7 +143,7 @@ public class DatasetService implements ConsentLogger {
       throw new IllegalArgumentException("Admin use only");
     }
     datasetDAO.updateDatasetDataUse(datasetId, dataUse.toString());
-    synchronizeDatasetInESIndex(d, user, false);
+    elasticSearchService.synchronizeDatasetInESIndex(d, user, false);
     return datasetDAO.findDatasetById(datasetId);
   }
 
@@ -156,7 +156,7 @@ public class DatasetService implements ConsentLogger {
     String translation = ontologyService.translateDataUse(dataset.getDataUse(),
         DataUseTranslationType.DATASET);
     datasetDAO.updateDatasetTranslatedDataUse(datasetId, translation);
-    synchronizeDatasetInESIndex(dataset, user, false);
+    elasticSearchService.synchronizeDatasetInESIndex(dataset, user, false);
     return datasetDAO.findDatasetById(datasetId);
   }
 
@@ -201,7 +201,7 @@ public class DatasetService implements ConsentLogger {
     //If it has, simply returned the dataset in the argument (which was already queried for in the resource)
     if (currentApprovalState == null || !currentApprovalState) {
       datasetDAO.updateDatasetApproval(approval, Instant.now(), user.getUserId(), datasetId);
-      synchronizeDatasetInESIndex(dataset, user, true);
+      elasticSearchService.synchronizeDatasetInESIndex(dataset, user, true);
       datasetReturn = datasetDAO.findDatasetById(datasetId);
     } else {
       if (approval == null || !approval) {
@@ -338,7 +338,7 @@ public class DatasetService implements ConsentLogger {
     if (studyConversion.getDatasetName() != null) {
       datasetDAO.updateDatasetName(dataset.getDatasetId(), studyConversion.getDatasetName());
     }
-    synchronizeDatasetInESIndex(dataset, user, false);
+    elasticSearchService.synchronizeDatasetInESIndex(dataset, user, false);
     List<Dictionary> dictionaries = datasetDAO.getDictionaryTerms();
     // Handle "Phenotype/Indication"
     if (studyConversion.getPhenotype() != null) {
@@ -399,7 +399,7 @@ public class DatasetService implements ConsentLogger {
     }
     List<Dataset> datasets = study.getDatasetIds().isEmpty() ? List.of()
         : datasetDAO.findDatasetsByIdList(study.getDatasetIds());
-    datasets.forEach(dataset -> synchronizeDatasetInESIndex(dataset, user, false));
+    datasets.forEach(dataset -> elasticSearchService.synchronizeDatasetInESIndex(dataset, user, false));
     return studyDAO.findStudyById(studyId);
   }
 
@@ -544,18 +544,6 @@ public class DatasetService implements ConsentLogger {
 
   public void setDatasetBatchSize(Integer datasetBatchSize) {
     this.datasetBatchSize = datasetBatchSize;
-  }
-
-  private void synchronizeDatasetInESIndex(Dataset dataset, User user, boolean force) {
-    if (force || dataset.getIndexedDate() != null) {
-      try (var response = elasticSearchService.indexDataset(dataset, user)) {
-        if (!HttpStatusCodes.isSuccess(response.getStatus())) {
-          logWarn("Response error, unable to index dataset: %s".formatted(dataset.getDatasetId()));
-        }
-      } catch (IOException e) {
-        logWarn("Exception, unable to index dataset: %s".formatted(dataset.getDatasetId()));
-      }
-    }
   }
 
 }

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -2,6 +2,7 @@ package org.broadinstitute.consent.http.service;
 
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.dataCustodianEmail;
 
+import com.google.api.client.http.HttpStatusCodes;
 import com.google.common.collect.Lists;
 import com.google.gson.Gson;
 import com.google.inject.Inject;
@@ -52,6 +53,7 @@ public class DatasetService implements ConsentLogger {
   private final DatasetDAO datasetDAO;
   private final DaaDAO daaDAO;
   private final DacDAO dacDAO;
+  private final ElasticSearchService elasticSearchService;
   private final EmailService emailService;
   private final OntologyService ontologyService;
   private final StudyDAO studyDAO;
@@ -60,12 +62,13 @@ public class DatasetService implements ConsentLogger {
   public Integer datasetBatchSize = 50;
 
   @Inject
-  public DatasetService(DatasetDAO dataSetDAO, DaaDAO daaDAO, DacDAO dacDAO, EmailService emailService,
-      OntologyService ontologyService, StudyDAO studyDAO,
-      DatasetServiceDAO datasetServiceDAO, UserDAO userDAO) {
+  public DatasetService(DatasetDAO dataSetDAO, DaaDAO daaDAO, DacDAO dacDAO, ElasticSearchService
+      elasticSearchService, EmailService emailService, OntologyService ontologyService, StudyDAO
+      studyDAO, DatasetServiceDAO datasetServiceDAO, UserDAO userDAO) {
     this.datasetDAO = dataSetDAO;
     this.daaDAO = daaDAO;
     this.dacDAO = dacDAO;
+    this.elasticSearchService = elasticSearchService;
     this.emailService = emailService;
     this.ontologyService = ontologyService;
     this.studyDAO = studyDAO;
@@ -140,7 +143,7 @@ public class DatasetService implements ConsentLogger {
       throw new IllegalArgumentException("Admin use only");
     }
     datasetDAO.updateDatasetDataUse(datasetId, dataUse.toString());
-    updateIfIndexed(d, user.getUserId(), Instant.now());
+    synchronizeDatasetInESIndex(d, user);
     return datasetDAO.findDatasetById(datasetId);
   }
 
@@ -153,20 +156,32 @@ public class DatasetService implements ConsentLogger {
     String translation = ontologyService.translateDataUse(dataset.getDataUse(),
         DataUseTranslationType.DATASET);
     datasetDAO.updateDatasetTranslatedDataUse(datasetId, translation);
-    updateIfIndexed(dataset, user.getUserId(), Instant.now());
+    synchronizeDatasetInESIndex(dataset, user);
     return datasetDAO.findDatasetById(datasetId);
   }
 
   public void deleteDataset(Integer datasetId, Integer userId) throws Exception {
-    // TODO: Figure out how to remove from index
     Dataset dataset = datasetDAO.findDatasetById(datasetId);
     if (dataset != null) {
+      try (var response = elasticSearchService.deleteIndex(datasetId, userId)) {
+        if (!HttpStatusCodes.isSuccess(response.getStatus())) {
+          logWarn("Response error, unable to delete dataset from index: %s".formatted(datasetId));
+        }
+      }
       datasetServiceDAO.deleteDataset(dataset, userId);
     }
   }
 
   public void deleteStudy(Study study, User user) throws Exception {
-    // TODO: Figure out how to remove from index
+    study.getDatasetIds().forEach(datasetId -> {
+      try (var response = elasticSearchService.deleteIndex(datasetId, user.getUserId())) {
+        if (!HttpStatusCodes.isSuccess(response.getStatus())) {
+          logWarn("Response error, unable to delete dataset from index: %s".formatted(datasetId));
+        }
+      } catch (SQLException| IOException e) {
+        throw new RuntimeException(e);
+      }
+    });
     datasetServiceDAO.deleteStudy(study, user);
   }
 
@@ -186,7 +201,7 @@ public class DatasetService implements ConsentLogger {
     //If it has, simply returned the dataset in the argument (which was already queried for in the resource)
     if (currentApprovalState == null || !currentApprovalState) {
       datasetDAO.updateDatasetApproval(approval, Instant.now(), user.getUserId(), datasetId);
-      updateIfIndexed(dataset, user.getUserId(), Instant.now());
+      synchronizeDatasetInESIndex(dataset, user);
       datasetReturn = datasetDAO.findDatasetById(datasetId);
     } else {
       if (approval == null || !approval) {
@@ -323,7 +338,7 @@ public class DatasetService implements ConsentLogger {
     if (studyConversion.getDatasetName() != null) {
       datasetDAO.updateDatasetName(dataset.getDatasetId(), studyConversion.getDatasetName());
     }
-    updateIfIndexed(dataset, user.getUserId(), Instant.now());
+    synchronizeDatasetInESIndex(dataset, user);
     List<Dictionary> dictionaries = datasetDAO.getDictionaryTerms();
     // Handle "Phenotype/Indication"
     if (studyConversion.getPhenotype() != null) {
@@ -384,10 +399,8 @@ public class DatasetService implements ConsentLogger {
     } else {
       studyDAO.insertStudyProperty(studyId, dataCustodianEmail, PropertyType.Json.toString(), custodians);
     }
-    study.getDatasetIds().forEach(datasetId -> {
-      Dataset updatedDataset = findDatasetById(datasetId);
-      updateIfIndexed(updatedDataset, user.getUserId(), Instant.now());
-    });
+    List<Dataset> datasets = study.getDatasetIds().isEmpty() ? List.of() : datasetDAO.findDatasetsByIdList(study.getDatasetIds());
+    datasets.forEach(dataset -> synchronizeDatasetInESIndex(dataset, user));
     return studyDAO.findStudyById(studyId);
   }
 
@@ -534,13 +547,13 @@ public class DatasetService implements ConsentLogger {
     this.datasetBatchSize = datasetBatchSize;
   }
 
-  protected void updateIfIndexed(Dataset dataset, Integer userId, Instant indexDate) {
-    if (dataset.getIndexedDate() != null) {
-      try {
-        datasetServiceDAO.updateDatasetIndex(dataset.getDatasetId(), userId, indexDate);
-      } catch (SQLException e) {
-        logWarn("Unable to update index date for dataset %s".formatted(dataset.getDatasetId()), e);
+  private void synchronizeDatasetInESIndex(Dataset dataset, User user) {
+    try (var response = elasticSearchService.indexDataset(dataset, user)) {
+      if (!HttpStatusCodes.isSuccess(response.getStatus())) {
+        logWarn("Response error, unable to index dataset: %s".formatted(dataset.getDatasetId()));
       }
+    } catch (IOException e) {
+      logWarn("Exception, unable to index dataset: %s".formatted(dataset.getDatasetId()));
     }
   }
 

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -382,24 +382,23 @@ public class DatasetService implements ConsentLogger {
   }
 
   public Study updateStudyCustodians(User user, Integer studyId, String custodians) {
-    logInfo(String.format("User %s is updating custodians for study id: %s; custodians: %s", user.getEmail(), studyId, custodians));
+    logInfo(String.format("User %s is updating custodians for study id: %s; custodians: %s",
+        user.getEmail(), studyId, custodians));
     Study study = studyDAO.findStudyById(studyId);
     if (study == null) {
       throw new NotFoundException("Study not found");
     }
-    Optional<StudyProperty> optionalProp = study.getProperties() == null ?
-        Optional.empty() :
-        study
-        .getProperties()
-        .stream()
-        .filter(p -> p.getKey().equals(dataCustodianEmail))
-        .findFirst();
-    if (optionalProp.isPresent()) {
-      studyDAO.updateStudyProperty(studyId, dataCustodianEmail, PropertyType.Json.toString(), custodians);
+    boolean propPresent = study.getProperties().stream()
+        .anyMatch(prop -> prop.getKey().equals(dataCustodianEmail));
+    if (propPresent) {
+      studyDAO.updateStudyProperty(studyId, dataCustodianEmail, PropertyType.Json.toString(),
+          custodians);
     } else {
-      studyDAO.insertStudyProperty(studyId, dataCustodianEmail, PropertyType.Json.toString(), custodians);
+      studyDAO.insertStudyProperty(studyId, dataCustodianEmail, PropertyType.Json.toString(),
+          custodians);
     }
-    List<Dataset> datasets = study.getDatasetIds().isEmpty() ? List.of() : datasetDAO.findDatasetsByIdList(study.getDatasetIds());
+    List<Dataset> datasets = study.getDatasetIds().isEmpty() ? List.of()
+        : datasetDAO.findDatasetsByIdList(study.getDatasetIds());
     datasets.forEach(dataset -> synchronizeDatasetInESIndex(dataset, user));
     return studyDAO.findStudyById(studyId);
   }

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -10,7 +10,6 @@ import jakarta.ws.rs.NotAuthorizedException;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.core.StreamingOutput;
 import java.io.IOException;
-import java.sql.SQLException;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Date;
@@ -524,12 +523,6 @@ public class DatasetService implements ConsentLogger {
 
   public void setDatasetBatchSize(Integer datasetBatchSize) {
     this.datasetBatchSize = datasetBatchSize;
-  }
-
-  public Dataset updateDatasetIndex(Integer datasetId, Integer userId, Instant indexDate)
-      throws SQLException {
-    datasetServiceDAO.updateDatasetIndex(datasetId, userId, indexDate);
-    return datasetDAO.findDatasetById(datasetId);
   }
 
 }

--- a/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
@@ -108,12 +108,7 @@ public class ElasticSearchService implements ConsentLogger {
     datasets.forEach(dsTerm -> {
       bulkApiCall.add(BULK_HEADER.formatted(dsTerm.getDatasetId()));
       bulkApiCall.add(GsonUtil.getInstance().toJson(dsTerm) + "\n");
-      try {
-        updateDatasetIndexDate(dsTerm.getDatasetId(), user.getUserId(), Instant.now());
-      } catch (SQLException e) {
-        // We don't want to send these to Sentry, but we do want to log them for follow up off cycle
-        logWarn("Error updating dataset indexed date for dataset id: %d ".formatted(dsTerm.getDatasetId()), e);
-      }
+      updateDatasetIndexDate(dsTerm.getDatasetId(), user.getUserId(), Instant.now());
     });
 
     Request bulkRequest = new Request(
@@ -127,7 +122,7 @@ public class ElasticSearchService implements ConsentLogger {
     return performRequest(bulkRequest);
   }
 
-  public Response deleteIndex(Integer datasetId, Integer userId) throws IOException, SQLException {
+  public Response deleteIndex(Integer datasetId, Integer userId) throws IOException {
     Request deleteRequest = new Request(
         HttpMethod.POST,
         "/" + esConfig.getDatasetIndexName() + "/_delete_by_query");
@@ -419,11 +414,16 @@ public class ElasticSearchService implements ConsentLogger {
   }
 
   protected void updateDatasetIndexDate(Integer datasetId, Integer userId, Instant indexDate)
-      throws SQLException {
+      {
     // It is possible that a dataset has been deleted. If so, we don't want to try and update it.
     Dataset dataset = datasetDAO.findDatasetById(datasetId);
     if (dataset != null) {
-      datasetServiceDAO.updateDatasetIndex(datasetId, userId, indexDate);
+      try {
+        datasetServiceDAO.updateDatasetIndex(datasetId, userId, indexDate);
+      } catch (SQLException e) {
+        // We don't want to send these to Sentry, but we do want to log them for follow up off cycle
+        logWarn("Error updating dataset indexed date for dataset id: %d ".formatted(datasetId), e);
+      }
     }
   }
 

--- a/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
@@ -396,7 +396,7 @@ public class ElasticSearchService implements ConsentLogger {
     return term;
   }
 
-  public void updateDatasetIndex(Integer datasetId, Integer userId, Instant indexDate)
+  protected void updateDatasetIndex(Integer datasetId, Integer userId, Instant indexDate)
       throws SQLException {
     datasetServiceDAO.updateDatasetIndex(datasetId, userId, indexDate);
   }

--- a/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
@@ -108,7 +108,7 @@ public class ElasticSearchService implements ConsentLogger {
       bulkApiCall.add(BULK_HEADER.formatted(dsTerm.getDatasetId()));
       bulkApiCall.add(GsonUtil.getInstance().toJson(dsTerm) + "\n");
       try {
-        updateDatasetIndex(dsTerm.getDatasetId(), user.getUserId(), Instant.now());
+        updateDatasetIndexDate(dsTerm.getDatasetId(), user.getUserId(), Instant.now());
       } catch (SQLException e) {
         // We don't want to send these to Sentry, but we do want to log them for follow up off cycle
         logWarn("Error updating dataset indexed date for dataset id: %d ".formatted(dsTerm.getDatasetId()), e);
@@ -133,7 +133,7 @@ public class ElasticSearchService implements ConsentLogger {
     deleteRequest.setEntity(new NStringEntity(
         DELETE_QUERY.formatted(datasetId),
         ContentType.APPLICATION_JSON));
-    updateDatasetIndex(datasetId, userId, null);
+    updateDatasetIndexDate(datasetId, userId, null);
     return performRequest(deleteRequest);
   }
 
@@ -396,7 +396,7 @@ public class ElasticSearchService implements ConsentLogger {
     return term;
   }
 
-  protected void updateDatasetIndex(Integer datasetId, Integer userId, Instant indexDate)
+  protected void updateDatasetIndexDate(Integer datasetId, Integer userId, Instant indexDate)
       throws SQLException {
     // It is possible that a dataset has been deleted. If so, we don't want to try and update it.
     Dataset dataset = datasetDAO.findDatasetById(datasetId);

--- a/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
@@ -257,7 +257,7 @@ public class ElasticSearchService implements ConsentLogger {
   }
 
   public Response indexDataset(Dataset dataset, User user) throws IOException {
-    return indexDatasetTerms(List.of(toDatasetTerm(dataset)), user);
+    return indexDatasets(List.of(dataset), user);
   }
 
   public Response indexDatasets(List<Dataset> datasets, User user) throws IOException {

--- a/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
@@ -398,7 +398,11 @@ public class ElasticSearchService implements ConsentLogger {
 
   protected void updateDatasetIndex(Integer datasetId, Integer userId, Instant indexDate)
       throws SQLException {
-    datasetServiceDAO.updateDatasetIndex(datasetId, userId, indexDate);
+    // It is possible that a dataset has been deleted. If so, we don't want to try and update it.
+    Dataset dataset = datasetDAO.findDatasetById(datasetId);
+    if (dataset != null) {
+      datasetServiceDAO.updateDatasetIndex(datasetId, userId, indexDate);
+    }
   }
 
   Optional<DatasetProperty> findDatasetProperty(Collection<DatasetProperty> props,

--- a/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
@@ -82,11 +82,11 @@ public class ElasticSearchService implements ConsentLogger {
   }
 
 
-  private static final String bulkHeader = """
+  private static final String BULK_HEADER = """
       { "index": {"_type": "dataset", "_id": "%d"} }
       """;
 
-  private static final String deleteQuery = """
+  private static final String DELETE_QUERY = """
       { "query": { "bool": { "must": [ { "match": { "_type": "dataset" } }, { "match": { "_id": "%d" } } ] } } }
       """;
 
@@ -105,7 +105,7 @@ public class ElasticSearchService implements ConsentLogger {
     List<String> bulkApiCall = new ArrayList<>();
 
     datasets.forEach(dsTerm -> {
-      bulkApiCall.add(bulkHeader.formatted(dsTerm.getDatasetId()));
+      bulkApiCall.add(BULK_HEADER.formatted(dsTerm.getDatasetId()));
       bulkApiCall.add(GsonUtil.getInstance().toJson(dsTerm) + "\n");
       try {
         updateDatasetIndex(dsTerm.getDatasetId(), user.getUserId(), Instant.now());
@@ -126,14 +126,14 @@ public class ElasticSearchService implements ConsentLogger {
     return performRequest(bulkRequest);
   }
 
-  public Response deleteIndex(Integer datasetId, User user) throws IOException, SQLException {
+  public Response deleteIndex(Integer datasetId, Integer userId) throws IOException, SQLException {
     Request deleteRequest = new Request(
         HttpMethod.POST,
         "/" + esConfig.getDatasetIndexName() + "/_delete_by_query");
     deleteRequest.setEntity(new NStringEntity(
-        deleteQuery.formatted(datasetId),
+        DELETE_QUERY.formatted(datasetId),
         ContentType.APPLICATION_JSON));
-    updateDatasetIndex(datasetId, user.getUserId(), null);
+    updateDatasetIndex(datasetId, userId, null);
     return performRequest(deleteRequest);
   }
 

--- a/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.consent.http.service;
 
+import com.google.api.client.http.HttpStatusCodes;
 import com.google.gson.JsonArray;
 import jakarta.ws.rs.HttpMethod;
 import jakarta.ws.rs.core.Response;
@@ -254,6 +255,27 @@ public class ElasticSearchService implements ConsentLogger {
       return null;
     }
     return new InstitutionTerm(institution.getId(), institution.getName());
+  }
+
+  /**
+   * Synchronize the dataset in the ES index. This will only index the dataset if it has been
+   * previously indexed, UNLESS the force argument is true which means it will index the dataset
+   * and update the dataset's last indexed date value.
+   *
+   * @param dataset The Dataset
+   * @param user    The User
+   * @param force   Boolean to force the index update regardless of dataset's indexed date status.
+   */
+  public void synchronizeDatasetInESIndex(Dataset dataset, User user, boolean force) {
+    if (force || dataset.getIndexedDate() != null) {
+      try (var response = indexDataset(dataset, user)) {
+        if (!HttpStatusCodes.isSuccess(response.getStatus())) {
+          logWarn("Response error, unable to index dataset: %s".formatted(dataset.getDatasetId()));
+        }
+      } catch (IOException e) {
+        logWarn("Exception, unable to index dataset: %s".formatted(dataset.getDatasetId()));
+      }
+    }
   }
 
   public Response indexDataset(Dataset dataset, User user) throws IOException {

--- a/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
@@ -7,6 +7,8 @@ import jakarta.ws.rs.core.Response.Status;
 import jakarta.ws.rs.core.StreamingOutput;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.sql.SQLException;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -37,6 +39,7 @@ import org.broadinstitute.consent.http.models.elastic_search.InstitutionTerm;
 import org.broadinstitute.consent.http.models.elastic_search.StudyTerm;
 import org.broadinstitute.consent.http.models.elastic_search.UserTerm;
 import org.broadinstitute.consent.http.models.ontology.DataUseSummary;
+import org.broadinstitute.consent.http.service.dao.DatasetServiceDAO;
 import org.broadinstitute.consent.http.util.ConsentLogger;
 import org.broadinstitute.consent.http.util.gson.GsonUtil;
 import org.elasticsearch.client.Request;
@@ -52,6 +55,7 @@ public class ElasticSearchService implements ConsentLogger {
   private final OntologyService ontologyService;
   private final InstitutionDAO institutionDAO;
   private final DatasetDAO datasetDAO;
+  private final DatasetServiceDAO datasetServiceDAO;
   private final StudyDAO studyDAO;
 
   public ElasticSearchService(
@@ -63,6 +67,7 @@ public class ElasticSearchService implements ConsentLogger {
       OntologyService ontologyService,
       InstitutionDAO institutionDAO,
       DatasetDAO datasetDAO,
+      DatasetServiceDAO datasetServiceDAO,
       StudyDAO studyDAO) {
     this.esClient = esClient;
     this.esConfig = esConfig;
@@ -72,6 +77,7 @@ public class ElasticSearchService implements ConsentLogger {
     this.ontologyService = ontologyService;
     this.institutionDAO = institutionDAO;
     this.datasetDAO = datasetDAO;
+    this.datasetServiceDAO = datasetServiceDAO;
     this.studyDAO = studyDAO;
   }
 
@@ -95,12 +101,18 @@ public class ElasticSearchService implements ConsentLogger {
     return Response.status(status).entity(body).build();
   }
 
-  public Response indexDatasetTerms(List<DatasetTerm> datasets) throws IOException {
+  public Response indexDatasetTerms(List<DatasetTerm> datasets, User user) throws IOException {
     List<String> bulkApiCall = new ArrayList<>();
 
     datasets.forEach(dsTerm -> {
       bulkApiCall.add(bulkHeader.formatted(dsTerm.getDatasetId()));
       bulkApiCall.add(GsonUtil.getInstance().toJson(dsTerm) + "\n");
+      try {
+        updateDatasetIndex(dsTerm.getDatasetId(), user.getUserId(), Instant.now());
+      } catch (SQLException e) {
+        // We don't want to send these to Sentry, but we do want to log them for follow up off cycle
+        logWarn("Error updating dataset indexed date for dataset id: %d ".formatted(dsTerm.getDatasetId()), e);
+      }
     });
 
     Request bulkRequest = new Request(
@@ -114,13 +126,14 @@ public class ElasticSearchService implements ConsentLogger {
     return performRequest(bulkRequest);
   }
 
-  public Response deleteIndex(Integer datasetId) throws IOException {
+  public Response deleteIndex(Integer datasetId, User user) throws IOException, SQLException {
     Request deleteRequest = new Request(
         HttpMethod.POST,
         "/" + esConfig.getDatasetIndexName() + "/_delete_by_query");
     deleteRequest.setEntity(new NStringEntity(
         deleteQuery.formatted(datasetId),
         ContentType.APPLICATION_JSON));
+    updateDatasetIndex(datasetId, user.getUserId(), null);
     return performRequest(deleteRequest);
   }
 
@@ -243,30 +256,30 @@ public class ElasticSearchService implements ConsentLogger {
     return new InstitutionTerm(institution.getId(), institution.getName());
   }
 
-  public Response indexDataset(Dataset dataset) throws IOException {
-    return indexDatasetTerms(List.of(toDatasetTerm(dataset)));
+  public Response indexDataset(Dataset dataset, User user) throws IOException {
+    return indexDatasetTerms(List.of(toDatasetTerm(dataset)), user);
   }
 
-  public Response indexDatasets(List<Dataset> datasets) throws IOException {
+  public Response indexDatasets(List<Dataset> datasets, User user) throws IOException {
     List<DatasetTerm> datasetTerms = datasets.stream().map(this::toDatasetTerm).toList();
-    return indexDatasetTerms(datasetTerms);
+    return indexDatasetTerms(datasetTerms, user);
   }
 
   /**
    * Sequentially index datasets to ElasticSearch by ID list. Note that this is intended for large
    * lists of dataset ids. For small sets of datasets (i.e. <~25), it is efficient to index them in
-   * bulk using the {@link #indexDatasets(List)} method.
+   * bulk using the {@link #indexDatasets(List, User)} method.
    *
    * @param datasetIds List of Dataset IDs to index
    * @return StreamingOutput of ElasticSearch responses from indexing datasets
    */
-  public StreamingOutput indexDatasetIds(List<Integer> datasetIds) {
+  public StreamingOutput indexDatasetIds(List<Integer> datasetIds, User user) {
     Integer lastDatasetId = datasetIds.get(datasetIds.size() - 1);
     return output -> {
       output.write("[".getBytes());
       datasetIds.forEach(id -> {
         Dataset dataset = datasetDAO.findDatasetById(id);
-        try (Response response = indexDataset(dataset)) {
+        try (Response response = indexDataset(dataset, user)) {
           output.write(response.getEntity().toString().getBytes());
           if (!id.equals(lastDatasetId)) {
             output.write(",".getBytes());
@@ -280,12 +293,12 @@ public class ElasticSearchService implements ConsentLogger {
     };
   }
 
-  public Response indexStudy(Integer studyId) {
+  public Response indexStudy(Integer studyId, User user) {
     Study study = studyDAO.findStudyById(studyId);
     // The dao call above does not populate its datasets so we need to check for datasetIds
     if (study != null && study.getDatasetIds() != null && !study.getDatasetIds().isEmpty()) {
       List<Dataset> datasets = datasetDAO.findDatasetsByIdList(study.getDatasetIds().stream().toList());
-      try (Response response = indexDatasets(datasets)) {
+      try (Response response = indexDatasets(datasets, user)) {
         return response;
       } catch (Exception e) {
         logException(String.format("Failed to index datasets for study id: %d", studyId), e);
@@ -381,6 +394,11 @@ public class ElasticSearchService implements ConsentLogger {
     );
 
     return term;
+  }
+
+  public void updateDatasetIndex(Integer datasetId, Integer userId, Instant indexDate)
+      throws SQLException {
+    datasetServiceDAO.updateDatasetIndex(datasetId, userId, indexDate);
   }
 
   Optional<DatasetProperty> findDatasetProperty(Collection<DatasetProperty> props,

--- a/src/main/java/org/broadinstitute/consent/http/service/VoteService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/VoteService.java
@@ -209,17 +209,18 @@ public class VoteService implements ConsentLogger {
    * @param votes     List of Votes to update
    * @param voteValue Value to update the votes to
    * @param rationale Value to update the rationales to. Only update if non-null.
+   * @param user      The user making the update
    * @return The updated Vote
    * @throws IllegalArgumentException when there are non-open, non-rp elections on any of the votes
    */
-  public List<Vote> updateVotesWithValue(List<Vote> votes, boolean voteValue, String rationale)
+  public List<Vote> updateVotesWithValue(List<Vote> votes, boolean voteValue, String rationale, User user)
       throws IllegalArgumentException {
     validateVotesCanUpdate(votes);
     try {
       List<Vote> updatedVotes = voteServiceDAO.updateVotesWithValue(votes, voteValue, rationale);
       if (voteValue) {
         try {
-          sendDatasetApprovalNotifications(updatedVotes);
+          sendDatasetApprovalNotifications(updatedVotes, user);
         } catch (Exception e) {
           // We can recover from email errors, log it and don't fail the overall process.
           String voteIds = votes.stream().map(Vote::getVoteId).map(Object::toString)
@@ -244,8 +245,9 @@ public class VoteService implements ConsentLogger {
    *              elections for datasets that all have the same data use restriction in a single
    *              DarCollection. This method is flexible enough to send email for any number of
    *              unrelated elections in various DarCollections.
+   * @param user
    */
-  public void sendDatasetApprovalNotifications(List<Vote> votes) {
+  public void sendDatasetApprovalNotifications(List<Vote> votes, User user) {
 
     List<Integer> finalElectionIds = votes.stream()
         .filter(Vote::getVote) // Safety check to ensure we're only emailing for approved election
@@ -278,7 +280,7 @@ public class VoteService implements ConsentLogger {
         datasetIds.isEmpty() ? List.of() : datasetDAO.findDatasetsByIdList(datasetIds);
 
     try {
-      elasticSearchService.indexDatasets(datasets);
+      elasticSearchService.indexDatasets(datasets, user);
     } catch (Exception e) {
       logException("Error indexing datasets for approved DARs: " + e.getMessage(), e);
     }

--- a/src/main/java/org/broadinstitute/consent/http/service/VoteService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/VoteService.java
@@ -245,7 +245,7 @@ public class VoteService implements ConsentLogger {
    *              elections for datasets that all have the same data use restriction in a single
    *              DarCollection. This method is flexible enough to send email for any number of
    *              unrelated elections in various DarCollections.
-   * @param user
+   * @param user  The user sending approval notifications
    */
   public void sendDatasetApprovalNotifications(List<Vote> votes, User user) {
 

--- a/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
@@ -335,12 +335,14 @@ class DatasetDAOTest extends DAOTestHelper {
 
   @Test
   void testFindDatasetsByEmptyIdList() {
+    insertDataset();
     List<Dataset> datasets = datasetDAO.findDatasetsByIdList(List.of());
     assertTrue(datasets.isEmpty());
   }
 
   @Test
   void testFindDatasetsByNullIdList() {
+    insertDataset();
     List<Dataset> datasets = datasetDAO.findDatasetsByIdList(null);
     assertTrue(datasets.isEmpty());
   }

--- a/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
@@ -22,8 +22,6 @@ import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.IntStream;
-import org.apache.commons.lang3.RandomStringUtils;
-import org.apache.commons.lang3.RandomUtils;
 import org.broadinstitute.consent.http.enumeration.ElectionStatus;
 import org.broadinstitute.consent.http.enumeration.ElectionType;
 import org.broadinstitute.consent.http.enumeration.FileCategory;
@@ -119,7 +117,7 @@ class DatasetDAOTest extends DAOTestHelper {
   void testTranslatedDataUse() {
     Dataset d1 = insertDataset();
 
-    String tdu = RandomStringUtils.randomAlphabetic(10);
+    String tdu = randomAlphabetic(10);
     datasetDAO.updateDatasetTranslatedDataUse(d1.getDatasetId(), tdu);
 
     d1 = datasetDAO.findDatasetById(d1.getDatasetId());
@@ -130,7 +128,7 @@ class DatasetDAOTest extends DAOTestHelper {
   @Test
   void testUpdateDatasetName() {
     Dataset dataset = insertDataset();
-    String newName = RandomStringUtils.randomAlphabetic(25);
+    String newName = randomAlphabetic(25);
     datasetDAO.updateDatasetName(dataset.getDatasetId(), newName);
     Dataset foundDataset = datasetDAO.findDatasetById(dataset.getDatasetId());
     assertNotNull(foundDataset);
@@ -194,9 +192,9 @@ class DatasetDAOTest extends DAOTestHelper {
   void testGetNIHInstitutionalFile_AlwaysLatestUpdated() {
     Dataset dataset = insertDataset();
 
-    String fileName = RandomStringUtils.randomAlphabetic(10);
-    String bucketName = RandomStringUtils.randomAlphabetic(10);
-    String gcsFileUri = RandomStringUtils.randomAlphabetic(10);
+    String fileName = randomAlphabetic(10);
+    String bucketName = randomAlphabetic(10);
+    String gcsFileUri = randomAlphabetic(10);
     User createUser = createUser();
 
     Integer nihFileIdCreatedFirstUpdatedSecond = fileStorageObjectDAO.insertNewFile(
@@ -223,15 +221,15 @@ class DatasetDAOTest extends DAOTestHelper {
 
     fileStorageObjectDAO.updateFileById(
         nihFileIdCreatedSecondUpdatedFirst,
-        RandomStringUtils.randomAlphabetic(20),
-        RandomStringUtils.randomAlphabetic(20),
+        randomAlphabetic(20),
+        randomAlphabetic(20),
         updateUser.getUserId(),
         Instant.ofEpochMilli(120));
 
     fileStorageObjectDAO.updateFileById(
         nihFileIdCreatedFirstUpdatedSecond,
-        RandomStringUtils.randomAlphabetic(20),
-        RandomStringUtils.randomAlphabetic(20),
+        randomAlphabetic(20),
+        randomAlphabetic(20),
         updateUser.getUserId(),
         Instant.ofEpochMilli(130));
 
@@ -246,9 +244,9 @@ class DatasetDAOTest extends DAOTestHelper {
   void testGetNIHInstitutionalFile_AlwaysLatestCreated() {
     Dataset dataset = insertDataset();
 
-    String fileName = RandomStringUtils.randomAlphabetic(10);
-    String bucketName = RandomStringUtils.randomAlphabetic(10);
-    String gcsFileUri = RandomStringUtils.randomAlphabetic(10);
+    String fileName = randomAlphabetic(10);
+    String bucketName = randomAlphabetic(10);
+    String gcsFileUri = randomAlphabetic(10);
     User createUser = createUser();
 
     Integer nihFileIdCreatedFirst = fileStorageObjectDAO.insertNewFile(
@@ -265,8 +263,8 @@ class DatasetDAOTest extends DAOTestHelper {
 
     fileStorageObjectDAO.updateFileById(
         nihFileIdCreatedFirst,
-        RandomStringUtils.randomAlphabetic(20),
-        RandomStringUtils.randomAlphabetic(20),
+        randomAlphabetic(20),
+        randomAlphabetic(20),
         updateUser.getUserId(),
         Instant.ofEpochMilli(120));
 
@@ -365,16 +363,16 @@ class DatasetDAOTest extends DAOTestHelper {
   void testFindDatasetPropertiesByDatasetId() {
     Dataset d = insertDataset();
     Set<DatasetProperty> properties = datasetDAO.findDatasetPropertiesByDatasetId(d.getDatasetId());
-    assertEquals(properties.size(), 1);
+    assertEquals(1, properties.size());
   }
 
   @Test
   void testUpdateDataset() {
     Dataset d = insertDataset();
     Dac dac = insertDac();
-    String name = RandomStringUtils.random(20, true, true);
+    String name = randomAlphanumeric(20);
     Timestamp now = new Timestamp(new Date().getTime());
-    Integer userId = RandomUtils.nextInt(1, 1000);
+    Integer userId = randomInt(1, 1000);
 
     datasetDAO.updateDataset(d.getDatasetId(), name, now, userId, dac.getDacId());
     Dataset updated = datasetDAO.findDatasetById(d.getDatasetId());
@@ -390,8 +388,13 @@ class DatasetDAOTest extends DAOTestHelper {
     Dataset d = insertDataset();
     Set<DatasetProperty> properties = datasetDAO.findDatasetPropertiesByDatasetId(d.getDatasetId());
     DatasetProperty originalProperty = properties.stream().toList().get(0);
-    DatasetProperty newProperty = new DatasetProperty(d.getDatasetId(), 1, "Updated Value",
-        PropertyType.String, new Date());
+    DatasetProperty newProperty = new DatasetProperty(
+        d.getDatasetId(),
+        1,
+        "dataAccessCommitteeId",
+        "Updated Value",
+        PropertyType.String, new Date()
+    );
     List<DatasetProperty> updatedProperties = new ArrayList<>();
     updatedProperties.add(newProperty);
     datasetDAO.updateDatasetProperty(d.getDatasetId(), updatedProperties.get(0).getPropertyKey(),
@@ -419,6 +422,7 @@ class DatasetDAOTest extends DAOTestHelper {
         new DatasetProperty(
             d.getDatasetId(),
             1,
+            "dataAccessCommitteeId",
             "10",
             PropertyType.Number,
             new Date())
@@ -447,6 +451,7 @@ class DatasetDAOTest extends DAOTestHelper {
     DatasetProperty propToAdd = new DatasetProperty(
         d.getDatasetId(),
         1,
+        "dataAccessCommitteeId",
         date.toString(),
         PropertyType.Date,
         new Date());
@@ -478,6 +483,7 @@ class DatasetDAOTest extends DAOTestHelper {
         new DatasetProperty(
             d.getDatasetId(),
             1,
+            "dataAccessCommitteeId",
             bool.toString(),
             PropertyType.Boolean,
             new Date())
@@ -508,6 +514,7 @@ class DatasetDAOTest extends DAOTestHelper {
         new DatasetProperty(
             d.getDatasetId(),
             1,
+            "dataAccessCommitteeId",
             jsonObject.toString(),
             PropertyType.Json,
             new Date())
@@ -537,6 +544,7 @@ class DatasetDAOTest extends DAOTestHelper {
         new DatasetProperty(
             d.getDatasetId(),
             1,
+            "dataAccessCommitteeId",
             value,
             PropertyType.String,
             new Date())
@@ -620,15 +628,15 @@ class DatasetDAOTest extends DAOTestHelper {
   @Test
   void testFindAllStudyNames() {
     Dataset ds1 = insertDataset();
-    String ds1Name = RandomStringUtils.randomAlphabetic(20);
+    String ds1Name = randomAlphabetic(20);
     createDatasetProperty(ds1.getDatasetId(), "studyName", ds1Name, PropertyType.String);
 
     Dataset ds2 = insertDataset();
-    String ds2Name = RandomStringUtils.randomAlphabetic(25);
+    String ds2Name = randomAlphabetic(25);
     createDatasetProperty(ds2.getDatasetId(), "studyName", ds2Name, PropertyType.String);
 
     Dataset ds3 = insertDataset();
-    String ds3Name = RandomStringUtils.randomAlphabetic(15);
+    String ds3Name = randomAlphabetic(15);
     createDatasetProperty(ds3.getDatasetId(), "studyName", ds3Name, PropertyType.String);
 
     Study study = insertStudyWithProperties();
@@ -713,7 +721,7 @@ class DatasetDAOTest extends DAOTestHelper {
   @Test
   void testUpdateDatasetNameWithUpdateUser() {
     Dataset dataset = insertDataset();
-    String newName = RandomStringUtils.randomAlphabetic(dataset.getName().length() + 5);
+    String newName = randomAlphabetic(dataset.getName().length() + 5);
     datasetDAO.updateDatasetNameWithUpdateUser(
         dataset.getDatasetId(),
         newName,
@@ -772,9 +780,9 @@ class DatasetDAOTest extends DAOTestHelper {
 
   @Test
   void testUniqueDatasetName() {
-    Dataset dataset0 = createStaticDataset();
+    createStaticDataset();
     try {
-      Dataset dataset1 = createStaticDataset();
+      createStaticDataset();
       Assertions.fail();
     } catch (Exception e) {
       assertTrue(e.getMessage().contains("duplicate key value violates unique constraint"));
@@ -865,9 +873,8 @@ class DatasetDAOTest extends DAOTestHelper {
     assertNotNull(approvedDatasets);
 
     // checks that all datasets in the result are approved
-    approvedDatasets.forEach(approvedDataset -> {
-      assertTrue(datasetDAO.findDatasetByAlias(approvedDataset.getAlias()).getDacApproval());
-    });
+    approvedDatasets.forEach(approvedDataset -> assertTrue(
+        datasetDAO.findDatasetByAlias(approvedDataset.getAlias()).getDacApproval()));
 
     ApprovedDataset expectedApprovedDataset1 = new ApprovedDataset(dataset3.getAlias(),
         dar2.getDarCode(), dataset3.getDatasetName(), dac2.getName(),
@@ -987,7 +994,7 @@ class DatasetDAOTest extends DAOTestHelper {
 
   private DarCollection createDarCollectionWithDatasets(int dacId, User user,
       List<Dataset> datasets) {
-    String darCode = "DAR-" + RandomUtils.nextInt(1, 999999);
+    String darCode = "DAR-" + randomInt(1, 999999);
     Integer collectionId = darCollectionDAO.insertDarCollection(darCode, user.getUserId(),
         new Date());
     IntStream.range(0, datasets.size()).forEach(index -> {
@@ -1003,18 +1010,17 @@ class DatasetDAOTest extends DAOTestHelper {
     dacDAO.addDacMember(roleId, userId, dacId);
   }
 
-  private FileStorageObject createFileStorageObject() {
+  private void createFileStorageObject() {
     FileCategory category = List.of(FileCategory.values())
         .get(new Random().nextInt(FileCategory.values().length));
-    String entityId = RandomStringUtils.randomAlphabetic(10);
-
-    return createFileStorageObject(entityId, category);
+    String entityId = randomAlphabetic(10);
+    createFileStorageObject(entityId, category);
   }
 
   private FileStorageObject createFileStorageObject(String entityId, FileCategory category) {
-    String fileName = RandomStringUtils.randomAlphabetic(10);
-    String bucketName = RandomStringUtils.randomAlphabetic(10);
-    String gcsFileUri = RandomStringUtils.randomAlphabetic(10);
+    String fileName = randomAlphabetic(10);
+    String bucketName = randomAlphabetic(10);
+    String gcsFileUri = randomAlphabetic(10);
     User createUser = createUser();
     Instant createDate = Instant.now();
 
@@ -1032,9 +1038,9 @@ class DatasetDAOTest extends DAOTestHelper {
 
   private Dataset insertDataset() {
     User user = createUser();
-    String name = "Name_" + RandomStringUtils.random(20, true, true);
+    String name = "Name_" + randomAlphanumeric(20);
     Timestamp now = new Timestamp(new Date().getTime());
-    String objectId = "Object ID_" + RandomStringUtils.random(20, true, true);
+    String objectId = "Object ID_" + randomAlphanumeric(20);
     DataUse dataUse = new DataUseBuilder().setGeneralUse(true).build();
     Integer id = datasetDAO.insertDataset(name, now, user.getUserId(), objectId,
         dataUse.toString(), null);
@@ -1059,8 +1065,8 @@ class DatasetDAOTest extends DAOTestHelper {
 
   private Dac insertDac() {
     Integer id = dacDAO.createDac(
-        "Test_" + RandomStringUtils.random(20, true, true),
-        "Test_" + RandomStringUtils.random(20, true, true),
+        "Test_" + randomAlphanumeric(20),
+        "Test_" + randomAlphanumeric(20),
         new Date());
     return dacDAO.findById(id);
   }
@@ -1073,13 +1079,13 @@ class DatasetDAOTest extends DAOTestHelper {
 
   private Study insertStudyWithProperties(User user) {
 
-    String name = RandomStringUtils.randomAlphabetic(20);
-    String description = RandomStringUtils.randomAlphabetic(20);
+    String name = randomAlphabetic(20);
+    String description = randomAlphabetic(20);
     List<String> dataTypes = List.of(
-        RandomStringUtils.randomAlphabetic(20),
-        RandomStringUtils.randomAlphabetic(20)
+        randomAlphabetic(20),
+        randomAlphabetic(20)
     );
-    String piName = RandomStringUtils.randomAlphabetic(20);
+    String piName = randomAlphabetic(20);
     Boolean publicVisibility = true;
 
     Integer id = studyDAO.insertStudy(
@@ -1117,13 +1123,13 @@ class DatasetDAOTest extends DAOTestHelper {
 
   private Study insertPrivateStudyWithProperties(User u) {
 
-    String name = RandomStringUtils.randomAlphabetic(20);
-    String description = RandomStringUtils.randomAlphabetic(20);
+    String name = randomAlphabetic(20);
+    String description = randomAlphabetic(20);
     List<String> dataTypes = List.of(
-        RandomStringUtils.randomAlphabetic(20),
-        RandomStringUtils.randomAlphabetic(20)
+        randomAlphabetic(20),
+        randomAlphabetic(20)
     );
-    String piName = RandomStringUtils.randomAlphabetic(20);
+    String piName = randomAlphabetic(20);
     Boolean publicVisibility = false;
 
     Integer id = studyDAO.insertStudy(
@@ -1154,15 +1160,14 @@ class DatasetDAOTest extends DAOTestHelper {
     return studyDAO.findStudyById(id);
   }
 
-  private DataAccessRequest createDataAccessRequestWithDatasetAndCollectionInfo(int collectionId,
+  private void createDataAccessRequestWithDatasetAndCollectionInfo(int collectionId,
       int datasetId, int userId) {
     DataAccessRequestData data = new DataAccessRequestData();
-    data.setProjectTitle(RandomStringUtils.randomAlphabetic(10));
-    String referenceId = RandomStringUtils.randomAlphanumeric(20);
+    data.setProjectTitle(randomAlphabetic(10));
+    String referenceId = randomAlphanumeric(20);
     dataAccessRequestDAO.insertDataAccessRequest(collectionId, referenceId, userId, new Date(),
         new Date(), new Date(), new Date(), data);
     dataAccessRequestDAO.insertDARDatasetRelation(referenceId, datasetId);
-    return dataAccessRequestDAO.findByReferenceId(referenceId);
   }
 
   private void createDatasetProperties(Integer datasetId) {
@@ -1178,9 +1183,9 @@ class DatasetDAOTest extends DAOTestHelper {
 
   private Dataset createDataset() {
     User user = createUser();
-    String name = "Name_" + RandomStringUtils.random(20, true, true);
+    String name = "Name_" + randomAlphanumeric(20);
     Timestamp now = new Timestamp(new Date().getTime());
-    String objectId = "Object ID_" + RandomStringUtils.random(20, true, true);
+    String objectId = "Object ID_" + randomAlphanumeric(20);
     DataUse dataUse = new DataUseBuilder().setGeneralUse(true).build();
     Integer id = datasetDAO.insertDataset(name, now, user.getUserId(), objectId,
         dataUse.toString(), null);
@@ -1191,10 +1196,10 @@ class DatasetDAOTest extends DAOTestHelper {
 
   private Dataset createDataset(boolean dacApproval) {
     User user = createUser();
-    String name = "Name_" + RandomStringUtils.random(20, true, true);
+    String name = "Name_" + randomAlphanumeric(20);
     Timestamp now = new Timestamp(new Date().getTime());
     Instant instant = Instant.now();
-    String objectId = "Object ID_" + RandomStringUtils.random(20, true, true);
+    String objectId = "Object ID_" + randomAlphanumeric(20);
     DataUse dataUse = new DataUseBuilder().setGeneralUse(true).build();
     Integer id = datasetDAO.insertDataset(name, now, user.getUserId(), objectId,
         dataUse.toString(), null);
@@ -1207,7 +1212,7 @@ class DatasetDAOTest extends DAOTestHelper {
     User user = createUser();
     String name = "test_unique_constraint_dataset_name";
     Timestamp now = new Timestamp(new Date().getTime());
-    String objectId = "Object ID_" + RandomStringUtils.random(20, true, true);
+    String objectId = "Object ID_" + randomAlphanumeric(20);
     DataUse dataUse = new DataUseBuilder().setGeneralUse(true).build();
     Integer id = datasetDAO.insertDataset(name, now, user.getUserId(), objectId,
         dataUse.toString(), null);
@@ -1231,6 +1236,5 @@ class DatasetDAOTest extends DAOTestHelper {
     datasetDAO.updateDatasetApproval(finalVoteApproval, Instant.now(), userId, datasetId);
     return electionDAO.findElectionById(electionId);
   }
-
 
 }

--- a/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
@@ -333,6 +333,18 @@ class DatasetDAOTest extends DAOTestHelper {
     assertNotNull(datasets.get(0).getCreateUser());
   }
 
+  @Test
+  void testFindDatasetsByEmptyIdList() {
+    List<Dataset> datasets = datasetDAO.findDatasetsByIdList(List.of());
+    assertTrue(datasets.isEmpty());
+  }
+
+  @Test
+  void testFindDatasetsByNullIdList() {
+    List<Dataset> datasets = datasetDAO.findDatasetsByIdList(null);
+    assertTrue(datasets.isEmpty());
+  }
+
   // User -> UserRoles -> DACs -> Consents -> Consent Associations -> DataSets
   @Test
   void testFindDataSetsByAuthUserEmail() {

--- a/src/test/java/org/broadinstitute/consent/http/models/DatasetTests.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/DatasetTests.java
@@ -60,7 +60,7 @@ class DatasetTests {
     JsonArray a = new JsonArray();
     a.add(user.getEmail());
     p.setValue(a);
-    study.addProperties(Set.of(p));
+    study.addProperties(p);
 
     assertTrue(dataset.isCustodian(user));
   }
@@ -80,7 +80,7 @@ class DatasetTests {
     JsonArray a = new JsonArray();
     a.add("different_user@test.com");
     p.setValue(a);
-    study.addProperties(Set.of(p));
+    study.addProperties(p);
 
     assertFalse(dataset.isCustodian(user));
   }

--- a/src/test/java/org/broadinstitute/consent/http/models/DatasetTests.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/DatasetTests.java
@@ -60,7 +60,7 @@ class DatasetTests {
     JsonArray a = new JsonArray();
     a.add(user.getEmail());
     p.setValue(a);
-    study.setProperties(Set.of(p));
+    study.addProperties(Set.of(p));
 
     assertTrue(dataset.isCustodian(user));
   }
@@ -80,7 +80,7 @@ class DatasetTests {
     JsonArray a = new JsonArray();
     a.add("different_user@test.com");
     p.setValue(a);
-    study.setProperties(Set.of(p));
+    study.addProperties(Set.of(p));
 
     assertFalse(dataset.isCustodian(user));
   }

--- a/src/test/java/org/broadinstitute/consent/http/models/dataset_registration_v1/DatasetRegistrationSchemaV1UpdateValidatorTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/dataset_registration_v1/DatasetRegistrationSchemaV1UpdateValidatorTest.java
@@ -296,7 +296,7 @@ class DatasetRegistrationSchemaV1UpdateValidatorTest {
     study.getDatasets().add(dataset);
     ArrayList<Integer> datasetIds = new ArrayList<>(study.getDatasetIds().stream().toList());
     datasetIds.add(dataset.getDatasetId());
-    study.setDatasetIds(new HashSet<>(datasetIds));
+    study.addDatasetIds(new HashSet<>(datasetIds));
 
     assertThrows(BadRequestException.class, () -> {
       validator.validate(study, registration);
@@ -432,7 +432,7 @@ class DatasetRegistrationSchemaV1UpdateValidatorTest {
     dataset.setDatasetId(RandomUtils.nextInt(10, 100));
     dataset.setDacId(RandomUtils.nextInt(10, 100));
     study.addDatasets(List.of(dataset));
-    study.setDatasetIds(Set.of(dataset.getDatasetId()));
+    study.addDatasetIds(Set.of(dataset.getDatasetId()));
     return study;
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/resources/DacResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DacResourceTest.java
@@ -623,7 +623,7 @@ class DacResourceTest {
     when(datasetService.findDatasetById(anyInt())).thenReturn(dataset);
     when(datasetService.approveDataset(any(Dataset.class), any(User.class), anyBoolean()))
         .thenReturn(dataset);
-    when(elasticSearchService.indexDataset(any())).thenReturn(Response.ok().build());
+    when(elasticSearchService.indexDataset(any(), any())).thenReturn(Response.ok().build());
     try (Response response = dacResource.approveDataset(authUser, 1, 1, "{approval: true}")) {
       assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
       assertEquals(GsonUtil.buildGson().toJson(dataset), response.getEntity());
@@ -644,7 +644,7 @@ class DacResourceTest {
     when(datasetService.findDatasetById(anyInt())).thenReturn(dataset);
     when(datasetService.approveDataset(any(Dataset.class), any(User.class), anyBoolean()))
         .thenReturn(datasetResponse);
-    when(elasticSearchService.indexDataset(any())).thenReturn(Response.ok().build());
+    when(elasticSearchService.indexDataset(any(), any())).thenReturn(Response.ok().build());
     try (Response response = dacResource.approveDataset(authUser, 1, 1, "{approval: true}")) {
       assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
       assertEquals(GsonUtil.buildGson().toJson(datasetResponse), response.getEntity());
@@ -681,7 +681,7 @@ class DacResourceTest {
     when(datasetService.findDatasetById(anyInt())).thenReturn(dataset);
     when(datasetService.approveDataset(any(Dataset.class), any(User.class), anyBoolean()))
         .thenReturn(datasetResponse);
-    when(elasticSearchService.indexDataset(any())).thenReturn(Response.serverError().build());
+    when(elasticSearchService.indexDataset(any(), any())).thenReturn(Response.serverError().build());
     try (Response response = dacResource.approveDataset(authUser, 1, 1, "{approval: true}")) {
       assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
       assertEquals(GsonUtil.buildGson().toJson(datasetResponse), response.getEntity());
@@ -702,7 +702,7 @@ class DacResourceTest {
     when(datasetService.findDatasetById(anyInt())).thenReturn(dataset);
     when(datasetService.approveDataset(any(Dataset.class), any(User.class), anyBoolean()))
         .thenReturn(datasetResponse);
-    when(elasticSearchService.indexDataset(any())).thenThrow(new IOException("Something went wrong"));
+    when(elasticSearchService.indexDataset(any(), any())).thenThrow(new IOException("Something went wrong"));
     try (Response response = dacResource.approveDataset(authUser, 1, 1, "{approval: true}")) {
       assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
       assertEquals(GsonUtil.buildGson().toJson(datasetResponse), response.getEntity());

--- a/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
@@ -1290,7 +1290,7 @@ class DatasetResourceTest extends AbstractTestHelper {
     dataCustodianEmailProperty.setType(PropertyType.Json);
     dataCustodianEmailProperty.setValue(List.of(randomAlphabetic(10)));
 
-    study.addProperties(Set.of(phenotypeProperty, speciesProperty, dataCustodianEmailProperty));
+    study.addProperties(phenotypeProperty, speciesProperty, dataCustodianEmailProperty);
 
     dataset.setStudy(study);
 

--- a/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
@@ -81,8 +81,7 @@ class DatasetResourceTest extends AbstractTestHelper {
   @Mock
   private UserService userService;
 
-  @Mock
-  private AuthUser authUser;
+  private final AuthUser authUser = new AuthUser().setEmail("test@test.com");
 
   @Mock
   private User user;
@@ -99,8 +98,7 @@ class DatasetResourceTest extends AbstractTestHelper {
 
   @Test
   void testPatchByDatasetUpdate_emptyInput() {
-    when(authUser.getEmail()).thenReturn("test@test.com");
-    when(userService.findUserByEmail("test@test.com")).thenReturn(user);
+    when(userService.findUserByEmail(authUser.getEmail())).thenReturn(user);
     when(user.getUserId()).thenReturn(randomInt(1, 100));
 
     Dataset dataset = new Dataset();
@@ -117,8 +115,7 @@ class DatasetResourceTest extends AbstractTestHelper {
 
   @Test
   void testPatchByDatasetUpdate_malformedInput() {
-    when(authUser.getEmail()).thenReturn("test@test.com");
-    when(userService.findUserByEmail("test@test.com")).thenReturn(user);
+    when(userService.findUserByEmail(authUser.getEmail())).thenReturn(user);
     when(user.getUserId()).thenReturn(randomInt(1, 100));
 
     Dataset dataset = new Dataset();
@@ -157,8 +154,7 @@ class DatasetResourceTest extends AbstractTestHelper {
     dataset.setDatasetId(randomInt(1, 10));
 
     when(datasetService.findDatasetById(any())).thenReturn(dataset);
-    when(authUser.getEmail()).thenReturn("test@test.com");
-    when(userService.findUserByEmail("test@test.com")).thenReturn(user);
+    when(userService.findUserByEmail(authUser.getEmail())).thenReturn(user);
     when(user.getUserId()).thenReturn(randomInt(1, 10));
     // This ensures the dataset create user is NOT the current authUser
     dataset.setCreateUserId(randomInt(100, 200));
@@ -188,8 +184,7 @@ class DatasetResourceTest extends AbstractTestHelper {
     DatasetPatch patch = new DatasetPatch(dataset.getDatasetName(),
         dataset.getProperties().stream().toList());
 
-    when(authUser.getEmail()).thenReturn("test@test.com");
-    when(userService.findUserByEmail("test@test.com")).thenReturn(user);
+    when(userService.findUserByEmail(authUser.getEmail())).thenReturn(user);
     when(user.getUserId()).thenReturn(randomInt(1, 100));
     dataset.setCreateUserId(user.getUserId());
 
@@ -225,8 +220,7 @@ class DatasetResourceTest extends AbstractTestHelper {
 
     DatasetPatch patch = new DatasetPatch(randomAlphabetic(20), List.of(patchProp));
 
-    when(authUser.getEmail()).thenReturn("test@test.com");
-    when(userService.findUserByEmail("test@test.com")).thenReturn(user);
+    when(userService.findUserByEmail(authUser.getEmail())).thenReturn(user);
     when(user.getUserId()).thenReturn(randomInt(1, 100));
     dataset.setCreateUserId(user.getUserId());
 
@@ -265,8 +259,7 @@ class DatasetResourceTest extends AbstractTestHelper {
     DatasetPatch patch = new DatasetPatch(randomAlphabetic(20), List.of(patchProp));
 
     when(datasetRegistrationService.patchDataset(any(), any(), any())).thenReturn(dataset);
-    when(authUser.getEmail()).thenReturn("test@test.com");
-    when(userService.findUserByEmail("test@test.com")).thenReturn(user);
+    when(userService.findUserByEmail(authUser.getEmail())).thenReturn(user);
     when(user.getUserId()).thenReturn(randomInt(1, 100));
     dataset.setCreateUserId(user.getUserId());
 
@@ -305,8 +298,7 @@ class DatasetResourceTest extends AbstractTestHelper {
     DatasetPatch patch = new DatasetPatch(null, List.of(patchProp));
 
     when(datasetRegistrationService.patchDataset(any(), any(), any())).thenReturn(dataset);
-    when(authUser.getEmail()).thenReturn("test@test.com");
-    when(userService.findUserByEmail("test@test.com")).thenReturn(user);
+    when(userService.findUserByEmail(authUser.getEmail())).thenReturn(user);
     when(user.getUserId()).thenReturn(randomInt(1, 100));
     dataset.setCreateUserId(user.getUserId());
 
@@ -330,8 +322,7 @@ class DatasetResourceTest extends AbstractTestHelper {
     DatasetPatch patch = new DatasetPatch(newName, List.of());
 
     when(datasetRegistrationService.patchDataset(any(), any(), any())).thenReturn(dataset);
-    when(authUser.getEmail()).thenReturn("test@test.com");
-    when(userService.findUserByEmail("test@test.com")).thenReturn(user);
+    when(userService.findUserByEmail(authUser.getEmail())).thenReturn(user);
     when(user.getUserId()).thenReturn(randomInt(1, 100));
     dataset.setCreateUserId(user.getUserId());
     when(elasticSearchService.indexDataset(dataset, user)).thenReturn(mockResponse);
@@ -339,7 +330,7 @@ class DatasetResourceTest extends AbstractTestHelper {
     initResource();
     try (Response response = resource.patchByDatasetUpdate(authUser, dataset.getDatasetId(),
         gson.toJson(patch))) {
-      verify(elasticSearchService, times(1)).indexDataset(dataset, user);
+      verify(elasticSearchService).indexDataset(dataset, user);
       assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
     }
   }
@@ -369,8 +360,7 @@ class DatasetResourceTest extends AbstractTestHelper {
 
     DatasetPatch patch = new DatasetPatch(randomAlphabetic(20), List.of(patchProp));
 
-    when(authUser.getEmail()).thenReturn("test@test.com");
-    when(userService.findUserByEmail("test@test.com")).thenReturn(user);
+    when(userService.findUserByEmail(authUser.getEmail())).thenReturn(user);
     when(user.getUserId()).thenReturn(randomInt(1, 100));
     dataset.setCreateUserId(user.getUserId());
 
@@ -386,7 +376,7 @@ class DatasetResourceTest extends AbstractTestHelper {
     Dataset testDataset = new Dataset();
     when(datasetService.getDatasetByName("test")).thenReturn(testDataset);
     initResource();
-    try(var response = resource.validateDatasetName("test")) {
+    try (var response = resource.validateDatasetName("test")) {
       assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
     }
   }
@@ -555,9 +545,7 @@ class DatasetResourceTest extends AbstractTestHelper {
       var baos = new ByteArrayOutputStream();
       entity.write(baos);
       var entityString = baos.toString();
-      Type listOfEsResponses = new TypeToken<List<JsonObject>>() {
-      }.getType();
-      List<JsonObject> responseList = gson.fromJson(entityString, listOfEsResponses);
+      List<JsonObject> responseList = gson.fromJson(entityString, new TypeToken<>() {});
       assertEquals(1, responseList.size());
       JsonArray items = responseList.get(0).getAsJsonArray("items");
       assertEquals(1, items.size());
@@ -600,8 +588,7 @@ class DatasetResourceTest extends AbstractTestHelper {
 
   @Test
   void testAutocompleteDatasets() {
-    when(authUser.getEmail()).thenReturn("testauthuser@test.com");
-    when(userService.findUserByEmail("testauthuser@test.com")).thenReturn(user);
+    when(userService.findUserByEmail(authUser.getEmail())).thenReturn(user);
     when(datasetService.searchDatasetSummaries(any())).thenReturn(
         List.of(new DatasetSummary(1, "ID", "Name")));
 
@@ -617,8 +604,7 @@ class DatasetResourceTest extends AbstractTestHelper {
 
     when(mockResponse.getStatus()).thenReturn(HttpStatusCodes.STATUS_CODE_OK);
     when(mockResponse.getEntity()).thenReturn(query);
-    when(authUser.getEmail()).thenReturn("testauthuser@test.com");
-    when(userService.findUserByEmail("testauthuser@test.com")).thenReturn(user);
+    when(userService.findUserByEmail(authUser.getEmail())).thenReturn(user);
     when(elasticSearchService.searchDatasets(any())).thenReturn(mockResponse);
 
     initResource();

--- a/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
@@ -1273,7 +1273,7 @@ class DatasetResourceTest extends AbstractTestHelper {
     study.setCreateUserId(9);
     study.setCreateUserEmail(randomAlphabetic(10));
     study.setPublicVisibility(true);
-    study.setDatasetIds(Set.of(dataset.getDatasetId()));
+    study.addDatasetIds(Set.of(dataset.getDatasetId()));
 
     StudyProperty phenotypeProperty = new StudyProperty();
     phenotypeProperty.setKey("phenotypeIndication");
@@ -1290,7 +1290,7 @@ class DatasetResourceTest extends AbstractTestHelper {
     dataCustodianEmailProperty.setType(PropertyType.Json);
     dataCustodianEmailProperty.setValue(List.of(randomAlphabetic(10)));
 
-    study.setProperties(Set.of(phenotypeProperty, speciesProperty, dataCustodianEmailProperty));
+    study.addProperties(Set.of(phenotypeProperty, speciesProperty, dataCustodianEmailProperty));
 
     dataset.setStudy(study);
 

--- a/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
@@ -1042,7 +1042,7 @@ class DatasetResourceTest extends AbstractTestHelper {
    * tests the case that there are no updates to the dataset properties, should result in success
    */
   @Test
-  void testUpdateDatasetWithNoProperties() {
+  void testUpdateDatasetWithNoProperties() throws Exception{
     Dataset dataset = new Dataset();
     FormDataContentDisposition content = FormDataContentDisposition
         .name("file")
@@ -1055,6 +1055,8 @@ class DatasetResourceTest extends AbstractTestHelper {
     FormDataMultiPart formDataMultiPart = mock(FormDataMultiPart.class);
     when(formDataMultiPart.getFields()).thenReturn(Map.of("file", List.of(formDataBodyPart)));
     when(datasetService.findDatasetById(any())).thenReturn(dataset);
+    when(datasetRegistrationService.updateDataset(any(), any(), any(), any())).thenReturn(dataset);
+    when(userService.findUserByEmail(any())).thenReturn(user);
     initResource();
     Response response = resource.updateByDatasetUpdate(authUser, 1, formDataMultiPart,
         "{\"properties\":[]}");

--- a/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
@@ -1102,7 +1102,7 @@ class DatasetResourceTest extends AbstractTestHelper {
 
   @Test
   void testSyncDataUseTranslation() {
-    when(datasetService.syncDatasetDataUseTranslation(any())).thenReturn(new Dataset());
+    when(datasetService.syncDatasetDataUseTranslation(any(), any())).thenReturn(new Dataset());
     initResource();
 
     Response response = resource.syncDataUseTranslation(authUser, 1);
@@ -1111,7 +1111,7 @@ class DatasetResourceTest extends AbstractTestHelper {
 
   @Test
   void testSyncDataUseTranslationNotFound() {
-    when(datasetService.syncDatasetDataUseTranslation(any())).thenThrow(new NotFoundException());
+    when(datasetService.syncDatasetDataUseTranslation(any(), any())).thenThrow(new NotFoundException());
     initResource();
 
     Response response = resource.syncDataUseTranslation(authUser, 1);

--- a/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
@@ -326,12 +326,11 @@ class DatasetResourceTest extends AbstractTestHelper {
     when(userService.findUserByEmail(authUser.getEmail())).thenReturn(user);
     when(user.getUserId()).thenReturn(randomInt(1, 100));
     dataset.setCreateUserId(user.getUserId());
-    when(elasticSearchService.indexDataset(dataset, user)).thenReturn(mockResponse);
 
     initResource();
     try (Response response = resource.patchByDatasetUpdate(authUser, dataset.getDatasetId(),
         gson.toJson(patch))) {
-      verify(elasticSearchService).indexDataset(dataset, user);
+      verify(elasticSearchService).synchronizeDatasetInESIndex(dataset, user, false);
       assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
     }
   }

--- a/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
@@ -12,6 +12,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -29,6 +30,7 @@ import java.io.IOException;
 import java.lang.reflect.Type;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -238,7 +240,7 @@ class DatasetResourceTest extends AbstractTestHelper {
   }
 
   @Test
-  void testPatchByDatasetUpdate_patchable() {
+  void testPatchByDatasetUpdate_patchable() throws Exception {
     Gson gson = GsonUtil.buildGson();
 
     Dataset dataset = new Dataset();
@@ -272,6 +274,7 @@ class DatasetResourceTest extends AbstractTestHelper {
     try (Response response = resource.patchByDatasetUpdate(authUser, dataset.getDatasetId(),
         gson.toJson(patch))) {
       assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+      verify(elasticSearchService, never()).indexDataset(dataset, user);
     }
   }
 
@@ -310,6 +313,33 @@ class DatasetResourceTest extends AbstractTestHelper {
     initResource();
     try (Response response = resource.patchByDatasetUpdate(authUser, dataset.getDatasetId(),
         gson.toJson(patch))) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+    }
+  }
+
+  @Test
+  void testPatchByDatasetUpdate_invokeIndexUpdate() throws Exception {
+    Gson gson = GsonUtil.buildGson();
+
+    Dataset dataset = new Dataset();
+    dataset.setDatasetId(randomInt(1, 100));
+    dataset.setName(randomAlphabetic(10));
+    dataset.setIndexedDate(new Date());
+    when(datasetService.findDatasetById(any())).thenReturn(dataset);
+    String newName = randomAlphabetic(20);
+    DatasetPatch patch = new DatasetPatch(newName, List.of());
+
+    when(datasetRegistrationService.patchDataset(any(), any(), any())).thenReturn(dataset);
+    when(authUser.getEmail()).thenReturn("test@test.com");
+    when(userService.findUserByEmail("test@test.com")).thenReturn(user);
+    when(user.getUserId()).thenReturn(randomInt(1, 100));
+    dataset.setCreateUserId(user.getUserId());
+    when(elasticSearchService.indexDataset(dataset, user)).thenReturn(response);
+
+    initResource();
+    try (Response response = resource.patchByDatasetUpdate(authUser, dataset.getDatasetId(),
+        gson.toJson(patch))) {
+      verify(elasticSearchService, times(1)).indexDataset(dataset, user);
       assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
     }
   }

--- a/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
@@ -32,8 +32,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import org.apache.commons.lang3.RandomStringUtils;
-import org.apache.commons.lang3.RandomUtils;
+import org.broadinstitute.consent.http.AbstractTestHelper;
 import org.broadinstitute.consent.http.enumeration.PropertyType;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.AuthUser;
@@ -68,7 +67,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-class DatasetResourceTest {
+class DatasetResourceTest extends AbstractTestHelper {
 
   @Mock
   private DatasetService datasetService;
@@ -110,11 +109,11 @@ class DatasetResourceTest {
   void testPatchByDatasetUpdate_emptyInput() {
     when(authUser.getEmail()).thenReturn("test@test.com");
     when(userService.findUserByEmail("test@test.com")).thenReturn(user);
-    when(user.getUserId()).thenReturn(RandomUtils.nextInt(1, 100));
+    when(user.getUserId()).thenReturn(randomInt(1, 100));
 
     Dataset dataset = new Dataset();
-    dataset.setDatasetId(RandomUtils.nextInt(1, 100));
-    dataset.setName(RandomStringUtils.randomAlphabetic(10));
+    dataset.setDatasetId(randomInt(1, 100));
+    dataset.setName(randomAlphabetic(10));
     dataset.setCreateUserId(user.getUserId());
     when(datasetService.findDatasetById(any())).thenReturn(dataset);
 
@@ -128,11 +127,11 @@ class DatasetResourceTest {
   void testPatchByDatasetUpdate_malformedInput() {
     when(authUser.getEmail()).thenReturn("test@test.com");
     when(userService.findUserByEmail("test@test.com")).thenReturn(user);
-    when(user.getUserId()).thenReturn(RandomUtils.nextInt(1, 100));
+    when(user.getUserId()).thenReturn(randomInt(1, 100));
 
     Dataset dataset = new Dataset();
-    dataset.setDatasetId(RandomUtils.nextInt(1, 100));
-    dataset.setName(RandomStringUtils.randomAlphabetic(10));
+    dataset.setDatasetId(randomInt(1, 100));
+    dataset.setName(randomAlphabetic(10));
     dataset.setCreateUserId(user.getUserId());
     when(datasetService.findDatasetById(any())).thenReturn(dataset);
 
@@ -163,14 +162,14 @@ class DatasetResourceTest {
   @Test
   void testPatchByDatasetUpdate_userForbiddenException() {
     Dataset dataset = new Dataset();
-    dataset.setDatasetId(RandomUtils.nextInt(1, 10));
+    dataset.setDatasetId(randomInt(1, 10));
 
     when(datasetService.findDatasetById(any())).thenReturn(dataset);
     when(authUser.getEmail()).thenReturn("test@test.com");
     when(userService.findUserByEmail("test@test.com")).thenReturn(user);
-    when(user.getUserId()).thenReturn(RandomUtils.nextInt(1, 10));
+    when(user.getUserId()).thenReturn(randomInt(1, 10));
     // This ensures the dataset create user is NOT the current authUser
-    dataset.setCreateUserId(RandomUtils.nextInt(100, 200));
+    dataset.setCreateUserId(randomInt(100, 200));
 
     initResource();
     try (Response response = resource.patchByDatasetUpdate(authUser, 1, "{}")) {
@@ -183,8 +182,8 @@ class DatasetResourceTest {
     Gson gson = GsonUtil.buildGson();
 
     Dataset dataset = new Dataset();
-    dataset.setDatasetId(RandomUtils.nextInt(1, 100));
-    dataset.setName(RandomStringUtils.randomAlphabetic(10));
+    dataset.setDatasetId(randomInt(1, 100));
+    dataset.setName(randomAlphabetic(10));
 
     DatasetProperty dataLocationProp = new DatasetProperty();
     dataLocationProp.setPropertyName("data location");
@@ -198,7 +197,7 @@ class DatasetResourceTest {
 
     when(authUser.getEmail()).thenReturn("test@test.com");
     when(userService.findUserByEmail("test@test.com")).thenReturn(user);
-    when(user.getUserId()).thenReturn(RandomUtils.nextInt(1, 100));
+    when(user.getUserId()).thenReturn(randomInt(1, 100));
     dataset.setCreateUserId(user.getUserId());
 
     initResource();
@@ -213,8 +212,8 @@ class DatasetResourceTest {
     Gson gson = GsonUtil.buildGson();
 
     Dataset dataset = new Dataset();
-    dataset.setDatasetId(RandomUtils.nextInt(1, 100));
-    dataset.setName(RandomStringUtils.randomAlphabetic(10));
+    dataset.setDatasetId(randomInt(1, 100));
+    dataset.setName(randomAlphabetic(10));
 
     DatasetProperty dataLocationProp = new DatasetProperty();
     dataLocationProp.setPropertyName("data location");
@@ -231,11 +230,11 @@ class DatasetResourceTest {
     patchProp.setPropertyType(PropertyType.String);
     patchProp.setPropertyValue(DataLocation.TDR_LOCATION.value());
 
-    DatasetPatch patch = new DatasetPatch(RandomStringUtils.randomAlphabetic(20), List.of(patchProp));
+    DatasetPatch patch = new DatasetPatch(randomAlphabetic(20), List.of(patchProp));
 
     when(authUser.getEmail()).thenReturn("test@test.com");
     when(userService.findUserByEmail("test@test.com")).thenReturn(user);
-    when(user.getUserId()).thenReturn(RandomUtils.nextInt(1, 100));
+    when(user.getUserId()).thenReturn(randomInt(1, 100));
     dataset.setCreateUserId(user.getUserId());
 
     when(datasetService.findAllDatasetNames()).thenReturn(List.of(dataset.getName(), patch.name()));
@@ -252,8 +251,8 @@ class DatasetResourceTest {
     Gson gson = GsonUtil.buildGson();
 
     Dataset dataset = new Dataset();
-    dataset.setDatasetId(RandomUtils.nextInt(1, 100));
-    dataset.setName(RandomStringUtils.randomAlphabetic(10));
+    dataset.setDatasetId(randomInt(1, 100));
+    dataset.setName(randomAlphabetic(10));
 
     DatasetProperty dataLocationProp = new DatasetProperty();
     dataLocationProp.setPropertyName("data location");
@@ -270,12 +269,12 @@ class DatasetResourceTest {
     patchProp.setPropertyType(PropertyType.String);
     patchProp.setPropertyValue(DataLocation.TDR_LOCATION.value());
 
-    DatasetPatch patch = new DatasetPatch(RandomStringUtils.randomAlphabetic(20), List.of(patchProp));
+    DatasetPatch patch = new DatasetPatch(randomAlphabetic(20), List.of(patchProp));
 
     when(datasetRegistrationService.patchDataset(any(), any(), any())).thenReturn(dataset);
     when(authUser.getEmail()).thenReturn("test@test.com");
     when(userService.findUserByEmail("test@test.com")).thenReturn(user);
-    when(user.getUserId()).thenReturn(RandomUtils.nextInt(1, 100));
+    when(user.getUserId()).thenReturn(randomInt(1, 100));
     dataset.setCreateUserId(user.getUserId());
 
     initResource();
@@ -290,8 +289,8 @@ class DatasetResourceTest {
     Gson gson = GsonUtil.buildGson();
 
     Dataset dataset = new Dataset();
-    dataset.setDatasetId(RandomUtils.nextInt(1, 100));
-    dataset.setName(RandomStringUtils.randomAlphabetic(10));
+    dataset.setDatasetId(randomInt(1, 100));
+    dataset.setName(randomAlphabetic(10));
 
     DatasetProperty dataLocationProp = new DatasetProperty();
     dataLocationProp.setPropertyName("data location");
@@ -314,7 +313,7 @@ class DatasetResourceTest {
     when(datasetRegistrationService.patchDataset(any(), any(), any())).thenReturn(dataset);
     when(authUser.getEmail()).thenReturn("test@test.com");
     when(userService.findUserByEmail("test@test.com")).thenReturn(user);
-    when(user.getUserId()).thenReturn(RandomUtils.nextInt(1, 100));
+    when(user.getUserId()).thenReturn(randomInt(1, 100));
     dataset.setCreateUserId(user.getUserId());
 
     initResource();
@@ -329,8 +328,8 @@ class DatasetResourceTest {
     Gson gson = GsonUtil.buildGson();
 
     Dataset dataset = new Dataset();
-    dataset.setDatasetId(RandomUtils.nextInt(1, 100));
-    dataset.setName(RandomStringUtils.randomAlphabetic(10));
+    dataset.setDatasetId(randomInt(1, 100));
+    dataset.setName(randomAlphabetic(10));
 
     DatasetProperty invalidProp = new DatasetProperty();
     invalidProp.setPropertyName("invalid");
@@ -347,11 +346,11 @@ class DatasetResourceTest {
     patchProp.setPropertyType(PropertyType.String);
     patchProp.setPropertyValue(AccessManagement.CONTROLLED.value());
 
-    DatasetPatch patch = new DatasetPatch(RandomStringUtils.randomAlphabetic(20), List.of(patchProp));
+    DatasetPatch patch = new DatasetPatch(randomAlphabetic(20), List.of(patchProp));
 
     when(authUser.getEmail()).thenReturn("test@test.com");
     when(userService.findUserByEmail("test@test.com")).thenReturn(user);
-    when(user.getUserId()).thenReturn(RandomUtils.nextInt(1, 100));
+    when(user.getUserId()).thenReturn(randomInt(1, 100));
     dataset.setCreateUserId(user.getUserId());
 
     initResource();
@@ -374,9 +373,7 @@ class DatasetResourceTest {
   void testValidateDatasetNameNotFound() {
     initResource();
 
-    assertThrows(NotFoundException.class, () -> {
-      resource.validateDatasetName("test");
-    });
+    assertThrows(NotFoundException.class, () -> resource.validateDatasetName("test"));
   }
 
   @Test
@@ -483,7 +480,7 @@ class DatasetResourceTest {
   @Test
   void testIndexAllDatasets() throws Exception {
     Dataset dataset = new Dataset();
-    dataset.setDatasetId(RandomUtils.nextInt(10, 100));
+    dataset.setDatasetId(randomInt(10, 100));
     Gson gson = GsonUtil.buildGson();
     String esResponseArray = """
         [
@@ -514,10 +511,11 @@ class DatasetResourceTest {
     StreamingOutput output = out -> out.write(
         esResponseArray.formatted(dataset.getDatasetId()).getBytes());
     when(datasetService.findAllDatasetIds()).thenReturn(List.of(dataset.getDatasetId()));
-    when(elasticSearchService.indexDatasetIds(List.of(dataset.getDatasetId()))).thenReturn(output);
+    when(elasticSearchService.indexDatasetIds(List.of(dataset.getDatasetId()), user)).thenReturn(output);
+    when(userService.findUserByEmail(any())).thenReturn(user);
 
     initResource();
-    try (Response response = resource.indexDatasets()) {
+    try (Response response = resource.indexDatasets(authUser)) {
       var entity = (StreamingOutput) response.getEntity();
       var baos = new ByteArrayOutputStream();
       entity.write(baos);
@@ -542,24 +540,27 @@ class DatasetResourceTest {
   @Test
   void testIndexDataset() throws IOException {
     Dataset dataset = new Dataset();
+    User user = new User();
+    user.setUserId(1);
 
     Response mockResponse = Response.ok().entity(dataset).build();
     when(datasetService.findDatasetById(any())).thenReturn(dataset);
-    when(elasticSearchService.indexDataset(dataset)).thenReturn(mockResponse);
+    when(elasticSearchService.indexDataset(dataset, user)).thenReturn(mockResponse);
+    when(userService.findUserByEmail(any())).thenReturn(user);
 
     initResource();
-    Response response = resource.indexDataset(1);
+    Response response = resource.indexDataset(authUser,1);
     assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
   }
 
   @Test
-  void testIndexDelete() throws IOException {
+  void testIndexDelete() throws IOException, SQLException {
     Response mockResponse = Response.status(HttpStatusCodes.STATUS_CODE_OK).entity("deleted")
         .build();
-    when(elasticSearchService.deleteIndex(any())).thenReturn(mockResponse);
+    when(elasticSearchService.deleteIndex(any(), any())).thenReturn(mockResponse);
 
     initResource();
-    Response response = resource.deleteDatasetIndex(0);
+    Response response = resource.deleteDatasetIndex(authUser,0);
     assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
   }
 
@@ -778,7 +779,7 @@ class DatasetResourceTest {
   @Test
   void testFindAllDatasetsStreaming() throws Exception {
     var dataset = new Dataset();
-    dataset.setDatasetId(RandomUtils.nextInt(100, 1000));
+    dataset.setDatasetId(randomInt(100, 1000));
     when(userService.findUserByEmail(any())).thenReturn(user);
     final Gson gson = GsonUtil.buildGson();
     StreamingOutput output = out -> out.write(gson.toJson(List.of(dataset)).getBytes());
@@ -1234,30 +1235,30 @@ class DatasetResourceTest {
     dataset.setDataUse(new DataUse());
 
     Study study = new Study();
-    study.setName(RandomStringUtils.randomAlphabetic(10));
-    study.setDescription(RandomStringUtils.randomAlphabetic(20));
+    study.setName(randomAlphabetic(10));
+    study.setDescription(randomAlphabetic(20));
     study.setStudyId(12345);
-    study.setPiName(RandomStringUtils.randomAlphabetic(10));
-    study.setDataTypes(List.of(RandomStringUtils.randomAlphabetic(10)));
+    study.setPiName(randomAlphabetic(10));
+    study.setDataTypes(List.of(randomAlphabetic(10)));
     study.setCreateUserId(9);
-    study.setCreateUserEmail(RandomStringUtils.randomAlphabetic(10));
+    study.setCreateUserEmail(randomAlphabetic(10));
     study.setPublicVisibility(true);
     study.setDatasetIds(Set.of(dataset.getDatasetId()));
 
     StudyProperty phenotypeProperty = new StudyProperty();
     phenotypeProperty.setKey("phenotypeIndication");
     phenotypeProperty.setType(PropertyType.String);
-    phenotypeProperty.setValue(RandomStringUtils.randomAlphabetic(10));
+    phenotypeProperty.setValue(randomAlphabetic(10));
 
     StudyProperty speciesProperty = new StudyProperty();
     speciesProperty.setKey("species");
     speciesProperty.setType(PropertyType.String);
-    speciesProperty.setValue(RandomStringUtils.randomAlphabetic(10));
+    speciesProperty.setValue(randomAlphabetic(10));
 
     StudyProperty dataCustodianEmailProperty = new StudyProperty();
     dataCustodianEmailProperty.setKey("dataCustodianEmail");
     dataCustodianEmailProperty.setType(PropertyType.Json);
-    dataCustodianEmailProperty.setValue(List.of(RandomStringUtils.randomAlphabetic(10)));
+    dataCustodianEmailProperty.setValue(List.of(randomAlphabetic(10)));
 
     study.setProperties(Set.of(phenotypeProperty, speciesProperty, dataCustodianEmailProperty));
 

--- a/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
@@ -85,6 +85,9 @@ class DatasetResourceTest extends AbstractTestHelper {
   @Mock
   private User user;
 
+  @Mock
+  private Response response;
+
   private DatasetResource resource;
 
   private void initResource() {
@@ -387,12 +390,13 @@ class DatasetResourceTest extends AbstractTestHelper {
   }
 
   @Test
-  void testDeleteSuccessAdmin() {
+  void testDeleteSuccessAdmin() throws Exception {
     Dataset dataSet = new Dataset();
 
     when(user.hasUserRole(UserRoles.ADMIN)).thenReturn(true);
     when(userService.findUserByEmail(authUser.getEmail())).thenReturn(user);
     when(datasetService.findDatasetById(any())).thenReturn(dataSet);
+    when(elasticSearchService.deleteIndex(any(), any())).thenReturn(response);
 
     initResource();
     try (var response = resource.delete(authUser, 1, null)) {
@@ -401,7 +405,7 @@ class DatasetResourceTest extends AbstractTestHelper {
   }
 
   @Test
-  void testDeleteSuccessChairperson() {
+  void testDeleteSuccessChairperson() throws Exception {
     Dataset dataSet = new Dataset();
     dataSet.setDatasetId(1);
     dataSet.setDacId(1);
@@ -413,6 +417,7 @@ class DatasetResourceTest extends AbstractTestHelper {
 
     when(userService.findUserByEmail(authUser.getEmail())).thenReturn(user);
     when(datasetService.findDatasetById(any())).thenReturn(dataSet);
+    when(elasticSearchService.deleteIndex(any(), any())).thenReturn(response);
 
     initResource();
     try (var response = resource.delete(authUser, 1, null)) {

--- a/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
@@ -51,8 +52,6 @@ import org.broadinstitute.consent.http.models.dataset_registration_v1.ConsentGro
 import org.broadinstitute.consent.http.models.dataset_registration_v1.ConsentGroup.DataLocation;
 import org.broadinstitute.consent.http.models.dataset_registration_v1.DatasetRegistrationSchemaV1;
 import org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder;
-import org.broadinstitute.consent.http.models.dto.DatasetDTO;
-import org.broadinstitute.consent.http.models.dto.DatasetPropertyDTO;
 import org.broadinstitute.consent.http.service.DatasetRegistrationService;
 import org.broadinstitute.consent.http.service.DatasetService;
 import org.broadinstitute.consent.http.service.ElasticSearchService;
@@ -91,18 +90,6 @@ class DatasetResourceTest extends AbstractTestHelper {
   private void initResource() {
     resource = new DatasetResource(datasetService, userService,
         datasetRegistrationService, elasticSearchService);
-  }
-
-  private String createPropertiesJson(List<DatasetPropertyDTO> properties) {
-    DatasetDTO json = new DatasetDTO();
-    json.setProperties(properties);
-    return new Gson().toJson(json);
-  }
-
-  private String createPropertiesJson(String propertyName, String propertyValue) {
-    List<DatasetPropertyDTO> jsonProperties = new ArrayList<>();
-    jsonProperties.add(new DatasetPropertyDTO(propertyName, propertyValue));
-    return createPropertiesJson(jsonProperties);
   }
 
   @Test
@@ -193,7 +180,8 @@ class DatasetResourceTest extends AbstractTestHelper {
     dataset.setProperties(Set.of(dataLocationProp));
 
     when(datasetService.findDatasetById(any())).thenReturn(dataset);
-    DatasetPatch patch = new DatasetPatch(dataset.getDatasetName(), dataset.getProperties().stream().toList());
+    DatasetPatch patch = new DatasetPatch(dataset.getDatasetName(),
+        dataset.getProperties().stream().toList());
 
     when(authUser.getEmail()).thenReturn("test@test.com");
     when(userService.findUserByEmail("test@test.com")).thenReturn(user);
@@ -365,31 +353,37 @@ class DatasetResourceTest extends AbstractTestHelper {
     Dataset testDataset = new Dataset();
     when(datasetService.getDatasetByName("test")).thenReturn(testDataset);
     initResource();
-    Response response = resource.validateDatasetName("test");
-    assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+    try(var response = resource.validateDatasetName("test")) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+    }
   }
 
   @Test
   void testValidateDatasetNameNotFound() {
     initResource();
-
-    assertThrows(NotFoundException.class, () -> resource.validateDatasetName("test"));
+    assertThrows(NotFoundException.class, () -> {
+      try (var response = resource.validateDatasetName("test")) {
+        fail("Should not get to this point");
+      }
+    });
   }
 
   @Test
   void testFindAllStudyNamesSuccess() {
     when(datasetService.findAllStudyNames()).thenReturn(Set.of("Hi", "Hello"));
     initResource();
-    Response response = resource.findAllStudyNames();
-    assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+    try (var response = resource.findAllStudyNames()) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+    }
   }
 
   @Test
   void testFindAllStudyNamesFail() {
     when(datasetService.findAllStudyNames()).thenThrow();
     initResource();
-    Response response = resource.findAllStudyNames();
-    assertEquals(HttpStatusCodes.STATUS_CODE_SERVER_ERROR, response.getStatus());
+    try (var response = resource.findAllStudyNames()) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_SERVER_ERROR, response.getStatus());
+    }
   }
 
   @Test
@@ -401,8 +395,9 @@ class DatasetResourceTest extends AbstractTestHelper {
     when(datasetService.findDatasetById(any())).thenReturn(dataSet);
 
     initResource();
-    Response response = resource.delete(authUser, 1, null);
-    assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+    try (var response = resource.delete(authUser, 1, null)) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+    }
   }
 
   @Test
@@ -420,8 +415,9 @@ class DatasetResourceTest extends AbstractTestHelper {
     when(datasetService.findDatasetById(any())).thenReturn(dataSet);
 
     initResource();
-    Response response = resource.delete(authUser, 1, null);
-    assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+    try (var response = resource.delete(authUser, 1, null)) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+    }
   }
 
   @Test
@@ -436,8 +432,9 @@ class DatasetResourceTest extends AbstractTestHelper {
     when(datasetService.findDatasetById(any())).thenReturn(dataSet);
 
     initResource();
-    Response response = resource.delete(authUser, 1, null);
-    assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
+    try (var response = resource.delete(authUser, 1, null)) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
+    }
   }
 
   @Test
@@ -454,8 +451,9 @@ class DatasetResourceTest extends AbstractTestHelper {
     when(datasetService.findDatasetById(any())).thenReturn(dataSet);
 
     initResource();
-    Response response = resource.delete(authUser, 1, null);
-    assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
+    try (var response = resource.delete(authUser, 1, null)) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
+    }
   }
 
   @Test
@@ -473,8 +471,9 @@ class DatasetResourceTest extends AbstractTestHelper {
     when(datasetService.findDatasetById(any())).thenReturn(dataSet);
 
     initResource();
-    Response response = resource.delete(authUser, 1, null);
-    assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
+    try (var response = resource.delete(authUser, 1, null)) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
+    }
   }
 
   @Test
@@ -511,7 +510,8 @@ class DatasetResourceTest extends AbstractTestHelper {
     StreamingOutput output = out -> out.write(
         esResponseArray.formatted(dataset.getDatasetId()).getBytes());
     when(datasetService.findAllDatasetIds()).thenReturn(List.of(dataset.getDatasetId()));
-    when(elasticSearchService.indexDatasetIds(List.of(dataset.getDatasetId()), user)).thenReturn(output);
+    when(elasticSearchService.indexDatasetIds(List.of(dataset.getDatasetId()), user)).thenReturn(
+        output);
     when(userService.findUserByEmail(any())).thenReturn(user);
 
     initResource();
@@ -540,17 +540,15 @@ class DatasetResourceTest extends AbstractTestHelper {
   @Test
   void testIndexDataset() throws IOException {
     Dataset dataset = new Dataset();
-    User user = new User();
-    user.setUserId(1);
-
     Response mockResponse = Response.ok().entity(dataset).build();
     when(datasetService.findDatasetById(any())).thenReturn(dataset);
     when(elasticSearchService.indexDataset(dataset, user)).thenReturn(mockResponse);
     when(userService.findUserByEmail(any())).thenReturn(user);
 
     initResource();
-    Response response = resource.indexDataset(authUser,1);
-    assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+    try (var response = resource.indexDataset(authUser, 1)) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+    }
   }
 
   @Test
@@ -561,8 +559,9 @@ class DatasetResourceTest extends AbstractTestHelper {
     when(userService.findUserByEmail(any())).thenReturn(user);
 
     initResource();
-    Response response = resource.deleteDatasetIndex(authUser,0);
-    assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+    try (var response = resource.deleteDatasetIndex(authUser, 0)) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+    }
   }
 
   @Test
@@ -573,7 +572,7 @@ class DatasetResourceTest extends AbstractTestHelper {
         List.of(new DatasetSummary(1, "ID", "Name")));
 
     initResource();
-    try (Response response = resource.autocompleteDatasets(authUser, "test")) {
+    try (var response = resource.autocompleteDatasets(authUser, "test")) {
       assertTrue(HttpStatusCodes.isSuccess(response.getStatus()));
     }
   }
@@ -588,10 +587,10 @@ class DatasetResourceTest extends AbstractTestHelper {
     when(elasticSearchService.searchDatasets(any())).thenReturn(mockResponse);
 
     initResource();
-    Response response = resource.searchDatasetIndex(authUser, query);
-
-    assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
-    assertTrue(response.getEntity().toString().length() > 2);
+    try (var response = resource.searchDatasetIndex(authUser, query)) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+      assertTrue(response.getEntity().toString().length() > 2);
+    }
   }
 
   @Test
@@ -726,8 +725,9 @@ class DatasetResourceTest extends AbstractTestHelper {
 
     initResource();
     String duString = new DataUseBuilder().setGeneralUse(true).build().toString();
-    Response response = resource.updateDatasetDataUse(new AuthUser(), 1, duString);
-    assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+    try (var response = resource.updateDatasetDataUse(new AuthUser(), 1, duString)) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+    }
   }
 
   @Test
@@ -735,8 +735,9 @@ class DatasetResourceTest extends AbstractTestHelper {
     when(userService.findUserByEmail(any())).thenReturn(new User());
 
     initResource();
-    Response response = resource.updateDatasetDataUse(new AuthUser(), 1, "invalid json");
-    assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
+    try (var response = resource.updateDatasetDataUse(new AuthUser(), 1, "invalid json")) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
+    }
   }
 
   @Test
@@ -749,8 +750,9 @@ class DatasetResourceTest extends AbstractTestHelper {
 
     initResource();
     String duString = new DataUseBuilder().setGeneralUse(true).build().toString();
-    Response response = resource.updateDatasetDataUse(new AuthUser(), 1, duString);
-    assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
+    try (var response = resource.updateDatasetDataUse(new AuthUser(), 1, duString)) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
+    }
   }
 
   @Test
@@ -760,8 +762,9 @@ class DatasetResourceTest extends AbstractTestHelper {
 
     initResource();
     String duString = new DataUseBuilder().setGeneralUse(true).build().toString();
-    Response response = resource.updateDatasetDataUse(new AuthUser(), 1, duString);
-    assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
+    try (var response = resource.updateDatasetDataUse(new AuthUser(), 1, duString)) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
+    }
   }
 
   @Test
@@ -773,8 +776,9 @@ class DatasetResourceTest extends AbstractTestHelper {
     when(datasetService.findDatasetById(any())).thenReturn(d);
 
     initResource();
-    Response response = resource.updateDatasetDataUse(new AuthUser(), 1, du.toString());
-    assertEquals(HttpStatusCodes.STATUS_CODE_NOT_MODIFIED, response.getStatus());
+    try (var response = resource.updateDatasetDataUse(new AuthUser(), 1, du.toString())) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_NOT_MODIFIED, response.getStatus());
+    }
   }
 
   @Test
@@ -787,17 +791,18 @@ class DatasetResourceTest extends AbstractTestHelper {
     when(datasetService.findAllDatasetsAsStreamingOutput()).thenReturn(output);
     initResource();
 
-    Response response = resource.findAllDatasetsStreaming(authUser);
-    assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
-    var entity = (StreamingOutput) response.getEntity();
-    var baos = new ByteArrayOutputStream();
-    entity.write(baos);
-    var entityString = baos.toString();
-    Type listOfDatasetsType = new TypeToken<List<Dataset>>() {
-    }.getType();
-    List<Dataset> returnedDatasets = gson.fromJson(entityString, listOfDatasetsType);
-    assertThat(returnedDatasets, hasSize(1));
-    assertEquals(dataset.getDatasetId(), returnedDatasets.get(0).getDatasetId());
+    try (var response = resource.findAllDatasetsStreaming(authUser)) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+      var entity = (StreamingOutput) response.getEntity();
+      var baos = new ByteArrayOutputStream();
+      entity.write(baos);
+      var entityString = baos.toString();
+      Type listOfDatasetsType = new TypeToken<List<Dataset>>() {
+      }.getType();
+      List<Dataset> returnedDatasets = gson.fromJson(entityString, listOfDatasetsType);
+      assertThat(returnedDatasets, hasSize(1));
+      assertEquals(dataset.getDatasetId(), returnedDatasets.get(0).getDatasetId());
+    }
   }
 
   @Test
@@ -805,22 +810,25 @@ class DatasetResourceTest extends AbstractTestHelper {
     when(userService.findUserByEmail(any())).thenReturn(user);
     when(datasetService.findAllDatasetStudySummaries()).thenReturn(List.of());
     initResource();
-    Response response = resource.findAllDatasetStudySummaries(authUser);
-    assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+    try (var response = resource.findAllDatasetStudySummaries(authUser)) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+    }
   }
 
   @Test
   void testCreateDatasetRegistration_invalidSchema_case1() {
     initResource();
-    Response response = resource.createDatasetRegistration(authUser, null, "");
-    assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
+    try (var response = resource.createDatasetRegistration(authUser, null, "")) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
+    }
   }
 
   @Test
   void testCreateDatasetRegistration_invalidSchema_case2() {
     initResource();
-    Response response = resource.createDatasetRegistration(authUser, null, "{}");
-    assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
+    try (var response = resource.createDatasetRegistration(authUser, null, "{}")) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
+    }
   }
 
   @Test
@@ -828,8 +836,9 @@ class DatasetResourceTest extends AbstractTestHelper {
     DatasetRegistrationSchemaV1 schemaV1 = new DatasetRegistrationSchemaV1();
     String schemaString = new Gson().toJson(schemaV1);
     initResource();
-    Response response = resource.createDatasetRegistration(authUser, null, schemaString);
-    assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
+    try (var response = resource.createDatasetRegistration(authUser, null, schemaString)) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
+    }
   }
 
   @Test
@@ -844,9 +853,9 @@ class DatasetResourceTest extends AbstractTestHelper {
     String schemaV1 = createDatasetRegistrationMock(user);
     initResource();
 
-    Response response = resource.createDatasetRegistration(authUser, null, schemaV1);
-    System.out.println(response.getEntity());
-    assertEquals(HttpStatusCodes.STATUS_CODE_CREATED, response.getStatus());
+    try (var response = resource.createDatasetRegistration(authUser, null, schemaV1)) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_CREATED, response.getStatus());
+    }
   }
 
   @Test
@@ -1009,41 +1018,36 @@ class DatasetResourceTest extends AbstractTestHelper {
     when(formDataMultiPart.getFields()).thenReturn(Map.of("file", List.of(formDataBodyPart)));
     initResource();
 
-    Response response = resource.updateByDatasetUpdate(authUser, 1, formDataMultiPart, json);
-    assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
-    assertEquals(Optional.of(preexistingDataset).get(), response.getEntity());
+    try (var response = resource.updateByDatasetUpdate(authUser, 1, formDataMultiPart, json)) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+      assertEquals(Optional.of(preexistingDataset).get(), response.getEntity());
+    }
   }
 
   @Test
   void testUpdateDatasetWithNoJson() {
-    FormDataContentDisposition content = FormDataContentDisposition
-        .name("file")
-        .fileName("validFile.txt")
-        .build();
     FormDataMultiPart formDataMultiPart = mock(FormDataMultiPart.class);
     initResource();
-    Response response = resource.updateByDatasetUpdate(authUser, 1, formDataMultiPart, "");
-    assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
+    try (var response = resource.updateByDatasetUpdate(authUser, 1, formDataMultiPart, "")) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
+    }
   }
 
   @Test
   void testUpdateDatasetWithInvalidJson() {
-    FormDataContentDisposition content = FormDataContentDisposition
-        .name("file")
-        .fileName("validFile.txt")
-        .build();
     String json = createInvalidDataset(user);
     FormDataMultiPart formDataMultiPart = mock(FormDataMultiPart.class);
     initResource();
-    Response response = resource.updateByDatasetUpdate(authUser, 1, formDataMultiPart, json);
-    assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
+    try (var response = resource.updateByDatasetUpdate(authUser, 1, formDataMultiPart, json)) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
+    }
   }
 
   /**
    * tests the case that there are no updates to the dataset properties, should result in success
    */
   @Test
-  void testUpdateDatasetWithNoProperties() throws Exception{
+  void testUpdateDatasetWithNoProperties() throws Exception {
     Dataset dataset = new Dataset();
     FormDataContentDisposition content = FormDataContentDisposition
         .name("file")
@@ -1059,24 +1063,22 @@ class DatasetResourceTest extends AbstractTestHelper {
     when(datasetRegistrationService.updateDataset(any(), any(), any(), any())).thenReturn(dataset);
     when(userService.findUserByEmail(any())).thenReturn(user);
     initResource();
-    Response response = resource.updateByDatasetUpdate(authUser, 1, formDataMultiPart,
-        "{\"properties\":[]}");
-    assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+    try (var response = resource.updateByDatasetUpdate(authUser, 1, formDataMultiPart,
+        "{\"properties\":[]}")) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+    }
   }
 
   @Test
   void testUpdateDatasetWIthDatasetIdNotFound() {
-    FormDataContentDisposition content = FormDataContentDisposition
-        .name("file")
-        .fileName("validFile.txt")
-        .build();
     FormDataMultiPart formDataMultiPart = mock(FormDataMultiPart.class);
     String json = createDatasetRegistrationMock(user);
     when(datasetService.findDatasetById(anyInt())).thenReturn(null);
 
     initResource();
-    Response response = resource.updateByDatasetUpdate(authUser, 1, formDataMultiPart, json);
-    assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
+    try (var response = resource.updateByDatasetUpdate(authUser, 1, formDataMultiPart, json)) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
+    }
   }
 
   @Test
@@ -1099,8 +1101,9 @@ class DatasetResourceTest extends AbstractTestHelper {
     when(formDataMultiPart.getFields()).thenReturn(Map.of("file", List.of(formDataBodyPart)));
     initResource();
 
-    Response response = resource.updateByDatasetUpdate(authUser, 1, formDataMultiPart, json);
-    assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
+    try (var response = resource.updateByDatasetUpdate(authUser, 1, formDataMultiPart, json)) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
+    }
   }
 
   @Test
@@ -1108,17 +1111,20 @@ class DatasetResourceTest extends AbstractTestHelper {
     when(datasetService.syncDatasetDataUseTranslation(any(), any())).thenReturn(new Dataset());
     initResource();
 
-    Response response = resource.syncDataUseTranslation(authUser, 1);
-    assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+    try (var response = resource.syncDataUseTranslation(authUser, 1)) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+    }
   }
 
   @Test
   void testSyncDataUseTranslationNotFound() {
-    when(datasetService.syncDatasetDataUseTranslation(any(), any())).thenThrow(new NotFoundException());
+    when(datasetService.syncDatasetDataUseTranslation(any(), any())).thenThrow(
+        new NotFoundException());
     initResource();
 
-    Response response = resource.syncDataUseTranslation(authUser, 1);
-    assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
+    try (var response = resource.syncDataUseTranslation(authUser, 1)) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
+    }
   }
 
   /**

--- a/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
@@ -88,7 +88,7 @@ class DatasetResourceTest extends AbstractTestHelper {
   private User user;
 
   @Mock
-  private Response response;
+  private Response mockResponse;
 
   private DatasetResource resource;
 
@@ -334,7 +334,7 @@ class DatasetResourceTest extends AbstractTestHelper {
     when(userService.findUserByEmail("test@test.com")).thenReturn(user);
     when(user.getUserId()).thenReturn(randomInt(1, 100));
     dataset.setCreateUserId(user.getUserId());
-    when(elasticSearchService.indexDataset(dataset, user)).thenReturn(response);
+    when(elasticSearchService.indexDataset(dataset, user)).thenReturn(mockResponse);
 
     initResource();
     try (Response response = resource.patchByDatasetUpdate(authUser, dataset.getDatasetId(),
@@ -426,7 +426,7 @@ class DatasetResourceTest extends AbstractTestHelper {
     when(user.hasUserRole(UserRoles.ADMIN)).thenReturn(true);
     when(userService.findUserByEmail(authUser.getEmail())).thenReturn(user);
     when(datasetService.findDatasetById(any())).thenReturn(dataSet);
-    when(elasticSearchService.deleteIndex(any(), any())).thenReturn(response);
+    when(elasticSearchService.deleteIndex(any(), any())).thenReturn(mockResponse);
 
     initResource();
     try (var response = resource.delete(authUser, 1, null)) {
@@ -447,7 +447,7 @@ class DatasetResourceTest extends AbstractTestHelper {
 
     when(userService.findUserByEmail(authUser.getEmail())).thenReturn(user);
     when(datasetService.findDatasetById(any())).thenReturn(dataSet);
-    when(elasticSearchService.deleteIndex(any(), any())).thenReturn(response);
+    when(elasticSearchService.deleteIndex(any(), any())).thenReturn(mockResponse);
 
     initResource();
     try (var response = resource.delete(authUser, 1, null)) {
@@ -575,7 +575,7 @@ class DatasetResourceTest extends AbstractTestHelper {
   @Test
   void testIndexDataset() throws IOException {
     Dataset dataset = new Dataset();
-    Response mockResponse = Response.ok().entity(dataset).build();
+    when(mockResponse.getStatus()).thenReturn(HttpStatusCodes.STATUS_CODE_OK);
     when(datasetService.findDatasetById(any())).thenReturn(dataset);
     when(elasticSearchService.indexDataset(dataset, user)).thenReturn(mockResponse);
     when(userService.findUserByEmail(any())).thenReturn(user);
@@ -588,8 +588,7 @@ class DatasetResourceTest extends AbstractTestHelper {
 
   @Test
   void testIndexDelete() throws IOException, SQLException {
-    Response mockResponse = Response.status(HttpStatusCodes.STATUS_CODE_OK).entity("deleted")
-        .build();
+    when(mockResponse.getStatus()).thenReturn(HttpStatusCodes.STATUS_CODE_OK);
     when(elasticSearchService.deleteIndex(any(), any())).thenReturn(mockResponse);
     when(userService.findUserByEmail(any())).thenReturn(user);
 
@@ -616,7 +615,8 @@ class DatasetResourceTest extends AbstractTestHelper {
   void testSearchDatasetIndex() throws IOException {
     String query = "{ \"dataUse\": [\"HMB\"] }";
 
-    Response mockResponse = Response.ok().entity(query).build();
+    when(mockResponse.getStatus()).thenReturn(HttpStatusCodes.STATUS_CODE_OK);
+    when(mockResponse.getEntity()).thenReturn(query);
     when(authUser.getEmail()).thenReturn("testauthuser@test.com");
     when(userService.findUserByEmail("testauthuser@test.com")).thenReturn(user);
     when(elasticSearchService.searchDatasets(any())).thenReturn(mockResponse);

--- a/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
@@ -558,6 +558,7 @@ class DatasetResourceTest extends AbstractTestHelper {
     Response mockResponse = Response.status(HttpStatusCodes.STATUS_CODE_OK).entity("deleted")
         .build();
     when(elasticSearchService.deleteIndex(any(), any())).thenReturn(mockResponse);
+    when(userService.findUserByEmail(any())).thenReturn(user);
 
     initResource();
     Response response = resource.deleteDatasetIndex(authUser,0);

--- a/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
@@ -2,6 +2,7 @@ package org.broadinstitute.consent.http.resources;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.contains;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -822,7 +823,7 @@ class DatasetResourceTest extends AbstractTestHelper {
       }.getType();
       List<Dataset> returnedDatasets = gson.fromJson(entityString, listOfDatasetsType);
       assertThat(returnedDatasets, hasSize(1));
-      assertEquals(dataset.getDatasetId(), returnedDatasets.get(0).getDatasetId());
+      assertThat(returnedDatasets, contains(dataset));
     }
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/resources/StudyResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/StudyResourceTest.java
@@ -226,7 +226,7 @@ class StudyResourceTest {
 
     try (Response response = resource.deleteStudyById(authUser, study.getStudyId())) {
       assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
-      verify(elasticSearchService, atLeastOnce()).deleteIndex(any());
+      verify(elasticSearchService, atLeastOnce()).deleteIndex(any(), any());
     }
   }
 
@@ -237,7 +237,7 @@ class StudyResourceTest {
 
     try (Response response = resource.deleteStudyById(authUser, study.getStudyId())) {
       assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
-      verify(elasticSearchService, never()).deleteIndex(any());
+      verify(elasticSearchService, never()).deleteIndex(any(), any());
     }
   }
 
@@ -254,7 +254,7 @@ class StudyResourceTest {
 
     try (Response response = resource.deleteStudyById(authUser, study.getStudyId())) {
       assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
-      verify(elasticSearchService, never()).deleteIndex(any());
+      verify(elasticSearchService, never()).deleteIndex(any(), any());
     }
   }
 
@@ -271,7 +271,7 @@ class StudyResourceTest {
 
     try (Response response = resource.deleteStudyById(authUser, study.getStudyId())) {
       assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
-      verify(elasticSearchService, never()).deleteIndex(any());
+      verify(elasticSearchService, never()).deleteIndex(any(), any());
     }
   }
 
@@ -288,7 +288,7 @@ class StudyResourceTest {
 
     try (Response response = resource.deleteStudyById(authUser, study.getStudyId())) {
       assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
-      verify(elasticSearchService, never()).deleteIndex(any());
+      verify(elasticSearchService, never()).deleteIndex(any(), any());
     }
   }
 
@@ -307,7 +307,7 @@ class StudyResourceTest {
 
     try (Response response = resource.deleteStudyById(authUser, study.getStudyId())) {
       assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
-      verify(elasticSearchService, never()).deleteIndex(any());
+      verify(elasticSearchService, never()).deleteIndex(any(), any());
     }
   }
 
@@ -320,12 +320,12 @@ class StudyResourceTest {
     admin.setAdminRole();
     admin.setUserId(study.getCreateUserId());
     when(userService.findUserByEmail(any())).thenReturn(admin);
-    when(elasticSearchService.deleteIndex(any())).thenThrow(new IOException());
+    when(elasticSearchService.deleteIndex(any(), any())).thenThrow(new IOException());
     initResource();
 
     try (Response response = resource.deleteStudyById(authUser, study.getStudyId())) {
       assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
-      verify(elasticSearchService, atLeastOnce()).deleteIndex(any());
+      verify(elasticSearchService, atLeastOnce()).deleteIndex(any(), any());
     }
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/resources/StudyResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/StudyResourceTest.java
@@ -126,7 +126,7 @@ class StudyResourceTest extends AbstractTestHelper {
     Study study = new Study();
     study.setName(randomAlphabetic(10));
     study.setStudyId(12345);
-    study.setDatasetIds(Set.of(1, 2, 3));
+    study.addDatasetIds(Set.of(1, 2, 3));
 
     when(datasetService.getStudyWithDatasetsById(12345)).thenReturn(study);
 
@@ -199,7 +199,7 @@ class StudyResourceTest extends AbstractTestHelper {
           DatasetRegistrationSchemaV1.class);
       List<Integer> datasetIds = schemaV1.getConsentGroups().stream()
           .map(ConsentGroup::getDatasetId).toList();
-      study.setDatasetIds(Set.of(datasetIds.get(0) + 1));
+      study.addDatasetIds(Set.of(datasetIds.get(0) + 1));
     }
     when(userService.findUserByEmail(any())).thenReturn(user);
     when(datasetRegistrationService.findStudyById(any())).thenReturn(study);
@@ -223,7 +223,7 @@ class StudyResourceTest extends AbstractTestHelper {
         .filter(Objects::nonNull)
         .collect(Collectors.toSet());
     study.getDatasetIds().clear();
-    study.setDatasetIds(datasetIds);
+    study.addDatasetIds(datasetIds);
     when(userService.findUserByEmail(any())).thenReturn(user);
     when(datasetRegistrationService.findStudyById(any())).thenReturn(study);
     initResource();
@@ -371,7 +371,7 @@ class StudyResourceTest extends AbstractTestHelper {
     study.setCreateUserId(9);
     study.setCreateUserEmail(randomAlphabetic(10));
     study.setPublicVisibility(true);
-    study.setDatasetIds(Set.of(dataset.getDatasetId()));
+    study.addDatasetIds(Set.of(dataset.getDatasetId()));
 
     StudyProperty phenotypeProperty = new StudyProperty();
     phenotypeProperty.setKey("phenotypeIndication");
@@ -388,7 +388,7 @@ class StudyResourceTest extends AbstractTestHelper {
     dataCustodianEmailProperty.setType(PropertyType.Json);
     dataCustodianEmailProperty.setValue(List.of(randomAlphabetic(10)));
 
-    study.setProperties(Set.of(phenotypeProperty, speciesProperty, dataCustodianEmailProperty));
+    study.addProperties(Set.of(phenotypeProperty, speciesProperty, dataCustodianEmailProperty));
 
     dataset.setStudy(study);
 

--- a/src/test/java/org/broadinstitute/consent/http/resources/StudyResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/StudyResourceTest.java
@@ -62,6 +62,9 @@ class StudyResourceTest {
   @Mock
   private User user;
 
+  @Mock
+  private Response response;
+
   private StudyResource resource;
 
   private void initResource() {
@@ -222,6 +225,7 @@ class StudyResourceTest {
     admin.setAdminRole();
     admin.setUserId(study.getCreateUserId());
     when(userService.findUserByEmail(any())).thenReturn(admin);
+    when(elasticSearchService.deleteIndex(any(), any())).thenReturn(response);
     initResource();
 
     try (Response response = resource.deleteStudyById(authUser, study.getStudyId())) {

--- a/src/test/java/org/broadinstitute/consent/http/resources/StudyResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/StudyResourceTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -16,7 +17,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
-import org.apache.commons.lang3.RandomStringUtils;
+import org.broadinstitute.consent.http.AbstractTestHelper;
 import org.broadinstitute.consent.http.enumeration.PropertyType;
 import org.broadinstitute.consent.http.models.AuthUser;
 import org.broadinstitute.consent.http.models.DataUse;
@@ -42,7 +43,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-class StudyResourceTest {
+class StudyResourceTest extends AbstractTestHelper {
 
   @Mock
   private DatasetService datasetService;
@@ -68,29 +69,36 @@ class StudyResourceTest {
   private StudyResource resource;
 
   private void initResource() {
-    resource = new StudyResource(datasetService, userService, datasetRegistrationService, elasticSearchService);
+    resource = new StudyResource(datasetService, userService, datasetRegistrationService,
+        elasticSearchService);
   }
 
   @Test
   void testUpdateCustodiansSuccess() {
     initResource();
-    Response response = resource.updateCustodians(authUser, 1, "[\"user_1@test.com\", \"user_2@test.com\"]");
-    assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+    try (var response = resource.updateCustodians(authUser, 1,
+        "[\"user_1@test.com\", \"user_2@test.com\"]")) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+    }
   }
 
   @Test
   void testUpdateCustodiansInvalidEmails() {
     initResource();
-    Response response = resource.updateCustodians(authUser, 1, "[\"user_1\", \"@test.com\"]");
-    assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
+    try (var response = resource.updateCustodians(authUser, 1, "[\"user_1\", \"@test.com\"]")) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
+    }
   }
 
   @Test
   void testUpdateCustodiansNotFound() {
-    when(datasetService.updateStudyCustodians(any(), any(), any())).thenThrow(new NotFoundException("Study not found"));
+    when(datasetService.updateStudyCustodians(any(), any(), any())).thenThrow(
+        new NotFoundException("Study not found"));
     initResource();
-    Response response = resource.updateCustodians(authUser, 1, "[\"user_1@test.com\", \"user_2@test.com\"]");
-    assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
+    try (var response = resource.updateCustodians(authUser, 1,
+        "[\"user_1@test.com\", \"user_2@test.com\"]")) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
+    }
   }
 
   @Test
@@ -100,8 +108,9 @@ class StudyResourceTest {
     study.setName("asdfasdfasdfasdfasdfasdf");
     when(datasetService.getStudyWithDatasetsById(1)).thenReturn(study);
     initResource();
-    Response response = resource.getStudyById(1);
-    assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+    try (var response = resource.getStudyById(1)) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+    }
   }
 
   @Test
@@ -115,16 +124,17 @@ class StudyResourceTest {
     List<Dataset> datasets = List.of(ds1, ds2, ds3);
 
     Study study = new Study();
-    study.setName(RandomStringUtils.randomAlphabetic(10));
+    study.setName(randomAlphabetic(10));
     study.setStudyId(12345);
     study.setDatasetIds(Set.of(1, 2, 3));
 
     when(datasetService.getStudyWithDatasetsById(12345)).thenReturn(study);
 
     initResource();
-    Response response = resource.getStudyById(12345);
-    assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
-    assertEquals(study.getDatasetIds().size(), datasets.size());
+    try (var response = resource.getStudyById(12345)) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+      assertEquals(study.getDatasetIds().size(), datasets.size());
+    }
   }
 
   @Test
@@ -132,8 +142,9 @@ class StudyResourceTest {
     when(datasetService.getStudyWithDatasetsById(1)).thenThrow(new NotFoundException());
 
     initResource();
-    Response response = resource.getStudyById(1);
-    assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
+    try (var response = resource.getStudyById(1)) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
+    }
   }
 
   @Test
@@ -142,8 +153,9 @@ class StudyResourceTest {
     when(datasetService.getStudyWithDatasetsById(any())).thenReturn(study);
 
     initResource();
-    Response response = resource.getRegistrationFromStudy(authUser, 1);
-    assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+    try (var response = resource.getRegistrationFromStudy(authUser, 1)) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+    }
   }
 
   @Test
@@ -153,8 +165,9 @@ class StudyResourceTest {
     when(datasetService.getStudyWithDatasetsById(any())).thenReturn(study);
 
     initResource();
-    Response response = resource.getRegistrationFromStudy(authUser, 1);
-    assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+    try (var response = resource.getRegistrationFromStudy(authUser, 1)) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+    }
   }
 
   @Test
@@ -163,8 +176,9 @@ class StudyResourceTest {
     when(datasetService.getStudyWithDatasetsById(any())).thenThrow(new NotFoundException());
 
     initResource();
-    Response response = resource.getRegistrationFromStudy(authUser, study.getStudyId());
-    assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
+    try (var response = resource.getRegistrationFromStudy(authUser, study.getStudyId())) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
+    }
   }
 
   @ParameterizedTest
@@ -191,8 +205,9 @@ class StudyResourceTest {
     when(datasetRegistrationService.findStudyById(any())).thenReturn(study);
     initResource();
 
-    Response response = resource.updateStudyByRegistration(authUser, null, 1, input);
-    assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
+    try (var response = resource.updateStudyByRegistration(authUser, null, 1, input)) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
+    }
   }
 
   @Test
@@ -212,8 +227,9 @@ class StudyResourceTest {
     when(datasetRegistrationService.findStudyById(any())).thenReturn(study);
     initResource();
 
-    Response response = resource.updateStudyByRegistration(authUser, null, 1, input);
-    assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+    try (var response = resource.updateStudyByRegistration(authUser, null, 1, input)) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+    }
   }
 
   @Test
@@ -228,9 +244,9 @@ class StudyResourceTest {
     when(elasticSearchService.deleteIndex(any(), any())).thenReturn(response);
     initResource();
 
-    try (Response response = resource.deleteStudyById(authUser, study.getStudyId())) {
+    try (var response = resource.deleteStudyById(authUser, study.getStudyId())) {
       assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
-      verify(elasticSearchService, atLeastOnce()).deleteIndex(any(), any());
+      verify(elasticSearchService, times(1)).deleteIndex(any(), any());
     }
   }
 
@@ -239,7 +255,7 @@ class StudyResourceTest {
     Study study = createMockStudy();
     initResource();
 
-    try (Response response = resource.deleteStudyById(authUser, study.getStudyId())) {
+    try (var response = resource.deleteStudyById(authUser, study.getStudyId())) {
       assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
       verify(elasticSearchService, never()).deleteIndex(any(), any());
     }
@@ -256,7 +272,7 @@ class StudyResourceTest {
     when(userService.findUserByEmail(any())).thenReturn(chair);
     initResource();
 
-    try (Response response = resource.deleteStudyById(authUser, study.getStudyId())) {
+    try (var response = resource.deleteStudyById(authUser, study.getStudyId())) {
       assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
       verify(elasticSearchService, never()).deleteIndex(any(), any());
     }
@@ -273,7 +289,7 @@ class StudyResourceTest {
     when(userService.findUserByEmail(any())).thenReturn(admin);
     initResource();
 
-    try (Response response = resource.deleteStudyById(authUser, study.getStudyId())) {
+    try (var response = resource.deleteStudyById(authUser, study.getStudyId())) {
       assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
       verify(elasticSearchService, never()).deleteIndex(any(), any());
     }
@@ -290,7 +306,7 @@ class StudyResourceTest {
     when(userService.findUserByEmail(any())).thenReturn(admin);
     initResource();
 
-    try (Response response = resource.deleteStudyById(authUser, study.getStudyId())) {
+    try (var response = resource.deleteStudyById(authUser, study.getStudyId())) {
       assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
       verify(elasticSearchService, never()).deleteIndex(any(), any());
     }
@@ -309,7 +325,7 @@ class StudyResourceTest {
     when(userService.findUserByEmail(any())).thenReturn(admin);
     initResource();
 
-    try (Response response = resource.deleteStudyById(authUser, study.getStudyId())) {
+    try (var response = resource.deleteStudyById(authUser, study.getStudyId())) {
       assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
       verify(elasticSearchService, never()).deleteIndex(any(), any());
     }
@@ -327,7 +343,7 @@ class StudyResourceTest {
     when(elasticSearchService.deleteIndex(any(), any())).thenThrow(new IOException());
     initResource();
 
-    try (Response response = resource.deleteStudyById(authUser, study.getStudyId())) {
+    try (var response = resource.deleteStudyById(authUser, study.getStudyId())) {
       assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
       verify(elasticSearchService, atLeastOnce()).deleteIndex(any(), any());
     }
@@ -346,30 +362,30 @@ class StudyResourceTest {
     dataset.setDataUse(new DataUse());
 
     Study study = new Study();
-    study.setName(RandomStringUtils.randomAlphabetic(10));
-    study.setDescription(RandomStringUtils.randomAlphabetic(20));
+    study.setName(randomAlphabetic(10));
+    study.setDescription(randomAlphabetic(20));
     study.setStudyId(12345);
-    study.setPiName(RandomStringUtils.randomAlphabetic(10));
-    study.setDataTypes(List.of(RandomStringUtils.randomAlphabetic(10)));
+    study.setPiName(randomAlphabetic(10));
+    study.setDataTypes(List.of(randomAlphabetic(10)));
     study.setCreateUserId(9);
-    study.setCreateUserEmail(RandomStringUtils.randomAlphabetic(10));
+    study.setCreateUserEmail(randomAlphabetic(10));
     study.setPublicVisibility(true);
     study.setDatasetIds(Set.of(dataset.getDatasetId()));
 
     StudyProperty phenotypeProperty = new StudyProperty();
     phenotypeProperty.setKey("phenotypeIndication");
     phenotypeProperty.setType(PropertyType.String);
-    phenotypeProperty.setValue(RandomStringUtils.randomAlphabetic(10));
+    phenotypeProperty.setValue(randomAlphabetic(10));
 
     StudyProperty speciesProperty = new StudyProperty();
     speciesProperty.setKey("species");
     speciesProperty.setType(PropertyType.String);
-    speciesProperty.setValue(RandomStringUtils.randomAlphabetic(10));
+    speciesProperty.setValue(randomAlphabetic(10));
 
     StudyProperty dataCustodianEmailProperty = new StudyProperty();
     dataCustodianEmailProperty.setKey("dataCustodianEmail");
     dataCustodianEmailProperty.setType(PropertyType.Json);
-    dataCustodianEmailProperty.setValue(List.of(RandomStringUtils.randomAlphabetic(10)));
+    dataCustodianEmailProperty.setValue(List.of(randomAlphabetic(10)));
 
     study.setProperties(Set.of(phenotypeProperty, speciesProperty, dataCustodianEmailProperty));
 

--- a/src/test/java/org/broadinstitute/consent/http/resources/StudyResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/StudyResourceTest.java
@@ -222,6 +222,7 @@ class StudyResourceTest extends AbstractTestHelper {
         .map(ConsentGroup::getDatasetId)
         .filter(Objects::nonNull)
         .collect(Collectors.toSet());
+    study.getDatasetIds().clear();
     study.setDatasetIds(datasetIds);
     when(userService.findUserByEmail(any())).thenReturn(user);
     when(datasetRegistrationService.findStudyById(any())).thenReturn(study);
@@ -316,7 +317,7 @@ class StudyResourceTest extends AbstractTestHelper {
   @Test
   void testDeleteStudyByIdNoDatasets() throws Exception {
     Study study = createMockStudy();
-    study.setDatasetIds(Set.of());
+    study.getDatasetIds().clear();
     study.getDatasets().clear();
     when(datasetService.getStudyWithDatasetsById(any())).thenReturn(study);
     User admin = new User();

--- a/src/test/java/org/broadinstitute/consent/http/resources/StudyResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/StudyResourceTest.java
@@ -388,7 +388,7 @@ class StudyResourceTest extends AbstractTestHelper {
     dataCustodianEmailProperty.setType(PropertyType.Json);
     dataCustodianEmailProperty.setValue(List.of(randomAlphabetic(10)));
 
-    study.addProperties(Set.of(phenotypeProperty, speciesProperty, dataCustodianEmailProperty));
+    study.addProperties(phenotypeProperty, speciesProperty, dataCustodianEmailProperty);
 
     dataset.setStudy(study);
 

--- a/src/test/java/org/broadinstitute/consent/http/resources/VoteResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/VoteResourceTest.java
@@ -10,7 +10,6 @@ import static org.mockito.Mockito.when;
 
 import com.google.api.client.http.HttpStatusCodes;
 import com.google.gson.Gson;
-import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.Response.Status;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -57,8 +56,9 @@ class VoteResourceTest {
   @Test
   void testUpdateVotes_invalidJson() {
     initResource();
-    Response response = resource.updateVotes(authUser, "{\"vote\": true, \"ID\":12345}");
-    assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
+    try (var response = resource.updateVotes(authUser, "{\"vote\": true, \"ID\":12345}")) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
+    }
   }
 
   @Test
@@ -68,18 +68,20 @@ class VoteResourceTest {
     voteUpdate.setVote(true);
     voteUpdate.setRationale("example");
 
-    Response response = resource.updateVotes(authUser,
-        gson.toJson(voteUpdate, Vote.VoteUpdate.class));
-    assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
+    try (var response = resource.updateVotes(authUser,
+        gson.toJson(voteUpdate, Vote.VoteUpdate.class))) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
+    }
   }
 
   @Test
   void testUpdateVotes_noIds() {
     initResource();
     Vote.VoteUpdate voteUpdate = new Vote.VoteUpdate(true, "example", new ArrayList<>());
-    Response response = resource.updateVotes(authUser,
-        gson.toJson(voteUpdate, Vote.VoteUpdate.class));
-    assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
+    try (var response = resource.updateVotes(authUser,
+        gson.toJson(voteUpdate, Vote.VoteUpdate.class))) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
+    }
   }
 
 
@@ -89,9 +91,10 @@ class VoteResourceTest {
     initResource();
 
     Vote.VoteUpdate voteUpdate = new Vote.VoteUpdate(true, "example", List.of(1));
-    Response response = resource.updateVotes(authUser,
-        gson.toJson(voteUpdate, Vote.VoteUpdate.class));
-    assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
+    try (var response = resource.updateVotes(authUser,
+        gson.toJson(voteUpdate, Vote.VoteUpdate.class))) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
+    }
   }
 
   @Test
@@ -102,9 +105,10 @@ class VoteResourceTest {
     voteUpdate.setRationale("example");
     voteUpdate.setVoteIds(List.of(1, 2, 3));
 
-    Response response = resource.updateVotes(authUser,
-        gson.toJson(voteUpdate, Vote.VoteUpdate.class));
-    assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
+    try (var response = resource.updateVotes(authUser,
+        gson.toJson(voteUpdate, Vote.VoteUpdate.class))) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
+    }
   }
 
   @Test
@@ -116,9 +120,10 @@ class VoteResourceTest {
     initResource();
 
     Vote.VoteUpdate voteUpdate = new Vote.VoteUpdate(true, "example", List.of(1, 2, 3));
-    Response response = resource.updateVotes(authUser,
-        gson.toJson(voteUpdate, Vote.VoteUpdate.class));
-    assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
+    try (var response = resource.updateVotes(authUser,
+        gson.toJson(voteUpdate, Vote.VoteUpdate.class))) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
+    }
   }
 
   @Test
@@ -129,9 +134,10 @@ class VoteResourceTest {
     initResource();
 
     Vote.VoteUpdate voteUpdate = new Vote.VoteUpdate(true, "example", List.of(1, 2, 3));
-    Response response = resource.updateVotes(authUser,
-        gson.toJson(voteUpdate, Vote.VoteUpdate.class));
-    assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
+    try (var response = resource.updateVotes(authUser,
+        gson.toJson(voteUpdate, Vote.VoteUpdate.class))) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
+    }
   }
 
   @Test
@@ -151,9 +157,10 @@ class VoteResourceTest {
         .thenReturn(List.of(vote));
     initResource();
 
-    Response response = resource.updateVotes(authUser,
-        gson.toJson(voteUpdate, Vote.VoteUpdate.class));
-    assertEquals(Status.OK.getStatusCode(), response.getStatus());
+    try (var response = resource.updateVotes(authUser,
+        gson.toJson(voteUpdate, Vote.VoteUpdate.class))) {
+      assertEquals(Status.OK.getStatusCode(), response.getStatus());
+    }
   }
 
   @Test
@@ -166,10 +173,6 @@ class VoteResourceTest {
     voteTwo.setVote(true);
     voteTwo.setType("Chairperson");
     voteTwo.setUserId(1);
-    Election election = new Election();
-    Election electionTwo = new Election();
-    election.setElectionType("RP");
-    electionTwo.setElectionType("RP");
     Vote.VoteUpdate voteUpdate = new Vote.VoteUpdate(true, "example", List.of(1, 2, 3));
     when(voteService.findVotesByIds(anyList())).thenReturn(List.of(vote, voteTwo));
     when(userService.findUserByEmail(any())).thenReturn(user);
@@ -178,9 +181,10 @@ class VoteResourceTest {
 
     initResource();
 
-    Response response = resource.updateVotes(authUser,
-        gson.toJson(voteUpdate, Vote.VoteUpdate.class));
-    assertEquals(Status.OK.getStatusCode(), response.getStatus());
+    try (var response = resource.updateVotes(authUser,
+        gson.toJson(voteUpdate, Vote.VoteUpdate.class))) {
+      assertEquals(Status.OK.getStatusCode(), response.getStatus());
+    }
   }
 
   @Test
@@ -200,9 +204,10 @@ class VoteResourceTest {
         .thenReturn(List.of(vote));
     initResource();
 
-    Response response = resource.updateVotes(authUser,
-        gson.toJson(voteUpdate, Vote.VoteUpdate.class));
-    assertEquals(Status.OK.getStatusCode(), response.getStatus());
+    try (var response = resource.updateVotes(authUser,
+        gson.toJson(voteUpdate, Vote.VoteUpdate.class))) {
+      assertEquals(Status.OK.getStatusCode(), response.getStatus());
+    }
   }
 
   @Test
@@ -231,9 +236,10 @@ class VoteResourceTest {
 
     initResource();
 
-    Response response = resource.updateVotes(authUser,
-        gson.toJson(voteUpdate, Vote.VoteUpdate.class));
-    assertEquals(Status.OK.getStatusCode(), response.getStatus());
+    try (var response = resource.updateVotes(authUser,
+        gson.toJson(voteUpdate, Vote.VoteUpdate.class))) {
+      assertEquals(Status.OK.getStatusCode(), response.getStatus());
+    }
   }
 
   @Test
@@ -248,8 +254,6 @@ class VoteResourceTest {
     voteTwo.setVoteId(2);
     voteTwo.setUserId(1);
     voteTwo.setVote(false);
-    Election election = new Election();
-    election.setElectionId(1);
     Vote.VoteUpdate voteUpdate = new Vote.VoteUpdate(false, "example", List.of(1, 2, 3));
     when(voteService.findVotesByIds(anyList())).thenReturn(List.of(vote, voteTwo));
     when(userService.findUserByEmail(any())).thenReturn(user);
@@ -257,9 +261,10 @@ class VoteResourceTest {
         .thenReturn(List.of(vote, voteTwo));
     initResource();
 
-    Response response = resource.updateVotes(authUser,
-        gson.toJson(voteUpdate, Vote.VoteUpdate.class));
-    assertEquals(Status.OK.getStatusCode(), response.getStatus());
+    try (var response = resource.updateVotes(authUser,
+        gson.toJson(voteUpdate, Vote.VoteUpdate.class))) {
+      assertEquals(Status.OK.getStatusCode(), response.getStatus());
+    }
   }
 
   @Test
@@ -287,9 +292,10 @@ class VoteResourceTest {
         .thenReturn(List.of(election));
     initResource();
 
-    Response response = resource.updateVotes(authUser,
-        gson.toJson(voteUpdate, Vote.VoteUpdate.class));
-    assertEquals(Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+    try (var response = resource.updateVotes(authUser,
+        gson.toJson(voteUpdate, Vote.VoteUpdate.class))) {
+      assertEquals(Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+    }
   }
 
   @Test
@@ -304,9 +310,10 @@ class VoteResourceTest {
     voteUpdate.setVote(false);
     voteUpdate.setVoteIds(List.of(1, 2, 3));
 
-    Response response = resource.updateVotes(authUser,
-        gson.toJson(voteUpdate, Vote.VoteUpdate.class));
-    assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+    try (var response = resource.updateVotes(authUser,
+        gson.toJson(voteUpdate, Vote.VoteUpdate.class))) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+    }
   }
 
   @Test
@@ -314,8 +321,9 @@ class VoteResourceTest {
     String invalidJson = "[]";
     initResource();
 
-    Response response = resource.updateVoteRationale(authUser, invalidJson);
-    assertEquals(Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+    try (var response = resource.updateVoteRationale(authUser, invalidJson)) {
+      assertEquals(Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+    }
   }
 
   @Test
@@ -324,8 +332,9 @@ class VoteResourceTest {
     update.setRationale("Rationale");
     initResource();
 
-    Response response = resource.updateVoteRationale(authUser, new Gson().toJson(update));
-    assertEquals(Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+    try (var response = resource.updateVoteRationale(authUser, new Gson().toJson(update))) {
+      assertEquals(Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+    }
   }
 
   @Test
@@ -338,8 +347,9 @@ class VoteResourceTest {
     update.setRationale("Rationale");
     initResource();
 
-    Response response = resource.updateVoteRationale(authUser, new Gson().toJson(update));
-    assertEquals(Status.NOT_FOUND.getStatusCode(), response.getStatus());
+    try (var response = resource.updateVoteRationale(authUser, new Gson().toJson(update))) {
+      assertEquals(Status.NOT_FOUND.getStatusCode(), response.getStatus());
+    }
   }
 
   @Test
@@ -353,8 +363,9 @@ class VoteResourceTest {
     update.setRationale("Rationale");
     initResource();
 
-    Response response = resource.updateVoteRationale(authUser, new Gson().toJson(update));
-    assertEquals(Status.NOT_FOUND.getStatusCode(), response.getStatus());
+    try (var response = resource.updateVoteRationale(authUser, new Gson().toJson(update))) {
+      assertEquals(Status.NOT_FOUND.getStatusCode(), response.getStatus());
+    }
   }
 
   @Test
@@ -369,7 +380,8 @@ class VoteResourceTest {
     update.setRationale("Rationale");
     initResource();
 
-    Response response = resource.updateVoteRationale(authUser, new Gson().toJson(update));
-    assertEquals(Status.OK.getStatusCode(), response.getStatus());
+    try (var response = resource.updateVoteRationale(authUser, new Gson().toJson(update))) {
+      assertEquals(Status.OK.getStatusCode(), response.getStatus());
+    }
   }
 }

--- a/src/test/java/org/broadinstitute/consent/http/resources/VoteResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/VoteResourceTest.java
@@ -147,7 +147,7 @@ class VoteResourceTest {
     Vote.VoteUpdate voteUpdate = new Vote.VoteUpdate(true, "example", List.of(1, 2, 3));
     when(voteService.findVotesByIds(anyList())).thenReturn(List.of(vote, voteTwo));
     when(userService.findUserByEmail(any())).thenReturn(user);
-    when(voteService.updateVotesWithValue(anyList(), anyBoolean(), anyString()))
+    when(voteService.updateVotesWithValue(anyList(), anyBoolean(), anyString(), any()))
         .thenReturn(List.of(vote));
     initResource();
 
@@ -173,7 +173,7 @@ class VoteResourceTest {
     Vote.VoteUpdate voteUpdate = new Vote.VoteUpdate(true, "example", List.of(1, 2, 3));
     when(voteService.findVotesByIds(anyList())).thenReturn(List.of(vote, voteTwo));
     when(userService.findUserByEmail(any())).thenReturn(user);
-    when(voteService.updateVotesWithValue(anyList(), anyBoolean(), anyString()))
+    when(voteService.updateVotesWithValue(anyList(), anyBoolean(), anyString(), any()))
         .thenReturn(List.of(vote));
 
     initResource();
@@ -196,7 +196,7 @@ class VoteResourceTest {
     Vote.VoteUpdate voteUpdate = new Vote.VoteUpdate(false, "example", List.of(1, 2, 3));
     when(voteService.findVotesByIds(anyList())).thenReturn(List.of(vote, voteTwo));
     when(userService.findUserByEmail(any())).thenReturn(user);
-    when(voteService.updateVotesWithValue(anyList(), anyBoolean(), anyString()))
+    when(voteService.updateVotesWithValue(anyList(), anyBoolean(), anyString(), any()))
         .thenReturn(List.of(vote));
     initResource();
 
@@ -222,7 +222,7 @@ class VoteResourceTest {
     Vote.VoteUpdate voteUpdate = new Vote.VoteUpdate(true, "example", List.of(1, 2, 3));
     when(voteService.findVotesByIds(anyList())).thenReturn(List.of(vote, voteTwo));
     when(userService.findUserByEmail(any())).thenReturn(user);
-    when(voteService.updateVotesWithValue(anyList(), anyBoolean(), anyString()))
+    when(voteService.updateVotesWithValue(anyList(), anyBoolean(), anyString(), any()))
         .thenReturn(List.of(vote, voteTwo));
     when(electionService.findElectionsByVoteIdsAndType(anyList(), anyString()))
         .thenReturn(List.of(election));
@@ -253,7 +253,7 @@ class VoteResourceTest {
     Vote.VoteUpdate voteUpdate = new Vote.VoteUpdate(false, "example", List.of(1, 2, 3));
     when(voteService.findVotesByIds(anyList())).thenReturn(List.of(vote, voteTwo));
     when(userService.findUserByEmail(any())).thenReturn(user);
-    when(voteService.updateVotesWithValue(anyList(), anyBoolean(), anyString()))
+    when(voteService.updateVotesWithValue(anyList(), anyBoolean(), anyString(), any()))
         .thenReturn(List.of(vote, voteTwo));
     initResource();
 

--- a/src/test/java/org/broadinstitute/consent/http/service/DatasetRegistrationServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DatasetRegistrationServiceTest.java
@@ -538,7 +538,7 @@ class DatasetRegistrationServiceTest {
     User user = mock();
     DatasetRegistrationSchemaV1 schema = createRandomMinimumDatasetRegistration(user);
     when(dacDAO.findById(any())).thenReturn(new Dac());
-    when(elasticSearchService.indexDatasets(any())).thenThrow(
+    when(elasticSearchService.indexDatasets(any(), any())).thenThrow(
         new ServerErrorException("Timeout connecting to [elasticsearch]", 500));
     initService();
     assertDoesNotThrow(() -> {

--- a/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
@@ -469,7 +469,7 @@ class DatasetServiceTest extends AbstractTestHelper {
     prop.setStudyId(study.getStudyId());
     prop.setType(PropertyType.Json);
     prop.setKey(dataCustodianEmail);
-    study.addProperties(Set.of(prop));
+    study.addProperties(prop);
     when(studyDAO.findStudyById(any())).thenReturn(study);
 
     datasetService.updateStudyCustodians(user, study.getStudyId(), "[new-user@test.com]");

--- a/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
@@ -23,7 +23,9 @@ import static org.mockito.Mockito.when;
 import com.google.gson.reflect.TypeToken;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.core.Response;
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.sql.SQLException;
 import java.time.Instant;
 import java.util.Collections;
@@ -56,6 +58,7 @@ import org.broadinstitute.consent.http.util.gson.GsonUtil;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -70,6 +73,8 @@ class DatasetServiceTest extends AbstractTestHelper {
   @Mock
   private DacDAO dacDAO;
   @Mock
+  private ElasticSearchService elasticSearchService;
+  @Mock
   private EmailService emailService;
   @Mock
   private OntologyService ontologyService;
@@ -79,10 +84,12 @@ class DatasetServiceTest extends AbstractTestHelper {
   private DatasetServiceDAO datasetServiceDAO;
   @Mock
   private UserDAO userDAO;
+  @Mock
+  private Response response;
 
   private void initService() {
-    datasetService = new DatasetService(datasetDAO, daaDAO, dacDAO, emailService,
-      ontologyService, studyDAO, datasetServiceDAO, userDAO);
+    datasetService = new DatasetService(datasetDAO, daaDAO, dacDAO, elasticSearchService,
+        emailService, ontologyService, studyDAO, datasetServiceDAO, userDAO);
   }
 
   @Test
@@ -192,9 +199,10 @@ class DatasetServiceTest extends AbstractTestHelper {
   }
 
   @Test
-  void testUpdateDatasetDataUseAdmin() {
+  void testUpdateDatasetDataUseAdmin() throws Exception {
     doNothing().when(datasetDAO).updateDatasetDataUse(any(), any());
     when(datasetDAO.findDatasetById(any())).thenReturn(new Dataset());
+    when(elasticSearchService.indexDataset(any(), any())).thenReturn(response);
     initService();
     User u = new User();
     u.setAdminRole();
@@ -323,6 +331,7 @@ class DatasetServiceTest extends AbstractTestHelper {
     dac.setName("DAC NAME");
     initService();
     when(dacDAO.findById(3)).thenReturn(dac);
+    when(elasticSearchService.indexDataset(any(), any())).thenReturn(response);
 
     Dataset returnedDataset = datasetService.approveDataset(dataset, user, payloadBool);
     assertEquals(dataset.getDatasetId(), returnedDataset.getDatasetId());
@@ -357,6 +366,7 @@ class DatasetServiceTest extends AbstractTestHelper {
     dac.setEmail("dacEmail@gmail.com");
     initService();
     when(dacDAO.findById(3)).thenReturn(dac);
+    when(elasticSearchService.indexDataset(any(), any())).thenReturn(response);
 
     Dataset returnedDataset = datasetService.approveDataset(dataset, user, payloadBool);
     assertEquals(dataset.getDatasetId(), returnedDataset.getDatasetId());
@@ -391,6 +401,7 @@ class DatasetServiceTest extends AbstractTestHelper {
     dac.setName("DAC NAME");
     initService();
     when(dacDAO.findById(3)).thenReturn(dac);
+    when(elasticSearchService.indexDataset(any(), any())).thenReturn(response);
 
     Dataset returnedDataset = datasetService.approveDataset(dataset, user, payloadBool);
     assertEquals(dataset.getDatasetId(), returnedDataset.getDatasetId());
@@ -407,7 +418,7 @@ class DatasetServiceTest extends AbstractTestHelper {
   }
 
   @Test
-  void testSyncDataUseTranslation() {
+  void testSyncDataUseTranslation() throws Exception {
     Dataset ds = new Dataset();
     ds.setDataUse(new DataUseBuilder().setGeneralUse(true).build());
 
@@ -422,6 +433,7 @@ class DatasetServiceTest extends AbstractTestHelper {
         """;
     when(ontologyService.translateDataUse(ds.getDataUse(),
         DataUseTranslationType.DATASET)).thenReturn(translation);
+    when(elasticSearchService.indexDataset(any(), any())).thenReturn(response);
 
     initService();
     datasetService.syncDatasetDataUseTranslation(1, new User());
@@ -515,16 +527,6 @@ class DatasetServiceTest extends AbstractTestHelper {
     assertDoesNotThrow(() -> datasetService.enforceDAARestrictions(user, List.of(1, 2, 3)));
     assertThrows(BadRequestException.class, () -> datasetService.enforceDAARestrictions(user, List.of(1, 2, 3, 4)));
     assertThrows(BadRequestException.class, () -> datasetService.enforceDAARestrictions(user, List.of(2, 3, 4, 5)));
-  }
-
-  @Test
-  void testUpdateIfIndexed() throws SQLException {
-    Dataset dataset = new Dataset();
-    dataset.setIndexedDate(new Date());
-    doNothing().when(datasetServiceDAO).updateDatasetIndex(any(), any(), any());
-    initService();
-    assertDoesNotThrow(() -> datasetService.updateIfIndexed(dataset, 1, Instant.now()));
-    assertDoesNotThrow(() -> datasetService.updateIfIndexed(dataset, 1, null));
   }
 
   /* Helper functions */

--- a/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
@@ -424,7 +424,7 @@ class DatasetServiceTest {
         DataUseTranslationType.DATASET)).thenReturn(translation);
 
     initService();
-    datasetService.syncDatasetDataUseTranslation(1);
+    datasetService.syncDatasetDataUseTranslation(1, new User());
 
     verify(datasetDAO, times(1)).updateDatasetTranslatedDataUse(1, translation);
   }
@@ -433,7 +433,7 @@ class DatasetServiceTest {
   void testSyncDataUseTranslationNotFound() {
     when(datasetDAO.findDatasetById(1)).thenReturn(null);
     initService();
-    assertThrows(NotFoundException.class, () -> datasetService.syncDatasetDataUseTranslation(1));
+    assertThrows(NotFoundException.class, () -> datasetService.syncDatasetDataUseTranslation(1, new User()));
 
   }
 
@@ -516,6 +516,14 @@ class DatasetServiceTest {
     assertDoesNotThrow(() -> datasetService.enforceDAARestrictions(user, List.of(1, 2, 3)));
     assertThrows(BadRequestException.class, () -> datasetService.enforceDAARestrictions(user, List.of(1, 2, 3, 4)));
     assertThrows(BadRequestException.class, () -> datasetService.enforceDAARestrictions(user, List.of(2, 3, 4, 5)));
+  }
+
+  @Test
+  void testUpdateDatasetIndex() throws SQLException {
+    doNothing().when(datasetServiceDAO).updateDatasetIndex(any(), any(), any());
+    initService();
+    assertDoesNotThrow(() -> datasetService.updateDatasetIndex(1, 1, Instant.now()));
+    assertDoesNotThrow(() -> datasetService.updateDatasetIndex(1, 1, null));
   }
 
   /* Helper functions */

--- a/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
@@ -518,15 +518,6 @@ class DatasetServiceTest {
     assertThrows(BadRequestException.class, () -> datasetService.enforceDAARestrictions(user, List.of(2, 3, 4, 5)));
   }
 
-  @Test
-  void testUpdateDatasetIndex() throws SQLException {
-    doNothing().when(datasetServiceDAO).updateDatasetIndex(any(), any(), any());
-    when(datasetDAO.findDatasetById(any())).thenReturn(new Dataset());
-    initService();
-    assertDoesNotThrow(() -> datasetService.updateDatasetIndex(1, 1, Instant.now()));
-    assertDoesNotThrow(() -> datasetService.updateDatasetIndex(1, 1, null));
-  }
-
   /* Helper functions */
 
   private List<Dataset> getDatasets() {

--- a/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
@@ -52,6 +52,7 @@ import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.UserRole;
 import org.broadinstitute.consent.http.service.dao.DatasetServiceDAO;
 import org.broadinstitute.consent.http.util.gson.GsonUtil;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -85,7 +86,8 @@ class DatasetServiceTest extends AbstractTestHelper {
   @Mock
   private Response response;
 
-  private void initService() {
+  @BeforeEach
+  public void initService() {
     datasetService = new DatasetService(datasetDAO, daaDAO, dacDAO, elasticSearchService,
         emailService, ontologyService, studyDAO, datasetServiceDAO, userDAO);
   }
@@ -93,42 +95,36 @@ class DatasetServiceTest extends AbstractTestHelper {
   @Test
   void testFindDatasetsByDacIds() {
     when(datasetDAO.findDatasetsByDacIds(anyList())).thenReturn(Collections.emptySet());
-    initService();
 
     assertDoesNotThrow(() -> datasetService.findDatasetsByDacIds(List.of(1, 2, 3)));
   }
 
   @Test
   void testFindDatasetsByDacIdsEmptyList() {
-    initService();
     assertThrows(BadRequestException.class,
         () -> datasetService.findDatasetsByDacIds(Collections.emptyList()));
   }
 
   @Test
   void testFindDatasetsByDacIdsNullList() {
-    initService();
     assertThrows(BadRequestException.class, () -> datasetService.findDatasetsByDacIds(null));
   }
 
   @Test
   void testFindDatasetListByDacIds() {
     when(datasetDAO.findDatasetListByDacIds(anyList())).thenReturn(List.of());
-    initService();
 
     assertDoesNotThrow(() -> datasetService.findDatasetListByDacIds(List.of(1, 2, 3)));
   }
 
   @Test
   void testFindDatasetListByDacIdsEmptyList() {
-    initService();
     assertThrows(BadRequestException.class,
         () -> datasetService.findDatasetListByDacIds(Collections.emptyList()));
   }
 
   @Test
   void testFindDatasetListByDacIdsNullList() {
-    initService();
     assertThrows(BadRequestException.class, () -> datasetService.findDatasetListByDacIds(null));
   }
 
@@ -136,7 +132,6 @@ class DatasetServiceTest extends AbstractTestHelper {
   void testGetDatasetByName() {
     when(datasetDAO.getDatasetByName(getDatasets().get(0).getName().toLowerCase()))
         .thenReturn(getDatasets().get(0));
-    initService();
 
     Dataset dataset = datasetService.getDatasetByName("Test Dataset 1");
 
@@ -148,7 +143,6 @@ class DatasetServiceTest extends AbstractTestHelper {
   void testFindStudyNames() {
     when(datasetDAO.findAllStudyNames())
         .thenReturn(Set.of("Hi", "Hello"));
-    initService();
 
     Set<String> returned = datasetService.findAllStudyNames();
 
@@ -160,7 +154,6 @@ class DatasetServiceTest extends AbstractTestHelper {
   void testFindDatasetById() {
     when(datasetDAO.findDatasetById(getDatasets().get(0).getDatasetId()))
         .thenReturn(getDatasets().get(0));
-    initService();
 
     Dataset dataset = datasetService.findDatasetById(1);
 
@@ -175,7 +168,6 @@ class DatasetServiceTest extends AbstractTestHelper {
     d.setDatasetIdentifier();
     when(datasetDAO.findDatasetByAlias(3)).thenReturn(d);
 
-    initService();
     assertEquals(d, datasetService.findDatasetByIdentifier("DUOS-000003"));
   }
 
@@ -186,7 +178,6 @@ class DatasetServiceTest extends AbstractTestHelper {
     d.setDatasetIdentifier();
     when(datasetDAO.findDatasetByAlias(3)).thenReturn(d);
 
-    initService();
     assertNull(datasetService.findDatasetByIdentifier("DUOS-0003"));
   }
 
@@ -194,7 +185,6 @@ class DatasetServiceTest extends AbstractTestHelper {
   void testFindDatasetByIdentifier_NoDataset() {
     when(datasetDAO.findDatasetByAlias(3)).thenReturn(null);
 
-    initService();
     assertNull(datasetService.findDatasetByIdentifier("DUOS-00003"));
   }
 
@@ -202,7 +192,6 @@ class DatasetServiceTest extends AbstractTestHelper {
   void testUpdateDatasetDataUseAdmin() {
     doNothing().when(datasetDAO).updateDatasetDataUse(any(), any());
     when(datasetDAO.findDatasetById(any())).thenReturn(new Dataset());
-    initService();
     User u = new User();
     u.setAdminRole();
     DataUse dataUse = new DataUseBuilder().setGeneralUse(true).build();
@@ -216,7 +205,6 @@ class DatasetServiceTest extends AbstractTestHelper {
   @Test
   void testUpdateDatasetDataUseNonAdmin() {
     when(datasetDAO.findDatasetById(any())).thenReturn(new Dataset());
-    initService();
     User u = new User();
     Stream.of(
         UserRoles.CHAIRPERSON,
@@ -245,7 +233,6 @@ class DatasetServiceTest extends AbstractTestHelper {
     datasets.forEach(
         d -> when(datasetDAO.findDatasetsByIdList(List.of(d.getDatasetId()))).thenReturn(
             List.of(d)));
-    initService();
     // The following forces the number of calls to datasetDAO.findDatasetsByIdList to be the same as
     // the number of datasets generated in the test.
     datasetService.setDatasetBatchSize(1);
@@ -279,7 +266,6 @@ class DatasetServiceTest extends AbstractTestHelper {
     dataset.setDacId(3);
     Dac dac = new Dac();
     dac.setName("DAC NAME");
-    initService();
 
     Dataset datasetResult = datasetService.approveDataset(dataset, user, true);
     assertNotNull(datasetResult);
@@ -299,7 +285,6 @@ class DatasetServiceTest extends AbstractTestHelper {
     Dataset dataset = new Dataset();
     User user = new User();
     dataset.setDacApproval(true);
-    initService();
 
     assertThrows(IllegalArgumentException.class,
         () -> datasetService.approveDataset(dataset, user, false));
@@ -310,7 +295,6 @@ class DatasetServiceTest extends AbstractTestHelper {
     Dataset dataset = new Dataset();
     User user = new User();
     dataset.setDacApproval(true);
-    initService();
 
     assertThrows(IllegalArgumentException.class,
         () -> datasetService.approveDataset(dataset, user, null));
@@ -334,7 +318,6 @@ class DatasetServiceTest extends AbstractTestHelper {
     dataset.setDacId(3);
     Dac dac = new Dac();
     dac.setName("DAC NAME");
-    initService();
     when(dacDAO.findById(3)).thenReturn(dac);
     when(elasticSearchService.indexDataset(any(), any())).thenReturn(response);
 
@@ -369,7 +352,6 @@ class DatasetServiceTest extends AbstractTestHelper {
     Dac dac = new Dac();
     dac.setName("DAC NAME");
     dac.setEmail("dacEmail@gmail.com");
-    initService();
     when(dacDAO.findById(3)).thenReturn(dac);
     when(elasticSearchService.indexDataset(any(), any())).thenReturn(response);
 
@@ -404,7 +386,6 @@ class DatasetServiceTest extends AbstractTestHelper {
     dataset.setDacId(3);
     Dac dac = new Dac();
     dac.setName("DAC NAME");
-    initService();
     when(dacDAO.findById(3)).thenReturn(dac);
     when(elasticSearchService.indexDataset(any(), any())).thenReturn(response);
 
@@ -439,7 +420,6 @@ class DatasetServiceTest extends AbstractTestHelper {
     when(ontologyService.translateDataUse(ds.getDataUse(),
         DataUseTranslationType.DATASET)).thenReturn(translation);
 
-    initService();
     datasetService.syncDatasetDataUseTranslation(1, user);
 
     verify(datasetDAO, times(1)).updateDatasetTranslatedDataUse(1, translation);
@@ -448,7 +428,6 @@ class DatasetServiceTest extends AbstractTestHelper {
   @Test
   void testSyncDataUseTranslationNotFound() {
     when(datasetDAO.findDatasetById(1)).thenReturn(null);
-    initService();
     assertThrows(NotFoundException.class,
         () -> datasetService.syncDatasetDataUseTranslation(1, user));
   }
@@ -456,21 +435,18 @@ class DatasetServiceTest extends AbstractTestHelper {
   @Test
   void testGetStudyWithDatasetsById() {
     when(studyDAO.findStudyById(anyInt())).thenReturn(new Study());
-    initService();
     assertDoesNotThrow(() -> datasetService.getStudyWithDatasetsById(1));
   }
 
   @Test
   void testGetStudyWithDatasetsByIdNFE() {
     when(studyDAO.findStudyById(anyInt())).thenReturn(null);
-    initService();
     assertThrows(NotFoundException.class, () -> datasetService.getStudyWithDatasetsById(1));
   }
 
   @Test
   void testGetStudyWithDatasetsByIdGeneralException() {
     when(studyDAO.findStudyById(anyInt())).thenThrow(new RuntimeException("General Exception"));
-    initService();
     assertThrows(Exception.class, () -> datasetService.getStudyWithDatasetsById(1));
   }
 
@@ -481,7 +457,6 @@ class DatasetServiceTest extends AbstractTestHelper {
     ApprovedDataset example = new ApprovedDataset(1, "sampleDarId", "sampleName", "sampleDac",
         new Date());
     when(datasetDAO.getApprovedDatasets(anyInt())).thenReturn(List.of(example));
-    initService();
     assertEquals(1, datasetService.getApprovedDatasets(user).size());
     assertTrue(datasetService.getApprovedDatasets(user).get(0).isApprovedDatasetEqual(example));
   }
@@ -500,7 +475,6 @@ class DatasetServiceTest extends AbstractTestHelper {
     study.setProperties(Set.of(prop));
     when(studyDAO.findStudyById(any())).thenReturn(study);
 
-    initService();
     datasetService.updateStudyCustodians(user, study.getStudyId(), "[new-user@test.com]");
     verify(studyDAO, times(1)).updateStudyProperty(any(), any(), any(), any());
     verify(studyDAO, never()).insertStudyProperty(any(), any(), any(), any());
@@ -514,7 +488,6 @@ class DatasetServiceTest extends AbstractTestHelper {
     study.setStudyId(randomInt(100, 10000));
     when(studyDAO.findStudyById(any())).thenReturn(study);
 
-    initService();
     datasetService.updateStudyCustodians(user, study.getStudyId(), "[new-user@test.com]");
     verify(studyDAO, never()).updateStudyProperty(any(), any(), any(), any());
     verify(studyDAO, times(1)).insertStudyProperty(any(), any(), any(), any());
@@ -526,7 +499,6 @@ class DatasetServiceTest extends AbstractTestHelper {
         List.of(UserRoles.Researcher()));
     when(daaDAO.findDaaDatasetIdsByUserId(any())).thenReturn(List.of(1, 2, 3));
 
-    initService();
     assertDoesNotThrow(() -> datasetService.enforceDAARestrictions(user, List.of(1)));
     assertDoesNotThrow(() -> datasetService.enforceDAARestrictions(user, List.of(1, 2)));
     assertDoesNotThrow(() -> datasetService.enforceDAARestrictions(user, List.of(1, 2, 3)));

--- a/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
@@ -319,7 +319,6 @@ class DatasetServiceTest extends AbstractTestHelper {
     Dac dac = new Dac();
     dac.setName("DAC NAME");
     when(dacDAO.findById(3)).thenReturn(dac);
-    when(elasticSearchService.indexDataset(any(), any())).thenReturn(response);
 
     Dataset returnedDataset = datasetService.approveDataset(dataset, user, payloadBool);
     assertEquals(dataset.getDatasetId(), returnedDataset.getDatasetId());
@@ -353,7 +352,6 @@ class DatasetServiceTest extends AbstractTestHelper {
     dac.setName("DAC NAME");
     dac.setEmail("dacEmail@gmail.com");
     when(dacDAO.findById(3)).thenReturn(dac);
-    when(elasticSearchService.indexDataset(any(), any())).thenReturn(response);
 
     Dataset returnedDataset = datasetService.approveDataset(dataset, user, payloadBool);
     assertEquals(dataset.getDatasetId(), returnedDataset.getDatasetId());
@@ -387,7 +385,6 @@ class DatasetServiceTest extends AbstractTestHelper {
     Dac dac = new Dac();
     dac.setName("DAC NAME");
     when(dacDAO.findById(3)).thenReturn(dac);
-    when(elasticSearchService.indexDataset(any(), any())).thenReturn(response);
 
     Dataset returnedDataset = datasetService.approveDataset(dataset, user, payloadBool);
     assertEquals(dataset.getDatasetId(), returnedDataset.getDatasetId());

--- a/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
@@ -95,7 +95,7 @@ class DatasetServiceTest extends AbstractTestHelper {
     when(datasetDAO.findDatasetsByDacIds(anyList())).thenReturn(Collections.emptySet());
     initService();
 
-    datasetService.findDatasetsByDacIds(List.of(1, 2, 3));
+    assertDoesNotThrow(() -> datasetService.findDatasetsByDacIds(List.of(1, 2, 3)));
   }
 
   @Test
@@ -116,7 +116,7 @@ class DatasetServiceTest extends AbstractTestHelper {
     when(datasetDAO.findDatasetListByDacIds(anyList())).thenReturn(List.of());
     initService();
 
-    datasetService.findDatasetListByDacIds(List.of(1, 2, 3));
+    assertDoesNotThrow(() -> datasetService.findDatasetListByDacIds(List.of(1, 2, 3)));
   }
 
   @Test
@@ -199,10 +199,9 @@ class DatasetServiceTest extends AbstractTestHelper {
   }
 
   @Test
-  void testUpdateDatasetDataUseAdmin() throws Exception {
+  void testUpdateDatasetDataUseAdmin() {
     doNothing().when(datasetDAO).updateDatasetDataUse(any(), any());
     when(datasetDAO.findDatasetById(any())).thenReturn(new Dataset());
-    when(elasticSearchService.indexDataset(any(), any())).thenReturn(response);
     initService();
     User u = new User();
     u.setAdminRole();
@@ -424,7 +423,7 @@ class DatasetServiceTest extends AbstractTestHelper {
   }
 
   @Test
-  void testSyncDataUseTranslation() throws Exception {
+  void testSyncDataUseTranslation() {
     Dataset ds = new Dataset();
     ds.setDataUse(new DataUseBuilder().setGeneralUse(true).build());
 
@@ -439,7 +438,6 @@ class DatasetServiceTest extends AbstractTestHelper {
         """;
     when(ontologyService.translateDataUse(ds.getDataUse(),
         DataUseTranslationType.DATASET)).thenReturn(translation);
-    when(elasticSearchService.indexDataset(any(), any())).thenReturn(response);
 
     initService();
     datasetService.syncDatasetDataUseTranslation(1, user);

--- a/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
@@ -25,9 +25,6 @@ import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.core.Response;
 import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.sql.SQLException;
-import java.time.Instant;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -58,7 +55,6 @@ import org.broadinstitute.consent.http.util.gson.GsonUtil;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -85,6 +81,8 @@ class DatasetServiceTest extends AbstractTestHelper {
   @Mock
   private UserDAO userDAO;
   @Mock
+  private User user;
+  @Mock
   private Response response;
 
   private void initService() {
@@ -103,7 +101,8 @@ class DatasetServiceTest extends AbstractTestHelper {
   @Test
   void testFindDatasetsByDacIdsEmptyList() {
     initService();
-    assertThrows(BadRequestException.class, () -> datasetService.findDatasetsByDacIds(Collections.emptyList()));
+    assertThrows(BadRequestException.class,
+        () -> datasetService.findDatasetsByDacIds(Collections.emptyList()));
   }
 
   @Test
@@ -123,7 +122,8 @@ class DatasetServiceTest extends AbstractTestHelper {
   @Test
   void testFindDatasetListByDacIdsEmptyList() {
     initService();
-    assertThrows(BadRequestException.class, () -> datasetService.findDatasetListByDacIds(Collections.emptyList()));
+    assertThrows(BadRequestException.class,
+        () -> datasetService.findDatasetListByDacIds(Collections.emptyList()));
   }
 
   @Test
@@ -241,8 +241,11 @@ class DatasetServiceTest extends AbstractTestHelper {
   @Test
   void testFindAllDatasetsAsStreamingOutput() throws Exception {
     var datasets = getDatasets(randomInt(10, 20));
-    when(datasetDAO.findAllDatasetIds()).thenReturn(datasets.stream().map(Dataset::getDatasetId).toList());
-    datasets.forEach(d -> when(datasetDAO.findDatasetsByIdList(List.of(d.getDatasetId()))).thenReturn(List.of(d)));
+    when(datasetDAO.findAllDatasetIds()).thenReturn(
+        datasets.stream().map(Dataset::getDatasetId).toList());
+    datasets.forEach(
+        d -> when(datasetDAO.findDatasetsByIdList(List.of(d.getDatasetId()))).thenReturn(
+            List.of(d)));
     initService();
     // The following forces the number of calls to datasetDAO.findDatasetsByIdList to be the same as
     // the number of datasets generated in the test.
@@ -252,7 +255,8 @@ class DatasetServiceTest extends AbstractTestHelper {
     var baos = new ByteArrayOutputStream();
     output.write(baos);
     var datasetsJson = baos.toString();
-    var listOfDatasetsType = new TypeToken<List<Dataset>>() {}.getType();
+    var listOfDatasetsType = new TypeToken<List<Dataset>>() {
+    }.getType();
     var gson = GsonUtil.buildGson();
     List<Dataset> returnedDatasets = gson.fromJson(datasetsJson, listOfDatasetsType);
     assertFalse(returnedDatasets.isEmpty());
@@ -298,7 +302,8 @@ class DatasetServiceTest extends AbstractTestHelper {
     dataset.setDacApproval(true);
     initService();
 
-    assertThrows(IllegalArgumentException.class, () -> datasetService.approveDataset(dataset, user, false));
+    assertThrows(IllegalArgumentException.class,
+        () -> datasetService.approveDataset(dataset, user, false));
   }
 
   @Test
@@ -308,7 +313,8 @@ class DatasetServiceTest extends AbstractTestHelper {
     dataset.setDacApproval(true);
     initService();
 
-    assertThrows(IllegalArgumentException.class, () -> datasetService.approveDataset(dataset, user, null));
+    assertThrows(IllegalArgumentException.class,
+        () -> datasetService.approveDataset(dataset, user, null));
   }
 
   @Test
@@ -445,7 +451,8 @@ class DatasetServiceTest extends AbstractTestHelper {
   void testSyncDataUseTranslationNotFound() {
     when(datasetDAO.findDatasetById(1)).thenReturn(null);
     initService();
-    assertThrows(NotFoundException.class, () -> datasetService.syncDatasetDataUseTranslation(1, new User()));
+    assertThrows(NotFoundException.class,
+        () -> datasetService.syncDatasetDataUseTranslation(1, user));
   }
 
   @Test
@@ -525,8 +532,10 @@ class DatasetServiceTest extends AbstractTestHelper {
     assertDoesNotThrow(() -> datasetService.enforceDAARestrictions(user, List.of(1)));
     assertDoesNotThrow(() -> datasetService.enforceDAARestrictions(user, List.of(1, 2)));
     assertDoesNotThrow(() -> datasetService.enforceDAARestrictions(user, List.of(1, 2, 3)));
-    assertThrows(BadRequestException.class, () -> datasetService.enforceDAARestrictions(user, List.of(1, 2, 3, 4)));
-    assertThrows(BadRequestException.class, () -> datasetService.enforceDAARestrictions(user, List.of(2, 3, 4, 5)));
+    assertThrows(BadRequestException.class,
+        () -> datasetService.enforceDAARestrictions(user, List.of(1, 2, 3, 4)));
+    assertThrows(BadRequestException.class,
+        () -> datasetService.enforceDAARestrictions(user, List.of(2, 3, 4, 5)));
   }
 
   /* Helper functions */
@@ -544,11 +553,14 @@ class DatasetServiceTest extends AbstractTestHelper {
 
   /**
    * Minimum count is 1
+   *
    * @param count The number of required datasets
    * @return List of datasets with minimum default mocked fields.
    */
   private List<Dataset> getDatasets(Integer count) {
-    if (count < 1) { count = 1; }
+    if (count < 1) {
+      count = 1;
+    }
     return IntStream.range(1, count + 1)
         .mapToObj(i -> {
           Dataset dataset = new Dataset();

--- a/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
@@ -442,7 +442,7 @@ class DatasetServiceTest extends AbstractTestHelper {
     when(elasticSearchService.indexDataset(any(), any())).thenReturn(response);
 
     initService();
-    datasetService.syncDatasetDataUseTranslation(1, new User());
+    datasetService.syncDatasetDataUseTranslation(1, user);
 
     verify(datasetDAO, times(1)).updateDatasetTranslatedDataUse(1, translation);
   }

--- a/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
@@ -33,7 +33,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
-import org.apache.commons.lang3.RandomUtils;
+import org.broadinstitute.consent.http.AbstractTestHelper;
 import org.broadinstitute.consent.http.db.DaaDAO;
 import org.broadinstitute.consent.http.db.DacDAO;
 import org.broadinstitute.consent.http.db.DatasetDAO;
@@ -59,7 +59,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-class DatasetServiceTest {
+class DatasetServiceTest extends AbstractTestHelper {
 
   private DatasetService datasetService;
 
@@ -232,7 +232,7 @@ class DatasetServiceTest {
 
   @Test
   void testFindAllDatasetsAsStreamingOutput() throws Exception {
-    var datasets = getDatasets(RandomUtils.nextInt(10, 20));
+    var datasets = getDatasets(randomInt(10, 20));
     when(datasetDAO.findAllDatasetIds()).thenReturn(datasets.stream().map(Dataset::getDatasetId).toList());
     datasets.forEach(d -> when(datasetDAO.findDatasetsByIdList(List.of(d.getDatasetId()))).thenReturn(List.of(d)));
     initService();
@@ -434,7 +434,6 @@ class DatasetServiceTest {
     when(datasetDAO.findDatasetById(1)).thenReturn(null);
     initService();
     assertThrows(NotFoundException.class, () -> datasetService.syncDatasetDataUseTranslation(1, new User()));
-
   }
 
   @Test
@@ -475,7 +474,7 @@ class DatasetServiceTest {
     User user = new User();
     user.setEmail("test@gmail.com");
     Study study = new Study();
-    study.setStudyId(RandomUtils.nextInt(100, 10000));
+    study.setStudyId(randomInt(100, 10000));
     StudyProperty prop = new StudyProperty();
     prop.setValue("[test@gmail.com]");
     prop.setStudyId(study.getStudyId());
@@ -495,7 +494,7 @@ class DatasetServiceTest {
     User user = new User();
     user.setEmail("test@gmail.com");
     Study study = new Study();
-    study.setStudyId(RandomUtils.nextInt(100, 10000));
+    study.setStudyId(randomInt(100, 10000));
     when(studyDAO.findStudyById(any())).thenReturn(study);
 
     initService();
@@ -519,11 +518,13 @@ class DatasetServiceTest {
   }
 
   @Test
-  void testUpdateDatasetIndex() throws SQLException {
+  void testUpdateIfIndexed() throws SQLException {
+    Dataset dataset = new Dataset();
+    dataset.setIndexedDate(new Date());
     doNothing().when(datasetServiceDAO).updateDatasetIndex(any(), any(), any());
     initService();
-    assertDoesNotThrow(() -> datasetService.updateDatasetIndex(1, 1, Instant.now()));
-    assertDoesNotThrow(() -> datasetService.updateDatasetIndex(1, 1, null));
+    assertDoesNotThrow(() -> datasetService.updateIfIndexed(dataset, 1, Instant.now()));
+    assertDoesNotThrow(() -> datasetService.updateIfIndexed(dataset, 1, null));
   }
 
   /* Helper functions */

--- a/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
@@ -469,7 +469,7 @@ class DatasetServiceTest extends AbstractTestHelper {
     prop.setStudyId(study.getStudyId());
     prop.setType(PropertyType.Json);
     prop.setKey(dataCustodianEmail);
-    study.setProperties(Set.of(prop));
+    study.addProperties(Set.of(prop));
     when(studyDAO.findStudyById(any())).thenReturn(study);
 
     datasetService.updateStudyCustodians(user, study.getStudyId(), "[new-user@test.com]");

--- a/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
@@ -459,7 +459,6 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
     term2.setDatasetId(2);
     User user = new User();
     user.setUserId(1);
-
     String datasetIndexName = randomAlphabetic(10);
 
     when(esConfig.getDatasetIndexName()).thenReturn(datasetIndexName);
@@ -468,9 +467,7 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
     initService();
     try (var response = service.indexDatasetTerms(List.of(term1, term2), user)) {
       verify(esClient).performRequest(request.capture());
-
       Request capturedRequest = request.getValue();
-
       assertEquals("PUT", capturedRequest.getMethod());
       assertEquals("""
               { "index": {"_type": "dataset", "_id": "1"} }

--- a/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -21,18 +22,19 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.lang.reflect.Type;
 import java.nio.charset.StandardCharsets;
+import java.sql.SQLException;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import org.apache.commons.lang3.RandomStringUtils;
-import org.apache.commons.lang3.RandomUtils;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpVersion;
 import org.apache.http.StatusLine;
 import org.apache.http.entity.ContentType;
 import org.apache.http.message.BasicStatusLine;
 import org.apache.http.nio.entity.NStringEntity;
+import org.broadinstitute.consent.http.AbstractTestHelper;
 import org.broadinstitute.consent.http.configurations.ElasticSearchConfiguration;
 import org.broadinstitute.consent.http.db.DacDAO;
 import org.broadinstitute.consent.http.db.DataAccessRequestDAO;
@@ -53,6 +55,7 @@ import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.elastic_search.DatasetTerm;
 import org.broadinstitute.consent.http.models.ontology.DataUseSummary;
 import org.broadinstitute.consent.http.models.ontology.DataUseTerm;
+import org.broadinstitute.consent.http.service.dao.DatasetServiceDAO;
 import org.broadinstitute.consent.http.util.gson.GsonUtil;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
@@ -65,7 +68,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-class ElasticSearchServiceTest {
+class ElasticSearchServiceTest extends AbstractTestHelper {
 
   private ElasticSearchService service;
 
@@ -92,6 +95,10 @@ class ElasticSearchServiceTest {
 
   @Mock
   private DatasetDAO datasetDAO;
+
+  @Mock
+  private DatasetServiceDAO datasetServiceDAO;
+
   @Mock
   private StudyDAO studyDAO;
 
@@ -105,6 +112,7 @@ class ElasticSearchServiceTest {
         ontologyService,
         institutionDAO,
         datasetDAO,
+        datasetServiceDAO,
         studyDAO);
   }
 
@@ -121,15 +129,15 @@ class ElasticSearchServiceTest {
 
   private Institution createInstitution() {
     Institution institution = new Institution();
-    institution.setId(RandomUtils.nextInt(1, 1000));
+    institution.setId(randomInt(1, 1000));
     return institution;
   }
 
   private User createUser(int start, int max) {
     User user = new User();
-    user.setUserId(RandomUtils.nextInt(start, max));
-    user.setDisplayName(RandomStringUtils.randomAlphabetic(10));
-    user.setEmail(RandomStringUtils.randomAlphabetic(10));
+    user.setUserId(randomInt(start, max));
+    user.setDisplayName(randomAlphabetic(10));
+    user.setEmail(randomAlphabetic(10));
     Institution i = createInstitution();
     user.setInstitution(i);
     user.setInstitutionId(i.getId());
@@ -138,11 +146,11 @@ class ElasticSearchServiceTest {
 
   private Dataset createDataset(User user, User updateUser, DataUse dataUse, Dac dac) {
     Dataset dataset = new Dataset();
-    dataset.setDatasetId(RandomUtils.nextInt(1, 100));
+    dataset.setDatasetId(randomInt(1, 100));
     dataset.setAlias(dataset.getDatasetId());
     dataset.setDatasetIdentifier();
     dataset.setDeletable(true);
-    dataset.setName(RandomStringUtils.randomAlphabetic(10));
+    dataset.setName(randomAlphabetic(10));
     dataset.setDatasetName(dataset.getName());
     dataset.setDacId(dac.getDacId());
     dataset.setDacApproval(true);
@@ -155,18 +163,18 @@ class ElasticSearchServiceTest {
 
   private Dac createDac() {
     Dac dac = new Dac();
-    dac.setDacId(RandomUtils.nextInt(1, 100));
-    dac.setName(RandomStringUtils.randomAlphabetic(10));
+    dac.setDacId(randomInt(1, 100));
+    dac.setName(randomAlphabetic(10));
     return dac;
   }
 
   private Study createStudy(User user) {
     Study study = new Study();
-    study.setName(RandomStringUtils.randomAlphabetic(10));
-    study.setDescription(RandomStringUtils.randomAlphabetic(20));
-    study.setStudyId(RandomUtils.nextInt(1, 100));
-    study.setPiName(RandomStringUtils.randomAlphabetic(10));
-    study.setDataTypes(List.of(RandomStringUtils.randomAlphabetic(10)));
+    study.setName(randomAlphabetic(10));
+    study.setDescription(randomAlphabetic(20));
+    study.setStudyId(randomInt(1, 100));
+    study.setPiName(randomAlphabetic(10));
+    study.setDataTypes(List.of(randomAlphabetic(10)));
     study.setPublicVisibility(true);
     study.setCreateUserEmail(user.getEmail());
     study.setCreateUserId(user.getUserId());
@@ -182,11 +190,11 @@ class ElasticSearchServiceTest {
       case Boolean -> prop.setValue(true);
       case Json -> {
         var val = new JsonArray();
-        val.add(RandomStringUtils.randomAlphabetic(10));
+        val.add(randomAlphabetic(10));
         prop.setValue(val);
       }
-      case Number -> prop.setValue(RandomUtils.nextInt(1, 100));
-      default -> prop.setValue(RandomStringUtils.randomAlphabetic(10));
+      case Number -> prop.setValue(randomInt(1, 100));
+      default -> prop.setValue(randomAlphabetic(10));
     }
     return prop;
   }
@@ -199,8 +207,8 @@ class ElasticSearchServiceTest {
     prop.setPropertyName(propertyName);
     switch (type) {
       case Boolean -> prop.setPropertyValue(true);
-      case Number -> prop.setPropertyValue(RandomUtils.nextInt(1, 100));
-      default -> prop.setPropertyValue(RandomStringUtils.randomAlphabetic(10));
+      case Number -> prop.setPropertyValue(randomInt(1, 100));
+      default -> prop.setPropertyValue(randomAlphabetic(10));
     }
     return prop;
   }
@@ -432,9 +440,9 @@ class ElasticSearchServiceTest {
   void testToDatasetTermNullStudyProps() {
     Dataset dataset = new Dataset();
     Study study = new Study();
-    study.setName(RandomStringUtils.randomAlphabetic(10));
-    study.setDescription(RandomStringUtils.randomAlphabetic(20));
-    study.setStudyId(RandomUtils.nextInt(1, 100));
+    study.setName(randomAlphabetic(10));
+    study.setDescription(randomAlphabetic(20));
+    study.setStudyId(randomInt(1, 100));
     dataset.setStudy(study);
     initService();
     assertDoesNotThrow(() -> service.toDatasetTerm(dataset));
@@ -449,14 +457,16 @@ class ElasticSearchServiceTest {
     term1.setDatasetId(1);
     DatasetTerm term2 = new DatasetTerm();
     term2.setDatasetId(2);
+    User user = new User();
+    user.setUserId(1);
 
-    String datasetIndexName = RandomStringUtils.randomAlphabetic(10);
+    String datasetIndexName = randomAlphabetic(10);
 
     when(esConfig.getDatasetIndexName()).thenReturn(datasetIndexName);
     mockElasticSearchResponse(200, "");
 
     initService();
-    service.indexDatasetTerms(List.of(term1, term2));
+    service.indexDatasetTerms(List.of(term1, term2), user);
 
     verify(esClient).performRequest(request.capture());
 
@@ -538,9 +548,11 @@ class ElasticSearchServiceTest {
 
   @Test
   void testIndexDatasetIds() throws Exception {
+    User user = new User();
+    user.setUserId(1);
     Gson gson = GsonUtil.buildGson();
     Dataset dataset = new Dataset();
-    dataset.setDatasetId(RandomUtils.nextInt(10, 100));
+    dataset.setDatasetId(randomInt(10, 100));
     String esResponseBody = """
           {
             "took": 2,
@@ -570,7 +582,7 @@ class ElasticSearchServiceTest {
 
     when(datasetDAO.findDatasetById(dataset.getDatasetId())).thenReturn(dataset);
     mockESClientResponse(200, esResponseBody.formatted(dataset.getDatasetId()));
-    StreamingOutput output = service.indexDatasetIds(List.of(dataset.getDatasetId()));
+    StreamingOutput output = service.indexDatasetIds(List.of(dataset.getDatasetId()), user);
     var baos = new ByteArrayOutputStream();
     output.write(baos);
     var entityString = baos.toString();
@@ -591,14 +603,16 @@ class ElasticSearchServiceTest {
 
   @Test
   void testIndexDatasetIdsErrors() throws Exception {
+    User user = new User();
+    user.setUserId(1);
     Gson gson = GsonUtil.buildGson();
     Dataset dataset = new Dataset();
-    dataset.setDatasetId(RandomUtils.nextInt(10, 100));
+    dataset.setDatasetId(randomInt(10, 100));
     when(datasetDAO.findDatasetById(dataset.getDatasetId())).thenReturn(dataset);
     mockESClientResponse(500, "error condition");
     initService();
 
-    StreamingOutput output = service.indexDatasetIds(List.of(dataset.getDatasetId()));
+    StreamingOutput output = service.indexDatasetIds(List.of(dataset.getDatasetId()), user);
     var baos = new ByteArrayOutputStream();
     output.write(baos);
     JsonArray jsonArray = gson.fromJson(baos.toString(), JsonArray.class);
@@ -623,6 +637,8 @@ class ElasticSearchServiceTest {
 
   @Test
   void testIndexStudyWithDatasets() {
+    User user = new User();
+    user.setUserId(1);
     Study study = new Study();
     study.setStudyId(1);
     Dataset d = new Dataset();
@@ -632,16 +648,27 @@ class ElasticSearchServiceTest {
     when(datasetDAO.findDatasetsByIdList(any())).thenReturn(List.of(d));
 
     initService();
-    assertDoesNotThrow(() -> service.indexStudy(1));
+    assertDoesNotThrow(() -> service.indexStudy(1, user));
   }
 
   @Test
   void testIndexStudyWithNoDatasets() {
+    User user = new User();
+    user.setUserId(1);
     Study study = new Study();
     study.setStudyId(1);
     when(studyDAO.findStudyById(any())).thenReturn(study);
 
     initService();
-    assertDoesNotThrow(() -> service.indexStudy(1));
+    assertDoesNotThrow(() -> service.indexStudy(1, user));
   }
+
+  @Test
+  void testUpdateDatasetIndex() throws SQLException {
+    doNothing().when(datasetServiceDAO).updateDatasetIndex(any(), any(), any());
+    initService();
+    assertDoesNotThrow(() -> service.updateDatasetIndex(1, 1, Instant.now()));
+    assertDoesNotThrow(() -> service.updateDatasetIndex(1, 1, null));
+  }
+
 }

--- a/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
@@ -235,12 +235,12 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
     User updateUser = createUser(101, 200);
     Dac dac = createDac();
     Study study = createStudy(user);
-    study.addProperties(Set.of(
+    study.addProperties(
         createStudyProperty("dbGaPPhsID", PropertyType.String),
         createStudyProperty("phenotypeIndication", PropertyType.String),
         createStudyProperty("species", PropertyType.String),
         createStudyProperty("dataCustodianEmail", PropertyType.Json)
-    ));
+    );
     Dataset dataset = createDataset(user, updateUser, new DataUse(), dac);
     dataset.setProperties(Set.of(
         createDatasetProperty("accessManagement", PropertyType.Boolean, "accessManagement"),
@@ -389,11 +389,11 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
     User updateUser = createUser(101, 200);
     Dac dac = createDac();
     Study study = createStudy(user);
-    study.addProperties(Set.of(
+    study.addProperties(
         createStudyProperty("phenotypeIndication", PropertyType.String),
         createStudyProperty("species", PropertyType.String),
         createStudyProperty("dataCustodianEmail", PropertyType.Json)
-    ));
+    );
     Dataset dataset = createDataset(user, updateUser, new DataUse(), dac);
     dataset.setProperties(Set.of(
         createDatasetProperty("numberOfParticipants", PropertyType.String, "# of participants"),

--- a/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
@@ -7,11 +7,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.google.api.client.http.HttpStatusCodes;
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
@@ -22,7 +24,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.lang.reflect.Type;
 import java.nio.charset.StandardCharsets;
-import java.sql.SQLException;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
@@ -658,15 +659,34 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
     when(studyDAO.findStudyById(any())).thenReturn(study);
 
     initService();
-    assertDoesNotThrow(() -> service.indexStudy(1, user));
+    assertDoesNotThrow(() -> {
+      try (var response = service.indexStudy(1, user)) {
+        assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
+      }
+    });
   }
 
   @Test
-  void testUpdateDatasetIndex() throws SQLException {
-    doNothing().when(datasetServiceDAO).updateDatasetIndex(any(), any(), any());
+  void testUpdateDatasetIndexWithValue() {
     initService();
     assertDoesNotThrow(() -> service.updateDatasetIndex(1, 1, Instant.now()));
+  }
+
+  @Test
+  void testDeleteDatasetIndexWhenDatasetExists() throws Exception {
+    Dataset dataset = new Dataset();
+    when(datasetDAO.findDatasetById(any())).thenReturn(dataset);
+    initService();
     assertDoesNotThrow(() -> service.updateDatasetIndex(1, 1, null));
+    verify(datasetServiceDAO, times(1)).updateDatasetIndex(any(), any(), any());
+  }
+
+  @Test
+  void testDeleteDatasetIndexWhenDatasetIsNull() throws Exception {
+    when(datasetDAO.findDatasetById(any())).thenReturn(null);
+    initService();
+    assertDoesNotThrow(() -> service.updateDatasetIndex(1, 1, null));
+    verify(datasetServiceDAO, never()).updateDatasetIndex(any(), any(), any());
   }
 
 }

--- a/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
@@ -235,7 +235,7 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
     User updateUser = createUser(101, 200);
     Dac dac = createDac();
     Study study = createStudy(user);
-    study.setProperties(Set.of(
+    study.addProperties(Set.of(
         createStudyProperty("dbGaPPhsID", PropertyType.String),
         createStudyProperty("phenotypeIndication", PropertyType.String),
         createStudyProperty("species", PropertyType.String),
@@ -389,7 +389,7 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
     User updateUser = createUser(101, 200);
     Dac dac = createDac();
     Study study = createStudy(user);
-    study.setProperties(Set.of(
+    study.addProperties(Set.of(
         createStudyProperty("phenotypeIndication", PropertyType.String),
         createStudyProperty("species", PropertyType.String),
         createStudyProperty("dataCustodianEmail", PropertyType.Json)

--- a/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
@@ -649,22 +649,22 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
   }
 
   @Test
-  void testUpdateDatasetIndexWithValue() {
-    assertDoesNotThrow(() -> service.updateDatasetIndex(1, 1, Instant.now()));
+  void testUpdateDatasetIndexDateWithValue() {
+    assertDoesNotThrow(() -> service.updateDatasetIndexDate(1, 1, Instant.now()));
   }
 
   @Test
   void testDeleteDatasetIndexWhenDatasetExists() throws Exception {
     Dataset dataset = new Dataset();
     when(datasetDAO.findDatasetById(any())).thenReturn(dataset);
-    assertDoesNotThrow(() -> service.updateDatasetIndex(1, 1, null));
+    assertDoesNotThrow(() -> service.updateDatasetIndexDate(1, 1, null));
     verify(datasetServiceDAO).updateDatasetIndex(any(), any(), any());
   }
 
   @Test
   void testDeleteDatasetIndexWhenDatasetIsNull() throws Exception {
     when(datasetDAO.findDatasetById(any())).thenReturn(null);
-    assertDoesNotThrow(() -> service.updateDatasetIndex(1, 1, null));
+    assertDoesNotThrow(() -> service.updateDatasetIndexDate(1, 1, null));
     verify(datasetServiceDAO, never()).updateDatasetIndex(any(), any(), any());
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
@@ -9,7 +9,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -61,6 +60,7 @@ import org.broadinstitute.consent.http.util.gson.GsonUtil;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.RestClient;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -103,7 +103,8 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
   @Mock
   private StudyDAO studyDAO;
 
-  private void initService() {
+  @BeforeEach
+  void initService() {
     service = new ElasticSearchService(
         esClient,
         esConfig,
@@ -117,10 +118,10 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
         studyDAO);
   }
 
-  private void mockElasticSearchResponse(int statusCode, String body) throws IOException {
+  private void mockElasticSearchResponse(String body) throws IOException {
     Response response = mock(Response.class);
-    String reasonPhrase = fromStatusCode(statusCode).getReasonPhrase();
-    BasicStatusLine status = new BasicStatusLine(HttpVersion.HTTP_1_1, statusCode, reasonPhrase);
+    String reasonPhrase = fromStatusCode(200).getReasonPhrase();
+    BasicStatusLine status = new BasicStatusLine(HttpVersion.HTTP_1_1, 200, reasonPhrase);
     HttpEntity entity = new NStringEntity(body, ContentType.APPLICATION_JSON);
 
     when(esClient.performRequest(any())).thenReturn(response);
@@ -266,7 +267,6 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
         datasetRecord.updateUser.getInstitution());
     when(dacDAO.findById(any())).thenReturn(datasetRecord.dac);
 
-    initService();
     DatasetTerm term = service.toDatasetTerm(datasetRecord.dataset);
     assertEquals(datasetRecord.createUser.getUserId(), term.getCreateUserId());
     assertEquals(datasetRecord.createUser.getDisplayName(), term.getCreateUserDisplayName());
@@ -293,7 +293,6 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
         datasetRecord.updateUser);
     when(dacDAO.findById(any())).thenReturn(datasetRecord.dac);
 
-    initService();
     DatasetTerm term = service.toDatasetTerm(datasetRecord.dataset);
     assertEquals(datasetRecord.study.getDescription(), term.getStudy().getDescription());
     assertEquals(datasetRecord.study.getName(), term.getStudy().getStudyName());
@@ -339,7 +338,6 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
     when(dacDAO.findById(any())).thenReturn(datasetRecord.dac);
     when(ontologyService.translateDataUseSummary(any())).thenReturn(dataUseSummary);
     when(dataAccessRequestDAO.findApprovedDARsByDatasetId(any())).thenReturn(List.of(dar1, dar2));
-    initService();
     DatasetTerm term = service.toDatasetTerm(datasetRecord.dataset);
 
     assertEquals(datasetRecord.dataset.getDatasetId(), term.getDatasetId());
@@ -377,7 +375,6 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
     when(dacDAO.findById(any())).thenReturn(datasetRecord.dac);
     when(userDao.findUserById(datasetRecord.createUser.getUserId())).thenReturn(
         datasetRecord.createUser);
-    initService();
     DatasetTerm term = service.toDatasetTerm(datasetRecord.dataset);
 
     assertEquals(datasetRecord.dataset.getDacApproval(), term.getDacApproval());
@@ -403,12 +400,11 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
         createDatasetProperty("url", PropertyType.String, "url")
     ));
     dataset.setStudy(study);
-    DatasetRecord record = new DatasetRecord(user, updateUser, dac, dataset, study);
+    DatasetRecord datasetRecord = new DatasetRecord(user, updateUser, dac, dataset, study);
     when(dacDAO.findById(any())).thenReturn(dac);
     when(userDao.findUserById(user.getUserId())).thenReturn(user);
-    when(dacDAO.findById(any())).thenReturn(record.dac);
-    when(userDao.findUserById(record.createUser.getUserId())).thenReturn(record.createUser);
-    initService();
+    when(dacDAO.findById(any())).thenReturn(datasetRecord.dac);
+    when(userDao.findUserById(datasetRecord.createUser.getUserId())).thenReturn(datasetRecord.createUser);
     assertDoesNotThrow(() -> service.toDatasetTerm(dataset));
   }
 
@@ -423,7 +419,6 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
     when(dataAccessRequestDAO.findApprovedDARsByDatasetId(any())).thenReturn(
         List.of());
 
-    initService();
     DatasetTerm term = service.toDatasetTerm(dataset);
 
     assertEquals(dataset.getDatasetId(), term.getDatasetId());
@@ -433,7 +428,6 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
   @Test
   void testToDatasetTermNullDatasetProps() {
     Dataset dataset = new Dataset();
-    initService();
     assertDoesNotThrow(() -> service.toDatasetTerm(dataset));
   }
 
@@ -445,7 +439,6 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
     study.setDescription(randomAlphabetic(20));
     study.setStudyId(randomInt(1, 100));
     dataset.setStudy(study);
-    initService();
     assertDoesNotThrow(() -> service.toDatasetTerm(dataset));
   }
 
@@ -463,9 +456,8 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
     String datasetIndexName = randomAlphabetic(10);
 
     when(esConfig.getDatasetIndexName()).thenReturn(datasetIndexName);
-    mockElasticSearchResponse(200, "");
+    mockElasticSearchResponse("");
 
-    initService();
     try (var response = service.indexDatasetTerms(List.of(term1, term2), user)) {
       verify(esClient).performRequest(request.capture());
       Request capturedRequest = request.getValue();
@@ -493,9 +485,8 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
      *  more classes and methods. Alternately, it is possible to just mock the Gson parsing, but
      *  this seems to affect the results of the other tests.
      */
-    mockElasticSearchResponse(200, "{\"valid\":true,\"hits\":{\"hits\":[]}}");
+    mockElasticSearchResponse("{\"valid\":true,\"hits\":{\"hits\":[]}}");
 
-    initService();
     try (var response = service.searchDatasets(query)) {
       assertEquals(200, response.getStatus());
     }
@@ -505,9 +496,8 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
   void testValidateQuery() throws IOException {
     String query = "{ \"query\": { \"query_string\": { \"query\": \"(GRU) AND (HMB)\" } } }";
 
-    mockElasticSearchResponse(200, "{\"valid\":true}");
+    mockElasticSearchResponse("{\"valid\":true}");
 
-    initService();
     assertTrue(service.validateQuery(query));
   }
 
@@ -515,9 +505,8 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
   void testValidateQueryWithFromAndSize() throws IOException {
     String query = "{ \"from\": 0, \"size\": 100, \"query\": { \"query_string\": { \"query\": \"(GRU) AND (HMB)\" } } }";
 
-    mockElasticSearchResponse(200, "{\"valid\":true}");
+    mockElasticSearchResponse("{\"valid\":true}");
 
-    initService();
     assertTrue(service.validateQuery(query));
   }
 
@@ -531,7 +520,6 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
     when(esClient.performRequest(any())).thenReturn(response);
     when(response.getStatusLine()).thenReturn(status);
 
-    initService();
     assertThrows(IOException.class, () -> service.validateQuery(query));
   }
 
@@ -539,9 +527,8 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
   void testValidateQueryInvalid() throws IOException {
     String query = "{ \"bad\": [\"and\", \"invalid\"] }";
 
-    mockElasticSearchResponse(200, "{\"valid\":false}");
+    mockElasticSearchResponse("{\"valid\":false}");
 
-    initService();
     assertFalse(service.validateQuery(query));
   }
 
@@ -577,8 +564,6 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
           }
         """;
 
-    initService();
-
     when(datasetDAO.findDatasetById(dataset.getDatasetId())).thenReturn(dataset);
     mockESClientResponse(200, esResponseBody.formatted(dataset.getDatasetId()));
     StreamingOutput output = service.indexDatasetIds(List.of(dataset.getDatasetId()), user);
@@ -609,7 +594,6 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
     dataset.setDatasetId(randomInt(10, 100));
     when(datasetDAO.findDatasetById(dataset.getDatasetId())).thenReturn(dataset);
     mockESClientResponse(500, "error condition");
-    initService();
 
     StreamingOutput output = service.indexDatasetIds(List.of(dataset.getDatasetId()), user);
     var baos = new ByteArrayOutputStream();
@@ -646,7 +630,6 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
     when(studyDAO.findStudyById(any())).thenReturn(study);
     when(datasetDAO.findDatasetsByIdList(any())).thenReturn(List.of(d));
 
-    initService();
     assertDoesNotThrow(() -> service.indexStudy(1, user));
   }
 
@@ -658,7 +641,6 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
     study.setStudyId(1);
     when(studyDAO.findStudyById(any())).thenReturn(study);
 
-    initService();
     assertDoesNotThrow(() -> {
       try (var response = service.indexStudy(1, user)) {
         assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
@@ -668,7 +650,6 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
 
   @Test
   void testUpdateDatasetIndexWithValue() {
-    initService();
     assertDoesNotThrow(() -> service.updateDatasetIndex(1, 1, Instant.now()));
   }
 
@@ -676,15 +657,13 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
   void testDeleteDatasetIndexWhenDatasetExists() throws Exception {
     Dataset dataset = new Dataset();
     when(datasetDAO.findDatasetById(any())).thenReturn(dataset);
-    initService();
     assertDoesNotThrow(() -> service.updateDatasetIndex(1, 1, null));
-    verify(datasetServiceDAO, times(1)).updateDatasetIndex(any(), any(), any());
+    verify(datasetServiceDAO).updateDatasetIndex(any(), any(), any());
   }
 
   @Test
   void testDeleteDatasetIndexWhenDatasetIsNull() throws Exception {
     when(datasetDAO.findDatasetById(any())).thenReturn(null);
-    initService();
     assertDoesNotThrow(() -> service.updateDatasetIndex(1, 1, null));
     verify(datasetServiceDAO, never()).updateDatasetIndex(any(), any(), any());
   }

--- a/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
@@ -466,22 +466,22 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
     mockElasticSearchResponse(200, "");
 
     initService();
-    service.indexDatasetTerms(List.of(term1, term2), user);
+    try (var response = service.indexDatasetTerms(List.of(term1, term2), user)) {
+      verify(esClient).performRequest(request.capture());
 
-    verify(esClient).performRequest(request.capture());
+      Request capturedRequest = request.getValue();
 
-    Request capturedRequest = request.getValue();
-
-    assertEquals("PUT", capturedRequest.getMethod());
-    assertEquals("""
-            { "index": {"_type": "dataset", "_id": "1"} }
-            {"datasetId":1}
-            { "index": {"_type": "dataset", "_id": "2"} }
-            {"datasetId":2}
-                        
-            """,
-        new String(capturedRequest.getEntity().getContent().readAllBytes(),
-            StandardCharsets.UTF_8));
+      assertEquals("PUT", capturedRequest.getMethod());
+      assertEquals("""
+              { "index": {"_type": "dataset", "_id": "1"} }
+              {"datasetId":1}
+              { "index": {"_type": "dataset", "_id": "2"} }
+              {"datasetId":2}
+              
+              """,
+          new String(capturedRequest.getEntity().getContent().readAllBytes(),
+              StandardCharsets.UTF_8));
+    }
   }
 
   @Test
@@ -498,8 +498,9 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
     mockElasticSearchResponse(200, "{\"valid\":true,\"hits\":{\"hits\":[]}}");
 
     initService();
-    var response = service.searchDatasets(query);
-    assertEquals(200, response.getStatus());
+    try (var response = service.searchDatasets(query)) {
+      assertEquals(200, response.getStatus());
+    }
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/VoteServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/VoteServiceTest.java
@@ -21,8 +21,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
-import org.apache.commons.lang3.RandomStringUtils;
-import org.apache.commons.lang3.RandomUtils;
+import org.broadinstitute.consent.http.AbstractTestHelper;
 import org.broadinstitute.consent.http.db.DarCollectionDAO;
 import org.broadinstitute.consent.http.db.DataAccessRequestDAO;
 import org.broadinstitute.consent.http.db.DatasetDAO;
@@ -55,7 +54,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-class VoteServiceTest {
+class VoteServiceTest extends AbstractTestHelper {
 
   private VoteService service;
 
@@ -89,9 +88,9 @@ class VoteServiceTest {
   @Test
   void testUpdateVote() {
     Vote v = new Vote();
-    v.setVoteId(RandomUtils.nextInt(1, 10));
-    v.setUserId(RandomUtils.nextInt(1, 10));
-    v.setElectionId(RandomUtils.nextInt(1, 10));
+    v.setVoteId(randomInt(1, 10));
+    v.setUserId(randomInt(1, 10));
+    v.setElectionId(randomInt(1, 10));
     v.setIsReminderSent(false);
     v.setVote(false);
     when(voteDAO.findVoteById(anyInt())).thenReturn(v);
@@ -114,9 +113,9 @@ class VoteServiceTest {
   @Test
   void testUpdateVote_ByReferenceId() {
     Vote v = new Vote();
-    v.setVoteId(RandomUtils.nextInt(1, 10));
-    v.setUserId(RandomUtils.nextInt(1, 10));
-    v.setElectionId(RandomUtils.nextInt(1, 10));
+    v.setVoteId(randomInt(1, 10));
+    v.setUserId(randomInt(1, 10));
+    v.setElectionId(randomInt(1, 10));
     v.setIsReminderSent(false);
     v.setVote(false);
     when(voteDAO.findVoteById(anyInt())).thenReturn(v);
@@ -131,7 +130,7 @@ class VoteServiceTest {
   void testUpdateVotesWithValue() {
     initService();
 
-    List<Vote> votes = service.updateVotesWithValue(List.of(), true, "rationale");
+    List<Vote> votes = service.updateVotesWithValue(List.of(), true, "rationale", new User());
     assertNotNull(votes);
     assertTrue(votes.isEmpty());
   }
@@ -269,7 +268,7 @@ class VoteServiceTest {
     initService();
 
     try {
-      service.updateVotesWithValue(List.of(v), true, null);
+      service.updateVotesWithValue(List.of(v), true, null, new User());
     } catch (Exception e) {
       fail(e.getMessage());
     }
@@ -279,7 +278,7 @@ class VoteServiceTest {
   void testUpdateVotesWithValue_emptyList() throws Exception {
     when(voteServiceDAO.updateVotesWithValue(any(), anyBoolean(), any())).thenReturn(List.of());
     initService();
-    List<Vote> votes = service.updateVotesWithValue(List.of(), true, "rationale");
+    List<Vote> votes = service.updateVotesWithValue(List.of(), true, "rationale", new User());
     assertNotNull(votes);
     assertTrue(votes.isEmpty());
   }
@@ -295,7 +294,7 @@ class VoteServiceTest {
     when(electionDAO.findElectionsByIds(any())).thenReturn(List.of(closedAccessElection));
 
     initService();
-    assertThrows(IllegalArgumentException.class, () -> service.updateVotesWithValue(List.of(v), true, "rationale"));
+    assertThrows(IllegalArgumentException.class, () -> service.updateVotesWithValue(List.of(v), true, "rationale", new User()));
   }
 
 
@@ -318,7 +317,7 @@ class VoteServiceTest {
 
     initService();
 
-    assertThrows(IllegalArgumentException.class, () -> service.updateVotesWithValue(List.of(v), true, "rationale"));
+    assertThrows(IllegalArgumentException.class, () -> service.updateVotesWithValue(List.of(v), true, "rationale", new User()));
   }
 
   @Test
@@ -363,7 +362,7 @@ class VoteServiceTest {
     initService();
 
     try {
-      service.updateVotesWithValue(List.of(v), true, "rationale");
+      service.updateVotesWithValue(List.of(v), true, "rationale", new User());
     } catch (Exception e) {
       fail(e.getMessage());
     }
@@ -383,7 +382,7 @@ class VoteServiceTest {
     initService();
 
     try {
-      service.updateVotesWithValue(List.of(v), true, "rationale");
+      service.updateVotesWithValue(List.of(v), true, "rationale", new User());
     } catch (Exception e) {
       fail(e.getMessage());
     }
@@ -466,13 +465,13 @@ class VoteServiceTest {
 
     Dataset d1 = new Dataset();
     d1.setDatasetId(1);
-    d1.setName(RandomStringUtils.random(50, true, false));
+    d1.setName(randomAlphabetic(50));
     d1.setAlias(1);
     d1.setDataUse(new DataUseBuilder().setGeneralUse(false).setNonProfitUse(true).build());
 
     Dataset d2 = new Dataset();
     d2.setDatasetId(2);
-    d2.setName(RandomStringUtils.random(50, true, false));
+    d2.setName(randomAlphabetic(50));
     d2.setAlias(2);
     d2.setDataUse(new DataUseBuilder().setGeneralUse(false).setHmbResearch(true).build());
 
@@ -527,7 +526,7 @@ class VoteServiceTest {
     when(userDAO.findUserById(any())).thenReturn(researcher);
 
     initService();
-    service.sendDatasetApprovalNotifications(List.of(v1, v2));
+    service.sendDatasetApprovalNotifications(List.of(v1, v2), researcher);
     // Since we have 1 collection with different DAR/Datasets, we should be sending 1 email
     verify(emailService, times(1)).sendResearcherDarApproved(any(), any(), anyList(), any());
   }
@@ -556,14 +555,14 @@ class VoteServiceTest {
 
     Dataset d1 = new Dataset();
     d1.setDatasetId(1);
-    d1.setName(RandomStringUtils.random(50, true, false));
+    d1.setName(randomAlphabetic(50));
     d1.setAlias(1);
     d1.setDataUse(new DataUseBuilder().setGeneralUse(false).setNonProfitUse(true).build());
     d1.setProperties(Set.of(depositorProp));
 
     Dataset d2 = new Dataset();
     d2.setDatasetId(2);
-    d2.setName(RandomStringUtils.random(50, true, false));
+    d2.setName(randomAlphabetic(50));
     d2.setAlias(2);
     d2.setDataUse(new DataUseBuilder().setGeneralUse(false).setHmbResearch(true).build());
     d2.setProperties(Set.of(depositorProp));
@@ -616,7 +615,7 @@ class VoteServiceTest {
     when(userDAO.findUserById(any())).thenReturn(researcher);
 
     initService();
-    service.sendDatasetApprovalNotifications(List.of(v1, v2));
+    service.sendDatasetApprovalNotifications(List.of(v1, v2), researcher);
     // Since we have 2 collections with different DAR/Datasets, we should be sending 2 emails
     verify(emailService, times(2)).sendResearcherDarApproved(any(), any(), anyList(), any());
   }
@@ -633,7 +632,7 @@ class VoteServiceTest {
 
     Dataset d1 = new Dataset();
     d1.setDatasetId(1);
-    d1.setName(RandomStringUtils.random(50, true, false));
+    d1.setName(randomAlphabetic(50));
     d1.setAlias(1);
     d1.setDataUse(new DataUseBuilder().setGeneralUse(false).setNonProfitUse(true).build());
 
@@ -650,7 +649,7 @@ class VoteServiceTest {
     c1.setDarCode("DAR-CODE-1");
 
     initService();
-    service.sendDatasetApprovalNotifications(List.of(v1));
+    service.sendDatasetApprovalNotifications(List.of(v1), new User());
     // Since we have a false vote, we should not be sending any email
     verify(emailService, times(0)).sendResearcherDarApproved(any(), any(), anyList(), any());
     // Similar check for all DAO calls
@@ -672,7 +671,7 @@ class VoteServiceTest {
 
     Dataset d1 = new Dataset();
     d1.setDatasetId(1);
-    d1.setName(RandomStringUtils.random(50, true, false));
+    d1.setName(randomAlphabetic(50));
     d1.setAlias(1);
     d1.setDataUse(new DataUseBuilder().setGeneralUse(false).setNonProfitUse(true).build());
 
@@ -689,7 +688,7 @@ class VoteServiceTest {
     c1.setDarCode("DAR-CODE-1");
 
     initService();
-    service.sendDatasetApprovalNotifications(List.of(v1));
+    service.sendDatasetApprovalNotifications(List.of(v1), new User());
     // Since we have a non-final vote, we should not be sending any email
     verify(emailService, times(0)).sendResearcherDarApproved(any(), any(), anyList(), any());
     // Similar check for all DAO calls
@@ -714,7 +713,7 @@ class VoteServiceTest {
 
     Dataset d1 = new Dataset();
     d1.setDatasetId(1);
-    d1.setName(RandomStringUtils.random(50, true, false));
+    d1.setName(randomAlphabetic(50));
     d1.setAlias(1);
     d1.setDataUse(new DataUseBuilder().setGeneralUse(false).setNonProfitUse(true).build());
     d1.setProperties(Set.of(depositorProp));
@@ -722,7 +721,7 @@ class VoteServiceTest {
 
     Dataset d2 = new Dataset();
     d2.setDatasetId(2);
-    d2.setName(RandomStringUtils.random(50, true, false));
+    d2.setName(randomAlphabetic(50));
     d2.setAlias(2);
     d2.setDataUse(new DataUseBuilder().setGeneralUse(false).setHmbResearch(true).build());
     d2.setProperties(Set.of(depositorProp));
@@ -764,7 +763,7 @@ class VoteServiceTest {
 
     Dataset d1 = new Dataset();
     d1.setDatasetId(1);
-    d1.setName(RandomStringUtils.random(50, true, false));
+    d1.setName(randomAlphabetic(50));
     d1.setAlias(1);
     d1.setDataUse(new DataUseBuilder().setGeneralUse(false).setNonProfitUse(true).build());
     d1.setProperties(Set.of(depositorProp));
@@ -772,7 +771,7 @@ class VoteServiceTest {
 
     Dataset d2 = new Dataset();
     d2.setDatasetId(2);
-    d2.setName(RandomStringUtils.random(50, true, false));
+    d2.setName(randomAlphabetic(50));
     d2.setAlias(2);
     d2.setDataUse(new DataUseBuilder().setGeneralUse(false).setHmbResearch(true).build());
     d2.setProperties(Set.of(depositorProp));
@@ -827,7 +826,7 @@ class VoteServiceTest {
 
     Dataset d1 = new Dataset();
     d1.setDatasetId(1);
-    d1.setName(RandomStringUtils.random(50, true, false));
+    d1.setName(randomAlphabetic(50));
     d1.setAlias(1);
     d1.setDataUse(new DataUseBuilder().setGeneralUse(false).setNonProfitUse(true).build());
     d1.setCreateUserId(datasetSubmitter.getUserId());
@@ -888,14 +887,14 @@ class VoteServiceTest {
     custodianStudyProperty.setValue(jsonArray);
 
     Study study = new Study();
-    study.setName(RandomStringUtils.randomAlphabetic(10));
+    study.setName(randomAlphabetic(10));
     study.setStudyId(1);
     study.setProperties(Set.of(custodianStudyProperty));
     study.setCreateUserId(studySubmitter.getUserId());
 
     Dataset d1 = new Dataset();
     d1.setDatasetId(1);
-    d1.setName(RandomStringUtils.random(50, true, false));
+    d1.setName(randomAlphabetic(50));
     d1.setAlias(1);
     d1.setDataUse(new DataUseBuilder().setGeneralUse(false).setNonProfitUse(true).build());
     d1.setCreateUserId(datasetSubmitter.getUserId());
@@ -928,7 +927,7 @@ class VoteServiceTest {
 
   private void setUpUserAndElectionVotes(UserRoles userRoles) {
     User user = new User();
-    user.setUserId(RandomUtils.nextInt(1, 10));
+    user.setUserId(randomInt(1, 10));
     UserRole chairRole = new UserRole();
     chairRole.setUserId(user.getUserId());
     chairRole.setRoleId(userRoles.getRoleId());
@@ -942,9 +941,9 @@ class VoteServiceTest {
 
   private Vote setUpTestVote(Boolean vote, Boolean reminderSent) {
     Vote v = new Vote();
-    v.setVoteId(RandomUtils.nextInt(1, 10));
-    v.setUserId(RandomUtils.nextInt(1, 10));
-    v.setElectionId(RandomUtils.nextInt(1, 10));
+    v.setVoteId(randomInt(1, 10));
+    v.setUserId(randomInt(1, 10));
+    v.setElectionId(randomInt(1, 10));
     v.setIsReminderSent(reminderSent);
     v.setVote(vote);
     return v;

--- a/src/test/java/org/broadinstitute/consent/http/service/VoteServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/VoteServiceTest.java
@@ -78,6 +78,8 @@ class VoteServiceTest extends AbstractTestHelper {
   private VoteDAO voteDAO;
   @Mock
   private VoteServiceDAO voteServiceDAO;
+  @Mock
+  private User user;
 
   private void initService() {
     service = new VoteService(userDAO, darCollectionDAO, dataAccessRequestDAO,
@@ -130,7 +132,7 @@ class VoteServiceTest extends AbstractTestHelper {
   void testUpdateVotesWithValue() {
     initService();
 
-    List<Vote> votes = service.updateVotesWithValue(List.of(), true, "rationale", new User());
+    List<Vote> votes = service.updateVotesWithValue(List.of(), true, "rationale", user);
     assertNotNull(votes);
     assertTrue(votes.isEmpty());
   }
@@ -268,7 +270,7 @@ class VoteServiceTest extends AbstractTestHelper {
     initService();
 
     try {
-      service.updateVotesWithValue(List.of(v), true, null, new User());
+      service.updateVotesWithValue(List.of(v), true, null, user);
     } catch (Exception e) {
       fail(e.getMessage());
     }
@@ -278,7 +280,7 @@ class VoteServiceTest extends AbstractTestHelper {
   void testUpdateVotesWithValue_emptyList() throws Exception {
     when(voteServiceDAO.updateVotesWithValue(any(), anyBoolean(), any())).thenReturn(List.of());
     initService();
-    List<Vote> votes = service.updateVotesWithValue(List.of(), true, "rationale", new User());
+    List<Vote> votes = service.updateVotesWithValue(List.of(), true, "rationale", user);
     assertNotNull(votes);
     assertTrue(votes.isEmpty());
   }
@@ -294,7 +296,9 @@ class VoteServiceTest extends AbstractTestHelper {
     when(electionDAO.findElectionsByIds(any())).thenReturn(List.of(closedAccessElection));
 
     initService();
-    assertThrows(IllegalArgumentException.class, () -> service.updateVotesWithValue(List.of(v), true, "rationale", new User()));
+    List<Vote> voteList = List.of(v);
+    assertThrows(IllegalArgumentException.class,
+        () -> service.updateVotesWithValue(voteList, true, "rationale", user));
   }
 
 
@@ -317,7 +321,9 @@ class VoteServiceTest extends AbstractTestHelper {
 
     initService();
 
-    assertThrows(IllegalArgumentException.class, () -> service.updateVotesWithValue(List.of(v), true, "rationale", new User()));
+    List<Vote> voteList = List.of(v);
+    assertThrows(IllegalArgumentException.class,
+        () -> service.updateVotesWithValue(voteList, true, "rationale", user));
   }
 
   @Test
@@ -362,7 +368,7 @@ class VoteServiceTest extends AbstractTestHelper {
     initService();
 
     try {
-      service.updateVotesWithValue(List.of(v), true, "rationale", new User());
+      service.updateVotesWithValue(List.of(v), true, "rationale", user);
     } catch (Exception e) {
       fail(e.getMessage());
     }
@@ -382,7 +388,7 @@ class VoteServiceTest extends AbstractTestHelper {
     initService();
 
     try {
-      service.updateVotesWithValue(List.of(v), true, "rationale", new User());
+      service.updateVotesWithValue(List.of(v), true, "rationale", user);
     } catch (Exception e) {
       fail(e.getMessage());
     }
@@ -432,7 +438,8 @@ class VoteServiceTest extends AbstractTestHelper {
     when(electionDAO.findElectionsByIds(any())).thenReturn(List.of(election));
     initService();
 
-    assertThrows(IllegalArgumentException.class, () -> service.updateRationaleByVoteIds(List.of(1), "rationale"));
+    assertThrows(IllegalArgumentException.class,
+        () -> service.updateRationaleByVoteIds(List.of(1), "rationale"));
   }
 
   @Test
@@ -443,7 +450,8 @@ class VoteServiceTest extends AbstractTestHelper {
     when(electionDAO.findElectionsByIds(any())).thenReturn(List.of(election));
     initService();
 
-    assertThrows(IllegalArgumentException.class, () -> service.updateRationaleByVoteIds(List.of(1), "rationale"));
+    assertThrows(IllegalArgumentException.class,
+        () -> service.updateRationaleByVoteIds(List.of(1), "rationale"));
   }
 
   @Test
@@ -785,7 +793,9 @@ class VoteServiceTest extends AbstractTestHelper {
     when(userDAO.findUserById(submitterNotFound.getUserId())).thenReturn(null);
 
     initService();
-    assertThrows(IllegalArgumentException.class, () -> service.notifyCustodiansOfApprovedDatasets(List.of(d1, d2), researcher, "Dar Code"));
+    List<Dataset> datasetsList = List.of(d1, d2);
+    assertThrows(IllegalArgumentException.class,
+        () -> service.notifyCustodiansOfApprovedDatasets(datasetsList, researcher, "Dar Code"));
     verify(emailService, times(0)).sendDataCustodianApprovalMessage(
         any(),
         any(),
@@ -839,7 +849,8 @@ class VoteServiceTest extends AbstractTestHelper {
 
     when(userDAO.findUserById(studySubmitter.getUserId())).thenReturn(studySubmitter);
     when(userDAO.findUserById(datasetSubmitter.getUserId())).thenReturn(datasetSubmitter);
-    when(userDAO.findUsersByEmailList(List.of(custodian.getEmail()))).thenReturn(List.of(custodian));
+    when(userDAO.findUsersByEmailList(List.of(custodian.getEmail()))).thenReturn(
+        List.of(custodian));
 
     initService();
 
@@ -858,8 +869,8 @@ class VoteServiceTest extends AbstractTestHelper {
   }
 
   /**
-   * This test exercises the bug seen in DUOS-3066:
-   * java.lang.ClassCastException: class com.google.gson.JsonArray cannot be cast to class java.lang.String
+   * This test exercises the bug seen in DUOS-3066: java.lang.ClassCastException: class
+   * com.google.gson.JsonArray cannot be cast to class java.lang.String
    */
   @Test
   void testNotifyStudyCustodiansAndSubmittersOfApprovedDatasetsWithJsonArrayCustodians() {
@@ -907,7 +918,8 @@ class VoteServiceTest extends AbstractTestHelper {
 
     when(userDAO.findUserById(studySubmitter.getUserId())).thenReturn(studySubmitter);
     when(userDAO.findUserById(datasetSubmitter.getUserId())).thenReturn(datasetSubmitter);
-    when(userDAO.findUsersByEmailList(List.of(custodian.getEmail()))).thenReturn(List.of(custodian));
+    when(userDAO.findUsersByEmailList(List.of(custodian.getEmail()))).thenReturn(
+        List.of(custodian));
 
     initService();
 

--- a/src/test/java/org/broadinstitute/consent/http/service/VoteServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/VoteServiceTest.java
@@ -657,7 +657,7 @@ class VoteServiceTest extends AbstractTestHelper {
     c1.setDarCode("DAR-CODE-1");
 
     initService();
-    service.sendDatasetApprovalNotifications(List.of(v1), new User());
+    service.sendDatasetApprovalNotifications(List.of(v1), user);
     // Since we have a false vote, we should not be sending any email
     verify(emailService, times(0)).sendResearcherDarApproved(any(), any(), anyList(), any());
     // Similar check for all DAO calls
@@ -696,7 +696,7 @@ class VoteServiceTest extends AbstractTestHelper {
     c1.setDarCode("DAR-CODE-1");
 
     initService();
-    service.sendDatasetApprovalNotifications(List.of(v1), new User());
+    service.sendDatasetApprovalNotifications(List.of(v1), user);
     // Since we have a non-final vote, we should not be sending any email
     verify(emailService, times(0)).sendResearcherDarApproved(any(), any(), anyList(), any());
     // Similar check for all DAO calls

--- a/src/test/java/org/broadinstitute/consent/http/service/VoteServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/VoteServiceTest.java
@@ -831,7 +831,7 @@ class VoteServiceTest extends AbstractTestHelper {
 
     Study study = new Study();
     study.setStudyId(1);
-    study.addProperties(Set.of(custodianStudyProperty));
+    study.addProperties(custodianStudyProperty);
     study.setCreateUserId(studySubmitter.getUserId());
 
     Dataset d1 = new Dataset();
@@ -900,7 +900,7 @@ class VoteServiceTest extends AbstractTestHelper {
     Study study = new Study();
     study.setName(randomAlphabetic(10));
     study.setStudyId(1);
-    study.addProperties(Set.of(custodianStudyProperty));
+    study.addProperties(custodianStudyProperty);
     study.setCreateUserId(studySubmitter.getUserId());
 
     Dataset d1 = new Dataset();

--- a/src/test/java/org/broadinstitute/consent/http/service/VoteServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/VoteServiceTest.java
@@ -831,7 +831,7 @@ class VoteServiceTest extends AbstractTestHelper {
 
     Study study = new Study();
     study.setStudyId(1);
-    study.setProperties(Set.of(custodianStudyProperty));
+    study.addProperties(Set.of(custodianStudyProperty));
     study.setCreateUserId(studySubmitter.getUserId());
 
     Dataset d1 = new Dataset();
@@ -900,7 +900,7 @@ class VoteServiceTest extends AbstractTestHelper {
     Study study = new Study();
     study.setName(randomAlphabetic(10));
     study.setStudyId(1);
-    study.setProperties(Set.of(custodianStudyProperty));
+    study.addProperties(Set.of(custodianStudyProperty));
     study.setCreateUserId(studySubmitter.getUserId());
 
     Dataset d1 = new Dataset();


### PR DESCRIPTION
### Addresses
Final part of https://broadworkbench.atlassian.net/browse/DT-1424

### Summary
* Move the service call to `ElasticSearchService` since that's where we needed it.
* Significant method signature changes to pass the updating `User` down to the service calls
* Significant test updates to move away from older/deprecated patterns
* Handle several new cases where we should have been re-indexing, but were not:
  * Sync Data Use Translation
  * Convert Dataset to Study
  * Update Study Custodians
  * Patch Dataset via patchable properties


----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
