### PR TITLE
[DT-1860] Check to make sure Integer is non-zero before assigning it in the mapper

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DataAccessRequestMapper.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DataAccessRequestMapper.java
@@ -25,8 +25,15 @@ public class DataAccessRequestMapper implements RowMapper<DataAccessRequest>, Ro
     if (hasColumn(resultSet, "dar_code")) {
       dar.setDarCode(resultSet.getString("dar_code"));
     }
-    dar.setParentId(resultSet.getInt("parent_id"));
-    dar.setUserId(resultSet.getInt("user_id"));
+
+    if (hasNonZeroColumn(resultSet,"parent_id")) {
+      dar.setParentId(resultSet.getInt("parent_id"));
+    }
+
+    if (hasNonZeroColumn(resultSet, "user_id")) {
+      dar.setUserId(resultSet.getInt("user_id"));
+    }
+
     dar.setCreateDate(resultSet.getTimestamp("create_date"));
     dar.setSortDate(resultSet.getTimestamp("sort_date"));
     dar.setSubmissionDate(resultSet.getTimestamp("submission_date"));

--- a/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
@@ -234,6 +234,7 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
     assertFalse(dars.isEmpty());
     assertEquals(3, dars.size());
     dars.forEach(dar -> assertNotNull(dar.getDarCode()));
+    dars.forEach(dar -> assertNull(dar.getParentId()));
   }
 
   @Test


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-1860](https://broadworkbench.atlassian.net/browse/DT-1860)

### Summary

This is a quirk of JDBI and this was leading to cases where we thought DARs were progress reports but the parent IDs were set to zero instead of null.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
