### PR TITLE
[DT-1624]Consent: Update data use acknowledgement on progress report submit

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequest.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequest.java
@@ -18,6 +18,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -332,6 +333,54 @@ public class DataAccessRequest {
                 (Objects.nonNull(this.getData().getNotHealth()) && this.getData().getNotHealth())
         );
   }
+
+  /**
+   * Populate a new Data Access Request from the JSON string and the parent Data Access Request.
+   * Copies all the data from the parent dar, then overwrites the collaborators and datasets. Adds
+   * all progress report specific fields.
+   *
+   * @param json      The JSON string to populate the new Progress Report.
+   * @param parentDar The parent Data Access Request to copy data from.
+   * @return A new Progress Report populated with the provided JSON string and parent DAR data.
+   */
+  public static DataAccessRequest populateProgressReportFromJsonString(String json,
+      DataAccessRequest parentDar) {
+    DataAccessRequest newDar = new DataAccessRequest();
+    DataAccessRequestData newData = DataAccessRequestData.populateDARData(json);
+    DataAccessRequestData originalDataCopy = DataAccessRequestData.fromString(
+        parentDar.getData().toString());
+
+    String referenceId = UUID.randomUUID().toString();
+    newDar.setReferenceId(referenceId);
+    newDar.setParentId(parentDar.getId().toString());
+    newDar.setCollectionId(parentDar.getCollectionId());
+
+    newDar.addDatasetIds(newData.getDatasetIds());
+    originalDataCopy.setInternalCollaborators(newData.getInternalCollaborators());
+    originalDataCopy.setExternalCollaborators(newData.getExternalCollaborators());
+    originalDataCopy.setLabCollaborators(newData.getLabCollaborators());
+    originalDataCopy.setProgressReportSummary(newData.getProgressReportSummary());
+    originalDataCopy.setIntellectualPropertySummary(newData.getIntellectualPropertySummary());
+    originalDataCopy.setPublications(newData.getPublications());
+    originalDataCopy.setPresentations(newData.getPresentations());
+    originalDataCopy.setDmi(newData.getDmi());
+    originalDataCopy.setResearchPlans(newData.getResearchPlans());
+    originalDataCopy.setCloseoutSupplement(newData.getCloseoutSupplement());
+    originalDataCopy.setPubAcknowledgement(newData.getPubAcknowledgement());
+    originalDataCopy.setDSAcknowledgement(newData.getDSAcknowledgement());
+    originalDataCopy.setGSOAcknowledgement(newData.getGSOAcknowledgement());
+
+    // These values will be updated in populateProgressReportWithDocuments if documents exist.
+    // Its important we don't copy over the parent values so those documents are not deleted.
+    originalDataCopy.setCollaborationLetterName(null);
+    originalDataCopy.setCollaborationLetterLocation(null);
+    originalDataCopy.setIrbDocumentName(null);
+    originalDataCopy.setIrbDocumentLocation(null);
+
+    newDar.setData(originalDataCopy);
+    return newDar;
+  }
+
 
   /**
    * Make a shallow copy of the dar. This is mostly a workaround for problems serializing dates when

--- a/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequestData.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequestData.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.google.gson.Gson;
 import com.google.gson.annotations.SerializedName;
+import jakarta.ws.rs.BadRequestException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -740,5 +741,18 @@ public class DataAccessRequestData {
   public void setCloseoutSupplement(
       CloseoutSupplement closeoutSupplement) {
     this.closeoutSupplement = closeoutSupplement;
+  }
+
+  public static DataAccessRequestData populateDARData(String json) {
+    DataAccessRequestData data;
+    try {
+      data = DataAccessRequestData.fromString(json);
+    } catch (Exception e) {
+      throw new BadRequestException("Unable to parse DAR from JSON string");
+    }
+    if (Objects.isNull(data)) {
+      data = new DataAccessRequestData();
+    }
+    return data;
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
@@ -88,19 +88,6 @@ public class DataAccessRequestResource extends Resource {
     this.matchService = matchService;
   }
 
-  private static DataAccessRequestData populateDARData(String json) {
-    DataAccessRequestData data;
-    try {
-      data = DataAccessRequestData.fromString(json);
-    } catch (Exception e) {
-      throw new BadRequestException("Unable to parse DAR from JSON string");
-    }
-    if (Objects.isNull(data)) {
-      data = new DataAccessRequestData();
-    }
-    return data;
-  }
-
   @GET
   @Produces("application/json")
   @PermitAll
@@ -444,7 +431,7 @@ public class DataAccessRequestResource extends Resource {
       if (!user.getUserId().equals(parentDar.getUserId())) {
         throw new ForbiddenException("User not authorized to update this Data Access Request");
       }
-      DataAccessRequest payload = populateProgressReportFromJsonString(dar, parentDar);
+      DataAccessRequest payload = DataAccessRequest.populateProgressReportFromJsonString(dar, parentDar);
       populateProgressReportWithDocuments(collabInputStream, collabFileDetails, ethicsInputStream,
           ethicsFileDetails, payload, parentDar);
       DataAccessRequest progressReport = dataAccessRequestService.createProgressReport(user,
@@ -568,7 +555,7 @@ public class DataAccessRequestResource extends Resource {
 
   private DataAccessRequest populateDarFromJsonString(User user, String json) {
     DataAccessRequest newDar = new DataAccessRequest();
-    DataAccessRequestData data = populateDARData(json);
+    DataAccessRequestData data = DataAccessRequestData.populateDARData(json);
     // When posting a submitted dar, there are two cases:
     // 1. those that existed previously as a draft dar
     // 2. those that are brand new
@@ -598,53 +585,6 @@ public class DataAccessRequestResource extends Resource {
     }
     newDar.setData(data);
     newDar.addDatasetIds(data.getDatasetIds());
-    return newDar;
-  }
-
-  /**
-   * Populate a new Data Access Request from the JSON string and the parent Data Access Request.
-   * Copies all the data from the parent dar, then overwrites the collaborators and datasets. Adds
-   * all progress report specific fields.
-   *
-   * @param json      The JSON string to populate the new Progress Report.
-   * @param parentDar The parent Data Access Request to copy data from.
-   * @return A new Progress Report populated with the provided JSON string and parent DAR data.
-   */
-  public DataAccessRequest populateProgressReportFromJsonString(String json,
-      DataAccessRequest parentDar) {
-    DataAccessRequest newDar = new DataAccessRequest();
-    DataAccessRequestData newData = populateDARData(json);
-    DataAccessRequestData originalDataCopy = DataAccessRequestData.fromString(
-        parentDar.getData().toString());
-
-    String referenceId = UUID.randomUUID().toString();
-    newDar.setReferenceId(referenceId);
-    newDar.setParentId(parentDar.getId().toString());
-    newDar.setCollectionId(parentDar.getCollectionId());
-
-    newDar.addDatasetIds(newData.getDatasetIds());
-    originalDataCopy.setInternalCollaborators(newData.getInternalCollaborators());
-    originalDataCopy.setExternalCollaborators(newData.getExternalCollaborators());
-    originalDataCopy.setLabCollaborators(newData.getLabCollaborators());
-    originalDataCopy.setProgressReportSummary(newData.getProgressReportSummary());
-    originalDataCopy.setIntellectualPropertySummary(newData.getIntellectualPropertySummary());
-    originalDataCopy.setPublications(newData.getPublications());
-    originalDataCopy.setPresentations(newData.getPresentations());
-    originalDataCopy.setDmi(newData.getDmi());
-    originalDataCopy.setResearchPlans(newData.getResearchPlans());
-    originalDataCopy.setCloseoutSupplement(newData.getCloseoutSupplement());
-    originalDataCopy.setPubAcknowledgement(newData.getPubAcknowledgement());
-    originalDataCopy.setDSAcknowledgement(newData.getDSAcknowledgement());
-    originalDataCopy.setGSOAcknowledgement(newData.getGSOAcknowledgement());
-
-    // These values will be updated in populateProgressReportWithDocuments if documents exist.
-    // Its important we don't copy over the parent values so those documents are not deleted.
-    originalDataCopy.setCollaborationLetterName(null);
-    originalDataCopy.setCollaborationLetterLocation(null);
-    originalDataCopy.setIrbDocumentName(null);
-    originalDataCopy.setIrbDocumentLocation(null);
-
-    newDar.setData(originalDataCopy);
     return newDar;
   }
 

--- a/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
@@ -633,6 +633,9 @@ public class DataAccessRequestResource extends Resource {
     originalDataCopy.setDmi(newData.getDmi());
     originalDataCopy.setResearchPlans(newData.getResearchPlans());
     originalDataCopy.setCloseoutSupplement(newData.getCloseoutSupplement());
+    originalDataCopy.setPubAcknowledgement(newData.getPubAcknowledgement());
+    originalDataCopy.setDSAcknowledgement(newData.getDSAcknowledgement());
+    originalDataCopy.setGSOAcknowledgement(newData.getGSOAcknowledgement());
 
     // These values will be updated in populateProgressReportWithDocuments if documents exist.
     // Its important we don't copy over the parent values so those documents are not deleted.

--- a/src/test/java/org/broadinstitute/consent/http/models/DataAccessRequestDataTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/DataAccessRequestDataTest.java
@@ -1,8 +1,12 @@
 package org.broadinstitute.consent.http.models;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import jakarta.ws.rs.BadRequestException;
 import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 
@@ -59,5 +63,37 @@ class DataAccessRequestDataTest {
     data.setSigningOfficialEmail(testEmail);
 
     assertEquals(testEmail, data.getSigningOfficialEmail());
+  }
+
+  @Test
+  void testPopulateDARDataWithValidJson() {
+    String validJson = """
+            {
+                "projectTitle": "Test Project",
+                "checkNihDataOnly": true
+            }
+        """;
+    DataAccessRequestData result = DataAccessRequestData.populateDARData(validJson);
+    assertNotNull(result);
+    assertEquals("Test Project", result.getProjectTitle());
+    assertTrue(result.getCheckNihDataOnly());
+  }
+
+  @Test
+  void testPopulateDARDataWithInvalidJson() {
+    String invalidJson = """
+            {
+                "projectTitle": "Test Project",
+                "checkNihDataOnly": true,
+        """;
+    assertThrows(BadRequestException.class, () -> DataAccessRequestData.populateDARData(invalidJson));
+  }
+
+  @Test
+  void testPopulateDARDataWithNullJson() {
+    DataAccessRequestData result = DataAccessRequestData.populateDARData(null);
+    assertNotNull(result);
+    assertNull(result.getProjectTitle());
+    assertNull(result.getCheckNihDataOnly());
   }
 }

--- a/src/test/java/org/broadinstitute/consent/http/models/DataAccessRequestTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/DataAccessRequestTest.java
@@ -1,0 +1,74 @@
+package org.broadinstitute.consent.http.models;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class DataAccessRequestTest {
+
+  @Test
+  void populateProgressReportFromJsonString() {
+    DataAccessRequest parentDar = new DataAccessRequest();
+    parentDar.setId(1);
+    parentDar.setReferenceId("parent-reference-id");
+    parentDar.setCollectionId(100);
+    DataAccessRequestData parentData = new DataAccessRequestData();
+    parentData.setProjectTitle("Parent Project Title");
+    Collaborator collaborator = new Collaborator();
+    collaborator.setName("Parent Collaborator");
+    parentData.setInternalCollaborators(List.of(collaborator));
+    parentData.setExternalCollaborators(List.of(collaborator));
+    parentData.setLabCollaborators(List.of(collaborator));
+    parentDar.setDatasetIds(List.of(1, 2, 3));
+    parentData.setCollaborationLetterName("collaboration_letter.txt");
+    parentData.setIrbDocumentName("irb_document.txt");
+    parentData.setCollaborationLetterLocation("collaboration_letter_location");
+    parentData.setIrbDocumentLocation("irb_document_location");
+    parentData.setDSAcknowledgement(false);
+    parentData.setGSOAcknowledgement(false);
+    parentData.setPubAcknowledgement(false);
+    parentDar.setData(parentData);
+
+    String json = """
+            {
+                "projectTitle": "New Project Title",
+                "internalCollaborators": [],
+                "externalCollaborators": [],
+                "labCollaborators": [],
+                "progressReportSummary": "New Summary",
+                "datasetIds": [1, 2],
+                "collaborationLetterName": "new_collaboration_letter.txt",
+                "irbDocumentName": "new_irb_document.txt",
+                "collaborationLetterLocation": "new_collaboration_letter_location",
+                "irbDocumentLocation": "new_irb_document_location",
+                "dsAcknowledgement": true,
+                "gsoAcknowledgement": true
+            }
+        """;
+
+    DataAccessRequest newDar = DataAccessRequest.populateProgressReportFromJsonString(json, parentDar);
+    DataAccessRequestData newData = newDar.getData();
+
+    assertNotNull(newDar);
+    assertNotEquals(parentDar.getReferenceId(), newDar.getReferenceId());
+    assertEquals(parentDar.getCollectionId(), newDar.getCollectionId());
+    assertEquals("Parent Project Title", newData.getProjectTitle());
+    assertEquals(List.of(), newData.getInternalCollaborators());
+    assertEquals(List.of(), newData.getExternalCollaborators());
+    assertEquals(List.of(), newData.getLabCollaborators());
+    assertEquals("New Summary", newData.getProgressReportSummary());
+    assertEquals(List.of(1, 2), newDar.getDatasetIds());
+    assertNull(newData.getCollaborationLetterName());
+    assertNull(newData.getIrbDocumentName());
+    assertNull(newData.getCollaborationLetterLocation());
+    assertNull(newData.getIrbDocumentLocation());
+    assertEquals(List.of(collaborator),
+        parentDar.getData().getInternalCollaborators()); // Ensure parent is unchanged
+    assertEquals("collaboration_letter.txt", parentDar.getData().getCollaborationLetterName());
+    assertTrue(newData.getDSAcknowledgement());
+    assertTrue(newData.getGSOAcknowledgement());
+    assertNull(newData.getPubAcknowledgement());
+  }
+
+}

--- a/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceTest.java
@@ -1,9 +1,6 @@
 package org.broadinstitute.consent.http.resources;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -46,7 +43,6 @@ import org.broadinstitute.consent.http.enumeration.DarDocumentType;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.exceptions.SubmittedDARCannotBeEditedException;
 import org.broadinstitute.consent.http.models.AuthUser;
-import org.broadinstitute.consent.http.models.Collaborator;
 import org.broadinstitute.consent.http.models.DataAccessRequest;
 import org.broadinstitute.consent.http.models.DataAccessRequestData;
 import org.broadinstitute.consent.http.models.DataUse;
@@ -659,71 +655,6 @@ class DataAccessRequestResourceTest extends AbstractTestHelper {
       assertEquals(newLocation, dar.getData().getIrbDocumentLocation());
       assertEquals(fileName, dar.getData().getIrbDocumentName());
     }
-  }
-
-  @Test
-  void populateProgressReportFromJsonString() {
-    DataAccessRequest parentDar = new DataAccessRequest();
-    parentDar.setId(1);
-    parentDar.setReferenceId("parent-reference-id");
-    parentDar.setCollectionId(100);
-    DataAccessRequestData parentData = new DataAccessRequestData();
-    parentData.setProjectTitle("Parent Project Title");
-    Collaborator collaborator = new Collaborator();
-    collaborator.setName("Parent Collaborator");
-    parentData.setInternalCollaborators(List.of(collaborator));
-    parentData.setExternalCollaborators(List.of(collaborator));
-    parentData.setLabCollaborators(List.of(collaborator));
-    parentDar.setDatasetIds(List.of(1, 2, 3));
-    parentData.setCollaborationLetterName("collaboration_letter.txt");
-    parentData.setIrbDocumentName("irb_document.txt");
-    parentData.setCollaborationLetterLocation("collaboration_letter_location");
-    parentData.setIrbDocumentLocation("irb_document_location");
-    parentData.setDSAcknowledgement(false);
-    parentData.setGSOAcknowledgement(false);
-    parentData.setPubAcknowledgement(false);
-    parentDar.setData(parentData);
-
-    String json = """
-            {
-                "projectTitle": "New Project Title",
-                "internalCollaborators": [],
-                "externalCollaborators": [],
-                "labCollaborators": [],
-                "progressReportSummary": "New Summary",
-                "datasetIds": [1, 2],
-                "collaborationLetterName": "new_collaboration_letter.txt",
-                "irbDocumentName": "new_irb_document.txt",
-                "collaborationLetterLocation": "new_collaboration_letter_location",
-                "irbDocumentLocation": "new_irb_document_location",
-                "dsAcknowledgement": true,
-                "gsoAcknowledgement": true
-            }
-        """;
-
-    initResource();
-    DataAccessRequest newDar = resource.populateProgressReportFromJsonString(json, parentDar);
-    DataAccessRequestData newData = newDar.getData();
-
-    assertNotNull(newDar);
-    assertNotEquals(parentDar.getReferenceId(), newDar.getReferenceId());
-    assertEquals(parentDar.getCollectionId(), newDar.getCollectionId());
-    assertEquals("Parent Project Title", newData.getProjectTitle());
-    assertEquals(List.of(), newData.getInternalCollaborators());
-    assertEquals(List.of(), newData.getExternalCollaborators());
-    assertEquals(List.of(), newData.getLabCollaborators());
-    assertEquals("New Summary", newData.getProgressReportSummary());
-    assertEquals(List.of(1, 2), newDar.getDatasetIds());
-    assertNull(newData.getCollaborationLetterName());
-    assertNull(newData.getIrbDocumentName());
-    assertNull(newData.getCollaborationLetterLocation());
-    assertNull(newData.getIrbDocumentLocation());
-    assertEquals(List.of(collaborator),
-        parentDar.getData().getInternalCollaborators()); // Ensure parent is unchanged
-    assertEquals("collaboration_letter.txt", parentDar.getData().getCollaborationLetterName());
-    assertTrue(newData.getDSAcknowledgement());
-    assertTrue(newData.getGSOAcknowledgement());
-    assertNull(newData.getPubAcknowledgement());
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceTest.java
@@ -679,6 +679,9 @@ class DataAccessRequestResourceTest extends AbstractTestHelper {
     parentData.setIrbDocumentName("irb_document.txt");
     parentData.setCollaborationLetterLocation("collaboration_letter_location");
     parentData.setIrbDocumentLocation("irb_document_location");
+    parentData.setDSAcknowledgement(false);
+    parentData.setGSOAcknowledgement(false);
+    parentData.setPubAcknowledgement(false);
     parentDar.setData(parentData);
 
     String json = """
@@ -692,29 +695,35 @@ class DataAccessRequestResourceTest extends AbstractTestHelper {
                 "collaborationLetterName": "new_collaboration_letter.txt",
                 "irbDocumentName": "new_irb_document.txt",
                 "collaborationLetterLocation": "new_collaboration_letter_location",
-                "irbDocumentLocation": "new_irb_document_location"
+                "irbDocumentLocation": "new_irb_document_location",
+                "dsAcknowledgement": true,
+                "gsoAcknowledgement": true
             }
         """;
 
     initResource();
     DataAccessRequest newDar = resource.populateProgressReportFromJsonString(json, parentDar);
+    DataAccessRequestData newData = newDar.getData();
 
     assertNotNull(newDar);
     assertNotEquals(parentDar.getReferenceId(), newDar.getReferenceId());
     assertEquals(parentDar.getCollectionId(), newDar.getCollectionId());
-    assertEquals("Parent Project Title", newDar.getData().getProjectTitle());
-    assertEquals(List.of(), newDar.getData().getInternalCollaborators());
-    assertEquals(List.of(), newDar.getData().getExternalCollaborators());
-    assertEquals(List.of(), newDar.getData().getLabCollaborators());
-    assertEquals("New Summary", newDar.getData().getProgressReportSummary());
+    assertEquals("Parent Project Title", newData.getProjectTitle());
+    assertEquals(List.of(), newData.getInternalCollaborators());
+    assertEquals(List.of(), newData.getExternalCollaborators());
+    assertEquals(List.of(), newData.getLabCollaborators());
+    assertEquals("New Summary", newData.getProgressReportSummary());
     assertEquals(List.of(1, 2), newDar.getDatasetIds());
-    assertNull(newDar.getData().getCollaborationLetterName());
-    assertNull(newDar.getData().getIrbDocumentName());
-    assertNull(newDar.getData().getCollaborationLetterLocation());
-    assertNull(newDar.getData().getIrbDocumentLocation());
+    assertNull(newData.getCollaborationLetterName());
+    assertNull(newData.getIrbDocumentName());
+    assertNull(newData.getCollaborationLetterLocation());
+    assertNull(newData.getIrbDocumentLocation());
     assertEquals(List.of(collaborator),
         parentDar.getData().getInternalCollaborators()); // Ensure parent is unchanged
     assertEquals("collaboration_letter.txt", parentDar.getData().getCollaborationLetterName());
+    assertTrue(newData.getDSAcknowledgement());
+    assertTrue(newData.getGSOAcknowledgement());
+    assertNull(newData.getPubAcknowledgement());
   }
 
   @Test


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-1624
We are going to add a section to include Data Use Acknowledgements in the Progress Report Application, so we need to save these new values on the backend.

### Summary
Set the Data Use Acknowledgement fields to the new value from the PR instead of copying from the parent.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
