### PR TITLE
[DT-1984] Prevent the removal of the chairperson and member roles through UserService

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
@@ -300,7 +300,7 @@ public class UserResource extends Resource {
       } else if (activeUser.hasUserRole(UserRoles.SIGNINGOFFICIAL)) {
         if (!UserRoles.isValidSoAdjustableRoleId(targetRole)) {
           throw new ForbiddenException(
-              "A Signing Official may only remove the following role ids: [6, 7, 8] ");
+              "A Signing Official may only remove the following role ids: [7, 8, 9] ");
         }
         if (Objects.equals(user.getUserId(), activeUser.getUserId())
             && (UserRoles.getUserRoleFromId(roleId) == UserRoles.SIGNINGOFFICIAL)) {

--- a/src/main/resources/assets/paths/userRole.yaml
+++ b/src/main/resources/assets/paths/userRole.yaml
@@ -52,7 +52,7 @@ put:
 delete:
   summary: Delete a role from a user
   description: Delete a role from a user, specified by given userId. Available to Admin and Signing Official roles.  
-    Signing Officials may remove user roles [6, 7, 8] for users in their organization.  They may not remove the
+    Signing Officials may remove user roles [7, 8, 9] for users in their organization.  They may not remove the
     Signing Official role from themselves.
   parameters:
     - name: userId

--- a/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
@@ -569,12 +569,24 @@ class UserResourceTest extends AbstractTestHelper {
   }
 
   @Test
-  void testDeleteRoleFromUser_InvalidRole() {
+  void testDeleteRoleFromUserDacRoleId() {
     User user = createUserWithRole();
     User activeUser = createUserWithRole();
     activeUser.setAdminRole();
+    when(userService.findUserByEmail(authUser.getEmail())).thenReturn(activeUser);
+    when(userService.findUserById(user.getUserId())).thenReturn(user);
 
-    try (Response response = userResource.deleteRoleFromUser(authUser, user.getUserId(), 20)) {
+    try (Response response = userResource.deleteRoleFromUser(authUser, user.getUserId(), 2)) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
+    }
+  }
+
+  @Test
+  void testDeleteRoleFromUserInvalidRoleId() {
+    User activeUser = createUserWithRole();
+    activeUser.setAdminRole();
+
+    try (Response response = userResource.deleteRoleFromUser(authUser, 1, 1000)) {
       assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
     }
   }
@@ -742,16 +754,6 @@ class UserResourceTest extends AbstractTestHelper {
     try (Response response = userResource.deleteRoleFromUser(authUser, 1,
         UserRoles.ADMIN.getRoleId())) {
       assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
-    }
-  }
-
-  @Test
-  void testDeleteRoleFromUserInvalidRoleId() {
-    User activeUser = createUserWithRole();
-    activeUser.setAdminRole();
-
-    try (Response response = userResource.deleteRoleFromUser(authUser, 1, 1000)) {
-      assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
     }
   }
 


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-1984

### Summary
The work for this ticket was already done. I just added a test for the case and updated the documentation.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
