### PR TITLE
[DT-1502] Enforce Library card rule on all DAR creation; return specific Error text when this rule is being enforced.

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
@@ -241,7 +241,7 @@ public class ConsentApplication extends Application<ConsentConfiguration> {
     env.jersey().register(new VoteResource(userService, voteService, electionService));
     env.jersey().register(new LivenessResource());
     env.jersey().register(
-        new TDRResource(tdrService, datasetService, userService, dataAccessRequestService));
+        new TDRResource(tdrService, datasetService));
     env.jersey().register(new MailResource(emailService));
     env.jersey().register(injector.getInstance(StudyResource.class));
     env.jersey().register(new OAuth2Resource(oidcService));

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/UserWithRolesReducer.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/UserWithRolesReducer.java
@@ -65,9 +65,7 @@ public class UserWithRolesReducer implements LinkedHashMapRowReducer<Integer, Us
       if (rowView.getColumn("lc_id", Integer.class) != null) {
         int lcId = rowView.getColumn("lc_id", Integer.class);
         LibraryCard lc;
-        Optional<LibraryCard> existingLibraryCard = user.getLibraryCards() == null ?
-            Optional.empty() :
-            user.getLibraryCards().stream()
+        Optional<LibraryCard> existingLibraryCard = user.getLibraryCards().stream()
                 .filter(card -> card.getId().equals(lcId))
                 .findFirst();
         lc = existingLibraryCard.orElseGet(() -> rowView.getRow(LibraryCard.class));

--- a/src/main/java/org/broadinstitute/consent/http/exceptions/LibraryCardRequiredException.java
+++ b/src/main/java/org/broadinstitute/consent/http/exceptions/LibraryCardRequiredException.java
@@ -1,7 +1,7 @@
 package org.broadinstitute.consent.http.exceptions;
 
 public class LibraryCardRequiredException extends UnprocessableEntityException{
-  public static final String MESSAGE = "Please register in DUOS with your institution's email and obtain approval from your Signing Official in order to submit a data access request.";
+  public static final String MESSAGE = "Please register in DUOS with your institution's email and obtain a library card from your Signing Official in order to submit a data access request.";
   public LibraryCardRequiredException() {
     super(MESSAGE);
   }

--- a/src/main/java/org/broadinstitute/consent/http/exceptions/LibraryCardRequiredException.java
+++ b/src/main/java/org/broadinstitute/consent/http/exceptions/LibraryCardRequiredException.java
@@ -1,0 +1,8 @@
+package org.broadinstitute.consent.http.exceptions;
+
+public class LibraryCardRequiredException extends UnprocessableEntityException{
+  public static final String MESSAGE = "Please register in DUOS with your institution's email and obtain approval from your Signing Official in order to submit a data access request.";
+  public LibraryCardRequiredException() {
+    super(MESSAGE);
+  }
+}

--- a/src/main/java/org/broadinstitute/consent/http/exceptions/NIHComplianceRuleException.java
+++ b/src/main/java/org/broadinstitute/consent/http/exceptions/NIHComplianceRuleException.java
@@ -1,0 +1,13 @@
+package org.broadinstitute.consent.http.exceptions;
+
+import com.google.api.client.http.HttpStatusCodes;
+import jakarta.ws.rs.ClientErrorException;
+
+public class NIHComplianceRuleException extends ClientErrorException {
+
+  public static final String MESSAGE = "NIH has received, reviewed, and processed your data access request. This request is denied. Please see Guide Notice [NOT-OD-25-083](https://grants.nih.gov/grants/guide/notice-files/NOT-OD-25-083.html) for more information.";
+
+  public NIHComplianceRuleException() {
+    super(MESSAGE, HttpStatusCodes.STATUS_CODE_UNPROCESSABLE_ENTITY);
+  }
+}

--- a/src/main/java/org/broadinstitute/consent/http/models/User.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/User.java
@@ -283,6 +283,9 @@ public class User {
   }
 
   public List<LibraryCard> getLibraryCards() {
+    if (this.libraryCards == null) {
+      this.libraryCards = new ArrayList<>();
+    }
     return this.libraryCards;
   }
 
@@ -306,11 +309,11 @@ public class User {
   }
 
   public void addLibraryCard(LibraryCard card) {
-    if (Objects.isNull(this.getLibraryCards())) {
-      this.setLibraryCards(new ArrayList<>());
+    if (this.libraryCards == null) {
+      this.libraryCards = new ArrayList<>();
     }
-    if (!this.getLibraryCards().contains(card)) {
-      this.getLibraryCards().add(card);
+    if (!this.libraryCards.contains(card)) {
+      this.libraryCards.add(card);
     }
   }
 

--- a/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
@@ -418,7 +418,12 @@ public class DataAccessRequestResource extends Resource {
       @FormDataParam("ethicsApprovalRequiredFile") FormDataContentDisposition ethicsFileDetails) {
     User user = userService.findUserByEmail(authUser.getEmail());
     DataAccessRequest parentDar = dataAccessRequestService.findByReferenceId(parentReferenceId);
-    checkAuthorizedUpdateUser(user, parentDar);
+    try {
+      checkAuthorizedUpdateUser(user, parentDar);
+    } catch (Exception e) {
+      return createExceptionResponse(e);
+    }
+
     DataAccessRequest payload = populateDarFromJsonString(user, dar);
     DataAccessRequest childDar = dataAccessRequestService.createDataAccessRequest(user, payload);
 
@@ -585,6 +590,9 @@ public class DataAccessRequestResource extends Resource {
   private void checkAuthorizedUpdateUser(User user, DataAccessRequest dar) {
     if (!user.getUserId().equals(dar.getUserId())) {
       throw new ForbiddenException("User not authorized to update this Data Access Request");
+    }
+    if (Objects.isNull(user.getLibraryCards()) || user.getLibraryCards().isEmpty()) {
+      throw new NIHComplianceRuleException();
     }
   }
 

--- a/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
@@ -35,7 +35,9 @@ import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.consent.http.cloudstore.GCSService;
 import org.broadinstitute.consent.http.enumeration.DarDocumentType;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
+import org.broadinstitute.consent.http.exceptions.LibraryCardRequiredException;
 import org.broadinstitute.consent.http.exceptions.NIHComplianceRuleException;
+import org.broadinstitute.consent.http.exceptions.UnprocessableEntityException;
 import org.broadinstitute.consent.http.models.AuthUser;
 import org.broadinstitute.consent.http.models.DataAccessAgreement;
 import org.broadinstitute.consent.http.models.DataAccessRequest;
@@ -592,7 +594,7 @@ public class DataAccessRequestResource extends Resource {
       throw new ForbiddenException("User not authorized to update this Data Access Request");
     }
     if (user.getLibraryCards().isEmpty()) {
-      throw new NIHComplianceRuleException();
+      throw new LibraryCardRequiredException();
     }
   }
 

--- a/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
@@ -106,7 +106,7 @@ public class DataAccessRequestResource extends Resource {
       @Auth AuthUser authUser, @Context UriInfo info, String dar) {
     try {
       User user = findUserByEmail(authUser.getEmail());
-      if (Objects.isNull(user.getLibraryCards()) || user.getLibraryCards().isEmpty()) {
+      if (user.getLibraryCards().isEmpty()) {
         throw new NIHComplianceRuleException();
       }
 
@@ -136,7 +136,7 @@ public class DataAccessRequestResource extends Resource {
       @Auth AuthUser authUser, @Context UriInfo info, String dar) {
     try {
       User user = findUserByEmail(authUser.getEmail());
-      if (Objects.isNull(user.getLibraryCards()) || user.getLibraryCards().isEmpty()) {
+      if (user.getLibraryCards().isEmpty()) {
         throw new NIHComplianceRuleException();
       }
       DataAccessRequest payload = populateDarFromJsonString(user, dar);
@@ -591,7 +591,7 @@ public class DataAccessRequestResource extends Resource {
     if (!user.getUserId().equals(dar.getUserId())) {
       throw new ForbiddenException("User not authorized to update this Data Access Request");
     }
-    if (Objects.isNull(user.getLibraryCards()) || user.getLibraryCards().isEmpty()) {
+    if (user.getLibraryCards().isEmpty()) {
       throw new NIHComplianceRuleException();
     }
   }

--- a/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
@@ -35,6 +35,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.consent.http.cloudstore.GCSService;
 import org.broadinstitute.consent.http.enumeration.DarDocumentType;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
+import org.broadinstitute.consent.http.exceptions.NIHComplianceRuleException;
 import org.broadinstitute.consent.http.models.AuthUser;
 import org.broadinstitute.consent.http.models.DataAccessAgreement;
 import org.broadinstitute.consent.http.models.DataAccessRequest;
@@ -106,7 +107,7 @@ public class DataAccessRequestResource extends Resource {
     try {
       User user = findUserByEmail(authUser.getEmail());
       if (Objects.isNull(user.getLibraryCards()) || user.getLibraryCards().isEmpty()) {
-        throw new IllegalArgumentException("User must have a library card to create a DAR.");
+        throw new NIHComplianceRuleException();
       }
 
       DataAccessRequest payload = populateDarFromJsonString(user, dar);
@@ -136,7 +137,7 @@ public class DataAccessRequestResource extends Resource {
     try {
       User user = findUserByEmail(authUser.getEmail());
       if (Objects.isNull(user.getLibraryCards()) || user.getLibraryCards().isEmpty()) {
-        throw new IllegalArgumentException("User must have a library card to create a DAR.");
+        throw new NIHComplianceRuleException();
       }
       DataAccessRequest payload = populateDarFromJsonString(user, dar);
       // DAA Enforcement

--- a/src/main/java/org/broadinstitute/consent/http/resources/Resource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/Resource.java
@@ -24,6 +24,7 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.exceptions.ConsentConflictException;
+import org.broadinstitute.consent.http.exceptions.NIHComplianceRuleException;
 import org.broadinstitute.consent.http.exceptions.UnknownIdentifierException;
 import org.broadinstitute.consent.http.exceptions.UnprocessableEntityException;
 import org.broadinstitute.consent.http.models.Error;
@@ -68,67 +69,22 @@ abstract public class Resource implements ConsentLogger {
       Map.entry("22021",
           ImmutablePair.of(Response.Status.BAD_REQUEST.getStatusCode(), "Invalid byte sequence"))
   );
-
-  protected Response createExceptionResponse(Exception e) {
-    try {
-      logWarn("Returning error response to client: " + e.getMessage());
-      ExceptionHandler handler = dispatch.get(e.getClass());
-      if (handler != null) {
-        return handler.handle(e);
-      } else {
-        logException(e);
-        return Response.serverError().type(MediaType.APPLICATION_JSON).entity(
-                new Error(e.getMessage(), Response.Status.INTERNAL_SERVER_ERROR.getStatusCode()))
-            .build();
-      }
-    } catch (Throwable t) {
-      logThrowable(t);
-      return Response.serverError().type(MediaType.APPLICATION_JSON)
-          .entity(new Error(e.getMessage(), Response.Status.INTERNAL_SERVER_ERROR.getStatusCode()))
-          .build();
-    }
-  }
-
-  StreamingOutput createStreamingOutput(InputStream inputStream) {
-    return output -> {
-      try {
-        output.write(IOUtils.toByteArray(inputStream));
-      } catch (Exception e) {
-        logException(e);
-        throw e;
-      }
-    };
-  }
-
-  protected void validateFileDetails(ContentDisposition contentDisposition) {
-    FileValidator validator = new FileValidator();
-    boolean validName = validator.isValidFileName("validating uploaded file name",
-        contentDisposition.getFileName(), true);
-    if (!validName) {
-      throw new IllegalArgumentException("File name is invalid");
-    }
-    boolean validSize = validator.getMaxFileUploadSize() >= contentDisposition.getSize();
-    if (!validSize) {
-      throw new IllegalArgumentException(
-          "File size is invalid. Max size is: " + validator.getMaxFileUploadSize() / 1000000
-              + " MB");
-    }
-  }
-
-  private interface ExceptionHandler {
-
-    Response handle(Exception e);
-  }
-
   private static final Map<Class<? extends Throwable>, ExceptionHandler> dispatch = new HashMap<>();
 
   static {
+    dispatch.put(NIHComplianceRuleException.class, e ->
+        Response.status(HttpStatusCodes.STATUS_CODE_UNPROCESSABLE_ENTITY)
+            .type(MediaType.APPLICATION_JSON)
+            .entity(new Error(e.getMessage(), HttpStatusCodes.STATUS_CODE_UNPROCESSABLE_ENTITY))
+            .build());
     dispatch.put(ConsentConflictException.class, e ->
         Response.status(Response.Status.CONFLICT).type(MediaType.APPLICATION_JSON)
             .entity(new Error(e.getMessage(), Response.Status.CONFLICT.getStatusCode())).build());
     dispatch.put(UnprocessableEntityException.class, e ->
-        Response.status(HttpStatusCodes.STATUS_CODE_UNPROCESSABLE_ENTITY).type(MediaType.APPLICATION_JSON)
-            .entity(new Error(e.getMessage(), HttpStatusCodes.STATUS_CODE_UNPROCESSABLE_ENTITY)).build());
+        Response.status(HttpStatusCodes.STATUS_CODE_UNPROCESSABLE_ENTITY)
+            .type(MediaType.APPLICATION_JSON)
+            .entity(new Error(e.getMessage(), HttpStatusCodes.STATUS_CODE_UNPROCESSABLE_ENTITY))
+            .build());
     dispatch.put(UnsupportedOperationException.class, e ->
         Response.status(Response.Status.CONFLICT).type(MediaType.APPLICATION_JSON)
             .entity(new Error(e.getMessage(), Response.Status.CONFLICT.getStatusCode())).build());
@@ -217,6 +173,52 @@ abstract public class Resource implements ConsentLogger {
         .build();
   }
 
+  protected Response createExceptionResponse(Exception e) {
+    try {
+      logWarn("Returning error response to client: " + e.getMessage());
+      ExceptionHandler handler = dispatch.get(e.getClass());
+      if (handler != null) {
+        return handler.handle(e);
+      } else {
+        logException(e);
+        return Response.serverError().type(MediaType.APPLICATION_JSON).entity(
+                new Error(e.getMessage(), Response.Status.INTERNAL_SERVER_ERROR.getStatusCode()))
+            .build();
+      }
+    } catch (Throwable t) {
+      logThrowable(t);
+      return Response.serverError().type(MediaType.APPLICATION_JSON)
+          .entity(new Error(e.getMessage(), Response.Status.INTERNAL_SERVER_ERROR.getStatusCode()))
+          .build();
+    }
+  }
+
+  StreamingOutput createStreamingOutput(InputStream inputStream) {
+    return output -> {
+      try {
+        output.write(IOUtils.toByteArray(inputStream));
+      } catch (Exception e) {
+        logException(e);
+        throw e;
+      }
+    };
+  }
+
+  protected void validateFileDetails(ContentDisposition contentDisposition) {
+    FileValidator validator = new FileValidator();
+    boolean validName = validator.isValidFileName("validating uploaded file name",
+        contentDisposition.getFileName(), true);
+    if (!validName) {
+      throw new IllegalArgumentException("File name is invalid");
+    }
+    boolean validSize = validator.getMaxFileUploadSize() >= contentDisposition.getSize();
+    if (!validSize) {
+      throw new IllegalArgumentException(
+          "File size is invalid. Max size is: " + validator.getMaxFileUploadSize() / 1000000
+              + " MB");
+    }
+  }
+
   /**
    * Validate that the current authenticated user can access this resource. If the user has one of
    * the provided roles, then access is allowed. If not, then the authenticated user must have the
@@ -295,5 +297,10 @@ abstract public class Resource implements ConsentLogger {
     }
 
     return files;
+  }
+
+  private interface ExceptionHandler {
+
+    Response handle(Exception e);
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/resources/Resource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/Resource.java
@@ -69,69 +69,69 @@ abstract public class Resource implements ConsentLogger {
       Map.entry("22021",
           ImmutablePair.of(Response.Status.BAD_REQUEST.getStatusCode(), "Invalid byte sequence"))
   );
-  private static final Map<Class<? extends Throwable>, ExceptionHandler> dispatch = new HashMap<>();
+  private static final Map<Class<? extends Throwable>, ExceptionHandler> DISPATCH = new HashMap<>();
 
   static {
-    dispatch.put(NIHComplianceRuleException.class, e ->
+    DISPATCH.put(NIHComplianceRuleException.class, e ->
         Response.status(HttpStatusCodes.STATUS_CODE_UNPROCESSABLE_ENTITY)
             .type(MediaType.APPLICATION_JSON)
             .entity(new Error(e.getMessage(), HttpStatusCodes.STATUS_CODE_UNPROCESSABLE_ENTITY))
             .build());
-    dispatch.put(ConsentConflictException.class, e ->
+    DISPATCH.put(ConsentConflictException.class, e ->
         Response.status(Response.Status.CONFLICT).type(MediaType.APPLICATION_JSON)
             .entity(new Error(e.getMessage(), Response.Status.CONFLICT.getStatusCode())).build());
-    dispatch.put(UnprocessableEntityException.class, e ->
+    DISPATCH.put(UnprocessableEntityException.class, e ->
         Response.status(HttpStatusCodes.STATUS_CODE_UNPROCESSABLE_ENTITY)
             .type(MediaType.APPLICATION_JSON)
             .entity(new Error(e.getMessage(), HttpStatusCodes.STATUS_CODE_UNPROCESSABLE_ENTITY))
             .build());
-    dispatch.put(UnsupportedOperationException.class, e ->
+    DISPATCH.put(UnsupportedOperationException.class, e ->
         Response.status(Response.Status.CONFLICT).type(MediaType.APPLICATION_JSON)
             .entity(new Error(e.getMessage(), Response.Status.CONFLICT.getStatusCode())).build());
-    dispatch.put(IllegalArgumentException.class, e ->
+    DISPATCH.put(IllegalArgumentException.class, e ->
         Response.status(Response.Status.BAD_REQUEST).type(MediaType.APPLICATION_JSON)
             .entity(new Error(e.getMessage(), Response.Status.BAD_REQUEST.getStatusCode()))
             .build());
-    dispatch.put(IOException.class, e ->
+    DISPATCH.put(IOException.class, e ->
         Response.status(Response.Status.BAD_REQUEST).type(MediaType.APPLICATION_JSON)
             .entity(new Error(e.getMessage(), Response.Status.BAD_REQUEST.getStatusCode()))
             .build());
-    dispatch.put(BadRequestException.class, e ->
+    DISPATCH.put(BadRequestException.class, e ->
         Response.status(Response.Status.BAD_REQUEST).type(MediaType.APPLICATION_JSON)
             .entity(new Error(e.getMessage(), Response.Status.BAD_REQUEST.getStatusCode()))
             .build());
-    dispatch.put(MalformedJsonException.class, e ->
+    DISPATCH.put(MalformedJsonException.class, e ->
         Response.status(Response.Status.BAD_REQUEST).type(MediaType.APPLICATION_JSON)
             .entity(new Error(e.getMessage(), Response.Status.BAD_REQUEST.getStatusCode()))
             .build());
-    dispatch.put(JsonSyntaxException.class, e ->
+    DISPATCH.put(JsonSyntaxException.class, e ->
         Response.status(Response.Status.BAD_REQUEST).type(MediaType.APPLICATION_JSON)
             .entity(new Error(e.getMessage(), Response.Status.BAD_REQUEST.getStatusCode()))
             .build());
-    dispatch.put(NotAuthorizedException.class, e ->
+    DISPATCH.put(NotAuthorizedException.class, e ->
         Response.status(Response.Status.UNAUTHORIZED).type(MediaType.APPLICATION_JSON)
             .entity(new Error(e.getMessage(), Response.Status.UNAUTHORIZED.getStatusCode()))
             .build());
-    dispatch.put(ForbiddenException.class, e ->
+    DISPATCH.put(ForbiddenException.class, e ->
         Response.status(Response.Status.FORBIDDEN).type(MediaType.APPLICATION_JSON)
             .entity(new Error(e.getMessage(), Response.Status.FORBIDDEN.getStatusCode())).build());
-    dispatch.put(NotFoundException.class, e ->
+    DISPATCH.put(NotFoundException.class, e ->
         Response.status(Response.Status.NOT_FOUND).type(MediaType.APPLICATION_JSON)
             .entity(new Error(e.getMessage(), Response.Status.NOT_FOUND.getStatusCode())).build());
-    dispatch.put(UnknownIdentifierException.class, e ->
+    DISPATCH.put(UnknownIdentifierException.class, e ->
         Response.status(Response.Status.NOT_FOUND).type(MediaType.APPLICATION_JSON)
             .entity(new Error(e.getMessage(), Response.Status.NOT_FOUND.getStatusCode())).build());
-    dispatch.put(UnableToExecuteStatementException.class,
+    DISPATCH.put(UnableToExecuteStatementException.class,
         Resource::unableToExecuteExceptionHandler);
-    dispatch.put(PSQLException.class,
+    DISPATCH.put(PSQLException.class,
         Resource::unableToExecuteExceptionHandler);
-    dispatch.put(SQLSyntaxErrorException.class, e ->
+    DISPATCH.put(SQLSyntaxErrorException.class, e ->
         errorLoggedExceptionHandler(e,
             new Error("Database Error", Response.Status.INTERNAL_SERVER_ERROR.getStatusCode())));
-    dispatch.put(SQLException.class, e ->
+    DISPATCH.put(SQLException.class, e ->
         errorLoggedExceptionHandler(e,
             new Error("Database Error", Response.Status.INTERNAL_SERVER_ERROR.getStatusCode())));
-    dispatch.put(Exception.class, e ->
+    DISPATCH.put(Exception.class, e ->
         errorLoggedExceptionHandler(e,
             new Error(Response.Status.INTERNAL_SERVER_ERROR.getReasonPhrase(),
                 Response.Status.INTERNAL_SERVER_ERROR.getStatusCode())));
@@ -176,7 +176,7 @@ abstract public class Resource implements ConsentLogger {
   protected Response createExceptionResponse(Exception e) {
     try {
       logWarn("Returning error response to client: " + e.getMessage());
-      ExceptionHandler handler = dispatch.get(e.getClass());
+      ExceptionHandler handler = DISPATCH.get(e.getClass());
       if (handler != null) {
         return handler.handle(e);
       } else {

--- a/src/main/java/org/broadinstitute/consent/http/resources/Resource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/Resource.java
@@ -24,6 +24,7 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.exceptions.ConsentConflictException;
+import org.broadinstitute.consent.http.exceptions.LibraryCardRequiredException;
 import org.broadinstitute.consent.http.exceptions.NIHComplianceRuleException;
 import org.broadinstitute.consent.http.exceptions.UnknownIdentifierException;
 import org.broadinstitute.consent.http.exceptions.UnprocessableEntityException;
@@ -72,6 +73,11 @@ abstract public class Resource implements ConsentLogger {
   private static final Map<Class<? extends Throwable>, ExceptionHandler> DISPATCH = new HashMap<>();
 
   static {
+    DISPATCH.put(LibraryCardRequiredException.class, e ->
+        Response.status(HttpStatusCodes.STATUS_CODE_UNPROCESSABLE_ENTITY)
+            .type(MediaType.APPLICATION_JSON)
+            .entity(new Error(e.getMessage(), HttpStatusCodes.STATUS_CODE_UNPROCESSABLE_ENTITY))
+            .build());
     DISPATCH.put(NIHComplianceRuleException.class, e ->
         Response.status(HttpStatusCodes.STATUS_CODE_UNPROCESSABLE_ENTITY)
             .type(MediaType.APPLICATION_JSON)

--- a/src/main/java/org/broadinstitute/consent/http/resources/TDRResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/TDRResource.java
@@ -4,28 +4,18 @@ import com.codahale.metrics.annotation.Timed;
 import com.google.inject.Inject;
 import io.dropwizard.auth.Auth;
 import jakarta.annotation.security.PermitAll;
-import jakarta.ws.rs.BadRequestException;
-import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.NotFoundException;
-import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
-import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.Response;
-import jakarta.ws.rs.core.UriBuilder;
-import java.net.URI;
 import java.util.Objects;
 import org.broadinstitute.consent.http.models.AuthUser;
-import org.broadinstitute.consent.http.models.DataAccessRequest;
 import org.broadinstitute.consent.http.models.Dataset;
-import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.tdr.ApprovedUsers;
-import org.broadinstitute.consent.http.service.DataAccessRequestService;
 import org.broadinstitute.consent.http.service.DatasetService;
 import org.broadinstitute.consent.http.service.TDRService;
-import org.broadinstitute.consent.http.service.UserService;
 
 
 @Path("api/tdr")
@@ -33,17 +23,12 @@ public class TDRResource extends Resource {
 
   private final TDRService tdrService;
   private final DatasetService datasetService;
-  private final UserService userService;
-  private final DataAccessRequestService darService;
 
 
   @Inject
-  public TDRResource(TDRService tdrService, DatasetService datasetService,
-      UserService userService, DataAccessRequestService darService) {
+  public TDRResource(TDRService tdrService, DatasetService datasetService) {
     this.datasetService = datasetService;
     this.tdrService = tdrService;
-    this.userService = userService;
-    this.darService = darService;
   }
 
   @GET
@@ -85,59 +70,4 @@ public class TDRResource extends Resource {
     }
   }
 
-  @POST
-  @Consumes("application/json")
-  @Produces("application/json")
-  @Path("/dar/draft")
-  @PermitAll
-  @Timed
-  public Response createDraftDataAccessRequest(
-      @Auth AuthUser authUser,
-      @QueryParam("identifiers") String identifiers,
-      @QueryParam("projectTitle") String projectTitle) {
-    try {
-      // Ensure that the user is a registered DUOS and SAM user
-      User user = userService.findOrCreateUser(authUser);
-      if (Objects.isNull(identifiers) || identifiers.isBlank()) {
-        throw new BadRequestException("No dataset identifiers were provided");
-      } else {
-        DataAccessRequest newDar = tdrService.populateDraftDarStubFromDatasetIdentifiers(identifiers, projectTitle);
-        DataAccessRequest result = darService.insertDraftDataAccessRequest(user, newDar);
-        // URI should return the new DAR url
-        URI uri = UriBuilder.fromPath("api/dar/v2/" + result.getReferenceId()).build();
-        return Response.created(uri).entity(result.convertToSimplifiedDar()).build();
-      }
-    } catch (Exception e) {
-      return createExceptionResponse(e);
-    }
-  }
-
-  @POST
-  @Consumes("application/json")
-  @Produces("application/json")
-  @Path("/v2/dar/draft")
-  @PermitAll
-  @Timed
-  public Response createDraftDataAccessRequestWithDAARestrictions(
-      @Auth AuthUser authUser,
-      @QueryParam("identifiers") String identifiers,
-      @QueryParam("projectTitle") String projectTitle) {
-    try {
-      // Ensure that the user is a registered DUOS and SAM user
-      User user = userService.findOrCreateUser(authUser);
-      if (Objects.isNull(identifiers) || identifiers.isBlank()) {
-        throw new BadRequestException("No dataset identifiers were provided");
-      } else {
-        DataAccessRequest newDar = tdrService.populateDraftDarStubFromDatasetIdentifiers(identifiers, projectTitle);
-        // DAA Enforcement
-        datasetService.enforceDAARestrictions(user, newDar.getDatasetIds());
-        DataAccessRequest result = darService.insertDraftDataAccessRequest(user, newDar);
-        // URI should return the new DAR url
-        URI uri = UriBuilder.fromPath("api/dar/v2/" + result.getReferenceId()).build();
-        return Response.created(uri).entity(result.convertToSimplifiedDar()).build();
-      }
-    } catch (Exception e) {
-      return createExceptionResponse(e);
-    }
-  }
 }

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
@@ -22,6 +22,7 @@ import org.broadinstitute.consent.http.db.UserDAO;
 import org.broadinstitute.consent.http.db.VoteDAO;
 import org.broadinstitute.consent.http.enumeration.DarStatus;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
+import org.broadinstitute.consent.http.exceptions.LibraryCardRequiredException;
 import org.broadinstitute.consent.http.exceptions.NIHComplianceRuleException;
 import org.broadinstitute.consent.http.models.DarCollection;
 import org.broadinstitute.consent.http.models.DarDataset;
@@ -108,7 +109,15 @@ public class DataAccessRequestService implements ConsentLogger {
 
   //NOTE: rewrite method into new servicedao method on another ticket
   public DataAccessRequest insertDraftDataAccessRequest(User user, DataAccessRequest dar) {
-    validateUserAndRequestObject(user, dar);
+    if (Objects.isNull(user) || Objects.isNull(dar) || Objects.isNull(
+        dar.getReferenceId()) || Objects.isNull(dar.getData())) {
+      throw new IllegalArgumentException("User and DataAccessRequest are required");
+    }
+
+    if (user.getLibraryCards().isEmpty()) {
+      throw new LibraryCardRequiredException();
+    }
+
     Date now = new Date();
     dataAccessRequestDAO.insertDraftDataAccessRequest(
         dar.getReferenceId(),
@@ -156,7 +165,7 @@ public class DataAccessRequestService implements ConsentLogger {
       throw new IllegalArgumentException("Source Collection must contain at least a single DAR");
     }
     if (user.getLibraryCards().isEmpty()) {
-      throw new NIHComplianceRuleException();
+      throw new LibraryCardRequiredException();
     }
     DataAccessRequest sourceDar = new ArrayList<>(sourceCollection.getDars().values()).get(0);
     DataAccessRequestData sourceData = sourceDar.getData();
@@ -239,7 +248,15 @@ public class DataAccessRequestService implements ConsentLogger {
    * @return The created DAR.
    */
   public DataAccessRequest createDataAccessRequest(User user, DataAccessRequest dataAccessRequest) {
-    validateUserAndRequestObject(user, dataAccessRequest);
+    if (Objects.isNull(user) || Objects.isNull(dataAccessRequest) || Objects.isNull(
+        dataAccessRequest.getReferenceId()) || Objects.isNull(dataAccessRequest.getData())) {
+      throw new IllegalArgumentException("User and DataAccessRequest are required");
+    }
+
+    if (user.getLibraryCards().isEmpty()) {
+      throw new NIHComplianceRuleException();
+    }
+
     Date now = new Date();
     long nowTime = now.getTime();
     DataAccessRequestData darData = dataAccessRequest.getData();
@@ -285,19 +302,6 @@ public class DataAccessRequestService implements ConsentLogger {
     }
     syncDataAccessRequestDatasets(datasetIds, referenceId);
     return findByReferenceId(referenceId);
-  }
-
-  private void validateUserAndRequestObject(User user, DataAccessRequest dataAccessRequest) {
-    if (Objects.isNull(user) || Objects.isNull(dataAccessRequest) || Objects.isNull(
-        dataAccessRequest.getReferenceId()) || Objects.isNull(dataAccessRequest.getData())) {
-      throw new IllegalArgumentException("User and DataAccessRequest are required");
-    }
-
-    if (user.getLibraryCards().isEmpty()) {
-      throw new NIHComplianceRuleException();
-    }
-
-    Date now = new Date();
   }
 
   /**

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
@@ -108,13 +108,7 @@ public class DataAccessRequestService implements ConsentLogger {
 
   //NOTE: rewrite method into new servicedao method on another ticket
   public DataAccessRequest insertDraftDataAccessRequest(User user, DataAccessRequest dar) {
-    if (Objects.isNull(user) || Objects.isNull(dar) || Objects.isNull(dar.getReferenceId())
-        || Objects.isNull(dar.getData())) {
-      throw new IllegalArgumentException("User and DataAccessRequest are required");
-    }
-    if (Objects.isNull(user.getLibraryCards()) || user.getLibraryCards().isEmpty()) {
-      throw new NIHComplianceRuleException();
-    }
+    validateUserAndRequestObject(user, dar);
     Date now = new Date();
     dataAccessRequestDAO.insertDraftDataAccessRequest(
         dar.getReferenceId(),
@@ -161,7 +155,7 @@ public class DataAccessRequestService implements ConsentLogger {
     if (Objects.isNull(sourceCollection.getDars()) || sourceCollection.getDars().isEmpty()) {
       throw new IllegalArgumentException("Source Collection must contain at least a single DAR");
     }
-    if (Objects.isNull(user.getLibraryCards()) || user.getLibraryCards().isEmpty()) {
+    if (user.getLibraryCards().isEmpty()) {
       throw new NIHComplianceRuleException();
     }
     DataAccessRequest sourceDar = new ArrayList<>(sourceCollection.getDars().values()).get(0);
@@ -245,15 +239,7 @@ public class DataAccessRequestService implements ConsentLogger {
    * @return The created DAR.
    */
   public DataAccessRequest createDataAccessRequest(User user, DataAccessRequest dataAccessRequest) {
-    if (Objects.isNull(user) || Objects.isNull(dataAccessRequest) || Objects.isNull(
-        dataAccessRequest.getReferenceId()) || Objects.isNull(dataAccessRequest.getData())) {
-      throw new IllegalArgumentException("User and DataAccessRequest are required");
-    }
-
-    if (Objects.isNull(user.getLibraryCards()) || user.getLibraryCards().isEmpty()) {
-      throw new NIHComplianceRuleException();
-    }
-
+    validateUserAndRequestObject(user, dataAccessRequest);
     Date now = new Date();
     long nowTime = now.getTime();
     DataAccessRequestData darData = dataAccessRequest.getData();
@@ -299,6 +285,19 @@ public class DataAccessRequestService implements ConsentLogger {
     }
     syncDataAccessRequestDatasets(datasetIds, referenceId);
     return findByReferenceId(referenceId);
+  }
+
+  private void validateUserAndRequestObject(User user, DataAccessRequest dataAccessRequest) {
+    if (Objects.isNull(user) || Objects.isNull(dataAccessRequest) || Objects.isNull(
+        dataAccessRequest.getReferenceId()) || Objects.isNull(dataAccessRequest.getData())) {
+      throw new IllegalArgumentException("User and DataAccessRequest are required");
+    }
+
+    if (user.getLibraryCards().isEmpty()) {
+      throw new NIHComplianceRuleException();
+    }
+
+    Date now = new Date();
   }
 
   /**

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
@@ -112,6 +112,9 @@ public class DataAccessRequestService implements ConsentLogger {
         || Objects.isNull(dar.getData())) {
       throw new IllegalArgumentException("User and DataAccessRequest are required");
     }
+    if (Objects.isNull(user.getLibraryCards()) || user.getLibraryCards().isEmpty()) {
+      throw new NIHComplianceRuleException();
+    }
     Date now = new Date();
     dataAccessRequestDAO.insertDraftDataAccessRequest(
         dar.getReferenceId(),
@@ -157,6 +160,9 @@ public class DataAccessRequestService implements ConsentLogger {
       DarCollection sourceCollection) {
     if (Objects.isNull(sourceCollection.getDars()) || sourceCollection.getDars().isEmpty()) {
       throw new IllegalArgumentException("Source Collection must contain at least a single DAR");
+    }
+    if (Objects.isNull(user.getLibraryCards()) || user.getLibraryCards().isEmpty()) {
+      throw new NIHComplianceRuleException();
     }
     DataAccessRequest sourceDar = new ArrayList<>(sourceCollection.getDars().values()).get(0);
     DataAccessRequestData sourceData = sourceDar.getData();

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
@@ -22,6 +22,7 @@ import org.broadinstitute.consent.http.db.UserDAO;
 import org.broadinstitute.consent.http.db.VoteDAO;
 import org.broadinstitute.consent.http.enumeration.DarStatus;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
+import org.broadinstitute.consent.http.exceptions.NIHComplianceRuleException;
 import org.broadinstitute.consent.http.models.DarCollection;
 import org.broadinstitute.consent.http.models.DarDataset;
 import org.broadinstitute.consent.http.models.DataAccessRequest;
@@ -244,7 +245,7 @@ public class DataAccessRequestService implements ConsentLogger {
     }
 
     if (Objects.isNull(user.getLibraryCards()) || user.getLibraryCards().isEmpty()) {
-      throw new IllegalArgumentException("User must have a library card.");
+      throw new NIHComplianceRuleException();
     }
 
     Date now = new Date();

--- a/src/main/java/org/broadinstitute/consent/http/service/TDRService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/TDRService.java
@@ -41,51 +41,6 @@ public class TDRService implements ConsentLogger {
     this.userDAO = userDAO;
   }
 
-  public DataAccessRequest populateDraftDarStubFromDatasetIdentifiers(String identifiers, String projectTitle) {
-    List<String> identifierList = Arrays.stream(identifiers.split(","))
-        .map(String::trim)
-        .filter(identifier -> !identifier.isBlank())
-        // this will filter duplicate identifier strings, ex. "DUOS-000594, DUOS-000594"
-        .distinct()
-        .toList();
-    List<Integer> aliasList = identifierList
-        .stream()
-        .map(Dataset::parseIdentifierToAlias)
-        // this will filter duplicate aliases, ex. "593, 593"
-        .distinct()
-        .toList();
-    List<Dataset> datasets = getDatasetsByIdentifier(aliasList);
-    List<Integer> datasetAliases = datasets.stream().map(Dataset::getAlias).toList();
-    // Check that we were able to find a dataset id for all identifiers provided
-    if (aliasList.size() != datasets.size()) {
-      // isolate a list of identifier strings that were not matched to datasets
-      List<String> notFoundIdentifiers = identifierList
-          .stream()
-          .filter(identifier -> !datasetAliases.contains(
-              Dataset.parseIdentifierToAlias(identifier)))
-          .toList();
-      // throw a NFE to let the client know which identifiers were NOT found so they can rectify their request
-      throw new NotFoundException(
-          "Invalid dataset identifiers were provided: " + notFoundIdentifiers);
-    }
-    List<Integer> datasetIds = datasets
-        .stream()
-        .map(Dataset::getDatasetId)
-        .toList();
-    DataAccessRequest newDar = new DataAccessRequest();
-    newDar.setCreateDate(new Timestamp(new Date().getTime()));
-    DataAccessRequestData data = new DataAccessRequestData();
-    String referenceId = UUID.randomUUID().toString();
-    newDar.setReferenceId(referenceId);
-    data.setReferenceId(referenceId);
-    if (!Objects.isNull(projectTitle) && !projectTitle.isBlank()) {
-      data.setProjectTitle(projectTitle);
-    }
-    newDar.setData(data);
-    newDar.setDatasetIds(datasetIds);
-    return newDar;
-  }
-
   public ApprovedUsers getApprovedUsersForDataset(AuthUser authUser, Dataset dataset) {
     Collection<DataAccessRequest> dars = dataAccessRequestService.getApprovedDARsForDataset(
         dataset);

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -511,10 +511,6 @@ paths:
     $ref: './paths/tdrDatasetApprovedUsers.yaml'
   /api/tdr/{identifier}:
     $ref: './paths/tdrDataset.yaml'
-  /api/tdr/dar/draft:
-    $ref: './paths/tdrDraftDAR.yaml'
-  /api/tdr/v2/dar/draft:
-    $ref: './paths/tdrV2DraftDAR.yaml'
   /api/emailNotifier/reminderMessage/{voteId}:
     post:
       summary: Send Reminder Email

--- a/src/test/java/org/broadinstitute/consent/http/db/DarCollectionDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DarCollectionDAOTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.runners.model.MultipleFailureException.assertEmpty;
 
 import java.sql.Timestamp;
 import java.util.ArrayList;
@@ -147,7 +148,7 @@ class DarCollectionDAOTest extends DAOTestHelper {
     userProperties.forEach(p -> assertEquals(collection.getCreateUserId(),
         p.getUserId()));
 
-    assertNull(returned.getCreateUser().getLibraryCards());
+    assertTrue(returned.getCreateUser().getLibraryCards().isEmpty());
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/db/DarCollectionDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DarCollectionDAOTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.runners.model.MultipleFailureException.assertEmpty;
 
 import java.sql.Timestamp;
 import java.util.ArrayList;

--- a/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceTest.java
@@ -433,8 +433,8 @@ class DataAccessRequestResourceTest {
     parentDar.getData().setCollaborationLetterLocation("collaborationLetterLocation");
     parentDar.getData().setIrbDocumentLocation("irbDocumentLocation");
     when(dataAccessRequestService.findByReferenceId(any())).thenReturn(parentDar);
-    Pair<InputStream, FormDataContentDisposition> collabFile = mockFormDataMultiPart("collab.txt");
-    Pair<InputStream, FormDataContentDisposition> ethicsFile = mockFormDataMultiPart("ethics.txt");
+    var collabFile = mockFormDataMultiPart("collab.txt");
+    var ethicsFile = mockFormDataMultiPart("ethics.txt");
     initResource();
     user.setLibraryCards(null);
     Response response = resource.postProgressReport(authUser, "", "", collabFile.getLeft(),

--- a/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceTest.java
@@ -462,8 +462,8 @@ class DataAccessRequestResourceTest {
     when(userService.findUserByEmail(user.getEmail())).thenReturn(user);
     DataAccessRequest parentDar = generateDataAccessRequest();
     when(dataAccessRequestService.findByReferenceId(any())).thenReturn(parentDar);
-    Pair<InputStream, FormDataContentDisposition> collabFile = mockFormDataMultiPart("collab.txt");
-    Pair<InputStream, FormDataContentDisposition> ethicsFile = mockFormDataMultiPart("ethics.txt");
+    var collabFile = mockFormDataMultiPart("collab.txt");
+    var ethicsFile = mockFormDataMultiPart("ethics.txt");
     initResource();
 
     assertThrows(BadRequestException.class, () -> {
@@ -502,8 +502,8 @@ class DataAccessRequestResourceTest {
     when(dataAccessRequestService.findByReferenceId(any())).thenReturn(parentDar);
     DataAccessRequest childDar = generateDataAccessRequest();
     when(dataAccessRequestService.createDataAccessRequest(any(), any())).thenReturn(childDar);
-    Pair<InputStream, FormDataContentDisposition> collabFile = mockFormDataMultiPart("collab.txt");
-    Pair<InputStream, FormDataContentDisposition> ethicsFile = mockFormDataMultiPart("ethics.txt");
+    var collabFile = mockFormDataMultiPart("collab.txt");
+    var ethicsFile = mockFormDataMultiPart("ethics.txt");
     Dataset dataset = mock(Dataset.class);
     when(datasetService.findDatasetById(any())).thenReturn(dataset);
     DataUse dataUseCollabAndEthics = new DataUseBuilder()
@@ -525,8 +525,8 @@ class DataAccessRequestResourceTest {
     when(dataAccessRequestService.findByReferenceId(any())).thenReturn(parentDar);
     DataAccessRequest childDar = generateDataAccessRequest();
     when(dataAccessRequestService.createDataAccessRequest(any(), any())).thenReturn(childDar);
-    Pair<InputStream, FormDataContentDisposition> collabFile = mockFormDataMultiPart("collab.txt");
-    Pair<InputStream, FormDataContentDisposition> ethicsFile = mockFormDataMultiPart("ethics.txt");
+    var collabFile = mockFormDataMultiPart("collab.txt");
+    var ethicsFile = mockFormDataMultiPart("ethics.txt");
     when(datasetService.findDatasetById(any())).thenReturn(null);
     initResource();
 
@@ -543,8 +543,8 @@ class DataAccessRequestResourceTest {
     when(dataAccessRequestService.findByReferenceId(any())).thenReturn(parentDar);
     DataAccessRequest childDar = generateDataAccessRequest();
     when(dataAccessRequestService.createDataAccessRequest(any(), any())).thenReturn(childDar);
-    Pair<InputStream, FormDataContentDisposition> collabFile = mockFormDataMultiPart("collab.txt");
-    Pair<InputStream, FormDataContentDisposition> ethicsFile = mockFormDataMultiPart("ethics.txt");
+    var collabFile = mockFormDataMultiPart("collab.txt");
+    var ethicsFile = mockFormDataMultiPart("ethics.txt");
     Dataset dataset = mock(Dataset.class);
     when(datasetService.findDatasetById(any())).thenReturn(dataset);
     when(dataset.getDataUse()).thenReturn(null);
@@ -563,8 +563,8 @@ class DataAccessRequestResourceTest {
     when(dataAccessRequestService.findByReferenceId(any())).thenReturn(parentDar);
     DataAccessRequest childDar = generateDataAccessRequest();
     when(dataAccessRequestService.createDataAccessRequest(any(), any())).thenReturn(childDar);
-    Pair<InputStream, FormDataContentDisposition> collabFile = mockFormDataMultiPart("collab.txt");
-    Pair<InputStream, FormDataContentDisposition> ethicsFile = mockFormDataMultiPart("ethics.txt");
+    var collabFile = mockFormDataMultiPart("collab.txt");
+    var ethicsFile = mockFormDataMultiPart("ethics.txt");
     Dataset dataset = mock(Dataset.class);
     when(datasetService.findDatasetById(any())).thenReturn(dataset);
     DataUse dataUseEthicsOnly = new DataUseBuilder().setEthicsApprovalRequired(true).build();
@@ -584,8 +584,8 @@ class DataAccessRequestResourceTest {
     when(dataAccessRequestService.findByReferenceId(any())).thenReturn(parentDar);
     DataAccessRequest childDar = generateDataAccessRequest();
     when(dataAccessRequestService.createDataAccessRequest(any(), any())).thenReturn(childDar);
-    Pair<InputStream, FormDataContentDisposition> collabFile = mockFormDataMultiPart("collab.txt");
-    Pair<InputStream, FormDataContentDisposition> ethicsFile = mockFormDataMultiPart("ethics.txt");
+    var collabFile = mockFormDataMultiPart("collab.txt");
+    var ethicsFile = mockFormDataMultiPart("ethics.txt");
     Dataset dataset = mock(Dataset.class);
     when(datasetService.findDatasetById(any())).thenReturn(dataset);
     DataUse dataUseCollaboratorOnly = new DataUseBuilder().setCollaboratorRequired(true).build();

--- a/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceTest.java
@@ -61,6 +61,24 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class DataAccessRequestResourceTest {
 
+  private final AuthUser authUser = new AuthUser("test@test.com");
+  private final AuthUser adminUser = new AuthUser("admin@test.com");
+  private final AuthUser chairpersonUser = new AuthUser("chariperson@test.com");
+  private final AuthUser memberUser = new AuthUser("member@test.com");
+  private final AuthUser anotherUser = new AuthUser("bob@test.com");
+  private final List<UserRole> roles = Collections.singletonList(UserRoles.Researcher());
+  private final List<UserRole> adminRoles = Collections.singletonList(UserRoles.Admin());
+  private final List<UserRole> chairpersonRoles = Collections.singletonList(
+      UserRoles.Chairperson());
+  private final List<UserRole> memberRoles = Collections.singletonList(UserRoles.Member());
+  private final User user = new User(1, authUser.getEmail(), "Display Name", new Date(), roles);
+  private final User admin = new User(2, adminUser.getEmail(), "Admin user", new Date(),
+      adminRoles);
+  private final User chairperson = new User(3, chairpersonUser.getEmail(), "Chairperson user",
+      new Date(), chairpersonRoles);
+  private final User member = new User(4, memberUser.getEmail(), "Member user", new Date(),
+      memberRoles);
+  private final User bob = new User(5, anotherUser.getEmail(), "Bob", new Date(), roles);
   @Mock
   private DaaService daaService;
   @Mock
@@ -81,28 +99,10 @@ class DataAccessRequestResourceTest {
   private UriBuilder builder;
   @Mock
   private User mockUser;
-
-  private final AuthUser authUser = new AuthUser("test@test.com");
-  private final AuthUser adminUser = new AuthUser("admin@test.com");
-  private final AuthUser chairpersonUser = new AuthUser("chariperson@test.com");
-  private final AuthUser memberUser = new AuthUser("member@test.com");
-  private final AuthUser anotherUser = new AuthUser("bob@test.com");
-  private final List<UserRole> roles = Collections.singletonList(UserRoles.Researcher());
-  private final List<UserRole> adminRoles = Collections.singletonList(UserRoles.Admin());
-  private final List<UserRole> chairpersonRoles = Collections.singletonList(UserRoles.Chairperson());
-  private final List<UserRole> memberRoles = Collections.singletonList(UserRoles.Member());
-  private final User user = new User(1, authUser.getEmail(), "Display Name", new Date(), roles);
-  private final User admin = new User(2, adminUser.getEmail(), "Admin user", new Date(),
-      adminRoles);
-  private final User chairperson = new User(3, chairpersonUser.getEmail(), "Chairperson user",
-      new Date(), chairpersonRoles);
-  private final User member = new User(4, memberUser.getEmail(), "Member user", new Date(),
-      memberRoles);
-  private final User bob = new User(5, anotherUser.getEmail(), "Bob", new Date(), roles);
-
   private DataAccessRequestResource resource;
 
   private void initResource() {
+    user.setLibraryCards(List.of(new LibraryCard()));
     try {
       resource =
           new DataAccessRequestResource(daaService,
@@ -127,7 +127,7 @@ class DataAccessRequestResourceTest {
       fail("Initialization Exception: " + e.getMessage());
     }
     initResource();
-
+    user.setLibraryCards(null);
     Response response = resource.createDataAccessRequest(authUser, info, "");
     assertEquals(HttpStatusCodes.STATUS_CODE_UNPROCESSABLE_ENTITY, response.getStatus());
   }
@@ -187,6 +187,7 @@ class DataAccessRequestResourceTest {
   @Test
   void testUpdateByReferenceId() {
     DataAccessRequest dar = generateDataAccessRequest();
+    user.setLibraryCards(List.of(new LibraryCard()));
     try {
       when(userService.findUserByEmail(any())).thenReturn(user);
       when(dataAccessRequestService.findByReferenceId(any())).thenReturn(dar);
@@ -418,11 +419,27 @@ class DataAccessRequestResourceTest {
     Pair<InputStream, FormDataContentDisposition> collabFile = mockFormDataMultiPart("collab.txt");
     Pair<InputStream, FormDataContentDisposition> ethicsFile = mockFormDataMultiPart("ethics.txt");
     initResource();
+    user.setLibraryCards(null);
 
-    assertThrows(ForbiddenException.class, () -> {
-      resource.postProgressReport(authUser, "", "", collabFile.getLeft(),
-          collabFile.getRight(), ethicsFile.getLeft(), ethicsFile.getRight());
-    });
+    Response response = resource.postProgressReport(authUser, "", "", collabFile.getLeft(),
+        collabFile.getRight(), ethicsFile.getLeft(), ethicsFile.getRight());
+    assertEquals(HttpStatusCodes.STATUS_CODE_FORBIDDEN, response.getStatus());
+  }
+
+  @Test
+  void testPostProgressReportCollabAndEthicsFilesWithoutLibraryCardsThrows() throws IOException {
+    when(userService.findUserByEmail(user.getEmail())).thenReturn(user);
+    DataAccessRequest parentDar = generateDataAccessRequest();
+    parentDar.getData().setCollaborationLetterLocation("collaborationLetterLocation");
+    parentDar.getData().setIrbDocumentLocation("irbDocumentLocation");
+    when(dataAccessRequestService.findByReferenceId(any())).thenReturn(parentDar);
+    Pair<InputStream, FormDataContentDisposition> collabFile = mockFormDataMultiPart("collab.txt");
+    Pair<InputStream, FormDataContentDisposition> ethicsFile = mockFormDataMultiPart("ethics.txt");
+    initResource();
+    user.setLibraryCards(null);
+    Response response = resource.postProgressReport(authUser, "", "", collabFile.getLeft(),
+        collabFile.getRight(), ethicsFile.getLeft(), ethicsFile.getRight());
+    assertEquals(HttpStatusCodes.STATUS_CODE_UNPROCESSABLE_ENTITY, response.getStatus());
   }
 
   @Test
@@ -815,7 +832,8 @@ class DataAccessRequestResourceTest {
       fail("Initialization Exception: " + e.getMessage());
     }
 
-    try (Response response = resource.createDataAccessRequestWithDAARestrictions(authUser, info, "")) {
+    try (Response response = resource.createDataAccessRequestWithDAARestrictions(authUser, info,
+        "")) {
       assertEquals(HttpStatusCodes.STATUS_CODE_CREATED, response.getStatus());
     }
   }
@@ -841,7 +859,8 @@ class DataAccessRequestResourceTest {
       fail("Initialization Exception: " + e.getMessage());
     }
 
-    try (Response response = resource.createDataAccessRequestWithDAARestrictions(authUser, info, "")) {
+    try (Response response = resource.createDataAccessRequestWithDAARestrictions(authUser, info,
+        "")) {
       assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
     }
   }
@@ -863,7 +882,8 @@ class DataAccessRequestResourceTest {
       fail("Initialization Exception: " + e.getMessage());
     }
 
-    try (Response response = resource.createDraftDataAccessRequestWithDAARestrictions(authUser, info, "")) {
+    try (Response response = resource.createDraftDataAccessRequestWithDAARestrictions(authUser,
+        info, "")) {
       assertEquals(HttpStatusCodes.STATUS_CODE_CREATED, response.getStatus());
     }
   }
@@ -881,7 +901,8 @@ class DataAccessRequestResourceTest {
       fail("Initialization Exception: " + e.getMessage());
     }
 
-    try (Response response = resource.createDraftDataAccessRequestWithDAARestrictions(authUser, info, "")) {
+    try (Response response = resource.createDraftDataAccessRequestWithDAARestrictions(authUser,
+        info, "")) {
       assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
     }
   }
@@ -894,7 +915,8 @@ class DataAccessRequestResourceTest {
     when(dataAccessRequestService.updateByReferenceId(any(), any())).thenReturn(dar);
     initResource();
 
-    try (Response response = resource.updatePartialDataAccessRequestWithDAARestrictions(authUser, "", "{}")) {
+    try (Response response = resource.updatePartialDataAccessRequestWithDAARestrictions(authUser,
+        "", "{}")) {
       assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
     }
   }
@@ -907,7 +929,8 @@ class DataAccessRequestResourceTest {
     doThrow(BadRequestException.class).when(datasetService).enforceDAARestrictions(any(), any());
     initResource();
 
-    try (Response response = resource.updatePartialDataAccessRequestWithDAARestrictions(authUser, "", "{}")) {
+    try (Response response = resource.updatePartialDataAccessRequestWithDAARestrictions(authUser,
+        "", "{}")) {
       assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
     }
   }

--- a/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceTest.java
@@ -129,7 +129,7 @@ class DataAccessRequestResourceTest {
     initResource();
 
     Response response = resource.createDataAccessRequest(authUser, info, "");
-    assertEquals(Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+    assertEquals(HttpStatusCodes.STATUS_CODE_UNPROCESSABLE_ENTITY, response.getStatus());
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/resources/TDRResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/TDRResourceTest.java
@@ -3,30 +3,16 @@ package org.broadinstitute.consent.http.resources;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 
-import com.google.api.client.http.HttpStatusCodes;
-import jakarta.ws.rs.BadRequestException;
-import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.core.Response;
-import jakarta.ws.rs.core.Response.Status;
-import java.util.Arrays;
-import java.util.Date;
 import java.util.List;
-import java.util.UUID;
 import org.broadinstitute.consent.http.models.AuthUser;
-import org.broadinstitute.consent.http.models.DataAccessRequest;
-import org.broadinstitute.consent.http.models.DataAccessRequestData;
 import org.broadinstitute.consent.http.models.Dataset;
-import org.broadinstitute.consent.http.models.Error;
-import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.tdr.ApprovedUser;
 import org.broadinstitute.consent.http.models.tdr.ApprovedUsers;
-import org.broadinstitute.consent.http.service.DataAccessRequestService;
 import org.broadinstitute.consent.http.service.DatasetService;
 import org.broadinstitute.consent.http.service.TDRService;
-import org.broadinstitute.consent.http.service.UserService;
 import org.broadinstitute.consent.http.util.gson.GsonUtil;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -38,24 +24,13 @@ class TDRResourceTest {
 
   @Mock
   private TDRService tdrService;
-
   @Mock
   private DatasetService datasetService;
-
-  @Mock
-  private UserService userService;
-
-  @Mock
-  private DataAccessRequestService darService;
-
-  private final AuthUser authUser = new AuthUser("test@test.com");
-  private final User user = new User(1, authUser.getEmail(), "Display Name", new Date());
-
   private TDRResource resource;
 
   private void initResource() {
     try {
-      resource = new TDRResource(tdrService, datasetService, userService, darService);
+      resource = new TDRResource(tdrService, datasetService);
     } catch (Exception e) {
       fail("Initialization Exception: " + e.getMessage());
     }
@@ -120,113 +95,4 @@ class TDRResourceTest {
     assertEquals(404, r.getStatus());
   }
 
-  // Created response when a new DAR draft is successful
-  @Test
-  void testCreateDraftDataAccessRequest() throws Exception {
-    String identifiers = "DUOS-00001, DUOS-00002";
-    DataAccessRequest newDar = generateDataAccessRequest();
-    when(userService.findOrCreateUser(any())).thenReturn(user);
-    when(tdrService.populateDraftDarStubFromDatasetIdentifiers(identifiers, "New Project")).thenReturn(newDar);
-    when(darService.insertDraftDataAccessRequest(any(), any())).thenReturn(newDar);
-    initResource();
-
-    String expectedUri = "api/dar/v2/" + newDar.getReferenceId();
-
-    try (Response r = resource.createDraftDataAccessRequest(authUser, identifiers, "New Project")) {
-      assertEquals(Status.CREATED.getStatusCode(), r.getStatus());
-      assertEquals(r.getLocation().toString(), expectedUri);
-    } catch (Exception e) {
-      fail(e.getMessage());
-    }
-  }
-
-  // Bad Request response (400) when no identifiers are provided
-  @Test
-  void testCreateDraftDataAccessRequestNoIdentifiers() throws Exception {
-    when(userService.findOrCreateUser(any())).thenReturn(user);
-    initResource();
-
-    try (Response r = resource.createDraftDataAccessRequest(authUser, null, null)) {
-      assertEquals(Status.BAD_REQUEST.getStatusCode(), r.getStatus());
-    } catch (Exception e) {
-      fail(e.getMessage());
-    }
-  }
-
-  // Not Found response (404) with list of invalid identifiers if any do not match to a dataset
-  @Test
-  void testCreateDraftDataAccessRequestInvalidIdentifiers() throws Exception {
-    String identifiers = "DUOS-00001, DUOS-00002";
-    when(userService.findOrCreateUser(any())).thenReturn(user);
-    doThrow(new NotFoundException("Invalid dataset identifiers were provided: [DUOS-00002]")).when(tdrService).populateDraftDarStubFromDatasetIdentifiers(any(), any());
-    initResource();
-
-    try (Response r = resource.createDraftDataAccessRequest(authUser, identifiers, "New Project")) {
-      Error notFoundError;
-      assertEquals(Status.NOT_FOUND.getStatusCode(), r.getStatus());
-      notFoundError = (Error) r.getEntity();
-      assertEquals("Invalid dataset identifiers were provided: [DUOS-00002]",
-          notFoundError.message());
-    } catch (Exception e) {
-      fail(e.getMessage());
-    }
-  }
-
-  @Test
-  void testCreateDraftDataAccessRequestWithDAARestrictions() throws Exception {
-    String identifiers = "DUOS-00001, DUOS-00002";
-    List<Integer> identifierList = Arrays.stream(identifiers.split(","))
-        .map(String::trim)
-        .filter(identifier -> !identifier.isBlank())
-        .map(Dataset::parseIdentifierToAlias)
-        .toList();
-
-    DataAccessRequest newDar = generateDataAccessRequest();
-
-    when(userService.findOrCreateUser(any())).thenReturn(user);
-    when(tdrService.populateDraftDarStubFromDatasetIdentifiers(identifiers, "New Project")).thenReturn(newDar);
-    when(darService.insertDraftDataAccessRequest(any(), any())).thenReturn(newDar);
-
-    initResource();
-
-    String expectedUri = "api/dar/v2/" + newDar.getReferenceId();
-
-    try (Response r = resource.createDraftDataAccessRequestWithDAARestrictions(authUser, identifiers, "New Project")) {
-      assertEquals(Status.CREATED.getStatusCode(), r.getStatus());
-      assertEquals(r.getLocation().toString(), expectedUri);
-    }
-  }
-
-  @Test
-  void testCreateDraftDataAccessRequestWithDAARestrictionsFailure() throws Exception {
-    String identifiers = "DUOS-00001, DUOS-00002";
-    List<Integer> identifierList = Arrays.stream(identifiers.split(","))
-        .map(String::trim)
-        .filter(identifier -> !identifier.isBlank())
-        .map(Dataset::parseIdentifierToAlias)
-        .toList();
-
-    DataAccessRequest newDar = generateDataAccessRequest();
-
-    when(userService.findOrCreateUser(any())).thenReturn(user);
-    when(tdrService.populateDraftDarStubFromDatasetIdentifiers(identifiers, "New Project")).thenReturn(newDar);
-    doThrow(BadRequestException.class).when(datasetService).enforceDAARestrictions(any(), any());
-
-    initResource();
-
-    try (Response r = resource.createDraftDataAccessRequestWithDAARestrictions(authUser, identifiers, "New Project")) {
-      assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, r.getStatus());
-    }
-  }
-
-  private DataAccessRequest generateDataAccessRequest() {
-    DataAccessRequest dar = new DataAccessRequest();
-    DataAccessRequestData data = new DataAccessRequestData();
-    dar.setReferenceId(UUID.randomUUID().toString());
-    data.setReferenceId(dar.getReferenceId());
-    dar.setDatasetIds(Arrays.asList(1, 2));
-    dar.setData(data);
-    dar.setUserId(user.getUserId());
-    return dar;
-  }
 }

--- a/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
@@ -31,6 +31,7 @@ import org.broadinstitute.consent.http.db.MatchDAO;
 import org.broadinstitute.consent.http.db.UserDAO;
 import org.broadinstitute.consent.http.db.VoteDAO;
 import org.broadinstitute.consent.http.enumeration.DarStatus;
+import org.broadinstitute.consent.http.exceptions.LibraryCardRequiredException;
 import org.broadinstitute.consent.http.exceptions.NIHComplianceRuleException;
 import org.broadinstitute.consent.http.models.DarCollection;
 import org.broadinstitute.consent.http.models.DataAccessRequest;
@@ -421,7 +422,7 @@ class DataAccessRequestServiceTest {
     dar.setReferenceId(data.getReferenceId());
     sourceCollection.addDar(dar);
     initService();
-    assertThrows(NIHComplianceRuleException.class,
+    assertThrows(LibraryCardRequiredException.class,
         () -> service.createDraftDarFromCanceledCollection(user, sourceCollection));
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
@@ -196,6 +196,7 @@ class DataAccessRequestServiceTest {
   void testInsertDraftDataAccessRequest() {
     User user = new User();
     user.setUserId(1);
+    user.setLibraryCards(List.of(new LibraryCard()));
     DataAccessRequest draft = generateDataAccessRequest();
     doNothing()
         .when(dataAccessRequestDAO)
@@ -311,6 +312,7 @@ class DataAccessRequestServiceTest {
   @Test
   void testCreateDraftDarFromCanceledCollection_NoDarData() {
     User user = new User();
+    user.setLibraryCards(List.of(new LibraryCard()));
     DarCollection sourceCollection = new DarCollection();
     DataAccessRequest newDar = new DataAccessRequest();
     newDar.setReferenceId(UUID.randomUUID().toString());
@@ -324,6 +326,7 @@ class DataAccessRequestServiceTest {
   @Test
   void testCreateDraftDarFromCanceledCollection_NoCanceledDars() {
     User user = new User();
+    user.setLibraryCards(List.of(new LibraryCard()));
     DarCollection sourceCollection = new DarCollection();
     DataAccessRequest dar = new DataAccessRequest();
     DataAccessRequestData data = new DataAccessRequestData();
@@ -341,6 +344,7 @@ class DataAccessRequestServiceTest {
   @Test
   void testCreateDraftDarFromCanceledCollection_NoDatasets() {
     User user = new User();
+    user.setLibraryCards(List.of(new LibraryCard()));
     DarCollection sourceCollection = new DarCollection();
     DataAccessRequest dar = new DataAccessRequest();
     DataAccessRequestData data = new DataAccessRequestData();
@@ -359,6 +363,7 @@ class DataAccessRequestServiceTest {
   @Test
   void testCreateDraftDarFromCanceledCollection_OpenElectionsOnCanceledDars() {
     User user = new User();
+    user.setLibraryCards(List.of(new LibraryCard()));
     DarCollection sourceCollection = new DarCollection();
     DataAccessRequest dar = new DataAccessRequest();
     DataAccessRequestData data = new DataAccessRequestData();
@@ -378,6 +383,7 @@ class DataAccessRequestServiceTest {
   @Test
   void testCreateDraftDarFromCanceledCollection() {
     User user = new User();
+    user.setLibraryCards(List.of(new LibraryCard()));
     DarCollection sourceCollection = new DarCollection();
     DataAccessRequest dar = new DataAccessRequest();
     DataAccessRequestData data = new DataAccessRequestData();
@@ -400,6 +406,23 @@ class DataAccessRequestServiceTest {
     when(dataAccessRequestDAO.findByReferenceId(any())).thenReturn(new DataAccessRequest());
     initService();
     service.createDraftDarFromCanceledCollection(user, sourceCollection);
+  }
+
+  @Test
+  void testCreateDraftDarFromCanceledCollectionNoLibraryCards() {
+    User user = new User();
+    DarCollection sourceCollection = new DarCollection();
+    DataAccessRequest dar = new DataAccessRequest();
+    DataAccessRequestData data = new DataAccessRequestData();
+    data.setStatus(DarStatus.CANCELED.getValue());
+    dar.addDatasetId(1);
+    data.setReferenceId(UUID.randomUUID().toString());
+    dar.setData(data);
+    dar.setReferenceId(data.getReferenceId());
+    sourceCollection.addDar(dar);
+    initService();
+    assertThrows(NIHComplianceRuleException.class,
+        () -> service.createDraftDarFromCanceledCollection(user, sourceCollection));
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
@@ -31,6 +31,7 @@ import org.broadinstitute.consent.http.db.MatchDAO;
 import org.broadinstitute.consent.http.db.UserDAO;
 import org.broadinstitute.consent.http.db.VoteDAO;
 import org.broadinstitute.consent.http.enumeration.DarStatus;
+import org.broadinstitute.consent.http.exceptions.NIHComplianceRuleException;
 import org.broadinstitute.consent.http.models.DarCollection;
 import org.broadinstitute.consent.http.models.DataAccessRequest;
 import org.broadinstitute.consent.http.models.DataAccessRequestData;
@@ -141,7 +142,7 @@ class DataAccessRequestServiceTest {
     user.setLibraryCards(List.of(new LibraryCard()));
     user.setLibraryCards(List.of());
     initService();
-    assertThrows(IllegalArgumentException.class, () -> {
+    assertThrows(NIHComplianceRuleException.class, () -> {
       service.createDataAccessRequest(user, dar);
     });
   }

--- a/src/test/java/org/broadinstitute/consent/http/service/TDRServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/TDRServiceTest.java
@@ -147,37 +147,4 @@ class TDRServiceTest {
     assertTrue(datasetIds.containsAll(List.of(dataset1, dataset2)));
   }
 
-  @Test
-  void testPopulateDraftDarStubFromDatasetIdentifiers() {
-    String identifiers = "DUOS-00001, DUOS-00002";
-    String title = "New Project";
-    Dataset dataset1 = new Dataset();
-    dataset1.setDatasetId(1);
-    dataset1.setAlias(00001);
-
-    Dataset dataset2 = new Dataset();
-    dataset2.setDatasetId(2);
-    dataset2.setAlias(00002);
-
-    when(datasetDAO.findDatasetsByAlias(any())).thenReturn(List.of(dataset1, dataset2));
-
-    initService();
-    assertDoesNotThrow(() -> {
-      DataAccessRequest dar = service.populateDraftDarStubFromDatasetIdentifiers(identifiers, "New Project");
-      assertNotNull(dar);
-      assertTrue(dar.getDatasetIds().contains(dataset1.getDatasetId()));
-      assertTrue(dar.getDatasetIds().contains(dataset2.getDatasetId()));
-      assertEquals(title, dar.getData().getProjectTitle());
-      assertNotNull(dar.getReferenceId());
-      assertNotNull(dar.getCreateDate());
-    });
-  }
-
-  @Test
-  void testPopulateDraftDarStubFromDatasetIdentifiersNotFound() {
-    String identifiers = "DUOS-00001, DUOS-00002";
-    initService();
-    assertThrows(NotFoundException.class, () -> service.populateDraftDarStubFromDatasetIdentifiers(identifiers, "New Project"));
-  }
-
 }

--- a/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
@@ -584,7 +584,7 @@ class UserServiceTest {
     assertNotNull(users);
     assertEquals(returnedUsers.size(), users.size());
     assertEquals(List.of(lc), users.get(0).getLibraryCards());
-    assertNull(users.get(1).getLibraryCards());
+    assertTrue(users.get(1).getLibraryCards().isEmpty());
   }
 
   @Test


### PR DESCRIPTION
### Addresses
[https://broadworkbench.atlassian.net/browse/DT-1502](https://broadworkbench.atlassian.net/browse/DT-1502)

### Summary
Ensures DARs can only be created when a user has a library card
Removes unused endpoints that allowed creation.
Modifies tests to conform to new rule.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
