### PR TITLE
[DT-1796] DAR Collection.dars needs to include the eRACommonsId.

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
@@ -132,7 +132,7 @@ public interface DarCollectionDAO extends Transactional<DarCollectionDAO> {
         up.property_id AS up_property_id, up.user_id AS up_user_id, up.property_key
         as up_property_key, up.property_value AS up_property_value,
         dar.id AS dar_id, dar.reference_id AS dar_reference_id, dar.collection_id AS dar_collection_id,
-        dar.parent_id AS dar_parent_id, dar.user_id AS dar_userId,
+        dar.parent_id AS dar_parent_id, dar.user_id AS dar_userId, dar.era_commons_id AS dar_era_commons_id,
         dar.create_date AS dar_create_date, dar.sort_date AS dar_sort_date, dar.submission_date AS dar_submission_date,
         dar.update_date AS dar_update_date, (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data, dd.dataset_id
         FROM dar_collection c
@@ -169,7 +169,7 @@ public interface DarCollectionDAO extends Transactional<DarCollectionDAO> {
           + LibraryCard.QUERY_FIELDS_WITH_LC_PREFIX + QUERY_FIELD_SEPARATOR
           + "dd.dataset_id, "
           + "dar.id AS dar_id, dar.reference_id AS dar_reference_id, dar.collection_id AS dar_collection_id, "
-          + "dar.parent_id AS dar_parent_id, dar.user_id AS dar_userId, "
+          + "dar.parent_id AS dar_parent_id, dar.user_id AS dar_userId, dar.era_commons_id AS dar_era_commons_id, "
           + "dar.create_date AS dar_create_date, dar.sort_date AS dar_sort_date, dar.submission_date AS dar_submission_date, "
           + "dar.update_date AS dar_update_date, (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data, "
           + "e.election_id AS e_election_id, e.reference_id AS e_reference_id, e.status AS e_status, e.create_date AS e_create_date, "

--- a/src/main/resources/assets/schemas/DataAccessRequest.yaml
+++ b/src/main/resources/assets/schemas/DataAccessRequest.yaml
@@ -39,6 +39,9 @@ properties:
     description: Map of elections tied to the DAR (electionid - election)
     items:
       $ref: './Election.yaml'
+  eraCommonsId:
+    type: string
+    description: The submitter's eraCommonsId at the time of request submission.
   projectTitle:
     type: string
     description: Project Title

--- a/src/test/java/org/broadinstitute/consent/http/db/DarCollectionDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DarCollectionDAOTest.java
@@ -124,6 +124,7 @@ class DarCollectionDAOTest extends DAOTestHelper {
     DarCollection returned = darCollectionDAO.findDARCollectionByCollectionId(
         collection.getDarCollectionId());
     assertNotNull(returned);
+    assertNotNull(returned.getMostRecentDar().getEraCommonsId());
     assertEquals(collection.getDarCode(), returned.getDarCode());
     assertEquals(collection.getCreateUserId(), returned.getCreateUserId());
     generateDatasetElectionForCollection(collection);
@@ -279,6 +280,7 @@ class DarCollectionDAOTest extends DAOTestHelper {
     testDar.setSortDate(now);
     testDar.setSubmissionDate(now);
     testDar.setUpdateDate(now);
+    testDar.setEraCommonsId(user.getEraCommonsId());
     DataAccessRequestData contents = new DataAccessRequestData();
     testDar.setData(contents);
 
@@ -394,6 +396,18 @@ class DarCollectionDAOTest extends DAOTestHelper {
 
     assertNull(archivedCollection);
     assertEquals(validCollection, testDarCollection2);
+  }
+
+  @Test
+  void testFindDARCollectionByReferenceIdIncludesERACommonsId() {
+    User user = createUserWithInstitution();
+    String eraCommonsId = randomAlphabetic(20);
+    //userDAO.updateEraCommonsId(user.getUserId(), eraCommonsId);
+    user.setEraCommonsId(eraCommonsId);
+    List<Object> newDarCollection1 = createDarCollectionWithDataset(user);
+    DataAccessRequest testDar1 = (DataAccessRequest) newDarCollection1.get(4);
+    DarCollection testDarCollection = darCollectionDAO.findDARCollectionByReferenceId(testDar1.getReferenceId());
+    assertNotNull(testDarCollection.getMostRecentDar().getEraCommonsId());
   }
 
   // findDARCollectionByCollectionId should exclude archived collections

--- a/src/test/java/org/broadinstitute/consent/http/db/DarCollectionDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DarCollectionDAOTest.java
@@ -402,7 +402,6 @@ class DarCollectionDAOTest extends DAOTestHelper {
   void testFindDARCollectionByReferenceIdIncludesERACommonsId() {
     User user = createUserWithInstitution();
     String eraCommonsId = randomAlphabetic(20);
-    //userDAO.updateEraCommonsId(user.getUserId(), eraCommonsId);
     user.setEraCommonsId(eraCommonsId);
     List<Object> newDarCollection1 = createDarCollectionWithDataset(user);
     DataAccessRequest testDar1 = (DataAccessRequest) newDarCollection1.get(4);

--- a/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
@@ -911,6 +911,7 @@ class UserServiceTest extends AbstractTestHelper {
     testUser.setInstitution(institutionFromEmail);
     Institution institutionFromDatabase = new Institution();
     institutionFromDatabase.setId(2);
+    testUser.setInstitutionId(institutionFromDatabase.getId());
 
     when(userDAO.findUserById(signingOfficial.getUserId())).thenReturn(signingOfficial);
     when(institutionService.findInstitutionForEmail(signingOfficial.getEmail())).thenReturn(institutionFromDatabase);


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-1796](https://broadworkbench.atlassian.net/browse/DT-1796)

### Summary

So that @PintoGideon can complete [https://broadworkbench.atlassian.net/browse/DT-1596](https://broadworkbench.atlassian.net/browse/DT-1596), the backend must enrich the collection with DARs that include the era_commons_id database property.  This was not included in the SQL for this endpoint.

This PR adds:

- The needed database field to the queries involved;
- Tests to verify the value is properly returned;
- Documentation to swagger for the property;

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
