### PR TITLE
[DT-1586] Prevent non-draft data access requests from being deleted.

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
@@ -553,8 +553,7 @@ public class DataAccessRequestResource extends Resource {
   public Response deleteDar(@Auth AuthUser authUser, @PathParam("referenceId") String referenceId) {
     try {
       validateAuthedRoleUser(Collections.singletonList(UserRoles.ADMIN), authUser, referenceId);
-      User user = findUserByEmail(authUser.getEmail());
-      dataAccessRequestService.deleteByReferenceId(user, referenceId);
+      dataAccessRequestService.deleteByReferenceId(referenceId);
       return Response.ok().build();
     } catch (Exception e) {
       return createExceptionResponse(e);

--- a/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
@@ -551,8 +551,8 @@ public class DataAccessRequestResource extends Resource {
   @Produces("application/json")
   @RolesAllowed({ADMIN, RESEARCHER})
   public Response deleteDar(@Auth AuthUser authUser, @PathParam("referenceId") String referenceId) {
-    validateAuthedRoleUser(Collections.singletonList(UserRoles.ADMIN), authUser, referenceId);
     try {
+      validateAuthedRoleUser(Collections.singletonList(UserRoles.ADMIN), authUser, referenceId);
       User user = findUserByEmail(authUser.getEmail());
       dataAccessRequestService.deleteByReferenceId(user, referenceId);
       return Response.ok().build();
@@ -700,6 +700,9 @@ public class DataAccessRequestResource extends Resource {
   private void validateAuthedRoleUser(final List<UserRoles> allowableRoles, AuthUser authUser,
       String referenceId) {
     DataAccessRequest dataAccessRequest = getDarById(referenceId);
+    if (!dataAccessRequest.getDraft()) {
+      throw new BadRequestException("Only draft data access requests can be deleted");
+    }
     User user = findUserByEmail(authUser.getEmail());
     if (Objects.nonNull(dataAccessRequest.getUserId()) && dataAccessRequest.getUserId() > 0) {
       super.validateAuthedRoleUser(allowableRoles, user, dataAccessRequest.getUserId());

--- a/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
@@ -552,8 +552,8 @@ public class DataAccessRequestResource extends Resource {
   @RolesAllowed({ADMIN, RESEARCHER})
   public Response deleteDar(@Auth AuthUser authUser, @PathParam("referenceId") String referenceId) {
     try {
-      validateAuthedRoleUser(Collections.singletonList(UserRoles.ADMIN), authUser, referenceId);
-      dataAccessRequestService.deleteByReferenceId(referenceId);
+      DataAccessRequest dataAccessRequest = validateAuthedRoleUser(Collections.singletonList(UserRoles.ADMIN), authUser, referenceId);
+      dataAccessRequestService.deleteDataAccessRequest(dataAccessRequest);
       return Response.ok().build();
     } catch (Exception e) {
       return createExceptionResponse(e);
@@ -695,13 +695,11 @@ public class DataAccessRequestResource extends Resource {
    * @param allowableRoles List of roles that would allow the user to access the resource
    * @param authUser       The AuthUser
    * @param referenceId    The referenceId of the resource.
+   * @return dataAccessRequest The data access request underlying the referenceId
    */
-  private void validateAuthedRoleUser(final List<UserRoles> allowableRoles, AuthUser authUser,
+  private DataAccessRequest validateAuthedRoleUser(final List<UserRoles> allowableRoles, AuthUser authUser,
       String referenceId) {
     DataAccessRequest dataAccessRequest = getDarById(referenceId);
-    if (!dataAccessRequest.getDraft()) {
-      throw new BadRequestException("Only draft data access requests can be deleted");
-    }
     User user = findUserByEmail(authUser.getEmail());
     if (Objects.nonNull(dataAccessRequest.getUserId()) && dataAccessRequest.getUserId() > 0) {
       super.validateAuthedRoleUser(allowableRoles, user, dataAccessRequest.getUserId());
@@ -709,5 +707,6 @@ public class DataAccessRequestResource extends Resource {
       logWarn("DataAccessRequest '" + referenceId + "' has an invalid userId");
       super.validateAuthedRoleUser(allowableRoles, user, dataAccessRequest.getUserId());
     }
+    return dataAccessRequest;
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
@@ -23,7 +23,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import org.apache.commons.validator.routines.EmailValidator;
-import org.bouncycastle.jcajce.provider.asymmetric.mldsa.MLDSAKeyFactorySpi.Hash;
 import org.broadinstitute.consent.http.configurations.ConsentConfiguration;
 import org.broadinstitute.consent.http.db.DAOContainer;
 import org.broadinstitute.consent.http.db.DarCollectionDAO;

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
@@ -30,6 +30,7 @@ import org.broadinstitute.consent.http.db.MatchDAO;
 import org.broadinstitute.consent.http.db.UserDAO;
 import org.broadinstitute.consent.http.db.VoteDAO;
 import org.broadinstitute.consent.http.enumeration.EmailType;
+import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.exceptions.InvalidEmailAddressException;
 import org.broadinstitute.consent.http.exceptions.LibraryCardRequiredException;
 import org.broadinstitute.consent.http.exceptions.NIHComplianceRuleException;

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
@@ -30,7 +30,6 @@ import org.broadinstitute.consent.http.db.MatchDAO;
 import org.broadinstitute.consent.http.db.UserDAO;
 import org.broadinstitute.consent.http.db.VoteDAO;
 import org.broadinstitute.consent.http.enumeration.EmailType;
-import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.exceptions.InvalidEmailAddressException;
 import org.broadinstitute.consent.http.exceptions.LibraryCardRequiredException;
 import org.broadinstitute.consent.http.exceptions.NIHComplianceRuleException;
@@ -105,7 +104,11 @@ public class DataAccessRequestService implements ConsentLogger {
     return dataAccessRequestDAO.findAllDraftsByUserId(userId);
   }
 
-  public void deleteByReferenceId(String referenceId) throws NotAcceptableException {
+  public void deleteDataAccessRequest(DataAccessRequest dataAccessRequest) throws NotAcceptableException {
+    String referenceId = dataAccessRequest.getReferenceId();
+    if (!dataAccessRequest.getDraft()) {
+      throw new BadRequestException("Only draft data access requests can be deleted");
+    }
     List<Election> elections = electionDAO.findElectionsByReferenceId(referenceId);
     if (!elections.isEmpty()) {
         String message = String.format(

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
@@ -105,21 +105,14 @@ public class DataAccessRequestService implements ConsentLogger {
     return dataAccessRequestDAO.findAllDraftsByUserId(userId);
   }
 
-  public void deleteByReferenceId(User user, String referenceId) throws NotAcceptableException {
+  public void deleteByReferenceId(String referenceId) throws NotAcceptableException {
     List<Election> elections = electionDAO.findElectionsByReferenceId(referenceId);
     if (!elections.isEmpty()) {
-      // If the user is an admin, delete all votes and elections
-      if (user.hasUserRole(UserRoles.ADMIN)) {
-        voteDAO.deleteVotesByReferenceId(referenceId);
-        List<Integer> electionIds = elections.stream().map(Election::getElectionId).toList();
-        electionDAO.deleteElectionsByIds(electionIds);
-      } else {
         String message = String.format(
             "Unable to delete DAR: '%s', there are existing elections that reference it.",
             referenceId);
         logWarn(message);
         throw new NotAcceptableException(message);
-      }
     }
     matchDAO.deleteRationalesByPurposeIds(List.of(referenceId));
     matchDAO.deleteMatchesByPurposeId(referenceId);

--- a/src/main/resources/assets/paths/darV2ByReferenceId.yaml
+++ b/src/main/resources/assets/paths/darV2ByReferenceId.yaml
@@ -55,9 +55,7 @@ put:
 delete:
   summary: Delete DAR by Reference Id
   description: | 
-    Deletes the DAR by reference id. If the user is the owner, and a researcher, the DAR
-    will only be deleted if there are no elections created for it. If the user is an Admin,
-    all votes and elections associated to the DAR will also be deleted.
+    Deletes a draft DAR by reference id. Admins may delete all drafts, researchers can only delete their own drafts.
   parameters:
     - name: referenceId
       in: path
@@ -78,6 +76,8 @@ delete:
       description: Forbidden
     404:
       description: The requested DAR couldn't be found.
+    400:
+      description: Only drafts can be deleted.
     406:
       description: There are existing resources that reference this Data Access Request
     500:

--- a/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceTest.java
@@ -1036,7 +1036,7 @@ class DataAccessRequestResourceTest extends AbstractTestHelper {
     assertTrue(dar.getDraft());
     when(userService.findUserByEmail(any())).thenReturn(user);
     when(dataAccessRequestService.findByReferenceId(dar.getReferenceId())).thenReturn(dar);
-    doNothing().when(dataAccessRequestService).deleteByReferenceId(user, dar.getReferenceId());
+    doNothing().when(dataAccessRequestService).deleteByReferenceId(dar.getReferenceId());
     try (Response response = resource.deleteDar(authUser, dar.getReferenceId())) {
       assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
     }

--- a/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceTest.java
@@ -1,6 +1,5 @@
 package org.broadinstitute.consent.http.resources;
 
-import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -1036,7 +1035,7 @@ class DataAccessRequestResourceTest extends AbstractTestHelper {
     assertTrue(dar.getDraft());
     when(userService.findUserByEmail(any())).thenReturn(user);
     when(dataAccessRequestService.findByReferenceId(dar.getReferenceId())).thenReturn(dar);
-    doNothing().when(dataAccessRequestService).deleteByReferenceId(dar.getReferenceId());
+    doNothing().when(dataAccessRequestService).deleteDataAccessRequest(dar);
     try (Response response = resource.deleteDar(authUser, dar.getReferenceId())) {
       assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
     }
@@ -1050,6 +1049,8 @@ class DataAccessRequestResourceTest extends AbstractTestHelper {
     dar.setSubmissionDate(Timestamp.from(Instant.now()));
     assertFalse(dar.getDraft());
     when(dataAccessRequestService.findByReferenceId(dar.getReferenceId())).thenReturn(dar);
+    when(userService.findUserByEmail(any())).thenReturn(user);
+    doThrow(BadRequestException.class).when(dataAccessRequestService).deleteDataAccessRequest(dar);
     try (Response response = resource.deleteDar(authUser, dar.getReferenceId())) {
       assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
     }

--- a/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceTest.java
@@ -1,9 +1,12 @@
 package org.broadinstitute.consent.http.resources;
 
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -1021,6 +1024,33 @@ class DataAccessRequestResourceTest extends AbstractTestHelper {
     String referenceId = UUID.randomUUID().toString();
     doThrow(BadRequestException.class).when(dataAccessRequestService).approveDataAccessRequestCloseout(user,referenceId);
     try (Response response = resource.approveCloseout(duosUser, request, referenceId)) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
+    }
+  }
+
+  @Test
+  void testDeleteDraftDataAccessRequestForDraft() {
+    DataAccessRequest dar = generateDataAccessRequest();
+    dar.setUserId(user.getUserId());
+    dar.setReferenceId(UUID.randomUUID().toString());
+    assertTrue(dar.getDraft());
+    when(userService.findUserByEmail(any())).thenReturn(user);
+    when(dataAccessRequestService.findByReferenceId(dar.getReferenceId())).thenReturn(dar);
+    doNothing().when(dataAccessRequestService).deleteByReferenceId(user, dar.getReferenceId());
+    try (Response response = resource.deleteDar(authUser, dar.getReferenceId())) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+    }
+  }
+
+  @Test
+  void testDeleteDraftDataAccessRequestThrowsForSubmittedDar() {
+    DataAccessRequest dar = generateDataAccessRequest();
+    dar.setUserId(user.getUserId());
+    dar.setReferenceId(UUID.randomUUID().toString());
+    dar.setSubmissionDate(Timestamp.from(Instant.now()));
+    assertFalse(dar.getDraft());
+    when(dataAccessRequestService.findByReferenceId(dar.getReferenceId())).thenReturn(dar);
+    try (Response response = resource.deleteDar(authUser, dar.getReferenceId())) {
       assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
     }
   }

--- a/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
@@ -728,8 +728,10 @@ institution or library cards issued: Internal Collaborator member:  \
   }
 
   @Test
-  void testDeleteByReferenceIdAdmin() {
+  void testDeleteDataAccessRequestAdmin() {
     String referenceId = UUID.randomUUID().toString();
+    DataAccessRequest dataAccessRequest = new DataAccessRequest();
+    dataAccessRequest.setReferenceId(referenceId);
     User adminUser = new User();
     adminUser.setAdminRole();
     Election election = new Election();
@@ -737,12 +739,14 @@ institution or library cards issued: Internal Collaborator member:  \
     election.setReferenceId(referenceId);
     when(electionDAO.findElectionsByReferenceId(any())).thenReturn(List.of(election));
 
-    assertThrows(NotAcceptableException.class, () -> service.deleteByReferenceId(referenceId));
+    assertThrows(NotAcceptableException.class, () -> service.deleteDataAccessRequest(dataAccessRequest));
   }
 
   @Test
-  void testDeleteByReferenceIdResearcherSuccess() {
+  void testDeleteDataAccessRequestResearcherSuccess() {
     String referenceId = UUID.randomUUID().toString();
+    DataAccessRequest dataAccessRequest = new DataAccessRequest();
+    dataAccessRequest.setReferenceId(referenceId);
     User user = new User();
     user.setResearcherRole();
     when(electionDAO.findElectionsByReferenceId(any())).thenReturn(List.of());
@@ -750,12 +754,14 @@ institution or library cards issued: Internal Collaborator member:  \
     doNothing().when(dataAccessRequestDAO).deleteByReferenceId(any());
     doNothing().when(dataAccessRequestDAO).deleteDARDatasetRelationByReferenceId(any());
 
-    assertDoesNotThrow(() -> service.deleteByReferenceId(referenceId));
+    assertDoesNotThrow(() -> service.deleteDataAccessRequest(dataAccessRequest));
   }
 
   @Test
-  void testDeleteByReferenceIdResearcherFailure() {
+  void testDeleteDataAccessRequestResearcherFailure() {
     String referenceId = UUID.randomUUID().toString();
+    DataAccessRequest dataAccessRequest = new DataAccessRequest();
+    dataAccessRequest.setReferenceId(referenceId);
     User user = new User();
     user.setResearcherRole();
     Election election = new Election();
@@ -764,7 +770,18 @@ institution or library cards issued: Internal Collaborator member:  \
     when(electionDAO.findElectionsByReferenceId(any())).thenReturn(List.of(election));
 
     assertThrows(NotAcceptableException.class,
-        () -> service.deleteByReferenceId(referenceId));
+        () -> service.deleteDataAccessRequest(dataAccessRequest));
+  }
+
+  @Test
+  void testDeleteDataAccessRequestSubmittedDarFailure() {
+    String referenceId = UUID.randomUUID().toString();
+    DataAccessRequest dataAccessRequest = new DataAccessRequest();
+    dataAccessRequest.setReferenceId(referenceId);
+    dataAccessRequest.setSubmissionDate(Timestamp.from(Instant.now()));
+
+    assertThrows(BadRequestException.class,
+        () -> service.deleteDataAccessRequest(dataAccessRequest));
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
@@ -736,15 +736,8 @@ institution or library cards issued: Internal Collaborator member:  \
     election.setElectionId(1);
     election.setReferenceId(referenceId);
     when(electionDAO.findElectionsByReferenceId(any())).thenReturn(List.of(election));
-    doNothing().when(voteDAO).deleteVotesByReferenceId(any());
-    doNothing().when(matchDAO).deleteMatchesByPurposeId(any());
-    doNothing().when(dataAccessRequestDAO).deleteByReferenceId(any());
 
-    try {
-      service.deleteByReferenceId(adminUser, referenceId);
-    } catch (Exception e) {
-      fail(e.getMessage());
-    }
+    assertThrows(NotAcceptableException.class, () -> service.deleteByReferenceId(referenceId));
   }
 
   @Test
@@ -757,7 +750,7 @@ institution or library cards issued: Internal Collaborator member:  \
     doNothing().when(dataAccessRequestDAO).deleteByReferenceId(any());
     doNothing().when(dataAccessRequestDAO).deleteDARDatasetRelationByReferenceId(any());
 
-    assertDoesNotThrow(() -> service.deleteByReferenceId(user, referenceId));
+    assertDoesNotThrow(() -> service.deleteByReferenceId(referenceId));
   }
 
   @Test
@@ -771,7 +764,7 @@ institution or library cards issued: Internal Collaborator member:  \
     when(electionDAO.findElectionsByReferenceId(any())).thenReturn(List.of(election));
 
     assertThrows(NotAcceptableException.class,
-        () -> service.deleteByReferenceId(user, referenceId));
+        () -> service.deleteByReferenceId(referenceId));
   }
 
   @Test


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-1586](https://broadworkbench.atlassian.net/browse/DT-1586)

### Summary

When an election does not exist for a data access request and it is a draft, 
- Users should be able to delete their own draft data access requests.
- Admins should be able to delete any draft data access requests.

No longer deletes elections and votes, even if an admin takes the action.
Adds coverage.
Swagger docs updated.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
