### PR TITLE
[DT-1978] Remove Deprecated Methods from DACAutomationRuleDAO

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/DACAutomationRuleDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DACAutomationRuleDAO.java
@@ -10,9 +10,7 @@ import org.broadinstitute.consent.http.rules.RuleAuditAction;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
 import org.jdbi.v3.sqlobject.customizer.Bind;
-import org.jdbi.v3.sqlobject.statement.GetGeneratedKeys;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
-import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 import org.jdbi.v3.sqlobject.transaction.Transactional;
 
 @RegisterRowMapper(DACAutomationRuleMapper.class)
@@ -27,26 +25,26 @@ public interface DACAutomationRuleDAO extends Transactional<DACAutomationRuleDAO
       Instant activationDate) {
     Handle handle = getHandle();
     Integer id;
-    String auditSql = """
+    String insertAuditSql = """
         INSERT INTO dac_rule_audit (action, dac_id, rule_id, user_id, action_date)
         VALUES (:auditType::rule_audit_action, :dacId, :ruleId, :auditUserId, :actionDate)
         """;
-    String insertSql = """
+    String insertRuleSql = """
         INSERT INTO dac_rule_settings (dac_id, rule_id, user_id, activation_date)
         VALUES (:dacId, :ruleId, :userId, current_timestamp)
         """;
     try (
-        var audit = handle.createUpdate(auditSql);
-        var insert = handle.createUpdate(insertSql)
+        var insertAudit = handle.createUpdate(insertAuditSql);
+        var insertRule = handle.createUpdate(insertRuleSql)
     ) {
-      audit
+      insertAudit
           .bind("dacId", dacId)
           .bind("ruleId", ruleId)
           .bind("auditUserId", userId)
           .bind("auditType", RuleAuditAction.ADD)
           .bind("actionDate", activationDate)
           .execute();
-      id = insert
+      id = insertRule
           .bind("dacId", dacId)
           .bind("ruleId", ruleId)
           .bind("userId", userId)
@@ -65,26 +63,26 @@ public interface DACAutomationRuleDAO extends Transactional<DACAutomationRuleDAO
 
   default void auditedDeleteDACRuleSetting(int dacId, int ruleId, int auditUserId) {
     Handle handle = getHandle();
-    String auditSql = """
+    String deleteAuditSql = """
         INSERT INTO dac_rule_audit (action, dac_id, rule_id, user_id, action_date)
         SELECT :auditType::rule_audit_action, s.dac_id, s.rule_id, :auditUserId, current_timestamp
         FROM dac_rule_settings s
         WHERE s.dac_id = :dacId AND s.rule_id = :ruleId
         """;
-    String deleteSql = """
+    String deleteRuleSql = """
         DELETE FROM dac_rule_settings WHERE dac_id = :dacId AND rule_id = :ruleId
         """;
     try (
-        var audit = handle.createUpdate(auditSql);
-        var delete = handle.createUpdate(deleteSql)
+        var insertAudit = handle.createUpdate(deleteAuditSql);
+        var deleteRule = handle.createUpdate(deleteRuleSql)
     ) {
-      audit
+      insertAudit
           .bind("dacId", dacId)
           .bind("ruleId", ruleId)
           .bind("auditUserId", auditUserId)
           .bind("auditType", RuleAuditAction.REMOVE)
           .execute();
-      delete
+      deleteRule
           .bind("dacId", dacId)
           .bind("ruleId", ruleId)
           .execute();
@@ -100,27 +98,27 @@ public interface DACAutomationRuleDAO extends Transactional<DACAutomationRuleDAO
   default Integer auditedDeleteDACRuleSettingByUser(int dacId, int userId, int auditUserId) {
     Handle handle = getHandle();
     // Note that we're logging the audit user as the user for the audit record
-    String auditSql = """
+    String insertAuditSql = """
         INSERT INTO dac_rule_audit (action, dac_id, rule_id, user_id, action_date)
         SELECT :auditType::rule_audit_action, s.dac_id, s.rule_id, :auditUserId, current_timestamp
         FROM dac_rule_settings s
         WHERE s.dac_id = :dacId  AND s.user_id = :userId;
         """;
-    String deleteSql = """
+    String deleteRuleSql = """
         DELETE FROM dac_rule_settings WHERE dac_id = :dacId  AND user_id = :userId
         """;
     Integer count;
     try (
-        var audit = handle.createUpdate(auditSql);
-        var delete = handle.createUpdate(deleteSql)
+        var insertAudit = handle.createUpdate(insertAuditSql);
+        var deleteRule = handle.createUpdate(deleteRuleSql)
     ) {
-      audit
+      insertAudit
           .bind("dacId", dacId)
           .bind("userId", userId)
           .bind("auditUserId", auditUserId)
           .bind("auditType", RuleAuditAction.REMOVE)
           .execute();
-      count = delete
+      count = deleteRule
           .bind("dacId", dacId)
           .bind("userId", userId)
           .execute();
@@ -136,26 +134,26 @@ public interface DACAutomationRuleDAO extends Transactional<DACAutomationRuleDAO
 
   default Integer auditedDeleteAllDACRuleSettingForUser(int userId, int auditUserId) {
     Handle handle = getHandle();
-    String auditSql = """
+    String insertAuditSql = """
         INSERT INTO dac_rule_audit (action, dac_id, rule_id, user_id, action_date)
         SELECT :auditType::rule_audit_action, s.dac_id, s.rule_id, :auditUserId, current_timestamp
         FROM dac_rule_settings s
         WHERE s.user_id = :userId;
         """;
-    String deleteSql = """
+    String deleteRulesSql = """
         DELETE FROM dac_rule_settings WHERE user_id = :userId
         """;
     Integer count;
     try (
-        var audit = handle.createUpdate(auditSql);
-        var delete = handle.createUpdate(deleteSql)
+        var insertAudit = handle.createUpdate(insertAuditSql);
+        var deleteRules = handle.createUpdate(deleteRulesSql)
     ) {
-      audit
+      insertAudit
           .bind("auditUserId", auditUserId)
           .bind("userId", userId)
           .bind("auditType", RuleAuditAction.REMOVE)
           .execute();
-      count = delete
+      count = deleteRules
           .bind("userId", userId)
           .execute();
       handle.commit();

--- a/src/main/java/org/broadinstitute/consent/http/db/DACAutomationRuleDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DACAutomationRuleDAO.java
@@ -37,6 +37,7 @@ public interface DACAutomationRuleDAO extends Transactional<DACAutomationRuleDAO
         var audit = handle.createUpdate(auditSql);
         var insertRule = handle.createUpdate(insertRuleSql)
     ) {
+      handle.begin();
       audit
           .bind("dacId", dacId)
           .bind("ruleId", ruleId)
@@ -76,6 +77,7 @@ public interface DACAutomationRuleDAO extends Transactional<DACAutomationRuleDAO
         var audit = handle.createUpdate(auditSql);
         var deleteRule = handle.createUpdate(deleteRuleSql)
     ) {
+      handle.begin();
       audit
           .bind("dacId", dacId)
           .bind("ruleId", ruleId)
@@ -112,6 +114,7 @@ public interface DACAutomationRuleDAO extends Transactional<DACAutomationRuleDAO
         var audit = handle.createUpdate(auditSql);
         var deleteRule = handle.createUpdate(deleteRuleSql)
     ) {
+      handle.begin();
       audit
           .bind("dacId", dacId)
           .bind("userId", userId)
@@ -148,6 +151,7 @@ public interface DACAutomationRuleDAO extends Transactional<DACAutomationRuleDAO
         var audit = handle.createUpdate(auditSql);
         var deleteRules = handle.createUpdate(deleteRulesSql)
     ) {
+      handle.begin();
       audit
           .bind("auditUserId", auditUserId)
           .bind("userId", userId)

--- a/src/main/java/org/broadinstitute/consent/http/db/DACAutomationRuleDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DACAutomationRuleDAO.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.consent.http.db;
 
+import java.sql.SQLException;
 import java.time.Instant;
 import java.util.List;
 import org.broadinstitute.consent.http.db.mapper.DACAutomationRuleAuditMapper;
@@ -7,7 +8,6 @@ import org.broadinstitute.consent.http.db.mapper.DACAutomationRuleMapper;
 import org.broadinstitute.consent.http.rules.DACAutomationRule;
 import org.broadinstitute.consent.http.rules.DACAutomationRuleAudit;
 import org.broadinstitute.consent.http.rules.RuleAuditAction;
-import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
 import org.jdbi.v3.sqlobject.customizer.Bind;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
@@ -23,151 +23,164 @@ public interface DACAutomationRuleDAO extends Transactional<DACAutomationRuleDAO
 
   default Integer auditedInsertDACRuleSetting(int dacId, int ruleId, int userId,
       Instant activationDate) {
-    Handle handle = getHandle();
-    Integer id;
-    String auditSql = """
-        INSERT INTO dac_rule_audit (action, dac_id, rule_id, user_id, action_date)
-        VALUES (:auditType::rule_audit_action, :dacId, :ruleId, :auditUserId, :actionDate)
-        """;
-    String insertRuleSql = """
-        INSERT INTO dac_rule_settings (dac_id, rule_id, user_id, activation_date)
-        VALUES (:dacId, :ruleId, :userId, current_timestamp)
-        """;
-    try (
-        var audit = handle.createUpdate(auditSql);
-        var insertRule = handle.createUpdate(insertRuleSql)
-    ) {
-      handle.begin();
-      audit
-          .bind("dacId", dacId)
-          .bind("ruleId", ruleId)
-          .bind("auditUserId", userId)
-          .bind("auditType", RuleAuditAction.ADD)
-          .bind("actionDate", activationDate)
-          .execute();
-      id = insertRule
-          .bind("dacId", dacId)
-          .bind("ruleId", ruleId)
-          .bind("userId", userId)
-          .executeAndReturnGeneratedKeys("id")
-          .mapTo(Integer.class)
-          .one();
-      handle.commit();
-    } catch (Exception e) {
-      handle.rollback();
-      throw e;
-    } finally {
-      handle.close();
-    }
-    return id;
+    return withHandle(handle -> {
+      try {
+        handle.getConnection().setAutoCommit(false);
+      } catch (SQLException e) {
+        throw new RuntimeException(e);
+      }
+
+      String auditSql = """
+          INSERT INTO dac_rule_audit (action, dac_id, rule_id, user_id, action_date)
+          VALUES (:auditType::rule_audit_action, :dacId, :ruleId, :auditUserId, :actionDate)
+          """;
+      String insertRuleSql = """
+          INSERT INTO dac_rule_settings (dac_id, rule_id, user_id, activation_date)
+          VALUES (:dacId, :ruleId, :userId, current_timestamp)
+          """;
+      try (
+          var audit = handle.createUpdate(auditSql);
+          var insertRule = handle.createUpdate(insertRuleSql)
+      ) {
+        audit
+            .bind("dacId", dacId)
+            .bind("ruleId", ruleId)
+            .bind("auditUserId", userId)
+            .bind("auditType", RuleAuditAction.ADD)
+            .bind("actionDate", activationDate)
+            .execute();
+        Integer id = insertRule
+            .bind("dacId", dacId)
+            .bind("ruleId", ruleId)
+            .bind("userId", userId)
+            .executeAndReturnGeneratedKeys("id")
+            .mapTo(Integer.class)
+            .one();
+        handle.commit();
+        return id;
+      } catch (Exception e) {
+        handle.rollback();
+        throw e;
+      }
+    });
   }
 
   default void auditedDeleteDACRuleSetting(int dacId, int ruleId, int auditUserId) {
-    Handle handle = getHandle();
-    String auditSql = """
-        INSERT INTO dac_rule_audit (action, dac_id, rule_id, user_id, action_date)
-        SELECT :auditType::rule_audit_action, s.dac_id, s.rule_id, :auditUserId, current_timestamp
-        FROM dac_rule_settings s
-        WHERE s.dac_id = :dacId AND s.rule_id = :ruleId
-        """;
-    String deleteRuleSql = """
-        DELETE FROM dac_rule_settings WHERE dac_id = :dacId AND rule_id = :ruleId
-        """;
-    try (
-        var audit = handle.createUpdate(auditSql);
-        var deleteRule = handle.createUpdate(deleteRuleSql)
-    ) {
-      handle.begin();
-      audit
-          .bind("dacId", dacId)
-          .bind("ruleId", ruleId)
-          .bind("auditUserId", auditUserId)
-          .bind("auditType", RuleAuditAction.REMOVE)
-          .execute();
-      deleteRule
-          .bind("dacId", dacId)
-          .bind("ruleId", ruleId)
-          .execute();
-      handle.commit();
-    } catch (Exception e) {
-      handle.rollback();
-      throw e;
-    } finally {
-      handle.close();
-    }
+    withHandle(handle -> {
+      try {
+        handle.getConnection().setAutoCommit(false);
+      } catch (SQLException e) {
+        throw new RuntimeException(e);
+      }
+      String auditSql = """
+          INSERT INTO dac_rule_audit (action, dac_id, rule_id, user_id, action_date)
+          SELECT :auditType::rule_audit_action, s.dac_id, s.rule_id, :auditUserId, current_timestamp
+          FROM dac_rule_settings s
+          WHERE s.dac_id = :dacId AND s.rule_id = :ruleId
+          """;
+      String deleteRuleSql = """
+          DELETE FROM dac_rule_settings WHERE dac_id = :dacId AND rule_id = :ruleId
+          """;
+      try (
+          var audit = handle.createUpdate(auditSql);
+          var deleteRule = handle.createUpdate(deleteRuleSql)
+      ) {
+        audit
+            .bind("dacId", dacId)
+            .bind("ruleId", ruleId)
+            .bind("auditUserId", auditUserId)
+            .bind("auditType", RuleAuditAction.REMOVE)
+            .execute();
+        deleteRule
+            .bind("dacId", dacId)
+            .bind("ruleId", ruleId)
+            .execute();
+        handle.commit();
+      } catch (Exception e) {
+        handle.rollback();
+        throw e;
+      }
+      return null;
+    });
   }
 
   default Integer auditedDeleteDACRuleSettingByUser(int dacId, int userId, int auditUserId) {
-    Handle handle = getHandle();
-    // Note that we're logging the audit user as the user for the audit record
-    String auditSql = """
-        INSERT INTO dac_rule_audit (action, dac_id, rule_id, user_id, action_date)
-        SELECT :auditType::rule_audit_action, s.dac_id, s.rule_id, :auditUserId, current_timestamp
-        FROM dac_rule_settings s
-        WHERE s.dac_id = :dacId  AND s.user_id = :userId;
-        """;
-    String deleteRuleSql = """
-        DELETE FROM dac_rule_settings WHERE dac_id = :dacId  AND user_id = :userId
-        """;
-    Integer count;
-    try (
-        var audit = handle.createUpdate(auditSql);
-        var deleteRule = handle.createUpdate(deleteRuleSql)
-    ) {
-      handle.begin();
-      audit
-          .bind("dacId", dacId)
-          .bind("userId", userId)
-          .bind("auditUserId", auditUserId)
-          .bind("auditType", RuleAuditAction.REMOVE)
-          .execute();
-      count = deleteRule
-          .bind("dacId", dacId)
-          .bind("userId", userId)
-          .execute();
-      handle.commit();
-    } catch (Exception e) {
-      handle.rollback();
-      throw e;
-    } finally {
-      handle.close();
-    }
-    return count;
+    return withHandle(handle -> {
+      try {
+        handle.getConnection().setAutoCommit(false);
+      } catch (SQLException e) {
+        throw new RuntimeException(e);
+      }
+      // Note that we're logging the audit user as the user for the audit record
+      String auditSql = """
+          INSERT INTO dac_rule_audit (action, dac_id, rule_id, user_id, action_date)
+          SELECT :auditType::rule_audit_action, s.dac_id, s.rule_id, :auditUserId, current_timestamp
+          FROM dac_rule_settings s
+          WHERE s.dac_id = :dacId  AND s.user_id = :userId;
+          """;
+      String deleteRuleSql = """
+          DELETE FROM dac_rule_settings WHERE dac_id = :dacId  AND user_id = :userId
+          """;
+      Integer count;
+      try (
+          var audit = handle.createUpdate(auditSql);
+          var deleteRule = handle.createUpdate(deleteRuleSql)
+      ) {
+        audit
+            .bind("dacId", dacId)
+            .bind("userId", userId)
+            .bind("auditUserId", auditUserId)
+            .bind("auditType", RuleAuditAction.REMOVE)
+            .execute();
+        count = deleteRule
+            .bind("dacId", dacId)
+            .bind("userId", userId)
+            .execute();
+        handle.commit();
+      } catch (Exception e) {
+        handle.rollback();
+        throw e;
+      }
+      return count;
+    });
   }
 
   default Integer auditedDeleteAllDACRuleSettingForUser(int userId, int auditUserId) {
-    Handle handle = getHandle();
-    String auditSql = """
-        INSERT INTO dac_rule_audit (action, dac_id, rule_id, user_id, action_date)
-        SELECT :auditType::rule_audit_action, s.dac_id, s.rule_id, :auditUserId, current_timestamp
-        FROM dac_rule_settings s
-        WHERE s.user_id = :userId;
-        """;
-    String deleteRulesSql = """
-        DELETE FROM dac_rule_settings WHERE user_id = :userId
-        """;
-    Integer count;
-    try (
-        var audit = handle.createUpdate(auditSql);
-        var deleteRules = handle.createUpdate(deleteRulesSql)
-    ) {
-      handle.begin();
-      audit
-          .bind("auditUserId", auditUserId)
-          .bind("userId", userId)
-          .bind("auditType", RuleAuditAction.REMOVE)
-          .execute();
-      count = deleteRules
-          .bind("userId", userId)
-          .execute();
-      handle.commit();
-    } catch (Exception e) {
-      handle.rollback();
-      throw e;
-    } finally {
-      handle.close();
-    }
-    return count;
+    return withHandle(handle -> {
+      try {
+        handle.getConnection().setAutoCommit(false);
+      } catch (SQLException e) {
+        throw new RuntimeException(e);
+      }
+      String auditSql = """
+          INSERT INTO dac_rule_audit (action, dac_id, rule_id, user_id, action_date)
+          SELECT :auditType::rule_audit_action, s.dac_id, s.rule_id, :auditUserId, current_timestamp
+          FROM dac_rule_settings s
+          WHERE s.user_id = :userId;
+          """;
+      String deleteRulesSql = """
+          DELETE FROM dac_rule_settings WHERE user_id = :userId
+          """;
+      Integer count;
+      try (
+          var audit = handle.createUpdate(auditSql);
+          var deleteRules = handle.createUpdate(deleteRulesSql)
+      ) {
+        audit
+            .bind("auditUserId", auditUserId)
+            .bind("userId", userId)
+            .bind("auditType", RuleAuditAction.REMOVE)
+            .execute();
+        count = deleteRules
+            .bind("userId", userId)
+            .execute();
+        handle.commit();
+      } catch (Exception e) {
+        handle.rollback();
+        throw e;
+      }
+      return count;
+    });
   }
 
   @SqlQuery("""

--- a/src/main/java/org/broadinstitute/consent/http/db/DACAutomationRuleDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DACAutomationRuleDAO.java
@@ -27,7 +27,7 @@ public interface DACAutomationRuleDAO extends Transactional<DACAutomationRuleDAO
       try {
         handle.getConnection().setAutoCommit(false);
       } catch (SQLException e) {
-        throw new RuntimeException(e);
+        throw new RuntimeException("Error setting database connection", e);
       }
 
       String auditSql = """
@@ -70,7 +70,7 @@ public interface DACAutomationRuleDAO extends Transactional<DACAutomationRuleDAO
       try {
         handle.getConnection().setAutoCommit(false);
       } catch (SQLException e) {
-        throw new RuntimeException(e);
+        throw new RuntimeException("Error setting database connection", e);
       }
       String auditSql = """
           INSERT INTO dac_rule_audit (action, dac_id, rule_id, user_id, action_date)
@@ -109,7 +109,7 @@ public interface DACAutomationRuleDAO extends Transactional<DACAutomationRuleDAO
       try {
         handle.getConnection().setAutoCommit(false);
       } catch (SQLException e) {
-        throw new RuntimeException(e);
+        throw new RuntimeException("Error setting database connection", e);
       }
       // Note that we're logging the audit user as the user for the audit record
       String auditSql = """
@@ -150,7 +150,7 @@ public interface DACAutomationRuleDAO extends Transactional<DACAutomationRuleDAO
       try {
         handle.getConnection().setAutoCommit(false);
       } catch (SQLException e) {
-        throw new RuntimeException(e);
+        throw new RuntimeException("Error setting database connection", e);
       }
       String auditSql = """
           INSERT INTO dac_rule_audit (action, dac_id, rule_id, user_id, action_date)

--- a/src/main/java/org/broadinstitute/consent/http/db/DACAutomationRuleDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DACAutomationRuleDAO.java
@@ -25,7 +25,7 @@ public interface DACAutomationRuleDAO extends Transactional<DACAutomationRuleDAO
       Instant activationDate) {
     Handle handle = getHandle();
     Integer id;
-    String insertAuditSql = """
+    String auditSql = """
         INSERT INTO dac_rule_audit (action, dac_id, rule_id, user_id, action_date)
         VALUES (:auditType::rule_audit_action, :dacId, :ruleId, :auditUserId, :actionDate)
         """;
@@ -34,10 +34,10 @@ public interface DACAutomationRuleDAO extends Transactional<DACAutomationRuleDAO
         VALUES (:dacId, :ruleId, :userId, current_timestamp)
         """;
     try (
-        var insertAudit = handle.createUpdate(insertAuditSql);
+        var audit = handle.createUpdate(auditSql);
         var insertRule = handle.createUpdate(insertRuleSql)
     ) {
-      insertAudit
+      audit
           .bind("dacId", dacId)
           .bind("ruleId", ruleId)
           .bind("auditUserId", userId)
@@ -63,7 +63,7 @@ public interface DACAutomationRuleDAO extends Transactional<DACAutomationRuleDAO
 
   default void auditedDeleteDACRuleSetting(int dacId, int ruleId, int auditUserId) {
     Handle handle = getHandle();
-    String deleteAuditSql = """
+    String auditSql = """
         INSERT INTO dac_rule_audit (action, dac_id, rule_id, user_id, action_date)
         SELECT :auditType::rule_audit_action, s.dac_id, s.rule_id, :auditUserId, current_timestamp
         FROM dac_rule_settings s
@@ -73,10 +73,10 @@ public interface DACAutomationRuleDAO extends Transactional<DACAutomationRuleDAO
         DELETE FROM dac_rule_settings WHERE dac_id = :dacId AND rule_id = :ruleId
         """;
     try (
-        var insertAudit = handle.createUpdate(deleteAuditSql);
+        var audit = handle.createUpdate(auditSql);
         var deleteRule = handle.createUpdate(deleteRuleSql)
     ) {
-      insertAudit
+      audit
           .bind("dacId", dacId)
           .bind("ruleId", ruleId)
           .bind("auditUserId", auditUserId)
@@ -98,7 +98,7 @@ public interface DACAutomationRuleDAO extends Transactional<DACAutomationRuleDAO
   default Integer auditedDeleteDACRuleSettingByUser(int dacId, int userId, int auditUserId) {
     Handle handle = getHandle();
     // Note that we're logging the audit user as the user for the audit record
-    String insertAuditSql = """
+    String auditSql = """
         INSERT INTO dac_rule_audit (action, dac_id, rule_id, user_id, action_date)
         SELECT :auditType::rule_audit_action, s.dac_id, s.rule_id, :auditUserId, current_timestamp
         FROM dac_rule_settings s
@@ -109,10 +109,10 @@ public interface DACAutomationRuleDAO extends Transactional<DACAutomationRuleDAO
         """;
     Integer count;
     try (
-        var insertAudit = handle.createUpdate(insertAuditSql);
+        var audit = handle.createUpdate(auditSql);
         var deleteRule = handle.createUpdate(deleteRuleSql)
     ) {
-      insertAudit
+      audit
           .bind("dacId", dacId)
           .bind("userId", userId)
           .bind("auditUserId", auditUserId)
@@ -134,7 +134,7 @@ public interface DACAutomationRuleDAO extends Transactional<DACAutomationRuleDAO
 
   default Integer auditedDeleteAllDACRuleSettingForUser(int userId, int auditUserId) {
     Handle handle = getHandle();
-    String insertAuditSql = """
+    String auditSql = """
         INSERT INTO dac_rule_audit (action, dac_id, rule_id, user_id, action_date)
         SELECT :auditType::rule_audit_action, s.dac_id, s.rule_id, :auditUserId, current_timestamp
         FROM dac_rule_settings s
@@ -145,10 +145,10 @@ public interface DACAutomationRuleDAO extends Transactional<DACAutomationRuleDAO
         """;
     Integer count;
     try (
-        var insertAudit = handle.createUpdate(insertAuditSql);
+        var audit = handle.createUpdate(auditSql);
         var deleteRules = handle.createUpdate(deleteRulesSql)
     ) {
-      insertAudit
+      audit
           .bind("auditUserId", auditUserId)
           .bind("userId", userId)
           .bind("auditType", RuleAuditAction.REMOVE)

--- a/src/main/java/org/broadinstitute/consent/http/db/DACAutomationRuleDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DACAutomationRuleDAO.java
@@ -1,6 +1,5 @@
 package org.broadinstitute.consent.http.db;
 
-import java.sql.SQLException;
 import java.time.Instant;
 import java.util.List;
 import org.broadinstitute.consent.http.db.mapper.DACAutomationRuleAuditMapper;

--- a/src/main/java/org/broadinstitute/consent/http/db/DACAutomationRuleDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DACAutomationRuleDAO.java
@@ -23,14 +23,6 @@ public interface DACAutomationRuleDAO extends Transactional<DACAutomationRuleDAO
       """)
   List<DACAutomationRule> findAll();
 
-  @SqlUpdate("""
-      INSERT INTO dac_rule_settings (dac_id, rule_id, user_id, activation_date) VALUES (:dacId, :ruleId, :userId, current_timestamp)
-      """)
-  @GetGeneratedKeys
-  Integer useAuditedInsertDACRuleSettingInsteadOfThisMethod(@Bind("dacId") int dacId,
-      @Bind("ruleId") int ruleId,
-      @Bind("userId") int userId);
-
   default Integer auditedInsertDACRuleSetting(int dacId, int ruleId, int userId,
       Instant activationDate) {
     Handle handle = getHandle();
@@ -39,7 +31,14 @@ public interface DACAutomationRuleDAO extends Transactional<DACAutomationRuleDAO
         INSERT INTO dac_rule_audit (action, dac_id, rule_id, user_id, action_date)
         VALUES (:auditType::rule_audit_action, :dacId, :ruleId, :auditUserId, :actionDate)
         """;
-    try (var audit = getHandle().createUpdate(auditSql)) {
+    String insertSql = """
+        INSERT INTO dac_rule_settings (dac_id, rule_id, user_id, activation_date)
+        VALUES (:dacId, :ruleId, :userId, current_timestamp)
+        """;
+    try (
+        var audit = handle.createUpdate(auditSql);
+        var delete = handle.createUpdate(insertSql)
+    ) {
       audit
           .bind("dacId", dacId)
           .bind("ruleId", ruleId)
@@ -47,7 +46,13 @@ public interface DACAutomationRuleDAO extends Transactional<DACAutomationRuleDAO
           .bind("auditType", RuleAuditAction.ADD)
           .bind("actionDate", activationDate)
           .execute();
-      id = useAuditedInsertDACRuleSettingInsteadOfThisMethod(dacId, ruleId, userId);
+      id = handle.createUpdate(insertSql)
+          .bind("dacId", dacId)
+          .bind("ruleId", ruleId)
+          .bind("userId", userId)
+          .executeAndReturnGeneratedKeys("id")
+          .mapTo(Integer.class)
+          .one();
       handle.commit();
     } catch (Exception e) {
       handle.rollback();
@@ -58,12 +63,6 @@ public interface DACAutomationRuleDAO extends Transactional<DACAutomationRuleDAO
     return id;
   }
 
-  @SqlUpdate("""
-      DELETE FROM dac_rule_settings WHERE dac_id = :dacId AND rule_id = :ruleId
-      """)
-  void useAuditedDeleteDACRuleSettingInsteadOfThisMethod(@Bind("dacId") int dacId,
-      @Bind("ruleId") int ruleId);
-
   default void auditedDeleteDACRuleSetting(int dacId, int ruleId, int auditUserId) {
     Handle handle = getHandle();
     String auditSql = """
@@ -72,14 +71,23 @@ public interface DACAutomationRuleDAO extends Transactional<DACAutomationRuleDAO
         FROM dac_rule_settings s
         WHERE s.dac_id = :dacId AND s.rule_id = :ruleId
         """;
-    try (var audit = getHandle().createUpdate(auditSql)) {
+    String deleteSql = """
+        DELETE FROM dac_rule_settings WHERE dac_id = :dacId AND rule_id = :ruleId
+        """;
+    try (
+        var audit = getHandle().createUpdate(auditSql);
+        var delete = getHandle().createUpdate(deleteSql)
+    ) {
       audit
           .bind("dacId", dacId)
           .bind("ruleId", ruleId)
           .bind("auditUserId", auditUserId)
           .bind("auditType", RuleAuditAction.REMOVE)
           .execute();
-      useAuditedDeleteDACRuleSettingInsteadOfThisMethod(dacId, ruleId);
+      delete
+          .bind("dacId", dacId)
+          .bind("ruleId", ruleId)
+          .execute();
       handle.commit();
     } catch (Exception e) {
       handle.rollback();
@@ -88,12 +96,6 @@ public interface DACAutomationRuleDAO extends Transactional<DACAutomationRuleDAO
       handle.close();
     }
   }
-
-  @SqlUpdate("""
-      DELETE FROM dac_rule_settings WHERE dac_id = :dacId  AND user_id = :userId
-      """)
-  Integer useAuditedDeleteDACRuleSettingByUserInsteadOfThisMethod(@Bind("dacId") int dacId,
-      @Bind("userId") int userId);
 
   default Integer auditedDeleteDACRuleSettingByUser(int dacId, int userId, int auditUserId) {
     Handle handle = getHandle();
@@ -104,15 +106,24 @@ public interface DACAutomationRuleDAO extends Transactional<DACAutomationRuleDAO
         FROM dac_rule_settings s
         WHERE s.dac_id = :dacId  AND s.user_id = :userId;
         """;
+    String deleteSql = """
+        DELETE FROM dac_rule_settings WHERE dac_id = :dacId  AND user_id = :userId
+        """;
     Integer count;
-    try (var audit = getHandle().createUpdate(auditSql)) {
+    try (
+        var audit = getHandle().createUpdate(auditSql);
+        var delete = getHandle().createUpdate(deleteSql)
+    ) {
       audit
           .bind("dacId", dacId)
           .bind("userId", userId)
           .bind("auditUserId", auditUserId)
           .bind("auditType", RuleAuditAction.REMOVE)
           .execute();
-      count = useAuditedDeleteDACRuleSettingByUserInsteadOfThisMethod(dacId, userId);
+      count = delete
+          .bind("dacId", dacId)
+          .bind("userId", userId)
+          .execute();
       handle.commit();
     } catch (Exception e) {
       handle.rollback();
@@ -123,11 +134,6 @@ public interface DACAutomationRuleDAO extends Transactional<DACAutomationRuleDAO
     return count;
   }
 
-  @SqlUpdate("""
-      DELETE FROM dac_rule_settings WHERE user_id = :userId 
-      """)
-  Integer useAuditedDeleteAllDACRuleSettingForUserInsteadOfThisMethod(@Bind("userId") int userId);
-
   default Integer auditedDeleteAllDACRuleSettingForUser(int userId, int auditUserId) {
     Handle handle = getHandle();
     String auditSql = """
@@ -136,14 +142,22 @@ public interface DACAutomationRuleDAO extends Transactional<DACAutomationRuleDAO
         FROM dac_rule_settings s
         WHERE s.user_id = :userId;
         """;
+    String deleteSql = """
+        DELETE FROM dac_rule_settings WHERE user_id = :userId
+        """;
     Integer count;
-    try (var audit = getHandle().createUpdate(auditSql)) {
+    try (
+        var audit = getHandle().createUpdate(auditSql);
+        var delete = getHandle().createUpdate(deleteSql)
+    ) {
       audit
           .bind("auditUserId", auditUserId)
           .bind("userId", userId)
           .bind("auditType", RuleAuditAction.REMOVE)
           .execute();
-      count = useAuditedDeleteAllDACRuleSettingForUserInsteadOfThisMethod(userId);
+      count = delete
+          .bind("userId", userId)
+          .execute();
       handle.commit();
     } catch (Exception e) {
       handle.rollback();

--- a/src/main/java/org/broadinstitute/consent/http/db/DACAutomationRuleDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DACAutomationRuleDAO.java
@@ -8,6 +8,7 @@ import org.broadinstitute.consent.http.db.mapper.DACAutomationRuleMapper;
 import org.broadinstitute.consent.http.rules.DACAutomationRule;
 import org.broadinstitute.consent.http.rules.DACAutomationRuleAudit;
 import org.broadinstitute.consent.http.rules.RuleAuditAction;
+import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
 import org.jdbi.v3.sqlobject.customizer.Bind;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
@@ -21,57 +22,39 @@ public interface DACAutomationRuleDAO extends Transactional<DACAutomationRuleDAO
       """)
   List<DACAutomationRule> findAll();
 
-  default Integer auditedInsertDACRuleSetting(int dacId, int ruleId, int userId,
-      Instant activationDate) {
-    return withHandle(handle -> {
-      try {
-        handle.getConnection().setAutoCommit(false);
-      } catch (SQLException e) {
-        throw new RuntimeException("Error setting database connection", e);
-      }
-
+  default Integer auditedInsertDACRuleSetting(int dacId, int ruleId, int userId, Instant activationDate) {
+    return inTransaction(d -> {
+      Handle handle = getHandle();
       String auditSql = """
-          INSERT INTO dac_rule_audit (action, dac_id, rule_id, user_id, action_date)
-          VALUES (:auditType::rule_audit_action, :dacId, :ruleId, :auditUserId, :actionDate)
-          """;
+        INSERT INTO dac_rule_audit (action, dac_id, rule_id, user_id, action_date)
+        VALUES (:auditType::rule_audit_action, :dacId, :ruleId, :auditUserId, :actionDate)
+        """;
       String insertRuleSql = """
-          INSERT INTO dac_rule_settings (dac_id, rule_id, user_id, activation_date)
-          VALUES (:dacId, :ruleId, :userId, current_timestamp)
-          """;
-      try (
-          var audit = handle.createUpdate(auditSql);
-          var insertRule = handle.createUpdate(insertRuleSql)
-      ) {
-        audit
-            .bind("dacId", dacId)
-            .bind("ruleId", ruleId)
-            .bind("auditUserId", userId)
-            .bind("auditType", RuleAuditAction.ADD)
-            .bind("actionDate", activationDate)
-            .execute();
-        Integer id = insertRule
-            .bind("dacId", dacId)
-            .bind("ruleId", ruleId)
-            .bind("userId", userId)
-            .executeAndReturnGeneratedKeys("id")
-            .mapTo(Integer.class)
-            .one();
-        handle.commit();
-        return id;
-      } catch (Exception e) {
-        handle.rollback();
-        throw e;
-      }
+        INSERT INTO dac_rule_settings (dac_id, rule_id, user_id, activation_date)
+        VALUES (:dacId, :ruleId, :userId, current_timestamp)
+        """;
+
+      handle.createUpdate(auditSql)
+          .bind("dacId", dacId)
+          .bind("ruleId", ruleId)
+          .bind("auditUserId", userId)
+          .bind("auditType", RuleAuditAction.ADD)
+          .bind("actionDate", activationDate)
+          .execute();
+
+      return handle.createUpdate(insertRuleSql)
+          .bind("dacId", dacId)
+          .bind("ruleId", ruleId)
+          .bind("userId", userId)
+          .executeAndReturnGeneratedKeys("id")
+          .mapTo(Integer.class)
+          .one();
     });
   }
 
   default void auditedDeleteDACRuleSetting(int dacId, int ruleId, int auditUserId) {
-    withHandle(handle -> {
-      try {
-        handle.getConnection().setAutoCommit(false);
-      } catch (SQLException e) {
-        throw new RuntimeException("Error setting database connection", e);
-      }
+    useTransaction(d -> {
+      Handle handle = getHandle();
       String auditSql = """
           INSERT INTO dac_rule_audit (action, dac_id, rule_id, user_id, action_date)
           SELECT :auditType::rule_audit_action, s.dac_id, s.rule_id, :auditUserId, current_timestamp
@@ -81,36 +64,24 @@ public interface DACAutomationRuleDAO extends Transactional<DACAutomationRuleDAO
       String deleteRuleSql = """
           DELETE FROM dac_rule_settings WHERE dac_id = :dacId AND rule_id = :ruleId
           """;
-      try (
-          var audit = handle.createUpdate(auditSql);
-          var deleteRule = handle.createUpdate(deleteRuleSql)
-      ) {
-        audit
+
+        handle.createUpdate(auditSql)
             .bind("dacId", dacId)
             .bind("ruleId", ruleId)
             .bind("auditUserId", auditUserId)
             .bind("auditType", RuleAuditAction.REMOVE)
             .execute();
-        deleteRule
+        handle.createUpdate(deleteRuleSql)
             .bind("dacId", dacId)
             .bind("ruleId", ruleId)
             .execute();
         handle.commit();
-      } catch (Exception e) {
-        handle.rollback();
-        throw e;
-      }
-      return null;
     });
   }
 
   default Integer auditedDeleteDACRuleSettingByUser(int dacId, int userId, int auditUserId) {
-    return withHandle(handle -> {
-      try {
-        handle.getConnection().setAutoCommit(false);
-      } catch (SQLException e) {
-        throw new RuntimeException("Error setting database connection", e);
-      }
+    return inTransaction(d -> {
+      Handle handle = getHandle();
       // Note that we're logging the audit user as the user for the audit record
       String auditSql = """
           INSERT INTO dac_rule_audit (action, dac_id, rule_id, user_id, action_date)
@@ -121,37 +92,23 @@ public interface DACAutomationRuleDAO extends Transactional<DACAutomationRuleDAO
       String deleteRuleSql = """
           DELETE FROM dac_rule_settings WHERE dac_id = :dacId  AND user_id = :userId
           """;
-      Integer count;
-      try (
-          var audit = handle.createUpdate(auditSql);
-          var deleteRule = handle.createUpdate(deleteRuleSql)
-      ) {
-        audit
-            .bind("dacId", dacId)
-            .bind("userId", userId)
-            .bind("auditUserId", auditUserId)
-            .bind("auditType", RuleAuditAction.REMOVE)
-            .execute();
-        count = deleteRule
-            .bind("dacId", dacId)
-            .bind("userId", userId)
-            .execute();
-        handle.commit();
-      } catch (Exception e) {
-        handle.rollback();
-        throw e;
-      }
-      return count;
+
+      handle.createUpdate(auditSql)
+          .bind("dacId", dacId)
+          .bind("userId", userId)
+          .bind("auditUserId", auditUserId)
+          .bind("auditType", RuleAuditAction.REMOVE)
+          .execute();
+      return handle.createUpdate(deleteRuleSql)
+          .bind("dacId", dacId)
+          .bind("userId", userId)
+          .execute();
     });
   }
 
   default Integer auditedDeleteAllDACRuleSettingForUser(int userId, int auditUserId) {
-    return withHandle(handle -> {
-      try {
-        handle.getConnection().setAutoCommit(false);
-      } catch (SQLException e) {
-        throw new RuntimeException("Error setting database connection", e);
-      }
+    return inTransaction(d -> {
+      Handle handle = getHandle();
       String auditSql = """
           INSERT INTO dac_rule_audit (action, dac_id, rule_id, user_id, action_date)
           SELECT :auditType::rule_audit_action, s.dac_id, s.rule_id, :auditUserId, current_timestamp
@@ -162,24 +119,14 @@ public interface DACAutomationRuleDAO extends Transactional<DACAutomationRuleDAO
           DELETE FROM dac_rule_settings WHERE user_id = :userId
           """;
       Integer count;
-      try (
-          var audit = handle.createUpdate(auditSql);
-          var deleteRules = handle.createUpdate(deleteRulesSql)
-      ) {
-        audit
-            .bind("auditUserId", auditUserId)
-            .bind("userId", userId)
-            .bind("auditType", RuleAuditAction.REMOVE)
-            .execute();
-        count = deleteRules
-            .bind("userId", userId)
-            .execute();
-        handle.commit();
-      } catch (Exception e) {
-        handle.rollback();
-        throw e;
-      }
-      return count;
+      handle.createUpdate(auditSql)
+          .bind("auditUserId", auditUserId)
+          .bind("userId", userId)
+          .bind("auditType", RuleAuditAction.REMOVE)
+          .execute();
+      return handle.createUpdate(deleteRulesSql)
+          .bind("userId", userId)
+          .execute();
     });
   }
 

--- a/src/main/java/org/broadinstitute/consent/http/db/DACAutomationRuleDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DACAutomationRuleDAO.java
@@ -37,7 +37,7 @@ public interface DACAutomationRuleDAO extends Transactional<DACAutomationRuleDAO
         """;
     try (
         var audit = handle.createUpdate(auditSql);
-        var delete = handle.createUpdate(insertSql)
+        var insert = handle.createUpdate(insertSql)
     ) {
       audit
           .bind("dacId", dacId)
@@ -46,7 +46,7 @@ public interface DACAutomationRuleDAO extends Transactional<DACAutomationRuleDAO
           .bind("auditType", RuleAuditAction.ADD)
           .bind("actionDate", activationDate)
           .execute();
-      id = handle.createUpdate(insertSql)
+      id = insert
           .bind("dacId", dacId)
           .bind("ruleId", ruleId)
           .bind("userId", userId)
@@ -75,8 +75,8 @@ public interface DACAutomationRuleDAO extends Transactional<DACAutomationRuleDAO
         DELETE FROM dac_rule_settings WHERE dac_id = :dacId AND rule_id = :ruleId
         """;
     try (
-        var audit = getHandle().createUpdate(auditSql);
-        var delete = getHandle().createUpdate(deleteSql)
+        var audit = handle.createUpdate(auditSql);
+        var delete = handle.createUpdate(deleteSql)
     ) {
       audit
           .bind("dacId", dacId)
@@ -111,8 +111,8 @@ public interface DACAutomationRuleDAO extends Transactional<DACAutomationRuleDAO
         """;
     Integer count;
     try (
-        var audit = getHandle().createUpdate(auditSql);
-        var delete = getHandle().createUpdate(deleteSql)
+        var audit = handle.createUpdate(auditSql);
+        var delete = handle.createUpdate(deleteSql)
     ) {
       audit
           .bind("dacId", dacId)
@@ -147,8 +147,8 @@ public interface DACAutomationRuleDAO extends Transactional<DACAutomationRuleDAO
         """;
     Integer count;
     try (
-        var audit = getHandle().createUpdate(auditSql);
-        var delete = getHandle().createUpdate(deleteSql)
+        var audit = handle.createUpdate(auditSql);
+        var delete = handle.createUpdate(deleteSql)
     ) {
       audit
           .bind("auditUserId", auditUserId)

--- a/src/test/java/org/broadinstitute/consent/http/db/DACAutomationRuleDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DACAutomationRuleDAOTest.java
@@ -63,9 +63,12 @@ class DACAutomationRuleDAOTest extends DAOTestHelper {
     );
     Assertions.assertEquals(0, auditRecords.size());
 
+    Integer ruleId = rulesByDacId.get(0).id();
+    Instant now = Instant.now();
+
     // Use -1 userId to force a failure and trigger a rollback
     Assertions.assertThrows(UnableToExecuteStatementException.class, () ->
-        dacAutomationRuleDAO.auditedInsertDACRuleSetting(dacId, rulesByDacId.get(0).id(), -1, Instant.now())
+        dacAutomationRuleDAO.auditedInsertDACRuleSetting(dacId, ruleId, -1, now)
     );
 
     List<DACAutomationRuleAudit> auditRecordsAfter = dacAutomationRuleDAO.findAutomationAuditsForDac(

--- a/src/test/java/org/broadinstitute/consent/http/db/DACAutomationRuleDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DACAutomationRuleDAOTest.java
@@ -9,6 +9,7 @@ import org.broadinstitute.consent.http.rules.DACAutomationRule;
 import org.broadinstitute.consent.http.rules.DACAutomationRuleAudit;
 import org.broadinstitute.consent.http.rules.DACAutomationRuleType;
 import org.broadinstitute.consent.http.rules.RuleAuditAction;
+import org.jdbi.v3.core.statement.UnableToExecuteStatementException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -63,7 +64,7 @@ class DACAutomationRuleDAOTest extends DAOTestHelper {
     Assertions.assertEquals(0, auditRecords.size());
 
     // Use -1 userId to force a failure and trigger a rollback
-    Assertions.assertThrows(Exception.class, () ->
+    Assertions.assertThrows(UnableToExecuteStatementException.class, () ->
         dacAutomationRuleDAO.auditedInsertDACRuleSetting(dacId, rulesByDacId.get(0).id(), -1, Instant.now())
     );
 

--- a/src/test/java/org/broadinstitute/consent/http/db/DACAutomationRuleDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DACAutomationRuleDAOTest.java
@@ -54,6 +54,27 @@ class DACAutomationRuleDAOTest extends DAOTestHelper {
   }
 
   @Test
+  void testAuditedInsertDACRuleSettingRollback() {
+    Integer dacId = createRandomDAC();
+    List<DACAutomationRule> rulesByDacId = dacAutomationRuleDAO.findAll();
+    List<DACAutomationRuleAudit> auditRecords = dacAutomationRuleDAO.findAutomationAuditsForDac(
+        dacId, 5, 0
+    );
+    Assertions.assertEquals(0, auditRecords.size());
+
+    // Use -1 userId to force a failure and trigger a rollback
+    Assertions.assertThrows(Exception.class, () ->
+        dacAutomationRuleDAO.auditedInsertDACRuleSetting(dacId, rulesByDacId.get(0).id(), -1, Instant.now())
+    );
+
+    List<DACAutomationRuleAudit> auditRecordsAfter = dacAutomationRuleDAO.findAutomationAuditsForDac(
+        dacId, 5, 0
+    );
+
+    Assertions.assertEquals(0, auditRecordsAfter.size());
+  }
+
+  @Test
   void testFindRulesByDacIdAddSetting() {
     Integer dacId = createRandomDAC();
     List<DACAutomationRule> rulesByDacId = dacAutomationRuleDAO.findAllDACAutomationRulesByDACId(


### PR DESCRIPTION
### Addresses


https://broadworkbench.atlassian.net/browse/DT-1978

### Summary

Removes the deprecated `useAuditedFoo` methods and inlines their SQL.
Also refactors how transactions/rollbacks are managed, leaning more into JDBI-provided utilities.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
