### PR TITLE
DT-1787: Filter closeouts from DAR and Dataset approval queries

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/DataAccessRequestDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DataAccessRequestDAO.java
@@ -62,33 +62,37 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
    * @return List of approved DARs for the dataset
    */
   @UseRowReducer(DataAccessRequestReducer.class)
-  @SqlQuery(
-      """
-              SELECT dar.id, dar.reference_id, dar.collection_id, dar.parent_id,
-                dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date,
-                (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data,
-                dd.dataset_id, collection.dar_code, dar.era_commons_id
-              FROM data_access_request dar
-              LEFT JOIN dar_collection collection on collection.collection_id = dar.collection_id
-              INNER JOIN dar_dataset dd ON dd.reference_id = dar.reference_id AND dd.dataset_id = :datasetId
-              INNER JOIN (
-                SELECT DISTINCT e.reference_id, LAST_VALUE(v.vote)
-                OVER(
-                  PARTITION BY e.reference_id
-                    ORDER BY v.createdate
-                    RANGE BETWEEN
-                      UNBOUNDED PRECEDING AND
-                      UNBOUNDED FOLLOWING
-                ) last_vote
-                FROM election e
-                INNER JOIN vote v ON e.election_id = v.electionid AND v.vote IS NOT NULL
-                WHERE e.dataset_id = :datasetId
-                AND LOWER(e.election_type) = 'dataaccess'
-                AND LOWER(v.type) = 'final') final_access_vote ON final_access_vote.reference_id = dar.reference_id
-              WHERE dar.submission_date > now() - interval '1 year'
-              AND final_access_vote.last_vote = TRUE
-              AND (LOWER(dar.data->>'status') != 'archived' OR dar.data->>'status' IS NULL)
-          """)
+  @SqlQuery("""
+      SELECT dar.id, dar.reference_id, dar.collection_id, dar.parent_id,
+        dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date,
+        (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data,
+        dd.dataset_id, collection.dar_code, dar.era_commons_id
+      FROM data_access_request dar
+      LEFT JOIN dar_collection collection on collection.collection_id = dar.collection_id
+      INNER JOIN dar_dataset dd ON dd.reference_id = dar.reference_id AND dd.dataset_id = :datasetId
+      INNER JOIN (
+        SELECT DISTINCT e.reference_id, LAST_VALUE(v.vote)
+        OVER(
+          PARTITION BY e.reference_id
+            ORDER BY v.createdate
+            RANGE BETWEEN
+              UNBOUNDED PRECEDING AND
+              UNBOUNDED FOLLOWING
+        ) last_vote
+        FROM election e
+        INNER JOIN vote v ON e.election_id = v.electionid AND v.vote IS NOT NULL
+        WHERE e.dataset_id = :datasetId
+        AND LOWER(e.election_type) = 'dataaccess'
+        AND LOWER(v.type) = 'final') final_access_vote ON final_access_vote.reference_id = dar.reference_id
+      WHERE dar.submission_date > now() - interval '1 year'
+      AND final_access_vote.last_vote = TRUE
+      AND (LOWER(dar.data->>'status') != 'archived' OR dar.data->>'status' IS NULL)
+      -- Exclude DARs that have a closeoutSupplement
+      AND dar.collection_id NOT IN (
+        SELECT DISTINCT collection_id
+        FROM data_access_request
+        WHERE (regexp_replace(data #>> '{}', '\\\\u0000', '', 'g'))::jsonb ->> 'closeoutSupplement' IS NOT NULL)
+      """)
   List<DataAccessRequest> findApprovedDARsByDatasetId(@Bind("datasetId") Integer datasetId);
 
   /**
@@ -129,6 +133,11 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
       WHERE final_access_vote.last_vote = TRUE
         AND dar.reference_id = :darReferenceId
         AND (LOWER(dar.data->>'status') != 'archived' OR dar.data->>'status' IS NULL)
+        -- Exclude DARs that have a closeoutSupplement
+        AND dar.collection_id NOT IN (
+          SELECT DISTINCT collection_id
+          FROM data_access_request
+          WHERE (regexp_replace(data #>> '{}', '\\\\u0000', '', 'g'))::jsonb ->> 'closeoutSupplement' IS NOT NULL)
       """)
   Set<Integer> findDatasetApprovalsByDar(@Bind("darReferenceId") String darReferenceId);
 

--- a/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
@@ -766,7 +766,7 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
         randomAlphabetic(10)
     );
 
-    // Ensure that we do NOT get the dataset from either the parent DAR
+    // Ensure that we do NOT get the dataset from the parent DAR
     Set<Integer> noApprovedDatasetIds1 = dataAccessRequestDAO.findDatasetApprovalsByDar(
         parentDAR.getReferenceId());
     assertTrue(noApprovedDatasetIds1.isEmpty(),

--- a/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
@@ -909,7 +909,6 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
     // Ensure we can find the parent DAR for the approved dataset
     List<DataAccessRequest> approvedDARs = dataAccessRequestDAO.findApprovedDARsByDatasetId(
         dataset.getDatasetId());
-    assertFalse(approvedDARs.isEmpty());
     assertEquals(1, approvedDARs.size());
     assertEquals(parentDAR.getReferenceId(), approvedDARs.get(0).getReferenceId());
 
@@ -930,9 +929,9 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
     );
 
     // Ensure we CANNOT find any DARs for the approved dataset
-    List<DataAccessRequest> nonApprovedDARs = dataAccessRequestDAO.findApprovedDARsByDatasetId(
+    List<DataAccessRequest> noApprovedDARs = dataAccessRequestDAO.findApprovedDARsByDatasetId(
         dataset.getDatasetId());
-    assertTrue(nonApprovedDARs.isEmpty());
+    assertTrue(noApprovedDARs.isEmpty());
   }
 
   // findAllDraftDataAccessRequests should exclude archived DARs

--- a/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
@@ -166,7 +166,7 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
         new Date(), dar.getData(), randomAlphabetic(10));
     dar = dataAccessRequestDAO.findByReferenceId(dar.getReferenceId());
     assertNull(dar.getSubmissionDate());
-    assertEquals(true, dar.getDraft());
+    assertTrue(dar.getDraft());
     assertFalse(dar.getExpired());
     assertNull(dar.getExpiresAt());
   }
@@ -180,7 +180,7 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
         new Date(),
         new Date(), dar.getData(), randomAlphabetic(10));
     dar = dataAccessRequestDAO.findByReferenceId(dar.getReferenceId());
-    assertEquals(false, dar.getDraft());
+    assertFalse(dar.getDraft());
     assertFalse(dar.getExpired());
     Timestamp expectedTimestamp = new Timestamp(
         dar.getSubmissionDate().getTime() + DataAccessRequest.EXPIRATION_DURATION_MILLIS);
@@ -193,11 +193,11 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
     DataAccessRequest dar = new ArrayList<>(darColl.getDars().values()).get(0);
 
     dar = dataAccessRequestDAO.findByReferenceId(dar.getReferenceId());
-    assertEquals(false, dar.getDraft());
+    assertFalse(dar.getDraft());
     dataAccessRequestDAO.updateDataByReferenceId(dar.referenceId, dar.userId, new Date(), null,
         new Date(), dar.getData(), randomAlphabetic(10));
     dar = dataAccessRequestDAO.findByReferenceId(dar.getReferenceId());
-    assertEquals(true, dar.getDraft());
+    assertTrue(dar.getDraft());
     assertNull(dar.getSubmissionDate());
     assertFalse(dar.getExpired());
     assertNull(dar.getExpiresAt());
@@ -375,7 +375,7 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
     Integer collectionId = collection.getDarCollectionId();
     dataAccessRequestDAO.updateDraftToSubmittedForCollection(collectionId, referenceId);
     DataAccessRequest updatedDraft = dataAccessRequestDAO.findByReferenceId(referenceId);
-    assertEquals(false, updatedDraft.getDraft());
+    assertFalse(updatedDraft.getDraft());
     assertEquals(collectionId, updatedDraft.getCollectionId());
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
@@ -24,6 +24,7 @@ import org.broadinstitute.consent.http.enumeration.ElectionStatus;
 import org.broadinstitute.consent.http.enumeration.ElectionType;
 import org.broadinstitute.consent.http.enumeration.EmailType;
 import org.broadinstitute.consent.http.enumeration.VoteType;
+import org.broadinstitute.consent.http.models.CloseoutSupplement;
 import org.broadinstitute.consent.http.models.DarCollection;
 import org.broadinstitute.consent.http.models.DataAccessRequest;
 import org.broadinstitute.consent.http.models.DataAccessRequestData;
@@ -717,6 +718,65 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
         testDar1.getReferenceId());
     assertEquals(1, approvedDatasetIds.size());
     assertTrue(approvedDatasetIds.contains(dataset1.getDatasetId()));
+  }
+
+  @Test
+  void testFindDatasetApprovalsByDAR_ExcludeCloseouts() {
+    // Create a dar collection
+    User user = createUserWithInstitution();
+    String darCode = "DAR-" + randomInt(1, 10000);
+    Integer collectionId = darCollectionDAO.insertDarCollection(darCode, user.getUserId(),
+        new Date());
+
+    // Create an approved DAR on a dataset
+    Dataset dataset = createDataset();
+    DataAccessRequest parentDAR = createDataAccessRequest(user.getUserId(), collectionId);
+    dataAccessRequestDAO.insertDARDatasetRelation(parentDAR.getReferenceId(),
+        dataset.getDatasetId());
+    Election election = createDataAccessElection(parentDAR.getReferenceId(),
+        dataset.getDatasetId());
+    Vote vote = createFinalVote(dataset.getCreateUserId(), election.getElectionId());
+    Date now = new Date();
+    voteDAO.updateVote(true,
+        "",
+        now,
+        vote.getVoteId(),
+        false,
+        election.getElectionId(),
+        now,
+        false);
+    // Ensure we can find the approved dataset for the parent DAR
+    Set<Integer> approvedDatasetIds = dataAccessRequestDAO.findDatasetApprovalsByDar(
+        parentDAR.getReferenceId());
+    assertTrue(approvedDatasetIds.contains(dataset.getDatasetId()));
+
+    // Create a closeout DAR for the parent DAR
+    DataAccessRequest closeoutDAR = createProgressReport(user.getUserId(), collectionId,
+        parentDAR.getId());
+    CloseoutSupplement closeout = new CloseoutSupplement(List.of("Reason"), "Other Reason",
+        user.getUserId());
+    closeoutDAR.getData().setCloseoutSupplement(closeout);
+    dataAccessRequestDAO.updateDataByReferenceId(
+        closeoutDAR.getReferenceId(),
+        user.getUserId(),
+        now,
+        now,
+        now,
+        closeoutDAR.getData(),
+        randomAlphabetic(10)
+    );
+
+    // Ensure that we do NOT get the dataset from either the parent DAR
+    Set<Integer> noApprovedDatasetIds1 = dataAccessRequestDAO.findDatasetApprovalsByDar(
+        parentDAR.getReferenceId());
+    assertTrue(noApprovedDatasetIds1.isEmpty(),
+        "Parent DAR should not be included in dataset approvals");
+
+    // Ensure that we do NOT get the dataset from the closeout DAR
+    Set<Integer> noApprovedDatasetIds2 = dataAccessRequestDAO.findDatasetApprovalsByDar(
+        closeoutDAR.getReferenceId());
+    assertTrue(noApprovedDatasetIds2.isEmpty(),
+        "Closeout DAR should not be included in dataset approvals");
   }
 
   /**

--- a/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
@@ -881,6 +881,60 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
             .size());
   }
 
+  @Test
+  void testFindApprovedDARsByDatasetId_ExcludeCloseouts() {
+    // Create a dar collection
+    User user = createUserWithInstitution();
+    String darCode = "DAR-" + randomInt(1, 10000);
+    Integer collectionId = darCollectionDAO.insertDarCollection(darCode, user.getUserId(),
+        new Date());
+
+    // Create an approved DAR on a dataset
+    Dataset dataset = createDataset();
+    DataAccessRequest parentDAR = createDataAccessRequest(user.getUserId(), collectionId);
+    dataAccessRequestDAO.insertDARDatasetRelation(parentDAR.getReferenceId(),
+        dataset.getDatasetId());
+    Election election = createDataAccessElection(parentDAR.getReferenceId(),
+        dataset.getDatasetId());
+    Vote vote = createFinalVote(dataset.getCreateUserId(), election.getElectionId());
+    Date now = new Date();
+    voteDAO.updateVote(true,
+        "",
+        now,
+        vote.getVoteId(),
+        false,
+        election.getElectionId(),
+        now,
+        false);
+    // Ensure we can find the parent DAR for the approved dataset
+    List<DataAccessRequest> approvedDARs = dataAccessRequestDAO.findApprovedDARsByDatasetId(
+        dataset.getDatasetId());
+    assertFalse(approvedDARs.isEmpty());
+    assertEquals(1, approvedDARs.size());
+    assertEquals(parentDAR.getReferenceId(), approvedDARs.get(0).getReferenceId());
+
+    // Create a closeout DAR from the parent DAR
+    DataAccessRequest closeoutDAR = createProgressReport(user.getUserId(), collectionId,
+        parentDAR.getId());
+    CloseoutSupplement closeout = new CloseoutSupplement(List.of("Reason"), "Other Reason",
+        user.getUserId());
+    closeoutDAR.getData().setCloseoutSupplement(closeout);
+    dataAccessRequestDAO.updateDataByReferenceId(
+        closeoutDAR.getReferenceId(),
+        user.getUserId(),
+        now,
+        now,
+        now,
+        closeoutDAR.getData(),
+        randomAlphabetic(10)
+    );
+
+    // Ensure we CANNOT find any DARs for the approved dataset
+    List<DataAccessRequest> nonApprovedDARs = dataAccessRequestDAO.findApprovedDARsByDatasetId(
+        dataset.getDatasetId());
+    assertTrue(nonApprovedDARs.isEmpty());
+  }
+
   // findAllDraftDataAccessRequests should exclude archived DARs
   @Test
   void testFindAllDraftsArchived() {


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-1787

### Summary
Please hide whitespace to minimize the sql changes.

Filters all Closeout DARs from two queries that govern approvals

1. `findApprovedDARsByDatasetId`: Ensures that DAR approvals for a Dataset do NOT have any form of a closeout
2. `findDatasetApprovalsByDar`: Looking for Dataset approvals, ensures that there are no closeouts on any other DAR in the collection of the queried DAR.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
