### PR TITLE
DT-1616: Prep work: change code to use enum types

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/models/DarCollectionSummary.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DarCollectionSummary.java
@@ -237,9 +237,8 @@ public class DarCollectionSummary {
     this.actions = actions;
   }
 
-  public void addAction(String action) {
-    String newAction = DarCollectionActions.valueOf(action.toUpperCase()).getValue();
-    actions.add(newAction);
+  public void addAction(DarCollectionActions action) {
+    actions.add(action.getValue());
   }
 
   public void addStatus(String status, String referenceId) {

--- a/src/main/java/org/broadinstitute/consent/http/resources/DarCollectionResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DarCollectionResource.java
@@ -56,9 +56,8 @@ public class DarCollectionResource extends Resource {
       @PathParam("roleName") String roleName) {
     try {
       User user = userService.findUserByEmail(authUser.getEmail());
-      validateUserHasRoleName(user, roleName);
-      List<DarCollectionSummary> summaries = darCollectionService.getSummariesForRoleName(user,
-          roleName);
+      var role = validateUserHasRoleName(user, roleName);
+      List<DarCollectionSummary> summaries = darCollectionService.getSummariesForRole(user, role);
       return Response.ok().entity(summaries).build();
     } catch (Exception e) {
       return createExceptionResponse(e);
@@ -74,31 +73,21 @@ public class DarCollectionResource extends Resource {
       @PathParam("roleName") String roleName, @PathParam("collectionId") Integer collectionId) {
     try {
       User user = userService.findUserByEmail(authUser.getEmail());
-      validateUserHasRoleName(user,
-          roleName); //throws BadRequestException if user does not have roleName
-      DarCollectionSummary summary = darCollectionService.getSummaryForRoleNameByCollectionId(user,
-          roleName, collectionId);
+      // throws BadRequestException if user does not have roleName
+      var role = validateUserHasRoleName(user, roleName);
+      DarCollectionSummary summary = darCollectionService.getSummaryForRoleByCollectionId(user, role, collectionId);
 
-      boolean allowedAccess;
-      switch (roleName) {
-        case Resource.ADMIN:
-          allowedAccess = true;
-          break;
-        case Resource.CHAIRPERSON:
-        case Resource.MEMBER:
+      boolean allowedAccess = switch (role) {
+        case ADMIN -> true;
+        case CHAIRPERSON, MEMBER -> {
           List<Integer> userDatasetIds = darCollectionService.findDatasetIdsByDACUser(user);
-          allowedAccess = summary.getDatasetIds().stream().anyMatch(userDatasetIds::contains);
-          break;
-        case Resource.SIGNINGOFFICIAL:
-          allowedAccess = Objects.nonNull(user.getInstitutionId()) &&
-              user.getInstitutionId().equals(summary.getInstitutionId());
-          break;
-        case Resource.RESEARCHER:
-          allowedAccess = user.getUserId().equals(summary.getResearcherId());
-          break;
-        default:
-          throw new BadRequestException("Invalid role selection: " + roleName);
-      }
+          yield summary.getDatasetIds().stream().anyMatch(userDatasetIds::contains);
+        }
+        case SIGNINGOFFICIAL -> Objects.nonNull(user.getInstitutionId()) &&
+            user.getInstitutionId().equals(summary.getInstitutionId());
+        case RESEARCHER -> user.getUserId().equals(summary.getResearcherId());
+        default -> throw new BadRequestException("Invalid role selection: " + roleName);
+      };
       if (!allowedAccess) {
         // user has role but is not allowed to view collection; throw NotFoundException to avoid leaking existence
         throw new NotFoundException(
@@ -199,22 +188,20 @@ public class DarCollectionResource extends Resource {
 
       // Default to the least impactful role if none provided.
       UserRoles actingRole = UserRoles.RESEARCHER;
-      if (Objects.nonNull(roleName)) {
-        validateUserHasRoleName(user, roleName);
-        UserRoles requestedRole = UserRoles.getUserRoleFromName(roleName);
-        if (Objects.nonNull(requestedRole)) {
-          actingRole = requestedRole;
-        }
+      if (roleName != null) {
+        actingRole = validateUserHasRoleName(user, roleName);
       }
 
-      DarCollection cancelledCollection = switch (actingRole) {
-        case ADMIN -> darCollectionService.cancelDarCollectionElectionsAsAdmin(collection);
-        case CHAIRPERSON -> darCollectionService.cancelDarCollectionElectionsAsChair(collection, user);
-        default -> {
-          validateUserIsCreator(user, collection);
-          yield darCollectionService.cancelDarCollectionAsResearcher(collection);
-        }
-      };
+      DarCollection cancelledCollection =
+          switch (actingRole) {
+            case ADMIN -> darCollectionService.cancelDarCollectionElectionsAsAdmin(collection);
+            case CHAIRPERSON ->
+                darCollectionService.cancelDarCollectionElectionsAsChair(collection, user);
+            default -> {
+              validateUserIsCreator(user, collection);
+              yield darCollectionService.cancelDarCollectionAsResearcher(collection);
+            }
+          };
       ComplianceLogger.logDARCancellation(user, cancelledCollection.getDatasets().stream().toList(),
               (ContainerRequest) request, Response.Status.OK.getStatusCode());
       return Response.ok().entity(cancelledCollection).build();

--- a/src/main/java/org/broadinstitute/consent/http/resources/Resource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/Resource.java
@@ -268,12 +268,14 @@ abstract public class Resource implements ConsentLogger {
    *
    * @param user     The User
    * @param roleName The UserRole name
+   * @return the user's role
    */
-  void validateUserHasRoleName(User user, String roleName) {
+  UserRoles validateUserHasRoleName(User user, String roleName) {
     UserRoles thisRole = UserRoles.getUserRoleFromName(roleName);
-    if (Objects.isNull(thisRole) || !user.hasUserRole(thisRole)) {
+    if (thisRole == null || !user.hasUserRole(thisRole)) {
       throw new BadRequestException("Invalid role selection: " + roleName);
     }
+    return thisRole;
   }
 
   /**

--- a/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
@@ -115,16 +115,16 @@ public class DarCollectionService implements ConsentLogger {
       Map<String, Integer> statusCount = new HashMap<>();
       Map<Integer, Election> elections = s.getElections();
       if (elections.size() == 0) {
-        s.addAction(DarCollectionActions.OPEN.getValue());
+        s.addAction(DarCollectionActions.OPEN);
         s.setStatus(DarCollectionStatus.SUBMITTED.getValue());
       } else {
         elections.values().forEach(e -> {
           String status = e.getStatus();
           updateStatusCount(statusCount, status);
           if (status.equals(ElectionStatus.OPEN.getValue())) {
-            s.addAction(DarCollectionActions.CANCEL.getValue());
+            s.addAction(DarCollectionActions.CANCEL);
           } else {
-            s.addAction(DarCollectionActions.OPEN.getValue());
+            s.addAction(DarCollectionActions.OPEN);
           }
         });
         determineCollectionStatus(s, statusCount, s.getDatasetCount(), s.getElections().size());
@@ -139,8 +139,8 @@ public class DarCollectionService implements ConsentLogger {
       summary.setDarCode(darCode);
       summary.setStatus(DarCollectionStatus.DRAFT.getValue());
       summary.setName(d.getData().getProjectTitle());
-      summary.addAction(DarCollectionActions.RESUME.getValue());
-      summary.addAction(DarCollectionActions.DELETE.getValue());
+      summary.addAction(DarCollectionActions.RESUME);
+      summary.addAction(DarCollectionActions.DELETE);
       summary.addReferenceId(d.referenceId);
       return summary;
     } catch (Exception e) {
@@ -156,19 +156,19 @@ public class DarCollectionService implements ConsentLogger {
     summaries.forEach(s -> {
       Map<String, Integer> statusCount = new HashMap<>();
       Map<Integer, Election> elections = s.getElections();
-      int electionCount = elections.values().size();
+      int electionCount = elections.size();
       elections.values().forEach(election -> updateStatusCount(statusCount, election.getStatus()));
-      s.addAction(DarCollectionActions.REVIEW.getValue());
+      s.addAction(DarCollectionActions.REVIEW);
       //check dar statuses, if they're all canceled show revise (but only if there are no elections)
       if (electionCount == 0) {
         Collection<String> darStatuses = s.getDarStatuses().values();
-        Boolean isCanceled = darStatuses.size() > 0 && darStatuses.stream()
+        boolean isCanceled = !darStatuses.isEmpty() && darStatuses.stream()
             .allMatch(st -> st.equalsIgnoreCase(DarStatus.CANCELED.getValue()));
         if (isCanceled) {
-          s.addAction(DarCollectionActions.REVISE.getValue());
+          s.addAction(DarCollectionActions.REVISE);
           s.setStatus(DarCollectionStatus.CANCELED.getValue());
         } else {
-          s.addAction(DarCollectionActions.CANCEL.getValue());
+          s.addAction(DarCollectionActions.CANCEL);
           s.setStatus(DarCollectionStatus.SUBMITTED.getValue());
         }
       } else {
@@ -187,7 +187,7 @@ public class DarCollectionService implements ConsentLogger {
       if (electionCount == 0) {
         s.setStatus(DarCollectionStatus.SUBMITTED.getValue());
       } else {
-        Boolean isVotable = elections
+        boolean isVotable = elections
             .stream()
             .anyMatch(
                 election -> election.getStatus().equalsIgnoreCase(ElectionStatus.OPEN.getValue()));
@@ -197,12 +197,12 @@ public class DarCollectionService implements ConsentLogger {
           List<Vote> votes = s.getVotes().stream()
               .filter(
                   v -> v.getUserId().equals(userId) && v.getType().equals(VoteType.DAC.getValue()))
-              .collect(Collectors.toList());
+              .toList();
           if (!votes.isEmpty()) {
-            Boolean hasVoted = votes.stream().allMatch(v -> Objects.nonNull(v.getVote()));
-            String targetActionString = hasVoted ? DarCollectionActions.UPDATE.getValue()
-                : DarCollectionActions.VOTE.getValue();
-            s.addAction(targetActionString);
+            boolean hasVoted = votes.stream().map(Vote::getVote).allMatch(Objects::nonNull);
+            DarCollectionActions targetAction = hasVoted ? DarCollectionActions.UPDATE
+                : DarCollectionActions.VOTE;
+            s.addAction(targetAction);
           }
         } else {
           //non-votable states
@@ -230,10 +230,10 @@ public class DarCollectionService implements ConsentLogger {
       Map<Integer, Election> elections = s.getElections();
       if (elections.size() == 0) {
         s.setStatus(DarCollectionStatus.SUBMITTED.getValue());
-        s.addAction(DarCollectionActions.OPEN.getValue());
+        s.addAction(DarCollectionActions.OPEN);
       } else {
         if (elections.size() < s.getDatasetCount()) {
-          s.addAction(DarCollectionActions.OPEN.getValue());
+          s.addAction(DarCollectionActions.OPEN);
         }
         elections.values().forEach(election -> {
           String statusString = election.getStatus();
@@ -242,10 +242,10 @@ public class DarCollectionService implements ConsentLogger {
           switch (status) {
             case CLOSED:
             case CANCELED:
-              s.addAction(DarCollectionActions.OPEN.getValue());
+              s.addAction(DarCollectionActions.OPEN);
               break;
             case OPEN:
-              s.addAction(DarCollectionActions.VOTE.getValue());
+              s.addAction(DarCollectionActions.VOTE);
             default:
               break;
           }
@@ -254,7 +254,7 @@ public class DarCollectionService implements ConsentLogger {
         Integer openCount = statusCount.get(ElectionStatus.OPEN.getValue());
         //add cancel if there are no closed elections and at least one open election
         if (Objects.isNull(closedCount) && Objects.nonNull(openCount)) {
-          s.addAction(DarCollectionActions.CANCEL.getValue());
+          s.addAction(DarCollectionActions.CANCEL);
         }
 
         determineCollectionStatus(s, statusCount, s.getDatasetCount(), s.getElections().size());
@@ -272,17 +272,16 @@ public class DarCollectionService implements ConsentLogger {
   }
 
   /**
-   * Find all DarCollectionSummaries for a given role name. Admins can see all summaries Chairs and
+   * Find all DarCollectionSummaries for a given role. Admins can see all summaries Chairs and
    * Members can see summaries for datasets they have access to Signing Officials can see summaries
    * for researchers in their institution Researchers can see only their own summaries
    *
    * @param user     The user making the request
-   * @param userRole The role the user is making the request as
+   * @param role The role the user is making the request as
    * @return List of DarCollectionSummary objects
    */
-  public List<DarCollectionSummary> getSummariesForRoleName(User user, String userRole) {
+  public List<DarCollectionSummary> getSummariesForRole(User user, UserRoles role) {
     List<DarCollectionSummary> summaries = new ArrayList<>();
-    UserRoles role = UserRoles.getUserRoleFromName(userRole);
     Integer userId = user.getUserId();
     List<Integer> datasetIds;
     switch (role) {
@@ -337,17 +336,16 @@ public class DarCollectionService implements ConsentLogger {
   }
 
   /**
-   * Finds the DarCollectionSummary for a given darCollectionId, processed by the given role name.
+   * Finds the DarCollectionSummary for a given darCollectionId, processed by the given role.
    *
    * @param user         The user making the request
-   * @param userRole     The role the user is making the request as
+   * @param role         The role the user is making the request as
    * @param collectionId The darCollectionId of the requested DarCollectionSummary
    * @return A DarCollectionSummary object
    */
-  public DarCollectionSummary getSummaryForRoleNameByCollectionId(User user, String userRole,
+  public DarCollectionSummary getSummaryForRoleByCollectionId(User user, UserRoles role,
       Integer collectionId) {
     DarCollectionSummary summary = null;
-    UserRoles role = UserRoles.getUserRoleFromName(userRole);
     Integer userId = user.getUserId();
     List<Integer> datasetIds;
     try {

--- a/src/test/java/org/broadinstitute/consent/http/resources/DarCollectionResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DarCollectionResourceTest.java
@@ -513,8 +513,8 @@ class DarCollectionResourceTest extends AbstractTestHelper {
     User user = new User();
     user.setMemberRole();
     DarCollectionSummary mockSummary = new DarCollectionSummary();
-    when(userService.findUserByEmail(anyString())).thenReturn(user);
-    when(darCollectionService.getSummariesForRoleName(any(User.class), anyString()))
+    when(userService.findUserByEmail(authUser.getEmail())).thenReturn(user);
+    when(darCollectionService.getSummariesForRole(user, UserRoles.MEMBER))
         .thenReturn(List.of(mockSummary));
     initResource();
 
@@ -528,8 +528,8 @@ class DarCollectionResourceTest extends AbstractTestHelper {
     User user = new User();
     user.setChairpersonRole();
     DarCollectionSummary mockSummary = new DarCollectionSummary();
-    when(userService.findUserByEmail(anyString())).thenReturn(user);
-    when(darCollectionService.getSummariesForRoleName(any(User.class), anyString()))
+    when(userService.findUserByEmail(authUser.getEmail())).thenReturn(user);
+    when(darCollectionService.getSummariesForRole(user, UserRoles.CHAIRPERSON))
         .thenReturn(List.of(mockSummary));
     initResource();
 
@@ -543,8 +543,8 @@ class DarCollectionResourceTest extends AbstractTestHelper {
     User user = new User();
     user.setSigningOfficialRole();
     DarCollectionSummary mockSummary = new DarCollectionSummary();
-    when(userService.findUserByEmail(anyString())).thenReturn(user);
-    when(darCollectionService.getSummariesForRoleName(any(User.class), anyString()))
+    when(userService.findUserByEmail(authUser.getEmail())).thenReturn(user);
+    when(darCollectionService.getSummariesForRole(user, UserRoles.SIGNINGOFFICIAL))
         .thenReturn(List.of(mockSummary));
     initResource();
 
@@ -558,8 +558,8 @@ class DarCollectionResourceTest extends AbstractTestHelper {
     User user = new User();
     user.setResearcherRole();
     DarCollectionSummary mockSummary = new DarCollectionSummary();
-    when(userService.findUserByEmail(anyString())).thenReturn(user);
-    when(darCollectionService.getSummariesForRoleName(any(User.class), anyString()))
+    when(userService.findUserByEmail(authUser.getEmail())).thenReturn(user);
+    when(darCollectionService.getSummariesForRole(user, UserRoles.RESEARCHER))
         .thenReturn(List.of(mockSummary));
     initResource();
 
@@ -573,8 +573,8 @@ class DarCollectionResourceTest extends AbstractTestHelper {
     User user = new User();
     user.setAdminRole();
     DarCollectionSummary mockSummary = new DarCollectionSummary();
-    when(userService.findUserByEmail(anyString())).thenReturn(user);
-    when(darCollectionService.getSummariesForRoleName(any(User.class), anyString()))
+    when(userService.findUserByEmail(authUser.getEmail())).thenReturn(user);
+    when(darCollectionService.getSummariesForRole(user, UserRoles.ADMIN))
         .thenReturn(List.of(mockSummary));
     initResource();
 
@@ -614,10 +614,9 @@ class DarCollectionResourceTest extends AbstractTestHelper {
     mockSummary.setDatasetIds(Set.of(1));
     Integer collectionId = randomInt(1, 100);
 
-    when(userService.findUserByEmail(anyString())).thenReturn(user);
+    when(userService.findUserByEmail(authUser.getEmail())).thenReturn(user);
     when(darCollectionService.findDatasetIdsByDACUser(user)).thenReturn(List.of(1, 2));
-    when(darCollectionService.getSummaryForRoleNameByCollectionId(any(User.class), anyString(),
-        anyInt()))
+    when(darCollectionService.getSummaryForRoleByCollectionId(user, UserRoles.MEMBER, collectionId))
         .thenReturn(mockSummary);
     initResource();
 
@@ -635,10 +634,9 @@ class DarCollectionResourceTest extends AbstractTestHelper {
     mockSummary.setDatasetIds(Set.of(1));
     Integer collectionId = randomInt(1, 100);
 
-    when(userService.findUserByEmail(anyString())).thenReturn(user);
+    when(userService.findUserByEmail(authUser.getEmail())).thenReturn(user);
     when(darCollectionService.findDatasetIdsByDACUser(user)).thenReturn(List.of(2));
-    when(darCollectionService.getSummaryForRoleNameByCollectionId(any(User.class), anyString(),
-        anyInt()))
+    when(darCollectionService.getSummaryForRoleByCollectionId(user, UserRoles.MEMBER, collectionId))
         .thenReturn(mockSummary);
     initResource();
 
@@ -656,10 +654,9 @@ class DarCollectionResourceTest extends AbstractTestHelper {
     mockSummary.setDatasetIds(Set.of(1));
     Integer collectionId = randomInt(1, 100);
 
-    when(userService.findUserByEmail(anyString())).thenReturn(user);
+    when(userService.findUserByEmail(authUser.getEmail())).thenReturn(user);
     when(darCollectionService.findDatasetIdsByDACUser(user)).thenReturn(List.of(1, 2));
-    when(darCollectionService.getSummaryForRoleNameByCollectionId(any(User.class), anyString(),
-        anyInt()))
+    when(darCollectionService.getSummaryForRoleByCollectionId(user, UserRoles.CHAIRPERSON, collectionId))
         .thenReturn(mockSummary);
     initResource();
 
@@ -677,10 +674,9 @@ class DarCollectionResourceTest extends AbstractTestHelper {
     mockSummary.setDatasetIds(Set.of(1));
     Integer collectionId = randomInt(1, 100);
 
-    when(userService.findUserByEmail(anyString())).thenReturn(user);
+    when(userService.findUserByEmail(authUser.getEmail())).thenReturn(user);
     when(darCollectionService.findDatasetIdsByDACUser(user)).thenReturn(List.of(2));
-    when(darCollectionService.getSummaryForRoleNameByCollectionId(any(User.class), anyString(),
-        anyInt()))
+    when(darCollectionService.getSummaryForRoleByCollectionId(user, UserRoles.CHAIRPERSON, collectionId))
         .thenReturn(mockSummary);
     initResource();
 
@@ -700,9 +696,9 @@ class DarCollectionResourceTest extends AbstractTestHelper {
     mockSummary.setInstitutionId(institutionId);
     Integer collectionId = randomInt(1, 100);
 
-    when(userService.findUserByEmail(anyString())).thenReturn(user);
-    when(darCollectionService.getSummaryForRoleNameByCollectionId(any(User.class), anyString(),
-        anyInt()))
+    when(userService.findUserByEmail(authUser.getEmail())).thenReturn(user);
+    when(darCollectionService.getSummaryForRoleByCollectionId(user, UserRoles.SIGNINGOFFICIAL,
+        collectionId))
         .thenReturn(mockSummary);
     initResource();
 
@@ -721,9 +717,9 @@ class DarCollectionResourceTest extends AbstractTestHelper {
     mockSummary.setInstitutionId(2);
     Integer collectionId = randomInt(1, 100);
 
-    when(userService.findUserByEmail(anyString())).thenReturn(user);
-    when(darCollectionService.getSummaryForRoleNameByCollectionId(any(User.class), anyString(),
-        anyInt()))
+    when(userService.findUserByEmail(authUser.getEmail())).thenReturn(user);
+    when(darCollectionService.getSummaryForRoleByCollectionId(user, UserRoles.SIGNINGOFFICIAL,
+        collectionId))
         .thenReturn(mockSummary);
     initResource();
 
@@ -743,9 +739,9 @@ class DarCollectionResourceTest extends AbstractTestHelper {
     mockSummary.setResearcherId(userId);
     Integer collectionId = randomInt(1, 100);
 
-    when(userService.findUserByEmail(anyString())).thenReturn(user);
-    when(darCollectionService.getSummaryForRoleNameByCollectionId(any(User.class), anyString(),
-        anyInt()))
+    when(userService.findUserByEmail(authUser.getEmail())).thenReturn(user);
+    when(darCollectionService.getSummaryForRoleByCollectionId(user, UserRoles.RESEARCHER,
+        collectionId))
         .thenReturn(mockSummary);
     initResource();
 
@@ -764,9 +760,9 @@ class DarCollectionResourceTest extends AbstractTestHelper {
     mockSummary.setResearcherId(2);
     Integer collectionId = randomInt(1, 100);
 
-    when(userService.findUserByEmail(anyString())).thenReturn(user);
-    when(darCollectionService.getSummaryForRoleNameByCollectionId(any(User.class), anyString(),
-        anyInt()))
+    when(userService.findUserByEmail(authUser.getEmail())).thenReturn(user);
+    when(darCollectionService.getSummaryForRoleByCollectionId(user, UserRoles.RESEARCHER,
+        collectionId))
         .thenReturn(mockSummary);
     initResource();
 
@@ -782,9 +778,9 @@ class DarCollectionResourceTest extends AbstractTestHelper {
     DarCollectionSummary mockSummary = new DarCollectionSummary();
     Integer collectionId = randomInt(1, 100);
 
-    when(userService.findUserByEmail(anyString())).thenReturn(user);
-    when(darCollectionService.getSummaryForRoleNameByCollectionId(any(User.class), anyString(),
-        anyInt()))
+    when(userService.findUserByEmail(authUser.getEmail())).thenReturn(user);
+    when(darCollectionService.getSummaryForRoleByCollectionId(user, UserRoles.ADMIN,
+        collectionId))
         .thenReturn(mockSummary);
     initResource();
 
@@ -824,9 +820,9 @@ class DarCollectionResourceTest extends AbstractTestHelper {
     user.setResearcherRole();
     Integer collectionId = randomInt(1, 100);
 
-    when(userService.findUserByEmail(anyString())).thenReturn(user);
-    when(darCollectionService.getSummaryForRoleNameByCollectionId(any(User.class), anyString(),
-        anyInt()))
+    when(userService.findUserByEmail(authUser.getEmail())).thenReturn(user);
+    when(darCollectionService.getSummaryForRoleByCollectionId(user, UserRoles.RESEARCHER,
+        collectionId))
         .thenThrow(new NotFoundException());
     initResource();
 

--- a/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
@@ -469,8 +469,8 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     when(darCollectionSummaryDAO.getDarCollectionSummariesForSO(any())).thenReturn(
         List.of(summary));
 
-    List<DarCollectionSummary> summaries = service.getSummariesForRoleName(user,
-        UserRoles.SIGNINGOFFICIAL.getRoleName());
+    List<DarCollectionSummary> summaries = service.getSummariesForRole(user,
+        UserRoles.SIGNINGOFFICIAL);
     assertNotNull(summaries);
     assertEquals(1, summaries.size());
     DarCollectionSummary s = summaries.get(0);
@@ -500,8 +500,8 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     when(darCollectionSummaryDAO.getDarCollectionSummariesForSO(any())).thenReturn(
         List.of(summary));
 
-    List<DarCollectionSummary> summaries = service.getSummariesForRoleName(user,
-        UserRoles.SIGNINGOFFICIAL.getRoleName());
+    List<DarCollectionSummary> summaries = service.getSummariesForRole(user,
+        UserRoles.SIGNINGOFFICIAL);
     assertNotNull(summaries);
     assertEquals(1, summaries.size());
     DarCollectionSummary s = summaries.get(0);
@@ -523,8 +523,8 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     when(darCollectionSummaryDAO.getDarCollectionSummariesForSO(any())).thenReturn(
         List.of(summary));
 
-    List<DarCollectionSummary> summaries = service.getSummariesForRoleName(user,
-        UserRoles.SIGNINGOFFICIAL.getRoleName());
+    List<DarCollectionSummary> summaries = service.getSummariesForRole(user,
+        UserRoles.SIGNINGOFFICIAL);
     assertNotNull(summaries);
     assertEquals(1, summaries.size());
     DarCollectionSummary s = summaries.get(0);
@@ -583,8 +583,8 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     when(darCollectionSummaryDAO.getDarCollectionSummariesForResearcher(any())).thenReturn(
         mockSummaries);
 
-    List<DarCollectionSummary> summaries = service.getSummariesForRoleName(user,
-        UserRoles.RESEARCHER.getRoleName());
+    List<DarCollectionSummary> summaries = service.getSummariesForRole(user,
+        UserRoles.RESEARCHER);
     assertNotNull(summaries);
     assertEquals(4, summaries.size());
 
@@ -684,8 +684,8 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     when(darCollectionSummaryDAO.getDarCollectionSummariesForAdmin())
         .thenReturn(List.of(summaryOne, summaryTwo, summaryThree, summaryFour));
 
-    List<DarCollectionSummary> summaries = service.getSummariesForRoleName(user,
-        UserRoles.ADMIN.getRoleName());
+    List<DarCollectionSummary> summaries = service.getSummariesForRole(user,
+        UserRoles.ADMIN);
 
     DarCollectionSummary testOne = summaries.get(0);
     Set<String> expectedOneActions = Set.of(
@@ -724,8 +724,8 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     User user = new User();
     user.setUserId(randomInt(1, 10));
     user.setMemberRole();
-    List<DarCollectionSummary> summaries = service.getSummariesForRoleName(user,
-        UserRoles.MEMBER.getRoleName());
+    List<DarCollectionSummary> summaries = service.getSummariesForRole(user,
+        UserRoles.MEMBER);
     assertTrue(summaries.isEmpty());
   }
 
@@ -736,8 +736,8 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     User user = new User();
     user.setUserId(randomInt(1, 10));
     user.setChairpersonRole();
-    List<DarCollectionSummary> summaries = service.getSummariesForRoleName(user,
-        UserRoles.CHAIRPERSON.getRoleName());
+    List<DarCollectionSummary> summaries = service.getSummariesForRole(user,
+        UserRoles.CHAIRPERSON);
     assertTrue(summaries.isEmpty());
   }
 
@@ -810,8 +810,8 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     when(darCollectionSummaryDAO.getDarCollectionSummariesForDAC(any(), any()))
         .thenReturn(List.of(summary, summaryTwo, summaryThree, summaryFour));
 
-    List<DarCollectionSummary> summaries = service.getSummariesForRoleName(user,
-        UserRoles.MEMBER.getRoleName());
+    List<DarCollectionSummary> summaries = service.getSummariesForRole(user,
+        UserRoles.MEMBER);
 
     assertNotNull(summaries);
     assertEquals(4, summaries.size());
@@ -937,8 +937,8 @@ class DarCollectionServiceTest extends AbstractTestHelper {
         datasetFive,
         datasetSix));
 
-    List<DarCollectionSummary> summaries = service.getSummariesForRoleName(user,
-        UserRoles.CHAIRPERSON.getRoleName());
+    List<DarCollectionSummary> summaries = service.getSummariesForRole(user,
+        UserRoles.CHAIRPERSON);
     assertEquals(6, summaries.size());
 
     DarCollectionSummary testOne = summaries.get(0);
@@ -992,7 +992,7 @@ class DarCollectionServiceTest extends AbstractTestHelper {
   }
 
   @Test
-  void testGetSummaryForRoleNameByCollectionId_SO() {
+  void testGetSummaryForRoleByCollectionId_SO() {
     User user = new User();
     user.setUserId(1);
 
@@ -1017,8 +1017,8 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     when(darCollectionSummaryDAO.getDarCollectionSummaryByCollectionId(collectionId))
         .thenReturn(summary);
 
-    DarCollectionSummary summaryResult = service.getSummaryForRoleNameByCollectionId(user,
-        UserRoles.SIGNINGOFFICIAL.getRoleName(), collectionId);
+    DarCollectionSummary summaryResult = service.getSummaryForRoleByCollectionId(user,
+        UserRoles.SIGNINGOFFICIAL, collectionId);
     assertNotNull(summaryResult);
 
     assertTrue(
@@ -1027,7 +1027,7 @@ class DarCollectionServiceTest extends AbstractTestHelper {
   }
 
   @Test
-  void testGetSummaryForRoleNameByCollectionId_Researcher() {
+  void testGetSummaryForRoleByCollectionId_Researcher() {
     User user = new User();
     user.setUserId(1);
 
@@ -1052,8 +1052,8 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     when(darCollectionSummaryDAO.getDarCollectionSummaryByCollectionId(collectionId))
         .thenReturn(summary);
 
-    DarCollectionSummary summaryResult = service.getSummaryForRoleNameByCollectionId(user,
-        UserRoles.RESEARCHER.getRoleName(), collectionId);
+    DarCollectionSummary summaryResult = service.getSummaryForRoleByCollectionId(user,
+        UserRoles.RESEARCHER, collectionId);
     assertNotNull(summaryResult);
 
     Set<String> expectedActions = Set.of(
@@ -1064,7 +1064,7 @@ class DarCollectionServiceTest extends AbstractTestHelper {
   }
 
   @Test
-  void testGetSummaryForRoleNameByCollectionId_Admin() {
+  void testGetSummaryForRoleByCollectionId_Admin() {
     User user = new User();
     user.setUserId(1);
 
@@ -1089,8 +1089,8 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     when(darCollectionSummaryDAO.getDarCollectionSummaryByCollectionId(collectionId))
         .thenReturn(summary);
 
-    DarCollectionSummary summaryResult = service.getSummaryForRoleNameByCollectionId(user,
-        UserRoles.ADMIN.getRoleName(), collectionId);
+    DarCollectionSummary summaryResult = service.getSummaryForRoleByCollectionId(user,
+        UserRoles.ADMIN, collectionId);
     assertNotNull(summaryResult);
 
     Set<String> expectedActions = Set.of(
@@ -1102,7 +1102,7 @@ class DarCollectionServiceTest extends AbstractTestHelper {
   }
 
   @Test
-  void testGetSummaryForRoleNameByCollectionId_Chair() {
+  void testGetSummaryForRoleByCollectionId_Chair() {
     Dac dac = new Dac();
     dac.setDacId(1);
     User user = new User();
@@ -1131,8 +1131,8 @@ class DarCollectionServiceTest extends AbstractTestHelper {
         .thenReturn(summary);
     when(datasetDAO.findDatasetListByDacIds(any())).thenReturn(List.of());
 
-    DarCollectionSummary summaryResult = service.getSummaryForRoleNameByCollectionId(user,
-        UserRoles.CHAIRPERSON.getRoleName(), collectionId);
+    DarCollectionSummary summaryResult = service.getSummaryForRoleByCollectionId(user,
+        UserRoles.CHAIRPERSON, collectionId);
     assertNotNull(summaryResult);
 
     Set<String> expectedActions = Set.of(
@@ -1145,7 +1145,7 @@ class DarCollectionServiceTest extends AbstractTestHelper {
   }
 
   @Test
-  void testGetSummaryForRoleNameByCollectionId_DACMember() {
+  void testGetSummaryForRoleByCollectionId_DACMember() {
     Dac dac = new Dac();
     dac.setDacId(1);
     User user = new User();
@@ -1177,8 +1177,8 @@ class DarCollectionServiceTest extends AbstractTestHelper {
         List.of(), collectionId))
         .thenReturn(summary);
 
-    DarCollectionSummary summaryResult = service.getSummaryForRoleNameByCollectionId(user,
-        UserRoles.MEMBER.getRoleName(), collectionId);
+    DarCollectionSummary summaryResult = service.getSummaryForRoleByCollectionId(user,
+        UserRoles.MEMBER, collectionId);
     assertNotNull(summaryResult);
 
     Set<String> expectedActions = Set.of(
@@ -1199,8 +1199,7 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     when(darCollectionSummaryDAO.getDarCollectionSummaryByCollectionId(collectionId))
         .thenReturn(null);
 
-    String reasearcherRoleName = UserRoles.RESEARCHER.getRoleName();
-    assertThrows(NotFoundException.class, () -> service.getSummaryForRoleNameByCollectionId(user, reasearcherRoleName, collectionId));
+    assertThrows(NotFoundException.class, () -> service.getSummaryForRoleByCollectionId(user, UserRoles.RESEARCHER, collectionId));
   }
 
   private DarCollection generateMockDarCollection(Set<Dataset> datasets) {


### PR DESCRIPTION
### Addresses

The code is using String instead of Enum types when it has an enum type on hand, requiring re-generating the enum type further down the call chain.

### Summary

In `DarCollectionService` and `DarCollectionResource`, replace Strings with enum types.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
