### PR TITLE
DT-1925: Simplify dataset/study lookup

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
@@ -274,14 +274,11 @@ public class DatasetResource extends Resource {
         throw new NotFoundException(
             "No dataset exists for dataset identifier: " + datasetIdentifier);
       }
-      Study study;
-      if (dataset.getStudy() != null && dataset.getStudy().getStudyId() != null) {
-        study = datasetService.findStudyById(dataset.getStudy().getStudyId());
-      } else {
+      if (dataset.getStudy() == null || dataset.getStudy().getStudyId() == null) {
         throw new NotFoundException("No study exists for dataset identifier: " + datasetIdentifier);
       }
       DatasetRegistrationSchemaV1 registration = new DatasetRegistrationSchemaV1Builder().build(
-          study, List.of(dataset));
+          dataset.getStudy(), List.of(dataset));
       String entity = GsonUtil.buildGsonNullSerializer().toJson(registration);
       return Response.ok().entity(entity).build();
     } catch (Exception e) {

--- a/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
@@ -981,7 +981,6 @@ class DatasetResourceTest extends AbstractTestHelper {
     Dataset dataset = study.getDatasets().stream().findFirst().orElse(null);
     assertNotNull(dataset);
     when(datasetService.findDatasetByIdentifier(any())).thenReturn(dataset);
-    when(datasetService.findStudyById(any())).thenReturn(study);
 
     initResource();
     Response response = resource.getRegistrationFromDatasetIdentifier(authUser,
@@ -991,11 +990,9 @@ class DatasetResourceTest extends AbstractTestHelper {
 
   @Test
   void testGetRegistrationFromDatasetIdentifierStudyNotFound() {
-    Study study = createMockStudy();
-    Dataset dataset = study.getDatasets().stream().findFirst().orElse(null);
+    Dataset dataset = createMockDataset();
     assertNotNull(dataset);
     when(datasetService.findDatasetByIdentifier(any())).thenReturn(dataset);
-    when(datasetService.findStudyById(any())).thenThrow(new NotFoundException());
 
     initResource();
     Response response = resource.getRegistrationFromDatasetIdentifier(authUser,
@@ -1256,12 +1253,7 @@ class DatasetResourceTest extends AbstractTestHelper {
    * Study mock
    */
   private Study createMockStudy() {
-    Dataset dataset = new Dataset();
-    dataset.setDatasetId(100);
-    dataset.setAlias(10);
-    dataset.setDatasetIdentifier();
-    dataset.setDacId(1);
-    dataset.setDataUse(new DataUse());
+    Dataset dataset = createMockDataset();
 
     Study study = new Study();
     study.setName(randomAlphabetic(10));
@@ -1290,9 +1282,18 @@ class DatasetResourceTest extends AbstractTestHelper {
     dataCustodianEmailProperty.setValue(List.of(randomAlphabetic(10)));
 
     study.addProperties(phenotypeProperty, speciesProperty, dataCustodianEmailProperty);
-
     dataset.setStudy(study);
+    study.addDatasets(List.of(dataset));
+    return study;
+  }
 
+  private Dataset createMockDataset() {
+    Dataset dataset = new Dataset();
+    dataset.setDatasetId(100);
+    dataset.setAlias(10);
+    dataset.setDatasetIdentifier();
+    dataset.setDacId(1);
+    dataset.setDataUse(new DataUse());
     DatasetProperty accessManagementProp = new DatasetProperty();
     accessManagementProp.setSchemaProperty("accessManagement");
     accessManagementProp.setPropertyType(PropertyType.String);
@@ -1309,8 +1310,6 @@ class DatasetResourceTest extends AbstractTestHelper {
     numParticipantsProp.setPropertyValue(20);
 
     dataset.setProperties(Set.of(accessManagementProp, dataLocationProp, numParticipantsProp));
-    study.addDatasets(List.of(dataset));
-
-    return study;
+    return dataset;
   }
 }


### PR DESCRIPTION
### Addresses
Partially addresses https://broadworkbench.atlassian.net/browse/DT-1925

### Summary
This PR simplifies the lookup of the study associated with a dataset for the get-registration-by-dataset-identifier API. Previously, we made two queries, one for the dataset and one for the study. The dataset query actually populates the associated study in this case, so the second study query is unnecessary. Local testing shows roughly a 20%-30% performance improvement.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
