### PR TITLE
DT-1472: Populate eRA Commons Id on DAR submission

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/DataAccessRequestDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DataAccessRequestDAO.java
@@ -4,7 +4,6 @@ import java.sql.Timestamp;
 import java.util.Date;
 import java.util.List;
 import java.util.Set;
-import org.broadinstitute.consent.http.db.mapper.DataAccessRequestDataMapper;
 import org.broadinstitute.consent.http.db.mapper.DataAccessRequestMapper;
 import org.broadinstitute.consent.http.db.mapper.DataAccessRequestReducer;
 import org.broadinstitute.consent.http.models.DarDataset;
@@ -66,8 +65,8 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
       """
               SELECT dar.id, dar.reference_id, dar.collection_id, dar.parent_id,
                 dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date,
-                (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data, dar.era_commons_id,
-                dd.dataset_id, collection.dar_code
+                (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data,
+                dd.dataset_id, collection.dar_code, dar.era_commons_id
               FROM data_access_request dar
               LEFT JOIN dar_collection collection on collection.collection_id = dar.collection_id
               INNER JOIN dar_dataset dd ON dd.reference_id = dar.reference_id AND dd.dataset_id = :datasetId
@@ -103,7 +102,7 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
    * value is `TRUE` so the denied election in the example would be filtered out.
    *
    * @param darReferenceId The DAR reference UUID
-   * @return List of approved Datasets for the DAR
+   * @return Set of approved Dataset Ids for the DAR
    */
   @SqlQuery(
       """
@@ -145,8 +144,8 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
       """
               SELECT dar.id, dar.reference_id, dar.collection_id, dar.parent_id,
                 dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date,
-                (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data, dar.era_commons_id,
-                dd.dataset_id, collection.dar_code
+                (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data,
+                dd.dataset_id, collection.dar_code, dar.era_commons_id
               FROM data_access_request dar
               LEFT JOIN dar_collection collection on collection.collection_id = dar.collection_id
               LEFT JOIN dar_dataset dd ON dd.reference_id = dar.reference_id
@@ -154,7 +153,7 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
               WHERE dar.submission_date >= :notBefore
               AND (dar.submission_date < now() - :interval ::interval)
               AND (email.email_type IS NULL)
-            
+          
           """)
   List<DataAccessRequest> findAgedDARsByEmailTypeOlderThanInterval(@Bind("emailType") Integer emailType,
       @Bind("interval") String interval, @Bind("notBefore") Timestamp notBefore);
@@ -168,7 +167,7 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
   @SqlQuery(
       """
               SELECT dd.dataset_id, dar.id, dar.reference_id, dar.collection_id, dar.parent_id, dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date,
-                (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data, collection.dar_code, dar.era_commons_id 
+                (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data, collection.dar_code, dar.era_commons_id
               FROM data_access_request dar
               LEFT JOIN dar_collection collection on collection.collection_id = dar.collection_id
               LEFT JOIN dar_dataset dd on dd.reference_id = dar.reference_id
@@ -197,25 +196,6 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
               ORDER BY dar.sort_date DESC
           """)
   List<DataAccessRequest> findAllDraftsByUserId(@Bind("userId") Integer userId);
-
-
-  /**
-   * Find all complete DataAccessRequests by user id, sorted descending order
-   *
-   * @return List<DataAccessRequest>
-   */
-  @UseRowReducer(DataAccessRequestReducer.class)
-  @SqlQuery(
-      """
-              SELECT dd.dataset_id, dar.id, dar.reference_id, dar.collection_id, dar.parent_id, dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date,
-              (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data FROM data_access_request dar
-              LEFT JOIN dar_dataset dd on dd.reference_id = dar.reference_id
-              WHERE dar.submission_date is not null
-                AND dar.user_id = :userId
-                AND (LOWER(dar.data->>'status') != 'archived' OR dar.data->>'status' IS NULL)
-              ORDER BY dar.sort_date DESC
-          """)
-  List<DataAccessRequest> findAllDarsByUserId(@Bind("userId") Integer userId);
 
   /**
    * Find DataAccessRequest by reference id
@@ -344,7 +324,7 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
       @Bind("data") @Json DataAccessRequestData data);
 
   /**
-   * Create new DataAccessRequest. This version supercedes `insertV2`
+   * Create new DataAccessRequest. This version supersedes `insertV2`
    *
    * @param collectionId   Integer DarCollection
    * @param referenceId    String
@@ -464,7 +444,7 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
   void deleteDARDatasetRelationByReferenceIds(@BindList("referenceIds") List<String> referenceIds);
 
   /**
-   * Returns all dataset_ids that match any of the referenceIds inside of the "referenceIds" list
+   * Returns all dataset_ids that match any of the referenceIds inside the "referenceIds" list
    *
    * @param referenceIds List<String>
    */

--- a/src/main/java/org/broadinstitute/consent/http/db/DataAccessRequestDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DataAccessRequestDAO.java
@@ -3,7 +3,6 @@ package org.broadinstitute.consent.http.db;
 import java.sql.Timestamp;
 import java.util.Date;
 import java.util.List;
-import org.broadinstitute.consent.http.db.mapper.DataAccessRequestDataMapper;
 import org.broadinstitute.consent.http.db.mapper.DataAccessRequestMapper;
 import org.broadinstitute.consent.http.db.mapper.DataAccessRequestReducer;
 import org.broadinstitute.consent.http.models.DarDataset;
@@ -38,7 +37,8 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
   @SqlQuery(
       """
           SELECT dd.dataset_id, dar.id, dar.reference_id, dar.collection_id, dar.parent_id, dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date,
-            (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data FROM data_access_request dar
+            (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data, dar.era_commons_id
+          FROM data_access_request dar
           LEFT JOIN dar_dataset dd on dd.reference_id = dar.reference_id
           WHERE dar.submission_date is not null
           AND (LOWER(dar.data->>'status') != 'archived' OR dar.data->>'status' IS NULL)""")
@@ -63,7 +63,7 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
       """
               SELECT dar.id, dar.reference_id, dar.collection_id, dar.parent_id,
                 dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date,
-                (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data,
+                (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data, dar.era_commons_id,
                 dd.dataset_id
               FROM data_access_request dar
               INNER JOIN dar_dataset dd ON dd.reference_id = dar.reference_id AND dd.dataset_id = :datasetId
@@ -100,7 +100,7 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
       """
               SELECT dar.id, dar.reference_id, dar.collection_id, dar.parent_id,
                 dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date,
-                (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data,
+                (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data, dar.era_commons_id,
                 dd.dataset_id
               FROM data_access_request dar
               LEFT JOIN dar_dataset dd ON dd.reference_id = dar.reference_id
@@ -118,7 +118,8 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
   @SqlQuery(
       """
               SELECT dd.dataset_id, dar.id, dar.reference_id, dar.collection_id, dar.parent_id, dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date,
-                (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data FROM data_access_request dar
+                (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data, dar.era_commons_id
+              FROM data_access_request dar
               LEFT JOIN dar_dataset dd on dd.reference_id = dar.reference_id
               WHERE dar.submission_date is null
                 AND (LOWER(dar.data->>'status') != 'archived' OR dar.data->>'status' IS NULL)
@@ -135,7 +136,8 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
   @SqlQuery(
       """
               SELECT dd.dataset_id, dar.id, dar.reference_id, dar.collection_id, dar.parent_id, dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date,
-                (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data FROM data_access_request dar
+                (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data, dar.era_commons_id
+              FROM data_access_request dar
               LEFT JOIN dar_dataset dd on dd.reference_id = dar.reference_id
               WHERE dar.submission_date is null
                 AND (LOWER(dar.data->>'status') != 'archived' OR dar.data->>'status' IS NULL)
@@ -154,7 +156,8 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
   @SqlQuery(
       """
               SELECT dd.dataset_id, dar.id, dar.reference_id, dar.collection_id, dar.parent_id, dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date,
-              (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data FROM data_access_request dar
+              (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data, dar.era_commons_id
+              FROM data_access_request dar
               LEFT JOIN dar_dataset dd on dd.reference_id = dar.reference_id
               WHERE dar.submission_date is not null
                 AND dar.user_id = :userId
@@ -173,7 +176,8 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
   @SqlQuery(
       """
               SELECT dd.dataset_id, dar.id, dar.reference_id, dar.collection_id, dar.parent_id, dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date,
-                (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data FROM data_access_request dar
+                (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data, dar.era_commons_id
+              FROM data_access_request dar
               LEFT JOIN dar_dataset dd on dd.reference_id = dar.reference_id
               WHERE dar.reference_id = :referenceId
                 AND (LOWER(dar.data->>'status') != 'archived' OR dar.data->>'status' IS NULL)
@@ -190,7 +194,8 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
   @SqlQuery(
       """
           SELECT dd.dataset_id, dar.id, dar.reference_id, dar.collection_id, dar.parent_id, dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date,
-            (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data FROM data_access_request dar
+            (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data, dar.era_commons_id
+          FROM data_access_request dar
           LEFT JOIN dar_dataset dd on dd.reference_id = dar.reference_id
           WHERE dar.reference_id IN (<referenceIds>)
             AND (LOWER(dar.data->>'status') != 'archived' OR dar.data->>'status' IS NULL)
@@ -206,13 +211,14 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
    * @param submissionDate Date Submission Date
    * @param updateDate     Date Update Date
    * @param data           DataAccessRequestData DAR Properties
+   * @param eraCommonsId   The user's era commons id at the time of update
    */
   @RegisterArgumentFactory(JsonArgumentFactory.class)
   @SqlUpdate(
       """
           UPDATE data_access_request
           SET data = to_jsonb(regexp_replace(:data, '\\\\u0000', '', 'g')), user_id = :userId, sort_date = :sortDate,
-            submission_date = :submissionDate, update_date = :updateDate
+            submission_date = :submissionDate, update_date = :updateDate, era_commons_id = :eraCommonsId
           WHERE reference_id = :referenceId
       """)
   void updateDataByReferenceId(
@@ -221,7 +227,8 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
       @Bind("sortDate") Date sortDate,
       @Bind("submissionDate") Date submissionDate,
       @Bind("updateDate") Date updateDate,
-      @Bind("data") @Json DataAccessRequestData data);
+      @Bind("data") @Json DataAccessRequestData data,
+      @Bind("eraCommonsId") String eraCommonsId);
 
   /**
    * Delete DataAccessRequest by reference id
@@ -299,9 +306,9 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
   @SqlUpdate(
       """
           INSERT INTO data_access_request
-            (collection_id, reference_id, user_id, create_date, sort_date, submission_date, update_date, data)
+            (collection_id, reference_id, user_id, create_date, sort_date, submission_date, update_date, data, era_commons_id)
           VALUES (:collectionId, :referenceId, :userId, :createDate, :sortDate,
-            :submissionDate, :updateDate, to_jsonb(:data))
+            :submissionDate, :updateDate, to_jsonb(:data), :eraCommonsId)
       """)
   void insertDataAccessRequest(
       @Bind("collectionId") Integer collectionId,
@@ -311,7 +318,8 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
       @Bind("sortDate") Date sortDate,
       @Bind("submissionDate") Date submissionDate,
       @Bind("updateDate") Date updateDate,
-      @Bind("data") @Json DataAccessRequestData data);
+      @Bind("data") @Json DataAccessRequestData data,
+      @Bind("eraCommonsId") String eraCommonsId);
 
   /**
    * Create new Progress Report.
@@ -351,16 +359,18 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
   void updateDraftToSubmittedForCollection(@Bind("collectionId") Integer collectionId,
       @Bind("referenceId") String referenceId);
 
-  @RegisterRowMapper(DataAccessRequestDataMapper.class)
-  @SqlQuery(
-      """
-          SELECT (data #>> '{}')::jsonb AS data
-          FROM data_access_request
-          WHERE (LOWER(data->>'status') != 'archived'
-            OR data->>'status' IS NULL)
-      """)
-  List<DataAccessRequestData> findAllDataAccessRequestDatas();
+// TODO: Unused
+//  @RegisterRowMapper(DataAccessRequestDataMapper.class)
+//  @SqlQuery(
+//      """
+//          SELECT (data #>> '{}')::jsonb AS data
+//          FROM data_access_request
+//          WHERE (LOWER(data->>'status') != 'archived'
+//            OR data->>'status' IS NULL)
+//      """)
+//  List<DataAccessRequestData> findAllDataAccessRequestDatas();
 
+  // TODO: Only used in tests, we should be able to remove it.
   @SqlUpdate(
       """
          UPDATE data_access_request

--- a/src/main/java/org/broadinstitute/consent/http/db/DataAccessRequestDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DataAccessRequestDAO.java
@@ -359,18 +359,6 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
   void updateDraftToSubmittedForCollection(@Bind("collectionId") Integer collectionId,
       @Bind("referenceId") String referenceId);
 
-// TODO: Unused
-//  @RegisterRowMapper(DataAccessRequestDataMapper.class)
-//  @SqlQuery(
-//      """
-//          SELECT (data #>> '{}')::jsonb AS data
-//          FROM data_access_request
-//          WHERE (LOWER(data->>'status') != 'archived'
-//            OR data->>'status' IS NULL)
-//      """)
-//  List<DataAccessRequestData> findAllDataAccessRequestDatas();
-
-  // TODO: Only used in tests, we should be able to remove it.
   @SqlUpdate(
       """
          UPDATE data_access_request

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DataAccessRequestMapper.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DataAccessRequestMapper.java
@@ -34,6 +34,7 @@ public class DataAccessRequestMapper implements RowMapper<DataAccessRequest>, Ro
       dar.addDatasetId(resultSet.getInt("dataset_id"));
     }
     dar.setData(data);
+    dar.setEraCommonsId(resultSet.getString("era_commons_id"));
     return dar;
   }
 

--- a/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequest.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequest.java
@@ -73,6 +73,8 @@ public class DataAccessRequest {
   public List<Integer> datasetIds;
   @JsonProperty
   private Map<Integer, Election> elections;
+  @JsonProperty
+  private String eraCommonsId;
 
   public DataAccessRequest() {
     this.elections = new HashMap<>();
@@ -237,6 +239,14 @@ public class DataAccessRequest {
     }
   }
 
+  public String getEraCommonsId() {
+    return eraCommonsId;
+  }
+
+  public void setEraCommonsId(String eraCommonsId) {
+    this.eraCommonsId = eraCommonsId;
+  }
+
   /**
    * Merges the DAR and the DAR Data into a single Map Ignores a series of deprecated keys Null
    * values are ignored by default
@@ -347,6 +357,9 @@ public class DataAccessRequest {
     }
     if (Objects.nonNull(dar.getParentId())) {
       copy.put("parentId", dar.getParentId());
+    }
+    if (dar.getEraCommonsId() != null) {
+      copy.put("eraCommonsId", dar.getEraCommonsId());
     }
     return copy;
   }

--- a/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
@@ -401,7 +401,8 @@ public class DarCollectionService implements ConsentLogger {
           now,
           null,
           now,
-          newData
+          newData,
+          null
       );
     });
 

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
@@ -182,7 +182,6 @@ public class DataAccessRequestService implements ConsentLogger {
     } else {
       String darCodeSequence = "DAR-" + counterService.getNextDarSequence();
       collectionId = darCollectionDAO.insertDarCollection(darCodeSequence, user.getUserId(), now);
-      darData.setDarCode(darCodeSequence);
     }
     String referenceId;
     List<Integer> datasetIds = dataAccessRequest.getDatasetIds();
@@ -196,7 +195,8 @@ public class DataAccessRequestService implements ConsentLogger {
           now,
           now,
           now,
-          darData);
+          darData,
+          user.getEraCommonsId());
     } else {
       referenceId = UUID.randomUUID().toString();
       dataAccessRequestDAO.insertDataAccessRequest(
@@ -207,7 +207,8 @@ public class DataAccessRequestService implements ConsentLogger {
           now,
           now,
           now,
-          darData);
+          darData,
+          user.getEraCommonsId());
     }
     syncDataAccessRequestDatasets(datasetIds, referenceId);
     return findByReferenceId(referenceId);
@@ -266,6 +267,10 @@ public class DataAccessRequestService implements ConsentLogger {
     }
 
     if (user.getLibraryCards().isEmpty()) {
+      throw new NIHComplianceRuleException();
+    }
+
+    if (user.getEraCommonsId() == null) {
       throw new NIHComplianceRuleException();
     }
 

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
@@ -270,10 +270,6 @@ public class DataAccessRequestService implements ConsentLogger {
       throw new NIHComplianceRuleException();
     }
 
-    if (user.getEraCommonsId() == null) {
-      throw new NIHComplianceRuleException();
-    }
-
     userService.hasValidActiveERACredentials(user);
 
     validateInternalCollaborators(dar, user);

--- a/src/main/java/org/broadinstitute/consent/http/service/UserService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/UserService.java
@@ -475,7 +475,7 @@ public class UserService implements ConsentLogger {
     if (cards.isEmpty()) {
       throw new LibraryCardRequiredException();
     }
-    boolean hasEraCommonsId = cards.stream().anyMatch(c -> c.getEraCommonsId() != null);
+    boolean hasEraCommonsId = user.getEraCommonsId() != null;
     if (!hasEraCommonsId) {
       throw new BadRequestException("User does not have an Era Commons ID");
     }

--- a/src/main/resources/changelog-master.xml
+++ b/src/main/resources/changelog-master.xml
@@ -170,4 +170,6 @@
     relativeToChangelogFile="true"/>
   <include file="changesets/changelog-consent-2025-04-21-dar-drop-draft-column.xml"
     relativeToChangelogFile="true" />
+  <include file="changesets/changelog-consent-2025-05-01-add-era-commons-to-dar.xml"
+    relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/src/main/resources/changesets/changelog-consent-2025-05-01-add-era-commons-to-dar.xml
+++ b/src/main/resources/changesets/changelog-consent-2025-05-01-add-era-commons-to-dar.xml
@@ -1,0 +1,17 @@
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+  <changeSet id="changelog-consent-2025-05-01-add-era-commons-to-dar" author="grushton">
+    <addColumn tableName="data_access_request">
+      <column name="era_commons_id" type="varchar(255)"/>
+    </addColumn>
+    <sql>
+      UPDATE data_access_request dar
+      SET era_commons_id = users.era_commons_id FROM (select user_id, era_commons_id FROM users) AS users
+      WHERE dar.user_id = users.user_id;
+    </sql>
+    <rollback>
+      <dropColumn tableName="data_access_request" columnName="era_commons_id"/>
+    </rollback>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/changesets/changelog-consent-2025-05-01-add-era-commons-to-dar.xml
+++ b/src/main/resources/changesets/changelog-consent-2025-05-01-add-era-commons-to-dar.xml
@@ -8,7 +8,8 @@
     <sql>
       UPDATE data_access_request dar
       SET era_commons_id = users.era_commons_id FROM (select user_id, era_commons_id FROM users) AS users
-      WHERE dar.user_id = users.user_id;
+      WHERE dar.user_id = users.user_id
+      AND dar.submission_date IS NOT NULL;
     </sql>
     <rollback>
       <dropColumn tableName="data_access_request" columnName="era_commons_id"/>

--- a/src/test/java/org/broadinstitute/consent/http/AbstractTestHelper.java
+++ b/src/test/java/org/broadinstitute/consent/http/AbstractTestHelper.java
@@ -22,8 +22,4 @@ public abstract class AbstractTestHelper {
     return RandomUtils.secureStrong().randomInt(startInclusive, endExclusive);
   }
 
-  public long randomLong() {
-    return RandomUtils.secureStrong().randomLong();
-  }
-
 }

--- a/src/test/java/org/broadinstitute/consent/http/AbstractTestHelper.java
+++ b/src/test/java/org/broadinstitute/consent/http/AbstractTestHelper.java
@@ -10,15 +10,15 @@ public abstract class AbstractTestHelper {
     return Boolean.parseBoolean(System.getProperty("enableTestContainers", defaultProp));
   }
 
-  public String randomAlphabetic(int length) {
+  public static String randomAlphabetic(int length) {
     return RandomStringUtils.secureStrong().nextAlphabetic(length);
   }
 
-  public String randomAlphanumeric(int length) {
+  public static String randomAlphanumeric(int length) {
     return RandomStringUtils.secureStrong().nextAlphanumeric(length);
   }
 
-  public int randomInt(int startInclusive, int endExclusive) {
+  public static int randomInt(int startInclusive, int endExclusive) {
     return RandomUtils.secureStrong().randomInt(startInclusive, endExclusive);
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
@@ -196,7 +196,6 @@ public class DAOTestHelper extends AbstractTestHelper implements TestExecutionLi
       String darCode) {
     DataAccessRequestData data = new DataAccessRequestData();
     data.setProjectTitle("Project Title: " + randomAlphabetic(50));
-//    data.setDarCode(darCode);
     DatasetEntry entry = new DatasetEntry();
     entry.setKey("key");
     entry.setValue("value");

--- a/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
@@ -196,7 +196,7 @@ public class DAOTestHelper extends AbstractTestHelper implements TestExecutionLi
       String darCode) {
     DataAccessRequestData data = new DataAccessRequestData();
     data.setProjectTitle("Project Title: " + randomAlphabetic(50));
-    data.setDarCode(darCode);
+//    data.setDarCode(darCode);
     DatasetEntry entry = new DatasetEntry();
     entry.setKey("key");
     entry.setValue("value");
@@ -211,7 +211,8 @@ public class DAOTestHelper extends AbstractTestHelper implements TestExecutionLi
         referenceId,
         userId,
         now, now, now, now,
-        data);
+        data,
+        randomAlphabetic(10));
     return dataAccessRequestDAO.findByReferenceId(referenceId);
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
@@ -182,9 +182,9 @@ public class DAOTestHelper extends AbstractTestHelper implements TestExecutionLi
     Integer collection_id = darCollectionDAO.insertDarCollection(darCode, user.getUserId(),
         new Date());
     for (int i = 0; i < 4; i++) {
-      createDataAccessRequest(user.getUserId(), collection_id, darCode);
+      createDataAccessRequest(user.getUserId(), collection_id);
     }
-    return createDataAccessRequest(user.getUserId(), collection_id, darCode);
+    return createDataAccessRequest(user.getUserId(), collection_id);
   }
 
   /**
@@ -192,8 +192,7 @@ public class DAOTestHelper extends AbstractTestHelper implements TestExecutionLi
    *
    * @return Populated DataAccessRequest
    */
-  private DataAccessRequest createDataAccessRequest(Integer userId, Integer collectionId,
-      String darCode) {
+  private DataAccessRequest createDataAccessRequest(Integer userId, Integer collectionId) {
     DataAccessRequestData data = new DataAccessRequestData();
     data.setProjectTitle("Project Title: " + randomAlphabetic(50));
     DatasetEntry entry = new DatasetEntry();

--- a/src/test/java/org/broadinstitute/consent/http/db/DacDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DacDAOTest.java
@@ -17,11 +17,9 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
-import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
 import org.broadinstitute.consent.http.enumeration.FileCategory;
-import org.broadinstitute.consent.http.enumeration.OrganizationType;
 import org.broadinstitute.consent.http.enumeration.PropertyType;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.Dac;
@@ -452,7 +450,8 @@ class DacDAOTest extends DAOTestHelper {
         referenceId,
         userId,
         now, now, now, now,
-        data);
+        data,
+        randomAlphabetic(10));
     return dataAccessRequestDAO.findByReferenceId(referenceId);
   }
 
@@ -470,7 +469,8 @@ class DacDAOTest extends DAOTestHelper {
         new Date(),
         new Date(),
         new Date(),
-        new DataAccessRequestData()
+        new DataAccessRequestData(),
+        user.getEraCommonsId()
     );
     dataAccessRequestDAO.insertDARDatasetRelation(randomUUID, d.getDatasetId());
   }

--- a/src/test/java/org/broadinstitute/consent/http/db/DarCollectionDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DarCollectionDAOTest.java
@@ -293,7 +293,8 @@ class DarCollectionDAOTest extends DAOTestHelper {
         testDar.getSortDate(),
         testDar.getSubmissionDate(),
         testDar.getUpdateDate(),
-        testDar.getData()
+        testDar.getData(),
+        user.getEraCommonsId()
     );
     dataAccessRequestDAO.insertDARDatasetRelation(testDar.getReferenceId(), dataset.getDatasetId());
     return testDar;
@@ -438,7 +439,8 @@ class DarCollectionDAOTest extends DAOTestHelper {
         referenceId,
         userId,
         now, now, now, now,
-        data);
+        data,
+        randomAlphabetic(10));
     return dataAccessRequestDAO.findByReferenceId(referenceId);
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/db/DarCollectionSummaryDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DarCollectionSummaryDAOTest.java
@@ -41,7 +41,7 @@ class DarCollectionSummaryDAOTest extends DAOTestHelper {
     data.setProjectTitle(RandomStringUtils.randomAlphabetic(20));
     data.setStatus("test");
     dataAccessRequestDAO.insertDataAccessRequest(collectionId, referenceId, userId, createDate,
-        new Date(), submissionDate, new Date(), data);
+        new Date(), submissionDate, new Date(), data, randomAlphabetic(10));
     return dataAccessRequestDAO.findByReferenceId(referenceId);
   }
 
@@ -482,7 +482,7 @@ class DarCollectionSummaryDAOTest extends DAOTestHelper {
 
     dataAccessRequestDAO.insertDARDatasetRelation(dar.getReferenceId(), dataset.getDatasetId());
     dataAccessRequestDAO.updateDataByReferenceId(dar.getReferenceId(), dar.userId, new Date(), null,
-        new Date(), dar.getData()); // draft DAR
+        new Date(), dar.getData(), randomAlphabetic(10)); // draft DAR
 
     List<DarCollectionSummary> summaries = darCollectionSummaryDAO.getDarCollectionSummariesForResearcher(
         userId);
@@ -532,7 +532,6 @@ class DarCollectionSummaryDAOTest extends DAOTestHelper {
     List<String> targetDatasetDacNames = List.of(dacOneName, dacTwoName);
     List<DarCollectionSummary> summaries = darCollectionSummaryDAO.getDarCollectionSummariesForAdmin();
     assertNotNull(summaries);
-    assertEquals(2, summaries.size());
     summaries.forEach((s) -> {
       assertEquals(1, s.getDatasetIds().size());
       s.getDatasetIds()
@@ -645,7 +644,7 @@ class DarCollectionSummaryDAOTest extends DAOTestHelper {
     dataAccessRequestDAO.insertDARDatasetRelation(archivedDar.getReferenceId(), dataset.getDatasetId());
     // draft DAR
     dataAccessRequestDAO.updateDataByReferenceId(draftDar.getReferenceId(), draftDar.userId, new Date(), null,
-        new Date(), draftDar.getData());
+        new Date(), draftDar.getData(), randomAlphabetic(10));
     // archived DAR
     dataAccessRequestDAO.archiveByReferenceIds(List.of(archivedDar.getReferenceId()));
 

--- a/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
@@ -18,7 +18,6 @@ import java.util.Date;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.broadinstitute.consent.http.enumeration.ElectionStatus;
 import org.broadinstitute.consent.http.enumeration.ElectionType;
 import org.broadinstitute.consent.http.enumeration.EmailType;
@@ -229,9 +228,7 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
     assertNotNull(dars);
     assertFalse(dars.isEmpty());
     assertEquals(3, dars.size());
-    dars.forEach(dar -> {
-      assertNotNull(dar.getDarCode());
-    });
+    dars.forEach(dar -> assertNotNull(dar.getDarCode()));
   }
 
   @Test
@@ -811,23 +808,8 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
     assertEquals(1, dars.size());
   }
 
-//  @Test
-//  void testFindDARsByDateRange() {
-//    DarCollection darCollection = createDarCollection();
-//    darCollection.getDars().keySet().forEach(referenceId ->
-//        dataAccessRequestDAO.updateDraftToSubmittedForCollection(darCollection.getDarCollectionId(),
-//            referenceId));
-//    Timestamp oneYearAgo = Timestamp.from(Instant.now().minus(365, ChronoUnit.DAYS));
-//    Timestamp oneMinuteInTheFuture = Timestamp.from(Instant.now().plus(1, ChronoUnit.MINUTES));
-//    List<DataAccessRequest> dars = dataAccessRequestDAO.findSubmittedDarsByTimeRange(oneYearAgo,
-//        oneMinuteInTheFuture);
-//    assertFalse(dars.isEmpty());
-//    assertEquals(1, dars.size());
-//  }
-
   @Test
-  void testFindAgedDARsByEmailTypeOlderThanIntervalSkipsEntriesBeforeNotBefore()
-      throws InterruptedException {
+  void testFindAgedDARsByEmailTypeOlderThanIntervalSkipsEntriesBeforeNotBefore() {
     User userOne = createUserWithInstitution();
     Integer userOneId = userOne.getUserId();
     Integer collectionOneId = createDarCollection(userOneId);
@@ -884,7 +866,7 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
 
     assertNotNull(dars);
     assertEquals(1, dars.size());
-    dars.forEach((dar) -> {
+    dars.forEach(dar -> {
       assertEquals(userOne.getUserId(), dar.getUserId());
       assertEquals(darOne.getReferenceId(), dar.getReferenceId());
       assertNotNull(dar.getDarCode());
@@ -920,7 +902,7 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
 
     assertNotNull(dars);
     assertEquals(2, dars.size());
-    dars.forEach((dar) -> {
+    dars.forEach(dar -> {
       assertNotNull(dar.getUserId());
       assertNotNull(dar.getReferenceId());
       assertNotNull(dar.getExpiresAt());
@@ -990,7 +972,7 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
 
     assertNotNull(dars);
     assertEquals(1, dars.size());
-    dars.forEach((dar) -> {
+    dars.forEach(dar -> {
       assertEquals(userTwo.getUserId(), dar.getUserId());
       assertEquals(darTwo.getReferenceId(), dar.getReferenceId());
       assertNotNull(dar.getDarCode());

--- a/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
@@ -16,8 +16,6 @@ import java.util.Date;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
-import org.apache.commons.lang3.RandomStringUtils;
-import org.apache.commons.lang3.RandomUtils;
 import org.broadinstitute.consent.http.enumeration.ElectionStatus;
 import org.broadinstitute.consent.http.enumeration.ElectionType;
 import org.broadinstitute.consent.http.enumeration.VoteType;
@@ -112,7 +110,7 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
     assertEquals(1, draftDars1.size());
     DataAccessRequestData darData = draftDars1.get(0).getData();
     dataAccessRequestDAO.updateDataByReferenceId(dar.referenceId, dar.userId, new Date(),
-        new Date(), new Date(), darData);
+        new Date(), new Date(), darData, randomAlphabetic(10));
     List<DataAccessRequest> draftDars2 = dataAccessRequestDAO.findAllDraftDataAccessRequests();
     assertTrue(draftDars2.isEmpty());
   }
@@ -125,7 +123,7 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
     assertTrue(draftDars1.isEmpty());
 
     dataAccessRequestDAO.updateDataByReferenceId(dar.getReferenceId(), dar.userId, new Date(), null,
-        new Date(), dar.getData());
+        new Date(), dar.getData(), randomAlphabetic(10));
     List<DataAccessRequest> draftDars2 = dataAccessRequestDAO.findAllDraftDataAccessRequests();
     assertFalse(draftDars2.isEmpty());
     assertEquals(1, draftDars2.size());
@@ -138,11 +136,11 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
     DataAccessRequest dar = new ArrayList<>(darColl.getDars().values()).get(0);
 
     dataAccessRequestDAO.updateDataByReferenceId(dar.referenceId, dar.userId, new Date(), null,
-        new Date(), dar.getData());
+        new Date(), dar.getData(), randomAlphabetic(10));
     dar = dataAccessRequestDAO.findByReferenceId(dar.getReferenceId());
     DataAccessRequestData darData = dar.getData();
     dataAccessRequestDAO.updateDataByReferenceId(dar.referenceId, dar.userId, new Date(),
-        new Date(), new Date(), darData);
+        new Date(), new Date(), darData, randomAlphabetic(10));
     dar = dataAccessRequestDAO.findByReferenceId(dar.getReferenceId());
     assertFalse(dar.getDraft());
     Timestamp expectedTimestamp = new Timestamp(
@@ -156,7 +154,7 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
     DataAccessRequest dar = new ArrayList<>(darColl.getDars().values()).get(0);
 
     dataAccessRequestDAO.updateDataByReferenceId(dar.referenceId, dar.userId, new Date(), null,
-        new Date(), dar.getData());
+        new Date(), dar.getData(), randomAlphabetic(10));
     dar = dataAccessRequestDAO.findByReferenceId(dar.getReferenceId());
     assertNull(dar.getSubmissionDate());
     assertEquals(true, dar.getDraft());
@@ -171,7 +169,7 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
 
     dataAccessRequestDAO.updateDataByReferenceId(dar.referenceId, dar.userId, new Date(),
         new Date(),
-        new Date(), dar.getData());
+        new Date(), dar.getData(), randomAlphabetic(10));
     dar = dataAccessRequestDAO.findByReferenceId(dar.getReferenceId());
     assertEquals(false, dar.getDraft());
     assertFalse(dar.getExpired());
@@ -188,7 +186,7 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
     dar = dataAccessRequestDAO.findByReferenceId(dar.getReferenceId());
     assertEquals(false, dar.getDraft());
     dataAccessRequestDAO.updateDataByReferenceId(dar.referenceId, dar.userId, new Date(), null,
-        new Date(), dar.getData());
+        new Date(), dar.getData(), randomAlphabetic(10));
     dar = dataAccessRequestDAO.findByReferenceId(dar.getReferenceId());
     assertEquals(true, dar.getDraft());
     assertNull(dar.getSubmissionDate());
@@ -199,10 +197,10 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
   @Test
   void testCreate() {
     User user = createUserWithInstitution();
-    String darCode = "DAR-" + RandomUtils.nextInt(1, 999999999);
+    String darCode = "DAR-" + randomInt(1, 999999999);
     Integer collection_id = darCollectionDAO.insertDarCollection(darCode, user.getUserId(),
         new Date());
-    DataAccessRequest dar = createDataAccessRequest(user.getUserId(), collection_id, darCode);
+    DataAccessRequest dar = createDataAccessRequest(user.getUserId(), collection_id);
     Dataset d1 = createDARDAOTestDataset();
     Dataset d2 = createDARDAOTestDataset();
     dataAccessRequestDAO.insertDARDatasetRelation(dar.getReferenceId(), d1.getDatasetId());
@@ -233,11 +231,11 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
     DataAccessRequest dar = createDataAccessRequestV3();
     Date now = new Date();
     User user = createUser();
-    String rus = RandomStringUtils.random(10, true, false);
+    String rus = randomAlphabetic(10);
     dar.getData().setRus(rus);
     dar.getData().setValidRestriction(false);
     dataAccessRequestDAO.updateDataByReferenceId(dar.getReferenceId(), user.getUserId(), now, now,
-        now, dar.getData());
+        now, dar.getData(), randomAlphabetic(10));
     DataAccessRequest updatedDar = dataAccessRequestDAO.findByReferenceId(dar.getReferenceId());
     assertEquals(rus, updatedDar.getData().getRus());
     assertFalse(updatedDar.getData().getValidRestriction());
@@ -256,7 +254,8 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
         referenceId,
         collection.getCreateUserId(),
         now, now, now, now,
-        data);
+        data,
+        randomAlphabetic(10));
     DataAccessRequest dar = dataAccessRequestDAO.findByReferenceId(referenceId);
     assertNotNull(dar);
     assertFalse(dar.getData().getRus().contains(unsupportedUnicode));
@@ -270,11 +269,11 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
     assertNotNull(dar);
     Date now = new Date();
 
-    String rus = RandomStringUtils.random(10, true, false);
+    String rus = randomAlphabetic(10);
     dar.getData().setRus(rus + String.format(" %s ", unsupportedUnicode));
     dataAccessRequestDAO.updateDataByReferenceId(dar.getReferenceId(), collection.getCreateUserId(),
         now, now,
-        now, dar.getData());
+        now, dar.getData(), randomAlphabetic(10));
 
     DataAccessRequest updatedDar = dataAccessRequestDAO.findByReferenceId(dar.getReferenceId());
     assertNotNull(updatedDar);
@@ -413,7 +412,8 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
         testDar.getSortDate(),
         testDar.getSubmissionDate(),
         testDar.getUpdateDate(),
-        testDar.getData()
+        testDar.getData(),
+        randomAlphabetic(10)
     );
     dataAccessRequestDAO.insertDARDatasetRelation(testDar.getReferenceId(), dataset.getDatasetId());
     return dataAccessRequestDAO.findByReferenceId(testDar.getReferenceId());
@@ -441,7 +441,7 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
     List<DataAccessRequest> dars = dataAccessRequestDAO.findAllDataAccessRequests();
     assertTrue(dars.isEmpty());
 
-    String darCode = "DAR-" + RandomUtils.nextInt(100, 1000);
+    String darCode = "DAR-" + randomInt(100, 1000);
     Dataset dataset = createDARDAOTestDataset();
     User user = createUserWithInstitution();
     DataAccessRequest testDar = createDAR(user, dataset, darCode);
@@ -457,8 +457,8 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
   void testFindAllFilterArchived() {
     User user = createUserWithInstitution();
 
-    String darCode1 = "DAR-" + RandomUtils.nextInt(100, 200);
-    String darCode2 = "DAR-" + RandomUtils.nextInt(201, 300);
+    String darCode1 = "DAR-" + randomInt(100, 200);
+    String darCode2 = "DAR-" + randomInt(201, 300);
     Dataset dataset1 = createDARDAOTestDataset();
     Dataset dataset2 = createDARDAOTestDataset();
 
@@ -472,8 +472,8 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
   // See: https://broadworkbench.atlassian.net/browse/DUOS-2182
   @Test
   void testEnsureOnlyDataAccessRequestsByDatasetIdReturnsJustForSpecificDatasetId() {
-    String darCode1 = "DAR-" + RandomUtils.nextInt(100, 1000);
-    String darCode2 = "DAR-" + RandomUtils.nextInt(100, 1000);
+    String darCode1 = "DAR-" + randomInt(100, 1000);
+    String darCode2 = "DAR-" + randomInt(100, 1000);
     Dataset dataset1 = createDARDAOTestDataset();
     Dataset dataset2 = createDARDAOTestDataset();
     User user1 = createUser();
@@ -513,9 +513,9 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
 
   @Test
   void testFindAllApprovedDataAccessRequestsByDatasetId() {
-    String darCode1 = "DAR-" + RandomUtils.nextInt(100, 1000000);
-    String darCode2 = "DAR-" + RandomUtils.nextInt(100, 1000000);
-    String darCode3 = "DAR-" + RandomUtils.nextInt(100, 1000000);
+    String darCode1 = "DAR-" + randomInt(100, 1000000);
+    String darCode2 = "DAR-" + randomInt(100, 1000000);
+    String darCode3 = "DAR-" + randomInt(100, 1000000);
     Dataset dataset1 = createDARDAOTestDataset();
     Dataset dataset2 = createDARDAOTestDataset();
 
@@ -607,7 +607,7 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
    */
   @Test
   void testFindAllApprovedDataAccessRequestsByDatasetId_ApprovedThenDeniedCase() {
-    String darCode1 = "DAR-" + RandomUtils.nextInt(100, 1000000);
+    String darCode1 = "DAR-" + randomInt(100, 1000000);
     Dataset dataset1 = createDARDAOTestDataset();
     User user1 = createUserWithInstitution();
     DataAccessRequest testDar1 = createDAR(user1, dataset1, darCode1);
@@ -649,7 +649,7 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
   @ParameterizedTest
   @ValueSource(longs = {200, 370})
   void testFindAllApprovedDataAccessRequestsByDatasetId_ExpiredDARCase(long submissionDaysAgo) {
-    String darCode1 = "DAR-" + RandomUtils.nextInt(100, 1000000);
+    String darCode1 = "DAR-" + randomInt(100, 1000000);
     Dataset dataset1 = createDARDAOTestDataset();
     User user1 = createUserWithInstitution();
     var submissionDate = new Timestamp(
@@ -681,7 +681,7 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
 
   @Test
   void testFindAllApprovedDataAccessRequestsByDatasetId_NullSubmissionDate() {
-    String darCode1 = "DAR-" + RandomUtils.nextInt(100, 1000000);
+    String darCode1 = "DAR-" + randomInt(100, 1000000);
     Dataset dataset1 = createDARDAOTestDataset();
     User user1 = createUserWithInstitution();
     DataAccessRequest testDar1 = createDAR(user1, dataset1, darCode1, null);
@@ -740,7 +740,7 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
     List<DataAccessRequest> dars = dataAccessRequestDAO.findAllDarsByUserId(user.getUserId());
     assertTrue(dars.isEmpty());
 
-    String darCode = "DAR-" + RandomUtils.nextInt(100, 1000);
+    String darCode = "DAR-" + randomInt(100, 1000);
     Dataset dataset = createDARDAOTestDataset();
 
     DataAccessRequest testDar = createDAR(user, dataset, darCode);
@@ -754,7 +754,7 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
   // findByReferenceId should exclude archived DARs
   @Test
   void testFindByReferenceIdArchived() {
-    String darCode = "DAR-" + RandomUtils.nextInt(100, 1000);
+    String darCode = "DAR-" + randomInt(100, 1000);
     Dataset dataset = createDARDAOTestDataset();
     User user = createUserWithInstitution();
     DataAccessRequest testDar = createDAR(user, dataset, darCode);
@@ -767,8 +767,8 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
   // findByReferenceIds should exclude archived DARs
   @Test
   void testFindByReferenceIdsArchived() {
-    String darCode1 = "DAR-" + RandomUtils.nextInt(100, 200);
-    String darCode2 = "DAR-" + RandomUtils.nextInt(201, 300);
+    String darCode1 = "DAR-" + randomInt(100, 200);
+    String darCode2 = "DAR-" + randomInt(201, 300);
     Dataset dataset1 = createDARDAOTestDataset();
     Dataset dataset2 = createDARDAOTestDataset();
     User user = createUserWithInstitution();
@@ -786,12 +786,12 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
   @Test
   void testFindAllDataAccessRequestDatasArchived() {
     User user = createUserWithInstitution();
-    List<DataAccessRequestData> dars = dataAccessRequestDAO.findAllDataAccessRequestDatas();
-    assertTrue(dars.isEmpty());
+//    List<DataAccessRequestData> dars = dataAccessRequestDAO.findAllDataAccessRequestDatas();
+//    assertTrue(dars.isEmpty());
 
-    String darCode1 = "DAR-" + RandomUtils.nextInt(100, 200);
-    String darCode2 = "DAR-" + RandomUtils.nextInt(201, 300);
-    String darCode3 = "DAR-" + RandomUtils.nextInt(301, 400);
+    String darCode1 = "DAR-" + randomInt(100, 200);
+    String darCode2 = "DAR-" + randomInt(201, 300);
+    String darCode3 = "DAR-" + randomInt(301, 400);
     Dataset dataset1 = createDARDAOTestDataset();
     Dataset dataset2 = createDARDAOTestDataset();
     Dataset dataset3 = createDARDAOTestDataset();
@@ -826,9 +826,9 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
   }
 
   @Test
-  void testFindDARsByDateRange() throws InterruptedException {
+  void testFindDARsByDateRange() {
     DarCollection darCollection = createDarCollection();
-    darCollection.getDars().keySet().forEach((referenceId) ->
+    darCollection.getDars().keySet().forEach(referenceId ->
       dataAccessRequestDAO.updateDraftToSubmittedForCollection(darCollection.getDarCollectionId(),
           referenceId));
     Timestamp oneYearAgo = Timestamp.from(Instant.now().minus(365, ChronoUnit.DAYS));
@@ -840,12 +840,10 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
   }
 
   @Test
-  void testFindDARsByDateRangeWithNoneInRange() throws InterruptedException {
+  void testFindDARsByDateRangeWithNoneInRange() {
     DarCollection darCollection = createDarCollection();
-    darCollection.getDars().keySet().forEach((referenceId) -> {
-      dataAccessRequestDAO.updateDraftToSubmittedForCollection(darCollection.getDarCollectionId(),
-          referenceId);
-    });
+    darCollection.getDars().keySet().forEach(referenceId -> dataAccessRequestDAO.updateDraftToSubmittedForCollection(darCollection.getDarCollectionId(),
+        referenceId));
     Instant oneHourAgo = Instant.now().minus(1, ChronoUnit.HOURS);
     Instant halfAnHourAgo = Instant.now().minus(30, ChronoUnit.MINUTES);
     // query far enough into the past so slight clock variations do not matter for this test
@@ -861,9 +859,9 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
    */
   private Dataset createDARDAOTestDataset() {
     User user = createUser();
-    String name = "Name_" + RandomStringUtils.random(20, true, true);
+    String name = "Name_" + randomAlphanumeric(20);
     Timestamp now = new Timestamp(new Date().getTime());
-    String objectId = "Object ID_" + RandomStringUtils.random(20, true, true);
+    String objectId = "Object ID_" + randomAlphanumeric(20);
     DataUse dataUse = new DataUseBuilder().setGeneralUse(true).build();
     Integer id = datasetDAO.insertDataset(name, now, user.getUserId(), objectId,
         dataUse.toString(), null);
@@ -883,10 +881,9 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
    *
    * @return Populated DataAccessRequest
    */
-  private DataAccessRequest createDataAccessRequest(Integer userId, Integer collectionId,
-      String darCode) {
+  private DataAccessRequest createDataAccessRequest(Integer userId, Integer collectionId) {
     DataAccessRequestData data = createDataAccessRequestData(
-        darCode);
+    );
     String referenceId = UUID.randomUUID().toString();
     Date now = new Date();
     dataAccessRequestDAO.insertDataAccessRequest(
@@ -894,14 +891,15 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
         referenceId,
         userId,
         now, now, now, now,
-        data);
+        data,
+        randomAlphabetic(10));
     return dataAccessRequestDAO.findByReferenceId(referenceId);
   }
 
   private DataAccessRequest createProgressReport(Integer userId, Integer collectionId,
       String darCode, Integer parentId) {
     DataAccessRequestData data = createDataAccessRequestData(
-        darCode);
+    );
     String referenceId = UUID.randomUUID().toString();
     dataAccessRequestDAO.insertProgressReport(
         parentId,
@@ -912,10 +910,10 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
     return dataAccessRequestDAO.findByReferenceId(referenceId);
   }
 
-  private static DataAccessRequestData createDataAccessRequestData(String darCode) {
+  private static DataAccessRequestData createDataAccessRequestData() {
     DataAccessRequestData data = new DataAccessRequestData();
-    data.setProjectTitle("Project Title: " + RandomStringUtils.random(50, true, false));
-    data.setDarCode(darCode);
+    data.setProjectTitle("Project Title: " + randomAlphabetic(50));
+//    data.setDarCode(darCode);
     DatasetEntry entry = new DatasetEntry();
     entry.setKey("key");
     entry.setValue("value");
@@ -928,19 +926,19 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
 
   private DarCollection createDarCollection() {
     User user = createUserWithInstitution();
-    String darCode = "DAR-" + RandomUtils.nextInt(1, 10000);
+    String darCode = "DAR-" + randomInt(1, 10000);
     Integer collection_id = darCollectionDAO.insertDarCollection(darCode, user.getUserId(),
         new Date());
     Dataset dataset = createDataset();
-    DataAccessRequest dar = createDataAccessRequest(user.getUserId(), collection_id, darCode);
+    DataAccessRequest dar = createDataAccessRequest(user.getUserId(), collection_id);
     dataAccessRequestDAO.insertDARDatasetRelation(dar.getReferenceId(), dataset.getDatasetId());
     Election cancelled = createCancelledAccessElection(dar.getReferenceId(),
         dataset.getDatasetId());
     Election access = createDataAccessElection(dar.getReferenceId(), dataset.getDatasetId());
     createFinalVote(user.getUserId(), cancelled.getElectionId());
     createFinalVote(user.getUserId(), access.getElectionId());
-    createDataAccessRequest(user.getUserId(), collection_id, darCode);
-    createDataAccessRequest(user.getUserId(), collection_id, darCode);
+    createDataAccessRequest(user.getUserId(), collection_id);
+    createDataAccessRequest(user.getUserId(), collection_id);
     return darCollectionDAO.findDARCollectionByCollectionId(collection_id);
   }
 
@@ -957,9 +955,9 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
 
   private Dataset createDataset() {
     User user = createUser();
-    String name = "Name_" + RandomStringUtils.random(20, true, true);
+    String name = "Name_" + randomAlphanumeric(20);
     Timestamp now = new Timestamp(new Date().getTime());
-    String objectId = "Object ID_" + RandomStringUtils.random(20, true, true);
+    String objectId = "Object ID_" + randomAlphanumeric(20);
     DataUse dataUse = new DataUseBuilder().setGeneralUse(true).build();
     Integer id = datasetDAO.insertDataset(name, now, user.getUserId(), objectId,
         dataUse.toString(), null);
@@ -980,10 +978,8 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
 
   private DataAccessRequest createDraftDataAccessRequest() {
     User user = createUser();
-    String darCode = "DAR-" + RandomUtils.nextInt(100, 1000);
     DataAccessRequestData data = new DataAccessRequestData();
-    data.setProjectTitle("Project Title: " + RandomStringUtils.random(50, true, false));
-    data.setDarCode(darCode);
+    data.setProjectTitle("Project Title: " + randomAlphabetic(50));
     String referenceId = UUID.randomUUID().toString();
     Date now = new Date();
     dataAccessRequestDAO.insertDraftDataAccessRequest(

--- a/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
@@ -610,7 +610,7 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
 
   @Test
   void testFindAllApprovedDatasetsByDar() {
-    String darCode1 = "DAR-" + RandomUtils.nextInt(100, 1000000);
+    String darCode1 = "DAR-" + randomInt(100, 1000000);
     Dataset dataset1 = createDARDAOTestDataset();
     Dataset dataset2 = createDARDAOTestDataset();
     Dataset dataset3 = createDARDAOTestDataset();

--- a/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
@@ -198,9 +198,9 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
   void testCreate() {
     User user = createUserWithInstitution();
     String darCode = "DAR-" + randomInt(1, 999999999);
-    Integer collection_id = darCollectionDAO.insertDarCollection(darCode, user.getUserId(),
+    Integer collectionId = darCollectionDAO.insertDarCollection(darCode, user.getUserId(),
         new Date());
-    DataAccessRequest dar = createDataAccessRequest(user.getUserId(), collection_id);
+    DataAccessRequest dar = createDataAccessRequest(user.getUserId(), collectionId);
     Dataset d1 = createDARDAOTestDataset();
     Dataset d2 = createDARDAOTestDataset();
     dataAccessRequestDAO.insertDARDatasetRelation(dar.getReferenceId(), d1.getDatasetId());
@@ -782,35 +782,12 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
     assertTrue(returnedDAR.isEmpty());
   }
 
-  // findAllDataAccessRequestDatas should exclude archived DARs
-  @Test
-  void testFindAllDataAccessRequestDatasArchived() {
-    User user = createUserWithInstitution();
-//    List<DataAccessRequestData> dars = dataAccessRequestDAO.findAllDataAccessRequestDatas();
-//    assertTrue(dars.isEmpty());
-
-    String darCode1 = "DAR-" + randomInt(100, 200);
-    String darCode2 = "DAR-" + randomInt(201, 300);
-    String darCode3 = "DAR-" + randomInt(301, 400);
-    Dataset dataset1 = createDARDAOTestDataset();
-    Dataset dataset2 = createDARDAOTestDataset();
-    Dataset dataset3 = createDARDAOTestDataset();
-    DataAccessRequest testDar1 = createDAR(user, dataset1, darCode1);
-    DataAccessRequest testDar2 = createDAR(user, dataset2, darCode2);
-    DataAccessRequest testDar3 = createDAR(user, dataset3, darCode3);
-
-    dataAccessRequestDAO.archiveByReferenceIds(List.of(testDar1.getReferenceId()));
-    dataAccessRequestDAO.archiveByReferenceIds(List.of(testDar2.getReferenceId()));
-    List<DataAccessRequest> returnedDAR = dataAccessRequestDAO.findByReferenceIds(
-        List.of(testDar1.getReferenceId(), testDar2.getReferenceId(), testDar3.getReferenceId()));
-    assertEquals(1, returnedDAR.size());
-  }
-
   @Test
   void createProgressReport() {
     DarCollection darCollection = createDarCollection();
     DataAccessRequest dar = new ArrayList<>(darCollection.getDars().values()).get(0);
-    DataAccessRequest progressReport = createProgressReport(dar.getUserId(), darCollection.getDarCollectionId(), darCollection.getDarCode(),
+    DataAccessRequest progressReport = createProgressReport(dar.getUserId(),
+        darCollection.getDarCollectionId(),
         dar.getId());
 
     assertNotNull(progressReport);
@@ -829,8 +806,8 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
   void testFindDARsByDateRange() {
     DarCollection darCollection = createDarCollection();
     darCollection.getDars().keySet().forEach(referenceId ->
-      dataAccessRequestDAO.updateDraftToSubmittedForCollection(darCollection.getDarCollectionId(),
-          referenceId));
+        dataAccessRequestDAO.updateDraftToSubmittedForCollection(darCollection.getDarCollectionId(),
+            referenceId));
     Timestamp oneYearAgo = Timestamp.from(Instant.now().minus(365, ChronoUnit.DAYS));
     Timestamp oneMinuteInTheFuture = Timestamp.from(Instant.now().plus(1, ChronoUnit.MINUTES));
     List<DataAccessRequest> dars = dataAccessRequestDAO.findSubmittedDarsByTimeRange(oneYearAgo,
@@ -842,8 +819,10 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
   @Test
   void testFindDARsByDateRangeWithNoneInRange() {
     DarCollection darCollection = createDarCollection();
-    darCollection.getDars().keySet().forEach(referenceId -> dataAccessRequestDAO.updateDraftToSubmittedForCollection(darCollection.getDarCollectionId(),
-        referenceId));
+    darCollection.getDars().keySet().forEach(
+        referenceId -> dataAccessRequestDAO.updateDraftToSubmittedForCollection(
+            darCollection.getDarCollectionId(),
+            referenceId));
     Instant oneHourAgo = Instant.now().minus(1, ChronoUnit.HOURS);
     Instant halfAnHourAgo = Instant.now().minus(30, ChronoUnit.MINUTES);
     // query far enough into the past so slight clock variations do not matter for this test
@@ -897,7 +876,7 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
   }
 
   private DataAccessRequest createProgressReport(Integer userId, Integer collectionId,
-      String darCode, Integer parentId) {
+      Integer parentId) {
     DataAccessRequestData data = createDataAccessRequestData(
     );
     String referenceId = UUID.randomUUID().toString();
@@ -913,7 +892,6 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
   private static DataAccessRequestData createDataAccessRequestData() {
     DataAccessRequestData data = new DataAccessRequestData();
     data.setProjectTitle("Project Title: " + randomAlphabetic(50));
-//    data.setDarCode(darCode);
     DatasetEntry entry = new DatasetEntry();
     entry.setKey("key");
     entry.setValue("value");
@@ -927,19 +905,19 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
   private DarCollection createDarCollection() {
     User user = createUserWithInstitution();
     String darCode = "DAR-" + randomInt(1, 10000);
-    Integer collection_id = darCollectionDAO.insertDarCollection(darCode, user.getUserId(),
+    Integer collectionId = darCollectionDAO.insertDarCollection(darCode, user.getUserId(),
         new Date());
     Dataset dataset = createDataset();
-    DataAccessRequest dar = createDataAccessRequest(user.getUserId(), collection_id);
+    DataAccessRequest dar = createDataAccessRequest(user.getUserId(), collectionId);
     dataAccessRequestDAO.insertDARDatasetRelation(dar.getReferenceId(), dataset.getDatasetId());
     Election cancelled = createCancelledAccessElection(dar.getReferenceId(),
         dataset.getDatasetId());
     Election access = createDataAccessElection(dar.getReferenceId(), dataset.getDatasetId());
     createFinalVote(user.getUserId(), cancelled.getElectionId());
     createFinalVote(user.getUserId(), access.getElectionId());
-    createDataAccessRequest(user.getUserId(), collection_id);
-    createDataAccessRequest(user.getUserId(), collection_id);
-    return darCollectionDAO.findDARCollectionByCollectionId(collection_id);
+    createDataAccessRequest(user.getUserId(), collectionId);
+    createDataAccessRequest(user.getUserId(), collectionId);
+    return darCollectionDAO.findDARCollectionByCollectionId(collectionId);
   }
 
   private Election createCancelledAccessElection(String referenceId, Integer datasetId) {

--- a/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
@@ -1166,7 +1166,7 @@ class DatasetDAOTest extends DAOTestHelper {
     data.setProjectTitle(randomAlphabetic(10));
     String referenceId = randomAlphanumeric(20);
     dataAccessRequestDAO.insertDataAccessRequest(collectionId, referenceId, userId, new Date(),
-        new Date(), new Date(), new Date(), data);
+        new Date(), new Date(), new Date(), data, randomAlphabetic(10));
     dataAccessRequestDAO.insertDARDatasetRelation(referenceId, datasetId);
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/db/ElectionDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/ElectionDAOTest.java
@@ -65,9 +65,9 @@ class ElectionDAOTest extends DAOTestHelper {
     Dac dac = createDac();
     User user = createUser();
     String darCode = "DAR-1234567890";
-    Integer collection_id = darCollectionDAO.insertDarCollection(darCode, user.getUserId(),
+    Integer collectionId = darCollectionDAO.insertDarCollection(darCode, user.getUserId(),
         new Date());
-    DataAccessRequest dar = createDataAccessRequest(user.getUserId(), collection_id);
+    DataAccessRequest dar = createDataAccessRequest(user.getUserId(), collectionId);
     Dataset dataset = createDataset();
     datasetDAO.updateDatasetDacId(dataset.getDatasetId(), dac.getDacId());
     Election election = createDataAccessElection(dar.getReferenceId(), dataset.getDatasetId());
@@ -133,9 +133,9 @@ class ElectionDAOTest extends DAOTestHelper {
     // We should find ONLY the most recent elections with this method
     User user = createUser();
     String darCode = "DAR-1234567890";
-    Integer collection_id = darCollectionDAO.insertDarCollection(darCode, user.getUserId(),
+    Integer collectionId = darCollectionDAO.insertDarCollection(darCode, user.getUserId(),
         new Date());
-    DataAccessRequest dar = createDataAccessRequest(user.getUserId(), collection_id);
+    DataAccessRequest dar = createDataAccessRequest(user.getUserId(), collectionId);
     Dataset d1 = createDataset();
     Dataset d2 = createDataset();
     dataAccessRequestDAO.insertDARDatasetRelation(dar.getReferenceId(), d1.getDatasetId());
@@ -196,9 +196,9 @@ class ElectionDAOTest extends DAOTestHelper {
   void testFindElectionsByReferenceIdAndDatasetId() {
     User user = createUser();
     String darCode = "DAR-1234567890";
-    Integer collection_id = darCollectionDAO.insertDarCollection(darCode, user.getUserId(),
+    Integer collectionId = darCollectionDAO.insertDarCollection(darCode, user.getUserId(),
         new Date());
-    DataAccessRequest dar = createDataAccessRequest(user.getUserId(), collection_id);
+    DataAccessRequest dar = createDataAccessRequest(user.getUserId(), collectionId);
     Dataset d1 = createDataset();
     dataAccessRequestDAO.insertDARDatasetRelation(dar.getReferenceId(), d1.getDatasetId());
     createRPElection(dar.getReferenceId(), d1.getDatasetId());
@@ -214,9 +214,9 @@ class ElectionDAOTest extends DAOTestHelper {
     Dac dac = createDac();
     User user = createUser();
     String darCode = "DAR-1234567890";
-    Integer collection_id = darCollectionDAO.insertDarCollection(darCode, user.getUserId(),
+    Integer collectionId = darCollectionDAO.insertDarCollection(darCode, user.getUserId(),
         new Date());
-    DataAccessRequest dar = createDataAccessRequest(user.getUserId(), collection_id);
+    DataAccessRequest dar = createDataAccessRequest(user.getUserId(), collectionId);
     Dataset dataset = createDataset();
     datasetDAO.updateDatasetDacId(dataset.getDatasetId(), dac.getDacId());
 
@@ -233,9 +233,9 @@ class ElectionDAOTest extends DAOTestHelper {
     Dataset dataset = createDataset();
     User user = createUser();
     String darCode = "DAR-1234567890";
-    Integer collection_id = darCollectionDAO.insertDarCollection(darCode, user.getUserId(),
+    Integer collectionId = darCollectionDAO.insertDarCollection(darCode, user.getUserId(),
         new Date());
-    DataAccessRequest dar = createDataAccessRequest(user.getUserId(), collection_id);
+    DataAccessRequest dar = createDataAccessRequest(user.getUserId(), collectionId);
     createDataAccessElection(dar.getReferenceId(), dataset.getDatasetId());
 
     List<Election> foundElections = electionDAO.findOpenElectionsByDacId(dac.getDacId());
@@ -248,9 +248,9 @@ class ElectionDAOTest extends DAOTestHelper {
     Dac dac = createDac();
     User user = createUser();
     String darCode = "DAR-1234567890";
-    Integer collection_id = darCollectionDAO.insertDarCollection(darCode, user.getUserId(),
+    Integer collectionId = darCollectionDAO.insertDarCollection(darCode, user.getUserId(),
         new Date());
-    DataAccessRequest dar = createDataAccessRequest(user.getUserId(), collection_id);
+    DataAccessRequest dar = createDataAccessRequest(user.getUserId(), collectionId);
     Dataset d = createDataset();
     datasetDAO.updateDatasetDacId(d.getDatasetId(), dac.getDacId());
 
@@ -273,9 +273,9 @@ class ElectionDAOTest extends DAOTestHelper {
     Dac dac = createDac();
     User user = createUser();
     String darCode = "DAR-1234567890";
-    Integer collection_id = darCollectionDAO.insertDarCollection(darCode, user.getUserId(),
+    Integer collectionId = darCollectionDAO.insertDarCollection(darCode, user.getUserId(),
         new Date());
-    DataAccessRequest dar = createDataAccessRequest(user.getUserId(), collection_id);
+    DataAccessRequest dar = createDataAccessRequest(user.getUserId(), collectionId);
     Dataset d = createDataset();
     datasetDAO.updateDatasetDacId(d.getDatasetId(), dac.getDacId());
 
@@ -294,9 +294,9 @@ class ElectionDAOTest extends DAOTestHelper {
     Dac dac = createDac();
     User user = createUser();
     String darCode = "DAR-1234567890";
-    Integer collection_id = darCollectionDAO.insertDarCollection(darCode, user.getUserId(),
+    Integer collectionId = darCollectionDAO.insertDarCollection(darCode, user.getUserId(),
         new Date());
-    DataAccessRequest dar = createDataAccessRequest(user.getUserId(), collection_id);
+    DataAccessRequest dar = createDataAccessRequest(user.getUserId(), collectionId);
     Dataset d = createDataset();
     datasetDAO.updateDatasetDacId(d.getDatasetId(), dac.getDacId());
 
@@ -332,9 +332,9 @@ class ElectionDAOTest extends DAOTestHelper {
     Dac dac = createDac();
     User user = createUser();
     String darCode = "DAR-1234567890";
-    Integer collection_id = darCollectionDAO.insertDarCollection(darCode, user.getUserId(),
+    Integer collectionId = darCollectionDAO.insertDarCollection(darCode, user.getUserId(),
         new Date());
-    DataAccessRequest dar = createDataAccessRequest(user.getUserId(), collection_id);
+    DataAccessRequest dar = createDataAccessRequest(user.getUserId(), collectionId);
     Dataset d = createDataset();
     User u = createUserWithRoleInDac(UserRoles.CHAIRPERSON.getRoleId(), dac.getDacId());
     datasetDAO.updateDatasetDacId(d.getDatasetId(), dac.getDacId());
@@ -658,9 +658,9 @@ class ElectionDAOTest extends DAOTestHelper {
   void testArchiveElectionByIds() {
     User user = createUser();
     String darCode = "DAR-1234567890";
-    Integer collection_id = darCollectionDAO.insertDarCollection(darCode, user.getUserId(),
+    Integer collectionId = darCollectionDAO.insertDarCollection(darCode, user.getUserId(),
         new Date());
-    DataAccessRequest dar = createDataAccessRequest(user.getUserId(), collection_id);
+    DataAccessRequest dar = createDataAccessRequest(user.getUserId(), collectionId);
     Dataset d1 = createDataset();
     dataAccessRequestDAO.insertDARDatasetRelation(dar.getReferenceId(), d1.getDatasetId());
     createRPElection(dar.getReferenceId(), d1.getDatasetId());

--- a/src/test/java/org/broadinstitute/consent/http/db/ElectionDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/ElectionDAOTest.java
@@ -14,8 +14,6 @@ import java.util.List;
 import java.util.Random;
 import java.util.UUID;
 import java.util.stream.Stream;
-import org.apache.commons.lang3.RandomStringUtils;
-import org.apache.commons.lang3.RandomUtils;
 import org.broadinstitute.consent.http.enumeration.ElectionStatus;
 import org.broadinstitute.consent.http.enumeration.ElectionType;
 import org.broadinstitute.consent.http.enumeration.OrganizationType;
@@ -69,7 +67,7 @@ class ElectionDAOTest extends DAOTestHelper {
     String darCode = "DAR-1234567890";
     Integer collection_id = darCollectionDAO.insertDarCollection(darCode, user.getUserId(),
         new Date());
-    DataAccessRequest dar = createDataAccessRequest(user.getUserId(), collection_id, darCode);
+    DataAccessRequest dar = createDataAccessRequest(user.getUserId(), collection_id);
     Dataset dataset = createDataset();
     datasetDAO.updateDatasetDacId(dataset.getDatasetId(), dac.getDacId());
     Election election = createDataAccessElection(dar.getReferenceId(), dataset.getDatasetId());
@@ -137,7 +135,7 @@ class ElectionDAOTest extends DAOTestHelper {
     String darCode = "DAR-1234567890";
     Integer collection_id = darCollectionDAO.insertDarCollection(darCode, user.getUserId(),
         new Date());
-    DataAccessRequest dar = createDataAccessRequest(user.getUserId(), collection_id, darCode);
+    DataAccessRequest dar = createDataAccessRequest(user.getUserId(), collection_id);
     Dataset d1 = createDataset();
     Dataset d2 = createDataset();
     dataAccessRequestDAO.insertDARDatasetRelation(dar.getReferenceId(), d1.getDatasetId());
@@ -200,7 +198,7 @@ class ElectionDAOTest extends DAOTestHelper {
     String darCode = "DAR-1234567890";
     Integer collection_id = darCollectionDAO.insertDarCollection(darCode, user.getUserId(),
         new Date());
-    DataAccessRequest dar = createDataAccessRequest(user.getUserId(), collection_id, darCode);
+    DataAccessRequest dar = createDataAccessRequest(user.getUserId(), collection_id);
     Dataset d1 = createDataset();
     dataAccessRequestDAO.insertDARDatasetRelation(dar.getReferenceId(), d1.getDatasetId());
     createRPElection(dar.getReferenceId(), d1.getDatasetId());
@@ -218,7 +216,7 @@ class ElectionDAOTest extends DAOTestHelper {
     String darCode = "DAR-1234567890";
     Integer collection_id = darCollectionDAO.insertDarCollection(darCode, user.getUserId(),
         new Date());
-    DataAccessRequest dar = createDataAccessRequest(user.getUserId(), collection_id, darCode);
+    DataAccessRequest dar = createDataAccessRequest(user.getUserId(), collection_id);
     Dataset dataset = createDataset();
     datasetDAO.updateDatasetDacId(dataset.getDatasetId(), dac.getDacId());
 
@@ -237,7 +235,7 @@ class ElectionDAOTest extends DAOTestHelper {
     String darCode = "DAR-1234567890";
     Integer collection_id = darCollectionDAO.insertDarCollection(darCode, user.getUserId(),
         new Date());
-    DataAccessRequest dar = createDataAccessRequest(user.getUserId(), collection_id, darCode);
+    DataAccessRequest dar = createDataAccessRequest(user.getUserId(), collection_id);
     createDataAccessElection(dar.getReferenceId(), dataset.getDatasetId());
 
     List<Election> foundElections = electionDAO.findOpenElectionsByDacId(dac.getDacId());
@@ -252,7 +250,7 @@ class ElectionDAOTest extends DAOTestHelper {
     String darCode = "DAR-1234567890";
     Integer collection_id = darCollectionDAO.insertDarCollection(darCode, user.getUserId(),
         new Date());
-    DataAccessRequest dar = createDataAccessRequest(user.getUserId(), collection_id, darCode);
+    DataAccessRequest dar = createDataAccessRequest(user.getUserId(), collection_id);
     Dataset d = createDataset();
     datasetDAO.updateDatasetDacId(d.getDatasetId(), dac.getDacId());
 
@@ -277,7 +275,7 @@ class ElectionDAOTest extends DAOTestHelper {
     String darCode = "DAR-1234567890";
     Integer collection_id = darCollectionDAO.insertDarCollection(darCode, user.getUserId(),
         new Date());
-    DataAccessRequest dar = createDataAccessRequest(user.getUserId(), collection_id, darCode);
+    DataAccessRequest dar = createDataAccessRequest(user.getUserId(), collection_id);
     Dataset d = createDataset();
     datasetDAO.updateDatasetDacId(d.getDatasetId(), dac.getDacId());
 
@@ -298,7 +296,7 @@ class ElectionDAOTest extends DAOTestHelper {
     String darCode = "DAR-1234567890";
     Integer collection_id = darCollectionDAO.insertDarCollection(darCode, user.getUserId(),
         new Date());
-    DataAccessRequest dar = createDataAccessRequest(user.getUserId(), collection_id, darCode);
+    DataAccessRequest dar = createDataAccessRequest(user.getUserId(), collection_id);
     Dataset d = createDataset();
     datasetDAO.updateDatasetDacId(d.getDatasetId(), dac.getDacId());
 
@@ -336,7 +334,7 @@ class ElectionDAOTest extends DAOTestHelper {
     String darCode = "DAR-1234567890";
     Integer collection_id = darCollectionDAO.insertDarCollection(darCode, user.getUserId(),
         new Date());
-    DataAccessRequest dar = createDataAccessRequest(user.getUserId(), collection_id, darCode);
+    DataAccessRequest dar = createDataAccessRequest(user.getUserId(), collection_id);
     Dataset d = createDataset();
     User u = createUserWithRoleInDac(UserRoles.CHAIRPERSON.getRoleId(), dac.getDacId());
     datasetDAO.updateDatasetDacId(d.getDatasetId(), dac.getDacId());
@@ -662,7 +660,7 @@ class ElectionDAOTest extends DAOTestHelper {
     String darCode = "DAR-1234567890";
     Integer collection_id = darCollectionDAO.insertDarCollection(darCode, user.getUserId(),
         new Date());
-    DataAccessRequest dar = createDataAccessRequest(user.getUserId(), collection_id, darCode);
+    DataAccessRequest dar = createDataAccessRequest(user.getUserId(), collection_id);
     Dataset d1 = createDataset();
     dataAccessRequestDAO.insertDARDatasetRelation(dar.getReferenceId(), d1.getDatasetId());
     createRPElection(dar.getReferenceId(), d1.getDatasetId());
@@ -730,12 +728,12 @@ class ElectionDAOTest extends DAOTestHelper {
   }
 
   private DataAccessRequest createDataAccessRequestWithUserIdV3(Integer userId) {
-    String darCode = "DAR-" + RandomUtils.nextInt(100, 1000);
+    String darCode = "DAR-" + randomInt(100, 1000);
     Integer collectionId = darCollectionDAO.insertDarCollection(darCode, userId, new Date());
     for (int i = 0; i < 4; i++) {
-      createDataAccessRequest(userId, collectionId, darCode);
+      createDataAccessRequest(userId, collectionId);
     }
-    return createDataAccessRequest(userId, collectionId, darCode);
+    return createDataAccessRequest(userId, collectionId);
   }
 
   /**
@@ -743,11 +741,9 @@ class ElectionDAOTest extends DAOTestHelper {
    *
    * @return Populated DataAccessRequest
    */
-  private DataAccessRequest createDataAccessRequest(Integer userId, Integer collectionId,
-      String darCode) {
+  private DataAccessRequest createDataAccessRequest(Integer userId, Integer collectionId) {
     DataAccessRequestData data = new DataAccessRequestData();
-    data.setProjectTitle("Project Title: " + RandomStringUtils.random(50, true, false));
-//    data.setDarCode(darCode);
+    data.setProjectTitle("Project Title: " + randomAlphabetic(50));
     DatasetEntry entry = new DatasetEntry();
     entry.setKey("key");
     entry.setValue("value");
@@ -769,17 +765,17 @@ class ElectionDAOTest extends DAOTestHelper {
 
   private Dac createDac() {
     Integer id = dacDAO.createDac(
-        "Test_" + RandomStringUtils.random(20, true, true),
-        "Test_" + RandomStringUtils.random(20, true, true),
+        "Test_" + randomAlphabetic(20),
+        "Test_" + randomAlphabetic(20),
         new Date());
     return dacDAO.findById(id);
   }
 
   private Dataset createDataset() {
     User user = createUser();
-    String name = "Name_" + RandomStringUtils.random(20, true, true);
+    String name = "Name_" + randomAlphabetic(20);
     Timestamp now = new Timestamp(new Date().getTime());
-    String objectId = "Object ID_" + RandomStringUtils.random(20, true, true);
+    String objectId = "Object ID_" + randomAlphabetic(20);
     DataUse dataUse = new DataUseBuilder().setGeneralUse(true).build();
     Integer id = datasetDAO.insertDataset(name, now, user.getUserId(), objectId,
         dataUse.toString(), null);
@@ -808,14 +804,14 @@ class ElectionDAOTest extends DAOTestHelper {
 
   private Institution createInstitution() {
     User createUser = createUser();
-    Integer id = institutionDAO.insertInstitution(RandomStringUtils.randomAlphabetic(20),
+    Integer id = institutionDAO.insertInstitution(randomAlphabetic(20),
         "itDirectorName",
         "itDirectorEmail",
-        RandomStringUtils.randomAlphabetic(10),
+        randomAlphabetic(10),
         new Random().nextInt(),
-        RandomStringUtils.randomAlphabetic(10),
-        RandomStringUtils.randomAlphabetic(10),
-        RandomStringUtils.randomAlphabetic(10),
+        randomAlphabetic(10),
+        randomAlphabetic(10),
+        randomAlphabetic(10),
         OrganizationType.NON_PROFIT.getValue(),
         createUser.getUserId(),
         createUser.getCreateDate());
@@ -845,9 +841,9 @@ class ElectionDAOTest extends DAOTestHelper {
 
   private Dataset createDatasetWithDac(Integer dacId) {
     User user = createUser();
-    String name = "Name_" + RandomStringUtils.random(20, true, true);
+    String name = "Name_" + randomAlphabetic(20);
     Timestamp now = new Timestamp(new Date().getTime());
-    String objectId = "Object ID_" + RandomStringUtils.random(20, true, true);
+    String objectId = "Object ID_" + randomAlphabetic(20);
     DataUse dataUse = new DataUseBuilder().setGeneralUse(true).build();
     Integer id = datasetDAO.insertDataset(name, now, user.getUserId(), objectId,
         dataUse.toString(), dacId);

--- a/src/test/java/org/broadinstitute/consent/http/db/ElectionDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/ElectionDAOTest.java
@@ -747,7 +747,7 @@ class ElectionDAOTest extends DAOTestHelper {
       String darCode) {
     DataAccessRequestData data = new DataAccessRequestData();
     data.setProjectTitle("Project Title: " + RandomStringUtils.random(50, true, false));
-    data.setDarCode(darCode);
+//    data.setDarCode(darCode);
     DatasetEntry entry = new DatasetEntry();
     entry.setKey("key");
     entry.setValue("value");
@@ -762,7 +762,8 @@ class ElectionDAOTest extends DAOTestHelper {
         referenceId,
         userId,
         now, now, now, now,
-        data);
+        data,
+        randomAlphabetic(10));
     return dataAccessRequestDAO.findByReferenceId(referenceId);
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/db/VoteDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/VoteDAOTest.java
@@ -486,7 +486,7 @@ class VoteDAOTest extends DAOTestHelper {
     data.setProjectTitle(RandomStringUtils.randomAlphabetic(10));
     String referenceId = RandomStringUtils.randomAlphanumeric(20);
     dataAccessRequestDAO.insertDataAccessRequest(collectionId, referenceId, userId, new Date(),
-        new Date(), new Date(), new Date(), data);
+        new Date(), new Date(), new Date(), data, randomAlphabetic(10));
     dataAccessRequestDAO.insertDARDatasetRelation(referenceId, datasetId);
     return dataAccessRequestDAO.findByReferenceId(referenceId);
   }

--- a/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Random;
 import java.util.UUID;
 import org.apache.commons.lang3.RandomUtils;
+import org.broadinstitute.consent.http.AbstractTestHelper;
 import org.broadinstitute.consent.http.db.DAOContainer;
 import org.broadinstitute.consent.http.db.DacDAO;
 import org.broadinstitute.consent.http.db.DarCollectionDAO;
@@ -57,7 +58,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-class DataAccessRequestServiceTest {
+class DataAccessRequestServiceTest extends AbstractTestHelper {
 
   private static final String PI_EMAIL = "pi@example.broadinstitute.org";
   private static final String SO_EMAIL = "so@example.broadinstitute.org";
@@ -131,7 +132,7 @@ class DataAccessRequestServiceTest {
     when(counterService.getNextDarSequence()).thenReturn(1);
     when(dataAccessRequestDAO.findByReferenceId(any())).thenReturn(dar);
     doNothing().when(dataAccessRequestDAO)
-        .updateDataByReferenceId(any(), any(), any(), any(), any(), any());
+        .updateDataByReferenceId(any(), any(), any(), any(), any(), any(), any());
     initService();
     DataAccessRequest newDar = service.createDataAccessRequest(user, dar);
     assertNotNull(newDar);
@@ -153,7 +154,7 @@ class DataAccessRequestServiceTest {
         RandomUtils.nextInt(1, 100));
     doNothing().when(dataAccessRequestDAO)
         .insertDataAccessRequest(anyInt(), anyString(), anyInt(), any(Date.class), any(Date.class),
-            any(Date.class), any(Date.class), any(DataAccessRequestData.class));
+            any(Date.class), any(Date.class), any(DataAccessRequestData.class), randomAlphabetic(10));
     initService();
     DataAccessRequest newDar = service.createDataAccessRequest(user, dar);
     assertNotNull(newDar);

--- a/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
@@ -25,7 +25,6 @@ import java.util.Date;
 import java.util.List;
 import java.util.Random;
 import java.util.UUID;
-import org.apache.commons.lang3.RandomUtils;
 import org.broadinstitute.consent.http.AbstractTestHelper;
 import org.broadinstitute.consent.http.db.DAOContainer;
 import org.broadinstitute.consent.http.db.DacDAO;
@@ -37,8 +36,8 @@ import org.broadinstitute.consent.http.db.InstitutionDAO;
 import org.broadinstitute.consent.http.db.MatchDAO;
 import org.broadinstitute.consent.http.db.UserDAO;
 import org.broadinstitute.consent.http.db.VoteDAO;
-import org.broadinstitute.consent.http.exceptions.NIHComplianceRuleException;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
+import org.broadinstitute.consent.http.exceptions.NIHComplianceRuleException;
 import org.broadinstitute.consent.http.exceptions.SubmittedDARCannotBeEditedException;
 import org.broadinstitute.consent.http.models.Collaborator;
 import org.broadinstitute.consent.http.models.DarDataset;
@@ -129,6 +128,7 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     dar.addDatasetIds(List.of(1, 2, 3));
     User user = new User(1, "email@test.org", "Display Name", new Date());
     user.setLibraryCards(List.of(new LibraryCard()));
+    user.setEraCommonsId("eraCommonsId");
     when(counterService.getNextDarSequence()).thenReturn(1);
     when(dataAccessRequestDAO.findByReferenceId(any())).thenReturn(dar);
     doNothing().when(dataAccessRequestDAO)
@@ -147,14 +147,15 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     dar.setReferenceId("id");
     User user = new User(1, "email@test.org", "Display Name", new Date());
     user.setLibraryCards(List.of(new LibraryCard()));
+    user.setEraCommonsId("eraCommonsId");
     when(counterService.getNextDarSequence()).thenReturn(1);
     when(dataAccessRequestDAO.findByReferenceId("id")).thenReturn(null);
     when(dataAccessRequestDAO.findByReferenceId(argThat(new LongerThanTwo()))).thenReturn(dar);
     when(darCollectionDAO.insertDarCollection(anyString(), anyInt(), any(Date.class))).thenReturn(
-        RandomUtils.nextInt(1, 100));
+        randomInt(1, 100));
     doNothing().when(dataAccessRequestDAO)
         .insertDataAccessRequest(anyInt(), anyString(), anyInt(), any(Date.class), any(Date.class),
-            any(Date.class), any(Date.class), any(DataAccessRequestData.class), randomAlphabetic(10));
+            any(Date.class), any(Date.class), any(DataAccessRequestData.class), anyString());
     initService();
     DataAccessRequest newDar = service.createDataAccessRequest(user, dar);
     assertNotNull(newDar);
@@ -170,11 +171,11 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     dar.setSubmissionDate(Timestamp.from(Instant.now()));
     User user = new User(1, "email@test.org", "Display Name", new Date());
     user.setLibraryCards(List.of(new LibraryCard()));
+    user.setEraCommonsId("eraCommonsId");
     when(dataAccessRequestDAO.findByReferenceId(any())).thenReturn(dar);
     initService();
-    assertThrows(SubmittedDARCannotBeEditedException.class, () -> {
-      service.createDataAccessRequest(user, dar);
-    });
+    assertThrows(SubmittedDARCannotBeEditedException.class,
+        () -> service.createDataAccessRequest(user, dar));
   }
 
   @Test
@@ -182,18 +183,17 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     DataAccessRequest dar = generateDataAccessRequest();
     User user = new User(1, "email@test.org", "Display Name", new Date());
     user.setLibraryCards(List.of(new LibraryCard()));
+    user.setEraCommonsId("eraCommonsId");
     doThrow(BadRequestException.class).when(userService).hasValidActiveERACredentials(user);
     initService();
-    assertThrows(BadRequestException.class, () -> {
-      service.createDataAccessRequest(user, dar);
-    });
+    assertThrows(BadRequestException.class, () -> service.createDataAccessRequest(user, dar));
   }
 
 
   @Test
-  void testUpdateByReferenceIdThrowsOnDraft() throws Exception {
+  void testUpdateByReferenceIdThrowsOnDraft() {
     DataAccessRequest dar = generateDataAccessRequest();
-    dar.setCollectionId(RandomUtils.nextInt(0, 100));
+    dar.setCollectionId(randomInt(0, 100));
     User user = new User(1, "email@test.org", "Display Name", new Date());
     dar.addDatasetIds(List.of(1, 2, 3));
     dar.setSubmissionDate(Timestamp.from(Instant.now()));
@@ -213,9 +213,8 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     User user = new User(1, "email@test.org", "Display Name", new Date());
     user.setLibraryCards(List.of());
     initService();
-    assertThrows(NIHComplianceRuleException.class, () -> {
-      service.createDataAccessRequest(user, dar);
-    });
+    assertThrows(NIHComplianceRuleException.class,
+        () -> service.createDataAccessRequest(user, dar));
   }
 
   @Test
@@ -227,27 +226,33 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     parentDar.setSubmissionDate(Timestamp.from(Instant.now()));
     User user = new User(1, "email@test.org", "Display Name", new Date());
     user.setLibraryCards(List.of(new LibraryCard()));
+    user.setEraCommonsId("eraCommonsId");
     parentDar.setUserId(user.getUserId());
-    when(dataAccessRequestDAO.findByReferenceId(progressReport.getReferenceId())).thenReturn(progressReport);
+    when(dataAccessRequestDAO.findByReferenceId(progressReport.getReferenceId())).thenReturn(
+        progressReport);
 
     initService();
     DataAccessRequest newDar = service.createProgressReport(user, progressReport, parentDar);
     assertNotNull(newDar);
     verify(dataAccessRequestDAO)
-        .insertProgressReport(parentDar.getId(), progressReport.getCollectionId(), progressReport.getReferenceId(), user.getUserId(),
+        .insertProgressReport(parentDar.getId(), progressReport.getCollectionId(),
+            progressReport.getReferenceId(), user.getUserId(),
             progressReport.getData());
-    verify(dataAccessRequestDAO).insertAllDarDatasets(argThat(new DarDatasetMatcher(progressReport)));
+    verify(dataAccessRequestDAO).insertAllDarDatasets(
+        argThat(new DarDatasetMatcher(progressReport)));
   }
 
   static class DarDatasetMatcher implements ArgumentMatcher<List<DarDataset>> {
+
     private final DataAccessRequest progressReport;
 
     public DarDatasetMatcher(DataAccessRequest progressReport) {
       this.progressReport = progressReport;
     }
+
     @Override
     public boolean matches(List<DarDataset> darDatasets) {
-      for (int i=0; i < darDatasets.size(); i++) {
+      for (int i = 0; i < darDatasets.size(); i++) {
         if (!darDatasets.get(i).getReferenceId().equals(progressReport.getReferenceId()) ||
             !darDatasets.get(i).getDatasetId().equals(progressReport.getDatasetIds().get(i))) {
           return false;
@@ -270,61 +275,77 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
   void validateProgressReportParentDarIsDraft() {
     User user = new User(1, "email@test.org", "Display Name", new Date());
     user.setLibraryCards(List.of(new LibraryCard()));
+    user.setEraCommonsId("eraCommonsId");
     DataAccessRequest progressReport = generateProgressReport();
     DataAccessRequest parentDar = generateDataAccessRequest();
     initService();
-    assertThrows(BadRequestException.class, () -> {
-      service.validateProgressReport(user, progressReport, parentDar);
-    });
+    assertThrows(BadRequestException.class,
+        () -> service.validateProgressReport(user, progressReport, parentDar));
   }
 
   @Test
   void validateProgressReportNoDatasetIds() {
     User user = new User(1, "email@test.org", "Display Name", new Date());
     user.setLibraryCards(List.of(new LibraryCard()));
+    user.setEraCommonsId("eraCommonsId");
     DataAccessRequest progressReport = generateProgressReport();
     progressReport.setDatasetIds(Collections.emptyList());
     DataAccessRequest parentDar = generateDataAccessRequest();
     parentDar.setSubmissionDate(Timestamp.from(Instant.now()));
     parentDar.setUserId(user.getUserId());
     initService();
-    assertThrows(BadRequestException.class, () -> {
-      service.validateProgressReport(user, progressReport, parentDar);
-    });
+    assertThrows(BadRequestException.class,
+        () -> service.validateProgressReport(user, progressReport, parentDar));
   }
 
   @Test
   void validateProgressReportNoSummary() {
     User user = new User(1, "email@test.org", "Display Name", new Date());
     user.setLibraryCards(List.of(new LibraryCard()));
+    user.setEraCommonsId("eraCommonsId");
     DataAccessRequest progressReport = generateProgressReport();
     progressReport.getData().setProgressReportSummary(null);
     DataAccessRequest parentDar = generateDataAccessRequest();
     parentDar.setSubmissionDate(Timestamp.from(Instant.now()));
     parentDar.setUserId(user.getUserId());
     initService();
-    assertThrows(BadRequestException.class, () -> {
-      service.validateProgressReport(user, progressReport, parentDar);
-    });
+    assertThrows(BadRequestException.class,
+        () -> service.validateProgressReport(user, progressReport, parentDar));
   }
 
   @Test
   void validateProgressReportNoIPSummary() {
     User user = new User(1, "email@test.org", "Display Name", new Date());
     user.setLibraryCards(List.of(new LibraryCard()));
+    user.setEraCommonsId("eraCommonsId");
     DataAccessRequest progressReport = generateProgressReport();
     progressReport.getData().setIntellectualPropertySummary(null);
     DataAccessRequest parentDar = generateDataAccessRequest();
     parentDar.setSubmissionDate(Timestamp.from(Instant.now()));
     parentDar.setUserId(user.getUserId());
     initService();
-    assertThrows(BadRequestException.class, () -> {
-      service.validateProgressReport(user, progressReport, parentDar);
-    });
+    assertThrows(BadRequestException.class,
+        () -> service.validateProgressReport(user, progressReport, parentDar));
   }
 
   @Test
   void validateProgressReportInvalidDatasetIds() {
+    User user = new User(1, "email@test.org", "Display Name", new Date());
+    user.setLibraryCards(List.of(new LibraryCard()));
+    user.setEraCommonsId("eraCommonsId");
+    DataAccessRequest progressReport = generateProgressReport();
+    progressReport.setDatasetIds(List.of(3, 4, 5)); // IDs not all in parent DAR
+    DataAccessRequest parentDar = generateDataAccessRequest();
+    parentDar.setSubmissionDate(Timestamp.from(Instant.now()));
+    parentDar.setDatasetIds(List.of(1, 2, 3));
+    parentDar.setUserId(user.getUserId());
+    initService();
+    assertThrows(BadRequestException.class,
+        () -> service.validateProgressReport(user, progressReport, parentDar));
+  }
+
+  @Test
+  void validateProgressReportNoEraCommonsId() {
     User user = new User(1, "email@test.org", "Display Name", new Date());
     user.setLibraryCards(List.of(new LibraryCard()));
     DataAccessRequest progressReport = generateProgressReport();
@@ -334,15 +355,15 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     parentDar.setDatasetIds(List.of(1, 2, 3));
     parentDar.setUserId(user.getUserId());
     initService();
-    assertThrows(BadRequestException.class, () -> {
-      service.validateProgressReport(user, progressReport, parentDar);
-    });
+    assertThrows(NIHComplianceRuleException.class,
+        () -> service.validateProgressReport(user, progressReport, parentDar));
   }
 
   @Test
   void validateProgressReport() {
     User user = new User(1, "email@test.org", "Display Name", new Date());
     user.setLibraryCards(List.of(new LibraryCard()));
+    user.setEraCommonsId("eraCommonsId");
     DataAccessRequest progressReport = generateProgressReport();
     progressReport.setDatasetIds(List.of(1, 2));
     DataAccessRequest parentDar = generateDataAccessRequest();
@@ -350,27 +371,21 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     parentDar.setDatasetIds(List.of(1, 2, 3));
     parentDar.setUserId(user.getUserId());
     initService();
-    assertDoesNotThrow(() -> {
-      service.validateProgressReport(user, progressReport, parentDar);
-    });
+    assertDoesNotThrow(() -> service.validateProgressReport(user, progressReport, parentDar));
   }
 
   @Test
   void validateDarNullUser() {
     DataAccessRequest dar = generateDataAccessRequest();
     initService();
-    assertThrows(IllegalArgumentException.class, () -> {
-      service.validateDar(null, dar);
-    });
+    assertThrows(IllegalArgumentException.class, () -> service.validateDar(null, dar));
   }
 
   @Test
   void validateDarNullDar() {
     User user = new User(1, "email@test.org", "Display Name", new Date());
     initService();
-    assertThrows(IllegalArgumentException.class, () -> {
-      service.validateDar(user, null);
-    });
+    assertThrows(IllegalArgumentException.class, () -> service.validateDar(user, null));
   }
 
   @Test
@@ -379,9 +394,7 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     dar.setReferenceId(null);
     User user = new User(1, "email@test.org", "Display Name", new Date());
     initService();
-    assertThrows(IllegalArgumentException.class, () -> {
-      service.validateDar(user, dar);
-    });
+    assertThrows(IllegalArgumentException.class, () -> service.validateDar(user, dar));
   }
 
   @Test
@@ -390,9 +403,7 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     dar.setData(null);
     User user = new User(1, "email@test.org", "Display Name", new Date());
     initService();
-    assertThrows(IllegalArgumentException.class, () -> {
-      service.validateDar(user, dar);
-    });
+    assertThrows(IllegalArgumentException.class, () -> service.validateDar(user, dar));
   }
 
   @Test
@@ -401,9 +412,16 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     User user = new User(1, "email@test.org", "Display Name", new Date());
     user.setLibraryCards(Collections.emptyList());
     initService();
-    assertThrows(NIHComplianceRuleException.class, () -> {
-      service.validateDar(user, dar);
-    });
+    assertThrows(NIHComplianceRuleException.class, () -> service.validateDar(user, dar));
+  }
+
+  @Test
+  void validateDarNoEraCommonsId() {
+    DataAccessRequest dar = generateDataAccessRequest();
+    User user = new User(1, "email@test.org", "Display Name", new Date());
+    user.setLibraryCards(List.of(new LibraryCard()));
+    initService();
+    assertThrows(NIHComplianceRuleException.class, () -> service.validateDar(user, dar));
   }
 
   @Test
@@ -411,10 +429,9 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     DataAccessRequest dar = generateDataAccessRequest();
     User user = new User(1, "email@test.org", "Display Name", new Date());
     user.setLibraryCards(List.of(new LibraryCard()));
+    user.setEraCommonsId("eraCommonsId");
     initService();
-    assertDoesNotThrow(() -> {
-      service.validateDar(user, dar);
-    });
+    assertDoesNotThrow(() -> service.validateDar(user, dar));
   }
 
   @Test
@@ -496,7 +513,7 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
   @Test
   void testUpdateByReferenceIdVersion2() throws Exception {
     DataAccessRequest dar = generateDataAccessRequest();
-    dar.setCollectionId(RandomUtils.nextInt(0, 100));
+    dar.setCollectionId(randomInt(0, 100));
     User user = new User(1, "email@test.org", "Display Name", new Date());
     dar.addDatasetIds(List.of(1, 2, 3));
     when(dataAccessRequestServiceDAO.updateByReferenceId(any(), any())).thenReturn(dar);
@@ -527,9 +544,9 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     user2.setUserId(20);
 
     DataAccessRequest dar1 = new DataAccessRequest();
-    dar1.setUserId(10);
+    dar1.setUserId(user1.getUserId());
     DataAccessRequest dar2 = new DataAccessRequest();
-    dar2.setUserId(20);
+    dar2.setUserId(user2.getUserId());
     when(dataAccessRequestDAO
         .findApprovedDARsByDatasetId(d.getDatasetId()))
         .thenReturn(List.of(dar1, dar2));
@@ -615,7 +632,7 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
         List.of(new DataAccessRequest()));
     initService();
     List<DataAccessRequest> drafts = service.findAllDraftDataAccessRequests();
-    assertEquals(drafts.size(), 1);
+    assertEquals(1, drafts.size());
   }
 
   @Test
@@ -624,7 +641,7 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
         List.of(new DataAccessRequest()));
     initService();
     List<DataAccessRequest> drafts = service.findAllDraftDataAccessRequestsByUser(1);
-    assertEquals(drafts.size(), 1);
+    assertEquals(1, drafts.size());
   }
 
   @Test
@@ -634,7 +651,7 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     when(dacService.filterDataAccessRequestsByDac(eq(dars), any())).thenReturn(dars);
     initService();
     List<DataAccessRequest> foundDars = service.getDataAccessRequestsByUserRole(new User());
-    assertEquals(foundDars.size(), 1);
+    assertEquals(1, foundDars.size());
   }
 
   @Test
@@ -650,9 +667,7 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
   void testFindByReferenceId_NotFound() {
     initService();
     when(dataAccessRequestDAO.findByReferenceId(any())).thenThrow(new NotFoundException());
-    assertThrows(NotFoundException.class, () -> {
-      service.findByReferenceId("referenceId");
-    });
+    assertThrows(NotFoundException.class, () -> service.findByReferenceId("referenceId"));
   }
 
   @Test
@@ -687,7 +702,7 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     doNothing().when(dataAccessRequestDAO).deleteDARDatasetRelationByReferenceId(any());
     initService();
 
-    service.deleteByReferenceId(user, referenceId);
+    assertDoesNotThrow(() -> service.deleteByReferenceId(user, referenceId));
   }
 
   @Test
@@ -701,9 +716,8 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     when(electionDAO.findElectionsByReferenceId(any())).thenReturn(List.of(election));
     initService();
 
-    assertThrows(NotAcceptableException.class, () -> {
-      service.deleteByReferenceId(user, referenceId);
-    });
+    assertThrows(NotAcceptableException.class,
+        () -> service.deleteByReferenceId(user, referenceId));
   }
 
   @Test
@@ -727,9 +741,8 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     data.setItDirectorEmail(IT_EMAIL);
     data.setSigningOfficialEmail(SO_EMAIL);
     initService();
-    assertThrows(IllegalArgumentException.class, () -> {
-      service.validateNoKeyPersonnelDuplicates(data);
-    });
+    assertThrows(IllegalArgumentException.class,
+        () -> service.validateNoKeyPersonnelDuplicates(data));
   }
 
   @Test
@@ -739,9 +752,8 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     data.setItDirectorEmail("invalid");
     data.setSigningOfficialEmail(SO_EMAIL);
     initService();
-    assertThrows(IllegalArgumentException.class, () -> {
-      service.validateNoKeyPersonnelDuplicates(data);
-    });
+    assertThrows(IllegalArgumentException.class,
+        () -> service.validateNoKeyPersonnelDuplicates(data));
   }
 
   @Test
@@ -751,9 +763,8 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     data.setItDirectorEmail(IT_EMAIL);
     data.setSigningOfficialEmail("invalid");
     initService();
-    assertThrows(IllegalArgumentException.class, () -> {
-      service.validateNoKeyPersonnelDuplicates(data);
-    });
+    assertThrows(IllegalArgumentException.class,
+        () -> service.validateNoKeyPersonnelDuplicates(data));
   }
 
   @Test
@@ -763,9 +774,8 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     data.setItDirectorEmail(PI_EMAIL);
     data.setSigningOfficialEmail(SO_EMAIL);
     initService();
-    assertThrows(IllegalArgumentException.class, () -> {
-      service.validateNoKeyPersonnelDuplicates(data);
-    });
+    assertThrows(IllegalArgumentException.class,
+        () -> service.validateNoKeyPersonnelDuplicates(data));
   }
 
   @Test
@@ -775,9 +785,8 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     data.setItDirectorEmail(IT_EMAIL);
     data.setSigningOfficialEmail(PI_EMAIL);
     initService();
-    assertThrows(IllegalArgumentException.class, () -> {
-      service.validateNoKeyPersonnelDuplicates(data);
-    });
+    assertThrows(IllegalArgumentException.class,
+        () -> service.validateNoKeyPersonnelDuplicates(data));
   }
 
   private static class LongerThanTwo implements ArgumentMatcher<String> {

--- a/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
@@ -345,21 +345,6 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
   }
 
   @Test
-  void validateProgressReportNoEraCommonsId() {
-    User user = new User(1, "email@test.org", "Display Name", new Date());
-    user.setLibraryCards(List.of(new LibraryCard()));
-    DataAccessRequest progressReport = generateProgressReport();
-    progressReport.setDatasetIds(List.of(3, 4, 5)); // IDs not all in parent DAR
-    DataAccessRequest parentDar = generateDataAccessRequest();
-    parentDar.setSubmissionDate(Timestamp.from(Instant.now()));
-    parentDar.setDatasetIds(List.of(1, 2, 3));
-    parentDar.setUserId(user.getUserId());
-    initService();
-    assertThrows(NIHComplianceRuleException.class,
-        () -> service.validateProgressReport(user, progressReport, parentDar));
-  }
-
-  @Test
   void validateProgressReport() {
     User user = new User(1, "email@test.org", "Display Name", new Date());
     user.setLibraryCards(List.of(new LibraryCard()));
@@ -411,15 +396,6 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     DataAccessRequest dar = generateDataAccessRequest();
     User user = new User(1, "email@test.org", "Display Name", new Date());
     user.setLibraryCards(Collections.emptyList());
-    initService();
-    assertThrows(NIHComplianceRuleException.class, () -> service.validateDar(user, dar));
-  }
-
-  @Test
-  void validateDarNoEraCommonsId() {
-    DataAccessRequest dar = generateDataAccessRequest();
-    User user = new User(1, "email@test.org", "Display Name", new Date());
-    user.setLibraryCards(List.of(new LibraryCard()));
     initService();
     assertThrows(NIHComplianceRuleException.class, () -> service.validateDar(user, dar));
   }

--- a/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
@@ -31,8 +31,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.lang3.RandomStringUtils;
-import org.apache.commons.lang3.RandomUtils;
+import org.broadinstitute.consent.http.AbstractTestHelper;
 import org.broadinstitute.consent.http.db.AcknowledgementDAO;
 import org.broadinstitute.consent.http.db.DaaDAO;
 import org.broadinstitute.consent.http.db.FileStorageObjectDAO;
@@ -67,7 +66,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-class UserServiceTest {
+class UserServiceTest extends AbstractTestHelper {
 
   @Mock
   private UserDAO userDAO;
@@ -147,12 +146,12 @@ class UserServiceTest {
     // We're modifying this user to have an SO role. This should leave in place
     // both the Researcher and Chairperson roles, but remove the Admin role.
     fields.setUserRoleIds(List.of(so.getRoleId()));
-    fields.setDisplayName(RandomStringUtils.random(10, true, false));
+    fields.setDisplayName(randomAlphabetic(10));
     fields.setInstitutionId(1);
     fields.setEmailPreference(true);
-    fields.setEraCommonsId(RandomStringUtils.random(10, true, false));
+    fields.setEraCommonsId(randomAlphabetic(10));
     fields.setSelectedSigningOfficialId(1);
-    fields.setSuggestedSigningOfficial(RandomStringUtils.random(10, true, false));
+    fields.setSuggestedSigningOfficial(randomAlphabetic(10));
     fields.setDaaAcceptance(true);
     assertEquals(3, fields.buildUserProperties(user.getUserId()).size());
     service.updateUserFieldsById(fields, user.getUserId());
@@ -168,7 +167,7 @@ class UserServiceTest {
   }
 
   @Test
-  void testUpdateUserFieldsById_SendsEmailWhenSOInitalized() throws Exception {
+  void testUpdateUserFieldsById_SendsEmailWhenSOInitialized() throws Exception {
     User user = new User();
     user.setUserId(1);
 
@@ -302,9 +301,7 @@ class UserServiceTest {
     List<UserRole> roles = List.of(generateRole(UserRoles.RESEARCHER.getRoleId()));
     u.setRoles(roles);
     when(userDAO.findUserByEmail(any())).thenReturn(u);
-    assertThrows(BadRequestException.class, () -> {
-      service.createUser(u);
-    });
+    assertThrows(BadRequestException.class, () -> service.createUser(u));
   }
 
   @Test
@@ -313,14 +310,13 @@ class UserServiceTest {
     List<UserRole> roles = List.of(generateRole(UserRoles.RESEARCHER.getRoleId()));
     u.setRoles(roles);
     u.setDisplayName(null);
-    assertThrows(BadRequestException.class, () -> {
-      service.createUser(u);
-    });
+    assertThrows(BadRequestException.class, () -> service.createUser(u));
   }
 
   @Test
   void testHasValidERACommonsCredentials() {
     User u = generateUser();
+    u.setEraCommonsId(randomAlphabetic(10));
     LibraryCard lc = generateLibraryCard(u.getEmail());
     lc.setEraCommonsId(u.getEmail());
     u.addLibraryCard(lc);
@@ -452,9 +448,7 @@ class UserServiceTest {
     User u = generateUser();
     List<UserRole> roles = List.of(generateRole(UserRoles.CHAIRPERSON.getRoleId()));
     u.setRoles(roles);
-    assertThrows(BadRequestException.class, () -> {
-      service.createUser(u);
-    });
+    assertThrows(BadRequestException.class, () -> service.createUser(u));
   }
 
   @Test
@@ -462,18 +456,14 @@ class UserServiceTest {
     User u = generateUser();
     List<UserRole> roles = List.of(generateRole(UserRoles.MEMBER.getRoleId()));
     u.setRoles(roles);
-    assertThrows(BadRequestException.class, () -> {
-      service.createUser(u);
-    });
+    assertThrows(BadRequestException.class, () -> service.createUser(u));
   }
 
   @Test
   void testCreateUserNoEmail() {
     User u = generateUser();
     u.setEmail(null);
-    assertThrows(BadRequestException.class, () -> {
-      service.createUser(u);
-    });
+    assertThrows(BadRequestException.class, () -> service.createUser(u));
   }
 
   @Test
@@ -524,9 +514,7 @@ class UserServiceTest {
     User u = generateUser();
     when(userDAO.findUserById(any())).thenReturn(null);
 
-    assertThrows(NotFoundException.class, () -> {
-      service.findUserById(u.getUserId());
-    });
+    assertThrows(NotFoundException.class, () -> service.findUserById(u.getUserId()));
   }
 
   @Test
@@ -560,9 +548,7 @@ class UserServiceTest {
     User u = generateUser();
     when(userDAO.findUserByEmail(any())).thenReturn(null);
 
-    assertThrows(NotFoundException.class, () -> {
-      service.findUserByEmail(u.getEmail());
-    });
+    assertThrows(NotFoundException.class, () -> service.findUserByEmail(u.getEmail()));
   }
 
   @Test
@@ -572,7 +558,7 @@ class UserServiceTest {
     when(userDAO.findUserByEmail(any())).thenReturn(u);
 
     try {
-      service.deleteUserByEmail(RandomStringUtils.random(10, true, false));
+      service.deleteUserByEmail(randomAlphabetic(10));
       verify(draftServiceDAO).deleteDraftsByUser(u);
     } catch (Exception e) {
       fail("Should not fail: " + e.getMessage());
@@ -582,9 +568,7 @@ class UserServiceTest {
   @Test
   void testDeleteUserFailure() {
     when(userDAO.findUserByEmail(any())).thenThrow(new NotFoundException());
-    assertThrows(NotFoundException.class, () -> {
-      service.deleteUserByEmail(RandomStringUtils.random(10, true, false));
-    });
+    assertThrows(NotFoundException.class, () -> service.deleteUserByEmail(randomAlphabetic(10)));
   }
 
   @Test
@@ -606,17 +590,13 @@ class UserServiceTest {
 
   @Test
   void testFindUsersByInstitutionIdNullId() {
-    assertThrows(IllegalArgumentException.class, () -> {
-      service.findUsersByInstitutionId(null);
-    });
+    assertThrows(IllegalArgumentException.class, () -> service.findUsersByInstitutionId(null));
   }
 
   @Test
   void testFindUsersByInstitutionIdNullInstitution() {
     doThrow(new NotFoundException()).when(institutionDAO).findInstitutionById(anyInt());
-    assertThrows(NotFoundException.class, () -> {
-      service.findUsersByInstitutionId(1);
-    });
+    assertThrows(NotFoundException.class, () -> service.findUsersByInstitutionId(1));
   }
 
   @Test
@@ -654,9 +634,8 @@ class UserServiceTest {
   void testGetUsersAsRoleSO_NoInstitution() {
     User u = generateUser();
     u.setInstitutionId(null);
-    assertThrows(NotFoundException.class, () -> {
-      service.getUsersAsRole(u, UserRoles.SIGNINGOFFICIAL.getRoleName());
-    });
+    assertThrows(NotFoundException.class,
+        () -> service.getUsersAsRole(u, UserRoles.SIGNINGOFFICIAL.getRoleName()));
   }
 
   @Test
@@ -694,7 +673,7 @@ class UserServiceTest {
   @Test
   void testGetUsersByDaaId() {
     User u1 = generateUser();
-    int dacId = RandomUtils.nextInt(0, 50);
+    int dacId = randomInt(0, 50);
     Instant now = Instant.now();
     LibraryCard card = generateLibraryCard(u1);
     int daaId = daaDAO.createDaa(card.getUserId(), now, card.getUserId(), now, dacId);
@@ -713,7 +692,7 @@ class UserServiceTest {
   void testGetUsersByDaaIdMultipleUsers() {
     User u1 = generateUser();
     User u2 = generateUser();
-    int dacId = RandomUtils.nextInt(0, 50);
+    int dacId = randomInt(0, 50);
     Instant now = Instant.now();
     LibraryCard card = generateLibraryCard(u1);
     LibraryCard card2 = generateLibraryCard(u2);
@@ -735,8 +714,8 @@ class UserServiceTest {
     User u1 = generateUser();
     User u2 = generateUser();
     User u3 = generateUser();
-    int dacId = RandomUtils.nextInt(0, 50);
-    int dacId2 = RandomUtils.nextInt(0, 50);
+    int dacId = randomInt(0, 50);
+    int dacId2 = randomInt(0, 50);
     Instant now = Instant.now();
     LibraryCard card = generateLibraryCard(u1);
     LibraryCard card2 = generateLibraryCard(u2);
@@ -766,7 +745,7 @@ class UserServiceTest {
   @Test
   void testGetUsersByDaaIdNoMatchingUsers() {
     User u1 = generateUser();
-    int dacId = RandomUtils.nextInt(0, 50);
+    int dacId = randomInt(0, 50);
     Instant now = Instant.now();
     LibraryCard card = generateLibraryCard(u1);
     int daaId = daaDAO.createDaa(card.getUserId(), now, card.getUserId(), now, dacId);
@@ -781,9 +760,7 @@ class UserServiceTest {
 
   @Test
   void testGetUsersByDaaIdNoMatchingDaa() {
-    assertThrows(NotFoundException.class, () -> {
-      service.getUsersByDaaId(RandomUtils.nextInt(10, 50));
-    });
+    assertThrows(NotFoundException.class, () -> service.getUsersByDaaId(randomInt(10, 50)));
   }
 
   @Test
@@ -802,7 +779,7 @@ class UserServiceTest {
     UserStatusInfo info = new UserStatusInfo().setUserEmail(user.getEmail()).setEnabled(true)
         .setUserSubjectId("subjectId");
     AuthUser authUser = new AuthUser().setEmail(user.getEmail())
-        .setAuthToken(RandomStringUtils.random(30, true, false)).setUserStatusInfo(info);
+        .setAuthToken(randomAlphabetic(30)).setUserStatusInfo(info);
     when(userDAO.findUserById(anyInt())).thenReturn(user);
     when(libraryCardDAO.findLibraryCardsByUserId(anyInt())).thenReturn(List.of(new LibraryCard()));
     when(userPropertyDAO.findUserPropertiesByUserIdAndPropertyKeys(anyInt(), any())).thenReturn(
@@ -823,7 +800,7 @@ class UserServiceTest {
     UserStatusInfo info = new UserStatusInfo().setUserEmail(user.getEmail()).setEnabled(true)
         .setUserSubjectId("subjectId");
     AuthUser authUser = new AuthUser().setEmail("not the user's email address")
-        .setAuthToken(RandomStringUtils.random(30, true, false)).setUserStatusInfo(info);
+        .setAuthToken(randomAlphabetic(30)).setUserStatusInfo(info);
     when(userDAO.findUserById(anyInt())).thenReturn(user);
     when(libraryCardDAO.findLibraryCardsByUserId(anyInt())).thenReturn(List.of(new LibraryCard()));
     when(userPropertyDAO.findUserPropertiesByUserIdAndPropertyKeys(anyInt(), any())).thenReturn(
@@ -846,7 +823,7 @@ class UserServiceTest {
         .setLdap(true);
     UserStatus status = new UserStatus().setUserInfo(info).setEnabled(enabled);
     AuthUser authUser = new AuthUser().setEmail(user.getEmail())
-        .setAuthToken(RandomStringUtils.random(30, true, false));
+        .setAuthToken(randomAlphabetic(30));
 
     when(userDAO.findUserByEmail(any())).thenReturn(user);
     when(samDAO.postRegistrationInfo(any())).thenReturn(status);
@@ -865,7 +842,7 @@ class UserServiceTest {
         .setLdap(true);
     UserStatus status = new UserStatus().setUserInfo(info).setEnabled(enabled);
     AuthUser authUser = new AuthUser().setName(user.getDisplayName()).setEmail(user.getEmail())
-        .setAuthToken(RandomStringUtils.random(30, true, false));
+        .setAuthToken(randomAlphabetic(30));
     Institution institution = new Institution();
 
     // mock findUserByEmail to throw the NFE on the first call (findOrCreateUser)
@@ -957,17 +934,13 @@ class UserServiceTest {
   void testFindUsersInJsonArrayInvalidJson() {
     // Missing closing bracket
     String json = "{users:[1,2,3}";
-    assertThrows(BadRequestException.class, () -> {
-      service.findUsersInJsonArray(json, "users");
-    });
+    assertThrows(BadRequestException.class, () -> service.findUsersInJsonArray(json, "users"));
   }
 
   @Test
   void testFindUsersInJsonArrayInvalidKey() {
     String json = "{users:[1,2,3]}";
-    assertThrows(BadRequestException.class, () -> {
-      service.findUsersInJsonArray(json, "invalidKey");
-    });
+    assertThrows(BadRequestException.class, () -> service.findUsersInJsonArray(json, "invalidKey"));
   }
 
   private User generateUserWithoutInstitution() {
@@ -978,35 +951,32 @@ class UserServiceTest {
 
   private User generateUser() {
     User u = new User();
-    int i1 = RandomUtils.nextInt(10, 50);
-    int i2 = RandomUtils.nextInt(10, 50);
-    int i3 = RandomUtils.nextInt(5, 25);
-    String email =
-        RandomStringUtils.randomAlphabetic(i1) + "@" + RandomStringUtils.randomAlphabetic(i2) + "."
-            + RandomStringUtils.randomAlphabetic(i3);
-    String displayName =
-        RandomStringUtils.randomAlphabetic(i1) + " " + RandomStringUtils.randomAlphabetic(i2);
+    int i1 = randomInt(10, 50);
+    int i2 = randomInt(10, 50);
+    int i3 = randomInt(5, 25);
+    String email = randomAlphabetic(i1) + "@" + randomAlphabetic(i2) + "." + randomAlphabetic(i3);
+    String displayName = randomAlphabetic(i1) + " " + randomAlphabetic(i2);
     u.setEmail(email);
     u.setDisplayName(displayName);
-    u.setUserId(RandomUtils.nextInt(1, 100));
-    u.setInstitutionId(RandomUtils.nextInt(1, 100));
+    u.setUserId(randomInt(1, 100));
+    u.setInstitutionId(randomInt(1, 100));
     return u;
   }
 
   private LibraryCard generateLibraryCard(String email) {
     LibraryCard libraryCard = new LibraryCard();
-    libraryCard.setId(RandomUtils.nextInt(1, 10));
-    libraryCard.setInstitutionId(RandomUtils.nextInt(1, 10));
+    libraryCard.setId(randomInt(1, 10));
+    libraryCard.setInstitutionId(randomInt(1, 10));
     libraryCard.setUserEmail(email);
-    libraryCard.setUserName(RandomStringUtils.randomAlphabetic(RandomUtils.nextInt(1, 10)));
+    libraryCard.setUserName(randomAlphabetic(randomInt(1, 10)));
     return libraryCard;
   }
 
   private LibraryCard generateLibraryCard(User user) {
     LibraryCard libraryCard = new LibraryCard();
-    libraryCard.setId(RandomUtils.nextInt(1, 10));
+    libraryCard.setId(randomInt(1, 10));
     libraryCard.setUserId(user.getUserId());
-    libraryCard.setInstitutionId(RandomUtils.nextInt(1, 10));
+    libraryCard.setInstitutionId(randomInt(1, 10));
     return libraryCard;
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DarCollectionServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DarCollectionServiceDAOTest.java
@@ -398,7 +398,7 @@ class DarCollectionServiceDAOTest extends DAOTestHelper {
     dataAccessRequestDAO.insertDARDatasetRelation(dar.getReferenceId(), dataset.getDatasetId());
     Date now = new Date();
     dataAccessRequestDAO.updateDataByReferenceId(
-        dar.getReferenceId(), dar.getUserId(), now, now, now, dar.getData());
+        dar.getReferenceId(), dar.getUserId(), now, now, now, dar.getData(), user.getEraCommonsId());
     return darCollectionDAO.findDARCollectionByReferenceId(dar.getReferenceId());
   }
 
@@ -460,7 +460,7 @@ class DarCollectionServiceDAOTest extends DAOTestHelper {
         now, now, data);
     dataAccessRequestDAO.updateDraftToSubmittedForCollection(collectionId, dar.getReferenceId());
     dataAccessRequestDAO.updateDataByReferenceId(dar.referenceId, dar.userId, new Date(),
-        new Date(), new Date(), data);
+        new Date(), new Date(), data, user.getEraCommonsId());
     dataAccessRequestDAO.insertDARDatasetRelation(dar.getReferenceId(), dataset.getDatasetId());
     return dataAccessRequestDAO.findByReferenceId(dar.getReferenceId());
   }

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DataAccessRequestServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DataAccessRequestServiceDAOTest.java
@@ -2,6 +2,7 @@ package org.broadinstitute.consent.http.service.dao;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import java.sql.Timestamp;
 import java.util.ArrayList;
@@ -9,8 +10,6 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 import java.util.UUID;
-import org.apache.commons.lang3.RandomStringUtils;
-import org.apache.commons.lang3.RandomUtils;
 import org.broadinstitute.consent.http.db.DAOTestHelper;
 import org.broadinstitute.consent.http.enumeration.ElectionStatus;
 import org.broadinstitute.consent.http.enumeration.ElectionType;
@@ -26,7 +25,6 @@ import org.broadinstitute.consent.http.models.DatasetEntry;
 import org.broadinstitute.consent.http.models.DatasetProperty;
 import org.broadinstitute.consent.http.models.Election;
 import org.broadinstitute.consent.http.models.User;
-import org.broadinstitute.consent.http.models.Vote;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -55,7 +53,7 @@ class DataAccessRequestServiceDAOTest extends DAOTestHelper {
     cal.set(Calendar.DAY_OF_MONTH, 1);
     Date old = cal.getTime();
 
-    String referenceId = RandomStringUtils.randomAlphanumeric(10);
+    String referenceId = randomAlphanumeric(10);
     DarDataset oldDarDataset = new DarDataset(referenceId, datasetOne.getDatasetId());
     DarDataset oldDarDatasetTwo = new DarDataset(referenceId, datasetTwo.getDatasetId());
     DarCollection collection = createDarCollection();
@@ -78,7 +76,7 @@ class DataAccessRequestServiceDAOTest extends DAOTestHelper {
     DataAccessRequest updatedDar = serviceDAO.updateByReferenceId(user, dar);
 
     Timestamp oldTimestamp = new Timestamp(old.getTime());
-    assertFalse(oldTimestamp.equals(updatedDar.getSortDate()));
+    assertNotEquals(oldTimestamp, updatedDar.getSortDate());
     assertFalse(oldTimestamp.equals(updatedDar.getUpdateDate()));
     assertEquals(newDatasetIds, updatedDar.getDatasetIds());
     DataAccessRequestData updatedData = updatedDar.getData();
@@ -93,9 +91,9 @@ class DataAccessRequestServiceDAOTest extends DAOTestHelper {
 
   private Dataset createDataset() {
     User user = createUser();
-    String name = "Name_" + RandomStringUtils.random(20, true, true);
+    String name = "Name_" + randomAlphanumeric(20);
     Timestamp now = new Timestamp(new Date().getTime());
-    String objectId = "Object ID_" + RandomStringUtils.random(20, true, true);
+    String objectId = "Object ID_" + randomAlphanumeric(20);
     DataUse dataUse = new DataUseBuilder().setGeneralUse(true).build();
     Integer id = datasetDAO.insertDataset(name, now, user.getUserId(), objectId,
         dataUse.toString(), null);
@@ -116,20 +114,20 @@ class DataAccessRequestServiceDAOTest extends DAOTestHelper {
 
   private DarCollection createDarCollection() {
     User user = createUserWithInstitution();
-    String darCode = "DAR-" + RandomUtils.nextInt(1, 10000);
-    Integer collection_id = darCollectionDAO.insertDarCollection(darCode, user.getUserId(),
+    String darCode = "DAR-" + randomInt(1, 10000);
+    Integer collectionId = darCollectionDAO.insertDarCollection(darCode, user.getUserId(),
         new Date());
     Dataset dataset = createDataset();
-    DataAccessRequest dar = createDataAccessRequest(user.getUserId(), collection_id, darCode);
+    DataAccessRequest dar = createDataAccessRequest(user.getUserId(), collectionId);
     dataAccessRequestDAO.insertDARDatasetRelation(dar.getReferenceId(), dataset.getDatasetId());
     Election cancelled = createCancelledAccessElection(dar.getReferenceId(),
         dataset.getDatasetId());
     Election access = createDataAccessElection(dar.getReferenceId(), dataset.getDatasetId());
     createFinalVote(user.getUserId(), cancelled.getElectionId());
     createFinalVote(user.getUserId(), access.getElectionId());
-    createDataAccessRequest(user.getUserId(), collection_id, darCode);
-    createDataAccessRequest(user.getUserId(), collection_id, darCode);
-    return darCollectionDAO.findDARCollectionByCollectionId(collection_id);
+    createDataAccessRequest(user.getUserId(), collectionId);
+    createDataAccessRequest(user.getUserId(), collectionId);
+    return darCollectionDAO.findDARCollectionByCollectionId(collectionId);
   }
 
   private Election createCancelledAccessElection(String referenceId, Integer datasetId) {
@@ -148,11 +146,9 @@ class DataAccessRequestServiceDAOTest extends DAOTestHelper {
    *
    * @return Populated DataAccessRequest
    */
-  private DataAccessRequest createDataAccessRequest(Integer userId, Integer collectionId,
-      String darCode) {
+  private DataAccessRequest createDataAccessRequest(Integer userId, Integer collectionId) {
     DataAccessRequestData data = new DataAccessRequestData();
-    data.setProjectTitle("Project Title: " + RandomStringUtils.random(50, true, false));
-//    data.setDarCode(darCode);
+    data.setProjectTitle("Project Title: " + randomAlphabetic(50));
     DatasetEntry entry = new DatasetEntry();
     entry.setKey("key");
     entry.setValue("value");
@@ -172,9 +168,8 @@ class DataAccessRequestServiceDAOTest extends DAOTestHelper {
     return dataAccessRequestDAO.findByReferenceId(referenceId);
   }
 
-  private Vote createFinalVote(Integer userId, Integer electionId) {
-    Integer voteId = voteDAO.insertVote(userId, electionId, VoteType.FINAL.getValue());
-    return voteDAO.findVoteById(voteId);
+  private void createFinalVote(Integer userId, Integer electionId) {
+    voteDAO.insertVote(userId, electionId, VoteType.FINAL.getValue());
   }
 
   private Election createDataAccessElection(String referenceId, Integer datasetId) {

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DataAccessRequestServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DataAccessRequestServiceDAOTest.java
@@ -61,7 +61,7 @@ class DataAccessRequestServiceDAOTest extends DAOTestHelper {
     DarCollection collection = createDarCollection();
     Integer collectionId = collection.getDarCollectionId();
     dataAccessRequestDAO.insertDataAccessRequest(collectionId, referenceId, user.getUserId(), old,
-        old, old, old, new DataAccessRequestData());
+        old, old, old, new DataAccessRequestData(), user.getEraCommonsId());
     dataAccessRequestDAO.insertAllDarDatasets(List.of(oldDarDataset, oldDarDatasetTwo));
 
     DataAccessRequest dar = new DataAccessRequest();
@@ -152,7 +152,7 @@ class DataAccessRequestServiceDAOTest extends DAOTestHelper {
       String darCode) {
     DataAccessRequestData data = new DataAccessRequestData();
     data.setProjectTitle("Project Title: " + RandomStringUtils.random(50, true, false));
-    data.setDarCode(darCode);
+//    data.setDarCode(darCode);
     DatasetEntry entry = new DatasetEntry();
     entry.setKey("key");
     entry.setValue("value");
@@ -167,7 +167,8 @@ class DataAccessRequestServiceDAOTest extends DAOTestHelper {
         referenceId,
         userId,
         now, now, now, now,
-        data);
+        data,
+        randomAlphabetic(10));
     return dataAccessRequestDAO.findByReferenceId(referenceId);
   }
 


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-1472

### Summary
This PR does the following:
* Add a new top level field on DAR for eRA Commons Id
  * This represents the id of the user at the time of DAR submission
* Back populate existing submitted DARs with the value of the create user
  * This isn't perfect as we can't know if this was the actual value at the time of submission, but it is the only value we have and is currently what we show to the DACs when they review a DAR.
* Update plumbing to save and return this value along with DAR records
* Insert this value from the user on DAR submission and on Progress Report submission
* Large number of minor updates to tests to address sonar warnings

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
