### PR TITLE
[DT-1834] Remove ability for admins to issue library cards

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/resources/LibraryCardResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/LibraryCardResource.java
@@ -80,7 +80,7 @@ public class LibraryCardResource extends Resource {
   @POST
   @Consumes("application/json")
   @Produces("application/json")
-  @RolesAllowed({ADMIN, SIGNINGOFFICIAL})
+  @RolesAllowed({SIGNINGOFFICIAL})
   public Response createLibraryCard(@Auth AuthUser authUser, String libraryCard) {
     try {
       User user = userService.findUserByEmail(authUser.getEmail());

--- a/src/main/java/org/broadinstitute/consent/http/service/LibraryCardService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/LibraryCardService.java
@@ -11,7 +11,6 @@ import java.util.Objects;
 import org.broadinstitute.consent.http.db.InstitutionDAO;
 import org.broadinstitute.consent.http.db.LibraryCardDAO;
 import org.broadinstitute.consent.http.db.UserDAO;
-import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.exceptions.ConsentConflictException;
 import org.broadinstitute.consent.http.mail.message.NewLibraryCardIssuedMessage;
 import org.broadinstitute.consent.http.models.Institution;
@@ -40,12 +39,9 @@ public class LibraryCardService implements ConsentLogger {
 
   public LibraryCard createLibraryCard(LibraryCard libraryCard, User user) {
     throwIfNull(libraryCard);
-    boolean isAdmin = checkIsAdmin(user);
     checkIfCardExists(libraryCard);
     processUserOnNewLC(libraryCard);
-    if (!isAdmin) {
-      checkForValidInstitution(user.getInstitutionId(), libraryCard.getUserEmail());
-    }
+    checkForValidInstitution(user.getInstitutionId(), libraryCard.getUserEmail());
     Date createDate = new Date();
     Integer id = libraryCardDAO.insertLibraryCard(
         libraryCard.getUserId(),
@@ -182,39 +178,23 @@ public class LibraryCardService implements ConsentLogger {
   }
 
   // Helper method to process user data on create LC payload.
-  // Needed since CREATE has a unique situation where admins can create LCs without an active
-  // user (save with userEmail instead).
   private void processUserOnNewLC(LibraryCard card) {
-    if (card.getUserId() == null) {
-      // No user ID is provided, email must exist in card request.
-      if (card.getUserEmail() == null) {
-        throw new BadRequestException();
-      }
-      // If a user is found, update the card to have the correct userId associated.
-      User user = userDAO.findUserByEmail(card.getUserEmail());
-      if (user != null) {
-        card.setUserId(user.getUserId());
-      }
-    } else {
-      // check if userId exists
-      User user = userDAO.findUserById(card.getUserId());
-      if (user == null) {
-        throw new BadRequestException();
-      }
-      if (card.getUserEmail() == null) {
-        // if no email is provided in the card request, use the one from the user.
-        card.setUserEmail(user.getEmail());
-      } else if (!(user.getEmail().equalsIgnoreCase(card.getUserEmail()))) {
-        // Emails do not match, throw an error.
-        throw new ConsentConflictException();
-      }
-      card.setUserName(user.getDisplayName());
+    // Both userId and userEmail should always be present
+    if (card.getUserId() == null || card.getUserEmail() == null) {
+      throw new BadRequestException();
     }
-  }
 
-  private boolean checkIsAdmin(User user) {
-    return user.getRoles()
-        .stream()
-        .anyMatch(role -> role.getName().equalsIgnoreCase(UserRoles.ADMIN.getRoleName()));
+    // Verify user exists
+    User user = userDAO.findUserById(card.getUserId());
+    if (user == null) {
+      throw new BadRequestException();
+    }
+
+    // Verify emails match
+    if (!user.getEmail().equalsIgnoreCase(card.getUserEmail())) {
+      throw new ConsentConflictException();
+    }
+
+    card.setUserName(user.getDisplayName());
   }
 }

--- a/src/test/java/org/broadinstitute/consent/http/service/LibraryCardServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/LibraryCardServiceTest.java
@@ -60,32 +60,6 @@ class LibraryCardServiceTest extends AbstractTestHelper {
   }
 
   @Test
-    // Test Admin LC create with userId and email
-  void testCreateLibraryCardFullUserDetailsAsAdmin() throws TemplateException, IOException {
-    Institution institution = testInstitution();
-    User user = testUser(institution.getId());
-    user.setEmail("testemail");
-    User adminUser = createUserWithRole(UserRoles.ADMIN.getRoleId(), UserRoles.ADMIN.getRoleName());
-    when(userDAO.findUserById(user.getUserId())).thenReturn(user);
-    when(userDAO.findUserByEmail(user.getEmail())).thenReturn(user);
-
-    LibraryCard payload = testLibraryCard(user.getUserId());
-    payload.setUserEmail(user.getEmail());
-    payload.setUserName("username");
-    payload.setCreateUserId(randomInt(1, 10));
-
-    //last two calls in the function, no need to test within this service test file
-    LibraryCard createdCard = new LibraryCard();
-    when(libraryCardDAO.findLibraryCardById(anyInt())).thenReturn(createdCard);
-
-    assertEquals(createdCard, service.createLibraryCard(payload, adminUser));
-    verify(libraryCardDAO).insertLibraryCard(eq(user.getUserId()),
-        eq(payload.getUserName()), eq(user.getEmail()),
-        eq(payload.getCreateUserId()), any());
-    verify(emailService).sendNewLibraryCardIssuedMessage(user);
-  }
-
-  @Test
     // Test SO LC create with userId and email success case
   void testCreateLibraryCardFullUserDetailsAsSOSameInstitution()
       throws TemplateException, IOException {
@@ -137,57 +111,33 @@ class LibraryCardServiceTest extends AbstractTestHelper {
 
   @Test
     //Test LC create with only user email (no userId)
-  void testCreateLibraryCardPartialUserDetailsEmail() throws TemplateException, IOException {
+  void testCreateLibraryCardPartialUserDetailsEmailThrowsBadRequest() {
     Institution institution = testInstitution();
     User user = testUser(institution.getId());
-    User adminUser = createUserWithRole(UserRoles.ADMIN.getRoleId(), UserRoles.ADMIN.getRoleName());
     user.setUserId(null);
     user.setEmail("testemail");
 
-    // last two calls in the function, no need to test within this service test file
-    when(libraryCardDAO.findLibraryCardById(anyInt())).thenReturn(new LibraryCard());
-    when(userDAO.findUserByEmail(user.getEmail())).thenReturn(null);
+    User signingOfficialUser = createUserWithRole(UserRoles.SIGNINGOFFICIAL.getRoleId(), UserRoles.SIGNINGOFFICIAL.getRoleName());
 
     LibraryCard payload = testLibraryCard(user.getUserId());
     payload.setUserEmail(user.getEmail());
-    service.createLibraryCard(payload, adminUser);
-    verify(libraryCardDAO).insertLibraryCard(eq(null), eq(null), any(), eq(null), any());
-    verify(emailService, times(0)).sendNewLibraryCardIssuedMessage(user);
+    assertThrows(BadRequestException.class, () ->
+        service.createLibraryCard(payload, signingOfficialUser));
   }
 
   @Test
     //Test LC create with only user id (no email)
-  void testCreateLibraryCardPartialUserDetailsId() {
+  void testCreateLibraryCardPartialUserDetailsIdThrowsBadRequest() {
     Institution institution = testInstitution();
     User user = testUser(institution.getId());
+    user.setEmail(null);
     user.setEmail("testemail");
-    User adminUser = createUserWithRole(UserRoles.ADMIN.getRoleId(), UserRoles.ADMIN.getRoleName());
 
-    when(userDAO.findUserById(user.getUserId())).thenReturn(user);
-    when(libraryCardDAO.findLibraryCardByUserId(user.getUserId())).thenReturn(null);
+    User signingOfficialUser = createUserWithRole(UserRoles.SIGNINGOFFICIAL.getRoleId(), UserRoles.SIGNINGOFFICIAL.getRoleName());
 
     LibraryCard payload = testLibraryCard(user.getUserId());
-    int cardId = 1;
-    when(libraryCardDAO.insertLibraryCard(anyInt(), eq(null), any(), eq(null), any()))
-        .thenReturn(cardId);
-    LibraryCard newCard = new LibraryCard();
-    when(libraryCardDAO.findLibraryCardById(cardId)).thenReturn(newCard);
-
-    assertEquals(newCard, service.createLibraryCard(payload, adminUser));
-  }
-
-  @Test
-  void stubTest() {
-    Institution institution = testInstitution();
-    User user = testUser(institution.getId());
-    user.setEmail("testemail");
-    when(userDAO.findUserById(user.getUserId())).thenReturn(user);
-    LibraryCard libraryCard = testLibraryCard(user.getUserId());
-    libraryCard.setCreateUserId(randomInt(1, 10));
-    when(libraryCardDAO.insertLibraryCard(eq(user.getUserId()), eq(null), eq(user.getEmail()),
-        eq(libraryCard.getCreateUserId()), any())).thenReturn(123);
-    service.createLibraryCard(libraryCard,
-        createUserWithRole(UserRoles.ADMIN.getRoleId(), UserRoles.ADMIN.getRoleName()));
+    assertThrows(BadRequestException.class, () ->
+        service.createLibraryCard(payload, signingOfficialUser));
   }
 
   @Test
@@ -217,7 +167,7 @@ class LibraryCardServiceTest extends AbstractTestHelper {
   void testCreateLibraryCardIncorrectUserIdAndEmail() {
     Institution institution = testInstitution();
     User user = testUser(institution.getId());
-    User adminUser = createUserWithRole(UserRoles.ADMIN.getRoleId(), UserRoles.ADMIN.getRoleName());
+    User signingOfficialUser = createUserWithRole(UserRoles.SIGNINGOFFICIAL.getRoleId(), UserRoles.SIGNINGOFFICIAL.getRoleName());
     user.setUserId(1);
     user.setEmail("testemail");
 
@@ -226,7 +176,7 @@ class LibraryCardServiceTest extends AbstractTestHelper {
 
     LibraryCard payload = testLibraryCard(user.getUserId());
     payload.setUserEmail("differentemail");
-    assertThrows(ConsentConflictException.class, () -> service.createLibraryCard(payload, adminUser));
+    assertThrows(ConsentConflictException.class, () -> service.createLibraryCard(payload, signingOfficialUser));
   }
 
   @Test
@@ -234,12 +184,12 @@ class LibraryCardServiceTest extends AbstractTestHelper {
   void testCreateLibraryCardAlreadyExistsOnUserId() {
     Institution institution = testInstitution();
     User user = testUser(institution.getId());
-    User adminUser = createUserWithRole(UserRoles.ADMIN.getRoleId(), UserRoles.ADMIN.getRoleName());
+    User signingOfficialUser = createUserWithRole(UserRoles.SIGNINGOFFICIAL.getRoleId(), UserRoles.SIGNINGOFFICIAL.getRoleName());
     LibraryCard savedCard = testLibraryCard(user.getUserId());
     LibraryCard payload = savedCard;
 
     when(libraryCardDAO.findLibraryCardByUserId(anyInt())).thenReturn(savedCard);
-    assertThrows(ConsentConflictException.class, () -> service.createLibraryCard(payload, adminUser));
+    assertThrows(ConsentConflictException.class, () -> service.createLibraryCard(payload, signingOfficialUser));
   }
 
   @Test
@@ -247,7 +197,7 @@ class LibraryCardServiceTest extends AbstractTestHelper {
   void testCreateLibraryCardAlreadyExistsOnUserEmail() {
     Institution institution = testInstitution();
     User user = testUser(institution.getId());
-    User adminUser = createUserWithRole(UserRoles.ADMIN.getRoleId(), UserRoles.ADMIN.getRoleName());
+    User signingOfficialUser = createUserWithRole(UserRoles.SIGNINGOFFICIAL.getRoleId(), UserRoles.SIGNINGOFFICIAL.getRoleName());
     user.setEmail("testemail");
     LibraryCard savedCard = testLibraryCard(null);
     savedCard.setUserEmail(user.getEmail());
@@ -256,18 +206,18 @@ class LibraryCardServiceTest extends AbstractTestHelper {
 
     when(libraryCardDAO.findLibraryCardByUserEmail(any())).thenReturn(savedCard);
     assertThrows(ConsentConflictException.class, () -> {
-      service.createLibraryCard(payload, adminUser);
+      service.createLibraryCard(payload, signingOfficialUser);
     });
   }
 
   @Test
     //Negative test, checks to see if error is thrown if email and userId are not provided
   void testCreateLibraryCardNoUserDetails() {
-    User adminUser = createUserWithRole(UserRoles.ADMIN.getRoleId(), UserRoles.ADMIN.getRoleName());
+    User signingOfficialUser = createUserWithRole(UserRoles.SIGNINGOFFICIAL.getRoleId(), UserRoles.SIGNINGOFFICIAL.getRoleName());
     LibraryCard payload = testLibraryCard(null);
 
     assertThrows(BadRequestException.class, () -> {
-      service.createLibraryCard(payload, adminUser);
+      service.createLibraryCard(payload, signingOfficialUser);
     });
   }
 
@@ -275,17 +225,17 @@ class LibraryCardServiceTest extends AbstractTestHelper {
     //Negative test, checks if error is thrown on null institutionId
   void testCreateLibraryCard_InvalidInstitution() {
     User user = testUser(1);
-    User adminUser = createUserWithRole(UserRoles.ADMIN.getRoleId(), UserRoles.ADMIN.getRoleName());
+    User signingOfficialUser = createUserWithRole(UserRoles.SIGNINGOFFICIAL.getRoleId(), UserRoles.SIGNINGOFFICIAL.getRoleName());
     LibraryCard libraryCard = testLibraryCard(user.getUserId());
 
-    assertThrows(BadRequestException.class, () -> service.createLibraryCard(libraryCard, adminUser));
+    assertThrows(BadRequestException.class, () -> service.createLibraryCard(libraryCard, signingOfficialUser));
   }
 
   @Test
     //Negative test, checks to see if error is thrown on null payload
   void testCreateLibraryCardNullPayload() {
-    User adminUser = createUserWithRole(UserRoles.ADMIN.getRoleId(), UserRoles.ADMIN.getRoleName());
-    assertThrows(NotFoundException.class, () -> service.createLibraryCard(null, adminUser));
+    User signingOfficialUser = createUserWithRole(UserRoles.SIGNINGOFFICIAL.getRoleId(), UserRoles.SIGNINGOFFICIAL.getRoleName());
+    assertThrows(NotFoundException.class, () -> service.createLibraryCard(null, signingOfficialUser));
   }
 
   @Test
@@ -454,7 +404,7 @@ class LibraryCardServiceTest extends AbstractTestHelper {
     Institution institution = testInstitution();
     User user = createUserWithRole(UserRoles.RESEARCHER.getRoleId(), UserRoles.RESEARCHER.getRoleName());
     user.setInstitutionId(institution.getId());
-    User signingOfficial = createUserWithRole(UserRoles.ADMIN.getRoleId(), UserRoles.ADMIN.getRoleName());
+    User signingOfficial = createUserWithRole(UserRoles.SIGNINGOFFICIAL.getRoleId(), UserRoles.SIGNINGOFFICIAL.getRoleName());
     signingOfficial.setInstitutionId(institution.getId());
     user.setEmail("testemail");
     LibraryCard newLc = new LibraryCard();
@@ -486,6 +436,7 @@ class LibraryCardServiceTest extends AbstractTestHelper {
   private User testUser(Integer institutionId) {
     User user = new User();
     user.setUserId(randomInt(1, 10));
+    user.setEmail("testemail");
     user.setInstitutionId(institutionId);
     return user;
   }

--- a/src/test/java/org/broadinstitute/consent/http/service/LibraryCardServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/LibraryCardServiceTest.java
@@ -400,7 +400,7 @@ class LibraryCardServiceTest extends AbstractTestHelper {
   }
 
   @Test
-  void testCreateLibraryCardForSigningOfficial() {
+  void testCreateLibraryCardForSigningOfficial() throws TemplateException, IOException {
     Institution institution = testInstitution();
     User user = createUserWithRole(UserRoles.RESEARCHER.getRoleId(), UserRoles.RESEARCHER.getRoleName());
     user.setInstitutionId(institution.getId());
@@ -411,6 +411,7 @@ class LibraryCardServiceTest extends AbstractTestHelper {
     newLc.setId(1);
 
     when(userDAO.findUserById(anyInt())).thenReturn(user);
+    when(userDAO.findUserByEmail(user.getEmail())).thenReturn(user);
     when(institutionDAO.findInstitutionById(anyInt())).thenReturn(institution);
     when(institutionService.findInstitutionForEmail(user.getEmail())).thenReturn(institution);
     when(libraryCardDAO.findLibraryCardByUserId(anyInt())).thenReturn(null);
@@ -422,6 +423,7 @@ class LibraryCardServiceTest extends AbstractTestHelper {
     LibraryCard card = service.createLibraryCardForSigningOfficial(user, signingOfficial);
     assertNotNull(card);
     assertEquals(card.getId(), newLc.getId());
+    verify(emailService).sendNewLibraryCardIssuedMessage(user);
   }
 
   @Test


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-1870

### Summary

* Prevents admins from being able to grant library cards
* Admins with the Signing Official role may still grant library cards

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
