### PR TITLE
[DT-1888] Memorialize user's eRA Commons ID when progress report is created

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/DataAccessRequestDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DataAccessRequestDAO.java
@@ -38,7 +38,7 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
   @UseRowReducer(DataAccessRequestReducer.class)
   @SqlQuery(
       """
-          SELECT collection.dar_code, dd.dataset_id, dar.id, dar.reference_id, dar.collection_id, 
+          SELECT collection.dar_code, dd.dataset_id, dar.id, dar.reference_id, dar.collection_id,
             dar.parent_id, dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date,
             (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data, dar.era_commons_id,
             dar.closeout_so_approval_timestamp, dar.closeout_approving_so_id
@@ -182,7 +182,7 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
       """
               SELECT dd.dataset_id, dar.id, dar.reference_id, dar.collection_id, dar.parent_id,
               dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date,
-              (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data, collection.dar_code, 
+              (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data, collection.dar_code,
               dar.era_commons_id, dar.closeout_so_approval_timestamp, dar.closeout_approving_so_id
               FROM data_access_request dar
               LEFT JOIN dar_collection collection on collection.collection_id = dar.collection_id
@@ -203,7 +203,7 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
       """
               SELECT dd.dataset_id, dar.id, dar.reference_id, dar.collection_id, dar.parent_id,
               dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date,
-              (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data, 
+              (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data,
               collection.dar_code, dar.era_commons_id, dar.closeout_so_approval_timestamp,
               dar.closeout_approving_so_id
               FROM data_access_request dar
@@ -390,15 +390,16 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
   @SqlUpdate(
       """
           INSERT INTO data_access_request
-            (parent_id, collection_id, reference_id, user_id, create_date, sort_date, submission_date, update_date, data)
-          VALUES (:parentId, :collectionId, :referenceId, :userId, now(), now(), now(), now(), to_jsonb(:data))
+            (parent_id, collection_id, reference_id, user_id, create_date, sort_date, submission_date, update_date, data, era_commons_id)
+          VALUES (:parentId, :collectionId, :referenceId, :userId, now(), now(), now(), now(), to_jsonb(:data), :eraCommonsId)
       """)
   void insertProgressReport(
       @Bind("parentId") Integer parentId,
       @Bind("collectionId") Integer collectionId,
       @Bind("referenceId") String referenceId,
       @Bind("userId") Integer userId,
-      @Bind("data") @Json DataAccessRequestData data);
+      @Bind("data") @Json DataAccessRequestData data,
+      @Bind("eraCommonsId") String eraCommonsId);
 
 
   /**

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
@@ -274,7 +274,8 @@ public class DataAccessRequestService implements ConsentLogger {
           progressReport.getCollectionId(),
           referenceId,
           user.getUserId(),
-          progressReport.getData());
+          progressReport.getData(),
+          user.getEraCommonsId());
     } catch (JdbiException e) {
       throw new BadRequestException(
           "Unable to create progress report for Data Access Request " + parentDar.getReferenceId());

--- a/src/test/java/org/broadinstitute/consent/http/db/DarCollectionSummaryDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DarCollectionSummaryDAOTest.java
@@ -55,7 +55,8 @@ class DarCollectionSummaryDAOTest extends DAOTestHelper {
         dar.getCollectionId(),
         referenceId,
         dar.getUserId(),
-        dar.getData());
+        dar.getData(),
+        dar.getEraCommonsId());
     DataAccessRequest progressReport = dataAccessRequestDAO.findByReferenceId(referenceId);
     dar.getDatasetIds().forEach(datasetId -> {
       dataAccessRequestDAO.insertDARDatasetRelation(referenceId, datasetId);
@@ -1100,7 +1101,8 @@ class DarCollectionSummaryDAOTest extends DAOTestHelper {
         parent.getCollectionId(),
         referenceId,
         userId,
-        data);
+        data,
+        parent.getEraCommonsId());
     // Insert dataset relations for the progress report
     parent.getDatasetIds().forEach(datasetId -> {
       dataAccessRequestDAO.insertDARDatasetRelation(referenceId, datasetId);

--- a/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
@@ -752,7 +752,7 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
     assertTrue(approvedDatasetIds.contains(dataset.getDatasetId()));
 
     // Create a closeout DAR for the parent DAR
-    DataAccessRequest closeoutDAR = createProgressReport(user.getUserId(), collectionId,
+    DataAccessRequest closeoutDAR = createProgressReport(user.getEraCommonsId(), user.getUserId(), collectionId,
         parentDAR.getId());
     CloseoutSupplement closeout = new CloseoutSupplement(List.of("Reason"), "Other Reason",
         user.getUserId());
@@ -914,7 +914,7 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
     assertEquals(parentDAR.getReferenceId(), approvedDARs.get(0).getReferenceId());
 
     // Create a closeout DAR from the parent DAR
-    DataAccessRequest closeoutDAR = createProgressReport(user.getUserId(), collectionId,
+    DataAccessRequest closeoutDAR = createProgressReport(user.getEraCommonsId(), user.getUserId(), collectionId,
         parentDAR.getId());
     CloseoutSupplement closeout = new CloseoutSupplement(List.of("Reason"), "Other Reason",
         user.getUserId());
@@ -998,7 +998,7 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
   void createProgressReport() {
     DarCollection darCollection = createDarCollection();
     DataAccessRequest dar = new ArrayList<>(darCollection.getDars().values()).get(0);
-    DataAccessRequest progressReport = createProgressReport(dar.getUserId(),
+    DataAccessRequest progressReport = createProgressReport(createUser().getEraCommonsId(), dar.getUserId(),
         darCollection.getDarCollectionId(),
         dar.getId());
 
@@ -1022,11 +1022,11 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
     Integer userId = dar.getUserId();
     Integer darCollectionId = darCollection.getDarCollectionId();
     Integer id = dar.getId();
-    DataAccessRequest progressReport = createProgressReport(userId, darCollectionId, id);
+    DataAccessRequest progressReport = createProgressReport(dar.getEraCommonsId(), userId, darCollectionId, id);
     assertNotNull(progressReport);
 
     // Insert of second progress report should fail.
-    assertThrows(JdbiException.class, () -> createProgressReport(userId, darCollectionId, id));
+    assertThrows(JdbiException.class, () -> createProgressReport(dar.getEraCommonsId(), userId, darCollectionId, id));
 
     // Check that the first progress report is not updated.
     DataAccessRequest firstProgressReport = dataAccessRequestDAO.findByReferenceId(progressReport.getReferenceId());
@@ -1290,7 +1290,7 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
     return dataAccessRequestDAO.findByReferenceId(referenceId);
   }
 
-  private DataAccessRequest createProgressReport(Integer userId, Integer collectionId,
+  private DataAccessRequest createProgressReport(String eraCommonsId, Integer userId, Integer collectionId,
       Integer parentId) {
     DataAccessRequestData data = createDataAccessRequestData(
     );
@@ -1300,7 +1300,8 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
         collectionId,
         referenceId,
         userId,
-        data);
+        data,
+        eraCommonsId);
     return dataAccessRequestDAO.findByReferenceId(referenceId);
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
@@ -1019,6 +1019,7 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
   void insertProgressReport_WithExistingProgressReport() {
     DarCollection darCollection = createDarCollection();
     DataAccessRequest dar = darCollection.getDars().values().stream().findFirst().orElseThrow();
+    String eraCommonsId = dar.getEraCommonsId();
     Integer userId = dar.getUserId();
     Integer darCollectionId = darCollection.getDarCollectionId();
     Integer id = dar.getId();
@@ -1026,7 +1027,7 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
     assertNotNull(progressReport);
 
     // Insert of second progress report should fail.
-    assertThrows(JdbiException.class, () -> createProgressReport(dar.getEraCommonsId(), userId, darCollectionId, id));
+    assertThrows(JdbiException.class, () -> createProgressReport(eraCommonsId, userId, darCollectionId, id));
 
     // Check that the first progress report is not updated.
     DataAccessRequest firstProgressReport = dataAccessRequestDAO.findByReferenceId(progressReport.getReferenceId());

--- a/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
@@ -282,7 +282,7 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     verify(dataAccessRequestDAO)
         .insertProgressReport(parentDar.getId(), progressReport.getCollectionId(),
             progressReport.getReferenceId(), user.getUserId(),
-            progressReport.getData());
+            progressReport.getData(), user.getEraCommonsId());
     verify(dataAccessRequestDAO).insertAllDarDatasets(
         argThat(new DarDatasetMatcher(progressReport)));
   }
@@ -325,7 +325,8 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
             progressReport.getCollectionId(),
             progressReport.getReferenceId(),
             user.getUserId(),
-            progressReport.getData());
+            progressReport.getData(),
+            user.getEraCommonsId());
     verify(dataAccessRequestDAO)
         .insertAllDarDatasets(argThat(new DarDatasetMatcher(progressReport)));
   }
@@ -361,7 +362,8 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
             parentDar.getCollectionId(),
             progressReport.referenceId,
             user.getUserId(),
-            progressReport.data);
+            progressReport.data,
+            user.getEraCommonsId());
     assertThrows(BadRequestException.class, () -> service.createProgressReport(user, progressReport, parentDar));
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DarCollectionServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DarCollectionServiceDAOTest.java
@@ -421,7 +421,8 @@ class DarCollectionServiceDAOTest extends DAOTestHelper {
         dar.getCollectionId(),
         referenceId,
         dar.getUserId(),
-        dar.getData());
+        dar.getData(),
+        randomAlphabetic(8));
     DataAccessRequest progressReport = dataAccessRequestDAO.findByReferenceId(referenceId);
     dar.getDatasetIds().forEach(datasetId ->
       dataAccessRequestDAO.insertDARDatasetRelation(referenceId, datasetId)


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-1888](https://broadworkbench.atlassian.net/browse/DT-1888)

### Summary
A user's eRA commons ID could have changed between when a DAR was created and when a progress report was made.  This PR memorializes a user's eRA Commons ID when a progress report is created so we can track the eRA commons Ids that were in use at the time the PR was created.

Discovered during implementation of [https://broadworkbench.atlassian.net/browse/DT-1596](https://broadworkbench.atlassian.net/browse/DT-1596)

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
