### PR TITLE
[DT-1785] Memorialize the SO approval of a closeout progress report.

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
@@ -88,8 +88,8 @@ public interface DarCollectionDAO extends Transactional<DarCollectionDAO> {
           "dar.id AS dar_id, dar.reference_id AS dar_reference_id, dar.collection_id AS dar_collection_id, "
           +
           "dar.parent_id AS dar_parent_id, dar.user_id AS dar_userId, " +
-          "dar.create_date AS dar_create_date, dar.sort_date AS dar_sort_date, dar.submission_date AS dar_submission_date, "
-          +
+          "dar.create_date AS dar_create_date, dar.sort_date AS dar_sort_date, dar.submission_date AS dar_submission_date, " +
+          "dar.closeout_so_approval_timestamp AS dar_closeout_so_approval_timestamp, dar.closeout_approving_so_id AS dar_closeout_approving_so_id, " +
           "dar.update_date AS dar_update_date, (dar.data #>> '{}')::jsonb AS data " +
           "FROM dar_collection c " +
           "INNER JOIN users u ON c.create_user_id = u.user_id " +
@@ -133,6 +133,8 @@ public interface DarCollectionDAO extends Transactional<DarCollectionDAO> {
         as up_property_key, up.property_value AS up_property_value,
         dar.id AS dar_id, dar.reference_id AS dar_reference_id, dar.collection_id AS dar_collection_id,
         dar.parent_id AS dar_parent_id, dar.user_id AS dar_userId, dar.era_commons_id AS dar_era_commons_id,
+        dar.closeout_so_approval_timestamp AS dar_closeout_so_approval_timestamp,
+        dar.closeout_approving_so_id AS dar_closeout_approving_so_id,
         dar.create_date AS dar_create_date, dar.sort_date AS dar_sort_date, dar.submission_date AS dar_submission_date,
         dar.update_date AS dar_update_date, (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data, dd.dataset_id
         FROM dar_collection c
@@ -172,6 +174,7 @@ public interface DarCollectionDAO extends Transactional<DarCollectionDAO> {
           + "dar.parent_id AS dar_parent_id, dar.user_id AS dar_userId, dar.era_commons_id AS dar_era_commons_id, "
           + "dar.create_date AS dar_create_date, dar.sort_date AS dar_sort_date, dar.submission_date AS dar_submission_date, "
           + "dar.update_date AS dar_update_date, (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data, "
+          + "dar.closeout_so_approval_timestamp AS dar_closeout_so_approval_timestamp, dar.closeout_approving_so_id AS dar_closeout_approving_so_id, "
           + "e.election_id AS e_election_id, e.reference_id AS e_reference_id, e.status AS e_status, e.create_date AS e_create_date, "
           + "e.last_update AS e_last_update, e.dataset_id AS e_dataset_id, e.election_type AS e_election_type, e.latest, "
           + "v.voteid as v_vote_id, v.vote as v_vote, v.user_id as v_user_id, v.rationale as v_rationale, v.electionid as v_election_id, "

--- a/src/main/java/org/broadinstitute/consent/http/db/DarCollectionSummaryDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DarCollectionSummaryDAO.java
@@ -23,6 +23,7 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
   @UseRowReducer(DarCollectionSummaryReducer.class)
   @SqlQuery("""
       SELECT c.collection_id as dar_collection_id, c.dar_code, latest_dar.submission_date, latest_dar.reference_id as latest_dar_reference_id, latest_dar.parent_id as latest_dar_parent_id,
+      latest_dar.closeout_approving_so_id as latest_dar_closeout_approving_so_id,  latest_dar.closeout_so_approval_timestamp AS latest_dar_closeout_so_approval_timestamp,
        u.display_name as researcher_name, i.institution_name, e.election_id, e.status, e.dataset_id, e.reference_id, v.voteid as v_vote_id, dd.dataset_id as dd_datasetid,
         v.user_id as v_user_id, v.vote as v_vote, v.electionid as v_election_id, v.createdate as v_create_date, v.updatedate as v_update_date, v.type as v_type,
         (regexp_replace(latest_dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb ->> 'projectTitle' AS name,
@@ -58,6 +59,7 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
         AND (LOWER(v.type) = 'final' OR (v.user_id = :currentUserId OR v.voteid IS NULL))
       GROUP BY
         c.collection_id, c.dar_code, latest_dar.submission_date, latest_dar.reference_id, latest_dar.parent_id,
+        latest_dar.closeout_approving_so_id, latest_dar.closeout_so_approval_timestamp,
         u.display_name, i.institution_name, e.election_id, e.status,
         e.reference_id, e.dataset_id, v.voteid, dd.dataset_id, v.user_id,
         v.vote, v.electionid, v.createdate, v.updatedate, v.type, latest_dar.data
@@ -78,6 +80,8 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
                latest_dar.submission_date,
                latest_dar.reference_id as latest_dar_reference_id,
                latest_dar.parent_id as latest_dar_parent_id,
+               latest_dar.closeout_approving_so_id as latest_dar_closeout_approving_so_id,
+               latest_dar.closeout_so_approval_timestamp as latest_dar_closeout_so_approval_timestamp,
                u.display_name as researcher_name,
                i.institution_name,
                e.election_id,
@@ -115,6 +119,7 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
                 AND (e.latest = e.election_id OR e.election_id IS NULL)
               GROUP BY
               c.collection_id, c.dar_code, latest_dar.submission_date, latest_dar.reference_id, latest_dar.parent_id,
+              latest_dar.closeout_approving_so_id, latest_dar.closeout_so_approval_timestamp,
               u.display_name, i.institution_name, e.election_id, e.status,
               e.reference_id, e.dataset_id, dd.dataset_id, latest_dar.data
           """
@@ -133,6 +138,8 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
               latest_dar.submission_date,
               latest_dar.reference_id AS latest_dar_reference_id,
               latest_dar.parent_id AS latest_dar_parent_id,
+              latest_dar.closeout_approving_so_id as latest_dar_closeout_approving_so_id,
+              latest_dar.closeout_so_approval_timestamp as latest_dar_closeout_so_approval_timestamp,
               u.display_name AS researcher_name,
               i.institution_name,
               e.election_id,
@@ -167,6 +174,7 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
           WHERE (e.latest = e.election_id OR e.election_id IS NULL)
           GROUP BY
               c.collection_id, c.dar_code, latest_dar.submission_date, latest_dar.reference_id, latest_dar.parent_id,
+              latest_dar.closeout_approving_so_id, latest_dar.closeout_so_approval_timestamp,
               u.display_name, i.institution_name, e.election_id, e.status,
               e.dataset_id, dd.dataset_id, latest_dar.data, dac.name
       """)
@@ -183,6 +191,8 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
         latest_dar.submission_date,
         latest_dar.reference_id AS latest_dar_reference_id,
         latest_dar.parent_id AS latest_dar_parent_id,
+        latest_dar.closeout_approving_so_id as latest_dar_closeout_approving_so_id,
+        latest_dar.closeout_so_approval_timestamp as latest_dar_closeout_so_approval_timestamp,
         u.display_name AS researcher_name,
         i.institution_name,
         e.election_id,
@@ -221,8 +231,10 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
         c.create_user_id = :userId
         AND (e.latest = e.election_id OR e.election_id IS NULL)
     GROUP BY
-        c.collection_id, c.dar_code, latest_dar.submission_date, latest_dar.reference_id, latest_dar.parent_id, u.display_name, i.institution_name,
-        e.election_id, e.status, e.dataset_id, e.reference_id, dd.dataset_id, latest_dar.data
+        c.collection_id, c.dar_code, latest_dar.submission_date, latest_dar.reference_id, latest_dar.parent_id, u.display_name,
+        latest_dar.closeout_approving_so_id, latest_dar.closeout_so_approval_timestamp,
+        i.institution_name, e.election_id, e.status, e.dataset_id, e.reference_id, dd.dataset_id,
+        latest_dar.data
 """)
   List<DarCollectionSummary> getDarCollectionSummariesForResearcher(@Bind("userId") Integer userId);
 
@@ -234,7 +246,10 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
   @UseRowReducer(DarCollectionSummaryReducer.class)
   @SqlQuery("""
       SELECT c.collection_id as dar_collection_id, c.dar_code, latest_dar.submission_date, latest_dar.reference_id AS latest_dar_reference_id,
-        latest_dar.parent_id AS latest_dar_parent_id, u.display_name as researcher_name, u.user_id as researcher_id,
+        latest_dar.parent_id AS latest_dar_parent_id,
+        latest_dar.closeout_approving_so_id as latest_dar_closeout_approving_so_id,
+        latest_dar.closeout_so_approval_timestamp as latest_dar_closeout_so_approval_timestamp,
+        u.display_name as researcher_name, u.user_id as researcher_id,
         i.institution_name, i.institution_id, e.election_id, e.status, e.dataset_id, e.reference_id, v.voteid as v_vote_id, dd.dataset_id as dd_datasetid,
         v.user_id as v_user_id, v.vote as v_vote, v.electionid as v_election_id, v.createdate as v_create_date, v.updatedate as v_update_date, v.type as v_type,
         (regexp_replace(latest_dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb ->> 'projectTitle' AS name,
@@ -270,7 +285,9 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
         AND (e.latest = e.election_id OR e.election_id IS NULL)
         AND (LOWER(v.type) = 'final' OR (v.user_id = :currentUserId OR v.voteid IS NULL))
       GROUP BY
-        c.collection_id, c.dar_code, latest_dar.submission_date, latest_dar.reference_id, latest_dar.parent_id, u.display_name, u.user_id,
+        c.collection_id, c.dar_code, latest_dar.submission_date, latest_dar.reference_id, latest_dar.parent_id,
+        latest_dar.closeout_approving_so_id, latest_dar.closeout_so_approval_timestamp,
+        u.display_name, u.user_id,
         i.institution_name, i.institution_id, e.election_id, e.status,
         e.reference_id, e.dataset_id, v.voteid, dd.dataset_id, v.user_id,
         v.vote, v.electionid, v.createdate, v.updatedate, v.type, latest_dar.data
@@ -288,7 +305,11 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
   @SqlQuery
       (
           """
-              SELECT c.collection_id as dar_collection_id, c.dar_code, latest_dar.submission_date, latest_dar.reference_id as latest_dar_reference_id, latest_dar.parent_id as latest_dar_parent_id, u.display_name as researcher_name,
+              SELECT c.collection_id as dar_collection_id, c.dar_code, latest_dar.submission_date,
+                latest_dar.reference_id as latest_dar_reference_id, latest_dar.parent_id as latest_dar_parent_id,
+                latest_dar.closeout_approving_so_id as latest_dar_closeout_approving_so_id,
+                latest_dar.closeout_so_approval_timestamp as latest_dar_closeout_so_approval_timestamp,
+                u.display_name as researcher_name,
                 u.user_id as researcher_id, i.institution_name, i.institution_id, e.election_id, e.status, e.dataset_id, e.reference_id, dd.dataset_id as dd_datasetid,
                 (regexp_replace(latest_dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb ->> 'projectTitle' AS name,
                 (regexp_replace(latest_dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb ->> 'status' AS dar_status,
@@ -320,7 +341,9 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
               WHERE c.collection_id = :collectionId
                 AND (e.latest = e.election_id OR e.election_id IS NULL)
               GROUP BY
-                c.collection_id, c.dar_code, latest_dar.submission_date, latest_dar.reference_id, latest_dar.parent_id, u.display_name, u.user_id, i.institution_name,
+                c.collection_id, c.dar_code, latest_dar.submission_date, latest_dar.reference_id, latest_dar.parent_id,
+                latest_dar.closeout_approving_so_id, latest_dar.closeout_so_approval_timestamp,
+                u.display_name, u.user_id, i.institution_name,
                 i.institution_id, e.election_id, e.status, e.dataset_id, e.reference_id, dd.dataset_id, latest_dar.data
           """
       )

--- a/src/main/java/org/broadinstitute/consent/http/db/DataAccessRequestDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DataAccessRequestDAO.java
@@ -38,8 +38,10 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
   @UseRowReducer(DataAccessRequestReducer.class)
   @SqlQuery(
       """
-          SELECT collection.dar_code, dd.dataset_id, dar.id, dar.reference_id, dar.collection_id, dar.parent_id, dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date,
-            (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data, dar.era_commons_id
+          SELECT collection.dar_code, dd.dataset_id, dar.id, dar.reference_id, dar.collection_id, 
+            dar.parent_id, dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date,
+            (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data, dar.era_commons_id,
+            dar.closeout_so_approval_timestamp, dar.closeout_approving_so_id
           FROM data_access_request dar
           LEFT JOIN dar_dataset dd on dd.reference_id = dar.reference_id
           LEFT JOIN dar_collection collection on collection.collection_id = dar.collection_id
@@ -67,7 +69,8 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
               SELECT dar.id, dar.reference_id, dar.collection_id, dar.parent_id,
                 dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date,
                 (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data,
-                dd.dataset_id, collection.dar_code, dar.era_commons_id
+                dd.dataset_id, collection.dar_code, dar.era_commons_id,
+                dar.closeout_so_approval_timestamp, dar.closeout_approving_so_id
               FROM data_access_request dar
               LEFT JOIN dar_collection collection on collection.collection_id = dar.collection_id
               INNER JOIN dar_dataset dd ON dd.reference_id = dar.reference_id AND dd.dataset_id = :datasetId
@@ -146,7 +149,8 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
               SELECT dar.id, dar.reference_id, dar.collection_id, dar.parent_id,
                 dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date,
                 (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data,
-                dd.dataset_id, collection.dar_code, dar.era_commons_id
+                dd.dataset_id, collection.dar_code, dar.era_commons_id,
+                dar.closeout_so_approval_timestamp, dar.closeout_approving_so_id
               FROM data_access_request dar
               LEFT JOIN dar_collection collection on collection.collection_id = dar.collection_id
               LEFT JOIN dar_dataset dd ON dd.reference_id = dar.reference_id
@@ -167,8 +171,10 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
   @UseRowReducer(DataAccessRequestReducer.class)
   @SqlQuery(
       """
-              SELECT dd.dataset_id, dar.id, dar.reference_id, dar.collection_id, dar.parent_id, dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date,
-                (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data, collection.dar_code, dar.era_commons_id
+              SELECT dd.dataset_id, dar.id, dar.reference_id, dar.collection_id, dar.parent_id,
+              dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date,
+              (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data, collection.dar_code, 
+              dar.era_commons_id, dar.closeout_so_approval_timestamp, dar.closeout_approving_so_id
               FROM data_access_request dar
               LEFT JOIN dar_collection collection on collection.collection_id = dar.collection_id
               LEFT JOIN dar_dataset dd on dd.reference_id = dar.reference_id
@@ -186,8 +192,11 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
   @UseRowReducer(DataAccessRequestReducer.class)
   @SqlQuery(
       """
-              SELECT dd.dataset_id, dar.id, dar.reference_id, dar.collection_id, dar.parent_id, dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date,
-                (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data, collection.dar_code, dar.era_commons_id
+              SELECT dd.dataset_id, dar.id, dar.reference_id, dar.collection_id, dar.parent_id,
+              dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date,
+              (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data, 
+              collection.dar_code, dar.era_commons_id, dar.closeout_so_approval_timestamp,
+              dar.closeout_approving_so_id
               FROM data_access_request dar
               LEFT JOIN dar_collection collection on collection.collection_id = dar.collection_id
               LEFT JOIN dar_dataset dd on dd.reference_id = dar.reference_id
@@ -207,8 +216,11 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
   @UseRowReducer(DataAccessRequestReducer.class)
   @SqlQuery(
       """
-              SELECT dd.dataset_id, dar.id, dar.reference_id, dar.collection_id, dar.parent_id, dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date,
-                (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data, collection.dar_code, dar.era_commons_id
+              SELECT dd.dataset_id, dar.id, dar.reference_id, dar.collection_id, dar.parent_id,
+                dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date,
+                (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data,
+                collection.dar_code, dar.era_commons_id, dar.closeout_so_approval_timestamp,
+                dar.closeout_approving_so_id
               FROM data_access_request dar
               LEFT JOIN dar_collection collection on collection.collection_id = dar.collection_id
               LEFT JOIN dar_dataset dd on dd.reference_id = dar.reference_id
@@ -227,7 +239,8 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
   @SqlQuery(
       """
           SELECT dd.dataset_id, dar.id, dar.reference_id, dar.collection_id, dar.parent_id, dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date,
-            (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data, collection.dar_code, dar.era_commons_id
+            (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data, collection.dar_code,
+            dar.era_commons_id, dar.closeout_so_approval_timestamp, dar.closeout_approving_so_id
           FROM data_access_request dar
           LEFT JOIN dar_collection collection on collection.collection_id = dar.collection_id
           LEFT JOIN dar_dataset dd on dd.reference_id = dar.reference_id
@@ -401,12 +414,19 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
       """)
   void archiveByReferenceIds(@BindList(value = "referenceIds", onEmpty = EmptyHandling.NULL_STRING) List<String> referenceIds);
 
+  @SqlUpdate(
+    """
+        UPDATE data_access_request
+          SET closeout_approving_so_id = :id, closeout_so_approval_timestamp = now()
+        WHERE reference_id = :referenceId
+    """)
+  void updateDarCloseoutSO(@Bind("id") Integer signingOfficialUserId, @Bind("referenceId") String referenceId);
 
   /**
    * Inserts into dar_dataset collection
    *
    * @param referenceId String
-   * @param datasetId   Integer
+   * @param datasetId Integer
    */
   @SqlUpdate(
       """
@@ -414,8 +434,8 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
           VALUES (:referenceId, :datasetId)
           ON CONFLICT DO NOTHING
       """)
-  void insertDARDatasetRelation(@Bind("referenceId") String referenceId,
-      @Bind("datasetId") Integer datasetId);
+  void insertDARDatasetRelation(
+      @Bind("referenceId") String referenceId, @Bind("datasetId") Integer datasetId);
 
   @SqlBatch(
       """

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DarCollectionSummaryReducer.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DarCollectionSummaryReducer.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.consent.http.db.mapper;
 
+import java.sql.Timestamp;
 import java.util.Map;
 import java.util.Objects;
 import org.broadinstitute.consent.http.models.DarCollectionSummary;
@@ -45,6 +46,10 @@ public class DarCollectionSummaryReducer implements
         }
         hasOptionalColumn(rowView, "latest_dar_parent_id", Integer.class)
             .ifPresent(darParentId -> summary.addParentChildRelationship(darParentId, darReferenceId));
+        hasOptionalColumn(rowView, "latest_dar_closeout_approving_so_id", Integer.class)
+            .ifPresent(summary::setCloseoutSigningOfficialId);
+        hasOptionalColumn(rowView, "latest_dar_closeout_so_approval_timestamp", Timestamp.class)
+            .ifPresent(summary::setCloseoutSigningOfficialApprovalDate);
         darStatus = rowView.getColumn("dar_status", String.class);
         if (Objects.nonNull(darStatus)) {
           summary.addStatus(darStatus, darReferenceId);

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DataAccessRequestMapper.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DataAccessRequestMapper.java
@@ -38,6 +38,8 @@ public class DataAccessRequestMapper implements RowMapper<DataAccessRequest>, Ro
     }
     dar.setData(data);
     dar.setEraCommonsId(resultSet.getString("era_commons_id"));
+    dar.setCloseoutSigningOfficialApprovedDate(resultSet.getTimestamp("closeout_so_approval_timestamp"));
+    dar.setCloseoutSigningOfficialApprovedUserId(resultSet.getInt("closeout_approving_so_id"));
     return dar;
   }
 

--- a/src/main/java/org/broadinstitute/consent/http/models/DarCollectionSummary.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DarCollectionSummary.java
@@ -59,6 +59,13 @@ public class DarCollectionSummary {
 
   @JsonProperty
   private String latestReferenceId;
+
+  @JsonProperty
+  private Integer closeoutSigningOfficialId;
+
+  @JsonProperty
+  private Timestamp closeoutSigningOfficialApprovalDate;
+
   private List<String> dacNames;
 
   private Integer researcherId;
@@ -163,6 +170,23 @@ public class DarCollectionSummary {
       this.expired = this.expiresAt.before(Timestamp.from(Instant.now()));
     }
     updateProgressReportStatus();
+  }
+
+  public void setCloseoutSigningOfficialId(Integer darCloseoutSigningOfficialApprovalId) {
+    this.closeoutSigningOfficialId = darCloseoutSigningOfficialApprovalId;
+  }
+
+  public Timestamp getCloseoutSigningOfficialApprovalDate() {
+    return closeoutSigningOfficialApprovalDate;
+  }
+
+  public void setCloseoutSigningOfficialApprovalDate(
+      Timestamp darCloseoutSigningOfficialApprovalDate) {
+    this.closeoutSigningOfficialApprovalDate = darCloseoutSigningOfficialApprovalDate;
+  }
+
+  public Integer getCloseoutSigningOfficialApprovalId() {
+    return closeoutSigningOfficialId;
   }
 
   public boolean isExpired() {

--- a/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequest.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequest.java
@@ -83,6 +83,12 @@ public class DataAccessRequest {
   @JsonProperty
   private String eraCommonsId;
 
+  @JsonProperty
+  public Timestamp closeoutSigningOfficialApprovedDate;
+
+  @JsonProperty
+  public Integer closeoutSigningOfficialApprovedUserId;
+
   public DataAccessRequest() {
     this.elections = new HashMap<>();
   }
@@ -266,6 +272,21 @@ public class DataAccessRequest {
     this.eraCommonsId = eraCommonsId;
   }
 
+  public Integer getCloseoutSigningOfficialApprovedUserId() {
+    return closeoutSigningOfficialApprovedUserId;
+  }
+
+  public void setCloseoutSigningOfficialApprovedUserId(Integer closeoutSigningOfficialApprovedUserId) {
+    this.closeoutSigningOfficialApprovedUserId = closeoutSigningOfficialApprovedUserId;
+  }
+
+  public Timestamp getCloseoutSigningOfficialApprovedDate() {
+    return closeoutSigningOfficialApprovedDate;
+  }
+
+  public void setCloseoutSigningOfficialApprovedDate(Timestamp closeoutSigningOfficialApprovedDate) {
+    this.closeoutSigningOfficialApprovedDate = closeoutSigningOfficialApprovedDate;
+  }
 
   /**
    * Merges the DAR and the DAR Data into a single Map Ignores a series of deprecated keys Null
@@ -394,9 +415,7 @@ public class DataAccessRequest {
     if (Objects.nonNull(dar.getCreateDate())) {
       copy.put("createDate", dar.getCreateDate().getTime());
     }
-    if (Objects.nonNull(dar.getDraft())) {
-      copy.put("draft", dar.getDraft());
-    }
+    copy.put("draft", dar.getDraft());
     copy.put("expired", dar.getExpired());
     copy.put("expiredAt", dar.getExpiresAt());
     if (Objects.nonNull(dar.getId())) {
@@ -432,6 +451,12 @@ public class DataAccessRequest {
     if (dar.getEraCommonsId() != null) {
       copy.put("eraCommonsId", dar.getEraCommonsId());
     }
+    if (dar.getCloseoutSigningOfficialApprovedUserId() != null) {
+      copy.put("closeoutSigningOfficialApprovedUserId", dar.getCloseoutSigningOfficialApprovedUserId());
+    }
+    if (dar.getCloseoutSigningOfficialApprovedDate() != null) {
+      copy.put("closeoutSigningOfficialApprovedDate", dar.getCloseoutSigningOfficialApprovedUserId());
+    }
     return copy;
   }
 
@@ -441,4 +466,15 @@ public class DataAccessRequest {
     progressReport = !getDraft() && (getParentId() != null);
   }
 
+  public boolean getIsCloseoutProgressReport() {
+    return getProgressReport()
+        && this.getData() != null
+        && this.getData().getCloseoutSupplement() != null
+        && !this.getData().getCloseoutSupplement().reasons().isEmpty();
+  }
+
+  public boolean getHasSOCloseoutApproval() {
+    return this.getCloseoutSigningOfficialApprovedDate() != null
+        && this.getCloseoutSigningOfficialApprovedUserId() != null;
+  }
 }

--- a/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
@@ -395,14 +395,19 @@ public class DataAccessRequestResource extends Resource {
   @RolesAllowed({SIGNINGOFFICIAL})
   @Path("/approve_closeout/{referenceId}")
   public Response approveCloseout(@Auth AuthUser authUser,
+      @Context Request request,
       @PathParam("referenceId") String referenceId) {
     try {
       User  user = findUserByEmail(authUser.getEmail());
       dataAccessRequestService.approveDataAccessRequestCloseout(user, referenceId);
+      DataAccessRequest dar = getDarById(referenceId);
+      List<Dataset> datasets = datasetService.findDatasetsByIds(dar.getDatasetIds());
+      ComplianceLogger.logCloseoutApprovalBySigningOfficial(user, datasets,
+          (ContainerRequest) request, HttpStatusCodes.STATUS_CODE_OK);
+      return Response.ok().build();
     } catch (Exception e) {
       return createExceptionResponse(e);
     }
-    return Response.ok().build();
   }
 
   @POST

--- a/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
@@ -391,6 +391,20 @@ public class DataAccessRequestResource extends Resource {
     }
   }
 
+  @PUT
+  @RolesAllowed({SIGNINGOFFICIAL})
+  @Path("/approve_closeout/{referenceId}")
+  public Response approveCloseout(@Auth AuthUser authUser,
+      @PathParam("referenceId") String referenceId) {
+    try {
+      User  user = findUserByEmail(authUser.getEmail());
+      dataAccessRequestService.approveDataAccessRequestCloseout(user, referenceId);
+    } catch (Exception e) {
+      return createExceptionResponse(e);
+    }
+    return Response.ok().build();
+  }
+
   @POST
   @Consumes(MediaType.MULTIPART_FORM_DATA)
   @Produces(MediaType.APPLICATION_JSON)

--- a/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
@@ -43,6 +43,7 @@ import org.broadinstitute.consent.http.models.DataAccessRequest;
 import org.broadinstitute.consent.http.models.DataAccessRequestData;
 import org.broadinstitute.consent.http.models.DataUse;
 import org.broadinstitute.consent.http.models.Dataset;
+import org.broadinstitute.consent.http.models.DuosUser;
 import org.broadinstitute.consent.http.models.Error;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.service.DaaService;
@@ -394,15 +395,14 @@ public class DataAccessRequestResource extends Resource {
   @PUT
   @RolesAllowed({SIGNINGOFFICIAL})
   @Path("/approve_closeout/{referenceId}")
-  public Response approveCloseout(@Auth AuthUser authUser,
+  public Response approveCloseout(@Auth DuosUser duosUser,
       @Context Request request,
       @PathParam("referenceId") String referenceId) {
     try {
-      User  user = findUserByEmail(authUser.getEmail());
-      dataAccessRequestService.approveDataAccessRequestCloseout(user, referenceId);
+      dataAccessRequestService.approveDataAccessRequestCloseout(duosUser.getUser(), referenceId);
       DataAccessRequest dar = getDarById(referenceId);
       List<Dataset> datasets = datasetService.findDatasetsByIds(dar.getDatasetIds());
-      ComplianceLogger.logCloseoutApprovalBySigningOfficial(user, datasets,
+      ComplianceLogger.logCloseoutApprovalBySigningOfficial(duosUser.getUser(), datasets,
           (ContainerRequest) request, HttpStatusCodes.STATUS_CODE_OK);
       return Response.ok().build();
     } catch (Exception e) {

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
@@ -309,7 +309,11 @@ public class DataAccessRequestService implements ConsentLogger {
       }
 
     } catch (NotFoundException e) {
-      // do nothing.  we'll allow the SO to process a closeout even if the  user can't be found.
+      // log the state.  we'll allow the SO to process a closeout even if the  user can't be found.
+      logWarn(
+          String.format(
+              "Signing Official approving closeout %s for non-existent user %d",
+              dataAccessRequest.getReferenceId(), dataAccessRequest.getUserId()));
     }
   }
 

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
@@ -280,6 +280,40 @@ public class DataAccessRequestService implements ConsentLogger {
     return findByReferenceId(referenceId);
   }
 
+  public DataAccessRequest approveDataAccessRequestCloseout(User signingOfficial, DataAccessRequest dataAccessRequest) {
+    validateCloseoutApproval(signingOfficial, dataAccessRequest);
+    String referenceId = dataAccessRequest.getReferenceId();
+    dataAccessRequestDAO.updateDarCloseoutSO(signingOfficial.getUserId(), referenceId);
+    return findByReferenceId(referenceId);
+  }
+
+  @VisibleForTesting
+  protected void validateCloseoutApproval(User signingOfficial, DataAccessRequest dataAccessRequest) {
+    // Note: we will allow a signing official to approve their own closeout.
+
+    if (!dataAccessRequest.getIsCloseoutProgressReport()) {
+      throw new BadRequestException("Signing officials can only approve closeout progress reports.");
+    }
+
+    if (dataAccessRequest.getHasSOCloseoutApproval()) {
+      throw new BadRequestException("This progress report closeout has already been approved by a signing official.");
+    }
+
+    if (signingOfficial.getUserId().equals(dataAccessRequest.getData().getCloseoutSupplement().signingOfficialId())) {
+      throw new BadRequestException("This request can only be approved by the signing official selected in the closeout request.");
+    }
+
+    try {
+      User submitter = userService.findUserById(dataAccessRequest.getUserId());
+      if (!submitter.getInstitutionId().equals(signingOfficial.getInstitutionId())) {
+        throw new BadRequestException("Signing Officials must be in the same institution as the creator of the closeout request.");
+      }
+
+    } catch (NotFoundException e) {
+      // do nothing.  we'll allow the SO to process a closeout even if the  user can't be found.
+    }
+  }
+
   public void validateProgressReport(User user, DataAccessRequest progressReport, DataAccessRequest parentDar) {
     validateCommonDarAndProgressReportElements(user, progressReport);
     validateInternalCollaborators(user, progressReport);
@@ -320,7 +354,7 @@ public class DataAccessRequestService implements ConsentLogger {
   }
 
   @VisibleForTesting
-  public void validateInternalCollaborators(User user, DataAccessRequest progressReport) {
+  protected void validateInternalCollaborators(User user, DataAccessRequest progressReport) {
     List<String> errorSummary = getCollaboratorAndLibraryCardErrors(user, progressReport.getData());
 
     if (!errorSummary.isEmpty()) {

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
@@ -130,7 +130,7 @@ public class DataAccessRequestService implements ConsentLogger {
   public DataAccessRequest findByReferenceId(String referencedId) {
     DataAccessRequest dar = dataAccessRequestDAO.findByReferenceId(referencedId);
     if (Objects.isNull(dar)) {
-      throw new NotFoundException("There does not exist a DAR with the given reference Id");
+      throw new NotFoundException("No data access request found for this reference Id");
     }
     return dar;
   }
@@ -280,11 +280,10 @@ public class DataAccessRequestService implements ConsentLogger {
     return findByReferenceId(referenceId);
   }
 
-  public DataAccessRequest approveDataAccessRequestCloseout(User signingOfficial, DataAccessRequest dataAccessRequest) {
-    validateCloseoutApproval(signingOfficial, dataAccessRequest);
-    String referenceId = dataAccessRequest.getReferenceId();
+  public void approveDataAccessRequestCloseout(User signingOfficial, String referenceId) {
+    DataAccessRequest dar = dataAccessRequestDAO.findByReferenceId(referenceId);
+    validateCloseoutApproval(signingOfficial, dar);
     dataAccessRequestDAO.updateDarCloseoutSO(signingOfficial.getUserId(), referenceId);
-    return findByReferenceId(referenceId);
   }
 
   @VisibleForTesting

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
@@ -299,7 +299,7 @@ public class DataAccessRequestService implements ConsentLogger {
       throw new BadRequestException("This progress report closeout has already been approved by a signing official.");
     }
 
-    if (signingOfficial.getUserId().equals(dataAccessRequest.getData().getCloseoutSupplement().signingOfficialId())) {
+    if (!signingOfficial.getUserId().equals(dataAccessRequest.getData().getCloseoutSupplement().signingOfficialId())) {
       throw new BadRequestException("This request can only be approved by the signing official selected in the closeout request.");
     }
 

--- a/src/main/java/org/broadinstitute/consent/http/util/ComplianceLogger.java
+++ b/src/main/java/org/broadinstitute/consent/http/util/ComplianceLogger.java
@@ -22,7 +22,8 @@ public class ComplianceLogger implements ConsentLogger {
     DAR_SUBMISSION,
     DAR_APPROVAL,
     DAR_REJECTION,
-    DAR_CANCELLATION
+    DAR_CANCELLATION,
+    CLOSEOUT_SO_APPROVAL
   }
 
   private static final String MESSAGE = """
@@ -100,6 +101,11 @@ public class ComplianceLogger implements ConsentLogger {
   public static void logDARCancellation(User user, List<Dataset> datasets, ContainerRequest request,
       int responseStatusCode) {
     getInstance().logEvent(user, datasets, request, responseStatusCode, ComplianceEvent.DAR_CANCELLATION);
+  }
+
+  public static void logCloseoutApprovalBySigningOfficial(User user, List<Dataset> datasets,
+      ContainerRequest request, int responseStatusCode) {
+    getInstance().logEvent(user, datasets, request, responseStatusCode, ComplianceEvent.CLOSEOUT_SO_APPROVAL);
   }
 
 }

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -438,7 +438,8 @@ paths:
 
   /api/dar/v2/progress_report/{parentReferenceId}:
     $ref: './paths/progressReport.yaml'
-
+  /api/dar/approve_closeout/{referenceId}:
+    $ref: './paths/approveCloseoutBySigningOfficial.yaml'
   /api/dataset/v2:
     $ref: './paths/datasetV2.yaml'
   /api/dataset/v3:

--- a/src/main/resources/assets/paths/approveCloseoutBySigningOfficial.yaml
+++ b/src/main/resources/assets/paths/approveCloseoutBySigningOfficial.yaml
@@ -1,0 +1,19 @@
+put:
+  summary: Allows the signing official named in a closeout to approve the closeout.
+  tags:
+    - Data Access Request
+  parameters:
+    - name: referenceId
+      in: path
+      description: The reference Id of the closeout
+      required: true
+      schema:
+        type: string
+        format: uuid
+  responses:
+    200:
+      description: Approval recorded
+    400:
+      description: Error, consult response for details
+    401:
+      description: Unauthorized

--- a/src/main/resources/assets/schemas/DarCollectionSummary.yaml
+++ b/src/main/resources/assets/schemas/DarCollectionSummary.yaml
@@ -48,3 +48,9 @@ properties:
     description: Indicator true when the collection contains a progress report.
   closeoutSupplement:
     $ref: '../schemas/CloseOutSupplement.yaml'
+  closeoutSigningOfficialApprovedDate:
+    type: number
+    description: When the Signing Official approved the closeout, in milliseconds since the epoch.
+  closeoutSigningOfficialApprovedUserId:
+    type: number
+    description: The user ID of the Signing Official that approved the closeout.

--- a/src/main/resources/assets/schemas/DataAccessRequest.yaml
+++ b/src/main/resources/assets/schemas/DataAccessRequest.yaml
@@ -19,6 +19,12 @@ properties:
   updateDate:
     type: number
     description: Update Date
+  closeoutSigningOfficialApprovedDate:
+    type: number
+    description: When the Signing Official approved the closeout, in milliseconds since the epoch.
+  closeoutSigningOfficialApprovedUserId:
+    type: number
+    description: The user ID of the Signing Official that approved the closeout.
   draft:
     type: boolean
     description: Draft status of this DAR

--- a/src/main/resources/changelog-master.xml
+++ b/src/main/resources/changelog-master.xml
@@ -182,4 +182,6 @@
     relativeToChangelogFile="true" />
   <include file="changesets/changelog-consent-2025-23-unique-lc-user.xml"
     relativeToChangelogFile="true" />
+  <include file="changesets/changelog-consent-2025-06-05-save-so-closeout-approval.xml"
+    relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/changesets/changelog-consent-2025-06-05-save-so-closeout-approval.xml
+++ b/src/main/resources/changesets/changelog-consent-2025-06-05-save-so-closeout-approval.xml
@@ -1,0 +1,12 @@
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+  <changeSet id="changelog-consent-2025-06-05-save-so-closeout-approval" author="otchet-broad">
+    <addColumn tableName="data_access_request">
+      <column name="closeout_approving_so_id" type="bigint">
+        <constraints foreignKeyName="fk_so_user_id" referencedTableName="users" referencedColumnNames="user_id" nullable="true"/>
+      </column>
+      <column name="closeout_so_approval_timestamp" type="timestamp"/>
+    </addColumn>
+  </changeSet>
+</databaseChangeLog>

--- a/src/test/java/org/broadinstitute/consent/http/db/DarCollectionSummaryDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DarCollectionSummaryDAOTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.sql.Timestamp;
+import java.time.Instant;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -296,6 +297,8 @@ class DarCollectionSummaryDAOTest extends DAOTestHelper {
     assertNotNull(summaries);
     assertEquals(1, summaries.size());
     assertEquals(collectionOneId, summaries.get(0).getDarCollectionId());
+    assertNull(summaries.get(0).getCloseoutSigningOfficialApprovalDate());
+    assertNull(summaries.get(0).getCloseoutSigningOfficialApprovalId());
   }
 
   @Test
@@ -312,7 +315,9 @@ class DarCollectionSummaryDAOTest extends DAOTestHelper {
     Integer collectionOneId = createDarCollection(userOneId);
     Integer collectionTwoId = createDarCollection(userTwoId);
     DataAccessRequest darOne = createDataAccessRequest(collectionOneId, userOneId);
+    dataAccessRequestDAO.updateDarCloseoutSO(userOneId, darOne.getReferenceId());
     DataAccessRequest darTwo = createDataAccessRequest(collectionTwoId, userTwoId);
+    dataAccessRequestDAO.updateDarCloseoutSO(userOneId, darTwo.getReferenceId());
 
     dataAccessRequestDAO.insertDARDatasetRelation(darOne.getReferenceId(), dataset.getDatasetId());
     dataAccessRequestDAO.insertDARDatasetRelation(darTwo.getReferenceId(),
@@ -344,6 +349,8 @@ class DarCollectionSummaryDAOTest extends DAOTestHelper {
       Integer electionId = collectionOneElection.getElectionId();
       s.getElections().forEach((key, value) -> assertEquals(electionId, key));
       assertEquals(1, s.getDatasetCount());
+      assertEquals(userOneId, s.getCloseoutSigningOfficialApprovalId());
+      assertNotNull(s.getCloseoutSigningOfficialApprovalDate());
     });
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/db/DarCollectionSummaryDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DarCollectionSummaryDAOTest.java
@@ -7,7 +7,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.sql.Timestamp;
-import java.time.Instant;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;

--- a/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
@@ -1116,6 +1116,23 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
     assertEquals(2, expiredDars.size());
   }
 
+  @Test
+  void testMarkSOApprovalOfCloseout() {
+    User user = createUserWithInstitution();
+    User signingOfficial = createUserWithInstitution();
+    Dataset dataset = createDataset(user.getUserId());
+    Integer collection = createDarCollection(user.getUserId());
+    DataAccessRequest darToStore = createDataAccessRequest(collection, user.getUserId(),
+        Date.from(Instant.now()));
+    dataAccessRequestDAO.insertDARDatasetRelation(darToStore.getReferenceId(), dataset.getDatasetId());
+    dataAccessRequestDAO.updateDarCloseoutSO(signingOfficial.getUserId(), darToStore.getReferenceId());
+
+    DataAccessRequest dar = dataAccessRequestDAO.findByReferenceId(darToStore.getReferenceId());
+
+    assertEquals(dar.getCloseoutSigningOfficialApprovedUserId(), signingOfficial.getUserId());
+    assertNotNull(dar.getCloseoutSigningOfficialApprovedDate());
+  }
+
   /**
    * Replace parent implementation of `createDataset()`
    *

--- a/src/test/java/org/broadinstitute/consent/http/models/DataAccessRequestTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/DataAccessRequestTest.java
@@ -2,6 +2,8 @@ package org.broadinstitute.consent.http.models;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.sql.Timestamp;
+import java.time.Instant;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
@@ -69,6 +71,46 @@ class DataAccessRequestTest {
     assertTrue(newData.getDSAcknowledgement());
     assertTrue(newData.getGSOAcknowledgement());
     assertNull(newData.getPubAcknowledgement());
+  }
+
+  @Test
+  void testIsCloseoutProgressReport_False() {
+    DataAccessRequest dar = new DataAccessRequest();
+    assertFalse(dar.getIsCloseoutProgressReport());
+  }
+
+  @Test
+  void testIsCloseoutProgressReport_FalseWithoutData() {
+    DataAccessRequest dar = new DataAccessRequest();
+    dar.setSubmissionDate(Timestamp.from(Instant.now()));
+    dar.setParentId(1);
+    assertFalse(dar.getIsCloseoutProgressReport());
+  }
+
+  @Test
+  void testIsCloseoutProgressReport_True() {
+    DataAccessRequest dar = new DataAccessRequest();
+    DataAccessRequestData darData = new DataAccessRequestData();
+    CloseoutSupplement supplement = new CloseoutSupplement(List.of("yes"), "", 1);
+    darData.setCloseoutSupplement(supplement);
+    dar.setData(darData);
+    dar.setSubmissionDate(Timestamp.from(Instant.now()));
+    dar.setParentId(1);
+    assertTrue(dar.getIsCloseoutProgressReport());
+  }
+
+  @Test
+  void testGetHasCloseoutApproval_False() {
+    DataAccessRequest dar = new DataAccessRequest();
+    assertFalse(dar.getHasSOCloseoutApproval());
+  }
+
+  @Test
+  void testGetHasCloseoutApproval_True() {
+    DataAccessRequest dar = new DataAccessRequest();
+    dar.setCloseoutSigningOfficialApprovedUserId(1);
+    dar.setCloseoutSigningOfficialApprovedDate(Timestamp.from(Instant.now()));
+    assertTrue(dar.getHasSOCloseoutApproval());
   }
 
 }

--- a/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceTest.java
@@ -50,6 +50,7 @@ import org.broadinstitute.consent.http.models.DataAccessRequestData;
 import org.broadinstitute.consent.http.models.DataUse;
 import org.broadinstitute.consent.http.models.DataUseBuilder;
 import org.broadinstitute.consent.http.models.Dataset;
+import org.broadinstitute.consent.http.models.DuosUser;
 import org.broadinstitute.consent.http.models.LibraryCard;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.UserRole;
@@ -85,6 +86,7 @@ class DataAccessRequestResourceTest extends AbstractTestHelper {
       UserRoles.Chairperson());
   private final List<UserRole> memberRoles = Collections.singletonList(UserRoles.Member());
   private final User user = new User(1, authUser.getEmail(), "Display Name", new Date(), roles);
+  private final DuosUser duosUser = new DuosUser(authUser, user);
   private final User admin = new User(2, adminUser.getEmail(), "Admin user", new Date(),
       adminRoles);
   private final User chairperson = new User(3, chairpersonUser.getEmail(), "Chairperson user",
@@ -1006,11 +1008,10 @@ class DataAccessRequestResourceTest extends AbstractTestHelper {
   @Test
   void testApproveCloseout() {
     String referenceId = UUID.randomUUID().toString();
-    when(userService.findUserByEmail(authUser.getEmail())).thenReturn(user);
     doNothing().when(dataAccessRequestService).approveDataAccessRequestCloseout(user,referenceId);
     when(dataAccessRequestService.findByReferenceId(referenceId)).thenReturn(new DataAccessRequest());
     when(datasetService.findDatasetsByIds(any())).thenReturn(List.of());
-    try (Response response = resource.approveCloseout(authUser,request, referenceId)) {
+    try (Response response = resource.approveCloseout(duosUser, request, referenceId)) {
       assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
     }
   }
@@ -1018,9 +1019,8 @@ class DataAccessRequestResourceTest extends AbstractTestHelper {
   @Test
   void testApproveCloseoutThrows() {
     String referenceId = UUID.randomUUID().toString();
-    when(userService.findUserByEmail(authUser.getEmail())).thenReturn(user);
     doThrow(BadRequestException.class).when(dataAccessRequestService).approveDataAccessRequestCloseout(user,referenceId);
-    try (Response response = resource.approveCloseout(authUser, request, referenceId)) {
+    try (Response response = resource.approveCloseout(duosUser, request, referenceId)) {
       assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
     }
   }

--- a/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceTest.java
@@ -1008,7 +1008,9 @@ class DataAccessRequestResourceTest extends AbstractTestHelper {
     String referenceId = UUID.randomUUID().toString();
     when(userService.findUserByEmail(authUser.getEmail())).thenReturn(user);
     doNothing().when(dataAccessRequestService).approveDataAccessRequestCloseout(user,referenceId);
-    try (Response response = resource.approveCloseout(authUser, referenceId)) {
+    when(dataAccessRequestService.findByReferenceId(referenceId)).thenReturn(new DataAccessRequest());
+    when(datasetService.findDatasetsByIds(any())).thenReturn(List.of());
+    try (Response response = resource.approveCloseout(authUser,request, referenceId)) {
       assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
     }
   }
@@ -1018,7 +1020,7 @@ class DataAccessRequestResourceTest extends AbstractTestHelper {
     String referenceId = UUID.randomUUID().toString();
     when(userService.findUserByEmail(authUser.getEmail())).thenReturn(user);
     doThrow(BadRequestException.class).when(dataAccessRequestService).approveDataAccessRequestCloseout(user,referenceId);
-    try (Response response = resource.approveCloseout(authUser, referenceId)) {
+    try (Response response = resource.approveCloseout(authUser, request, referenceId)) {
       assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
     }
   }

--- a/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceTest.java
@@ -1003,4 +1003,23 @@ class DataAccessRequestResourceTest extends AbstractTestHelper {
     }
   }
 
+  @Test
+  void testApproveCloseout() {
+    String referenceId = UUID.randomUUID().toString();
+    when(userService.findUserByEmail(authUser.getEmail())).thenReturn(user);
+    doNothing().when(dataAccessRequestService).approveDataAccessRequestCloseout(user,referenceId);
+    try (Response response = resource.approveCloseout(authUser, referenceId)) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+    }
+  }
+
+  @Test
+  void testApproveCloseoutThrows() {
+    String referenceId = UUID.randomUUID().toString();
+    when(userService.findUserByEmail(authUser.getEmail())).thenReturn(user);
+    doThrow(BadRequestException.class).when(dataAccessRequestService).approveDataAccessRequestCloseout(user,referenceId);
+    try (Response response = resource.approveCloseout(authUser, referenceId)) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
+    }
+  }
 }

--- a/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
@@ -1225,23 +1225,34 @@ institution or library cards issued: Internal Collaborator member:  \
 
   @Test
   void testValidateCloseoutApproval(){
-    User actor = new User();
-    actor.setUserId(123);
-    actor.setInstitutionId(1);
-    User darSubmitter = new User();
-    darSubmitter.setUserId(124);
-    darSubmitter.setInstitutionId(1);
-    DataAccessRequest dar = new DataAccessRequest();
-    dar.setUserId(darSubmitter.getUserId());
-    dar.setSubmissionDate(Timestamp.from(Instant.now()));
-    dar.setParentId(1);
+    CloseoutWithUserAndSigningOfficialApproval closeout = new CloseoutWithUserAndSigningOfficialApproval();
 
-    DataAccessRequestData data =  new DataAccessRequestData();
-    data.setCloseoutSupplement(new CloseoutSupplement(List.of(""), "", actor.getUserId()));
-    dar.setData(data);
+    when(userService.findUserById(closeout.submitter.getUserId())).thenReturn(closeout.submitter);
+    assertDoesNotThrow(()->service.validateCloseoutApproval(closeout.actor, closeout.dar));
+  }
 
-    when(userService.findUserById(darSubmitter.getUserId())).thenReturn(darSubmitter);
-    assertDoesNotThrow(()->service.validateCloseoutApproval(actor, dar));
+  @Test
+  void approveDataAccessRequest() {
+    CloseoutWithUserAndSigningOfficialApproval closeout = new CloseoutWithUserAndSigningOfficialApproval();
+    when(userService.findUserById(closeout.submitter.getUserId())).thenReturn(closeout.submitter);
+    when(dataAccessRequestDAO.findByReferenceId(closeout.dar.referenceId)).thenReturn(closeout.dar);
+    assertDoesNotThrow(()->service.approveDataAccessRequestCloseout(closeout.actor, closeout.dar.getReferenceId()));
+  }
+
+  record  CloseoutWithUserAndSigningOfficialApproval(User actor, User submitter, DataAccessRequest dar) {
+    public CloseoutWithUserAndSigningOfficialApproval() {
+      this(new User(), new User(),  new DataAccessRequest());
+      actor.setUserId(123);
+      actor.setInstitutionId(1);
+      submitter.setUserId(124);
+      submitter.setInstitutionId(1);
+      dar.setUserId(submitter.getUserId());
+      dar.setSubmissionDate(Timestamp.from(Instant.now()));
+      dar.setParentId(1);
+      DataAccessRequestData data =  new DataAccessRequestData();
+      data.setCloseoutSupplement(new CloseoutSupplement(List.of(""), "", actor.getUserId()));
+      dar.setData(data);
+    }
   }
 
   private DataAccessRequest getMockedDar(String darCode, String referenceId, User user) {

--- a/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
@@ -1172,11 +1172,76 @@ institution or library cards issued: Internal Collaborator member:  \
     dar.setCloseoutSigningOfficialApprovedDate(Timestamp.from(Instant.now()));
     dar.setCloseoutSigningOfficialApprovedUserId(1);
     DataAccessRequestData data =  new DataAccessRequestData();
-    data.setCloseoutSupplement(new CloseoutSupplement(List.of("foo"), "", 1));
+    data.setCloseoutSupplement(new CloseoutSupplement(List.of(""), "", 1));
     dar.setData(data);
 
     BadRequestException exception = assertThrows(BadRequestException.class, ()->service.validateCloseoutApproval(user, dar));
     assertThat(exception.getMessage(), containsString("This progress report closeout has already been approved by a signing official."));
+  }
+
+  @Test
+  void testValidateCloseoutApproval_NotTheSelectedSigningOfficial(){
+    User user = new User();
+    user.setUserId(123);
+    DataAccessRequest dar = new DataAccessRequest();
+    dar.setSubmissionDate(Timestamp.from(Instant.now()));
+    dar.setParentId(1);
+
+    DataAccessRequestData data =  new DataAccessRequestData();
+    data.setCloseoutSupplement(new CloseoutSupplement(List.of(""), "", 1));
+    dar.setData(data);
+
+    BadRequestException exception = assertThrows(BadRequestException.class, ()->service.validateCloseoutApproval(user, dar));
+    assertThat(
+        exception.getMessage(),
+        containsString(
+           "This request can only be approved by the signing official selected in the closeout request."));
+  }
+
+  @Test
+  void testValidateCloseoutApproval_NotInSameInstitution(){
+    User actor = new User();
+    actor.setUserId(123);
+    actor.setInstitutionId(1);
+    User darSubmitter = new User();
+    darSubmitter.setUserId(124);
+    darSubmitter.setInstitutionId(2);
+    DataAccessRequest dar = new DataAccessRequest();
+    dar.setUserId(darSubmitter.getUserId());
+    dar.setSubmissionDate(Timestamp.from(Instant.now()));
+    dar.setParentId(1);
+
+    DataAccessRequestData data =  new DataAccessRequestData();
+    data.setCloseoutSupplement(new CloseoutSupplement(List.of(""), "", actor.getUserId()));
+    dar.setData(data);
+
+    when(userService.findUserById(darSubmitter.getUserId())).thenReturn(darSubmitter);
+    BadRequestException exception = assertThrows(BadRequestException.class, ()->service.validateCloseoutApproval(actor, dar));
+    assertThat(
+        exception.getMessage(),
+        containsString(
+            "Signing Officials must be in the same institution as the creator of the closeout request."));
+  }
+
+  @Test
+  void testValidateCloseoutApproval(){
+    User actor = new User();
+    actor.setUserId(123);
+    actor.setInstitutionId(1);
+    User darSubmitter = new User();
+    darSubmitter.setUserId(124);
+    darSubmitter.setInstitutionId(1);
+    DataAccessRequest dar = new DataAccessRequest();
+    dar.setUserId(darSubmitter.getUserId());
+    dar.setSubmissionDate(Timestamp.from(Instant.now()));
+    dar.setParentId(1);
+
+    DataAccessRequestData data =  new DataAccessRequestData();
+    data.setCloseoutSupplement(new CloseoutSupplement(List.of(""), "", actor.getUserId()));
+    dar.setData(data);
+
+    when(userService.findUserById(darSubmitter.getUserId())).thenReturn(darSubmitter);
+    assertDoesNotThrow(()->service.validateCloseoutApproval(actor, dar));
   }
 
   private DataAccessRequest getMockedDar(String darCode, String referenceId, User user) {

--- a/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
@@ -50,6 +50,7 @@ import org.broadinstitute.consent.http.enumeration.ElectionType;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.exceptions.NIHComplianceRuleException;
 import org.broadinstitute.consent.http.exceptions.SubmittedDARCannotBeEditedException;
+import org.broadinstitute.consent.http.models.CloseoutSupplement;
 import org.broadinstitute.consent.http.models.Collaborator;
 import org.broadinstitute.consent.http.models.DarCollection;
 import org.broadinstitute.consent.http.models.DarDataset;
@@ -1149,6 +1150,33 @@ institution or library cards issued: Internal Collaborator member:  \
     assertDoesNotThrow(()->service.sendExpirationNotices());
 
     assertEquals(2, listAppender.list.size());
+  }
+
+  @Test
+  void testValidateCloseoutApproval_NonCloseout(){
+    User user = new User();
+    user.setUserId(123);
+    DataAccessRequest dar = new DataAccessRequest();
+    BadRequestException exception = assertThrows(BadRequestException.class, ()->service.validateCloseoutApproval(user, dar));
+    assertThat(exception.getMessage(), containsString("Signing officials can only approve closeout progress reports."));
+  }
+
+
+  @Test
+  void testValidateCloseoutApproval_AlreadyApproved(){
+    User user = new User();
+    user.setUserId(123);
+    DataAccessRequest dar = new DataAccessRequest();
+    dar.setSubmissionDate(Timestamp.from(Instant.now()));
+    dar.setParentId(1);
+    dar.setCloseoutSigningOfficialApprovedDate(Timestamp.from(Instant.now()));
+    dar.setCloseoutSigningOfficialApprovedUserId(1);
+    DataAccessRequestData data =  new DataAccessRequestData();
+    data.setCloseoutSupplement(new CloseoutSupplement(List.of("foo"), "", 1));
+    dar.setData(data);
+
+    BadRequestException exception = assertThrows(BadRequestException.class, ()->service.validateCloseoutApproval(user, dar));
+    assertThat(exception.getMessage(), containsString("This progress report closeout has already been approved by a signing official."));
   }
 
   private DataAccessRequest getMockedDar(String darCode, String referenceId, User user) {

--- a/src/test/java/org/broadinstitute/consent/http/util/ComplianceLoggerTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/util/ComplianceLoggerTest.java
@@ -107,6 +107,15 @@ class ComplianceLoggerTest extends AbstractTestHelper {
     assertThat(event.getFormattedMessage(), containsString(ComplianceEvent.DAR_CANCELLATION.toString()));
   }
 
+  @Test
+  void testLogSOCloseoutApproval() {
+    ComplianceLogger.logCloseoutApprovalBySigningOfficial(user, List.of(dataset), request, HttpStatusCodes.STATUS_CODE_OK);
+    assertEquals(1, testAppender.getSize());
+    ILoggingEvent event = testAppender.getLoggedEvents().get(0);
+    assertMessageContainsValueFields(event);
+    assertThat(event.getFormattedMessage(), containsString(ComplianceEvent.CLOSEOUT_SO_APPROVAL.toString()));
+  }
+
   private static class TestAppender extends ListAppender<ILoggingEvent> {
     public void reset() {
       this.list.clear();


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-1785](https://broadworkbench.atlassian.net/browse/DT-1785)

### Summary

Adds new Resource endpoint and swagger documentation to enable SO to record approvals on a Closeout Progress Report
Adds business logic to enforce closeout approval business rules needed by the flow
Adds Compliance logging for the action
Modifies the database schema for data_access_request to store the SO and when they approved the closeout
Updates existing queries and objects needed to return the information on DARs, Dar Collections, Dar Collection Summaries
Adds test coverage for the feature.

Does not alter the metrics query at this time because that query seems like it might have specific requirements that aren't currently captured.

![image](https://github.com/user-attachments/assets/bdfa6960-10b6-4a6f-bbd0-ec99a4c6a185)


----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
