### PR TITLE
[DT-1548] Validate user has eRA commons login set when submitting a DAR to a DAC.

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
@@ -519,7 +519,8 @@ public class ConsentModule extends AbstractModule {
 
   @Provides
   InstitutionService providesInstitutionService() {
-    return new InstitutionService(providesInstitutionDAO(), providesUserDAO(), providesGCSService());
+    return new InstitutionService(providesInstitutionDAO(), providesUserDAO(),
+        providesGCSService());
   }
 
   @Provides

--- a/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
@@ -247,7 +247,8 @@ public class ConsentModule extends AbstractModule {
         providesCounterService(),
         providesDAOContainer(),
         providesDacService(),
-        providesDataAccessRequestServiceDAO()
+        providesDataAccessRequestServiceDAO(),
+        providesUserService()
     );
   }
 

--- a/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
@@ -84,6 +84,19 @@ public class DataAccessRequestResource extends Resource {
     this.matchService = matchService;
   }
 
+  private static DataAccessRequestData populateDARData(String json) {
+    DataAccessRequestData data;
+    try {
+      data = DataAccessRequestData.fromString(json);
+    } catch (Exception e) {
+      throw new BadRequestException("Unable to parse DAR from JSON string");
+    }
+    if (Objects.isNull(data)) {
+      data = new DataAccessRequestData();
+    }
+    return data;
+  }
+
   @GET
   @Produces("application/json")
   @PermitAll
@@ -413,6 +426,10 @@ public class DataAccessRequestResource extends Resource {
       @FormDataParam("ethicsApprovalRequiredFile") FormDataContentDisposition ethicsFileDetails) {
     try {
       User user = userService.findUserByEmail(authUser.getEmail());
+      // added here because other dataAccessRequestServices calls are invoked that do not normally
+      // require this sequence.  hasValidActiveERACredentials will also check for a LC so no
+      // additional LC check needed.
+      userService.hasValidActiveERACredentials(user);
       DataAccessRequest parentDar = dataAccessRequestService.findByReferenceId(parentReferenceId);
       // needs to happen before docs are uploaded
       if (!user.getUserId().equals(parentDar.getUserId())) {
@@ -421,7 +438,8 @@ public class DataAccessRequestResource extends Resource {
       DataAccessRequest payload = populateProgressReportFromJsonString(dar, parentDar);
       populateProgressReportWithDocuments(collabInputStream, collabFileDetails, ethicsInputStream,
           ethicsFileDetails, payload, parentDar);
-      DataAccessRequest progressReport = dataAccessRequestService.createProgressReport(user, payload, parentDar);
+      DataAccessRequest progressReport = dataAccessRequestService.createProgressReport(user,
+          payload, parentDar);
       return Response.ok(progressReport.convertToSimplifiedDar()).build();
     } catch (Exception e) {
       return createExceptionResponse(e);
@@ -576,17 +594,19 @@ public class DataAccessRequestResource extends Resource {
 
   /**
    * Populate a new Data Access Request from the JSON string and the parent Data Access Request.
-   * Copies all the data from the parent dar, then overwrites the collaborators and datasets.
-   * Adds all progress report specific fields.
+   * Copies all the data from the parent dar, then overwrites the collaborators and datasets. Adds
+   * all progress report specific fields.
    *
    * @param json      The JSON string to populate the new Progress Report.
    * @param parentDar The parent Data Access Request to copy data from.
    * @return A new Progress Report populated with the provided JSON string and parent DAR data.
    */
-  public DataAccessRequest populateProgressReportFromJsonString(String json, DataAccessRequest parentDar) {
+  public DataAccessRequest populateProgressReportFromJsonString(String json,
+      DataAccessRequest parentDar) {
     DataAccessRequest newDar = new DataAccessRequest();
     DataAccessRequestData newData = populateDARData(json);
-    DataAccessRequestData originalDataCopy = DataAccessRequestData.fromString(parentDar.getData().toString());
+    DataAccessRequestData originalDataCopy = DataAccessRequestData.fromString(
+        parentDar.getData().toString());
 
     String referenceId = UUID.randomUUID().toString();
     newDar.setReferenceId(referenceId);
@@ -616,19 +636,6 @@ public class DataAccessRequestResource extends Resource {
     return newDar;
   }
 
-  private static DataAccessRequestData populateDARData(String json) {
-    DataAccessRequestData data;
-    try {
-      data = DataAccessRequestData.fromString(json);
-    } catch (Exception e) {
-      throw new BadRequestException("Unable to parse DAR from JSON string");
-    }
-    if (Objects.isNull(data)) {
-      data = new DataAccessRequestData();
-    }
-    return data;
-  }
-
   private void checkAuthorizedUpdateUser(User user, DataAccessRequest dar) {
     if (!user.getUserId().equals(dar.getUserId())) {
       throw new ForbiddenException("User not authorized to update this Data Access Request");
@@ -656,13 +663,14 @@ public class DataAccessRequestResource extends Resource {
   /**
    * Uploads the document contents to GCS and mutates the dar data object with the blobId.
    *
-   * @param type            The type of document (IRB or Collaboration)
-   * @param dar             The Data Access Request
+   * @param type              The type of document (IRB or Collaboration)
+   * @param dar               The Data Access Request
    * @param uploadInputStream The input stream of the file to be uploaded
-   * @param fileDetail      The file details
+   * @param fileDetail        The file details
    * @throws IOException if an error occurs during upload
    */
-  public void uploadDocumentContents(DarDocumentType type, DataAccessRequest dar, InputStream uploadInputStream,
+  public void uploadDocumentContents(DarDocumentType type, DataAccessRequest dar,
+      InputStream uploadInputStream,
       FormDataContentDisposition fileDetail) throws IOException {
     // This should be moved to service tier logic and the transactions should be coordinated
     validateFileDetails(fileDetail);

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
@@ -44,13 +44,14 @@ public class DataAccessRequestService implements ConsentLogger {
   private final MatchDAO matchDAO;
   private final VoteDAO voteDAO;
   private final UserDAO userDAO;
+  private final UserService userService;
   private final DataAccessRequestServiceDAO dataAccessRequestServiceDAO;
 
   private final DacService dacService;
 
   @Inject
   public DataAccessRequestService(CounterService counterService, DAOContainer container,
-      DacService dacService, DataAccessRequestServiceDAO dataAccessRequestServiceDAO) {
+      DacService dacService, DataAccessRequestServiceDAO dataAccessRequestServiceDAO, UserService userService) {
     this.counterService = counterService;
     this.dataAccessRequestDAO = container.getDataAccessRequestDAO();
     this.darCollectionDAO = container.getDarCollectionDAO();
@@ -60,6 +61,7 @@ public class DataAccessRequestService implements ConsentLogger {
     this.userDAO = container.getUserDAO();
     this.dacService = dacService;
     this.dataAccessRequestServiceDAO = dataAccessRequestServiceDAO;
+    this.userService = userService;
   }
 
   public List<DataAccessRequest> findAllDraftDataAccessRequests() {
@@ -171,6 +173,8 @@ public class DataAccessRequestService implements ConsentLogger {
     if (user.getLibraryCards().isEmpty()) {
       throw new NIHComplianceRuleException();
     }
+
+  userService.hasValidActiveERACredentials(user);
 
     validateInternalCollaborators(dataAccessRequest, user);
 

--- a/src/main/java/org/broadinstitute/consent/http/service/UserService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/UserService.java
@@ -10,6 +10,7 @@ import com.google.gson.JsonObject;
 import com.google.inject.Inject;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.NotFoundException;
+import java.time.Instant;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -32,6 +33,7 @@ import org.broadinstitute.consent.http.db.VoteDAO;
 import org.broadinstitute.consent.http.enumeration.UserFields;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.exceptions.ConsentConflictException;
+import org.broadinstitute.consent.http.exceptions.LibraryCardRequiredException;
 import org.broadinstitute.consent.http.models.AuthUser;
 import org.broadinstitute.consent.http.models.DataAccessAgreement;
 import org.broadinstitute.consent.http.models.Institution;
@@ -467,32 +469,36 @@ public class UserService implements ConsentLogger {
     return jsonElementList.stream().distinct().map(e -> findUserById(e.getAsInt())).toList();
   }
 
-  public void hasValidActiveERACredentials(Integer userId) {
-    List<LibraryCard> cards = libraryCardDAO.findLibraryCardsByUserId(userId);
-    List<UserProperty> userProperties = findAllUserProperties(userId);
-    boolean hasEraCommonsId = cards.stream().anyMatch(c -> c.getEraCommonsId() != null);
-    if (!hasEraCommonsId) {
-      throw new BadRequestException("User does not have an Era Commons ID");
-    }
-    List<UserProperty> eraStatusProps = userProperties.stream().filter(
-            userProperty -> userProperty.getPropertyKey().equalsIgnoreCase(ERA_STATUS.getValue()))
-        .toList();
-    List<UserProperty> eraExpirationProps = userProperties.stream().filter(
-            userProperty -> userProperty.getPropertyKey()
-                .equalsIgnoreCase(ERA_EXPIRATION_DATE.getValue()))
-        .toList();
-    if (eraStatusProps.size() == 1 && eraExpirationProps.size() == 1) {
-      if (!eraStatusProps.get(0).getPropertyValue().equalsIgnoreCase("true")) {
-        throw new BadRequestException("User does not have an Era Commons ID that is authorized.");
+    public void hasValidActiveERACredentials(User user) {
+      List<LibraryCard> cards = user.getLibraryCards();
+      List<UserProperty> userProperties = findAllUserProperties(user.getUserId());
+      if (cards.isEmpty()) {
+        throw new LibraryCardRequiredException();
       }
-      if (Long.parseLong(eraExpirationProps.get(0).getPropertyValue()) < System.currentTimeMillis()) {
-        throw new BadRequestException("User has an expired Era Commons ID.");
+      boolean hasEraCommonsId = cards.stream().anyMatch(c -> c.getEraCommonsId() != null);
+      if (!hasEraCommonsId) {
+        throw new BadRequestException("User does not have an Era Commons ID");
       }
-    } else {
-      throw new BadRequestException(
-          "Invalid ERA configuration for this user.  Only one ERA Commons ID is allowed.");
+      List<UserProperty> eraStatusProps = userProperties.stream().filter(
+              userProperty -> userProperty.getPropertyKey().equalsIgnoreCase(ERA_STATUS.getValue()))
+          .toList();
+      List<UserProperty> eraExpirationProps = userProperties.stream().filter(
+              userProperty -> userProperty.getPropertyKey()
+                  .equalsIgnoreCase(ERA_EXPIRATION_DATE.getValue()))
+          .toList();
+      if (eraStatusProps.size() == 1 && eraExpirationProps.size() == 1) {
+        if (!eraStatusProps.get(0).getPropertyValue().equalsIgnoreCase("true")) {
+          throw new BadRequestException("User does not have an Era Commons ID that is authorized.");
+        }
+        if (Instant.ofEpochMilli(Long.parseLong(eraExpirationProps.get(0).getPropertyValue()))
+            .isBefore(Instant.now())) {
+          throw new BadRequestException("User has an expired Era Commons ID.");
+        }
+      } else {
+        throw new BadRequestException(
+            "Invalid ERA configuration for this user.  Only one ERA Commons ID is allowed.");
+      }
     }
-  }
 
   public static class SimplifiedUser {
 

--- a/src/main/java/org/broadinstitute/consent/http/service/UserService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/UserService.java
@@ -469,36 +469,36 @@ public class UserService implements ConsentLogger {
     return jsonElementList.stream().distinct().map(e -> findUserById(e.getAsInt())).toList();
   }
 
-    public void hasValidActiveERACredentials(User user) {
-      List<LibraryCard> cards = user.getLibraryCards();
-      List<UserProperty> userProperties = findAllUserProperties(user.getUserId());
-      if (cards.isEmpty()) {
-        throw new LibraryCardRequiredException();
-      }
-      boolean hasEraCommonsId = cards.stream().anyMatch(c -> c.getEraCommonsId() != null);
-      if (!hasEraCommonsId) {
-        throw new BadRequestException("User does not have an Era Commons ID");
-      }
-      List<UserProperty> eraStatusProps = userProperties.stream().filter(
-              userProperty -> userProperty.getPropertyKey().equalsIgnoreCase(ERA_STATUS.getValue()))
-          .toList();
-      List<UserProperty> eraExpirationProps = userProperties.stream().filter(
-              userProperty -> userProperty.getPropertyKey()
-                  .equalsIgnoreCase(ERA_EXPIRATION_DATE.getValue()))
-          .toList();
-      if (eraStatusProps.size() == 1 && eraExpirationProps.size() == 1) {
-        if (!eraStatusProps.get(0).getPropertyValue().equalsIgnoreCase("true")) {
-          throw new BadRequestException("User does not have an Era Commons ID that is authorized.");
-        }
-        if (Instant.ofEpochMilli(Long.parseLong(eraExpirationProps.get(0).getPropertyValue()))
-            .isBefore(Instant.now())) {
-          throw new BadRequestException("User has an expired Era Commons ID.");
-        }
-      } else {
-        throw new BadRequestException(
-            "Invalid ERA configuration for this user.  Only one ERA Commons ID is allowed.");
-      }
+  public void hasValidActiveERACredentials(User user) {
+    List<LibraryCard> cards = user.getLibraryCards();
+    List<UserProperty> userProperties = findAllUserProperties(user.getUserId());
+    if (cards.isEmpty()) {
+      throw new LibraryCardRequiredException();
     }
+    boolean hasEraCommonsId = cards.stream().anyMatch(c -> c.getEraCommonsId() != null);
+    if (!hasEraCommonsId) {
+      throw new BadRequestException("User does not have an Era Commons ID");
+    }
+    List<UserProperty> eraStatusProps = userProperties.stream().filter(
+            userProperty -> userProperty.getPropertyKey().equalsIgnoreCase(ERA_STATUS.getValue()))
+        .toList();
+    List<UserProperty> eraExpirationProps = userProperties.stream().filter(
+            userProperty -> userProperty.getPropertyKey()
+                .equalsIgnoreCase(ERA_EXPIRATION_DATE.getValue()))
+        .toList();
+    if (eraStatusProps.size() == 1 && eraExpirationProps.size() == 1) {
+      if (!eraStatusProps.get(0).getPropertyValue().equalsIgnoreCase("true")) {
+        throw new BadRequestException("User does not have an Era Commons ID that is authorized.");
+      }
+      if (Instant.ofEpochMilli(Long.parseLong(eraExpirationProps.get(0).getPropertyValue()))
+          .isBefore(Instant.now())) {
+        throw new BadRequestException("User has an expired Era Commons ID.");
+      }
+    } else {
+      throw new BadRequestException(
+          "Invalid ERA configuration for this user.  Only one ERA Commons ID is allowed.");
+    }
+  }
 
   public static class SimplifiedUser {
 

--- a/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -168,6 +169,21 @@ class DataAccessRequestResourceTest {
     assertEquals(HttpStatusCodes.STATUS_CODE_UNPROCESSABLE_ENTITY, response.getStatus());
     org.broadinstitute.consent.http.models.Error error = (org.broadinstitute.consent.http.models.Error) response.getEntity();
     assertEquals(SubmittedDARCannotBeEditedException.MESSAGE, error.message());
+  }
+
+  @Test
+  void testCreateDataAccessRequestWithoutValidERACommons() {
+    User userWithCards = new User(1, authUser.getEmail(), "Display Name", new Date(), roles);
+    userWithCards.setLibraryCards(List.of(new LibraryCard()));
+    when(userService.findUserByEmail(any())).thenReturn(userWithCards);
+    doThrow(new BadRequestException()).when(dataAccessRequestService).createDataAccessRequest(eq(user), any());
+    resource =
+        new DataAccessRequestResource(daaService,
+            dataAccessRequestService, emailService, gcsService, userService, datasetService,
+            matchService);
+
+    Response response = resource.createDataAccessRequest(authUser, info, "");
+    assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceTest.java
@@ -424,7 +424,8 @@ class DataAccessRequestResourceTest {
     DataAccessRequest parentDar = generateDataAccessRequest();
     when(dataAccessRequestService.findByReferenceId(any())).thenReturn(parentDar);
     DataAccessRequest childDar = generateDataAccessRequest();
-    when(dataAccessRequestService.createProgressReport(eq(user), any(), eq(parentDar))).thenReturn(childDar);
+    when(dataAccessRequestService.createProgressReport(eq(user), any(), eq(parentDar))).thenReturn(
+        childDar);
     Pair<InputStream, FormDataContentDisposition> collabFile = mockFormDataMultiPart("collab.txt");
     Pair<InputStream, FormDataContentDisposition> ethicsFile = mockFormDataMultiPart("ethics.txt");
 
@@ -479,6 +480,17 @@ class DataAccessRequestResourceTest {
   }
 
   @Test
+  void testPostProgressReportThrowsWhenNoERACommonsID() {
+    when(userService.findUserByEmail(user.getEmail())).thenReturn(user);
+    doThrow(BadRequestException.class).when(userService).hasValidActiveERACredentials(user);
+    initResource();
+
+    Response response = resource.postProgressReport(authUser, "", "",
+        null, null, null, null);
+    assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
+  }
+
+  @Test
   void populateProgressReportWithDocuments() throws Exception {
     DataAccessRequest parentDar = generateDataAccessRequest();
     parentDar.getData().setCollaborationLetterLocation("existing_collab_location");
@@ -501,12 +513,14 @@ class DataAccessRequestResourceTest {
     when(datasetService.findDatasetById(2)).thenReturn(dataset2);
 
     String fileType = "text/plain";
-    InputStream collabInputStream = IOUtils.toInputStream("collab content", Charset.defaultCharset());
+    InputStream collabInputStream = IOUtils.toInputStream("collab content",
+        Charset.defaultCharset());
     FormDataContentDisposition collabFileDetails = mock(FormDataContentDisposition.class);
     when(collabFileDetails.getFileName()).thenReturn("collab_document.txt");
     when(collabFileDetails.getType()).thenReturn(fileType);
 
-    InputStream ethicsInputStream = IOUtils.toInputStream("ethics content", Charset.defaultCharset());
+    InputStream ethicsInputStream = IOUtils.toInputStream("ethics content",
+        Charset.defaultCharset());
     FormDataContentDisposition ethicsFileDetails = mock(FormDataContentDisposition.class);
     when(ethicsFileDetails.getFileName()).thenReturn("ethics_document.txt");
     when(ethicsFileDetails.getType()).thenReturn(fileType);
@@ -516,7 +530,8 @@ class DataAccessRequestResourceTest {
     when(gcsService.storeDocument(eq(ethicsInputStream), eq(fileType), any())).thenReturn(blobId);
     initResource();
     resource.populateProgressReportWithDocuments(
-        collabInputStream, collabFileDetails, ethicsInputStream, ethicsFileDetails, childDar, parentDar);
+        collabInputStream, collabFileDetails, ethicsInputStream, ethicsFileDetails, childDar,
+        parentDar);
     verify(gcsService, times(2)).storeDocument(any(), any(), any());
 
   }
@@ -628,7 +643,8 @@ class DataAccessRequestResourceTest {
 
     String newLocation = "new_location";
     BlobId mockBlobId = BlobId.of("bucket", newLocation);
-    when(gcsService.storeDocument(eq(uploadInputStream), eq(fileType), any())).thenReturn(mockBlobId);
+    when(gcsService.storeDocument(eq(uploadInputStream), eq(fileType), any())).thenReturn(
+        mockBlobId);
     when(gcsService.deleteDocument(existingLocation)).thenReturn(true);
 
     initResource();
@@ -664,19 +680,19 @@ class DataAccessRequestResourceTest {
     parentDar.setData(parentData);
 
     String json = """
-        {
-            "projectTitle": "New Project Title",
-            "internalCollaborators": [],
-            "externalCollaborators": [],
-            "labCollaborators": [],
-            "progressReportSummary": "New Summary",
-            "datasetIds": [1, 2],
-            "collaborationLetterName": "new_collaboration_letter.txt",
-            "irbDocumentName": "new_irb_document.txt",
-            "collaborationLetterLocation": "new_collaboration_letter_location",
-            "irbDocumentLocation": "new_irb_document_location"
-        }
-    """;
+            {
+                "projectTitle": "New Project Title",
+                "internalCollaborators": [],
+                "externalCollaborators": [],
+                "labCollaborators": [],
+                "progressReportSummary": "New Summary",
+                "datasetIds": [1, 2],
+                "collaborationLetterName": "new_collaboration_letter.txt",
+                "irbDocumentName": "new_irb_document.txt",
+                "collaborationLetterLocation": "new_collaboration_letter_location",
+                "irbDocumentLocation": "new_irb_document_location"
+            }
+        """;
 
     initResource();
     DataAccessRequest newDar = resource.populateProgressReportFromJsonString(json, parentDar);
@@ -694,7 +710,8 @@ class DataAccessRequestResourceTest {
     assertNull(newDar.getData().getIrbDocumentName());
     assertNull(newDar.getData().getCollaborationLetterLocation());
     assertNull(newDar.getData().getIrbDocumentLocation());
-    assertEquals(List.of(collaborator), parentDar.getData().getInternalCollaborators()); // Ensure parent is unchanged
+    assertEquals(List.of(collaborator),
+        parentDar.getData().getInternalCollaborators()); // Ensure parent is unchanged
     assertEquals("collaboration_letter.txt", parentDar.getData().getCollaborationLetterName());
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceTest.java
@@ -176,7 +176,8 @@ class DataAccessRequestResourceTest {
     User userWithCards = new User(1, authUser.getEmail(), "Display Name", new Date(), roles);
     userWithCards.setLibraryCards(List.of(new LibraryCard()));
     when(userService.findUserByEmail(any())).thenReturn(userWithCards);
-    doThrow(new BadRequestException()).when(dataAccessRequestService).createDataAccessRequest(eq(user), any());
+    doThrow(new BadRequestException()).when(dataAccessRequestService)
+        .createDataAccessRequest(eq(user), any());
     resource =
         new DataAccessRequestResource(daaService,
             dataAccessRequestService, emailService, gcsService, userService, datasetService,

--- a/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
@@ -175,11 +175,6 @@ class DataAccessRequestServiceTest {
   @Test
   void testCreateDataAccessRequestCreateWithoutERACommons() {
     DataAccessRequest dar = generateDataAccessRequest();
-    dar.addDatasetIds(List.of(1, 2, 3));
-    dar.setCreateDate(new Timestamp(1000));
-    dar.setSortDate(new Timestamp(1000));
-    dar.setReferenceId("id");
-    dar.setSubmissionDate(Timestamp.from(Instant.now()));
     User user = new User(1, "email@test.org", "Display Name", new Date());
     user.setLibraryCards(List.of(new LibraryCard()));
     doThrow(BadRequestException.class).when(userService).hasValidActiveERACredentials(user);

--- a/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
@@ -11,6 +11,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 
 import jakarta.ws.rs.BadRequestException;
@@ -84,7 +85,7 @@ class DataAccessRequestServiceTest {
   @Mock
   private DataAccessRequestServiceDAO dataAccessRequestServiceDAO;
   @Mock
-  private UseRestrictionConverter useRestrictionConverter;
+  private UserService userService;
   private DataAccessRequestService service;
 
   private static Collaborator createCollaborator() {
@@ -114,7 +115,7 @@ class DataAccessRequestServiceTest {
     container.setVoteDAO(voteDAO);
     container.setMatchDAO(matchDAO);
     service = new DataAccessRequestService(counterService, container, dacService,
-        dataAccessRequestServiceDAO);
+        dataAccessRequestServiceDAO, userService);
   }
 
   @Test
@@ -141,7 +142,6 @@ class DataAccessRequestServiceTest {
     dar.setReferenceId("id");
     User user = new User(1, "email@test.org", "Display Name", new Date());
     user.setLibraryCards(List.of(new LibraryCard()));
-    user.setLibraryCards(List.of(new LibraryCard()));
     when(counterService.getNextDarSequence()).thenReturn(1);
     when(dataAccessRequestDAO.findByReferenceId("id")).thenReturn(null);
     when(dataAccessRequestDAO.findByReferenceId(argThat(new LongerThanTwo()))).thenReturn(dar);
@@ -165,13 +165,30 @@ class DataAccessRequestServiceTest {
     dar.setSubmissionDate(Timestamp.from(Instant.now()));
     User user = new User(1, "email@test.org", "Display Name", new Date());
     user.setLibraryCards(List.of(new LibraryCard()));
-    user.setLibraryCards(List.of(new LibraryCard()));
     when(dataAccessRequestDAO.findByReferenceId(any())).thenReturn(dar);
     initService();
     assertThrows(SubmittedDARCannotBeEditedException.class, () -> {
       service.createDataAccessRequest(user, dar);
     });
   }
+
+  @Test
+  void testCreateDataAccessRequestCreateWithoutERACommons() {
+    DataAccessRequest dar = generateDataAccessRequest();
+    dar.addDatasetIds(List.of(1, 2, 3));
+    dar.setCreateDate(new Timestamp(1000));
+    dar.setSortDate(new Timestamp(1000));
+    dar.setReferenceId("id");
+    dar.setSubmissionDate(Timestamp.from(Instant.now()));
+    User user = new User(1, "email@test.org", "Display Name", new Date());
+    user.setLibraryCards(List.of(new LibraryCard()));
+    doThrow(BadRequestException.class).when(userService).hasValidActiveERACredentials(user);
+    initService();
+    assertThrows(BadRequestException.class, () -> {
+      service.createDataAccessRequest(user, dar);
+    });
+  }
+
 
   @Test
   void testUpdateByReferenceIdThrowsOnDraft() throws Exception {
@@ -194,7 +211,6 @@ class DataAccessRequestServiceTest {
     dar.setSortDate(new Timestamp(1000));
     dar.setReferenceId("id");
     User user = new User(1, "email@test.org", "Display Name", new Date());
-    user.setLibraryCards(List.of(new LibraryCard()));
     user.setLibraryCards(List.of());
     initService();
     assertThrows(NIHComplianceRuleException.class, () -> {

--- a/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
@@ -318,123 +318,123 @@ class UserServiceTest {
     });
   }
 
-    @Test
-    void testHasValidERACommonsCredentials() {
-      User u = generateUser();
-      LibraryCard lc = generateLibraryCard(u.getEmail());
-      lc.setEraCommonsId(u.getEmail());
-      u.addLibraryCard(lc);
-      UserProperty eraStatus = new UserProperty(1, u.getUserId(), ERA_STATUS.getValue(), "true");
-      //standard practice is that these expire in 30 days.
-      Timestamp eraExpirationTime = new Timestamp(
-          System.currentTimeMillis() + TimeUnit.DAYS.toMillis(30));
-      UserProperty eraExpirationDate = new UserProperty(2, u.getUserId(),
-          ERA_EXPIRATION_DATE.getValue(), Long.toString(eraExpirationTime.getTime()));
-      List<UserProperty> userProperties = new ArrayList<>();
-      userProperties.add(eraStatus);
-      userProperties.add(eraExpirationDate);
-      u.setProperties(userProperties);
-      when(userPropertyDAO.findUserPropertiesByUserIdAndPropertyKeys(u.getUserId(),
-          UserFields.getValues())).thenReturn(u.getProperties());
-      assertDoesNotThrow(() -> service.hasValidActiveERACredentials(u));
-    }
+  @Test
+  void testHasValidERACommonsCredentials() {
+    User u = generateUser();
+    LibraryCard lc = generateLibraryCard(u.getEmail());
+    lc.setEraCommonsId(u.getEmail());
+    u.addLibraryCard(lc);
+    UserProperty eraStatus = new UserProperty(1, u.getUserId(), ERA_STATUS.getValue(), "true");
+    //standard practice is that these expire in 30 days.
+    Timestamp eraExpirationTime = new Timestamp(
+        System.currentTimeMillis() + TimeUnit.DAYS.toMillis(30));
+    UserProperty eraExpirationDate = new UserProperty(2, u.getUserId(),
+        ERA_EXPIRATION_DATE.getValue(), Long.toString(eraExpirationTime.getTime()));
+    List<UserProperty> userProperties = new ArrayList<>();
+    userProperties.add(eraStatus);
+    userProperties.add(eraExpirationDate);
+    u.setProperties(userProperties);
+    when(userPropertyDAO.findUserPropertiesByUserIdAndPropertyKeys(u.getUserId(),
+        UserFields.getValues())).thenReturn(u.getProperties());
+    assertDoesNotThrow(() -> service.hasValidActiveERACredentials(u));
+  }
 
-    @Test
-    void testValidateERACommonsCredentialsMissingLibraryCards() {
-      User u = generateUser();
-      UserProperty eraStatus = new UserProperty(1, u.getUserId(), ERA_STATUS.getValue(), "true");
-      //standard practice is that these expire in 30 days.
-      Timestamp eraExpirationTime = new Timestamp(
-          System.currentTimeMillis() + TimeUnit.DAYS.toMillis(30));
-      UserProperty eraExpirationDate = new UserProperty(2, u.getUserId(),
-          ERA_EXPIRATION_DATE.getValue(), Long.toString(eraExpirationTime.getTime()));
-      List<UserProperty> userProperties = new ArrayList<>();
-      userProperties.add(eraStatus);
-      userProperties.add(eraExpirationDate);
-      u.setProperties(userProperties);
-      when(userPropertyDAO.findUserPropertiesByUserIdAndPropertyKeys(u.getUserId(),
-          UserFields.getValues())).thenReturn(u.getProperties());
-      assertThrows(LibraryCardRequiredException.class,
-          () -> service.hasValidActiveERACredentials(u));
-    }
+  @Test
+  void testValidateERACommonsCredentialsMissingLibraryCards() {
+    User u = generateUser();
+    UserProperty eraStatus = new UserProperty(1, u.getUserId(), ERA_STATUS.getValue(), "true");
+    //standard practice is that these expire in 30 days.
+    Timestamp eraExpirationTime = new Timestamp(
+        System.currentTimeMillis() + TimeUnit.DAYS.toMillis(30));
+    UserProperty eraExpirationDate = new UserProperty(2, u.getUserId(),
+        ERA_EXPIRATION_DATE.getValue(), Long.toString(eraExpirationTime.getTime()));
+    List<UserProperty> userProperties = new ArrayList<>();
+    userProperties.add(eraStatus);
+    userProperties.add(eraExpirationDate);
+    u.setProperties(userProperties);
+    when(userPropertyDAO.findUserPropertiesByUserIdAndPropertyKeys(u.getUserId(),
+        UserFields.getValues())).thenReturn(u.getProperties());
+    assertThrows(LibraryCardRequiredException.class,
+        () -> service.hasValidActiveERACredentials(u));
+  }
 
-    @Test
-    void testValidateERACommonsCredentialsMissingERACommonsId() {
-      User u = generateUser();
-      LibraryCard lc = generateLibraryCard(u.getEmail());
-      lc.setEraCommonsId(null);
-      u.addLibraryCard(lc);
-      UserProperty eraStatus = new UserProperty(1, u.getUserId(), ERA_STATUS.getValue(), "true");
-      //standard practice is that these expire in 30 days.
-      Timestamp eraExpirationTime = new Timestamp(
-          System.currentTimeMillis() + TimeUnit.DAYS.toMillis(30));
-      UserProperty eraExpirationDate = new UserProperty(2, u.getUserId(),
-          ERA_EXPIRATION_DATE.getValue(), Long.toString(eraExpirationTime.getTime()));
-      List<UserProperty> userProperties = new ArrayList<>();
-      userProperties.add(eraStatus);
-      userProperties.add(eraExpirationDate);
-      u.setProperties(userProperties);
-      when(userPropertyDAO.findUserPropertiesByUserIdAndPropertyKeys(u.getUserId(),
-          UserFields.getValues())).thenReturn(u.getProperties());
-      assertThrows(BadRequestException.class,
-          () -> service.hasValidActiveERACredentials(u));
-    }
+  @Test
+  void testValidateERACommonsCredentialsMissingERACommonsId() {
+    User u = generateUser();
+    LibraryCard lc = generateLibraryCard(u.getEmail());
+    lc.setEraCommonsId(null);
+    u.addLibraryCard(lc);
+    UserProperty eraStatus = new UserProperty(1, u.getUserId(), ERA_STATUS.getValue(), "true");
+    //standard practice is that these expire in 30 days.
+    Timestamp eraExpirationTime = new Timestamp(
+        System.currentTimeMillis() + TimeUnit.DAYS.toMillis(30));
+    UserProperty eraExpirationDate = new UserProperty(2, u.getUserId(),
+        ERA_EXPIRATION_DATE.getValue(), Long.toString(eraExpirationTime.getTime()));
+    List<UserProperty> userProperties = new ArrayList<>();
+    userProperties.add(eraStatus);
+    userProperties.add(eraExpirationDate);
+    u.setProperties(userProperties);
+    when(userPropertyDAO.findUserPropertiesByUserIdAndPropertyKeys(u.getUserId(),
+        UserFields.getValues())).thenReturn(u.getProperties());
+    assertThrows(BadRequestException.class,
+        () -> service.hasValidActiveERACredentials(u));
+  }
 
-    @Test
-    void testValidateRACommonsCredentialsMissingERAStatusShouldFail() {
-      User u = generateUser();
-      LibraryCard lc = generateLibraryCard(u.getEmail());
-      lc.setEraCommonsId(u.getEmail());
-      u.addLibraryCard(lc);
-      //standard practice is that these expire in 30 days.
-      Timestamp eraExpirationTime = new Timestamp(
-          System.currentTimeMillis() + TimeUnit.DAYS.toMillis(30));
-      UserProperty eraExpirationDate = new UserProperty(2, u.getUserId(),
-          ERA_EXPIRATION_DATE.getValue(), Long.toString(eraExpirationTime.getTime()));
-      List<UserProperty> userProperties = new ArrayList<>();
-      userProperties.add(eraExpirationDate);
-      u.setProperties(userProperties);
-      when(userPropertyDAO.findUserPropertiesByUserIdAndPropertyKeys(u.getUserId(),
-          UserFields.getValues())).thenReturn(u.getProperties());
-      assertThrows(BadRequestException.class,
-          () -> service.hasValidActiveERACredentials(u));
-    }
+  @Test
+  void testValidateRACommonsCredentialsMissingERAStatusShouldFail() {
+    User u = generateUser();
+    LibraryCard lc = generateLibraryCard(u.getEmail());
+    lc.setEraCommonsId(u.getEmail());
+    u.addLibraryCard(lc);
+    //standard practice is that these expire in 30 days.
+    Timestamp eraExpirationTime = new Timestamp(
+        System.currentTimeMillis() + TimeUnit.DAYS.toMillis(30));
+    UserProperty eraExpirationDate = new UserProperty(2, u.getUserId(),
+        ERA_EXPIRATION_DATE.getValue(), Long.toString(eraExpirationTime.getTime()));
+    List<UserProperty> userProperties = new ArrayList<>();
+    userProperties.add(eraExpirationDate);
+    u.setProperties(userProperties);
+    when(userPropertyDAO.findUserPropertiesByUserIdAndPropertyKeys(u.getUserId(),
+        UserFields.getValues())).thenReturn(u.getProperties());
+    assertThrows(BadRequestException.class,
+        () -> service.hasValidActiveERACredentials(u));
+  }
 
-    @Test
-    void testValidateERACommonsCredentialsMissingERAStatusAndExpirationShouldFail() {
-      User u = generateUser();
-      LibraryCard lc = generateLibraryCard(u.getEmail());
-      lc.setEraCommonsId(u.getEmail());
-      u.addLibraryCard(lc);
-      List<UserProperty> userProperties = new ArrayList<>();
-      u.setProperties(userProperties);
-      when(userPropertyDAO.findUserPropertiesByUserIdAndPropertyKeys(u.getUserId(),
-          UserFields.getValues())).thenReturn(u.getProperties());
-      assertThrows(BadRequestException.class,
-          () -> service.hasValidActiveERACredentials(u));
-    }
+  @Test
+  void testValidateERACommonsCredentialsMissingERAStatusAndExpirationShouldFail() {
+    User u = generateUser();
+    LibraryCard lc = generateLibraryCard(u.getEmail());
+    lc.setEraCommonsId(u.getEmail());
+    u.addLibraryCard(lc);
+    List<UserProperty> userProperties = new ArrayList<>();
+    u.setProperties(userProperties);
+    when(userPropertyDAO.findUserPropertiesByUserIdAndPropertyKeys(u.getUserId(),
+        UserFields.getValues())).thenReturn(u.getProperties());
+    assertThrows(BadRequestException.class,
+        () -> service.hasValidActiveERACredentials(u));
+  }
 
-    @Test
-    void testValidateERACommonsCredentialsWithExpiredERAExpirationDateShouldFail() {
-      User u = generateUser();
-      LibraryCard lc = generateLibraryCard(u.getEmail());
-      lc.setEraCommonsId(u.getEmail());
-      u.addLibraryCard(lc);
-      UserProperty eraStatus = new UserProperty(1, u.getUserId(), ERA_STATUS.getValue(), "true");
-      // set expiration date to 30 days ago!
-      Timestamp eraExpirationTime = new Timestamp(
-          System.currentTimeMillis() - TimeUnit.DAYS.toMillis(30));
-      UserProperty eraExpirationDate = new UserProperty(2, u.getUserId(),
-          ERA_EXPIRATION_DATE.getValue(), Long.toString(eraExpirationTime.getTime()));
-      List<UserProperty> userProperties = new ArrayList<>();
-      userProperties.add(eraStatus);
-      userProperties.add(eraExpirationDate);
-      u.setProperties(userProperties);
-      when(userPropertyDAO.findUserPropertiesByUserIdAndPropertyKeys(u.getUserId(),
-          UserFields.getValues())).thenReturn(u.getProperties());
-      assertThrows(BadRequestException.class,
-          () -> service.hasValidActiveERACredentials(u));
-    }
+  @Test
+  void testValidateERACommonsCredentialsWithExpiredERAExpirationDateShouldFail() {
+    User u = generateUser();
+    LibraryCard lc = generateLibraryCard(u.getEmail());
+    lc.setEraCommonsId(u.getEmail());
+    u.addLibraryCard(lc);
+    UserProperty eraStatus = new UserProperty(1, u.getUserId(), ERA_STATUS.getValue(), "true");
+    // set expiration date to 30 days ago!
+    Timestamp eraExpirationTime = new Timestamp(
+        System.currentTimeMillis() - TimeUnit.DAYS.toMillis(30));
+    UserProperty eraExpirationDate = new UserProperty(2, u.getUserId(),
+        ERA_EXPIRATION_DATE.getValue(), Long.toString(eraExpirationTime.getTime()));
+    List<UserProperty> userProperties = new ArrayList<>();
+    userProperties.add(eraStatus);
+    userProperties.add(eraExpirationDate);
+    u.setProperties(userProperties);
+    when(userPropertyDAO.findUserPropertiesByUserIdAndPropertyKeys(u.getUserId(),
+        UserFields.getValues())).thenReturn(u.getProperties());
+    assertThrows(BadRequestException.class,
+        () -> service.hasValidActiveERACredentials(u));
+  }
 
   @Test
   void testCreateUserNoRoles() {

--- a/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
@@ -45,6 +45,7 @@ import org.broadinstitute.consent.http.db.UserRoleDAO;
 import org.broadinstitute.consent.http.db.VoteDAO;
 import org.broadinstitute.consent.http.enumeration.UserFields;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
+import org.broadinstitute.consent.http.exceptions.LibraryCardRequiredException;
 import org.broadinstitute.consent.http.models.AuthUser;
 import org.broadinstitute.consent.http.models.DataAccessAgreement;
 import org.broadinstitute.consent.http.models.Institution;
@@ -317,129 +318,123 @@ class UserServiceTest {
     });
   }
 
-  @Test
-  void testHasValidERACommonsCredentials() {
-    User u = generateUser();
-    LibraryCard lc = generateLibraryCard(u.getEmail());
-    lc.setEraCommonsId(u.getEmail());
-    u.addLibraryCard(lc);
-    UserProperty eraStatus = new UserProperty(1, u.getUserId(), ERA_STATUS.getValue(), "true");
-    //standard practice is that these expire in 30 days.
-    Timestamp eraExpirationTime = new Timestamp(
-        System.currentTimeMillis() + TimeUnit.DAYS.toMillis(30));
-    UserProperty eraExpirationDate = new UserProperty(2, u.getUserId(),
-        ERA_EXPIRATION_DATE.getValue(), Long.toString(eraExpirationTime.getTime()));
-    List<UserProperty> userProperties = new ArrayList<>();
-    userProperties.add(eraStatus);
-    userProperties.add(eraExpirationDate);
-    u.setProperties(userProperties);
-    when(libraryCardDAO.findLibraryCardsByUserId(u.getUserId())).thenReturn(u.getLibraryCards());
-    when(userPropertyDAO.findUserPropertiesByUserIdAndPropertyKeys(u.getUserId(),
-        UserFields.getValues())).thenReturn(u.getProperties());
-    assertDoesNotThrow(() -> service.hasValidActiveERACredentials(u.getUserId()));
-  }
+    @Test
+    void testHasValidERACommonsCredentials() {
+      User u = generateUser();
+      LibraryCard lc = generateLibraryCard(u.getEmail());
+      lc.setEraCommonsId(u.getEmail());
+      u.addLibraryCard(lc);
+      UserProperty eraStatus = new UserProperty(1, u.getUserId(), ERA_STATUS.getValue(), "true");
+      //standard practice is that these expire in 30 days.
+      Timestamp eraExpirationTime = new Timestamp(
+          System.currentTimeMillis() + TimeUnit.DAYS.toMillis(30));
+      UserProperty eraExpirationDate = new UserProperty(2, u.getUserId(),
+          ERA_EXPIRATION_DATE.getValue(), Long.toString(eraExpirationTime.getTime()));
+      List<UserProperty> userProperties = new ArrayList<>();
+      userProperties.add(eraStatus);
+      userProperties.add(eraExpirationDate);
+      u.setProperties(userProperties);
+      when(userPropertyDAO.findUserPropertiesByUserIdAndPropertyKeys(u.getUserId(),
+          UserFields.getValues())).thenReturn(u.getProperties());
+      assertDoesNotThrow(() -> service.hasValidActiveERACredentials(u));
+    }
 
-  @Test
-  void testValidateERACommonsCredentialsMissingLibraryCards() {
-    User u = generateUser();
-    UserProperty eraStatus = new UserProperty(1, u.getUserId(), ERA_STATUS.getValue(), "true");
-    //standard practice is that these expire in 30 days.
-    Timestamp eraExpirationTime = new Timestamp(
-        System.currentTimeMillis() + TimeUnit.DAYS.toMillis(30));
-    UserProperty eraExpirationDate = new UserProperty(2, u.getUserId(),
-        ERA_EXPIRATION_DATE.getValue(), Long.toString(eraExpirationTime.getTime()));
-    List<UserProperty> userProperties = new ArrayList<>();
-    userProperties.add(eraStatus);
-    userProperties.add(eraExpirationDate);
-    u.setProperties(userProperties);
-    when(libraryCardDAO.findLibraryCardsByUserId(u.getUserId())).thenReturn(u.getLibraryCards());
-    when(userPropertyDAO.findUserPropertiesByUserIdAndPropertyKeys(u.getUserId(),
-        UserFields.getValues())).thenReturn(u.getProperties());
-    assertThrows(BadRequestException.class,
-        () -> service.hasValidActiveERACredentials(u.getUserId()));
-  }
+    @Test
+    void testValidateERACommonsCredentialsMissingLibraryCards() {
+      User u = generateUser();
+      UserProperty eraStatus = new UserProperty(1, u.getUserId(), ERA_STATUS.getValue(), "true");
+      //standard practice is that these expire in 30 days.
+      Timestamp eraExpirationTime = new Timestamp(
+          System.currentTimeMillis() + TimeUnit.DAYS.toMillis(30));
+      UserProperty eraExpirationDate = new UserProperty(2, u.getUserId(),
+          ERA_EXPIRATION_DATE.getValue(), Long.toString(eraExpirationTime.getTime()));
+      List<UserProperty> userProperties = new ArrayList<>();
+      userProperties.add(eraStatus);
+      userProperties.add(eraExpirationDate);
+      u.setProperties(userProperties);
+      when(userPropertyDAO.findUserPropertiesByUserIdAndPropertyKeys(u.getUserId(),
+          UserFields.getValues())).thenReturn(u.getProperties());
+      assertThrows(LibraryCardRequiredException.class,
+          () -> service.hasValidActiveERACredentials(u));
+    }
 
-  @Test
-  void testValidateERACommonsCredentialsMissingERACommonsId() {
-    User u = generateUser();
-    LibraryCard lc = generateLibraryCard(u.getEmail());
-    lc.setEraCommonsId(null);
-    u.addLibraryCard(lc);
-    UserProperty eraStatus = new UserProperty(1, u.getUserId(), ERA_STATUS.getValue(), "true");
-    //standard practice is that these expire in 30 days.
-    Timestamp eraExpirationTime = new Timestamp(
-        System.currentTimeMillis() + TimeUnit.DAYS.toMillis(30));
-    UserProperty eraExpirationDate = new UserProperty(2, u.getUserId(),
-        ERA_EXPIRATION_DATE.getValue(), Long.toString(eraExpirationTime.getTime()));
-    List<UserProperty> userProperties = new ArrayList<>();
-    userProperties.add(eraStatus);
-    userProperties.add(eraExpirationDate);
-    u.setProperties(userProperties);
-    when(libraryCardDAO.findLibraryCardsByUserId(u.getUserId())).thenReturn(u.getLibraryCards());
-    when(userPropertyDAO.findUserPropertiesByUserIdAndPropertyKeys(u.getUserId(),
-        UserFields.getValues())).thenReturn(u.getProperties());
-    assertThrows(BadRequestException.class,
-        () -> service.hasValidActiveERACredentials(u.getUserId()));
-  }
+    @Test
+    void testValidateERACommonsCredentialsMissingERACommonsId() {
+      User u = generateUser();
+      LibraryCard lc = generateLibraryCard(u.getEmail());
+      lc.setEraCommonsId(null);
+      u.addLibraryCard(lc);
+      UserProperty eraStatus = new UserProperty(1, u.getUserId(), ERA_STATUS.getValue(), "true");
+      //standard practice is that these expire in 30 days.
+      Timestamp eraExpirationTime = new Timestamp(
+          System.currentTimeMillis() + TimeUnit.DAYS.toMillis(30));
+      UserProperty eraExpirationDate = new UserProperty(2, u.getUserId(),
+          ERA_EXPIRATION_DATE.getValue(), Long.toString(eraExpirationTime.getTime()));
+      List<UserProperty> userProperties = new ArrayList<>();
+      userProperties.add(eraStatus);
+      userProperties.add(eraExpirationDate);
+      u.setProperties(userProperties);
+      when(userPropertyDAO.findUserPropertiesByUserIdAndPropertyKeys(u.getUserId(),
+          UserFields.getValues())).thenReturn(u.getProperties());
+      assertThrows(BadRequestException.class,
+          () -> service.hasValidActiveERACredentials(u));
+    }
 
-  @Test
-  void testValidateRACommonsCredentialsMissingERAStatusShouldFail() {
-    User u = generateUser();
-    LibraryCard lc = generateLibraryCard(u.getEmail());
-    lc.setEraCommonsId(u.getEmail());
-    u.addLibraryCard(lc);
-    //standard practice is that these expire in 30 days.
-    Timestamp eraExpirationTime = new Timestamp(
-        System.currentTimeMillis() + TimeUnit.DAYS.toMillis(30));
-    UserProperty eraExpirationDate = new UserProperty(2, u.getUserId(),
-        ERA_EXPIRATION_DATE.getValue(), Long.toString(eraExpirationTime.getTime()));
-    List<UserProperty> userProperties = new ArrayList<>();
-    userProperties.add(eraExpirationDate);
-    u.setProperties(userProperties);
-    when(libraryCardDAO.findLibraryCardsByUserId(u.getUserId())).thenReturn(u.getLibraryCards());
-    when(userPropertyDAO.findUserPropertiesByUserIdAndPropertyKeys(u.getUserId(),
-        UserFields.getValues())).thenReturn(u.getProperties());
-    assertThrows(BadRequestException.class,
-        () -> service.hasValidActiveERACredentials(u.getUserId()));
-  }
+    @Test
+    void testValidateRACommonsCredentialsMissingERAStatusShouldFail() {
+      User u = generateUser();
+      LibraryCard lc = generateLibraryCard(u.getEmail());
+      lc.setEraCommonsId(u.getEmail());
+      u.addLibraryCard(lc);
+      //standard practice is that these expire in 30 days.
+      Timestamp eraExpirationTime = new Timestamp(
+          System.currentTimeMillis() + TimeUnit.DAYS.toMillis(30));
+      UserProperty eraExpirationDate = new UserProperty(2, u.getUserId(),
+          ERA_EXPIRATION_DATE.getValue(), Long.toString(eraExpirationTime.getTime()));
+      List<UserProperty> userProperties = new ArrayList<>();
+      userProperties.add(eraExpirationDate);
+      u.setProperties(userProperties);
+      when(userPropertyDAO.findUserPropertiesByUserIdAndPropertyKeys(u.getUserId(),
+          UserFields.getValues())).thenReturn(u.getProperties());
+      assertThrows(BadRequestException.class,
+          () -> service.hasValidActiveERACredentials(u));
+    }
 
-  @Test
-  void testValidateERACommonsCredentialsMissingERAStatusAndExpirationShouldFail() {
-    User u = generateUser();
-    LibraryCard lc = generateLibraryCard(u.getEmail());
-    lc.setEraCommonsId(u.getEmail());
-    u.addLibraryCard(lc);
-    List<UserProperty> userProperties = new ArrayList<>();
-    u.setProperties(userProperties);
-    when(libraryCardDAO.findLibraryCardsByUserId(u.getUserId())).thenReturn(u.getLibraryCards());
-    when(userPropertyDAO.findUserPropertiesByUserIdAndPropertyKeys(u.getUserId(),
-        UserFields.getValues())).thenReturn(u.getProperties());
-    assertThrows(BadRequestException.class,
-        () -> service.hasValidActiveERACredentials(u.getUserId()));
-  }
+    @Test
+    void testValidateERACommonsCredentialsMissingERAStatusAndExpirationShouldFail() {
+      User u = generateUser();
+      LibraryCard lc = generateLibraryCard(u.getEmail());
+      lc.setEraCommonsId(u.getEmail());
+      u.addLibraryCard(lc);
+      List<UserProperty> userProperties = new ArrayList<>();
+      u.setProperties(userProperties);
+      when(userPropertyDAO.findUserPropertiesByUserIdAndPropertyKeys(u.getUserId(),
+          UserFields.getValues())).thenReturn(u.getProperties());
+      assertThrows(BadRequestException.class,
+          () -> service.hasValidActiveERACredentials(u));
+    }
 
-  @Test
-  void testValidateERACommonsCredentialsWithExpiredERAExpirationDateShouldFail() {
-    User u = generateUser();
-    LibraryCard lc = generateLibraryCard(u.getEmail());
-    lc.setEraCommonsId(u.getEmail());
-    u.addLibraryCard(lc);
-    UserProperty eraStatus = new UserProperty(1, u.getUserId(), ERA_STATUS.getValue(), "true");
-    // set expiration date to 30 days ago!
-    Timestamp eraExpirationTime = new Timestamp(
-        System.currentTimeMillis() - TimeUnit.DAYS.toMillis(30));
-    UserProperty eraExpirationDate = new UserProperty(2, u.getUserId(),
-        ERA_EXPIRATION_DATE.getValue(), Long.toString(eraExpirationTime.getTime()));
-    List<UserProperty> userProperties = new ArrayList<>();
-    userProperties.add(eraStatus);
-    userProperties.add(eraExpirationDate);
-    u.setProperties(userProperties);
-    when(libraryCardDAO.findLibraryCardsByUserId(u.getUserId())).thenReturn(u.getLibraryCards());
-    when(userPropertyDAO.findUserPropertiesByUserIdAndPropertyKeys(u.getUserId(),
-        UserFields.getValues())).thenReturn(u.getProperties());
-    assertThrows(BadRequestException.class,
-        () -> service.hasValidActiveERACredentials(u.getUserId()));
-  }
+    @Test
+    void testValidateERACommonsCredentialsWithExpiredERAExpirationDateShouldFail() {
+      User u = generateUser();
+      LibraryCard lc = generateLibraryCard(u.getEmail());
+      lc.setEraCommonsId(u.getEmail());
+      u.addLibraryCard(lc);
+      UserProperty eraStatus = new UserProperty(1, u.getUserId(), ERA_STATUS.getValue(), "true");
+      // set expiration date to 30 days ago!
+      Timestamp eraExpirationTime = new Timestamp(
+          System.currentTimeMillis() - TimeUnit.DAYS.toMillis(30));
+      UserProperty eraExpirationDate = new UserProperty(2, u.getUserId(),
+          ERA_EXPIRATION_DATE.getValue(), Long.toString(eraExpirationTime.getTime()));
+      List<UserProperty> userProperties = new ArrayList<>();
+      userProperties.add(eraStatus);
+      userProperties.add(eraExpirationDate);
+      u.setProperties(userProperties);
+      when(userPropertyDAO.findUserPropertiesByUserIdAndPropertyKeys(u.getUserId(),
+          UserFields.getValues())).thenReturn(u.getProperties());
+      assertThrows(BadRequestException.class,
+          () -> service.hasValidActiveERACredentials(u));
+    }
 
   @Test
   void testCreateUserNoRoles() {


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-1548](https://broadworkbench.atlassian.net/browse/DT-1548)

### Summary

Ensures that a DAR submitted to a DAC is done so by a user with valid eRA account linked to their DUOS account.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
