### PR TITLE
DT-1627: Prevent the creation of "sibling" progress reports

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequest.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequest.java
@@ -47,7 +47,7 @@ public class DataAccessRequest {
   public String darCode;
 
   @JsonProperty
-  public boolean draft = true;
+  public Boolean draft = true;
 
   @JsonProperty
   public Boolean progressReport = false;

--- a/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequest.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequest.java
@@ -47,7 +47,7 @@ public class DataAccessRequest {
   public String darCode;
 
   @JsonProperty
-  public Boolean draft = true;
+  public boolean draft = true;
 
   @JsonProperty
   public Boolean progressReport = false;

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
@@ -34,6 +34,7 @@ import org.broadinstitute.consent.http.models.LibraryCard;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.service.dao.DataAccessRequestServiceDAO;
 import org.broadinstitute.consent.http.util.ConsentLogger;
+import org.jdbi.v3.core.JdbiException;
 import org.jdbi.v3.core.statement.UnableToExecuteStatementException;
 
 public class DataAccessRequestService implements ConsentLogger {
@@ -235,12 +236,17 @@ public class DataAccessRequestService implements ConsentLogger {
     if (!darDatasetIds.containsAll(progressReportDatasetIds)) {
       throw new BadRequestException("Progress report can only be created for approved datasets in the parent DAR");
     }
-    dataAccessRequestDAO.insertProgressReport(
+    try {
+      dataAccessRequestDAO.insertProgressReport(
           Integer.valueOf(progressReport.getParentId()),
           progressReport.getCollectionId(),
           referenceId,
           user.getUserId(),
           progressReport.getData());
+    } catch (JdbiException e) {
+      throw new BadRequestException(
+          "Unable to create progress report for Data Access Request " + parentDar.getReferenceId());
+    }
     syncDataAccessRequestDatasets(progressReportDatasetIds, referenceId);
     return findByReferenceId(referenceId);
   }

--- a/src/main/resources/changelog-master.xml
+++ b/src/main/resources/changelog-master.xml
@@ -176,4 +176,6 @@
     relativeToChangelogFile="true" />
   <include file="changesets/changelog-consent-2025-05-08-rm-old-user-props.xml"
     relativeToChangelogFile="true" />
+  <include file="changesets/changelog-consent-2025-05-16-disallow-pr-siblings.xml"
+    relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/src/main/resources/changesets/changelog-consent-2025-05-16-disallow-pr-siblings.xml
+++ b/src/main/resources/changesets/changelog-consent-2025-05-16-disallow-pr-siblings.xml
@@ -1,0 +1,8 @@
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+  <changeSet id="changelog-consent-2025-05-16-disallow-pr-siblings" author="pshapiro">
+    <addUniqueConstraint tableName="data_access_request" columnNames="parent_id"
+                         constraintName="uk_parent_id" />
+  </changeSet>
+</databaseChangeLog>

--- a/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.sql.Timestamp;
@@ -34,6 +35,7 @@ import org.broadinstitute.consent.http.models.DatasetProperty;
 import org.broadinstitute.consent.http.models.Election;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.Vote;
+import org.jdbi.v3.core.JdbiException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -966,6 +968,24 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
     assertNotNull(progressReport.getUpdateDate());
     assertNotEquals(dar.getReferenceId(), progressReport.getReferenceId());
     assertTrue(progressReport.getProgressReport());
+  }
+
+  @Test
+  void insertProgressReport_WithExistingProgressReport() {
+    DarCollection darCollection = createDarCollection();
+    DataAccessRequest dar = darCollection.getDars().values().stream().findFirst().orElseThrow();
+    Integer userId = dar.getUserId();
+    Integer darCollectionId = darCollection.getDarCollectionId();
+    Integer id = dar.getId();
+    DataAccessRequest progressReport = createProgressReport(userId, darCollectionId, id);
+    assertNotNull(progressReport);
+
+    // Insert of second progress report should fail.
+    assertThrows(JdbiException.class, () -> createProgressReport(userId, darCollectionId, id));
+
+    // Check that the first progress report is not updated.
+    DataAccessRequest firstProgressReport = dataAccessRequestDAO.findByReferenceId(progressReport.getReferenceId());
+    assertEquals(progressReport.id, firstProgressReport.id);
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
@@ -32,8 +32,6 @@ import java.util.List;
 import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
-import org.apache.commons.lang3.RandomStringUtils;
-import org.apache.commons.lang3.RandomUtils;
 import org.broadinstitute.consent.http.AbstractTestHelper;
 import org.broadinstitute.consent.http.configurations.ConsentConfiguration;
 import org.broadinstitute.consent.http.db.DAOContainer;
@@ -271,15 +269,14 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
   void createProgressReportFailsIfDAOOperationFails() {
     DataAccessRequest parentDar = generateDataAccessRequest();
     DataAccessRequest progressReport = generateProgressReport();
-    progressReport.setParentId(parentDar.getId().toString());
+    progressReport.setParentId(parentDar.getId());
     progressReport.setCollectionId(parentDar.getCollectionId());
     parentDar.setSubmissionDate(Timestamp.from(Instant.now()));
-    User user = new User(1, "email@test.org", "Display Name", new Date());
-    user.setLibraryCards(List.of(new LibraryCard()));
-    user.setEraCommonsId("eraCommonsId");
+    User user = createUserWithPrerequisites();
     parentDar.setUserId(user.getUserId());
     when(dataAccessRequestDAO.findDatasetApprovalsByDars(List.of(parentDar.getReferenceId()))).thenReturn(
         Set.copyOf(progressReport.getDatasetIds()));
+    when(institutionService.findInstitutionForEmail(any())).thenReturn(user.getInstitution());
     doThrow(new UnableToExecuteStatementException("Test exception"))
         .when(dataAccessRequestDAO)
         .insertProgressReport(
@@ -987,24 +984,24 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
   @Test
   void testSendReminderMessage() throws TemplateException, IOException {
     Election election = new Election();
-    election.setElectionId(RandomUtils.nextInt());
+    election.setElectionId(randomInt(0, 100));
     election.setReferenceId(UUID.randomUUID().toString());
     election.setElectionType(ElectionType.DATA_ACCESS.getValue());
     when(electionDAO.findElectionWithFinalVoteById(any())).thenReturn(election);
 
     Vote vote = new Vote();
-    vote.setVoteId(RandomUtils.nextInt());
+    vote.setVoteId(randomInt(0, 100));
     vote.setElectionId(election.getElectionId());
     when(voteDAO.findVoteById(any())).thenReturn(vote);
 
     DarCollection collection = new DarCollection();
-    collection.setDarCollectionId(RandomUtils.nextInt());
+    collection.setDarCollectionId(randomInt(0, 100));
     collection.setDarCode("DAR-12345");
     when(darCollectionDAO.findDARCollectionByReferenceId(any())).thenReturn(collection);
 
     User user = new User();
-    user.setDisplayName(RandomStringUtils.randomAlphanumeric(10));
-    user.setEmail(RandomStringUtils.randomAlphanumeric(10));
+    user.setDisplayName(randomAlphanumeric(10));
+    user.setEmail(randomAlphanumeric(10));
     when(userDAO.findUserById(any())).thenReturn(user);
 
     initService();

--- a/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
@@ -51,6 +51,8 @@ import org.broadinstitute.consent.http.models.LibraryCard;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.UserRole;
 import org.broadinstitute.consent.http.service.dao.DataAccessRequestServiceDAO;
+import org.jdbi.v3.core.statement.UnableToExecuteStatementException;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentMatcher;
@@ -107,7 +109,8 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     return dar;
   }
 
-  private void initService() {
+  @BeforeEach
+  void initService() {
     DAOContainer container = new DAOContainer();
     container.setDataAccessRequestDAO(dataAccessRequestDAO);
     container.setDarCollectionDAO(darCollectionDAO);
@@ -134,7 +137,6 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     when(dataAccessRequestDAO.findByReferenceId(any())).thenReturn(dar);
     doNothing().when(dataAccessRequestDAO)
         .updateDataByReferenceId(any(), any(), any(), any(), any(), any(), any());
-    initService();
     DataAccessRequest newDar = service.createDataAccessRequest(user, dar);
     assertNotNull(newDar);
   }
@@ -157,7 +159,6 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     doNothing().when(dataAccessRequestDAO)
         .insertDataAccessRequest(anyInt(), anyString(), anyInt(), any(Date.class), any(Date.class),
             any(Date.class), any(Date.class), any(DataAccessRequestData.class), anyString());
-    initService();
     DataAccessRequest newDar = service.createDataAccessRequest(user, dar);
     assertNotNull(newDar);
   }
@@ -174,7 +175,6 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     user.setLibraryCards(List.of(new LibraryCard()));
     user.setEraCommonsId("eraCommonsId");
     when(dataAccessRequestDAO.findByReferenceId(any())).thenReturn(dar);
-    initService();
     assertThrows(SubmittedDARCannotBeEditedException.class,
         () -> service.createDataAccessRequest(user, dar));
   }
@@ -186,7 +186,6 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     user.setLibraryCards(List.of(new LibraryCard()));
     user.setEraCommonsId("eraCommonsId");
     doThrow(BadRequestException.class).when(userService).hasValidActiveERACredentials(user);
-    initService();
     assertThrows(BadRequestException.class, () -> service.createDataAccessRequest(user, dar));
   }
 
@@ -198,7 +197,6 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     User user = new User(1, "email@test.org", "Display Name", new Date());
     dar.addDatasetIds(List.of(1, 2, 3));
     dar.setSubmissionDate(Timestamp.from(Instant.now()));
-    initService();
     assertThrows(SubmittedDARCannotBeEditedException.class, () ->
         service.updateByReferenceId(user, dar)
     );
@@ -213,7 +211,6 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     dar.setReferenceId("id");
     User user = new User(1, "email@test.org", "Display Name", new Date());
     user.setLibraryCards(List.of());
-    initService();
     assertThrows(NIHComplianceRuleException.class,
         () -> service.createDataAccessRequest(user, dar));
   }
@@ -233,7 +230,6 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     when(dataAccessRequestDAO.findDatasetApprovalsByDars(List.of(parentDar.getReferenceId()))).thenReturn(
         Set.copyOf(progressReport.getDatasetIds()));
 
-    initService();
     DataAccessRequest newDar = service.createProgressReport(user, progressReport, parentDar);
     assertNotNull(newDar);
     verify(dataAccessRequestDAO)
@@ -255,7 +251,30 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     user.setLibraryCards(List.of(new LibraryCard()));
     parentDar.setUserId(user.getUserId());
     when(dataAccessRequestDAO.findDatasetApprovalsByDars(List.of(parentDar.getReferenceId()))).thenReturn(Set.of());
-    initService();
+    assertThrows(BadRequestException.class, () -> service.createProgressReport(user, progressReport, parentDar));
+  }
+
+  @Test
+  void createProgressReportFailsIfDAOOperationFails() {
+    DataAccessRequest parentDar = generateDataAccessRequest();
+    DataAccessRequest progressReport = generateProgressReport();
+    progressReport.setParentId(parentDar.getId().toString());
+    progressReport.setCollectionId(parentDar.getCollectionId());
+    parentDar.setSubmissionDate(Timestamp.from(Instant.now()));
+    User user = new User(1, "email@test.org", "Display Name", new Date());
+    user.setLibraryCards(List.of(new LibraryCard()));
+    user.setEraCommonsId("eraCommonsId");
+    parentDar.setUserId(user.getUserId());
+    when(dataAccessRequestDAO.findDatasetApprovalsByDars(List.of(parentDar.getReferenceId()))).thenReturn(
+        Set.copyOf(progressReport.getDatasetIds()));
+    doThrow(new UnableToExecuteStatementException("Test exception"))
+        .when(dataAccessRequestDAO)
+        .insertProgressReport(
+            parentDar.getId(),
+            parentDar.getCollectionId(),
+            progressReport.referenceId,
+            user.getUserId(),
+            progressReport.data);
     assertThrows(BadRequestException.class, () -> service.createProgressReport(user, progressReport, parentDar));
   }
 
@@ -295,7 +314,6 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     user.setEraCommonsId("eraCommonsId");
     DataAccessRequest progressReport = generateProgressReport();
     DataAccessRequest parentDar = generateDataAccessRequest();
-    initService();
     assertThrows(BadRequestException.class,
         () -> service.validateProgressReport(user, progressReport, parentDar));
   }
@@ -310,7 +328,6 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     DataAccessRequest parentDar = generateDataAccessRequest();
     parentDar.setSubmissionDate(Timestamp.from(Instant.now()));
     parentDar.setUserId(user.getUserId());
-    initService();
     assertThrows(BadRequestException.class,
         () -> service.validateProgressReport(user, progressReport, parentDar));
   }
@@ -325,7 +342,6 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     DataAccessRequest parentDar = generateDataAccessRequest();
     parentDar.setSubmissionDate(Timestamp.from(Instant.now()));
     parentDar.setUserId(user.getUserId());
-    initService();
     assertThrows(BadRequestException.class,
         () -> service.validateProgressReport(user, progressReport, parentDar));
   }
@@ -340,7 +356,6 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     DataAccessRequest parentDar = generateDataAccessRequest();
     parentDar.setSubmissionDate(Timestamp.from(Instant.now()));
     parentDar.setUserId(user.getUserId());
-    initService();
     assertThrows(BadRequestException.class,
         () -> service.validateProgressReport(user, progressReport, parentDar));
   }
@@ -356,7 +371,6 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     parentDar.setSubmissionDate(Timestamp.from(Instant.now()));
     parentDar.setDatasetIds(List.of(1, 2, 3));
     parentDar.setUserId(user.getUserId());
-    initService();
     assertThrows(BadRequestException.class,
         () -> service.validateProgressReport(user, progressReport, parentDar));
   }
@@ -372,21 +386,18 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     parentDar.setSubmissionDate(Timestamp.from(Instant.now()));
     parentDar.setDatasetIds(List.of(1, 2, 3));
     parentDar.setUserId(user.getUserId());
-    initService();
     assertDoesNotThrow(() -> service.validateProgressReport(user, progressReport, parentDar));
   }
 
   @Test
   void validateDarNullUser() {
     DataAccessRequest dar = generateDataAccessRequest();
-    initService();
     assertThrows(IllegalArgumentException.class, () -> service.validateDar(null, dar));
   }
 
   @Test
   void validateDarNullDar() {
     User user = new User(1, "email@test.org", "Display Name", new Date());
-    initService();
     assertThrows(IllegalArgumentException.class, () -> service.validateDar(user, null));
   }
 
@@ -395,7 +406,6 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     DataAccessRequest dar = generateDataAccessRequest();
     dar.setReferenceId(null);
     User user = new User(1, "email@test.org", "Display Name", new Date());
-    initService();
     assertThrows(IllegalArgumentException.class, () -> service.validateDar(user, dar));
   }
 
@@ -404,7 +414,6 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     DataAccessRequest dar = generateDataAccessRequest();
     dar.setData(null);
     User user = new User(1, "email@test.org", "Display Name", new Date());
-    initService();
     assertThrows(IllegalArgumentException.class, () -> service.validateDar(user, dar));
   }
 
@@ -413,7 +422,6 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     DataAccessRequest dar = generateDataAccessRequest();
     User user = new User(1, "email@test.org", "Display Name", new Date());
     user.setLibraryCards(Collections.emptyList());
-    initService();
     assertThrows(NIHComplianceRuleException.class, () -> service.validateDar(user, dar));
   }
 
@@ -423,7 +431,6 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     User user = new User(1, "email@test.org", "Display Name", new Date());
     user.setLibraryCards(List.of(new LibraryCard()));
     user.setEraCommonsId("eraCommonsId");
-    initService();
     assertDoesNotThrow(() -> service.validateDar(user, dar));
   }
 
@@ -431,7 +438,6 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
   void testValidateInternalCollaboratorsNone() {
     User requestingUser = createRequestingUser();
     DataAccessRequest dar = createDataAccessRequest(List.of());
-    initService();
     assertDoesNotThrow(() -> service.validateInternalCollaborators(dar, requestingUser));
   }
 
@@ -448,7 +454,6 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     DataAccessRequest dar = createDataAccessRequest(List.of(validCollaborator));
     when(userDAO.findUserByEmail(validCollaborator.getEmail())).thenReturn(collaboratorUser);
 
-    initService();
     assertDoesNotThrow(() -> service.validateInternalCollaborators(dar, requestingUser));
   }
 
@@ -459,7 +464,6 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     DataAccessRequest dar = createDataAccessRequest(List.of(invalidCollaborator));
     when(userDAO.findUserByEmail(invalidCollaborator.getEmail())).thenReturn(null);
 
-    initService();
     NotFoundException exception = assertThrows(NotFoundException.class, () ->
         service.validateInternalCollaborators(dar, requestingUser));
     assertEquals(exception.getMessage(),
@@ -476,7 +480,6 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     DataAccessRequest dar = createDataAccessRequest(List.of(invalidCollaborator));
     when(userDAO.findUserByEmail(invalidCollaborator.getEmail())).thenReturn(collaboratorUser);
 
-    initService();
     BadRequestException exception = assertThrows(BadRequestException.class, () ->
         service.validateInternalCollaborators(dar, requestingUser)
     );
@@ -495,7 +498,6 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     DataAccessRequest dar = createDataAccessRequest(List.of(invalidCollaborator));
     when(userDAO.findUserByEmail(invalidCollaborator.getEmail())).thenReturn(collaboratorUser);
 
-    initService();
     BadRequestException exception = assertThrows(BadRequestException.class, () ->
         service.validateInternalCollaborators(dar, requestingUser)
     );
@@ -510,7 +512,6 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     User user = new User(1, "email@test.org", "Display Name", new Date());
     dar.addDatasetIds(List.of(1, 2, 3));
     when(dataAccessRequestServiceDAO.updateByReferenceId(any(), any())).thenReturn(dar);
-    initService();
     DataAccessRequest newDar = service.updateByReferenceId(user, dar);
     assertNotNull(newDar);
   }
@@ -521,7 +522,6 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     User user = new User(1, "email@test.org", "Display Name", new Date());
     dar.addDatasetIds(List.of(1, 2, 3));
     when(dataAccessRequestServiceDAO.updateByReferenceId(user, dar)).thenReturn(dar);
-    initService();
     DataAccessRequest newDar = service.updateByReferenceId(user, dar);
     assertNotNull(newDar);
   }
@@ -543,7 +543,6 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     when(dataAccessRequestDAO
         .findApprovedDARsByDatasetId(d.getDatasetId()))
         .thenReturn(List.of(dar1, dar2));
-    initService();
 
     assertEquals(List.of(dar1, dar2), service.getApprovedDARsForDataset(d));
   }
@@ -558,18 +557,13 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
         .when(dataAccessRequestDAO)
         .insertDraftDataAccessRequest(any(), any(), any(), any(), any(), any());
     when(dataAccessRequestDAO.findByReferenceId(any())).thenReturn(draft);
-    initService();
     DataAccessRequest dar = service.insertDraftDataAccessRequest(user, draft);
     assertNotNull(dar);
   }
 
   @Test
   void testInsertDraftDataAccessRequestFailure() {
-    initService();
-    assertThrows(IllegalArgumentException.class, () -> {
-      DataAccessRequest dar = service.insertDraftDataAccessRequest(null, null);
-      assertNotNull(dar);
-    });
+    assertThrows(IllegalArgumentException.class, () -> service.insertDraftDataAccessRequest(null, null));
   }
 
   private DataAccessRequest generateProgressReport() {
@@ -623,7 +617,6 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
   void testFindAllDraftDataAccessRequests() {
     when(dataAccessRequestDAO.findAllDraftDataAccessRequests()).thenReturn(
         List.of(new DataAccessRequest()));
-    initService();
     List<DataAccessRequest> drafts = service.findAllDraftDataAccessRequests();
     assertEquals(1, drafts.size());
   }
@@ -632,7 +625,6 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
   void testFindAllDraftDataAccessRequestsByUser() {
     when(dataAccessRequestDAO.findAllDraftsByUserId(any())).thenReturn(
         List.of(new DataAccessRequest()));
-    initService();
     List<DataAccessRequest> drafts = service.findAllDraftDataAccessRequestsByUser(1);
     assertEquals(1, drafts.size());
   }
@@ -642,14 +634,12 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     List<DataAccessRequest> dars = List.of(new DataAccessRequest());
     when(dataAccessRequestDAO.findAllDataAccessRequests()).thenReturn(dars);
     when(dacService.filterDataAccessRequestsByDac(eq(dars), any())).thenReturn(dars);
-    initService();
     List<DataAccessRequest> foundDars = service.getDataAccessRequestsByUserRole(new User());
     assertEquals(1, foundDars.size());
   }
 
   @Test
   void testFindByReferenceId() {
-    initService();
     DataAccessRequest dar = new DataAccessRequest();
     when(dataAccessRequestDAO.findByReferenceId(any())).thenReturn(dar);
     DataAccessRequest foundDar = service.findByReferenceId("refId");
@@ -658,7 +648,6 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
 
   @Test
   void testFindByReferenceId_NotFound() {
-    initService();
     when(dataAccessRequestDAO.findByReferenceId(any())).thenThrow(new NotFoundException());
     assertThrows(NotFoundException.class, () -> service.findByReferenceId("referenceId"));
   }
@@ -675,7 +664,6 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     doNothing().when(voteDAO).deleteVotesByReferenceId(any());
     doNothing().when(matchDAO).deleteMatchesByPurposeId(any());
     doNothing().when(dataAccessRequestDAO).deleteByReferenceId(any());
-    initService();
 
     try {
       service.deleteByReferenceId(adminUser, referenceId);
@@ -693,7 +681,6 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     doNothing().when(matchDAO).deleteMatchesByPurposeId(any());
     doNothing().when(dataAccessRequestDAO).deleteByReferenceId(any());
     doNothing().when(dataAccessRequestDAO).deleteDARDatasetRelationByReferenceId(any());
-    initService();
 
     assertDoesNotThrow(() -> service.deleteByReferenceId(user, referenceId));
   }
@@ -707,7 +694,6 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     election.setElectionId(1);
     election.setReferenceId(referenceId);
     when(electionDAO.findElectionsByReferenceId(any())).thenReturn(List.of(election));
-    initService();
 
     assertThrows(NotAcceptableException.class,
         () -> service.deleteByReferenceId(user, referenceId));
@@ -719,7 +705,6 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     data.setPiEmail(PI_EMAIL);
     data.setItDirectorEmail(IT_EMAIL);
     data.setSigningOfficialEmail(SO_EMAIL);
-    initService();
     try {
       service.validateNoKeyPersonnelDuplicates(data);
     } catch (IllegalArgumentException e) {
@@ -733,7 +718,6 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     data.setPiEmail("invalid");
     data.setItDirectorEmail(IT_EMAIL);
     data.setSigningOfficialEmail(SO_EMAIL);
-    initService();
     assertThrows(IllegalArgumentException.class,
         () -> service.validateNoKeyPersonnelDuplicates(data));
   }
@@ -744,7 +728,6 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     data.setPiEmail(PI_EMAIL);
     data.setItDirectorEmail("invalid");
     data.setSigningOfficialEmail(SO_EMAIL);
-    initService();
     assertThrows(IllegalArgumentException.class,
         () -> service.validateNoKeyPersonnelDuplicates(data));
   }
@@ -755,7 +738,6 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     data.setPiEmail(PI_EMAIL);
     data.setItDirectorEmail(IT_EMAIL);
     data.setSigningOfficialEmail("invalid");
-    initService();
     assertThrows(IllegalArgumentException.class,
         () -> service.validateNoKeyPersonnelDuplicates(data));
   }
@@ -766,7 +748,6 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     data.setPiEmail(PI_EMAIL);
     data.setItDirectorEmail(PI_EMAIL);
     data.setSigningOfficialEmail(SO_EMAIL);
-    initService();
     assertThrows(IllegalArgumentException.class,
         () -> service.validateNoKeyPersonnelDuplicates(data));
   }
@@ -777,7 +758,6 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     data.setPiEmail(PI_EMAIL);
     data.setItDirectorEmail(IT_EMAIL);
     data.setSigningOfficialEmail(PI_EMAIL);
-    initService();
     assertThrows(IllegalArgumentException.class,
         () -> service.validateNoKeyPersonnelDuplicates(data));
   }


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DT-1627

### Addresses

Until we add support for "branching" progress reports, we disallow creating more than one progress report for a single data access request.

### Summary

To prevent multiple progress reports for a single data access request, make the parent ID for a data access request a unique key. Trying to insert another progress report results in a JDBI exception, which is caught and converted into a 400 client error (HTTP BAD_REQUEST).

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
