### PR TITLE
DT-1777: Fix SO required endpoints

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
@@ -161,8 +161,8 @@ public class DataAccessRequestResource extends Resource {
   public Response getByReferenceId(
       @Auth AuthUser authUser, @PathParam("referenceId") String referenceId) {
     validateAuthedRoleUser(
-        Stream.of(UserRoles.ADMIN, UserRoles.CHAIRPERSON, UserRoles.MEMBER,
-            UserRoles.SIGNINGOFFICIAL).toList(),
+        List.of(UserRoles.ADMIN, UserRoles.CHAIRPERSON, UserRoles.MEMBER,
+            UserRoles.SIGNINGOFFICIAL),
         authUser, referenceId);
     try {
       DataAccessRequest dar = dataAccessRequestService.findByReferenceId(referenceId);

--- a/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
@@ -161,8 +161,8 @@ public class DataAccessRequestResource extends Resource {
   public Response getByReferenceId(
       @Auth AuthUser authUser, @PathParam("referenceId") String referenceId) {
     validateAuthedRoleUser(
-        Stream.of(UserRoles.ADMIN, UserRoles.CHAIRPERSON, UserRoles.MEMBER)
-            .collect(Collectors.toList()),
+        Stream.of(UserRoles.ADMIN, UserRoles.CHAIRPERSON, UserRoles.MEMBER,
+            UserRoles.SIGNINGOFFICIAL).toList(),
         authUser, referenceId);
     try {
       DataAccessRequest dar = dataAccessRequestService.findByReferenceId(referenceId);

--- a/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
@@ -161,7 +161,7 @@ public class UserResource extends Resource {
   @GET
   @Path("/{userId}")
   @Produces("application/json")
-  @RolesAllowed({ADMIN, CHAIRPERSON, MEMBER, DATASUBMITTER})
+  @RolesAllowed({ADMIN, CHAIRPERSON, MEMBER, DATASUBMITTER, SIGNINGOFFICIAL})
   public Response getUserById(@Auth AuthUser authUser, @PathParam("userId") Integer userId) {
     try {
       JsonObject userJson = userService.findUserWithPropertiesByIdAsJsonObject(authUser, userId);

--- a/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceTest.java
@@ -203,9 +203,9 @@ class DataAccessRequestResourceTest extends AbstractTestHelper {
   void testGetByReferenceIdForbidden() {
     when(mockUser.getUserId()).thenReturn(user.getUserId() + 1);
     when(userService.findUserByEmail(any())).thenReturn(mockUser);
-    when(dataAccessRequestService.findByReferenceId(any())).thenReturn(generateDataAccessRequest());
+    when(dataAccessRequestService.findByReferenceId("id")).thenReturn(generateDataAccessRequest());
 
-    assertThrows(ForbiddenException.class, () -> resource.getByReferenceId(authUser, ""));
+    assertThrows(ForbiddenException.class, () -> resource.getByReferenceId(authUser, "id"));
   }
 
   @ParameterizedTest
@@ -217,9 +217,9 @@ class DataAccessRequestResourceTest extends AbstractTestHelper {
     // Set the DAR create user to be a different user from the roleUser
     DataAccessRequest dar = generateDataAccessRequest();
     dar.setUserId(roleUser.getUserId() + 1);
-    when(dataAccessRequestService.findByReferenceId(any())).thenReturn(dar);
+    when(dataAccessRequestService.findByReferenceId("id")).thenReturn(dar);
 
-    Response response = resource.getByReferenceId(authUser, "");
+    Response response = resource.getByReferenceId(authUser, "id");
     assertEquals(200, response.getStatus());
   }
 
@@ -232,8 +232,8 @@ class DataAccessRequestResourceTest extends AbstractTestHelper {
     // Set the DAR create user to be a different user from the roleUser
     DataAccessRequest dar = generateDataAccessRequest();
     dar.setUserId(roleUser.getUserId() + 1);
-    when(dataAccessRequestService.findByReferenceId(any())).thenReturn(dar);
-    assertThrows(ForbiddenException.class, () -> resource.getByReferenceId(authUser, ""));
+    when(dataAccessRequestService.findByReferenceId("id")).thenReturn(dar);
+    assertThrows(ForbiddenException.class, () -> resource.getByReferenceId(authUser, "id"));
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceTest.java
@@ -19,6 +19,7 @@ import com.google.cloud.storage.BlobId;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.ForbiddenException;
 import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.Path;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.Response.Status;
 import jakarta.ws.rs.core.UriBuilder;
@@ -205,6 +206,34 @@ class DataAccessRequestResourceTest extends AbstractTestHelper {
     when(userService.findUserByEmail(any())).thenReturn(mockUser);
     when(dataAccessRequestService.findByReferenceId(any())).thenReturn(generateDataAccessRequest());
 
+    assertThrows(ForbiddenException.class, () -> resource.getByReferenceId(authUser, ""));
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = UserRoles.class, names = {"ADMIN", "CHAIRPERSON", "MEMBER", "SIGNINGOFFICIAL"})
+  void testGetByReferenceIdAllowedRoles(UserRoles role) {
+    UserRole userRole = new UserRole(role.getRoleId(), role.getRoleName());
+    User roleUser = new User(1, authUser.getEmail(), "Display Name", new Date(), List.of(userRole));
+    when(userService.findUserByEmail(roleUser.getEmail())).thenReturn(roleUser);
+    // Set the DAR create user to be a different user from the roleUser
+    DataAccessRequest dar = generateDataAccessRequest();
+    dar.setUserId(roleUser.getUserId() + 1);
+    when(dataAccessRequestService.findByReferenceId(any())).thenReturn(dar);
+
+    Response response = resource.getByReferenceId(authUser, "");
+    assertEquals(200, response.getStatus());
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = UserRoles.class, names = {"ALUMNI", "DATASUBMITTER", "ITDIRECTOR", "SERVICE_ACCOUNT", "RESEARCHER"})
+  void testGetByReferenceIdDisallowedRoles(UserRoles role) {
+    UserRole userRole = new UserRole(role.getRoleId(), role.getRoleName());
+    User roleUser = new User(1, authUser.getEmail(), "Display Name", new Date(), List.of(userRole));
+    when(userService.findUserByEmail(roleUser.getEmail())).thenReturn(roleUser);
+    // Set the DAR create user to be a different user from the roleUser
+    DataAccessRequest dar = generateDataAccessRequest();
+    dar.setUserId(roleUser.getUserId() + 1);
+    when(dataAccessRequestService.findByReferenceId(any())).thenReturn(dar);
     assertThrows(ForbiddenException.class, () -> resource.getByReferenceId(authUser, ""));
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceTest.java
@@ -19,7 +19,6 @@ import com.google.cloud.storage.BlobId;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.ForbiddenException;
 import jakarta.ws.rs.NotFoundException;
-import jakarta.ws.rs.Path;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.Response.Status;
 import jakarta.ws.rs.core.UriBuilder;


### PR DESCRIPTION
### Addresses
Partially addresses https://broadworkbench.atlassian.net/browse/DT-1777

### Summary
See https://github.com/DataBiosphere/duos-ui/pull/2891 for the front end work.
SOs need to be able to get a user by id and DAR by reference id so they can view a DAR review page.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
