### PR TITLE
DT-1877: Update Dataset Queries User Joins

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
@@ -170,7 +170,7 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
               fso.deleted AS fso_deleted,
               fso.delete_user_id AS fso_delete_user_id
           FROM dataset d
-          INNER JOIN users u on d.create_user_id = u.user_id
+          LEFT JOIN users u on d.create_user_id = u.user_id
           LEFT JOIN (SELECT DISTINCT dataset_id AS id FROM dar_dataset) dar_ds_ids ON dar_ds_ids.id = d.dataset_id
           LEFT JOIN dataset_property dp ON dp.dataset_id = d.dataset_id
           LEFT JOIN dictionary k ON k.key_id = dp.property_key
@@ -217,7 +217,7 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
               u.institution_id AS u_institution_id, u.era_commons_id AS u_era_commons_id,
               k.key, dp.property_value, dp.property_key, dp.property_type, dp.schema_property, dp.property_id
           FROM dataset d
-          INNER JOIN users u on d.create_user_id = u.user_id
+          LEFT JOIN users u on d.create_user_id = u.user_id
           LEFT JOIN (SELECT DISTINCT dataset_id AS id FROM dar_dataset) dar_ds_ids ON dar_ds_ids.id = d.dataset_id
           LEFT JOIN dataset_property dp ON dp.dataset_id = d.dataset_id
           LEFT JOIN dictionary k ON k.key_id = dp.property_key
@@ -282,7 +282,7 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
               fso.deleted AS fso_deleted,
               fso.delete_user_id AS fso_delete_user_id
           FROM dataset d
-          INNER JOIN users u on d.create_user_id = u.user_id
+          LEFT JOIN users u on d.create_user_id = u.user_id
           LEFT JOIN (SELECT DISTINCT dataset_id AS id FROM dar_dataset) dar_ds_ids ON dar_ds_ids.id = d.dataset_id
           LEFT JOIN dataset_property dp ON dp.dataset_id = d.dataset_id
           LEFT JOIN dictionary k ON k.key_id = dp.property_key
@@ -323,7 +323,7 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
               fso.deleted AS fso_deleted,
               fso.delete_user_id AS fso_delete_user_id
           FROM dataset d
-          INNER JOIN users u on d.create_user_id = u.user_id
+          LEFT JOIN users u on d.create_user_id = u.user_id
           LEFT JOIN (SELECT DISTINCT dataset_id AS id FROM dar_dataset) dar_ds_ids ON dar_ds_ids.id = d.dataset_id
           LEFT JOIN dataset_property dp ON dp.dataset_id = d.dataset_id
           LEFT JOIN dictionary k ON k.key_id = dp.property_key

--- a/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
@@ -332,10 +332,6 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
       """)
   List<Dataset> findDatasetsByAlias(@BindList(value = "aliases", onEmpty = EmptyHandling.NULL_STRING) List<Integer> aliases);
 
-  @Deprecated
-  @SqlBatch("INSERT INTO dataset (name, create_date, object_id, alias, data_use) VALUES (:name, :createDate, :objectId, :alias, :dataUse)")
-  void insertAll(@BindBean Collection<Dataset> datasets);
-
   @SqlUpdate("UPDATE dataset SET dac_id = :dacId WHERE dataset_id = :datasetId")
   void updateDatasetDacId(@Bind("datasetId") Integer datasetId, @Bind("dacId") Integer dacId);
 


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-1877

### Summary
There exist datasets with null create users. In that case, they are being filtered out of the DAR summary view. For example, this DAR on dev shows only 2 of the 5 datasets that exist for it due to this bug:

![Screenshot 2025-06-24 at 1 58 33 PM](https://github.com/user-attachments/assets/2548acb8-86da-49fd-b8e8-8cb2a18025e8)

This PR relaxes the join on user and removes the old method that allowed for this case to exist.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
