### PR TITLE
DT-1790: Fix flaky election dao test

### DIFF
--- a/src/test/java/org/broadinstitute/consent/http/db/ElectionDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/ElectionDAOTest.java
@@ -444,8 +444,8 @@ class ElectionDAOTest extends DAOTestHelper {
     Dataset dataset = createDataset();
     int datasetId = dataset.getDatasetId();
     createLibraryCard(lcUser);
-    DataAccessRequest lcDAR = createDataAccessRequestWithUserIdV3(lcUser.getUserId());
-    DataAccessRequest nonLCDAR = createDataAccessRequestWithUserIdV3(nonLCUser.getUserId());
+    DataAccessRequest lcDAR = createDataAccessRequestWithUserIdV3(lcUser.getUserId(),"DAR-0001000");
+    DataAccessRequest nonLCDAR = createDataAccessRequestWithUserIdV3(nonLCUser.getUserId(),"DAR-0002000");
     Election lcElection = createDataAccessElection(lcDAR.getReferenceId(), datasetId);
     Election nonLCElection = createDataAccessElection(nonLCDAR.getReferenceId(), datasetId);
     List<Integer> electionIds = List.of(lcElection.getElectionId(), nonLCElection.getElectionId());
@@ -701,8 +701,7 @@ class ElectionDAOTest extends DAOTestHelper {
     return voteDAO.findVoteById(voteId);
   }
 
-  private DataAccessRequest createDataAccessRequestWithUserIdV3(Integer userId) {
-    String darCode = "DAR-" + randomInt(100, 1000);
+  private DataAccessRequest createDataAccessRequestWithUserIdV3(Integer userId, String darCode) {
     Integer collectionId = darCollectionDAO.insertDarCollection(darCode, userId, new Date());
     for (int i = 0; i < 4; i++) {
       createDataAccessRequest(userId, collectionId);


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-1790

### Summary
Remove the potential for DAR ID collisions in test set up.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
