### PR TITLE
[DT-1485] Undeprecate `piEmail` field

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequestData.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequestData.java
@@ -23,7 +23,7 @@ public class DataAccessRequestData {
   public static final List<String> DEPRECATED_PROPS = Arrays
       .asList("referenceId", "investigator",
           "institution", "department", "address1", "address2", "city", "zipcode", "zipCode",
-          "state", "country", "researcher", "userId", "isThePi", "havePi", "piEmail",
+          "state", "country", "researcher", "userId", "isThePi", "havePi",
           "profileName", "pubmedId", "scientificUrl", "eraExpiration", "academicEmail",
           "eraAuthorized", "nihUsername", "linkedIn", "orcid", "researcherGate", "datasetDetail",
           "datasets", "datasetId", "validRestriction", "restriction", "translatedUseRestriction",


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-1485

### Summary

Undeprecates the `piEmail` field so it is returned from endpoints again.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
