### PR TITLE
[DT-1612] Use era Commons Id value from user object instead of LC.

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/service/UserService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/UserService.java
@@ -475,7 +475,7 @@ public class UserService implements ConsentLogger {
     if (cards.isEmpty()) {
       throw new LibraryCardRequiredException();
     }
-    boolean hasEraCommonsId = cards.stream().anyMatch(c -> c.getEraCommonsId() != null);
+    boolean hasEraCommonsId = user.getEraCommonsId() != null;
     if (!hasEraCommonsId) {
       throw new BadRequestException("User does not have an Era Commons ID");
     }

--- a/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
@@ -361,8 +361,8 @@ class UserServiceTest {
   @Test
   void testValidateERACommonsCredentialsMissingERACommonsId() {
     User u = generateUser();
+    u.setEraCommonsId(null);
     LibraryCard lc = generateLibraryCard(u.getEmail());
-    lc.setEraCommonsId(null);
     u.addLibraryCard(lc);
     UserProperty eraStatus = new UserProperty(1, u.getUserId(), ERA_STATUS.getValue(), "true");
     //standard practice is that these expire in 30 days.
@@ -987,6 +987,7 @@ class UserServiceTest {
     String displayName =
         RandomStringUtils.randomAlphabetic(i1) + " " + RandomStringUtils.randomAlphabetic(i2);
     u.setEmail(email);
+    u.setEraCommonsId(email);
     u.setDisplayName(displayName);
     u.setUserId(RandomUtils.nextInt(1, 100));
     u.setInstitutionId(RandomUtils.nextInt(1, 100));


### PR DESCRIPTION
Changes to pull eraCommonsId from library card object to user object because value in LC can be unreliable.

### Addresses

[https://broadworkbench.atlassian.net/browse/DT-1612](https://broadworkbench.atlassian.net/browse/DT-1612)

### Summary

Updates the validation method and tests.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
