### PR TITLE
DT-1805: Update bean utils to latest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -743,6 +743,19 @@
       <groupId>commons-validator</groupId>
       <artifactId>commons-validator</artifactId>
       <version>1.9.0</version>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-beanutils</groupId>
+          <artifactId>commons-beanutils-core</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <!-- https://mvnrepository.com/artifact/commons-beanutils/commons-beanutils -->
+    <dependency>
+      <groupId>commons-beanutils</groupId>
+      <artifactId>commons-beanutils</artifactId>
+      <version>1.11.0</version>
     </dependency>
 
     <!-- https://mvnrepository.com/artifact/com.cloudbees.thirdparty/zendesk-java-client -->


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DT-1805

## Summary
Address security warning for apache bean utils

### Testing
Run 
```
mvn clean dependency::tree -Dverbose=true
```
and you'll see that the vulnerable library (`1.9.4`) is omitted due to the inclusion of the non-vulnerable version (`1.11.0`).

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
