### PR TITLE
[DT-1520] DAR Expiration.

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
@@ -86,7 +86,7 @@ public interface DarCollectionDAO extends Transactional<DarCollectionDAO> {
           "dd.dataset_id, " +
           "dar.id AS dar_id, dar.reference_id AS dar_reference_id, dar.collection_id AS dar_collection_id, "
           +
-          "dar.parent_id AS dar_parent_id, dar.draft AS dar_draft, dar.user_id AS dar_userId, " +
+          "dar.parent_id AS dar_parent_id, dar.user_id AS dar_userId, " +
           "dar.create_date AS dar_create_date, dar.sort_date AS dar_sort_date, dar.submission_date AS dar_submission_date, "
           +
           "dar.update_date AS dar_update_date, (dar.data #>> '{}')::jsonb AS data " +
@@ -127,10 +127,11 @@ public interface DarCollectionDAO extends Transactional<DarCollectionDAO> {
           UserProperty.QUERY_FIELDS_WITH_UP_PREFIX + QUERY_FIELD_SEPARATOR +
           "dar.id AS dar_id, dar.reference_id AS dar_reference_id, dar.collection_id AS dar_collection_id, "
           +
-          "dar.parent_id AS dar_parent_id, dar.draft AS dar_draft, dar.user_id AS dar_userId, " +
+          "dar.parent_id AS dar_parent_id, dar.user_id AS dar_userId, " +
           "dar.create_date AS dar_create_date, dar.sort_date AS dar_sort_date, dar.submission_date AS dar_submission_date, "
           +
-          "dar.update_date AS dar_update_date, (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data, dd.dataset_id " +
+          "dar.update_date AS dar_update_date, (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data, dd.dataset_id "
+          +
           "FROM dar_collection c " +
           "INNER JOIN users u ON c.create_user_id = u.user_id " +
           "LEFT JOIN user_property up ON u.user_id = up.user_id " +
@@ -165,7 +166,7 @@ public interface DarCollectionDAO extends Transactional<DarCollectionDAO> {
           + LibraryCard.QUERY_FIELDS_WITH_LC_PREFIX + QUERY_FIELD_SEPARATOR
           + "dd.dataset_id, "
           + "dar.id AS dar_id, dar.reference_id AS dar_reference_id, dar.collection_id AS dar_collection_id, "
-          + "dar.parent_id AS dar_parent_id, dar.draft AS dar_draft, dar.user_id AS dar_userId, "
+          + "dar.parent_id AS dar_parent_id, dar.user_id AS dar_userId, "
           + "dar.create_date AS dar_create_date, dar.sort_date AS dar_sort_date, dar.submission_date AS dar_submission_date, "
           + "dar.update_date AS dar_update_date, (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data, "
           + "e.election_id AS e_election_id, e.reference_id AS e_reference_id, e.status AS e_status, e.create_date AS e_create_date, "

--- a/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
@@ -121,26 +121,28 @@ public interface DarCollectionDAO extends Transactional<DarCollectionDAO> {
   @RegisterBeanMapper(value = UserProperty.class, prefix = "up")
   @UseRowReducer(DarCollectionReducer.class)
   @SqlQuery(
-      "SELECT c.*, " +
-          User.QUERY_FIELDS_WITH_U_PREFIX + QUERY_FIELD_SEPARATOR +
-          Institution.QUERY_FIELDS_WITH_I_PREFIX + QUERY_FIELD_SEPARATOR +
-          UserProperty.QUERY_FIELDS_WITH_UP_PREFIX + QUERY_FIELD_SEPARATOR +
-          "dar.id AS dar_id, dar.reference_id AS dar_reference_id, dar.collection_id AS dar_collection_id, "
-          +
-          "dar.parent_id AS dar_parent_id, dar.user_id AS dar_userId, " +
-          "dar.create_date AS dar_create_date, dar.sort_date AS dar_sort_date, dar.submission_date AS dar_submission_date, "
-          +
-          "dar.update_date AS dar_update_date, (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data, dd.dataset_id "
-          +
-          "FROM dar_collection c " +
-          "INNER JOIN users u ON c.create_user_id = u.user_id " +
-          "LEFT JOIN user_property up ON u.user_id = up.user_id " +
-          "LEFT JOIN institution i ON i.institution_id = u.institution_id " +
-          "INNER JOIN data_access_request dar ON c.collection_id = dar.collection_id " +
-          "LEFT JOIN dar_dataset dd on dd.reference_id = dar.reference_id " +
-          "WHERE c.collection_id = (SELECT collection_id FROM data_access_request WHERE reference_id = :referenceId) "
-          +
-          "AND (LOWER(data->>'status')!='archived' OR data->>'status' IS NULL) ")
+      """
+        SELECT c.*,
+        u.user_id as u_user_id, u.email as u_email, u.display_name as u_display_name, u.create_date
+        as u_create_date, u.email_preference as u_email_preference, u.institution_id
+        as u_institution_id, u.era_commons_id as u_era_commons_id, i.institution_id as i_id,
+        i.institution_name as i_name, i.it_director_name as i_it_director_name,  i.it_director_email
+        as i_it_director_email, i.create_date as i_create_date, i.update_date as i_update_date,
+        up.property_id AS up_property_id, up.user_id AS up_user_id, up.property_key
+        as up_property_key, up.property_value AS up_property_value,
+        dar.id AS dar_id, dar.reference_id AS dar_reference_id, dar.collection_id AS dar_collection_id,
+        dar.parent_id AS dar_parent_id, dar.user_id AS dar_userId,
+        dar.create_date AS dar_create_date, dar.sort_date AS dar_sort_date, dar.submission_date AS dar_submission_date,
+        dar.update_date AS dar_update_date, (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data, dd.dataset_id
+        FROM dar_collection c
+        INNER JOIN users u ON c.create_user_id = u.user_id
+        LEFT JOIN user_property up ON u.user_id = up.user_id
+        LEFT JOIN institution i ON i.institution_id = u.institution_id
+        INNER JOIN data_access_request dar ON c.collection_id = dar.collection_id
+        LEFT JOIN dar_dataset dd on dd.reference_id = dar.reference_id
+        WHERE c.collection_id = (SELECT collection_id FROM data_access_request WHERE reference_id = :referenceId)
+        AND (LOWER(data->>'status')!='archived' OR data->>'status' IS NULL)
+      """)
   DarCollection findDARCollectionByReferenceId(@Bind("referenceId") String referenceId);
 
   /**
@@ -200,9 +202,12 @@ public interface DarCollectionDAO extends Transactional<DarCollectionDAO> {
    *
    * @return Integer, ID of newly created DarCollection
    */
-  @SqlUpdate("INSERT INTO dar_collection " +
-      " (dar_code, create_user_id, create_date) " +
-      " VALUES (:darCode, :createUserId, :createDate)")
+  @SqlUpdate(
+      """
+        INSERT INTO dar_collection
+        (dar_code, create_user_id, create_date)
+        VALUES (:darCode, :createUserId, :createDate)
+      """)
   @GetGeneratedKeys
   Integer insertDarCollection(@Bind("darCode") String darCode,
       @Bind("createUserId") Integer createUserId,

--- a/src/main/java/org/broadinstitute/consent/http/db/DarCollectionSummaryDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DarCollectionSummaryDAO.java
@@ -60,26 +60,26 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
       (
           """
               SELECT c.collection_id as dar_collection_id, c.dar_code, dar.submission_date, dar.reference_id as dar_reference_id, u.display_name as researcher_name,
-              i.institution_name, e.election_id, e.status, e.dataset_id, e.reference_id, dd.dataset_id as dd_datasetid,
-              (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb ->> 'projectTitle' AS name
+                i.institution_name, e.election_id, e.status, e.dataset_id, e.reference_id, dd.dataset_id as dd_datasetid,
+                (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb ->> 'projectTitle' AS name
               FROM dar_collection c
               INNER JOIN users u
-              ON u.user_id = c.create_user_id
+                ON u.user_id = c.create_user_id
               LEFT JOIN institution i
-              ON i.institution_id = u.institution_id
+                ON i.institution_id = u.institution_id
               INNER JOIN data_access_request dar
-              ON dar.collection_id = c.collection_id
+                ON dar.collection_id = c.collection_id
               LEFT JOIN (
-              SELECT election.*, MAX(election.election_id) OVER(PARTITION BY election.reference_id, election.dataset_id) AS latest
-              FROM election
-              WHERE LOWER(election.election_type) = 'dataaccess'
-              ) AS e
+                SELECT election.*, MAX(election.election_id) OVER(PARTITION BY election.reference_id, election.dataset_id) AS latest
+                FROM election
+                WHERE LOWER(election.election_type) = 'dataaccess'
+                ) AS e
               ON e.reference_id = dar.reference_id
               INNER JOIN dar_dataset dd
               ON dar.reference_id = dd.reference_id
               WHERE u.institution_id = :institutionId
-              AND (e.latest = e.election_id OR e.election_id IS NULL)
-              AND (LOWER(data->>'status') != 'archived' OR data->>'status' IS NULL )
+                AND (e.latest = e.election_id OR e.election_id IS NULL)
+                AND (LOWER(data->>'status') != 'archived' OR data->>'status' IS NULL )
           """
       )
   List<DarCollectionSummary> getDarCollectionSummariesForSO(
@@ -119,9 +119,9 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
       (
           """
               SELECT c.collection_id as dar_collection_id, c.dar_code, dar.submission_date, dar.reference_id as dar_reference_id, u.display_name as researcher_name,
-              i.institution_name, e.election_id, e.status, e.dataset_id, e.reference_id, dd.dataset_id as dd_datasetid,
-              (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb ->> 'projectTitle' AS name,
-              (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb ->> 'status' AS dar_status
+                i.institution_name, e.election_id, e.status, e.dataset_id, e.reference_id, dd.dataset_id as dd_datasetid,
+                (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb ->> 'projectTitle' AS name,
+                (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb ->> 'status' AS dar_status
               FROM dar_collection c
               INNER JOIN users u
               ON u.user_id = c.create_user_id
@@ -130,17 +130,17 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
               INNER JOIN data_access_request dar
               ON dar.collection_id = c.collection_id
               LEFT JOIN (
-              SELECT election.*, MAX(election.election_id) OVER(PARTITION BY election.reference_id, election.dataset_id) AS latest
-              FROM election
-              WHERE LOWER(election.election_type) = 'dataaccess'
+                SELECT election.*, MAX(election.election_id) OVER(PARTITION BY election.reference_id, election.dataset_id) AS latest
+                FROM election
+                WHERE LOWER(election.election_type) = 'dataaccess'
               ) AS e
               ON e.reference_id = dar.reference_id
               INNER JOIN dar_dataset dd
               ON dar.reference_id = dd.reference_id
               WHERE c.create_user_id = :userId
-              AND (e.latest = e.election_id OR e.election_id IS NULL)
-              AND (LOWER(data->>'status') != 'archived' OR data->>'status' IS NULL )
-              AND (EXISTS (SELECT 1 FROM data_access_request WHERE (collection_id = c.collection_id and dar.submission_date is not null)))
+                AND (e.latest = e.election_id OR e.election_id IS NULL)
+                AND (LOWER(data->>'status') != 'archived' OR data->>'status' IS NULL )
+                AND (EXISTS (SELECT 1 FROM data_access_request WHERE (collection_id = c.collection_id and dar.submission_date is not null)))
         """
       )
   List<DarCollectionSummary> getDarCollectionSummariesForResearcher(
@@ -194,9 +194,9 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
       (
           """
               SELECT c.collection_id as dar_collection_id, c.dar_code, dar.submission_date, dar.reference_id as dar_reference_id, u.display_name as researcher_name,
-              u.user_id as researcher_id, i.institution_name, i.institution_id, e.election_id, e.status, e.dataset_id, e.reference_id, dd.dataset_id as dd_datasetid,
-              (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb ->> 'projectTitle' AS name,
-              (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb ->> 'status' AS dar_status
+                u.user_id as researcher_id, i.institution_name, i.institution_id, e.election_id, e.status, e.dataset_id, e.reference_id, dd.dataset_id as dd_datasetid,
+                (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb ->> 'projectTitle' AS name,
+                (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb ->> 'status' AS dar_status
               FROM dar_collection c
               INNER JOIN users u
               ON u.user_id = c.create_user_id
@@ -205,16 +205,16 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
               INNER JOIN data_access_request dar
               ON dar.collection_id = c.collection_id
               LEFT JOIN (
-              SELECT election.*, MAX(election.election_id) OVER(PARTITION BY election.reference_id, election.dataset_id) AS latest
-              FROM election
-              WHERE LOWER(election.election_type) = 'dataaccess'
+                SELECT election.*, MAX(election.election_id) OVER(PARTITION BY election.reference_id, election.dataset_id) AS latest
+                FROM election
+                WHERE LOWER(election.election_type) = 'dataaccess'
               ) AS e
               ON e.reference_id = dar.reference_id
               INNER JOIN dar_dataset dd
               ON dar.reference_id = dd.reference_id
               WHERE c.collection_id = :collectionId
-              AND (e.latest = e.election_id OR e.election_id IS NULL)
-              AND (LOWER(data->>'status') != 'archived' OR data->>'status' IS NULL )
+                AND (e.latest = e.election_id OR e.election_id IS NULL)
+                AND (LOWER(data->>'status') != 'archived' OR data->>'status' IS NULL )
           """
       )
   DarCollectionSummary getDarCollectionSummaryByCollectionId(

--- a/src/main/java/org/broadinstitute/consent/http/db/DarCollectionSummaryDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DarCollectionSummaryDAO.java
@@ -62,7 +62,8 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
               +
               "i.institution_name, e.election_id, e.status, e.dataset_id, e.reference_id, dd.dataset_id as dd_datasetid, "
               +
-              "(regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb ->> 'projectTitle' AS name " +
+              "(regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb ->> 'projectTitle' AS name "
+              +
               "FROM dar_collection c " +
               "INNER JOIN users u " +
               "ON u.user_id = c.create_user_id " +
@@ -122,8 +123,10 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
               +
               "i.institution_name, e.election_id, e.status, e.dataset_id, e.reference_id, dd.dataset_id as dd_datasetid, "
               +
-              "(regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb ->> 'projectTitle' AS name, " +
-              "(regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb ->> 'status' AS dar_status " +
+              "(regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb ->> 'projectTitle' AS name, "
+              +
+              "(regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb ->> 'status' AS dar_status "
+              +
               "FROM dar_collection c " +
               "INNER JOIN users u " +
               "ON u.user_id = c.create_user_id " +
@@ -143,7 +146,7 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
               "WHERE c.create_user_id = :userId " +
               "AND (e.latest = e.election_id OR e.election_id IS NULL) " +
               "AND (LOWER(data->>'status') != 'archived' OR data->>'status' IS NULL ) " +
-              "AND (EXISTS (SELECT 1 FROM data_access_request WHERE (collection_id = c.collection_id and draft = false)))"
+              "AND (EXISTS (SELECT 1 FROM data_access_request WHERE (collection_id = c.collection_id and dar.submission_date is not null)))"
       )
   List<DarCollectionSummary> getDarCollectionSummariesForResearcher(
       @Bind("userId") Integer userId);
@@ -198,8 +201,10 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
               +
               "u.user_id as researcher_id, i.institution_name, i.institution_id, e.election_id, e.status, e.dataset_id, e.reference_id, dd.dataset_id as dd_datasetid, "
               +
-              "(regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb ->> 'projectTitle' AS name, " +
-              "(regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb ->> 'status' AS dar_status " +
+              "(regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb ->> 'projectTitle' AS name, "
+              +
+              "(regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb ->> 'status' AS dar_status "
+              +
               "FROM dar_collection c " +
               "INNER JOIN users u " +
               "ON u.user_id = c.create_user_id " +

--- a/src/main/java/org/broadinstitute/consent/http/db/DarCollectionSummaryDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DarCollectionSummaryDAO.java
@@ -58,31 +58,29 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
   @UseRowReducer(DarCollectionSummaryReducer.class)
   @SqlQuery
       (
-          "SELECT c.collection_id as dar_collection_id, c.dar_code, dar.submission_date, dar.reference_id as dar_reference_id, u.display_name as researcher_name, "
-              +
-              "i.institution_name, e.election_id, e.status, e.dataset_id, e.reference_id, dd.dataset_id as dd_datasetid, "
-              +
-              "(regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb ->> 'projectTitle' AS name "
-              +
-              "FROM dar_collection c " +
-              "INNER JOIN users u " +
-              "ON u.user_id = c.create_user_id " +
-              "LEFT JOIN institution i " +
-              "ON i.institution_id = u.institution_id " +
-              "INNER JOIN data_access_request dar " +
-              "ON dar.collection_id = c.collection_id " +
-              "LEFT JOIN ( " +
-              "SELECT election.*, MAX(election.election_id) OVER(PARTITION BY election.reference_id, election.dataset_id) AS latest "
-              +
-              "FROM election " +
-              "WHERE LOWER(election.election_type) = 'dataaccess'" +
-              ") AS e " +
-              "ON e.reference_id = dar.reference_id " +
-              "INNER JOIN dar_dataset dd " +
-              "ON dar.reference_id = dd.reference_id " +
-              "WHERE u.institution_id = :institutionId " +
-              "AND (e.latest = e.election_id OR e.election_id IS NULL) " +
-              "AND (LOWER(data->>'status') != 'archived' OR data->>'status' IS NULL ) "
+          """
+              SELECT c.collection_id as dar_collection_id, c.dar_code, dar.submission_date, dar.reference_id as dar_reference_id, u.display_name as researcher_name,
+              i.institution_name, e.election_id, e.status, e.dataset_id, e.reference_id, dd.dataset_id as dd_datasetid,
+              (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb ->> 'projectTitle' AS name
+              FROM dar_collection c
+              INNER JOIN users u
+              ON u.user_id = c.create_user_id
+              LEFT JOIN institution i
+              ON i.institution_id = u.institution_id
+              INNER JOIN data_access_request dar
+              ON dar.collection_id = c.collection_id
+              LEFT JOIN (
+              SELECT election.*, MAX(election.election_id) OVER(PARTITION BY election.reference_id, election.dataset_id) AS latest
+              FROM election
+              WHERE LOWER(election.election_type) = 'dataaccess'
+              ) AS e
+              ON e.reference_id = dar.reference_id
+              INNER JOIN dar_dataset dd
+              ON dar.reference_id = dd.reference_id
+              WHERE u.institution_id = :institutionId
+              AND (e.latest = e.election_id OR e.election_id IS NULL)
+              AND (LOWER(data->>'status') != 'archived' OR data->>'status' IS NULL )
+          """
       )
   List<DarCollectionSummary> getDarCollectionSummariesForSO(
       @Bind("institutionId") Integer institutionId);
@@ -119,34 +117,31 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
   @UseRowReducer(DarCollectionSummaryReducer.class)
   @SqlQuery
       (
-          "SELECT c.collection_id as dar_collection_id, c.dar_code, dar.submission_date, dar.reference_id as dar_reference_id, u.display_name as researcher_name, "
-              +
-              "i.institution_name, e.election_id, e.status, e.dataset_id, e.reference_id, dd.dataset_id as dd_datasetid, "
-              +
-              "(regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb ->> 'projectTitle' AS name, "
-              +
-              "(regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb ->> 'status' AS dar_status "
-              +
-              "FROM dar_collection c " +
-              "INNER JOIN users u " +
-              "ON u.user_id = c.create_user_id " +
-              "LEFT JOIN institution i " +
-              "ON i.institution_id = u.institution_id " +
-              "INNER JOIN data_access_request dar " +
-              "ON dar.collection_id = c.collection_id " +
-              "LEFT JOIN ( " +
-              "SELECT election.*, MAX(election.election_id) OVER(PARTITION BY election.reference_id, election.dataset_id) AS latest "
-              +
-              "FROM election " +
-              "WHERE LOWER(election.election_type) = 'dataaccess'" +
-              ") AS e " +
-              "ON e.reference_id = dar.reference_id " +
-              "INNER JOIN dar_dataset dd " +
-              "ON dar.reference_id = dd.reference_id " +
-              "WHERE c.create_user_id = :userId " +
-              "AND (e.latest = e.election_id OR e.election_id IS NULL) " +
-              "AND (LOWER(data->>'status') != 'archived' OR data->>'status' IS NULL ) " +
-              "AND (EXISTS (SELECT 1 FROM data_access_request WHERE (collection_id = c.collection_id and dar.submission_date is not null)))"
+          """
+              SELECT c.collection_id as dar_collection_id, c.dar_code, dar.submission_date, dar.reference_id as dar_reference_id, u.display_name as researcher_name,
+              i.institution_name, e.election_id, e.status, e.dataset_id, e.reference_id, dd.dataset_id as dd_datasetid,
+              (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb ->> 'projectTitle' AS name,
+              (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb ->> 'status' AS dar_status
+              FROM dar_collection c
+              INNER JOIN users u
+              ON u.user_id = c.create_user_id
+              LEFT JOIN institution i
+              ON i.institution_id = u.institution_id
+              INNER JOIN data_access_request dar
+              ON dar.collection_id = c.collection_id
+              LEFT JOIN (
+              SELECT election.*, MAX(election.election_id) OVER(PARTITION BY election.reference_id, election.dataset_id) AS latest
+              FROM election
+              WHERE LOWER(election.election_type) = 'dataaccess'
+              ) AS e
+              ON e.reference_id = dar.reference_id
+              INNER JOIN dar_dataset dd
+              ON dar.reference_id = dd.reference_id
+              WHERE c.create_user_id = :userId
+              AND (e.latest = e.election_id OR e.election_id IS NULL)
+              AND (LOWER(data->>'status') != 'archived' OR data->>'status' IS NULL )
+              AND (EXISTS (SELECT 1 FROM data_access_request WHERE (collection_id = c.collection_id and dar.submission_date is not null)))
+        """
       )
   List<DarCollectionSummary> getDarCollectionSummariesForResearcher(
       @Bind("userId") Integer userId);
@@ -197,33 +192,30 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
   @UseRowReducer(DarCollectionSummaryReducer.class)
   @SqlQuery
       (
-          "SELECT c.collection_id as dar_collection_id, c.dar_code, dar.submission_date, dar.reference_id as dar_reference_id, u.display_name as researcher_name, "
-              +
-              "u.user_id as researcher_id, i.institution_name, i.institution_id, e.election_id, e.status, e.dataset_id, e.reference_id, dd.dataset_id as dd_datasetid, "
-              +
-              "(regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb ->> 'projectTitle' AS name, "
-              +
-              "(regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb ->> 'status' AS dar_status "
-              +
-              "FROM dar_collection c " +
-              "INNER JOIN users u " +
-              "ON u.user_id = c.create_user_id " +
-              "LEFT JOIN institution i " +
-              "ON i.institution_id = u.institution_id " +
-              "INNER JOIN data_access_request dar " +
-              "ON dar.collection_id = c.collection_id " +
-              "LEFT JOIN ( " +
-              "SELECT election.*, MAX(election.election_id) OVER(PARTITION BY election.reference_id, election.dataset_id) AS latest "
-              +
-              "FROM election " +
-              "WHERE LOWER(election.election_type) = 'dataaccess'" +
-              ") AS e " +
-              "ON e.reference_id = dar.reference_id " +
-              "INNER JOIN dar_dataset dd " +
-              "ON dar.reference_id = dd.reference_id " +
-              "WHERE c.collection_id = :collectionId " +
-              "AND (e.latest = e.election_id OR e.election_id IS NULL) " +
-              "AND (LOWER(data->>'status') != 'archived' OR data->>'status' IS NULL )"
+          """
+              SELECT c.collection_id as dar_collection_id, c.dar_code, dar.submission_date, dar.reference_id as dar_reference_id, u.display_name as researcher_name,
+              u.user_id as researcher_id, i.institution_name, i.institution_id, e.election_id, e.status, e.dataset_id, e.reference_id, dd.dataset_id as dd_datasetid,
+              (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb ->> 'projectTitle' AS name,
+              (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb ->> 'status' AS dar_status
+              FROM dar_collection c
+              INNER JOIN users u
+              ON u.user_id = c.create_user_id
+              LEFT JOIN institution i
+              ON i.institution_id = u.institution_id
+              INNER JOIN data_access_request dar
+              ON dar.collection_id = c.collection_id
+              LEFT JOIN (
+              SELECT election.*, MAX(election.election_id) OVER(PARTITION BY election.reference_id, election.dataset_id) AS latest
+              FROM election
+              WHERE LOWER(election.election_type) = 'dataaccess'
+              ) AS e
+              ON e.reference_id = dar.reference_id
+              INNER JOIN dar_dataset dd
+              ON dar.reference_id = dd.reference_id
+              WHERE c.collection_id = :collectionId
+              AND (e.latest = e.election_id OR e.election_id IS NULL)
+              AND (LOWER(data->>'status') != 'archived' OR data->>'status' IS NULL )
+          """
       )
   DarCollectionSummary getDarCollectionSummaryByCollectionId(
       @Bind("collectionId") Integer collectionId);

--- a/src/main/java/org/broadinstitute/consent/http/db/DataAccessRequestDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DataAccessRequestDAO.java
@@ -35,30 +35,30 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
    */
   @UseRowReducer(DataAccessRequestReducer.class)
   @SqlQuery(
-      "SELECT dd.dataset_id, dar.id, dar.reference_id, dar.collection_id, dar.parent_id, dar.draft, dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date, "
+      "SELECT dd.dataset_id, dar.id, dar.reference_id, dar.collection_id, dar.parent_id, dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date, "
           + "  (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data FROM data_access_request dar"
           + "  LEFT JOIN dar_dataset dd on dd.reference_id = dar.reference_id "
-          + "  WHERE dar.draft != true "
+          + "  WHERE dar.submission_date is not null "
           + "  AND (LOWER(dar.data->>'status') != 'archived' OR dar.data->>'status' IS NULL)")
   List<DataAccessRequest> findAllDataAccessRequests();
 
   /**
-   * This query finds DARs on dar-dataset combinations where the most recent vote is true.
-   * The query accomplishes this by creating a view that is a grouping of election reference
-   * ids and LAST vote in the group of final votes for all data access elections. We need to group
-   * them due to the case of multiple elections on a dar-dataset request. Election 1 may have been
-   * denied. Election 2 may have been approved. Election 3 may have been denied again. When we
-   * partition over the election reference id, we'll get all final votes. The `LAST_VALUE` function
-   * selects the last result in the partition, which would be `FALSE` in the example above. Outside
-   * the JOIN, we filter on groupings where the final vote value is `TRUE` so the denied election in
-   * the example would be filtered out.
+   * This query finds DARs submitted within the last year on dar-dataset combinations where the most
+   * recent vote is true. The query accomplishes this by creating a view that is a grouping of
+   * election reference ids and LAST vote in the group of final votes for all data access elections.
+   * We need to group them due to the case of multiple elections on a dar-dataset request. Election
+   * 1 may have been denied. Election 2 may have been approved. Election 3 may have been denied
+   * again. When we partition over the election reference id, we'll get all final votes. The
+   * `LAST_VALUE` function selects the last result in the partition, which would be `FALSE` in the
+   * example above. Outside the JOIN, we filter on groupings where the final vote value is `TRUE` so
+   * the denied election in the example would be filtered out.
    *
    * @param datasetId The dataset id
    * @return List of approved DARs for the dataset
    */
   @UseRowReducer(DataAccessRequestReducer.class)
   @SqlQuery("""
-          SELECT dar.id, dar.reference_id, dar.collection_id, dar.parent_id, dar.draft,
+          SELECT dar.id, dar.reference_id, dar.collection_id, dar.parent_id,
             dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date,
             (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data,
             dd.dataset_id
@@ -78,11 +78,32 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
             WHERE e.dataset_id = :datasetId
             AND LOWER(e.election_type) = 'dataaccess'
             AND LOWER(v.type) = 'final') final_access_vote ON final_access_vote.reference_id = dar.reference_id
-          WHERE dar.draft = false
+          WHERE dar.submission_date BETWEEN SYMMETRIC now() - interval '1' year AND now()
           AND final_access_vote.last_vote = TRUE
           AND (LOWER(dar.data->>'status') != 'archived' OR dar.data->>'status' IS NULL)
       """)
   List<DataAccessRequest> findApprovedDARsByDatasetId(@Bind("datasetId") Integer datasetId);
+
+  /**
+   * This query finds submitted DARs based on a date range.  This would be useful if we wanted to
+   * send notifications for "expiring" DARs 30 days before expiration and again at 7 days.
+   *
+   * @param begin Oldest submission date, in seconds since the epoch
+   * @param end   Newest submission date, in seconds since the epoch
+   * @return List of approved DARs for the dataset
+   */
+  @UseRowReducer(DataAccessRequestReducer.class)
+  @SqlQuery("""
+          SELECT dar.id, dar.reference_id, dar.collection_id, dar.parent_id,
+            dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date,
+            (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data,
+            dd.dataset_id
+          FROM data_access_request dar
+          LEFT JOIN dar_dataset dd ON dd.reference_id = dar.reference_id
+          WHERE dar.submission_date BETWEEN SYMMETRIC to_timestamp(:begin) AND to_timestamp(:end)
+      """)
+  List<DataAccessRequest> findSubmittedDarsByTimeRange(@Bind("begin") double begin,
+      @Bind("end") double end);
 
   /**
    * Find all draft/partial DataAccessRequests, sorted descending order
@@ -91,10 +112,10 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
    */
   @UseRowReducer(DataAccessRequestReducer.class)
   @SqlQuery(
-      "SELECT dd.dataset_id, dar.id, dar.reference_id, dar.collection_id, dar.parent_id, dar.draft, dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date, "
+      "SELECT dd.dataset_id, dar.id, dar.reference_id, dar.collection_id, dar.parent_id, dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date, "
           + "  (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data FROM data_access_request dar"
           + "  LEFT JOIN dar_dataset dd on dd.reference_id = dar.reference_id "
-          + "  WHERE dar.draft = true "
+          + "  WHERE dar.submission_date is null "
           + "  AND (LOWER(dar.data->>'status') != 'archived' OR dar.data->>'status' IS NULL) "
           + "  ORDER BY dar.update_date DESC")
   List<DataAccessRequest> findAllDraftDataAccessRequests();
@@ -106,10 +127,10 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
    */
   @UseRowReducer(DataAccessRequestReducer.class)
   @SqlQuery(
-      "SELECT dd.dataset_id, dar.id, dar.reference_id, dar.collection_id, dar.parent_id, dar.draft, dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date, "
+      "SELECT dd.dataset_id, dar.id, dar.reference_id, dar.collection_id, dar.parent_id, dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date, "
           + "  (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data FROM data_access_request dar"
           + "  LEFT JOIN dar_dataset dd on dd.reference_id = dar.reference_id "
-          + "  WHERE dar.draft = true "
+          + "  WHERE dar.submission_date is null"
           + "  AND (LOWER(dar.data->>'status') != 'archived' OR dar.data->>'status' IS NULL) "
           + "  AND dar.user_id = :userId "
           + "  ORDER BY dar.sort_date DESC")
@@ -123,10 +144,10 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
    */
   @UseRowReducer(DataAccessRequestReducer.class)
   @SqlQuery(
-      "SELECT dd.dataset_id, dar.id, dar.reference_id, dar.collection_id, dar.parent_id, dar.draft, dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date, "
+      "SELECT dd.dataset_id, dar.id, dar.reference_id, dar.collection_id, dar.parent_id, dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date, "
           + "  (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data FROM data_access_request dar"
           + "  LEFT JOIN dar_dataset dd on dd.reference_id = dar.reference_id "
-          + "  WHERE dar.draft = false "
+          + "  WHERE dar.submission_date is not null "
           + "  AND dar.user_id = :userId "
           + "  AND (LOWER(dar.data->>'status') != 'archived' OR dar.data->>'status' IS NULL) "
           + "  ORDER BY dar.sort_date DESC")
@@ -140,7 +161,7 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
    */
   @UseRowReducer(DataAccessRequestReducer.class)
   @SqlQuery(
-      "SELECT dd.dataset_id, dar.id, dar.reference_id, dar.collection_id, dar.parent_id, dar.draft, dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date, "
+      "SELECT dd.dataset_id, dar.id, dar.reference_id, dar.collection_id, dar.parent_id, dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date, "
           + "  (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data FROM data_access_request dar"
           + "  LEFT JOIN dar_dataset dd on dd.reference_id = dar.reference_id "
           + "  WHERE dar.reference_id = :referenceId "
@@ -155,7 +176,7 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
    */
   @UseRowReducer(DataAccessRequestReducer.class)
   @SqlQuery(
-      "SELECT dd.dataset_id, dar.id, dar.reference_id, dar.collection_id, dar.parent_id, dar.draft, dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date, "
+      "SELECT dd.dataset_id, dar.id, dar.reference_id, dar.collection_id, dar.parent_id, dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date, "
           + "  (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data FROM data_access_request dar"
           + "  LEFT JOIN dar_dataset dd on dd.reference_id = dar.reference_id "
           + "  WHERE dar.reference_id IN (<referenceIds>) "
@@ -215,26 +236,24 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
   /**
    * Create new DataAccessRequest in draft status
    *
-   * @param referenceId    String
-   * @param userId         Integer User
-   * @param createDate     Date Creation Date
-   * @param sortDate       Date Sorting Date
-   * @param submissionDate Date Submission Date
-   * @param updateDate     Date Update Date
-   * @param data           DataAccessRequestData DAR Properties
+   * @param referenceId String
+   * @param userId      Integer User
+   * @param createDate  Date Creation Date
+   * @param sortDate    Date Sorting Date
+   * @param updateDate  Date Update Date
+   * @param data        DataAccessRequestData DAR Properties
    */
   @RegisterArgumentFactory(JsonArgumentFactory.class)
   @SqlUpdate(
       "INSERT INTO data_access_request "
-          + "(reference_id, user_id, create_date, sort_date, submission_date, update_date, data, draft) "
+          + "(reference_id, user_id, create_date, sort_date, update_date, data) "
           + "VALUES (:referenceId, :userId, :createDate, :sortDate, "
-          + ":submissionDate, :updateDate, to_jsonb(:data), true)")
+          + " :updateDate, to_jsonb(:data))")
   void insertDraftDataAccessRequest(
       @Bind("referenceId") String referenceId,
       @Bind("userId") Integer userId,
       @Bind("createDate") Date createDate,
       @Bind("sortDate") Date sortDate,
-      @Bind("submissionDate") Date submissionDate,
       @Bind("updateDate") Date updateDate,
       @Bind("data") @Json DataAccessRequestData data);
 
@@ -266,30 +285,12 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
       @Bind("updateDate") Date updateDate,
       @Bind("data") @Json DataAccessRequestData data);
 
-  /**
-   * Converts a Draft DataAccessRequest into a non-draft DataAccessRequest
-   *
-   * @param referenceId String
-   */
-  @SqlUpdate(
-      "UPDATE data_access_request "
-          + "SET draft = :draft "
-          + "WHERE reference_id = :referenceId")
-  void updateDraftByReferenceId(@Bind("referenceId") String referenceId,
-      @Bind("draft") Boolean draft);
 
   @SqlUpdate(
       "UPDATE data_access_request "
-          + "SET draft = :draft "
-          + "WHERE collection_id = :collectionId")
-  void updateDraftByCollectionId(@Bind("collectionId") Integer collectionId,
-      @Bind("draft") Boolean draft);
-
-  @SqlUpdate(
-      "UPDATE data_access_request "
-          + "SET draft = false, collection_id = :collectionId "
+          + "SET  submission_date = now(), collection_id = :collectionId "
           + "WHERE reference_id = :referenceId")
-  void updateDraftForCollection(@Bind("collectionId") Integer collectionId,
+  void updateDraftToSubmittedForCollection(@Bind("collectionId") Integer collectionId,
       @Bind("referenceId") String referenceId);
 
   @RegisterRowMapper(DataAccessRequestDataMapper.class)

--- a/src/main/java/org/broadinstitute/consent/http/db/DataAccessRequestDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DataAccessRequestDAO.java
@@ -37,7 +37,7 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
   @SqlQuery(
       """
           SELECT dd.dataset_id, dar.id, dar.reference_id, dar.collection_id, dar.parent_id, dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date,
-          (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data FROM data_access_request dar
+            (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data FROM data_access_request dar
           LEFT JOIN dar_dataset dd on dd.reference_id = dar.reference_id 
           WHERE dar.submission_date is not null
           AND (LOWER(dar.data->>'status') != 'archived' OR dar.data->>'status' IS NULL)""")
@@ -117,10 +117,10 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
   @SqlQuery(
       """
               SELECT dd.dataset_id, dar.id, dar.reference_id, dar.collection_id, dar.parent_id, dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date, 
-              (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data FROM data_access_request dar
+                (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data FROM data_access_request dar
               LEFT JOIN dar_dataset dd on dd.reference_id = dar.reference_id
               WHERE dar.submission_date is null
-              AND (LOWER(dar.data->>'status') != 'archived' OR dar.data->>'status' IS NULL)
+                AND (LOWER(dar.data->>'status') != 'archived' OR dar.data->>'status' IS NULL)
               ORDER BY dar.update_date DESC
           """)
   List<DataAccessRequest> findAllDraftDataAccessRequests();
@@ -134,11 +134,11 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
   @SqlQuery(
       """
               SELECT dd.dataset_id, dar.id, dar.reference_id, dar.collection_id, dar.parent_id, dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date,
-              (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data FROM data_access_request dar
+                (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data FROM data_access_request dar
               LEFT JOIN dar_dataset dd on dd.reference_id = dar.reference_id
               WHERE dar.submission_date is null
-              AND (LOWER(dar.data->>'status') != 'archived' OR dar.data->>'status' IS NULL)
-              AND dar.user_id = :userId
+                AND (LOWER(dar.data->>'status') != 'archived' OR dar.data->>'status' IS NULL)
+                AND dar.user_id = :userId
               ORDER BY dar.sort_date DESC
           """)
   List<DataAccessRequest> findAllDraftsByUserId(@Bind("userId") Integer userId);
@@ -156,8 +156,8 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
               (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data FROM data_access_request dar
               LEFT JOIN dar_dataset dd on dd.reference_id = dar.reference_id
               WHERE dar.submission_date is not null
-              AND dar.user_id = :userId
-              AND (LOWER(dar.data->>'status') != 'archived' OR dar.data->>'status' IS NULL)
+                AND dar.user_id = :userId
+                AND (LOWER(dar.data->>'status') != 'archived' OR dar.data->>'status' IS NULL)
               ORDER BY dar.sort_date DESC
           """)
   List<DataAccessRequest> findAllDarsByUserId(@Bind("userId") Integer userId);
@@ -172,10 +172,10 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
   @SqlQuery(
       """
               SELECT dd.dataset_id, dar.id, dar.reference_id, dar.collection_id, dar.parent_id, dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date,
-              (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data FROM data_access_request dar
+                (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data FROM data_access_request dar
               LEFT JOIN dar_dataset dd on dd.reference_id = dar.reference_id
               WHERE dar.reference_id = :referenceId
-              AND (LOWER(dar.data->>'status') != 'archived' OR dar.data->>'status' IS NULL)
+                AND (LOWER(dar.data->>'status') != 'archived' OR dar.data->>'status' IS NULL)
           """)
   DataAccessRequest findByReferenceId(@Bind("referenceId") String referenceId);
 
@@ -189,10 +189,10 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
   @SqlQuery(
       """
           SELECT dd.dataset_id, dar.id, dar.reference_id, dar.collection_id, dar.parent_id, dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date,
-          (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data FROM data_access_request dar
+            (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data FROM data_access_request dar
           LEFT JOIN dar_dataset dd on dd.reference_id = dar.reference_id
           WHERE dar.reference_id IN (<referenceIds>)
-          AND (LOWER(dar.data->>'status') != 'archived' OR dar.data->>'status' IS NULL)
+            AND (LOWER(dar.data->>'status') != 'archived' OR dar.data->>'status' IS NULL)
       """)
   List<DataAccessRequest> findByReferenceIds(@BindList("referenceIds") List<String> referenceIds);
 
@@ -211,7 +211,7 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
       """
           UPDATE data_access_request
           SET data = to_jsonb(regexp_replace(:data, '\\\\u0000', '', 'g')), user_id = :userId, sort_date = :sortDate,
-          submission_date = :submissionDate, update_date = :updateDate
+            submission_date = :submissionDate, update_date = :updateDate
           WHERE reference_id = :referenceId
       """)
   void updateDataByReferenceId(
@@ -240,7 +240,7 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
   @SqlUpdate(
       """
           UPDATE data_access_request dar
-          SET data=jsonb_set((regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb, '{status}', '\"Canceled\"')
+          SET data=jsonb_set((regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb, '{status}', '"Canceled"')
           WHERE reference_id IN (<referenceIds>)
       """)
   void cancelByReferenceIds(@BindList("referenceIds") List<String> referenceIds);
@@ -270,9 +270,9 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
   @SqlUpdate(
       """
           INSERT INTO data_access_request
-          (reference_id, user_id, create_date, sort_date, update_date, data)
+            (reference_id, user_id, create_date, sort_date, update_date, data)
           VALUES (:referenceId, :userId, :createDate, :sortDate,
-          :updateDate, to_jsonb(:data))
+            :updateDate, to_jsonb(:data))
       """)
   void insertDraftDataAccessRequest(
       @Bind("referenceId") String referenceId,
@@ -298,9 +298,9 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
   @SqlUpdate(
       """
           INSERT INTO data_access_request
-          (collection_id, reference_id, user_id, create_date, sort_date, submission_date, update_date, data)
+            (collection_id, reference_id, user_id, create_date, sort_date, submission_date, update_date, data)
           VALUES (:collectionId, :referenceId, :userId, :createDate, :sortDate,
-          :submissionDate, :updateDate, to_jsonb(:data))
+            :submissionDate, :updateDate, to_jsonb(:data))
       """)
   void insertDataAccessRequest(
       @Bind("collectionId") Integer collectionId,
@@ -316,7 +316,7 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
   @SqlUpdate(
       """
           UPDATE data_access_request
-          SET  submission_date = now(), collection_id = :collectionId
+            SET  submission_date = now(), collection_id = :collectionId
           WHERE reference_id = :referenceId
        """)
   void updateDraftToSubmittedForCollection(@Bind("collectionId") Integer collectionId,
@@ -328,14 +328,14 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
           SELECT (data #>> '{}')::jsonb AS data
           FROM data_access_request
           WHERE (LOWER(data->>'status') != 'archived'
-          OR data->>'status' IS NULL)
+            OR data->>'status' IS NULL)
       """)
   List<DataAccessRequestData> findAllDataAccessRequestDatas();
 
   @SqlUpdate(
       """
          UPDATE data_access_request
-          SET data = jsonb_set ((data #>> '{}')::jsonb, '{status}', '\"Archived\"', true)
+          SET data = jsonb_set ((data #>> '{}')::jsonb, '{status}', '"Archived"', true)
           WHERE reference_id IN (<referenceIds>)
       """)
   void archiveByReferenceIds(@BindList("referenceIds") List<String> referenceIds);

--- a/src/main/java/org/broadinstitute/consent/http/db/DataAccessRequestDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DataAccessRequestDAO.java
@@ -80,10 +80,9 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
                 WHERE e.dataset_id = :datasetId
                 AND LOWER(e.election_type) = 'dataaccess'
                 AND LOWER(v.type) = 'final') final_access_vote ON final_access_vote.reference_id = dar.reference_id
-              WHERE dar.submission_date BETWEEN SYMMETRIC now() - interval '1' year AND now()
+              WHERE dar.submission_date > now() - interval '1 year'
               AND final_access_vote.last_vote = TRUE
               AND (LOWER(dar.data->>'status') != 'archived' OR dar.data->>'status' IS NULL)
-              AND dar.submission_date > now() - interval '1 year'
           """)
   List<DataAccessRequest> findApprovedDARsByDatasetId(@Bind("datasetId") Integer datasetId);
 

--- a/src/main/java/org/broadinstitute/consent/http/db/DataAccessRequestDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DataAccessRequestDAO.java
@@ -35,11 +35,12 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
    */
   @UseRowReducer(DataAccessRequestReducer.class)
   @SqlQuery(
-      "SELECT dd.dataset_id, dar.id, dar.reference_id, dar.collection_id, dar.parent_id, dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date, "
-          + "  (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data FROM data_access_request dar"
-          + "  LEFT JOIN dar_dataset dd on dd.reference_id = dar.reference_id "
-          + "  WHERE dar.submission_date is not null "
-          + "  AND (LOWER(dar.data->>'status') != 'archived' OR dar.data->>'status' IS NULL)")
+      """
+          SELECT dd.dataset_id, dar.id, dar.reference_id, dar.collection_id, dar.parent_id, dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date,
+          (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data FROM data_access_request dar
+          LEFT JOIN dar_dataset dd on dd.reference_id = dar.reference_id 
+          WHERE dar.submission_date is not null
+          AND (LOWER(dar.data->>'status') != 'archived' OR dar.data->>'status' IS NULL)""")
   List<DataAccessRequest> findAllDataAccessRequests();
 
   /**
@@ -57,32 +58,33 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
    * @return List of approved DARs for the dataset
    */
   @UseRowReducer(DataAccessRequestReducer.class)
-  @SqlQuery("""
-          SELECT dar.id, dar.reference_id, dar.collection_id, dar.parent_id,
-            dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date,
-            (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data,
-            dd.dataset_id
-          FROM data_access_request dar
-          INNER JOIN dar_dataset dd ON dd.reference_id = dar.reference_id AND dd.dataset_id = :datasetId
-          INNER JOIN (
-            SELECT DISTINCT e.reference_id, LAST_VALUE(v.vote)
-            OVER(
-              PARTITION BY e.reference_id
-                ORDER BY v.createdate
-                RANGE BETWEEN
-                  UNBOUNDED PRECEDING AND
-                  UNBOUNDED FOLLOWING
-            ) last_vote
-            FROM election e
-            INNER JOIN vote v ON e.election_id = v.electionid AND v.vote IS NOT NULL
-            WHERE e.dataset_id = :datasetId
-            AND LOWER(e.election_type) = 'dataaccess'
-            AND LOWER(v.type) = 'final') final_access_vote ON final_access_vote.reference_id = dar.reference_id
-          WHERE dar.submission_date BETWEEN SYMMETRIC now() - interval '1' year AND now()
-          AND final_access_vote.last_vote = TRUE
-          AND (LOWER(dar.data->>'status') != 'archived' OR dar.data->>'status' IS NULL)
-          AND dar.submission_date > now() - interval '1 year'
-      """)
+  @SqlQuery(
+      """
+              SELECT dar.id, dar.reference_id, dar.collection_id, dar.parent_id,
+                dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date,
+                (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data,
+                dd.dataset_id
+              FROM data_access_request dar
+              INNER JOIN dar_dataset dd ON dd.reference_id = dar.reference_id AND dd.dataset_id = :datasetId
+              INNER JOIN (
+                SELECT DISTINCT e.reference_id, LAST_VALUE(v.vote)
+                OVER(
+                  PARTITION BY e.reference_id
+                    ORDER BY v.createdate
+                    RANGE BETWEEN
+                      UNBOUNDED PRECEDING AND
+                      UNBOUNDED FOLLOWING
+                ) last_vote
+                FROM election e
+                INNER JOIN vote v ON e.election_id = v.electionid AND v.vote IS NOT NULL
+                WHERE e.dataset_id = :datasetId
+                AND LOWER(e.election_type) = 'dataaccess'
+                AND LOWER(v.type) = 'final') final_access_vote ON final_access_vote.reference_id = dar.reference_id
+              WHERE dar.submission_date BETWEEN SYMMETRIC now() - interval '1' year AND now()
+              AND final_access_vote.last_vote = TRUE
+              AND (LOWER(dar.data->>'status') != 'archived' OR dar.data->>'status' IS NULL)
+              AND dar.submission_date > now() - interval '1 year'
+          """)
   List<DataAccessRequest> findApprovedDARsByDatasetId(@Bind("datasetId") Integer datasetId);
 
   /**
@@ -94,15 +96,16 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
    * @return List of approved DARs for the dataset
    */
   @UseRowReducer(DataAccessRequestReducer.class)
-  @SqlQuery("""
-          SELECT dar.id, dar.reference_id, dar.collection_id, dar.parent_id,
-            dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date,
-            (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data,
-            dd.dataset_id
-          FROM data_access_request dar
-          LEFT JOIN dar_dataset dd ON dd.reference_id = dar.reference_id
-          WHERE dar.submission_date BETWEEN SYMMETRIC to_timestamp(:begin) AND to_timestamp(:end)
-      """)
+  @SqlQuery(
+      """
+              SELECT dar.id, dar.reference_id, dar.collection_id, dar.parent_id,
+                dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date,
+                (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data,
+                dd.dataset_id
+              FROM data_access_request dar
+              LEFT JOIN dar_dataset dd ON dd.reference_id = dar.reference_id
+              WHERE dar.submission_date BETWEEN SYMMETRIC to_timestamp(:begin) AND to_timestamp(:end)
+          """)
   List<DataAccessRequest> findSubmittedDarsByTimeRange(@Bind("begin") double begin,
       @Bind("end") double end);
 
@@ -113,12 +116,14 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
    */
   @UseRowReducer(DataAccessRequestReducer.class)
   @SqlQuery(
-      "SELECT dd.dataset_id, dar.id, dar.reference_id, dar.collection_id, dar.parent_id, dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date, "
-          + "  (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data FROM data_access_request dar"
-          + "  LEFT JOIN dar_dataset dd on dd.reference_id = dar.reference_id "
-          + "  WHERE dar.submission_date is null "
-          + "  AND (LOWER(dar.data->>'status') != 'archived' OR dar.data->>'status' IS NULL) "
-          + "  ORDER BY dar.update_date DESC")
+      """
+              SELECT dd.dataset_id, dar.id, dar.reference_id, dar.collection_id, dar.parent_id, dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date, 
+              (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data FROM data_access_request dar
+              LEFT JOIN dar_dataset dd on dd.reference_id = dar.reference_id
+              WHERE dar.submission_date is null
+              AND (LOWER(dar.data->>'status') != 'archived' OR dar.data->>'status' IS NULL)
+              ORDER BY dar.update_date DESC
+          """)
   List<DataAccessRequest> findAllDraftDataAccessRequests();
 
   /**
@@ -128,13 +133,15 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
    */
   @UseRowReducer(DataAccessRequestReducer.class)
   @SqlQuery(
-      "SELECT dd.dataset_id, dar.id, dar.reference_id, dar.collection_id, dar.parent_id, dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date, "
-          + "  (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data FROM data_access_request dar"
-          + "  LEFT JOIN dar_dataset dd on dd.reference_id = dar.reference_id "
-          + "  WHERE dar.submission_date is null"
-          + "  AND (LOWER(dar.data->>'status') != 'archived' OR dar.data->>'status' IS NULL) "
-          + "  AND dar.user_id = :userId "
-          + "  ORDER BY dar.sort_date DESC")
+      """
+              SELECT dd.dataset_id, dar.id, dar.reference_id, dar.collection_id, dar.parent_id, dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date,
+              (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data FROM data_access_request dar
+              LEFT JOIN dar_dataset dd on dd.reference_id = dar.reference_id
+              WHERE dar.submission_date is null
+              AND (LOWER(dar.data->>'status') != 'archived' OR dar.data->>'status' IS NULL)
+              AND dar.user_id = :userId
+              ORDER BY dar.sort_date DESC
+          """)
   List<DataAccessRequest> findAllDraftsByUserId(@Bind("userId") Integer userId);
 
 
@@ -145,13 +152,15 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
    */
   @UseRowReducer(DataAccessRequestReducer.class)
   @SqlQuery(
-      "SELECT dd.dataset_id, dar.id, dar.reference_id, dar.collection_id, dar.parent_id, dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date, "
-          + "  (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data FROM data_access_request dar"
-          + "  LEFT JOIN dar_dataset dd on dd.reference_id = dar.reference_id "
-          + "  WHERE dar.submission_date is not null "
-          + "  AND dar.user_id = :userId "
-          + "  AND (LOWER(dar.data->>'status') != 'archived' OR dar.data->>'status' IS NULL) "
-          + "  ORDER BY dar.sort_date DESC")
+      """
+              SELECT dd.dataset_id, dar.id, dar.reference_id, dar.collection_id, dar.parent_id, dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date,
+              (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data FROM data_access_request dar
+              LEFT JOIN dar_dataset dd on dd.reference_id = dar.reference_id
+              WHERE dar.submission_date is not null
+              AND dar.user_id = :userId
+              AND (LOWER(dar.data->>'status') != 'archived' OR dar.data->>'status' IS NULL)
+              ORDER BY dar.sort_date DESC
+          """)
   List<DataAccessRequest> findAllDarsByUserId(@Bind("userId") Integer userId);
 
   /**
@@ -162,11 +171,13 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
    */
   @UseRowReducer(DataAccessRequestReducer.class)
   @SqlQuery(
-      "SELECT dd.dataset_id, dar.id, dar.reference_id, dar.collection_id, dar.parent_id, dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date, "
-          + "  (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data FROM data_access_request dar"
-          + "  LEFT JOIN dar_dataset dd on dd.reference_id = dar.reference_id "
-          + "  WHERE dar.reference_id = :referenceId "
-          + "  AND (LOWER(dar.data->>'status') != 'archived' OR dar.data->>'status' IS NULL)")
+      """
+              SELECT dd.dataset_id, dar.id, dar.reference_id, dar.collection_id, dar.parent_id, dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date,
+              (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data FROM data_access_request dar
+              LEFT JOIN dar_dataset dd on dd.reference_id = dar.reference_id
+              WHERE dar.reference_id = :referenceId
+              AND (LOWER(dar.data->>'status') != 'archived' OR dar.data->>'status' IS NULL)
+          """)
   DataAccessRequest findByReferenceId(@Bind("referenceId") String referenceId);
 
   /**
@@ -177,11 +188,13 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
    */
   @UseRowReducer(DataAccessRequestReducer.class)
   @SqlQuery(
-      "SELECT dd.dataset_id, dar.id, dar.reference_id, dar.collection_id, dar.parent_id, dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date, "
-          + "  (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data FROM data_access_request dar"
-          + "  LEFT JOIN dar_dataset dd on dd.reference_id = dar.reference_id "
-          + "  WHERE dar.reference_id IN (<referenceIds>) "
-          + "  AND (LOWER(dar.data->>'status') != 'archived' OR dar.data->>'status' IS NULL)")
+      """
+          SELECT dd.dataset_id, dar.id, dar.reference_id, dar.collection_id, dar.parent_id, dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date,
+          (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data FROM data_access_request dar
+          LEFT JOIN dar_dataset dd on dd.reference_id = dar.reference_id
+          WHERE dar.reference_id IN (<referenceIds>)
+          AND (LOWER(dar.data->>'status') != 'archived' OR dar.data->>'status' IS NULL)
+      """)
   List<DataAccessRequest> findByReferenceIds(@BindList("referenceIds") List<String> referenceIds);
 
   /**
@@ -196,10 +209,12 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
    */
   @RegisterArgumentFactory(JsonArgumentFactory.class)
   @SqlUpdate(
-      "UPDATE data_access_request "
-          + "SET data = to_jsonb(regexp_replace(:data, '\\\\u0000', '', 'g')), user_id = :userId, sort_date = :sortDate, "
-          + "submission_date = :submissionDate, update_date = :updateDate "
-          + "WHERE reference_id = :referenceId")
+      """
+          UPDATE data_access_request
+          SET data = to_jsonb(regexp_replace(:data, '\\\\u0000', '', 'g')), user_id = :userId, sort_date = :sortDate,
+          submission_date = :submissionDate, update_date = :updateDate
+          WHERE reference_id = :referenceId
+      """)
   void updateDataByReferenceId(
       @Bind("referenceId") String referenceId,
       @Bind("userId") Integer userId,
@@ -213,7 +228,10 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
    *
    * @param referenceId String
    */
-  @SqlUpdate("DELETE FROM data_access_request WHERE reference_id = :referenceId")
+  @SqlUpdate(
+    """
+        DELETE FROM data_access_request WHERE reference_id = :referenceId
+    """)
   void deleteByReferenceId(@Bind("referenceId") String referenceId);
 
 
@@ -221,9 +239,11 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
   void deleteByReferenceIds(@BindList("referenceIds") List<String> referenceIds);
 
   @SqlUpdate(
-      "UPDATE data_access_request dar "
-          + "SET data=jsonb_set((regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb, '{status}', '\"Canceled\"') "
-          + "WHERE reference_id IN (<referenceIds>)")
+      """
+          UPDATE data_access_request dar
+          SET data=jsonb_set((regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb, '{status}', '\"Canceled\"')
+          WHERE reference_id IN (<referenceIds>)
+      """)
   void cancelByReferenceIds(@BindList("referenceIds") List<String> referenceIds);
 
   /**
@@ -231,7 +251,10 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
    *
    * @param collectionId Integer
    */
-  @SqlUpdate("DELETE FROM data_access_request WHERE collection_id = :collectionId")
+  @SqlUpdate(
+    """
+        DELETE FROM data_access_request WHERE collection_id = :collectionId
+    """)
   void deleteByCollectionId(@Bind("collectionId") Integer collectionId);
 
   /**
@@ -246,10 +269,12 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
    */
   @RegisterArgumentFactory(JsonArgumentFactory.class)
   @SqlUpdate(
-      "INSERT INTO data_access_request "
-          + "(reference_id, user_id, create_date, sort_date, update_date, data) "
-          + "VALUES (:referenceId, :userId, :createDate, :sortDate, "
-          + " :updateDate, to_jsonb(:data))")
+      """
+          INSERT INTO data_access_request
+          (reference_id, user_id, create_date, sort_date, update_date, data)
+          VALUES (:referenceId, :userId, :createDate, :sortDate,
+          :updateDate, to_jsonb(:data))
+      """)
   void insertDraftDataAccessRequest(
       @Bind("referenceId") String referenceId,
       @Bind("userId") Integer userId,
@@ -272,10 +297,12 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
    */
   @RegisterArgumentFactory(JsonArgumentFactory.class)
   @SqlUpdate(
-      "INSERT INTO data_access_request "
-          + "(collection_id, reference_id, user_id, create_date, sort_date, submission_date, update_date, data) "
-          + "VALUES (:collectionId, :referenceId, :userId, :createDate, :sortDate, " +
-          ":submissionDate, :updateDate, to_jsonb(:data))")
+      """
+          INSERT INTO data_access_request
+          (collection_id, reference_id, user_id, create_date, sort_date, submission_date, update_date, data)
+          VALUES (:collectionId, :referenceId, :userId, :createDate, :sortDate,
+          :submissionDate, :updateDate, to_jsonb(:data))
+      """)
   void insertDataAccessRequest(
       @Bind("collectionId") Integer collectionId,
       @Bind("referenceId") String referenceId,
@@ -288,24 +315,30 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
 
 
   @SqlUpdate(
-      "UPDATE data_access_request "
-          + "SET  submission_date = now(), collection_id = :collectionId "
-          + "WHERE reference_id = :referenceId")
+      """
+          UPDATE data_access_request
+          SET  submission_date = now(), collection_id = :collectionId
+          WHERE reference_id = :referenceId
+       """)
   void updateDraftToSubmittedForCollection(@Bind("collectionId") Integer collectionId,
       @Bind("referenceId") String referenceId);
 
   @RegisterRowMapper(DataAccessRequestDataMapper.class)
   @SqlQuery(
-      "SELECT (data #>> '{}')::jsonb AS data "
-          + "FROM data_access_request "
-          + "WHERE (LOWER(data->>'status') != 'archived' "
-          + "OR data->>'status' IS NULL)")
+      """
+          SELECT (data #>> '{}')::jsonb AS data
+          FROM data_access_request
+          WHERE (LOWER(data->>'status') != 'archived'
+          OR data->>'status' IS NULL)
+      """)
   List<DataAccessRequestData> findAllDataAccessRequestDatas();
 
   @SqlUpdate(
-      " UPDATE data_access_request"
-          + " SET data = jsonb_set ((data #>> '{}')::jsonb, '{status}', '\"Archived\"', true) "
-          + " WHERE reference_id IN (<referenceIds>)")
+      """
+         UPDATE data_access_request
+          SET data = jsonb_set ((data #>> '{}')::jsonb, '{status}', '\"Archived\"', true)
+          WHERE reference_id IN (<referenceIds>)
+      """)
   void archiveByReferenceIds(@BindList("referenceIds") List<String> referenceIds);
 
 
@@ -316,16 +349,20 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
    * @param datasetId   Integer
    */
   @SqlUpdate(
-      "INSERT INTO dar_dataset (reference_id, dataset_id) "
-          + "VALUES (:referenceId, :datasetId) "
-          + "ON CONFLICT DO NOTHING")
+      """
+          INSERT INTO dar_dataset (reference_id, dataset_id)
+          VALUES (:referenceId, :datasetId)
+          ON CONFLICT DO NOTHING
+      """)
   void insertDARDatasetRelation(@Bind("referenceId") String referenceId,
       @Bind("datasetId") Integer datasetId);
 
   @SqlBatch(
-      "INSERT INTO dar_dataset (reference_id, dataset_id) "
-          + "VALUES (:referenceId, :datasetId) "
-          + "ON CONFLICT DO NOTHING")
+      """
+          INSERT INTO dar_dataset (reference_id, dataset_id)
+          VALUES (:referenceId, :datasetId)
+          ON CONFLICT DO NOTHING
+      """)
   void insertAllDarDatasets(@BindBean List<DarDataset> darDatasets);
 
   /**
@@ -333,7 +370,10 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
    *
    * @param referenceId String
    */
-  @SqlUpdate("DELETE FROM dar_dataset WHERE reference_id = :referenceId")
+  @SqlUpdate(
+      """
+          DELETE FROM dar_dataset WHERE reference_id = :referenceId
+       """)
   void deleteDARDatasetRelationByReferenceId(@Bind("referenceId") String referenceId);
 
   /**

--- a/src/main/java/org/broadinstitute/consent/http/db/DataAccessRequestDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DataAccessRequestDAO.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.consent.http.db;
 
+import java.sql.Timestamp;
 import java.util.Date;
 import java.util.List;
 import org.broadinstitute.consent.http.db.mapper.DataAccessRequestDataMapper;
@@ -103,10 +104,10 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
                 dd.dataset_id
               FROM data_access_request dar
               LEFT JOIN dar_dataset dd ON dd.reference_id = dar.reference_id
-              WHERE dar.submission_date BETWEEN SYMMETRIC to_timestamp(:begin) AND to_timestamp(:end)
+              WHERE dar.submission_date BETWEEN SYMMETRIC :begin AND :end
           """)
-  List<DataAccessRequest> findSubmittedDarsByTimeRange(@Bind("begin") double begin,
-      @Bind("end") double end);
+  List<DataAccessRequest> findSubmittedDarsByTimeRange(@Bind("begin") Timestamp begin,
+      @Bind("end") Timestamp end);
 
   /**
    * Find all draft/partial DataAccessRequests, sorted descending order

--- a/src/main/java/org/broadinstitute/consent/http/db/DataAccessRequestDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DataAccessRequestDAO.java
@@ -93,7 +93,7 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
    *
    * @param begin Oldest submission date, in seconds since the epoch
    * @param end   Newest submission date, in seconds since the epoch
-   * @return List of approved DARs for the dataset
+   * @return List of submitted DARs within the date range provided.
    */
   @UseRowReducer(DataAccessRequestReducer.class)
   @SqlQuery(

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DataAccessRequestMapper.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DataAccessRequestMapper.java
@@ -23,7 +23,6 @@ public class DataAccessRequestMapper implements RowMapper<DataAccessRequest>, Ro
       }
     }
     dar.setParentId(resultSet.getString("parent_id"));
-    dar.setDraft(resultSet.getBoolean("draft"));
     dar.setUserId(resultSet.getInt("user_id"));
     dar.setCreateDate(resultSet.getTimestamp("create_date"));
     dar.setSortDate(resultSet.getTimestamp("sort_date"));

--- a/src/main/java/org/broadinstitute/consent/http/models/DarCollection.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DarCollection.java
@@ -19,10 +19,11 @@ public class DarCollection {
   public static final String DAR_FILTER_QUERY_COLUMNS =
       "dar.id AS dar_id, dar.reference_id AS dar_reference_id, dar.collection_id AS dar_collection_id, "
           +
-          "dar.parent_id AS dar_parent_id, dar.draft AS dar_draft, dar.user_id AS dar_userId, " +
+          "dar.parent_id AS dar_parent_id, dar.user_id AS dar_userId, " +
           "dar.create_date AS dar_create_date, dar.sort_date AS dar_sort_date, dar.submission_date AS dar_submission_date, "
           +
-          "dar.update_date AS dar_update_date, (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data, " +
+          "dar.update_date AS dar_update_date, (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data, "
+          +
           "(regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb ->> 'projectTitle' as projectTitle ";
 
   @JsonProperty
@@ -147,12 +148,12 @@ public class DarCollection {
     this.datasets.add(dataset);
   }
 
-  public void setDatasets(Set<Dataset> datasets) {
-    this.datasets = datasets;
-  }
-
   public Set<Dataset> getDatasets() {
     return datasets;
+  }
+
+  public void setDatasets(Set<Dataset> datasets) {
+    this.datasets = datasets;
   }
 
   @Override

--- a/src/main/java/org/broadinstitute/consent/http/models/DarCollectionSummary.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DarCollectionSummary.java
@@ -3,6 +3,7 @@ package org.broadinstitute.consent.http.models;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.gson.Gson;
 import java.sql.Timestamp;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -29,6 +30,12 @@ public class DarCollectionSummary {
 
   @JsonProperty
   private Timestamp submissionDate;
+
+  @JsonProperty
+  private boolean expired;
+
+  @JsonProperty
+  private Timestamp expiresAt;
 
   @JsonProperty
   private String researcherName;
@@ -134,6 +141,18 @@ public class DarCollectionSummary {
 
   public void setSubmissionDate(Timestamp submissionDate) {
     this.submissionDate = submissionDate;
+    if (submissionDate != null) {
+      this.expiresAt = Timestamp.from(Instant.ofEpochMilli(submissionDate.getTime() + DataAccessRequest.EXPIRATION_DURATION_MILLIS));
+      this.expired = this.expiresAt.before(Timestamp.from(Instant.now()));
+    }
+  }
+
+  public boolean isExpired() {
+    return expired;
+  }
+
+  public Timestamp getExpiresAt() {
+    return expiresAt;
   }
 
   public String getResearcherName() {

--- a/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequest.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequest.java
@@ -12,6 +12,7 @@ import com.google.gson.JsonSerializer;
 import com.google.gson.reflect.TypeToken;
 import java.lang.reflect.Type;
 import java.sql.Timestamp;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
@@ -23,6 +24,9 @@ import java.util.stream.Stream;
 
 @JsonInclude(Include.NON_NULL)
 public class DataAccessRequest {
+
+  public static final long EXPIRATION_DURATION_MILLIS = 365L * 24 * 60 * 60
+      * 1000; // 365 days/year 24 hours/day 60 minutes/hour 60 seconds/minute 1000 ms/second
 
   @JsonProperty
   public Integer id;
@@ -40,7 +44,13 @@ public class DataAccessRequest {
   public DataAccessRequestData data;
 
   @JsonProperty
-  public Boolean draft;
+  public Boolean draft = true;
+
+  @JsonProperty
+  public Boolean expired = false;
+
+  @JsonProperty
+  public long expiresAt = -1;
 
   @JsonProperty
   public Integer userId;
@@ -60,12 +70,10 @@ public class DataAccessRequest {
 
   @JsonProperty
   public Timestamp updateDate;
-
-  @JsonProperty
-  private Map<Integer, Election> elections;
-
   @JsonProperty
   public List<Integer> datasetIds;
+  @JsonProperty
+  private Map<Integer, Election> elections;
 
   public DataAccessRequest() {
     this.elections = new HashMap<>();
@@ -123,8 +131,12 @@ public class DataAccessRequest {
     return draft;
   }
 
-  public void setDraft(Boolean draft) {
-    this.draft = draft;
+  public boolean getExpired() {
+    return expired;
+  }
+
+  public long getExpiresAt() {
+    return expiresAt;
   }
 
   public Integer getUserId() {
@@ -157,6 +169,11 @@ public class DataAccessRequest {
 
   public void setSubmissionDate(Timestamp submissionDate) {
     this.submissionDate = submissionDate;
+    draft = submissionDate == null;
+    expired = submissionDate != null
+        && Instant.now().toEpochMilli() - submissionDate.getTime() > EXPIRATION_DURATION_MILLIS;
+    expiresAt = (submissionDate != null) ? submissionDate.getTime() + EXPIRATION_DURATION_MILLIS
+        : -1; // no expiration for drafts;
   }
 
   public Timestamp getUpdateDate() {
@@ -167,12 +184,12 @@ public class DataAccessRequest {
     this.updateDate = updateDate;
   }
 
-  public void setElections(Map<Integer, Election> elections) {
-    this.elections = elections;
-  }
-
   public Map<Integer, Election> getElections() {
     return elections;
+  }
+
+  public void setElections(Map<Integer, Election> elections) {
+    this.elections = elections;
   }
 
   public void addElection(Election election) {
@@ -195,6 +212,10 @@ public class DataAccessRequest {
     return datasetIds;
   }
 
+  public void setDatasetIds(List<Integer> datasetIds) {
+    this.datasetIds = datasetIds;
+  }
+
   public void addDatasetId(Integer id) {
     if (Objects.isNull(datasetIds)) {
       datasetIds = new ArrayList<>();
@@ -214,10 +235,6 @@ public class DataAccessRequest {
           .distinct()
           .collect(Collectors.toList());
     }
-  }
-
-  public void setDatasetIds(List<Integer> datasetIds) {
-    this.datasetIds = datasetIds;
   }
 
   /**
@@ -301,6 +318,12 @@ public class DataAccessRequest {
     }
     if (Objects.nonNull(dar.getDraft())) {
       copy.put("draft", dar.getDraft());
+    }
+    if (Objects.nonNull(dar.getExpired())) {
+      copy.put("expired", dar.getExpired());
+    }
+    if (Objects.nonNull(dar.getExpiresAt())) {
+      copy.put("expiredAt", dar.getExpiresAt());
     }
     if (Objects.nonNull(dar.getId())) {
       copy.put("id", dar.getId());

--- a/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequest.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequest.java
@@ -12,7 +12,6 @@ import com.google.gson.JsonSerializer;
 import com.google.gson.reflect.TypeToken;
 import java.lang.reflect.Type;
 import java.sql.Timestamp;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
@@ -50,7 +49,7 @@ public class DataAccessRequest {
   public Boolean expired = false;
 
   @JsonProperty
-  public long expiresAt = -1;
+  public Timestamp expiresAt;
 
   @JsonProperty
   public Integer userId;
@@ -135,7 +134,7 @@ public class DataAccessRequest {
     return expired;
   }
 
-  public long getExpiresAt() {
+  public Timestamp getExpiresAt() {
     return expiresAt;
   }
 
@@ -171,9 +170,10 @@ public class DataAccessRequest {
     this.submissionDate = submissionDate;
     draft = submissionDate == null;
     expired = submissionDate != null
-        && Instant.now().toEpochMilli() - submissionDate.getTime() > EXPIRATION_DURATION_MILLIS;
-    expiresAt = (submissionDate != null) ? submissionDate.getTime() + EXPIRATION_DURATION_MILLIS
-        : -1; // no expiration for drafts;
+        && submissionDate.before(
+        new Timestamp(System.currentTimeMillis() - EXPIRATION_DURATION_MILLIS));
+    expiresAt = (submissionDate != null) ? new Timestamp(
+        submissionDate.getTime() + EXPIRATION_DURATION_MILLIS) : null;
   }
 
   public Timestamp getUpdateDate() {
@@ -319,12 +319,8 @@ public class DataAccessRequest {
     if (Objects.nonNull(dar.getDraft())) {
       copy.put("draft", dar.getDraft());
     }
-    if (Objects.nonNull(dar.getExpired())) {
-      copy.put("expired", dar.getExpired());
-    }
-    if (Objects.nonNull(dar.getExpiresAt())) {
-      copy.put("expiredAt", dar.getExpiresAt());
-    }
+    copy.put("expired", dar.getExpired());
+    copy.put("expiredAt", dar.getExpiresAt());
     if (Objects.nonNull(dar.getId())) {
       copy.put("id", dar.getId());
     }

--- a/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequest.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequest.java
@@ -19,14 +19,14 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 @JsonInclude(Include.NON_NULL)
 public class DataAccessRequest {
 
-  public static final long EXPIRATION_DURATION_MILLIS = 365L * 24 * 60 * 60
-      * 1000; // 365 days/year 24 hours/day 60 minutes/hour 60 seconds/minute 1000 ms/second
+  public static final long EXPIRATION_DURATION_MILLIS = TimeUnit.DAYS.toMillis(365);
 
   @JsonProperty
   public Integer id;

--- a/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
@@ -387,8 +387,6 @@ public class DarCollectionService implements ConsentLogger {
   }
 
   public DarCollectionSummary updateCollectionToDraftStatus(DarCollection sourceCollection) {
-    this.dataAccessRequestDAO.updateDraftByCollectionId(sourceCollection.getDarCollectionId(),
-        true);
     sourceCollection.getDars().values().forEach((d) -> {
       Date now = new Date();
       DataAccessRequestData newData = new Gson().fromJson(d.getData().toString(),

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
@@ -117,7 +117,6 @@ public class DataAccessRequestService implements ConsentLogger {
         user.getUserId(),
         now,
         now,
-        null,
         now,
         dar.getData()
     );
@@ -210,7 +209,6 @@ public class DataAccessRequestService implements ConsentLogger {
         user.getUserId(),
         now,
         now,
-        null,
         now,
         newData
     );
@@ -269,7 +267,7 @@ public class DataAccessRequestService implements ConsentLogger {
     List<Integer> datasetIds = dataAccessRequest.getDatasetIds();
     if (Objects.nonNull(existingDar)) {
       referenceId = dataAccessRequest.getReferenceId();
-      dataAccessRequestDAO.updateDraftForCollection(collectionId,
+      dataAccessRequestDAO.updateDraftToSubmittedForCollection(collectionId,
           referenceId);
       dataAccessRequestDAO.updateDataByReferenceId(
           referenceId,

--- a/src/main/resources/assets/schemas/DarCollectionSummary.yaml
+++ b/src/main/resources/assets/schemas/DarCollectionSummary.yaml
@@ -15,9 +15,8 @@ properties:
     type: string
     description: Collection name
   submissionDate:
-    type: string
-    format: date
-    description: Collection submission date
+    type: number
+    description: Collection submission date as milliseconds from the epoch
   researcherName:
     type: string
     description: Collection creator's name
@@ -38,3 +37,9 @@ properties:
   datasetCount:
     type: integer
     description: The count of datasets for this collection
+  expiresAt:
+    type: number
+    description: Collection expiration date as milliseconds from the epoch
+  expired:
+    type: boolean
+    description: Indicator true when the collection is expired.

--- a/src/main/resources/assets/schemas/DataAccessRequest.yaml
+++ b/src/main/resources/assets/schemas/DataAccessRequest.yaml
@@ -22,6 +22,12 @@ properties:
   draft:
     type: boolean
     description: Draft status of this DAR
+  expired:
+    type: boolean
+    description: Expired status of this DAR
+  expiredAt:
+    type: number
+    description: When this DAR expires, in milliseconds since the epoch.  A value of -1 indicates this DAR does not have an expiration date because it is a draft.
   darCode:
     type: string
     description: Unique DAR Code

--- a/src/main/resources/assets/schemas/DataAccessRequest.yaml
+++ b/src/main/resources/assets/schemas/DataAccessRequest.yaml
@@ -27,7 +27,7 @@ properties:
     description: Expired status of this DAR
   expiredAt:
     type: number
-    description: When this DAR expires, in milliseconds since the epoch.  A value of -1 indicates this DAR does not have an expiration date because it is a draft.
+    description: When this DAR expires, in milliseconds since the epoch.  Present if the DAR is no longer a draft.
   darCode:
     type: string
     description: Unique DAR Code

--- a/src/main/resources/changelog-master.xml
+++ b/src/main/resources/changelog-master.xml
@@ -168,4 +168,6 @@
     relativeToChangelogFile="true"/>
   <include file="changesets/changelog-consent-2025-03-19-indexed.xml"
     relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-2025-04-21-dar-drop-draft-column.xml"
+    relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/src/main/resources/changesets/changelog-consent-2025-04-21-dar-drop-draft-column.xml
+++ b/src/main/resources/changesets/changelog-consent-2025-04-21-dar-drop-draft-column.xml
@@ -1,0 +1,9 @@
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+  <changeSet id="changelog-consent-2025-03-19-indexed.xml" author="otchet-broad">
+      <dropColumn tableName="data_access_request">
+        <column name="draft"/>
+      </dropColumn>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/changesets/changelog-consent-2025-04-21-dar-drop-draft-column.xml
+++ b/src/main/resources/changesets/changelog-consent-2025-04-21-dar-drop-draft-column.xml
@@ -5,5 +5,8 @@
       <dropColumn tableName="data_access_request">
         <column name="draft"/>
       </dropColumn>
+    <createIndex tableName="data_access_request" indexName="idx_submission_date">
+      <column name="submission_date"/>
+    </createIndex>
   </changeSet>
 </databaseChangeLog>

--- a/src/test/java/org/broadinstitute/consent/http/db/DarCollectionDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DarCollectionDAOTest.java
@@ -578,7 +578,6 @@ class DarCollectionDAOTest extends DAOTestHelper {
         now,
         now,
         now,
-        now,
         data
     );
     return dataAccessRequestDAO.findByReferenceId(referenceId);

--- a/src/test/java/org/broadinstitute/consent/http/db/DarCollectionSummaryDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DarCollectionSummaryDAOTest.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.consent.http.db;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -26,6 +27,7 @@ import org.broadinstitute.consent.http.models.Election;
 import org.broadinstitute.consent.http.models.Institution;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.Vote;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -249,9 +251,10 @@ class DarCollectionSummaryDAOTest extends DAOTestHelper {
     assertEquals(1, summaries.size());
     summaries.forEach((s) -> {
       assertEquals(1, s.getDatasetIds().size());
-      s.getDatasetIds().stream()
+      s.getDatasetIds()
           .forEach((id) -> assertTrue(targetDatasets.contains(id)));
-
+      assertFalse(s.isExpired());
+      assertTrue(s.getExpiresAt().after(new Date()));
       assertEquals(0, s.getElections().size());
       assertEquals(0, s.getVotes().size());
       assertEquals(1, s.getDatasetCount());

--- a/src/test/java/org/broadinstitute/consent/http/db/DarCollectionSummaryDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DarCollectionSummaryDAOTest.java
@@ -546,7 +546,8 @@ class DarCollectionSummaryDAOTest extends DAOTestHelper {
     DataAccessRequest dar = createDataAccessRequest(collectionId, userId);
 
     dataAccessRequestDAO.insertDARDatasetRelation(dar.getReferenceId(), dataset.getDatasetId());
-    dataAccessRequestDAO.updateDraftByReferenceId(dar.getReferenceId(), true); // draft DAR
+    dataAccessRequestDAO.updateDataByReferenceId(dar.getReferenceId(), dar.userId, new Date(), null,
+        new Date(), dar.getData()); // draft DAR
 
     List<DarCollectionSummary> summaries = darCollectionSummaryDAO.getDarCollectionSummariesForResearcher(
         userId);

--- a/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
@@ -8,11 +8,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.sql.Timestamp;
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.RandomUtils;
 import org.broadinstitute.consent.http.enumeration.ElectionStatus;
@@ -650,7 +652,7 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
     Dataset dataset1 = createDARDAOTestDataset();
     User user1 = createUserWithInstitution();
     var submissionDate = new Timestamp(
-        new Date().getTime() - 1000 * 60 * 60 * 24 * submissionDaysAgo);
+        new Date().getTime() - TimeUnit.DAYS.toMillis(submissionDaysAgo));
     DataAccessRequest testDar1 = createDAR(user1, dataset1, darCode1, submissionDate);
 
     Election e1 = createDataAccessElection(testDar1.getReferenceId(), dataset1.getDatasetId());
@@ -806,14 +808,11 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
   @Test
   void testFindDARsByDateRange() throws InterruptedException {
     DarCollection darCollection = createDarCollection();
-    darCollection.getDars().keySet().forEach((referenceId) -> {
+    darCollection.getDars().keySet().forEach((referenceId) ->
       dataAccessRequestDAO.updateDraftToSubmittedForCollection(darCollection.getDarCollectionId(),
-          referenceId);
-    });
-    Timestamp oneYearAgo = Timestamp.from(
-        Instant.ofEpochMilli(new Date().getTime() - DataAccessRequest.EXPIRATION_DURATION_MILLIS));
-    Timestamp oneMinuteInTheFuture = Timestamp.from(
-        Instant.ofEpochMilli(new Date().getTime() + (60 * 1000)));
+          referenceId));
+    Timestamp oneYearAgo = Timestamp.from(Instant.now().minus(365, ChronoUnit.DAYS));
+    Timestamp oneMinuteInTheFuture = Timestamp.from(Instant.now().plus(1, ChronoUnit.MINUTES));
     List<DataAccessRequest> dars = dataAccessRequestDAO.findSubmittedDarsByTimeRange(oneYearAgo,
         oneMinuteInTheFuture);
     assertFalse(dars.isEmpty());
@@ -827,13 +826,11 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
       dataAccessRequestDAO.updateDraftToSubmittedForCollection(darCollection.getDarCollectionId(),
           referenceId);
     });
-    Timestamp oneHourAgo = Timestamp.from(
-        Instant.ofEpochMilli(new Date().getTime() - (60 * 60 * 1000)));
-    Timestamp halfAnHourAgo = Timestamp.from(
-        Instant.ofEpochMilli(new Date().getTime() - (30 * 60 * 1000)));
+    Instant oneHourAgo = Instant.now().minus(1, ChronoUnit.HOURS);
+    Instant halfAnHourAgo = Instant.now().minus(30, ChronoUnit.MINUTES);
     // query far enough into the past so slight clock variations do not matter for this test
     List<DataAccessRequest> dars = dataAccessRequestDAO.findSubmittedDarsByTimeRange(
-        oneHourAgo, halfAnHourAgo);
+        Timestamp.from(oneHourAgo), Timestamp.from(halfAnHourAgo));
     assertTrue(dars.isEmpty());
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
@@ -13,6 +13,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Random;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.RandomUtils;
 import org.broadinstitute.consent.http.enumeration.ElectionStatus;
@@ -785,10 +786,9 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
       dataAccessRequestDAO.updateDraftToSubmittedForCollection(darCollection.getDarCollectionId(),
           referenceId);
     });
-    List<DataAccessRequest> dars = dataAccessRequestDAO.findSubmittedDarsByTimeRange(
-        (double) (new Date().getTime() - DataAccessRequest.EXPIRATION_DURATION_MILLIS) / 1000,
-        (double) new Date().getTime()
-            / 1000);
+    double oneYearAgo = new Date().getTime() - DataAccessRequest.EXPIRATION_DURATION_MILLIS;
+    double oneMinuteInTheFuture = new Date().getTime() + (60 * 1000);
+    List<DataAccessRequest> dars = dataAccessRequestDAO.findSubmittedDarsByTimeRange(oneYearAgo/1000, oneMinuteInTheFuture/1000);
     assertFalse(dars.isEmpty());
     assertEquals(darCollection.getDars().size(), dars.size());
   }

--- a/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
@@ -106,8 +106,9 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
     List<DataAccessRequest> draftDars1 = dataAccessRequestDAO.findAllDraftDataAccessRequests();
     assertFalse(draftDars1.isEmpty());
     assertEquals(1, draftDars1.size());
-
-    dataAccessRequestDAO.updateDraftByReferenceId(dar.referenceId, false);
+    DataAccessRequestData darData = draftDars1.get(0).getData();
+    dataAccessRequestDAO.updateDataByReferenceId(dar.referenceId, dar.userId, new Date(),
+        new Date(), new Date(), darData);
     List<DataAccessRequest> draftDars2 = dataAccessRequestDAO.findAllDraftDataAccessRequests();
     assertTrue(draftDars2.isEmpty());
   }
@@ -119,7 +120,8 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
     List<DataAccessRequest> draftDars1 = dataAccessRequestDAO.findAllDraftDataAccessRequests();
     assertTrue(draftDars1.isEmpty());
 
-    dataAccessRequestDAO.updateDraftByReferenceId(dar.referenceId, true);
+    dataAccessRequestDAO.updateDataByReferenceId(dar.getReferenceId(), dar.userId, new Date(), null,
+        new Date(), dar.getData());
     List<DataAccessRequest> draftDars2 = dataAccessRequestDAO.findAllDraftDataAccessRequests();
     assertFalse(draftDars2.isEmpty());
     assertEquals(1, draftDars2.size());
@@ -131,12 +133,20 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
     DarCollection darColl = createDarCollection();
     DataAccessRequest dar = new ArrayList<>(darColl.getDars().values()).get(0);
 
-    dataAccessRequestDAO.updateDraftByReferenceId(dar.referenceId, true);
+    dataAccessRequestDAO.updateDataByReferenceId(dar.referenceId, dar.userId, new Date(), null,
+        new Date(), dar.getData());
     dar = dataAccessRequestDAO.findByReferenceId(dar.getReferenceId());
+    assertNull(dar.getSubmissionDate());
     assertEquals(true, dar.getDraft());
-    dataAccessRequestDAO.updateDraftByReferenceId(dar.referenceId, false);
+    assertFalse(dar.getExpired());
+    assertEquals(-1, dar.getExpiresAt());
+    DataAccessRequestData darData = dar.getData();
+    dataAccessRequestDAO.updateDataByReferenceId(dar.referenceId, dar.userId, new Date(),
+        new Date(), new Date(), darData);
     dar = dataAccessRequestDAO.findByReferenceId(dar.getReferenceId());
-    assertEquals(false, dar.getDraft());
+    assertFalse(dar.getDraft());
+    assertEquals(dar.getSubmissionDate().getTime() + DataAccessRequest.EXPIRATION_DURATION_MILLIS,
+        dar.getExpiresAt());
   }
 
   @Test
@@ -146,9 +156,16 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
 
     dar = dataAccessRequestDAO.findByReferenceId(dar.getReferenceId());
     assertEquals(false, dar.getDraft());
-    dataAccessRequestDAO.updateDraftByReferenceId(dar.referenceId, true);
+    assertFalse(dar.getExpired());
+    assertEquals(dar.getSubmissionDate().getTime() + DataAccessRequest.EXPIRATION_DURATION_MILLIS,
+        dar.getExpiresAt(), dar.getExpiresAt());
+    dataAccessRequestDAO.updateDataByReferenceId(dar.referenceId, dar.userId, new Date(), null,
+        new Date(), dar.getData());
     dar = dataAccessRequestDAO.findByReferenceId(dar.getReferenceId());
     assertEquals(true, dar.getDraft());
+    assertNull(dar.getSubmissionDate());
+    assertFalse(dar.getExpired());
+    assertEquals(-1, dar.getExpiresAt());
   }
 
   @Test
@@ -250,7 +267,6 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
         now,
         now,
         now,
-        now,
         data
     );
     DataAccessRequest dar = dataAccessRequestDAO.findByReferenceId(referenceId);
@@ -315,12 +331,12 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
   }
 
   @Test
-  void testUpdateDraftForCollection() {
+  void testUpdateDraftToSubmittedForCollection() {
     DarCollection collection = createDarCollection();
     DataAccessRequest draft = createDraftDataAccessRequest();
     String referenceId = draft.getReferenceId();
     Integer collectionId = collection.getDarCollectionId();
-    dataAccessRequestDAO.updateDraftForCollection(collectionId, referenceId);
+    dataAccessRequestDAO.updateDraftToSubmittedForCollection(collectionId, referenceId);
     DataAccessRequest updatedDraft = dataAccessRequestDAO.findByReferenceId(referenceId);
     assertEquals(false, updatedDraft.getDraft());
     assertEquals(collectionId, updatedDraft.getCollectionId());
@@ -378,7 +394,6 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
     dataAccessRequestDAO.insertDraftDataAccessRequest(
         referenceId,
         user.getUserId(),
-        now,
         now,
         now,
         now,
@@ -544,7 +559,8 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
         now,
         false);
 
-    List<DataAccessRequest> approvedDars = dataAccessRequestDAO.findApprovedDARsByDatasetId(dataset2.getDatasetId());
+    List<DataAccessRequest> approvedDars = dataAccessRequestDAO.findApprovedDARsByDatasetId(
+        dataset2.getDatasetId());
     List<Integer> approvedDarIds = approvedDars.stream().map(DataAccessRequest::getId).toList();
     assertEquals(2, approvedDarIds.size());
     assertTrue(approvedDarIds.contains(testDar3.getId()));
@@ -698,6 +714,36 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
     assertEquals(1, returnedDAR.size());
   }
 
+  @Test
+  void testFindDARsByDateRange() throws InterruptedException {
+    DarCollection darCollection = createDarCollection();
+    darCollection.getDars().keySet().forEach((referenceId) -> {
+      dataAccessRequestDAO.updateDraftToSubmittedForCollection(darCollection.getDarCollectionId(),
+          referenceId);
+    });
+    List<DataAccessRequest> dars = dataAccessRequestDAO.findSubmittedDarsByTimeRange(
+        (double) (new Date().getTime() - DataAccessRequest.EXPIRATION_DURATION_MILLIS) / 1000,
+        (double) new Date().getTime()
+            / 1000);
+    assertFalse(dars.isEmpty());
+    assertEquals(darCollection.getDars().size(), dars.size());
+  }
+
+  @Test
+  void testFindDARsByDateRangeWithNoneInRange() throws InterruptedException {
+    DarCollection darCollection = createDarCollection();
+    darCollection.getDars().keySet().forEach((referenceId) -> {
+      dataAccessRequestDAO.updateDraftToSubmittedForCollection(darCollection.getDarCollectionId(),
+          referenceId);
+    });
+    //we need to sleep for one second to ensure the clock has ticked since the query resolution is in seconds since
+    //the epoch.
+    Thread.sleep(1000);
+    List<DataAccessRequest> dars = dataAccessRequestDAO.findSubmittedDarsByTimeRange(
+        (double) (new Date().getTime()) / 1000, (double) new Date().getTime() / 1000);
+    assertTrue(dars.isEmpty());
+  }
+
   /**
    * Replace parent implementation of `createDataset()`
    *
@@ -813,7 +859,6 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
     dataAccessRequestDAO.insertDraftDataAccessRequest(
         referenceId,
         user.getUserId(),
-        now,
         now,
         now,
         now,

--- a/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
@@ -7,18 +7,16 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.sql.Timestamp;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
-import java.util.Random;
 import java.util.UUID;
-import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.RandomUtils;
 import org.broadinstitute.consent.http.enumeration.ElectionStatus;
 import org.broadinstitute.consent.http.enumeration.ElectionType;
-import org.broadinstitute.consent.http.enumeration.OrganizationType;
 import org.broadinstitute.consent.http.enumeration.VoteType;
 import org.broadinstitute.consent.http.models.DarCollection;
 import org.broadinstitute.consent.http.models.DataAccessRequest;
@@ -365,7 +363,8 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
   }
 
   // local method to create a DAR
-  protected DataAccessRequest createDAR(User user, Dataset dataset, String darCode, Timestamp submissionDate) {
+  protected DataAccessRequest createDAR(User user, Dataset dataset, String darCode,
+      Timestamp submissionDate) {
     var now = new Timestamp(new Date().getTime());
     Integer collectionId = darCollectionDAO.insertDarCollection(darCode, user.getUserId(),
         now);
@@ -626,7 +625,8 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
     String darCode1 = "DAR-" + RandomUtils.nextInt(100, 1000000);
     Dataset dataset1 = createDARDAOTestDataset();
     User user1 = createUserWithInstitution();
-    var submissionDate = new Timestamp(new Date().getTime() - 1000 * 60 * 60 * 24 * submissionDaysAgo);
+    var submissionDate = new Timestamp(
+        new Date().getTime() - 1000 * 60 * 60 * 24 * submissionDaysAgo);
     DataAccessRequest testDar1 = createDAR(user1, dataset1, darCode1, submissionDate);
 
     Election e1 = createDataAccessElection(testDar1.getReferenceId(), dataset1.getDatasetId());
@@ -786,9 +786,12 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
       dataAccessRequestDAO.updateDraftToSubmittedForCollection(darCollection.getDarCollectionId(),
           referenceId);
     });
-    double oneYearAgo = new Date().getTime() - DataAccessRequest.EXPIRATION_DURATION_MILLIS;
-    double oneMinuteInTheFuture = new Date().getTime() + (60 * 1000);
-    List<DataAccessRequest> dars = dataAccessRequestDAO.findSubmittedDarsByTimeRange(oneYearAgo/1000, oneMinuteInTheFuture/1000);
+    Timestamp oneYearAgo = Timestamp.from(
+        Instant.ofEpochMilli(new Date().getTime() - DataAccessRequest.EXPIRATION_DURATION_MILLIS));
+    Timestamp oneMinuteInTheFuture = Timestamp.from(
+        Instant.ofEpochMilli(new Date().getTime() + (60 * 1000)));
+    List<DataAccessRequest> dars = dataAccessRequestDAO.findSubmittedDarsByTimeRange(oneYearAgo,
+        oneMinuteInTheFuture);
     assertFalse(dars.isEmpty());
     assertEquals(darCollection.getDars().size(), dars.size());
   }
@@ -800,8 +803,10 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
       dataAccessRequestDAO.updateDraftToSubmittedForCollection(darCollection.getDarCollectionId(),
           referenceId);
     });
-    double oneHourAgo = ((double) new Date().getTime() /1000 - (60*60));
-    double halfAnHourAgo = ((double) new Date().getTime() /1000 - (30*60));
+    Timestamp oneHourAgo = Timestamp.from(
+        Instant.ofEpochMilli(new Date().getTime() - (60 * 60 * 1000)));
+    Timestamp halfAnHourAgo = Timestamp.from(
+        Instant.ofEpochMilli(new Date().getTime() - (30 * 60 * 1000)));
     // query far enough into the past so slight clock variations do not matter for this test
     List<DataAccessRequest> dars = dataAccessRequestDAO.findSubmittedDarsByTimeRange(
         oneHourAgo, halfAnHourAgo);

--- a/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
@@ -800,11 +800,11 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
       dataAccessRequestDAO.updateDraftToSubmittedForCollection(darCollection.getDarCollectionId(),
           referenceId);
     });
-    //we need to sleep for one second to ensure the clock has ticked since the query resolution is in seconds since
-    //the epoch.
-    Thread.sleep(1000);
+    double oneHourAgo = ((double) new Date().getTime() /1000 - (60*60));
+    double halfAnHourAgo = ((double) new Date().getTime() /1000 - (30*60));
+    // query far enough into the past so slight clock variations do not matter for this test
     List<DataAccessRequest> dars = dataAccessRequestDAO.findSubmittedDarsByTimeRange(
-        (double) (new Date().getTime()) / 1000, (double) new Date().getTime() / 1000);
+        oneHourAgo, halfAnHourAgo);
     assertTrue(dars.isEmpty());
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
@@ -137,17 +137,44 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
     dataAccessRequestDAO.updateDataByReferenceId(dar.referenceId, dar.userId, new Date(), null,
         new Date(), dar.getData());
     dar = dataAccessRequestDAO.findByReferenceId(dar.getReferenceId());
-    assertNull(dar.getSubmissionDate());
-    assertEquals(true, dar.getDraft());
-    assertFalse(dar.getExpired());
-    assertEquals(-1, dar.getExpiresAt());
     DataAccessRequestData darData = dar.getData();
     dataAccessRequestDAO.updateDataByReferenceId(dar.referenceId, dar.userId, new Date(),
         new Date(), new Date(), darData);
     dar = dataAccessRequestDAO.findByReferenceId(dar.getReferenceId());
     assertFalse(dar.getDraft());
-    assertEquals(dar.getSubmissionDate().getTime() + DataAccessRequest.EXPIRATION_DURATION_MILLIS,
-        dar.getExpiresAt());
+    Timestamp expectedTimestamp = new Timestamp(
+        dar.getSubmissionDate().getTime() + DataAccessRequest.EXPIRATION_DURATION_MILLIS);
+    assertEquals(expectedTimestamp, dar.getExpiresAt());
+  }
+
+  @Test
+  void testDataAccessRequestSubmissionDateAbsent() {
+    DarCollection darColl = createDarCollection();
+    DataAccessRequest dar = new ArrayList<>(darColl.getDars().values()).get(0);
+
+    dataAccessRequestDAO.updateDataByReferenceId(dar.referenceId, dar.userId, new Date(), null,
+        new Date(), dar.getData());
+    dar = dataAccessRequestDAO.findByReferenceId(dar.getReferenceId());
+    assertNull(dar.getSubmissionDate());
+    assertEquals(true, dar.getDraft());
+    assertFalse(dar.getExpired());
+    assertNull(dar.getExpiresAt());
+  }
+
+  @Test
+  void testDataAccessRequestSubmissionDatePresent() {
+    DarCollection darColl = createDarCollection();
+    DataAccessRequest dar = new ArrayList<>(darColl.getDars().values()).get(0);
+
+    dataAccessRequestDAO.updateDataByReferenceId(dar.referenceId, dar.userId, new Date(),
+        new Date(),
+        new Date(), dar.getData());
+    dar = dataAccessRequestDAO.findByReferenceId(dar.getReferenceId());
+    assertEquals(false, dar.getDraft());
+    assertFalse(dar.getExpired());
+    Timestamp expectedTimestamp = new Timestamp(
+        dar.getSubmissionDate().getTime() + DataAccessRequest.EXPIRATION_DURATION_MILLIS);
+    assertEquals(expectedTimestamp, dar.getExpiresAt());
   }
 
   @Test
@@ -157,16 +184,13 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
 
     dar = dataAccessRequestDAO.findByReferenceId(dar.getReferenceId());
     assertEquals(false, dar.getDraft());
-    assertFalse(dar.getExpired());
-    assertEquals(dar.getSubmissionDate().getTime() + DataAccessRequest.EXPIRATION_DURATION_MILLIS,
-        dar.getExpiresAt(), dar.getExpiresAt());
     dataAccessRequestDAO.updateDataByReferenceId(dar.referenceId, dar.userId, new Date(), null,
         new Date(), dar.getData());
     dar = dataAccessRequestDAO.findByReferenceId(dar.getReferenceId());
     assertEquals(true, dar.getDraft());
     assertNull(dar.getSubmissionDate());
     assertFalse(dar.getExpired());
-    assertEquals(-1, dar.getExpiresAt());
+    assertNull(dar.getExpiresAt());
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
@@ -131,7 +131,8 @@ class DarCollectionServiceTest {
     dataset.setDatasetId(datasetIds.get(0));
 
     // mocking out findDatasetsByIdList to only return one of the datasets
-    when(datasetDAO.findDatasetsByIdList(List.of(dataset.getDatasetId()))).thenReturn(List.of(dataset));
+    when(datasetDAO.findDatasetsByIdList(List.of(dataset.getDatasetId()))).thenReturn(
+        List.of(dataset));
     when(dataAccessRequestDAO.findAllDARDatasetRelations(any())).thenReturn(datasetIds);
 
     collections = service.addDatasetsToCollections(collections, List.of(dataset.getDatasetId()));
@@ -584,7 +585,6 @@ class DarCollectionServiceTest {
     DataAccessRequestData data = new DataAccessRequestData();
     data.setProjectTitle(RandomStringUtils.randomAlphabetic(10));
     data.setCreateDate(draft.getCreateDate().getTime());
-    draft.setDraft(true);
     draft.setData(data);
     List<DarCollectionSummary> mockSummaries = new ArrayList<>();
     mockSummaries.add(summaryOne);

--- a/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
@@ -198,7 +198,7 @@ class DataAccessRequestServiceTest {
     DataAccessRequest draft = generateDataAccessRequest();
     doNothing()
         .when(dataAccessRequestDAO)
-        .insertDraftDataAccessRequest(any(), any(), any(), any(), any(), any(), any());
+        .insertDraftDataAccessRequest(any(), any(), any(), any(), any(), any());
     when(dataAccessRequestDAO.findByReferenceId(any())).thenReturn(draft);
     initService();
     DataAccessRequest dar = service.insertDraftDataAccessRequest(user, draft);
@@ -388,7 +388,6 @@ class DataAccessRequestServiceTest {
     sourceCollection.addDar(dar);
     when(electionDAO.getElectionIdsByReferenceIds(any())).thenReturn(List.of());
     doNothing().when(dataAccessRequestDAO).insertDraftDataAccessRequest(
-        any(),
         any(),
         any(),
         any(),

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DarCollectionServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DarCollectionServiceDAOTest.java
@@ -457,9 +457,10 @@ class DarCollectionServiceDAOTest extends DAOTestHelper {
     DataAccessRequestData data = new DataAccessRequestData();
     dar.setData(data);
     dataAccessRequestDAO.insertDraftDataAccessRequest(dar.getReferenceId(), user.getUserId(), now,
-        now, now, now, data);
-    dataAccessRequestDAO.updateDraftForCollection(collectionId, dar.getReferenceId());
-    dataAccessRequestDAO.updateDraftByReferenceId(dar.getReferenceId(), false);
+        now, now, data);
+    dataAccessRequestDAO.updateDraftToSubmittedForCollection(collectionId, dar.getReferenceId());
+    dataAccessRequestDAO.updateDataByReferenceId(dar.referenceId, dar.userId, new Date(),
+        new Date(), new Date(), data);
     dataAccessRequestDAO.insertDARDatasetRelation(dar.getReferenceId(), dataset.getDatasetId());
     return dataAccessRequestDAO.findByReferenceId(dar.getReferenceId());
   }


### PR DESCRIPTION
### Addresses
[https://broadworkbench.atlassian.net/browse/DT-1520](https://broadworkbench.atlassian.net/browse/DT-1520)
### Summary
Consent had two state machines for determining if a Data Access Request was in draft form or submitted for a Data Access Committee to consider for approval.  This PR aligns the code so that only one state machine exists.  It is now centered on submission_date.

When submission_date is non-null, the DAR has been submitted by a RESEARCHER to a DATA ACCESS COMMITTEE for consideration.  When the submission_date is null, it is considered a draft.  This was the behavior in the existing code paths except for some tests that leveraged methods to short circuit that requirement. 

The DataAccessRequest class now computes the fields `draft`, `expired`, and `expiredAt` fields when the submissionDate is set.  These three values are now returned to the UI for enrichment.

~~Of **critical importance** is the update to `DataAccessRequestDAO.findApprovedDARsByDatasetId` that now requires DARs to be submitted within the last year in order to be considered "approved."~~ <- This was already completed in [https://github.com/DataBiosphere/consent/pull/2487](https://github.com/DataBiosphere/consent/pull/2487)

Also added in `DataAccessRequestDAO` is `findSubmittedDarsByTimeRange`. This method is intended to be used by a to-be-built notification component that can alert users to expiring DARs.  It allows the caller to specify the date range of approved DARs so that notifications can be sent.  For example, give me the list of DARs that will expire 30 days from today.  Those DARs would have a submission_date during the time of 1745193600.000 to 1745279999.999 

To simplify our codebase, other test only methods that were impacting draft state were removed.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
