### PR TITLE
[DT-1862] Use service method to populate needed information.

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/service/DacService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DacService.java
@@ -295,9 +295,8 @@ public class DacService implements ConsentLogger {
   }
 
   public Set<Dac> findByDatasetId(List<Integer> datasetIds) {
-    Set<Dac> returnSet = new HashSet<>();
-    dacDAO.findDacsForDatasetIds(datasetIds).forEach(dac -> returnSet.add(findById(dac.getDacId())));
-    return returnSet;
+    return dacDAO.findDacsForDatasetIds(datasetIds).stream().map(dac -> findById(dac.getDacId())).collect(
+        Collectors.toUnmodifiableSet());
   }
 
 }

--- a/src/main/java/org/broadinstitute/consent/http/service/DacService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DacService.java
@@ -11,6 +11,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -294,7 +295,9 @@ public class DacService implements ConsentLogger {
   }
 
   public Set<Dac> findByDatasetId(List<Integer> datasetIds) {
-    return dacDAO.findDacsForDatasetIds(datasetIds);
+    Set<Dac> returnSet = new HashSet<>();
+    dacDAO.findDacsForDatasetIds(datasetIds).forEach(dac -> returnSet.add(findById(dac.getDacId())));
+    return returnSet;
   }
 
 }


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-1862](https://broadworkbench.atlassian.net/browse/DT-1862)

### Summary

We have objects returned from the DAC DAO that aren't fully populated. This update will rely on an existing service method to populate the needed information so the list of chairpeople to notify can be built.

This PR is taking the limited approach of populating the necessary information using the patterns already in this class.  A ticket for a [larger refactor to stop producing thinly populated objects](https://broadworkbench.atlassian.net/browse/DT-1863) has been created.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
