### PR TITLE
[DT-1862] Dac object not populated from dao

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
@@ -539,7 +539,8 @@ public class ConsentModule extends AbstractModule {
         providesLibraryCardDAO(),
         providesInstitutionDAO(),
         providesInstitutionService(),
-        providesUserDAO());
+        providesUserDAO(),
+        providesEmailService());
   }
 
   @Provides

--- a/src/main/java/org/broadinstitute/consent/http/enumeration/EmailType.java
+++ b/src/main/java/org/broadinstitute/consent/http/enumeration/EmailType.java
@@ -27,7 +27,8 @@ public enum EmailType {
   NEW_PROGRESS_REPORT_CASE(23, "new-progress-report-case.html"),
   RESEARCHER_PROGRESS_REPORT_APPROVED(24, "researcher-progress-report-approved.html"),
   RESEARCHER_CLOSEOUT_COMPLETED(25, "researcher-closeout-completed.html"),
-  SUBMITTED_CLOSEOUT(26, "submitted-closeout.html");
+  SUBMITTED_CLOSEOUT(26, "submitted-closeout.html"),
+  NEW_LIBRARY_CARD_ISSUED(27, "new-library-card-issued.html");
 
   private final Integer typeInt;
   public final String templateName;

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/NewLibraryCardIssuedMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/NewLibraryCardIssuedMessage.java
@@ -4,9 +4,8 @@ import java.util.Map;
 import org.broadinstitute.consent.http.enumeration.EmailType;
 import org.broadinstitute.consent.http.models.User;
 
-public class NewLibraryCardIssuedMessage extends MailMessage{
-  private static final String NEW_LIBRARY_CARD_ISSUED =
-      "Library Card Issued in DUOS.";
+public class NewLibraryCardIssuedMessage extends MailMessage {
+  private static final String NEW_LIBRARY_CARD_ISSUED = "Library Card Issued in DUOS.";
 
   public NewLibraryCardIssuedMessage(User toUser) {
     super(toUser, EmailType.NEW_LIBRARY_CARD_ISSUED);

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/NewLibraryCardIssuedMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/NewLibraryCardIssuedMessage.java
@@ -1,0 +1,32 @@
+package org.broadinstitute.consent.http.mail.message;
+
+import java.util.Map;
+import org.broadinstitute.consent.http.enumeration.EmailType;
+import org.broadinstitute.consent.http.models.User;
+
+public class NewLibraryCardIssuedMessage extends MailMessage{
+  private static final String NEW_LIBRARY_CARD_ISSUED =
+      "Library Card Issued in DUOS.";
+
+  public NewLibraryCardIssuedMessage(User toUser) {
+    super(toUser, EmailType.NEW_LIBRARY_CARD_ISSUED);
+  }
+
+  @Override
+  public String createSubject() {
+    return NEW_LIBRARY_CARD_ISSUED;
+  }
+
+  @Override
+  public Object createModel(String serverUrl) {
+    return Map.of(
+        "linkUrl", serverUrl + "datalibrary",
+        "displayName", toUser.getDisplayName()
+    );
+  }
+
+  @Override
+  public String getEntityReferenceId() {
+    return toUser.getEmail();
+  }
+}

--- a/src/main/java/org/broadinstitute/consent/http/service/DacService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DacService.java
@@ -11,6 +11,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -294,7 +295,9 @@ public class DacService implements ConsentLogger {
   }
 
   public Set<Dac> findByDatasetId(List<Integer> datasetIds) {
-    return dacDAO.findDacsForDatasetIds(datasetIds);
+    Set<Dac> returnSet = new HashSet<>();
+    dacDAO.findDacsForDatasetIds(datasetIds).forEach(dac -> returnSet.add(findById(dac.getDacId())));
+    return returnSet;
   }
 
 }

--- a/src/main/java/org/broadinstitute/consent/http/service/EmailService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/EmailService.java
@@ -35,6 +35,7 @@ import org.broadinstitute.consent.http.mail.message.NewCaseMessage;
 import org.broadinstitute.consent.http.mail.message.NewDAAUploadResearcherMessage;
 import org.broadinstitute.consent.http.mail.message.NewDAAUploadSOMessage;
 import org.broadinstitute.consent.http.mail.message.NewDARRequestMessage;
+import org.broadinstitute.consent.http.mail.message.NewLibraryCardIssuedMessage;
 import org.broadinstitute.consent.http.mail.message.NewProgressReportCaseMessage;
 import org.broadinstitute.consent.http.mail.message.NewProgressReportRequestMessage;
 import org.broadinstitute.consent.http.mail.message.NewResearcherLibraryRequestMessage;
@@ -47,6 +48,7 @@ import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.Vote;
 import org.broadinstitute.consent.http.models.dto.DatasetMailDTO;
 import org.broadinstitute.consent.http.util.ConsentLogger;
+import org.eclipse.jetty.util.IO;
 
 public class EmailService implements ConsentLogger {
 
@@ -307,5 +309,15 @@ public class EmailService implements ConsentLogger {
   public void sendSubmittedCloseoutMessage(User toUser, String darId, String referenceId, String closeoutUrl)
       throws TemplateException, IOException {
     sendMessage(new SubmittedCloseoutMessage(toUser, darId, referenceId, closeoutUrl), toUser.getUserId());
+  }
+
+  /**
+   * Send a message to the user when they are issued a library card
+   * @param toUser              The user to send the message to
+   * @throws TemplateException  Template processing exception
+   * @throws IOException        IOException when processing the template or sending the email
+   */
+  public void sendNewLibraryCardIssuedMessage(User toUser) throws TemplateException, IOException {
+    sendMessage(new NewLibraryCardIssuedMessage(toUser), toUser.getUserId());
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/service/EmailService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/EmailService.java
@@ -48,7 +48,6 @@ import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.Vote;
 import org.broadinstitute.consent.http.models.dto.DatasetMailDTO;
 import org.broadinstitute.consent.http.util.ConsentLogger;
-import org.eclipse.jetty.util.IO;
 
 public class EmailService implements ConsentLogger {
 
@@ -313,9 +312,10 @@ public class EmailService implements ConsentLogger {
 
   /**
    * Send a message to the user when they are issued a library card
-   * @param toUser              The user to send the message to
-   * @throws TemplateException  Template processing exception
-   * @throws IOException        IOException when processing the template or sending the email
+   *
+   * @param toUser The user to send the message to
+   * @throws TemplateException Template processing exception
+   * @throws IOException IOException when processing the template or sending the email
    */
   public void sendNewLibraryCardIssuedMessage(User toUser) throws TemplateException, IOException {
     sendMessage(new NewLibraryCardIssuedMessage(toUser), toUser.getUserId());

--- a/src/main/java/org/broadinstitute/consent/http/service/LibraryCardService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/LibraryCardService.java
@@ -1,8 +1,10 @@
 package org.broadinstitute.consent.http.service;
 
 import com.google.inject.Inject;
+import freemarker.template.TemplateException;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.NotFoundException;
+import java.io.IOException;
 import java.util.Date;
 import java.util.List;
 import java.util.Objects;
@@ -11,25 +13,29 @@ import org.broadinstitute.consent.http.db.LibraryCardDAO;
 import org.broadinstitute.consent.http.db.UserDAO;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.exceptions.ConsentConflictException;
+import org.broadinstitute.consent.http.mail.message.NewLibraryCardIssuedMessage;
 import org.broadinstitute.consent.http.models.Institution;
 import org.broadinstitute.consent.http.models.LibraryCard;
 import org.broadinstitute.consent.http.models.User;
+import org.broadinstitute.consent.http.util.ConsentLogger;
 
-public class LibraryCardService {
+public class LibraryCardService implements ConsentLogger {
 
   private final LibraryCardDAO libraryCardDAO;
   private final InstitutionDAO institutionDAO;
   private final InstitutionService institutionService;
   private final UserDAO userDAO;
+  private final EmailService emailService;
 
   @Inject
   public LibraryCardService(LibraryCardDAO libraryCardDAO, InstitutionDAO institutionDAO,
       InstitutionService institutionService,
-      UserDAO userDAO) {
+      UserDAO userDAO, EmailService emailService) {
     this.libraryCardDAO = libraryCardDAO;
     this.institutionDAO = institutionDAO;
     this.institutionService = institutionService;
     this.userDAO = userDAO;
+    this.emailService = emailService;
   }
 
   public LibraryCard createLibraryCard(LibraryCard libraryCard, User user) {
@@ -47,6 +53,14 @@ public class LibraryCardService {
         libraryCard.getUserEmail(),
         libraryCard.getCreateUserId(),
         createDate);
+    User toUser = userDAO.findUserByEmail(libraryCard.getUserEmail());
+    if (toUser != null) {
+      try {
+        emailService.sendNewLibraryCardIssuedMessage(toUser);
+      } catch (IOException | TemplateException e) {
+          logWarn("Failed to send library card issuance notification for user " + user.getUserId(), e);
+        }
+    }
     return libraryCardDAO.findLibraryCardById(id);
   }
 

--- a/src/main/resources/freemarker/new-library-card-issued.html
+++ b/src/main/resources/freemarker/new-library-card-issued.html
@@ -26,7 +26,7 @@
       </td>
     </tr>
     <tr>
-      <td style="padding: 15px 15px 0; font-family: 'Montserrat', sans-serif; font-size: 16px; color: #1F3B50; text-align: justify; line-height: 25px;">
+      <td id="content" style="padding: 15px 15px 0; font-family: 'Montserrat', sans-serif; font-size: 16px; color: #1F3B50; text-align: justify; line-height: 25px;">
         You have successfully been issued a Library Card by your institution’s Signing Official.
         You can now initiate data access requests. Get started by searching for data you would like
         to access in the DUOS <a href="${linkUrl}"

--- a/src/main/resources/freemarker/new-library-card-issued.html
+++ b/src/main/resources/freemarker/new-library-card-issued.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Broad Data Use Oversight System - Your Library Card Has Been Issued!</title>
+</head>
+
+<body
+    style="text-align: center; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none; width: 100%; height: 100%; margin: 0; padding: 0;">
+<div style="text-align: left; margin: 0 auto; width: 600px;">
+  <table style="width: 600px">
+    <tr>
+      <th></th>
+    </tr>
+    <tr>
+      <td style="padding: 15px 15px 0; text-align: center;">
+        <img src="https://duos.org/images/favicon/android-chrome-192x192.png" height="100px"
+             width="100px" alt="DUOS Logo">
+      </td>
+    </tr>
+    <tr>
+      <td id="displayName"
+          style="padding: 15px 15px 0; font-family: 'Montserrat', sans-serif; font-size: 22px; color: #1F3B50; text-align: left; line-height: 25px; display: block; font-weight: 500;">
+        Hello ${displayName},
+      </td>
+    </tr>
+    <tr>
+      <td style="padding: 15px 15px 0; font-family: 'Montserrat', sans-serif; font-size: 16px; color: #1F3B50; text-align: justify; line-height: 25px;">
+        You have successfully been issued a Library Card by your institution’s Signing Official.
+        You can now initiate data access requests. Get started by searching for data you would like
+        to access in the DUOS <a href="${linkUrl}"
+          style="text-decoration: none; font-family: 'Montserrat', sans-serif; color: #00609F; font-size: 20px; font-weight: bold;"
+      >Data Library</a>.
+      </td>
+    </tr>
+  </table>
+</div>
+</body>
+</html>

--- a/src/test/java/org/broadinstitute/consent/http/mail/message/NewLibraryCardIssuedMessageTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mail/message/NewLibraryCardIssuedMessageTest.java
@@ -1,0 +1,57 @@
+package org.broadinstitute.consent.http.mail.message;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import freemarker.template.TemplateException;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.Objects;
+import org.broadinstitute.consent.http.configurations.FreeMarkerConfiguration;
+import org.broadinstitute.consent.http.mail.freemarker.FreeMarkerTemplateHelper;
+import org.broadinstitute.consent.http.models.User;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class NewLibraryCardIssuedMessageTest {
+  private FreeMarkerTemplateHelper helper;
+
+  @BeforeEach
+  void setUp() {
+    FreeMarkerConfiguration freeMarkerConfig = new FreeMarkerConfiguration();
+    freeMarkerConfig.setTemplateDirectory("/freemarker");
+    freeMarkerConfig.setDefaultEncoding("UTF-8");
+    helper = new FreeMarkerTemplateHelper(freeMarkerConfig);
+  }
+
+  @Test
+  void testNewLibraryCardIssuedTemplate() throws IOException, TemplateException {
+    User toUser = new User();
+    toUser.setDisplayName("Test User");
+    toUser.setEmail("test.user@test.com");
+    toUser.setUserId(1);
+    String serverUrl = "http://localhost:8080/";
+    String expectedUrl = serverUrl+"datalibrary";
+    var message = new NewLibraryCardIssuedMessage(toUser);
+    assertEquals(toUser.getEmail(), message.getEntityReferenceId());
+
+    var template = helper.getTemplate(message.getTemplateName());
+
+    var out = new StringWriter();
+    template.process(message.createModel(serverUrl), out);
+    var templateString = out.toString();
+    Document parsedTemplate = Jsoup.parse(templateString);
+    assertEquals("Broad Data Use Oversight System - Your Library Card Has Been Issued!",
+        parsedTemplate.title());
+
+    assertEquals("Hello %s,".formatted(toUser.getDisplayName()), getElementTextById(parsedTemplate, "displayName"));
+    assertThat(getElementTextById(parsedTemplate,"content"), contains(expectedUrl));
+  }
+
+  String getElementTextById(Document document, String id) {
+    return Objects.requireNonNull(document.getElementById(id)).text();
+  }
+}

--- a/src/test/java/org/broadinstitute/consent/http/mail/message/NewLibraryCardIssuedMessageTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mail/message/NewLibraryCardIssuedMessageTest.java
@@ -1,8 +1,10 @@
 package org.broadinstitute.consent.http.mail.message;
 
+
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import freemarker.template.TemplateException;
 import java.io.IOException;
@@ -16,7 +18,7 @@ import org.jsoup.nodes.Document;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class NewLibraryCardIssuedMessageTest {
+class NewLibraryCardIssuedMessageTest {
   private FreeMarkerTemplateHelper helper;
 
   @BeforeEach
@@ -34,7 +36,7 @@ public class NewLibraryCardIssuedMessageTest {
     toUser.setEmail("test.user@test.com");
     toUser.setUserId(1);
     String serverUrl = "http://localhost:8080/";
-    String expectedUrl = serverUrl+"datalibrary";
+    String expectedUrl = serverUrl + "datalibrary";
     var message = new NewLibraryCardIssuedMessage(toUser);
     assertEquals(toUser.getEmail(), message.getEntityReferenceId());
 
@@ -44,11 +46,21 @@ public class NewLibraryCardIssuedMessageTest {
     template.process(message.createModel(serverUrl), out);
     var templateString = out.toString();
     Document parsedTemplate = Jsoup.parse(templateString);
-    assertEquals("Broad Data Use Oversight System - Your Library Card Has Been Issued!",
+    assertEquals(
+        "Broad Data Use Oversight System - Your Library Card Has Been Issued!",
         parsedTemplate.title());
 
-    assertEquals("Hello %s,".formatted(toUser.getDisplayName()), getElementTextById(parsedTemplate, "displayName"));
-    assertThat(getElementTextById(parsedTemplate,"content"), contains(expectedUrl));
+    assertEquals(
+        "Hello %s,".formatted(toUser.getDisplayName()),
+        getElementTextById(parsedTemplate, "displayName"));
+    assertThat(
+        getElementTextById(parsedTemplate, "content"),
+        containsString(
+            "You can now initiate data access requests. Get started by searching for data you would like to access in the DUOS Data Library."));
+    assertTrue(
+        Objects.requireNonNull(parsedTemplate.getElementById("content"))
+            .html()
+            .contains(expectedUrl));
   }
 
   String getElementTextById(Document document, String id) {

--- a/src/test/java/org/broadinstitute/consent/http/service/EmailServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/EmailServiceTest.java
@@ -440,6 +440,28 @@ class EmailServiceTest extends AbstractTestHelper {
     );
   }
 
+  @Test
+  void testSendNewLibraryCardIssuedMessage() throws Exception {
+    User toUser = new User();
+    toUser.setDisplayName("Test User");
+    toUser.setEmail("test.user@test.com");
+    when(templateHelper.getTemplate(EmailType.NEW_LIBRARY_CARD_ISSUED.templateName)).thenReturn(mock());
+
+    service.sendNewLibraryCardIssuedMessage(toUser);
+    verify(sendGridAPI).sendMessage(any(Mail.class), eq(toUser.getEmail()));
+    verify(emailDAO).insert(
+        eq(toUser.getEmail()),
+        eq(null),
+        eq(toUser.getUserId()),
+        eq(EmailType.NEW_LIBRARY_CARD_ISSUED.getTypeInt()),
+        any(),
+        any(),
+        any(),
+        any(),
+        any()
+    );
+  }
+
   private List<MailMessage> generateMailMessageList() {
     return Collections.nCopies(2, generateMailMessage());
   }

--- a/src/test/java/org/broadinstitute/consent/http/service/LibraryCardServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/LibraryCardServiceTest.java
@@ -11,11 +11,15 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import freemarker.template.TemplateException;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.NotFoundException;
+import java.io.IOException;
 import java.util.List;
 import org.broadinstitute.consent.http.AbstractTestHelper;
 import org.broadinstitute.consent.http.db.InstitutionDAO;
@@ -47,20 +51,23 @@ class LibraryCardServiceTest extends AbstractTestHelper {
   private InstitutionService institutionService;
   @Mock
   private UserDAO userDAO;
+  @Mock
+  private EmailService emailService;
 
   @BeforeEach
   void initService() {
-    service = new LibraryCardService(libraryCardDAO, institutionDAO, institutionService, userDAO);
+    service = new LibraryCardService(libraryCardDAO, institutionDAO, institutionService, userDAO, emailService);
   }
 
   @Test
     // Test Admin LC create with userId and email
-  void testCreateLibraryCardFullUserDetailsAsAdmin() {
+  void testCreateLibraryCardFullUserDetailsAsAdmin() throws TemplateException, IOException {
     Institution institution = testInstitution();
     User user = testUser(institution.getId());
     user.setEmail("testemail");
     User adminUser = createUserWithRole(UserRoles.ADMIN.getRoleId(), UserRoles.ADMIN.getRoleName());
     when(userDAO.findUserById(user.getUserId())).thenReturn(user);
+    when(userDAO.findUserByEmail(user.getEmail())).thenReturn(user);
 
     LibraryCard payload = testLibraryCard(user.getUserId());
     payload.setUserEmail(user.getEmail());
@@ -75,20 +82,23 @@ class LibraryCardServiceTest extends AbstractTestHelper {
     verify(libraryCardDAO).insertLibraryCard(eq(user.getUserId()),
         eq(payload.getUserName()), eq(user.getEmail()),
         eq(payload.getCreateUserId()), any());
+    verify(emailService).sendNewLibraryCardIssuedMessage(user);
   }
 
   @Test
     // Test SO LC create with userId and email success case
-  void testCreateLibraryCardFullUserDetailsAsSOSameInstitution() {
+  void testCreateLibraryCardFullUserDetailsAsSOSameInstitution()
+      throws TemplateException, IOException {
     Institution institution = testInstitution();
     User user = testUser(institution.getId());
     user.setEmail("testemail");
     User soUser = createUserWithRole(UserRoles.SIGNINGOFFICIAL.getRoleId(), UserRoles.SIGNINGOFFICIAL.getRoleName());
     soUser.setInstitutionId(institution.getId());
     when(userDAO.findUserById(user.getUserId())).thenReturn(user);
+    when(userDAO.findUserByEmail(user.getEmail())).thenReturn(user);
     when(institutionDAO.findInstitutionById(institution.getId())).thenReturn(institution);
     when(institutionService.findInstitutionForEmail(user.getEmail())).thenReturn(institution);
-
+    doThrow(IOException.class).when(emailService).sendNewLibraryCardIssuedMessage(user);
     LibraryCard payload = testLibraryCard(user.getUserId());
     payload.setUserEmail(user.getEmail());
     payload.setUserName("username");
@@ -127,7 +137,7 @@ class LibraryCardServiceTest extends AbstractTestHelper {
 
   @Test
     //Test LC create with only user email (no userId)
-  void testCreateLibraryCardPartialUserDetailsEmail() {
+  void testCreateLibraryCardPartialUserDetailsEmail() throws TemplateException, IOException {
     Institution institution = testInstitution();
     User user = testUser(institution.getId());
     User adminUser = createUserWithRole(UserRoles.ADMIN.getRoleId(), UserRoles.ADMIN.getRoleName());
@@ -136,11 +146,13 @@ class LibraryCardServiceTest extends AbstractTestHelper {
 
     // last two calls in the function, no need to test within this service test file
     when(libraryCardDAO.findLibraryCardById(anyInt())).thenReturn(new LibraryCard());
+    when(userDAO.findUserByEmail(user.getEmail())).thenReturn(null);
 
     LibraryCard payload = testLibraryCard(user.getUserId());
     payload.setUserEmail(user.getEmail());
     service.createLibraryCard(payload, adminUser);
     verify(libraryCardDAO).insertLibraryCard(eq(null), eq(null), any(), eq(null), any());
+    verify(emailService, times(0)).sendNewLibraryCardIssuedMessage(user);
   }
 
   @Test


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-1862](https://broadworkbench.atlassian.net/browse/DT-1862)

### Summary

We have objects returned from the DAC DAO that aren't fully populated.  This update will rely on an existing service method to populate the needed information so the list of chairpeople to notify can be built.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
