### PR TITLE
[DT-1570]Add CREATE_PROGRESS_REPORT Action

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/DataAccessRequestDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DataAccessRequestDAO.java
@@ -102,47 +102,6 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
    * `FALSE` in the example above. Outside the JOIN, we filter on groupings where the final vote
    * value is `TRUE` so the denied election in the example would be filtered out.
    *
-   * @param darReferenceId The DAR reference UUID
-   * @return Set of approved Dataset Ids for the DAR
-   */
-  @SqlQuery(
-      """
-      SELECT dd.dataset_id
-      FROM data_access_request dar
-      INNER JOIN dar_dataset dd ON dd.reference_id = dar.reference_id
-      INNER JOIN (
-        SELECT DISTINCT e.reference_id, e.dataset_id, LAST_VALUE(v.vote)
-        OVER(
-          PARTITION BY e.dataset_id
-            ORDER BY v.createdate
-            RANGE BETWEEN
-              UNBOUNDED PRECEDING AND
-              UNBOUNDED FOLLOWING
-        ) last_vote
-        FROM election e
-        INNER JOIN vote v ON e.election_id = v.electionid AND v.vote IS NOT NULL
-        AND LOWER(e.election_type) = 'dataaccess'
-        AND LOWER(v.type) = 'final') final_access_vote ON
-          final_access_vote.reference_id = dar.reference_id AND
-          final_access_vote.dataset_id = dd.dataset_id
-      WHERE final_access_vote.last_vote = TRUE
-      AND dar.reference_id = :darReferenceId
-      AND (LOWER(dar.data->>'status') != 'archived' OR dar.data->>'status' IS NULL)
-      """)
-  Set<Integer> findDatasetApprovalsByDar(@Bind("darReferenceId") String darReferenceId);
-
-  /**
-   * This query finds dataset ids on dar-dataset combinations where the most recent vote is true.
-   * This includes datasets that are a part of expired DARs, UNLIKE findApprovedDARsByDatasetId.
-   * The query accomplishes this by creating a view that is a grouping
-   * of election reference ids and LAST vote in the group of final votes for all data access
-   * elections. We need to group them due to the case of multiple elections on a dar-dataset
-   * request. Election 1 may have been denied. Election 2 may have been approved. Election 3 may
-   * have been denied again. When we partition over the election reference id, we'll get all final
-   * votes. The `LAST_VALUE` function selects the last result in the partition, which would be
-   * `FALSE` in the example above. Outside the JOIN, we filter on groupings where the final vote
-   * value is `TRUE` so the denied election in the example would be filtered out.
-   *
    * @param darReferenceIds The DARs reference UUIDs
    * @return Set of approved Dataset Ids for the list of DARs
    */

--- a/src/main/java/org/broadinstitute/consent/http/db/DataAccessRequestDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DataAccessRequestDAO.java
@@ -91,8 +91,9 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
   List<DataAccessRequest> findApprovedDARsByDatasetId(@Bind("datasetId") Integer datasetId);
 
   /**
-   * This query finds dataset ids submitted within the last year on dar-dataset combinations where
-   * the most recent vote is true. The query accomplishes this by creating a view that is a grouping
+   * This query finds dataset ids on dar-dataset combinations where the most recent vote is true.
+   * This includes datasets that are a part of expired DARs, UNLIKE findApprovedDARsByDatasetId.
+   * The query accomplishes this by creating a view that is a grouping
    * of election reference ids and LAST vote in the group of final votes for all data access
    * elections. We need to group them due to the case of multiple elections on a dar-dataset
    * request. Election 1 may have been denied. Election 2 may have been approved. Election 3 may
@@ -124,12 +125,52 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
         AND LOWER(v.type) = 'final') final_access_vote ON
           final_access_vote.reference_id = dar.reference_id AND
           final_access_vote.dataset_id = dd.dataset_id
-      WHERE dar.submission_date > now() - interval '1 year'
-      AND final_access_vote.last_vote = TRUE
+      WHERE final_access_vote.last_vote = TRUE
       AND dar.reference_id = :darReferenceId
       AND (LOWER(dar.data->>'status') != 'archived' OR dar.data->>'status' IS NULL)
       """)
   Set<Integer> findApprovedDatasetsByDar(@Bind("darReferenceId") String darReferenceId);
+
+  /**
+   * This query finds dataset ids on dar-dataset combinations where the most recent vote is true.
+   * This includes datasets that are a part of expired DARs, UNLIKE findApprovedDARsByDatasetId.
+   * The query accomplishes this by creating a view that is a grouping
+   * of election reference ids and LAST vote in the group of final votes for all data access
+   * elections. We need to group them due to the case of multiple elections on a dar-dataset
+   * request. Election 1 may have been denied. Election 2 may have been approved. Election 3 may
+   * have been denied again. When we partition over the election reference id, we'll get all final
+   * votes. The `LAST_VALUE` function selects the last result in the partition, which would be
+   * `FALSE` in the example above. Outside the JOIN, we filter on groupings where the final vote
+   * value is `TRUE` so the denied election in the example would be filtered out.
+   *
+   * @param darReferenceIds The DARs reference UUIDs
+   * @return Set of approved Dataset Ids for the list of DARs
+   */
+  @SqlQuery(
+      """
+      SELECT dd.dataset_id
+      FROM data_access_request dar
+      INNER JOIN dar_dataset dd ON dd.reference_id = dar.reference_id
+      INNER JOIN (
+        SELECT DISTINCT e.reference_id, e.dataset_id, LAST_VALUE(v.vote)
+        OVER(
+          PARTITION BY e.dataset_id
+            ORDER BY v.createdate
+            RANGE BETWEEN
+              UNBOUNDED PRECEDING AND
+              UNBOUNDED FOLLOWING
+        ) last_vote
+        FROM election e
+        INNER JOIN vote v ON e.election_id = v.electionid AND v.vote IS NOT NULL
+        AND LOWER(e.election_type) = 'dataaccess'
+        AND LOWER(v.type) = 'final') final_access_vote ON
+          final_access_vote.reference_id = dar.reference_id AND
+          final_access_vote.dataset_id = dd.dataset_id
+      WHERE final_access_vote.last_vote = TRUE
+        AND dar.reference_id IN (<darReferenceIds>)
+        AND (LOWER(dar.data->>'status') != 'archived' OR dar.data->>'status' IS NULL)
+      """)
+  Set<Integer> findApprovedDatasetsByDars(@BindList("darReferenceIds") List<String> darReferenceIds);
 
   /**
    * This query finds submitted DARs based on a date range.  This would be useful if we wanted to

--- a/src/main/java/org/broadinstitute/consent/http/db/DataAccessRequestDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DataAccessRequestDAO.java
@@ -129,7 +129,7 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
       AND dar.reference_id = :darReferenceId
       AND (LOWER(dar.data->>'status') != 'archived' OR dar.data->>'status' IS NULL)
       """)
-  Set<Integer> findApprovedDatasetsByDar(@Bind("darReferenceId") String darReferenceId);
+  Set<Integer> findDatasetApprovalsByDar(@Bind("darReferenceId") String darReferenceId);
 
   /**
    * This query finds dataset ids on dar-dataset combinations where the most recent vote is true.
@@ -170,7 +170,7 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
         AND dar.reference_id IN (<darReferenceIds>)
         AND (LOWER(dar.data->>'status') != 'archived' OR dar.data->>'status' IS NULL)
       """)
-  Set<Integer> findApprovedDatasetsByDars(@BindList("darReferenceIds") List<String> darReferenceIds);
+  Set<Integer> findDatasetApprovalsByDars(@BindList("darReferenceIds") List<String> darReferenceIds);
 
   /**
    * This query finds submitted DARs based on a date range.  This would be useful if we wanted to

--- a/src/main/java/org/broadinstitute/consent/http/enumeration/DarCollectionActions.java
+++ b/src/main/java/org/broadinstitute/consent/http/enumeration/DarCollectionActions.java
@@ -8,7 +8,8 @@ public enum DarCollectionActions {
   REVIEW("Review"),
   REVISE("Revise"),
   RESUME("Resume"),
-  DELETE("Delete");
+  DELETE("Delete"),
+  CREATE_PROGRESS_REPORT("Create_Progress_Report");
 
   private final String value;
 

--- a/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
@@ -160,7 +160,7 @@ public class DarCollectionService implements ConsentLogger {
       elections.values().forEach(election -> updateStatusCount(statusCount, election.getStatus()));
       s.addAction(DarCollectionActions.REVIEW.getValue());
       //if any DARs in the collection have approved datasets, include create progress report action
-      Set<Integer> datasetIds = dataAccessRequestDAO.findApprovedDatasetsByDars(List.copyOf(s.getReferenceIds()));
+      Set<Integer> datasetIds = dataAccessRequestDAO.findDatasetApprovalsByDars(List.copyOf(s.getReferenceIds()));
       if (!datasetIds.isEmpty()) {
         s.addAction(DarCollectionActions.CREATE_PROGRESS_REPORT.getValue());
       }

--- a/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
@@ -159,7 +159,6 @@ public class DarCollectionService implements ConsentLogger {
       int electionCount = elections.size();
       elections.values().forEach(election -> updateStatusCount(statusCount, election.getStatus()));
       s.addAction(DarCollectionActions.REVIEW);
-      s.addAction(DarCollectionActions.REVIEW.getValue());
       //if any DARs in the collection have approved datasets, include create progress report action
       Set<Integer> datasetIds = dataAccessRequestDAO.findDatasetApprovalsByDars(List.copyOf(s.getReferenceIds()));
       if (!datasetIds.isEmpty()) {

--- a/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
@@ -159,6 +159,12 @@ public class DarCollectionService implements ConsentLogger {
       int electionCount = elections.values().size();
       elections.values().forEach(election -> updateStatusCount(statusCount, election.getStatus()));
       s.addAction(DarCollectionActions.REVIEW.getValue());
+      // if any DARs in the collection have approved datasets, include create progress report action
+      if (s.getReferenceIds().stream()
+          .map(dataAccessRequestDAO::findApprovedDatasetsByDar)
+          .anyMatch(approvedDatasetIds -> !approvedDatasetIds.isEmpty())) {
+        s.addAction(DarCollectionActions.CREATE_PROGRESS_REPORT.getValue());
+      }
       //check dar statuses, if they're all canceled show revise (but only if there are no elections)
       if (electionCount == 0) {
         Collection<String> darStatuses = s.getDarStatuses().values();

--- a/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
@@ -159,10 +159,9 @@ public class DarCollectionService implements ConsentLogger {
       int electionCount = elections.values().size();
       elections.values().forEach(election -> updateStatusCount(statusCount, election.getStatus()));
       s.addAction(DarCollectionActions.REVIEW.getValue());
-      // if any DARs in the collection have approved datasets, include create progress report action
-      if (s.getReferenceIds().stream()
-          .map(dataAccessRequestDAO::findApprovedDatasetsByDar)
-          .anyMatch(approvedDatasetIds -> !approvedDatasetIds.isEmpty())) {
+      //if any DARs in the collection have approved datasets, include create progress report action
+      Set<Integer> datasetIds = dataAccessRequestDAO.findApprovedDatasetsByDars(List.copyOf(s.getReferenceIds()));
+      if (!datasetIds.isEmpty()) {
         s.addAction(DarCollectionActions.CREATE_PROGRESS_REPORT.getValue());
       }
       //check dar statuses, if they're all canceled show revise (but only if there are no elections)

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
@@ -8,7 +8,6 @@ import jakarta.ws.rs.NotFoundException;
 import java.sql.SQLException;
 import java.util.Collection;
 import java.util.Date;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -232,7 +231,7 @@ public class DataAccessRequestService implements ConsentLogger {
 
     String referenceId = progressReport.getReferenceId();
     List<Integer> progressReportDatasetIds = progressReport.getDatasetIds();
-    Set<Integer> darDatasetIds = dataAccessRequestDAO.findApprovedDatasetsByDar(parentDar.getReferenceId());
+    Set<Integer> darDatasetIds = dataAccessRequestDAO.findDatasetApprovalsByDar(parentDar.getReferenceId());
     if (!darDatasetIds.containsAll(progressReportDatasetIds)) {
       throw new BadRequestException("Progress report can only be created for approved datasets in the parent DAR");
     }

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
@@ -231,7 +231,7 @@ public class DataAccessRequestService implements ConsentLogger {
 
     String referenceId = progressReport.getReferenceId();
     List<Integer> progressReportDatasetIds = progressReport.getDatasetIds();
-    Set<Integer> darDatasetIds = dataAccessRequestDAO.findDatasetApprovalsByDar(parentDar.getReferenceId());
+    Set<Integer> darDatasetIds = dataAccessRequestDAO.findDatasetApprovalsByDars(List.of(parentDar.getReferenceId()));
     if (!darDatasetIds.containsAll(progressReportDatasetIds)) {
       throw new BadRequestException("Progress report can only be created for approved datasets in the parent DAR");
     }

--- a/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
@@ -756,6 +756,7 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
     assertEquals(2, approvedDatasetIds.size());
     assertTrue(approvedDatasetIds.containsAll(List.of(dataset1.getDatasetId(), dataset4.getDatasetId())));
   }
+
   @Test
   void testFindAllDatasetApprovalsByDars_IncludesExpired() {
     String darCode1 = "DAR-" + randomInt(100, 1000000);

--- a/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
@@ -616,7 +616,7 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
   }
 
   @Test
-  void testFindAllApprovedDatasetsByDar() {
+  void testFindAllDatasetApprovalsByDar() {
     String darCode1 = "DAR-" + randomInt(100, 1000000);
     Dataset dataset1 = createDARDAOTestDataset();
     Dataset dataset2 = createDARDAOTestDataset();
@@ -639,7 +639,7 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
     Date now = new Date();
 
     assertTrue(
-        dataAccessRequestDAO.findApprovedDatasetsByDar(testDar1.getReferenceId())
+        dataAccessRequestDAO.findDatasetApprovalsByDar(testDar1.getReferenceId())
             .isEmpty());
 
     voteDAO.updateVote(true,
@@ -651,7 +651,7 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
         now,
         false);
 
-    Set<Integer> approvedDatasetIds = dataAccessRequestDAO.findApprovedDatasetsByDar(
+    Set<Integer> approvedDatasetIds = dataAccessRequestDAO.findDatasetApprovalsByDar(
         testDar1.getReferenceId());
     assertEquals(1, approvedDatasetIds.size());
     assertTrue(approvedDatasetIds.contains(dataset1.getDatasetId()));
@@ -665,7 +665,7 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
         now,
         false);
 
-    approvedDatasetIds = dataAccessRequestDAO.findApprovedDatasetsByDar(testDar1.getReferenceId());
+    approvedDatasetIds = dataAccessRequestDAO.findDatasetApprovalsByDar(testDar1.getReferenceId());
 
     assertEquals(2, approvedDatasetIds.size());
     assertTrue(approvedDatasetIds.contains(dataset1.getDatasetId()));
@@ -681,7 +681,7 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
         now,
         false);
 
-    approvedDatasetIds = dataAccessRequestDAO.findApprovedDatasetsByDar(testDar1.getReferenceId());
+    approvedDatasetIds = dataAccessRequestDAO.findDatasetApprovalsByDar(testDar1.getReferenceId());
 
     assertEquals(2, approvedDatasetIds.size());
     assertTrue(approvedDatasetIds.contains(dataset1.getDatasetId()));
@@ -689,7 +689,7 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
   }
 
   @Test
-  void testFindAllApprovedDatasetsByDar_IncludesExpired() {
+  void testFindAllDatasetApprovalsByDar_IncludesExpired() {
     String darCode1 = "DAR-" + randomInt(100, 1000000);
     Dataset dataset1 = createDARDAOTestDataset();
 
@@ -708,14 +708,14 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
         now,
         false);
 
-    Set<Integer> approvedDatasetIds = dataAccessRequestDAO.findApprovedDatasetsByDar(
+    Set<Integer> approvedDatasetIds = dataAccessRequestDAO.findDatasetApprovalsByDar(
         testDar1.getReferenceId());
     assertEquals(1, approvedDatasetIds.size());
     assertTrue(approvedDatasetIds.contains(dataset1.getDatasetId()));
   }
 
   @Test
-  void testFindAllApprovedDatasetsByDars() {
+  void testFindAllDatasetApprovalsByDars() {
     String darCode1 = "DAR-" + randomInt(100, 1000000);
     String darCode2 = "DAR-" + randomInt(100, 1000000);
     Dataset dataset1 = createDARDAOTestDataset();
@@ -777,13 +777,13 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
         now,
         false);
 
-    Set<Integer> approvedDatasetIds = dataAccessRequestDAO.findApprovedDatasetsByDars(
+    Set<Integer> approvedDatasetIds = dataAccessRequestDAO.findDatasetApprovalsByDars(
         List.of(testDar1.getReferenceId(), testDar2.getReferenceId()));
     assertEquals(2, approvedDatasetIds.size());
     assertTrue(approvedDatasetIds.containsAll(List.of(dataset1.getDatasetId(), dataset4.getDatasetId())));
   }
   @Test
-  void testFindAllApprovedDatasetsByDars_IncludesExpired() {
+  void testFindAllDatasetApprovalsByDars_IncludesExpired() {
     String darCode1 = "DAR-" + randomInt(100, 1000000);
     Dataset dataset1 = createDARDAOTestDataset();
 
@@ -805,7 +805,7 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
         now,
         false);
 
-    Set<Integer> approvedDatasetIds = dataAccessRequestDAO.findApprovedDatasetsByDars(
+    Set<Integer> approvedDatasetIds = dataAccessRequestDAO.findDatasetApprovalsByDars(
         List.of(testDar1.getReferenceId()));
     assertEquals(1, approvedDatasetIds.size());
     assertTrue(approvedDatasetIds.contains(dataset1.getDatasetId()));

--- a/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
@@ -395,6 +395,12 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
     return createDAR(user, dataset, darCode, new Timestamp(new Date().getTime()));
   }
 
+  protected DataAccessRequest createExpiredDAR(User user, Dataset dataset, String darCode) {
+    Instant now = Instant.now();
+    Instant overAYearAgo = now.minus(370, ChronoUnit.DAYS);
+    return createDAR(user, dataset, darCode, new Timestamp(overAYearAgo.toEpochMilli()));
+  }
+
   // local method to create a DAR
   protected DataAccessRequest createDAR(User user, Dataset dataset, String darCode,
       Timestamp submissionDate) {
@@ -680,6 +686,129 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
     assertEquals(2, approvedDatasetIds.size());
     assertTrue(approvedDatasetIds.contains(dataset1.getDatasetId()));
     assertTrue(approvedDatasetIds.contains(dataset2.getDatasetId()));
+  }
+
+  @Test
+  void testFindAllApprovedDatasetsByDar_IncludesExpired() {
+    String darCode1 = "DAR-" + randomInt(100, 1000000);
+    Dataset dataset1 = createDARDAOTestDataset();
+
+    User user1 = createUserWithInstitution();
+    DataAccessRequest testDar1 = createExpiredDAR(user1, dataset1, darCode1);
+
+    Election election = createDataAccessElection(testDar1.getReferenceId(), dataset1.getDatasetId());
+    Vote v1 = createFinalVote(dataset1.getCreateUserId(), election.getElectionId());
+    Date now = new Date();
+    voteDAO.updateVote(true,
+        "",
+        now,
+        v1.getVoteId(),
+        false,
+        election.getElectionId(),
+        now,
+        false);
+
+    Set<Integer> approvedDatasetIds = dataAccessRequestDAO.findApprovedDatasetsByDar(
+        testDar1.getReferenceId());
+    assertEquals(1, approvedDatasetIds.size());
+    assertTrue(approvedDatasetIds.contains(dataset1.getDatasetId()));
+  }
+
+  @Test
+  void testFindAllApprovedDatasetsByDars() {
+    String darCode1 = "DAR-" + randomInt(100, 1000000);
+    String darCode2 = "DAR-" + randomInt(100, 1000000);
+    Dataset dataset1 = createDARDAOTestDataset();
+    Dataset dataset2 = createDARDAOTestDataset();
+    Dataset dataset3 = createDARDAOTestDataset();
+    Dataset dataset4 = createDARDAOTestDataset();
+
+    User user1 = createUserWithInstitution();
+    // dar with three datasets
+    DataAccessRequest testDar1 = createDAR(user1, dataset1, darCode1);
+    dataAccessRequestDAO.insertDARDatasetRelation(testDar1.getReferenceId(), dataset2.getDatasetId());
+    dataAccessRequestDAO.insertDARDatasetRelation(testDar1.getReferenceId(), dataset3.getDatasetId());
+    //dar with one dataset
+    DataAccessRequest testDar2 = createDAR(user1, dataset4, darCode2);
+
+    Election e1 = createDataAccessElection(testDar1.getReferenceId(), dataset1.getDatasetId());
+    Vote v1 = createFinalVote(dataset1.getCreateUserId(), e1.getElectionId());
+
+    Election e2 = createDataAccessElection(testDar1.getReferenceId(), dataset2.getDatasetId());
+    Vote v2 = createFinalVote(dataset2.getCreateUserId(), e2.getElectionId());
+
+    Election e3 = createDataAccessElection(testDar1.getReferenceId(), dataset3.getDatasetId());
+    createFinalVote(dataset3.getCreateUserId(), e3.getElectionId());
+
+    Election e4 = createDataAccessElection(testDar2.getReferenceId(), dataset4.getDatasetId());
+    Vote v4 = createFinalVote(dataset4.getCreateUserId(), e4.getElectionId());
+
+    Date now = new Date();
+
+    // election1 for dataset1 updated to true
+    voteDAO.updateVote(true,
+        "",
+        now,
+        v1.getVoteId(),
+        false,
+        e1.getElectionId(),
+        now,
+        false);
+
+    // election2 for dataset2 updated to false
+    voteDAO.updateVote(false,
+        "",
+        now,
+        v2.getVoteId(),
+        false,
+        e2.getElectionId(),
+        now,
+        false);
+
+    // election3 for dataset3 final vote not updated
+
+    // election4 for dataset4 updated to true
+    voteDAO.updateVote(true,
+        "",
+        now,
+        v4.getVoteId(),
+        false,
+        e4.getElectionId(),
+        now,
+        false);
+
+    Set<Integer> approvedDatasetIds = dataAccessRequestDAO.findApprovedDatasetsByDars(
+        List.of(testDar1.getReferenceId(), testDar2.getReferenceId()));
+    assertEquals(2, approvedDatasetIds.size());
+    assertTrue(approvedDatasetIds.containsAll(List.of(dataset1.getDatasetId(), dataset4.getDatasetId())));
+  }
+  @Test
+  void testFindAllApprovedDatasetsByDars_IncludesExpired() {
+    String darCode1 = "DAR-" + randomInt(100, 1000000);
+    Dataset dataset1 = createDARDAOTestDataset();
+
+    User user1 = createUserWithInstitution();
+    DataAccessRequest testDar1 = createExpiredDAR(user1, dataset1, darCode1);
+    dataAccessRequestDAO.insertDARDatasetRelation(testDar1.getReferenceId(), dataset1.getDatasetId());
+
+    Election election = createDataAccessElection(testDar1.getReferenceId(), dataset1.getDatasetId());
+    Vote v1 = createFinalVote(dataset1.getCreateUserId(), election.getElectionId());
+
+    Date now = new Date();
+
+    voteDAO.updateVote(true,
+        "",
+        now,
+        v1.getVoteId(),
+        false,
+        election.getElectionId(),
+        now,
+        false);
+
+    Set<Integer> approvedDatasetIds = dataAccessRequestDAO.findApprovedDatasetsByDars(
+        List.of(testDar1.getReferenceId()));
+    assertEquals(1, approvedDatasetIds.size());
+    assertTrue(approvedDatasetIds.contains(dataset1.getDatasetId()));
   }
 
   /**

--- a/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
@@ -639,7 +639,7 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
     Date now = new Date();
 
     assertTrue(
-        dataAccessRequestDAO.findDatasetApprovalsByDar(testDar1.getReferenceId())
+        dataAccessRequestDAO.findDatasetApprovalsByDars(List.of(testDar1.getReferenceId()))
             .isEmpty());
 
     voteDAO.updateVote(true,
@@ -651,8 +651,8 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
         now,
         false);
 
-    Set<Integer> approvedDatasetIds = dataAccessRequestDAO.findDatasetApprovalsByDar(
-        testDar1.getReferenceId());
+    Set<Integer> approvedDatasetIds = dataAccessRequestDAO.findDatasetApprovalsByDars(
+        List.of(testDar1.getReferenceId()));
     assertEquals(1, approvedDatasetIds.size());
     assertTrue(approvedDatasetIds.contains(dataset1.getDatasetId()));
 
@@ -665,7 +665,7 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
         now,
         false);
 
-    approvedDatasetIds = dataAccessRequestDAO.findDatasetApprovalsByDar(testDar1.getReferenceId());
+    approvedDatasetIds = dataAccessRequestDAO.findDatasetApprovalsByDars(List.of(testDar1.getReferenceId()));
 
     assertEquals(2, approvedDatasetIds.size());
     assertTrue(approvedDatasetIds.contains(dataset1.getDatasetId()));
@@ -681,37 +681,11 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
         now,
         false);
 
-    approvedDatasetIds = dataAccessRequestDAO.findDatasetApprovalsByDar(testDar1.getReferenceId());
+    approvedDatasetIds = dataAccessRequestDAO.findDatasetApprovalsByDars(List.of(testDar1.getReferenceId()));
 
     assertEquals(2, approvedDatasetIds.size());
     assertTrue(approvedDatasetIds.contains(dataset1.getDatasetId()));
     assertTrue(approvedDatasetIds.contains(dataset2.getDatasetId()));
-  }
-
-  @Test
-  void testFindAllDatasetApprovalsByDar_IncludesExpired() {
-    String darCode1 = "DAR-" + randomInt(100, 1000000);
-    Dataset dataset1 = createDARDAOTestDataset();
-
-    User user1 = createUserWithInstitution();
-    DataAccessRequest testDar1 = createExpiredDAR(user1, dataset1, darCode1);
-
-    Election election = createDataAccessElection(testDar1.getReferenceId(), dataset1.getDatasetId());
-    Vote v1 = createFinalVote(dataset1.getCreateUserId(), election.getElectionId());
-    Date now = new Date();
-    voteDAO.updateVote(true,
-        "",
-        now,
-        v1.getVoteId(),
-        false,
-        election.getElectionId(),
-        now,
-        false);
-
-    Set<Integer> approvedDatasetIds = dataAccessRequestDAO.findDatasetApprovalsByDar(
-        testDar1.getReferenceId());
-    assertEquals(1, approvedDatasetIds.size());
-    assertTrue(approvedDatasetIds.contains(dataset1.getDatasetId()));
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
@@ -594,7 +594,8 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     when(dataAccessRequestDAO.findAllDraftsByUserId(any())).thenReturn(List.of(draft));
     when(darCollectionSummaryDAO.getDarCollectionSummariesForResearcher(any())).thenReturn(
         mockSummaries);
-    when(dataAccessRequestDAO.findApprovedDatasetsByDar("ref1"))
+    when(dataAccessRequestDAO.findApprovedDatasetsByDars(List.of())).thenReturn(Set.of());
+    when(dataAccessRequestDAO.findApprovedDatasetsByDars(List.of("ref1")))
         .thenReturn(Set.of(datasetSix.getDatasetId()));
 
     List<DarCollectionSummary> summaries = service.getSummariesForRoleName(user,
@@ -1084,16 +1085,14 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     user.setUserId(1);
 
     DarCollectionSummary summary = createDarCollectionSummaryWithElections();
-    summary.setReferenceIds(Set.of("ref1", "ref2"));
+    summary.setReferenceIds(Set.of("ref1"));
     Integer collectionId = summary.getDarCollectionId();
 
     when(darCollectionSummaryDAO.getDarCollectionSummaryByCollectionId(collectionId))
         .thenReturn(summary);
 
-    when(dataAccessRequestDAO.findApprovedDatasetsByDar("ref1"))
+    when(dataAccessRequestDAO.findApprovedDatasetsByDars(List.of("ref1")))
         .thenReturn(Set.of(1));
-    when(dataAccessRequestDAO.findApprovedDatasetsByDar("ref2"))
-        .thenReturn(Set.of());
 
     DarCollectionSummary summaryResult = service.getSummaryForRoleNameByCollectionId(user,
         UserRoles.RESEARCHER.getRoleName(), collectionId);

--- a/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
@@ -539,6 +539,7 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     //summaryTwo -> no elections
     //summaryThree -> no elections, canceled
     //summaryThree -> draft
+    //summaryFour -> closed election, approved datasets
 
     User user = new User();
     user.setUserId(1);
@@ -569,6 +570,16 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     summaryThree.addDatasetId(datasetFive.getDatasetId());
     summaryThree.addStatus(DarStatus.CANCELED.getValue(), randomAlphabetic(3));
 
+    DarCollectionSummary summaryFour = new DarCollectionSummary();
+    Dataset datasetSix = new Dataset();
+    datasetSix.setDatasetId(6);
+    summaryFour.addDatasetId(datasetSix.getDatasetId());
+    Election electionTwo = new Election();
+    electionOne.setElectionId(2);
+    electionOne.setStatus(ElectionStatus.CLOSED.getValue());
+    summaryFour.addElection(electionTwo);
+    summaryFour.setReferenceIds(Set.of("ref1"));
+
     DataAccessRequest draft = new DataAccessRequest();
     draft.setCreateDate(new Timestamp(new Date().getTime()));
     DataAccessRequestData data = new DataAccessRequestData();
@@ -579,14 +590,17 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     mockSummaries.add(summaryOne);
     mockSummaries.add(summaryTwo);
     mockSummaries.add(summaryThree);
+    mockSummaries.add(summaryFour);
     when(dataAccessRequestDAO.findAllDraftsByUserId(any())).thenReturn(List.of(draft));
     when(darCollectionSummaryDAO.getDarCollectionSummariesForResearcher(any())).thenReturn(
         mockSummaries);
+    when(dataAccessRequestDAO.findApprovedDatasetsByDar("ref1"))
+        .thenReturn(Set.of(datasetSix.getDatasetId()));
 
     List<DarCollectionSummary> summaries = service.getSummariesForRoleName(user,
         UserRoles.RESEARCHER.getRoleName());
     assertNotNull(summaries);
-    assertEquals(4, summaries.size());
+    assertEquals(5, summaries.size());
 
     DarCollectionSummary testOne = summaries.get(0);
     Set<String> expectedOneActions = Set.of(
@@ -613,7 +627,15 @@ class DarCollectionServiceTest extends AbstractTestHelper {
         testThree.getStatus().equalsIgnoreCase(DarCollectionStatus.CANCELED.getValue()));
     assertEquals(testThree.getActions(), expectedThreeActions);
 
-    DarCollectionSummary testDraft = summaries.get(3);
+    DarCollectionSummary testFour = summaries.get(3);
+    Set<String> expectedFourActions = Set.of(
+        DarCollectionActions.REVIEW.getValue(),
+        DarCollectionActions.CREATE_PROGRESS_REPORT.getValue());
+    assertTrue(
+        testFour.getStatus().equalsIgnoreCase(DarCollectionStatus.COMPLETE.getValue()));
+    assertEquals(testFour.getActions(), expectedFourActions);
+
+    DarCollectionSummary testDraft = summaries.get(4);
     Set<String> expectedDraftActions = Set.of(
         DarCollectionActions.RESUME.getValue(),
         DarCollectionActions.DELETE.getValue());
@@ -996,23 +1018,8 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     User user = new User();
     user.setUserId(1);
 
-    DarCollectionSummary summary = new DarCollectionSummary();
-    Integer collectionId = randomInt(1, 100);
-    summary.setDarCollectionId(collectionId);
-    Dataset datasetOne = new Dataset();
-    datasetOne.setDatasetId(1);
-    Dataset datasetTwo = new Dataset();
-    datasetTwo.setDatasetId(2);
-    Election electionOne = new Election();
-    electionOne.setElectionId(1);
-    electionOne.setStatus(ElectionStatus.OPEN.getValue());
-    Election electionTwo = new Election();
-    electionTwo.setElectionId(2);
-    electionTwo.setStatus(ElectionStatus.CLOSED.getValue());
-    summary.addElection(electionOne);
-    summary.addElection(electionTwo);
-    summary.addDatasetId(datasetOne.getDatasetId());
-    summary.addDatasetId(datasetTwo.getDatasetId());
+    DarCollectionSummary summary = createDarCollectionSummaryWithElections();
+    Integer collectionId = summary.getDarCollectionId();
 
     when(darCollectionSummaryDAO.getDarCollectionSummaryByCollectionId(collectionId))
         .thenReturn(summary);
@@ -1031,23 +1038,8 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     User user = new User();
     user.setUserId(1);
 
-    DarCollectionSummary summary = new DarCollectionSummary();
-    Integer collectionId = randomInt(1, 100);
-    summary.setDarCollectionId(collectionId);
-    Dataset datasetOne = new Dataset();
-    datasetOne.setDatasetId(1);
-    Dataset datasetTwo = new Dataset();
-    datasetTwo.setDatasetId(2);
-    Election electionOne = new Election();
-    electionOne.setElectionId(1);
-    electionOne.setStatus(ElectionStatus.OPEN.getValue());
-    Election electionTwo = new Election();
-    electionTwo.setElectionId(2);
-    electionTwo.setStatus(ElectionStatus.CLOSED.getValue());
-    summary.addElection(electionOne);
-    summary.addElection(electionTwo);
-    summary.addDatasetId(datasetOne.getDatasetId());
-    summary.addDatasetId(datasetTwo.getDatasetId());
+    DarCollectionSummary summary = createDarCollectionSummaryWithElections();
+    Integer collectionId = summary.getDarCollectionId();
 
     when(darCollectionSummaryDAO.getDarCollectionSummaryByCollectionId(collectionId))
         .thenReturn(summary);
@@ -1068,23 +1060,8 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     User user = new User();
     user.setUserId(1);
 
-    DarCollectionSummary summary = new DarCollectionSummary();
-    Integer collectionId = randomInt(1, 100);
-    summary.setDarCollectionId(collectionId);
-    Dataset datasetOne = new Dataset();
-    datasetOne.setDatasetId(1);
-    Dataset datasetTwo = new Dataset();
-    datasetTwo.setDatasetId(2);
-    Election electionOne = new Election();
-    electionOne.setElectionId(1);
-    electionOne.setStatus(ElectionStatus.OPEN.getValue());
-    Election electionTwo = new Election();
-    electionTwo.setElectionId(2);
-    electionTwo.setStatus(ElectionStatus.CLOSED.getValue());
-    summary.addElection(electionOne);
-    summary.addElection(electionTwo);
-    summary.addDatasetId(datasetOne.getDatasetId());
-    summary.addDatasetId(datasetTwo.getDatasetId());
+    DarCollectionSummary summary = createDarCollectionSummaryWithElections();
+    Integer collectionId = summary.getDarCollectionId();
 
     when(darCollectionSummaryDAO.getDarCollectionSummaryByCollectionId(collectionId))
         .thenReturn(summary);
@@ -1102,29 +1079,46 @@ class DarCollectionServiceTest extends AbstractTestHelper {
   }
 
   @Test
+  void testGetSummaryForRoleNameByCollectionId_Researcher_PR() {
+    User user = new User();
+    user.setUserId(1);
+
+    DarCollectionSummary summary = createDarCollectionSummaryWithElections();
+    summary.setReferenceIds(Set.of("ref1", "ref2"));
+    Integer collectionId = summary.getDarCollectionId();
+
+    when(darCollectionSummaryDAO.getDarCollectionSummaryByCollectionId(collectionId))
+        .thenReturn(summary);
+
+    when(dataAccessRequestDAO.findApprovedDatasetsByDar("ref1"))
+        .thenReturn(Set.of(1));
+    when(dataAccessRequestDAO.findApprovedDatasetsByDar("ref2"))
+        .thenReturn(Set.of());
+
+    DarCollectionSummary summaryResult = service.getSummaryForRoleNameByCollectionId(user,
+        UserRoles.RESEARCHER.getRoleName(), collectionId);
+
+    assertNotNull(summaryResult);
+
+    // Verify that the create_progress_report action is included
+    Set<String> expectedActions = Set.of(
+        DarCollectionActions.REVIEW.getValue(),
+        DarCollectionActions.CREATE_PROGRESS_REPORT.getValue());
+    assertTrue(
+        summaryResult.getStatus().equalsIgnoreCase(DarCollectionStatus.IN_PROCESS.getValue()));
+    assertEquals(expectedActions, summaryResult.getActions());
+  }
+
+  @Test
   void testGetSummaryForRoleNameByCollectionId_Chair() {
     Dac dac = new Dac();
     dac.setDacId(1);
     User user = new User();
     user.setUserId(1);
     user.setChairpersonRoleWithDAC(dac.getDacId());
-    DarCollectionSummary summary = new DarCollectionSummary();
-    Integer collectionId = randomInt(1, 100);
-    summary.setDarCollectionId(collectionId);
-    Dataset datasetOne = new Dataset();
-    datasetOne.setDatasetId(1);
-    Dataset datasetTwo = new Dataset();
-    datasetTwo.setDatasetId(2);
-    Election electionOne = new Election();
-    electionOne.setElectionId(1);
-    electionOne.setStatus(ElectionStatus.OPEN.getValue());
-    Election electionTwo = new Election();
-    electionTwo.setElectionId(2);
-    electionTwo.setStatus(ElectionStatus.CANCELED.getValue());
-    summary.addElection(electionOne);
-    summary.addElection(electionTwo);
-    summary.addDatasetId(datasetOne.getDatasetId());
-    summary.addDatasetId(datasetTwo.getDatasetId());
+
+    DarCollectionSummary summary = createDarCollectionSummaryWithElections();
+    Integer collectionId = summary.getDarCollectionId();
 
     when(darCollectionSummaryDAO.getDarCollectionSummaryForDACByCollectionId(user.getUserId(),
         List.of(), collectionId))
@@ -1201,6 +1195,27 @@ class DarCollectionServiceTest extends AbstractTestHelper {
 
     String reasearcherRoleName = UserRoles.RESEARCHER.getRoleName();
     assertThrows(NotFoundException.class, () -> service.getSummaryForRoleNameByCollectionId(user, reasearcherRoleName, collectionId));
+  }
+
+  private DarCollectionSummary createDarCollectionSummaryWithElections() {
+    DarCollectionSummary summary = new DarCollectionSummary();
+    Integer collectionId = randomInt(1, 100);
+    summary.setDarCollectionId(collectionId);
+    Dataset datasetOne = new Dataset();
+    datasetOne.setDatasetId(1);
+    Dataset datasetTwo = new Dataset();
+    datasetTwo.setDatasetId(2);
+    Election electionOne = new Election();
+    electionOne.setElectionId(1);
+    electionOne.setStatus(ElectionStatus.OPEN.getValue());
+    Election electionTwo = new Election();
+    electionTwo.setElectionId(2);
+    electionTwo.setStatus(ElectionStatus.CANCELED.getValue());
+    summary.addElection(electionOne);
+    summary.addElection(electionTwo);
+    summary.addDatasetId(datasetOne.getDatasetId());
+    summary.addDatasetId(datasetTwo.getDatasetId());
+    return summary;
   }
 
   private DarCollection generateMockDarCollection(Set<Dataset> datasets) {

--- a/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
@@ -594,8 +594,8 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     when(dataAccessRequestDAO.findAllDraftsByUserId(any())).thenReturn(List.of(draft));
     when(darCollectionSummaryDAO.getDarCollectionSummariesForResearcher(any())).thenReturn(
         mockSummaries);
-    when(dataAccessRequestDAO.findApprovedDatasetsByDars(List.of())).thenReturn(Set.of());
-    when(dataAccessRequestDAO.findApprovedDatasetsByDars(List.of("ref1")))
+    when(dataAccessRequestDAO.findDatasetApprovalsByDars(List.of())).thenReturn(Set.of());
+    when(dataAccessRequestDAO.findDatasetApprovalsByDars(List.of("ref1")))
         .thenReturn(Set.of(datasetSix.getDatasetId()));
 
     List<DarCollectionSummary> summaries = service.getSummariesForRoleName(user,
@@ -1091,7 +1091,7 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     when(darCollectionSummaryDAO.getDarCollectionSummaryByCollectionId(collectionId))
         .thenReturn(summary);
 
-    when(dataAccessRequestDAO.findApprovedDatasetsByDars(List.of("ref1")))
+    when(dataAccessRequestDAO.findDatasetApprovalsByDars(List.of("ref1")))
         .thenReturn(Set.of(1));
 
     DarCollectionSummary summaryResult = service.getSummaryForRoleNameByCollectionId(user,

--- a/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
@@ -1094,8 +1094,8 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     when(dataAccessRequestDAO.findDatasetApprovalsByDars(List.of("ref1")))
         .thenReturn(Set.of(1));
 
-    DarCollectionSummary summaryResult = service.getSummaryForRoleNameByCollectionId(user,
-        UserRoles.RESEARCHER.getRoleName(), collectionId);
+    DarCollectionSummary summaryResult = service.getSummaryForRoleByCollectionId(user,
+        UserRoles.RESEARCHER, collectionId);
 
     assertNotNull(summaryResult);
 

--- a/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
@@ -230,7 +230,7 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     user.setEraCommonsId("eraCommonsId");
     parentDar.setUserId(user.getUserId());
     when(dataAccessRequestDAO.findByReferenceId(progressReport.getReferenceId())).thenReturn(progressReport);
-    when(dataAccessRequestDAO.findApprovedDatasetsByDar(parentDar.getReferenceId())).thenReturn(
+    when(dataAccessRequestDAO.findDatasetApprovalsByDar(parentDar.getReferenceId())).thenReturn(
         Set.copyOf(progressReport.getDatasetIds()));
 
     initService();
@@ -254,7 +254,7 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     User user = new User(1, "email@test.org", "Display Name", new Date());
     user.setLibraryCards(List.of(new LibraryCard()));
     parentDar.setUserId(user.getUserId());
-    when(dataAccessRequestDAO.findApprovedDatasetsByDar(parentDar.getReferenceId())).thenReturn(Set.of());
+    when(dataAccessRequestDAO.findDatasetApprovalsByDar(parentDar.getReferenceId())).thenReturn(Set.of());
     initService();
     assertThrows(BadRequestException.class, () -> service.createProgressReport(user, progressReport, parentDar));
   }

--- a/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
@@ -230,7 +230,7 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     user.setEraCommonsId("eraCommonsId");
     parentDar.setUserId(user.getUserId());
     when(dataAccessRequestDAO.findByReferenceId(progressReport.getReferenceId())).thenReturn(progressReport);
-    when(dataAccessRequestDAO.findDatasetApprovalsByDar(parentDar.getReferenceId())).thenReturn(
+    when(dataAccessRequestDAO.findDatasetApprovalsByDars(List.of(parentDar.getReferenceId()))).thenReturn(
         Set.copyOf(progressReport.getDatasetIds()));
 
     initService();
@@ -254,7 +254,7 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     User user = new User(1, "email@test.org", "Display Name", new Date());
     user.setLibraryCards(List.of(new LibraryCard()));
     parentDar.setUserId(user.getUserId());
-    when(dataAccessRequestDAO.findDatasetApprovalsByDar(parentDar.getReferenceId())).thenReturn(Set.of());
+    when(dataAccessRequestDAO.findDatasetApprovalsByDars(List.of(parentDar.getReferenceId()))).thenReturn(Set.of());
     initService();
     assertThrows(BadRequestException.class, () -> service.createProgressReport(user, progressReport, parentDar));
   }


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-1570

### Summary
Adds a new action CREATE_PROGRESS_REPORT
Adds the action to a DarCollectionSummary for Researchers if there at least one DAR in the collection with at least one approved Dataset

### Bug fix
This also includes a fix to findApprovedDatasetsByDar - this method is used to determine if a progress report can be made. It was filtering out expired Datasets, but a DAR can still be made in the case that all access is expired. So, I removed that line in the query and added a test. I think this bug might have existed because another similar method, findApprovedDARsByDatasetId, does need to filter out expired DARs, because it is used to determine access.

### Testing
Adds new unit test and expands existing unit test

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
