### PR TITLE
[DT-99] Update DAR table to show latest in Dar Collection

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/DarCollectionSummaryDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DarCollectionSummaryDAO.java
@@ -142,11 +142,13 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
             SELECT *
             FROM data_access_request
             WHERE data_access_request.collection_id = c.collection_id
+            AND data_access_request.submission_date IS NOT NULL
             ORDER BY data_access_request.submission_date DESC
             LIMIT 1
         ) dar ON true
     INNER JOIN
         data_access_request dar_all ON dar_all.collection_id = c.collection_id
+        AND dar_all.submission_date IS NOT NULL
     LEFT JOIN
         LATERAL (
             SELECT
@@ -163,6 +165,7 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
         c.create_user_id = :userId
         AND (e.latest = e.election_id OR e.election_id IS NULL)
         AND (LOWER(dar.data->>'status') != 'archived' OR dar.data->>'status' IS NULL)
+        AND (EXISTS (SELECT 1 FROM data_access_request WHERE (collection_id = c.collection_id AND dar.submission_date IS  NOT NULL)))
     GROUP BY
         c.collection_id, c.dar_code, dar.submission_date, dar.reference_id, u.display_name, i.institution_name,
         e.election_id, e.status, e.dataset_id, e.reference_id, dd.dataset_id, dar.data

--- a/src/main/java/org/broadinstitute/consent/http/db/DarCollectionSummaryDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DarCollectionSummaryDAO.java
@@ -93,11 +93,24 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
       SELECT c.collection_id as dar_collection_id, c.dar_code, dar.submission_date, dar.reference_id as dar_reference_id, u.display_name as researcher_name,
         i.institution_name, e.election_id, e.status, e.dataset_id, e.reference_id, dd.dataset_id as dd_datasetid,
         (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb ->> 'projectTitle' AS name,
-        dac.name as dac_name
+        dac.name as dac_name, ARRAY_AGG(dar_all.reference_id) AS reference_ids
       FROM dar_collection c
       INNER JOIN users u ON u.user_id = c.create_user_id
       LEFT JOIN institution i ON i.institution_id = u.institution_id
-      INNER JOIN data_access_request dar ON dar.collection_id = c.collection_id
+      INNER JOIN
+              LATERAL (
+                  SELECT *
+                  FROM data_access_request
+                  WHERE data_access_request.collection_id = c.collection_id
+                  AND data_access_request.submission_date IS NOT NULL
+                  AND (LOWER(data_access_request.data->>'status') != 'archived' OR data_access_request.data->>'status' IS NULL)
+                  ORDER BY data_access_request.submission_date DESC
+                  LIMIT 1
+              ) dar ON true
+      INNER JOIN
+              data_access_request dar_all ON dar_all.collection_id = c.collection_id
+              AND dar_all.submission_date IS NOT NULL
+              AND (LOWER(dar_all.data->>'status') != 'archived' OR dar_all.data->>'status' IS NULL)
       LEFT JOIN (
         SELECT election.*, MAX(election.election_id) OVER(PARTITION BY election.reference_id, election.dataset_id) AS latest
         FROM election
@@ -107,7 +120,9 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
       LEFT JOIN dataset dataset on dataset.dataset_id = dd.dataset_id
       LEFT JOIN dac dac on dac.dac_id = dataset.dac_id
       WHERE (e.latest = e.election_id OR e.election_id IS NULL)
-        AND (LOWER(data->>'status') != 'archived' OR data->>'status' IS NULL )
+      GROUP BY
+              c.collection_id, c.dar_code, dar.submission_date, dar.reference_id, u.display_name, i.institution_name,
+              e.election_id, e.status, e.dataset_id, e.reference_id, dd.dataset_id, dar.data, dac.name
       """)
   List<DarCollectionSummary> getDarCollectionSummariesForAdmin();
 
@@ -151,16 +166,11 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
         data_access_request dar_all ON dar_all.collection_id = c.collection_id
         AND dar_all.submission_date IS NOT NULL
         AND (LOWER(dar_all.data->>'status') != 'archived' OR dar_all.data->>'status' IS NULL)
-    LEFT JOIN
-        LATERAL (
-            SELECT
-                election.*,
-                MAX(election.election_id) OVER (PARTITION BY election.reference_id, election.dataset_id) AS latest
-            FROM
-                election
-            WHERE
-                LOWER(election.election_type) = 'dataaccess'
-        ) e ON e.reference_id = dar.reference_id
+    LEFT JOIN (
+        SELECT election.*, MAX(election.election_id) OVER(PARTITION BY election.reference_id, election.dataset_id) AS latest
+        FROM election
+        WHERE LOWER(election.election_type) = 'dataaccess'
+    ) AS e ON e.reference_id = dar.reference_id
     INNER JOIN
         dar_dataset dd ON dar.reference_id = dd.reference_id
     WHERE

--- a/src/main/java/org/broadinstitute/consent/http/db/DarCollectionSummaryDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DarCollectionSummaryDAO.java
@@ -115,36 +115,59 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
   @RegisterBeanMapper(value = DarCollection.class)
   @RegisterBeanMapper(value = Election.class)
   @UseRowReducer(DarCollectionSummaryReducer.class)
-  @SqlQuery
-      (
-          """
-              SELECT c.collection_id as dar_collection_id, c.dar_code, dar.submission_date, dar.reference_id as dar_reference_id, u.display_name as researcher_name,
-                i.institution_name, e.election_id, e.status, e.dataset_id, e.reference_id, dd.dataset_id as dd_datasetid,
-                (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb ->> 'projectTitle' AS name,
-                (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb ->> 'status' AS dar_status
-              FROM dar_collection c
-              INNER JOIN users u
-              ON u.user_id = c.create_user_id
-              LEFT JOIN institution i
-              ON i.institution_id = u.institution_id
-              INNER JOIN data_access_request dar
-              ON dar.collection_id = c.collection_id
-              LEFT JOIN (
-                SELECT election.*, MAX(election.election_id) OVER(PARTITION BY election.reference_id, election.dataset_id) AS latest
-                FROM election
-                WHERE LOWER(election.election_type) = 'dataaccess'
-              ) AS e
-              ON e.reference_id = dar.reference_id
-              INNER JOIN dar_dataset dd
-              ON dar.reference_id = dd.reference_id
-              WHERE c.create_user_id = :userId
-                AND (e.latest = e.election_id OR e.election_id IS NULL)
-                AND (LOWER(data->>'status') != 'archived' OR data->>'status' IS NULL )
-                AND (EXISTS (SELECT 1 FROM data_access_request WHERE (collection_id = c.collection_id and dar.submission_date is not null)))
-        """
-      )
-  List<DarCollectionSummary> getDarCollectionSummariesForResearcher(
-      @Bind("userId") Integer userId);
+  @SqlQuery("""
+    SELECT
+        c.collection_id AS dar_collection_id,
+        c.dar_code,
+        dar.submission_date,
+        dar.reference_id AS dar_reference_id,
+        u.display_name AS researcher_name,
+        i.institution_name,
+        e.election_id,
+        e.status,
+        e.dataset_id,
+        e.reference_id AS election_reference_id,
+        dd.dataset_id AS dd_datasetid,
+        (regexp_replace(dar.data #>> '{}', '\\u0000', '', 'g'))::jsonb ->> 'projectTitle' AS name,
+        (regexp_replace(dar.data #>> '{}', '\\u0000', '', 'g'))::jsonb ->> 'status' AS dar_status,
+        ARRAY_AGG(dar_all.reference_id)::text[] AS reference_ids
+    FROM
+        dar_collection c
+    INNER JOIN
+        users u ON u.user_id = c.create_user_id
+    LEFT JOIN
+        institution i ON i.institution_id = u.institution_id
+    INNER JOIN
+        LATERAL (
+            SELECT *
+            FROM data_access_request
+            WHERE data_access_request.collection_id = c.collection_id
+            ORDER BY data_access_request.submission_date DESC
+            LIMIT 1
+        ) dar ON true
+    INNER JOIN
+        data_access_request dar_all ON dar_all.collection_id = c.collection_id
+    LEFT JOIN
+        LATERAL (
+            SELECT
+                election.*,
+                MAX(election.election_id) OVER (PARTITION BY election.reference_id, election.dataset_id) AS latest
+            FROM
+                election
+            WHERE
+                LOWER(election.election_type) = 'dataaccess'
+        ) e ON e.reference_id = dar.reference_id
+    INNER JOIN
+        dar_dataset dd ON dar.reference_id = dd.reference_id
+    WHERE
+        c.create_user_id = :userId
+        AND (e.latest = e.election_id OR e.election_id IS NULL)
+        AND (LOWER(dar.data->>'status') != 'archived' OR dar.data->>'status' IS NULL)
+    GROUP BY
+        c.collection_id, c.dar_code, dar.submission_date, dar.reference_id, u.display_name, i.institution_name,
+        e.election_id, e.status, e.dataset_id, e.reference_id, dd.dataset_id, dar.data
+""")
+  List<DarCollectionSummary> getDarCollectionSummariesForResearcher(@Bind("userId") Integer userId);
 
 
   @RegisterBeanMapper(value = DarCollectionSummary.class)

--- a/src/main/java/org/broadinstitute/consent/http/db/DarCollectionSummaryDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DarCollectionSummaryDAO.java
@@ -119,14 +119,14 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
               AND dar_all.submission_date IS NOT NULL
               AND (LOWER(dar_all.data->>'status') != 'archived' OR dar_all.data->>'status' IS NULL)
           LEFT JOIN (
-              SELECT DISTINCT ON (reference_id, dataset_id) *
-              FROM election
-              WHERE LOWER(election_type) = 'dataaccess'
-              ORDER BY reference_id, dataset_id, election_id DESC
-          ) e ON e.reference_id = dar.reference_id
+                  SELECT election.*, MAX(election.election_id) OVER(PARTITION BY election.reference_id, election.dataset_id) AS latest
+                  FROM election
+                  WHERE LOWER(election.election_type) = 'dataaccess'
+                ) AS e ON e.reference_id = dar.reference_id
           INNER JOIN dar_dataset dd ON dar.reference_id = dd.reference_id
           LEFT JOIN dataset ON dataset.dataset_id = dd.dataset_id
           LEFT JOIN dac ON dac.dac_id = dataset.dac_id
+          WHERE (e.latest = e.election_id OR e.election_id IS NULL)
           GROUP BY
               c.collection_id, c.dar_code, dar.submission_date, dar.reference_id,
               u.display_name, i.institution_name, e.election_id, e.status,
@@ -160,16 +160,13 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
         users u ON u.user_id = c.create_user_id
     LEFT JOIN
         institution i ON i.institution_id = u.institution_id
-    INNER JOIN
-        LATERAL (
-            SELECT *
-            FROM data_access_request
-            WHERE data_access_request.collection_id = c.collection_id
-            AND data_access_request.submission_date IS NOT NULL
-            AND (LOWER(data_access_request.data->>'status') != 'archived' OR data_access_request.data->>'status' IS NULL)
-            ORDER BY data_access_request.submission_date DESC
-            LIMIT 1
-        ) dar ON true
+    INNER JOIN (
+         SELECT DISTINCT ON (collection_id) *
+         FROM data_access_request
+         WHERE submission_date IS NOT NULL
+         AND (LOWER(data->>'status') != 'archived' OR data->>'status' IS NULL)
+         ORDER BY collection_id, submission_date DESC
+    ) dar ON dar.collection_id = c.collection_id
     INNER JOIN
         data_access_request dar_all ON dar_all.collection_id = c.collection_id
         AND dar_all.submission_date IS NOT NULL

--- a/src/main/java/org/broadinstitute/consent/http/db/DarCollectionSummaryDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DarCollectionSummaryDAO.java
@@ -90,54 +90,48 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
   @RegisterBeanMapper(value = Election.class)
   @UseRowReducer(DarCollectionSummaryReducer.class)
   @SqlQuery("""
-    SELECT
-        c.collection_id AS dar_collection_id,
-        c.dar_code,
-        dar.submission_date,
-        dar.reference_id AS dar_reference_id,
-        u.display_name AS researcher_name,
-        i.institution_name,
-        e.election_id,
-        e.status,
-        e.dataset_id,
-        dd.dataset_id AS dd_datasetid,
-        (regexp_replace(dar.data #>> '{}', '\\u0000', '', 'g'))::jsonb ->> 'projectTitle' AS name,
-        dac.name AS dac_name,
-        ARRAY_AGG(dar_all.reference_id) AS reference_ids
-    FROM dar_collection c
-    INNER JOIN users u ON u.user_id = c.create_user_id
-    LEFT JOIN institution i ON i.institution_id = u.institution_id
-    INNER JOIN (
-        SELECT *
-        FROM (
-            SELECT *, ROW_NUMBER() OVER (PARTITION BY collection_id ORDER BY submission_date DESC) as rn
-            FROM data_access_request
-            WHERE submission_date IS NOT NULL
-            AND (LOWER(data->>'status') != 'archived' OR data->>'status' IS NULL)
-        ) latest_dar
-        WHERE rn = 1
-    ) dar ON dar.collection_id = c.collection_id
-    INNER JOIN data_access_request dar_all
-        ON dar_all.collection_id = c.collection_id
-        AND dar_all.submission_date IS NOT NULL
-        AND (LOWER(dar_all.data->>'status') != 'archived' OR dar_all.data->>'status' IS NULL)
-    LEFT JOIN (
-        SELECT *
-        FROM (
-            SELECT *, ROW_NUMBER() OVER (PARTITION BY reference_id, dataset_id ORDER BY election_id DESC) as rn
-            FROM election
-            WHERE LOWER(election_type) = 'dataaccess'
-        ) latest_election
-        WHERE rn = 1
-    ) e ON e.reference_id = dar.reference_id
-    INNER JOIN dar_dataset dd ON dar.reference_id = dd.reference_id
-    LEFT JOIN dataset ON dataset.dataset_id = dd.dataset_id
-    LEFT JOIN dac ON dac.dac_id = dataset.dac_id
-    GROUP BY
-        c.collection_id, c.dar_code, dar.submission_date, dar.reference_id,
-        u.display_name, i.institution_name, e.election_id, e.status,
-        e.dataset_id, dd.dataset_id, dar.data, dac.name
-""")
+          SELECT
+              c.collection_id AS dar_collection_id,
+              c.dar_code,
+              dar.submission_date,
+              dar.reference_id AS dar_reference_id,
+              u.display_name AS researcher_name,
+              i.institution_name,
+              e.election_id,
+              e.status,
+              e.dataset_id,
+              dd.dataset_id AS dd_datasetid,
+              (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb ->> 'projectTitle' AS name,
+              dac.name AS dac_name,
+              ARRAY_AGG(dar_all.reference_id) AS reference_ids
+          FROM dar_collection c
+          INNER JOIN users u ON u.user_id = c.create_user_id
+          LEFT JOIN institution i ON i.institution_id = u.institution_id
+          INNER JOIN (
+              SELECT DISTINCT ON (collection_id) *
+              FROM data_access_request
+              WHERE submission_date IS NOT NULL
+              AND (LOWER(data->>'status') != 'archived' OR data->>'status' IS NULL)
+              ORDER BY collection_id, submission_date DESC
+          ) dar ON dar.collection_id = c.collection_id
+          INNER JOIN data_access_request dar_all
+              ON dar_all.collection_id = c.collection_id
+              AND dar_all.submission_date IS NOT NULL
+              AND (LOWER(dar_all.data->>'status') != 'archived' OR dar_all.data->>'status' IS NULL)
+          LEFT JOIN (
+              SELECT DISTINCT ON (reference_id, dataset_id) *
+              FROM election
+              WHERE LOWER(election_type) = 'dataaccess'
+              ORDER BY reference_id, dataset_id, election_id DESC
+          ) e ON e.reference_id = dar.reference_id
+          INNER JOIN dar_dataset dd ON dar.reference_id = dd.reference_id
+          LEFT JOIN dataset ON dataset.dataset_id = dd.dataset_id
+          LEFT JOIN dac ON dac.dac_id = dataset.dac_id
+          GROUP BY
+              c.collection_id, c.dar_code, dar.submission_date, dar.reference_id,
+              u.display_name, i.institution_name, e.election_id, e.status,
+              e.dataset_id, dd.dataset_id, dar.data, dac.name
+      """)
   List<DarCollectionSummary> getDarCollectionSummariesForAdmin();
 
   @RegisterBeanMapper(value = DarCollectionSummary.class)

--- a/src/main/java/org/broadinstitute/consent/http/db/DarCollectionSummaryDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DarCollectionSummaryDAO.java
@@ -130,7 +130,7 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
         dd.dataset_id AS dd_datasetid,
         (regexp_replace(dar.data #>> '{}', '\\u0000', '', 'g'))::jsonb ->> 'projectTitle' AS name,
         (regexp_replace(dar.data #>> '{}', '\\u0000', '', 'g'))::jsonb ->> 'status' AS dar_status,
-        ARRAY_AGG(dar_all.reference_id)::text[] AS reference_ids
+        ARRAY_AGG(dar_all.reference_id) AS reference_ids
     FROM
         dar_collection c
     INNER JOIN

--- a/src/main/java/org/broadinstitute/consent/http/db/DarCollectionSummaryDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DarCollectionSummaryDAO.java
@@ -90,40 +90,54 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
   @RegisterBeanMapper(value = Election.class)
   @UseRowReducer(DarCollectionSummaryReducer.class)
   @SqlQuery("""
-      SELECT c.collection_id as dar_collection_id, c.dar_code, dar.submission_date, dar.reference_id as dar_reference_id, u.display_name as researcher_name,
-        i.institution_name, e.election_id, e.status, e.dataset_id, e.reference_id, dd.dataset_id as dd_datasetid,
-        (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb ->> 'projectTitle' AS name,
-        dac.name as dac_name, ARRAY_AGG(dar_all.reference_id) AS reference_ids
-      FROM dar_collection c
-      INNER JOIN users u ON u.user_id = c.create_user_id
-      LEFT JOIN institution i ON i.institution_id = u.institution_id
-      INNER JOIN
-              LATERAL (
-                  SELECT *
-                  FROM data_access_request
-                  WHERE data_access_request.collection_id = c.collection_id
-                  AND data_access_request.submission_date IS NOT NULL
-                  AND (LOWER(data_access_request.data->>'status') != 'archived' OR data_access_request.data->>'status' IS NULL)
-                  ORDER BY data_access_request.submission_date DESC
-                  LIMIT 1
-              ) dar ON true
-      INNER JOIN
-              data_access_request dar_all ON dar_all.collection_id = c.collection_id
-              AND dar_all.submission_date IS NOT NULL
-              AND (LOWER(dar_all.data->>'status') != 'archived' OR dar_all.data->>'status' IS NULL)
-      LEFT JOIN (
-        SELECT election.*, MAX(election.election_id) OVER(PARTITION BY election.reference_id, election.dataset_id) AS latest
-        FROM election
-        WHERE LOWER(election.election_type) = 'dataaccess'
-      ) AS e ON e.reference_id = dar.reference_id
-      INNER JOIN dar_dataset dd ON dar.reference_id = dd.reference_id
-      LEFT JOIN dataset dataset on dataset.dataset_id = dd.dataset_id
-      LEFT JOIN dac dac on dac.dac_id = dataset.dac_id
-      WHERE (e.latest = e.election_id OR e.election_id IS NULL)
-      GROUP BY
-              c.collection_id, c.dar_code, dar.submission_date, dar.reference_id, u.display_name, i.institution_name,
-              e.election_id, e.status, e.dataset_id, e.reference_id, dd.dataset_id, dar.data, dac.name
-      """)
+    SELECT
+        c.collection_id AS dar_collection_id,
+        c.dar_code,
+        dar.submission_date,
+        dar.reference_id AS dar_reference_id,
+        u.display_name AS researcher_name,
+        i.institution_name,
+        e.election_id,
+        e.status,
+        e.dataset_id,
+        dd.dataset_id AS dd_datasetid,
+        (regexp_replace(dar.data #>> '{}', '\\u0000', '', 'g'))::jsonb ->> 'projectTitle' AS name,
+        dac.name AS dac_name,
+        ARRAY_AGG(dar_all.reference_id) AS reference_ids
+    FROM dar_collection c
+    INNER JOIN users u ON u.user_id = c.create_user_id
+    LEFT JOIN institution i ON i.institution_id = u.institution_id
+    INNER JOIN (
+        SELECT *
+        FROM (
+            SELECT *, ROW_NUMBER() OVER (PARTITION BY collection_id ORDER BY submission_date DESC) as rn
+            FROM data_access_request
+            WHERE submission_date IS NOT NULL
+            AND (LOWER(data->>'status') != 'archived' OR data->>'status' IS NULL)
+        ) latest_dar
+        WHERE rn = 1
+    ) dar ON dar.collection_id = c.collection_id
+    INNER JOIN data_access_request dar_all
+        ON dar_all.collection_id = c.collection_id
+        AND dar_all.submission_date IS NOT NULL
+        AND (LOWER(dar_all.data->>'status') != 'archived' OR dar_all.data->>'status' IS NULL)
+    LEFT JOIN (
+        SELECT *
+        FROM (
+            SELECT *, ROW_NUMBER() OVER (PARTITION BY reference_id, dataset_id ORDER BY election_id DESC) as rn
+            FROM election
+            WHERE LOWER(election_type) = 'dataaccess'
+        ) latest_election
+        WHERE rn = 1
+    ) e ON e.reference_id = dar.reference_id
+    INNER JOIN dar_dataset dd ON dar.reference_id = dd.reference_id
+    LEFT JOIN dataset ON dataset.dataset_id = dd.dataset_id
+    LEFT JOIN dac ON dac.dac_id = dataset.dac_id
+    GROUP BY
+        c.collection_id, c.dar_code, dar.submission_date, dar.reference_id,
+        u.display_name, i.institution_name, e.election_id, e.status,
+        e.dataset_id, dd.dataset_id, dar.data, dac.name
+""")
   List<DarCollectionSummary> getDarCollectionSummariesForAdmin();
 
   @RegisterBeanMapper(value = DarCollectionSummary.class)

--- a/src/main/java/org/broadinstitute/consent/http/db/DarCollectionSummaryDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DarCollectionSummaryDAO.java
@@ -143,12 +143,14 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
             FROM data_access_request
             WHERE data_access_request.collection_id = c.collection_id
             AND data_access_request.submission_date IS NOT NULL
+            AND (LOWER(data_access_request.data->>'status') != 'archived' OR data_access_request.data->>'status' IS NULL)
             ORDER BY data_access_request.submission_date DESC
             LIMIT 1
         ) dar ON true
     INNER JOIN
         data_access_request dar_all ON dar_all.collection_id = c.collection_id
         AND dar_all.submission_date IS NOT NULL
+        AND (LOWER(dar_all.data->>'status') != 'archived' OR dar_all.data->>'status' IS NULL)
     LEFT JOIN
         LATERAL (
             SELECT
@@ -164,8 +166,6 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
     WHERE
         c.create_user_id = :userId
         AND (e.latest = e.election_id OR e.election_id IS NULL)
-        AND (LOWER(dar.data->>'status') != 'archived' OR dar.data->>'status' IS NULL)
-        AND (EXISTS (SELECT 1 FROM data_access_request WHERE (collection_id = c.collection_id AND dar.submission_date IS  NOT NULL)))
     GROUP BY
         c.collection_id, c.dar_code, dar.submission_date, dar.reference_id, u.display_name, i.institution_name,
         e.election_id, e.status, e.dataset_id, e.reference_id, dd.dataset_id, dar.data

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DarCollectionSummaryReducer.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DarCollectionSummaryReducer.java
@@ -41,7 +41,9 @@ public class DarCollectionSummaryReducer implements
       try {
         darReferenceId = rowView.getColumn("dar_reference_id", String.class);
         if (Objects.nonNull(darReferenceId)) {
-          summary.addReferenceId(darReferenceId);
+          if (!summary.getReferenceIds().contains(darReferenceId)) {
+            summary.addReferenceId(darReferenceId);
+          }
         }
 
         darStatus = rowView.getColumn("dar_status", String.class);

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DarCollectionSummaryReducer.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DarCollectionSummaryReducer.java
@@ -41,9 +41,7 @@ public class DarCollectionSummaryReducer implements
       try {
         darReferenceId = rowView.getColumn("dar_reference_id", String.class);
         if (Objects.nonNull(darReferenceId)) {
-          if (!summary.getReferenceIds().contains(darReferenceId)) {
-            summary.addReferenceId(darReferenceId);
-          }
+          summary.addReferenceId(darReferenceId);
         }
 
         darStatus = rowView.getColumn("dar_status", String.class);

--- a/src/main/java/org/broadinstitute/consent/http/models/DarCollectionSummary.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DarCollectionSummary.java
@@ -88,7 +88,7 @@ public class DarCollectionSummary {
   }
 
   public void setReferenceIds(Set<String> referenceIds) {
-    this.referenceIds = referenceIds;
+    this.referenceIds = new HashSet<>(referenceIds);
   }
 
   public void addVote(Vote vote) {

--- a/src/test/java/org/broadinstitute/consent/http/db/DarCollectionSummaryDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DarCollectionSummaryDAOTest.java
@@ -24,7 +24,6 @@ import org.broadinstitute.consent.http.models.Dataset;
 import org.broadinstitute.consent.http.models.Election;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.Vote;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -488,6 +487,55 @@ class DarCollectionSummaryDAOTest extends DAOTestHelper {
 
     assertEquals(0, summaries.size());
 
+  }
+
+  @Test
+  void testGetDarCollectionSummariesForResearcher_TwoDataAccessRequests() {
+    User userOne = createUser();
+    Integer userOneId = userOne.getUserId();
+
+    Dataset dataset = createDataset(userOneId);
+    Dataset dataset1 = createDataset(userOneId);
+
+    Integer collectionId = createDarCollection(userOneId);
+
+    // Create two DataAccessRequests in the same collection
+    DataAccessRequest olderDar = createDataAccessRequest(collectionId, userOneId);
+    DataAccessRequest newerDar = createDataAccessRequest(collectionId, userOneId);
+
+    // Insert dataset relations for both DARs
+    // the older DAR has two datasets and the newer DAR has one
+    dataAccessRequestDAO.insertDARDatasetRelation(olderDar.getReferenceId(), dataset.getDatasetId());
+    dataAccessRequestDAO.insertDARDatasetRelation(olderDar.getReferenceId(), dataset1.getDatasetId());
+    dataAccessRequestDAO.insertDARDatasetRelation(newerDar.getReferenceId(), dataset.getDatasetId());
+
+    // Create an election for the older DAR
+    createElection(ElectionType.DATA_ACCESS.getValue(),
+        ElectionStatus.OPEN.getValue(),
+        olderDar.getReferenceId(), dataset.getDatasetId());
+
+    List<DarCollectionSummary> summaries = darCollectionSummaryDAO.getDarCollectionSummariesForResearcher(userOneId);
+
+    assertNotNull(summaries);
+    assertEquals(1, summaries.size());
+    DarCollectionSummary summary = summaries.get(0);
+    assertEquals(collectionId, summary.getDarCollectionId());
+
+    // Ensure the reference IDs include both DARs
+    assertNotNull(summary.getReferenceIds());
+    assertEquals(2, summary.getReferenceIds().size());
+    assertTrue(summary.getReferenceIds().contains(olderDar.getReferenceId()));
+    assertTrue(summary.getReferenceIds().contains(newerDar.getReferenceId()));
+
+    // Ensure the election from the older DAR is not included
+    assertTrue(summary.getElections().isEmpty());
+
+    // Ensure the summary represents the most recently submitted DAR
+    assertEquals(newerDar.getSubmissionDate(), summary.getSubmissionDate());
+    assertEquals(newerDar.getExpiresAt(), summary.getExpiresAt());
+    // should only be one dataset because the newer dar has one dataset
+    assertEquals(1, summary.getDatasetIds().size());
+    assertTrue(summary.getDatasetIds().contains(dataset.getDatasetId()));
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/db/DarCollectionSummaryDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DarCollectionSummaryDAOTest.java
@@ -490,7 +490,7 @@ class DarCollectionSummaryDAOTest extends DAOTestHelper {
   }
 
   @Test
-  void testGetDarCollectionSummaryForResearcher_DraftNotIncluded() {
+  void testGetDarCollectionSummaryForResearcher_DraftAndArchivedNotIncluded() {
     User user = createUser();
     Integer userId = user.getUserId();
 
@@ -501,14 +501,17 @@ class DarCollectionSummaryDAOTest extends DAOTestHelper {
     // Create two DataAccessRequests in the same collection
     DataAccessRequest olderDar = createDataAccessRequest(collectionId, userId);
     DataAccessRequest draftDar = createDataAccessRequest(collectionId, userId);
+    DataAccessRequest archivedDar = createDataAccessRequest(collectionId, userId);
 
-    // Insert dataset relations for both DARs
-    // the older DAR has two datasets, the newer DAR has one, the draft also has one
+    // Insert dataset relations for all DARs
     dataAccessRequestDAO.insertDARDatasetRelation(olderDar.getReferenceId(), dataset.getDatasetId());
     dataAccessRequestDAO.insertDARDatasetRelation(draftDar.getReferenceId(), dataset.getDatasetId());
+    dataAccessRequestDAO.insertDARDatasetRelation(archivedDar.getReferenceId(), dataset.getDatasetId());
     // draft DAR
     dataAccessRequestDAO.updateDataByReferenceId(draftDar.getReferenceId(), draftDar.userId, new Date(), null,
         new Date(), draftDar.getData());
+    // archived DAR
+    dataAccessRequestDAO.archiveByReferenceIds(List.of(archivedDar.getReferenceId()));
 
     List<DarCollectionSummary> summaries = darCollectionSummaryDAO.getDarCollectionSummariesForResearcher(userId);
 
@@ -517,13 +520,13 @@ class DarCollectionSummaryDAOTest extends DAOTestHelper {
     DarCollectionSummary summary = summaries.get(0);
     assertEquals(collectionId, summary.getDarCollectionId());
 
-    // Ensure the reference IDs include both DARs
+    // Ensure the reference IDs include only the non-draft non-archived DAR
     assertNotNull(summary.getReferenceIds());
     assertEquals(1, summary.getReferenceIds().size());
     assertTrue(summary.getReferenceIds().contains(olderDar.getReferenceId()));
     assertFalse(summary.getReferenceIds().contains(draftDar.getReferenceId()));
 
-    // Ensure the summary represents the older DAR, because the most recent DAR is a draft
+    // Ensure the summary represents the older DAR
     assertEquals(olderDar.getSubmissionDate(), summary.getSubmissionDate());
     assertEquals(olderDar.getExpiresAt(), summary.getExpiresAt());
   }
@@ -572,7 +575,7 @@ class DarCollectionSummaryDAOTest extends DAOTestHelper {
     // Ensure the summary represents the most recently submitted DAR
     assertEquals(newerDar.getSubmissionDate(), summary.getSubmissionDate());
     assertEquals(newerDar.getExpiresAt(), summary.getExpiresAt());
-    // should only be one dataset because the newer dar has one dataset
+    // should only be one dataset because the newer DAR has one dataset
     assertEquals(1, summary.getDatasetIds().size());
     assertTrue(summary.getDatasetIds().contains(dataset.getDatasetId()));
   }

--- a/src/test/java/org/broadinstitute/consent/http/db/DarCollectionSummaryDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DarCollectionSummaryDAOTest.java
@@ -26,6 +26,8 @@ import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.Vote;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -490,97 +492,6 @@ class DarCollectionSummaryDAOTest extends DAOTestHelper {
   }
 
   @Test
-  void testGetDarCollectionSummaryForResearcher_DraftAndArchivedNotIncluded() {
-    User user = createUser();
-    Integer userId = user.getUserId();
-
-    Dataset dataset = createDataset(userId);
-
-    Integer collectionId = createDarCollection(userId);
-
-    // Create two DataAccessRequests in the same collection
-    DataAccessRequest olderDar = createDataAccessRequest(collectionId, userId);
-    DataAccessRequest draftDar = createDataAccessRequest(collectionId, userId);
-    DataAccessRequest archivedDar = createDataAccessRequest(collectionId, userId);
-
-    // Insert dataset relations for all DARs
-    dataAccessRequestDAO.insertDARDatasetRelation(olderDar.getReferenceId(), dataset.getDatasetId());
-    dataAccessRequestDAO.insertDARDatasetRelation(draftDar.getReferenceId(), dataset.getDatasetId());
-    dataAccessRequestDAO.insertDARDatasetRelation(archivedDar.getReferenceId(), dataset.getDatasetId());
-    // draft DAR
-    dataAccessRequestDAO.updateDataByReferenceId(draftDar.getReferenceId(), draftDar.userId, new Date(), null,
-        new Date(), draftDar.getData());
-    // archived DAR
-    dataAccessRequestDAO.archiveByReferenceIds(List.of(archivedDar.getReferenceId()));
-
-    List<DarCollectionSummary> summaries = darCollectionSummaryDAO.getDarCollectionSummariesForResearcher(userId);
-
-    assertNotNull(summaries);
-    assertEquals(1, summaries.size());
-    DarCollectionSummary summary = summaries.get(0);
-    assertEquals(collectionId, summary.getDarCollectionId());
-
-    // Ensure the reference IDs include only the non-draft non-archived DAR
-    assertNotNull(summary.getReferenceIds());
-    assertEquals(1, summary.getReferenceIds().size());
-    assertTrue(summary.getReferenceIds().contains(olderDar.getReferenceId()));
-    assertFalse(summary.getReferenceIds().contains(draftDar.getReferenceId()));
-
-    // Ensure the summary represents the older DAR
-    assertEquals(olderDar.getSubmissionDate(), summary.getSubmissionDate());
-    assertEquals(olderDar.getExpiresAt(), summary.getExpiresAt());
-  }
-
-  @Test
-  void testGetDarCollectionSummaryForResearcher_TwoDataAccessRequests() {
-    User userOne = createUser();
-    Integer userOneId = userOne.getUserId();
-
-    Dataset dataset = createDataset(userOneId);
-    Dataset dataset1 = createDataset(userOneId);
-
-    Integer collectionId = createDarCollection(userOneId);
-
-    // Create two DataAccessRequests in the same collection
-    DataAccessRequest olderDar = createDataAccessRequest(collectionId, userOneId);
-    DataAccessRequest newerDar = createDataAccessRequest(collectionId, userOneId);
-
-    // Insert dataset relations for both DARs
-    // the older DAR has two datasets and the newer DAR has one
-    dataAccessRequestDAO.insertDARDatasetRelation(olderDar.getReferenceId(), dataset.getDatasetId());
-    dataAccessRequestDAO.insertDARDatasetRelation(olderDar.getReferenceId(), dataset1.getDatasetId());
-    dataAccessRequestDAO.insertDARDatasetRelation(newerDar.getReferenceId(), dataset.getDatasetId());
-
-    // Create an election for the older DAR
-    createElection(ElectionType.DATA_ACCESS.getValue(),
-        ElectionStatus.OPEN.getValue(),
-        olderDar.getReferenceId(), dataset.getDatasetId());
-
-    List<DarCollectionSummary> summaries = darCollectionSummaryDAO.getDarCollectionSummariesForResearcher(userOneId);
-
-    assertNotNull(summaries);
-    assertEquals(1, summaries.size());
-    DarCollectionSummary summary = summaries.get(0);
-    assertEquals(collectionId, summary.getDarCollectionId());
-
-    // Ensure the reference IDs include both DARs
-    assertNotNull(summary.getReferenceIds());
-    assertEquals(2, summary.getReferenceIds().size());
-    assertTrue(summary.getReferenceIds().contains(olderDar.getReferenceId()));
-    assertTrue(summary.getReferenceIds().contains(newerDar.getReferenceId()));
-
-    // Ensure the election from the older DAR is not included
-    assertTrue(summary.getElections().isEmpty());
-
-    // Ensure the summary represents the most recently submitted DAR
-    assertEquals(newerDar.getSubmissionDate(), summary.getSubmissionDate());
-    assertEquals(newerDar.getExpiresAt(), summary.getExpiresAt());
-    // should only be one dataset because the newer DAR has one dataset
-    assertEquals(1, summary.getDatasetIds().size());
-    assertTrue(summary.getDatasetIds().contains(dataset.getDatasetId()));
-  }
-
-  @Test
   void testGetDarCollectionSummaryForAdmin() {
 
     User userOne = createUser();
@@ -711,6 +622,107 @@ class DarCollectionSummaryDAOTest extends DAOTestHelper {
     assertNotNull(summaries);
     assertEquals(1, summaries.size());
     assertEquals(collectionOneId, summaries.get(0).getDarCollectionId());
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings= {"admin", "researcher"})
+  void testGetDarCollectionSummaryDraftAndArchivedNotIncluded(String type) {
+    User user = createUser();
+    Integer userId = user.getUserId();
+
+    Dataset dataset = createDataset(userId);
+
+    Integer collectionId = createDarCollection(userId);
+
+    // Create two DataAccessRequests in the same collection
+    DataAccessRequest olderDar = createDataAccessRequest(collectionId, userId);
+    DataAccessRequest draftDar = createDataAccessRequest(collectionId, userId);
+    DataAccessRequest archivedDar = createDataAccessRequest(collectionId, userId);
+
+    // Insert dataset relations for all DARs
+    dataAccessRequestDAO.insertDARDatasetRelation(olderDar.getReferenceId(), dataset.getDatasetId());
+    dataAccessRequestDAO.insertDARDatasetRelation(draftDar.getReferenceId(), dataset.getDatasetId());
+    dataAccessRequestDAO.insertDARDatasetRelation(archivedDar.getReferenceId(), dataset.getDatasetId());
+    // draft DAR
+    dataAccessRequestDAO.updateDataByReferenceId(draftDar.getReferenceId(), draftDar.userId, new Date(), null,
+        new Date(), draftDar.getData());
+    // archived DAR
+    dataAccessRequestDAO.archiveByReferenceIds(List.of(archivedDar.getReferenceId()));
+
+    List<DarCollectionSummary> summaries = switch (type) {
+      case "admin" -> darCollectionSummaryDAO.getDarCollectionSummariesForAdmin();
+      case "researcher" -> darCollectionSummaryDAO.getDarCollectionSummariesForResearcher(userId);
+      default -> throw new IllegalArgumentException("Invalid type: " + type);
+    };
+
+    assertNotNull(summaries);
+    assertEquals(1, summaries.size());
+    DarCollectionSummary summary = summaries.get(0);
+    assertEquals(collectionId, summary.getDarCollectionId());
+
+    // Ensure the reference IDs include only the non-draft non-archived DAR
+    assertNotNull(summary.getReferenceIds());
+    assertEquals(1, summary.getReferenceIds().size());
+    assertTrue(summary.getReferenceIds().contains(olderDar.getReferenceId()));
+    assertFalse(summary.getReferenceIds().contains(draftDar.getReferenceId()));
+
+    // Ensure the summary represents the older DAR
+    assertEquals(olderDar.getSubmissionDate(), summary.getSubmissionDate());
+    assertEquals(olderDar.getExpiresAt(), summary.getExpiresAt());
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings= {"admin", "researcher"})
+  void testGetDarCollectionSummaryTwoDataAccessRequests(String type) {
+    User userOne = createUser();
+    Integer userOneId = userOne.getUserId();
+
+    Dataset dataset = createDataset(userOneId);
+    Dataset dataset1 = createDataset(userOneId);
+
+    Integer collectionId = createDarCollection(userOneId);
+
+    // Create two DataAccessRequests in the same collection
+    DataAccessRequest olderDar = createDataAccessRequest(collectionId, userOneId);
+    DataAccessRequest newerDar = createDataAccessRequest(collectionId, userOneId);
+
+    // Insert dataset relations for both DARs
+    // the older DAR has two datasets and the newer DAR has one
+    dataAccessRequestDAO.insertDARDatasetRelation(olderDar.getReferenceId(), dataset.getDatasetId());
+    dataAccessRequestDAO.insertDARDatasetRelation(olderDar.getReferenceId(), dataset1.getDatasetId());
+    dataAccessRequestDAO.insertDARDatasetRelation(newerDar.getReferenceId(), dataset.getDatasetId());
+
+    // Create an election for the older DAR
+    createElection(ElectionType.DATA_ACCESS.getValue(),
+        ElectionStatus.OPEN.getValue(),
+        olderDar.getReferenceId(), dataset.getDatasetId());
+
+    List<DarCollectionSummary> summaries = switch (type) {
+      case "admin" -> darCollectionSummaryDAO.getDarCollectionSummariesForAdmin();
+      case "researcher" ->
+          darCollectionSummaryDAO.getDarCollectionSummariesForResearcher(userOneId);
+      default -> throw new IllegalArgumentException("Invalid type: " + type);
+    };
+    assertNotNull(summaries);
+    assertEquals(1, summaries.size());
+    DarCollectionSummary summary = summaries.get(0);
+    assertEquals(collectionId, summary.getDarCollectionId());
+
+    // Ensure the reference IDs include both DARs
+    assertNotNull(summary.getReferenceIds());
+    assertEquals(2, summary.getReferenceIds().size());
+    assertTrue(summary.getReferenceIds().contains(olderDar.getReferenceId()));
+    assertTrue(summary.getReferenceIds().contains(newerDar.getReferenceId()));
+
+    // Ensure the election from the older DAR is not included
+    assertTrue(summary.getElections().isEmpty());
+
+    // Ensure the summary represents the most recently submitted DAR
+    assertEquals(newerDar.getSubmissionDate(), summary.getSubmissionDate());
+    assertEquals(newerDar.getExpiresAt(), summary.getExpiresAt());
+    // should only be one dataset because the newer DAR has one dataset
+    assertEquals(1, summary.getDatasetIds().size());
+    assertTrue(summary.getDatasetIds().contains(dataset.getDatasetId()));
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/db/DarCollectionSummaryDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DarCollectionSummaryDAOTest.java
@@ -490,7 +490,46 @@ class DarCollectionSummaryDAOTest extends DAOTestHelper {
   }
 
   @Test
-  void testGetDarCollectionSummariesForResearcher_TwoDataAccessRequests() {
+  void testGetDarCollectionSummaryForResearcher_DraftNotIncluded() {
+    User user = createUser();
+    Integer userId = user.getUserId();
+
+    Dataset dataset = createDataset(userId);
+
+    Integer collectionId = createDarCollection(userId);
+
+    // Create two DataAccessRequests in the same collection
+    DataAccessRequest olderDar = createDataAccessRequest(collectionId, userId);
+    DataAccessRequest draftDar = createDataAccessRequest(collectionId, userId);
+
+    // Insert dataset relations for both DARs
+    // the older DAR has two datasets, the newer DAR has one, the draft also has one
+    dataAccessRequestDAO.insertDARDatasetRelation(olderDar.getReferenceId(), dataset.getDatasetId());
+    dataAccessRequestDAO.insertDARDatasetRelation(draftDar.getReferenceId(), dataset.getDatasetId());
+    // draft DAR
+    dataAccessRequestDAO.updateDataByReferenceId(draftDar.getReferenceId(), draftDar.userId, new Date(), null,
+        new Date(), draftDar.getData());
+
+    List<DarCollectionSummary> summaries = darCollectionSummaryDAO.getDarCollectionSummariesForResearcher(userId);
+
+    assertNotNull(summaries);
+    assertEquals(1, summaries.size());
+    DarCollectionSummary summary = summaries.get(0);
+    assertEquals(collectionId, summary.getDarCollectionId());
+
+    // Ensure the reference IDs include both DARs
+    assertNotNull(summary.getReferenceIds());
+    assertEquals(1, summary.getReferenceIds().size());
+    assertTrue(summary.getReferenceIds().contains(olderDar.getReferenceId()));
+    assertFalse(summary.getReferenceIds().contains(draftDar.getReferenceId()));
+
+    // Ensure the summary represents the older DAR, because the most recent DAR is a draft
+    assertEquals(olderDar.getSubmissionDate(), summary.getSubmissionDate());
+    assertEquals(olderDar.getExpiresAt(), summary.getExpiresAt());
+  }
+
+  @Test
+  void testGetDarCollectionSummaryForResearcher_TwoDataAccessRequests() {
     User userOne = createUser();
     Integer userOneId = userOne.getUserId();
 

--- a/src/test/java/org/broadinstitute/consent/http/db/DarCollectionSummaryDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DarCollectionSummaryDAOTest.java
@@ -72,9 +72,9 @@ class DarCollectionSummaryDAOTest extends DAOTestHelper {
     return dacDAO.findById(id);
   }
 
-  private Election createElection(String type, String status, String referenceId,
+  private Election createElection(ElectionType type, String status, String referenceId,
       Integer datasetId) {
-    Integer electionId = electionDAO.insertElection(type, status, new Date(), referenceId,
+    Integer electionId = electionDAO.insertElection(type.getValue(), status, new Date(), referenceId,
         datasetId);
     return electionDAO.findElectionById(electionId);
   }
@@ -110,18 +110,18 @@ class DarCollectionSummaryDAOTest extends DAOTestHelper {
     dataAccessRequestDAO.insertDARDatasetRelation(excludedDar.getReferenceId(),
         excludedDataset.getDatasetId());
 
-    Election collectionOnePrevElection = createElection(ElectionType.DATA_ACCESS.getValue(),
+    Election collectionOnePrevElection = createElection(ElectionType.DATA_ACCESS,
         ElectionStatus.CLOSED.getValue(),
         darOne.getReferenceId(),
         dataset.getDatasetId()); //non-latest dataset, need to make sure this isn't pulled into query results
-    Election collectionOneElection = createElection(ElectionType.DATA_ACCESS.getValue(),
+    Election collectionOneElection = createElection(ElectionType.DATA_ACCESS,
         ElectionStatus.OPEN.getValue(), darOne.getReferenceId(), dataset.getDatasetId());
     Integer collectionOneElectionId = collectionOneElection.getElectionId();
     Integer collectionOnePrevElectionId = collectionOnePrevElection.getElectionId();
-    Election excludedElection = createElection(ElectionType.DATA_ACCESS.getValue(),
+    Election excludedElection = createElection(ElectionType.DATA_ACCESS,
         ElectionStatus.CLOSED.getValue(), //tied to excluded dataset, it should not be pulled in
         excludedDar.getReferenceId(), excludedDataset.getDatasetId());
-    Election collectionTwoElection = createElection(ElectionType.DATA_ACCESS.getValue(),
+    Election collectionTwoElection = createElection(ElectionType.DATA_ACCESS,
         ElectionStatus.OPEN.getValue(),
         darTwo.getReferenceId(), datasetTwo.getDatasetId());
     Integer collectionTwoElectionId = collectionTwoElection.getElectionId();
@@ -206,7 +206,7 @@ class DarCollectionSummaryDAOTest extends DAOTestHelper {
     dataAccessRequestDAO.insertDARDatasetRelation(excludedDar.getReferenceId(),
         excludedDataset.getDatasetId());
 
-    Election excludedElection = createElection(ElectionType.DATA_ACCESS.getValue(),
+    Election excludedElection = createElection(ElectionType.DATA_ACCESS,
         ElectionStatus.CLOSED.getValue(),
         excludedDar.getReferenceId(), excludedDataset.getDatasetId());
     Integer excludedElectionId = excludedElection.getElectionId();
@@ -279,15 +279,15 @@ class DarCollectionSummaryDAOTest extends DAOTestHelper {
     dataAccessRequestDAO.insertDARDatasetRelation(darTwo.getReferenceId(),
         datasetTwo.getDatasetId());
 
-    Election collectionOnePrevElection = createElection(ElectionType.DATA_ACCESS.getValue(),
+    Election collectionOnePrevElection = createElection(ElectionType.DATA_ACCESS,
         ElectionStatus.CLOSED.getValue(),
         darOne.getReferenceId(), dataset.getDatasetId());
-    Election collectionOneElection = createElection(ElectionType.DATA_ACCESS.getValue(),
+    Election collectionOneElection = createElection(ElectionType.DATA_ACCESS,
         ElectionStatus.OPEN.getValue(),
         darOne.getReferenceId(), dataset.getDatasetId());
     Integer collectionOneElectionId = collectionOneElection.getElectionId();
     Integer collectionOnePrevElectionId = collectionOnePrevElection.getElectionId();
-    Election collectionTwoElection = createElection(ElectionType.DATA_ACCESS.getValue(),
+    Election collectionTwoElection = createElection(ElectionType.DATA_ACCESS,
         ElectionStatus.OPEN.getValue(),
         darTwo.getReferenceId(), datasetTwo.getDatasetId());
     Integer collectionTwoElectionId = collectionTwoElection.getElectionId();
@@ -377,15 +377,15 @@ class DarCollectionSummaryDAOTest extends DAOTestHelper {
     dataAccessRequestDAO.insertDARDatasetRelation(darTwo.getReferenceId(),
         datasetTwo.getDatasetId());
 
-    Election collectionOnePrevElection = createElection(ElectionType.DATA_ACCESS.getValue(),
+    Election collectionOnePrevElection = createElection(ElectionType.DATA_ACCESS,
         ElectionStatus.CLOSED.getValue(),
         darOne.getReferenceId(), dataset.getDatasetId());
-    Election collectionOneElection = createElection(ElectionType.DATA_ACCESS.getValue(),
+    Election collectionOneElection = createElection(ElectionType.DATA_ACCESS,
         ElectionStatus.OPEN.getValue(),
         darOne.getReferenceId(), dataset.getDatasetId());
     Integer collectionOneElectionId = collectionOneElection.getElectionId();
     Integer collectionOnePrevElectionId = collectionOnePrevElection.getElectionId();
-    Election collectionTwoElection = createElection(ElectionType.DATA_ACCESS.getValue(),
+    Election collectionTwoElection = createElection(ElectionType.DATA_ACCESS,
         ElectionStatus.OPEN.getValue(),
         darTwo.getReferenceId(), datasetTwo.getDatasetId());
     Integer collectionTwoElectionId = collectionTwoElection.getElectionId();
@@ -427,7 +427,7 @@ class DarCollectionSummaryDAOTest extends DAOTestHelper {
     dataAccessRequestDAO.insertDARDatasetRelation(darTwo.getReferenceId(),
         datasetTwo.getDatasetId());
 
-    Election collectionTwoElection = createElection(ElectionType.DATA_ACCESS.getValue(),
+    Election collectionTwoElection = createElection(ElectionType.DATA_ACCESS,
         ElectionStatus.OPEN.getValue(),
         darTwo.getReferenceId(), datasetTwo.getDatasetId());
     Integer collectionTwoElectionId = collectionTwoElection.getElectionId();
@@ -515,15 +515,15 @@ class DarCollectionSummaryDAOTest extends DAOTestHelper {
     dataAccessRequestDAO.insertDARDatasetRelation(darTwo.getReferenceId(),
         datasetTwo.getDatasetId());
 
-    Election collectionOnePrevElection = createElection(ElectionType.DATA_ACCESS.getValue(),
+    Election collectionOnePrevElection = createElection(ElectionType.DATA_ACCESS,
         ElectionStatus.CLOSED.getValue(),
         darOne.getReferenceId(), dataset.getDatasetId());
-    Election collectionOneElection = createElection(ElectionType.DATA_ACCESS.getValue(),
+    Election collectionOneElection = createElection(ElectionType.DATA_ACCESS,
         ElectionStatus.OPEN.getValue(),
         darOne.getReferenceId(), dataset.getDatasetId());
     Integer collectionOneElectionId = collectionOneElection.getElectionId();
     Integer collectionOnePrevElectionId = collectionOnePrevElection.getElectionId();
-    Election collectionTwoElection = createElection(ElectionType.DATA_ACCESS.getValue(),
+    Election collectionTwoElection = createElection(ElectionType.DATA_ACCESS,
         ElectionStatus.OPEN.getValue(),
         darTwo.getReferenceId(), datasetTwo.getDatasetId());
     Integer collectionTwoElectionId = collectionTwoElection.getElectionId();
@@ -664,7 +664,6 @@ class DarCollectionSummaryDAOTest extends DAOTestHelper {
     assertNotNull(summary.getReferenceIds());
     assertEquals(1, summary.getReferenceIds().size());
     assertTrue(summary.getReferenceIds().contains(olderDar.getReferenceId()));
-    assertFalse(summary.getReferenceIds().contains(draftDar.getReferenceId()));
 
     // Ensure the summary represents the older DAR
     assertEquals(olderDar.getSubmissionDate(), summary.getSubmissionDate());
@@ -693,7 +692,7 @@ class DarCollectionSummaryDAOTest extends DAOTestHelper {
     dataAccessRequestDAO.insertDARDatasetRelation(newerDar.getReferenceId(), dataset.getDatasetId());
 
     // Create an election for the older DAR
-    createElection(ElectionType.DATA_ACCESS.getValue(),
+    createElection(ElectionType.DATA_ACCESS,
         ElectionStatus.OPEN.getValue(),
         olderDar.getReferenceId(), dataset.getDatasetId());
 
@@ -711,8 +710,7 @@ class DarCollectionSummaryDAOTest extends DAOTestHelper {
     // Ensure the reference IDs include both DARs
     assertNotNull(summary.getReferenceIds());
     assertEquals(2, summary.getReferenceIds().size());
-    assertTrue(summary.getReferenceIds().contains(olderDar.getReferenceId()));
-    assertTrue(summary.getReferenceIds().contains(newerDar.getReferenceId()));
+    assertTrue(summary.getReferenceIds().containsAll(List.of(olderDar.getReferenceId(), newerDar.getReferenceId())));
 
     // Ensure the election from the older DAR is not included
     assertTrue(summary.getElections().isEmpty());
@@ -743,15 +741,15 @@ class DarCollectionSummaryDAOTest extends DAOTestHelper {
     dataAccessRequestDAO.insertDARDatasetRelation(darTwo.getReferenceId(),
         datasetTwo.getDatasetId());
 
-    Election collectionOnePrevElection = createElection(ElectionType.DATA_ACCESS.getValue(),
+    Election collectionOnePrevElection = createElection(ElectionType.DATA_ACCESS,
         ElectionStatus.CLOSED.getValue(),
         darOne.getReferenceId(), dataset.getDatasetId());
-    Election collectionOneElection = createElection(ElectionType.DATA_ACCESS.getValue(),
+    Election collectionOneElection = createElection(ElectionType.DATA_ACCESS,
         ElectionStatus.OPEN.getValue(),
         darOne.getReferenceId(), dataset.getDatasetId());
     Integer collectionOneElectionId = collectionOneElection.getElectionId();
     Integer collectionOnePrevElectionId = collectionOnePrevElection.getElectionId();
-    Election collectionTwoElection = createElection(ElectionType.DATA_ACCESS.getValue(),
+    Election collectionTwoElection = createElection(ElectionType.DATA_ACCESS,
         ElectionStatus.OPEN.getValue(),
         darTwo.getReferenceId(), datasetTwo.getDatasetId());
     Integer collectionTwoElectionId = collectionTwoElection.getElectionId();
@@ -792,7 +790,7 @@ class DarCollectionSummaryDAOTest extends DAOTestHelper {
     dataAccessRequestDAO.insertDARDatasetRelation(darTwo.getReferenceId(),
         datasetTwo.getDatasetId());
 
-    Election collectionTwoElection = createElection(ElectionType.DATA_ACCESS.getValue(),
+    Election collectionTwoElection = createElection(ElectionType.DATA_ACCESS,
         ElectionStatus.OPEN.getValue(),
         darTwo.getReferenceId(), datasetTwo.getDatasetId());
     Integer collectionTwoElectionId = collectionTwoElection.getElectionId();
@@ -830,15 +828,15 @@ class DarCollectionSummaryDAOTest extends DAOTestHelper {
     dataAccessRequestDAO.insertDARDatasetRelation(excludedDar.getReferenceId(),
         datasetTwo.getDatasetId());
 
-    Election collectionOnePrevElection = createElection(ElectionType.DATA_ACCESS.getValue(),
+    Election collectionOnePrevElection = createElection(ElectionType.DATA_ACCESS,
         ElectionStatus.CLOSED.getValue(),
         darOne.getReferenceId(),
         dataset.getDatasetId()); //non-latest dataset, need to make sure this isn't pulled into query results
-    Election collectionOneElection = createElection(ElectionType.DATA_ACCESS.getValue(),
+    Election collectionOneElection = createElection(ElectionType.DATA_ACCESS,
         ElectionStatus.OPEN.getValue(), darOne.getReferenceId(), dataset.getDatasetId());
     Integer collectionOneElectionId = collectionOneElection.getElectionId();
     Integer collectionOnePrevElectionId = collectionOnePrevElection.getElectionId();
-    Election excludedCollectionElection = createElection(ElectionType.DATA_ACCESS.getValue(),
+    Election excludedCollectionElection = createElection(ElectionType.DATA_ACCESS,
         ElectionStatus.OPEN.getValue(),
         excludedDar.getReferenceId(), datasetTwo.getDatasetId());
     Integer excludedCollectionElectionId = excludedCollectionElection.getElectionId();
@@ -906,7 +904,7 @@ class DarCollectionSummaryDAOTest extends DAOTestHelper {
     dataAccessRequestDAO.insertDARDatasetRelation(excludedDar.getReferenceId(),
         excludedDataset.getDatasetId());
 
-    Election excludedElection = createElection(ElectionType.DATA_ACCESS.getValue(),
+    Election excludedElection = createElection(ElectionType.DATA_ACCESS,
         ElectionStatus.CLOSED.getValue(),
         excludedDar.getReferenceId(), excludedDataset.getDatasetId());
     Integer excludedElectionId = excludedElection.getElectionId();


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-99
We want to show the information from the latest DAR in the collection on the researcher console DAR page. We want to do this for all DAR tables in the UI which means updating all the DarCollectionSummaryDAO queries.

### Summary
Maintain the structure of the DarCollectionSummary by aggregating all referenceIds that share a collectionId and still include them in the summary, but update the information of the summary to only look at the the latest DAR by submission date instead.

### Testing
Manual testing shows the UI looks as expected and checked that the summary information represents the latest DAR
Added unit tests
I also tested performance and the new queries have a similar performance to the existing queries (~100ms on 600 Dar Collections)

### To Do
I only updated the researcher query, something similar needs to be done for the other queries. There is a ticket for the rest of this work: https://broadworkbench.atlassian.net/browse/DT-1598

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
