### PR TITLE
[DT-1419] Run patch updates on 1st and 15th of month

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,15 @@ updates:
       action-dependencies:
         patterns:
           - "*"
+        update-types:
+          - "major"
+          - "minor"
+      action-patch-updates:
+        update-types:
+          - "patch"
+        schedule:
+          interval: cron
+          cronjob: "0 0 1,15 * *"
   - package-ecosystem: maven
     directory: "/"
     schedule:
@@ -26,6 +35,15 @@ updates:
       maven-dependencies:
         patterns:
           - "*"
+        update-types:
+          - "major"
+          - "minor"
+      maven-patch-updates:
+        update-types:
+          - "patch"
+        schedule:
+          interval: cron
+          cronjob: "0 0 1,15 * *"
   - package-ecosystem: docker
     directory: "/"
     schedule:
@@ -40,3 +58,12 @@ updates:
       docker-dependencies:
         patterns:
           - "*"
+        update-types:
+          - "major"
+          - "minor"
+      docker-patch-updates:
+        update-types:
+          - "patch"
+        schedule:
+          interval: cron
+          cronjob: "0 0 1,15 * *"


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-1419

### Summary

Reduce the burden of Dependabot updates by running patch updates twice a month.

Cron doesn't have an exact way to specify "twice a month" or "every two weeks", so instead this runs on the 1st and 15th of the month.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
