### PR TITLE
[DT-1771] Send Chair notifications after SO approval

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/service/DacService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DacService.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.broadinstitute.consent.http.db.DacDAO;
 import org.broadinstitute.consent.http.db.DataAccessRequestDAO;
@@ -290,6 +291,10 @@ public class DacService implements ConsentLogger {
       }
     }
     return Collections.emptyList();
+  }
+
+  public Set<Dac> findByDatasetId(List<Integer> datasetIds) {
+    return dacDAO.findDacsForDatasetIds(datasetIds);
   }
 
 }

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
@@ -297,7 +297,7 @@ public class DataAccessRequestService implements ConsentLogger {
                 chairperson,
                 dar.getDarCode(),
                 dar.getReferenceId(),
-                serverUrl + "progress_report_application/%d".formatted(dar.getCollectionId()));
+                serverUrl + "dar_application_review/%d".formatted(dar.getCollectionId()));
           } catch (Exception e) {
             logWarn("Unable to send close out message for Data Access Request " + referenceId, e);
           }

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
@@ -16,11 +16,13 @@ import java.time.LocalTime;
 import java.time.ZoneOffset;
 import java.util.Collection;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import org.apache.commons.validator.routines.EmailValidator;
+import org.bouncycastle.jcajce.provider.asymmetric.mldsa.MLDSAKeyFactorySpi.Hash;
 import org.broadinstitute.consent.http.configurations.ConsentConfiguration;
 import org.broadinstitute.consent.http.db.DAOContainer;
 import org.broadinstitute.consent.http.db.DarCollectionDAO;
@@ -36,6 +38,7 @@ import org.broadinstitute.consent.http.exceptions.LibraryCardRequiredException;
 import org.broadinstitute.consent.http.exceptions.NIHComplianceRuleException;
 import org.broadinstitute.consent.http.exceptions.SubmittedDARCannotBeEditedException;
 import org.broadinstitute.consent.http.models.Collaborator;
+import org.broadinstitute.consent.http.models.Dac;
 import org.broadinstitute.consent.http.models.DarCollection;
 import org.broadinstitute.consent.http.models.DarDataset;
 import org.broadinstitute.consent.http.models.DataAccessRequest;
@@ -284,6 +287,21 @@ public class DataAccessRequestService implements ConsentLogger {
     DataAccessRequest dar = dataAccessRequestDAO.findByReferenceId(referenceId);
     validateCloseoutApproval(signingOfficial, dar);
     dataAccessRequestDAO.updateDarCloseoutSO(signingOfficial.getUserId(), referenceId);
+    Set<User> chairs = new HashSet<>();
+    Set<Dac> dacs = dacService.findByDatasetId(dar.getDatasetIds());
+    dacs.forEach(dac -> chairs.addAll(dac.getChairpersons()));
+    chairs.forEach(
+        chairperson -> {
+          try {
+            emailService.sendSubmittedCloseoutMessage(
+                chairperson,
+                dar.getDarCode(),
+                dar.getReferenceId(),
+                serverUrl + "progress_report_application/%d".formatted(dar.getCollectionId()));
+          } catch (Exception e) {
+            logWarn("Unable to send close out message for Data Access Request " + referenceId, e);
+          }
+        });
   }
 
   @VisibleForTesting

--- a/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
@@ -52,6 +52,7 @@ import org.broadinstitute.consent.http.exceptions.NIHComplianceRuleException;
 import org.broadinstitute.consent.http.exceptions.SubmittedDARCannotBeEditedException;
 import org.broadinstitute.consent.http.models.CloseoutSupplement;
 import org.broadinstitute.consent.http.models.Collaborator;
+import org.broadinstitute.consent.http.models.Dac;
 import org.broadinstitute.consent.http.models.DarCollection;
 import org.broadinstitute.consent.http.models.DarDataset;
 import org.broadinstitute.consent.http.models.DataAccessRequest;
@@ -112,6 +113,7 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
   @Mock
   private InstitutionService institutionService;
   private DataAccessRequestService service;
+  private String serverUrl;
 
   private static Collaborator createCollaborator() {
     Collaborator validCollaborator = new Collaborator();
@@ -177,6 +179,7 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     container.setElectionDAO(electionDAO);
     container.setVoteDAO(voteDAO);
     container.setMatchDAO(matchDAO);
+    serverUrl = config.getServicesConfiguration().getLocalURL();
     service = new DataAccessRequestService(counterService, container, dacService,
         dataAccessRequestServiceDAO, userService, institutionService,  emailService, config);
   }
@@ -1232,11 +1235,17 @@ institution or library cards issued: Internal Collaborator member:  \
   }
 
   @Test
-  void approveDataAccessRequest() {
+  void approveDataAccessRequest() throws TemplateException, IOException {
     CloseoutWithUserAndSigningOfficialApproval closeout = new CloseoutWithUserAndSigningOfficialApproval();
+    Dac dac = new Dac();
+    User chair = new User(1, "chair@duos.org", "A Chair", new Date());
+    dac.setChairpersons(List.of(chair));
     when(userService.findUserById(closeout.submitter.getUserId())).thenReturn(closeout.submitter);
     when(dataAccessRequestDAO.findByReferenceId(closeout.dar.referenceId)).thenReturn(closeout.dar);
+    when(dacService.findByDatasetId(closeout.dar().getDatasetIds())).thenReturn(Set.of(dac));
     assertDoesNotThrow(()->service.approveDataAccessRequestCloseout(closeout.actor, closeout.dar.getReferenceId()));
+    verify(dacService).findByDatasetId(closeout.dar().getDatasetIds());
+    verify(emailService).sendSubmittedCloseoutMessage(chair, closeout.dar().getDarCode(), closeout.dar().getReferenceId(), serverUrl + "progress_report_application/%d".formatted(closeout.dar().getCollectionId()));
   }
 
   record  CloseoutWithUserAndSigningOfficialApproval(User actor, User submitter, DataAccessRequest dar) {
@@ -1249,6 +1258,10 @@ institution or library cards issued: Internal Collaborator member:  \
       dar.setUserId(submitter.getUserId());
       dar.setSubmissionDate(Timestamp.from(Instant.now()));
       dar.setParentId(1);
+      dar.setDatasetIds(List.of(1));
+      dar.setDarCode("DAR-0001");
+      dar.setCollectionId(4);
+      dar.setReferenceId(UUID.randomUUID().toString());
       DataAccessRequestData data =  new DataAccessRequestData();
       data.setCloseoutSupplement(new CloseoutSupplement(List.of(""), "", actor.getUserId()));
       dar.setData(data);

--- a/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
@@ -1236,16 +1236,25 @@ institution or library cards issued: Internal Collaborator member:  \
 
   @Test
   void approveDataAccessRequest() throws TemplateException, IOException {
-    CloseoutWithUserAndSigningOfficialApproval closeout = new CloseoutWithUserAndSigningOfficialApproval();
+    CloseoutWithUserAndSigningOfficialApproval closeout =
+        new CloseoutWithUserAndSigningOfficialApproval();
     Dac dac = new Dac();
     User chair = new User(1, "chair@duos.org", "A Chair", new Date());
     dac.setChairpersons(List.of(chair));
     when(userService.findUserById(closeout.submitter.getUserId())).thenReturn(closeout.submitter);
     when(dataAccessRequestDAO.findByReferenceId(closeout.dar.referenceId)).thenReturn(closeout.dar);
     when(dacService.findByDatasetId(closeout.dar().getDatasetIds())).thenReturn(Set.of(dac));
-    assertDoesNotThrow(()->service.approveDataAccessRequestCloseout(closeout.actor, closeout.dar.getReferenceId()));
+    assertDoesNotThrow(
+        () ->
+            service.approveDataAccessRequestCloseout(
+                closeout.actor, closeout.dar.getReferenceId()));
     verify(dacService).findByDatasetId(closeout.dar().getDatasetIds());
-    verify(emailService).sendSubmittedCloseoutMessage(chair, closeout.dar().getDarCode(), closeout.dar().getReferenceId(), serverUrl + "progress_report_application/%d".formatted(closeout.dar().getCollectionId()));
+    verify(emailService)
+        .sendSubmittedCloseoutMessage(
+            chair,
+            closeout.dar().getDarCode(),
+            closeout.dar().getReferenceId(),
+            serverUrl + "dar_application_review/%d".formatted(closeout.dar().getCollectionId()));
   }
 
   record  CloseoutWithUserAndSigningOfficialApproval(User actor, User submitter, DataAccessRequest dar) {


### PR DESCRIPTION
### Addresses
[https://broadworkbench.atlassian.net/browse/DT-1771](https://broadworkbench.atlassian.net/browse/DT-1771)

### Summary

- Extends the DataAccessRequestService that memorializes an SO approval to trigger the email sent to DAC chairpeople for all of the datasets in the closeout.
- Pulls a dacDAO method through the DacService so that it can be leveraged without needing to add an additional DAO to the DataAccessRequestService.  This method is under transitive test by existing coverage in dacDAO.  
- Adds coverage.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
