### PR TITLE
DT-1537: Ensure that study info is populated when indexing dataset terms

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/resources/DacResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DacResource.java
@@ -270,7 +270,7 @@ public class DacResource extends Resource {
         throw new BadRequestException("Invalid request payload");
       }
       Dataset updatedDataset = datasetService.approveDataset(dataset, user, payload.getApproval());
-      try (Response indexResponse = elasticSearchService.indexDataset(updatedDataset, user))  {
+      try (Response indexResponse = elasticSearchService.indexDataset(updatedDataset.getDatasetId(), user))  {
         if (indexResponse.getStatus() >= Status.BAD_REQUEST.getStatusCode()) {
           logWarn("Non-OK response when reindexing dataset with id: " + datasetId);
         }

--- a/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
@@ -409,8 +409,7 @@ public class DatasetResource extends Resource {
   public Response indexDataset(@Auth AuthUser authUser, @PathParam("datasetId") Integer datasetId) {
     try {
       User user = userService.findUserByEmail(authUser.getEmail());
-      var dataset = datasetService.findDatasetById(datasetId);
-      return elasticSearchService.indexDataset(dataset, user);
+      return elasticSearchService.indexDataset(datasetId, user);
     } catch (Exception e) {
       return createExceptionResponse(e);
     }

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetRegistrationService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetRegistrationService.java
@@ -207,7 +207,7 @@ public class DatasetRegistrationService implements ConsentLogger {
 
     List<Dataset> datasets = datasetDAO.findDatasetsByIdList(createdDatasetIds);
     sendDatasetSubmittedEmails(datasets);
-    try (Response response = elasticSearchService.indexDatasets(datasets, user)) {
+    try (Response response = elasticSearchService.indexDatasets(createdDatasetIds, user)) {
       if (response.getStatus() >= 400) {
         logWarn(String.format("Error indexing datasets from registration: %s", registration.getStudyName()));
       }

--- a/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
@@ -278,7 +278,12 @@ public class ElasticSearchService implements ConsentLogger {
   }
 
   public Response indexDatasets(List<Dataset> datasets, User user) throws IOException {
-    List<DatasetTerm> datasetTerms = datasets.stream().map(this::toDatasetTerm).toList();
+    // Datasets in list context may not have their study populated, so we need to ensure that is
+    // true before trying to index them in ES.
+    List<DatasetTerm> datasetTerms = datasets.stream()
+        .map(d -> datasetDAO.findDatasetById(d.getDatasetId()))
+        .map(this::toDatasetTerm)
+        .toList();
     return indexDatasetTerms(datasetTerms, user);
   }
 

--- a/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
@@ -263,7 +263,7 @@ public class ElasticSearchService implements ConsentLogger {
    */
   public void synchronizeDatasetInESIndex(Dataset dataset, User user, boolean force) {
     if (force || dataset.getIndexedDate() != null) {
-      try (var response = indexDataset(dataset, user)) {
+      try (var response = indexDataset(dataset.getDatasetId(), user)) {
         if (!HttpStatusCodes.isSuccess(response.getStatus())) {
           logWarn("Response error, unable to index dataset: %s".formatted(dataset.getDatasetId()));
         }
@@ -273,15 +273,15 @@ public class ElasticSearchService implements ConsentLogger {
     }
   }
 
-  public Response indexDataset(Dataset dataset, User user) throws IOException {
-    return indexDatasets(List.of(dataset), user);
+  public Response indexDataset(Integer datasetId, User user) throws IOException {
+    return indexDatasets(List.of(datasetId), user);
   }
 
-  public Response indexDatasets(List<Dataset> datasets, User user) throws IOException {
+  public Response indexDatasets(List<Integer> datasetIds, User user) throws IOException {
     // Datasets in list context may not have their study populated, so we need to ensure that is
     // true before trying to index them in ES.
-    List<DatasetTerm> datasetTerms = datasets.stream()
-        .map(d -> datasetDAO.findDatasetById(d.getDatasetId()))
+    List<DatasetTerm> datasetTerms = datasetIds.stream()
+        .map(datasetDAO::findDatasetById)
         .map(this::toDatasetTerm)
         .toList();
     return indexDatasetTerms(datasetTerms, user);
@@ -300,15 +300,14 @@ public class ElasticSearchService implements ConsentLogger {
     return output -> {
       output.write("[".getBytes());
       datasetIds.forEach(id -> {
-        Dataset dataset = datasetDAO.findDatasetById(id);
-        try (Response response = indexDataset(dataset, user)) {
+        try (Response response = indexDataset(id, user)) {
           output.write(response.getEntity().toString().getBytes());
           if (!id.equals(lastDatasetId)) {
             output.write(",".getBytes());
           }
           output.write("\n".getBytes());
         } catch (IOException e) {
-          logException("Error indexing dataset term for dataset id: %d ".formatted(dataset.getDatasetId()), e);
+          logException("Error indexing dataset term for dataset id: %d ".formatted(id), e);
         }
       });
       output.write("]".getBytes());
@@ -318,9 +317,8 @@ public class ElasticSearchService implements ConsentLogger {
   public Response indexStudy(Integer studyId, User user) {
     Study study = studyDAO.findStudyById(studyId);
     // The dao call above does not populate its datasets so we need to check for datasetIds
-    if (study != null && study.getDatasetIds() != null && !study.getDatasetIds().isEmpty()) {
-      List<Dataset> datasets = datasetDAO.findDatasetsByIdList(study.getDatasetIds().stream().toList());
-      try (Response response = indexDatasets(datasets, user)) {
+    if (study != null && !study.getDatasetIds().isEmpty()) {
+      try (Response response = indexDatasets(study.getDatasetIds().stream().toList(), user)) {
         return response;
       } catch (Exception e) {
         logException(String.format("Failed to index datasets for study id: %d", studyId), e);

--- a/src/main/java/org/broadinstitute/consent/http/service/VoteService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/VoteService.java
@@ -280,7 +280,7 @@ public class VoteService implements ConsentLogger {
         datasetIds.isEmpty() ? List.of() : datasetDAO.findDatasetsByIdList(datasetIds);
 
     try {
-      elasticSearchService.indexDatasets(datasets, user);
+      elasticSearchService.indexDatasets(datasetIds, user);
     } catch (Exception e) {
       logException("Error indexing datasets for approved DARs: " + e.getMessage(), e);
     }

--- a/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
@@ -268,7 +268,7 @@ class DatasetResourceTest extends AbstractTestHelper {
     try (Response response = resource.patchByDatasetUpdate(authUser, dataset.getDatasetId(),
         gson.toJson(patch))) {
       assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
-      verify(elasticSearchService, never()).indexDataset(dataset, user);
+      verify(elasticSearchService, never()).indexDataset(dataset.getDatasetId(), user);
     }
   }
 
@@ -311,7 +311,7 @@ class DatasetResourceTest extends AbstractTestHelper {
   }
 
   @Test
-  void testPatchByDatasetUpdate_invokeIndexUpdate() throws Exception {
+  void testPatchByDatasetUpdate_invokeIndexUpdate() {
     Gson gson = GsonUtil.buildGson();
 
     Dataset dataset = new Dataset();
@@ -564,18 +564,17 @@ class DatasetResourceTest extends AbstractTestHelper {
   void testIndexDataset() throws IOException {
     Dataset dataset = new Dataset();
     when(mockResponse.getStatus()).thenReturn(HttpStatusCodes.STATUS_CODE_OK);
-    when(datasetService.findDatasetById(any())).thenReturn(dataset);
-    when(elasticSearchService.indexDataset(dataset, user)).thenReturn(mockResponse);
-    when(userService.findUserByEmail(any())).thenReturn(user);
+    when(elasticSearchService.indexDataset(dataset.getDatasetId(), user)).thenReturn(mockResponse);
+    when(userService.findUserByEmail(authUser.getEmail())).thenReturn(user);
 
     initResource();
-    try (var response = resource.indexDataset(authUser, 1)) {
+    try (var response = resource.indexDataset(authUser, dataset.getDatasetId())) {
       assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
     }
   }
 
   @Test
-  void testIndexDelete() throws IOException, SQLException {
+  void testIndexDelete() throws IOException {
     when(mockResponse.getStatus()).thenReturn(HttpStatusCodes.STATUS_CODE_OK);
     when(elasticSearchService.deleteIndex(any(), any())).thenReturn(mockResponse);
     when(userService.findUserByEmail(any())).thenReturn(user);
@@ -1018,7 +1017,7 @@ class DatasetResourceTest extends AbstractTestHelper {
   }
 
   @Test
-  void testupdateDatasetByDatasetIntakeSuccess() throws SQLException, IOException {
+  void testUpdateDatasetByDatasetIntakeSuccess() throws SQLException, IOException {
     Dataset preexistingDataset = new Dataset();
     when(datasetService.findDatasetById(anyInt())).thenReturn(preexistingDataset);
     when(datasetRegistrationService.updateDataset(any(), any(), any(), any())).thenReturn(

--- a/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
@@ -495,7 +495,7 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
     when(mockResponse.getStatusLine()).thenReturn(statusLine);
     when(statusLine.getStatusCode()).thenReturn(200);
 
-    try (var ignored = service.indexDatasets(List.of(dataset1, dataset2),
+    try (var ignored = service.indexDatasets(List.of(dataset1.getDatasetId(), dataset2.getDatasetId()),
         datasetRecord.createUser)) {
       // Each dataset should be looked up once when defining the term and a second time
       // when updating the indexed date.
@@ -658,7 +658,6 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
     d.setDatasetId(1);
     study.addDatasetId(d.getDatasetId());
     when(studyDAO.findStudyById(any())).thenReturn(study);
-    when(datasetDAO.findDatasetsByIdList(any())).thenReturn(List.of(d));
 
     assertDoesNotThrow(() -> service.indexStudy(1, user));
   }

--- a/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -32,6 +33,7 @@ import org.apache.http.HttpEntity;
 import org.apache.http.HttpVersion;
 import org.apache.http.StatusLine;
 import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
 import org.apache.http.message.BasicStatusLine;
 import org.apache.http.nio.entity.NStringEntity;
 import org.broadinstitute.consent.http.AbstractTestHelper;
@@ -46,6 +48,7 @@ import org.broadinstitute.consent.http.enumeration.PropertyType;
 import org.broadinstitute.consent.http.models.Dac;
 import org.broadinstitute.consent.http.models.DataAccessRequest;
 import org.broadinstitute.consent.http.models.DataUse;
+import org.broadinstitute.consent.http.models.DataUseBuilder;
 import org.broadinstitute.consent.http.models.Dataset;
 import org.broadinstitute.consent.http.models.DatasetProperty;
 import org.broadinstitute.consent.http.models.Institution;
@@ -446,7 +449,7 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
   ArgumentCaptor<Request> request;
 
   @Test
-  void testIndexDatasets() throws IOException {
+  void testIndexDatasetTerms() throws IOException {
     DatasetTerm term1 = new DatasetTerm();
     term1.setDatasetId(1);
     DatasetTerm term2 = new DatasetTerm();
@@ -471,6 +474,33 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
               """,
           new String(capturedRequest.getEntity().getContent().readAllBytes(),
               StandardCharsets.UTF_8));
+    }
+  }
+
+  @Test
+  void testIndexDatasets() throws Exception {
+    DatasetRecord datasetRecord = createDatasetRecord();
+    Dataset dataset1 = datasetRecord.dataset;
+    Dataset dataset2 = createDataset(datasetRecord.createUser, datasetRecord.updateUser,
+        new DataUseBuilder().setGeneralUse(true).build(), datasetRecord.dac);
+    dataset2.setStudy(datasetRecord.study);
+    when(datasetDAO.findDatasetById(dataset1.getDatasetId())).thenReturn(dataset1);
+    when(datasetDAO.findDatasetById(dataset2.getDatasetId())).thenReturn(dataset2);
+    when(userDao.findUserById(dataset1.getCreateUserId())).thenReturn(datasetRecord.createUser);
+    when(userDao.findUserById(dataset2.getCreateUserId())).thenReturn(datasetRecord.createUser);
+    org.elasticsearch.client.Response mockResponse = mock();
+    when(esClient.performRequest(any())).thenReturn(mockResponse);
+    when(mockResponse.getEntity()).thenReturn(new StringEntity("response body"));
+    StatusLine statusLine = mock();
+    when(mockResponse.getStatusLine()).thenReturn(statusLine);
+    when(statusLine.getStatusCode()).thenReturn(200);
+
+    try (var ignored = service.indexDatasets(List.of(dataset1, dataset2),
+        datasetRecord.createUser)) {
+      // Each dataset should be looked up once when defining the term and a second time
+      // when updating the indexed date.
+      verify(datasetDAO, times(2)).findDatasetById(dataset1.getDatasetId());
+      verify(datasetDAO, times(2)).findDatasetById(dataset2.getDatasetId());
     }
   }
 


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-1537

### Summary
Datasets, when queried in list context, do not have study information populated, so when we index a collection, we need to ensure that we have study info before publishing to the index.

This PR does some minor updates to the method signatures to clean up db lookups and simplify usages of the index methods.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
