### PR TITLE
DT-1496: Prevent update self from updating institution id

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/models/UserUpdateFields.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/UserUpdateFields.java
@@ -18,7 +18,7 @@ public class UserUpdateFields {
   protected static final List<Integer> IGNORE_ROLE_IDS = List.of(UserRoles.CHAIRPERSON.getRoleId(),
       UserRoles.MEMBER.getRoleId());
   private static final List<Integer> VALID_ROLE_IDS = Arrays.stream(UserRoles.values())
-      .map(UserRoles::getRoleId).collect(Collectors.toList());
+      .map(UserRoles::getRoleId).toList();
   private String displayName;
   private Integer institutionId;
   private Boolean emailPreference;
@@ -177,6 +177,33 @@ public class UserUpdateFields {
                   VALID_ROLE_IDS.contains(
                       id);                            // Only remove roles we know about
             })
-        .collect(Collectors.toList());
+        .toList();
   }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    UserUpdateFields that = (UserUpdateFields) o;
+    return com.google.common.base.Objects.equal(displayName, that.displayName)
+        && com.google.common.base.Objects.equal(institutionId, that.institutionId)
+        && com.google.common.base.Objects.equal(emailPreference, that.emailPreference)
+        && com.google.common.base.Objects.equal(userRoleIds, that.userRoleIds)
+        && com.google.common.base.Objects.equal(eraCommonsId, that.eraCommonsId)
+        && com.google.common.base.Objects.equal(selectedSigningOfficialId,
+        that.selectedSigningOfficialId) && com.google.common.base.Objects.equal(
+        suggestedInstitution,
+        that.suggestedInstitution) && com.google.common.base.Objects.equal(suggestedSigningOfficial,
+        that.suggestedSigningOfficial) && com.google.common.base.Objects.equal(daaAcceptance,
+        that.daaAcceptance);
+  }
+
+  @Override
+  public int hashCode() {
+    return com.google.common.base.Objects.hashCode(displayName, institutionId, emailPreference,
+        userRoleIds, eraCommonsId,
+        selectedSigningOfficialId, suggestedInstitution, suggestedSigningOfficial, daaAcceptance);
+  }
+
 }

--- a/src/main/java/org/broadinstitute/consent/http/models/UserUpdateFields.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/UserUpdateFields.java
@@ -1,5 +1,7 @@
 package org.broadinstitute.consent.http.models;
 
+import static com.google.common.base.Objects.equal;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -186,17 +188,15 @@ public class UserUpdateFields {
       return false;
     }
     UserUpdateFields that = (UserUpdateFields) o;
-    return com.google.common.base.Objects.equal(displayName, that.displayName)
-        && com.google.common.base.Objects.equal(institutionId, that.institutionId)
-        && com.google.common.base.Objects.equal(emailPreference, that.emailPreference)
-        && com.google.common.base.Objects.equal(userRoleIds, that.userRoleIds)
-        && com.google.common.base.Objects.equal(eraCommonsId, that.eraCommonsId)
-        && com.google.common.base.Objects.equal(selectedSigningOfficialId,
-        that.selectedSigningOfficialId) && com.google.common.base.Objects.equal(
-        suggestedInstitution,
-        that.suggestedInstitution) && com.google.common.base.Objects.equal(suggestedSigningOfficial,
-        that.suggestedSigningOfficial) && com.google.common.base.Objects.equal(daaAcceptance,
-        that.daaAcceptance);
+    return equal(displayName, that.displayName)
+        && equal(institutionId, that.institutionId)
+        && equal(emailPreference, that.emailPreference)
+        && equal(userRoleIds, that.userRoleIds)
+        && equal(eraCommonsId, that.eraCommonsId)
+        && equal(selectedSigningOfficialId, that.selectedSigningOfficialId)
+        && equal(suggestedInstitution, that.suggestedInstitution)
+        && equal(suggestedSigningOfficial, that.suggestedSigningOfficial)
+        && equal(daaAcceptance, that.daaAcceptance);
   }
 
   @Override

--- a/src/main/java/org/broadinstitute/consent/http/models/UserUpdateFields.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/UserUpdateFields.java
@@ -1,7 +1,5 @@
 package org.broadinstitute.consent.http.models;
 
-import static com.google.common.base.Objects.equal;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -187,23 +185,30 @@ public class UserUpdateFields {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
+
     UserUpdateFields that = (UserUpdateFields) o;
-    return equal(displayName, that.displayName)
-        && equal(institutionId, that.institutionId)
-        && equal(emailPreference, that.emailPreference)
-        && equal(userRoleIds, that.userRoleIds)
-        && equal(eraCommonsId, that.eraCommonsId)
-        && equal(selectedSigningOfficialId, that.selectedSigningOfficialId)
-        && equal(suggestedInstitution, that.suggestedInstitution)
-        && equal(suggestedSigningOfficial, that.suggestedSigningOfficial)
-        && equal(daaAcceptance, that.daaAcceptance);
+    return Objects.equals(displayName, that.displayName) && Objects.equals(
+        institutionId, that.institutionId) && Objects.equals(emailPreference,
+        that.emailPreference) && Objects.equals(userRoleIds, that.userRoleIds)
+        && Objects.equals(eraCommonsId, that.eraCommonsId) && Objects.equals(
+        selectedSigningOfficialId, that.selectedSigningOfficialId) && Objects.equals(
+        suggestedInstitution, that.suggestedInstitution) && Objects.equals(
+        suggestedSigningOfficial, that.suggestedSigningOfficial) && Objects.equals(
+        daaAcceptance, that.daaAcceptance);
   }
 
   @Override
   public int hashCode() {
-    return com.google.common.base.Objects.hashCode(displayName, institutionId, emailPreference,
-        userRoleIds, eraCommonsId, selectedSigningOfficialId, suggestedInstitution,
-        suggestedSigningOfficial, daaAcceptance);
+    int result = Objects.hashCode(displayName);
+    result = 31 * result + Objects.hashCode(institutionId);
+    result = 31 * result + Objects.hashCode(emailPreference);
+    result = 31 * result + Objects.hashCode(userRoleIds);
+    result = 31 * result + Objects.hashCode(eraCommonsId);
+    result = 31 * result + Objects.hashCode(selectedSigningOfficialId);
+    result = 31 * result + Objects.hashCode(suggestedInstitution);
+    result = 31 * result + Objects.hashCode(suggestedSigningOfficial);
+    result = 31 * result + Objects.hashCode(daaAcceptance);
+    return result;
   }
 
 }

--- a/src/main/java/org/broadinstitute/consent/http/models/UserUpdateFields.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/UserUpdateFields.java
@@ -202,8 +202,8 @@ public class UserUpdateFields {
   @Override
   public int hashCode() {
     return com.google.common.base.Objects.hashCode(displayName, institutionId, emailPreference,
-        userRoleIds, eraCommonsId,
-        selectedSigningOfficialId, suggestedInstitution, suggestedSigningOfficial, daaAcceptance);
+        userRoleIds, eraCommonsId, selectedSigningOfficialId, suggestedInstitution,
+        suggestedSigningOfficial, daaAcceptance);
   }
 
 }

--- a/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
@@ -3,7 +3,6 @@ package org.broadinstitute.consent.http.resources;
 
 import com.codahale.metrics.annotation.Timed;
 import com.google.api.client.http.HttpStatusCodes;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.google.gson.reflect.TypeToken;
@@ -229,13 +228,14 @@ public class UserResource extends Resource {
       User user = userService.findUserByEmail(authUser.getEmail());
       UserUpdateFields userUpdateFields = gson.fromJson(json, UserUpdateFields.class);
 
+      // Users cannot update their own institution id through this service
+      if (userUpdateFields.getInstitutionId() != null) {
+        throw new BadRequestException("Institution ID is not updatable");
+      }
+
       if (Objects.nonNull(userUpdateFields.getUserRoleIds()) && !user.hasUserRole(
           UserRoles.ADMIN)) {
         throw new BadRequestException("Cannot change user's roles.");
-      }
-
-      if (!canUpdateInstitution(user, userUpdateFields.getInstitutionId())) {
-        throw new BadRequestException("Cannot update user's institution id.");
       }
 
       user = userService.updateUserFieldsById(userUpdateFields, user.getUserId());
@@ -246,24 +246,6 @@ public class UserResource extends Resource {
       return Response.ok().entity(gson.toJson(jsonUser)).build();
     } catch (Exception e) {
       return createExceptionResponse(e);
-    }
-  }
-
-  @VisibleForTesting
-  protected boolean canUpdateInstitution(User user, Integer newInstitutionId) {
-    if ((!Objects.isNull(user.getUserId()) || !Objects.isNull(newInstitutionId)) && !Objects.equals(
-        user.getInstitutionId(), newInstitutionId)) {
-      if (user.hasUserRole(UserRoles.ADMIN)) {
-        return true; // admins can do everything.
-      }
-      if (user.hasUserRole(UserRoles.SIGNINGOFFICIAL) || user.hasUserRole(UserRoles.ITDIRECTOR)) {
-        // can only update institution if not set.
-        return Objects.isNull(user.getInstitutionId()) && Objects.nonNull(newInstitutionId);
-      }
-      // User is not restricted based on role
-      return true;
-    } else {
-      return true; // no op, no change, supports keeping no institution set to no institution.
     }
   }
 

--- a/src/main/resources/assets/paths/user.yaml
+++ b/src/main/resources/assets/paths/user.yaml
@@ -34,9 +34,6 @@ put:
             displayName:
               description: The display name for the user
               type: string
-            institutionId:
-              description: The institution id for the user
-              type: number
             emailPreference:
               description: True for receiving email, false for disabling all email
               type: boolean
@@ -62,6 +59,8 @@ put:
         application/json:
           schema:
             $ref: '../schemas/User.yaml'
+    400:
+      description: Bad request if invalid input is provided
     404:
       description: User not found
     500:

--- a/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
@@ -719,7 +719,6 @@ class UserResourceTest {
     when(datasetService.findDatasetListByDacIds(anyList())).thenReturn(List.of(new Dataset()));
     when(userService.findUserByEmail(anyString())).thenReturn(user);
 
-
     Response response = userResource.getDatasetsFromUserDacsV2(authUser);
     assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
   }
@@ -775,7 +774,6 @@ class UserResourceTest {
 
   @Test
   void testPostAcknowledgementBadJson() {
-
     String jsonString = "The quick brown fox jumped over the lazy dog.";
 
     Response response = userResource.postAcknowledgements(authUser, jsonString);
@@ -784,16 +782,12 @@ class UserResourceTest {
 
   @Test
   void testPostAcknowledgementEmptyJson() {
-
-
     Response response = userResource.postAcknowledgements(authUser, "");
     assertEquals(Status.BAD_REQUEST.getStatusCode(), response.getStatus());
   }
 
   @Test
   void testPostAcknowledgementEmptyJsonList() {
-
-
     Response response = userResource.postAcknowledgements(authUser, "[]");
     assertEquals(Status.BAD_REQUEST.getStatusCode(), response.getStatus());
   }
@@ -877,9 +871,8 @@ class UserResourceTest {
 
   @Test
   void testDeleteMissingAcknowledgementForUser() {
-    User user = createUserWithRole();
+    createUserWithRole();
     when(acknowledgementService.findAcknowledgementForUserByKey(any(), any())).thenReturn(null);
-
 
     Response response = userResource.deleteUserAcknowledgement(authUser, "key");
     assertEquals(Status.NOT_FOUND.getStatusCode(), response.getStatus());
@@ -891,7 +884,6 @@ class UserResourceTest {
     User user = createUserWithRole();
     Map<String, Acknowledgement> acknowledgementMap = getDefaultAcknowledgementForUser(user,
         acknowledgementKey);
-
 
     Response response = userResource.getUserAcknowledgements(authUser);
     assertEquals(Status.OK.getStatusCode(), response.getStatus());

--- a/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
@@ -46,6 +46,7 @@ import org.broadinstitute.consent.http.util.gson.GsonUtil;
 import org.jdbi.v3.core.statement.StatementContext;
 import org.jdbi.v3.core.statement.StatementExceptions;
 import org.jdbi.v3.core.statement.UnableToExecuteStatementException;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -79,7 +80,7 @@ class UserResourceTest {
   @Mock
   private AcknowledgementService acknowledgementService;
 
-  private final String TEST_EMAIL = "test@gmail.com";
+  private static final String TEST_EMAIL = "test@gmail.com";
 
   private final Gson gson = GsonUtil.getInstance();
 
@@ -89,7 +90,8 @@ class UserResourceTest {
       .setEmail(TEST_EMAIL)
       .setUserStatusInfo(userStatusInfo);
 
-  private void initResource() {
+  @BeforeEach
+  void initResource() {
     userResource = new UserResource(samService, userService, datasetService,
         acknowledgementService);
   }
@@ -98,7 +100,6 @@ class UserResourceTest {
   void testGetMe() {
     User user = createUserWithRole();
     when(userService.findUserByEmail(any())).thenReturn(user);
-    initResource();
 
     Response response = userResource.getUser(authUser);
     assertEquals(Status.OK.getStatusCode(), response.getStatus());
@@ -106,7 +107,6 @@ class UserResourceTest {
 
   @Test
   void testGetUserById() {
-    initResource();
 
     Response response = userResource.getUserById(authUser, 1);
     assertEquals(Status.OK.getStatusCode(), response.getStatus());
@@ -116,7 +116,6 @@ class UserResourceTest {
   void testGetUserByIdNotFound() {
     when(userService.findUserWithPropertiesByIdAsJsonObject(any(), any())).thenThrow(
         new NotFoundException());
-    initResource();
 
     Response response = userResource.getUserById(authUser, 1);
     assertEquals(Status.NOT_FOUND.getStatusCode(), response.getStatus());
@@ -129,7 +128,6 @@ class UserResourceTest {
     when(userService.findUserByEmail(any())).thenReturn(user);
     when(userService.getUsersAsRole(user, "SigningOfficial")).thenReturn(
         Arrays.asList(new User(), new User()));
-    initResource();
 
     Response response = userResource.getUsers(authUser, "SigningOfficial");
     assertEquals(Status.OK.getStatusCode(), response.getStatus());
@@ -139,7 +137,6 @@ class UserResourceTest {
   void testGetUsers_SO_NoRole() {
     User user = createUserWithRole();
     when(userService.findUserByEmail(any())).thenReturn(user);
-    initResource();
 
     Response response = userResource.getUsers(authUser, "SigningOfficial");
     assertEquals(Status.NOT_FOUND.getStatusCode(), response.getStatus());
@@ -152,7 +149,6 @@ class UserResourceTest {
     when(userService.findUserByEmail(any())).thenReturn(user);
     when(userService.getUsersAsRole(user, "Admin")).thenReturn(
         Arrays.asList(new User(), new User()));
-    initResource();
 
     Response response = userResource.getUsers(authUser, "Admin");
     assertEquals(Status.OK.getStatusCode(), response.getStatus());
@@ -162,7 +158,6 @@ class UserResourceTest {
   void testGetUsers_Admin_NoRole() {
     User user = createUserWithRole();
     when(userService.findUserByEmail(any())).thenReturn(user);
-    initResource();
 
     Response response = userResource.getUsers(authUser, "Admin");
     assertEquals(Status.NOT_FOUND.getStatusCode(), response.getStatus());
@@ -172,7 +167,6 @@ class UserResourceTest {
   void testGetUsers_UnsupportedRole() {
     User user = createUserWithRole();
     when(userService.findUserByEmail(any())).thenReturn(user);
-    initResource();
 
     Response response = userResource.getUsers(authUser, "Researcher");
     assertEquals(Status.BAD_REQUEST.getStatusCode(), response.getStatus());
@@ -182,7 +176,7 @@ class UserResourceTest {
   void testGetUsers_InvalidRole() {
     User user = createUserWithRole();
     when(userService.findUserByEmail(any())).thenReturn(user);
-    initResource();
+
 
     Response response = userResource.getUsers(authUser, "BadRequest");
     assertEquals(Status.BAD_REQUEST.getStatusCode(), response.getStatus());
@@ -191,7 +185,6 @@ class UserResourceTest {
   @Test
   void testGetUsers_UserNotFound() {
     when(userService.findUserByEmail(any())).thenThrow(new NotFoundException());
-    initResource();
 
     Response response = userResource.getUsers(authUser, "Admin");
     assertEquals(Status.NOT_FOUND.getStatusCode(), response.getStatus());
@@ -204,7 +197,6 @@ class UserResourceTest {
     user.addRole(UserRoles.Admin());
     user.addRole(UserRoles.Researcher());
     when(userService.findUserByEmail(user.getEmail())).thenReturn(user);
-    initResource();
 
     Response response = userResource.createResearcher(uriInfo, authUser);
     assertEquals(Status.CONFLICT.getStatusCode(), response.getStatus());
@@ -212,8 +204,6 @@ class UserResourceTest {
 
   @Test
   void testCreateFailingGoogleIdentity() {
-    initResource();
-
     Response response = userResource.createResearcher(uriInfo, new AuthUser(TEST_EMAIL));
     assertEquals(Status.BAD_REQUEST.getStatusCode(), response.getStatus());
   }
@@ -229,7 +219,6 @@ class UserResourceTest {
     when(uriBuilder.build(anyString())).thenReturn(new URI("http://localhost:8180/dacuser/api"));
     when(userService.findUserByEmail(any())).thenThrow(new NotFoundException());
     when(userService.createUser(user)).thenReturn(user);
-    initResource();
 
     Response response = userResource.createResearcher(uriInfo, authUser);
     assertEquals(Status.CREATED.getStatusCode(), response.getStatus());
@@ -238,7 +227,7 @@ class UserResourceTest {
   @Test
   void testDeleteUser() {
     doNothing().when(userService).deleteUserByEmail(any());
-    initResource();
+
     Response response = userResource.delete(RandomStringUtils.randomAlphabetic(10), uriInfo);
     assertEquals(200, response.getStatus());
   }
@@ -250,7 +239,7 @@ class UserResourceTest {
     activeUser.setAdminRole();
     when(userService.findUserById(any())).thenReturn(user);
     when(userService.findUserByEmail(any())).thenReturn(activeUser);
-    initResource();
+
     Response response = userResource.addRoleToUser(authUser, 1, UserRoles.ADMIN.getRoleId());
     assertEquals(200, response.getStatus());
   }
@@ -261,7 +250,7 @@ class UserResourceTest {
     activeUser.setAdminRole();
     when(userService.findUserByEmail(any())).thenReturn(activeUser);
     doThrow(new NotFoundException()).when(userService).findUserById(any());
-    initResource();
+
     Response response = userResource.addRoleToUser(authUser, 1, UserRoles.ADMIN.getRoleId());
     assertEquals(404, response.getStatus());
   }
@@ -273,7 +262,7 @@ class UserResourceTest {
     User user = createUserWithRole();
     when(userService.findUserById(any())).thenReturn(user);
     when(userService.findUserByEmail(any())).thenReturn(activeUser);
-    initResource();
+
     Response response = userResource.addRoleToUser(authUser, 1, UserRoles.RESEARCHER.getRoleId());
     assertEquals(304, response.getStatus());
   }
@@ -282,7 +271,7 @@ class UserResourceTest {
   void testAddRoleToUserBadRequest() {
     User activeUser = createUserWithRole();
     activeUser.setAdminRole();
-    initResource();
+
     Response response = userResource.addRoleToUser(authUser, 1, 1000);
     assertEquals(400, response.getStatus());
   }
@@ -294,7 +283,7 @@ class UserResourceTest {
     User user = createUserWithRole();
     when(userService.findUserById(any())).thenReturn(user);
     when(userService.findUserByEmail(any())).thenReturn(activeUser);
-    initResource();
+
     Response response = userResource.addRoleToUser(authUser, 1,
         UserRoles.DATASUBMITTER.getRoleId());
     assertEquals(400, response.getStatus());
@@ -308,7 +297,7 @@ class UserResourceTest {
     User user = createUserWithRole();
     when(userService.findUserById(any())).thenReturn(user);
     when(userService.findUserByEmail(any())).thenReturn(activeUser);
-    initResource();
+
     Response response = userResource.addRoleToUser(authUser, 1,
         UserRoles.DATASUBMITTER.getRoleId());
     assertEquals(200, response.getStatus());
@@ -322,7 +311,7 @@ class UserResourceTest {
     user.setInstitutionId(10);
     when(userService.findUserById(any())).thenReturn(user);
     when(userService.findUserByEmail(any())).thenReturn(activeUser);
-    initResource();
+
     Response response = userResource.addRoleToUser(authUser, 1,
         UserRoles.DATASUBMITTER.getRoleId());
     assertEquals(400, response.getStatus());
@@ -337,7 +326,7 @@ class UserResourceTest {
     user.setInstitutionId(10);
     when(userService.findUserById(any())).thenReturn(user);
     when(userService.findUserByEmail(any())).thenReturn(activeUser);
-    initResource();
+
     Response response = userResource.addRoleToUser(authUser, 1, UserRoles.ADMIN.getRoleId());
     assertEquals(400, response.getStatus());
     response = userResource.addRoleToUser(authUser, 1, UserRoles.RESEARCHER.getRoleId());
@@ -359,7 +348,7 @@ class UserResourceTest {
     user.setInstitutionId(10);
     when(userService.findUserById(any())).thenReturn(user);
     when(userService.findUserByEmail(any())).thenReturn(activeUser);
-    initResource();
+
     Response response = userResource.addRoleToUser(authUser, 1,
         UserRoles.DATASUBMITTER.getRoleId());
     assertEquals(200, response.getStatus());
@@ -377,7 +366,7 @@ class UserResourceTest {
     when(userService.findUserByEmail(any())).thenReturn(user);
     when(userService.findSOsByInstitutionId(any())).thenReturn(
         Arrays.asList(new UserService.SimplifiedUser(so), new UserService.SimplifiedUser(so)));
-    initResource();
+
     Response response = userResource.getSOsForInstitution(authUser);
     assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
     var body = (List<UserService.SimplifiedUser>) response.getEntity();
@@ -390,7 +379,7 @@ class UserResourceTest {
   void testGetSOsForInstitution_NoInstitution() {
     User user = createUserWithRole();
     when(userService.findUserByEmail(any())).thenReturn(user);
-    initResource();
+
     Response response = userResource.getSOsForInstitution(authUser);
     assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
     var body = (List) response.getEntity();
@@ -400,7 +389,7 @@ class UserResourceTest {
   @Test
   void testGetSOsForInstitution_UserNotFound() {
     when(userService.findUserByEmail(any())).thenThrow(new NotFoundException());
-    initResource();
+
     Response response = userResource.getSOsForInstitution(authUser);
     assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
   }
@@ -409,7 +398,7 @@ class UserResourceTest {
   void testGetUnassignedUsers() {
     List<User> users = Collections.singletonList(createUserWithRole());
     when(userService.findUsersWithNoInstitution()).thenReturn(users);
-    initResource();
+
     Response response = userResource.getUnassignedUsers(authUser);
     assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
   }
@@ -418,7 +407,6 @@ class UserResourceTest {
   void testGetUsersByInstitutionNoInstitution() {
     Integer institutionId = 1;
     doThrow(new NotFoundException()).when(userService).findUsersByInstitutionId(institutionId);
-    initResource();
 
     Response response = userResource.getUsersByInstitution(authUser, institutionId);
     assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
@@ -429,7 +417,6 @@ class UserResourceTest {
     Integer institutionId = null;
     doThrow(new IllegalArgumentException()).when(userService)
         .findUsersByInstitutionId(institutionId);
-    initResource();
 
     Response response = userResource.getUsersByInstitution(authUser, institutionId);
     assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
@@ -438,7 +425,6 @@ class UserResourceTest {
   @Test
   void testGetUsersByInstitutionSuccess() {
     when(userService.findUsersByInstitutionId(any())).thenReturn(Collections.emptyList());
-    initResource();
 
     Response response = userResource.getUsersByInstitution(authUser, 1);
     assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
@@ -448,11 +434,11 @@ class UserResourceTest {
   void testUpdateSelf() {
     User user = createUserWithRole();
     UserUpdateFields userUpdateFields = new UserUpdateFields();
-    when(userService.findUserByEmail(any())).thenReturn(user);
-    when(userService.updateUserFieldsById(any(), any())).thenReturn(user);
-    when(userService.findUserWithPropertiesByIdAsJsonObject(any(), any())).thenReturn(
+    when(userService.findUserByEmail(authUser.getEmail())).thenReturn(user);
+    when(userService.updateUserFieldsById(userUpdateFields, user.getUserId())).thenReturn(user);
+    when(userService.findUserWithPropertiesByIdAsJsonObject(authUser, user.getUserId())).thenReturn(
         gson.toJsonTree(user).getAsJsonObject());
-    initResource();
+
     Response response = userResource.updateSelf(authUser, uriInfo, gson.toJson(userUpdateFields));
     assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
   }
@@ -474,12 +460,12 @@ class UserResourceTest {
     String invalidName = "invalid\0name";
     UserUpdateFields userUpdateFields = new UserUpdateFields();
     userUpdateFields.setDisplayName(invalidName);
-    when(userService.findUserByEmail(any())).thenReturn(user);
+    when(userService.findUserByEmail(authUser.getEmail())).thenReturn(user);
     when(userService.updateUserFieldsById(any(), any())).thenThrow(exception);
-    initResource();
 
-    Response response = userResource.updateSelf(authUser, uriInfo, gson.toJson(userUpdateFields));
-    assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
+    try (var response = userResource.updateSelf(authUser, uriInfo, gson.toJson(userUpdateFields))) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
+    }
   }
 
   @Test
@@ -487,165 +473,25 @@ class UserResourceTest {
     User user = createUserWithRole();
     UserUpdateFields userUpdateFields = new UserUpdateFields();
     userUpdateFields.setUserRoleIds(List.of(1)); // any roles
-    when(userService.findUserByEmail(any())).thenReturn(user);
-    initResource();
-    Response response = userResource.updateSelf(authUser, uriInfo, gson.toJson(userUpdateFields));
-    assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
+    when(userService.findUserByEmail(authUser.getEmail())).thenReturn(user);
+
+    try (var response = userResource.updateSelf(authUser, uriInfo, gson.toJson(userUpdateFields))) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
+    }
   }
 
   @Test
-  void testUpdateSelfInstitutionIdAsSO() {
-    User user = createUserWithRole();
-    user.setSigningOfficialRole();
-    UserUpdateFields userUpdateFields = new UserUpdateFields();
-    userUpdateFields.setInstitutionId(10);
-    when(userService.findUserByEmail(any())).thenReturn(user);
-    when(userService.updateUserFieldsById(any(), any())).thenReturn(user);
-    when(userService.findUserWithPropertiesByIdAsJsonObject(any(), any())).thenReturn(
-        gson.toJsonTree(user).getAsJsonObject());
-    initResource();
-    Response response = userResource.updateSelf(authUser, uriInfo, gson.toJson(userUpdateFields));
-    assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
-  }
-
-  @Test
-  void testUpdateSelfInstitutionIdAsSO_ExistingInstitution() {
-    User user = createUserWithRole();
-    user.setSigningOfficialRole();
-    user.setInstitutionId(10);
-    UserUpdateFields userUpdateFields = new UserUpdateFields();
-    userUpdateFields.setInstitutionId(20);
-    when(userService.findUserByEmail(any())).thenReturn(user);
-    initResource();
-    Response response = userResource.updateSelf(authUser, uriInfo, gson.toJson(userUpdateFields));
-    assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
-  }
-
-  @Test
-  void testUpdateSelfInstitutionIdAsSO_SameInstitution() {
-    User user = createUserWithRole();
-    user.setSigningOfficialRole();
-    user.setInstitutionId(10);
-    UserUpdateFields userUpdateFields = new UserUpdateFields();
-    userUpdateFields.setInstitutionId(10);
-    when(userService.findUserByEmail(any())).thenReturn(user);
-    when(userService.updateUserFieldsById(any(), any())).thenReturn(user);
-    when(userService.findUserWithPropertiesByIdAsJsonObject(any(), any())).thenReturn(
-        gson.toJsonTree(user).getAsJsonObject());
-    initResource();
-    Response response = userResource.updateSelf(authUser, uriInfo, gson.toJson(userUpdateFields));
-    assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
-  }
-
-  @Test
-  void testUpdateSelfInstitutionIdAsITDirector() {
-    User user = createUserWithRole();
-    user.setITDirectorRole();
-    UserUpdateFields userUpdateFields = new UserUpdateFields();
-    userUpdateFields.setInstitutionId(10);
-    when(userService.findUserByEmail(any())).thenReturn(user);
-    when(userService.updateUserFieldsById(any(), any())).thenReturn(user);
-    when(userService.findUserWithPropertiesByIdAsJsonObject(any(), any())).thenReturn(
-        gson.toJsonTree(user).getAsJsonObject());
-    initResource();
-    Response response = userResource.updateSelf(authUser, uriInfo, gson.toJson(userUpdateFields));
-    assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
-  }
-
-  @Test
-  void testUpdateSelfInstitutionIdAsITDirector_ExistingInstitution() {
+  void testUpdateSelfShouldNotPassInstitutionId() {
     User user = createUserWithRole();
     user.setITDirectorRole();
     user.setInstitutionId(10);
     UserUpdateFields userUpdateFields = new UserUpdateFields();
     userUpdateFields.setInstitutionId(20);
-    when(userService.findUserByEmail(any())).thenReturn(user);
-    initResource();
-    Response response = userResource.updateSelf(authUser, uriInfo, gson.toJson(userUpdateFields));
-    assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
-  }
+    when(userService.findUserByEmail(authUser.getEmail())).thenReturn(user);
 
-  @Test
-  void testUpdateSelfInstitutionIdNullAsSO_ExistingInstitution() {
-    User user = createUserWithRole();
-    user.setSigningOfficialRole();
-    user.setInstitutionId(10);
-    UserUpdateFields userUpdateFields = new UserUpdateFields();
-    userUpdateFields.setInstitutionId(null);
-    when(userService.findUserByEmail(any())).thenReturn(user);
-    when(userService.updateUserFieldsById(any(), any())).thenReturn(user);
-    when(userService.findUserWithPropertiesByIdAsJsonObject(any(), any())).thenReturn(
-        gson.toJsonTree(user).getAsJsonObject());
-    initResource();
-    Response response = userResource.updateSelf(authUser, uriInfo, gson.toJson(userUpdateFields));
-    assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
-    user.setInstitutionId(20);
-    userUpdateFields.setInstitutionId(20);
-    Response response2 = userResource.updateSelf(authUser, uriInfo, gson.toJson(userUpdateFields));
-    assertEquals(HttpStatusCodes.STATUS_CODE_OK, response2.getStatus());
-  }
-
-
-  @Test
-  void testCanUpdateInstitution() {
-    initResource();
-
-    // User with no roles and no institution can update their institution
-    User u1 = new User();
-    boolean canUpdate = userResource.canUpdateInstitution(u1, 1);
-    assertTrue(canUpdate);
-
-    // Researcher user with no institution can update their institution
-    User u2 = new User();
-    u2.setResearcherRole();
-    canUpdate = userResource.canUpdateInstitution(u2, 1);
-    assertTrue(canUpdate);
-
-    // Researcher user with an institution can update their institution
-    User u3 = new User();
-    u3.setInstitutionId(10);
-    u3.setResearcherRole();
-    canUpdate = userResource.canUpdateInstitution(u3, 1);
-    assertTrue(canUpdate);
-
-    // SO user with no institution can update their institution
-    User u4 = new User();
-    u4.setSigningOfficialRole();
-    canUpdate = userResource.canUpdateInstitution(u4, 1);
-    assertTrue(canUpdate);
-
-    // SO user with an institution CANNOT update their institution
-    User u4a = new User();
-    u4a.setInstitutionId(10);
-    u4a.setSigningOfficialRole();
-    canUpdate = userResource.canUpdateInstitution(u4a, 1);
-    assertFalse(canUpdate);
-
-    // IT user with no institution can update their institution
-    User u5 = new User();
-    u5.setITDirectorRole();
-    canUpdate = userResource.canUpdateInstitution(u5, 1);
-    assertTrue(canUpdate);
-
-    // IT user with an institution CANNOT update their institution
-    User u5a = new User();
-    u5a.setInstitutionId(10);
-    u5a.setITDirectorRole();
-    canUpdate = userResource.canUpdateInstitution(u5a, 1);
-    assertFalse(canUpdate);
-
-    // Admin user with no institution can update their institution
-    User u6 = new User();
-    u6.setAdminRole();
-    canUpdate = userResource.canUpdateInstitution(u6, 1);
-    assertTrue(canUpdate);
-
-    // Admin user with an institution can update their institution
-    User u7 = new User();
-    u7.setInstitutionId(10);
-    u7.setAdminRole();
-    canUpdate = userResource.canUpdateInstitution(u7, 1);
-    assertTrue(canUpdate);
+    try (var response = userResource.updateSelf(authUser, uriInfo, gson.toJson(userUpdateFields))) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
+    }
   }
 
   @Test
@@ -656,7 +502,7 @@ class UserResourceTest {
     when(userService.updateUserFieldsById(any(), any())).thenReturn(user);
     when(userService.findUserWithPropertiesByIdAsJsonObject(any(), any())).thenReturn(
         gson.toJsonTree(user).getAsJsonObject());
-    initResource();
+
     Response response = userResource.update(authUser, uriInfo, user.getUserId(),
         gson.toJson(userUpdateFields));
     assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
@@ -666,7 +512,7 @@ class UserResourceTest {
   void testUpdateUserNotFound() {
     User user = createUserWithRole();
     when(userService.findUserById(any())).thenThrow(new NotFoundException());
-    initResource();
+
     Response response = userResource.update(authUser, uriInfo, user.getUserId(), "");
     assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
   }
@@ -674,7 +520,7 @@ class UserResourceTest {
   @Test
   void testUpdateUserInvalidJson() {
     User user = createUserWithRole();
-    initResource();
+
     Response response = userResource.update(authUser, uriInfo, user.getUserId(), "}{][");
     assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
   }
@@ -691,7 +537,7 @@ class UserResourceTest {
     JsonElement userJson = gson.toJsonTree(user);
     when(userService.findUserWithPropertiesByIdAsJsonObject(any(), any())).thenReturn(
         userJson.getAsJsonObject());
-    initResource();
+
     Response response = userResource.deleteRoleFromUser(authUser, user.getUserId(),
         UserRoles.RESEARCHER.getRoleId());
     assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
@@ -704,7 +550,7 @@ class UserResourceTest {
     User user = createUserWithRole();
     User activeUser = createUserWithRole();
     activeUser.setAdminRole();
-    initResource();
+
     Response response = userResource.deleteRoleFromUser(authUser, user.getUserId(), 20);
     assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
   }
@@ -724,7 +570,7 @@ class UserResourceTest {
     activeUser.setInstitutionId(10);
     when(userService.findUserById(any())).thenReturn(user);
     when(userService.findUserByEmail(any())).thenReturn(activeUser);
-    initResource();
+
     Response response = userResource.deleteRoleFromUser(authUser, user.getUserId(),
         UserRoles.ADMIN.getRoleId());
     assertEquals(HttpStatusCodes.STATUS_CODE_FORBIDDEN, response.getStatus());
@@ -757,7 +603,7 @@ class UserResourceTest {
     activeUser.setInstitutionId(10);
     when(userService.findUserById(any())).thenReturn(user);
     when(userService.findUserByEmail(any())).thenReturn(activeUser);
-    initResource();
+
     Response response = userResource.deleteRoleFromUser(authUser, user.getUserId(),
         UserRoles.ITDIRECTOR.getRoleId());
     assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
@@ -782,7 +628,7 @@ class UserResourceTest {
     activeUser.setInstitutionId(10);
     when(userService.findUserById(any())).thenReturn(user);
     when(userService.findUserByEmail(any())).thenReturn(activeUser);
-    initResource();
+
     Response response = userResource.deleteRoleFromUser(authUser, user.getUserId(),
         UserRoles.ITDIRECTOR.getRoleId());
     assertEquals(HttpStatusCodes.STATUS_CODE_FORBIDDEN, response.getStatus());
@@ -807,7 +653,7 @@ class UserResourceTest {
     assertNotEquals(user.getInstitutionId(), activeUser.getInstitutionId());
     when(userService.findUserById(any())).thenReturn(user);
     when(userService.findUserByEmail(any())).thenReturn(activeUser);
-    initResource();
+
     Response response = userResource.deleteRoleFromUser(authUser, user.getUserId(),
         UserRoles.SIGNINGOFFICIAL.getRoleId());
     assertEquals(HttpStatusCodes.STATUS_CODE_FORBIDDEN, response.getStatus());
@@ -820,7 +666,7 @@ class UserResourceTest {
     user.setInstitutionId(1);
     when(userService.findUserById(any())).thenReturn(user);
     when(userService.findUserByEmail(any())).thenReturn(user);
-    initResource();
+
     Response response = userResource.deleteRoleFromUser(authUser, user.getUserId(),
         UserRoles.SIGNINGOFFICIAL.getRoleId());
     assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
@@ -838,7 +684,7 @@ class UserResourceTest {
     JsonElement userJson = gson.toJsonTree(user);
     when(userService.findUserWithPropertiesByIdAsJsonObject(any(), any())).thenReturn(
         userJson.getAsJsonObject());
-    initResource();
+
     Response response = userResource.deleteRoleFromUser(authUser, user.getUserId(),
         UserRoles.ADMIN.getRoleId());
     assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
@@ -852,7 +698,7 @@ class UserResourceTest {
     activeUser.setAdminRole();
     when(userService.findUserById(any())).thenThrow(new NotFoundException());
     when(userService.findUserByEmail(any())).thenReturn(activeUser);
-    initResource();
+
     Response response = userResource.deleteRoleFromUser(authUser, 1, UserRoles.ADMIN.getRoleId());
     assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
   }
@@ -861,7 +707,7 @@ class UserResourceTest {
   void testDeleteRoleFromUserInvalidRoleId() {
     User activeUser = createUserWithRole();
     activeUser.setAdminRole();
-    initResource();
+
     Response response = userResource.deleteRoleFromUser(authUser, 1, 1000);
     assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
   }
@@ -872,7 +718,7 @@ class UserResourceTest {
     user.setChairpersonRoleWithDAC(1);
     when(datasetService.findDatasetListByDacIds(anyList())).thenReturn(List.of(new Dataset()));
     when(userService.findUserByEmail(anyString())).thenReturn(user);
-    initResource();
+
 
     Response response = userResource.getDatasetsFromUserDacsV2(authUser);
     assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
@@ -884,7 +730,7 @@ class UserResourceTest {
     user.setChairpersonRoleWithDAC(1);
     when(datasetService.findDatasetListByDacIds(anyList())).thenReturn(List.of());
     when(userService.findUserByEmail(anyString())).thenReturn(user);
-    initResource();
+
 
     Response response = userResource.getDatasetsFromUserDacsV2(authUser);
     assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
@@ -894,7 +740,7 @@ class UserResourceTest {
   void testGetDatasetsFromUserDacsV2UserNotFound() {
     when(userService.findUserByEmail(anyString())).thenThrow(
         new NotFoundException("User not found"));
-    initResource();
+
 
     Response response = userResource.getDatasetsFromUserDacsV2(authUser);
     assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
@@ -908,7 +754,7 @@ class UserResourceTest {
         acknowledgementKey);
     when(acknowledgementService.makeAcknowledgements(anyList(), any())).thenReturn(
         acknowledgementMap);
-    initResource();
+
 
     String jsonString = userResource.unmarshal(List.of(acknowledgementKey));
     Response response = userResource.postAcknowledgements(authUser, jsonString);
@@ -920,7 +766,7 @@ class UserResourceTest {
     String acknowledgementKey = "key1";
     doThrow(new RuntimeException("exception during post")).when(acknowledgementService)
         .makeAcknowledgements(anyList(), any());
-    initResource();
+
     String jsonString = userResource.unmarshal(List.of(acknowledgementKey));
 
     Response response = userResource.postAcknowledgements(authUser, jsonString);
@@ -929,7 +775,7 @@ class UserResourceTest {
 
   @Test
   void testPostAcknowledgementBadJson() {
-    initResource();
+
     String jsonString = "The quick brown fox jumped over the lazy dog.";
 
     Response response = userResource.postAcknowledgements(authUser, jsonString);
@@ -938,7 +784,7 @@ class UserResourceTest {
 
   @Test
   void testPostAcknowledgementEmptyJson() {
-    initResource();
+
 
     Response response = userResource.postAcknowledgements(authUser, "");
     assertEquals(Status.BAD_REQUEST.getStatusCode(), response.getStatus());
@@ -946,7 +792,7 @@ class UserResourceTest {
 
   @Test
   void testPostAcknowledgementEmptyJsonList() {
-    initResource();
+
 
     Response response = userResource.postAcknowledgements(authUser, "[]");
     assertEquals(Status.BAD_REQUEST.getStatusCode(), response.getStatus());
@@ -956,7 +802,7 @@ class UserResourceTest {
   void testMissingAcknowledgement() {
     String acknowledgementKey = "key1";
     when(acknowledgementService.findAcknowledgementForUserByKey(any(), any())).thenReturn(null);
-    initResource();
+
 
     Response response = userResource.getUserAcknowledgement(authUser, acknowledgementKey);
     assertEquals(Status.NOT_FOUND.getStatusCode(), response.getStatus());
@@ -967,7 +813,7 @@ class UserResourceTest {
     String acknowledgementKey = "key1";
     doThrow(new RuntimeException("some exception during get.")).when(acknowledgementService)
         .findAcknowledgementForUserByKey(any(), any());
-    initResource();
+
 
     Response response = userResource.getUserAcknowledgement(authUser, acknowledgementKey);
     assertEquals(Status.INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatus());
@@ -976,7 +822,7 @@ class UserResourceTest {
   @Test
   void testGetAcknowledgementNull() {
     when(acknowledgementService.findAcknowledgementForUserByKey(any(), any())).thenReturn(null);
-    initResource();
+
 
     Response response = userResource.getUserAcknowledgement(authUser, null);
     assertEquals(Status.NOT_FOUND.getStatusCode(), response.getStatus());
@@ -985,7 +831,7 @@ class UserResourceTest {
   @Test
   void testGetUnsetAcknowledgementsForUser() {
     when(acknowledgementService.findAcknowledgementsForUser(any())).thenReturn(null);
-    initResource();
+
 
     Response response = userResource.getUserAcknowledgements(authUser);
     assertEquals(Status.OK.getStatusCode(), response.getStatus());
@@ -995,7 +841,7 @@ class UserResourceTest {
   void testGetAcknowledgementsForUserException() {
     doThrow(new RuntimeException("some get exception")).when(acknowledgementService)
         .findAcknowledgementsForUser(any());
-    initResource();
+
 
     Response response = userResource.getUserAcknowledgements(authUser);
     assertEquals(Status.INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatus());
@@ -1009,7 +855,7 @@ class UserResourceTest {
         acknowledgementKey);
     when(acknowledgementService.findAcknowledgementForUserByKey(any(), any())).thenReturn(
         acknowledgementMap.get(acknowledgementKey));
-    initResource();
+
 
     Response response = userResource.getUserAcknowledgement(authUser, acknowledgementKey);
     assertEquals(Status.OK.getStatusCode(), response.getStatus());
@@ -1023,7 +869,7 @@ class UserResourceTest {
         acknowledgementKey);
     when(acknowledgementService.findAcknowledgementForUserByKey(any(), any())).thenReturn(
         acknowledgementMap.get(acknowledgementKey));
-    initResource();
+
 
     Response response = userResource.deleteUserAcknowledgement(authUser, acknowledgementKey);
     assertEquals(Status.OK.getStatusCode(), response.getStatus());
@@ -1033,7 +879,7 @@ class UserResourceTest {
   void testDeleteMissingAcknowledgementForUser() {
     User user = createUserWithRole();
     when(acknowledgementService.findAcknowledgementForUserByKey(any(), any())).thenReturn(null);
-    initResource();
+
 
     Response response = userResource.deleteUserAcknowledgement(authUser, "key");
     assertEquals(Status.NOT_FOUND.getStatusCode(), response.getStatus());
@@ -1045,7 +891,7 @@ class UserResourceTest {
     User user = createUserWithRole();
     Map<String, Acknowledgement> acknowledgementMap = getDefaultAcknowledgementForUser(user,
         acknowledgementKey);
-    initResource();
+
 
     Response response = userResource.getUserAcknowledgements(authUser);
     assertEquals(Status.OK.getStatusCode(), response.getStatus());
@@ -1056,7 +902,7 @@ class UserResourceTest {
     ApprovedDataset example = new ApprovedDataset(1, "sampleDarId", "sampleName", "sampleDac",
         new Date());
     when(datasetService.getApprovedDatasets(any())).thenReturn(List.of(example));
-    initResource();
+
     Response response = userResource.getApprovedDatasets(authUser);
     assertEquals(Status.OK.getStatusCode(), response.getStatus());
   }


### PR DESCRIPTION
### Addresses
Back end work for https://broadworkbench.atlassian.net/browse/DT-1496

### Summary
Prevent users from updating their institution id via the self update endpoint.
If a user tries to do this, return a bad request response.
Relatively large change to resource test due to the removal of previous logic and some other minor cleanup efforts.
See https://github.com/DataBiosphere/duos-ui/pull/2821 for related front end work.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
