### PR TITLE
[DT-1966] Delete institution by ID doesn't delete domains.

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/InstitutionDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/InstitutionDAO.java
@@ -164,7 +164,11 @@ public interface InstitutionDAO extends Transactional<InstitutionDAO> {
     return findInstitutionById(institutionId);
   }
 
-  @SqlUpdate("DELETE FROM institution WHERE institution_id = :institutionId")
+  @SqlUpdate(
+  """
+     WITH domain_deletes AS (DELETE FROM institution_domains d WHERE d.institution_id = :institutionId)
+     DELETE FROM institution WHERE institution_id = :institutionId
+  """)
   void deleteInstitutionById(@Bind("institutionId") Integer institutionId);
 
   @UseRowReducer(InstitutionReducer.class)

--- a/src/main/resources/changelog-master.xml
+++ b/src/main/resources/changelog-master.xml
@@ -190,4 +190,6 @@
     relativeToChangelogFile="true" />
   <include file="changesets/changelog-consent-2025-07-07-election-idx-refId-datasetd.xml"
     relativeToChangelogFile="true" />
+  <include file="changesets/changelog-consent-2025-07-10-institution-domains-add-foreign-key.xml"
+    relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/src/main/resources/changesets/changelog-consent-2025-07-10-institution-domains-add-foreign-key.xml
+++ b/src/main/resources/changesets/changelog-consent-2025-07-10-institution-domains-add-foreign-key.xml
@@ -4,14 +4,14 @@
   <changeSet id="changelog-consent-2025-07-10-institution-domains-cleanup-data" author="otchet">
     <sql>
       DELETE
-      FROM INSTITUTION_DOMAIN
-      WHERE INSTITUTION_DOMAIN.INSTITUTION_ID IN (SELECT INSTITUTION_DOMAINS.INSTITUTION_ID
-                                                  FROM INSTITUTION_DOMAINS
-                                                         LEFT OUTER JOIN INSTITUTION ON
-                                                    INSTITUTION_DOMAINS.INSTITUTION_ID =
-                                                    INSTITUTION.INSTITUTION_ID
-                                                  WHERE
-                                                    INSTITUTION.INSTITUTION_ID IS NULL)
+      FROM INSTITUTION_DOMAINS
+      WHERE INSTITUTION_DOMAINS.INSTITUTION_ID IN (SELECT INSTITUTION_DOMAINS.INSTITUTION_ID
+                                                   FROM INSTITUTION_DOMAINS
+                                                          LEFT OUTER JOIN INSTITUTION ON
+                                                     INSTITUTION_DOMAINS.INSTITUTION_ID =
+                                                     INSTITUTION.INSTITUTION_ID
+                                                   WHERE
+                                                     INSTITUTION.INSTITUTION_ID IS NULL)
     </sql>
   </changeSet>
   <changeSet id="changelog-consent-2025-07-10-institution-domains-add-foreign-key" author="otchet">

--- a/src/main/resources/changesets/changelog-consent-2025-07-10-institution-domains-add-foreign-key.xml
+++ b/src/main/resources/changesets/changelog-consent-2025-07-10-institution-domains-add-foreign-key.xml
@@ -1,6 +1,19 @@
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
          http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+  <changeSet id="changelog-consent-2025-07-10-institution-domains-cleanup-data" author="otchet">
+    <sql>
+      DELETE
+      FROM INSTITUTION_DOMAIN
+      WHERE INSTITUTION_DOMAIN.INSTITUTION_ID IN (SELECT INSTITUTION_DOMAINS.INSTITUTION_ID
+                                                  FROM INSTITUTION_DOMAINS
+                                                         LEFT OUTER JOIN INSTITUTION ON
+                                                    INSTITUTION_DOMAINS.INSTITUTION_ID =
+                                                    INSTITUTION.INSTITUTION_ID
+                                                  WHERE
+                                                    INSTITUTION.INSTITUTION_ID IS NULL)
+    </sql>
+  </changeSet>
   <changeSet id="changelog-consent-2025-07-10-institution-domains-add-foreign-key" author="otchet">
     <modifyDataType
       columnName="institution_id"

--- a/src/main/resources/changesets/changelog-consent-2025-07-10-institution-domains-add-foreign-key.xml
+++ b/src/main/resources/changesets/changelog-consent-2025-07-10-institution-domains-add-foreign-key.xml
@@ -1,0 +1,13 @@
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+  <changeSet id="changelog-consent-2025-07-10-institution-domains-add-foreign-key" author="otchet">
+    <modifyDataType
+      columnName="institution_id"
+      newDataType="bigint"
+      tableName="institution_domains"/>
+    <addForeignKeyConstraint baseTableName="institution_domains" baseColumnNames="institution_id"
+      referencedTableName="institution" referencedColumnNames="institution_id"
+      constraintName="fkInstitutionId"/>
+  </changeSet>
+</databaseChangeLog>

--- a/src/test/java/org/broadinstitute/consent/http/db/InstitutionDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/InstitutionDAOTest.java
@@ -108,6 +108,18 @@ class InstitutionDAOTest extends DAOTestHelper {
   }
 
   @Test
+  void testDeleteInstitutionById_WithDomain() throws SQLException {
+    Institution institution = createInstitution();
+    institution.setDomains(List.of("domain1", "domain2"));
+    institutionDAO.updateFullInstitution(institution, institution.getCreateUserId());
+    assertEquals(
+        institution.getDomains(),
+        institutionDAO.findInstitutionById(institution.getId()).getDomains());
+    institutionDAO.deleteInstitutionById(institution.getId());
+    assertNull(institutionDAO.findInstitutionById(institution.getId()));
+  }
+
+  @Test
   void testFindInstitutionById() {
     Institution institution = createInstitution();
     Integer id = institution.getId();


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-1966](https://broadworkbench.atlassian.net/browse/DT-1966)

### Summary

Items addressed by this PR:
1) cleans up the database to remove entires where institutions have been deleted but domains remain.
2) modifies the column type of `institution_domains.institution_id` to match the id type in the `institution table`
3) adds a foreign key relationship between institution and institution_domains based on the institution_id
4) updates delete sql so that when an institution is removed by ID, the associated domains are also removed
5) adds test coverage for this case.


----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
