### PR TITLE
Replace SimplifiedUser with User

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/InstitutionDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/InstitutionDAO.java
@@ -6,7 +6,6 @@ import org.broadinstitute.consent.http.db.mapper.InstitutionMapper;
 import org.broadinstitute.consent.http.db.mapper.InstitutionWithUsersReducer;
 import org.broadinstitute.consent.http.models.Institution;
 import org.broadinstitute.consent.http.models.User;
-import org.broadinstitute.consent.http.service.UserService.SimplifiedUser;
 import org.jdbi.v3.sqlobject.config.RegisterBeanMapper;
 import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
 import org.jdbi.v3.sqlobject.customizer.Bind;
@@ -92,7 +91,6 @@ public interface InstitutionDAO extends Transactional<InstitutionDAO> {
   List<Institution> findInstitutionsByName(@Bind("name") String name);
 
   @RegisterBeanMapper(value = User.class, prefix = "u")
-  @RegisterBeanMapper(value = SimplifiedUser.class, prefix = "so")
   @UseRowReducer(InstitutionWithUsersReducer.class)
   @SqlQuery(
       "SELECT i.*, "
@@ -121,7 +119,6 @@ public interface InstitutionDAO extends Transactional<InstitutionDAO> {
   List<Institution> findAllInstitutions();
 
   @RegisterBeanMapper(value = User.class, prefix = "u")
-  @RegisterBeanMapper(value = SimplifiedUser.class, prefix = "so")
   @UseRowReducer(InstitutionWithUsersReducer.class)
   @SqlQuery(
       """

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/InstitutionWithUsersReducer.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/InstitutionWithUsersReducer.java
@@ -5,7 +5,6 @@ import java.util.Map;
 import java.util.Objects;
 import org.broadinstitute.consent.http.models.Institution;
 import org.broadinstitute.consent.http.models.User;
-import org.broadinstitute.consent.http.service.UserService.SimplifiedUser;
 import org.jdbi.v3.core.result.LinkedHashMapRowReducer;
 import org.jdbi.v3.core.result.RowView;
 
@@ -38,7 +37,10 @@ public class InstitutionWithUsersReducer implements LinkedHashMapRowReducer<Inte
     institution.setUpdateUser(update_user);
 
     if (Objects.nonNull(rowView.getColumn("so_user_id", Integer.class))) {
-      SimplifiedUser so_user = rowView.getRow(SimplifiedUser.class);
+      User so_user = new User();
+      so_user.setUserId(rowView.getColumn("so_user_id", Integer.class));
+      so_user.setEmail(rowView.getColumn("so_email", String.class));
+      so_user.setDisplayName(rowView.getColumn("so_display_name", String.class));
       institution.addSigningOfficial(so_user);
     }
 

--- a/src/main/java/org/broadinstitute/consent/http/models/Institution.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/Institution.java
@@ -2,12 +2,10 @@ package org.broadinstitute.consent.http.models;
 
 import java.util.ArrayList;
 import java.util.Date;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Objects;
+import java.util.Set;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.broadinstitute.consent.http.enumeration.OrganizationType;
-import org.broadinstitute.consent.http.service.UserService.SimplifiedUser;
 
 public class Institution {
 
@@ -31,7 +29,7 @@ public class Institution {
   private String name;
   private String itDirectorName;
   private String itDirectorEmail;
-  private List<SimplifiedUser> signingOfficials;
+  private final List<User> signingOfficials = new ArrayList<>();
   private String institutionUrl;
   private Integer dunsNumber;
   private String orgChartUrl;
@@ -66,7 +64,6 @@ public class Institution {
     this.name = name;
     this.itDirectorName = itDirectorName;
     this.itDirectorEmail = itDirectorEmail;
-    this.signingOfficials = new ArrayList<>();
     this.createDate = createDate;
     this.createUserId = createUserId;
     this.institutionUrl = institutionUrl;
@@ -97,7 +94,6 @@ public class Institution {
     this.name = name;
     this.itDirectorName = itDirectorName;
     this.itDirectorEmail = itDirectorEmail;
-    this.signingOfficials = new ArrayList<>();
     this.institutionUrl = institutionUrl;
     this.dunsNumber = dunsNumber;
     this.orgChartUrl = orgChartUrl;
@@ -126,19 +122,17 @@ public class Institution {
     this.itDirectorName = itDirectorName;
   }
 
-  public List<SimplifiedUser> getSigningOfficials() {
+  public List<User> getSigningOfficials() {
     return signingOfficials;
   }
 
-  public void setSigningOfficials(List<SimplifiedUser> signingOfficials) {
-    this.signingOfficials = signingOfficials;
+  public void setSigningOfficials(List<User> signingOfficials) {
+    this.signingOfficials.clear();
+    this.signingOfficials.addAll(signingOfficials);
   }
 
-  public void addSigningOfficial(SimplifiedUser so) {
-    if (Objects.isNull(signingOfficials)) {
-      this.setSigningOfficials(new ArrayList<>());
-    }
-    if (!new HashSet<>(signingOfficials).contains(so)) {
+  public void addSigningOfficial(User so) {
+    if (!Set.copyOf(signingOfficials).contains(so)) {
       signingOfficials.add(so);
     }
   }

--- a/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
@@ -32,7 +32,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
@@ -48,7 +47,6 @@ import org.broadinstitute.consent.http.models.dto.DatasetDTO;
 import org.broadinstitute.consent.http.service.AcknowledgementService;
 import org.broadinstitute.consent.http.service.DatasetService;
 import org.broadinstitute.consent.http.service.UserService;
-import org.broadinstitute.consent.http.service.UserService.SimplifiedUser;
 import org.broadinstitute.consent.http.service.sam.SamService;
 
 @Path("api/user")
@@ -402,8 +400,7 @@ public class UserResource extends Resource {
     try {
       User user = userService.findUserByEmail(authUser.getEmail());
       if (Objects.nonNull(user.getInstitutionId())) {
-        List<SimplifiedUser> signingOfficials = userService.findSOsByInstitutionId(
-            user.getInstitutionId());
+        var signingOfficials = userService.findSOsByInstitutionId(user.getInstitutionId());
         return Response.ok().entity(signingOfficials).build();
       }
       return Response.ok().entity(Collections.emptyList()).build();

--- a/src/main/java/org/broadinstitute/consent/http/service/DaaService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DaaService.java
@@ -15,7 +15,6 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.consent.http.cloudstore.GCSService;
 import org.broadinstitute.consent.http.db.DaaDAO;
@@ -27,7 +26,6 @@ import org.broadinstitute.consent.http.models.DataAccessAgreement;
 import org.broadinstitute.consent.http.models.FileStorageObject;
 import org.broadinstitute.consent.http.models.Institution;
 import org.broadinstitute.consent.http.models.User;
-import org.broadinstitute.consent.http.service.UserService.SimplifiedUser;
 import org.broadinstitute.consent.http.service.dao.DaaServiceDAO;
 import org.broadinstitute.consent.http.util.ConsentLogger;
 import org.glassfish.jersey.media.multipart.FormDataContentDisposition;
@@ -158,17 +156,14 @@ public class DaaService implements ConsentLogger {
       if (institution == null) {
         throw new BadRequestException("This user has not set their institution: " + user.getDisplayName());
       }
-      List<SimplifiedUser> signingOfficials = institution.getSigningOfficials();
+      var signingOfficials = institution.getSigningOfficials();
       if (signingOfficials.isEmpty()) {
         throw new NotFoundException("No signing officials found for user: " + user.getDisplayName());
       }
-      for (SimplifiedUser signingOfficial : signingOfficials) {
+      for (var signingOfficial : signingOfficials) {
         DataAccessAgreement daa = findById(daaId);
         String daaName = daa.getFile().getFileName();
-        User toUser = new User();
-        toUser.setEmail(signingOfficial.email);
-        toUser.setDisplayName(signingOfficial.displayName);
-        emailService.sendDaaRequestMessage(toUser, user, daaName, daaId);
+        emailService.sendDaaRequestMessage(signingOfficial, user, daaName, daaId);
       }
     } catch (Exception e) {
       logException(e);
@@ -181,22 +176,17 @@ public class DaaService implements ConsentLogger {
       DataAccessAgreement daa = findById(daaId);
       if (daa != null) {
         String previousDaaName = daa.getFile().getFileName();
-        List<SimplifiedUser> researchers = userService.getUsersByDaaId(daaId);
-        List<SimplifiedUser> signingOfficials = researchers.stream()
-            .flatMap(researcher -> userService.findSOsByInstitutionId(researcher.institutionId).stream())
+        var researchers = userService.getUsersByDaaId(daaId);
+        var signingOfficials = researchers.stream()
+            .flatMap(researcher -> userService.findSOsByInstitutionId(researcher.getInstitutionId()).stream())
             .distinct()
             .toList();
-        User toUser = new User();
 
-        for (SimplifiedUser researcher : researchers) {
-          toUser.setEmail(researcher.email);
-          toUser.setDisplayName(researcher.displayName);
-          emailService.sendNewDAAUploadResearcherMessage(toUser, dacName, previousDaaName, newDaaName, user.getUserId());
+        for (var researcher : researchers) {
+          emailService.sendNewDAAUploadResearcherMessage(researcher, dacName, previousDaaName, newDaaName, user.getUserId());
         }
-        for (SimplifiedUser signingOfficial : signingOfficials) {
-          toUser.setEmail(signingOfficial.email);
-          toUser.setDisplayName(signingOfficial.displayName);
-          emailService.sendNewDAAUploadSOMessage(toUser, dacName, previousDaaName, newDaaName, user.getUserId());
+        for (var signingOfficial : signingOfficials) {
+          emailService.sendNewDAAUploadSOMessage(signingOfficial, dacName, previousDaaName, newDaaName, user.getUserId());
         }
       }
     } catch (Exception e) {

--- a/src/main/java/org/broadinstitute/consent/http/service/InstitutionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/InstitutionService.java
@@ -8,13 +8,11 @@ import java.io.IOException;
 import java.util.Date;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 import org.broadinstitute.consent.http.cloudstore.GCSService;
 import org.broadinstitute.consent.http.db.InstitutionDAO;
 import org.broadinstitute.consent.http.db.UserDAO;
 import org.broadinstitute.consent.http.models.Institution;
 import org.broadinstitute.consent.http.models.InstitutionDomainMap;
-import org.broadinstitute.consent.http.service.UserService.SimplifiedUser;
 
 public class InstitutionService {
 
@@ -85,10 +83,7 @@ public class InstitutionService {
     Institution institution = institutionDAO.findInstitutionById(id);
     isInstitutionNull(institution);
 
-    List<SimplifiedUser> signingOfficials = userDAO.getSOsByInstitution(id).stream()
-        .map(SimplifiedUser::new)
-        .collect(Collectors.toList());
-    institution.setSigningOfficials(signingOfficials);
+    institution.setSigningOfficials(userDAO.getSOsByInstitution(id));
 
     return institution;
   }

--- a/src/main/java/org/broadinstitute/consent/http/service/UserService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/UserService.java
@@ -237,7 +237,7 @@ public class UserService implements ConsentLogger {
     return Collections.emptyList();
   }
 
-  public List<SimplifiedUser> getUsersByDaaId(Integer daaId) {
+  public List<User> getUsersByDaaId(Integer daaId) {
     if (Objects.isNull(daaId)) {
       throw new IllegalArgumentException();
     }
@@ -245,8 +245,7 @@ public class UserService implements ConsentLogger {
     if (Objects.isNull(daa)) {
       throw new NotFoundException();
     }
-    List<User> users = userDAO.getUsersWithCardsByDaaId(daaId);
-    return users.stream().map(SimplifiedUser::new).collect(Collectors.toList());
+    return userDAO.getUsersWithCardsByDaaId(daaId);
   }
 
   public void deleteUserByEmail(String email) {
@@ -292,13 +291,12 @@ public class UserService implements ConsentLogger {
     userDAO.updateEmailPreference(userId, preference);
   }
 
-  public List<SimplifiedUser> findSOsByInstitutionId(Integer institutionId) {
+  public List<User> findSOsByInstitutionId(Integer institutionId) {
     if (Objects.isNull(institutionId)) {
       return Collections.emptyList();
     }
 
-    List<User> users = userDAO.getSOsByInstitution(institutionId);
-    return users.stream().map(SimplifiedUser::new).collect(Collectors.toList());
+    return userDAO.getSOsByInstitution(institutionId);
   }
 
   public List<User> findUsersByInstitutionId(Integer institutionId) {
@@ -451,57 +449,6 @@ public class UserService implements ConsentLogger {
     } else {
       throw new BadRequestException(
           "Invalid ERA configuration for this user.  Only one ERA Commons ID is allowed.");
-    }
-  }
-
-  public static class SimplifiedUser {
-
-    public Integer userId;
-    public String displayName;
-    public String email;
-    public Integer institutionId;
-
-    public SimplifiedUser(User user) {
-      this.userId = user.getUserId();
-      this.displayName = user.getDisplayName();
-      this.email = user.getEmail();
-      this.institutionId = user.getInstitutionId();
-    }
-
-    public SimplifiedUser() {
-    }
-
-    public void setUserId(Integer userId) {
-      this.userId = userId;
-    }
-
-    public void setDisplayName(String name) {
-      this.displayName = name;
-    }
-
-    public void setEmail(String email) {
-      this.email = email;
-    }
-
-    public void setInstitutionId(Integer institutionId) {
-      this.institutionId = institutionId;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-      if (this == o) {
-        return true;
-      }
-      if (o == null || getClass() != o.getClass()) {
-        return false;
-      }
-      SimplifiedUser that = (SimplifiedUser) o;
-      return Objects.equals(userId, that.userId);
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hash(userId);
     }
   }
 }

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -742,7 +742,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/SimplifiedUser'
+                  $ref: '#/components/schemas/User'
         404:
           description: User not found
         500:
@@ -1111,8 +1111,6 @@ components:
       $ref: './schemas/Vote.yaml'
     MatchResult:
       $ref: './schemas/MatchResult.yaml'
-    SimplifiedUser:
-      $ref: './schemas/SimplifiedUser.yaml'
     SamSelfDiagnostics:
       $ref: './schemas/SamSelfDiagnostics.yaml'
     SamUserInfo:

--- a/src/main/resources/assets/schemas/Institution.yaml
+++ b/src/main/resources/assets/schemas/Institution.yaml
@@ -49,4 +49,4 @@ properties:
     description: Signing officials belonging to the institution.
     type: array
     items:
-      $ref: './SimplifiedUser.yaml'
+      $ref: './User.yaml'

--- a/src/test/java/org/broadinstitute/consent/http/db/InstitutionDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/InstitutionDAOTest.java
@@ -10,7 +10,6 @@ import java.util.Date;
 import java.util.List;
 import java.util.Random;
 import org.apache.commons.lang3.RandomStringUtils;
-import org.apache.commons.lang3.RandomUtils;
 import org.broadinstitute.consent.http.enumeration.OrganizationType;
 import org.broadinstitute.consent.http.models.Institution;
 import org.broadinstitute.consent.http.models.User;
@@ -147,7 +146,7 @@ class InstitutionDAOTest extends DAOTestHelper {
     assertEquals(1, institution.getSigningOfficials().size());
     assertEquals(user.getInstitutionId(), institution.getId());
     assertEquals(user.getDisplayName(),
-        institution.getSigningOfficials().get(0).displayName);
+        institution.getSigningOfficials().get(0).getDisplayName());
   }
 
   @Test
@@ -177,11 +176,11 @@ class InstitutionDAOTest extends DAOTestHelper {
 
   @Test
   void testFindInstitutionWithSOById() {
-    Institution institution = createInstitution();
     User user = createUserWithInstitution();
     Institution institutionWithSO = institutionDAO.findInstitutionWithSOById(user.getInstitutionId());
     assertEquals(1, institutionWithSO.getSigningOfficials().size());
-    assertEquals(user.getDisplayName(), institutionWithSO.getSigningOfficials().get(0).displayName);
+    assertEquals(user.getDisplayName(),
+        institutionWithSO.getSigningOfficials().get(0).getDisplayName());
   }
 
   private Institution createInstitution() {

--- a/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
@@ -364,14 +364,13 @@ class UserResourceTest {
     User user = createUserWithInstitution();
     User so = createUserWithRole();
     when(userService.findUserByEmail(any())).thenReturn(user);
-    when(userService.findSOsByInstitutionId(any())).thenReturn(
-        Arrays.asList(new UserService.SimplifiedUser(so), new UserService.SimplifiedUser(so)));
+    when(userService.findSOsByInstitutionId(any())).thenReturn(Arrays.asList(so, so));
 
     Response response = userResource.getSOsForInstitution(authUser);
     assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
-    var body = (List<UserService.SimplifiedUser>) response.getEntity();
+    var body = (List<User>) response.getEntity();
     assertFalse(body.isEmpty());
-    assertEquals(so.getDisplayName(), body.get(0).displayName);
+    assertEquals(so.getDisplayName(), body.get(0).getDisplayName());
   }
 
   @SuppressWarnings("rawtypes")

--- a/src/test/java/org/broadinstitute/consent/http/service/DaaServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DaaServiceTest.java
@@ -22,6 +22,7 @@ import jakarta.ws.rs.ServerErrorException;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import org.apache.commons.lang3.RandomStringUtils;
@@ -35,7 +36,6 @@ import org.broadinstitute.consent.http.models.DataAccessAgreement;
 import org.broadinstitute.consent.http.models.FileStorageObject;
 import org.broadinstitute.consent.http.models.Institution;
 import org.broadinstitute.consent.http.models.User;
-import org.broadinstitute.consent.http.service.UserService.SimplifiedUser;
 import org.broadinstitute.consent.http.service.dao.DaaServiceDAO;
 import org.glassfish.jersey.media.multipart.FormDataContentDisposition;
 import org.junit.jupiter.api.Test;
@@ -209,126 +209,113 @@ class DaaServiceTest {
 
   @Test
   void testSendDaaRequestEmailsWithSigningOfficials() throws Exception {
-    User user = mock(User.class);
-    when(user.getInstitutionId()).thenReturn(1);
+    User user = new User();
+    user.setInstitutionId(1);
 
-    SimplifiedUser signingOfficial = mock(SimplifiedUser.class);
-    signingOfficial.displayName = "Official Name";
-    signingOfficial.email = "official@example.com";
+    var signingOfficial = new User(1, "Official Name", "official@example.com", new Date());
+    signingOfficial.setInstitutionId(1);
 
-    Institution institution = mock(Institution.class);
-    when(institution.getSigningOfficials()).thenReturn(List.of(signingOfficial));
+    Institution institution = new Institution();
+    institution.setSigningOfficials(List.of(signingOfficial));
 
     when(institutionDAO.findInstitutionWithSOById(any())).thenReturn(institution);
 
-    DataAccessAgreement daa = mock(DataAccessAgreement.class);
-    FileStorageObject file = mock(FileStorageObject.class);
-    when(file.getFileName()).thenReturn("daaName");
-    when(daa.getFile()).thenReturn(file);
+    DataAccessAgreement daa = new DataAccessAgreement();
+    FileStorageObject file = new FileStorageObject();
+    file.setFileName("daaName");
+    daa.setFile(file);
     when(daaDAO.findById(any())).thenReturn(daa);
 
     initService();
 
-    assertDoesNotThrow(() -> service.sendDaaRequestEmails(user, 1));
+    service.sendDaaRequestEmails(user, 1);
     verify(emailService).sendDaaRequestMessage(any(), any(), any(), any());
   }
 
   @Test
   void testSendDaaRequestEmailsWithMultipleSigningOfficials() throws Exception {
-    User user = mock(User.class);
-    when(user.getInstitutionId()).thenReturn(1);
+    User user = new User();
+    user.setInstitutionId(1);
 
-    SimplifiedUser signingOfficial = mock(SimplifiedUser.class);
-    signingOfficial.displayName = "Official Name";
-    signingOfficial.email = "official@example.com";
+    var signingOfficial = new User(1, "Official Name", "official@example.com", new Date());
+    signingOfficial.setInstitutionId(1);
 
-    SimplifiedUser signingOfficial2 = mock(SimplifiedUser.class);
-    signingOfficial2.displayName = "Official Name2";
-    signingOfficial2.email = "official2@example.com";
+    var signingOfficial2 = new User(2, "Official Name2", "official2@example.com", new Date());
+    signingOfficial2.setInstitutionId(1);
 
-    Institution institution = mock(Institution.class);
-    when(institution.getSigningOfficials()).thenReturn(List.of(signingOfficial, signingOfficial2));
+    Institution institution = new Institution();
+    institution.setSigningOfficials(List.of(signingOfficial, signingOfficial2));
 
     when(institutionDAO.findInstitutionWithSOById(any())).thenReturn(institution);
 
-    DataAccessAgreement daa = mock(DataAccessAgreement.class);
-    FileStorageObject file = mock(FileStorageObject.class);
-    when(file.getFileName()).thenReturn("daaName");
-    when(daa.getFile()).thenReturn(file);
+    DataAccessAgreement daa = new DataAccessAgreement();
+    FileStorageObject file = new FileStorageObject();
+    file.setFileName("daaName");
+    daa.setFile(file);
     when(daaDAO.findById(any())).thenReturn(daa);
 
     initService();
 
-    assertDoesNotThrow(() -> service.sendDaaRequestEmails(user, 1));
+    service.sendDaaRequestEmails(user, 1);
     verify(emailService, times(2)).sendDaaRequestMessage(any(), any(), any(), any());
   }
 
   @Test
   void testSendNewDaaEmails() throws Exception {
-    User user = mock(User.class);
+    User user = new User();
 
-    SimplifiedUser researcher = mock(SimplifiedUser.class);
-    researcher.displayName = "Official Name";
-    researcher.email = "official@example.com";
-    researcher.institutionId = RandomUtils.nextInt(0,50);
+    var researcher = new User(1, "Researcher Name", "reasearcher@example.com", new Date());
+    researcher.setInstitutionId(RandomUtils.nextInt(0,50));
 
-    SimplifiedUser researcher2 = mock(SimplifiedUser.class);
-    researcher2.displayName = "Official Name2";
-    researcher2.email = "official2@example.com";
-    researcher2.institutionId = RandomUtils.nextInt(0,50);
+    var researcher2 = new User(2, "Researcher Name2", "reasearcher2@example.com", new Date());
+    researcher2.setInstitutionId(RandomUtils.nextInt(0,50));
 
-    SimplifiedUser signingOfficial = mock(SimplifiedUser.class);
-    signingOfficial.displayName = "Official Name";
-    signingOfficial.email = "official@example.com";
+    var signingOfficial = new User(3, "Official Name", "official@example.com", new Date());
+    signingOfficial.setInstitutionId(1);
 
-    SimplifiedUser signingOfficial2 = mock(SimplifiedUser.class);
-    signingOfficial2.displayName = "Official Name2";
-    signingOfficial2.email = "official2@example.com";
+    var signingOfficial2 = new User(4, "Official Name2", "official2@example.com", new Date());
+    signingOfficial2.setInstitutionId(1);
 
-    DataAccessAgreement daa = mock(DataAccessAgreement.class);
-    FileStorageObject file = mock(FileStorageObject.class);
-    when(file.getFileName()).thenReturn("previousDaaName");
-    when(daa.getFile()).thenReturn(file);
+    DataAccessAgreement daa = new DataAccessAgreement();
+    FileStorageObject file = new FileStorageObject();
+    file.setFileName("daaName");
+    daa.setFile(file);
     when(daaDAO.findById(any())).thenReturn(daa);
 
     initService();
 
     when(userService.getUsersByDaaId(any())).thenReturn(List.of(researcher, researcher2));
     when(userService.findSOsByInstitutionId(any())).thenReturn(List.of(signingOfficial, signingOfficial2));
-    assertDoesNotThrow(() -> service.sendNewDaaEmails(user, 1, "dacName", "newDaaName"));
+    service.sendNewDaaEmails(user, 1, "dacName", "newDaaName");
     verify(emailService, times(2)).sendNewDAAUploadResearcherMessage(any(), any(), any(), any(), any());
     verify(emailService, times(2)).sendNewDAAUploadSOMessage(any(), any(), any(), any(), any());
   }
 
   @Test
   void testSendNewDaaEmailsOneResearcher() throws Exception {
-    User user = mock(User.class);
+    User user = new User();
 
-    SimplifiedUser researcher = mock(SimplifiedUser.class);
-    researcher.displayName = "Official Name";
-    researcher.email = "official@example.com";
-    researcher.institutionId = RandomUtils.nextInt(0,50);
+    var researcher = new User(1, "Researcher Name", "reasearcher@example.com", new Date());
+    researcher.setInstitutionId(RandomUtils.nextInt(0,50));
 
-    SimplifiedUser signingOfficial = mock(SimplifiedUser.class);
-    signingOfficial.displayName = "Official Name";
-    signingOfficial.email = "official@example.com";
+    var signingOfficial = new User(2, "Official Name", "official@example.com", new Date());
+    signingOfficial.setInstitutionId(1);
 
-    SimplifiedUser signingOfficial2 = mock(SimplifiedUser.class);
-    signingOfficial2.displayName = "Official Name2";
-    signingOfficial2.email = "official2@example.com";
+    var signingOfficial2 = new User(3, "Official Name2", "official2@example.com", new Date());
+    signingOfficial2.setInstitutionId(1);
 
-    DataAccessAgreement daa = mock(DataAccessAgreement.class);
-    FileStorageObject file = mock(FileStorageObject.class);
-    when(file.getFileName()).thenReturn("previousDaaName");
-    when(daa.getFile()).thenReturn(file);
+    DataAccessAgreement daa = new DataAccessAgreement();
+    FileStorageObject file = new FileStorageObject();
+    file.setFileName("previousDaaName");
+    daa.setFile(file);
     when(daaDAO.findById(any())).thenReturn(daa);
 
     initService();
 
     when(userService.getUsersByDaaId(any())).thenReturn(List.of(researcher));
     when(userService.findSOsByInstitutionId(any())).thenReturn(List.of(signingOfficial, signingOfficial2));
-    assertDoesNotThrow(() -> service.sendNewDaaEmails(user, 1, "dacName", "newDaaName"));
-    verify(emailService, times(1)).sendNewDAAUploadResearcherMessage(any(), any(), any(), any(), any());
+    service.sendNewDaaEmails(user, 1, "dacName", "newDaaName");
+    verify(emailService).sendNewDAAUploadResearcherMessage(any(), any(), any(), any(), any());
     verify(emailService, times(2)).sendNewDAAUploadSOMessage(any(), any(), any(), any(), any());
   }
 
@@ -341,7 +328,7 @@ class DaaServiceTest {
   }
 
   @Test
-  void testSendNewDaaEmailsDAANoResearchersAndSOs() throws Exception {
+  void testSendNewDaaEmailsDAANoResearchersAndSOs() {
     User user = mock(User.class);
 
     DataAccessAgreement daa = mock(DataAccessAgreement.class);
@@ -372,22 +359,21 @@ class DaaServiceTest {
 
   @Test
   void testSendNewDaaEmailsWithSigningOfficials() throws Exception {
-    User user = mock(User.class);
-    when(user.getInstitutionId()).thenReturn(1);
+    User user = new User();
+    user.setInstitutionId(1);
 
-    SimplifiedUser signingOfficial = mock(SimplifiedUser.class);
-    signingOfficial.displayName = "Official Name";
-    signingOfficial.email = "official@example.com";
+    var signingOfficial = new User(1, "Official Name", "official@example.com", new Date());
+    signingOfficial.setInstitutionId(1);
 
-    Institution institution = mock(Institution.class);
-    when(institution.getSigningOfficials()).thenReturn(List.of(signingOfficial));
+    Institution institution = new Institution();
+    institution.setSigningOfficials(List.of(signingOfficial));
 
     when(institutionDAO.findInstitutionWithSOById(any())).thenReturn(institution);
 
-    DataAccessAgreement daa = mock(DataAccessAgreement.class);
-    FileStorageObject file = mock(FileStorageObject.class);
-    when(file.getFileName()).thenReturn("daaName");
-    when(daa.getFile()).thenReturn(file);
+    DataAccessAgreement daa = new DataAccessAgreement();
+    FileStorageObject file = new FileStorageObject();
+    file.setFileName("daaName");
+    daa.setFile(file);
     when(daaDAO.findById(any())).thenReturn(daa);
 
     initService();
@@ -398,26 +384,24 @@ class DaaServiceTest {
 
   @Test
   void testSendNewDaaEmailsWithMultipleSigningOfficials() throws Exception {
-    User user = mock(User.class);
-    when(user.getInstitutionId()).thenReturn(1);
+    User user = new User();
+    user.setInstitutionId(1);
 
-    SimplifiedUser signingOfficial = mock(SimplifiedUser.class);
-    signingOfficial.displayName = "Official Name";
-    signingOfficial.email = "official@example.com";
+    var signingOfficial = new User(1, "Official Name", "official@example.com", new Date());
+    signingOfficial.setInstitutionId(1);
 
-    SimplifiedUser signingOfficial2 = mock(SimplifiedUser.class);
-    signingOfficial2.displayName = "Official Name2";
-    signingOfficial2.email = "official2@example.com";
+    var signingOfficial2 = new User(2, "Official Name2", "official2@example.com", new Date());
+    signingOfficial2.setInstitutionId(1);
 
-    Institution institution = mock(Institution.class);
-    when(institution.getSigningOfficials()).thenReturn(List.of(signingOfficial, signingOfficial2));
+    Institution institution = new Institution();
+    institution.setSigningOfficials(List.of(signingOfficial, signingOfficial2));
 
     when(institutionDAO.findInstitutionWithSOById(any())).thenReturn(institution);
 
-    DataAccessAgreement daa = mock(DataAccessAgreement.class);
-    FileStorageObject file = mock(FileStorageObject.class);
-    when(file.getFileName()).thenReturn("daaName");
-    when(daa.getFile()).thenReturn(file);
+    DataAccessAgreement daa = new DataAccessAgreement();
+    FileStorageObject file = new FileStorageObject();
+    file.setFileName("daaName");
+    daa.setFile(file);
     when(daaDAO.findById(any())).thenReturn(daa);
 
     initService();

--- a/src/test/java/org/broadinstitute/consent/http/service/InstitutionServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/InstitutionServiceTest.java
@@ -21,7 +21,6 @@ import org.broadinstitute.consent.http.db.InstitutionDAO;
 import org.broadinstitute.consent.http.db.UserDAO;
 import org.broadinstitute.consent.http.models.Institution;
 import org.broadinstitute.consent.http.models.User;
-import org.broadinstitute.consent.http.service.UserService.SimplifiedUser;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -169,12 +168,12 @@ class InstitutionServiceTest {
     initService();
 
     Institution institution = service.findInstitutionById(anyInt());
-    List<SimplifiedUser> signingOfficials = institution.getSigningOfficials();
+    var signingOfficials = institution.getSigningOfficials();
     assertEquals(getInstitutions().get(0), institution);
     assertEquals(1, signingOfficials.size());
-    assertEquals(u.getDisplayName(), signingOfficials.get(0).displayName);
-    assertEquals(u.getEmail(), signingOfficials.get(0).email);
-    assertEquals(u.getUserId(), signingOfficials.get(0).userId);
+    assertEquals(u.getDisplayName(), signingOfficials.get(0).getDisplayName());
+    assertEquals(u.getEmail(), signingOfficials.get(0).getEmail());
+    assertEquals(u.getUserId(), signingOfficials.get(0).getUserId());
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
@@ -54,7 +54,6 @@ import org.broadinstitute.consent.http.models.UserRole;
 import org.broadinstitute.consent.http.models.UserUpdateFields;
 import org.broadinstitute.consent.http.models.sam.UserStatus;
 import org.broadinstitute.consent.http.models.sam.UserStatusInfo;
-import org.broadinstitute.consent.http.service.UserService.SimplifiedUser;
 import org.broadinstitute.consent.http.service.dao.DraftServiceDAO;
 import org.broadinstitute.consent.http.service.dao.UserServiceDAO;
 import org.jdbi.v3.core.transaction.TransactionException;
@@ -100,9 +99,6 @@ class UserServiceTest extends AbstractTestHelper {
 
   @Mock
   private DaaDAO daaDAO;
-
-  @Mock
-  private EmailService emailService;
 
   @Mock
   private DraftServiceDAO draftServiceDAO;
@@ -472,15 +468,15 @@ class UserServiceTest extends AbstractTestHelper {
     User u = generateUser();
     Integer institutionId = u.getInstitutionId();
     when(userDAO.getSOsByInstitution(any())).thenReturn(List.of(u, u, u));
-    List<SimplifiedUser> users = service.findSOsByInstitutionId(institutionId);
+    var users = service.findSOsByInstitutionId(institutionId);
     assertEquals(3, users.size());
-    assertEquals(u.getDisplayName(), users.get(0).displayName);
-    assertEquals(u.getEmail(), users.get(0).email);
+    assertEquals(u.getDisplayName(), users.get(0).getDisplayName());
+    assertEquals(u.getEmail(), users.get(0).getEmail());
   }
 
   @Test
   void testFindSOsByInstitutionId_NullId() {
-    List<SimplifiedUser> users = service.findSOsByInstitutionId(null);
+    var users = service.findSOsByInstitutionId(null);
     assertEquals(0, users.size());
   }
 
@@ -578,10 +574,10 @@ class UserServiceTest extends AbstractTestHelper {
     when(daaDAO.findById(any())).thenReturn(daa);
     when(userDAO.getUsersWithCardsByDaaId(any())).thenReturn(List.of(u1));
     libraryCardDAO.createLibraryCardDaaRelation(card.getId(), daaId);
-    List<SimplifiedUser> users = service.getUsersByDaaId(daaId);
+    var users = service.getUsersByDaaId(daaId);
     assertNotNull(users);
     assertEquals(1, users.size());
-    assertEquals(List.of(new SimplifiedUser(u1)), users);
+    assertEquals(List.of(u1), users);
   }
 
   @Test
@@ -599,10 +595,10 @@ class UserServiceTest extends AbstractTestHelper {
     when(userDAO.getUsersWithCardsByDaaId(any())).thenReturn(List.of(u1, u2));
     libraryCardDAO.createLibraryCardDaaRelation(card.getId(), daaId);
     libraryCardDAO.createLibraryCardDaaRelation(card2.getId(), daaId);
-    List<SimplifiedUser> users = service.getUsersByDaaId(daaId);
+    var users = service.getUsersByDaaId(daaId);
     assertNotNull(users);
     assertEquals(2, users.size());
-    assertEquals(List.of(new SimplifiedUser(u1), new SimplifiedUser(u2)), users);
+    assertEquals(List.of(u1, u2), users);
   }
 
   @Test
@@ -627,15 +623,15 @@ class UserServiceTest extends AbstractTestHelper {
     libraryCardDAO.createLibraryCardDaaRelation(card.getId(), daaId);
     libraryCardDAO.createLibraryCardDaaRelation(card2.getId(), daaId);
     libraryCardDAO.createLibraryCardDaaRelation(card3.getId(), daaId2);
-    List<SimplifiedUser> users = service.getUsersByDaaId(daaId);
+    var users = service.getUsersByDaaId(daaId);
     assertNotNull(users);
     assertEquals(2, users.size());
-    assertEquals(List.of(new SimplifiedUser(u1), new SimplifiedUser(u2)), users);
+    assertEquals(List.of(u1, u2), users);
 
-    List<SimplifiedUser> users2 = service.getUsersByDaaId(daaId2);
+    var users2 = service.getUsersByDaaId(daaId2);
     assertNotNull(users2);
     assertEquals(1, users2.size());
-    assertEquals(List.of(new SimplifiedUser(u3)), users2);
+    assertEquals(List.of(u3), users2);
   }
 
   @Test
@@ -648,10 +644,9 @@ class UserServiceTest extends AbstractTestHelper {
     DataAccessAgreement daa = new DataAccessAgreement();
     daa.setDaaId(daaId);
     when(daaDAO.findById(any())).thenReturn(daa);
-    List<SimplifiedUser> users = service.getUsersByDaaId(daaId);
+    var users = service.getUsersByDaaId(daaId);
     assertNotNull(users);
     assertEquals(0, users.size());
-    assertEquals(Collections.emptyList(), users);
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/util/InstitutionUtilTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/util/InstitutionUtilTest.java
@@ -74,6 +74,7 @@ class InstitutionUtilTest {
     Institution mockInstitution = initMockInstitution();
     Gson builder = util.getGsonBuilder(false);
     String json = builder.toJson(mockInstitution);
-    assertEquals("{\"id\":1,\"name\":\"Test Name\"}", json);
+    assertEquals("""
+        {"id":1,"name":"Test Name","signingOfficials":[]}""", json);
   }
 }


### PR DESCRIPTION
### Addresses

It would be simpler to not have `SimplifiedUser` since it is a subset of `User`. It's true that it's unclear in our code when we have a completely populated object and an incompletely populated one, and having classes like `SimplifiedUser` can make this more apparent. But this practice isn't followed elsewhere in the code for other DAOs, and having two different objects means that we need to convert between them.

If we decide that we want two different types, another approach would be to make `SimplifiedUser` a base class of `User`, so conversion wouldn't be necessary.

### Summary

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
