### PR TITLE
DT-1497: Add code to auto-set institution on user creation

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
@@ -519,7 +519,7 @@ public class ConsentModule extends AbstractModule {
 
   @Provides
   InstitutionService providesInstitutionService() {
-    return new InstitutionService(providesInstitutionDAO(), providesUserDAO());
+    return new InstitutionService(providesInstitutionDAO(), providesUserDAO(), providesGCSService());
   }
 
   @Provides
@@ -575,7 +575,7 @@ public class ConsentModule extends AbstractModule {
         providesDaaDAO(),
         providesEmailService(),
         providesDraftService(),
-        providesGCSService());
+        providesInstitutionService());
   }
 
   @Provides

--- a/src/main/java/org/broadinstitute/consent/http/db/UserDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/UserDAO.java
@@ -122,12 +122,14 @@ public interface UserDAO extends Transactional<UserDAO> {
       """)
   List<User> findUsersByEmailList(@BindList("emails") List<String> emails);
 
-  @SqlUpdate("INSERT INTO users (email, display_name, create_date) values (:email, :displayName, :createDate)")
+  @SqlUpdate("INSERT INTO users (email, display_name, institution_id, create_date) values (:email, :displayName, :institutionId, :createDate)")
   @GetGeneratedKeys
   Integer insertUser(@Bind("email") String email,
       @Bind("displayName") String displayName,
+      @Bind("institutionId") Integer institutionId,
       @Bind("createDate") Date createDate);
 
+  // Only used by tests; all users except Admin have an institution ID set on creation.
   @SqlUpdate("UPDATE users SET display_name=:displayName, institution_id=:institutionId WHERE user_id=:id")
   void updateUser(@Bind("displayName") String displayName,
       @Bind("id") Integer id,

--- a/src/main/java/org/broadinstitute/consent/http/enumeration/UserFields.java
+++ b/src/main/java/org/broadinstitute/consent/http/enumeration/UserFields.java
@@ -1,26 +1,20 @@
 package org.broadinstitute.consent.http.enumeration;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public enum UserFields {
-  ERA_EXPIRATION_DATE("eraExpiration", false),
-  ERA_STATUS("eraAuthorized", false),
-  SELECTED_SIGNING_OFFICIAL_ID("selectedSigningOfficialId", false),
-  SUGGESTED_SIGNING_OFFICIAL("suggestedSigningOfficial", false),
-  SUGGESTED_INSTITUTION("suggestedInstitution", false),
-  DAA_ACCEPTANCE("daaAcceptance", false);
+  ERA_EXPIRATION_DATE("eraExpiration"),
+  ERA_STATUS("eraAuthorized"),
+  SELECTED_SIGNING_OFFICIAL_ID("selectedSigningOfficialId"),
+  SUGGESTED_SIGNING_OFFICIAL("suggestedSigningOfficial"),
+  DAA_ACCEPTANCE("daaAcceptance");
 
-  public static final String LIBRARY_CARDS = "libraryCards";
-  public static final String LIBRARY_CARD_ENTRIES = "libraryCardEntries";
   private final String value;
-  private final Boolean required;
 
-  UserFields(String value, Boolean required) {
+  UserFields(String value) {
     this.value = value;
-    this.required = required;
   }
 
   public String getValue() {
@@ -28,29 +22,6 @@ public enum UserFields {
   }
 
   public static List<String> getValues() {
-    return Stream.of(UserFields.values()).map(UserFields::getValue).collect(Collectors.toList());
-  }
-
-  public Boolean getRequired() {
-    return required;
-  }
-
-  public static List<UserFields> getRequiredFields() {
-    List<UserFields> requiredValues = new ArrayList<>();
-    for (UserFields researcherField : UserFields.values()) {
-      if (researcherField.getRequired()) {
-        requiredValues.add(researcherField);
-      }
-    }
-    return requiredValues;
-  }
-
-  public static Boolean containsValue(String value) {
-    for (UserFields researcherField : UserFields.values()) {
-      if (researcherField.getValue().equals(value)) {
-        return true;
-      }
-    }
-    return false;
+    return Stream.of(UserFields.values()).map(UserFields::getValue).toList();
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/enumeration/UserRoles.java
+++ b/src/main/java/org/broadinstitute/consent/http/enumeration/UserRoles.java
@@ -1,7 +1,6 @@
 package org.broadinstitute.consent.http.enumeration;
 
 import java.util.EnumSet;
-import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
 import org.broadinstitute.consent.http.models.UserRole;
@@ -20,18 +19,10 @@ public enum UserRoles {
 
   private final String roleName;
   private final Integer roleId;
-  private static final HashSet<Integer> LIST_OF_NON_DAC_ROLE_IDS = new HashSet<>(Set.of(
-      ALUMNI.getRoleId(),
-      ADMIN.getRoleId(),
-      RESEARCHER.getRoleId(),
-      SIGNINGOFFICIAL.getRoleId(),
-      DATASUBMITTER.getRoleId(),
-      ITDIRECTOR.getRoleId()));
-  private static final HashSet<Integer> LIST_OF_SO_AUTHORIZED_ROLES_TO_ADJUST = new HashSet<>(
-      Set.of(
-          ITDIRECTOR.getRoleId(),
-          SIGNINGOFFICIAL.getRoleId(),
-          DATASUBMITTER.getRoleId()));
+  private static final Set<UserRoles> NON_DAC_ROLES =
+      Set.of(ALUMNI, ADMIN, RESEARCHER, SIGNINGOFFICIAL, DATASUBMITTER, ITDIRECTOR);
+  private static final Set<UserRoles> SO_AUTHORIZED_ROLES_TO_ADJUST =
+      Set.of(ITDIRECTOR, SIGNINGOFFICIAL, DATASUBMITTER);
 
   UserRoles(String roleName, Integer roleId) {
     this.roleName = roleName;
@@ -106,12 +97,12 @@ public enum UserRoles {
         .anyMatch(roleName::equalsIgnoreCase);
   }
 
-  public static boolean isValidNonDACRoleId(Integer roleId) {
-    return !Objects.isNull(roleId) && LIST_OF_NON_DAC_ROLE_IDS.contains(roleId);
+  public static boolean isValidNonDACRoleId(UserRoles role) {
+    return NON_DAC_ROLES.contains(role);
   }
 
-  public static boolean isValidSoAdjustableRoleId(Integer roleId) {
-    return !Objects.isNull(roleId) && LIST_OF_SO_AUTHORIZED_ROLES_TO_ADJUST.contains(roleId);
+  public static boolean isValidSoAdjustableRoleId(UserRoles role) {
+    return SO_AUTHORIZED_ROLES_TO_ADJUST.contains(role);
   }
 
 }

--- a/src/main/java/org/broadinstitute/consent/http/models/InstitutionDomainMap.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/InstitutionDomainMap.java
@@ -18,4 +18,13 @@ public class InstitutionDomainMap {
   public Set<String> getDomainsForInstitution(String institution) {
     return institutionDomainMap.get(institution);
   }
+
+  public String getInstitutionForEmail(String email) {
+    String domain = email.substring(email.indexOf('@') + 1);
+    return institutionDomainMap.entrySet().stream()
+        .filter(entry -> entry.getValue().contains(domain))
+        .map(Map.Entry::getKey)
+        .findFirst()
+        .orElse(null);
+  }
 }

--- a/src/main/java/org/broadinstitute/consent/http/models/UserUpdateFields.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/UserUpdateFields.java
@@ -80,14 +80,6 @@ public class UserUpdateFields {
     this.selectedSigningOfficialId = selectedSigningOfficialId;
   }
 
-  public String getSuggestedInstitution() {
-    return suggestedInstitution;
-  }
-
-  public void setSuggestedInstitution(String suggestedInstitution) {
-    this.suggestedInstitution = suggestedInstitution;
-  }
-
   public String getSuggestedSigningOfficial() {
     return suggestedSigningOfficial;
   }
@@ -118,13 +110,6 @@ public class UserUpdateFields {
       prop.setUserId(userId);
       prop.setPropertyKey(UserFields.SUGGESTED_SIGNING_OFFICIAL.getValue());
       prop.setPropertyValue(this.getSuggestedSigningOfficial());
-      userProps.add(prop);
-    }
-    if (Objects.nonNull(this.getSuggestedInstitution())) {
-      UserProperty prop = new UserProperty();
-      prop.setUserId(userId);
-      prop.setPropertyKey(UserFields.SUGGESTED_INSTITUTION.getValue());
-      prop.setPropertyValue(this.getSuggestedInstitution());
       userProps.add(prop);
     }
     if (Objects.nonNull(this.getDaaAcceptance())) {
@@ -187,28 +172,17 @@ public class UserUpdateFields {
     }
 
     UserUpdateFields that = (UserUpdateFields) o;
-    return Objects.equals(displayName, that.displayName) && Objects.equals(
-        institutionId, that.institutionId) && Objects.equals(emailPreference,
-        that.emailPreference) && Objects.equals(userRoleIds, that.userRoleIds)
-        && Objects.equals(eraCommonsId, that.eraCommonsId) && Objects.equals(
-        selectedSigningOfficialId, that.selectedSigningOfficialId) && Objects.equals(
-        suggestedInstitution, that.suggestedInstitution) && Objects.equals(
-        suggestedSigningOfficial, that.suggestedSigningOfficial) && Objects.equals(
-        daaAcceptance, that.daaAcceptance);
+    return Objects.equals(displayName, that.displayName) && Objects.equals(institutionId,
+        that.institutionId) && Objects.equals(emailPreference, that.emailPreference)
+        && Objects.equals(userRoleIds, that.userRoleIds) && Objects.equals(eraCommonsId,
+        that.eraCommonsId) && Objects.equals(selectedSigningOfficialId,
+        that.selectedSigningOfficialId) && Objects.equals(suggestedSigningOfficial,
+        that.suggestedSigningOfficial) && Objects.equals(daaAcceptance, that.daaAcceptance);
   }
 
   @Override
   public int hashCode() {
-    int result = Objects.hashCode(displayName);
-    result = 31 * result + Objects.hashCode(institutionId);
-    result = 31 * result + Objects.hashCode(emailPreference);
-    result = 31 * result + Objects.hashCode(userRoleIds);
-    result = 31 * result + Objects.hashCode(eraCommonsId);
-    result = 31 * result + Objects.hashCode(selectedSigningOfficialId);
-    result = 31 * result + Objects.hashCode(suggestedInstitution);
-    result = 31 * result + Objects.hashCode(suggestedSigningOfficial);
-    result = 31 * result + Objects.hashCode(daaAcceptance);
-    return result;
+    return Objects.hash(displayName, institutionId, emailPreference, userRoleIds, eraCommonsId,
+        selectedSigningOfficialId, suggestedSigningOfficial, daaAcceptance);
   }
-
 }

--- a/src/main/java/org/broadinstitute/consent/http/models/UserUpdateFields.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/UserUpdateFields.java
@@ -25,7 +25,6 @@ public class UserUpdateFields {
   private List<Integer> userRoleIds;
   private String eraCommonsId;
   private Integer selectedSigningOfficialId;
-  private String suggestedInstitution;
   private String suggestedSigningOfficial;
   private Boolean daaAcceptance;
 

--- a/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
@@ -264,22 +264,10 @@ public class UserResource extends Resource {
       User activeUser = userService.findUserByEmail(authUser.getEmail());
       User user = userService.findUserById(userId);
       List<Integer> currentUserRoleIds = user.getUserRoleIdsFromUser();
-      if (activeUser.hasUserRole(UserRoles.ADMIN) && UserRoles.isValidNonDACRoleId(roleId)) {
+      if ((activeUser.hasUserRole(UserRoles.ADMIN) && UserRoles.isValidNonDACRoleId(targetRole)) ||
+          signingOfficialMeetsRequirements(targetRole, activeUser, user)) {
         if (!currentUserRoleIds.contains(roleId)) {
-          userService.insertUserRoles(Collections.singletonList(role), user.getUserId());
-          return getUserResponse(authUser, userId);
-        } else {
-          return Response.notModified().build();
-        }
-      } else if (signingOfficialMeetsRequirements(roleId, activeUser, user)) {
-        // update the user role with the active user's institution id.
-        if (!currentUserRoleIds.contains(roleId)) {
-          // update the user's institution if it was set to null and add the role.
-          if (user.getInstitutionId() == null) {
-            userService.insertRoleAndInstitutionForUser(role, activeUser.getInstitutionId(), user);
-          } else {
-            userService.insertUserRoles(Collections.singletonList(role), user.getUserId());
-          }
+          userService.insertRoleAndInstitutionForUser(role, user);
           return getUserResponse(authUser, userId);
         } else {
           return Response.notModified().build();
@@ -292,13 +280,12 @@ public class UserResource extends Resource {
     }
   }
 
-  private static boolean signingOfficialMeetsRequirements(Integer roleId, User activeUser,
+  private static boolean signingOfficialMeetsRequirements(UserRoles role, User activeUser,
       User user) {
     return activeUser.hasUserRole(UserRoles.SIGNINGOFFICIAL)
-        && Objects.nonNull(activeUser.getInstitutionId())
-        && UserRoles.isValidSoAdjustableRoleId(roleId)
-        && (Objects.equals(user.getInstitutionId(), activeUser.getInstitutionId()) ||
-        Optional.ofNullable(user.getInstitutionId()).isEmpty());
+        && activeUser.getInstitutionId() != null
+        && UserRoles.isValidSoAdjustableRoleId(role)
+        && (user.getInstitutionId() == null || user.getInstitutionId().equals(activeUser.getInstitutionId()));
   }
 
   private Response getUserResponse(AuthUser authUser, Integer userId) {
@@ -320,12 +307,12 @@ public class UserResource extends Resource {
       User activeUser = userService.findUserByEmail(authUser.getEmail());
       User user = userService.findUserById(userId);
       if (activeUser.hasUserRole(UserRoles.ADMIN)) {
-        if (!UserRoles.isValidNonDACRoleId(roleId)) {
+        if (!UserRoles.isValidNonDACRoleId(targetRole)) {
           throw new BadRequestException("Invalid Role Id");
         }
         return doDelete(authUser, userId, roleId, activeUser, user);
       } else if (activeUser.hasUserRole(UserRoles.SIGNINGOFFICIAL)) {
-        if (!UserRoles.isValidSoAdjustableRoleId(roleId)) {
+        if (!UserRoles.isValidSoAdjustableRoleId(targetRole)) {
           throw new ForbiddenException(
               "A Signing Official may only remove the following role ids: [6, 7, 8] ");
         }

--- a/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
@@ -228,6 +228,11 @@ public class UserResource extends Resource {
       User user = userService.findUserByEmail(authUser.getEmail());
       UserUpdateFields userUpdateFields = gson.fromJson(json, UserUpdateFields.class);
 
+      // Users cannot update their own institution id through this service
+      if (userUpdateFields.getInstitutionId() != null) {
+        throw new BadRequestException("Institution ID is not updatable");
+      }
+
       if (Objects.nonNull(userUpdateFields.getUserRoleIds()) && !user.hasUserRole(
           UserRoles.ADMIN)) {
         throw new BadRequestException("Cannot change user's roles.");

--- a/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
@@ -228,11 +228,6 @@ public class UserResource extends Resource {
       User user = userService.findUserByEmail(authUser.getEmail());
       UserUpdateFields userUpdateFields = gson.fromJson(json, UserUpdateFields.class);
 
-      // Users cannot update their own institution id through this service
-      if (userUpdateFields.getInstitutionId() != null) {
-        throw new BadRequestException("Institution ID is not updatable");
-      }
-
       if (Objects.nonNull(userUpdateFields.getUserRoleIds()) && !user.hasUserRole(
           UserRoles.ADMIN)) {
         throw new BadRequestException("Cannot change user's roles.");
@@ -275,9 +270,8 @@ public class UserResource extends Resource {
         // update the user role with the active user's institution id.
         if (!currentUserRoleIds.contains(roleId)) {
           // update the user's institution if it was set to null and add the role.
-          if (Optional.ofNullable(user.getInstitutionId()).isEmpty()) {
-            userService.insertRoleAndInstitutionForUser(role, activeUser.getInstitutionId(),
-                user.getUserId());
+          if (user.getInstitutionId() == null) {
+            userService.insertRoleAndInstitutionForUser(role, activeUser.getInstitutionId(), user);
           } else {
             userService.insertUserRoles(Collections.singletonList(role), user.getUserId());
           }

--- a/src/main/java/org/broadinstitute/consent/http/service/InstitutionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/InstitutionService.java
@@ -1,25 +1,32 @@
 package org.broadinstitute.consent.http.service;
 
+import com.google.api.client.http.HttpStatusCodes;
 import com.google.inject.Inject;
 import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.ServerErrorException;
+import java.io.IOException;
 import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
+import org.broadinstitute.consent.http.cloudstore.GCSService;
 import org.broadinstitute.consent.http.db.InstitutionDAO;
 import org.broadinstitute.consent.http.db.UserDAO;
 import org.broadinstitute.consent.http.models.Institution;
+import org.broadinstitute.consent.http.models.InstitutionDomainMap;
 import org.broadinstitute.consent.http.service.UserService.SimplifiedUser;
 
 public class InstitutionService {
 
   private final InstitutionDAO institutionDAO;
   private final UserDAO userDAO;
+  private final GCSService store;
 
   @Inject
-  public InstitutionService(InstitutionDAO institutionDAO, UserDAO userDAO) {
+  public InstitutionService(InstitutionDAO institutionDAO, UserDAO userDAO, GCSService store) {
     this.institutionDAO = institutionDAO;
     this.userDAO = userDAO;
+    this.store = store;
   }
 
   public Institution createInstitution(Institution institution, Integer userId) {
@@ -84,6 +91,27 @@ public class InstitutionService {
     institution.setSigningOfficials(signingOfficials);
 
     return institution;
+  }
+
+  private InstitutionDomainMap getInstitutionDomainMap() {
+    try {
+      return store.readJsonFileFromBucket("institution-domain/allowlist.json",
+          InstitutionDomainMap.class);
+    } catch (IOException e) {
+      throw new ServerErrorException("Could not load institution configuration",
+          HttpStatusCodes.STATUS_CODE_SERVER_ERROR, e);
+    }
+  }
+
+  public Institution findInstitutionForEmail(String email) {
+    String name = getInstitutionDomainMap().getInstitutionForEmail(email);
+    if (name != null) {
+      var institutions = institutionDAO.findInstitutionsByName(name);
+      if (institutions.size() == 1) {
+        return institutions.get(0);
+      }
+    }
+    return null;
   }
 
   public List<Institution> findAllInstitutions() {

--- a/src/main/java/org/broadinstitute/consent/http/service/UserService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/UserService.java
@@ -7,7 +7,6 @@ import com.google.gson.JsonObject;
 import com.google.inject.Inject;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.NotFoundException;
-import java.io.IOException;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -17,7 +16,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.broadinstitute.consent.http.cloudstore.GCSService;
 import org.broadinstitute.consent.http.db.AcknowledgementDAO;
 import org.broadinstitute.consent.http.db.DaaDAO;
 import org.broadinstitute.consent.http.db.FileStorageObjectDAO;
@@ -34,7 +32,6 @@ import org.broadinstitute.consent.http.exceptions.ConsentConflictException;
 import org.broadinstitute.consent.http.models.AuthUser;
 import org.broadinstitute.consent.http.models.DataAccessAgreement;
 import org.broadinstitute.consent.http.models.Institution;
-import org.broadinstitute.consent.http.models.InstitutionDomainMap;
 import org.broadinstitute.consent.http.models.LibraryCard;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.UserProperty;
@@ -66,14 +63,14 @@ public class UserService implements ConsentLogger {
   private final DaaDAO daaDAO;
   private final EmailService emailService;
   private final DraftServiceDAO draftServiceDAO;
-  private final GCSService store;
+  private final InstitutionService institutionService;
 
   @Inject
   public UserService(UserDAO userDAO, UserPropertyDAO userPropertyDAO, UserRoleDAO userRoleDAO,
       VoteDAO voteDAO, InstitutionDAO institutionDAO, LibraryCardDAO libraryCardDAO,
       AcknowledgementDAO acknowledgementDAO, FileStorageObjectDAO fileStorageObjectDAO,
       SamDAO samDAO, UserServiceDAO userServiceDAO, DaaDAO daaDAO, EmailService emailService,
-      DraftServiceDAO draftServiceDAO, GCSService store) {
+      DraftServiceDAO draftServiceDAO, InstitutionService institutionService) {
     this.userDAO = userDAO;
     this.userPropertyDAO = userPropertyDAO;
     this.userRoleDAO = userRoleDAO;
@@ -87,7 +84,7 @@ public class UserService implements ConsentLogger {
     this.daaDAO = daaDAO;
     this.emailService = emailService;
     this.draftServiceDAO = draftServiceDAO;
-    this.store = store;
+    this.institutionService = institutionService;
   }
 
   /**
@@ -163,25 +160,26 @@ public class UserService implements ConsentLogger {
   }
 
   public void insertRoleAndInstitutionForUser(UserRole role, Integer institutionId,
-      Integer userId) {
+      User user) {
+    var userId = user.getUserId();
     try {
+      Institution institution = institutionService.findInstitutionForEmail(user.getEmail());
+      if (!institution.getId().equals(institutionId)) {
+        throw new BadRequestException("User %s cannot be associated with institution %s".formatted(
+            user.getEmail(), institutionId));
+      }
       userServiceDAO.insertRoleAndInstitutionTxn(role, institutionId, userId);
     } catch (Exception e) {
       logException(
-          "Error when updating user: %s, institution: %s, role: %s".formatted(userId.toString(),
-              institutionId.toString(), role.toString()), e);
+          "Error when updating user: %s, institution: %s, role: %s".formatted(userId,
+              institutionId, role), e);
       throw e;
     }
   }
 
-  public User createUser(User user) throws IOException {
-    var institutionDomainMap = store.readJsonFileFromBucket("institution-domain/allowlist.json",
-        InstitutionDomainMap.class);
-    if (institutionDomainMap != null) {
-      logDebug("remove this check after implementation of institution domain");
-    }
+  public User createUser(User user) {
     // Default role is researcher.
-    if (Objects.isNull(user.getRoles()) || CollectionUtils.isEmpty(user.getRoles())) {
+    if (CollectionUtils.isEmpty(user.getRoles())) {
       user.setResearcherRole();
     }
     validateRequiredFields(user);
@@ -189,7 +187,11 @@ public class UserService implements ConsentLogger {
     if (Objects.nonNull(existingUser)) {
       throw new BadRequestException("User exists with this email address: " + user.getEmail());
     }
-    Integer userId = userDAO.insertUser(user.getEmail(), user.getDisplayName(), new Date());
+    Institution institution = institutionService.findInstitutionForEmail(user.getEmail());
+    if (institution != null) {
+      user.setInstitutionId(institution.getId());
+    }
+    Integer userId = userDAO.insertUser(user.getEmail(), user.getDisplayName(), user.getInstitutionId(), new Date());
     insertUserRoles(user.getRoles(), userId);
     addExistingLibraryCards(user);
     return userDAO.findUserById(userId);
@@ -362,17 +364,15 @@ public class UserService implements ConsentLogger {
   }
 
   private void validateRequiredFields(User user) {
-    if (Objects.isNull(user.getDisplayName()) || StringUtils.isEmpty(user.getDisplayName())) {
+    if (StringUtils.isEmpty(user.getDisplayName())) {
       throw new BadRequestException("Display Name cannot be empty");
     }
-    if (Objects.isNull(user.getEmail()) || StringUtils.isEmpty(user.getEmail())) {
+    if (StringUtils.isEmpty(user.getEmail())) {
       throw new BadRequestException("Email address cannot be empty");
     }
+    List<String> validRoleNameList = Stream.of(UserRoles.RESEARCHER, UserRoles.ALUMNI,
+        UserRoles.ADMIN).map(UserRoles::getRoleName).toList();
     user.getRoles().forEach(role -> {
-      List<UserRoles> validRoles = Stream.of(UserRoles.RESEARCHER,
-          UserRoles.ALUMNI, UserRoles.ADMIN).collect(Collectors.toList());
-      List<String> validRoleNameList = validRoles.stream().map(UserRoles::getRoleName)
-          .collect(Collectors.toList());
       if (!validRoleNameList.contains(role.getName())) {
         String validRoleNames = String.join(", ", validRoleNameList);
         throw new BadRequestException(
@@ -416,18 +416,8 @@ public class UserService implements ConsentLogger {
   private void addExistingLibraryCards(User user) {
     List<LibraryCard> libraryCards = libraryCardDAO.findAllLibraryCardsByUserEmail(user.getEmail());
 
-    if (Objects.isNull(libraryCards) || libraryCards.isEmpty()) {
-      return;
-    }
-
     libraryCards
         .forEach(lc -> {
-          lc.setUserId(user.getUserId());
-
-          if (!Objects.isNull(lc.getInstitutionId())) {
-            user.setInstitutionId(lc.getInstitutionId());
-          }
-
           libraryCardDAO.updateLibraryCardById(
               lc.getId(),
               lc.getUserId(),
@@ -438,8 +428,6 @@ public class UserService implements ConsentLogger {
               user.getUserId(),
               new Date());
         });
-
-    userDAO.updateUser(user.getDisplayName(), user.getUserId(), user.getInstitutionId());
   }
 
   public User findOrCreateUser(AuthUser authUser) throws Exception {

--- a/src/main/java/org/broadinstitute/consent/http/service/UserService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/UserService.java
@@ -164,6 +164,9 @@ public class UserService implements ConsentLogger {
     try {
       if (user.getInstitutionId() == null) {
         Institution institution = institutionService.findInstitutionForEmail(user.getEmail());
+        if (institution == null) {
+          throw new BadRequestException("No institution found for user: %s".formatted(user.getEmail()));
+        }
         userServiceDAO.insertRoleAndInstitutionTxn(role, institution.getId(), userId);
       } else {
         userRoleDAO.insertSingleUserRole(role.getRoleId(), userId);

--- a/src/main/java/org/broadinstitute/consent/http/service/UserService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/UserService.java
@@ -159,20 +159,18 @@ public class UserService implements ConsentLogger {
     return findUserById(userId);
   }
 
-  public void insertRoleAndInstitutionForUser(UserRole role, Integer institutionId,
-      User user) {
+  public void insertRoleAndInstitutionForUser(UserRole role, User user) {
     var userId = user.getUserId();
     try {
-      Institution institution = institutionService.findInstitutionForEmail(user.getEmail());
-      if (!institution.getId().equals(institutionId)) {
-        throw new BadRequestException("User %s cannot be associated with institution %s".formatted(
-            user.getEmail(), institutionId));
+      if (user.getInstitutionId() == null) {
+        Institution institution = institutionService.findInstitutionForEmail(user.getEmail());
+        userServiceDAO.insertRoleAndInstitutionTxn(role, institution.getId(), userId);
+      } else {
+        userRoleDAO.insertSingleUserRole(role.getRoleId(), userId);
       }
-      userServiceDAO.insertRoleAndInstitutionTxn(role, institutionId, userId);
     } catch (Exception e) {
       logException(
-          "Error when updating user: %s, institution: %s, role: %s".formatted(userId,
-              institutionId, role), e);
+          "Error when updating user: %s, role: %s".formatted(userId, role), e);
       throw e;
     }
   }
@@ -420,7 +418,7 @@ public class UserService implements ConsentLogger {
         .forEach(lc -> {
           libraryCardDAO.updateLibraryCardById(
               lc.getId(),
-              lc.getUserId(),
+              user.getUserId(),
               lc.getInstitutionId(),
               lc.getEraCommonsId(),
               lc.getUserName(),

--- a/src/main/resources/assets/paths/user.yaml
+++ b/src/main/resources/assets/paths/user.yaml
@@ -43,9 +43,6 @@ put:
             selectedSigningOfficialId:
               description: The selected user id of the user's preferred signing official
               type: number
-            suggestedInstitution:
-              description: The suggested institution for the user
-              type: string
             suggestedSigningOfficial:
               description: The suggested signing official for the user
               type: string

--- a/src/main/resources/assets/paths/userByIdv2.yaml
+++ b/src/main/resources/assets/paths/userByIdv2.yaml
@@ -63,9 +63,6 @@ put:
             selectedSigningOfficialId:
               description: The selected user id of the user's preferred signing official
               type: number
-            suggestedInstitution:
-              description: The suggested institution for the user
-              type: string
             suggestedSigningOfficial:
               description: The suggested signing official for the user
               type: string

--- a/src/main/resources/assets/schemas/UserProperty.yaml
+++ b/src/main/resources/assets/schemas/UserProperty.yaml
@@ -4,8 +4,6 @@ properties:
     type: string
   eraExpiration:
     type: string
-  suggestedInstitution:
-    type: string
   suggestedSigningOfficial:
     type: string
   selectedSigningOfficial:

--- a/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
@@ -16,13 +16,11 @@ import org.broadinstitute.consent.http.AbstractTestHelper;
 import org.broadinstitute.consent.http.ConsentApplication;
 import org.broadinstitute.consent.http.configurations.ConsentConfiguration;
 import org.broadinstitute.consent.http.enumeration.OrganizationType;
-import org.broadinstitute.consent.http.enumeration.UserFields;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.DataAccessRequest;
 import org.broadinstitute.consent.http.models.DataAccessRequestData;
 import org.broadinstitute.consent.http.models.DatasetEntry;
 import org.broadinstitute.consent.http.models.User;
-import org.broadinstitute.consent.http.models.UserProperty;
 import org.broadinstitute.consent.http.util.gson.GsonUtil;
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.gson2.Gson2Config;
@@ -176,13 +174,8 @@ public class DAOTestHelper extends AbstractTestHelper implements TestExecutionLi
         randomAlphabetic(i2) +
         "." +
         randomAlphabetic(i3);
-    Integer userId = userDAO.insertUser(email, "display name", new Date());
+    Integer userId = userDAO.insertUser(email, "display name", null, new Date());
     userRoleDAO.insertSingleUserRole(UserRoles.RESEARCHER.getRoleId(), userId);
-    UserProperty prop = new UserProperty();
-    prop.setUserId(userId);
-    prop.setPropertyKey(UserFields.SUGGESTED_INSTITUTION.getValue());
-    prop.setPropertyValue("test");
-    userPropertyDAO.insertAll(List.of(prop));
     return userDAO.findUserById(userId);
   }
 
@@ -196,7 +189,7 @@ public class DAOTestHelper extends AbstractTestHelper implements TestExecutionLi
     int i1 = randomInt(5, 10);
     String email = randomAlphabetic(i1);
     String name = randomAlphabetic(10);
-    Integer userId = userDAO.insertUser(email, name, new Date());
+    Integer userId = userDAO.insertUser(email, name, null, new Date());
     Integer institutionId = institutionDAO.insertInstitution(randomAlphabetic(20),
         "itDirectorName",
         "itDirectorEmail",
@@ -248,4 +241,40 @@ public class DAOTestHelper extends AbstractTestHelper implements TestExecutionLi
     return dataAccessRequestDAO.findByReferenceId(referenceId);
   }
 
+  User createUserWithRoleInDac(Integer roleId, Integer dacId) {
+    User user = createUserWithRole(roleId);
+    dacDAO.addDacMember(roleId, user.getUserId(), dacId);
+    return user;
+  }
+
+  User createUserWithRole(Integer roleId) {
+    int i1 = randomInt(5, 10);
+    int i2 = randomInt(5, 10);
+    int i3 = randomInt(3, 5);
+    String email = randomAlphabetic(i1) + "@" + randomAlphabetic(i2) + "." + randomAlphabetic(i3);
+    Integer userId = userDAO.insertUser(email, "display name", null, new Date());
+    userRoleDAO.insertSingleUserRole(roleId, userId);
+    return userDAO.findUserById(userId);
+  }
+
+  User createUserWithInstitution() {
+    int i1 = randomInt(5, 10);
+    String email = randomAlphabetic(i1);
+    String name = randomAlphabetic(10);
+    Integer userId = userDAO.insertUser(email, name, null, new Date());
+    Integer institutionId = institutionDAO.insertInstitution(randomAlphabetic(20),
+        "itDirectorName",
+        "itDirectorEmail",
+        randomAlphabetic(10),
+        new Random().nextInt(),
+        randomAlphabetic(10),
+        randomAlphabetic(10),
+        randomAlphabetic(10),
+        OrganizationType.NON_PROFIT.getValue(),
+        userId,
+        new Date());
+    userDAO.updateUser(name, userId, institutionId);
+    userRoleDAO.insertSingleUserRole(7, userId);
+    return userDAO.findUserById(userId);
+  }
 }

--- a/src/test/java/org/broadinstitute/consent/http/db/DaaDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DaaDAOTest.java
@@ -31,7 +31,8 @@ class DaaDAOTest extends DAOTestHelper {
 
   @Test
   void testInsert() {
-    Integer userId = userDAO.insertUser(RandomStringUtils.randomAlphabetic(5), RandomStringUtils.randomAlphabetic(5), new Date());
+    Integer userId = userDAO.insertUser(RandomStringUtils.randomAlphabetic(5), RandomStringUtils.randomAlphabetic(5),
+        null, new Date());
     Integer dacId = dacDAO.createDac(RandomStringUtils.randomAlphabetic(5), RandomStringUtils.randomAlphabetic(5), "",  new Date());
     Integer daaId = daaDAO.createDaa(userId, new Date().toInstant(), userId, new Date().toInstant(), dacId);
     assertNotNull(daaId);
@@ -39,7 +40,8 @@ class DaaDAOTest extends DAOTestHelper {
 
   @Test
   void testInsertMultipleDaasOneDacId() {
-    Integer userId = userDAO.insertUser(RandomStringUtils.randomAlphabetic(5), RandomStringUtils.randomAlphabetic(5), new Date());
+    Integer userId = userDAO.insertUser(RandomStringUtils.randomAlphabetic(5), RandomStringUtils.randomAlphabetic(5),
+        null, new Date());
     Integer dacId = dacDAO.createDac(RandomStringUtils.randomAlphabetic(5), RandomStringUtils.randomAlphabetic(5), "",  new Date());
     Integer daaId1 = daaDAO.createDaa(userId, new Date().toInstant(), userId, new Date().toInstant(), dacId);
     Integer daaId2 = daaDAO.createDaa(userId, new Date().toInstant(), userId, new Date().toInstant(), dacId);
@@ -57,7 +59,8 @@ class DaaDAOTest extends DAOTestHelper {
 
   @Test
   void testFindAllOneDaa() {
-    Integer userId = userDAO.insertUser(RandomStringUtils.randomAlphabetic(5), RandomStringUtils.randomAlphabetic(5), new Date());
+    Integer userId = userDAO.insertUser(RandomStringUtils.randomAlphabetic(5), RandomStringUtils.randomAlphabetic(5),
+        null, new Date());
     Integer dacId = dacDAO.createDac(RandomStringUtils.randomAlphabetic(5), RandomStringUtils.randomAlphabetic(5), "",  new Date());
     Integer daaId = daaDAO.createDaa(userId, new Date().toInstant(), userId, new Date().toInstant(), dacId);
     assertNotNull(daaId);
@@ -68,7 +71,8 @@ class DaaDAOTest extends DAOTestHelper {
 
   @Test
   void testFindAllMultipleDaas() {
-    Integer userId = userDAO.insertUser(RandomStringUtils.randomAlphabetic(5), RandomStringUtils.randomAlphabetic(5), new Date());
+    Integer userId = userDAO.insertUser(RandomStringUtils.randomAlphabetic(5), RandomStringUtils.randomAlphabetic(5),
+        null, new Date());
     Integer dacId = dacDAO.createDac(RandomStringUtils.randomAlphabetic(5), RandomStringUtils.randomAlphabetic(5), "",  new Date());
     Integer daaId1 = daaDAO.createDaa(userId, new Date().toInstant(), userId, new Date().toInstant(), dacId);
     Integer daaId2 = daaDAO.createDaa(userId, new Date().toInstant(), userId, new Date().toInstant(), dacId);
@@ -90,7 +94,8 @@ class DaaDAOTest extends DAOTestHelper {
 
   @Test
   void testFindById() {
-    Integer userId = userDAO.insertUser(RandomStringUtils.randomAlphabetic(5), RandomStringUtils.randomAlphabetic(5), new Date());
+    Integer userId = userDAO.insertUser(RandomStringUtils.randomAlphabetic(5), RandomStringUtils.randomAlphabetic(5),
+        null, new Date());
     Integer dacId = dacDAO.createDac(RandomStringUtils.randomAlphabetic(5), RandomStringUtils.randomAlphabetic(5), "",  new Date());
     Integer daaId1 = daaDAO.createDaa(userId, new Date().toInstant(), userId, new Date().toInstant(), dacId);
     Integer daaId2 = daaDAO.createDaa(userId, new Date().toInstant(), userId, new Date().toInstant(), dacId);
@@ -112,7 +117,8 @@ class DaaDAOTest extends DAOTestHelper {
 
   @Test
   void testFindByDacId() {
-    Integer userId = userDAO.insertUser(RandomStringUtils.randomAlphabetic(5), RandomStringUtils.randomAlphabetic(5), new Date());
+    Integer userId = userDAO.insertUser(RandomStringUtils.randomAlphabetic(5), RandomStringUtils.randomAlphabetic(5),
+        null, new Date());
     Integer dacId = dacDAO.createDac(RandomStringUtils.randomAlphabetic(5), RandomStringUtils.randomAlphabetic(5), "",  new Date());
     Integer dacId2 = dacDAO.createDac(RandomStringUtils.randomAlphabetic(5), RandomStringUtils.randomAlphabetic(5), "",  new Date());
     Integer daaId1 = daaDAO.createDaa(userId, new Date().toInstant(), userId, new Date().toInstant(), dacId);
@@ -130,7 +136,8 @@ class DaaDAOTest extends DAOTestHelper {
 
   @Test
   void testFindByDacIdInvalid() {
-    Integer userId = userDAO.insertUser(RandomStringUtils.randomAlphabetic(5), RandomStringUtils.randomAlphabetic(5), new Date());
+    Integer userId = userDAO.insertUser(RandomStringUtils.randomAlphabetic(5), RandomStringUtils.randomAlphabetic(5),
+        null, new Date());
     Integer dacId = dacDAO.createDac(RandomStringUtils.randomAlphabetic(5), RandomStringUtils.randomAlphabetic(5), "",  new Date());
     Integer dacId2 = dacDAO.createDac(RandomStringUtils.randomAlphabetic(5), RandomStringUtils.randomAlphabetic(5), "",  new Date());
     daaDAO.createDaa(userId, new Date().toInstant(), userId, new Date().toInstant(), dacId);
@@ -145,7 +152,8 @@ class DaaDAOTest extends DAOTestHelper {
 
   @Test
   void testCreateDaaDacRelation() {
-    Integer userId = userDAO.insertUser(RandomStringUtils.randomAlphabetic(5), RandomStringUtils.randomAlphabetic(5), new Date());
+    Integer userId = userDAO.insertUser(RandomStringUtils.randomAlphabetic(5), RandomStringUtils.randomAlphabetic(5),
+        null, new Date());
     Integer dacId = dacDAO.createDac(RandomStringUtils.randomAlphabetic(5), RandomStringUtils.randomAlphabetic(5), "",  new Date());
     Integer dacId2 = dacDAO.createDac(RandomStringUtils.randomAlphabetic(5), RandomStringUtils.randomAlphabetic(5), "",  new Date());
     Integer dacId3 = dacDAO.createDac(RandomStringUtils.randomAlphabetic(5), RandomStringUtils.randomAlphabetic(5), "",  new Date());
@@ -166,7 +174,8 @@ class DaaDAOTest extends DAOTestHelper {
 
   @Test
   void testDeleteDaaDacRelation() {
-    Integer userId = userDAO.insertUser(RandomStringUtils.randomAlphabetic(5), RandomStringUtils.randomAlphabetic(5), new Date());
+    Integer userId = userDAO.insertUser(RandomStringUtils.randomAlphabetic(5), RandomStringUtils.randomAlphabetic(5),
+        null, new Date());
     Integer dacId = dacDAO.createDac(RandomStringUtils.randomAlphabetic(5), RandomStringUtils.randomAlphabetic(5), "",  new Date());
     Integer dacId2 = dacDAO.createDac(RandomStringUtils.randomAlphabetic(5), RandomStringUtils.randomAlphabetic(5), "",  new Date());
     Integer dacId3 = dacDAO.createDac(RandomStringUtils.randomAlphabetic(5), RandomStringUtils.randomAlphabetic(5), "",  new Date());
@@ -190,7 +199,8 @@ class DaaDAOTest extends DAOTestHelper {
 
   @Test
   void testFindWithFileStorageObject() {
-    Integer userId = userDAO.insertUser(RandomStringUtils.randomAlphabetic(5), RandomStringUtils.randomAlphabetic(5), new Date());
+    Integer userId = userDAO.insertUser(RandomStringUtils.randomAlphabetic(5), RandomStringUtils.randomAlphabetic(5),
+        null, new Date());
     Integer dacId = dacDAO.createDac(RandomStringUtils.randomAlphabetic(5), RandomStringUtils.randomAlphabetic(5), "",  new Date());
     Integer daaId = daaDAO.createDaa(userId, new Date().toInstant(), userId, new Date().toInstant(), dacId);
     Integer fsoId = fileStorageObjectDAO.insertNewFile(
@@ -210,7 +220,8 @@ class DaaDAOTest extends DAOTestHelper {
 
   @Test
   void testFindWithDacs() {
-    Integer userId = userDAO.insertUser(RandomStringUtils.randomAlphabetic(15), RandomStringUtils.randomAlphabetic(5), new Date());
+    Integer userId = userDAO.insertUser(RandomStringUtils.randomAlphabetic(15), RandomStringUtils.randomAlphabetic(5),
+        null, new Date());
     Integer dacId = dacDAO.createDac(RandomStringUtils.randomAlphabetic(5), "Dac 1", RandomStringUtils.randomAlphabetic(15),  new Date());
     Integer dacId2 = dacDAO.createDac(RandomStringUtils.randomAlphabetic(5), "Dac 2", RandomStringUtils.randomAlphabetic(15),  new Date());
     Integer dacId3 = dacDAO.createDac(RandomStringUtils.randomAlphabetic(5), "Dac 3", RandomStringUtils.randomAlphabetic(15),  new Date());
@@ -261,7 +272,8 @@ class DaaDAOTest extends DAOTestHelper {
 
   @Test
   void testDeleteDaa() {
-    Integer userId = userDAO.insertUser(RandomStringUtils.randomAlphabetic(5), RandomStringUtils.randomAlphabetic(5), new Date());
+    Integer userId = userDAO.insertUser(RandomStringUtils.randomAlphabetic(5), RandomStringUtils.randomAlphabetic(5),
+        null, new Date());
     User user = userDAO.findUserById(userId);
     Institution institution = createRandomInstitution(user.getUserId());
     Integer dacId = dacDAO.createDac(RandomStringUtils.randomAlphabetic(5), RandomStringUtils.randomAlphabetic(5), "",  new Date());;
@@ -284,7 +296,8 @@ class DaaDAOTest extends DAOTestHelper {
     // This test requires a good deal of model setup: DAR, Dataset, DAC, and DataAccessAgreements
     // We'll create a single DAR with 2 datasets, each one in a separate DAC with separate DAAs
     // and a third dac/dataset/daa that should not be found.
-    Integer dataSubmitterId = userDAO.insertUser(RandomStringUtils.randomAlphabetic(5), RandomStringUtils.randomAlphabetic(5), new Date());
+    Integer dataSubmitterId = userDAO.insertUser(RandomStringUtils.randomAlphabetic(5), RandomStringUtils.randomAlphabetic(5),
+        null, new Date());
     User dataSubmitter = userDAO.findUserById(dataSubmitterId);
 
     // DAC/Dataset/DAA 1
@@ -327,7 +340,7 @@ class DaaDAOTest extends DAOTestHelper {
 
   private User createRandomUser() {
     int userId = userDAO.insertUser(RandomStringUtils.randomAlphabetic(15),
-        RandomStringUtils.randomAlphabetic(5), new Date());
+        RandomStringUtils.randomAlphabetic(5), null, new Date());
     return userDAO.findUserById(userId);
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/db/DacDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DacDAOTest.java
@@ -423,27 +423,6 @@ class DacDAOTest extends DAOTestHelper {
     return dacDAO.findById(id);
   }
 
-  private User createUserWithInstitution() {
-    int i1 = randomInt(5, 10);
-    String email = randomAlphabetic(i1);
-    String name = randomAlphabetic(10);
-    Integer userId = userDAO.insertUser(email, name, new Date());
-    Integer institutionId = institutionDAO.insertInstitution(randomAlphabetic(20),
-        "itDirectorName",
-        "itDirectorEmail",
-        randomAlphabetic(10),
-        new Random().nextInt(),
-        randomAlphabetic(10),
-        randomAlphabetic(10),
-        randomAlphabetic(10),
-        OrganizationType.NON_PROFIT.getValue(),
-        userId,
-        new Date());
-    userDAO.updateUser(name, userId, institutionId);
-    userRoleDAO.insertSingleUserRole(7, userId);
-    return userDAO.findUserById(userId);
-  }
-
   private DarCollection createDarCollection() {
     User user = createUserWithInstitution();
     String darCode = "DAR-" + randomInt(1, 10000);

--- a/src/test/java/org/broadinstitute/consent/http/db/DarCollectionDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DarCollectionDAOTest.java
@@ -509,7 +509,6 @@ class DarCollectionDAOTest extends DAOTestHelper {
     User user = createUser();
     Integer userId = user.getUserId();
     createUserProperty(userId, UserFields.SUGGESTED_SIGNING_OFFICIAL.getValue());
-    createUserProperty(userId, UserFields.SUGGESTED_INSTITUTION.getValue());
     createUserProperty(userId, UserFields.ERA_STATUS.getValue());
     String darCode = "DAR-" + RandomUtils.nextInt(100, 1000);
     Integer collection_id = darCollectionDAO.insertDarCollection(darCode, user.getUserId(),
@@ -599,26 +598,4 @@ class DarCollectionDAOTest extends DAOTestHelper {
     );
     return electionDAO.findElectionById(electionId);
   }
-
-  private User createUserWithInstitution() {
-    int i1 = RandomUtils.nextInt(5, 10);
-    String email = RandomStringUtils.randomAlphabetic(i1);
-    String name = RandomStringUtils.randomAlphabetic(10);
-    Integer userId = userDAO.insertUser(email, name, new Date());
-    Integer institutionId = institutionDAO.insertInstitution(RandomStringUtils.randomAlphabetic(20),
-        "itDirectorName",
-        "itDirectorEmail",
-        RandomStringUtils.randomAlphabetic(10),
-        new Random().nextInt(),
-        RandomStringUtils.randomAlphabetic(10),
-        RandomStringUtils.randomAlphabetic(10),
-        RandomStringUtils.randomAlphabetic(10),
-        OrganizationType.NON_PROFIT.getValue(),
-        userId,
-        new Date());
-    userDAO.updateUser(name, userId, institutionId);
-    userRoleDAO.insertSingleUserRole(7, userId);
-    return userDAO.findUserById(userId);
-  }
-
 }

--- a/src/test/java/org/broadinstitute/consent/http/db/DarCollectionSummaryDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DarCollectionSummaryDAOTest.java
@@ -62,7 +62,7 @@ class DarCollectionSummaryDAOTest extends DAOTestHelper {
 
   private User createUserForTest() {
     Integer userId = userDAO.insertUser(RandomStringUtils.randomAlphabetic(10),
-        RandomStringUtils.randomAlphabetic(10), new Date());
+        RandomStringUtils.randomAlphabetic(10), null, new Date());
     return userDAO.findUserById(userId);
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
@@ -837,26 +837,4 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
     );
     return electionDAO.findElectionById(electionId);
   }
-
-  private User createUserWithInstitution() {
-    int i1 = RandomUtils.nextInt(5, 10);
-    String email = RandomStringUtils.randomAlphabetic(i1);
-    String name = RandomStringUtils.randomAlphabetic(10);
-    Integer userId = userDAO.insertUser(email, name, new Date());
-    Integer institutionId = institutionDAO.insertInstitution(RandomStringUtils.randomAlphabetic(20),
-        "itDirectorName",
-        "itDirectorEmail",
-        RandomStringUtils.randomAlphabetic(10),
-        new Random().nextInt(),
-        RandomStringUtils.randomAlphabetic(10),
-        RandomStringUtils.randomAlphabetic(10),
-        RandomStringUtils.randomAlphabetic(10),
-        OrganizationType.NON_PROFIT.getValue(),
-        userId,
-        new Date());
-    userDAO.updateUser(name, userId, institutionId);
-    userRoleDAO.insertSingleUserRole(7, userId);
-    return userDAO.findUserById(userId);
-  }
-
 }

--- a/src/test/java/org/broadinstitute/consent/http/db/ElectionDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/ElectionDAOTest.java
@@ -875,25 +875,4 @@ class ElectionDAOTest extends DAOTestHelper {
     );
     return electionDAO.findElectionById(electionId);
   }
-
-  private User createUserWithRoleInDac(Integer roleId, Integer dacId) {
-    User user = createUserWithRole(roleId);
-    dacDAO.addDacMember(roleId, user.getUserId(), dacId);
-    return user;
-  }
-
-  private User createUserWithRole(Integer roleId) {
-    int i1 = RandomUtils.nextInt(5, 10);
-    int i2 = RandomUtils.nextInt(5, 10);
-    int i3 = RandomUtils.nextInt(3, 5);
-    String email = RandomStringUtils.randomAlphabetic(i1) +
-        "@" +
-        RandomStringUtils.randomAlphabetic(i2) +
-        "." +
-        RandomStringUtils.randomAlphabetic(i3);
-    Integer userId = userDAO.insertUser(email, "display name", new Date());
-    userRoleDAO.insertSingleUserRole(roleId, userId);
-    return userDAO.findUserById(userId);
-  }
-
 }

--- a/src/test/java/org/broadinstitute/consent/http/db/InstitutionDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/InstitutionDAOTest.java
@@ -215,26 +215,4 @@ class InstitutionDAOTest extends DAOTestHelper {
     );
     return institutionDAO.findInstitutionById(id);
   }
-
-  private User createUserWithInstitution() {
-    int i1 = RandomUtils.nextInt(5, 10);
-    String email = RandomStringUtils.randomAlphabetic(i1);
-    String name = RandomStringUtils.randomAlphabetic(10);
-    Integer userId = userDAO.insertUser(email, name, new Date());
-    Integer institutionId = institutionDAO.insertInstitution(RandomStringUtils.randomAlphabetic(20),
-        "itDirectorName",
-        "itDirectorEmail",
-        RandomStringUtils.randomAlphabetic(10),
-        new Random().nextInt(),
-        RandomStringUtils.randomAlphabetic(10),
-        RandomStringUtils.randomAlphabetic(10),
-        RandomStringUtils.randomAlphabetic(10),
-        OrganizationType.NON_PROFIT.getValue(),
-        userId,
-        new Date());
-    userDAO.updateUser(name, userId, institutionId);
-    userRoleDAO.insertSingleUserRole(7, userId);
-    return userDAO.findUserById(userId);
-  }
-
 }

--- a/src/test/java/org/broadinstitute/consent/http/db/LibraryCardDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/LibraryCardDAOTest.java
@@ -149,7 +149,8 @@ class LibraryCardDAOTest extends DAOTestHelper {
   @Test
   void testFindLibraryCardDaaByIdMultipleDaas() {
     LibraryCard card = createLibraryCard();
-    Integer userId = userDAO.insertUser(RandomStringUtils.randomAlphabetic(5), RandomStringUtils.randomAlphabetic(5), new Date());
+    Integer userId = userDAO.insertUser(RandomStringUtils.randomAlphabetic(5), RandomStringUtils.randomAlphabetic(5),
+        null, new Date());
     Integer dacId = dacDAO.createDac(RandomStringUtils.randomAlphabetic(5), RandomStringUtils.randomAlphabetic(5), "",  new Date());
     Integer daaId1 = daaDAO.createDaa(userId, new Date().toInstant(), userId, new Date().toInstant(), dacId);
     Integer daaId2 = daaDAO.createDaa(userId, new Date().toInstant(), userId, new Date().toInstant(), dacId);
@@ -421,7 +422,7 @@ class LibraryCardDAOTest extends DAOTestHelper {
   private LibraryCard createLibraryCard() {
     Integer institutionId = createInstitution().getId();
     String email = RandomStringUtils.randomAlphabetic(11);
-    Integer userId = userDAO.insertUser(email, "displayName", new Date());
+    Integer userId = userDAO.insertUser(email, "displayName", null, new Date());
     userDAO.updateUser(email, userId, institutionId);
     String stringValue = "value";
     Integer id = libraryCardDAO.insertLibraryCard(userId, institutionId, stringValue, stringValue,

--- a/src/test/java/org/broadinstitute/consent/http/db/UserDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/UserDAOTest.java
@@ -534,53 +534,11 @@ class UserDAOTest extends DAOTestHelper {
   private LibraryCard createLibraryCard() {
     Integer institutionId = createInstitution().getId();
     String email = RandomStringUtils.randomAlphabetic(11);
-    Integer userId = userDAO.insertUser(email, "displayName", new Date());
+    Integer userId = userDAO.insertUser(email, "displayName", null, new Date());
     userDAO.updateUser(email, userId, institutionId);
     String stringValue = "value";
     Integer id = libraryCardDAO.insertLibraryCard(userId, institutionId, stringValue, stringValue,
         stringValue, userId, new Date());
     return libraryCardDAO.findLibraryCardById(id);
   }
-
-  private User createUserWithRoleInDac(Integer roleId, Integer dacId) {
-    User user = createUserWithRole(roleId);
-    dacDAO.addDacMember(roleId, user.getUserId(), dacId);
-    return user;
-  }
-
-  private User createUserWithRole(Integer roleId) {
-    int i1 = RandomUtils.nextInt(5, 10);
-    int i2 = RandomUtils.nextInt(5, 10);
-    int i3 = RandomUtils.nextInt(3, 5);
-    String email = RandomStringUtils.randomAlphabetic(i1) +
-        "@" +
-        RandomStringUtils.randomAlphabetic(i2) +
-        "." +
-        RandomStringUtils.randomAlphabetic(i3);
-    Integer userId = userDAO.insertUser(email, "display name", new Date());
-    userRoleDAO.insertSingleUserRole(roleId, userId);
-    return userDAO.findUserById(userId);
-  }
-
-  private User createUserWithInstitution() {
-    int i1 = RandomUtils.nextInt(5, 10);
-    String email = RandomStringUtils.randomAlphabetic(i1);
-    String name = RandomStringUtils.randomAlphabetic(10);
-    Integer userId = userDAO.insertUser(email, name, new Date());
-    Integer institutionId = institutionDAO.insertInstitution(RandomStringUtils.randomAlphabetic(20),
-        "itDirectorName",
-        "itDirectorEmail",
-        RandomStringUtils.randomAlphabetic(10),
-        new Random().nextInt(),
-        RandomStringUtils.randomAlphabetic(10),
-        RandomStringUtils.randomAlphabetic(10),
-        RandomStringUtils.randomAlphabetic(10),
-        OrganizationType.NON_PROFIT.getValue(),
-        userId,
-        new Date());
-    userDAO.updateUser(name, userId, institutionId);
-    userRoleDAO.insertSingleUserRole(7, userId);
-    return userDAO.findUserById(userId);
-  }
-
 }

--- a/src/test/java/org/broadinstitute/consent/http/db/UserPropertyDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/UserPropertyDAOTest.java
@@ -3,10 +3,7 @@ package org.broadinstitute.consent.http.db;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.Date;
 import java.util.List;
-import org.apache.commons.lang3.RandomStringUtils;
-import org.apache.commons.lang3.RandomUtils;
 import org.broadinstitute.consent.http.enumeration.UserFields;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.User;
@@ -16,20 +13,20 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-public class UserPropertyDAOTest extends DAOTestHelper {
+class UserPropertyDAOTest extends DAOTestHelper {
 
   @Test
-  public void testFindUserProperties() {
+  void testFindUserProperties() {
     User user = createUserWithRole(UserRoles.RESEARCHER.getRoleId());
 
     UserProperty suggestedSigningOfficial = new UserProperty();
     suggestedSigningOfficial.setPropertyKey(UserFields.SUGGESTED_SIGNING_OFFICIAL.getValue());
-    suggestedSigningOfficial.setPropertyValue(RandomStringUtils.randomAlphabetic(10));
+    suggestedSigningOfficial.setPropertyValue(randomAlphabetic(10));
     suggestedSigningOfficial.setUserId(user.getUserId());
 
     UserProperty notPresent = new UserProperty();
     notPresent.setPropertyKey("nonExistentKey");
-    notPresent.setPropertyValue(RandomStringUtils.randomAlphabetic(10));
+    notPresent.setPropertyValue(randomAlphabetic(10));
     notPresent.setUserId(user.getUserId());
 
     List<UserProperty> props = userPropertyDAO.findUserPropertiesByUserIdAndPropertyKeys(
@@ -49,7 +46,7 @@ public class UserPropertyDAOTest extends DAOTestHelper {
         List.of(UserFields.SUGGESTED_SIGNING_OFFICIAL.getValue(),
             UserFields.ERA_EXPIRATION_DATE.getValue()));
 
-    assertEquals(2, props.size());
+    assertEquals(1, props.size());
 
     assertTrue(props.stream().anyMatch((p) ->
         (p.getPropertyKey().equals(UserFields.SUGGESTED_SIGNING_OFFICIAL.getValue())

--- a/src/test/java/org/broadinstitute/consent/http/db/UserPropertyDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/UserPropertyDAOTest.java
@@ -22,11 +22,6 @@ public class UserPropertyDAOTest extends DAOTestHelper {
   public void testFindUserProperties() {
     User user = createUserWithRole(UserRoles.RESEARCHER.getRoleId());
 
-    UserProperty suggestedInstitution = new UserProperty();
-    suggestedInstitution.setPropertyKey(UserFields.SUGGESTED_INSTITUTION.getValue());
-    suggestedInstitution.setPropertyValue(RandomStringUtils.randomAlphabetic(10));
-    suggestedInstitution.setUserId(user.getUserId());
-
     UserProperty suggestedSigningOfficial = new UserProperty();
     suggestedSigningOfficial.setPropertyKey(UserFields.SUGGESTED_SIGNING_OFFICIAL.getValue());
     suggestedSigningOfficial.setPropertyValue(RandomStringUtils.randomAlphabetic(10));
@@ -39,47 +34,25 @@ public class UserPropertyDAOTest extends DAOTestHelper {
 
     List<UserProperty> props = userPropertyDAO.findUserPropertiesByUserIdAndPropertyKeys(
         user.getUserId(),
-        List.of(UserFields.SUGGESTED_INSTITUTION.getValue(),
-            UserFields.SUGGESTED_SIGNING_OFFICIAL.getValue(),
+        List.of(UserFields.SUGGESTED_SIGNING_OFFICIAL.getValue(),
             UserFields.ERA_EXPIRATION_DATE.getValue()));
 
     assertEquals(0, props.size());
 
     userPropertyDAO.insertAll(List.of(
-        suggestedInstitution,
         suggestedSigningOfficial,
         notPresent
     ));
 
     props = userPropertyDAO.findUserPropertiesByUserIdAndPropertyKeys(
         user.getUserId(),
-        List.of(UserFields.SUGGESTED_INSTITUTION.getValue(),
-            UserFields.SUGGESTED_SIGNING_OFFICIAL.getValue(),
+        List.of(UserFields.SUGGESTED_SIGNING_OFFICIAL.getValue(),
             UserFields.ERA_EXPIRATION_DATE.getValue()));
 
     assertEquals(2, props.size());
 
     assertTrue(props.stream().anyMatch((p) ->
-        (p.getPropertyKey().equals(UserFields.SUGGESTED_INSTITUTION.getValue())
-            && p.getPropertyValue().equals(suggestedInstitution.getPropertyValue()))));
-
-    assertTrue(props.stream().anyMatch((p) ->
         (p.getPropertyKey().equals(UserFields.SUGGESTED_SIGNING_OFFICIAL.getValue())
             && p.getPropertyValue().equals(suggestedSigningOfficial.getPropertyValue()))));
   }
-
-  private User createUserWithRole(Integer roleId) {
-    int i1 = RandomUtils.nextInt(5, 10);
-    int i2 = RandomUtils.nextInt(5, 10);
-    int i3 = RandomUtils.nextInt(3, 5);
-    String email = RandomStringUtils.randomAlphabetic(i1) +
-        "@" +
-        RandomStringUtils.randomAlphabetic(i2) +
-        "." +
-        org.apache.commons.lang3.RandomStringUtils.randomAlphabetic(i3);
-    Integer userId = userDAO.insertUser(email, "display name", new Date());
-    userRoleDAO.insertSingleUserRole(roleId, userId);
-    return userDAO.findUserById(userId);
-  }
-
 }

--- a/src/test/java/org/broadinstitute/consent/http/db/UserRoleDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/UserRoleDAOTest.java
@@ -148,19 +148,4 @@ class UserRoleDAOTest extends DAOTestHelper {
         UserRoles.CHAIRPERSON.getRoleId());
     assertNotNull(userRole);
   }
-
-  private User createUserWithRole(Integer roleId) {
-    int i1 = RandomUtils.nextInt(5, 10);
-    int i2 = RandomUtils.nextInt(5, 10);
-    int i3 = RandomUtils.nextInt(3, 5);
-    String email = RandomStringUtils.randomAlphabetic(i1) +
-        "@" +
-        RandomStringUtils.randomAlphabetic(i2) +
-        "." +
-        RandomStringUtils.randomAlphabetic(i3);
-    Integer userId = userDAO.insertUser(email, "display name", new Date());
-    userRoleDAO.insertSingleUserRole(roleId, userId);
-    return userDAO.findUserById(userId);
-  }
-
 }

--- a/src/test/java/org/broadinstitute/consent/http/db/VoteDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/VoteDAOTest.java
@@ -565,25 +565,4 @@ class VoteDAOTest extends DAOTestHelper {
     );
     return electionDAO.findElectionById(electionId);
   }
-
-  private User createUserWithRoleInDac(Integer roleId, Integer dacId) {
-    User user = createUserWithRole(roleId);
-    dacDAO.addDacMember(roleId, user.getUserId(), dacId);
-    return user;
-  }
-
-  private User createUserWithRole(Integer roleId) {
-    int i1 = RandomUtils.nextInt(5, 10);
-    int i2 = RandomUtils.nextInt(5, 10);
-    int i3 = RandomUtils.nextInt(3, 5);
-    String email = RandomStringUtils.randomAlphabetic(i1) +
-        "@" +
-        RandomStringUtils.randomAlphabetic(i2) +
-        "." +
-        RandomStringUtils.randomAlphabetic(i3);
-    Integer userId = userDAO.insertUser(email, "display name", new Date());
-    userRoleDAO.insertSingleUserRole(roleId, userId);
-    return userDAO.findUserById(userId);
-  }
-
 }

--- a/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
@@ -218,7 +218,8 @@ class DataAccessRequestServiceTest {
   private DataAccessRequest generateDataAccessRequest() {
     DataAccessRequest dar = new DataAccessRequest();
     DataAccessRequestData data = new DataAccessRequestData();
-    Integer userId = userDAO.insertUser(UUID.randomUUID().toString(), "displayName", new Date());
+    Integer userId = userDAO.insertUser(UUID.randomUUID().toString(), "displayName",
+        null, new Date());
     dar.setUserId(userId);
     dar.setReferenceId(UUID.randomUUID().toString());
     data.setReferenceId(dar.getReferenceId());

--- a/src/test/java/org/broadinstitute/consent/http/service/InstitutionServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/InstitutionServiceTest.java
@@ -16,6 +16,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.RandomUtils;
+import org.broadinstitute.consent.http.cloudstore.GCSService;
 import org.broadinstitute.consent.http.db.InstitutionDAO;
 import org.broadinstitute.consent.http.db.UserDAO;
 import org.broadinstitute.consent.http.models.Institution;
@@ -37,8 +38,11 @@ class InstitutionServiceTest {
   @Mock
   private UserDAO userDAO;
 
+  @Mock
+  private GCSService store;
+
   private void initService() {
-    service = new InstitutionService(institutionDAO, userDAO);
+    service = new InstitutionService(institutionDAO, userDAO, store);
   }
 
   private Institution initMockModel() {

--- a/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
@@ -2,7 +2,6 @@ package org.broadinstitute.consent.http.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -363,9 +362,9 @@ class UserServiceTest {
     User user = service.findUserById(u.getUserId());
     assertNotNull(user);
     assertNotNull(user.getLibraryCards());
-    assertEquals(user.getLibraryCards().size(), 2);
-    assertEquals(user.getLibraryCards().get(0).getId(), one.getId());
-    assertEquals(user.getLibraryCards().get(1).getId(), two.getId());
+    assertEquals(2, user.getLibraryCards().size());
+    assertEquals(one.getId(), user.getLibraryCards().get(0).getId());
+    assertEquals(two.getId(), user.getLibraryCards().get(1).getId());
   }
 
   @Test
@@ -761,25 +760,15 @@ class UserServiceTest {
     Institution institution = new Institution();
     institution.setId(1);
     User testUser = generateUserWithoutInstitution();
-    User returnUser = new User();
     Integer testUserId = testUser.getUserId();
-    returnUser.setUserId(testUserId);
-    returnUser.setEmail(testUser.getEmail());
-    returnUser.setDisplayName(testUser.getDisplayName());
-    returnUser.setInstitutionId(1);
     UserRole role = UserRoles.Researcher();
-    assertNotEquals(testUser.getInstitutionId(), returnUser.getInstitutionId());
-    when(userDAO.findUserById(testUserId)).thenReturn(returnUser);
     when(institutionService.findInstitutionForEmail(testUser.getEmail())).thenReturn(institution);
     service.insertRoleAndInstitutionForUser(role, testUser);
     verify(userServiceDAO).insertRoleAndInstitutionTxn(role, institution.getId(), testUserId);
-    User fetchedUser = service.findUserById(testUserId);
-    assertEquals(fetchedUser.getUserId(), testUserId);
-    assertEquals(fetchedUser.getInstitutionId(), returnUser.getInstitutionId());
   }
 
   @Test
-  void insertUserRole() {
+  void insertUserRoleAndInstitution_roleOnly() {
     User testUser = generateUser();
     UserRole role = UserRoles.Researcher();
     service.insertRoleAndInstitutionForUser(role, testUser);
@@ -799,6 +788,13 @@ class UserServiceTest {
     doThrow(new TransactionException("txn error")).when(userServiceDAO)
         .insertRoleAndInstitutionTxn(role, institution.getId(), testUser.getUserId());
     assertThrows(TransactionException.class, () -> service.insertRoleAndInstitutionForUser(role, testUser));
+  }
+
+  @Test
+  void insertUserRoleAndInstitution_FailingInstitution() {
+    User testUser = generateUserWithoutInstitution();
+    UserRole role = UserRoles.Researcher();
+    assertThrows(BadRequestException.class, () -> service.insertRoleAndInstitutionForUser(role, testUser));
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
@@ -10,6 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
@@ -27,7 +28,6 @@ import java.util.Collections;
 import java.util.List;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.RandomUtils;
-import org.broadinstitute.consent.http.cloudstore.GCSService;
 import org.broadinstitute.consent.http.db.AcknowledgementDAO;
 import org.broadinstitute.consent.http.db.DaaDAO;
 import org.broadinstitute.consent.http.db.FileStorageObjectDAO;
@@ -42,7 +42,6 @@ import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.AuthUser;
 import org.broadinstitute.consent.http.models.DataAccessAgreement;
 import org.broadinstitute.consent.http.models.Institution;
-import org.broadinstitute.consent.http.models.InstitutionDomainMap;
 import org.broadinstitute.consent.http.models.LibraryCard;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.UserProperty;
@@ -102,14 +101,14 @@ class UserServiceTest {
   private DraftServiceDAO draftServiceDAO;
 
   @Mock
-  private GCSService store;
+  private InstitutionService institutionService;
 
   private UserService service;
 
   private void initService() {
     service = new UserService(userDAO, userPropertyDAO, userRoleDAO, voteDAO, institutionDAO,
         libraryCardDAO, acknowledgementDAO, fileStorageObjectDAO, samDAO, userServiceDAO, daaDAO,
-        emailService, draftServiceDAO, store);
+        emailService, draftServiceDAO, institutionService);
   }
 
   @Test
@@ -145,7 +144,6 @@ class UserServiceTest {
       fields.setEraCommonsId(RandomStringUtils.random(10, true, false));
       fields.setSelectedSigningOfficialId(1);
       fields.setSuggestedSigningOfficial(RandomStringUtils.random(10, true, false));
-      fields.setSuggestedInstitution(RandomStringUtils.random(10, true, false));
       fields.setDaaAcceptance(true);
       assertEquals(4, fields.buildUserProperties(user.getUserId()).size());
       service.updateUserFieldsById(fields, user.getUserId());
@@ -154,7 +152,6 @@ class UserServiceTest {
     }
     // We added 3 user property values, we should have props for them:
     verify(userDAO, times(1)).updateDisplayName(any(), any());
-    verify(userDAO, times(1)).updateInstitutionId(any(), any());
     verify(userDAO, times(1)).updateEmailPreference(any(), any());
     verify(userDAO, times(1)).updateEraCommonsId(any(), any());
     verify(userPropertyDAO, times(1)).insertAll(any());
@@ -186,7 +183,6 @@ class UserServiceTest {
     }
     // We added 3 user property values, we should have props for them:
     verify(userDAO, never()).updateDisplayName(any(), any());
-    verify(userDAO, never()).updateInstitutionId(any(), any());
     verify(userDAO, never()).updateEmailPreference(any(), any());
     verify(userDAO, never()).updateEraCommonsId(any(), any());
     verify(userPropertyDAO, times(1)).insertAll(any());
@@ -219,7 +215,6 @@ class UserServiceTest {
     }
     // We added 3 user property values, we should have props for them:
     verify(userDAO, never()).updateDisplayName(any(), any());
-    verify(userDAO, never()).updateInstitutionId(any(), any());
     verify(userDAO, never()).updateEmailPreference(any(), any());
     verify(userDAO, never()).updateEraCommonsId(any(), any());
     verify(userPropertyDAO, times(1)).insertAll(any());
@@ -250,7 +245,6 @@ class UserServiceTest {
     }
     // We added 3 user property values, we should have props for them:
     verify(userDAO, never()).updateDisplayName(any(), any());
-    verify(userDAO, never()).updateInstitutionId(any(), any());
     verify(userDAO, never()).updateEmailPreference(any(), any());
     verify(userDAO, never()).updateEraCommonsId(any(), any());
     verify(userPropertyDAO, times(1)).insertAll(any());
@@ -320,14 +314,15 @@ class UserServiceTest {
   }
 
   @Test
-  void testCreateUserNoRoles() throws IOException {
+  void testCreateUserNoRoles() {
     User u = generateUser();
-    when(userDAO.findUserById(any())).thenReturn(u);
-    when(store.readJsonFileFromBucket("institution-domain/allowlist.json",
-        InstitutionDomainMap.class)).thenReturn(new InstitutionDomainMap());
+    when(userDAO.findUserById(u.getUserId())).thenReturn(u);
+    Institution institution = new Institution();
+    when(institutionService.findInstitutionForEmail(u.getEmail())).thenReturn(institution);
     initService();
     User user = service.createUser(u);
     assertFalse(user.getRoles().isEmpty());
+    assertEquals(institution, user.getInstitution());
     assertEquals(UserRoles.RESEARCHER.getRoleId(), user.getRoles().get(0).getRoleId());
   }
 
@@ -785,16 +780,15 @@ class UserServiceTest {
     // mock findUserByEmail to throw the NFE on the first call (findOrCreateUser) and then return null (createUser)
     when(userDAO.findUserByEmail(authUser.getEmail())).thenThrow(new NotFoundException())
         .thenReturn(null);
-    when(userDAO.insertUser(any(), any(), any())).thenReturn(user.getUserId());
+    when(userDAO.insertUser(any(), any(), eq(user.getInstitutionId()), any())).thenReturn(user.getUserId());
     when(userDAO.findUserById(any())).thenReturn(user);
     when(samDAO.postRegistrationInfo(any())).thenReturn(status);
     initService();
 
     User newUser = service.findOrCreateUser(authUser);
     assertEquals(user.getEmail(), newUser.getEmail());
-    verify(userRoleDAO, times(1)).insertUserRoles(any(), any());
-    verify(libraryCardDAO, times(1)).findAllLibraryCardsByUserEmail(any());
-    verify(userDAO, times(1)).insertUser(any(), any(), any());
+    verify(userRoleDAO).insertUserRoles(any(), any());
+    verify(libraryCardDAO).findAllLibraryCardsByUserEmail(any());
   }
 
   @Test
@@ -813,7 +807,7 @@ class UserServiceTest {
     when(userDAO.findUserById(anyInt())).thenReturn(returnUser);
     initService();
     try {
-      service.insertRoleAndInstitutionForUser(role, institutionId, testUser.getUserId());
+      service.insertRoleAndInstitutionForUser(role, institutionId, testUser);
     } catch (Exception e) {
       encounteredException = true;
     }
@@ -834,7 +828,7 @@ class UserServiceTest {
         .insertRoleAndInstitutionTxn(any(), any(), any());
     initService();
     try {
-      service.insertRoleAndInstitutionForUser(role, institutionId, testUser.getUserId());
+      service.insertRoleAndInstitutionForUser(role, institutionId, testUser);
     } catch (Exception e) {
       encounteredException = true;
     }

--- a/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
@@ -16,16 +16,17 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.google.gson.JsonObject;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.NotFoundException;
-import java.io.IOException;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.RandomUtils;
 import org.broadinstitute.consent.http.db.AcknowledgementDAO;
@@ -52,6 +53,8 @@ import org.broadinstitute.consent.http.models.sam.UserStatusInfo;
 import org.broadinstitute.consent.http.service.UserService.SimplifiedUser;
 import org.broadinstitute.consent.http.service.dao.DraftServiceDAO;
 import org.broadinstitute.consent.http.service.dao.UserServiceDAO;
+import org.jdbi.v3.core.transaction.TransactionException;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -105,7 +108,8 @@ class UserServiceTest {
 
   private UserService service;
 
-  private void initService() {
+  @BeforeEach
+  void initService() {
     service = new UserService(userDAO, userPropertyDAO, userRoleDAO, voteDAO, institutionDAO,
         libraryCardDAO, acknowledgementDAO, fileStorageObjectDAO, samDAO, userServiceDAO, daaDAO,
         emailService, draftServiceDAO, institutionService);
@@ -132,24 +136,21 @@ class UserServiceTest {
     prop.setPropertyValue("1");
     when(userPropertyDAO.findUserPropertiesByUserIdAndPropertyKeys(any(), any())).thenReturn(
         List.of(prop));
-    initService();
-    try {
-      UserUpdateFields fields = new UserUpdateFields();
-      // We're modifying this user to have an SO role. This should leave in place
-      // both the Researcher and Chairperson roles, but remove the Admin role.
-      fields.setUserRoleIds(List.of(so.getRoleId()));
-      fields.setDisplayName(RandomStringUtils.random(10, true, false));
-      fields.setInstitutionId(1);
-      fields.setEmailPreference(true);
-      fields.setEraCommonsId(RandomStringUtils.random(10, true, false));
-      fields.setSelectedSigningOfficialId(1);
-      fields.setSuggestedSigningOfficial(RandomStringUtils.random(10, true, false));
-      fields.setDaaAcceptance(true);
-      assertEquals(4, fields.buildUserProperties(user.getUserId()).size());
-      service.updateUserFieldsById(fields, user.getUserId());
-    } catch (Exception e) {
-      fail(e.getMessage());
-    }
+
+    UserUpdateFields fields = new UserUpdateFields();
+    // We're modifying this user to have an SO role. This should leave in place
+    // both the Researcher and Chairperson roles, but remove the Admin role.
+    fields.setUserRoleIds(List.of(so.getRoleId()));
+    fields.setDisplayName(RandomStringUtils.random(10, true, false));
+    fields.setInstitutionId(1);
+    fields.setEmailPreference(true);
+    fields.setEraCommonsId(RandomStringUtils.random(10, true, false));
+    fields.setSelectedSigningOfficialId(1);
+    fields.setSuggestedSigningOfficial(RandomStringUtils.random(10, true, false));
+    fields.setDaaAcceptance(true);
+    assertEquals(3, fields.buildUserProperties(user.getUserId()).size());
+    service.updateUserFieldsById(fields, user.getUserId());
+
     // We added 3 user property values, we should have props for them:
     verify(userDAO, times(1)).updateDisplayName(any(), any());
     verify(userDAO, times(1)).updateEmailPreference(any(), any());
@@ -171,7 +172,6 @@ class UserServiceTest {
     when(userPropertyDAO.findUserPropertiesByUserIdAndPropertyKeys(any(), any())).thenReturn(
             List.of()) // first time, no SO id
         .thenReturn(List.of(prop)); // second time, has SO id
-    initService();
     try {
       UserUpdateFields fields = new UserUpdateFields();
       fields.setSelectedSigningOfficialId(1);
@@ -203,7 +203,6 @@ class UserServiceTest {
     when(userPropertyDAO.findUserPropertiesByUserIdAndPropertyKeys(any(), any())).thenReturn(
             List.of(prop1)) // first SO id
         .thenReturn(List.of(prop2)); // second SO id
-    initService();
     try {
       UserUpdateFields fields = new UserUpdateFields();
       fields.setSelectedSigningOfficialId(2);
@@ -233,7 +232,6 @@ class UserServiceTest {
     when(userPropertyDAO.findUserPropertiesByUserIdAndPropertyKeys(any(), any())).thenReturn(
             List.of(prop)) // first SO id
         .thenReturn(List.of(prop)); // second SO id
-    initService();
     try {
       UserUpdateFields fields = new UserUpdateFields();
       fields.setSelectedSigningOfficialId(1);
@@ -259,7 +257,6 @@ class UserServiceTest {
     u.setRoles(roles);
     when(userDAO.findUserById(any())).thenReturn(u);
     when(libraryCardDAO.findAllLibraryCardsByUserEmail(any())).thenReturn(Collections.emptyList());
-    initService();
     try {
       service.createUser(u);
     } catch (Exception e) {
@@ -270,23 +267,27 @@ class UserServiceTest {
   @Test
   void createUserWithLibraryCardTest() {
     User u = generateUser();
-    LibraryCard libraryCard = generateLibraryCard(u.getEmail());
-    Integer institutionId = libraryCard.getInstitutionId();
+    LibraryCard lc = generateLibraryCard(u.getEmail());
+    Integer institutionId = lc.getInstitutionId();
+    Institution institution = new Institution();
+    institution.setId(institutionId);
     List<UserRole> roles = List.of(generateRole(UserRoles.RESEARCHER.getRoleId()));
     u.setRoles(roles);
-    when(userDAO.findUserById(any())).thenReturn(u);
     when(libraryCardDAO.findAllLibraryCardsByUserEmail(u.getEmail())).thenReturn(
-        List.of(libraryCard));
-    initService();
+        List.of(lc));
+    when(institutionService.findInstitutionForEmail(u.getEmail())).thenReturn(institution);
 
-    try {
-      service.createUser(u);
-    } catch (Exception e) {
-      fail(e.getMessage());
-    }
+    service.createUser(u);
 
-    assertEquals(institutionId, u.getInstitutionId());
-    assertEquals(u.getUserId(), libraryCard.getUserId());
+    verify(libraryCardDAO).updateLibraryCardById(
+        eq(lc.getId()),
+        eq(u.getUserId()),
+        eq(lc.getInstitutionId()),
+        eq(lc.getEraCommonsId()),
+        eq(lc.getUserName()),
+        eq(lc.getUserEmail()),
+        eq(u.getUserId()),
+        any());
   }
 
   @Test
@@ -295,7 +296,6 @@ class UserServiceTest {
     List<UserRole> roles = List.of(generateRole(UserRoles.RESEARCHER.getRoleId()));
     u.setRoles(roles);
     when(userDAO.findUserByEmail(any())).thenReturn(u);
-    initService();
     assertThrows(BadRequestException.class, () -> {
       service.createUser(u);
     });
@@ -307,7 +307,6 @@ class UserServiceTest {
     List<UserRole> roles = List.of(generateRole(UserRoles.RESEARCHER.getRoleId()));
     u.setRoles(roles);
     u.setDisplayName(null);
-    initService();
     assertThrows(BadRequestException.class, () -> {
       service.createUser(u);
     });
@@ -316,14 +315,11 @@ class UserServiceTest {
   @Test
   void testCreateUserNoRoles() {
     User u = generateUser();
-    when(userDAO.findUserById(u.getUserId())).thenReturn(u);
-    Institution institution = new Institution();
-    when(institutionService.findInstitutionForEmail(u.getEmail())).thenReturn(institution);
-    initService();
-    User user = service.createUser(u);
-    assertFalse(user.getRoles().isEmpty());
-    assertEquals(institution, user.getInstitution());
-    assertEquals(UserRoles.RESEARCHER.getRoleId(), user.getRoles().get(0).getRoleId());
+    assertTrue(CollectionUtils.isEmpty(u.getRoles()));
+    int userId = 123;
+    when(userDAO.insertUser(eq(u.getEmail()), eq(u.getDisplayName()), eq(u.getInstitutionId()), any())).thenReturn(userId);
+    service.createUser(u);
+    verify(userRoleDAO).insertUserRoles(List.of(UserRoles.Researcher()), userId);
   }
 
   @Test
@@ -331,7 +327,6 @@ class UserServiceTest {
     User u = generateUser();
     List<UserRole> roles = List.of(generateRole(UserRoles.CHAIRPERSON.getRoleId()));
     u.setRoles(roles);
-    initService();
     assertThrows(BadRequestException.class, () -> {
       service.createUser(u);
     });
@@ -342,7 +337,6 @@ class UserServiceTest {
     User u = generateUser();
     List<UserRole> roles = List.of(generateRole(UserRoles.MEMBER.getRoleId()));
     u.setRoles(roles);
-    initService();
     assertThrows(BadRequestException.class, () -> {
       service.createUser(u);
     });
@@ -352,7 +346,6 @@ class UserServiceTest {
   void testCreateUserNoEmail() {
     User u = generateUser();
     u.setEmail(null);
-    initService();
     assertThrows(BadRequestException.class, () -> {
       service.createUser(u);
     });
@@ -366,7 +359,6 @@ class UserServiceTest {
     List<LibraryCard> cards = List.of(one, two);
     when(userDAO.findUserById(any())).thenReturn(u);
     when(libraryCardDAO.findLibraryCardsByUserId(any())).thenReturn(cards);
-    initService();
 
     User user = service.findUserById(u.getUserId());
     assertNotNull(user);
@@ -380,7 +372,6 @@ class UserServiceTest {
   void testFindUserByIdNoRoles() {
     User u = generateUser();
     when(userDAO.findUserById(any())).thenReturn(u);
-    initService();
 
     User user = service.findUserById(u.getUserId());
     assertNotNull(user);
@@ -395,7 +386,6 @@ class UserServiceTest {
         generateRole(UserRoles.MEMBER.getRoleId()));
     u.setRoles(roleList);
     when(userDAO.findUserById(any())).thenReturn(u);
-    initService();
 
     User user = service.findUserById(u.getUserId());
     assertNotNull(user);
@@ -408,7 +398,6 @@ class UserServiceTest {
   void testFindUserByIdNotFound() {
     User u = generateUser();
     when(userDAO.findUserById(any())).thenReturn(null);
-    initService();
 
     assertThrows(NotFoundException.class, () -> {
       service.findUserById(u.getUserId());
@@ -419,7 +408,6 @@ class UserServiceTest {
   void testFindUserByEmailNoRoles() {
     User u = generateUser();
     when(userDAO.findUserByEmail(any())).thenReturn(u);
-    initService();
 
     User user = service.findUserByEmail(u.getEmail());
     assertNotNull(user);
@@ -434,7 +422,6 @@ class UserServiceTest {
         generateRole(UserRoles.MEMBER.getRoleId()));
     u.setRoles(roleList);
     when(userDAO.findUserByEmail(any())).thenReturn(u);
-    initService();
 
     User user = service.findUserByEmail(u.getEmail());
     assertNotNull(user);
@@ -447,7 +434,6 @@ class UserServiceTest {
   void testFindUserByEmailNotFound() {
     User u = generateUser();
     when(userDAO.findUserByEmail(any())).thenReturn(null);
-    initService();
 
     assertThrows(NotFoundException.class, () -> {
       service.findUserByEmail(u.getEmail());
@@ -459,7 +445,6 @@ class UserServiceTest {
     User u = generateUser();
     doNothing().when(userPropertyDAO).deleteAllPropertiesByUser(any());
     when(userDAO.findUserByEmail(any())).thenReturn(u);
-    initService();
 
     try {
       service.deleteUserByEmail(RandomStringUtils.random(10, true, false));
@@ -472,7 +457,6 @@ class UserServiceTest {
   @Test
   void testDeleteUserFailure() {
     when(userDAO.findUserByEmail(any())).thenThrow(new NotFoundException());
-    initService();
     assertThrows(NotFoundException.class, () -> {
       service.deleteUserByEmail(RandomStringUtils.random(10, true, false));
     });
@@ -483,7 +467,6 @@ class UserServiceTest {
     User u = generateUser();
     Integer institutionId = u.getInstitutionId();
     when(userDAO.getSOsByInstitution(any())).thenReturn(List.of(u, u, u));
-    initService();
     List<SimplifiedUser> users = service.findSOsByInstitutionId(institutionId);
     assertEquals(3, users.size());
     assertEquals(u.getDisplayName(), users.get(0).displayName);
@@ -492,14 +475,12 @@ class UserServiceTest {
 
   @Test
   void testFindSOsByInstitutionId_NullId() {
-    initService();
     List<SimplifiedUser> users = service.findSOsByInstitutionId(null);
     assertEquals(0, users.size());
   }
 
   @Test
   void testFindUsersByInstitutionIdNullId() {
-    initService();
     assertThrows(IllegalArgumentException.class, () -> {
       service.findUsersByInstitutionId(null);
     });
@@ -508,7 +489,6 @@ class UserServiceTest {
   @Test
   void testFindUsersByInstitutionIdNullInstitution() {
     doThrow(new NotFoundException()).when(institutionDAO).findInstitutionById(anyInt());
-    initService();
     assertThrows(NotFoundException.class, () -> {
       service.findUsersByInstitutionId(1);
     });
@@ -517,7 +497,6 @@ class UserServiceTest {
   @Test
   void testFindUsersByInstitutionIdSuccess() {
     when(institutionDAO.findInstitutionById(anyInt())).thenReturn(new Institution());
-    initService();
     List<User> users = service.findUsersByInstitutionId(1);
     assertNotNull(users);
     assertTrue(users.isEmpty());
@@ -527,7 +506,6 @@ class UserServiceTest {
   void testFindUsersByInstitutionIdSuccessWithUsers() {
     when(institutionDAO.findInstitutionById(anyInt())).thenReturn(new Institution());
     when(userDAO.findUsersByInstitution(anyInt())).thenReturn(List.of(new User()));
-    initService();
     List<User> users = service.findUsersByInstitutionId(1);
     assertNotNull(users);
     assertFalse(users.isEmpty());
@@ -540,7 +518,6 @@ class UserServiceTest {
     LibraryCard lc = generateLibraryCard(u);
     u.setLibraryCards(List.of(lc));
     when(userDAO.getUsersFromInstitutionWithCards(anyInt())).thenReturn(List.of(u, new User()));
-    initService();
 
     List<User> users = service.getUsersAsRole(u, UserRoles.SIGNINGOFFICIAL.getRoleName());
     assertNotNull(users);
@@ -552,7 +529,6 @@ class UserServiceTest {
   void testGetUsersAsRoleSO_NoInstitution() {
     User u = generateUser();
     u.setInstitutionId(null);
-    initService();
     assertThrows(NotFoundException.class, () -> {
       service.getUsersAsRole(u, UserRoles.SIGNINGOFFICIAL.getRoleName());
     });
@@ -574,7 +550,6 @@ class UserServiceTest {
     LibraryCard lc = generateLibraryCard(u1);
     u1.setLibraryCards(List.of(lc));
     when(userDAO.findUsersWithLCsAndInstitution()).thenReturn(returnedUsers);
-    initService();
     List<User> users = service.getUsersAsRole(u1, UserRoles.ADMIN.getRoleName());
     assertNotNull(users);
     assertEquals(returnedUsers.size(), users.size());
@@ -585,7 +560,6 @@ class UserServiceTest {
   @Test
   void testGetUsersAsRoleInvalidRole() {
     User u1 = generateUser();
-    initService();
     List<User> users = service.getUsersAsRole(u1, UserRoles.ADMIN.getRoleName());
     assertNotNull(users);
     assertEquals(0, users.size());
@@ -604,7 +578,6 @@ class UserServiceTest {
     when(daaDAO.findById(any())).thenReturn(daa);
     when(userDAO.getUsersWithCardsByDaaId(any())).thenReturn(List.of(u1));
     libraryCardDAO.createLibraryCardDaaRelation(card.getId(), daaId);
-    initService();
     List<SimplifiedUser> users = service.getUsersByDaaId(daaId);
     assertNotNull(users);
     assertEquals(1, users.size());
@@ -626,7 +599,6 @@ class UserServiceTest {
     when(userDAO.getUsersWithCardsByDaaId(any())).thenReturn(List.of(u1, u2));
     libraryCardDAO.createLibraryCardDaaRelation(card.getId(), daaId);
     libraryCardDAO.createLibraryCardDaaRelation(card2.getId(), daaId);
-    initService();
     List<SimplifiedUser> users = service.getUsersByDaaId(daaId);
     assertNotNull(users);
     assertEquals(2, users.size());
@@ -655,7 +627,6 @@ class UserServiceTest {
     libraryCardDAO.createLibraryCardDaaRelation(card.getId(), daaId);
     libraryCardDAO.createLibraryCardDaaRelation(card2.getId(), daaId);
     libraryCardDAO.createLibraryCardDaaRelation(card3.getId(), daaId2);
-    initService();
     List<SimplifiedUser> users = service.getUsersByDaaId(daaId);
     assertNotNull(users);
     assertEquals(2, users.size());
@@ -677,7 +648,6 @@ class UserServiceTest {
     DataAccessAgreement daa = new DataAccessAgreement();
     daa.setDaaId(daaId);
     when(daaDAO.findById(any())).thenReturn(daa);
-    initService();
     List<SimplifiedUser> users = service.getUsersByDaaId(daaId);
     assertNotNull(users);
     assertEquals(0, users.size());
@@ -686,7 +656,6 @@ class UserServiceTest {
 
   @Test
   void testGetUsersByDaaIdNoMatchingDaa() {
-    initService();
     assertThrows(NotFoundException.class, () -> {
       service.getUsersByDaaId(RandomUtils.nextInt(10, 50));
     });
@@ -696,7 +665,6 @@ class UserServiceTest {
   void testFindUsersWithNoInstitution() {
     User user = generateUser();
     when(userDAO.getUsersWithNoInstitution()).thenReturn(List.of(user));
-    initService();
     List<User> users = service.findUsersWithNoInstitution();
     assertNotNull(users);
     assertEquals(1, users.size());
@@ -715,7 +683,6 @@ class UserServiceTest {
     when(userPropertyDAO.findUserPropertiesByUserIdAndPropertyKeys(anyInt(), any())).thenReturn(
         List.of(new UserProperty()));
 
-    initService();
     JsonObject userJson = service.findUserWithPropertiesByIdAsJsonObject(authUser,
         user.getUserId());
     assertNotNull(userJson);
@@ -737,7 +704,6 @@ class UserServiceTest {
     when(userPropertyDAO.findUserPropertiesByUserIdAndPropertyKeys(anyInt(), any())).thenReturn(
         List.of(new UserProperty()));
 
-    initService();
     JsonObject userJson = service.findUserWithPropertiesByIdAsJsonObject(authUser,
         user.getUserId());
     assertNotNull(userJson);
@@ -759,7 +725,6 @@ class UserServiceTest {
 
     when(userDAO.findUserByEmail(any())).thenReturn(user);
     when(samDAO.postRegistrationInfo(any())).thenReturn(status);
-    initService();
 
     User existingUser = service.findOrCreateUser(authUser);
     assertEquals(existingUser, user);
@@ -776,14 +741,14 @@ class UserServiceTest {
     UserStatus status = new UserStatus().setUserInfo(info).setEnabled(enabled);
     AuthUser authUser = new AuthUser().setName(user.getDisplayName()).setEmail(user.getEmail())
         .setAuthToken(RandomStringUtils.random(30, true, false));
+    Institution institution = new Institution();
 
-    // mock findUserByEmail to throw the NFE on the first call (findOrCreateUser) and then return null (createUser)
-    when(userDAO.findUserByEmail(authUser.getEmail())).thenThrow(new NotFoundException())
-        .thenReturn(null);
-    when(userDAO.insertUser(any(), any(), eq(user.getInstitutionId()), any())).thenReturn(user.getUserId());
-    when(userDAO.findUserById(any())).thenReturn(user);
-    when(samDAO.postRegistrationInfo(any())).thenReturn(status);
-    initService();
+    // mock findUserByEmail to throw the NFE on the first call (findOrCreateUser)
+    when(userDAO.findUserByEmail(authUser.getEmail())).thenThrow(new NotFoundException()).thenReturn(null);
+    when(userDAO.insertUser(eq(authUser.getEmail()), eq(authUser.getName()), eq(institution.getId()), any())).thenReturn(user.getUserId());
+    when(userDAO.findUserById(user.getUserId())).thenReturn(user);
+    when(samDAO.postRegistrationInfo(authUser)).thenReturn(status);
+    when(institutionService.findInstitutionForEmail(user.getEmail())).thenReturn(institution);
 
     User newUser = service.findOrCreateUser(authUser);
     assertEquals(user.getEmail(), newUser.getEmail());
@@ -793,46 +758,47 @@ class UserServiceTest {
 
   @Test
   void insertUserRoleAndInstitution() {
-    boolean encounteredException = false;
-    Integer institutionId = 1;
+    Institution institution = new Institution();
+    institution.setId(1);
     User testUser = generateUserWithoutInstitution();
     User returnUser = new User();
-    returnUser.setUserId(testUser.getUserId());
+    Integer testUserId = testUser.getUserId();
+    returnUser.setUserId(testUserId);
     returnUser.setEmail(testUser.getEmail());
     returnUser.setDisplayName(testUser.getDisplayName());
     returnUser.setInstitutionId(1);
     UserRole role = UserRoles.Researcher();
     assertNotEquals(testUser.getInstitutionId(), returnUser.getInstitutionId());
-    doNothing().when(userServiceDAO).insertRoleAndInstitutionTxn(any(), any(), any());
-    when(userDAO.findUserById(anyInt())).thenReturn(returnUser);
-    initService();
-    try {
-      service.insertRoleAndInstitutionForUser(role, institutionId, testUser);
-    } catch (Exception e) {
-      encounteredException = true;
-    }
-    User fetchedUser = service.findUserById(testUser.getUserId());
-    assertEquals(fetchedUser.getUserId(), testUser.getUserId());
+    when(userDAO.findUserById(testUserId)).thenReturn(returnUser);
+    when(institutionService.findInstitutionForEmail(testUser.getEmail())).thenReturn(institution);
+    service.insertRoleAndInstitutionForUser(role, testUser);
+    verify(userServiceDAO).insertRoleAndInstitutionTxn(role, institution.getId(), testUserId);
+    User fetchedUser = service.findUserById(testUserId);
+    assertEquals(fetchedUser.getUserId(), testUserId);
     assertEquals(fetchedUser.getInstitutionId(), returnUser.getInstitutionId());
-    assertFalse(encounteredException);
+  }
+
+  @Test
+  void insertUserRole() {
+    User testUser = generateUser();
+    UserRole role = UserRoles.Researcher();
+    service.insertRoleAndInstitutionForUser(role, testUser);
+    verifyNoInteractions(institutionService);
+    verifyNoInteractions(userServiceDAO);
+    verify(userRoleDAO).insertSingleUserRole(role.getRoleId(), testUser.getUserId());
   }
 
   @Test
   void insertUserRoleAndInstitution_FailingTxn() {
-    boolean encounteredException = false;
-    Integer institutionId = 1;
+    Institution institution = new Institution();
+    institution.setId(1);
     User testUser = generateUserWithoutInstitution();
     assertNull(testUser.getInstitutionId());
     UserRole role = UserRoles.Researcher();
-    doThrow(new RuntimeException("txn error")).when(userServiceDAO)
-        .insertRoleAndInstitutionTxn(any(), any(), any());
-    initService();
-    try {
-      service.insertRoleAndInstitutionForUser(role, institutionId, testUser);
-    } catch (Exception e) {
-      encounteredException = true;
-    }
-    assertTrue(encounteredException);
+    when(institutionService.findInstitutionForEmail(testUser.getEmail())).thenReturn(institution);
+    doThrow(new TransactionException("txn error")).when(userServiceDAO)
+        .insertRoleAndInstitutionTxn(role, institution.getId(), testUser.getUserId());
+    assertThrows(TransactionException.class, () -> service.insertRoleAndInstitutionForUser(role, testUser));
   }
 
   @Test
@@ -840,7 +806,6 @@ class UserServiceTest {
     String json = "{users:[1,2,3]}";
     List<User> users = List.of(generateUser(), generateUser(), generateUser());
     when(userDAO.findUserById(anyInt())).thenReturn(users.get(0), users.get(1), users.get(2));
-    initService();
     List<User> foundUsers = service.findUsersInJsonArray(json, "users");
     assertEquals(3, foundUsers.size());
   }
@@ -850,7 +815,6 @@ class UserServiceTest {
     String json = "{users:[1,1,2,3]}";
     List<User> users = List.of(generateUser(), generateUser(), generateUser());
     when(userDAO.findUserById(anyInt())).thenReturn(users.get(0), users.get(1), users.get(2));
-    initService();
     List<User> foundUsers = service.findUsersInJsonArray(json, "users");
     assertEquals(3, foundUsers.size());
   }
@@ -858,7 +822,6 @@ class UserServiceTest {
   @Test
   void testFindUsersInJsonArrayEmptyArray() {
     String json = "{users:[]}";
-    initService();
     List<User> foundUsers = service.findUsersInJsonArray(json, "users");
     assertTrue(foundUsers.isEmpty());
   }
@@ -867,7 +830,6 @@ class UserServiceTest {
   void testFindUsersInJsonArrayInvalidJson() {
     // Missing closing bracket
     String json = "{users:[1,2,3}";
-    initService();
     assertThrows(BadRequestException.class, () -> {
       service.findUsersInJsonArray(json, "users");
     });
@@ -876,7 +838,6 @@ class UserServiceTest {
   @Test
   void testFindUsersInJsonArrayInvalidKey() {
     String json = "{users:[1,2,3]}";
-    initService();
     assertThrows(BadRequestException.class, () -> {
       service.findUsersInJsonArray(json, "invalidKey");
     });

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DarCollectionServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DarCollectionServiceDAOTest.java
@@ -491,7 +491,7 @@ class DarCollectionServiceDAOTest extends DAOTestHelper {
         RandomStringUtils.randomAlphabetic(i2) +
         "." +
         RandomStringUtils.randomAlphabetic(i3);
-    Integer userId = userDAO.insertUser(email, "display name", new Date());
+    Integer userId = userDAO.insertUser(email, "display name", null, new Date());
     userRoleDAO.insertSingleUserRole(roleId, userId);
     return userDAO.findUserById(userId);
   }

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DataAccessRequestServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DataAccessRequestServiceDAOTest.java
@@ -193,7 +193,7 @@ class DataAccessRequestServiceDAOTest extends DAOTestHelper {
     int i1 = RandomUtils.nextInt(5, 10);
     String email = RandomStringUtils.randomAlphabetic(i1);
     String name = RandomStringUtils.randomAlphabetic(10);
-    Integer userId = userDAO.insertUser(email, name, new Date());
+    Integer userId = userDAO.insertUser(email, name, null, new Date());
     Integer institutionId = institutionDAO.insertInstitution(RandomStringUtils.randomAlphabetic(20),
         "itDirectorName",
         "itDirectorEmail",


### PR DESCRIPTION
### Addresses

Institution is no longer selected by user but is assigned based on a user's email address and the DUOS configured domain-to-institution mapping.

### Summary

Add code to auto-set institution on user creation based on the domain to institution configuration. Remove code paths where institution is changed after a user is created.

Many files were changed due to refactoring and API changes. Interesting changes are in `UserDAO` `InstitutionDomainMap`, `InstitutionService`, `UserService`.

### Behavior changes

When a user is created, their institution is assigned automatically based on email, if possible. If no institution is found, it will remain `null` until an admin user assigns it, or until an admin or signing official adds the user to a role (and, for a signing official, the signing official's institution also matches the user's email).

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
