### PR TITLE
DT-1607 Implement truth table as check when we resolve user in request.

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/authentication/AuthorizationHelper.java
+++ b/src/main/java/org/broadinstitute/consent/http/authentication/AuthorizationHelper.java
@@ -49,8 +49,7 @@ public class AuthorizationHelper implements ConsentLogger {
       logWarn(String.format(
           "Reading oauth2 claim headers: email is null, auth user is incomplete. Aud: %s Name: %s",
           aud, name));
-    }
-    if (email != null) {
+    } else {
       User user = userService.findUserByEmail(email);
       if (user != null) {
         userService.enforceInstitutionAndLibraryCardTruthTable(user);

--- a/src/main/java/org/broadinstitute/consent/http/authentication/AuthorizationHelper.java
+++ b/src/main/java/org/broadinstitute/consent/http/authentication/AuthorizationHelper.java
@@ -50,9 +50,11 @@ public class AuthorizationHelper implements ConsentLogger {
           "Reading oauth2 claim headers: email is null, auth user is incomplete. Aud: %s Name: %s",
           aud, name));
     } else {
-      User user = userService.findUserByEmail(email);
-      if (user != null) {
+      try {
+        User user = userService.findUserByEmail(email);
         userService.enforceInstitutionAndLibraryCardTruthTable(user);
+      } catch (NotFoundException nfe) {
+        // nothing to do.  new user.
       }
     }
     return new AuthUser(token, email, name, aud);

--- a/src/main/java/org/broadinstitute/consent/http/authentication/AuthorizationHelper.java
+++ b/src/main/java/org/broadinstitute/consent/http/authentication/AuthorizationHelper.java
@@ -99,7 +99,6 @@ public class AuthorizationHelper implements ConsentLogger {
     boolean authorize = false;
     try {
       User user = userService.findUserByEmail(authUser.getEmail());
-      user = userService.enforceInstitutionAndLibraryCardTruthTable(user);
       return user.getRoles().stream().anyMatch(r -> r.getName().equalsIgnoreCase(role));
     } catch (NotFoundException e) {
       logWarn("User not found, authorization incomplete: %s".formatted(authUser.getEmail()));

--- a/src/main/java/org/broadinstitute/consent/http/authentication/AuthorizationHelper.java
+++ b/src/main/java/org/broadinstitute/consent/http/authentication/AuthorizationHelper.java
@@ -50,6 +50,12 @@ public class AuthorizationHelper implements ConsentLogger {
           "Reading oauth2 claim headers: email is null, auth user is incomplete. Aud: %s Name: %s",
           aud, name));
     }
+    if (email != null) {
+      User user = userService.findUserByEmail(email);
+      if (user != null) {
+        userService.enforceInstitutionAndLibraryCardTruthTable(user);
+      }
+    }
     return new AuthUser(token, email, name, aud);
   }
 
@@ -94,6 +100,7 @@ public class AuthorizationHelper implements ConsentLogger {
     boolean authorize = false;
     try {
       User user = userService.findUserByEmail(authUser.getEmail());
+      user = userService.enforceInstitutionAndLibraryCardTruthTable(user);
       return user.getRoles().stream().anyMatch(r -> r.getName().equalsIgnoreCase(role));
     } catch (NotFoundException e) {
       logWarn("User not found, authorization incomplete: %s".formatted(authUser.getEmail()));

--- a/src/main/java/org/broadinstitute/consent/http/service/DaaService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DaaService.java
@@ -166,8 +166,8 @@ public class DaaService implements ConsentLogger {
         DataAccessAgreement daa = findById(daaId);
         String daaName = daa.getFile().getFileName();
         User toUser = new User();
-        toUser.setEmail(signingOfficial.email);
-        toUser.setDisplayName(signingOfficial.displayName);
+        toUser.setEmail(signingOfficial.getEmail());
+        toUser.setDisplayName(signingOfficial.getDisplayName());
         emailService.sendDaaRequestMessage(toUser, user, daaName, daaId);
       }
     } catch (Exception e) {
@@ -183,19 +183,19 @@ public class DaaService implements ConsentLogger {
         String previousDaaName = daa.getFile().getFileName();
         List<SimplifiedUser> researchers = userService.getUsersByDaaId(daaId);
         List<SimplifiedUser> signingOfficials = researchers.stream()
-            .flatMap(researcher -> userService.findSOsByInstitutionId(researcher.institutionId).stream())
+            .flatMap(researcher -> userService.findSOsByInstitutionId(researcher.getInstitutionId()).stream())
             .distinct()
             .toList();
         User toUser = new User();
 
         for (SimplifiedUser researcher : researchers) {
-          toUser.setEmail(researcher.email);
-          toUser.setDisplayName(researcher.displayName);
+          toUser.setEmail(researcher.getEmail());
+          toUser.setDisplayName(researcher.getDisplayName());
           emailService.sendNewDAAUploadResearcherMessage(toUser, dacName, previousDaaName, newDaaName, user.getUserId());
         }
         for (SimplifiedUser signingOfficial : signingOfficials) {
-          toUser.setEmail(signingOfficial.email);
-          toUser.setDisplayName(signingOfficial.displayName);
+          toUser.setEmail(signingOfficial.getEmail());
+          toUser.setDisplayName(signingOfficial.getDisplayName());
           emailService.sendNewDAAUploadSOMessage(toUser, dacName, previousDaaName, newDaaName, user.getUserId());
         }
       }

--- a/src/main/java/org/broadinstitute/consent/http/service/InstitutionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/InstitutionService.java
@@ -8,7 +8,6 @@ import java.io.IOException;
 import java.util.Date;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 import org.broadinstitute.consent.http.cloudstore.GCSService;
 import org.broadinstitute.consent.http.db.InstitutionDAO;
 import org.broadinstitute.consent.http.db.UserDAO;
@@ -81,13 +80,13 @@ public class InstitutionService {
     institutionDAO.deleteInstitutionById(id);
   }
 
-  public Institution findInstitutionById(Integer id) {
+  public Institution findInstitutionById(Integer id) throws NotFoundException {
     Institution institution = institutionDAO.findInstitutionById(id);
     isInstitutionNull(institution);
 
     List<SimplifiedUser> signingOfficials = userDAO.getSOsByInstitution(id).stream()
         .map(SimplifiedUser::new)
-        .collect(Collectors.toList());
+        .toList();
     institution.setSigningOfficials(signingOfficials);
 
     return institution;

--- a/src/main/java/org/broadinstitute/consent/http/service/UserService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/UserService.java
@@ -454,6 +454,14 @@ public class UserService implements ConsentLogger {
     }
   }
 
+  /**
+   * Compliance method defined in
+   * <a href="https://broadworkbench.atlassian.net/browse/DT-1607">this ticket</a> that implements
+   * a truth table of rules in order to ensure Library Card and Institution matching rules are
+   * adhered to when authorizing users of the system.
+   * @param user the User being evaluated
+   * @return user with the Institution and Library Card rules applied
+   */
   public User enforceInstitutionAndLibraryCardTruthTable(User user) {
     Institution institutionFromEmail = institutionService.findInstitutionForEmail(user.getEmail());
     Institution institutionFromDatabase = null;

--- a/src/main/java/org/broadinstitute/consent/http/service/UserService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/UserService.java
@@ -3,6 +3,7 @@ package org.broadinstitute.consent.http.service;
 import static org.broadinstitute.consent.http.enumeration.UserFields.ERA_EXPIRATION_DATE;
 import static org.broadinstitute.consent.http.enumeration.UserFields.ERA_STATUS;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
@@ -15,7 +16,6 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -47,6 +47,7 @@ import org.broadinstitute.consent.http.service.dao.DraftServiceDAO;
 import org.broadinstitute.consent.http.service.dao.UserServiceDAO;
 import org.broadinstitute.consent.http.util.ConsentLogger;
 import org.broadinstitute.consent.http.util.gson.GsonUtil;
+import org.checkerframework.checker.nullness.qual.NonNull;
 
 public class UserService implements ConsentLogger {
 
@@ -122,7 +123,7 @@ public class UserService implements ConsentLogger {
       // Handle Roles
       if (Objects.nonNull(userUpdateFields.getUserRoleIds())) {
         List<Integer> currentRoleIds = userRoleDAO.findRolesByUserId(userId).stream()
-            .map(UserRole::getRoleId).collect(Collectors.toList());
+            .map(UserRole::getRoleId).toList();
         List<Integer> roleIdsToAdd = userUpdateFields.getRoleIdsToAdd(currentRoleIds);
         List<Integer> roleIdsToRemove = userUpdateFields.getRoleIdsToRemove(currentRoleIds);
         // Add the new role ids to the user
@@ -130,7 +131,7 @@ public class UserService implements ConsentLogger {
           List<UserRole> newRoles = roleIdsToAdd.stream()
               .map(id -> new UserRole(id,
                   Objects.requireNonNull(UserRoles.getUserRoleFromId(id)).getRoleName()))
-              .collect(Collectors.toList());
+              .toList();
           userRoleDAO.insertUserRoles(newRoles, userId);
         }
         // Remove the old role ids from the user
@@ -246,7 +247,7 @@ public class UserService implements ConsentLogger {
       throw new NotFoundException();
     }
     List<User> users = userDAO.getUsersWithCardsByDaaId(daaId);
-    return users.stream().map(SimplifiedUser::new).collect(Collectors.toList());
+    return users.stream().map(SimplifiedUser::new).toList();
   }
 
   public void deleteUserByEmail(String email) {
@@ -259,13 +260,13 @@ public class UserService implements ConsentLogger {
         findRolesByUserId(userId).
         stream().
         map(UserRole::getRoleId).
-        collect(Collectors.toList());
+        toList();
     if (!roleIds.isEmpty()) {
       userRoleDAO.removeUserRoles(userId, roleIds);
     }
     List<Vote> votes = voteDAO.findVotesByUserId(userId);
     if (!votes.isEmpty()) {
-      List<Integer> voteIds = votes.stream().map(Vote::getVoteId).collect(Collectors.toList());
+      List<Integer> voteIds = votes.stream().map(Vote::getVoteId).toList();
       voteDAO.removeVotesByIds(voteIds);
     }
     try {
@@ -298,7 +299,7 @@ public class UserService implements ConsentLogger {
     }
 
     List<User> users = userDAO.getSOsByInstitution(institutionId);
-    return users.stream().map(SimplifiedUser::new).collect(Collectors.toList());
+    return users.stream().map(SimplifiedUser::new).toList();
   }
 
   public List<User> findUsersByInstitutionId(Integer institutionId) {
@@ -381,15 +382,15 @@ public class UserService implements ConsentLogger {
     List<LibraryCard> libraryCards = libraryCardDAO.findAllLibraryCardsByUserEmail(user.getEmail());
 
     libraryCards
-        .forEach(lc -> {
+        .forEach(lc ->
           libraryCardDAO.updateLibraryCardById(
               lc.getId(),
               user.getUserId(),
               lc.getUserName(),
               lc.getUserEmail(),
               user.getUserId(),
-              new Date());
-        });
+              new Date())
+        );
   }
 
   public User findOrCreateUser(AuthUser authUser) throws Exception {
@@ -454,12 +455,127 @@ public class UserService implements ConsentLogger {
     }
   }
 
+  public User enforceInstitutionAndLibraryCardTruthTable(@NonNull User user) {
+    Institution institutionFromEmail = institutionService.findInstitutionForEmail(user.getEmail());
+    Institution institutionFromDatabase = null;
+    try {
+      institutionFromDatabase = institutionService.findInstitutionById(user.getInstitutionId());
+    } catch (NotFoundException nfe) {
+      // do nothing.
+    }
+
+    boolean hasInstitutionMatchingEmailDomain =
+        hasInstitutionMatchingEmailDomain(institutionFromEmail);
+    boolean hasLibraryCard = hasLibraryCard(user);
+    boolean hasAssignedInstitutionInDatabase = institutionFromDatabase != null;
+    boolean hasMatchingInstitutionInDatabase =
+        hasMatchingInstitutionInDatabase(institutionFromEmail, institutionFromDatabase);
+
+    // take action
+    // case 2
+    if (hasInstitutionMatchingEmailDomain
+        && hasLibraryCard
+        && hasAssignedInstitutionInDatabase
+        && !hasMatchingInstitutionInDatabase) {
+      return dropLCAndInstitutionForUser(user);
+    }
+
+    // case 4
+    if (hasInstitutionMatchingEmailDomain
+        && hasLibraryCard
+        && !hasAssignedInstitutionInDatabase
+        && !hasMatchingInstitutionInDatabase) {
+      updateInstitutionForUser(user, institutionFromEmail.getId());
+      return dropLibraryCardForUser(user);
+    }
+    // case 6
+    if (hasInstitutionMatchingEmailDomain
+        && !hasLibraryCard
+        && hasAssignedInstitutionInDatabase
+        && !hasMatchingInstitutionInDatabase) {
+      return updateInstitutionForUserAndReturnUpdatedUser(user, institutionFromEmail.getId());
+    }
+    // case 8
+    if (hasInstitutionMatchingEmailDomain
+        && !hasLibraryCard
+        && !hasAssignedInstitutionInDatabase
+        && !hasMatchingInstitutionInDatabase) {
+      return updateInstitutionForUserAndReturnUpdatedUser(user, null);
+    }
+    // case 10
+    if (!hasInstitutionMatchingEmailDomain
+        && hasLibraryCard
+        && hasAssignedInstitutionInDatabase
+        && !hasMatchingInstitutionInDatabase) {
+      return dropLCAndInstitutionForUser(user);
+    }
+    // case 12
+    if (!hasInstitutionMatchingEmailDomain
+        && hasLibraryCard
+        && !hasAssignedInstitutionInDatabase
+        && !hasMatchingInstitutionInDatabase) {
+      dropLibraryCardForUser(user);
+      return findUserByEmail(user.getEmail());
+    }
+    // case 14
+    if (!hasInstitutionMatchingEmailDomain
+        && !hasLibraryCard
+        && hasAssignedInstitutionInDatabase
+        && !hasMatchingInstitutionInDatabase) {
+      return updateInstitutionForUserAndReturnUpdatedUser(user, null);
+    }
+
+    // do nothing cases 1, 5, 15, 16
+    return user;
+
+    // not possible cases: 3, 7, 9, 11, 13
+  }
+
+  private User dropLCAndInstitutionForUser(User user) {
+    updateInstitutionForUser(user, null);
+    libraryCardDAO.deleteAllLibraryCardsByUser(user.getUserId());
+    return findUserByEmail(user.getEmail());
+  }
+
+  private void updateInstitutionForUser(User user, Integer institutionId) {
+    userDAO.updateInstitutionId(user.getUserId(), institutionId);
+  }
+
+  private User updateInstitutionForUserAndReturnUpdatedUser(User user, Integer institutionId) {
+    updateInstitutionForUser(user, institutionId);
+    return findUserByEmail(user.getEmail());
+  }
+
+  private User dropLibraryCardForUser(User user) {
+    libraryCardDAO.deleteAllLibraryCardsByUser(user.getUserId());
+    return findUserByEmail(user.getEmail());
+  }
+
+  @VisibleForTesting
+  protected boolean hasInstitutionMatchingEmailDomain(Institution institution) {
+    return institution != null;
+  }
+
+  @VisibleForTesting
+  protected boolean hasLibraryCard(User user) {
+    return !user.getLibraryCards().isEmpty();
+  }
+
+  @VisibleForTesting
+  protected boolean hasMatchingInstitutionInDatabase(
+      Institution institutionFromEmail, Institution institutionFromDatabase) {
+    if (institutionFromEmail == null || institutionFromDatabase == null) {
+      return false;
+    }
+    return institutionFromDatabase.equals(institutionFromEmail);
+  }
+
   public static class SimplifiedUser {
 
-    public Integer userId;
-    public String displayName;
-    public String email;
-    public Integer institutionId;
+    private Integer userId;
+    private String displayName;
+    private String email;
+    private Integer institutionId;
 
     public SimplifiedUser(User user) {
       this.userId = user.getUserId();
@@ -485,6 +601,22 @@ public class UserService implements ConsentLogger {
 
     public void setInstitutionId(Integer institutionId) {
       this.institutionId = institutionId;
+    }
+
+    public String getDisplayName() {
+      return displayName;
+    }
+
+    public String getEmail() {
+      return email;
+    }
+
+    public Integer getInstitutionId() {
+      return institutionId;
+    }
+
+    public Integer getUserId() {
+      return userId;
     }
 
     @Override

--- a/src/main/java/org/broadinstitute/consent/http/service/UserService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/UserService.java
@@ -530,14 +530,14 @@ public class UserService implements ConsentLogger {
     // not possible cases: 3, 7, 9, 11, 13
   }
 
+  private void updateInstitutionForUser(User user, Integer institutionId) {
+    userDAO.updateInstitutionId(user.getUserId(), institutionId);
+  }
+
   private User dropLCAndInstitutionForUser(User user) {
     updateInstitutionForUser(user, null);
     libraryCardDAO.deleteAllLibraryCardsByUser(user.getUserId());
     return findUserByEmail(user.getEmail());
-  }
-
-  private void updateInstitutionForUser(User user, Integer institutionId) {
-    userDAO.updateInstitutionId(user.getUserId(), institutionId);
   }
 
   private User updateInstitutionForUserAndReturnUpdatedUser(User user, Integer institutionId) {

--- a/src/main/java/org/broadinstitute/consent/http/service/UserService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/UserService.java
@@ -516,7 +516,8 @@ public class UserService implements ConsentLogger {
         && !hasMatchingInstitutionInDatabase) {
       return dropLCAndInstitutionForUser(user);
     }
-    // case 12
+
+    // case 11, 12
     if (!hasInstitutionMatchingEmailDomain
         && hasLibraryCard
         && !hasAssignedInstitutionInDatabase
@@ -535,7 +536,7 @@ public class UserService implements ConsentLogger {
     // do nothing cases 1, 5, 15, 16
     return user;
 
-    // not possible cases: 3, 7, 9, 11, 13
+    // not possible cases: 3, 7, 9, 13
   }
 
   private void updateInstitutionForUser(User user, Integer institutionId) {

--- a/src/main/java/org/broadinstitute/consent/http/service/UserService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/UserService.java
@@ -47,7 +47,6 @@ import org.broadinstitute.consent.http.service.dao.DraftServiceDAO;
 import org.broadinstitute.consent.http.service.dao.UserServiceDAO;
 import org.broadinstitute.consent.http.util.ConsentLogger;
 import org.broadinstitute.consent.http.util.gson.GsonUtil;
-import org.checkerframework.checker.nullness.qual.NonNull;
 
 public class UserService implements ConsentLogger {
 
@@ -455,7 +454,7 @@ public class UserService implements ConsentLogger {
     }
   }
 
-  public User enforceInstitutionAndLibraryCardTruthTable(@NonNull User user) {
+  public User enforceInstitutionAndLibraryCardTruthTable(User user) {
     Institution institutionFromEmail = institutionService.findInstitutionForEmail(user.getEmail());
     Institution institutionFromDatabase = null;
     try {

--- a/src/test/java/org/broadinstitute/consent/http/authentication/AuthorizationHelperTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/authentication/AuthorizationHelperTest.java
@@ -76,6 +76,7 @@ class AuthorizationHelperTest extends AbstractTestHelper {
     user.setEmail(unauthorizedUser.getEmail());
     user.addRole(UserRoles.Chairperson());
     when(userService.findUserByEmail(unauthorizedUser.getEmail())).thenReturn(user);
+    when(userService.enforceInstitutionAndLibraryCardTruthTable(user)).thenReturn(user);
     assertTrue(authorizationHelper.authorize(authorizedUser, Resource.CHAIRPERSON));
     assertTrue(authorizationHelper.authorize(authorizedDuosUser, Resource.CHAIRPERSON));
   }
@@ -91,6 +92,7 @@ class AuthorizationHelperTest extends AbstractTestHelper {
     user.setEmail(unauthorizedUser.getEmail());
     user.addRole(UserRoles.Researcher());
     when(userService.findUserByEmail(unauthorizedUser.getEmail())).thenReturn(user);
+    when(userService.enforceInstitutionAndLibraryCardTruthTable(user)).thenReturn(user);
     assertFalse(authorizationHelper.authorize(unauthorizedUser, roleName));
     assertFalse(authorizationHelper.authorize(unauthorizedDuosUser, roleName));
   }

--- a/src/test/java/org/broadinstitute/consent/http/authentication/AuthorizationHelperTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/authentication/AuthorizationHelperTest.java
@@ -92,7 +92,6 @@ class AuthorizationHelperTest extends AbstractTestHelper {
     user.setEmail(unauthorizedUser.getEmail());
     user.addRole(UserRoles.Researcher());
     when(userService.findUserByEmail(unauthorizedUser.getEmail())).thenReturn(user);
-    when(userService.enforceInstitutionAndLibraryCardTruthTable(user)).thenReturn(user);
     assertFalse(authorizationHelper.authorize(unauthorizedUser, roleName));
     assertFalse(authorizationHelper.authorize(unauthorizedDuosUser, roleName));
   }

--- a/src/test/java/org/broadinstitute/consent/http/authentication/AuthorizationHelperTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/authentication/AuthorizationHelperTest.java
@@ -76,7 +76,6 @@ class AuthorizationHelperTest extends AbstractTestHelper {
     user.setEmail(unauthorizedUser.getEmail());
     user.addRole(UserRoles.Chairperson());
     when(userService.findUserByEmail(unauthorizedUser.getEmail())).thenReturn(user);
-    when(userService.enforceInstitutionAndLibraryCardTruthTable(user)).thenReturn(user);
     assertTrue(authorizationHelper.authorize(authorizedUser, Resource.CHAIRPERSON));
     assertTrue(authorizationHelper.authorize(authorizedDuosUser, Resource.CHAIRPERSON));
   }

--- a/src/test/java/org/broadinstitute/consent/http/db/InstitutionDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/InstitutionDAOTest.java
@@ -147,7 +147,7 @@ class InstitutionDAOTest extends DAOTestHelper {
     assertEquals(1, institution.getSigningOfficials().size());
     assertEquals(user.getInstitutionId(), institution.getId());
     assertEquals(user.getDisplayName(),
-        institution.getSigningOfficials().get(0).displayName);
+        institution.getSigningOfficials().get(0).getDisplayName());
   }
 
   @Test
@@ -181,7 +181,7 @@ class InstitutionDAOTest extends DAOTestHelper {
     User user = createUserWithInstitution();
     Institution institutionWithSO = institutionDAO.findInstitutionWithSOById(user.getInstitutionId());
     assertEquals(1, institutionWithSO.getSigningOfficials().size());
-    assertEquals(user.getDisplayName(), institutionWithSO.getSigningOfficials().get(0).displayName);
+    assertEquals(user.getDisplayName(), institutionWithSO.getSigningOfficials().get(0).getDisplayName());
   }
 
   private Institution createInstitution() {

--- a/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
@@ -28,8 +28,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.apache.commons.lang3.RandomStringUtils;
-import org.apache.commons.lang3.RandomUtils;
+import org.broadinstitute.consent.http.AbstractTestHelper;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.Acknowledgement;
 import org.broadinstitute.consent.http.models.ApprovedDataset;
@@ -55,7 +54,7 @@ import org.postgresql.util.PSQLException;
 import org.postgresql.util.PSQLState;
 
 @ExtendWith(MockitoExtension.class)
-class UserResourceTest {
+class UserResourceTest extends AbstractTestHelper {
 
   @Mock
   private UserService userService;
@@ -228,7 +227,7 @@ class UserResourceTest {
   void testDeleteUser() {
     doNothing().when(userService).deleteUserByEmail(any());
 
-    Response response = userResource.delete(authUser, RandomStringUtils.randomAlphabetic(10), uriInfo);
+    Response response = userResource.delete(authUser, randomAlphabetic(10), uriInfo);
     assertEquals(200, response.getStatus());
   }
 
@@ -371,7 +370,7 @@ class UserResourceTest {
     assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
     var body = (List<UserService.SimplifiedUser>) response.getEntity();
     assertFalse(body.isEmpty());
-    assertEquals(so.getDisplayName(), body.get(0).displayName);
+    assertEquals(so.getDisplayName(), body.get(0).getDisplayName());
   }
 
   @SuppressWarnings("rawtypes")
@@ -884,7 +883,7 @@ class UserResourceTest {
     User user = createUserWithRole();
     Map<String, Acknowledgement> acknowledgementMap = getDefaultAcknowledgementForUser(user,
         acknowledgementKey);
-
+    when(acknowledgementService.findAcknowledgementsForUser(any())).thenReturn(acknowledgementMap);
     Response response = userResource.getUserAcknowledgements(authUser);
     assertEquals(Status.OK.getStatusCode(), response.getStatus());
   }
@@ -915,7 +914,7 @@ class UserResourceTest {
 
   private User createUserWithRole() {
     User user = new User();
-    user.setUserId(RandomUtils.nextInt(1, 100));
+    user.setUserId(randomInt(1, 100));
     user.setDisplayName("Test");
     user.setEmail("Test");
     user.addRole(UserRoles.Researcher());

--- a/src/test/java/org/broadinstitute/consent/http/service/DaaServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DaaServiceTest.java
@@ -213,8 +213,8 @@ class DaaServiceTest {
     when(user.getInstitutionId()).thenReturn(1);
 
     SimplifiedUser signingOfficial = mock(SimplifiedUser.class);
-    signingOfficial.displayName = "Official Name";
-    signingOfficial.email = "official@example.com";
+    signingOfficial.setDisplayName("Official Name");
+    signingOfficial.setEmail("official@example.com");
 
     Institution institution = mock(Institution.class);
     when(institution.getSigningOfficials()).thenReturn(List.of(signingOfficial));
@@ -239,12 +239,12 @@ class DaaServiceTest {
     when(user.getInstitutionId()).thenReturn(1);
 
     SimplifiedUser signingOfficial = mock(SimplifiedUser.class);
-    signingOfficial.displayName = "Official Name";
-    signingOfficial.email = "official@example.com";
+    signingOfficial.setDisplayName("Official Name");
+    signingOfficial.setEmail("official@example.com");
 
     SimplifiedUser signingOfficial2 = mock(SimplifiedUser.class);
-    signingOfficial2.displayName = "Official Name2";
-    signingOfficial2.email = "official2@example.com";
+    signingOfficial2.setDisplayName("Official Name2");
+    signingOfficial2.setEmail("official2@example.com");
 
     Institution institution = mock(Institution.class);
     when(institution.getSigningOfficials()).thenReturn(List.of(signingOfficial, signingOfficial2));
@@ -268,22 +268,22 @@ class DaaServiceTest {
     User user = mock(User.class);
 
     SimplifiedUser researcher = mock(SimplifiedUser.class);
-    researcher.displayName = "Official Name";
-    researcher.email = "official@example.com";
-    researcher.institutionId = RandomUtils.nextInt(0,50);
+    researcher.setDisplayName("Official Name");
+    researcher.setEmail("official@example.com");
+    researcher.setInstitutionId(RandomUtils.nextInt(0,50));
 
     SimplifiedUser researcher2 = mock(SimplifiedUser.class);
-    researcher2.displayName = "Official Name2";
-    researcher2.email = "official2@example.com";
-    researcher2.institutionId = RandomUtils.nextInt(0,50);
+    researcher2.setDisplayName("Official Name2");
+    researcher2.setEmail("official2@example.com");
+    researcher2.setInstitutionId(RandomUtils.nextInt(0,50));
 
     SimplifiedUser signingOfficial = mock(SimplifiedUser.class);
-    signingOfficial.displayName = "Official Name";
-    signingOfficial.email = "official@example.com";
+    signingOfficial.setDisplayName("Official Name");
+    signingOfficial.setEmail("official@example.com");
 
     SimplifiedUser signingOfficial2 = mock(SimplifiedUser.class);
-    signingOfficial2.displayName = "Official Name2";
-    signingOfficial2.email = "official2@example.com";
+    signingOfficial2.setDisplayName("Official Name2");
+    signingOfficial2.setEmail("official2@example.com");
 
     DataAccessAgreement daa = mock(DataAccessAgreement.class);
     FileStorageObject file = mock(FileStorageObject.class);
@@ -305,17 +305,17 @@ class DaaServiceTest {
     User user = mock(User.class);
 
     SimplifiedUser researcher = mock(SimplifiedUser.class);
-    researcher.displayName = "Official Name";
-    researcher.email = "official@example.com";
-    researcher.institutionId = RandomUtils.nextInt(0,50);
+    researcher.setDisplayName("Official Name");
+    researcher.setEmail("official@example.com");
+    researcher.setInstitutionId(RandomUtils.nextInt(0,50));
 
     SimplifiedUser signingOfficial = mock(SimplifiedUser.class);
-    signingOfficial.displayName = "Official Name";
-    signingOfficial.email = "official@example.com";
+    signingOfficial.setDisplayName("Official Name");
+    signingOfficial.setEmail("official@example.com");
 
     SimplifiedUser signingOfficial2 = mock(SimplifiedUser.class);
-    signingOfficial2.displayName = "Official Name2";
-    signingOfficial2.email = "official2@example.com";
+    signingOfficial2.setDisplayName("Official Name2");
+    signingOfficial2.setEmail("official2@example.com");
 
     DataAccessAgreement daa = mock(DataAccessAgreement.class);
     FileStorageObject file = mock(FileStorageObject.class);
@@ -376,8 +376,8 @@ class DaaServiceTest {
     when(user.getInstitutionId()).thenReturn(1);
 
     SimplifiedUser signingOfficial = mock(SimplifiedUser.class);
-    signingOfficial.displayName = "Official Name";
-    signingOfficial.email = "official@example.com";
+    signingOfficial.setDisplayName("Official Name");
+    signingOfficial.setEmail("official@example.com");
 
     Institution institution = mock(Institution.class);
     when(institution.getSigningOfficials()).thenReturn(List.of(signingOfficial));
@@ -402,12 +402,12 @@ class DaaServiceTest {
     when(user.getInstitutionId()).thenReturn(1);
 
     SimplifiedUser signingOfficial = mock(SimplifiedUser.class);
-    signingOfficial.displayName = "Official Name";
-    signingOfficial.email = "official@example.com";
+    signingOfficial.setDisplayName("Official Name");
+    signingOfficial.setEmail("official@example.com");
 
     SimplifiedUser signingOfficial2 = mock(SimplifiedUser.class);
-    signingOfficial2.displayName = "Official Name2";
-    signingOfficial2.email = "official2@example.com";
+    signingOfficial2.setDisplayName("Official Name2");
+    signingOfficial2.setEmail("official2@example.com");
 
     Institution institution = mock(Institution.class);
     when(institution.getSigningOfficials()).thenReturn(List.of(signingOfficial, signingOfficial2));

--- a/src/test/java/org/broadinstitute/consent/http/service/InstitutionServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/InstitutionServiceTest.java
@@ -172,9 +172,9 @@ class InstitutionServiceTest {
     List<SimplifiedUser> signingOfficials = institution.getSigningOfficials();
     assertEquals(getInstitutions().get(0), institution);
     assertEquals(1, signingOfficials.size());
-    assertEquals(u.getDisplayName(), signingOfficials.get(0).displayName);
-    assertEquals(u.getEmail(), signingOfficials.get(0).email);
-    assertEquals(u.getUserId(), signingOfficials.get(0).userId);
+    assertEquals(u.getDisplayName(), signingOfficials.get(0).getDisplayName());
+    assertEquals(u.getEmail(), signingOfficials.get(0).getEmail());
+    assertEquals(u.getUserId(), signingOfficials.get(0).getUserId());
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
@@ -5,6 +5,7 @@ import static org.broadinstitute.consent.http.enumeration.UserFields.ERA_STATUS;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -29,6 +30,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 import org.apache.commons.collections4.CollectionUtils;
 import org.broadinstitute.consent.http.AbstractTestHelper;
 import org.broadinstitute.consent.http.db.AcknowledgementDAO;
@@ -61,6 +63,11 @@ import org.jdbi.v3.core.transaction.TransactionException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -474,8 +481,8 @@ class UserServiceTest extends AbstractTestHelper {
     when(userDAO.getSOsByInstitution(any())).thenReturn(List.of(u, u, u));
     List<SimplifiedUser> users = service.findSOsByInstitutionId(institutionId);
     assertEquals(3, users.size());
-    assertEquals(u.getDisplayName(), users.get(0).displayName);
-    assertEquals(u.getEmail(), users.get(0).email);
+    assertEquals(u.getDisplayName(), users.get(0).getDisplayName());
+    assertEquals(u.getEmail(), users.get(0).getEmail());
   }
 
   @Test
@@ -847,6 +854,103 @@ class UserServiceTest extends AbstractTestHelper {
   void testFindUsersInJsonArrayInvalidKey() {
     String json = "{users:[1,2,3]}";
     assertThrows(BadRequestException.class, () -> service.findUsersInJsonArray(json, "invalidKey"));
+  }
+
+  @Test
+  void hasInstitutionMatchingEmailDomain() {
+    Institution institution = new Institution();
+    assertTrue(service.hasInstitutionMatchingEmailDomain(institution));
+  }
+
+  @Test
+  void hasInstitutionMatchingEmailDomain_Bad() {
+    assertFalse(service.hasInstitutionMatchingEmailDomain(null));
+  }
+
+  @Test
+  void hasLibraryCard() {
+    User testUser = generateUser();
+    testUser.setLibraryCards(List.of(new LibraryCard()));
+    assertTrue(service.hasLibraryCard(testUser));
+  }
+
+  @Test
+  void hasLibraryCard_NoLibraryCard() {
+    User testUser = generateUser();
+    assertFalse(service.hasLibraryCard(testUser));
+  }
+
+  @Test
+  void hasMatchingInstitutionInDatabase() {
+    Institution institution = new Institution();
+    institution.setId(1);
+    assertTrue(service.hasMatchingInstitutionInDatabase(institution, institution));
+  }
+
+  @Test
+  void hasMatchingInstitutionInDatabase_NoInstitutionInDB() {
+    Institution institution = new Institution();
+    institution.setId(1);
+    assertFalse(service.hasMatchingInstitutionInDatabase(null, institution));
+  }
+
+  @Test
+  void hasMatchingInstitutionInDatabase_NoInstitutionEmailMap() {
+    Institution institution = new Institution();
+    institution.setId(1);
+    assertFalse(service.hasMatchingInstitutionInDatabase(institution, null));
+  }
+
+  static class TruthTableArgumentsProvider implements ArgumentsProvider {
+    @Override
+    public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+      Institution institution1 = new Institution();
+      institution1.setId(1);
+      Institution institution2 = new Institution();
+      institution2.setId(2);
+      List<LibraryCard> libraryCards1 = List.of(new LibraryCard());
+      return Stream.of(
+          Arguments.of(institution1, libraryCards1, institution1, false),
+          Arguments.of(institution1, libraryCards1, institution2, true),
+          Arguments.of(institution1, libraryCards1, null, true),
+          Arguments.of(institution1, null, institution1, false),
+          Arguments.of(institution1, null, institution2, true),
+          Arguments.of(institution1, null, null, true),
+          Arguments.of(null, libraryCards1, institution2, true),
+          Arguments.of(null, libraryCards1, null, true),
+          Arguments.of(null, null, institution2, true),
+          Arguments.of(null, null, null, false)
+      );
+    }
+  }
+
+  @ParameterizedTest
+  @ArgumentsSource(TruthTableArgumentsProvider.class)
+  void testEnforceInstitutionAndLibraryCardTruthTable_TruthTable(Institution institutionFromMap, List<LibraryCard> libraryCard, Institution institutionFromDatabase, boolean expectsUserMod) {
+    User testUser = generateUser();
+    testUser.setLibraryCards(libraryCard);
+    User alteredUser = new User();
+    alteredUser.setEmail(testUser.getEmail());
+    when(institutionService.findInstitutionForEmail(testUser.getEmail())).thenReturn(institutionFromMap);
+    when(institutionService.findInstitutionById(testUser.getInstitutionId())).thenReturn(institutionFromDatabase);
+    if (expectsUserMod) {
+      when(userDAO.findUserByEmail(testUser.getEmail())).thenReturn(alteredUser);
+      validateAlteredUserIsReturned(testUser, service.enforceInstitutionAndLibraryCardTruthTable(testUser));
+    } else {
+      validateUserIsUnmodified(testUser, service.enforceInstitutionAndLibraryCardTruthTable(testUser));
+    }
+  }
+
+  private void validateUserIsUnmodified(User left, User right) {
+    assertEquals(left.getEmail(), right.getEmail());
+    assertEquals(left.getInstitutionId(), right.getInstitutionId());
+    assertEquals(left.getLibraryCards(), right.getLibraryCards());
+    assertEquals(left.getInstitutionId(), right.getInstitutionId());
+  }
+
+  private void validateAlteredUserIsReturned(User left, User right) {
+    assertEquals(left.getEmail(), right.getEmail());
+    assertNotEquals(left.getInstitutionId(), right.getInstitutionId());
   }
 
   private User generateUserWithoutInstitution() {


### PR DESCRIPTION
### Addresses
[https://broadworkbench.atlassian.net/browse/DT-1607](https://broadworkbench.atlassian.net/browse/DT-1607)
### Summary

At the point where we extract an email address from an Oauth claim, perform validation logic to adjust the user object based on a truth table of rules defined in the ticket.

The general flavor of the rules is that when the institution derived from the email address of the requestor doesn't match our expectations for library cards or the values stored in our database,  fix our database to align with these rules.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
