### PR TITLE
[DT-1690] Remove update library card endpoint

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/resources/LibraryCardResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/LibraryCardResource.java
@@ -10,7 +10,6 @@ import jakarta.ws.rs.ForbiddenException;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.POST;
-import jakarta.ws.rs.PUT;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
@@ -89,24 +88,6 @@ public class LibraryCardResource extends Resource {
       payload.setCreateUserId(user.getUserId());
       LibraryCard newLibraryCard = libraryCardService.createLibraryCard(payload, user);
       return Response.status(HttpStatusCodes.STATUS_CODE_CREATED).entity(newLibraryCard).build();
-    } catch (Exception e) {
-      return createExceptionResponse(e);
-    }
-  }
-
-  @PUT
-  @Consumes("application/json")
-  @Produces("application/json")
-  @Path("/{id}")
-  @RolesAllowed(ADMIN)
-  public Response updateLibraryCard(@Auth AuthUser authUser, @PathParam("id") Integer id,
-      String libraryCard) {
-    try {
-      User user = userService.findUserByEmail(authUser.getEmail());
-      LibraryCard payload = GsonUtil.getInstance().fromJson(libraryCard, LibraryCard.class);
-      LibraryCard updatedLibraryCard = libraryCardService.updateLibraryCard(payload, id,
-          user.getUserId());
-      return Response.ok().entity(updatedLibraryCard).build();
     } catch (Exception e) {
       return createExceptionResponse(e);
     }

--- a/src/main/java/org/broadinstitute/consent/http/service/LibraryCardService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/LibraryCardService.java
@@ -52,24 +52,6 @@ public class LibraryCardService {
     return libraryCardDAO.findLibraryCardById(id);
   }
 
-  public LibraryCard updateLibraryCard(LibraryCard libraryCard, Integer id, Integer userId) {
-    LibraryCard updateCard = libraryCardDAO.findLibraryCardById(id);
-    throwIfNull(updateCard);
-    checkUserId(userId);
-    checkForValidUser(libraryCard.getUserId());
-
-    Date updateDate = new Date();
-    libraryCardDAO.updateLibraryCardById(
-        id,
-        libraryCard.getUserId(),
-        libraryCard.getUserName(),
-        libraryCard.getUserEmail(),
-        userId,
-        updateDate
-    );
-    return libraryCardDAO.findLibraryCardById(id);
-  }
-
   public void deleteLibraryCardById(Integer id) {
     LibraryCard card = findLibraryCardById(id);
     throwIfNull(card);

--- a/src/main/java/org/broadinstitute/consent/http/service/LibraryCardService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/LibraryCardService.java
@@ -140,26 +140,9 @@ public class LibraryCardService {
     }
   }
 
-  private void checkForValidUser(Integer userId) {
-    if (Objects.isNull(userId)) {
-      return;
-    }
-
-    User user = userDAO.findUserById(userId);
-    if (Objects.isNull(user)) {
-      throw new IllegalArgumentException("Invalid User Id");
-    }
-  }
-
   private void checkInstitutionId(Integer institutionId) {
     if (Objects.isNull(institutionId)) {
       throw new IllegalArgumentException("Institution ID is a required parameter");
-    }
-  }
-
-  private void checkUserId(Integer userId) {
-    if (Objects.isNull(userId)) {
-      throw new IllegalArgumentException("User ID is a required parameter");
     }
   }
 

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -608,43 +608,6 @@ paths:
           description: Library Card not found
         500:
           description: Internal server error
-    put:
-      summary: Library Card PUT resource
-      description: Update target Library Card based on id parameter and user provided json
-      tags:
-        - Library Card
-        - Admin
-      parameters:
-        - name: id
-          in: path
-          description: Library Card ID
-          required: true
-          schema:
-            type: integer
-      requestBody:
-        description: 'JSON representation of updated Library Card state'
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/LibraryCard'
-      responses:
-        200:
-          description: Library Card PUT request success
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/LibraryCard'
-        400:
-          description: Bad request (Issues with json payload)
-        401:
-          description: User not authorized
-        404:
-          description: Library Card not found
-        409:
-          description: Library Card payload conflicts with an existing record
-        500:
-          description: Internal server error
     delete:
       summary: Library Card DELETE resource
       description: Delete target Library Card based on id parameter

--- a/src/test/java/org/broadinstitute/consent/http/db/LibraryCardDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/LibraryCardDAOTest.java
@@ -1,11 +1,10 @@
 package org.broadinstitute.consent.http.db;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-
 
 import java.time.Instant;
 import java.util.Date;
@@ -55,33 +54,6 @@ class LibraryCardDAOTest extends DAOTestHelper {
           0, new Date());
     } catch (Exception e) {
       assertEquals(PSQLState.FOREIGN_KEY_VIOLATION.getState(),
-          ((PSQLException) e.getCause()).getSQLState());
-    }
-  }
-
-  @Test
-  void testUpdateLibraryCardById() {
-    Integer userId = createUser().getUserId();
-    String newValue = "New Value";
-    LibraryCard card = createLibraryCard();
-    Integer id = card.getId();
-    card.setUserName("name");
-    libraryCardDAO.updateLibraryCardById(id, userId, newValue, newValue,
-        userId, new Date());
-    LibraryCard updated = libraryCardDAO.findLibraryCardById(id);
-    assertEquals(newValue, updated.getUserName());
-    assertEquals(userId, updated.getUpdateUserId());
-  }
-
-  @Test
-  void testUpdateLibraryCardByIdNegative() {
-    Integer userId = createUser().getUserId();
-    String newValue = "New Value";
-    try {
-      libraryCardDAO.updateLibraryCardById(0, userId, newValue, newValue,
-          userId, new Date());
-    } catch (Exception e) {
-      assertEquals(PSQLState.UNIQUE_VIOLATION.getState(),
           ((PSQLException) e.getCause()).getSQLState());
     }
   }

--- a/src/test/java/org/broadinstitute/consent/http/resources/LibraryCardResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/LibraryCardResourceTest.java
@@ -187,55 +187,6 @@ class LibraryCardResourceTest {
   }
 
   @Test
-  void testUpdateLibraryCard() {
-    LibraryCard mockCard = mockLibraryCardSetup();
-    String payload = GsonUtil.getInstance().toJson(mockCard);
-    when(userService.findUserByEmail(anyString())).thenReturn(user);
-    when(libraryCardService.updateLibraryCard(any(LibraryCard.class), anyInt(), anyInt()))
-        .thenReturn(mockCard);
-    initResource();
-    Response response = resource.updateLibraryCard(authUser, 1, payload);
-    String json = response.getEntity().toString();
-    assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
-    assertNotNull(json);
-  }
-
-  @Test
-  void testUpdateLibraryCardThrowsIllegalArgumentException() {
-    LibraryCard mockCard = mockLibraryCardSetup();
-    String payload = GsonUtil.getInstance().toJson(mockCard);
-    when(userService.findUserByEmail(anyString())).thenReturn(user);
-    when(libraryCardService.updateLibraryCard(any(LibraryCard.class), anyInt(), anyInt()))
-        .thenThrow(new IllegalArgumentException());
-    initResource();
-    Response response = resource.updateLibraryCard(authUser, 1, payload);
-    assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
-  }
-
-  @Test
-  void testUpdateLibraryCardThrowsNotFoundException() {
-    when(userService.findUserByEmail(anyString())).thenReturn(user);
-    when(libraryCardService.updateLibraryCard(any(LibraryCard.class), anyInt(), anyInt()))
-        .thenThrow(new NotFoundException());
-    String payload = GsonUtil.getInstance().toJson(mockLibraryCardSetup());
-    initResource();
-    Response response = resource.updateLibraryCard(authUser, 1, payload);
-    assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
-  }
-
-  @Test
-  void testUpdateLibraryCardThrowsUniqueViolation() {
-    UnableToExecuteStatementException exception = generateUniqueViolationException();
-    when(userService.findUserByEmail(anyString())).thenReturn(user);
-    when(libraryCardService.updateLibraryCard(any(LibraryCard.class), anyInt(), anyInt()))
-        .thenThrow(exception);
-    String payload = GsonUtil.getInstance().toJson(mockLibraryCardSetup());
-    initResource();
-    Response response = resource.updateLibraryCard(authUser, 1, payload);
-    assertEquals(HttpStatusCodes.STATUS_CODE_CONFLICT, response.getStatus());
-  }
-
-  @Test
   void deleteLibraryCard() {
     LibraryCard card = mockLibraryCardSetup();
     card.setId(1);

--- a/src/test/java/org/broadinstitute/consent/http/service/LibraryCardServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/LibraryCardServiceTest.java
@@ -54,7 +54,7 @@ class LibraryCardServiceTest extends AbstractTestHelper {
   }
 
   @Test
-  // Test Admin LC create with userId and email
+    // Test Admin LC create with userId and email
   void testCreateLibraryCardFullUserDetailsAsAdmin() {
     Institution institution = testInstitution();
     User user = testUser(institution.getId());
@@ -78,7 +78,7 @@ class LibraryCardServiceTest extends AbstractTestHelper {
   }
 
   @Test
-  // Test SO LC create with userId and email success case
+    // Test SO LC create with userId and email success case
   void testCreateLibraryCardFullUserDetailsAsSOSameInstitution() {
     Institution institution = testInstitution();
     User user = testUser(institution.getId());
@@ -105,7 +105,7 @@ class LibraryCardServiceTest extends AbstractTestHelper {
   }
 
   @Test
-  // Test SO LC create with userId and email but in different institutions
+    // Test SO LC create with userId and email but in different institutions
   void testCreateLibraryCardFullUserDetailsAsSODifferentInstitution() {
     Institution institution = testInstitution();
     User user = testUser(institution.getId());
@@ -126,7 +126,7 @@ class LibraryCardServiceTest extends AbstractTestHelper {
   }
 
   @Test
-  //Test LC create with only user email (no userId)
+    //Test LC create with only user email (no userId)
   void testCreateLibraryCardPartialUserDetailsEmail() {
     Institution institution = testInstitution();
     User user = testUser(institution.getId());
@@ -144,7 +144,7 @@ class LibraryCardServiceTest extends AbstractTestHelper {
   }
 
   @Test
-  //Test LC create with only user id (no email)
+    //Test LC create with only user id (no email)
   void testCreateLibraryCardPartialUserDetailsId() {
     Institution institution = testInstitution();
     User user = testUser(institution.getId());
@@ -201,7 +201,7 @@ class LibraryCardServiceTest extends AbstractTestHelper {
   }
 
   @Test
-  //Negative test, checks if error is thrown if payload email and userId don't match up to those on user record
+    //Negative test, checks if error is thrown if payload email and userId don't match up to those on user record
   void testCreateLibraryCardIncorrectUserIdAndEmail() {
     Institution institution = testInstitution();
     User user = testUser(institution.getId());
@@ -218,7 +218,7 @@ class LibraryCardServiceTest extends AbstractTestHelper {
   }
 
   @Test
-  //Negative test, checks to see if error thrown if card already exists on user id and institution id
+    //Negative test, checks to see if error thrown if card already exists on user id and institution id
   void testCreateLibraryCardAlreadyExistsOnUserId() {
     Institution institution = testInstitution();
     User user = testUser(institution.getId());
@@ -232,7 +232,7 @@ class LibraryCardServiceTest extends AbstractTestHelper {
   }
 
   @Test
-  // Negative test, checks to see if error thrown if card already exists on user email and institution id
+    // Negative test, checks to see if error thrown if card already exists on user email and institution id
   void testCreateLibraryCardAlreadyExistsOnUserEmail() {
     Institution institution = testInstitution();
     User user = testUser(institution.getId());
@@ -251,7 +251,7 @@ class LibraryCardServiceTest extends AbstractTestHelper {
   }
 
   @Test
-  //Negative test, checks to see if error is thrown if email and userId are not provided
+    //Negative test, checks to see if error is thrown if email and userId are not provided
   void testCreateLibraryCardNoUserDetails() {
     User adminUser = createUserWithRole(UserRoles.ADMIN.getRoleId(), UserRoles.ADMIN.getRoleName());
     LibraryCard payload = testLibraryCard(null);
@@ -262,7 +262,7 @@ class LibraryCardServiceTest extends AbstractTestHelper {
   }
 
   @Test
-  //Negative test, checks if error is thrown on null institutionId
+    //Negative test, checks if error is thrown on null institutionId
   void testCreateLibraryCard_InvalidInstitution() {
     User user = testUser(1);
     User adminUser = createUserWithRole(UserRoles.ADMIN.getRoleId(), UserRoles.ADMIN.getRoleName());
@@ -272,7 +272,7 @@ class LibraryCardServiceTest extends AbstractTestHelper {
   }
 
   @Test
-  //Negative test, checks to see if error is thrown on null payload
+    //Negative test, checks to see if error is thrown on null payload
   void testCreateLibraryCardNullPayload() {
     User adminUser = createUserWithRole(UserRoles.ADMIN.getRoleId(), UserRoles.ADMIN.getRoleName());
     assertThrows(NotFoundException.class, () -> service.createLibraryCard(null, adminUser));
@@ -295,32 +295,6 @@ class LibraryCardServiceTest extends AbstractTestHelper {
     LibraryCard card = testLibraryCard(2);
     assertThrows(BadRequestException.class, () -> {
       service.createLibraryCard(card, soUser);
-    });
-  }
-
-  @Test
-  void testUpdateLibraryCard() {
-    Institution institution = testInstitution();
-    User user = testUser(institution.getId());
-    LibraryCard libraryCard = testLibraryCard(user.getUserId());
-    when(libraryCardDAO.findLibraryCardById(libraryCard.getId())).thenReturn(libraryCard);
-    when(userDAO.findUserById(user.getUserId())).thenReturn(user);
-    doNothing().when(libraryCardDAO)
-        .updateLibraryCardById(any(), any(), any(), any(), any(), any());
-
-    LibraryCard resultCard = service.updateLibraryCard(libraryCard, libraryCard.getId(), 1);
-    assertNotNull(resultCard);
-    assertEquals(resultCard.getId(), libraryCard.getId());
-  }
-
-  @Test
-  void testUpdateLibraryCard_NotFound() {
-    Institution institution = testInstitution();
-    User user = testUser(institution.getId());
-    LibraryCard libraryCard = testLibraryCard(user.getUserId());
-
-    assertThrows(NotFoundException.class, () -> {
-      service.updateLibraryCard(libraryCard, libraryCard.getId(), 1);
     });
   }
 


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-1690

### Summary

Removes the update library card endpoint. There is a bunch of other update library card functionality that we cannot remove because when we create a user, they may already have library cards associated with their email which we then associate to the user, which is also considered a "library card update".

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
