### PR TITLE
Minor updates to db-connect script

### DIFF
--- a/scripts/db-connect.sh
+++ b/scripts/db-connect.sh
@@ -6,6 +6,19 @@
 # USAGE: ./db-connect.sh ENV
 #   ENV must be one of dev, staging, or prod
 #
+# NOTE: This does not support bee deployments. You can connect to a bee deployment database
+# by running these commands, where <pshapiro-test> is the name of your bee:
+#
+# Connect to the cluster and port-forward the postgres pod to the local port 5432.
+# $ gcloud container clusters get-credentials terra-qa-bees --zone us-central1-a --project broad-dsde-qa
+#
+# $ kubectl port-forward --namespace terra-pshapiro-test $(kubectl get pod --namespace terra-pshapiro-test --selector="selectorLabel=consent-postgres" --output jsonpath='{.items[0].metadata.name}') 5432:5432 &
+#
+# Print out the postgres password. The user is always "consent".
+# $ kubectl get secret consent-db-creds-eso --namespace terra-pshapiro-test -o json | jq -r .data.password
+#
+# At this point, you can use psql or an IDE to connect to the database. When you're done, don't
+# forget to kill the port-forward process.
 
 set -eu
 set -o pipefail

--- a/scripts/db-connect.sh
+++ b/scripts/db-connect.sh
@@ -9,9 +9,10 @@
 # NOTE: This does not support bee deployments. You can connect to a bee deployment database
 # by running these commands, where <pshapiro-test> is the name of your bee:
 #
-# Connect to the cluster and port-forward the postgres pod to the local port 5432.
+# Get the credentials for the cluster.
 # $ gcloud container clusters get-credentials terra-qa-bees --zone us-central1-a --project broad-dsde-qa
 #
+# Connect to the cluster and port-forward the postgres pod to the local port 5432.
 # $ kubectl port-forward --namespace terra-pshapiro-test $(kubectl get pod --namespace terra-pshapiro-test --selector="selectorLabel=consent-postgres" --output jsonpath='{.items[0].metadata.name}') 5432:5432 &
 #
 # Print out the postgres password. The user is always "consent".

--- a/scripts/db-connect.sh
+++ b/scripts/db-connect.sh
@@ -4,7 +4,7 @@
 # to be able to use this script.
 #
 # USAGE: ./db-connect.sh ENV
-#   ENV must be one of dev, alpha, or staging
+#   ENV must be one of dev, staging, or prod
 #
 
 set -eu
@@ -26,7 +26,7 @@ check_color_support() {
 
 # print out usage to stdout
 usage() {
-    printf "Usage: %s ${BLD}ENV${RST}\n  ${BLD}ENV${RST} must be one of dev, alpha, or staging\n" "$0"
+    printf "Usage: %s ${BLD}ENV${RST}\n  ${BLD}ENV${RST} must be one of dev, staging, or prod\n" "$0"
     exit 0
 }
 
@@ -69,13 +69,20 @@ if [ -z "${1+:}" ]; then
 fi
 
 case $1 in
-    --help ) usage;;
-    dev|alpha|staging ) ;;
-    prod ) error "This script cannot be run against prod.";;
-    * ) error "ENV must be one of dev, alpha, or staging";;
+    --help) usage;;
+    dev)
+      PROJECT=broad-dsde-dev
+      ;;
+    staging)
+      PROJECT=broad-dsde-staging
+      ;;
+    prod)
+      PROJECT=broad-dsde-prod
+      ;;
+    *) error "ENV must be one of dev, staging, or prod";;
 esac
 
-PG_JSON=$(gcloud secrets versions access latest --secret=consent-postgres-creds)
+PG_JSON=$(gcloud --project $PROJECT secrets versions access latest --secret=consent-postgres-creds)
 
 INSTANCE=$(echo "$PG_JSON" | jq -r .instance_name)
 USERNAME=$(echo "$PG_JSON" | jq -r .username)


### PR DESCRIPTION
### Addresses

- add `--project` argument to `gcloud secrets` operation, so the correct google project is always used
- add support for `prod`, remove `alpha` since we don't have an `alpha` deployment anymore

### Testing

Manually tested locally against `dev`, `staging`, and `prod`. Note that `prod` database connection requires authenticating using a suitable user account and being on the Broad VPN.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
