### PR TITLE
DT-1905: only block on open DataAccess elections

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
@@ -34,6 +34,7 @@ import java.util.UUID;
 import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.consent.http.cloudstore.GCSService;
 import org.broadinstitute.consent.http.enumeration.DarDocumentType;
+import org.broadinstitute.consent.http.enumeration.ElectionType;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.exceptions.LibraryCardRequiredException;
 import org.broadinstitute.consent.http.exceptions.SubmittedDARCannotBeEditedException;
@@ -435,9 +436,12 @@ public class DataAccessRequestResource extends Resource {
       if (!user.getUserId().equals(parentDar.getUserId())) {
         throw new ForbiddenException("User not authorized to update this Data Access Request");
       }
-      // Prevent creation if there are open elections for the parent DAR
+      // Prevent creation if there are open DataAccess elections for the parent DAR
       List<Election> openElections = dataAccessRequestService.findOpenElectionsByReferenceId(parentDar.getReferenceId());
-      if (!openElections.isEmpty()) {
+      boolean hasOpenDataAccessElections = openElections
+          .stream()
+          .anyMatch(election -> election.getElectionType().equalsIgnoreCase(ElectionType.DATA_ACCESS.getValue()));
+      if (hasOpenDataAccessElections) {
         throw new BadRequestException("Cannot create a progress report for a DAR with an open election: " + parentDar.getReferenceId());
       }
       DataAccessRequest payload = DataAccessRequest.populateProgressReportFromJsonString(dar, parentDar);

--- a/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceTest.java
@@ -44,6 +44,7 @@ import org.broadinstitute.consent.http.AbstractTestHelper;
 import org.broadinstitute.consent.http.cloudstore.GCSService;
 import org.broadinstitute.consent.http.enumeration.DarDocumentType;
 import org.broadinstitute.consent.http.enumeration.ElectionStatus;
+import org.broadinstitute.consent.http.enumeration.ElectionType;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.exceptions.SubmittedDARCannotBeEditedException;
 import org.broadinstitute.consent.http.models.AuthUser;
@@ -493,6 +494,7 @@ class DataAccessRequestResourceTest extends AbstractTestHelper {
     when(dataAccessRequestService.findByReferenceId(any())).thenReturn(parentDar);
     Election election = new Election();
     election.setStatus(ElectionStatus.OPEN.getValue());
+    election.setElectionType(ElectionType.DATA_ACCESS.getValue());
     election.setReferenceId(parentDar.getReferenceId());
     when(dataAccessRequestService.findOpenElectionsByReferenceId(parentDar.getReferenceId())).thenReturn(List.of(election));
     var collabFile = mockFormDataMultiPart("collab.txt");


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-1905

### Summary
Only block new PR creation on open DataAccess elections

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
