### PR TITLE
[DT-99] Update db-connect.sh to use gcloud secrets

### DIFF
--- a/scripts/db-connect.sh
+++ b/scripts/db-connect.sh
@@ -75,12 +75,11 @@ case $1 in
     * ) error "ENV must be one of dev, alpha, or staging";;
 esac
 
-VAULT_PATH="secret/dsde/firecloud/$1/consent/secrets/postgres/app_sql_user"
-VAULT_JSON=$(vault read -format=json "$VAULT_PATH")
+PG_JSON=$(gcloud secrets versions access latest --secret=consent-postgres-creds)
 
-INSTANCE=$(echo "$VAULT_JSON" | jq -r .data.instance_name)
-USERNAME=$(echo "$VAULT_JSON" | jq -r .data.username)
-PASSWORD=$(echo "$VAULT_JSON" | jq -r .data.password)
+INSTANCE=$(echo "$PG_JSON" | jq -r .instance_name)
+USERNAME=$(echo "$PG_JSON" | jq -r .username)
+PASSWORD=$(echo "$PG_JSON" | jq -r .password)
 
 INSTANCE="broad-dsde-$1:us-central1:$INSTANCE"
 


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-99

### Summary

Follow-up to Rae's work to allow the `db-connect.sh` script to connect using `gcloud` instead of `vault`.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
