### PR TITLE
DT-1774: Remove actions on summaries for Admins and Chairs when there is a closeout

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
@@ -73,7 +73,8 @@ public class DarCollectionService implements ConsentLogger {
   public DarCollectionService(DarCollectionDAO darCollectionDAO,
       DarCollectionServiceDAO collectionServiceDAO, DatasetDAO datasetDAO, ElectionDAO electionDAO,
       DataAccessRequestDAO dataAccessRequestDAO, EmailService emailService, VoteDAO voteDAO,
-      MatchDAO matchDAO, DarCollectionSummaryDAO darCollectionSummaryDAO, UserDAO userDAO, DacDAO dacDAO) {
+      MatchDAO matchDAO, DarCollectionSummaryDAO darCollectionSummaryDAO, UserDAO userDAO,
+      DacDAO dacDAO) {
     this.darCollectionDAO = darCollectionDAO;
     this.collectionServiceDAO = collectionServiceDAO;
     this.datasetDAO = datasetDAO;
@@ -117,17 +118,19 @@ public class DarCollectionService implements ConsentLogger {
     summaries.forEach(s -> {
       Map<String, Integer> statusCount = new HashMap<>();
       Map<Integer, Election> elections = s.getElections();
-      if (elections.isEmpty()) {
+      if (elections.isEmpty() && s.getCloseoutSupplement() == null) {
         s.addAction(DarCollectionActions.OPEN);
         s.setStatus(DarCollectionStatus.SUBMITTED.getValue());
       } else {
         elections.values().forEach(e -> {
           String status = e.getStatus();
           updateStatusCount(statusCount, status);
-          if (status.equals(ElectionStatus.OPEN.getValue())) {
-            s.addAction(DarCollectionActions.CANCEL);
-          } else {
-            s.addAction(DarCollectionActions.OPEN);
+          if (s.getCloseoutSupplement() == null) {
+            if (status.equals(ElectionStatus.OPEN.getValue())) {
+              s.addAction(DarCollectionActions.CANCEL);
+            } else {
+              s.addAction(DarCollectionActions.OPEN);
+            }
           }
         });
         determineCollectionStatus(s, statusCount, s.getDatasetCount(), s.getElections().size());
@@ -164,11 +167,12 @@ public class DarCollectionService implements ConsentLogger {
       s.addAction(DarCollectionActions.REVIEW);
       //if the latest DAR in the collection has at least one approved dataset,
       //include the create progress report action
-      Set<Integer> datasetIds = dataAccessRequestDAO.findDatasetApprovalsByDar(s.getLatestReferenceId());
+      Set<Integer> datasetIds = dataAccessRequestDAO.findDatasetApprovalsByDar(
+          s.getLatestReferenceId());
       // Can only create a progress report if there are approved datasets and no closeout supplement
       if (!datasetIds.isEmpty() && s.getCloseoutSupplement() == null) {
-          s.addAction(DarCollectionActions.CREATE_PROGRESS_REPORT);
-        }
+        s.addAction(DarCollectionActions.CREATE_PROGRESS_REPORT);
+      }
 
       //check dar statuses, if they're all canceled show revise (but only if there are no elections)
       if (electionCount == 0) {
@@ -241,26 +245,30 @@ public class DarCollectionService implements ConsentLogger {
       //if there are any open elections, show cancel and vote
       Map<String, Integer> statusCount = new HashMap<>();
       Map<Integer, Election> elections = s.getElections();
-      if (elections.size() == 0) {
+      if (elections.isEmpty()) {
         s.setStatus(DarCollectionStatus.SUBMITTED.getValue());
-        s.addAction(DarCollectionActions.OPEN);
+        if (s.getCloseoutSupplement() == null) {
+          s.addAction(DarCollectionActions.OPEN);
+        }
       } else {
-        if (elections.size() < s.getDatasetCount()) {
+        if (elections.size() < s.getDatasetCount() && s.getCloseoutSupplement() == null) {
           s.addAction(DarCollectionActions.OPEN);
         }
         elections.values().forEach(election -> {
           String statusString = election.getStatus();
           updateStatusCount(statusCount, statusString);
           ElectionStatus status = ElectionStatus.getStatusFromString(statusString);
-          switch (status) {
-            case CLOSED, CANCELED:
-              s.addAction(DarCollectionActions.OPEN);
-              break;
-            case OPEN:
-              s.addAction(DarCollectionActions.VOTE);
-              break;
-            default:
-              break;
+          if (s.getCloseoutSupplement() == null) {
+            switch (Objects.requireNonNull(status)) {
+              case CLOSED, CANCELED:
+                s.addAction(DarCollectionActions.OPEN);
+                break;
+              case OPEN:
+                s.addAction(DarCollectionActions.VOTE);
+                break;
+              default:
+                break;
+            }
           }
         });
         Integer closedCount = statusCount.get(ElectionStatus.CLOSED.getValue());
@@ -289,7 +297,7 @@ public class DarCollectionService implements ConsentLogger {
    * Members can see summaries for datasets they have access to Signing Officials can see summaries
    * for researchers in their institution Researchers can see only their own summaries
    *
-   * @param user     The user making the request
+   * @param user The user making the request
    * @param role The role the user is making the request as
    * @return List of DarCollectionSummary objects
    */
@@ -516,7 +524,7 @@ public class DarCollectionService implements ConsentLogger {
   /**
    * Given a DarCollection, add its relevant datasets.
    *
-   * @param collection      The list of DarCollections to iterate over.
+   * @param collection The list of DarCollections to iterate over.
    * @return collection with datasets added
    */
   @VisibleForTesting
@@ -531,15 +539,15 @@ public class DarCollectionService implements ConsentLogger {
           .distinct()
           .collect(Collectors.toMap(Dataset::getDatasetId, Function.identity()));
 
-        Set<Dataset> collectionDatasets = collection.getDars().values().stream()
-            .map(DataAccessRequest::getDatasetIds)
-            .flatMap(Collection::stream)
-            .map(datasetMap::get)
-            .filter(Objects::nonNull) // filtering out nulls which were getting captured by map
-            .collect(Collectors.toSet());
-        DarCollection copy = collection.deepCopy();
-        copy.setDatasets(collectionDatasets);
-        return copy;
+      Set<Dataset> collectionDatasets = collection.getDars().values().stream()
+          .map(DataAccessRequest::getDatasetIds)
+          .flatMap(Collection::stream)
+          .map(datasetMap::get)
+          .filter(Objects::nonNull) // filtering out nulls which were getting captured by map
+          .collect(Collectors.toSet());
+      DarCollection copy = collection.deepCopy();
+      copy.setDatasets(collectionDatasets);
+      return copy;
     }
     // There were no datasets to add, so we return the original list
     return collection;
@@ -551,10 +559,11 @@ public class DarCollectionService implements ConsentLogger {
    *
    * @param user       The User initiating the cancel
    * @param collection The DarCollection
-   * @param role       The role of the user, must be one of ADMIN, CHAIRPERSON, or RESEARCHER
+   * @param role       The role of the user must be one of ADMIN, CHAIRPERSON, or RESEARCHER
    * @return The DarCollection that has been canceled
    */
-  public DarCollection cancelDarCollectionByRole(User user, DarCollection collection, UserRoles role) {
+  public DarCollection cancelDarCollectionByRole(User user, DarCollection collection,
+      UserRoles role) {
     Collection<DataAccessRequest> dars = collection.getDars().values();
     if (dars.isEmpty()) {
       logWarn("DAR Collection ID: [%s] does not have any associated DAR ids".formatted(
@@ -564,8 +573,7 @@ public class DarCollectionService implements ConsentLogger {
 
     return switch (role) {
       case ADMIN -> cancelDarCollectionElectionsAsAdmin(collection);
-      case CHAIRPERSON ->
-          cancelDarCollectionElectionsAsChair(collection, user);
+      case CHAIRPERSON -> cancelDarCollectionElectionsAsChair(collection, user);
       default -> cancelDarCollectionAsResearcher(collection, user);
     };
   }
@@ -578,7 +586,7 @@ public class DarCollectionService implements ConsentLogger {
    * decline or cancel the elections for the collection.
    *
    * @param collection The DarCollection
-   * @param user the researcher requesting the cancel
+   * @param user       the researcher requesting the cancel
    * @return The canceled DarCollection
    */
   private DarCollection cancelDarCollectionAsResearcher(DarCollection collection, User user) {
@@ -686,7 +694,8 @@ public class DarCollectionService implements ConsentLogger {
         List<User> voteUsers = voteDAO.findVoteUsersByElectionReferenceIdList(
             createdElectionReferenceIds);
         if (dar.getProgressReport()) {
-          emailService.sendProgressReportNewCollectionElectionMessage(voteUsers, collection.getDarCode());
+          emailService.sendProgressReportNewCollectionElectionMessage(voteUsers,
+              collection.getDarCode());
         } else {
           emailService.sendDarNewCollectionElectionMessage(voteUsers, collection.getDarCode());
         }
@@ -755,9 +764,11 @@ public class DarCollectionService implements ConsentLogger {
       if (dar.getProgressReport()) {
         // Use the reference ID to link the fact that this progress report will have been noted.
         // the DAR Code at this point will be ambiguous.
-        emailService.sendNewProgressReportRequestEmail(user, sendList, researcherName, collection.getDarCode(), dar.getReferenceId());
+        emailService.sendNewProgressReportRequestEmail(user, sendList, researcherName,
+            collection.getDarCode(), dar.getReferenceId());
       } else {
-        emailService.sendNewDARRequestEmail(user, sendList, researcherName, collection.getDarCode());
+        emailService.sendNewDARRequestEmail(user, sendList, researcherName,
+            collection.getDarCode());
       }
     }
   }

--- a/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
@@ -118,22 +118,23 @@ public class DarCollectionService implements ConsentLogger {
     summaries.forEach(s -> {
       Map<String, Integer> statusCount = new HashMap<>();
       Map<Integer, Election> elections = s.getElections();
-      if (elections.isEmpty() && s.getCloseoutSupplement() == null) {
+      if (elections.isEmpty()) {
         s.addAction(DarCollectionActions.OPEN);
         s.setStatus(DarCollectionStatus.SUBMITTED.getValue());
       } else {
         elections.values().forEach(e -> {
           String status = e.getStatus();
           updateStatusCount(statusCount, status);
-          if (s.getCloseoutSupplement() == null) {
-            if (status.equals(ElectionStatus.OPEN.getValue())) {
-              s.addAction(DarCollectionActions.CANCEL);
-            } else {
-              s.addAction(DarCollectionActions.OPEN);
-            }
+          if (status.equals(ElectionStatus.OPEN.getValue())) {
+            s.addAction(DarCollectionActions.CANCEL);
+          } else {
+            s.addAction(DarCollectionActions.OPEN);
           }
         });
         determineCollectionStatus(s, statusCount, s.getDatasetCount(), s.getElections().size());
+      }
+      if (s.getCloseoutSupplement() != null) {
+        s.getActions().clear();
       }
     });
   }
@@ -247,28 +248,24 @@ public class DarCollectionService implements ConsentLogger {
       Map<Integer, Election> elections = s.getElections();
       if (elections.isEmpty()) {
         s.setStatus(DarCollectionStatus.SUBMITTED.getValue());
-        if (s.getCloseoutSupplement() == null) {
-          s.addAction(DarCollectionActions.OPEN);
-        }
+        s.addAction(DarCollectionActions.OPEN);
       } else {
-        if (elections.size() < s.getDatasetCount() && s.getCloseoutSupplement() == null) {
+        if (elections.size() < s.getDatasetCount()) {
           s.addAction(DarCollectionActions.OPEN);
         }
         elections.values().forEach(election -> {
           String statusString = election.getStatus();
           updateStatusCount(statusCount, statusString);
           ElectionStatus status = ElectionStatus.getStatusFromString(statusString);
-          if (s.getCloseoutSupplement() == null) {
-            switch (Objects.requireNonNull(status)) {
-              case CLOSED, CANCELED:
-                s.addAction(DarCollectionActions.OPEN);
-                break;
-              case OPEN:
-                s.addAction(DarCollectionActions.VOTE);
-                break;
-              default:
-                break;
-            }
+          switch (status) {
+            case CLOSED, CANCELED:
+              s.addAction(DarCollectionActions.OPEN);
+              break;
+            case OPEN:
+              s.addAction(DarCollectionActions.VOTE);
+              break;
+            default:
+              break;
           }
         });
         Integer closedCount = statusCount.get(ElectionStatus.CLOSED.getValue());
@@ -279,6 +276,9 @@ public class DarCollectionService implements ConsentLogger {
         }
 
         determineCollectionStatus(s, statusCount, s.getDatasetCount(), s.getElections().size());
+      }
+      if (s.getCloseoutSupplement() != null) {
+        s.getActions().clear();
       }
     });
   }

--- a/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
@@ -236,49 +236,70 @@ public class DarCollectionService implements ConsentLogger {
     });
   }
 
-
+  /**
+   * Process the DarCollectionSummaries for a chairperson. Note that this decorates the raw
+   * summaries with status and actions based on the elections present in each summary.
+   *
+   * @param summaries The list of DarCollectionSummaries to process
+   */
   private void processDarCollectionSummariesForChair(List<DarCollectionSummary> summaries) {
     summaries.forEach(s -> {
-      //if there are no elections, only show open
-      //if there is any closed or canceled elections, or if some datasets dont have an election, show open
-      //if there are any open elections, show cancel and vote
       Map<String, Integer> statusCount = new HashMap<>();
       Map<Integer, Election> elections = s.getElections();
-      if (elections.size() == 0) {
-        s.setStatus(DarCollectionStatus.SUBMITTED.getValue());
+      if (elections.size() < s.getDatasetCount()) {
         s.addAction(DarCollectionActions.OPEN);
-      } else {
-        if (elections.size() < s.getDatasetCount()) {
-          s.addAction(DarCollectionActions.OPEN);
-        }
-        elections.values().forEach(election -> {
-          String statusString = election.getStatus();
-          updateStatusCount(statusCount, statusString);
-          ElectionStatus status = ElectionStatus.getStatusFromString(statusString);
-          switch (status) {
-            case CLOSED, CANCELED:
-              s.addAction(DarCollectionActions.OPEN);
-              break;
-            case OPEN:
-              s.addAction(DarCollectionActions.VOTE);
-              break;
-            default:
-              break;
-          }
-        });
-        Integer closedCount = statusCount.get(ElectionStatus.CLOSED.getValue());
-        Integer openCount = statusCount.get(ElectionStatus.OPEN.getValue());
-        //add cancel if there are no closed elections and at least one open election
-        if (Objects.isNull(closedCount) && Objects.nonNull(openCount)) {
-          s.addAction(DarCollectionActions.CANCEL);
-        }
-
-        determineCollectionStatus(s, statusCount, s.getDatasetCount(), s.getElections().size());
       }
-      if (s.getCloseoutSupplement() != null) {
-        s.getActions().clear();
+      elections.values().forEach(election -> updateStatusCount(statusCount, election.getStatus()));
+      Integer closedCount = statusCount.get(ElectionStatus.CLOSED.getValue());
+      Integer openCount = statusCount.get(ElectionStatus.OPEN.getValue());
+      determineCollectionStatus(s, statusCount, s.getDatasetCount(), s.getElections().size());
+      updateSummaryActionsForChair(s, closedCount, openCount);
+    });
+  }
+
+  /**
+   * Update the summary actions for a chairperson based on the summary and election counts.
+   *
+   * @param summary  The DarCollectionSummary to update
+   * @param closedCount The count of closed elections
+   * @param openCount The count of open elections
+   */
+  private void updateSummaryActionsForChair(
+      DarCollectionSummary summary,
+      Integer closedCount,
+      Integer openCount) {
+
+    // No actions can be taken on a closeout supplement
+    if (summary.getCloseoutSupplement() != null) {
+      summary.getActions().clear();
+      return;
+    }
+
+    // If there are no elections, only show open
+    if (summary.getElections().isEmpty()) {
+      summary.addAction(DarCollectionActions.OPEN);
+    }
+
+    // If there are closed or canceled elections, show open
+    // If there are any open elections, show vote
+    summary.getElections().values().forEach(election -> {
+      ElectionStatus status = ElectionStatus.getStatusFromString(election.getStatus());
+      switch (Objects.requireNonNull(status)) {
+        case CLOSED, CANCELED:
+          summary.addAction(DarCollectionActions.OPEN);
+          break;
+        case OPEN:
+          summary.addAction(DarCollectionActions.VOTE);
+          break;
+        default:
+          break;
       }
     });
+
+    // Add cancel if there are no closed elections and at least one open election
+    if (Objects.isNull(closedCount) && Objects.nonNull(openCount)) {
+      summary.addAction(DarCollectionActions.CANCEL);
+    }
   }
 
   private void processDarCollectionSummariesForSO(List<DarCollectionSummary> summaries) {

--- a/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
@@ -73,8 +73,7 @@ public class DarCollectionService implements ConsentLogger {
   public DarCollectionService(DarCollectionDAO darCollectionDAO,
       DarCollectionServiceDAO collectionServiceDAO, DatasetDAO datasetDAO, ElectionDAO electionDAO,
       DataAccessRequestDAO dataAccessRequestDAO, EmailService emailService, VoteDAO voteDAO,
-      MatchDAO matchDAO, DarCollectionSummaryDAO darCollectionSummaryDAO, UserDAO userDAO,
-      DacDAO dacDAO) {
+      MatchDAO matchDAO, DarCollectionSummaryDAO darCollectionSummaryDAO, UserDAO userDAO, DacDAO dacDAO) {
     this.darCollectionDAO = darCollectionDAO;
     this.collectionServiceDAO = collectionServiceDAO;
     this.datasetDAO = datasetDAO;
@@ -168,12 +167,11 @@ public class DarCollectionService implements ConsentLogger {
       s.addAction(DarCollectionActions.REVIEW);
       //if the latest DAR in the collection has at least one approved dataset,
       //include the create progress report action
-      Set<Integer> datasetIds = dataAccessRequestDAO.findDatasetApprovalsByDar(
-          s.getLatestReferenceId());
+      Set<Integer> datasetIds = dataAccessRequestDAO.findDatasetApprovalsByDar(s.getLatestReferenceId());
       // Can only create a progress report if there are approved datasets and no closeout supplement
       if (!datasetIds.isEmpty() && s.getCloseoutSupplement() == null) {
-        s.addAction(DarCollectionActions.CREATE_PROGRESS_REPORT);
-      }
+          s.addAction(DarCollectionActions.CREATE_PROGRESS_REPORT);
+        }
 
       //check dar statuses, if they're all canceled show revise (but only if there are no elections)
       if (electionCount == 0) {
@@ -246,7 +244,7 @@ public class DarCollectionService implements ConsentLogger {
       //if there are any open elections, show cancel and vote
       Map<String, Integer> statusCount = new HashMap<>();
       Map<Integer, Election> elections = s.getElections();
-      if (elections.isEmpty()) {
+      if (elections.size() == 0) {
         s.setStatus(DarCollectionStatus.SUBMITTED.getValue());
         s.addAction(DarCollectionActions.OPEN);
       } else {
@@ -297,7 +295,7 @@ public class DarCollectionService implements ConsentLogger {
    * Members can see summaries for datasets they have access to Signing Officials can see summaries
    * for researchers in their institution Researchers can see only their own summaries
    *
-   * @param user The user making the request
+   * @param user     The user making the request
    * @param role The role the user is making the request as
    * @return List of DarCollectionSummary objects
    */
@@ -524,7 +522,7 @@ public class DarCollectionService implements ConsentLogger {
   /**
    * Given a DarCollection, add its relevant datasets.
    *
-   * @param collection The list of DarCollections to iterate over.
+   * @param collection      The list of DarCollections to iterate over.
    * @return collection with datasets added
    */
   @VisibleForTesting
@@ -539,15 +537,15 @@ public class DarCollectionService implements ConsentLogger {
           .distinct()
           .collect(Collectors.toMap(Dataset::getDatasetId, Function.identity()));
 
-      Set<Dataset> collectionDatasets = collection.getDars().values().stream()
-          .map(DataAccessRequest::getDatasetIds)
-          .flatMap(Collection::stream)
-          .map(datasetMap::get)
-          .filter(Objects::nonNull) // filtering out nulls which were getting captured by map
-          .collect(Collectors.toSet());
-      DarCollection copy = collection.deepCopy();
-      copy.setDatasets(collectionDatasets);
-      return copy;
+        Set<Dataset> collectionDatasets = collection.getDars().values().stream()
+            .map(DataAccessRequest::getDatasetIds)
+            .flatMap(Collection::stream)
+            .map(datasetMap::get)
+            .filter(Objects::nonNull) // filtering out nulls which were getting captured by map
+            .collect(Collectors.toSet());
+        DarCollection copy = collection.deepCopy();
+        copy.setDatasets(collectionDatasets);
+        return copy;
     }
     // There were no datasets to add, so we return the original list
     return collection;
@@ -559,11 +557,10 @@ public class DarCollectionService implements ConsentLogger {
    *
    * @param user       The User initiating the cancel
    * @param collection The DarCollection
-   * @param role       The role of the user must be one of ADMIN, CHAIRPERSON, or RESEARCHER
+   * @param role       The role of the user, must be one of ADMIN, CHAIRPERSON, or RESEARCHER
    * @return The DarCollection that has been canceled
    */
-  public DarCollection cancelDarCollectionByRole(User user, DarCollection collection,
-      UserRoles role) {
+  public DarCollection cancelDarCollectionByRole(User user, DarCollection collection, UserRoles role) {
     Collection<DataAccessRequest> dars = collection.getDars().values();
     if (dars.isEmpty()) {
       logWarn("DAR Collection ID: [%s] does not have any associated DAR ids".formatted(
@@ -573,7 +570,8 @@ public class DarCollectionService implements ConsentLogger {
 
     return switch (role) {
       case ADMIN -> cancelDarCollectionElectionsAsAdmin(collection);
-      case CHAIRPERSON -> cancelDarCollectionElectionsAsChair(collection, user);
+      case CHAIRPERSON ->
+          cancelDarCollectionElectionsAsChair(collection, user);
       default -> cancelDarCollectionAsResearcher(collection, user);
     };
   }
@@ -586,7 +584,7 @@ public class DarCollectionService implements ConsentLogger {
    * decline or cancel the elections for the collection.
    *
    * @param collection The DarCollection
-   * @param user       the researcher requesting the cancel
+   * @param user the researcher requesting the cancel
    * @return The canceled DarCollection
    */
   private DarCollection cancelDarCollectionAsResearcher(DarCollection collection, User user) {
@@ -694,8 +692,7 @@ public class DarCollectionService implements ConsentLogger {
         List<User> voteUsers = voteDAO.findVoteUsersByElectionReferenceIdList(
             createdElectionReferenceIds);
         if (dar.getProgressReport()) {
-          emailService.sendProgressReportNewCollectionElectionMessage(voteUsers,
-              collection.getDarCode());
+          emailService.sendProgressReportNewCollectionElectionMessage(voteUsers, collection.getDarCode());
         } else {
           emailService.sendDarNewCollectionElectionMessage(voteUsers, collection.getDarCode());
         }
@@ -764,11 +761,9 @@ public class DarCollectionService implements ConsentLogger {
       if (dar.getProgressReport()) {
         // Use the reference ID to link the fact that this progress report will have been noted.
         // the DAR Code at this point will be ambiguous.
-        emailService.sendNewProgressReportRequestEmail(user, sendList, researcherName,
-            collection.getDarCode(), dar.getReferenceId());
+        emailService.sendNewProgressReportRequestEmail(user, sendList, researcherName, collection.getDarCode(), dar.getReferenceId());
       } else {
-        emailService.sendNewDARRequestEmail(user, sendList, researcherName,
-            collection.getDarCode());
+        emailService.sendNewDARRequestEmail(user, sendList, researcherName, collection.getDarCode());
       }
     }
   }

--- a/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
@@ -30,8 +30,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Stream;
-import org.apache.commons.lang3.RandomStringUtils;
-import org.apache.commons.lang3.RandomUtils;
 import org.broadinstitute.consent.http.AbstractTestHelper;
 import org.broadinstitute.consent.http.db.DacDAO;
 import org.broadinstitute.consent.http.db.DarCollectionDAO;
@@ -583,6 +581,41 @@ class DarCollectionServiceTest extends AbstractTestHelper {
   }
 
   @Test
+  void testProcessDarCollectionSummariesForAdminWithCloseout() {
+    User user = new User();
+    user.setUserId(1);
+    DarCollectionSummary summary = new DarCollectionSummary();
+    summary.setLatestReferenceId(UUID.randomUUID().toString());
+    summary.setCloseoutSupplement(new CloseoutSupplement(List.of("Closeout"), "Closeout", 1));
+    when(darCollectionSummaryDAO.getDarCollectionSummariesForAdmin())
+        .thenReturn(List.of(summary));
+
+    List<DarCollectionSummary> summaries = service.getSummariesForRole(user, UserRoles.ADMIN);
+
+    assertNotNull(summaries);
+    assertEquals(1, summaries.size());
+    // Admin summary should not have any actions
+    assertTrue(summaries.get(0).getActions().isEmpty());
+  }
+
+  @Test
+  void testProcessDarCollectionSummariesForAdminWithoutCloseout() {
+    User user = new User();
+    user.setUserId(1);
+    DarCollectionSummary summary = new DarCollectionSummary();
+    summary.setLatestReferenceId(UUID.randomUUID().toString());
+    when(darCollectionSummaryDAO.getDarCollectionSummariesForAdmin())
+        .thenReturn(List.of(summary));
+
+    List<DarCollectionSummary> summaries = service.getSummariesForRole(user, UserRoles.ADMIN);
+
+    assertNotNull(summaries);
+    assertEquals(1, summaries.size());
+    // With no elections, there should be an Open action
+    assertTrue(summaries.get(0).getActions().contains(DarCollectionActions.OPEN.getValue()));
+  }
+
+  @Test
   void testProcessDarCollectionSummariesForResearcher() {
 
     // summaryOne -> in review (elections present)
@@ -1123,6 +1156,43 @@ class DarCollectionServiceTest extends AbstractTestHelper {
   }
 
   @Test
+  void testProcessDarCollectionSummariesForChairWithCloseout() {
+    User user = new User();
+    user.setUserId(1);
+    user.addRole(UserRoles.Chairperson());
+    DarCollectionSummary summary = new DarCollectionSummary();
+    summary.setLatestReferenceId(UUID.randomUUID().toString());
+    summary.setCloseoutSupplement(new CloseoutSupplement(List.of("Closeout"), "Closeout", 1));
+    when(darCollectionSummaryDAO.getDarCollectionSummariesForDAC(user.getUserId(), List.of()))
+        .thenReturn(List.of(summary));
+
+    List<DarCollectionSummary> summaries = service.getSummariesForRole(user, UserRoles.CHAIRPERSON);
+
+    assertNotNull(summaries);
+    assertEquals(1, summaries.size());
+    // Chair summary should not have any actions
+    assertTrue(summaries.get(0).getActions().isEmpty());
+  }
+
+  @Test
+  void testProcessDarCollectionSummariesForChairWithoutCloseout() {
+    User user = new User();
+    user.setUserId(1);
+    user.addRole(UserRoles.Chairperson());
+    DarCollectionSummary summary = new DarCollectionSummary();
+    summary.setLatestReferenceId(UUID.randomUUID().toString());
+    when(darCollectionSummaryDAO.getDarCollectionSummariesForDAC(user.getUserId(), List.of()))
+        .thenReturn(List.of(summary));
+
+    List<DarCollectionSummary> summaries = service.getSummariesForRole(user, UserRoles.CHAIRPERSON);
+
+    assertNotNull(summaries);
+    assertEquals(1, summaries.size());
+    // With no elections, there should be an Open action
+    assertTrue(summaries.get(0).getActions().contains(DarCollectionActions.OPEN.getValue()));
+  }
+
+  @Test
   void testGetSummaryForRoleByCollectionId_SO() {
     User user = new User();
     user.setUserId(1);
@@ -1407,18 +1477,18 @@ class DarCollectionServiceTest extends AbstractTestHelper {
 
   private Dataset createDataset(Integer dacId) {
     Dataset dataset = new Dataset();
-    dataset.setDatasetId(RandomUtils.nextInt(1, 100000));
+    dataset.setDatasetId(randomInt(1, 100000));
     dataset.setAlias(dataset.getDatasetId());
     dataset.setDatasetIdentifier();
     dataset.setDacId(dacId);
-    dataset.setName(String.format("Dataset %s-%s", RandomStringUtils.randomAlphabetic(10),
+    dataset.setName(String.format("Dataset %s-%s", randomAlphabetic(10),
         dataset.getDatasetId()));
     return dataset;
   }
 
   private User createUserWithRole(UserRoles userRoles, Integer dacId) {
     User user = new User();
-    user.setUserId(RandomUtils.nextInt(1, 100000));
+    user.setUserId(randomInt(1, 100000));
     user.setDisplayName(String.format("%s - %s", userRoles.getRoleName(), user.getUserId()));
     user.setEmail(String.format("%s@test.com", userRoles.getRoleName()));
     UserRole role = new UserRole(


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-1774

### Summary
This PR prevents any DAR Summary actions for admins and chairs when there is a closeout present.

Due to the current complexity of `processDarCollectionSummariesForChair`, I have refactored it into two parts. All action-related calculations are extracted to `updateSummaryActionsForChair` and all status calculations are maintained in `processDarCollectionSummariesForChair`

Note that there is some very similar (but not exact) calculations in `processDarCollectionSummariesForAdmin`. I have chosen not to tackle that refactor now.

### Testing
 Start out with a DAR that will be updated to have a closeout. The Admin and Chair screens appropriately show a Re-open action:

![Screenshot 2025-06-12 at 1 19 51 PM](https://github.com/user-attachments/assets/404f5be1-8686-474e-a7a2-1f20eff4e53f)

![Screenshot 2025-06-12 at 1 19 42 PM](https://github.com/user-attachments/assets/d92c93bc-ac0c-4817-8794-23d35c5faa3c)

After submitting a closeout on DAR-672, the Admin and Chair consoles no longer have an action:

![Screenshot 2025-06-12 at 1 21 33 PM](https://github.com/user-attachments/assets/53c3d29b-a431-4839-8184-249f72600050)

![Screenshot 2025-06-12 at 1 21 19 PM](https://github.com/user-attachments/assets/c6a92fde-eaa4-4bb1-9f3a-0f9f9bc3d258)


----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
