### PR TITLE
[DT-1974] VoteType: DACBOTAPPROVE with a fixed Rationale (back end)

### DIFF
--- a/DEVNOTES.md
+++ b/DEVNOTES.md
@@ -59,12 +59,12 @@ Or, if not using docker:
 java -jar /path/to/consent.jar server /path/to/config/file
 ```
 
-Visit local swagger page: https://local.broadinstitute.org:27443/swagger/
+Visit local swagger page: https://local.dsde-dev.broadinstitute.org:27443/swagger/
 
 ### Debugging
 
 Port 7777 is open in the configured docker compose.
-Set up a remote debug configuration pointing to `local.broadinstitute.org`
+Set up a remote debug configuration pointing to `local.dsde-dev.broadinstitute.org`
 and the defaults should be correct.
 
 ### Developing with a local Elastic Search instance:

--- a/migration/dar/migrate.groovy
+++ b/migration/dar/migrate.groovy
@@ -16,7 +16,7 @@ import static groovyx.net.http.util.SslUtils.ignoreSslIssues
  * Sample Usage:
  *   groovy migrate.groovy \
  *     `gcloud auth print-access-token` \
- *     https://local.broadinstitute.org:27443
+ *     https://local.dsde-dev.broadinstitute.org:27443
  */
 
 migrateDars(args[0], args[1])

--- a/migration/dar/prod-dev-migrate.groovy
+++ b/migration/dar/prod-dev-migrate.groovy
@@ -14,7 +14,7 @@ import static groovyx.net.http.util.SslUtils.ignoreSslIssues
  * Sample Usage:
  *   groovy prod-dev-migrate.groovy \
  *     `gcloud auth print-access-token` \
- *     https://local.broadinstitute.org:27443
+ *     https://local.dsde-dev.broadinstitute.org:27443
  */
 
 migrateDars(args[0], args[1])

--- a/migration/insitution/README.md
+++ b/migration/insitution/README.md
@@ -8,7 +8,7 @@ from the command line:
 node app.js \
     --file=./institutions.txt
     --token=`gcloud auth print-access-token` \
-    --host=https://local.broadinstitute.org:27443 \
+    --host=https://local.dsde-dev.broadinstitute.org:27443 \
 ```
 
 * Ensure that you have an admin role in the consent environment you are pointing to.

--- a/migration/insitution/app.js
+++ b/migration/insitution/app.js
@@ -15,7 +15,7 @@ const { hideBin } = require('yargs/helpers')
  *   node app.js \
  *     --file=./institutions.txt
  *     --token=`gcloud auth print-access-token` \
- *     --host=https://local.broadinstitute.org:27443 \
+ *     --host=https://local.dsde-dev.broadinstitute.org:27443 \
  *
  *
  * EXAMPLE LINE IN FILE:

--- a/migration/libraryCardPopulation/populateLibraryCards.groovy
+++ b/migration/libraryCardPopulation/populateLibraryCards.groovy
@@ -13,7 +13,7 @@ import static groovyx.net.http.util.SslUtils.ignoreSslIssues
  * Sample Usage:
  *   groovy populateLibraryCards.groovy \
  *     `gcloud auth print-access-token` \
- *     https://local.broadinstitute.org:27443 \
+ *     https://local.dsde-dev.broadinstitute.org:27443 \
  *     '/path/to/fileOfLibraryCards'
  *
  * EXAMPLE LINE IN FILE:

--- a/migration/matchPopulation/reprocessMatches.groovy
+++ b/migration/matchPopulation/reprocessMatches.groovy
@@ -13,7 +13,7 @@ import static groovyx.net.http.util.SslUtils.ignoreSslIssues
  * Sample Usage:
  *   groovy reprocessMatches.groovy \
  *     `gcloud auth print-access-token` \
- *     https://local.broadinstitute.org:27443 \
+ *     https://local.dsde-dev.broadinstitute.org:27443 \
  *     '/path/to/fileOfPurposeIds'
  */
 

--- a/src/main/java/org/broadinstitute/consent/http/enumeration/VoteType.java
+++ b/src/main/java/org/broadinstitute/consent/http/enumeration/VoteType.java
@@ -4,7 +4,7 @@ import org.broadinstitute.consent.http.resources.Resource;
 
 public enum VoteType {
 
-  DAC("DAC"), FINAL("FINAL"), DACBOTAPPROVE("DACBOTAPPROVE"), AGREEMENT("AGREEMENT"), CHAIRPERSON(Resource.CHAIRPERSON);
+  DAC("DAC"), FINAL("FINAL"), RADARAPPROVE("RADARAPPROVE"), AGREEMENT("AGREEMENT"), CHAIRPERSON(Resource.CHAIRPERSON);
 
   private final String value;
 

--- a/src/main/java/org/broadinstitute/consent/http/enumeration/VoteType.java
+++ b/src/main/java/org/broadinstitute/consent/http/enumeration/VoteType.java
@@ -4,7 +4,7 @@ import org.broadinstitute.consent.http.resources.Resource;
 
 public enum VoteType {
 
-  DAC("DAC"), FINAL("FINAL"), RADARAPPROVE("RADARAPPROVE"), AGREEMENT("AGREEMENT"), CHAIRPERSON(Resource.CHAIRPERSON);
+  DAC("DAC"), FINAL("FINAL"), RADAR_APPROVE("RADAR_APPROVE"), AGREEMENT("AGREEMENT"), CHAIRPERSON(Resource.CHAIRPERSON);
 
   private final String value;
 

--- a/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequestSummaryDetail.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequestSummaryDetail.java
@@ -123,7 +123,7 @@ public class DataAccessRequestSummaryDetail implements SummaryDetail {
             .findFirst();
     Optional<Vote> dacbotApproveVote =
         getAccessVotes().stream()
-            .filter(v -> v.getType().equalsIgnoreCase(VoteType.RADARAPPROVE.getValue()))
+            .filter(v -> v.getType().equalsIgnoreCase(VoteType.RADAR_APPROVE.getValue()))
             .filter(v -> Objects.nonNull(v.getVote()))
             .findFirst();
     Optional<User> chairpersonUser =

--- a/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequestSummaryDetail.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequestSummaryDetail.java
@@ -123,7 +123,7 @@ public class DataAccessRequestSummaryDetail implements SummaryDetail {
             .findFirst();
     Optional<Vote> dacbotApproveVote =
         getAccessVotes().stream()
-            .filter(v -> v.getType().equalsIgnoreCase(VoteType.DACBOTAPPROVE.getValue()))
+            .filter(v -> v.getType().equalsIgnoreCase(VoteType.RADARAPPROVE.getValue()))
             .filter(v -> Objects.nonNull(v.getVote()))
             .findFirst();
     Optional<User> chairpersonUser =

--- a/src/main/java/org/broadinstitute/consent/http/resources/VoteResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/VoteResource.java
@@ -102,7 +102,7 @@ public class VoteResource extends Resource {
         voteUpdateLCCheck(votes);
       }
 
-      if (votes.stream().anyMatch(vote -> vote.getType() != null  && vote.getType().equalsIgnoreCase(VoteType.RADARAPPROVE.getValue()))) {
+      if (votes.stream().anyMatch(vote -> vote.getType() != null  && vote.getType().equalsIgnoreCase(VoteType.RADAR_APPROVE.getValue()))) {
         return createExceptionResponse(new BadRequestException("Manual Rule Automated DAR (RADAR) Approval is not permitted"));
       }
 

--- a/src/main/java/org/broadinstitute/consent/http/resources/VoteResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/VoteResource.java
@@ -102,8 +102,8 @@ public class VoteResource extends Resource {
         voteUpdateLCCheck(votes);
       }
 
-      if (votes.stream().anyMatch(vote -> vote.getType() != null  && vote.getType().equalsIgnoreCase(VoteType.DACBOTAPPROVE.getValue()))) {
-        return createExceptionResponse(new BadRequestException("Manual DACBot Approval is not permitted"));
+      if (votes.stream().anyMatch(vote -> vote.getType() != null  && vote.getType().equalsIgnoreCase(VoteType.RADARAPPROVE.getValue()))) {
+        return createExceptionResponse(new BadRequestException("Manual Rule Automated DAR (RADAR) Approval is not permitted"));
       }
 
       List<Vote> updatedVotes = voteService.updateVotesWithValue(votes, voteUpdate.getVote(),

--- a/src/main/java/org/broadinstitute/consent/http/service/DACAutomationRuleService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DACAutomationRuleService.java
@@ -170,10 +170,10 @@ public class DACAutomationRuleService implements ConsentLogger {
     int electionId = electionDAO.insertElection(ElectionType.DATA_ACCESS.getValue(),
         ElectionStatus.OPEN.getValue(), new Date(), dar.getReferenceId(), dataset.getDatasetId());
     int voteId = voteDAO.insertVote(rule.enabledByUserId(), electionId,
-        VoteType.DACBOTAPPROVE.getValue());
+        VoteType.RADARAPPROVE.getValue());
     Vote vote = voteDAO.findVoteById(voteId);
     try {
-      voteServiceDAO.updateVotesWithValue(List.of(vote), true, String.format("DACBot Approval using rule: %s", ruleImplementation.getRuleType()));
+      voteServiceDAO.updateVotesWithValue(List.of(vote), true, String.format("Rule Automated DAR (RADAR) Approval using rule: %s", ruleImplementation.getRuleType()));
       datasetsAuthorized.add(dataset);
     } catch (SQLException e) {
       logException("Error updating vote", e);

--- a/src/main/java/org/broadinstitute/consent/http/service/DACAutomationRuleService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DACAutomationRuleService.java
@@ -170,7 +170,7 @@ public class DACAutomationRuleService implements ConsentLogger {
     int electionId = electionDAO.insertElection(ElectionType.DATA_ACCESS.getValue(),
         ElectionStatus.OPEN.getValue(), new Date(), dar.getReferenceId(), dataset.getDatasetId());
     int voteId = voteDAO.insertVote(rule.enabledByUserId(), electionId,
-        VoteType.RADARAPPROVE.getValue());
+        VoteType.RADAR_APPROVE.getValue());
     Vote vote = voteDAO.findVoteById(voteId);
     try {
       voteServiceDAO.updateVotesWithValue(List.of(vote), true, String.format("Rule Automated DAR (RADAR) Approval using rule: %s", ruleImplementation.getRuleType()));

--- a/src/main/java/org/broadinstitute/consent/http/service/dao/VoteServiceDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/dao/VoteServiceDAO.java
@@ -66,7 +66,7 @@ public class VoteServiceDAO {
                       voteUpdate.bind("voteId", vote.getVoteId());
                       voteUpdate.execute();
                       if (vote.getType().equalsIgnoreCase(VoteType.FINAL.getValue())
-                          || vote.getType().equalsIgnoreCase(VoteType.RADARAPPROVE.getValue())) {
+                          || vote.getType().equalsIgnoreCase(VoteType.RADAR_APPROVE.getValue())) {
                         Update electionUpdate = h.createUpdate(updateElectionStatus);
                         electionUpdate.bind("status", ElectionStatus.CLOSED.getValue());
                         electionUpdate.bind("electionId", vote.getElectionId());

--- a/src/main/java/org/broadinstitute/consent/http/service/dao/VoteServiceDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/dao/VoteServiceDAO.java
@@ -66,7 +66,7 @@ public class VoteServiceDAO {
                       voteUpdate.bind("voteId", vote.getVoteId());
                       voteUpdate.execute();
                       if (vote.getType().equalsIgnoreCase(VoteType.FINAL.getValue())
-                          || vote.getType().equalsIgnoreCase(VoteType.DACBOTAPPROVE.getValue())) {
+                          || vote.getType().equalsIgnoreCase(VoteType.RADARAPPROVE.getValue())) {
                         Update electionUpdate = h.createUpdate(updateElectionStatus);
                         electionUpdate.bind("status", ElectionStatus.CLOSED.getValue());
                         electionUpdate.bind("electionId", vote.getElectionId());

--- a/src/test/java/org/broadinstitute/consent/http/service/DACAutomationRuleServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DACAutomationRuleServiceTest.java
@@ -273,7 +273,7 @@ class DACAutomationRuleServiceTest {
     mockInsertElection(dar, dataset, electionId);
 
     Integer voteId = 5;
-    when(voteDAO.insertVote(rule.enabledByUserId(), electionId, VoteType.DACBOTAPPROVE.getValue()))
+    when(voteDAO.insertVote(rule.enabledByUserId(), electionId, VoteType.RADARAPPROVE.getValue()))
         .thenReturn(voteId);
 
     Vote vote = mockFindVoteById(voteId);
@@ -283,7 +283,7 @@ class DACAutomationRuleServiceTest {
     verify(voteServiceDAO).updateVotesWithValue(
           List.of(vote),
           true,
-          "DACBot Approval using rule: GRU_V1");
+          "Rule Automated DAR (RADAR) Approval using rule: GRU_V1");
     assertEquals(1, datasetsAuthorized.size());
     assertEquals(dataset, datasetsAuthorized.get(0));
   }
@@ -300,7 +300,7 @@ class DACAutomationRuleServiceTest {
     mockInsertElection(dar, dataset, electionId);
 
     Integer voteId = 5;
-    when(voteDAO.insertVote(rule.enabledByUserId(), electionId, VoteType.DACBOTAPPROVE.getValue()))
+    when(voteDAO.insertVote(rule.enabledByUserId(), electionId, VoteType.RADARAPPROVE.getValue()))
         .thenReturn(voteId);
 
     Vote vote = mockFindVoteById(voteId);
@@ -308,7 +308,7 @@ class DACAutomationRuleServiceTest {
     doThrow(new SQLException("Test error")).when(voteServiceDAO).updateVotesWithValue(
           List.of(vote),
           true,
-          "DACBot Approval using rule: GRU_V1");
+          "Rule Automated DAR (RADAR) Approval using rule: GRU_V1");
 
     service.openElectionAndApprove(rule, ruleImplementation, dar, datasetsAuthorized, dataset);
 

--- a/src/test/java/org/broadinstitute/consent/http/service/DACAutomationRuleServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DACAutomationRuleServiceTest.java
@@ -273,7 +273,7 @@ class DACAutomationRuleServiceTest {
     mockInsertElection(dar, dataset, electionId);
 
     Integer voteId = 5;
-    when(voteDAO.insertVote(rule.enabledByUserId(), electionId, VoteType.RADARAPPROVE.getValue()))
+    when(voteDAO.insertVote(rule.enabledByUserId(), electionId, VoteType.RADAR_APPROVE.getValue()))
         .thenReturn(voteId);
 
     Vote vote = mockFindVoteById(voteId);
@@ -300,7 +300,7 @@ class DACAutomationRuleServiceTest {
     mockInsertElection(dar, dataset, electionId);
 
     Integer voteId = 5;
-    when(voteDAO.insertVote(rule.enabledByUserId(), electionId, VoteType.RADARAPPROVE.getValue()))
+    when(voteDAO.insertVote(rule.enabledByUserId(), electionId, VoteType.RADAR_APPROVE.getValue()))
         .thenReturn(voteId);
 
     Vote vote = mockFindVoteById(voteId);


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-1974

### Summary
DACBOT votes already had a fixed Rationale. So, instead of adding a rationale, I changed rationale to say RADAR instead of DAC BOT. I also updated the name of the VoteType to RADARAPPROVE.

Also, as a drive by fix, updates documentation to point to local.dsde-dev.broadinstitute instead of local.broadinstitute

Updated tests to reflect the new language.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
