### PR TITLE
DT-1924: Add timing to capture metrics

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
@@ -86,6 +86,7 @@ public class DatasetResource extends Resource {
   @Produces({MediaType.APPLICATION_JSON})
   @Path("/v3")
   @RolesAllowed({ADMIN, CHAIRPERSON, DATASUBMITTER})
+  @Timed
   /*
    * This endpoint accepts a json instance of a dataset-registration-schema_v1.json schema.
    * With that object, we can fully create datasets from the provided values.
@@ -264,6 +265,7 @@ public class DatasetResource extends Resource {
   @Path("/registration/{datasetIdentifier}")
   @Produces(MediaType.APPLICATION_JSON)
   @PermitAll
+  @Timed
   public Response getRegistrationFromDatasetIdentifier(@Auth AuthUser authUser,
       @PathParam("datasetIdentifier") String datasetIdentifier) {
     try {

--- a/src/main/java/org/broadinstitute/consent/http/resources/StudyResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/StudyResource.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.consent.http.resources;
 
+import com.codahale.metrics.annotation.Timed;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import com.google.inject.Inject;
@@ -119,6 +120,7 @@ public class StudyResource extends Resource {
   @Path("/{studyId}")
   @Produces(MediaType.APPLICATION_JSON)
   @PermitAll
+  @Timed
   public Response getStudyById(@PathParam("studyId") Integer studyId) {
     try {
       Study study = datasetService.getStudyWithDatasetsById(studyId);
@@ -175,6 +177,7 @@ public class StudyResource extends Resource {
   @Path("/registration/{studyId}")
   @Produces(MediaType.APPLICATION_JSON)
   @PermitAll
+  @Timed
   public Response getRegistrationFromStudy(@Auth AuthUser authUser,
       @PathParam("studyId") Integer studyId) {
     try {
@@ -195,6 +198,7 @@ public class StudyResource extends Resource {
   @Produces({MediaType.APPLICATION_JSON})
   @Path("/{studyId}")
   @RolesAllowed({ADMIN, CHAIRPERSON, DATASUBMITTER})
+  @Timed
   /*
    * This endpoint accepts a json instance of a dataset-registration-schema_v1.json schema.
    * With that object, we can fully update the study/datasets from the provided values.


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-1924

### Summary
To report on any API metric, the API needs to be annotated with `@Timed`. This PR adds this to the following endpoints for future metrics reporting in Grafana:

* `POST /api/dataset/v3`
* `GET /api/dataset/registration/{datasetIdentifier}`
* `GET /api/study/{studyId}`
* `GET /api/study/registration/{studyId}`
* `PUT /api/study/{studyId}`

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
