### PR TITLE
DT-1941: Migrate user email domain lookups to database

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
@@ -528,8 +528,7 @@ public class ConsentModule extends AbstractModule {
 
   @Provides
   InstitutionService providesInstitutionService() {
-    return new InstitutionService(providesInstitutionDAO(), providesUserDAO(),
-        providesGCSService());
+    return new InstitutionService(providesInstitutionDAO(), providesUserDAO());
   }
 
   @Provides

--- a/src/main/java/org/broadinstitute/consent/http/cloudstore/GCSService.java
+++ b/src/main/java/org/broadinstitute/consent/http/cloudstore/GCSService.java
@@ -8,14 +8,12 @@ import com.google.cloud.storage.Bucket;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.gson.Gson;
 import com.google.inject.Inject;
 import jakarta.ws.rs.NotFoundException;
 import java.io.ByteArrayInputStream;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -24,11 +22,8 @@ import java.util.UUID;
 import org.apache.commons.io.IOUtils;
 import org.broadinstitute.consent.http.configurations.StoreConfiguration;
 import org.broadinstitute.consent.http.util.ConsentLogger;
-import org.broadinstitute.consent.http.util.gson.GsonUtil;
 
 public class GCSService implements ConsentLogger {
-
-  private static final Gson GSON = GsonUtil.gsonBuilderWithAdapters().create();
 
   private StoreConfiguration config;
   private Storage storage;
@@ -140,23 +135,6 @@ public class GCSService implements ConsentLogger {
       return output;
     } else {
       throw new NotFoundException("Document Not Found: " + blobIds.toString());
-    }
-  }
-
-  /**
-   * Read JSON file from GCS bucket
-   *
-   * @param blobIdName String value of the document blob id name
-   * @param valueType  Class type of the object to be read
-   * @return Object of the specified type
-   */
-  public <T> T readJsonFileFromBucket(String blobIdName, Class<T> valueType) throws IOException {
-    try (InputStream is = getDocument(blobIdName)) {
-      InputStreamReader reader = new InputStreamReader(is);
-      return GSON.fromJson(reader, valueType);
-    } catch (Exception e) {
-      logException("Error reading JSON file from bucket: " + e.getMessage(), e);
-      throw new IOException("Failed to read JSON file from bucket: " + blobIdName, e);
     }
   }
 

--- a/src/main/java/org/broadinstitute/consent/http/db/InstitutionDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/InstitutionDAO.java
@@ -263,11 +263,34 @@ public interface InstitutionDAO extends Transactional<InstitutionDAO> {
     });
   }
 
-  @UseRowReducer(InstitutionReducer.class)
+  @RegisterBeanMapper(value = User.class, prefix = "u")
+  @RegisterBeanMapper(value = SimplifiedUser.class, prefix = "so")
+  @UseRowReducer(InstitutionWithUsersReducer.class)
   @SqlQuery("""
-      SELECT i.*
+      SELECT i.*,
+        d.domain,
+        u.user_id AS u_user_id,
+        u.email AS u_email,
+        u.display_name AS u_display_name,
+        u.create_date AS u_create_date,
+        u.email_preference AS u_email_preference,
+        u.era_commons_id AS u_era_commons_id,
+        u2.user_id AS u2_user_id, u2.email AS u2_email,
+        u2.display_name AS u2_display_name, u2.create_date AS u2_create_date,
+        u2.email_preference AS u2_email_preference,
+        u2.era_commons_id AS u2_era_commons_id,
+        so.so_user_id, so.so_email, so.so_display_name
       FROM institution i
       INNER JOIN institution_domains d ON d.institution_id = i.institution_id
+      LEFT JOIN users u ON u.user_id = i.create_user
+      LEFT JOIN users u2 ON u2.user_id = i.update_user
+      LEFT JOIN
+           (SELECT
+               so.user_id AS so_user_id, so.email AS so_email,
+               so.display_name AS so_display_name, so.institution_id AS so_institution_id
+               FROM users so
+               LEFT JOIN user_role ur ON ur.user_id = so.user_id
+               WHERE ur.role_id = 7) so ON i.institution_id = so.so_institution_id
       WHERE LOWER(d.domain) = LOWER(:domain)
       LIMIT 1
       """)

--- a/src/main/java/org/broadinstitute/consent/http/db/InstitutionDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/InstitutionDAO.java
@@ -294,4 +294,12 @@ public interface InstitutionDAO extends Transactional<InstitutionDAO> {
       WHERE LOWER(d.domain) = LOWER(:domain)
       """)
   Institution findInstitutionByDomain(@Bind("domain") String domain);
+
+  @SqlQuery("""
+      SELECT distinct i.institution_id
+      FROM institution i
+      INNER JOIN institution_domains d ON d.institution_id = i.institution_id
+      WHERE LOWER(d.domain) = LOWER(:domain)
+      """)
+  Integer findInstitutionIdByDomain(@Bind("domain") String domain);
 }

--- a/src/main/java/org/broadinstitute/consent/http/db/InstitutionDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/InstitutionDAO.java
@@ -262,4 +262,14 @@ public interface InstitutionDAO extends Transactional<InstitutionDAO> {
       handle.commit();
     });
   }
+
+  @UseRowReducer(InstitutionReducer.class)
+  @SqlQuery("""
+      SELECT i.*
+      FROM institution i
+      INNER JOIN institution_domains d ON d.institution_id = i.institution_id
+      WHERE LOWER(d.domain) = LOWER(:domain)
+      LIMIT 1
+      """)
+  Institution findInstitutionByDomain(@Bind("domain") String domain);
 }

--- a/src/main/java/org/broadinstitute/consent/http/db/InstitutionDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/InstitutionDAO.java
@@ -292,7 +292,6 @@ public interface InstitutionDAO extends Transactional<InstitutionDAO> {
                LEFT JOIN user_role ur ON ur.user_id = so.user_id
                WHERE ur.role_id = 7) so ON i.institution_id = so.so_institution_id
       WHERE LOWER(d.domain) = LOWER(:domain)
-      LIMIT 1
       """)
   Institution findInstitutionByDomain(@Bind("domain") String domain);
 }

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/InstitutionWithUsersReducer.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/InstitutionWithUsersReducer.java
@@ -23,25 +23,26 @@ public class InstitutionWithUsersReducer implements LinkedHashMapRowReducer<Inte
         rowView.getColumn("institution_id", Integer.class),
         id -> rowView.getRow(Institution.class));
 
-    User create_user = new User();
+    User createUser = new User();
     if (Objects.nonNull(rowView.getColumn("u_user_id", Integer.class))) {
-      create_user = rowView.getRow(User.class);
+      createUser = rowView.getRow(User.class);
     }
 
-    User update_user = new User();
-    update_user.setUserId(rowView.getColumn("u2_user_id", Integer.class));
-    update_user.setEmail(rowView.getColumn("u2_email", String.class));
-    update_user.setDisplayName(rowView.getColumn("u2_display_name", String.class));
-    update_user.setCreateDate(rowView.getColumn("u2_create_date", Timestamp.class));
-    update_user.setEmailPreference(rowView.getColumn("u2_email_preference", Boolean.class));
-    update_user.setEraCommonsId(rowView.getColumn("u2_era_commons_id", String.class));
+    User updateUser = new User();
+    updateUser.setUserId(rowView.getColumn("u2_user_id", Integer.class));
+    updateUser.setEmail(rowView.getColumn("u2_email", String.class));
+    updateUser.setDisplayName(rowView.getColumn("u2_display_name", String.class));
+    updateUser.setCreateDate(rowView.getColumn("u2_create_date", Timestamp.class));
+    updateUser.setEmailPreference(rowView.getColumn("u2_email_preference", Boolean.class));
+    updateUser.setEraCommonsId(rowView.getColumn("u2_era_commons_id", String.class));
 
-    institution.setCreateUser(create_user);
-    institution.setUpdateUser(update_user);
+    institution.setCreateUser(createUser);
+    institution.setUpdateUser(updateUser);
 
     if (Objects.nonNull(rowView.getColumn("so_user_id", Integer.class))) {
-      SimplifiedUser so_user = rowView.getRow(SimplifiedUser.class);
-      institution.addSigningOfficial(so_user);
+      SimplifiedUser signingOfficial = rowView.getRow(SimplifiedUser.class);
+      signingOfficial.setInstitutionId(institution.getId());
+      institution.addSigningOfficial(signingOfficial);
     }
     if (hasColumn(rowView, "domain", String.class)) {
       String domain = rowView.getColumn("domain", String.class);

--- a/src/main/java/org/broadinstitute/consent/http/models/InstitutionDomainMap.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/InstitutionDomainMap.java
@@ -18,20 +18,4 @@ public class InstitutionDomainMap {
   public Set<String> getDomainsForInstitution(String institution) {
     return institutionDomainMap.get(institution);
   }
-
-  /**
-   * Returns the institution name for a given email address.
-   * @param email the email address to check
-   * @return the institution name if found, otherwise null
-   */
-  public String getInstitutionForEmail(String email) {
-    String trimmedEmail = email.trim();
-    String domain = trimmedEmail.substring(trimmedEmail.indexOf('@') + 1);
-    return institutionDomainMap.entrySet().stream()
-        .filter(entry -> entry.getValue().stream()
-            .anyMatch(d -> d.equalsIgnoreCase(domain)))
-        .map(Map.Entry::getKey)
-        .findFirst()
-        .orElse(null);
-  }
 }

--- a/src/main/java/org/broadinstitute/consent/http/resources/InstitutionResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/InstitutionResource.java
@@ -17,6 +17,7 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.Response;
 import java.util.ArrayList;
 import java.util.List;
+import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.exceptions.ConsentConflictException;
 import org.broadinstitute.consent.http.models.DuosUser;
 import org.broadinstitute.consent.http.models.Institution;
@@ -47,7 +48,7 @@ public class InstitutionResource extends Resource {
   @PermitAll
   public Response getInstitutions(@Auth DuosUser duosUser) {
     try {
-      Boolean isAdmin = institutionUtil.checkIfAdmin(duosUser.getUser());
+      Boolean isAdmin = duosUser.getUser().hasUserRole(UserRoles.ADMIN);
       Gson gson = institutionUtil.getGsonBuilder(isAdmin);
       List<Institution> institutions = institutionService.findAllInstitutions();
       return Response.ok().entity(gson.toJson(institutions)).build();
@@ -62,7 +63,7 @@ public class InstitutionResource extends Resource {
   @PermitAll
   public Response getInstitution(@Auth DuosUser duosUser, @PathParam("id") Integer id) {
     try {
-      Boolean isAdmin = institutionUtil.checkIfAdmin(duosUser.getUser());
+      Boolean isAdmin = duosUser.getUser().hasUserRole(UserRoles.ADMIN);
       Gson gson = institutionUtil.getGsonBuilder(isAdmin);
       Institution institution = institutionService.findInstitutionById(id);
       return Response.ok().entity(gson.toJson(institution)).build();

--- a/src/main/java/org/broadinstitute/consent/http/service/InstitutionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/InstitutionService.java
@@ -60,10 +60,32 @@ public class InstitutionService {
     return institution;
   }
 
+  /**
+   * Finds the institution for a given email address. This method returns a fully populated
+   * institution with signing officials, users, and domains.
+   *
+   * @param email the email address to search for
+   * @return The Institution associated with the email's domain, or null if not found
+   */
   public Institution findInstitutionForEmail(String email) {
+    return institutionDAO.findInstitutionByDomain(trimmedEmailDomain(email));
+  }
+
+  /**
+   * Finds the institution ID for a given email address. This is a simplified version of the more
+   * expansive findInstitutionForEmail method that will only return just the ID for verification and
+   * validation of a user's institutional affiliation and library card assignments.
+   *
+   * @param email the email address to search for
+   * @return The Institution ID associated with the email's domain, or null if not found
+   */
+  public Integer findInstitutionIdForEmail(String email) {
+    return institutionDAO.findInstitutionIdByDomain(trimmedEmailDomain(email));
+  }
+
+  private String trimmedEmailDomain(String email) {
     String trimmedEmail = email.trim();
-    String domain = trimmedEmail.substring(trimmedEmail.indexOf('@') + 1);
-    return institutionDAO.findInstitutionByDomain(domain);
+    return trimmedEmail.substring(trimmedEmail.indexOf('@') + 1);
   }
 
   public List<Institution> findAllInstitutions() {

--- a/src/main/java/org/broadinstitute/consent/http/service/InstitutionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/InstitutionService.java
@@ -4,28 +4,23 @@ import com.google.api.client.http.HttpStatusCodes;
 import com.google.inject.Inject;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.ServerErrorException;
-import java.io.IOException;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.Objects;
-import org.broadinstitute.consent.http.cloudstore.GCSService;
 import org.broadinstitute.consent.http.db.InstitutionDAO;
 import org.broadinstitute.consent.http.db.UserDAO;
 import org.broadinstitute.consent.http.models.Institution;
-import org.broadinstitute.consent.http.models.InstitutionDomainMap;
 import org.broadinstitute.consent.http.service.UserService.SimplifiedUser;
 
 public class InstitutionService {
 
   private final InstitutionDAO institutionDAO;
   private final UserDAO userDAO;
-  private final GCSService store;
 
   @Inject
-  public InstitutionService(InstitutionDAO institutionDAO, UserDAO userDAO, GCSService store) {
+  public InstitutionService(InstitutionDAO institutionDAO, UserDAO userDAO) {
     this.institutionDAO = institutionDAO;
     this.userDAO = userDAO;
-    this.store = store;
   }
 
   public Institution createInstitution(Institution institution, Integer userId) {
@@ -65,25 +60,10 @@ public class InstitutionService {
     return institution;
   }
 
-  private InstitutionDomainMap getInstitutionDomainMap() {
-    try {
-      return store.readJsonFileFromBucket("institution-domain/allowlist.json",
-          InstitutionDomainMap.class);
-    } catch (IOException e) {
-      throw new ServerErrorException("Could not load institution configuration",
-          HttpStatusCodes.STATUS_CODE_SERVER_ERROR, e);
-    }
-  }
-
   public Institution findInstitutionForEmail(String email) {
-    String name = getInstitutionDomainMap().getInstitutionForEmail(email);
-    if (name != null) {
-      var institutions = institutionDAO.findInstitutionsByName(name);
-      if (institutions.size() == 1) {
-        return institutions.get(0);
-      }
-    }
-    return null;
+    String trimmedEmail = email.trim();
+    String domain = trimmedEmail.substring(trimmedEmail.indexOf('@') + 1);
+    return institutionDAO.findInstitutionByDomain(domain);
   }
 
   public List<Institution> findAllInstitutions() {

--- a/src/main/java/org/broadinstitute/consent/http/service/UserService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/UserService.java
@@ -461,7 +461,7 @@ public class UserService implements ConsentLogger {
    */
   public User enforceInstitutionAndLibraryCardRules(String email) {
     User user;
-    Institution institutionFromEmail = institutionService.findInstitutionForEmail(email);
+    Integer institutionId = institutionService.findInstitutionIdForEmail(email);
     try {
       user = findUserByEmail(email);
     } catch (NotFoundException nfe) {
@@ -470,8 +470,8 @@ public class UserService implements ConsentLogger {
 
     boolean modifiedUser = false;
 
-    if (institutionFromEmail != null) {
-      if (handleUserWithInstitutionInMap(user, institutionFromEmail)) {
+    if (institutionId != null) {
+      if (handleUserWithInstitutionInMap(user, institutionId)) {
         modifiedUser = true;
       }
     } else {
@@ -488,15 +488,14 @@ public class UserService implements ConsentLogger {
   }
 
   @VisibleForTesting
-  protected boolean handleUserWithInstitutionInMap(User user, Institution institutionFromEmail) {
-    boolean needsLCRemoved = needsLibraryCardRemovedForUser(user, institutionFromEmail);
-    boolean needsInstitutionAssigned = !institutionFromEmail.getId()
-        .equals(user.getInstitutionId());
+  protected boolean handleUserWithInstitutionInMap(User user, Integer institutionId) {
+    boolean needsLCRemoved = needsLibraryCardRemovedForUser(user, institutionId);
+    boolean needsInstitutionAssigned = !institutionId.equals(user.getInstitutionId());
 
     if (needsInstitutionAssigned && needsLCRemoved) {
-      userServiceDAO.updateInstitutionAndClearLibraryCardForUser(user.getUserId(), institutionFromEmail.getId());
+      userServiceDAO.updateInstitutionAndClearLibraryCardForUser(user.getUserId(), institutionId);
     } else if (needsInstitutionAssigned) {
-      userDAO.updateInstitutionId(user.getUserId(), institutionFromEmail.getId());
+      userDAO.updateInstitutionId(user.getUserId(), institutionId);
     } else if (needsLCRemoved) {
       libraryCardDAO.deleteAllLibraryCardsByUser(user.getUserId());
     }
@@ -505,13 +504,13 @@ public class UserService implements ConsentLogger {
   }
 
   @VisibleForTesting
-  protected boolean needsLibraryCardRemovedForUser(User user, Institution userInstitution) {
+  protected boolean needsLibraryCardRemovedForUser(User user, Integer userInstitutionId) {
     boolean needsLCRemoved = false;
     if (hasLibraryCard(user)) {
       try {
         User lcIssuer = findUserById(user.getLibraryCard().getCreateUserId());
         Institution lcIssuerInstitution = institutionService.findInstitutionForEmail(lcIssuer.getEmail());
-        if (!userInstitution.equals(lcIssuerInstitution)) {
+        if (lcIssuerInstitution == null || !userInstitutionId.equals(lcIssuerInstitution.getId())) {
           needsLCRemoved = true;
         }
       } catch (NotFoundException nfe) {

--- a/src/main/java/org/broadinstitute/consent/http/util/InstitutionUtil.java
+++ b/src/main/java/org/broadinstitute/consent/http/util/InstitutionUtil.java
@@ -49,7 +49,16 @@ public class InstitutionUtil implements ConsentLogger {
             || fieldName.equals("signingOfficials")
             || fieldName.equals("displayName")
             || fieldName.equals("userId")
-            || fieldName.equals("email"));
+            || fieldName.equals("email")
+            || fieldName.equals("itDirectorName")
+            || fieldName.equals("itDirectorEmail")
+            || fieldName.equals("institutionUrl")
+            || fieldName.equals("dunsNumber")
+            || fieldName.equals("orgChartUrl")
+            || fieldName.equals("verificationUrl")
+            || fieldName.equals("verificationFilename")
+            || fieldName.equals("organizationType")
+            || fieldName.equals("domains"));
       }
 
       // NOTE: shouldSkipClass is mandatory when creating an ExclusionStrategy

--- a/src/main/java/org/broadinstitute/consent/http/util/InstitutionUtil.java
+++ b/src/main/java/org/broadinstitute/consent/http/util/InstitutionUtil.java
@@ -4,11 +4,6 @@ import com.google.gson.ExclusionStrategy;
 import com.google.gson.FieldAttributes;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import java.util.List;
-import java.util.Objects;
-import org.broadinstitute.consent.http.enumeration.UserRoles;
-import org.broadinstitute.consent.http.models.User;
-import org.broadinstitute.consent.http.models.UserRole;
 import org.broadinstitute.consent.http.util.gson.GsonUtil;
 
 public class InstitutionUtil implements ConsentLogger {

--- a/src/main/java/org/broadinstitute/consent/http/util/InstitutionUtil.java
+++ b/src/main/java/org/broadinstitute/consent/http/util/InstitutionUtil.java
@@ -28,16 +28,6 @@ public class InstitutionUtil implements ConsentLogger {
     return gson.addSerializationExclusionStrategy(strategy).create();
   }
 
-  public Boolean checkIfAdmin(User user) {
-    List<UserRole> roles = user.getRoles();
-    if (roles == null || roles.isEmpty()) {
-      logWarn("User has no roles: " + user.getEmail());
-      return false;
-    }
-    return roles.stream()
-        .anyMatch((userRole) -> Objects.equals(userRole.getRoleId(), UserRoles.ADMIN.getRoleId()));
-  }
-
   private ExclusionStrategy getSerializationExclusionStrategy(Boolean isAdmin) {
     return new ExclusionStrategy() {
       @Override

--- a/src/test/java/org/broadinstitute/consent/http/cloudstore/GCSServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/cloudstore/GCSServiceTest.java
@@ -138,25 +138,4 @@ class GCSServiceTest {
     boolean deleted = service.deleteDocument(RandomStringUtils.random(10));
     assertTrue(deleted);
   }
-
-  @Test
-  void testReadJsonFileFromBucket() throws Exception {
-    String testJson = """
-        {
-          "hello": "world",
-          "foo": "bar"
-        }
-        """;
-
-    when(blob.getContent()).thenReturn(testJson.getBytes());
-    when(storage.get(any(BlobId.class))).thenReturn(blob);
-
-    initStore();
-
-    var result = service.readJsonFileFromBucket("test.json", Map.class);
-
-    assertNotNull(result);
-    assertEquals(2, result.size());
-    assertEquals("world", result.get("hello"));
-  }
 }

--- a/src/test/java/org/broadinstitute/consent/http/cloudstore/GCSServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/cloudstore/GCSServiceTest.java
@@ -19,7 +19,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.RandomStringUtils;
+import org.broadinstitute.consent.http.AbstractTestHelper;
 import org.broadinstitute.consent.http.configurations.StoreConfiguration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -29,7 +29,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 
 @ExtendWith(MockitoExtension.class)
-class GCSServiceTest {
+class GCSServiceTest extends AbstractTestHelper {
 
   @Mock
   private Storage storage;
@@ -71,10 +71,9 @@ class GCSServiceTest {
 
   @Test
   void testGetDocument() throws Exception {
-    String fileName = RandomStringUtils.randomAlphanumeric(10);
-    String fileContent = RandomStringUtils.randomAlphanumeric(10);
+    String fileName = randomAlphanumeric(10);
+    String fileContent = randomAlphanumeric(10);
     String urlString = "http://localhost/bucket/" + fileName;
-    Blob blob = mock(Blob.class);
     when(blob.getContent()).thenReturn((fileContent).getBytes());
     when(storage.get(any(BlobId.class))).thenReturn(blob);
 
@@ -87,8 +86,7 @@ class GCSServiceTest {
 
   @Test
   void testGetDocument_ByBlobId() throws Exception {
-    String fileContent = RandomStringUtils.randomAlphanumeric(10);
-    Blob blob = mock(Blob.class);
+    String fileContent = randomAlphanumeric(10);
     when(blob.getContent()).thenReturn((fileContent).getBytes());
     when(storage.get(any(BlobId.class))).thenReturn(blob);
 
@@ -101,10 +99,10 @@ class GCSServiceTest {
 
   @Test
   void testGetDocuments() throws Exception {
-    String fileName1 = RandomStringUtils.randomAlphanumeric(10);
-    String fileName2 = RandomStringUtils.randomAlphanumeric(10);
-    String fileContent1 = RandomStringUtils.randomAlphanumeric(10);
-    String fileContent2 = RandomStringUtils.randomAlphanumeric(10);
+    String fileName1 = randomAlphanumeric(10);
+    String fileName2 = randomAlphanumeric(10);
+    String fileContent1 = randomAlphanumeric(10);
+    String fileContent2 = randomAlphanumeric(10);
 
     Blob blob1 = mock(Blob.class);
     BlobId blobId1 = BlobId.of("bucket", fileName1);
@@ -128,14 +126,13 @@ class GCSServiceTest {
 
   @Test
   void testDeleteDocument() {
-    String fileName = RandomStringUtils.random(10, true, false);
-    Blob blob = mock(Blob.class);
+    String fileName = randomAlphabetic(10);
     BlobId blobId = BlobId.of("bucket", fileName);
     when(blob.getBlobId()).thenReturn(blobId);
     when(storage.get(any(BlobId.class))).thenReturn(blob);
     when(storage.delete(any(BlobId.class))).thenReturn(true);
     initStore();
-    boolean deleted = service.deleteDocument(RandomStringUtils.random(10));
+    boolean deleted = service.deleteDocument(randomAlphabetic(10));
     assertTrue(deleted);
   }
 }

--- a/src/test/java/org/broadinstitute/consent/http/db/InstitutionDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/InstitutionDAOTest.java
@@ -395,10 +395,12 @@ class InstitutionDAOTest extends DAOTestHelper {
     User user = createUser();
     Institution fullInstitution = institutionDAO.insertFullInstitution(institution, user.getUserId());
 
-    Institution foundInstitution = institutionDAO.findInstitutionByDomain(domain.toUpperCase());
-    assertEquals(fullInstitution.getId(), foundInstitution.getId());
+    Institution foundInstitution1 = institutionDAO.findInstitutionByDomain(domain.toUpperCase());
+    assertEquals(fullInstitution.getId(), foundInstitution1.getId());
+    assertTrue(foundInstitution1.getDomains().contains(domain), "Domain should be found in institution's domains");
     Institution foundInstitution2 = institutionDAO.findInstitutionByDomain(domain.toLowerCase());
     assertEquals(fullInstitution.getId(), foundInstitution2.getId());
+    assertTrue(foundInstitution2.getDomains().contains(domain), "Domain should be found in institution's domains");
     Institution notFoundInstitution = institutionDAO.findInstitutionByDomain("nonexistentdomain.org");
     assertNull(notFoundInstitution, "Should return null for non-existent domain");
   }

--- a/src/test/java/org/broadinstitute/consent/http/db/InstitutionDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/InstitutionDAOTest.java
@@ -15,6 +15,8 @@ import org.broadinstitute.consent.http.models.Institution;
 import org.broadinstitute.consent.http.models.User;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.postgresql.util.PSQLException;
 import org.postgresql.util.PSQLState;
@@ -374,5 +376,30 @@ class InstitutionDAOTest extends DAOTestHelper {
     Institution reloadedInstitution = institutionDAO.updateFullInstitution(updatedInstitution,
         user.getUserId());
     assertNull(reloadedInstitution.getDomains(), "Domains should be empty after update");
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"testdoMain.com", "AnotherDomain.com", "uniÇodé.c©m", "Broad.mちt.eDu"})
+  void testFindInstitutionByDomain(String domain) throws Exception {
+    Institution institution = new Institution();
+    institution.setName("Test Institution");
+    institution.setItDirectorName("Test Director");
+    institution.setItDirectorEmail("email");
+    institution.setInstitutionUrl("http://testinstitution.com");
+    institution.setDunsNumber(123456789);
+    institution.setOrgChartUrl("http://testinstitution.com/orgchart");
+    institution.setVerificationUrl("http://testinstitution.com/verification");
+    institution.setVerificationFilename("verification.pdf");
+    institution.setOrganizationType(OrganizationType.NON_PROFIT);
+    institution.setDomains(List.of(domain));
+    User user = createUser();
+    Institution fullInstitution = institutionDAO.insertFullInstitution(institution, user.getUserId());
+
+    Institution foundInstitution = institutionDAO.findInstitutionByDomain(domain.toUpperCase());
+    assertEquals(fullInstitution.getId(), foundInstitution.getId());
+    Institution foundInstitution2 = institutionDAO.findInstitutionByDomain(domain.toLowerCase());
+    assertEquals(fullInstitution.getId(), foundInstitution2.getId());
+    Institution notFoundInstitution = institutionDAO.findInstitutionByDomain("nonexistentdomain.org");
+    assertNull(notFoundInstitution, "Should return null for non-existent domain");
   }
 }

--- a/src/test/java/org/broadinstitute/consent/http/db/InstitutionDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/InstitutionDAOTest.java
@@ -381,17 +381,7 @@ class InstitutionDAOTest extends DAOTestHelper {
   @ParameterizedTest
   @ValueSource(strings = {"testdoMain.com", "AnotherDomain.com", "uniÇodé.c©m", "Broad.mちt.eDu"})
   void testFindInstitutionByDomain(String domain) throws Exception {
-    Institution institution = new Institution();
-    institution.setName("Test Institution");
-    institution.setItDirectorName("Test Director");
-    institution.setItDirectorEmail("email");
-    institution.setInstitutionUrl("http://testinstitution.com");
-    institution.setDunsNumber(123456789);
-    institution.setOrgChartUrl("http://testinstitution.com/orgchart");
-    institution.setVerificationUrl("http://testinstitution.com/verification");
-    institution.setVerificationFilename("verification.pdf");
-    institution.setOrganizationType(OrganizationType.NON_PROFIT);
-    institution.setDomains(List.of(domain));
+    Institution institution = createMockInstitution(domain);
     User user = createUser();
     Institution fullInstitution = institutionDAO.insertFullInstitution(institution, user.getUserId());
 
@@ -403,5 +393,35 @@ class InstitutionDAOTest extends DAOTestHelper {
     assertTrue(foundInstitution2.getDomains().contains(domain), "Domain should be found in institution's domains");
     Institution notFoundInstitution = institutionDAO.findInstitutionByDomain("nonexistentdomain.org");
     assertNull(notFoundInstitution, "Should return null for non-existent domain");
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"testdoMain.com", "AnotherDomain.com", "uniÇodé.c©m", "Broad.mちt.eDu"})
+  void testFindInstitutionIdByDomain(String domain) throws Exception {
+    Institution institution = createMockInstitution(domain);
+    User user = createUser();
+    Institution fullInstitution = institutionDAO.insertFullInstitution(institution, user.getUserId());
+
+    Integer foundId1 = institutionDAO.findInstitutionIdByDomain(domain.toUpperCase());
+    assertEquals(fullInstitution.getId(), foundId1);
+    Integer foundId2 = institutionDAO.findInstitutionIdByDomain(domain.toLowerCase());
+    assertEquals(fullInstitution.getId(), foundId2);
+    Integer notFoundId = institutionDAO.findInstitutionIdByDomain("nonexistentdomain.org");
+    assertNull(notFoundId, "Should return null for non-existent domain");
+  }
+
+  private Institution createMockInstitution(String domain) {
+    Institution institution = new Institution();
+    institution.setName("Test Institution");
+    institution.setItDirectorName("Test Director");
+    institution.setItDirectorEmail("email");
+    institution.setInstitutionUrl("http://testinstitution.com");
+    institution.setDunsNumber(123456789);
+    institution.setOrgChartUrl("http://testinstitution.com/orgchart");
+    institution.setVerificationUrl("http://testinstitution.com/verification");
+    institution.setVerificationFilename("verification.pdf");
+    institution.setOrganizationType(OrganizationType.NON_PROFIT);
+    institution.setDomains(List.of(domain));
+    return institution;
   }
 }

--- a/src/test/java/org/broadinstitute/consent/http/models/InstitutionDomainMapTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/InstitutionDomainMapTest.java
@@ -8,8 +8,6 @@ import com.google.gson.Gson;
 import java.util.Map;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 
 class InstitutionDomainMapTest {
 
@@ -81,56 +79,5 @@ class InstitutionDomainMapTest {
 
     Set<String> emptyDomains = map.getDomainsForInstitution("Non-Existent Institution");
     assertNull(emptyDomains);
-  }
-
-  @ParameterizedTest
-  @ValueSource(strings = {
-      "user_こ*@BroadInstitute.ORG",
-      "test@BroadInstitute.ORG",
-      "test@Broad.mIt.eDu",
-      " test@Broad.mIt.eDu ",
-      "TesT-User@BROADINSTITUTE.ORG"
-  })
-  void testGetInstitutionForEmail(String email) {
-    InstitutionDomainMap map = new InstitutionDomainMap();
-
-    Map<String, Set<String>> testMap = Map.of("Broad Institute", Set.of("broadinstitute.org", "broad.mit.edu"));
-    map.setInstitutionDomainMap(testMap);
-    String institution = map.getInstitutionForEmail(email);
-    assertEquals("Broad Institute", institution);
-  }
-
-  @ParameterizedTest
-  @ValueSource(strings = {
-      "user_こ*@Broadちnstitute.ORG",
-      "test@Broadちnstitute.ORG",
-      " test@Broad.mちt.eDu ",
-      "test@Broad.mちt.eDu",
-      "TesT-User@BROADちNSTITUTE.ORG"
-  })
-  void testGetInstitutionForEmailWithUTF8Domains(String email) {
-    InstitutionDomainMap map = new InstitutionDomainMap();
-
-    Map<String, Set<String>> testMap = Map.of("Broad Institute", Set.of("broadちnstitute.org", "broad.mちt.edu"));
-    map.setInstitutionDomainMap(testMap);
-    String institution = map.getInstitutionForEmail(email);
-    assertEquals("Broad Institute", institution);
-  }
-
-  @ParameterizedTest
-  @ValueSource(strings = {
-      "t-ち-t@B_roadInstitute.ORG",
-      "test@B_roadInstitute.ORG",
-      " test@Broad.*mIt.eDu ",
-      "test@Broad.*mIt.eDu",
-      "TesT-User@BROAD1NSTITUTE.ORG"
-  })
-  void testGetInstitutionForEmailFailures(String email) {
-    InstitutionDomainMap map = new InstitutionDomainMap();
-
-    Map<String, Set<String>> testMap = Map.of("Broad Institute", Set.of("broadinstitute.org", "broad.mit.edu"));
-    map.setInstitutionDomainMap(testMap);
-    String institution = map.getInstitutionForEmail(email);
-    assertNull(institution);
   }
 }

--- a/src/test/java/org/broadinstitute/consent/http/service/InstitutionServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/InstitutionServiceTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.when;
 
@@ -17,7 +16,6 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.RandomUtils;
-import org.broadinstitute.consent.http.cloudstore.GCSService;
 import org.broadinstitute.consent.http.db.InstitutionDAO;
 import org.broadinstitute.consent.http.db.UserDAO;
 import org.broadinstitute.consent.http.models.Institution;
@@ -39,11 +37,8 @@ class InstitutionServiceTest {
   @Mock
   private UserDAO userDAO;
 
-  @Mock
-  private GCSService store;
-
   private void initService() {
-    service = new InstitutionService(institutionDAO, userDAO, store);
+    service = new InstitutionService(institutionDAO, userDAO);
   }
 
   private Institution initMockModel() {

--- a/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
@@ -886,7 +886,7 @@ class UserServiceTest extends AbstractTestHelper {
     Institution institutionFromEmail = new Institution();
     institutionFromEmail.setId(1);
     testUser.setInstitutionId(1);
-    assertFalse(service.handleUserWithInstitutionInMap(testUser, institutionFromEmail));
+    assertFalse(service.handleUserWithInstitutionInMap(testUser, institutionFromEmail.getId()));
   }
 
   @Test
@@ -895,7 +895,7 @@ class UserServiceTest extends AbstractTestHelper {
     Institution institutionFromEmail = new Institution();
     institutionFromEmail.setId(1);
     testUser.setInstitutionId(2);
-    assertTrue(service.handleUserWithInstitutionInMap(testUser, institutionFromEmail));
+    assertTrue(service.handleUserWithInstitutionInMap(testUser, institutionFromEmail.getId()));
     verify(userDAO).updateInstitutionId(testUser.getUserId(), institutionFromEmail.getId());
   }
 
@@ -916,7 +916,7 @@ class UserServiceTest extends AbstractTestHelper {
     when(userDAO.findUserById(signingOfficial.getUserId())).thenReturn(signingOfficial);
     when(institutionService.findInstitutionForEmail(signingOfficial.getEmail())).thenReturn(institutionFromDatabase);
 
-    assertTrue(service.handleUserWithInstitutionInMap(testUser, institutionFromEmail));
+    assertTrue(service.handleUserWithInstitutionInMap(testUser, institutionFromEmail.getId()));
     verify(userServiceDAO).updateInstitutionAndClearLibraryCardForUser(testUser.getUserId(), institutionFromEmail.getId());
   }
 
@@ -935,7 +935,7 @@ class UserServiceTest extends AbstractTestHelper {
 
     when(userDAO.findUserById(signingOfficial.getUserId())).thenReturn(null);
 
-    assertTrue(service.handleUserWithInstitutionInMap(testUser, institutionFromEmail));
+    assertTrue(service.handleUserWithInstitutionInMap(testUser, institutionFromEmail.getId()));
     verify(userServiceDAO).updateInstitutionAndClearLibraryCardForUser(testUser.getUserId(), institutionFromEmail.getId());
   }
 
@@ -955,7 +955,7 @@ class UserServiceTest extends AbstractTestHelper {
     when(userDAO.findUserById(signingOfficial.getUserId())).thenReturn(signingOfficial);
     when(institutionService.findInstitutionForEmail(signingOfficial.getEmail())).thenReturn(institutionFromEmail);
 
-    assertFalse(service.handleUserWithInstitutionInMap(testUser, institutionFromEmail));
+    assertFalse(service.handleUserWithInstitutionInMap(testUser, institutionFromEmail.getId()));
   }
 
 
@@ -975,7 +975,7 @@ class UserServiceTest extends AbstractTestHelper {
     when(userDAO.findUserById(signingOfficial.getUserId())).thenReturn(signingOfficial);
     when(institutionService.findInstitutionForEmail(signingOfficial.getEmail())).thenReturn(null);
 
-    assertTrue(service.handleUserWithInstitutionInMap(testUser, institutionFromEmail));
+    assertTrue(service.handleUserWithInstitutionInMap(testUser, institutionFromEmail.getId()));
     verify(userDAO, times(0)).updateInstitutionId(any(), any());
     verify(libraryCardDAO).deleteAllLibraryCardsByUser(testUser.getUserId());
   }
@@ -984,7 +984,7 @@ class UserServiceTest extends AbstractTestHelper {
   void needsLibraryCardRemovedForUser() {
     User testUser = generateUser();
     Institution institution = new Institution();
-    assertFalse(service.needsLibraryCardRemovedForUser(testUser, institution));
+    assertFalse(service.needsLibraryCardRemovedForUser(testUser, institution.getId()));
   }
 
   @Test
@@ -998,7 +998,7 @@ class UserServiceTest extends AbstractTestHelper {
     testUser.setLibraryCard(lc);
 
     when(userDAO.findUserById(signingOfficial.getUserId())).thenReturn(null);
-    assertTrue(service.needsLibraryCardRemovedForUser(testUser, institution));
+    assertTrue(service.needsLibraryCardRemovedForUser(testUser, institution.getId()));
   }
 
   @Test
@@ -1013,11 +1013,11 @@ class UserServiceTest extends AbstractTestHelper {
     testUser.setInstitution(institutionFromEmail);
 
     Institution soInstitution = new Institution();
-    institutionFromEmail.setId(2);
+    soInstitution.setId(2);
 
     when(userDAO.findUserById(signingOfficial.getUserId())).thenReturn(signingOfficial);
     when(institutionService.findInstitutionForEmail(signingOfficial.getEmail())).thenReturn(soInstitution);
-    assertTrue(service.needsLibraryCardRemovedForUser(testUser, institutionFromEmail));
+    assertTrue(service.needsLibraryCardRemovedForUser(testUser, institutionFromEmail.getId()));
   }
 
   public static Stream<Arguments> testEnforceInstitutionAndLibraryCardVariations() {
@@ -1046,8 +1046,13 @@ class UserServiceTest extends AbstractTestHelper {
     testUser.setLibraryCard(card);
     User alteredUser = new User();
     alteredUser.setEmail(testUser.getEmail());
-    when(institutionService.findInstitutionForEmail(testUser.getEmail()))
-        .thenReturn(institutionFromMap);
+    if (institutionFromMap != null) {
+      when(institutionService.findInstitutionIdForEmail(testUser.getEmail()))
+          .thenReturn(institutionFromMap.getId());
+    } else {
+      when(institutionService.findInstitutionIdForEmail(testUser.getEmail()))
+          .thenReturn(null);
+    }
     if (expectsUserMod) {
       when(userDAO.findUserByEmail(testUser.getEmail())).thenReturn(testUser, alteredUser);
       validateAlteredUserIsReturned(

--- a/src/test/java/org/broadinstitute/consent/http/util/InstitutionUtilTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/util/InstitutionUtilTest.java
@@ -1,17 +1,10 @@
 package org.broadinstitute.consent.http.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.gson.Gson;
-import java.util.Collections;
 import java.util.Date;
-import java.util.List;
-import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.Institution;
-import org.broadinstitute.consent.http.models.User;
-import org.broadinstitute.consent.http.models.UserRole;
 import org.broadinstitute.consent.http.util.gson.GsonUtil;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -19,12 +12,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class InstitutionUtilTest {
-
-  private final List<UserRole> adminRoles = Collections.singletonList(UserRoles.Admin());
-  private final List<UserRole> researcherRoles = Collections.singletonList(UserRoles.Researcher());
-  private final User adminUser = new User(1, "Admin", "Display Name", new Date(), adminRoles);
-  private final User researcherUser = new User(1, "Researcher", "Display Name", new Date(),
-      researcherRoles);
 
   private InstitutionUtil util;
 
@@ -41,14 +28,6 @@ class InstitutionUtilTest {
 
   private void initUtil() {
     util = new InstitutionUtil();
-  }
-
-  @Test
-  void testCheckIfAdminAdmin() {
-    initUtil();
-    assertTrue(util.checkIfAdmin(adminUser));
-    assertFalse(util.checkIfAdmin(researcherUser));
-    assertFalse(util.checkIfAdmin(new User()));
   }
 
   @Test


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-1941

### Summary
The primary goal of this PR is to look up user email domains from the domains associated to institutions in the database as opposed to the static JSON file we have in GCS. Along the way, the following updates are included:

* New DAO method and tests
* Remove JSON lookup code in GCS service code
* Simplify admin role checks on user in `InstitutionResource`
* Cleanup `InstitutionDomainMap` methods and tests
* Cleanup `InstitutionUtil` methods and tests
* Expand visible fields to non-admins in `InstitutionUtil`
* Fix reducer bug where signing official institution id was not getting set in the list of SOs
* Split the enforce user institution code paths to use a simpler id-only query.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
