### PR TITLE
DT-1680: Fix deletion of LCs with no active DUOS user.

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/resources/LibraryCardResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/LibraryCardResource.java
@@ -127,7 +127,7 @@ public class LibraryCardResource extends Resource {
     }
     try {
       // If user is not an admin and SO institutionID doesn't match the user's throw an exception
-      if (lcUser != null && !checkIsAdmin(user) && !lcUser.getInstitutionId().equals(user.getInstitutionId())) {
+      if (lcUser != null && !checkIsAdmin(user) && !lcUser.getInstitution().equals(user.getInstitution())) {
         throw new ForbiddenException("You are not authorized to delete this library card");
       }
       libraryCardService.deleteLibraryCardById(id);

--- a/src/main/java/org/broadinstitute/consent/http/resources/LibraryCardResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/LibraryCardResource.java
@@ -8,6 +8,7 @@ import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.ForbiddenException;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.PUT;
 import jakarta.ws.rs.Path;
@@ -118,10 +119,15 @@ public class LibraryCardResource extends Resource {
   public Response deleteLibraryCard(@Auth AuthUser authUser, @PathParam("id") Integer id) {
     User user = userService.findUserByEmail(authUser.getEmail());
     LibraryCard card = libraryCardService.findLibraryCardById(id);
-    User lcUser = userService.findUserById(card.getUserId());
+    User lcUser = null;
+    try {
+      lcUser = userService.findUserById(card.getUserId());
+    } catch (NotFoundException nfe) {
+      // LC User can be null - do not need to error here
+    }
     try {
       // If user is not an admin and SO institutionID doesn't match the user's throw an exception
-      if (!checkIsAdmin(user) && !lcUser.getInstitutionId().equals(user.getInstitutionId())) {
+      if (lcUser != null && !checkIsAdmin(user) && !lcUser.getInstitutionId().equals(user.getInstitutionId())) {
         throw new ForbiddenException("You are not authorized to delete this library card");
       }
       libraryCardService.deleteLibraryCardById(id);

--- a/src/test/java/org/broadinstitute/consent/http/resources/LibraryCardResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/LibraryCardResourceTest.java
@@ -257,6 +257,19 @@ class LibraryCardResourceTest {
   }
 
   @Test
+  void deleteLibraryCardUserNotFound() {
+    LibraryCard card = mockLibraryCardSetup();
+    card.setUserId(null);
+    when(userService.findUserByEmail(user.getEmail())).thenReturn(user);
+    when(userService.findUserById(null)).thenThrow(new NotFoundException());
+    when(libraryCardService.findLibraryCardById(anyInt())).thenReturn(card);
+    initResource();
+
+    Response response = resource.deleteLibraryCard(authUser, 1);
+    assertEquals(HttpStatusCodes.STATUS_CODE_NO_CONTENT, response.getStatus());
+  }
+
+  @Test
   void deleteLibraryCardThrowsForbiddenException() {
     LibraryCard card = mockLibraryCardSetup();
     User soUser = mockSOUser();

--- a/src/test/java/org/broadinstitute/consent/http/resources/LibraryCardResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/LibraryCardResourceTest.java
@@ -18,6 +18,7 @@ import java.util.Date;
 import java.util.List;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.AuthUser;
+import org.broadinstitute.consent.http.models.Institution;
 import org.broadinstitute.consent.http.models.LibraryCard;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.UserRole;
@@ -278,9 +279,15 @@ class LibraryCardResourceTest {
   void deleteLibraryCardThrowsForbiddenException() {
     LibraryCard card = mockLibraryCardSetup();
     User soUser = mockSOUser();
-    soUser.setInstitutionId(1);
+    Institution soInstitution = new Institution();
+    soInstitution.setId(1);
+    soUser.setInstitution(soInstitution);
+    soUser.setInstitutionId(soInstitution.getId());
     // Mocks that the user is in a different institution than the SO
-    lcUser.setInstitutionId(2);
+    Institution lcUserInstitution = new Institution();
+    lcUserInstitution.setId(2);
+    lcUser.setInstitution(lcUserInstitution);
+    lcUser.setInstitutionId(lcUserInstitution.getId());
 
     when(userService.findUserByEmail(anyString())).thenReturn(soUser);
     when(libraryCardService.findLibraryCardById(anyInt())).thenReturn(card);

--- a/src/test/java/org/broadinstitute/consent/http/resources/LibraryCardResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/LibraryCardResourceTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.api.client.http.HttpStatusCodes;
@@ -236,12 +237,29 @@ class LibraryCardResourceTest {
   @Test
   void deleteLibraryCard() {
     LibraryCard card = mockLibraryCardSetup();
+    card.setId(1);
     when(userService.findUserByEmail(anyString())).thenReturn(user);
     when(libraryCardService.findLibraryCardById(anyInt())).thenReturn(card);
     initResource();
 
-    Response response = resource.deleteLibraryCard(authUser, 1);
+    Response response = resource.deleteLibraryCard(authUser, card.getId());
     assertEquals(HttpStatusCodes.STATUS_CODE_NO_CONTENT, response.getStatus());
+    verify(libraryCardService).deleteLibraryCardById(card.getId());
+  }
+
+  @Test
+  void deleteLibraryCardUserNotFound() {
+    LibraryCard card = mockLibraryCardSetup();
+    card.setId(1);
+    card.setUserId(null);
+    when(userService.findUserByEmail(user.getEmail())).thenReturn(user);
+    when(userService.findUserById(null)).thenThrow(new NotFoundException());
+    when(libraryCardService.findLibraryCardById(anyInt())).thenReturn(card);
+    initResource();
+
+    Response response = resource.deleteLibraryCard(authUser, card.getId());
+    assertEquals(HttpStatusCodes.STATUS_CODE_NO_CONTENT, response.getStatus());
+    verify(libraryCardService).deleteLibraryCardById(card.getId());
   }
 
   @Test
@@ -254,19 +272,6 @@ class LibraryCardResourceTest {
 
     Response response = resource.deleteLibraryCard(authUser, 1);
     assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
-  }
-
-  @Test
-  void deleteLibraryCardUserNotFound() {
-    LibraryCard card = mockLibraryCardSetup();
-    card.setUserId(null);
-    when(userService.findUserByEmail(user.getEmail())).thenReturn(user);
-    when(userService.findUserById(null)).thenThrow(new NotFoundException());
-    when(libraryCardService.findLibraryCardById(anyInt())).thenReturn(card);
-    initResource();
-
-    Response response = resource.deleteLibraryCard(authUser, 1);
-    assertEquals(HttpStatusCodes.STATUS_CODE_NO_CONTENT, response.getStatus());
   }
 
   @Test


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-1680

### Summary
Library Cards can be created for users that do not exist in the system yet, but the delete endpoint was explicitly expecting a user to exist. This bug was introduced with [this PR](https://github.com/DataBiosphere/consent/pull/2526)

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
