### PR TITLE
DT-1662: Ensure single Library Card per User

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -49,6 +49,7 @@
       </option>
       <option name="IMPORT_LAYOUT_TABLE">
         <value>
+          <package name="" withSubpackages="true" static="false" module="true" />
           <package name="" withSubpackages="true" static="true" />
           <emptyLine />
           <package name="" withSubpackages="true" static="false" />

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -49,7 +49,6 @@
       </option>
       <option name="IMPORT_LAYOUT_TABLE">
         <value>
-          <package name="" withSubpackages="true" static="false" module="true" />
           <package name="" withSubpackages="true" static="true" />
           <emptyLine />
           <package name="" withSubpackages="true" static="false" />

--- a/src/main/java/org/broadinstitute/consent/http/db/LibraryCardDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/LibraryCardDAO.java
@@ -89,7 +89,7 @@ public interface LibraryCardDAO extends Transactional<LibraryCardDAO> {
       LEFT JOIN lc_daa ld ON lc.id = ld.lc_id
       WHERE lc.user_id = :userId
       """)
-  List<LibraryCard> findLibraryCardsByUserId(@Bind("userId") Integer userId);
+  LibraryCard findLibraryCardByUserId(@Bind("userId") Integer userId);
 
   @RegisterBeanMapper(value = LibraryCard.class)
   @UseRowReducer(LibraryCardReducer.class)
@@ -115,7 +115,7 @@ public interface LibraryCardDAO extends Transactional<LibraryCardDAO> {
   @UseRowReducer(LibraryCardReducer.class)
   @SqlQuery("SELECT * FROM library_card " +
       "WHERE user_email = :email")
-  List<LibraryCard> findAllLibraryCardsByUserEmail(@Bind("email") String email);
+  LibraryCard findLibraryCardByUserEmail(@Bind("email") String email);
 
   @SqlUpdate("DELETE FROM library_card WHERE user_id = :userId OR create_user_id = :userId OR update_user_id = :userId")
   void deleteAllLibraryCardsByUser(@Bind("userId") Integer userId);

--- a/src/main/java/org/broadinstitute/consent/http/db/UserDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/UserDAO.java
@@ -27,16 +27,38 @@ public interface UserDAO extends Transactional<UserDAO> {
   @RegisterBeanMapper(value = User.class, prefix = "u")
   @RegisterBeanMapper(value = UserRole.class)
   @RegisterBeanMapper(value = Institution.class, prefix = "i")
+  @RegisterBeanMapper(value = LibraryCard.class, prefix = "lc")
   @UseRowReducer(UserWithRolesReducer.class)
-  @SqlQuery("SELECT "
-      + User.QUERY_FIELDS_WITH_U_PREFIX + QUERY_FIELD_SEPARATOR
-      + Institution.QUERY_FIELDS_WITH_I_PREFIX + QUERY_FIELD_SEPARATOR
-      + "     ur.user_role_id, ur.user_id, ur.role_id, ur.dac_id, r.name  "
-      + " FROM users u "
-      + " LEFT JOIN user_role ur ON ur.user_id = u.user_id "
-      + " LEFT JOIN roles r ON r.role_id = ur.role_id "
-      + " LEFT JOIN institution i ON u.institution_id = i.institution_id"
-      + " WHERE u.user_id = :userId")
+  @SqlQuery("""
+            SELECT
+          u.user_id as u_user_id,
+          u.email as u_email,
+          u.display_name as u_display_name,
+          u.create_date as u_create_date,
+          u.email_preference as u_email_preference,
+          u.institution_id as u_institution_id,
+          u.era_commons_id as u_era_commons_id,
+          i.institution_id as i_id,
+          i.institution_name as i_name,
+          i.it_director_name as i_it_director_name,
+          i.it_director_email as i_it_director_email,
+          i.create_date as i_create_date,
+          i.update_date as i_update_date,
+          ur.user_role_id as ur_user_role_id, ur.user_id as ur_user_id,
+          ur.role_id as ur_role_id, ur.dac_id as ur_dac_id, r.name as ur_name,
+          lc.id AS lc_id, lc.user_id AS lc_user_id,
+          lc.user_name AS lc_user_name, lc.user_email AS lc_user_email,
+          lc.create_user_id AS lc_create_user_id, lc.create_date AS lc_create_date,
+          lc.update_user_id AS lc_update_user_id,
+          ld.daa_id as lc_daa_id
+      FROM users u
+      LEFT JOIN user_role ur ON ur.user_id = u.user_id
+      LEFT JOIN roles r ON r.role_id = ur.role_id
+      LEFT JOIN institution i ON u.institution_id = i.institution_id
+      LEFT JOIN library_card lc ON lc.user_id = u.user_id
+      LEFT JOIN lc_daa ld ON lc.id = ld.lc_id
+      WHERE u.user_id = :userId
+      """)
   User findUserById(@Bind("userId") Integer userId);
 
   @RegisterBeanMapper(value = User.class, prefix = "u")
@@ -92,17 +114,38 @@ public interface UserDAO extends Transactional<UserDAO> {
   @RegisterBeanMapper(value = User.class, prefix = "u")
   @RegisterBeanMapper(value = UserRole.class, prefix = "ur")
   @RegisterBeanMapper(value = Institution.class, prefix = "i")
+  @RegisterBeanMapper(value = LibraryCard.class, prefix = "lc")
   @UseRowReducer(UserWithRolesReducer.class)
-  @SqlQuery("SELECT "
-      + User.QUERY_FIELDS_WITH_U_PREFIX + QUERY_FIELD_SEPARATOR
-      + Institution.QUERY_FIELDS_WITH_I_PREFIX + QUERY_FIELD_SEPARATOR
-      + "     ur.user_role_id as ur_user_role_id, ur.user_id as ur_user_id, "
-      + "     ur.role_id as ur_role_id, ur.dac_id as ur_dac_id, r.name as ur_name "
-      + " FROM users u "
-      + " LEFT JOIN user_role ur ON ur.user_id = u.user_id "
-      + " LEFT JOIN roles r ON r.role_id = ur.role_id "
-      + " LEFT JOIN institution i ON u.institution_id = i.institution_id"
-      + " WHERE LOWER(u.email) = LOWER(:email)")
+  @SqlQuery("""
+      SELECT
+          u.user_id as u_user_id,
+          u.email as u_email,
+          u.display_name as u_display_name,
+          u.create_date as u_create_date,
+          u.email_preference as u_email_preference,
+          u.institution_id as u_institution_id,
+          u.era_commons_id as u_era_commons_id,
+          i.institution_id as i_id,
+          i.institution_name as i_name,
+          i.it_director_name as i_it_director_name,
+          i.it_director_email as i_it_director_email,
+          i.create_date as i_create_date,
+          i.update_date as i_update_date,
+          ur.user_role_id as ur_user_role_id, ur.user_id as ur_user_id,
+          ur.role_id as ur_role_id, ur.dac_id as ur_dac_id, r.name as ur_name,
+          lc.id AS lc_id, lc.user_id AS lc_user_id,
+          lc.user_name AS lc_user_name, lc.user_email AS lc_user_email,
+          lc.create_user_id AS lc_create_user_id, lc.create_date AS lc_create_date,
+          lc.update_user_id AS lc_update_user_id,
+          ld.daa_id as lc_daa_id
+      FROM users u
+      LEFT JOIN user_role ur ON ur.user_id = u.user_id
+      LEFT JOIN roles r ON r.role_id = ur.role_id
+      LEFT JOIN institution i ON u.institution_id = i.institution_id
+      LEFT JOIN library_card lc ON lc.user_id = u.user_id
+      LEFT JOIN lc_daa ld ON lc.id = ld.lc_id
+      WHERE LOWER(u.email) = LOWER(:email)
+      """)
   User findUserByEmail(@Bind("email") String email);
 
   @RegisterBeanMapper(value = User.class, prefix = "u")

--- a/src/main/java/org/broadinstitute/consent/http/db/UserDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/UserDAO.java
@@ -30,7 +30,7 @@ public interface UserDAO extends Transactional<UserDAO> {
   @RegisterBeanMapper(value = LibraryCard.class, prefix = "lc")
   @UseRowReducer(UserWithRolesReducer.class)
   @SqlQuery("""
-            SELECT
+      SELECT
           u.user_id as u_user_id,
           u.email as u_email,
           u.display_name as u_display_name,

--- a/src/main/java/org/broadinstitute/consent/http/db/UserDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/UserDAO.java
@@ -218,19 +218,6 @@ public interface UserDAO extends Transactional<UserDAO> {
   List<User> describeUsersByRoleAndEmailPreference(@Bind("roleName") String roleName,
       @Bind("emailPreference") Boolean emailPreference);
 
-  @RegisterBeanMapper(value = User.class, prefix = "u")
-  @RegisterBeanMapper(value = UserRole.class)
-  @UseRowReducer(UserWithRolesReducer.class)
-  @SqlQuery("SELECT "
-      + User.QUERY_FIELDS_WITH_U_PREFIX + QUERY_FIELD_SEPARATOR
-      + "     ur.user_role_id, ur.user_id, ur.role_id, ur.dac_id, r.name "
-      + " FROM users u "
-      + " LEFT JOIN user_role ur ON ur.user_id = u.user_id "
-      + " LEFT JOIN roles r ON r.role_id = ur.role_id "
-      + " WHERE LOWER(u.email) = LOWER(:email) "
-      + " AND r.role_id = :roleId")
-  User findUserByEmailAndRoleId(@Bind("email") String email, @Bind("roleId") Integer roleId);
-
   @UseRowMapper(UserWithRolesMapper.class)
   @SqlQuery("select du.*, r.role_id, r.name, ur.user_role_id, ur.user_id, ur.role_id, ur.dac_id " +
       " from users du " +

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DarCollectionReducer.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DarCollectionReducer.java
@@ -94,7 +94,7 @@ public class DarCollectionReducer
         user.setInstitution(institution);
       }
       if (Objects.nonNull(libraryCard)) {
-        user.addLibraryCard(libraryCard);
+        user.setLibraryCard(libraryCard);
       }
       if (Objects.nonNull(userProperty)) {
         user.addProperty(userProperty);

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/UserWithRolesReducer.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/UserWithRolesReducer.java
@@ -48,7 +48,7 @@ public class UserWithRolesReducer implements LinkedHashMapRowReducer<Integer, Us
         }
       }
     } catch (MappingException e) {
-      logWarn("Error adding Institution to User", e);
+      logDebug("Error adding Institution to User: %s".formatted(e.getMessage()));
     }
     //user role join can cause duplication of data if done in tandem with joins on other tables
     //ex) The same LC can end up being repeated multiple times
@@ -62,7 +62,7 @@ public class UserWithRolesReducer implements LinkedHashMapRowReducer<Integer, Us
         user.setLibraryCard(lc);
       }
     } catch (MappingException e) {
-      logWarn("Error adding Library Card to User", e);
+      logDebug("Error adding Library Card to User: %s".formatted(e.getMessage()));
     }
     try {
       if (Objects.nonNull(rowView.getColumn("up_property_id", Integer.class))) {
@@ -70,7 +70,7 @@ public class UserWithRolesReducer implements LinkedHashMapRowReducer<Integer, Us
         user.addProperty(p);
       }
     } catch (MappingException e) {
-      logWarn("Error adding User Property to User", e);
+      logDebug("Error adding User Property to User: %s".formatted(e.getMessage()));
     }
   }
 

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/UserWithRolesReducer.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/UserWithRolesReducer.java
@@ -2,7 +2,6 @@ package org.broadinstitute.consent.http.db.mapper;
 
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import org.broadinstitute.consent.http.models.Institution;
 import org.broadinstitute.consent.http.models.LibraryCard;
 import org.broadinstitute.consent.http.models.User;
@@ -33,19 +32,12 @@ public class UserWithRolesReducer implements LinkedHashMapRowReducer<Integer, Us
             id -> rowView.getRow(User.class));
 
     try {
-      // Some queries look for `user_role_id` while those that use a prefix look for `u_user_role_id`
-      Integer userRoleId = null;
-      if (hasNonZeroColumn(rowView, "user_role_id")) {
-        userRoleId = rowView.getColumn("user_role_id", Integer.class);
-      } else if (hasNonZeroColumn(rowView, "ur_user_role_id")) {
-        userRoleId = rowView.getColumn("ur_user_role_id", Integer.class);
-      }
-      if (Objects.nonNull(userRoleId)) {
-        UserRole ur = rowView.getRow(UserRole.class);
-        user.addRole(ur);
+      UserRole userRole = mapUserRoleFromRowView(rowView, userId);
+      if (userRole != null) {
+        user.addRole(userRole);
       }
     } catch (MappingException e) {
-      // Ignore any attempt to map a column that doesn't exist
+      logWarn("Error adding User Role to User", e);
     }
     try {
       if (Objects.nonNull(rowView.getColumn("i_id", Integer.class))) {
@@ -56,26 +48,21 @@ public class UserWithRolesReducer implements LinkedHashMapRowReducer<Integer, Us
         }
       }
     } catch (MappingException e) {
-      //Ignore institution mapping errors, possible for new users to not have an institution
+      logWarn("Error adding Institution to User", e);
     }
     //user role join can cause duplication of data if done in tandem with joins on other tables
     //ex) The same LC can end up being repeated multiple times
     //Below only adds LC if not currently saved on the array
     try {
       if (rowView.getColumn("lc_id", Integer.class) != null) {
-        int lcId = rowView.getColumn("lc_id", Integer.class);
-        LibraryCard lc;
-        Optional<LibraryCard> existingLibraryCard = user.getLibraryCards().stream()
-                .filter(card -> card.getId().equals(lcId))
-                .findFirst();
-        lc = existingLibraryCard.orElseGet(() -> rowView.getRow(LibraryCard.class));
+        LibraryCard lc = rowView.getRow(LibraryCard.class);
         if (rowView.getColumn("lc_daa_id", Integer.class) != null) {
           lc.addDaa(rowView.getColumn("lc_daa_id", Integer.class));
         }
-        user.addLibraryCard(lc);
+        user.setLibraryCard(lc);
       }
     } catch (MappingException e) {
-      //Ignore exceptions here, user may not have a library card issued under this instiution
+      logWarn("Error adding Library Card to User", e);
     }
     try {
       if (Objects.nonNull(rowView.getColumn("up_property_id", Integer.class))) {
@@ -83,7 +70,33 @@ public class UserWithRolesReducer implements LinkedHashMapRowReducer<Integer, Us
         user.addProperty(p);
       }
     } catch (MappingException e) {
-      // Ignore any attempt to map a column that doesn't exist
+      logWarn("Error adding User Property to User", e);
     }
+  }
+
+  private UserRole mapUserRoleFromRowView(RowView rowView, Integer userId) {
+    Integer userRoleId;
+    Integer roleId;
+    String name;
+    Integer dacId = null;
+    // Some queries look for `user_role_id` while those that use a prefix look for `ur_user_role_id`
+    if (hasNonZeroColumn(rowView, "user_role_id")) {
+      userRoleId = rowView.getColumn("user_role_id", Integer.class);
+      roleId = rowView.getColumn("role_id", Integer.class);
+      name = rowView.getColumn("name", String.class);
+      if (hasNonZeroColumn(rowView, "dac_id")) {
+        dacId = rowView.getColumn("dac_id", Integer.class);
+      }
+      return new UserRole(userRoleId, userId, roleId, name, dacId);
+    } else if (hasNonZeroColumn(rowView, "ur_user_role_id")) {
+      userRoleId = rowView.getColumn("ur_user_role_id", Integer.class);
+      roleId = rowView.getColumn("ur_role_id", Integer.class);
+      name = rowView.getColumn("ur_name", String.class);
+      if (hasNonZeroColumn(rowView, "ur_dac_id")) {
+        dacId = rowView.getColumn("ur_dac_id", Integer.class);
+      }
+      return new UserRole(userRoleId, userId, roleId, name, dacId);
+    }
+    return null;
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/UserWithRolesReducer.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/UserWithRolesReducer.java
@@ -74,6 +74,7 @@ public class UserWithRolesReducer implements LinkedHashMapRowReducer<Integer, Us
     }
   }
 
+  // Some queries look for `user_role_id` while those that use a prefix look for `u_user_role_id`
   private UserRole mapUserRoleFromRowView(RowView rowView, Integer userId) {
     Integer userRoleId;
     Integer roleId;

--- a/src/main/java/org/broadinstitute/consent/http/models/LibraryCard.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/LibraryCard.java
@@ -3,6 +3,7 @@ package org.broadinstitute.consent.http.models;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Objects;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 
 public class LibraryCard {
@@ -114,6 +115,12 @@ public class LibraryCard {
     }
     LibraryCard other = (LibraryCard) libraryCard;
     return new EqualsBuilder().append(id, other.getId()).isEquals();
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, userId, userName, userEmail, createDate, createUserId, updateDate,
+        updateUserId, daaIds);
   }
 
   public void addDaa(Integer daaId) {

--- a/src/main/java/org/broadinstitute/consent/http/models/User.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/User.java
@@ -57,7 +57,7 @@ public class User {
 
   private Institution institution;
 
-  private List<LibraryCard> libraryCards;
+  private LibraryCard libraryCard;
 
   public User() {
   }
@@ -101,7 +101,7 @@ public class User {
     // Nor do we need to retrieve the full institution object from user-provided data.
     JsonObject filteredUserJsonObject = filterFields(
         userJsonObject,
-        Arrays.asList("createDate", "institution", "libraryCards"));
+        Arrays.asList("createDate", "institution", "libraryCard"));
     User u = gson.fromJson(filteredUserJsonObject.toString(), User.class);
     setUserId(u);
     setEmail(u);
@@ -278,15 +278,12 @@ public class User {
     return institution;
   }
 
-  public void setLibraryCards(List<LibraryCard> cards) {
-    this.libraryCards = cards;
+  public LibraryCard getLibraryCard() {
+    return libraryCard;
   }
 
-  public List<LibraryCard> getLibraryCards() {
-    if (this.libraryCards == null) {
-      this.libraryCards = new ArrayList<>();
-    }
-    return this.libraryCards;
+  public void setLibraryCard(LibraryCard libraryCard) {
+    this.libraryCard = libraryCard;
   }
 
   public void addRole(UserRole userRole) {
@@ -305,15 +302,6 @@ public class User {
     }
     if (!this.getProperties().contains(userProp)) {
       this.getProperties().add(userProp);
-    }
-  }
-
-  public void addLibraryCard(LibraryCard card) {
-    if (this.libraryCards == null) {
-      this.libraryCards = new ArrayList<>();
-    }
-    if (!this.libraryCards.contains(card)) {
-      this.libraryCards.add(card);
     }
   }
 

--- a/src/main/java/org/broadinstitute/consent/http/resources/DaaResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DaaResource.java
@@ -252,7 +252,7 @@ public class DaaResource extends Resource implements ConsentLogger {
       }
       daaService.findById(daaId);
       for (User user : users) {
-        libraryCardService.addDaaToUserLibraryCardByInstitution(user, authedUser, daaId);
+        libraryCardService.addDaaToUserLibraryCard(user, authedUser, daaId);
       }
       return Response.ok().build();
     } catch (Exception e) {
@@ -304,7 +304,7 @@ public class DaaResource extends Resource implements ConsentLogger {
       }
       List<DataAccessAgreement> daaList = daaService.findDAAsInJsonArray(json, "daaList");
       for (DataAccessAgreement daa : daaList) {
-        libraryCardService.addDaaToUserLibraryCardByInstitution(user, authedUser, daa.getDaaId());
+        libraryCardService.addDaaToUserLibraryCard(user, authedUser, daa.getDaaId());
       }
       return Response.ok().build();
     } catch (Exception e) {

--- a/src/main/java/org/broadinstitute/consent/http/resources/DaaResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DaaResource.java
@@ -114,19 +114,14 @@ public class DaaResource extends Resource implements ConsentLogger {
       } else if (authedUser.hasUserRole(UserRoles.SIGNINGOFFICIAL) && authedUserInstitutionId != userInstitutionId) {
           return Response.status(Status.FORBIDDEN).build();
       }
-      List<LibraryCard> libraryCards = libraryCardService.findLibraryCardsByUserId(userId);
-      LibraryCard workingLibraryCard;
-      if (libraryCards.isEmpty()) {
-        workingLibraryCard = libraryCardService.createLibraryCardForSigningOfficial(user, authedUser);
-      } else {
-        workingLibraryCard = libraryCards.get(0);
-      }
-      int libraryCardId = workingLibraryCard.getId();
-      libraryCardService.addDaaToLibraryCard(libraryCardId, daaId);
+      LibraryCard libraryCard = user.getLibraryCard() == null ?
+          libraryCardService.createLibraryCardForSigningOfficial(user, authedUser) :
+          user.getLibraryCard();
+      libraryCardService.addDaaToLibraryCard(libraryCard.getId(), daaId);
       URI uri = info.getBaseUriBuilder()
           .replacePath("api/libraryCards/{libraryCardId}")
-          .build(libraryCardId);
-      return Response.ok().location(uri).entity(workingLibraryCard).build();
+          .build(libraryCard.getId());
+      return Response.ok().location(uri).entity(libraryCard).build();
     } catch (Exception e) {
       return createExceptionResponse(e);
     }
@@ -186,10 +181,9 @@ public class DaaResource extends Resource implements ConsentLogger {
       @PathParam("daaId") Integer daaId,
       @PathParam("userId") Integer userId) {
     try {
-      User user = userService.findUserByEmail(authUser.getEmail());
-      List<LibraryCard> libraryCards = libraryCardService.findLibraryCardsByUserId(userId);
-      for (LibraryCard libraryCard : libraryCards) {
-        libraryCardService.removeDaaFromLibraryCard(libraryCard.getId(), daaId);
+      User user = userService.findUserById(userId);
+      if (user.getLibraryCard() != null) {
+        libraryCardService.removeDaaFromLibraryCard(user.getLibraryCard().getId(), daaId);
       }
       return Response.ok().build();
     } catch (Exception e) {
@@ -225,8 +219,10 @@ public class DaaResource extends Resource implements ConsentLogger {
       if (user.getInstitutionId() == null) {
         throw new BadRequestException("This user has not set their institution: " + user.getDisplayName());
       }
-      if (user.getLibraryCards().stream()
-          .anyMatch(libraryCard -> libraryCard.getDaaIds().contains(daaId))) {
+      if (user.getLibraryCard() == null) {
+        throw new BadRequestException("This user does not have a library card: " + user.getDisplayName());
+      }
+      if (user.getLibraryCard().getDaaIds().contains(daaId)) {
         throw new IllegalArgumentException("User already has this DAA associated with their Library Card");
       }
       daaService.sendDaaRequestEmails(user, daaId);
@@ -284,7 +280,7 @@ public class DaaResource extends Resource implements ConsentLogger {
       }
       daaService.findById(daaId);
       for (User user : users) {
-        libraryCardService.removeDaaFromUserLibraryCards(user, daaId);
+        libraryCardService.removeDaaFromUserLibraryCard(user, daaId);
       }
       return Response.ok().build();
     } catch (Exception e) {
@@ -332,7 +328,7 @@ public class DaaResource extends Resource implements ConsentLogger {
       }
       List<DataAccessAgreement> daaList = daaService.findDAAsInJsonArray(json, "daaList");
       for (DataAccessAgreement daa : daaList) {
-        libraryCardService.removeDaaFromUserLibraryCards(user, daa.getDaaId());
+        libraryCardService.removeDaaFromUserLibraryCard(user, daa.getDaaId());
       }
       return Response.ok().build();
     } catch (Exception e) {

--- a/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
@@ -643,7 +643,7 @@ public class DataAccessRequestResource extends Resource {
     if (!user.getUserId().equals(dar.getUserId())) {
       throw new ForbiddenException("User not authorized to update this Data Access Request");
     }
-    if (user.getLibraryCards().isEmpty()) {
+    if (user.getLibraryCard() == null) {
       throw new LibraryCardRequiredException();
     }
   }

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
@@ -135,7 +135,7 @@ public class DataAccessRequestService implements ConsentLogger {
       throw new IllegalArgumentException("User and DataAccessRequest are required");
     }
 
-    if (user.getLibraryCards().isEmpty()) {
+    if (user.getLibraryCard() == null) {
       throw new LibraryCardRequiredException();
     }
 
@@ -297,7 +297,7 @@ public class DataAccessRequestService implements ConsentLogger {
       throw new IllegalArgumentException("User and DataAccessRequest are required");
     }
 
-    if (user.getLibraryCards().isEmpty()) {
+    if (user.getLibraryCard() == null) {
       throw new NIHComplianceRuleException();
     }
 
@@ -317,8 +317,7 @@ public class DataAccessRequestService implements ConsentLogger {
         throw new NotFoundException(
             "Unable to find User with the provided email: " + collaborator.getEmail());
       }
-      List<LibraryCard> libraryCards = collabUser.getLibraryCards();
-      if (libraryCards.isEmpty()) {
+      if (collabUser.getLibraryCard() == null) {
         throw new BadRequestException(
             "Collaborator " + collaborator.getEmail() + " does not have a library card.");
       }

--- a/src/main/java/org/broadinstitute/consent/http/service/LibraryCardService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/LibraryCardService.java
@@ -3,11 +3,9 @@ package org.broadinstitute.consent.http.service;
 import com.google.inject.Inject;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.NotFoundException;
-import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 import org.broadinstitute.consent.http.db.InstitutionDAO;
 import org.broadinstitute.consent.http.db.LibraryCardDAO;
 import org.broadinstitute.consent.http.db.UserDAO;
@@ -80,8 +78,8 @@ public class LibraryCardService {
     return libraryCardDAO.findAllLibraryCards();
   }
 
-  public List<LibraryCard> findLibraryCardsByUserId(Integer userId) {
-    return libraryCardDAO.findLibraryCardsByUserId(userId);
+  public LibraryCard findLibraryCardByUserId(Integer userId) {
+    return libraryCardDAO.findLibraryCardByUserId(userId);
   }
 
   public List<LibraryCard> findLibraryCardsByInstitutionId(Integer institutionId) {
@@ -108,29 +106,26 @@ public class LibraryCardService {
     libraryCardDAO.deleteLibraryCardDaaRelation(libraryCardId, daaId);
   }
 
-  public List<LibraryCard> addDaaToUserLibraryCardByInstitution(User user, User signingOfficial, Integer daaId) {
+  public LibraryCard addDaaToUserLibraryCardByInstitution(User user, User signingOfficial, Integer daaId) {
     if (signingOfficial.getInstitutionId() == null) {
       throw new BadRequestException("This signing official does not have an institution.");
     }
-    List<LibraryCard> libraryCards = new ArrayList<>(libraryCardDAO.findLibraryCardsByUserId(user.getUserId()));
-    if (libraryCards.isEmpty()) {
-      LibraryCard lc = createLibraryCardForSigningOfficial(user, signingOfficial);
-      libraryCards.add(lc);
+    LibraryCard libraryCard = libraryCardDAO.findLibraryCardByUserId(user.getUserId());
+    if (libraryCard == null) {
+      libraryCard = createLibraryCardForSigningOfficial(user, signingOfficial);
     }
     // typically there should be one library card per user per institution
-    for (LibraryCard libraryCard : libraryCards) {
-      addDaaToLibraryCard(libraryCard.getId(), daaId);
-    }
-    return libraryCardDAO.findLibraryCardsByUserId(user.getUserId());
+    addDaaToLibraryCard(libraryCard.getId(), daaId);
+    return libraryCardDAO.findLibraryCardByUserId(user.getUserId());
   }
 
-  public List<LibraryCard> removeDaaFromUserLibraryCards(User user, Integer daaId) {
-    List<LibraryCard> libraryCards = findLibraryCardsByUserId(user.getUserId());
+  public LibraryCard removeDaaFromUserLibraryCard(User user, Integer daaId) {
+    LibraryCard libraryCard = findLibraryCardByUserId(user.getUserId());
     // typically there should be one library card per user
-    for (LibraryCard libraryCard : libraryCards) {
+    if (libraryCard != null) {
       removeDaaFromLibraryCard(libraryCard.getId(), daaId);
     }
-    return libraryCards;
+    return findLibraryCardByUserId(user.getUserId());
   }
 
   public LibraryCard createLibraryCardForSigningOfficial(User user, User signingOfficial) {
@@ -189,26 +184,22 @@ public class LibraryCardService {
 
   //helper method for create method, checks to see if card already exists
   private void checkIfCardExists(LibraryCard payload) {
-    Integer userId = payload.getUserId();
-    String email = payload.getUserEmail();
-    Optional<LibraryCard> foundCard;
-    List<LibraryCard> results;
+    LibraryCard result = null;
 
-    if (Objects.nonNull(payload.getUserId())) {
-      results = libraryCardDAO.findLibraryCardsByUserId(userId);
-    } else if (Objects.nonNull(email)) {
-      results = libraryCardDAO.findAllLibraryCardsByUserEmail(email);
+    if (payload.getUserId() != null) {
+      result = libraryCardDAO.findLibraryCardByUserId(payload.getUserId());
+    } else if (payload.getUserEmail() != null) {
+      result = libraryCardDAO.findLibraryCardByUserEmail(payload.getUserEmail());
     } else {
       throw new BadRequestException();
     }
-    foundCard = results.stream().filter(card -> {
-      Boolean sameUserId = Objects.nonNull(userId) && card.getUserId().equals(userId);
-      Boolean sameUserEmail = Objects.nonNull(email) && card.getUserEmail().equalsIgnoreCase(email);
-      return (sameUserId || sameUserEmail);
-    }).findFirst();
 
-    if (foundCard.isPresent()) {
-      throw new ConsentConflictException();
+    if (result != null) {
+      Boolean sameUserId = payload.getUserId() != null && result.getUserId().equals(payload.getUserId());
+      Boolean sameUserEmail = payload.getUserEmail() != null && result.getUserEmail().equalsIgnoreCase(payload.getUserEmail());
+      if (sameUserId || sameUserEmail) {
+        throw new ConsentConflictException("Library card already exists for this user.");
+      }
     }
   }
 

--- a/src/main/java/org/broadinstitute/consent/http/service/LibraryCardService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/LibraryCardService.java
@@ -88,7 +88,7 @@ public class LibraryCardService {
     libraryCardDAO.deleteLibraryCardDaaRelation(libraryCardId, daaId);
   }
 
-  public LibraryCard addDaaToUserLibraryCardByInstitution(User user, User signingOfficial, Integer daaId) {
+  public LibraryCard addDaaToUserLibraryCard(User user, User signingOfficial, Integer daaId) {
     if (signingOfficial.getInstitutionId() == null) {
       throw new BadRequestException("This signing official does not have an institution.");
     }
@@ -96,7 +96,6 @@ public class LibraryCardService {
     if (libraryCard == null) {
       libraryCard = createLibraryCardForSigningOfficial(user, signingOfficial);
     }
-    // typically there should be one library card per user per institution
     addDaaToLibraryCard(libraryCard.getId(), daaId);
     return libraryCardDAO.findLibraryCardByUserId(user.getUserId());
   }

--- a/src/main/java/org/broadinstitute/consent/http/service/UserService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/UserService.java
@@ -181,7 +181,7 @@ public class UserService implements ConsentLogger {
     Integer userId = userDAO.insertUser(user.getEmail(), user.getDisplayName(),
         user.getInstitutionId(), new Date());
     insertUserRoles(user.getRoles(), userId);
-    addFloatingLibraryCardToUser(user);
+    assignExistingLibraryCardToUser(user);
     return userDAO.findUserById(userId);
   }
 
@@ -372,7 +372,7 @@ public class UserService implements ConsentLogger {
     userRoleDAO.insertUserRoles(roles, userId);
   }
 
-  private void addFloatingLibraryCardToUser(User user) {
+  private void assignExistingLibraryCardToUser(User user) {
     LibraryCard libraryCard = libraryCardDAO.findLibraryCardByUserEmail(user.getEmail());
     if (libraryCard != null) {
       libraryCardDAO.updateLibraryCardById(

--- a/src/main/java/org/broadinstitute/consent/http/service/UserService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/UserService.java
@@ -50,7 +50,8 @@ import org.broadinstitute.consent.http.util.gson.GsonUtil;
 
 public class UserService implements ConsentLogger {
 
-  public static final String LIBRARY_CARDS_FIELD = "libraryCard";
+  public static final String LIBRARY_CARD_FIELD = "libraryCard";
+  public static final String LIBRARY_CARDS_FIELD = "libraryCards";
   public static final String USER_PROPERTIES_FIELD = "properties";
   public static final String USER_STATUS_INFO_FIELD = "userStatusInfo";
 
@@ -329,7 +330,12 @@ public class UserService implements ConsentLogger {
     JsonObject userJson = gson.toJsonTree(user).getAsJsonObject();
     JsonArray propsJson = gson.toJsonTree(props).getAsJsonArray();
     userJson.add(USER_PROPERTIES_FIELD, propsJson);
-    userJson.add(LIBRARY_CARDS_FIELD, gson.toJsonTree(user.getLibraryCard()));
+    if (user.getLibraryCard() != null) {
+      JsonObject libraryCardJson = gson.toJsonTree(user.getLibraryCard()).getAsJsonObject();
+      userJson.add(LIBRARY_CARD_FIELD, libraryCardJson);
+      // Note that this is provided for backwards compatibility with the UI and will be removed
+      userJson.add(LIBRARY_CARDS_FIELD, gson.toJsonTree(List.of(libraryCardJson)));
+    }
     if (authUser.getEmail().equalsIgnoreCase(user.getEmail()) && Objects.nonNull(
         authUser.getUserStatusInfo())) {
       JsonObject userStatusInfoJson = gson.toJsonTree(authUser.getUserStatusInfo())

--- a/src/main/java/org/broadinstitute/consent/http/service/UserService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/UserService.java
@@ -50,7 +50,7 @@ import org.broadinstitute.consent.http.util.gson.GsonUtil;
 
 public class UserService implements ConsentLogger {
 
-  public static final String LIBRARY_CARDS_FIELD = "libraryCards";
+  public static final String LIBRARY_CARDS_FIELD = "libraryCard";
   public static final String USER_PROPERTIES_FIELD = "properties";
   public static final String USER_STATUS_INFO_FIELD = "userStatusInfo";
 
@@ -180,7 +180,7 @@ public class UserService implements ConsentLogger {
     Integer userId = userDAO.insertUser(user.getEmail(), user.getDisplayName(),
         user.getInstitutionId(), new Date());
     insertUserRoles(user.getRoles(), userId);
-    addExistingLibraryCards(user);
+    addFloatingLibraryCardToUser(user);
     return userDAO.findUserById(userId);
   }
 
@@ -189,10 +189,6 @@ public class UserService implements ConsentLogger {
     if (user == null) {
       throw new NotFoundException("Unable to find user with id: " + id);
     }
-    List<LibraryCard> cards = libraryCardDAO.findLibraryCardsByUserId(user.getUserId());
-    if (Objects.nonNull(cards) && !cards.isEmpty()) {
-      user.setLibraryCards(cards);
-    }
     return user;
   }
 
@@ -200,10 +196,6 @@ public class UserService implements ConsentLogger {
     User user = userDAO.findUserByEmail(email);
     if (user == null) {
       throw new NotFoundException("Unable to find user with email: " + email);
-    }
-    List<LibraryCard> cards = libraryCardDAO.findLibraryCardsByUserId(user.getUserId());
-    if (Objects.nonNull(cards) && !cards.isEmpty()) {
-      user.setLibraryCards(cards);
     }
     return user;
   }
@@ -334,13 +326,10 @@ public class UserService implements ConsentLogger {
     Gson gson = GsonUtil.getInstance();
     User user = findUserById(userId);
     List<UserProperty> props = findAllUserProperties(user.getUserId());
-    List<LibraryCard> entries =
-        Objects.nonNull(user.getLibraryCards()) ? user.getLibraryCards() : List.of();
     JsonObject userJson = gson.toJsonTree(user).getAsJsonObject();
     JsonArray propsJson = gson.toJsonTree(props).getAsJsonArray();
-    JsonArray entriesJson = gson.toJsonTree(entries).getAsJsonArray();
     userJson.add(USER_PROPERTIES_FIELD, propsJson);
-    userJson.add(LIBRARY_CARDS_FIELD, entriesJson);
+    userJson.add(LIBRARY_CARDS_FIELD, gson.toJsonTree(user.getLibraryCard()));
     if (authUser.getEmail().equalsIgnoreCase(user.getEmail()) && Objects.nonNull(
         authUser.getUserStatusInfo())) {
       JsonObject userStatusInfoJson = gson.toJsonTree(authUser.getUserStatusInfo())
@@ -377,19 +366,15 @@ public class UserService implements ConsentLogger {
     userRoleDAO.insertUserRoles(roles, userId);
   }
 
-  private void addExistingLibraryCards(User user) {
-    List<LibraryCard> libraryCards = libraryCardDAO.findAllLibraryCardsByUserEmail(user.getEmail());
-
-    libraryCards
-        .forEach(lc -> {
-          libraryCardDAO.updateLibraryCardById(
-              lc.getId(),
-              user.getUserId(),
-              lc.getUserName(),
-              lc.getUserEmail(),
-              user.getUserId(),
-              new Date());
-        });
+  private void addFloatingLibraryCardToUser(User user) {
+    LibraryCard libraryCard = libraryCardDAO.findLibraryCardByUserEmail(user.getEmail());
+    libraryCardDAO.updateLibraryCardById(
+        libraryCard.getId(),
+        user.getUserId(),
+        user.getDisplayName(),
+        user.getEmail(),
+        user.getUserId(),
+        new Date());
   }
 
   public User findOrCreateUser(AuthUser authUser) throws Exception {
@@ -424,15 +409,14 @@ public class UserService implements ConsentLogger {
   }
 
   public void hasValidActiveERACredentials(User user) {
-    List<LibraryCard> cards = user.getLibraryCards();
-    List<UserProperty> userProperties = findAllUserProperties(user.getUserId());
-    if (cards.isEmpty()) {
+    if (user.getLibraryCard() == null) {
       throw new LibraryCardRequiredException();
     }
     boolean hasEraCommonsId = user.getEraCommonsId() != null;
     if (!hasEraCommonsId) {
       throw new BadRequestException("User does not have an Era Commons ID");
     }
+    List<UserProperty> userProperties = findAllUserProperties(user.getUserId());
     List<UserProperty> eraStatusProps = userProperties.stream().filter(
             userProperty -> userProperty.getPropertyKey().equalsIgnoreCase(ERA_STATUS.getValue()))
         .toList();

--- a/src/main/java/org/broadinstitute/consent/http/service/UserService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/UserService.java
@@ -368,13 +368,15 @@ public class UserService implements ConsentLogger {
 
   private void addFloatingLibraryCardToUser(User user) {
     LibraryCard libraryCard = libraryCardDAO.findLibraryCardByUserEmail(user.getEmail());
-    libraryCardDAO.updateLibraryCardById(
-        libraryCard.getId(),
-        user.getUserId(),
-        user.getDisplayName(),
-        user.getEmail(),
-        user.getUserId(),
-        new Date());
+    if (libraryCard != null) {
+      libraryCardDAO.updateLibraryCardById(
+          libraryCard.getId(),
+          user.getUserId(),
+          user.getDisplayName(),
+          user.getEmail(),
+          user.getUserId(),
+          new Date());
+    }
   }
 
   public User findOrCreateUser(AuthUser authUser) throws Exception {

--- a/src/main/resources/assets/schemas/User.yaml
+++ b/src/main/resources/assets/schemas/User.yaml
@@ -22,7 +22,10 @@ properties:
       $ref: './UserRole.yaml'
   properties:
     $ref: './UserProperties.yaml'
+  libraryCard:
+    $ref: './LibraryCard.yaml'
   libraryCards:
+    deprecated: true
     type: array
     items:
       $ref: './LibraryCard.yaml'

--- a/src/main/resources/changelog-master.xml
+++ b/src/main/resources/changelog-master.xml
@@ -180,4 +180,6 @@
     relativeToChangelogFile="true" />
   <include file="changesets/changelog-consent-2025-05-16-disallow-pr-siblings.xml"
     relativeToChangelogFile="true" />
+  <include file="changesets/changelog-consent-2025-23-unique-lc-user.xml"
+    relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/src/main/resources/changesets/changelog-consent-2025-23-unique-lc-user.xml
+++ b/src/main/resources/changesets/changelog-consent-2025-23-unique-lc-user.xml
@@ -2,7 +2,36 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
          http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
   <changeSet id="changelog-consent-2025-23-unique-lc-user" author="grushton">
+    <sql>
+      -- Remove DAA associations - these are not in use yet and cause FK problems
+      DELETE
+      FROM lc_daa;
+
+      -- Remove duplicate library cards based on user_id
+      DELETE
+      FROM library_card
+      WHERE id IN
+            (SELECT id
+             FROM (SELECT id,
+                          ROW_NUMBER() OVER( PARTITION BY user_id
+        ORDER BY  id ) AS row_num
+                   FROM library_card) t
+             WHERE t.row_num > 1);
+
+      -- Remove duplicate library cards based on user_email
+      DELETE
+      FROM library_card
+      WHERE id IN
+            (SELECT id
+             FROM (SELECT id,
+                          ROW_NUMBER() OVER( PARTITION BY user_email
+        ORDER BY  id ) AS row_num
+                   FROM library_card) t
+             WHERE t.row_num > 1);
+    </sql>
     <addUniqueConstraint tableName="library_card" columnNames="user_id"
                          constraintName="uk_lc_user_id" />
+    <addUniqueConstraint tableName="library_card" columnNames="user_email"
+                         constraintName="uk_lc_user_email" />
   </changeSet>
 </databaseChangeLog>

--- a/src/main/resources/changesets/changelog-consent-2025-23-unique-lc-user.xml
+++ b/src/main/resources/changesets/changelog-consent-2025-23-unique-lc-user.xml
@@ -15,7 +15,8 @@
              FROM (SELECT id,
                           ROW_NUMBER() OVER( PARTITION BY user_id
         ORDER BY  id ) AS row_num
-                   FROM library_card) t
+                   FROM library_card
+                   WHERE user_id IS NOT NULL) t
              WHERE t.row_num > 1);
 
       -- Remove duplicate library cards based on user_email where user_id is null

--- a/src/main/resources/changesets/changelog-consent-2025-23-unique-lc-user.xml
+++ b/src/main/resources/changesets/changelog-consent-2025-23-unique-lc-user.xml
@@ -1,0 +1,8 @@
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+  <changeSet id="changelog-consent-2025-23-unique-lc-user" author="grushton">
+    <addUniqueConstraint tableName="library_card" columnNames="user_id"
+                         constraintName="uk_lc_user_id" />
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/changesets/changelog-consent-2025-23-unique-lc-user.xml
+++ b/src/main/resources/changesets/changelog-consent-2025-23-unique-lc-user.xml
@@ -18,7 +18,7 @@
                    FROM library_card) t
              WHERE t.row_num > 1);
 
-      -- Remove duplicate library cards based on user_email
+      -- Remove duplicate library cards based on user_email where user_id is null
       DELETE
       FROM library_card
       WHERE id IN
@@ -26,7 +26,8 @@
              FROM (SELECT id,
                           ROW_NUMBER() OVER( PARTITION BY user_email
         ORDER BY  id ) AS row_num
-                   FROM library_card) t
+                   FROM library_card
+                   WHERE user_id IS NULL) t
              WHERE t.row_num > 1);
     </sql>
     <addUniqueConstraint tableName="library_card" columnNames="user_id"

--- a/src/test/java/org/broadinstitute/consent/http/db/DarCollectionDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DarCollectionDAOTest.java
@@ -144,7 +144,7 @@ class DarCollectionDAOTest extends DAOTestHelper {
     userProperties.forEach(p -> assertEquals(collection.getCreateUserId(),
         p.getUserId()));
 
-    assertTrue(returned.getCreateUser().getLibraryCards().isEmpty());
+    assertNull(returned.getCreateUser().getLibraryCard());
   }
 
   @Test
@@ -163,20 +163,20 @@ class DarCollectionDAOTest extends DAOTestHelper {
   @Test
   void testFindDARCollectionByCollectionIdLibraryCard() {
     User user = createUser();
-    LibraryCard libraryCard = createLibraryCard(user);
+    createLibraryCard(user);
+    User updatedUser = userDAO.findUserById(user.getUserId());
     String darCode = "DAR-" + randomInt(100, 1000);
-    Integer collectionId = darCollectionDAO.insertDarCollection(darCode, user.getUserId(),
+    Integer collectionId = darCollectionDAO.insertDarCollection(darCode, updatedUser.getUserId(),
         new Date());
-    createDataAccessRequest(user.getUserId(), collectionId);
+    createDataAccessRequest(updatedUser.getUserId(), collectionId);
 
     DarCollection collection = darCollectionDAO.findDARCollectionByCollectionId(collectionId);
     User returnedUser = collection.getCreateUser();
-    assertEquals(user, returnedUser);
+    assertEquals(updatedUser, returnedUser);
 
-    List<LibraryCard> returnedLibraryCards = returnedUser.getLibraryCards();
-    assertEquals(1, returnedLibraryCards.size());
-    assertEquals(libraryCard, returnedLibraryCards.get(0));
-    assertEquals(user.getUserId(), returnedLibraryCards.get(0).getUserId());
+    LibraryCard returnedLibraryCard = returnedUser.getLibraryCard();
+    assertNotNull(returnedLibraryCard);
+    assertEquals(updatedUser.getLibraryCard(), returnedLibraryCard);
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/db/LibraryCardDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/LibraryCardDAOTest.java
@@ -3,7 +3,6 @@ package org.broadinstitute.consent.http.db;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Instant;

--- a/src/test/java/org/broadinstitute/consent/http/db/LibraryCardDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/LibraryCardDAOTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.time.Instant;
 import java.util.Date;
@@ -29,26 +30,49 @@ class LibraryCardDAOTest extends DAOTestHelper {
   }
 
   @Test
-  void testInsertLibraryCardNegative() {
-    Integer userId = createUser().getUserId();
-    String stringValue = "value";
+  void testInsertLibraryCardFKConstraintErrors() {
+    User user = createUser();
+    // Test FK on library_card.user_id
     try {
-      libraryCardDAO.insertLibraryCard(0, stringValue, stringValue,
-          userId, new Date());
+      libraryCardDAO.insertLibraryCard(0, user.getDisplayName(), user.getEmail(),
+          user.getUserId(), new Date());
+      fail("Should have thrown an exception");
     } catch (Exception e) {
       assertEquals(PSQLState.FOREIGN_KEY_VIOLATION.getState(),
           ((PSQLException) e.getCause()).getSQLState());
     }
+    // Test FK on library_card.create_user_id
     try {
-      libraryCardDAO.insertLibraryCard(userId, stringValue, stringValue, userId,
+      libraryCardDAO.insertLibraryCard(user.getUserId(), user.getDisplayName(), user.getEmail(), 0,
           new Date());
+      fail("Should have thrown an exception");
     } catch (Exception e) {
       assertEquals(PSQLState.FOREIGN_KEY_VIOLATION.getState(),
           ((PSQLException) e.getCause()).getSQLState());
     }
+  }
+
+  @Test
+  void testInsertLibraryCardUniqueConstraintErrors() {
+    User user1 = createUser();
+    // Set up LC that will trigger the unique constraints on subsequent inserts
+    libraryCardDAO.insertLibraryCard(user1.getUserId(), user1.getDisplayName(), user1.getEmail(),
+        user1.getUserId(), new Date());
+    // Test Unique on library_card.user_id
     try {
-      libraryCardDAO.insertLibraryCard(userId, stringValue, stringValue,
-          0, new Date());
+      libraryCardDAO.insertLibraryCard(user1.getUserId(), user1.getDisplayName(), user1.getEmail(),
+          user1.getUserId(), new Date());
+      fail("Should have thrown an exception");
+    } catch (Exception e) {
+      assertEquals(PSQLState.UNIQUE_VIOLATION.getState(),
+          ((PSQLException) e.getCause()).getSQLState());
+    }
+    User user2 = createUser();
+    // Test Unique on library_card.user_email - note that we're using the same email as user1
+    try {
+      libraryCardDAO.insertLibraryCard(user2.getUserId(), user2.getDisplayName(), user1.getEmail(),
+          user2.getUserId(), new Date());
+      fail("Should have thrown an exception");
     } catch (Exception e) {
       assertEquals(PSQLState.UNIQUE_VIOLATION.getState(),
           ((PSQLException) e.getCause()).getSQLState());

--- a/src/test/java/org/broadinstitute/consent/http/db/LibraryCardDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/LibraryCardDAOTest.java
@@ -50,7 +50,7 @@ class LibraryCardDAOTest extends DAOTestHelper {
       libraryCardDAO.insertLibraryCard(userId, stringValue, stringValue,
           0, new Date());
     } catch (Exception e) {
-      assertEquals(PSQLState.FOREIGN_KEY_VIOLATION.getState(),
+      assertEquals(PSQLState.UNIQUE_VIOLATION.getState(),
           ((PSQLException) e.getCause()).getSQLState());
     }
   }

--- a/src/test/java/org/broadinstitute/consent/http/db/LibraryCardDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/LibraryCardDAOTest.java
@@ -3,15 +3,12 @@ package org.broadinstitute.consent.http.db;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-
 
 import java.time.Instant;
 import java.util.Date;
 import java.util.List;
-import org.apache.commons.lang3.RandomStringUtils;
-import org.apache.commons.lang3.RandomUtils;
 import org.broadinstitute.consent.http.models.DataAccessAgreement;
 import org.broadinstitute.consent.http.models.Institution;
 import org.broadinstitute.consent.http.models.LibraryCard;
@@ -97,7 +94,7 @@ class LibraryCardDAOTest extends DAOTestHelper {
   @Test
   void testDeleteLibraryCardByIdNegative() {
     try {
-      libraryCardDAO.deleteLibraryCardById(RandomUtils.nextInt(1, 1000));
+      libraryCardDAO.deleteLibraryCardById(randomInt(1, 1000));
     } catch (Exception e) {
       assertEquals(PSQLState.UNIQUE_VIOLATION.getState(),
           ((PSQLException) e.getCause()).getSQLState());
@@ -112,7 +109,7 @@ class LibraryCardDAOTest extends DAOTestHelper {
     // 3. DAA so we can link it to a user's Library Card
     // 4. Library Card <-> DAA relationship that represents a Signing Official's acceptance of a DAA for the user
     LibraryCard card = createLibraryCard();
-    int dacId = dacDAO.createDac(RandomStringUtils.randomAlphabetic(10), RandomStringUtils.randomAlphabetic(10), new Date());
+    int dacId = dacDAO.createDac(randomAlphabetic(10), randomAlphabetic(10), new Date());
     int daaId = daaDAO.createDaa(card.getCreateUserId(), Instant.now(), card.getCreateUserId(), Instant.now(), dacId);
     daaDAO.createDacDaaRelation(dacId, daaId);
     libraryCardDAO.createLibraryCardDaaRelation(card.getId(), daaId);
@@ -135,7 +132,7 @@ class LibraryCardDAOTest extends DAOTestHelper {
 
   @Test
   void testFindLibraryCardByIdNegative() {
-    LibraryCard cardFromDAO = libraryCardDAO.findLibraryCardById(RandomUtils.nextInt(100, 200));
+    LibraryCard cardFromDAO = libraryCardDAO.findLibraryCardById(randomInt(100, 200));
     assertNull(cardFromDAO);
   }
 
@@ -198,7 +195,7 @@ class LibraryCardDAOTest extends DAOTestHelper {
 
   @Test
   void testFindLibraryCardDaaByIdNegative() {
-    LibraryCard cardFromDAO = libraryCardDAO.findLibraryCardDaaById(RandomUtils.nextInt(100, 200));
+    LibraryCard cardFromDAO = libraryCardDAO.findLibraryCardDaaById(randomInt(100, 200));
     assertNull(cardFromDAO);
   }
 
@@ -222,18 +219,15 @@ class LibraryCardDAOTest extends DAOTestHelper {
   @Test
   void testFindLibraryCardByUserIdInstitutionId() {
     LibraryCard libraryCard = createLibraryCard();
-    int dacId = dacDAO.createDac(RandomStringUtils.randomAlphabetic(5), RandomStringUtils.randomAlphabetic(5), RandomStringUtils.randomAlphabetic(5), new Date());
+    int dacId = dacDAO.createDac(randomAlphabetic(5), randomAlphabetic(5), randomAlphabetic(5), new Date());
     Instant now = Instant.now();
     int daaId = daaDAO.createDaa(libraryCard.getUserId(), now, libraryCard.getUserId(), now, dacId);
     daaDAO.createDacDaaRelation(dacId, daaId);
     libraryCardDAO.createLibraryCardDaaRelation(libraryCard.getId(), daaId);
-    List<LibraryCard> cardsFromDAO = libraryCardDAO.findLibraryCardsByUserId(
+    LibraryCard cardFromDAO = libraryCardDAO.findLibraryCardByUserId(
         libraryCard.getUserId());
-    assertNotNull(cardsFromDAO);
-    assertEquals(1, cardsFromDAO.size());
-    assertEquals(cardsFromDAO.get(0).getId(), libraryCard.getId());
-    assertEquals(cardsFromDAO.get(0).getUserId(), libraryCard.getUserId());
-    assertFalse(cardsFromDAO.get(0).getDaaIds().isEmpty());
+    assertNotNull(cardFromDAO);
+    assertEquals(cardFromDAO, libraryCard);
   }
 
   @Test
@@ -248,28 +242,21 @@ class LibraryCardDAOTest extends DAOTestHelper {
   }
 
   @Test
-  void testFindAllLibraryCardsByUserEmail() {
+  void testFindLibraryCardsByUserEmail() {
     User user = createUser();
     LibraryCard libraryCard = createLibraryCard(user);
-    List<LibraryCard> libraryCards = libraryCardDAO.findAllLibraryCardsByUserEmail(user.getEmail());
-    assertNotNull(libraryCards);
-    assertEquals(1, libraryCards.size());
-    assertEquals(user.getEmail(), libraryCards.get(0).getUserEmail());
-    assertEquals(libraryCard.getId(), libraryCards.get(0).getId());
+    LibraryCard cardFromDAO = libraryCardDAO.findLibraryCardByUserEmail(user.getEmail());
+    assertNotNull(cardFromDAO);
+    assertEquals(cardFromDAO, libraryCard);
   }
 
   @Test
-  void testFindAllLibraryCardsByUserId() {
+  void testFindLibraryCardsByUserId() {
     User user = createUser();
     LibraryCard one = createLibraryCard(user);
-    LibraryCard two = createLibraryCard(user);
-    List<LibraryCard> libraryCards = libraryCardDAO.findLibraryCardsByUserId(user.getUserId());
-    assertNotNull(libraryCards);
-    assertEquals(2, libraryCards.size());
-    assertEquals(one.getId(), libraryCards.get(0).getId());
-    assertEquals(two.getId(), libraryCards.get(1).getId());
-    assertTrue(one.getDaaIds().isEmpty());
-    assertTrue(two.getDaaIds().isEmpty());
+    LibraryCard cardFromDAO = libraryCardDAO.findLibraryCardByUserId(user.getUserId());
+    assertNotNull(cardFromDAO);
+    assertEquals(cardFromDAO, one);
   }
 
   @Test
@@ -287,8 +274,8 @@ class LibraryCardDAOTest extends DAOTestHelper {
     LibraryCard card = createLibraryCard(user);
     LibraryCard card2 = createLibraryCard(user2);
     Integer userId = user.getUserId();
-    Integer dacId = dacDAO.createDac(RandomStringUtils.randomAlphabetic(5), RandomStringUtils.randomAlphabetic(5), "",  new Date());
-    Integer dacId2 = dacDAO.createDac(RandomStringUtils.randomAlphabetic(5), RandomStringUtils.randomAlphabetic(5), "",  new Date());
+    Integer dacId = dacDAO.createDac(randomAlphabetic(5), randomAlphabetic(5), "",  new Date());
+    Integer dacId2 = dacDAO.createDac(randomAlphabetic(5), randomAlphabetic(5), "",  new Date());
     Integer daaId1 = daaDAO.createDaa(userId, new Date().toInstant(), userId, new Date().toInstant(), dacId);
     Integer daaId2 = daaDAO.createDaa(userId, new Date().toInstant(), userId, new Date().toInstant(), dacId2);
     libraryCardDAO.createLibraryCardDaaRelation(card.getId(), daaId1);
@@ -309,7 +296,7 @@ class LibraryCardDAOTest extends DAOTestHelper {
     User user = createUser();
     LibraryCard card = createLibraryCard(user);
     Integer userId = user.getUserId();
-    Integer dacId = dacDAO.createDac(RandomStringUtils.randomAlphabetic(5), RandomStringUtils.randomAlphabetic(5), "",  new Date());
+    Integer dacId = dacDAO.createDac(randomAlphabetic(5), randomAlphabetic(5), "",  new Date());
     Integer daaId1 = daaDAO.createDaa(userId, new Date().toInstant(), userId, new Date().toInstant(), dacId);
 
     try {
@@ -338,8 +325,8 @@ class LibraryCardDAOTest extends DAOTestHelper {
     LibraryCard card = createLibraryCard(user);
     LibraryCard card2 = createLibraryCard(user2);
     Integer userId = user.getUserId();
-    Integer dacId = dacDAO.createDac(RandomStringUtils.randomAlphabetic(5), RandomStringUtils.randomAlphabetic(5), "",  new Date());
-    Integer dacId2 = dacDAO.createDac(RandomStringUtils.randomAlphabetic(5), RandomStringUtils.randomAlphabetic(5), "", new Date());
+    Integer dacId = dacDAO.createDac(randomAlphabetic(5), randomAlphabetic(5), "",  new Date());
+    Integer dacId2 = dacDAO.createDac(randomAlphabetic(5), randomAlphabetic(5), "", new Date());
     Integer daaId1 = daaDAO.createDaa(userId, new Date().toInstant(), userId, new Date().toInstant(), dacId);
     Integer daaId2 = daaDAO.createDaa(userId, new Date().toInstant(), userId, new Date().toInstant(), dacId2);
     libraryCardDAO.createLibraryCardDaaRelation(card.getId(), daaId1);

--- a/src/test/java/org/broadinstitute/consent/http/db/UserDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/UserDAOTest.java
@@ -273,16 +273,6 @@ class UserDAOTest extends DAOTestHelper {
   }
 
   @Test
-  void testFindUserByEmailAndRoleId() {
-    User chair = createUserWithRole(UserRoles.CHAIRPERSON.getRoleId());
-    User user = userDAO.findUserByEmailAndRoleId(chair.getEmail(),
-        UserRoles.CHAIRPERSON.getRoleId());
-    assertNotNull(user);
-    assertEquals(chair.getUserId(), user.getUserId());
-    assertEquals(chair.getDisplayName(), user.getDisplayName());
-  }
-
-  @Test
   void testFindUsersForDatasetsByRole() {
     Dataset dataset = createDataset();
     Dac dac = createDac();

--- a/src/test/java/org/broadinstitute/consent/http/db/UserDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/UserDAOTest.java
@@ -197,8 +197,8 @@ class UserDAOTest extends DAOTestHelper {
   @Test
   void testFindUsersWithLCsAndInstitution() {
     User user = createUserWithInstitution();
-    int dacId = dacDAO.createDac(RandomStringUtils.randomAlphabetic(5),
-        RandomStringUtils.randomAlphabetic(5), new Date());
+    int dacId = dacDAO.createDac(randomAlphabetic(5),
+        randomAlphabetic(5), new Date());
     Instant now = Instant.now();
     int daaId = daaDAO.createDaa(user.getUserId(), now, user.getUserId(), now, dacId);
     int lcId1 = libraryCardDAO.insertLibraryCard(user.getUserId(),
@@ -207,7 +207,7 @@ class UserDAOTest extends DAOTestHelper {
 
     User user2 = createUserWithInstitution();
     int lcId2 = libraryCardDAO.insertLibraryCard(user2.getUserId(),
-        user.getDisplayName(), user.getEmail(), user.getUserId(), new Date());
+        user2.getDisplayName(), user2.getEmail(), user2.getUserId(), new Date());
     libraryCardDAO.createLibraryCardDaaRelation(lcId2, daaId);
 
     List<User> users = userDAO.findUsersWithLCsAndInstitution();
@@ -333,8 +333,8 @@ class UserDAOTest extends DAOTestHelper {
 
   @Test
   void testGetUsersFromInstitutionWithCards() {
-    int dacId = dacDAO.createDac(RandomStringUtils.randomAlphabetic(5),
-        RandomStringUtils.randomAlphabetic(5), new Date());
+    int dacId = dacDAO.createDac(randomAlphabetic(5),
+        randomAlphabetic(5), new Date());
     Instant now = Instant.now();
     LibraryCard card = createLibraryCard();
     int daaId = daaDAO.createDaa(card.getUserId(), now, card.getUserId(), now, dacId);
@@ -353,8 +353,8 @@ class UserDAOTest extends DAOTestHelper {
 
   @Test
   void testGetUsersWithCardsByDaaId() {
-    int dacId = dacDAO.createDac(RandomStringUtils.randomAlphabetic(5),
-        RandomStringUtils.randomAlphabetic(5), new Date());
+    int dacId = dacDAO.createDac(randomAlphabetic(5),
+        randomAlphabetic(5), new Date());
     Instant now = Instant.now();
     LibraryCard card = createLibraryCard();
     int daaId = daaDAO.createDaa(card.getUserId(), now, card.getUserId(), now, dacId);

--- a/src/test/java/org/broadinstitute/consent/http/db/UserDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/UserDAOTest.java
@@ -36,7 +36,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class UserDAOTest extends DAOTestHelper {
 
   @Test
-  void testFindDACUserById() {
+  void testFindUserById() {
     User user = createUserWithRole(UserRoles.ALUMNI.getRoleId());
     assertNotNull(user);
     assertFalse(user.getRoles().isEmpty());
@@ -62,6 +62,22 @@ class UserDAOTest extends DAOTestHelper {
     assert (queriedUser3.getUserId()).equals(user3.getUserId());
     assertNotNull(queriedUser3.getInstitutionId());
     assert (queriedUser3.getInstitution().getId()).equals(user3.getInstitution().getId());
+  }
+
+  @Test
+  void testFindUserByIdWithLibraryCard() {
+    LibraryCard libraryCard = createLibraryCard();
+    User user = userDAO.findUserById(libraryCard.getUserId());
+    assertNotNull(user);
+    assertEquals(libraryCard, user.getLibraryCard());
+  }
+
+  @Test
+  void testFindUserByEmailWithLibraryCard() {
+    LibraryCard libraryCard = createLibraryCard();
+    User user = userDAO.findUserByEmail(libraryCard.getUserEmail());
+    assertNotNull(user);
+    assertEquals(libraryCard, user.getLibraryCard());
   }
 
   @Test
@@ -477,10 +493,8 @@ class UserDAOTest extends DAOTestHelper {
 
   private LibraryCard createLibraryCard() {
     User user = createUserWithInstitution();
-    Integer userId = user.getUserId();
-    String stringValue = "value";
-    Integer id = libraryCardDAO.insertLibraryCard(userId, stringValue,
-        stringValue, userId, new Date());
+    Integer id = libraryCardDAO.insertLibraryCard(user.getUserId(), user.getDisplayName(),
+        user.getEmail(), user.getUserId(), new Date());
     return libraryCardDAO.findLibraryCardById(id);
   }
 }

--- a/src/test/java/org/broadinstitute/consent/http/db/UserDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/UserDAOTest.java
@@ -203,11 +203,9 @@ class UserDAOTest extends DAOTestHelper {
         .toList();
     assertEquals(2, users.size());
     assertNotNull(users.get(0).getInstitution());
-    assertNotNull(users.get(0).getLibraryCards());
-    assertEquals(1, users.get(0).getLibraryCards().size());
+    assertNotNull(users.get(0).getLibraryCard());
     assertNotNull(users.get(1).getInstitution());
-    assertNotNull(users.get(1).getLibraryCards());
-    assertEquals(1, users.get(1).getLibraryCards().size());
+    assertNotNull(users.get(1).getLibraryCard());
   }
 
   @Test
@@ -342,7 +340,7 @@ class UserDAOTest extends DAOTestHelper {
     User returnedUser = users.get(0);
     assertEquals(userId, returnedUser.getUserId());
 
-    LibraryCard returnedCard = returnedUser.getLibraryCards().get(0);
+    LibraryCard returnedCard = returnedUser.getLibraryCard();
     assertEquals(card.getId(), returnedCard.getId());
     assertEquals(userId, returnedCard.getUserId());
   }
@@ -365,7 +363,7 @@ class UserDAOTest extends DAOTestHelper {
     assertEquals(1, users2.size());
     User returnedUser = users.get(0);
 
-    LibraryCard returnedCard = returnedUser.getLibraryCards().get(0);
+    LibraryCard returnedCard = returnedUser.getLibraryCard();
     assertEquals(card.getId(), returnedCard.getId());
     assertEquals(returnedCard.getDaaIds(), List.of(daaId));
     assertEquals(userId, returnedCard.getUserId());

--- a/src/test/java/org/broadinstitute/consent/http/db/UserDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/UserDAOTest.java
@@ -353,27 +353,29 @@ class UserDAOTest extends DAOTestHelper {
 
   @Test
   void testGetUsersWithCardsByDaaId() {
-    int dacId = dacDAO.createDac(randomAlphabetic(5),
-        randomAlphabetic(5), new Date());
+    int dacId = dacDAO.createDac(randomAlphabetic(5), randomAlphabetic(5), new Date());
     Instant now = Instant.now();
-    LibraryCard card = createLibraryCard();
-    int daaId = daaDAO.createDaa(card.getUserId(), now, card.getUserId(), now, dacId);
-    libraryCardDAO.createLibraryCardDaaRelation(card.getId(), daaId);
+    LibraryCard card1 = createLibraryCard();
+    int daaId1 = daaDAO.createDaa(card1.getUserId(), now, card1.getUserId(), now, dacId);
+    libraryCardDAO.createLibraryCardDaaRelation(card1.getId(), daaId1);
     LibraryCard card2 = createLibraryCard();
     int daaId2 = daaDAO.createDaa(card2.getUserId(), now, card2.getUserId(), now, dacId);
     libraryCardDAO.createLibraryCardDaaRelation(card2.getId(), daaId2);
-    Integer userId = card.getUserId();
-    List<User> users = userDAO.getUsersWithCardsByDaaId(daaId);
-    List<User> users2 = userDAO.getUsersWithCardsByDaaId(daaId2);
-    assertEquals(1, users.size());
-    assertEquals(1, users2.size());
-    User returnedUser = users.get(0);
 
-    LibraryCard returnedCard = returnedUser.getLibraryCard();
-    assertEquals(card.getId(), returnedCard.getId());
-    assertEquals(returnedCard.getDaaIds(), List.of(daaId));
-    assertEquals(userId, returnedCard.getUserId());
-    assertNotEquals(users, users2);
+    List<User> daa1UserList = userDAO.getUsersWithCardsByDaaId(daaId1);
+    assertEquals(1, daa1UserList.size());
+
+    List<User> daa2UserList = userDAO.getUsersWithCardsByDaaId(daaId2);
+    assertEquals(1, daa2UserList.size());
+    assertNotEquals(daa1UserList, daa2UserList);
+
+    User daa1User = daa1UserList.get(0);
+    assertEquals(card1, daa1User.getLibraryCard());
+    assertEquals(daa1User.getLibraryCard().getDaaIds(), List.of(daaId1));
+
+    User daa2User = daa2UserList.get(0);
+    assertEquals(card2, daa2User.getLibraryCard());
+    assertEquals(daa2User.getLibraryCard().getDaaIds(), List.of(daaId2));
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/resources/DaaResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DaaResourceTest.java
@@ -651,7 +651,7 @@ class DaaResourceTest extends AbstractTestHelper {
     when(userService.findUserByEmail(any())).thenReturn(authedUser);
     when(userService.findUsersInJsonArray(any(), any())).thenReturn(users);
     when(daaService.findById(daaId)).thenReturn(new DataAccessAgreement());
-    when(libraryCardService.addDaaToUserLibraryCardByInstitution(any(), any(), any())).thenReturn(null);
+    when(libraryCardService.addDaaToUserLibraryCard(any(), any(), any())).thenReturn(null);
 
     resource = new DaaResource(daaService, dacService, userService, libraryCardService);
 
@@ -858,7 +858,7 @@ class DaaResourceTest extends AbstractTestHelper {
     when(userService.findUserByEmail(any())).thenReturn(authedUser);
     when(userService.findUserById(userId)).thenReturn(researcher);
     when(daaService.findDAAsInJsonArray(any(), any())).thenReturn(agreements);
-    when(libraryCardService.addDaaToUserLibraryCardByInstitution(any(), any(), any())).thenReturn(null);
+    when(libraryCardService.addDaaToUserLibraryCard(any(), any(), any())).thenReturn(null);
 
     resource = new DaaResource(daaService, dacService, userService, libraryCardService);
 
@@ -885,7 +885,7 @@ class DaaResourceTest extends AbstractTestHelper {
     when(userService.findUserByEmail(any())).thenReturn(authedUser);
     when(userService.findUserById(userId)).thenReturn(researcher);
     when(daaService.findDAAsInJsonArray(any(), any())).thenReturn(agreements);
-    when(libraryCardService.addDaaToUserLibraryCardByInstitution(any(), any(), any())).thenReturn(null);
+    when(libraryCardService.addDaaToUserLibraryCard(any(), any(), any())).thenReturn(null);
 
     resource = new DaaResource(daaService, dacService, userService, libraryCardService);
 

--- a/src/test/java/org/broadinstitute/consent/http/resources/DaaResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DaaResourceTest.java
@@ -21,8 +21,8 @@ import java.util.Collections;
 import java.util.List;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.RandomStringUtils;
-import org.apache.commons.lang3.RandomUtils;
 import org.apache.http.HttpStatus;
+import org.broadinstitute.consent.http.AbstractTestHelper;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.AuthUser;
 import org.broadinstitute.consent.http.models.Dac;
@@ -42,7 +42,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-class DaaResourceTest {
+class DaaResourceTest extends AbstractTestHelper {
 
   @Mock
   private DaaService daaService;
@@ -64,7 +64,7 @@ class DaaResourceTest {
     when(info.getBaseUriBuilder()).thenReturn(builder);
     when(builder.replacePath(any())).thenReturn(builder);
     Dac dac = new Dac();
-    dac.setDacId(RandomUtils.nextInt(10, 100));
+    dac.setDacId(randomInt(10, 100));
     User admin = new User();
     admin.setAdminRole();
     FormDataContentDisposition fileDetail = mock(FormDataContentDisposition.class);
@@ -87,7 +87,7 @@ class DaaResourceTest {
     when(info.getBaseUriBuilder()).thenReturn(builder);
     when(builder.replacePath(any())).thenReturn(builder);
     Dac dac = new Dac();
-    dac.setDacId(RandomUtils.nextInt(10, 100));
+    dac.setDacId(randomInt(10, 100));
     User admin = new User();
     admin.setChairpersonRoleWithDAC(dac.getDacId());
     FormDataContentDisposition fileDetail = mock(FormDataContentDisposition.class);
@@ -105,7 +105,7 @@ class DaaResourceTest {
   void testCreateDaaForDac_InvalidChairCase() {
     UriInfo info = mock(UriInfo.class);
     Dac dac = new Dac();
-    dac.setDacId(RandomUtils.nextInt(10, 100));
+    dac.setDacId(randomInt(10, 100));
     User admin = new User();
     admin.setChairpersonRoleWithDAC(1);
     FormDataContentDisposition fileDetail = mock(FormDataContentDisposition.class);
@@ -123,7 +123,7 @@ class DaaResourceTest {
     UriInfo info = mock(UriInfo.class);
     UriBuilder builder = mock(UriBuilder.class);
     Dac dac = new Dac();
-    dac.setDacId(RandomUtils.nextInt(10, 100));
+    dac.setDacId(randomInt(10, 100));
     User admin = new User();
     admin.setAdminRole();
     FormDataContentDisposition fileDetail = mock(FormDataContentDisposition.class);
@@ -140,7 +140,7 @@ class DaaResourceTest {
   void testCreateDaaForDac_UserWithoutInstitution() {
     UriInfo info = mock(UriInfo.class);
     Dac dac = new Dac();
-    dac.setDacId(RandomUtils.nextInt(10, 100));
+    dac.setDacId(randomInt(10, 100));
     User admin = new User();
     admin.setAdminRole();
     FormDataContentDisposition fileDetail = mock(FormDataContentDisposition.class);
@@ -192,7 +192,7 @@ class DaaResourceTest {
 
  @Test
   void testFindDaaByDaaId() {
-    int expectedDaaId = RandomUtils.nextInt(10, 100);
+    int expectedDaaId = randomInt(10, 100);
     DataAccessAgreement expectedDaa = new DataAccessAgreement();
     expectedDaa.setDaaId(expectedDaaId);
     when(daaService.findById(expectedDaaId)).thenReturn(expectedDaa);
@@ -206,7 +206,7 @@ class DaaResourceTest {
 
   @Test
   void testFindDaaByDaaIdInvalidId() {
-    int invalidId = RandomUtils.nextInt(10, 100);
+    int invalidId = randomInt(10, 100);
     when(daaService.findById(invalidId)).thenThrow(new NotFoundException());
     resource = new DaaResource(daaService, dacService, userService, libraryCardService);
 
@@ -216,7 +216,7 @@ class DaaResourceTest {
 
   @Test
   void testFindDaaFileByDaaId() throws IOException {
-    int expectedDaaId = RandomUtils.nextInt(10, 100);
+    int expectedDaaId = randomInt(10, 100);
     DataAccessAgreement expectedDaa = new DataAccessAgreement();
     expectedDaa.setDaaId(expectedDaaId);
     String fileName = RandomStringUtils.randomAlphanumeric(10) + ".txt";
@@ -239,7 +239,7 @@ class DaaResourceTest {
 
   @Test
   void testFindDaaFileByDaaIdInvalid() {
-    int invalidId = RandomUtils.nextInt(10, 100);
+    int invalidId = randomInt(10, 100);
     when(daaService.findFileById(invalidId)).thenThrow(new NotFoundException());
     resource = new DaaResource(daaService, dacService, userService, libraryCardService);
 
@@ -249,7 +249,7 @@ class DaaResourceTest {
 
   @Test
   void testFindDaaFileByDaaIdDatabaseError() {
-    int expectedDaaId = RandomUtils.nextInt(10, 100);
+    int expectedDaaId = randomInt(10, 100);
     when(daaService.findFileById(expectedDaaId)).thenThrow(new RuntimeException());
     resource = new DaaResource(daaService, dacService, userService, libraryCardService);
 
@@ -264,7 +264,7 @@ class DaaResourceTest {
     when(info.getBaseUriBuilder()).thenReturn(builder);
     when(builder.replacePath(any())).thenReturn(builder);
     Dac dac = new Dac();
-    dac.setDacId(RandomUtils.nextInt(10, 100));
+    dac.setDacId(randomInt(10, 100));
     User admin = new User();
     admin.setAdminRole();
     admin.setInstitutionId(1);
@@ -278,10 +278,10 @@ class DaaResourceTest {
     daa.setDaaId(1);
     LibraryCard lc = new LibraryCard();
     lc.setId(1);
+    researcher.setLibraryCard(lc);
 
     when(userService.findUserByEmail(any())).thenReturn(admin);
     when(userService.findUserById(any())).thenReturn(researcher);
-    when(libraryCardService.findLibraryCardsByUserId(any())).thenReturn(Collections.singletonList(lc));
 
     resource = new DaaResource(daaService, dacService, userService, libraryCardService);
     Response response = resource.createLibraryCardDaaRelation(info, authUser, daa.getDaaId(),  admin.getUserId());
@@ -295,7 +295,7 @@ class DaaResourceTest {
     when(info.getBaseUriBuilder()).thenReturn(builder);
     when(builder.replacePath(any())).thenReturn(builder);
     Dac dac = new Dac();
-    dac.setDacId(RandomUtils.nextInt(10, 100));
+    dac.setDacId(randomInt(10, 100));
     User admin = new User();
     admin.setSigningOfficialRole();
     admin.setInstitutionId(1);
@@ -308,10 +308,10 @@ class DaaResourceTest {
     daa.setDaaId(1);
     LibraryCard lc = new LibraryCard();
     lc.setId(1);
+    researcher.setLibraryCard(lc);
 
     when(userService.findUserByEmail(any())).thenReturn(admin);
     when(userService.findUserById(any())).thenReturn(researcher);
-    when(libraryCardService.findLibraryCardsByUserId(any())).thenReturn(Collections.singletonList(lc));
 
     resource = new DaaResource(daaService, dacService, userService, libraryCardService);
     Response response = resource.createLibraryCardDaaRelation(info, authUser, daa.getDaaId(),  admin.getUserId());
@@ -323,7 +323,7 @@ class DaaResourceTest {
     UriInfo info = mock(UriInfo.class);
     UriBuilder builder = mock(UriBuilder.class);
     Dac dac = new Dac();
-    dac.setDacId(RandomUtils.nextInt(10, 100));
+    dac.setDacId(randomInt(10, 100));
     User admin = new User();
     admin.setSigningOfficialRole();
     admin.setInstitutionId(2);
@@ -348,7 +348,7 @@ class DaaResourceTest {
     UriInfo info = mock(UriInfo.class);
     UriBuilder builder = mock(UriBuilder.class);
     Dac dac = new Dac();
-    dac.setDacId(RandomUtils.nextInt(10, 100));
+    dac.setDacId(randomInt(10, 100));
     User admin = new User();
     admin.setResearcherRole();
     admin.setInstitutionId(2);
@@ -372,7 +372,7 @@ class DaaResourceTest {
   void testCreateLibraryCardDaaRelation_InvalidDaaIdCase() {
     UriInfo info = mock(UriInfo.class);
     Dac dac = new Dac();
-    dac.setDacId(RandomUtils.nextInt(10, 100));
+    dac.setDacId(randomInt(10, 100));
     User admin = new User();
     admin.setSigningOfficialRole();
     admin.setInstitutionId(1);
@@ -383,11 +383,10 @@ class DaaResourceTest {
     daa.setDaaId(1);
     LibraryCard lc = new LibraryCard();
     lc.setId(1);
+    researcher.setLibraryCard(lc);
 
     when(userService.findUserByEmail(any())).thenReturn(admin);
     when(userService.findUserById(any())).thenReturn(researcher);
-    when(libraryCardService.findLibraryCardsByUserId(any())).thenReturn(Collections.singletonList(lc));
-
 
     resource = new DaaResource(daaService, dacService, userService, libraryCardService);
     Response response = resource.createLibraryCardDaaRelation(info, authUser, daa.getDaaId(),  4);
@@ -401,7 +400,7 @@ class DaaResourceTest {
     when(info.getBaseUriBuilder()).thenReturn(builder);
     when(builder.replacePath(any())).thenReturn(builder);
     Dac dac = new Dac();
-    dac.setDacId(RandomUtils.nextInt(10, 100));
+    dac.setDacId(randomInt(10, 100));
     User admin = new User();
     admin.setSigningOfficialRole();
     admin.setInstitutionId(1);
@@ -412,13 +411,11 @@ class DaaResourceTest {
     daa.setDaaId(1);
     LibraryCard lc = new LibraryCard();
     lc.setId(1);
-    LibraryCard newLc = new LibraryCard();
-    newLc.setId(2);
+    researcher.setLibraryCard(lc);
 
 
     when(userService.findUserByEmail(any())).thenReturn(admin);
     when(userService.findUserById(any())).thenReturn(researcher);
-    when(libraryCardService.findLibraryCardsByUserId(any())).thenReturn(Collections.singletonList(lc));
 
     resource = new DaaResource(daaService, dacService, userService, libraryCardService);
     Response response = resource.createLibraryCardDaaRelation(info, authUser, daa.getDaaId(),  admin.getUserId());
@@ -432,7 +429,7 @@ class DaaResourceTest {
     when(info.getBaseUriBuilder()).thenReturn(builder);
     when(builder.replacePath(any())).thenReturn(builder);
     Dac dac = new Dac();
-    dac.setDacId(RandomUtils.nextInt(10, 100));
+    dac.setDacId(randomInt(10, 100));
     User admin = new User();
     admin.setSigningOfficialRole();
     admin.setInstitutionId(1);
@@ -444,10 +441,8 @@ class DaaResourceTest {
     LibraryCard newLc = new LibraryCard();
     newLc.setId(1);
 
-
     when(userService.findUserByEmail(any())).thenReturn(admin);
     when(userService.findUserById(any())).thenReturn(researcher);
-    when(libraryCardService.findLibraryCardsByUserId(any())).thenReturn(List.of());
     when(libraryCardService.createLibraryCardForSigningOfficial(any(), any())).thenReturn(newLc);
 
     resource = new DaaResource(daaService, dacService, userService, libraryCardService);
@@ -457,30 +452,29 @@ class DaaResourceTest {
 
   @Test
   void testDeleteDaaValidUser() {
-    Integer daaId = RandomUtils.nextInt(10, 100);
+    Integer daaId = randomInt(10, 100);
 
     User user = new User();
+    user.setUserId(1);
     user.setAdminRole();
 
     LibraryCard libraryCard = new LibraryCard();
     libraryCard.setUserId(user.getUserId());
     libraryCard.setDaaIds(List.of(daaId));
+    user.setLibraryCard(libraryCard);
 
-    when(userService.findUserByEmail(any())).thenReturn(user);
-    when(libraryCardService.findLibraryCardsByUserId(any())).thenReturn(List.of(libraryCard));
+    when(userService.findUserById(any())).thenReturn(user);
     doNothing().when(libraryCardService).removeDaaFromLibraryCard(any(), any());
 
     resource = new DaaResource(daaService, dacService, userService, libraryCardService);
-    Response response = resource.deleteDaaForUser(authUser, daaId, RandomUtils.nextInt(10, 100));
+    Response response = resource.deleteDaaForUser(authUser, daaId, randomInt(10, 100));
     assert response.getStatus() == HttpStatus.SC_OK;
   }
 
   @Test
   void testDeleteDaaForInvalidUser() {
-    when(userService.findUserByEmail(any())).thenThrow(new RuntimeException("Internal server error"));
-
     resource = new DaaResource(daaService, dacService, userService, libraryCardService);
-    Response response = resource.deleteDaaForUser(authUser, RandomUtils.nextInt(10, 100), RandomUtils.nextInt(10, 100));
+    Response response = resource.deleteDaaForUser(authUser, randomInt(10, 100), randomInt(10, 100));
     assert response.getStatus() == HttpStatus.SC_INTERNAL_SERVER_ERROR;
   }
 
@@ -489,13 +483,13 @@ class DaaResourceTest {
     User user = new User();
     LibraryCard lc = new LibraryCard();
     user.setResearcherRole();
-    user.setInstitutionId(RandomUtils.nextInt(0,10));
-    user.addLibraryCard(lc);
+    user.setInstitutionId(randomInt(0,10));
+    user.setLibraryCard(lc);
     when(userService.findUserByEmail(any())).thenReturn(user);
     doNothing().when(daaService).sendDaaRequestEmails(any(), any());
 
     resource = new DaaResource(daaService, dacService, userService, libraryCardService);
-    Response response = resource.sendDaaRequestMessage(authUser, RandomUtils.nextInt(10, 100));
+    Response response = resource.sendDaaRequestMessage(authUser, randomInt(10, 100));
     assert response.getStatus() == HttpStatus.SC_OK;
   }
 
@@ -506,7 +500,7 @@ class DaaResourceTest {
     when(userService.findUserByEmail(any())).thenThrow(new NotFoundException());
 
     resource = new DaaResource(daaService, dacService, userService, libraryCardService);
-    Response response = resource.sendDaaRequestMessage(authUser, RandomUtils.nextInt(10, 100));
+    Response response = resource.sendDaaRequestMessage(authUser, randomInt(10, 100));
     assert response.getStatus() == HttpStatus.SC_NOT_FOUND;
   }
 
@@ -515,13 +509,13 @@ class DaaResourceTest {
     User user = new User();
     LibraryCard lc = new LibraryCard();
     user.setResearcherRole();
-    user.setInstitutionId(RandomUtils.nextInt(0,10));
-    user.addLibraryCard(lc);
+    user.setInstitutionId(randomInt(0,10));
+    user.setLibraryCard(lc);
     when(userService.findUserByEmail(any())).thenReturn(user);
     doThrow(new NotFoundException()).when(daaService).sendDaaRequestEmails(any(), any());
 
     resource = new DaaResource(daaService, dacService, userService, libraryCardService);
-    Response response = resource.sendDaaRequestMessage(authUser, RandomUtils.nextInt(10, 100));
+    Response response = resource.sendDaaRequestMessage(authUser, randomInt(10, 100));
     assert response.getStatus() == HttpStatus.SC_NOT_FOUND;
   }
 
@@ -530,24 +524,24 @@ class DaaResourceTest {
     User user = new User();
     LibraryCard lc = new LibraryCard();
     user.setResearcherRole();
-    user.setInstitutionId(RandomUtils.nextInt(0,10));
-    user.addLibraryCard(lc);
+    user.setInstitutionId(randomInt(0,10));
+    user.setLibraryCard(lc);
     when(userService.findUserByEmail(any())).thenReturn(user);
     doThrow(new Exception()).when(daaService).sendDaaRequestEmails(any(), any());
 
     resource = new DaaResource(daaService, dacService, userService, libraryCardService);
-    Response response = resource.sendDaaRequestMessage(authUser, RandomUtils.nextInt(10, 100));
+    Response response = resource.sendDaaRequestMessage(authUser, randomInt(10, 100));
     assert response.getStatus() == HttpStatus.SC_INTERNAL_SERVER_ERROR;
   }
 
   @Test
   void testSendDaaRequestMessageAssociationAlreadyExists() throws Exception {
     User user = new User();
-    int daaId = RandomUtils.nextInt(10, 100);
+    int daaId = randomInt(10, 100);
     LibraryCard lc = new LibraryCard();
     lc.setDaaIds(List.of(daaId));
     user.setResearcherRole();
-    user.setLibraryCards(List.of(lc));
+    user.setLibraryCard(lc);
     when(userService.findUserByEmail(any())).thenReturn(user);
 
     resource = new DaaResource(daaService, dacService, userService, libraryCardService);
@@ -558,76 +552,76 @@ class DaaResourceTest {
   @Test
   void testSendNewDAAMessage() throws Exception {
     User user = new User();
-    int dacId = RandomUtils.nextInt(10,20);
+    int dacId = randomInt(10,20);
     Dac dac = new Dac();
     dac.setDacId(dacId);
-    dac.setName(RandomStringUtils.randomAlphabetic(10));
+    dac.setName(randomAlphabetic(10));
     user.setChairpersonRoleWithDAC(dacId);
     when(userService.findUserByEmail(any())).thenReturn(user);
     when(dacService.findById(any())).thenReturn(dac);
     doNothing().when(daaService).sendNewDaaEmails(any(), any(), any(), any());
 
     resource = new DaaResource(daaService, dacService, userService, libraryCardService);
-    Response response = resource.sendNewDaaMessage(authUser, dacId,  RandomUtils.nextInt(10, 100), RandomStringUtils.randomAlphabetic(10));
+    Response response = resource.sendNewDaaMessage(authUser, dacId,  randomInt(10, 100), randomAlphabetic(10));
     assert response.getStatus() == HttpStatus.SC_OK;
   }
 
   @Test
   void testSendNewDAAMessageUserNotFound() {
     User user = new User();
-    int dacId = RandomUtils.nextInt(10,20);
+    int dacId = randomInt(10,20);
     user.setChairpersonRoleWithDAC(dacId);
     when(userService.findUserByEmail(any())).thenThrow(new NotFoundException());
 
     resource = new DaaResource(daaService, dacService, userService, libraryCardService);
-    Response response = resource.sendNewDaaMessage(authUser, dacId,  RandomUtils.nextInt(10, 100), RandomStringUtils.randomAlphabetic(10));
+    Response response = resource.sendNewDaaMessage(authUser, dacId,  randomInt(10, 100), randomAlphabetic(10));
     assert response.getStatus() == HttpStatus.SC_NOT_FOUND;
   }
 
   @Test
   void testSendNewDAAMessageDacNotFound() {
     User user = new User();
-    int dacId = RandomUtils.nextInt(10,20);
+    int dacId = randomInt(10,20);
     user.setChairpersonRoleWithDAC(dacId);
     when(userService.findUserByEmail(any())).thenReturn(user);
     when(dacService.findById(dacId)).thenThrow(new NotFoundException());
 
     resource = new DaaResource(daaService, dacService, userService, libraryCardService);
-    Response response = resource.sendNewDaaMessage(authUser, dacId, RandomUtils.nextInt(10, 100), RandomStringUtils.randomAlphabetic(10));
+    Response response = resource.sendNewDaaMessage(authUser, dacId, randomInt(10, 100), randomAlphabetic(10));
     assert response.getStatus() == HttpStatus.SC_NOT_FOUND;
   }
 
   @Test
   void testSendNewDAAMessageDaaNotFound() throws Exception {
     User user = new User();
-    int dacId = RandomUtils.nextInt(10,20);
+    int dacId = randomInt(10,20);
     Dac dac = new Dac();
     dac.setDacId(dacId);
-    dac.setName(RandomStringUtils.randomAlphabetic(10));
+    dac.setName(randomAlphabetic(10));
     user.setChairpersonRoleWithDAC(dacId);
     when(userService.findUserByEmail(any())).thenReturn(user);
     when(dacService.findById(dacId)).thenReturn(dac);
     doThrow(new NotFoundException()).when(daaService).sendNewDaaEmails(any(), any(), any(), any());
 
     resource = new DaaResource(daaService, dacService, userService, libraryCardService);
-    Response response = resource.sendNewDaaMessage(authUser, dacId, RandomUtils.nextInt(10, 100), RandomStringUtils.randomAlphabetic(10));
+    Response response = resource.sendNewDaaMessage(authUser, dacId, randomInt(10, 100), randomAlphabetic(10));
     assert response.getStatus() == HttpStatus.SC_NOT_FOUND;
   }
 
   @Test
   void testSendNewDAAMessageEmailError() throws Exception {
     User user = new User();
-    int dacId = RandomUtils.nextInt(10,20);
+    int dacId = randomInt(10,20);
     Dac dac = new Dac();
     dac.setDacId(dacId);
-    dac.setName(RandomStringUtils.randomAlphabetic(10));
+    dac.setName(randomAlphabetic(10));
     user.setChairpersonRoleWithDAC(dacId);
     when(userService.findUserByEmail(any())).thenReturn(user);
     when(dacService.findById(dacId)).thenReturn(dac);
     doThrow(new Exception()).when(daaService).sendNewDaaEmails(any(), any(), any(), any());
 
     resource = new DaaResource(daaService, dacService, userService, libraryCardService);
-    Response response = resource.sendNewDaaMessage(authUser, dacId, RandomUtils.nextInt(10, 100), RandomStringUtils.randomAlphabetic(10));
+    Response response = resource.sendNewDaaMessage(authUser, dacId, randomInt(10, 100), randomAlphabetic(10));
     assert response.getStatus() == HttpStatus.SC_INTERNAL_SERVER_ERROR;
   }
 
@@ -657,7 +651,7 @@ class DaaResourceTest {
     when(userService.findUserByEmail(any())).thenReturn(authedUser);
     when(userService.findUsersInJsonArray(any(), any())).thenReturn(users);
     when(daaService.findById(daaId)).thenReturn(new DataAccessAgreement());
-    when(libraryCardService.addDaaToUserLibraryCardByInstitution(any(), any(), any())).thenReturn(List.of());
+    when(libraryCardService.addDaaToUserLibraryCardByInstitution(any(), any(), any())).thenReturn(null);
 
     resource = new DaaResource(daaService, dacService, userService, libraryCardService);
 
@@ -756,7 +750,7 @@ class DaaResourceTest {
     when(userService.findUserByEmail(any())).thenReturn(authedUser);
     when(userService.findUsersInJsonArray(any(), any())).thenReturn(users);
     when(daaService.findById(daaId)).thenReturn(new DataAccessAgreement());
-    when(libraryCardService.removeDaaFromUserLibraryCards(any(), any())).thenReturn(List.of());
+    when(libraryCardService.removeDaaFromUserLibraryCard(any(), any())).thenReturn(null);
 
     resource = new DaaResource(daaService, dacService, userService, libraryCardService);
 
@@ -782,7 +776,7 @@ class DaaResourceTest {
     when(userService.findUserByEmail(any())).thenReturn(authedUser);
     when(userService.findUsersInJsonArray(any(), any())).thenReturn(users);
     when(daaService.findById(daaId)).thenReturn(new DataAccessAgreement());
-    when(libraryCardService.removeDaaFromUserLibraryCards(any(), any())).thenReturn(List.of());
+    when(libraryCardService.removeDaaFromUserLibraryCard(any(), any())).thenReturn(null);
 
     resource = new DaaResource(daaService, dacService, userService, libraryCardService);
 
@@ -864,7 +858,7 @@ class DaaResourceTest {
     when(userService.findUserByEmail(any())).thenReturn(authedUser);
     when(userService.findUserById(userId)).thenReturn(researcher);
     when(daaService.findDAAsInJsonArray(any(), any())).thenReturn(agreements);
-    when(libraryCardService.addDaaToUserLibraryCardByInstitution(any(), any(), any())).thenReturn(List.of());
+    when(libraryCardService.addDaaToUserLibraryCardByInstitution(any(), any(), any())).thenReturn(null);
 
     resource = new DaaResource(daaService, dacService, userService, libraryCardService);
 
@@ -891,7 +885,7 @@ class DaaResourceTest {
     when(userService.findUserByEmail(any())).thenReturn(authedUser);
     when(userService.findUserById(userId)).thenReturn(researcher);
     when(daaService.findDAAsInJsonArray(any(), any())).thenReturn(agreements);
-    when(libraryCardService.addDaaToUserLibraryCardByInstitution(any(), any(), any())).thenReturn(List.of());
+    when(libraryCardService.addDaaToUserLibraryCardByInstitution(any(), any(), any())).thenReturn(null);
 
     resource = new DaaResource(daaService, dacService, userService, libraryCardService);
 
@@ -956,7 +950,7 @@ class DaaResourceTest {
     when(userService.findUserByEmail(any())).thenReturn(authedUser);
     when(userService.findUserById(userId)).thenReturn(researcher);
     when(daaService.findDAAsInJsonArray(any(), any())).thenReturn(agreements);
-    when(libraryCardService.removeDaaFromUserLibraryCards(any(), any())).thenReturn(List.of());
+    when(libraryCardService.removeDaaFromUserLibraryCard(any(), any())).thenReturn(null);
 
     resource = new DaaResource(daaService, dacService, userService, libraryCardService);
 
@@ -983,7 +977,7 @@ class DaaResourceTest {
     when(userService.findUserByEmail(any())).thenReturn(authedUser);
     when(userService.findUserById(userId)).thenReturn(researcher);
     when(daaService.findDAAsInJsonArray(any(), any())).thenReturn(agreements);
-    when(libraryCardService.removeDaaFromUserLibraryCards(any(), any())).thenReturn(List.of());
+    when(libraryCardService.removeDaaFromUserLibraryCard(any(), any())).thenReturn(null);
 
     resource = new DaaResource(daaService, dacService, userService, libraryCardService);
 
@@ -1031,11 +1025,11 @@ class DaaResourceTest {
 
   @Test
   void testAddDacToDaaAdmin() {
-    int daaId = RandomUtils.nextInt(10, 100);
+    int daaId = randomInt(10, 100);
     DataAccessAgreement daa = new DataAccessAgreement();
     daa.setDaaId(daaId);
     Dac dac = new Dac();
-    dac.setDacId(RandomUtils.nextInt(10, 100));
+    dac.setDacId(randomInt(10, 100));
 
     User admin = new User();
     admin.setAdminRole();
@@ -1051,11 +1045,11 @@ class DaaResourceTest {
 
   @Test
   void testAddDacToDaaChairperson() {
-    int daaId = RandomUtils.nextInt(10, 100);
+    int daaId = randomInt(10, 100);
     DataAccessAgreement daa = new DataAccessAgreement();
     daa.setDaaId(daaId);
     Dac dac = new Dac();
-    dac.setDacId(RandomUtils.nextInt(10, 100));
+    dac.setDacId(randomInt(10, 100));
 
     User chairperson = new User();
     chairperson.setChairpersonRoleWithDAC(dac.getDacId());
@@ -1071,13 +1065,13 @@ class DaaResourceTest {
 
   @Test
   void testAddDacToDaaChairpersonNoMatchingDac() {
-    int daaId = RandomUtils.nextInt(10, 100);
+    int daaId = randomInt(10, 100);
     DataAccessAgreement daa = new DataAccessAgreement();
     Dac dac = new Dac();
-    dac.setDacId(RandomUtils.nextInt(10, 100));
+    dac.setDacId(randomInt(10, 100));
 
     User chairperson = new User();
-    chairperson.setChairpersonRoleWithDAC(RandomUtils.nextInt(100,200));
+    chairperson.setChairpersonRoleWithDAC(randomInt(100,200));
 
     when(userService.findUserByEmail(any())).thenReturn(chairperson);
 
@@ -1089,9 +1083,9 @@ class DaaResourceTest {
 
   @Test
   void testAddDacToDaaFromUserForbidden() {
-    int daaId = RandomUtils.nextInt(10, 100);
+    int daaId = randomInt(10, 100);
     Dac dac = new Dac();
-    dac.setDacId(RandomUtils.nextInt(10, 100));
+    dac.setDacId(randomInt(10, 100));
 
     User researcher = new User();
     researcher.setResearcherRole();
@@ -1106,10 +1100,10 @@ class DaaResourceTest {
 
   @Test
   void testAddDacToDaaDaaNotFound() {
-    int daaId = RandomUtils.nextInt(10, 100);
+    int daaId = randomInt(10, 100);
     DataAccessAgreement daa = new DataAccessAgreement();
     Dac dac = new Dac();
-    dac.setDacId(RandomUtils.nextInt(10, 100));
+    dac.setDacId(randomInt(10, 100));
 
     User admin = new User();
     admin.setAdminRole();
@@ -1125,10 +1119,10 @@ class DaaResourceTest {
 
   @Test
   void testAddDacToDaaDacNotFound() {
-    int daaId = RandomUtils.nextInt(10, 100);
+    int daaId = randomInt(10, 100);
     DataAccessAgreement daa = new DataAccessAgreement();
     Dac dac = new Dac();
-    dac.setDacId(RandomUtils.nextInt(10, 100));
+    dac.setDacId(randomInt(10, 100));
 
     User admin = new User();
     admin.setAdminRole();
@@ -1143,11 +1137,11 @@ class DaaResourceTest {
 
   @Test
   void testAddDacToDaaAlreadyExists() {
-    int daaId = RandomUtils.nextInt(10, 100);
+    int daaId = randomInt(10, 100);
     DataAccessAgreement daa = new DataAccessAgreement();
     daa.setDaaId(daaId);
     Dac dac = new Dac();
-    dac.setDacId(RandomUtils.nextInt(10, 100));
+    dac.setDacId(randomInt(10, 100));
 
     User admin = new User();
     admin.setAdminRole();
@@ -1163,17 +1157,17 @@ class DaaResourceTest {
 
   @Test
   void testAddDacToDaaDaaWithDacs() {
-    int daaId = RandomUtils.nextInt(10, 100);
+    int daaId = randomInt(10, 100);
     DataAccessAgreement daa = new DataAccessAgreement();
     daa.setDaaId(daaId);
     Dac dac1 = new Dac();
-    dac1.setDacId(RandomUtils.nextInt(10, 100));
+    dac1.setDacId(randomInt(10, 100));
     Dac dac2 = new Dac();
-    dac2.setDacId(RandomUtils.nextInt(10, 100));
+    dac2.setDacId(randomInt(10, 100));
     daa.addDac(dac1);
     daa.addDac(dac2);
     Dac dac3 = new Dac();
-    dac3.setDacId(RandomUtils.nextInt(10, 100));
+    dac3.setDacId(randomInt(10, 100));
 
     User admin = new User();
     admin.setAdminRole();
@@ -1189,11 +1183,11 @@ class DaaResourceTest {
 
   @Test
   void testRemoveDacFromDaaAdmin() throws Exception {
-    int daaId = RandomUtils.nextInt(10, 100);
+    int daaId = randomInt(10, 100);
     DataAccessAgreement daa = new DataAccessAgreement();
     daa.setDaaId(daaId);
     Dac dac = new Dac();
-    dac.setDacId(RandomUtils.nextInt(10, 100));
+    dac.setDacId(randomInt(10, 100));
     daa.addDac(dac);
 
     User admin = new User();
@@ -1210,11 +1204,11 @@ class DaaResourceTest {
 
   @Test
   void testRemoveDacFromDaaChairperson() throws Exception {
-    int daaId = RandomUtils.nextInt(10, 100);
+    int daaId = randomInt(10, 100);
     DataAccessAgreement daa = new DataAccessAgreement();
     daa.setDaaId(daaId);
     Dac dac = new Dac();
-    dac.setDacId(RandomUtils.nextInt(10, 100));
+    dac.setDacId(randomInt(10, 100));
     daa.addDac(dac);
 
     User chairperson = new User();
@@ -1231,15 +1225,15 @@ class DaaResourceTest {
 
   @Test
   void testRemoveDacFromDaaChairpersonNoMatchingDac() {
-    int daaId = RandomUtils.nextInt(10, 100);
+    int daaId = randomInt(10, 100);
     DataAccessAgreement daa = new DataAccessAgreement();
     daa.setDaaId(daaId);
     Dac dac = new Dac();
-    dac.setDacId(RandomUtils.nextInt(10, 100));
+    dac.setDacId(randomInt(10, 100));
     daa.addDac(dac);
 
     User chairperson = new User();
-    chairperson.setChairpersonRoleWithDAC(RandomUtils.nextInt(100,200));
+    chairperson.setChairpersonRoleWithDAC(randomInt(100,200));
 
     when(userService.findUserByEmail(any())).thenReturn(chairperson);
 
@@ -1251,11 +1245,11 @@ class DaaResourceTest {
 
   @Test
   void testRemoveDacFromDaaFromUserForbidden() {
-    int daaId = RandomUtils.nextInt(10, 100);
+    int daaId = randomInt(10, 100);
     DataAccessAgreement daa = new DataAccessAgreement();
     daa.setDaaId(daaId);
     Dac dac = new Dac();
-    dac.setDacId(RandomUtils.nextInt(10, 100));
+    dac.setDacId(randomInt(10, 100));
     daa.addDac(dac);
 
     User researcher = new User();
@@ -1271,11 +1265,11 @@ class DaaResourceTest {
 
   @Test
   void testRemoveDacFromDaaDaaNotFound() {
-    int daaId = RandomUtils.nextInt(10, 100);
+    int daaId = randomInt(10, 100);
     DataAccessAgreement daa = new DataAccessAgreement();
     daa.setDaaId(daaId);
     Dac dac = new Dac();
-    dac.setDacId(RandomUtils.nextInt(10, 100));
+    dac.setDacId(randomInt(10, 100));
     daa.addDac(dac);
 
     User admin = new User();
@@ -1292,11 +1286,11 @@ class DaaResourceTest {
 
   @Test
   void testRemoveDacFromDaaDacNotFound() {
-    int daaId = RandomUtils.nextInt(10, 100);
+    int daaId = randomInt(10, 100);
     DataAccessAgreement daa = new DataAccessAgreement();
     daa.setDaaId(daaId);
     Dac dac = new Dac();
-    dac.setDacId(RandomUtils.nextInt(10, 100));
+    dac.setDacId(randomInt(10, 100));
     daa.addDac(dac);
 
     User admin = new User();
@@ -1312,11 +1306,11 @@ class DaaResourceTest {
 
   @Test
   void testRemoveDacFromDaaDoesNotExist() throws Exception {
-    int daaId = RandomUtils.nextInt(10, 100);
+    int daaId = randomInt(10, 100);
     DataAccessAgreement daa = new DataAccessAgreement();
     daa.setDaaId(daaId);
     Dac dac = new Dac();
-    dac.setDacId(RandomUtils.nextInt(10, 100));
+    dac.setDacId(randomInt(10, 100));
 
     User admin = new User();
     admin.setAdminRole();
@@ -1332,7 +1326,7 @@ class DaaResourceTest {
 
   @Test
   void testDeleteDaaAdmin() {
-    int daaId = RandomUtils.nextInt(10, 100);
+    int daaId = randomInt(10, 100);
 
     User admin = new User();
     admin.setAdminRole();
@@ -1351,7 +1345,7 @@ class DaaResourceTest {
 
   @Test
   void testDeleteDaaDaaNotFound() {
-    int daaId = RandomUtils.nextInt(10, 100);
+    int daaId = randomInt(10, 100);
 
     User admin = new User();
     admin.setAdminRole();
@@ -1368,7 +1362,7 @@ class DaaResourceTest {
 
   @Test
   void testDeleteDaaForbiddenUser() {
-    int daaId = RandomUtils.nextInt(10, 100);
+    int daaId = randomInt(10, 100);
 
     User researcher = new User();
     researcher.setResearcherRole();

--- a/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceTest.java
@@ -117,7 +117,7 @@ class DataAccessRequestResourceTest extends AbstractTestHelper {
 
   @BeforeEach
   void initResource() {
-    user.setLibraryCards(List.of(new LibraryCard()));
+    user.setLibraryCard(new LibraryCard());
     try {
       resource =
           new DataAccessRequestResource(daaService,
@@ -132,7 +132,7 @@ class DataAccessRequestResourceTest extends AbstractTestHelper {
   void testCreateDataAccessRequest() {
     try {
       User userWithCards = new User(1, authUser.getEmail(), "Display Name", new Date(), roles);
-      userWithCards.setLibraryCards(List.of(new LibraryCard()));
+      userWithCards.setLibraryCard(new LibraryCard());
       when(userService.findUserByEmail(any())).thenReturn(userWithCards);
       DataAccessRequest dar = new DataAccessRequest();
       dar.setReferenceId(UUID.randomUUID().toString());
@@ -158,7 +158,7 @@ class DataAccessRequestResourceTest extends AbstractTestHelper {
   @Test
   void testCreateDataAccessRequestWithSubmittedDAR() {
     User userWithCards = new User(1, authUser.getEmail(), "Display Name", new Date(), roles);
-    userWithCards.setLibraryCards(List.of(new LibraryCard()));
+    userWithCards.setLibraryCard(new LibraryCard());
     when(userService.findUserByEmail(any())).thenReturn(userWithCards);
     DataAccessRequest dar = new DataAccessRequest();
     dar.setReferenceId(UUID.randomUUID().toString());
@@ -180,7 +180,7 @@ class DataAccessRequestResourceTest extends AbstractTestHelper {
   @Test
   void testCreateDataAccessRequestWithoutValidERACommons() {
     User userWithCards = new User(1, authUser.getEmail(), "Display Name", new Date(), roles);
-    userWithCards.setLibraryCards(List.of(new LibraryCard()));
+    userWithCards.setLibraryCard(new LibraryCard());
     when(userService.findUserByEmail(any())).thenReturn(userWithCards);
     doThrow(new BadRequestException()).when(dataAccessRequestService)
         .createDataAccessRequest(eq(user), any());
@@ -211,7 +211,7 @@ class DataAccessRequestResourceTest extends AbstractTestHelper {
   @Test
   void testUpdateByReferenceId() {
     DataAccessRequest dar = generateDataAccessRequest();
-    user.setLibraryCards(List.of(new LibraryCard()));
+    user.setLibraryCard(new LibraryCard());
     try {
       when(userService.findUserByEmail(any())).thenReturn(user);
       when(dataAccessRequestService.findByReferenceId(any())).thenReturn(dar);
@@ -809,7 +809,7 @@ class DataAccessRequestResourceTest extends AbstractTestHelper {
   void testCreateDataAccessRequestWithDAARestrictions() {
     try {
       User userWithCards = new User(1, authUser.getEmail(), "Display Name", new Date(), roles);
-      userWithCards.setLibraryCards(List.of(new LibraryCard()));
+      userWithCards.setLibraryCard(new LibraryCard());
       when(userService.findUserByEmail(any())).thenReturn(userWithCards);
       DataAccessRequest dar = new DataAccessRequest();
       dar.setReferenceId(UUID.randomUUID().toString());
@@ -837,7 +837,7 @@ class DataAccessRequestResourceTest extends AbstractTestHelper {
   void testCreateDataAccessRequestWithDAARestrictionsFailure() {
     try {
       User userWithCards = new User(1, authUser.getEmail(), "Display Name", new Date(), roles);
-      userWithCards.setLibraryCards(List.of(new LibraryCard()));
+      userWithCards.setLibraryCard(new LibraryCard());
       when(userService.findUserByEmail(any())).thenReturn(userWithCards);
       DataAccessRequest dar = new DataAccessRequest();
       dar.setReferenceId(UUID.randomUUID().toString());

--- a/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
@@ -223,7 +223,6 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     dar.setSortDate(new Timestamp(1000));
     dar.setReferenceId("id");
     User user = new User(1, "email@test.org", "Display Name", new Date());
-    user.setLibraryCard(null);
     assertThrows(NIHComplianceRuleException.class,
         () -> service.createDataAccessRequest(user, dar));
   }
@@ -412,7 +411,6 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
   void validateDarNoLibraryCards() {
     DataAccessRequest dar = generateDataAccessRequest();
     User user = new User(1, "email@test.org", "Display Name", new Date());
-    user.setLibraryCard(null);
     assertThrows(NIHComplianceRuleException.class, () -> service.validateDar(user, dar));
   }
 
@@ -464,7 +462,6 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     User collaboratorUser = new User(2, invalidCollaborator.getEmail(), "Collaborator", new Date(),
         roles);
     collaboratorUser.setInstitutionId(requestingUser.getInstitutionId());
-    collaboratorUser.setLibraryCard(null);
     DataAccessRequest dar = createDataAccessRequest(List.of(invalidCollaborator));
     when(userDAO.findUserByEmail(invalidCollaborator.getEmail())).thenReturn(collaboratorUser);
 

--- a/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
@@ -223,7 +223,7 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     dar.setSortDate(new Timestamp(1000));
     dar.setReferenceId("id");
     User user = new User(1, "email@test.org", "Display Name", new Date());
-    user.setLibraryCards(List.of());
+    user.setLibraryCard(null);
     assertThrows(NIHComplianceRuleException.class,
         () -> service.createDataAccessRequest(user, dar));
   }
@@ -412,7 +412,7 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
   void validateDarNoLibraryCards() {
     DataAccessRequest dar = generateDataAccessRequest();
     User user = new User(1, "email@test.org", "Display Name", new Date());
-    user.setLibraryCards(Collections.emptyList());
+    user.setLibraryCard(null);
     assertThrows(NIHComplianceRuleException.class, () -> service.validateDar(user, dar));
   }
 
@@ -438,7 +438,7 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
         roles);
     collaboratorUser.setInstitutionId(requestingUser.getInstitutionId());
     LibraryCard libraryCard = new LibraryCard();
-    collaboratorUser.setLibraryCards(List.of(libraryCard));
+    collaboratorUser.setLibraryCard(libraryCard);
     DataAccessRequest dar = createDataAccessRequest(List.of(validCollaborator));
     when(userDAO.findUserByEmail(validCollaborator.getEmail())).thenReturn(collaboratorUser);
 
@@ -464,7 +464,7 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     User collaboratorUser = new User(2, invalidCollaborator.getEmail(), "Collaborator", new Date(),
         roles);
     collaboratorUser.setInstitutionId(requestingUser.getInstitutionId());
-    collaboratorUser.setLibraryCards(Collections.emptyList());
+    collaboratorUser.setLibraryCard(null);
     DataAccessRequest dar = createDataAccessRequest(List.of(invalidCollaborator));
     when(userDAO.findUserByEmail(invalidCollaborator.getEmail())).thenReturn(collaboratorUser);
 
@@ -521,7 +521,7 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
   void testInsertDraftDataAccessRequest() {
     User user = new User();
     user.setUserId(1);
-    user.setLibraryCards(List.of(new LibraryCard()));
+    user.setLibraryCard(new LibraryCard());
     DataAccessRequest draft = generateDataAccessRequest();
     doNothing()
         .when(dataAccessRequestDAO)
@@ -963,7 +963,7 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     Institution institution = new Institution();
     institution.setId(1);
     user.setInstitution(institution);
-    user.setLibraryCards(List.of(new LibraryCard()));
+    user.setLibraryCard(new LibraryCard());
     user.setEraCommonsId("eraCommonsId");
     return user;
   }

--- a/src/test/java/org/broadinstitute/consent/http/service/LibraryCardServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/LibraryCardServiceTest.java
@@ -3,7 +3,9 @@ package org.broadinstitute.consent.http.service;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -14,9 +16,7 @@ import static org.mockito.Mockito.when;
 
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.NotFoundException;
-import java.util.Collections;
 import java.util.List;
-import org.apache.commons.lang3.RandomUtils;
 import org.broadinstitute.consent.http.AbstractTestHelper;
 import org.broadinstitute.consent.http.db.InstitutionDAO;
 import org.broadinstitute.consent.http.db.LibraryCardDAO;
@@ -65,7 +65,7 @@ class LibraryCardServiceTest extends AbstractTestHelper {
     LibraryCard payload = testLibraryCard(user.getUserId());
     payload.setUserEmail(user.getEmail());
     payload.setUserName("username");
-    payload.setCreateUserId(RandomUtils.nextInt(1, 10));
+    payload.setCreateUserId(randomInt(1, 10));
 
     //last two calls in the function, no need to test within this service test file
     LibraryCard createdCard = new LibraryCard();
@@ -152,7 +152,7 @@ class LibraryCardServiceTest extends AbstractTestHelper {
     User adminUser = createUserWithRole(UserRoles.ADMIN.getRoleId(), UserRoles.ADMIN.getRoleName());
 
     when(userDAO.findUserById(user.getUserId())).thenReturn(user);
-    when(libraryCardDAO.findLibraryCardsByUserId(user.getUserId())).thenReturn(List.of());
+    when(libraryCardDAO.findLibraryCardByUserId(user.getUserId())).thenReturn(null);
 
     LibraryCard payload = testLibraryCard(user.getUserId());
     int cardId = 1;
@@ -171,7 +171,7 @@ class LibraryCardServiceTest extends AbstractTestHelper {
     user.setEmail("testemail");
     when(userDAO.findUserById(user.getUserId())).thenReturn(user);
     LibraryCard libraryCard = testLibraryCard(user.getUserId());
-    libraryCard.setCreateUserId(RandomUtils.nextInt(1, 10));
+    libraryCard.setCreateUserId(randomInt(1, 10));
     when(libraryCardDAO.insertLibraryCard(eq(user.getUserId()), eq(null), eq(user.getEmail()),
         eq(libraryCard.getCreateUserId()), any())).thenReturn(123);
     service.createLibraryCard(libraryCard,
@@ -189,7 +189,7 @@ class LibraryCardServiceTest extends AbstractTestHelper {
     when(userDAO.findUserById(anyInt())).thenReturn(soUser);
     when(institutionDAO.findInstitutionById(anyInt())).thenReturn(institution);
     when(institutionService.findInstitutionForEmail("testemail")).thenReturn(institution);
-    when(libraryCardDAO.findLibraryCardsByUserId(anyInt())).thenReturn(Collections.emptyList());
+    when(libraryCardDAO.findLibraryCardByUserId(anyInt())).thenReturn(null);
 
     // last two calls in the function, no need to test within this service test file
     when(libraryCardDAO.insertLibraryCard(anyInt(), eq(null), anyString(), eq(null), any())).thenReturn(1);
@@ -210,7 +210,7 @@ class LibraryCardServiceTest extends AbstractTestHelper {
     user.setEmail("testemail");
 
     when(userDAO.findUserById(anyInt())).thenReturn(user);
-    when(libraryCardDAO.findLibraryCardsByUserId(anyInt())).thenReturn(Collections.emptyList());
+    when(libraryCardDAO.findLibraryCardByUserId(anyInt())).thenReturn(null);
 
     LibraryCard payload = testLibraryCard(user.getUserId());
     payload.setUserEmail("differentemail");
@@ -226,8 +226,7 @@ class LibraryCardServiceTest extends AbstractTestHelper {
     LibraryCard savedCard = testLibraryCard(user.getUserId());
     LibraryCard payload = savedCard;
 
-    when(libraryCardDAO.findLibraryCardsByUserId(anyInt())).thenReturn(
-        Collections.singletonList(savedCard));
+    when(libraryCardDAO.findLibraryCardByUserId(anyInt())).thenReturn(savedCard);
     assertThrows(ConsentConflictException.class, () -> service.createLibraryCard(payload, adminUser));
   }
 
@@ -243,8 +242,7 @@ class LibraryCardServiceTest extends AbstractTestHelper {
 
     LibraryCard payload = savedCard;
 
-    when(libraryCardDAO.findAllLibraryCardsByUserEmail(any())).thenReturn(
-        Collections.singletonList(savedCard));
+    when(libraryCardDAO.findLibraryCardByUserEmail(any())).thenReturn(savedCard);
     assertThrows(ConsentConflictException.class, () -> {
       service.createLibraryCard(payload, adminUser);
     });
@@ -361,8 +359,8 @@ class LibraryCardServiceTest extends AbstractTestHelper {
   void testFindLibraryCardByIdDaa() {
     LibraryCard libraryCard = testLibraryCard(1);
     DataAccessAgreement daa1 = new DataAccessAgreement();
-    int daaId1 = RandomUtils.nextInt(1, 10);
-    int daaId2 = RandomUtils.nextInt(1, 10);
+    int daaId1 = randomInt(1, 10);
+    int daaId2 = randomInt(1, 10);
     daa1.setDaaId(daaId1);
     DataAccessAgreement daa2 = new DataAccessAgreement();
     daa2.setDaaId(daaId2);
@@ -401,15 +399,10 @@ class LibraryCardServiceTest extends AbstractTestHelper {
     User signingOfficial = createUserWithRole(UserRoles.SIGNINGOFFICIAL.getRoleId(), UserRoles.SIGNINGOFFICIAL.getRoleName());
     signingOfficial.setInstitutionId(1);
     Integer userId = user.getUserId();
-    List<LibraryCard> libraryCards = List.of(
-        testLibraryCard(userId),
-        testLibraryCard(userId)
-    );
-    when(libraryCardDAO.findLibraryCardsByUserId(user.getUserId()))
-        .thenReturn(libraryCards);
+    when(libraryCardDAO.findLibraryCardByUserId(user.getUserId())).thenReturn(testLibraryCard(userId));
     doNothing().when(libraryCardDAO).createLibraryCardDaaRelation(any(), any());
-    List<LibraryCard> cards = service.addDaaToUserLibraryCardByInstitution(user, signingOfficial, 1);
-    assertEquals(2, cards.size());
+    LibraryCard card = service.addDaaToUserLibraryCardByInstitution(user, signingOfficial, 1);
+    assertNotNull(card);
   }
 
   @Test
@@ -432,10 +425,10 @@ class LibraryCardServiceTest extends AbstractTestHelper {
     LibraryCard payload = testLibraryCard(user.getUserId());
     payload.setUserEmail("testemail");
     // There are two calls to findLibraryCardsByUserId for checks before creation
-    when(libraryCardDAO.findLibraryCardsByUserId(userId))
-        .thenReturn(List.of())
-        .thenReturn(List.of())
-        .thenReturn(List.of(payload));
+    when(libraryCardDAO.findLibraryCardByUserId(userId))
+        .thenReturn(null)
+        .thenReturn(null)
+        .thenReturn(payload);
     when(institutionDAO.findInstitutionById(institution.getId())).thenReturn(institution);
     when(institutionService.findInstitutionForEmail(any())).thenReturn(institution);
     when(userDAO.findUserById(user.getUserId())).thenReturn(user);
@@ -443,8 +436,8 @@ class LibraryCardServiceTest extends AbstractTestHelper {
         .thenReturn(1);
     when(libraryCardDAO.findLibraryCardById(anyInt())).thenReturn(new LibraryCard());
 
-    List<LibraryCard> cards = service.addDaaToUserLibraryCardByInstitution(user, signingOfficial, 1);
-    assertEquals(1, cards.size());
+    LibraryCard card = service.addDaaToUserLibraryCardByInstitution(user, signingOfficial, 1);
+    assertNotNull(card);
   }
 
   @Test
@@ -460,34 +453,23 @@ class LibraryCardServiceTest extends AbstractTestHelper {
   void testRemoveDaaFromUserLibraryCards() {
     User user = testUser(1);
     Integer userId = user.getUserId();
-    List<LibraryCard> libraryCards = List.of(
-        testLibraryCard(userId),
-        testLibraryCard(userId),
-        testLibraryCard(userId),
-        testLibraryCard(userId)
-    );
-    when(libraryCardDAO.findLibraryCardsByUserId(user.getUserId()))
-        .thenReturn(libraryCards);
+    when(libraryCardDAO.findLibraryCardByUserId(user.getUserId())).thenReturn(testLibraryCard(userId));
     doNothing().when(libraryCardDAO).deleteLibraryCardDaaRelation(any(), any());
-    List<LibraryCard> cards = service.removeDaaFromUserLibraryCards(user, 1);
+    LibraryCard card = service.removeDaaFromUserLibraryCard(user, 1);
     // The above deletion only affects the lc-daa join table and does not remove library cards
-    assertEquals(libraryCards.size(), cards.size());
+    assertNotNull(card);
+    assertTrue(card.getDaaIds().isEmpty());
   }
 
   @Test
   void testRemoveDaaFromUserLibraryCardsNoMatchingInstitutions() {
     User user = testUser(1);
     Integer userId = user.getUserId();
-    List<LibraryCard> libraryCards = List.of(
-        testLibraryCard(userId),
-        testLibraryCard(userId),
-        testLibraryCard(userId),
-        testLibraryCard(userId)
-    );
-    when(libraryCardDAO.findLibraryCardsByUserId(user.getUserId())).thenReturn(libraryCards);
-    List<LibraryCard> cards = service.removeDaaFromUserLibraryCards(user, 1);
+    when(libraryCardDAO.findLibraryCardByUserId(user.getUserId())).thenReturn(testLibraryCard(userId));
+    LibraryCard card = service.removeDaaFromUserLibraryCard(user, 1);
     // DAA removal should not delete library cards
-    assertEquals(libraryCards.size(), cards.size());
+    assertNotNull(card);
+    assertTrue(card.getDaaIds().isEmpty());
   }
 
   @Test
@@ -504,7 +486,7 @@ class LibraryCardServiceTest extends AbstractTestHelper {
     when(userDAO.findUserById(anyInt())).thenReturn(user);
     when(institutionDAO.findInstitutionById(anyInt())).thenReturn(institution);
     when(institutionService.findInstitutionForEmail(user.getEmail())).thenReturn(institution);
-    when(libraryCardDAO.findLibraryCardsByUserId(anyInt())).thenReturn(Collections.emptyList());
+    when(libraryCardDAO.findLibraryCardByUserId(anyInt())).thenReturn(null);
 
     when(libraryCardDAO.insertLibraryCard(anyInt(), any(), any(), anyInt(),
         any())).thenReturn(1);
@@ -519,22 +501,21 @@ class LibraryCardServiceTest extends AbstractTestHelper {
   void testRemoveDaaFromUserLibraryCardByInstitutionNoLibraryCards() {
     User user = testUser(1);
     Integer userId = user.getUserId();
-    when(libraryCardDAO.findLibraryCardsByUserId(userId))
-        .thenReturn(Collections.emptyList());
-    List<LibraryCard> cards = service.removeDaaFromUserLibraryCards(user,1);
-    assertEquals(0, cards.size());
+    when(libraryCardDAO.findLibraryCardByUserId(userId)).thenReturn(null);
+    LibraryCard card = service.removeDaaFromUserLibraryCard(user,1);
+    assertNull(card);
   }
 
   private User testUser(Integer institutionId) {
     User user = new User();
-    user.setUserId(RandomUtils.nextInt(1, 10));
+    user.setUserId(randomInt(1, 10));
     user.setInstitutionId(institutionId);
     return user;
   }
 
   private LibraryCard testLibraryCard(Integer userId) {
     LibraryCard libraryCard = new LibraryCard();
-    libraryCard.setId(RandomUtils.nextInt(1, 10));
+    libraryCard.setId(randomInt(1, 10));
     libraryCard.setUserId(userId);
 
     return libraryCard;
@@ -542,7 +523,7 @@ class LibraryCardServiceTest extends AbstractTestHelper {
 
   private Institution testInstitution() {
     Institution institution = new Institution();
-    institution.setId(RandomUtils.nextInt(1, 10));
+    institution.setId(randomInt(1, 10));
     institution.setName("Test Institution");
 
     return institution;

--- a/src/test/java/org/broadinstitute/consent/http/service/LibraryCardServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/LibraryCardServiceTest.java
@@ -367,7 +367,7 @@ class LibraryCardServiceTest extends AbstractTestHelper {
   }
 
   @Test
-  void testAddDaaToUserLibraryCardByInstitution() {
+  void testAddDaaToUserLibraryCard() {
     User user = testUser(1);
     user.setRoles(List.of(new UserRole(UserRoles.RESEARCHER.getRoleId(), UserRoles.RESEARCHER.getRoleName())));
     User signingOfficial = createUserWithRole(UserRoles.SIGNINGOFFICIAL.getRoleId(), UserRoles.SIGNINGOFFICIAL.getRoleName());
@@ -375,17 +375,17 @@ class LibraryCardServiceTest extends AbstractTestHelper {
     Integer userId = user.getUserId();
     when(libraryCardDAO.findLibraryCardByUserId(user.getUserId())).thenReturn(testLibraryCard(userId));
     doNothing().when(libraryCardDAO).createLibraryCardDaaRelation(any(), any());
-    LibraryCard card = service.addDaaToUserLibraryCardByInstitution(user, signingOfficial, 1);
+    LibraryCard card = service.addDaaToUserLibraryCard(user, signingOfficial, 1);
     assertNotNull(card);
   }
 
   @Test
-  void testAddDaaToUserLibraryCardByInstitutionNoMatchingInstitutions() {
+  void testAddDaaToUserLibraryCardNoMatchingInstitutions() {
     User user = testUser(1);
     user.setRoles(List.of(new UserRole(UserRoles.RESEARCHER.getRoleId(), UserRoles.RESEARCHER.getRoleName())));
     User signingOfficial = createUserWithRole(UserRoles.SIGNINGOFFICIAL.getRoleId(), UserRoles.SIGNINGOFFICIAL.getRoleName());
     signingOfficial.setInstitutionId(4);
-    assertThrows(BadRequestException.class, () -> service.addDaaToUserLibraryCardByInstitution(user, signingOfficial, 1));
+    assertThrows(BadRequestException.class, () -> service.addDaaToUserLibraryCard(user, signingOfficial, 1));
   }
 
   @Test
@@ -410,17 +410,8 @@ class LibraryCardServiceTest extends AbstractTestHelper {
         .thenReturn(1);
     when(libraryCardDAO.findLibraryCardById(anyInt())).thenReturn(new LibraryCard());
 
-    LibraryCard card = service.addDaaToUserLibraryCardByInstitution(user, signingOfficial, 1);
+    LibraryCard card = service.addDaaToUserLibraryCard(user, signingOfficial, 1);
     assertNotNull(card);
-  }
-
-  @Test
-  void testAddDaaToUserLibraryCardByInstitutionSigningOfficialNoInstitution() {
-    User user = testUser(1);
-    user.setRoles(List.of(new UserRole(UserRoles.RESEARCHER.getRoleId(), UserRoles.RESEARCHER.getRoleName())));
-    User signingOfficial = new User();
-    signingOfficial.setRoles(List.of(new UserRole(UserRoles.SIGNINGOFFICIAL.getRoleId(), UserRoles.SIGNINGOFFICIAL.getRoleName())));
-    assertThrows(BadRequestException.class, () -> service.addDaaToUserLibraryCardByInstitution(user, signingOfficial, 1));
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -102,9 +103,6 @@ class UserServiceTest extends AbstractTestHelper {
   private DaaDAO daaDAO;
 
   @Mock
-  private EmailService emailService;
-
-  @Mock
   private DraftServiceDAO draftServiceDAO;
 
   @Mock
@@ -165,7 +163,7 @@ class UserServiceTest extends AbstractTestHelper {
     List<UserRole> roles = List.of(generateRole(UserRoles.RESEARCHER.getRoleId()));
     u.setRoles(roles);
     when(userDAO.findUserById(any())).thenReturn(u);
-    when(libraryCardDAO.findAllLibraryCardsByUserEmail(any())).thenReturn(Collections.emptyList());
+    when(libraryCardDAO.findLibraryCardByUserEmail(u.getEmail())).thenReturn(null);
     try {
       service.createUser(u);
     } catch (Exception e) {
@@ -180,8 +178,7 @@ class UserServiceTest extends AbstractTestHelper {
     Institution institution = new Institution();
     List<UserRole> roles = List.of(generateRole(UserRoles.RESEARCHER.getRoleId()));
     u.setRoles(roles);
-    when(libraryCardDAO.findAllLibraryCardsByUserEmail(u.getEmail())).thenReturn(
-        List.of(lc));
+    when(libraryCardDAO.findLibraryCardByUserEmail(u.getEmail())).thenReturn(lc);
     when(institutionService.findInstitutionForEmail(u.getEmail())).thenReturn(institution);
 
     service.createUser(u);
@@ -218,7 +215,7 @@ class UserServiceTest extends AbstractTestHelper {
     User u = generateUser();
     u.setEraCommonsId(randomAlphabetic(10));
     LibraryCard lc = generateLibraryCard(u.getEmail());
-    u.addLibraryCard(lc);
+    u.setLibraryCard(lc);
     UserProperty eraStatus = new UserProperty(1, u.getUserId(), ERA_STATUS.getValue(), "true");
     //standard practice is that these expire in 30 days.
     Timestamp eraExpirationTime = new Timestamp(
@@ -247,8 +244,6 @@ class UserServiceTest extends AbstractTestHelper {
     userProperties.add(eraStatus);
     userProperties.add(eraExpirationDate);
     u.setProperties(userProperties);
-    when(userPropertyDAO.findUserPropertiesByUserIdAndPropertyKeys(u.getUserId(),
-        UserFields.getValues())).thenReturn(u.getProperties());
     assertThrows(LibraryCardRequiredException.class,
         () -> service.hasValidActiveERACredentials(u));
   }
@@ -258,7 +253,7 @@ class UserServiceTest extends AbstractTestHelper {
     User u = generateUser();
     u.setEraCommonsId(null);
     LibraryCard lc = generateLibraryCard(u.getEmail());
-    u.addLibraryCard(lc);
+    u.setLibraryCard(lc);
     UserProperty eraStatus = new UserProperty(1, u.getUserId(), ERA_STATUS.getValue(), "true");
     //standard practice is that these expire in 30 days.
     Timestamp eraExpirationTime = new Timestamp(
@@ -269,8 +264,6 @@ class UserServiceTest extends AbstractTestHelper {
     userProperties.add(eraStatus);
     userProperties.add(eraExpirationDate);
     u.setProperties(userProperties);
-    when(userPropertyDAO.findUserPropertiesByUserIdAndPropertyKeys(u.getUserId(),
-        UserFields.getValues())).thenReturn(u.getProperties());
     assertThrows(BadRequestException.class,
         () -> service.hasValidActiveERACredentials(u));
   }
@@ -279,7 +272,7 @@ class UserServiceTest extends AbstractTestHelper {
   void testValidateRACommonsCredentialsMissingERAStatusShouldFail() {
     User u = generateUser();
     LibraryCard lc = generateLibraryCard(u.getEmail());
-    u.addLibraryCard(lc);
+    u.setLibraryCard(lc);
     //standard practice is that these expire in 30 days.
     Timestamp eraExpirationTime = new Timestamp(
         System.currentTimeMillis() + TimeUnit.DAYS.toMillis(30));
@@ -298,7 +291,7 @@ class UserServiceTest extends AbstractTestHelper {
   void testValidateERACommonsCredentialsMissingERAStatusAndExpirationShouldFail() {
     User u = generateUser();
     LibraryCard lc = generateLibraryCard(u.getEmail());
-    u.addLibraryCard(lc);
+    u.setLibraryCard(lc);
     List<UserProperty> userProperties = new ArrayList<>();
     u.setProperties(userProperties);
     when(userPropertyDAO.findUserPropertiesByUserIdAndPropertyKeys(u.getUserId(),
@@ -311,7 +304,7 @@ class UserServiceTest extends AbstractTestHelper {
   void testValidateERACommonsCredentialsWithExpiredERAExpirationDateShouldFail() {
     User u = generateUser();
     LibraryCard lc = generateLibraryCard(u.getEmail());
-    u.addLibraryCard(lc);
+    u.setLibraryCard(lc);
     UserProperty eraStatus = new UserProperty(1, u.getUserId(), ERA_STATUS.getValue(), "true");
     // set expiration date to 30 days ago!
     Timestamp eraExpirationTime = new Timestamp(
@@ -366,17 +359,14 @@ class UserServiceTest extends AbstractTestHelper {
   void testFindUserById_HasLibraryCards() {
     User u = generateUser();
     LibraryCard one = generateLibraryCard(u);
-    LibraryCard two = generateLibraryCard(u);
-    List<LibraryCard> cards = List.of(one, two);
+    u.setLibraryCard(one);
     when(userDAO.findUserById(any())).thenReturn(u);
-    when(libraryCardDAO.findLibraryCardsByUserId(any())).thenReturn(cards);
+    when(libraryCardDAO.findLibraryCardByUserId(any())).thenReturn(one);
 
     User user = service.findUserById(u.getUserId());
     assertNotNull(user);
-    assertNotNull(user.getLibraryCards());
-    assertEquals(2, user.getLibraryCards().size());
-    assertEquals(one.getId(), user.getLibraryCards().get(0).getId());
-    assertEquals(two.getId(), user.getLibraryCards().get(1).getId());
+    assertNotNull(user.getLibraryCard());
+    assertSame(one, user.getLibraryCard());
   }
 
   @Test
@@ -517,13 +507,13 @@ class UserServiceTest extends AbstractTestHelper {
     User u = generateUser();
     u.setInstitutionId(1);
     LibraryCard lc = generateLibraryCard(u);
-    u.setLibraryCards(List.of(lc));
+    u.setLibraryCard(lc);
     when(userDAO.getUsersFromInstitutionWithCards(anyInt())).thenReturn(List.of(u, new User()));
 
     List<User> users = service.getUsersAsRole(u, UserRoles.SIGNINGOFFICIAL.getRoleName());
     assertNotNull(users);
     assertEquals(2, users.size());
-    assertEquals(List.of(lc), users.get(0).getLibraryCards());
+    assertSame(lc, users.get(0).getLibraryCard());
   }
 
   @Test
@@ -548,13 +538,13 @@ class UserServiceTest extends AbstractTestHelper {
       returnedUsers.add(u3);
     }
     LibraryCard lc = generateLibraryCard(u1);
-    u1.setLibraryCards(List.of(lc));
+    u1.setLibraryCard(lc);
     when(userDAO.findUsersWithLCsAndInstitution()).thenReturn(returnedUsers);
     List<User> users = service.getUsersAsRole(u1, UserRoles.ADMIN.getRoleName());
     assertNotNull(users);
     assertEquals(returnedUsers.size(), users.size());
-    assertEquals(List.of(lc), users.get(0).getLibraryCards());
-    assertTrue(users.get(1).getLibraryCards().isEmpty());
+    assertEquals(lc, users.get(0).getLibraryCard());
+    assertNull(users.get(1).getLibraryCard());
   }
 
   @Test
@@ -677,7 +667,7 @@ class UserServiceTest extends AbstractTestHelper {
     AuthUser authUser = new AuthUser().setEmail(user.getEmail())
         .setAuthToken(randomAlphabetic(30)).setUserStatusInfo(info);
     when(userDAO.findUserById(anyInt())).thenReturn(user);
-    when(libraryCardDAO.findLibraryCardsByUserId(anyInt())).thenReturn(List.of(new LibraryCard()));
+    when(libraryCardDAO.findLibraryCardByUserId(anyInt())).thenReturn(new LibraryCard());
     when(userPropertyDAO.findUserPropertiesByUserIdAndPropertyKeys(anyInt(), any())).thenReturn(
         List.of(new UserProperty()));
 
@@ -698,7 +688,7 @@ class UserServiceTest extends AbstractTestHelper {
     AuthUser authUser = new AuthUser().setEmail("not the user's email address")
         .setAuthToken(randomAlphabetic(30)).setUserStatusInfo(info);
     when(userDAO.findUserById(anyInt())).thenReturn(user);
-    when(libraryCardDAO.findLibraryCardsByUserId(anyInt())).thenReturn(List.of(new LibraryCard()));
+    when(libraryCardDAO.findLibraryCardByUserId(anyInt())).thenReturn(new LibraryCard());
     when(userPropertyDAO.findUserPropertiesByUserIdAndPropertyKeys(anyInt(), any())).thenReturn(
         List.of(new UserProperty()));
 
@@ -754,7 +744,7 @@ class UserServiceTest extends AbstractTestHelper {
     User newUser = service.findOrCreateUser(authUser);
     assertEquals(user.getEmail(), newUser.getEmail());
     verify(userRoleDAO).insertUserRoles(any(), any());
-    verify(libraryCardDAO).findAllLibraryCardsByUserEmail(any());
+    verify(libraryCardDAO).findLibraryCardByUserEmail(any());
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
@@ -175,6 +175,7 @@ class UserServiceTest extends AbstractTestHelper {
   void createUserWithLibraryCardTest() {
     User u = generateUser();
     LibraryCard lc = generateLibraryCard(u.getEmail());
+    lc.setUserName(u.getDisplayName());
     Institution institution = new Institution();
     List<UserRole> roles = List.of(generateRole(UserRoles.RESEARCHER.getRoleId()));
     u.setRoles(roles);

--- a/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
@@ -674,7 +674,8 @@ class UserServiceTest extends AbstractTestHelper {
     JsonObject userJson = service.findUserWithPropertiesByIdAsJsonObject(authUser,
         user.getUserId());
     assertNotNull(userJson);
-    assertTrue(userJson.get(UserService.LIBRARY_CARDS_FIELD).getAsJsonObject().isJsonObject());
+    assertTrue(userJson.get(UserService.LIBRARY_CARD_FIELD).getAsJsonObject().isJsonObject());
+    assertTrue(userJson.get(UserService.LIBRARY_CARDS_FIELD).getAsJsonArray().isJsonArray());
     assertTrue(
         userJson.get(UserService.USER_PROPERTIES_FIELD).getAsJsonArray().isJsonArray());
     assertTrue(userJson.get(UserService.USER_STATUS_INFO_FIELD).getAsJsonObject().isJsonObject());
@@ -695,7 +696,8 @@ class UserServiceTest extends AbstractTestHelper {
     JsonObject userJson = service.findUserWithPropertiesByIdAsJsonObject(authUser,
         user.getUserId());
     assertNotNull(userJson);
-    assertTrue(userJson.get(UserService.LIBRARY_CARDS_FIELD).getAsJsonObject().isJsonObject());
+    assertTrue(userJson.get(UserService.LIBRARY_CARD_FIELD).getAsJsonObject().isJsonObject());
+    assertTrue(userJson.get(UserService.LIBRARY_CARDS_FIELD).getAsJsonArray().isJsonArray());
     assertTrue(
         userJson.get(UserService.USER_PROPERTIES_FIELD).getAsJsonArray().isJsonArray());
     assertNull(userJson.get(UserService.USER_STATUS_INFO_FIELD));

--- a/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
@@ -362,12 +362,11 @@ class UserServiceTest extends AbstractTestHelper {
     LibraryCard one = generateLibraryCard(u);
     u.setLibraryCard(one);
     when(userDAO.findUserById(any())).thenReturn(u);
-    when(libraryCardDAO.findLibraryCardByUserId(any())).thenReturn(one);
 
     User user = service.findUserById(u.getUserId());
     assertNotNull(user);
     assertNotNull(user.getLibraryCard());
-    assertSame(one, user.getLibraryCard());
+    assertEquals(one, user.getLibraryCard());
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
@@ -662,19 +662,19 @@ class UserServiceTest extends AbstractTestHelper {
   @Test
   void testFindUserWithPropertiesAsJsonObjectById() {
     User user = generateUser();
+    user.setLibraryCard(new LibraryCard());
     UserStatusInfo info = new UserStatusInfo().setUserEmail(user.getEmail()).setEnabled(true)
         .setUserSubjectId("subjectId");
     AuthUser authUser = new AuthUser().setEmail(user.getEmail())
         .setAuthToken(randomAlphabetic(30)).setUserStatusInfo(info);
     when(userDAO.findUserById(anyInt())).thenReturn(user);
-    when(libraryCardDAO.findLibraryCardByUserId(anyInt())).thenReturn(new LibraryCard());
     when(userPropertyDAO.findUserPropertiesByUserIdAndPropertyKeys(anyInt(), any())).thenReturn(
         List.of(new UserProperty()));
 
     JsonObject userJson = service.findUserWithPropertiesByIdAsJsonObject(authUser,
         user.getUserId());
     assertNotNull(userJson);
-    assertTrue(userJson.get(UserService.LIBRARY_CARDS_FIELD).getAsJsonArray().isJsonArray());
+    assertTrue(userJson.get(UserService.LIBRARY_CARDS_FIELD).getAsJsonObject().isJsonObject());
     assertTrue(
         userJson.get(UserService.USER_PROPERTIES_FIELD).getAsJsonArray().isJsonArray());
     assertTrue(userJson.get(UserService.USER_STATUS_INFO_FIELD).getAsJsonObject().isJsonObject());

--- a/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
@@ -683,19 +683,19 @@ class UserServiceTest extends AbstractTestHelper {
   @Test
   void testFindUserWithPropertiesAsJsonObjectByIdNonAuthUser() {
     User user = generateUser();
+    user.setLibraryCard(new LibraryCard());
     UserStatusInfo info = new UserStatusInfo().setUserEmail(user.getEmail()).setEnabled(true)
         .setUserSubjectId("subjectId");
     AuthUser authUser = new AuthUser().setEmail("not the user's email address")
         .setAuthToken(randomAlphabetic(30)).setUserStatusInfo(info);
     when(userDAO.findUserById(anyInt())).thenReturn(user);
-    when(libraryCardDAO.findLibraryCardByUserId(anyInt())).thenReturn(new LibraryCard());
     when(userPropertyDAO.findUserPropertiesByUserIdAndPropertyKeys(anyInt(), any())).thenReturn(
         List.of(new UserProperty()));
 
     JsonObject userJson = service.findUserWithPropertiesByIdAsJsonObject(authUser,
         user.getUserId());
     assertNotNull(userJson);
-    assertTrue(userJson.get(UserService.LIBRARY_CARDS_FIELD).getAsJsonArray().isJsonArray());
+    assertTrue(userJson.get(UserService.LIBRARY_CARDS_FIELD).getAsJsonObject().isJsonObject());
     assertTrue(
         userJson.get(UserService.USER_PROPERTIES_FIELD).getAsJsonArray().isJsonArray());
     assertNull(userJson.get(UserService.USER_STATUS_INFO_FIELD));

--- a/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
@@ -162,7 +162,7 @@ class UserServiceTest extends AbstractTestHelper {
     User u = generateUser();
     List<UserRole> roles = List.of(generateRole(UserRoles.RESEARCHER.getRoleId()));
     u.setRoles(roles);
-    when(userDAO.findUserById(any())).thenReturn(u);
+    when(userDAO.findUserByEmail(u.getEmail())).thenReturn(null);
     when(libraryCardDAO.findLibraryCardByUserEmail(u.getEmail())).thenReturn(null);
     try {
       service.createUser(u);

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/NihServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/NihServiceDAOTest.java
@@ -1,7 +1,8 @@
 package org.broadinstitute.consent.http.service.dao;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.any;
@@ -89,8 +90,8 @@ class NihServiceDAOTest extends DAOTestHelper {
     User updatedUser = userDAO.findUserById(user.getUserId());
     assertEquals(updatedUser.getEraCommonsId(), userAccount.getNihUsername());
 
-    List<LibraryCard> cards = libraryCardDAO.findLibraryCardsByUserId(user.getUserId());
-    assertFalse(cards.isEmpty());
+    LibraryCard card = libraryCardDAO.findLibraryCardByUserId(user.getUserId());
+    assertNotNull(card);
   }
 
   @Test
@@ -133,8 +134,8 @@ class NihServiceDAOTest extends DAOTestHelper {
     assertEquals(updatedUser.getEraCommonsId(), userAccount.getNihUsername());
 
     // ensure that we did not make any LC updates
-    List<LibraryCard> cards = libraryCardDAO.findLibraryCardsByUserId(user.getUserId());
-    assertTrue(cards.isEmpty());
+    LibraryCard card = libraryCardDAO.findLibraryCardByUserId(user.getUserId());
+    assertNull(card);
   }
 
   @Test


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DT-1662

## Summary
This PR enforces that a user can only have a single library card. There are a significant number of test changes to support this requirement. For backwards compatibility with the UI, we're populating the User object with a `libraryCard` and a list of `libraryCards`. When the UI is updated to match this, we can come back and remove the deprecated field.

### Notes
There will need to be a follow-on PR in the UI to deal with the user model describing an array of library cards. See https://github.com/DataBiosphere/duos-ui/blob/ee9e70640759c33bed9e6b9f8b5393f4692dea8b/src/types/model.ts#L51 for where we need to start there.

See these tickets for that work:
* https://broadworkbench.atlassian.net/browse/DT-1695
* https://broadworkbench.atlassian.net/browse/DT-1696

There are deletes for duplicate `user_id` and `user_email` rows. In Prod, there are no records affected. In Dev and Staging, there are 2 and 1 record respectively that will be removed.

### Testing
Tested the db update with a recent db download from
* ✅ Dev
* ✅ Staging
* ✅ Prod

Tested the UI Admin/SO Library Card table functionality
* ✅  Dev
* ✅ Staging
* ✅ Prod

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
