### PR TITLE
[DT-1663]Update CreateProgressReport Action to only be included if the Latest DAR in the collection has an approved dataset

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/DarCollectionSummaryDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DarCollectionSummaryDAO.java
@@ -22,10 +22,10 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
   @RegisterBeanMapper(value = Election.class)
   @UseRowReducer(DarCollectionSummaryReducer.class)
   @SqlQuery("""
-      SELECT c.collection_id as dar_collection_id, c.dar_code, dar.submission_date, dar.reference_id as dar_reference_id, dar.parent_id as dar_parent_id,
+      SELECT c.collection_id as dar_collection_id, c.dar_code, latest_dar.submission_date, latest_dar.reference_id as latest_dar_reference_id, latest_dar.parent_id as latest_dar_parent_id,
        u.display_name as researcher_name, i.institution_name, e.election_id, e.status, e.dataset_id, e.reference_id, v.voteid as v_vote_id, dd.dataset_id as dd_datasetid,
         v.user_id as v_user_id, v.vote as v_vote, v.electionid as v_election_id, v.createdate as v_create_date, v.updatedate as v_update_date, v.type as v_type,
-        (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb ->> 'projectTitle' AS name,
+        (regexp_replace(latest_dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb ->> 'projectTitle' AS name,
         ARRAY_AGG(dar_all.reference_id) AS reference_ids
       FROM dar_collection c
       INNER JOIN users u
@@ -38,7 +38,7 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
         WHERE submission_date IS NOT NULL
         AND (LOWER(data->>'status') != 'archived' OR data->>'status' IS NULL)
         ORDER BY collection_id, submission_date DESC
-        ) dar ON dar.collection_id = c.collection_id
+        ) latest_dar ON latest_dar.collection_id = c.collection_id
       INNER JOIN data_access_request dar_all
         ON dar_all.collection_id = c.collection_id
         AND dar_all.submission_date IS NOT NULL
@@ -48,19 +48,19 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
         FROM election
         WHERE LOWER(election.election_type) = 'dataaccess' AND election.dataset_id IN (<datasetIds>)
       ) AS e
-        ON e.reference_id = dar.reference_id
+        ON e.reference_id = latest_dar.reference_id
       LEFT JOIN vote v
         ON e.election_id = v.electionid
       INNER JOIN dar_dataset dd
-        ON dar.reference_id = dd.reference_id
+        ON latest_dar.reference_id = dd.reference_id
       WHERE dd.dataset_id IN (<datasetIds>)
         AND (e.latest = e.election_id OR e.election_id IS NULL)
         AND (LOWER(v.type) = 'final' OR (v.user_id = :currentUserId OR v.voteid IS NULL))
       GROUP BY
-        c.collection_id, c.dar_code, dar.submission_date, dar.reference_id, dar.parent_id,
+        c.collection_id, c.dar_code, latest_dar.submission_date, latest_dar.reference_id, latest_dar.parent_id,
         u.display_name, i.institution_name, e.election_id, e.status,
         e.reference_id, e.dataset_id, v.voteid, dd.dataset_id, v.user_id,
-        v.vote, v.electionid, v.createdate, v.updatedate, v.type, dar.data
+        v.vote, v.electionid, v.createdate, v.updatedate, v.type, latest_dar.data
       """)
   List<DarCollectionSummary> getDarCollectionSummariesForDAC(
       @Bind("currentUserId") Integer currentUserId,
@@ -75,9 +75,9 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
           """
               SELECT c.collection_id as dar_collection_id,
                c.dar_code,
-               dar.submission_date,
-               dar.reference_id as dar_reference_id,
-               dar.parent_id as dar_parent_id,
+               latest_dar.submission_date,
+               latest_dar.reference_id as latest_dar_reference_id,
+               latest_dar.parent_id as latest_dar_parent_id,
                u.display_name as researcher_name,
                i.institution_name,
                e.election_id,
@@ -85,7 +85,7 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
                e.dataset_id,
                e.reference_id,
                dd.dataset_id as dd_datasetid,
-               (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb ->> 'projectTitle' AS name,
+               (regexp_replace(latest_dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb ->> 'projectTitle' AS name,
                ARRAY_AGG(dar_all.reference_id) AS reference_ids
               FROM dar_collection c
               INNER JOIN users u
@@ -98,7 +98,7 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
                 WHERE submission_date IS NOT NULL
                 AND (LOWER(data->>'status') != 'archived' OR data->>'status' IS NULL)
                 ORDER BY collection_id, submission_date DESC
-              ) dar ON dar.collection_id = c.collection_id
+              ) latest_dar ON latest_dar.collection_id = c.collection_id
               INNER JOIN data_access_request dar_all
                ON dar_all.collection_id = c.collection_id
                AND dar_all.submission_date IS NOT NULL
@@ -108,15 +108,15 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
                 FROM election
                 WHERE LOWER(election.election_type) = 'dataaccess'
                 ) AS e
-              ON e.reference_id = dar.reference_id
+              ON e.reference_id = latest_dar.reference_id
               INNER JOIN dar_dataset dd
-              ON dar.reference_id = dd.reference_id
+              ON latest_dar.reference_id = dd.reference_id
               WHERE u.institution_id = :institutionId
                 AND (e.latest = e.election_id OR e.election_id IS NULL)
               GROUP BY
-              c.collection_id, c.dar_code, dar.submission_date, dar.reference_id, dar.parent_id,
+              c.collection_id, c.dar_code, latest_dar.submission_date, latest_dar.reference_id, latest_dar.parent_id,
               u.display_name, i.institution_name, e.election_id, e.status,
-              e.reference_id, e.dataset_id, dd.dataset_id, dar.data
+              e.reference_id, e.dataset_id, dd.dataset_id, latest_dar.data
           """
       )
   List<DarCollectionSummary> getDarCollectionSummariesForSO(
@@ -130,16 +130,16 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
           SELECT
               c.collection_id AS dar_collection_id,
               c.dar_code,
-              dar.submission_date,
-              dar.reference_id AS dar_reference_id,
-              dar.parent_id AS dar_parent_id,
+              latest_dar.submission_date,
+              latest_dar.reference_id AS latest_dar_reference_id,
+              latest_dar.parent_id AS latest_dar_parent_id,
               u.display_name AS researcher_name,
               i.institution_name,
               e.election_id,
               e.status,
               e.dataset_id,
               dd.dataset_id AS dd_datasetid,
-              (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb ->> 'projectTitle' AS name,
+              (regexp_replace(latest_dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb ->> 'projectTitle' AS name,
               dac.name AS dac_name,
               ARRAY_AGG(dar_all.reference_id) AS reference_ids
           FROM dar_collection c
@@ -151,7 +151,7 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
               WHERE submission_date IS NOT NULL
               AND (LOWER(data->>'status') != 'archived' OR data->>'status' IS NULL)
               ORDER BY collection_id, submission_date DESC
-          ) dar ON dar.collection_id = c.collection_id
+          ) latest_dar ON latest_dar.collection_id = c.collection_id
           INNER JOIN data_access_request dar_all
               ON dar_all.collection_id = c.collection_id
               AND dar_all.submission_date IS NOT NULL
@@ -160,15 +160,15 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
                   SELECT election.*, MAX(election.election_id) OVER(PARTITION BY election.reference_id, election.dataset_id) AS latest
                   FROM election
                   WHERE LOWER(election.election_type) = 'dataaccess'
-                ) AS e ON e.reference_id = dar.reference_id
-          INNER JOIN dar_dataset dd ON dar.reference_id = dd.reference_id
+                ) AS e ON e.reference_id = latest_dar.reference_id
+          INNER JOIN dar_dataset dd ON latest_dar.reference_id = dd.reference_id
           LEFT JOIN dataset ON dataset.dataset_id = dd.dataset_id
           LEFT JOIN dac ON dac.dac_id = dataset.dac_id
           WHERE (e.latest = e.election_id OR e.election_id IS NULL)
           GROUP BY
-              c.collection_id, c.dar_code, dar.submission_date, dar.reference_id, dar.parent_id,
+              c.collection_id, c.dar_code, latest_dar.submission_date, latest_dar.reference_id, latest_dar.parent_id,
               u.display_name, i.institution_name, e.election_id, e.status,
-              e.dataset_id, dd.dataset_id, dar.data, dac.name
+              e.dataset_id, dd.dataset_id, latest_dar.data, dac.name
       """)
   List<DarCollectionSummary> getDarCollectionSummariesForAdmin();
 
@@ -180,9 +180,9 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
     SELECT
         c.collection_id AS dar_collection_id,
         c.dar_code,
-        dar.submission_date,
-        dar.reference_id AS dar_reference_id,
-        dar.parent_id AS dar_parent_id,
+        latest_dar.submission_date,
+        latest_dar.reference_id AS latest_dar_reference_id,
+        latest_dar.parent_id AS latest_dar_parent_id,
         u.display_name AS researcher_name,
         i.institution_name,
         e.election_id,
@@ -190,8 +190,8 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
         e.dataset_id,
         e.reference_id AS election_reference_id,
         dd.dataset_id AS dd_datasetid,
-        (regexp_replace(dar.data #>> '{}', '\\u0000', '', 'g'))::jsonb ->> 'projectTitle' AS name,
-        (regexp_replace(dar.data #>> '{}', '\\u0000', '', 'g'))::jsonb ->> 'status' AS dar_status,
+        (regexp_replace(latest_dar.data #>> '{}', '\\u0000', '', 'g'))::jsonb ->> 'projectTitle' AS name,
+        (regexp_replace(latest_dar.data #>> '{}', '\\u0000', '', 'g'))::jsonb ->> 'status' AS dar_status,
         ARRAY_AGG(dar_all.reference_id) AS reference_ids
     FROM
         dar_collection c
@@ -205,7 +205,7 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
          WHERE submission_date IS NOT NULL
          AND (LOWER(data->>'status') != 'archived' OR data->>'status' IS NULL)
          ORDER BY collection_id, submission_date DESC
-    ) dar ON dar.collection_id = c.collection_id
+    ) latest_dar ON latest_dar.collection_id = c.collection_id
     INNER JOIN
         data_access_request dar_all ON dar_all.collection_id = c.collection_id
         AND dar_all.submission_date IS NOT NULL
@@ -214,15 +214,15 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
         SELECT election.*, MAX(election.election_id) OVER(PARTITION BY election.reference_id, election.dataset_id) AS latest
         FROM election
         WHERE LOWER(election.election_type) = 'dataaccess'
-    ) AS e ON e.reference_id = dar.reference_id
+    ) AS e ON e.reference_id = latest_dar.reference_id
     INNER JOIN
-        dar_dataset dd ON dar.reference_id = dd.reference_id
+        dar_dataset dd ON latest_dar.reference_id = dd.reference_id
     WHERE
         c.create_user_id = :userId
         AND (e.latest = e.election_id OR e.election_id IS NULL)
     GROUP BY
-        c.collection_id, c.dar_code, dar.submission_date, dar.reference_id, dar.parent_id, u.display_name, i.institution_name,
-        e.election_id, e.status, e.dataset_id, e.reference_id, dd.dataset_id, dar.data
+        c.collection_id, c.dar_code, latest_dar.submission_date, latest_dar.reference_id, latest_dar.parent_id, u.display_name, i.institution_name,
+        e.election_id, e.status, e.dataset_id, e.reference_id, dd.dataset_id, latest_dar.data
 """)
   List<DarCollectionSummary> getDarCollectionSummariesForResearcher(@Bind("userId") Integer userId);
 
@@ -233,11 +233,11 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
   @RegisterBeanMapper(value = Election.class)
   @UseRowReducer(DarCollectionSummaryReducer.class)
   @SqlQuery("""
-      SELECT c.collection_id as dar_collection_id, c.dar_code, dar.submission_date, dar.reference_id AS dar_reference_id,
-        dar.parent_id AS dar_parent_id, u.display_name as researcher_name, u.user_id as researcher_id,
+      SELECT c.collection_id as dar_collection_id, c.dar_code, latest_dar.submission_date, latest_dar.reference_id AS latest_dar_reference_id,
+        latest_dar.parent_id AS latest_dar_parent_id, u.display_name as researcher_name, u.user_id as researcher_id,
         i.institution_name, i.institution_id, e.election_id, e.status, e.dataset_id, e.reference_id, v.voteid as v_vote_id, dd.dataset_id as dd_datasetid,
         v.user_id as v_user_id, v.vote as v_vote, v.electionid as v_election_id, v.createdate as v_create_date, v.updatedate as v_update_date, v.type as v_type,
-        (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb ->> 'projectTitle' AS name,
+        (regexp_replace(latest_dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb ->> 'projectTitle' AS name,
         ARRAY_AGG(dar_all.reference_id) AS reference_ids
       FROM dar_collection c
       INNER JOIN users u
@@ -250,7 +250,7 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
         WHERE submission_date IS NOT NULL
         AND (LOWER(data->>'status') != 'archived' OR data->>'status' IS NULL)
         ORDER BY collection_id, submission_date DESC
-      ) dar ON dar.collection_id = c.collection_id
+      ) latest_dar ON latest_dar.collection_id = c.collection_id
       INNER JOIN
         data_access_request dar_all ON dar_all.collection_id = c.collection_id
         AND dar_all.submission_date IS NOT NULL
@@ -260,20 +260,20 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
         FROM election
         WHERE LOWER(election.election_type) = 'dataaccess' AND election.dataset_id IN (<datasetIds>)
       ) AS e
-        ON e.reference_id = dar.reference_id
+        ON e.reference_id = latest_dar.reference_id
       LEFT JOIN vote v
         ON e.election_id = v.electionid
       INNER JOIN dar_dataset dd
-        ON dar.reference_id = dd.reference_id
+        ON latest_dar.reference_id = dd.reference_id
       WHERE c.collection_id= :collectionId
         AND dd.dataset_id IN (<datasetIds>)
         AND (e.latest = e.election_id OR e.election_id IS NULL)
         AND (LOWER(v.type) = 'final' OR (v.user_id = :currentUserId OR v.voteid IS NULL))
       GROUP BY
-        c.collection_id, c.dar_code, dar.submission_date, dar.reference_id, dar.parent_id, u.display_name, u.user_id,
+        c.collection_id, c.dar_code, latest_dar.submission_date, latest_dar.reference_id, latest_dar.parent_id, u.display_name, u.user_id,
         i.institution_name, i.institution_id, e.election_id, e.status,
         e.reference_id, e.dataset_id, v.voteid, dd.dataset_id, v.user_id,
-        v.vote, v.electionid, v.createdate, v.updatedate, v.type, dar.data
+        v.vote, v.electionid, v.createdate, v.updatedate, v.type, latest_dar.data
       """)
   DarCollectionSummary getDarCollectionSummaryForDACByCollectionId(
       @Bind("currentUserId") Integer currentUserId,
@@ -288,10 +288,10 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
   @SqlQuery
       (
           """
-              SELECT c.collection_id as dar_collection_id, c.dar_code, dar.submission_date, dar.reference_id as dar_reference_id, dar.parent_id as dar_parent_id, u.display_name as researcher_name,
+              SELECT c.collection_id as dar_collection_id, c.dar_code, latest_dar.submission_date, latest_dar.reference_id as latest_dar_reference_id, latest_dar.parent_id as latest_dar_parent_id, u.display_name as researcher_name,
                 u.user_id as researcher_id, i.institution_name, i.institution_id, e.election_id, e.status, e.dataset_id, e.reference_id, dd.dataset_id as dd_datasetid,
-                (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb ->> 'projectTitle' AS name,
-                (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb ->> 'status' AS dar_status,
+                (regexp_replace(latest_dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb ->> 'projectTitle' AS name,
+                (regexp_replace(latest_dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb ->> 'status' AS dar_status,
                 ARRAY_AGG(dar_all.reference_id) AS reference_ids
               FROM dar_collection c
               INNER JOIN users u
@@ -304,7 +304,7 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
                WHERE submission_date IS NOT NULL
                AND (LOWER(data->>'status') != 'archived' OR data->>'status' IS NULL)
                ORDER BY collection_id, submission_date DESC
-              ) dar ON dar.collection_id = c.collection_id
+              ) latest_dar ON latest_dar.collection_id = c.collection_id
               INNER JOIN
                data_access_request dar_all ON dar_all.collection_id = c.collection_id
                AND dar_all.submission_date IS NOT NULL
@@ -314,14 +314,14 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
                 FROM election
                 WHERE LOWER(election.election_type) = 'dataaccess'
               ) AS e
-              ON e.reference_id = dar.reference_id
+              ON e.reference_id = latest_dar.reference_id
               INNER JOIN dar_dataset dd
-              ON dar.reference_id = dd.reference_id
+              ON latest_dar.reference_id = dd.reference_id
               WHERE c.collection_id = :collectionId
                 AND (e.latest = e.election_id OR e.election_id IS NULL)
               GROUP BY
-                c.collection_id, c.dar_code, dar.submission_date, dar.reference_id, dar.parent_id, u.display_name, u.user_id, i.institution_name,
-                i.institution_id, e.election_id, e.status, e.dataset_id, e.reference_id, dd.dataset_id, dar.data
+                c.collection_id, c.dar_code, latest_dar.submission_date, latest_dar.reference_id, latest_dar.parent_id, u.display_name, u.user_id, i.institution_name,
+                i.institution_id, e.election_id, e.status, e.dataset_id, e.reference_id, dd.dataset_id, latest_dar.data
           """
       )
   DarCollectionSummary getDarCollectionSummaryByCollectionId(

--- a/src/main/java/org/broadinstitute/consent/http/db/DataAccessRequestDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DataAccessRequestDAO.java
@@ -126,10 +126,10 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
           final_access_vote.reference_id = dar.reference_id AND
           final_access_vote.dataset_id = dd.dataset_id
       WHERE final_access_vote.last_vote = TRUE
-        AND dar.reference_id IN (<darReferenceIds>)
+        AND dar.reference_id = :darReferenceId
         AND (LOWER(dar.data->>'status') != 'archived' OR dar.data->>'status' IS NULL)
       """)
-  Set<Integer> findDatasetApprovalsByDars(@BindList("darReferenceIds") List<String> darReferenceIds);
+  Set<Integer> findDatasetApprovalsByDar(@Bind("darReferenceId") String darReferenceIds);
 
   /**
    * This query finds submitted DARs based on a date range.  This would be useful if we wanted to

--- a/src/main/java/org/broadinstitute/consent/http/db/DataAccessRequestDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DataAccessRequestDAO.java
@@ -102,7 +102,7 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
    * `FALSE` in the example above. Outside the JOIN, we filter on groupings where the final vote
    * value is `TRUE` so the denied election in the example would be filtered out.
    *
-   * @param darReferenceIds The DARs reference UUIDs
+   * @param darReferenceId The DARs reference UUID
    * @return Set of approved Dataset Ids for the list of DARs
    */
   @SqlQuery(
@@ -129,7 +129,7 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
         AND dar.reference_id = :darReferenceId
         AND (LOWER(dar.data->>'status') != 'archived' OR dar.data->>'status' IS NULL)
       """)
-  Set<Integer> findDatasetApprovalsByDar(@Bind("darReferenceId") String darReferenceIds);
+  Set<Integer> findDatasetApprovalsByDar(@Bind("darReferenceId") String darReferenceId);
 
   /**
    * This query finds submitted DARs based on a date range.  This would be useful if we wanted to

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DarCollectionSummaryReducer.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DarCollectionSummaryReducer.java
@@ -39,11 +39,11 @@ public class DarCollectionSummaryReducer implements
       }
 
       try {
-        darReferenceId = rowView.getColumn("dar_reference_id", String.class);
+        darReferenceId = rowView.getColumn("latest_dar_reference_id", String.class);
         if (Objects.nonNull(darReferenceId)) {
           summary.setLatestReferenceId(darReferenceId);
         }
-        hasOptionalColumn(rowView, "dar_parent_id", Integer.class)
+        hasOptionalColumn(rowView, "latest_dar_parent_id", Integer.class)
             .ifPresent(darParentId -> summary.addParentChildRelationship(darParentId, darReferenceId));
         darStatus = rowView.getColumn("dar_status", String.class);
         if (Objects.nonNull(darStatus)) {

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DarCollectionSummaryReducer.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DarCollectionSummaryReducer.java
@@ -40,6 +40,9 @@ public class DarCollectionSummaryReducer implements
 
       try {
         darReferenceId = rowView.getColumn("dar_reference_id", String.class);
+        if (Objects.nonNull(darReferenceId)) {
+          summary.setLatestReferenceId(darReferenceId);
+        }
         hasOptionalColumn(rowView, "dar_parent_id", Integer.class)
             .ifPresent(darParentId -> summary.addParentChildRelationship(darParentId, darReferenceId));
         darStatus = rowView.getColumn("dar_status", String.class);

--- a/src/main/java/org/broadinstitute/consent/http/models/DarCollectionSummary.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DarCollectionSummary.java
@@ -57,6 +57,8 @@ public class DarCollectionSummary {
   @JsonProperty
   private boolean progressReport;
 
+  @JsonProperty
+  private String latestReferenceId;
   private List<String> dacNames;
 
   private Integer researcherId;
@@ -268,6 +270,14 @@ public class DarCollectionSummary {
 
   public boolean getProgressReport() {
     return progressReport;
+  }
+
+  public String getLatestReferenceId() {
+    return latestReferenceId;
+  }
+
+  public void setLatestReferenceId(String latestReferenceId) {
+    this.latestReferenceId = latestReferenceId;
   }
 
   private void updateProgressReportStatus() {

--- a/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
@@ -153,7 +153,7 @@ public class DarCollectionService implements ConsentLogger {
       s.addAction(DarCollectionActions.REVIEW);
       //if the latest DAR in the collection has at least one approved dataset,
       //include the create progress report action
-      Set<Integer> datasetIds = dataAccessRequestDAO.findDatasetApprovalsByDars(List.of(s.getLatestReferenceId()));
+      Set<Integer> datasetIds = dataAccessRequestDAO.findDatasetApprovalsByDar(s.getLatestReferenceId());
       if (!datasetIds.isEmpty()) {
         s.addAction(DarCollectionActions.CREATE_PROGRESS_REPORT);
       }

--- a/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
@@ -151,8 +151,9 @@ public class DarCollectionService implements ConsentLogger {
       int electionCount = elections.size();
       elections.values().forEach(election -> updateStatusCount(statusCount, election.getStatus()));
       s.addAction(DarCollectionActions.REVIEW);
-      //if any DARs in the collection have approved datasets, include create progress report action
-      Set<Integer> datasetIds = dataAccessRequestDAO.findDatasetApprovalsByDars(List.copyOf(s.getReferenceIds()));
+      //if the latest DAR in the collection has at least one approved dataset,
+      //include the create progress report action
+      Set<Integer> datasetIds = dataAccessRequestDAO.findDatasetApprovalsByDars(List.of(s.getLatestReferenceId()));
       if (!datasetIds.isEmpty()) {
         s.addAction(DarCollectionActions.CREATE_PROGRESS_REPORT);
       }

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
@@ -231,7 +231,7 @@ public class DataAccessRequestService implements ConsentLogger {
 
     String referenceId = progressReport.getReferenceId();
     List<Integer> progressReportDatasetIds = progressReport.getDatasetIds();
-    Set<Integer> darDatasetIds = dataAccessRequestDAO.findDatasetApprovalsByDars(List.of(parentDar.getReferenceId()));
+    Set<Integer> darDatasetIds = dataAccessRequestDAO.findDatasetApprovalsByDar(parentDar.getReferenceId());
     if (!darDatasetIds.containsAll(progressReportDatasetIds)) {
       throw new BadRequestException("Progress report can only be created for approved datasets in the parent DAR");
     }

--- a/src/test/java/org/broadinstitute/consent/http/db/DarCollectionSummaryDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DarCollectionSummaryDAOTest.java
@@ -13,7 +13,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 import org.apache.commons.lang3.RandomStringUtils;
-import org.apache.commons.lang3.tuple.Pair;
 import org.broadinstitute.consent.http.enumeration.ElectionStatus;
 import org.broadinstitute.consent.http.enumeration.ElectionType;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
@@ -751,10 +750,11 @@ class DarCollectionSummaryDAOTest extends DAOTestHelper {
     DarCollectionSummary summary = summaries.get(0);
     assertEquals(collectionId, summary.getDarCollectionId());
 
-    // Ensure the reference IDs include both DARs
+    // Ensure the reference IDs include both DARs and latest represents the newer DAR
     assertNotNull(summary.getReferenceIds());
     assertEquals(2, summary.getReferenceIds().size());
     assertTrue(summary.getReferenceIds().containsAll(List.of(olderDar.getReferenceId(), newerDar.getReferenceId())));
+    assertEquals(newerDar.getReferenceId(), summary.getLatestReferenceId());
 
     // Ensure the election from the older DAR is not included
     assertTrue(summary.getElections().isEmpty());
@@ -1151,7 +1151,7 @@ class DarCollectionSummaryDAOTest extends DAOTestHelper {
     return new Setup(userId, chairId, summary);
   }
 
-  public record Setup(Integer userId, Integer chairId, DarCollectionSummary summary) {};
+  public record Setup(Integer userId, Integer chairId, DarCollectionSummary summary) {}
 
   private void validateSummaryObjectForResearcherWithParent(Integer userId, String referenceId) {
     DataAccessRequest dar = dataAccessRequestDAO.findByReferenceId(

--- a/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
@@ -639,7 +639,7 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
     Date now = new Date();
 
     assertTrue(
-        dataAccessRequestDAO.findDatasetApprovalsByDars(List.of(testDar1.getReferenceId()))
+        dataAccessRequestDAO.findDatasetApprovalsByDar(testDar1.getReferenceId())
             .isEmpty());
 
     voteDAO.updateVote(true,
@@ -651,8 +651,8 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
         now,
         false);
 
-    Set<Integer> approvedDatasetIds = dataAccessRequestDAO.findDatasetApprovalsByDars(
-        List.of(testDar1.getReferenceId()));
+    Set<Integer> approvedDatasetIds = dataAccessRequestDAO.findDatasetApprovalsByDar(
+        testDar1.getReferenceId());
     assertEquals(1, approvedDatasetIds.size());
     assertTrue(approvedDatasetIds.contains(dataset1.getDatasetId()));
 
@@ -665,7 +665,7 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
         now,
         false);
 
-    approvedDatasetIds = dataAccessRequestDAO.findDatasetApprovalsByDars(List.of(testDar1.getReferenceId()));
+    approvedDatasetIds = dataAccessRequestDAO.findDatasetApprovalsByDar(testDar1.getReferenceId());
 
     assertEquals(2, approvedDatasetIds.size());
     assertTrue(approvedDatasetIds.contains(dataset1.getDatasetId()));
@@ -681,80 +681,11 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
         now,
         false);
 
-    approvedDatasetIds = dataAccessRequestDAO.findDatasetApprovalsByDars(List.of(testDar1.getReferenceId()));
+    approvedDatasetIds = dataAccessRequestDAO.findDatasetApprovalsByDar(testDar1.getReferenceId());
 
     assertEquals(2, approvedDatasetIds.size());
     assertTrue(approvedDatasetIds.contains(dataset1.getDatasetId()));
     assertTrue(approvedDatasetIds.contains(dataset2.getDatasetId()));
-  }
-
-  @Test
-  void testFindAllDatasetApprovalsByDars() {
-    String darCode1 = "DAR-" + randomInt(100, 1000000);
-    String darCode2 = "DAR-" + randomInt(100, 1000000);
-    Dataset dataset1 = createDARDAOTestDataset();
-    Dataset dataset2 = createDARDAOTestDataset();
-    Dataset dataset3 = createDARDAOTestDataset();
-    Dataset dataset4 = createDARDAOTestDataset();
-
-    User user1 = createUserWithInstitution();
-    // dar with three datasets
-    DataAccessRequest testDar1 = createDAR(user1, dataset1, darCode1);
-    dataAccessRequestDAO.insertDARDatasetRelation(testDar1.getReferenceId(), dataset2.getDatasetId());
-    dataAccessRequestDAO.insertDARDatasetRelation(testDar1.getReferenceId(), dataset3.getDatasetId());
-    //dar with one dataset
-    DataAccessRequest testDar2 = createDAR(user1, dataset4, darCode2);
-
-    Election e1 = createDataAccessElection(testDar1.getReferenceId(), dataset1.getDatasetId());
-    Vote v1 = createFinalVote(dataset1.getCreateUserId(), e1.getElectionId());
-
-    Election e2 = createDataAccessElection(testDar1.getReferenceId(), dataset2.getDatasetId());
-    Vote v2 = createFinalVote(dataset2.getCreateUserId(), e2.getElectionId());
-
-    Election e3 = createDataAccessElection(testDar1.getReferenceId(), dataset3.getDatasetId());
-    createFinalVote(dataset3.getCreateUserId(), e3.getElectionId());
-
-    Election e4 = createDataAccessElection(testDar2.getReferenceId(), dataset4.getDatasetId());
-    Vote v4 = createFinalVote(dataset4.getCreateUserId(), e4.getElectionId());
-
-    Date now = new Date();
-
-    // election1 for dataset1 updated to true
-    voteDAO.updateVote(true,
-        "",
-        now,
-        v1.getVoteId(),
-        false,
-        e1.getElectionId(),
-        now,
-        false);
-
-    // election2 for dataset2 updated to false
-    voteDAO.updateVote(false,
-        "",
-        now,
-        v2.getVoteId(),
-        false,
-        e2.getElectionId(),
-        now,
-        false);
-
-    // election3 for dataset3 final vote not updated
-
-    // election4 for dataset4 updated to true
-    voteDAO.updateVote(true,
-        "",
-        now,
-        v4.getVoteId(),
-        false,
-        e4.getElectionId(),
-        now,
-        false);
-
-    Set<Integer> approvedDatasetIds = dataAccessRequestDAO.findDatasetApprovalsByDars(
-        List.of(testDar1.getReferenceId(), testDar2.getReferenceId()));
-    assertEquals(2, approvedDatasetIds.size());
-    assertTrue(approvedDatasetIds.containsAll(List.of(dataset1.getDatasetId(), dataset4.getDatasetId())));
   }
 
   @Test
@@ -780,8 +711,8 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
         now,
         false);
 
-    Set<Integer> approvedDatasetIds = dataAccessRequestDAO.findDatasetApprovalsByDars(
-        List.of(testDar1.getReferenceId()));
+    Set<Integer> approvedDatasetIds = dataAccessRequestDAO.findDatasetApprovalsByDar(
+        testDar1.getReferenceId());
     assertEquals(1, approvedDatasetIds.size());
     assertTrue(approvedDatasetIds.contains(dataset1.getDatasetId()));
   }

--- a/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
@@ -609,8 +609,8 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     when(dataAccessRequestDAO.findAllDraftsByUserId(any())).thenReturn(List.of(draft));
     when(darCollectionSummaryDAO.getDarCollectionSummariesForResearcher(any())).thenReturn(
         List.of(summaryOne, summaryTwo, summaryThree, summaryFour, summaryFive));
-    when(dataAccessRequestDAO.findDatasetApprovalsByDars(List.of("ref1"))).thenReturn(Set.of());
-    when(dataAccessRequestDAO.findDatasetApprovalsByDars(List.of("ref4")))
+    when(dataAccessRequestDAO.findDatasetApprovalsByDar("ref1")).thenReturn(Set.of());
+    when(dataAccessRequestDAO.findDatasetApprovalsByDar("ref4"))
         .thenReturn(Set.of(datasetSix.getDatasetId()));
 
     List<DarCollectionSummary> summaries = service.getSummariesForRole(user,
@@ -1063,7 +1063,7 @@ class DarCollectionServiceTest extends AbstractTestHelper {
 
     when(darCollectionSummaryDAO.getDarCollectionSummaryByCollectionId(collectionId))
         .thenReturn(summary);
-    when(dataAccessRequestDAO.findDatasetApprovalsByDars(List.of("ref1"))).thenReturn(Set.of());
+    when(dataAccessRequestDAO.findDatasetApprovalsByDar("ref1")).thenReturn(Set.of());
 
     DarCollectionSummary summaryResult = service.getSummaryForRoleByCollectionId(user,
         UserRoles.RESEARCHER, collectionId);
@@ -1111,7 +1111,7 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     when(darCollectionSummaryDAO.getDarCollectionSummaryByCollectionId(collectionId))
         .thenReturn(summary);
 
-    when(dataAccessRequestDAO.findDatasetApprovalsByDars(List.of("ref1")))
+    when(dataAccessRequestDAO.findDatasetApprovalsByDar("ref1"))
         .thenReturn(Set.of(1));
 
     DarCollectionSummary summaryResult = service.getSummaryForRoleByCollectionId(user,

--- a/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
@@ -561,6 +561,7 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     summaryOne.addElection(electionOne);
     summaryOne.addDatasetId(datasetOne.getDatasetId());
     summaryOne.addDatasetId(datasetTwo.getDatasetId());
+    summaryOne.setLatestReferenceId("ref1");
 
     DarCollectionSummary summaryTwo = new DarCollectionSummary();
     Dataset datasetThree = new Dataset();
@@ -569,12 +570,14 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     datasetFour.setDatasetId(4);
     summaryTwo.addDatasetId(datasetThree.getDatasetId());
     summaryTwo.addDatasetId(datasetFour.getDatasetId());
+    summaryTwo.setLatestReferenceId("ref1");
 
     DarCollectionSummary summaryThree = new DarCollectionSummary();
     Dataset datasetFive = new Dataset();
     datasetFive.setDatasetId(5);
     summaryThree.addDatasetId(datasetFive.getDatasetId());
     summaryThree.addStatus(DarStatus.CANCELED.getValue(), randomAlphabetic(3));
+    summaryThree.setLatestReferenceId("ref1");
 
     DarCollectionSummary summaryFour = new DarCollectionSummary();
     Dataset datasetSix = new Dataset();
@@ -584,7 +587,7 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     electionOne.setElectionId(2);
     electionOne.setStatus(ElectionStatus.CLOSED.getValue());
     summaryFour.addElection(electionTwo);
-    summaryFour.setReferenceIds(Set.of("ref1"));
+    summaryFour.setLatestReferenceId("ref4");
 
     DarCollectionSummary summaryFive = new DarCollectionSummary();
     {
@@ -594,6 +597,7 @@ class DarCollectionServiceTest extends AbstractTestHelper {
       election.setElectionId(234);
       election.setStatus(ElectionStatus.OPEN.getValue());
       summaryFive.addElection(election);
+      summaryFive.setLatestReferenceId("ref1");
     }
 
     DataAccessRequest draft = new DataAccessRequest();
@@ -605,8 +609,8 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     when(dataAccessRequestDAO.findAllDraftsByUserId(any())).thenReturn(List.of(draft));
     when(darCollectionSummaryDAO.getDarCollectionSummariesForResearcher(any())).thenReturn(
         List.of(summaryOne, summaryTwo, summaryThree, summaryFour, summaryFive));
-    when(dataAccessRequestDAO.findDatasetApprovalsByDars(List.of())).thenReturn(Set.of());
-    when(dataAccessRequestDAO.findDatasetApprovalsByDars(List.of("ref1")))
+    when(dataAccessRequestDAO.findDatasetApprovalsByDars(List.of("ref1"))).thenReturn(Set.of());
+    when(dataAccessRequestDAO.findDatasetApprovalsByDars(List.of("ref4")))
         .thenReturn(Set.of(datasetSix.getDatasetId()));
 
     List<DarCollectionSummary> summaries = service.getSummariesForRole(user,
@@ -1054,10 +1058,12 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     user.setUserId(1);
 
     DarCollectionSummary summary = createDarCollectionSummaryWithElections();
+    summary.setLatestReferenceId("ref1");
     Integer collectionId = summary.getDarCollectionId();
 
     when(darCollectionSummaryDAO.getDarCollectionSummaryByCollectionId(collectionId))
         .thenReturn(summary);
+    when(dataAccessRequestDAO.findDatasetApprovalsByDars(List.of("ref1"))).thenReturn(Set.of());
 
     DarCollectionSummary summaryResult = service.getSummaryForRoleByCollectionId(user,
         UserRoles.RESEARCHER, collectionId);
@@ -1099,7 +1105,7 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     user.setUserId(1);
 
     DarCollectionSummary summary = createDarCollectionSummaryWithElections();
-    summary.setReferenceIds(Set.of("ref1"));
+    summary.setLatestReferenceId("ref1");
     Integer collectionId = summary.getDarCollectionId();
 
     when(darCollectionSummaryDAO.getDarCollectionSummaryByCollectionId(collectionId))

--- a/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
@@ -230,7 +230,7 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     user.setEraCommonsId("eraCommonsId");
     parentDar.setUserId(user.getUserId());
     when(dataAccessRequestDAO.findByReferenceId(progressReport.getReferenceId())).thenReturn(progressReport);
-    when(dataAccessRequestDAO.findDatasetApprovalsByDars(List.of(parentDar.getReferenceId()))).thenReturn(
+    when(dataAccessRequestDAO.findDatasetApprovalsByDar(parentDar.getReferenceId())).thenReturn(
         Set.copyOf(progressReport.getDatasetIds()));
 
     initService();
@@ -254,7 +254,7 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     User user = new User(1, "email@test.org", "Display Name", new Date());
     user.setLibraryCards(List.of(new LibraryCard()));
     parentDar.setUserId(user.getUserId());
-    when(dataAccessRequestDAO.findDatasetApprovalsByDars(List.of(parentDar.getReferenceId()))).thenReturn(Set.of());
+    when(dataAccessRequestDAO.findDatasetApprovalsByDar(parentDar.getReferenceId())).thenReturn(Set.of());
     initService();
     assertThrows(BadRequestException.class, () -> service.createProgressReport(user, progressReport, parentDar));
   }

--- a/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
@@ -566,10 +566,8 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
   @Test
   void testInsertDraftDataAccessRequestFailure() {
     initService();
-    assertThrows(IllegalArgumentException.class, () -> {
-      DataAccessRequest dar = service.insertDraftDataAccessRequest(null, null);
-      assertNotNull(dar);
-    });
+    assertThrows(IllegalArgumentException.class, () ->
+        service.insertDraftDataAccessRequest(null, null));
   }
 
   private DataAccessRequest generateProgressReport() {


### PR DESCRIPTION
### Addresses

The previous code included the action if any DAR in the collection had approved datasets, now that we are assuming chaining of PRs (and not branching) this needs to be changed to only include the action if the latest DAR in the collection has approved datasets. The work that this modifies was originally done here: https://github.com/DataBiosphere/consent/pull/2520

### Summary

Adds a new field on the summary that stores the latest DAR referenceId. This field was already being selected in the query, so only an update to the reducer was required to set the field.
Update DAO test to check for latest reference Id
In the collectionService, instead of checking for approvals of all DARs in the collection, only check for approvals for the latest DAR in the collection.
TO DO: update collectionService test


----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
