### PR TITLE
DT-2000: Simplify Summary By Role Lookup

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
@@ -471,6 +471,11 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
       """)
   List<Dataset> findDatasetListByDacIds(@BindList(value = "dacIds", onEmpty = EmptyHandling.NULL_STRING) List<Integer> dacIds);
 
+  @SqlQuery("""
+      SELECT distinct d.dataset_id FROM dataset d WHERE d.dac_id IN (<dacIds>)
+      """)
+  List<Integer> findDatasetIdsByDacIds(@BindList(value = "dacIds", onEmpty = EmptyHandling.NULL_STRING) List<Integer> dacIds);
+
   @SqlUpdate(
       "UPDATE dataset " +
           "SET dac_approval = :dacApproval, " +

--- a/src/main/java/org/broadinstitute/consent/http/models/DarCollectionSummary.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DarCollectionSummary.java
@@ -1,7 +1,7 @@
 package org.broadinstitute.consent.http.models;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.gson.Gson;
+import com.google.gson.annotations.Expose;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -16,64 +16,54 @@ import org.broadinstitute.consent.http.enumeration.DarCollectionActions;
 
 public class DarCollectionSummary {
 
-  @JsonProperty
+  @Expose
   private Integer darCollectionId;
-
-  @JsonProperty
+  @Expose
   private Set<String> referenceIds;
-
-  @JsonProperty
+  @Expose
   private String darCode;
-
-  @JsonProperty
+  @Expose
   private String name;
-
-  @JsonProperty
+  @Expose
   private Timestamp submissionDate;
-
-  @JsonProperty
+  @Expose
   private boolean expired;
-
-  @JsonProperty
+  @Expose
   private Timestamp expiresAt;
-
-  @JsonProperty
+  @Expose
   private String researcherName;
-
-  @JsonProperty
+  @Expose
   private String institutionName;
-
-  @JsonProperty
+  @Expose
   private String status;
-
-  @JsonProperty
+  @Expose
   private Set<String> actions;
-
-  @JsonProperty
+  @Expose
   private int datasetCount;
-
+  @Expose
   private final Map<Integer, Set<String>> parentToReferenceIds;
-
-  @JsonProperty
+  @Expose
   private boolean progressReport;
-
-  @JsonProperty
+  @Expose
   private String latestReferenceId;
-
-  @JsonProperty
+  @Expose
   private Integer closeoutSigningOfficialId;
-
-  @JsonProperty
+  @Expose
   private Timestamp closeoutSigningOfficialApprovalDate;
-
+  @Expose
   private List<String> dacNames;
-
+  @Expose
   private Integer researcherId;
+  @Expose
   private Integer institutionId;
+  @Expose
   private Set<Integer> datasetIds;
+
+  // Normally unused by the UI, but used in data population. Can be included in the JSON response
+  // if needed by using a GsonBuilder without `excludeFieldsWithoutExposeAnnotation`.
   private List<Vote> votes;
   private Map<Integer, Election> elections;
-  private Map<String, String> darStatuses;
+  private final Map<String, String> darStatuses;
   private CloseoutSupplement closeoutSupplement;
 
   public DarCollectionSummary() {

--- a/src/main/java/org/broadinstitute/consent/http/resources/DarCollectionResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DarCollectionResource.java
@@ -1,6 +1,7 @@
 package org.broadinstitute.consent.http.resources;
 
 import com.codahale.metrics.annotation.Timed;
+import com.google.gson.Gson;
 import com.google.inject.Inject;
 import io.dropwizard.auth.Auth;
 import jakarta.annotation.security.PermitAll;
@@ -31,6 +32,7 @@ import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.service.DarCollectionService;
 import org.broadinstitute.consent.http.service.UserService;
 import org.broadinstitute.consent.http.util.ComplianceLogger;
+import org.broadinstitute.consent.http.util.gson.GsonUtil;
 import org.glassfish.jersey.server.ContainerRequest;
 
 @Path("api/collections")
@@ -56,7 +58,9 @@ public class DarCollectionResource extends Resource {
       User user = userService.findUserByEmail(authUser.getEmail());
       var role = validateUserHasRoleName(user, roleName);
       List<DarCollectionSummary> summaries = darCollectionService.getSummariesForRole(user, role);
-      return Response.ok().entity(summaries).build();
+      // When querying in list context, we only want the exposed fields
+      Gson gson = GsonUtil.gsonBuilderWithAdapters().excludeFieldsWithoutExposeAnnotation().create();
+      return Response.ok().entity(gson.toJson(summaries)).build();
     } catch (Exception e) {
       return createExceptionResponse(e);
     }

--- a/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
@@ -382,12 +382,7 @@ public class DarCollectionService implements ConsentLogger {
         .map(UserRole::getDacId)
         .filter(Objects::nonNull)
         .toList();
-    return Stream.of(roleDacIds)
-        .filter(Predicate.not(List::isEmpty))
-        .map(datasetDAO::findDatasetListByDacIds)
-        .flatMap(List::stream)
-        .map(Dataset::getDatasetId)
-        .toList();
+    return datasetDAO.findDatasetIdsByDacIds(roleDacIds);
   }
 
   /**

--- a/src/main/resources/assets/schemas/DarCollectionSummary.yaml
+++ b/src/main/resources/assets/schemas/DarCollectionSummary.yaml
@@ -46,8 +46,6 @@ properties:
   progressReport:
     type: boolean
     description: Indicator true when the collection contains a progress report.
-  closeoutSupplement:
-    $ref: '../schemas/CloseOutSupplement.yaml'
   closeoutSigningOfficialApprovedDate:
     type: number
     description: When the Signing Official approved the closeout, in milliseconds since the epoch.

--- a/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
@@ -676,6 +676,26 @@ class DatasetDAOTest extends DAOTestHelper {
   }
 
   @Test
+  void testFindDatasetIdsByDacIds() {
+    Dataset dataset = insertDataset();
+    Dac dac = insertDac();
+
+    Dataset datasetTwo = insertDataset();
+    Dac dacTwo = insertDac();
+
+    Dataset datasetThree = insertDataset();
+
+    datasetDAO.updateDatasetDacId(dataset.getDatasetId(), dac.getDacId());
+    datasetDAO.updateDatasetDacId(datasetTwo.getDatasetId(), dacTwo.getDacId());
+
+    List<Integer> datasetIds = List.of(dataset.getDatasetId(), datasetTwo.getDatasetId());
+    List<Integer> foundDatasetIds = datasetDAO.findDatasetIdsByDacIds(
+        List.of(dac.getDacId(), dacTwo.getDacId()));
+    assertTrue(datasetIds.containsAll(foundDatasetIds));
+    assertFalse(foundDatasetIds.contains(datasetThree.getDatasetId()));
+  }
+
+  @Test
   void testUpdateDatasetDataUse() {
     Dataset dataset = insertDataset();
     DataUse oldDataUse = dataset.getDataUse();

--- a/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
@@ -1053,7 +1053,7 @@ class DarCollectionServiceTest extends AbstractTestHelper {
           return d;
         })
         .toList();
-    when(datasetDAO.findDatasetListByDacIds(any())).thenReturn(datasets);
+    when(datasetDAO.findDatasetIdsByDacIds(any())).thenReturn(datasets.stream().map(Dataset::getDatasetId).toList());
     when(darCollectionSummaryDAO.getDarCollectionSummariesForDAC(any(), any()))
         .thenReturn(List.of(summary, summaryTwo, summaryThree, summaryFour));
 
@@ -1176,13 +1176,13 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     when(darCollectionSummaryDAO.getDarCollectionSummariesForDAC(any(), any()))
         .thenReturn(
             List.of(summaryOne, summaryTwo, summaryThree, summaryFour, summaryFive, summarySix));
-    when(datasetDAO.findDatasetListByDacIds(any())).thenReturn(List.of(datasetOne,
-        datasetTwo,
-        datasetThree,
-        datasetFour,
-        datasetFive,
-        datasetFive,
-        datasetSix));
+    when(datasetDAO.findDatasetIdsByDacIds(any())).thenReturn(List.of(datasetOne.getDatasetId(),
+        datasetTwo.getDatasetId(),
+        datasetThree.getDatasetId(),
+        datasetFour.getDatasetId(),
+        datasetFive.getDatasetId(),
+        datasetFive.getDatasetId(),
+        datasetSix.getDatasetId()));
 
     List<DarCollectionSummary> summaries = service.getSummariesForRole(user,
         UserRoles.CHAIRPERSON);
@@ -1420,7 +1420,7 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     when(darCollectionSummaryDAO.getDarCollectionSummaryForDACByCollectionId(user.getUserId(),
         List.of(), collectionId))
         .thenReturn(summary);
-    when(datasetDAO.findDatasetListByDacIds(any())).thenReturn(List.of());
+    when(datasetDAO.findDatasetIdsByDacIds(any())).thenReturn(List.of());
 
     DarCollectionSummary summaryResult = service.getSummaryForRoleByCollectionId(user,
         UserRoles.CHAIRPERSON, collectionId);


### PR DESCRIPTION
### Addresses
Partially addresses https://broadworkbench.atlassian.net/browse/DT-2000

### Summary
This is just phase one of optimizing the performance of user's DAR Console pages. Future PRs will look more closely at the DAO layer to improve the underlying query. My local testing trims the overall API call for a chairperson call with lots of collections from ~4 seconds to about ~3.5 seconds. This should be a noticeable improvement in dev where the same call can take ~18-20 seconds.

This PR does two small-ish things. 

1. Update query to find Dataset ids by DAC Ids. Previously, we were making a looped DAO call that populated a basic dataset object only to then pull out the ids. This fix queries for the ids directly and removes the looped call. 

2. Simplify the return object in list context. Previously, we were blowing out the payload with elections and votes which the UI doesn't need to see.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
