### PR TITLE
DT-1659, DT-1675: Filter approved users to those with library cards

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
@@ -456,7 +456,8 @@ public class ConsentModule extends AbstractModule {
         providesInstitutionDAO(),
         providesDatasetDAO(),
         providesDatasetServiceDAO(),
-        providesStudyDAO()
+        providesStudyDAO(),
+        providesLibraryCardDAO()
     );
   }
 

--- a/src/main/java/org/broadinstitute/consent/http/db/LibraryCardDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/LibraryCardDAO.java
@@ -138,7 +138,7 @@ public interface LibraryCardDAO extends Transactional<LibraryCardDAO> {
 
   /**
    * Finds library cards by user emails.
-   * @param emails A list of email addresses
+   * @param emails A list of LOWER cased email addresses
    * @return List of LibraryCard objects associated with the provided emails.
    */
   @RegisterBeanMapper(value = LibraryCard.class)
@@ -146,7 +146,7 @@ public interface LibraryCardDAO extends Transactional<LibraryCardDAO> {
   @SqlQuery("""
       SELECT *
       FROM library_card
-      WHERE user_email ILIKE ANY (ARRAY[<emails>])
+      WHERE LOWER(user_email) in (<emails>)
       """)
   List<LibraryCard> findByUserEmails(
       @BindList(value = "emails", onEmpty = EmptyHandling.NULL_STRING) List<String> emails);

--- a/src/main/java/org/broadinstitute/consent/http/db/LibraryCardDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/LibraryCardDAO.java
@@ -139,7 +139,7 @@ public interface LibraryCardDAO extends Transactional<LibraryCardDAO> {
 
   /**
    * Finds library cards by user emails.
-   * @param emails A list of LOWER cased email addresses
+   * @param emails A list of email addresses
    * @return List of LibraryCard objects associated with the provided emails.
    */
   @RegisterBeanMapper(value = LibraryCard.class)
@@ -147,7 +147,7 @@ public interface LibraryCardDAO extends Transactional<LibraryCardDAO> {
   @SqlQuery("""
       SELECT *
       FROM library_card
-      WHERE LOWER(user_email) in (<emails>)
+      WHERE LOWER(user_email) = ANY(ARRAY(SELECT LOWER(UNNEST(ARRAY[<emails>]))))
       """)
   List<LibraryCard> findByUserEmails(
       @BindList(value = "emails", onEmpty = EmptyHandling.NULL_STRING) List<String> emails);

--- a/src/main/java/org/broadinstitute/consent/http/db/LibraryCardDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/LibraryCardDAO.java
@@ -154,7 +154,7 @@ public interface LibraryCardDAO extends Transactional<LibraryCardDAO> {
   /**
    * Finds library cards by user ids.
    * @param userIds A list of user IDs
-   * @return List of LibraryCard objects associated with the provided emails.
+   * @return List of LibraryCard objects associated with the provided ids.
    */
   @RegisterBeanMapper(value = LibraryCard.class)
   @UseRowReducer(LibraryCardReducer.class)

--- a/src/main/java/org/broadinstitute/consent/http/db/LibraryCardDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/LibraryCardDAO.java
@@ -1,6 +1,5 @@
 package org.broadinstitute.consent.http.db;
 
-import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 import org.broadinstitute.consent.http.db.mapper.LibraryCardReducer;

--- a/src/main/java/org/broadinstitute/consent/http/db/LibraryCardDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/LibraryCardDAO.java
@@ -19,9 +19,9 @@ import org.jdbi.v3.sqlobject.transaction.Transactional;
 public interface LibraryCardDAO extends Transactional<LibraryCardDAO> {
 
   @SqlUpdate("""
-        INSERT INTO library_card (user_id, user_name, user_email, create_user_id, create_date)
-        VALUES (:userId, :userName, :userEmail, :createUserId, :createDate)
-        """)
+      INSERT INTO library_card (user_id, user_name, user_email, create_user_id, create_date)
+      VALUES (:userId, :userName, :userEmail, :createUserId, :createDate)
+      """)
   @GetGeneratedKeys
   Integer insertLibraryCard(@Bind("userId") Integer userId,
       @Bind("userName") String userName,
@@ -138,6 +138,7 @@ public interface LibraryCardDAO extends Transactional<LibraryCardDAO> {
 
   /**
    * Finds library cards by user emails.
+   *
    * @param emails A list of email addresses
    * @return List of LibraryCard objects associated with the provided emails.
    */
@@ -153,6 +154,7 @@ public interface LibraryCardDAO extends Transactional<LibraryCardDAO> {
 
   /**
    * Finds library cards by user ids.
+   *
    * @param userIds A list of user IDs
    * @return List of LibraryCard objects associated with the provided ids.
    */
@@ -163,6 +165,7 @@ public interface LibraryCardDAO extends Transactional<LibraryCardDAO> {
       FROM library_card
       WHERE user_id in (<userIds>)
       """)
-  List<LibraryCard> findLibraryCardsByUserIds(@BindList(value = "userIds", onEmpty = EmptyHandling.NULL_STRING) List<Integer> userIds);
+  List<LibraryCard> findLibraryCardsByUserIds(
+      @BindList(value = "userIds", onEmpty = EmptyHandling.NULL_STRING) List<Integer> userIds);
 
 }

--- a/src/main/java/org/broadinstitute/consent/http/db/LibraryCardDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/LibraryCardDAO.java
@@ -8,6 +8,8 @@ import org.broadinstitute.consent.http.models.DataAccessAgreement;
 import org.broadinstitute.consent.http.models.LibraryCard;
 import org.jdbi.v3.sqlobject.config.RegisterBeanMapper;
 import org.jdbi.v3.sqlobject.customizer.Bind;
+import org.jdbi.v3.sqlobject.customizer.BindList;
+import org.jdbi.v3.sqlobject.customizer.BindList.EmptyHandling;
 import org.jdbi.v3.sqlobject.statement.GetGeneratedKeys;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
@@ -133,4 +135,19 @@ public interface LibraryCardDAO extends Transactional<LibraryCardDAO> {
       AND daa_id = :daaId
       """)
   void deleteLibraryCardDaaRelation(@Bind("lcId") Integer lcId, @Bind("daaId") Integer daaId);
+
+  /**
+   * Finds library cards by user emails.
+   * @param emails A list of email addresses
+   * @return List of LibraryCard objects associated with the provided emails.
+   */
+  @RegisterBeanMapper(value = LibraryCard.class)
+  @UseRowReducer(LibraryCardReducer.class)
+  @SqlQuery("""
+      SELECT *
+      FROM library_card
+      WHERE user_email ILIKE ANY (ARRAY[<emails>])
+      """)
+  List<LibraryCard> findByUserEmails(
+      @BindList(value = "emails", onEmpty = EmptyHandling.NULL_STRING) List<String> emails);
 }

--- a/src/main/java/org/broadinstitute/consent/http/db/LibraryCardDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/LibraryCardDAO.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.consent.http.db;
 
+import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 import org.broadinstitute.consent.http.db.mapper.LibraryCardReducer;
@@ -150,4 +151,19 @@ public interface LibraryCardDAO extends Transactional<LibraryCardDAO> {
       """)
   List<LibraryCard> findByUserEmails(
       @BindList(value = "emails", onEmpty = EmptyHandling.NULL_STRING) List<String> emails);
+
+  /**
+   * Finds library cards by user ids.
+   * @param userIds A list of user IDs
+   * @return List of LibraryCard objects associated with the provided emails.
+   */
+  @RegisterBeanMapper(value = LibraryCard.class)
+  @UseRowReducer(LibraryCardReducer.class)
+  @SqlQuery("""
+      SELECT *
+      FROM library_card
+      WHERE user_id in (<userIds>)
+      """)
+  List<LibraryCard> findLibraryCardsByUserIds(@BindList(value = "userIds", onEmpty = EmptyHandling.NULL_STRING) List<Integer> userIds);
+
 }

--- a/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
@@ -23,6 +23,7 @@ import org.broadinstitute.consent.http.db.DacDAO;
 import org.broadinstitute.consent.http.db.DataAccessRequestDAO;
 import org.broadinstitute.consent.http.db.DatasetDAO;
 import org.broadinstitute.consent.http.db.InstitutionDAO;
+import org.broadinstitute.consent.http.db.LibraryCardDAO;
 import org.broadinstitute.consent.http.db.StudyDAO;
 import org.broadinstitute.consent.http.db.UserDAO;
 import org.broadinstitute.consent.http.models.Dac;
@@ -30,6 +31,7 @@ import org.broadinstitute.consent.http.models.DataAccessRequest;
 import org.broadinstitute.consent.http.models.Dataset;
 import org.broadinstitute.consent.http.models.DatasetProperty;
 import org.broadinstitute.consent.http.models.Institution;
+import org.broadinstitute.consent.http.models.LibraryCard;
 import org.broadinstitute.consent.http.models.Study;
 import org.broadinstitute.consent.http.models.StudyProperty;
 import org.broadinstitute.consent.http.models.User;
@@ -58,6 +60,7 @@ public class ElasticSearchService implements ConsentLogger {
   private final DatasetDAO datasetDAO;
   private final DatasetServiceDAO datasetServiceDAO;
   private final StudyDAO studyDAO;
+  private final LibraryCardDAO libraryCardDAO;
 
   public ElasticSearchService(
       RestClient esClient,
@@ -69,7 +72,8 @@ public class ElasticSearchService implements ConsentLogger {
       InstitutionDAO institutionDAO,
       DatasetDAO datasetDAO,
       DatasetServiceDAO datasetServiceDAO,
-      StudyDAO studyDAO) {
+      StudyDAO studyDAO,
+      LibraryCardDAO libraryCardDAO) {
     this.esClient = esClient;
     this.esConfig = esConfig;
     this.dacDAO = dacDAO;
@@ -80,6 +84,7 @@ public class ElasticSearchService implements ConsentLogger {
     this.datasetDAO = datasetDAO;
     this.datasetServiceDAO = datasetServiceDAO;
     this.studyDAO = studyDAO;
+    this.libraryCardDAO = libraryCardDAO;
   }
 
 
@@ -370,7 +375,11 @@ public class ElasticSearchService implements ConsentLogger {
         .toList();
 
     if (!approvedUserIds.isEmpty()) {
-      term.setApprovedUserIds(approvedUserIds);
+      List<Integer> approvedLCUserIds = libraryCardDAO.findLibraryCardsByUserIds(approvedUserIds)
+          .stream()
+          .map(LibraryCard::getUserId)
+          .toList();
+      term.setApprovedUserIds(approvedLCUserIds);
     }
 
     if (Objects.nonNull(dataset.getDataUse())) {

--- a/src/main/java/org/broadinstitute/consent/http/service/TDRService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/TDRService.java
@@ -2,17 +2,13 @@ package org.broadinstitute.consent.http.service;
 
 import com.google.inject.Inject;
 import jakarta.ws.rs.NotAuthorizedException;
-import jakarta.ws.rs.NotFoundException;
-import java.sql.Timestamp;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
-import java.util.Date;
 import java.util.List;
 import java.util.Objects;
-import java.util.UUID;
 import java.util.stream.Stream;
 import org.broadinstitute.consent.http.db.DatasetDAO;
+import org.broadinstitute.consent.http.db.LibraryCardDAO;
 import org.broadinstitute.consent.http.db.SamDAO;
 import org.broadinstitute.consent.http.db.UserDAO;
 import org.broadinstitute.consent.http.models.AuthUser;
@@ -20,6 +16,7 @@ import org.broadinstitute.consent.http.models.Collaborator;
 import org.broadinstitute.consent.http.models.DataAccessRequest;
 import org.broadinstitute.consent.http.models.DataAccessRequestData;
 import org.broadinstitute.consent.http.models.Dataset;
+import org.broadinstitute.consent.http.models.LibraryCard;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.tdr.ApprovedUser;
 import org.broadinstitute.consent.http.models.tdr.ApprovedUsers;
@@ -29,14 +26,16 @@ public class TDRService implements ConsentLogger {
 
   private final DataAccessRequestService dataAccessRequestService;
   private final DatasetDAO datasetDAO;
+  private final LibraryCardDAO libraryCardDAO;
   private final SamDAO samDAO;
   private final UserDAO userDAO;
 
   @Inject
   public TDRService(DataAccessRequestService dataAccessRequestService, DatasetDAO datasetDAO,
-      SamDAO samDAO, UserDAO userDAO) {
+      LibraryCardDAO libraryCardDAO, SamDAO samDAO, UserDAO userDAO) {
     this.dataAccessRequestService = dataAccessRequestService;
     this.datasetDAO = datasetDAO;
+    this.libraryCardDAO = libraryCardDAO;
     this.samDAO = samDAO;
     this.userDAO = userDAO;
   }
@@ -74,9 +73,16 @@ public class TDRService implements ConsentLogger {
         .filter(email -> !email.isBlank())
         .toList();
 
-    List<ApprovedUser> approvedUsers = Stream.of(labCollaborators, userEmails)
+    // Filter to users where that have a library card
+    List<String> allEmails = Stream.of(labCollaborators, userEmails)
         .flatMap(List::stream)
         .distinct()
+        .map(String::toLowerCase)
+        .toList();
+
+    List<ApprovedUser> approvedUsers = libraryCardDAO.findByUserEmails(allEmails)
+        .stream()
+        .map(LibraryCard::getUserEmail)
         .map(ApprovedUser::new)
         .sorted(Comparator.comparing(ApprovedUser::email))
         .toList();

--- a/src/main/java/org/broadinstitute/consent/http/service/TDRService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/TDRService.java
@@ -77,6 +77,7 @@ public class TDRService implements ConsentLogger {
     List<String> allEmails = Stream.of(labCollaborators, userEmails)
         .flatMap(List::stream)
         .distinct()
+        .map(String::toLowerCase)
         .toList();
 
     List<ApprovedUser> approvedUsers = libraryCardDAO.findByUserEmails(allEmails)

--- a/src/main/java/org/broadinstitute/consent/http/service/TDRService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/TDRService.java
@@ -77,7 +77,6 @@ public class TDRService implements ConsentLogger {
     List<String> allEmails = Stream.of(labCollaborators, userEmails)
         .flatMap(List::stream)
         .distinct()
-        .map(String::toLowerCase)
         .toList();
 
     List<ApprovedUser> approvedUsers = libraryCardDAO.findByUserEmails(allEmails)

--- a/src/test/java/org/broadinstitute/consent/http/db/LibraryCardDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/LibraryCardDAOTest.java
@@ -1,6 +1,7 @@
 package org.broadinstitute.consent.http.db;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -348,6 +349,8 @@ class LibraryCardDAOTest extends DAOTestHelper {
     LibraryCard card1 = createLibraryCard(user1);
     LibraryCard card2 = createLibraryCard(user2);
     LibraryCard card3 = createLibraryCard(user3);
+    // This card will not be returned since its email is not in the list
+    LibraryCard card4 = createLibraryCard(createUser());
 
     List<LibraryCard> cardsFromDAO = libraryCardDAO.findByUserEmails(
         List.of(user1.getEmail().toUpperCase(), user2.getEmail().toLowerCase(), user3.getEmail()));
@@ -356,6 +359,7 @@ class LibraryCardDAOTest extends DAOTestHelper {
     assertTrue(cardsFromDAO.contains(card1));
     assertTrue(cardsFromDAO.contains(card2));
     assertTrue(cardsFromDAO.contains(card3));
+    assertFalse(cardsFromDAO.contains(card4));
   }
 
   private LibraryCard createLibraryCardForIndex() {

--- a/src/test/java/org/broadinstitute/consent/http/db/LibraryCardDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/LibraryCardDAOTest.java
@@ -340,6 +340,23 @@ class LibraryCardDAOTest extends DAOTestHelper {
     assertTrue(lc1.getDaaIds().isEmpty());
   }
 
+  @Test
+  void testFindByUserEmails() {
+    User user1 = createUser();
+    User user2 = createUser();
+    User user3 = createUser();
+    LibraryCard card1 = createLibraryCard(user1);
+    LibraryCard card2 = createLibraryCard(user2);
+    LibraryCard card3 = createLibraryCard(user3);
+
+    List<LibraryCard> cardsFromDAO = libraryCardDAO.findByUserEmails(
+        List.of(user1.getEmail().toUpperCase(), user2.getEmail().toLowerCase(), user3.getEmail()));
+
+    assertEquals(3, cardsFromDAO.size());
+    assertTrue(cardsFromDAO.contains(card1));
+    assertTrue(cardsFromDAO.contains(card2));
+    assertTrue(cardsFromDAO.contains(card3));
+  }
 
   private LibraryCard createLibraryCardForIndex() {
     Integer userId = createUser().getUserId();

--- a/src/test/java/org/broadinstitute/consent/http/db/LibraryCardDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/LibraryCardDAOTest.java
@@ -410,6 +410,26 @@ class LibraryCardDAOTest extends DAOTestHelper {
     });
   }
 
+  @Test
+  void testFindByUserIds() {
+    User user1 = createUser();
+    User user2 = createUser();
+    User user3 = createUser();
+    LibraryCard card1 = createLibraryCard(user1);
+    LibraryCard card2 = createLibraryCard(user2);
+    LibraryCard card3 = createLibraryCard(user3);
+    // This card will not be returned since its email is not in the list
+    LibraryCard card4 = createLibraryCard(createUser());
+
+    List<LibraryCard> cardsFromDAO = libraryCardDAO.findLibraryCardsByUserIds(
+        List.of(user1.getUserId(), user2.getUserId(), user3.getUserId()));
+
+    assertEquals(3, cardsFromDAO.size());
+    assertTrue(cardsFromDAO.contains(card1));
+    assertTrue(cardsFromDAO.contains(card2));
+    assertTrue(cardsFromDAO.contains(card3));
+    assertFalse(cardsFromDAO.contains(card4));
+  }
 
   private LibraryCard createLibraryCardForIndex() {
     Integer userId = createUser().getUserId();

--- a/src/test/java/org/broadinstitute/consent/http/db/LibraryCardDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/LibraryCardDAOTest.java
@@ -367,8 +367,7 @@ class LibraryCardDAOTest extends DAOTestHelper {
     LibraryCard card4 = createLibraryCard(createUser());
 
     List<LibraryCard> cardsFromDAO = libraryCardDAO.findByUserEmails(
-        List.of(user1.getEmail().toLowerCase(), user2.getEmail().toLowerCase(),
-            user3.getEmail().toLowerCase()));
+        List.of(user1.getEmail().toLowerCase(), user2.getEmail().toUpperCase(), user3.getEmail()));
 
     assertEquals(3, cardsFromDAO.size());
     assertTrue(cardsFromDAO.contains(card1));

--- a/src/test/java/org/broadinstitute/consent/http/db/LibraryCardDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/LibraryCardDAOTest.java
@@ -10,12 +10,15 @@ import static org.junit.jupiter.api.Assertions.fail;
 import java.time.Instant;
 import java.util.Date;
 import java.util.List;
+import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.DataAccessAgreement;
 import org.broadinstitute.consent.http.models.Institution;
 import org.broadinstitute.consent.http.models.LibraryCard;
 import org.broadinstitute.consent.http.models.User;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.postgresql.util.PSQLException;
 import org.postgresql.util.PSQLState;
@@ -107,7 +110,8 @@ class LibraryCardDAOTest extends DAOTestHelper {
     // 4. Library Card <-> DAA relationship that represents a Signing Official's acceptance of a DAA for the user
     LibraryCard card = createLibraryCard();
     int dacId = dacDAO.createDac(randomAlphabetic(10), randomAlphabetic(10), new Date());
-    int daaId = daaDAO.createDaa(card.getCreateUserId(), Instant.now(), card.getCreateUserId(), Instant.now(), dacId);
+    int daaId = daaDAO.createDaa(card.getCreateUserId(), Instant.now(), card.getCreateUserId(),
+        Instant.now(), dacId);
     daaDAO.createDacDaaRelation(dacId, daaId);
     libraryCardDAO.createLibraryCardDaaRelation(card.getId(), daaId);
 
@@ -137,9 +141,11 @@ class LibraryCardDAOTest extends DAOTestHelper {
   void testFindLibraryCardDaaByIdMultipleDaas() {
     LibraryCard card = createLibraryCard();
     Integer userId = createUser().getUserId();
-    Integer dacId = dacDAO.createDac(randomAlphabetic(5), randomAlphabetic(5), "",  new Date());
-    Integer daaId1 = daaDAO.createDaa(userId, new Date().toInstant(), userId, new Date().toInstant(), dacId);
-    Integer daaId2 = daaDAO.createDaa(userId, new Date().toInstant(), userId, new Date().toInstant(), dacId);
+    Integer dacId = dacDAO.createDac(randomAlphabetic(5), randomAlphabetic(5), "", new Date());
+    Integer daaId1 = daaDAO.createDaa(userId, new Date().toInstant(), userId,
+        new Date().toInstant(), dacId);
+    Integer daaId2 = daaDAO.createDaa(userId, new Date().toInstant(), userId,
+        new Date().toInstant(), dacId);
     DataAccessAgreement daa1 = daaDAO.findById(daaId1);
     DataAccessAgreement daa2 = daaDAO.findById(daaId2);
     card.addDaa(daa1.getDaaId());
@@ -216,7 +222,8 @@ class LibraryCardDAOTest extends DAOTestHelper {
   @Test
   void testFindLibraryCardByUserIdInstitutionId() {
     LibraryCard libraryCard = createLibraryCard();
-    int dacId = dacDAO.createDac(randomAlphabetic(5), randomAlphabetic(5), randomAlphabetic(5), new Date());
+    int dacId = dacDAO.createDac(randomAlphabetic(5), randomAlphabetic(5), randomAlphabetic(5),
+        new Date());
     Instant now = Instant.now();
     int daaId = daaDAO.createDaa(libraryCard.getUserId(), now, libraryCard.getUserId(), now, dacId);
     daaDAO.createDacDaaRelation(dacId, daaId);
@@ -270,10 +277,12 @@ class LibraryCardDAOTest extends DAOTestHelper {
     LibraryCard card = createLibraryCard(user);
     LibraryCard card2 = createLibraryCard(user2);
     Integer userId = user.getUserId();
-    Integer dacId = dacDAO.createDac(randomAlphabetic(5), randomAlphabetic(5), "",  new Date());
-    Integer dacId2 = dacDAO.createDac(randomAlphabetic(5), randomAlphabetic(5), "",  new Date());
-    Integer daaId1 = daaDAO.createDaa(userId, new Date().toInstant(), userId, new Date().toInstant(), dacId);
-    Integer daaId2 = daaDAO.createDaa(userId, new Date().toInstant(), userId, new Date().toInstant(), dacId2);
+    Integer dacId = dacDAO.createDac(randomAlphabetic(5), randomAlphabetic(5), "", new Date());
+    Integer dacId2 = dacDAO.createDac(randomAlphabetic(5), randomAlphabetic(5), "", new Date());
+    Integer daaId1 = daaDAO.createDaa(userId, new Date().toInstant(), userId,
+        new Date().toInstant(), dacId);
+    Integer daaId2 = daaDAO.createDaa(userId, new Date().toInstant(), userId,
+        new Date().toInstant(), dacId2);
     libraryCardDAO.createLibraryCardDaaRelation(card.getId(), daaId1);
     libraryCardDAO.createLibraryCardDaaRelation(card.getId(), daaId2);
     libraryCardDAO.createLibraryCardDaaRelation(card2.getId(), daaId1);
@@ -292,8 +301,9 @@ class LibraryCardDAOTest extends DAOTestHelper {
     User user = createUser();
     LibraryCard card = createLibraryCard(user);
     Integer userId = user.getUserId();
-    Integer dacId = dacDAO.createDac(randomAlphabetic(5), randomAlphabetic(5), "",  new Date());
-    Integer daaId1 = daaDAO.createDaa(userId, new Date().toInstant(), userId, new Date().toInstant(), dacId);
+    Integer dacId = dacDAO.createDac(randomAlphabetic(5), randomAlphabetic(5), "", new Date());
+    Integer daaId1 = daaDAO.createDaa(userId, new Date().toInstant(), userId,
+        new Date().toInstant(), dacId);
 
     try {
       libraryCardDAO.createLibraryCardDaaRelation(card.getId(), 2);
@@ -321,10 +331,12 @@ class LibraryCardDAOTest extends DAOTestHelper {
     LibraryCard card = createLibraryCard(user);
     LibraryCard card2 = createLibraryCard(user2);
     Integer userId = user.getUserId();
-    Integer dacId = dacDAO.createDac(randomAlphabetic(5), randomAlphabetic(5), "",  new Date());
+    Integer dacId = dacDAO.createDac(randomAlphabetic(5), randomAlphabetic(5), "", new Date());
     Integer dacId2 = dacDAO.createDac(randomAlphabetic(5), randomAlphabetic(5), "", new Date());
-    Integer daaId1 = daaDAO.createDaa(userId, new Date().toInstant(), userId, new Date().toInstant(), dacId);
-    Integer daaId2 = daaDAO.createDaa(userId, new Date().toInstant(), userId, new Date().toInstant(), dacId2);
+    Integer daaId1 = daaDAO.createDaa(userId, new Date().toInstant(), userId,
+        new Date().toInstant(), dacId);
+    Integer daaId2 = daaDAO.createDaa(userId, new Date().toInstant(), userId,
+        new Date().toInstant(), dacId2);
     libraryCardDAO.createLibraryCardDaaRelation(card.getId(), daaId1);
     libraryCardDAO.createLibraryCardDaaRelation(card.getId(), daaId2);
 
@@ -332,11 +344,13 @@ class LibraryCardDAOTest extends DAOTestHelper {
     LibraryCard lc1 = lcs.get(0);
     assertEquals(2, lc1.getDaaIds().size());
 
-    libraryCardDAO.deleteLibraryCardDaaRelation(card.getId(), daaId1);lcs = libraryCardDAO.findAllLibraryCards();
+    libraryCardDAO.deleteLibraryCardDaaRelation(card.getId(), daaId1);
+    lcs = libraryCardDAO.findAllLibraryCards();
     lc1 = lcs.get(0);
     assertEquals(1, lc1.getDaaIds().size());
 
-    libraryCardDAO.deleteLibraryCardDaaRelation(card.getId(), daaId2);lcs = libraryCardDAO.findAllLibraryCards();
+    libraryCardDAO.deleteLibraryCardDaaRelation(card.getId(), daaId2);
+    lcs = libraryCardDAO.findAllLibraryCards();
     lc1 = lcs.get(0);
     assertTrue(lc1.getDaaIds().isEmpty());
   }
@@ -353,7 +367,8 @@ class LibraryCardDAOTest extends DAOTestHelper {
     LibraryCard card4 = createLibraryCard(createUser());
 
     List<LibraryCard> cardsFromDAO = libraryCardDAO.findByUserEmails(
-        List.of(user1.getEmail().toUpperCase(), user2.getEmail().toLowerCase(), user3.getEmail()));
+        List.of(user1.getEmail().toLowerCase(), user2.getEmail().toLowerCase(),
+            user3.getEmail().toLowerCase()));
 
     assertEquals(3, cardsFromDAO.size());
     assertTrue(cardsFromDAO.contains(card1));
@@ -361,6 +376,40 @@ class LibraryCardDAOTest extends DAOTestHelper {
     assertTrue(cardsFromDAO.contains(card3));
     assertFalse(cardsFromDAO.contains(card4));
   }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"", " ", "invalid-email", "user@domain", "user@domain.", "@domain.com",
+      "user@.com", "user_@domain.com", "user%@domain.com", "user*@domain.com", "user.@domain.com",
+      "user-@domain.com"})
+  void testFindByUserEmailsWithSpecialCharacters(String email) {
+    Integer userId = userDAO.insertUser(email, "display name", null, new Date());
+    userRoleDAO.insertSingleUserRole(UserRoles.RESEARCHER.getRoleId(), userId);
+    User user = userDAO.findUserById(userId);
+    LibraryCard card1 = createLibraryCard(user);
+    List<LibraryCard> cardsFromDAO = libraryCardDAO.findByUserEmails(List.of(user.getEmail()));
+    assertTrue(cardsFromDAO.contains(card1));
+  }
+
+  @Test
+  void testFindByUserEmailsWithConflictingSpecialCharacters() {
+    List<String> emails = List.of("user_@domain.com", "user%@domain.com", "user*@domain.com",
+        "user.@domain.com", "user-@domain.com");
+    // Create users with emails that have special characters that could conflict with SQL queries
+    emails.forEach(email -> {
+      Integer userId = userDAO.insertUser(email, "display name " + randomAlphabetic(25), null,
+          new Date());
+      userRoleDAO.insertSingleUserRole(UserRoles.RESEARCHER.getRoleId(), userId);
+      User user = userDAO.findUserById(userId);
+      createLibraryCard(user);
+    });
+
+    // Fetch library cards by emails and ensure that multiples (due to regexes in emails) are not returned
+    emails.forEach(email -> {
+      List<LibraryCard> cards = libraryCardDAO.findByUserEmails(List.of(email));
+      assertEquals(1, cards.size(), "Should return exactly one card for email: " + email);
+    });
+  }
+
 
   private LibraryCard createLibraryCardForIndex() {
     Integer userId = createUser().getUserId();

--- a/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
@@ -42,6 +42,7 @@ import org.broadinstitute.consent.http.db.DacDAO;
 import org.broadinstitute.consent.http.db.DataAccessRequestDAO;
 import org.broadinstitute.consent.http.db.DatasetDAO;
 import org.broadinstitute.consent.http.db.InstitutionDAO;
+import org.broadinstitute.consent.http.db.LibraryCardDAO;
 import org.broadinstitute.consent.http.db.StudyDAO;
 import org.broadinstitute.consent.http.db.UserDAO;
 import org.broadinstitute.consent.http.enumeration.PropertyType;
@@ -52,6 +53,7 @@ import org.broadinstitute.consent.http.models.DataUseBuilder;
 import org.broadinstitute.consent.http.models.Dataset;
 import org.broadinstitute.consent.http.models.DatasetProperty;
 import org.broadinstitute.consent.http.models.Institution;
+import org.broadinstitute.consent.http.models.LibraryCard;
 import org.broadinstitute.consent.http.models.Study;
 import org.broadinstitute.consent.http.models.StudyProperty;
 import org.broadinstitute.consent.http.models.User;
@@ -106,6 +108,9 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
   @Mock
   private StudyDAO studyDAO;
 
+  @Mock
+  private LibraryCardDAO libraryCardDAO;
+
   @BeforeEach
   void initService() {
     service = new ElasticSearchService(
@@ -118,7 +123,8 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
         institutionDAO,
         datasetDAO,
         datasetServiceDAO,
-        studyDAO);
+        studyDAO,
+        libraryCardDAO);
   }
 
   private void mockElasticSearchResponse(String body) throws IOException {
@@ -338,6 +344,12 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
         datasetRecord.createUser);
     when(userDao.findUserById(datasetRecord.updateUser.getUserId())).thenReturn(
         datasetRecord.updateUser);
+    LibraryCard card1 = new LibraryCard();
+    card1.setUserId(dar1.getUserId());
+    LibraryCard card2 = new LibraryCard();
+    card2.setUserId(dar2.getUserId());
+    when(libraryCardDAO.findLibraryCardsByUserIds(
+        List.of(dar1.getUserId(), dar2.getUserId()))).thenReturn(List.of(card1, card2));
     when(dacDAO.findById(any())).thenReturn(datasetRecord.dac);
     when(ontologyService.translateDataUseSummary(any())).thenReturn(dataUseSummary);
     when(dataAccessRequestDAO.findApprovedDARsByDatasetId(any())).thenReturn(List.of(dar1, dar2));
@@ -407,7 +419,8 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
     when(dacDAO.findById(any())).thenReturn(dac);
     when(userDao.findUserById(user.getUserId())).thenReturn(user);
     when(dacDAO.findById(any())).thenReturn(datasetRecord.dac);
-    when(userDao.findUserById(datasetRecord.createUser.getUserId())).thenReturn(datasetRecord.createUser);
+    when(userDao.findUserById(datasetRecord.createUser.getUserId())).thenReturn(
+        datasetRecord.createUser);
     assertDoesNotThrow(() -> service.toDatasetTerm(dataset));
   }
 
@@ -495,7 +508,8 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
     when(mockResponse.getStatusLine()).thenReturn(statusLine);
     when(statusLine.getStatusCode()).thenReturn(200);
 
-    try (var ignored = service.indexDatasets(List.of(dataset1.getDatasetId(), dataset2.getDatasetId()),
+    try (var ignored = service.indexDatasets(
+        List.of(dataset1.getDatasetId(), dataset2.getDatasetId()),
         datasetRecord.createUser)) {
       // Each dataset should be looked up once when defining the term and a second time
       // when updating the indexed date.

--- a/src/test/java/org/broadinstitute/consent/http/service/TDRServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/TDRServiceTest.java
@@ -1,19 +1,19 @@
 package org.broadinstitute.consent.http.service;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import jakarta.ws.rs.NotFoundException;
 import java.util.Arrays;
 import java.util.List;
+import org.broadinstitute.consent.http.AbstractTestHelper;
 import org.broadinstitute.consent.http.db.DatasetDAO;
+import org.broadinstitute.consent.http.db.LibraryCardDAO;
 import org.broadinstitute.consent.http.db.SamDAO;
 import org.broadinstitute.consent.http.db.UserDAO;
 import org.broadinstitute.consent.http.models.AuthUser;
@@ -21,6 +21,7 @@ import org.broadinstitute.consent.http.models.Collaborator;
 import org.broadinstitute.consent.http.models.DataAccessRequest;
 import org.broadinstitute.consent.http.models.DataAccessRequestData;
 import org.broadinstitute.consent.http.models.Dataset;
+import org.broadinstitute.consent.http.models.LibraryCard;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.tdr.ApprovedUser;
 import org.broadinstitute.consent.http.models.tdr.ApprovedUsers;
@@ -30,7 +31,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-class TDRServiceTest {
+class TDRServiceTest extends AbstractTestHelper {
 
   @Mock
   private DataAccessRequestService darService;
@@ -39,15 +40,20 @@ class TDRServiceTest {
   private DatasetDAO datasetDAO;
 
   @Mock
+  private LibraryCardDAO libraryCardDAO;
+
+  @Mock
   private UserDAO userDAO;
 
-  @Mock SamDAO samDAO;
+  @Mock
+  SamDAO samDAO;
 
-  @Mock AuthUser authUser;
+  @Mock
+  AuthUser authUser;
   private TDRService service;
 
   private void initService() {
-    service = new TDRService(darService, datasetDAO, samDAO, userDAO);
+    service = new TDRService(darService, datasetDAO, libraryCardDAO, samDAO, userDAO);
   }
 
   @Test
@@ -57,6 +63,9 @@ class TDRServiceTest {
     User user1 = new User();
     user1.setUserId(1);
     user1.setEmail("asdf1@gmail.com");
+    LibraryCard libraryCard1 = new LibraryCard();
+    libraryCard1.setUserEmail(user1.getEmail());
+    user1.setLibraryCard(libraryCard1);
     DataAccessRequest dar1 = new DataAccessRequest();
     dar1.setUserId(user1.getUserId());
     DataAccessRequestData data = new DataAccessRequestData();
@@ -65,16 +74,24 @@ class TDRServiceTest {
     data.setLabCollaborators(List.of(lab));
     Collaborator internal = new Collaborator();
     internal.setEmail("internal@gmail.com");
+    LibraryCard libraryCard3 = new LibraryCard();
+    libraryCard3.setUserEmail(internal.getEmail());
     data.setInternalCollaborators(List.of(internal));
     dar1.setData(data);
     User user2 = new User();
     user2.setUserId(2);
     user2.setEmail("asdf2@gmail.com");
+    LibraryCard libraryCard2 = new LibraryCard();
+    libraryCard2.setUserEmail(user2.getEmail());
+    user2.setLibraryCard(libraryCard2);
     DataAccessRequest dar2 = new DataAccessRequest();
     dar2.setUserId(user2.getUserId());
 
     when(darService.getApprovedDARsForDataset(dataset)).thenReturn(List.of(dar1, dar2));
     when(userDAO.findUsers(any())).thenReturn(List.of(user1, user2));
+    // Mock that the library cards exist for user 1, 2, and internal collaborator, but not the internal lab staff.
+    when(libraryCardDAO.findByUserEmails(anyList()))
+        .thenReturn(List.of(libraryCard1, libraryCard2, libraryCard3));
     initService();
 
     ApprovedUsers approvedUsers = service.getApprovedUsersForDataset(authUser, dataset);
@@ -83,7 +100,13 @@ class TDRServiceTest {
         .toList();
 
     assertTrue(
-        approvedUsersEmails.containsAll(List.of(user1.getEmail(), user2.getEmail(), lab.getEmail(), internal.getEmail())));
+        approvedUsersEmails.containsAll(
+            List.of(user1.getEmail(), user2.getEmail(), internal.getEmail())),
+        "Approved users should include user1, user2, and internal collaborator");
+    assertFalse(
+        approvedUsersEmails.contains(lab.getEmail()),
+        "Lab collaborator should not be included as they do not have a library card"
+    );
   }
 
   @Test


### PR DESCRIPTION
### Addresses
Partially addresses https://broadworkbench.atlassian.net/browse/DT-1675
* Separate UI work will be necessary to address the suspension aspects of DT-1675.
* Separate backend work will be necessary to address the notification aspects of DT-1675.

Completely addresses https://broadworkbench.atlassian.net/browse/DT-1659

### Summary
This PR adds additional backend filtering to ensure that there is a library card for every approved user we provide as the approved users for a dataset.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
