### PR TITLE
DT-1788: Ensure user never has the same institution as institutionFromEmail

### DIFF
--- a/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
@@ -903,7 +903,7 @@ class UserServiceTest extends AbstractTestHelper {
   void handleUserWithInstitutionInMap_DifferentInDatabaseWithLibraryCard() {
     User testUser = generateUser();
     // Ensure that testUser has an institution id that will never be the same as the institution from email
-    testUser.setInstitutionId(-1);
+    testUser.setInstitutionId(3);
     User signingOfficial = generateUser();
     LibraryCard lc = new LibraryCard();
     lc.setCreateUserId(signingOfficial.getUserId());

--- a/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
@@ -902,6 +902,8 @@ class UserServiceTest extends AbstractTestHelper {
   @Test
   void handleUserWithInstitutionInMap_DifferentInDatabaseWithLibraryCard() {
     User testUser = generateUser();
+    // Ensure that testUser has an institution id that will never be the same as the institution from email
+    testUser.setInstitutionId(-1);
     User signingOfficial = generateUser();
     LibraryCard lc = new LibraryCard();
     lc.setCreateUserId(signingOfficial.getUserId());


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-1788

### Summary
Minor test update to address flakiness. Without this change, the test fails when the test user's randomly generated institution id is the same as the manually set institution from email id.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
