### PR TITLE
[DT-1958] Delete Delete User API

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
@@ -371,15 +371,6 @@ public class UserResource extends Resource {
     }
   }
 
-  @DELETE
-  @Produces(MediaType.APPLICATION_JSON)
-  @Path("/{email}")
-  @RolesAllowed(ADMIN)
-  public Response delete(@Auth AuthUser authUser, @PathParam("email") String email, @Context UriInfo info) {
-    userService.deleteUserByEmail(email);
-    return Response.ok().build();
-  }
-
   @GET
   @Produces(MediaType.APPLICATION_JSON)
   @Path("/signing-officials")

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -784,26 +784,6 @@ paths:
           description: Server error.
   /api/user/{userId}/{roleId}:
     $ref: './paths/userRole.yaml'
-  /api/user/{email}:
-    delete:
-      summary: Delete User by email
-      description: Deletes the user identified by the email.
-      parameters:
-        - name: email
-          in: path
-          description: The email of the user.
-          required: true
-          schema:
-            type: string
-      tags:
-        - User
-      responses:
-        200:
-          description: Successful operation
-          content:
-            application/json:
-              schema:
-                type: string
   /api/user/acknowledgements/{key}:
     get:
       summary: Get Acknowledgement by key

--- a/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
@@ -7,7 +7,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -225,15 +224,6 @@ class UserResourceTest extends AbstractTestHelper {
 
     try (Response response = userResource.createResearcher(uriInfo, authUser)) {
       assertEquals(Status.CREATED.getStatusCode(), response.getStatus());
-    }
-  }
-
-  @Test
-  void testDeleteUser() {
-    doNothing().when(userService).deleteUserByEmail(any());
-
-    try (Response response = userResource.delete(authUser, randomAlphabetic(10), uriInfo)) {
-      assertEquals(200, response.getStatus());
     }
   }
 


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-1958

### Summary
Remove delete user endpoint from resource and api docs
Keep service layer intact

### Testing
Manually verified the endpoint is not included in APIs anymore nor on Swagger

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
