### PR TITLE
[DT-1991] Validate institution names and domains on create and update

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/models/Institution.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/Institution.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Objects;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.validator.routines.DomainValidator;
 import org.broadinstitute.consent.http.enumeration.OrganizationType;
 import org.broadinstitute.consent.http.service.UserService.SimplifiedUser;
 

--- a/src/main/java/org/broadinstitute/consent/http/models/Institution.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/Institution.java
@@ -7,7 +7,6 @@ import java.util.List;
 import java.util.Objects;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.validator.routines.DomainValidator;
 import org.broadinstitute.consent.http.enumeration.OrganizationType;
 import org.broadinstitute.consent.http.service.UserService.SimplifiedUser;
 

--- a/src/main/java/org/broadinstitute/consent/http/resources/InstitutionResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/InstitutionResource.java
@@ -101,6 +101,11 @@ public class InstitutionResource extends Resource {
     try {
       Institution existingInstitution = institutionService.findInstitutionById(id);
       Institution payload = GsonUtil.getInstance().fromJson(institution, Institution.class);
+      //TODO maybe run this validation elsewhere? like on Institution.setDomains?
+      List<String> invalidDomains = InstitutionUtil.getInvalidInstitutionDomains(payload);
+      if( invalidDomains != null && !invalidDomains.isEmpty()) {
+        throw new ConsentConflictException("Invalid domain(s) provided for institution: " + String.join(", ", invalidDomains));
+      }
       Institution mergedPayload = payload.mergeUpdatableFields(existingInstitution);
       Institution updatedInstitution = institutionService.updateInstitutionById(mergedPayload, id,
           duosUser.getUserId());

--- a/src/main/java/org/broadinstitute/consent/http/resources/InstitutionResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/InstitutionResource.java
@@ -5,7 +5,6 @@ import com.google.inject.Inject;
 import io.dropwizard.auth.Auth;
 import jakarta.annotation.security.PermitAll;
 import jakarta.annotation.security.RolesAllowed;
-import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;

--- a/src/main/java/org/broadinstitute/consent/http/resources/InstitutionResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/InstitutionResource.java
@@ -18,7 +18,6 @@ import jakarta.ws.rs.core.Response;
 import java.util.ArrayList;
 import java.util.List;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
-import org.broadinstitute.consent.http.exceptions.ConsentConflictException;
 import org.broadinstitute.consent.http.models.DuosUser;
 import org.broadinstitute.consent.http.models.Institution;
 import org.broadinstitute.consent.http.models.InstitutionDomainMap;
@@ -79,11 +78,6 @@ public class InstitutionResource extends Resource {
   public Response createInstitution(@Auth DuosUser duosUser, String institution) {
     try {
       Institution payload = GsonUtil.getInstance().fromJson(institution, Institution.class);
-      List<Institution> conflicts = institutionService.findAllInstitutionsByName(payload.getName());
-      if (!conflicts.isEmpty()) {
-        throw new ConsentConflictException(
-            "An institution exists with the name of '" + payload.getName() + "'");
-      }
       Institution newInstitution = institutionService.createInstitution(payload, duosUser.getUser().getUserId());
       return Response.ok().entity(newInstitution).build();
     } catch (Exception e) {

--- a/src/main/java/org/broadinstitute/consent/http/resources/InstitutionResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/InstitutionResource.java
@@ -5,6 +5,7 @@ import com.google.inject.Inject;
 import io.dropwizard.auth.Auth;
 import jakarta.annotation.security.PermitAll;
 import jakarta.annotation.security.RolesAllowed;
+import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
@@ -101,11 +102,6 @@ public class InstitutionResource extends Resource {
     try {
       Institution existingInstitution = institutionService.findInstitutionById(id);
       Institution payload = GsonUtil.getInstance().fromJson(institution, Institution.class);
-      //TODO maybe run this validation elsewhere? like on Institution.setDomains?
-      List<String> invalidDomains = InstitutionUtil.validateInstitutionDomains(payload);
-      if( invalidDomains != null && !invalidDomains.isEmpty()) {
-        throw new ConsentConflictException("Invalid domain(s) provided for institution: " + String.join(", ", invalidDomains));
-      }
       Institution mergedPayload = payload.mergeUpdatableFields(existingInstitution);
       Institution updatedInstitution = institutionService.updateInstitutionById(mergedPayload, id,
           duosUser.getUserId());

--- a/src/main/java/org/broadinstitute/consent/http/resources/InstitutionResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/InstitutionResource.java
@@ -102,7 +102,7 @@ public class InstitutionResource extends Resource {
       Institution existingInstitution = institutionService.findInstitutionById(id);
       Institution payload = GsonUtil.getInstance().fromJson(institution, Institution.class);
       //TODO maybe run this validation elsewhere? like on Institution.setDomains?
-      List<String> invalidDomains = InstitutionUtil.getInvalidInstitutionDomains(payload);
+      List<String> invalidDomains = InstitutionUtil.validateInstitutionDomains(payload);
       if( invalidDomains != null && !invalidDomains.isEmpty()) {
         throw new ConsentConflictException("Invalid domain(s) provided for institution: " + String.join(", ", invalidDomains));
       }

--- a/src/main/java/org/broadinstitute/consent/http/service/InstitutionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/InstitutionService.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Objects;
 import org.broadinstitute.consent.http.db.InstitutionDAO;
 import org.broadinstitute.consent.http.db.UserDAO;
+import org.broadinstitute.consent.http.exceptions.ConsentConflictException;
 import org.broadinstitute.consent.http.models.Institution;
 import org.broadinstitute.consent.http.service.UserService.SimplifiedUser;
 import org.broadinstitute.consent.http.util.InstitutionUtil;
@@ -28,6 +29,7 @@ public class InstitutionService {
     checkUserId(userId);
     // Name validation
     checkForEmptyName(institution);
+    checkNameUniqueness(institution);
     String canonicalName = InstitutionUtil.canonicalizeInstitutionName(institution.getName());
     institution.setName(canonicalName);
 
@@ -49,6 +51,7 @@ public class InstitutionService {
 
     // Name validation
     checkForEmptyName(institutionPayload);
+    checkNameUniqueness(institutionPayload);
     String canonicalName = InstitutionUtil.canonicalizeInstitutionName(institutionPayload.getName());
     institutionPayload.setName(canonicalName);
 
@@ -128,6 +131,17 @@ public class InstitutionService {
   private void isInstitutionNull(Institution institution) {
     if (Objects.isNull(institution)) {
       throw new NotFoundException("Institution not found");
+    }
+  }
+
+  private void checkNameUniqueness(Institution institution) {
+    List<Institution> conflicts = findAllInstitutionsByName(institution.getName());
+    // We need to make sure that any found institutions are not the same as the one being updated
+    conflicts.removeIf(existingInstitution ->
+        institution.getId() != null && existingInstitution.getId().equals(institution.getId()));
+    if (!conflicts.isEmpty()) {
+      throw new ConsentConflictException(
+          "An institution exists with the name of '" + institution.getName() + "'");
     }
   }
 

--- a/src/main/java/org/broadinstitute/consent/http/service/InstitutionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/InstitutionService.java
@@ -25,8 +25,13 @@ public class InstitutionService {
   }
 
   public Institution createInstitution(Institution institution, Integer userId) {
-    checkForEmptyName(institution);
     checkUserId(userId);
+    // Name validation
+    checkForEmptyName(institution);
+    String canonicalName = InstitutionUtil.canonicalizeInstitutionName(institution.getName());
+    institution.setName(canonicalName);
+
+    // Domain validation
     InstitutionUtil.validateInstitutionDomains(institution);
     checkDomainUniqueness(institution);
     try {
@@ -38,10 +43,16 @@ public class InstitutionService {
 
   public Institution updateInstitutionById(Institution institutionPayload, Integer id,
       Integer userId) throws SQLException {
+    checkUserId(userId);
     Institution targetInstitution = institutionDAO.findInstitutionById(id);
     isInstitutionNull(targetInstitution);
-    checkUserId(userId);
+
+    // Name validation
     checkForEmptyName(institutionPayload);
+    String canonicalName = InstitutionUtil.canonicalizeInstitutionName(institutionPayload.getName());
+    institutionPayload.setName(canonicalName);
+
+    // Domain validation
     InstitutionUtil.validateInstitutionDomains(institutionPayload);
     checkDomainUniqueness(institutionPayload);
     return institutionDAO.updateFullInstitution(institutionPayload, userId);

--- a/src/main/java/org/broadinstitute/consent/http/service/InstitutionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/InstitutionService.java
@@ -135,10 +135,13 @@ public class InstitutionService {
   }
 
   private void checkNameUniqueness(Institution institution) {
-    List<Institution> conflicts = findAllInstitutionsByName(institution.getName());
-    // We need to make sure that any found institutions are not the same as the one being updated
-    conflicts.removeIf(existingInstitution ->
-        institution.getId() != null && existingInstitution.getId().equals(institution.getId()));
+    List<Institution> conflicts = findAllInstitutionsByName(institution.getName())
+        .stream()
+        // Filter out the institution being updated, so it doesn't conflict with itself
+        .filter(existingInstitution ->
+            !existingInstitution.getId().equals(institution.getId()))
+        .toList();
+
     if (!conflicts.isEmpty()) {
       throw new ConsentConflictException(
           "An institution exists with the name of '" + institution.getName() + "'");

--- a/src/main/java/org/broadinstitute/consent/http/service/InstitutionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/InstitutionService.java
@@ -40,9 +40,9 @@ public class InstitutionService {
       Integer userId) throws SQLException {
     Institution targetInstitution = institutionDAO.findInstitutionById(id);
     isInstitutionNull(targetInstitution);
-    InstitutionUtil.validateInstitutionDomains(institutionPayload);
     checkUserId(userId);
     checkForEmptyName(institutionPayload);
+    InstitutionUtil.validateInstitutionDomains(institutionPayload);
     checkDomainUniqueness(institutionPayload);
     return institutionDAO.updateFullInstitution(institutionPayload, userId);
   }

--- a/src/main/java/org/broadinstitute/consent/http/service/InstitutionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/InstitutionService.java
@@ -153,6 +153,10 @@ public class InstitutionService {
       return;
     }
 
+    if (institution.getDomains().stream().distinct().count() < institution.getDomains().size()) {
+      throw new IllegalArgumentException("Institution domains must be unique");
+    }
+
     List<String> conflictingDomains = institution.getDomains().stream()
         .map(domain -> {
           Integer existingInstitutionId = institutionDAO.findInstitutionIdByDomain(domain);

--- a/src/main/java/org/broadinstitute/consent/http/service/InstitutionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/InstitutionService.java
@@ -28,6 +28,7 @@ public class InstitutionService {
     checkForEmptyName(institution);
     checkUserId(userId);
     InstitutionUtil.validateInstitutionDomains(institution);
+    checkForDomainConflicts(institution, null);
     try {
       return institutionDAO.insertFullInstitution(institution, userId);
     } catch (SQLException e) {
@@ -42,6 +43,7 @@ public class InstitutionService {
     InstitutionUtil.validateInstitutionDomains(institutionPayload);
     checkUserId(userId);
     checkForEmptyName(institutionPayload);
+    checkForDomainConflicts(institutionPayload, id);
     return institutionDAO.updateFullInstitution(institutionPayload, userId);
   }
 
@@ -115,6 +117,30 @@ public class InstitutionService {
   private void isInstitutionNull(Institution institution) {
     if (Objects.isNull(institution)) {
       throw new NotFoundException("Institution not found");
+    }
+  }
+
+  private void checkForDomainConflicts(Institution institution, Integer institutionId) {
+    if (institution.getDomains() == null || institution.getDomains().isEmpty()) {
+      return;
+    }
+
+    //TODO make this more efficient?
+    List<String> conflictingDomains = institution.getDomains().stream()
+        .map(domain -> {
+          Institution existingInstitution = institutionDAO.findInstitutionByDomain(domain);
+          if (existingInstitution != null &&
+              (!existingInstitution.getId().equals(institutionId))) {
+            return domain;
+          }
+          return null;
+        })
+        .filter(Objects::nonNull)
+        .toList();
+
+    if (!conflictingDomains.isEmpty()) {
+      throw new IllegalArgumentException(
+          "Domain(s) already associated with another institution: " + String.join(", ", conflictingDomains));
     }
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/service/InstitutionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/InstitutionService.java
@@ -11,6 +11,7 @@ import org.broadinstitute.consent.http.db.InstitutionDAO;
 import org.broadinstitute.consent.http.db.UserDAO;
 import org.broadinstitute.consent.http.models.Institution;
 import org.broadinstitute.consent.http.service.UserService.SimplifiedUser;
+import org.broadinstitute.consent.http.util.InstitutionUtil;
 
 public class InstitutionService {
 
@@ -26,6 +27,7 @@ public class InstitutionService {
   public Institution createInstitution(Institution institution, Integer userId) {
     checkForEmptyName(institution);
     checkUserId(userId);
+    InstitutionUtil.validateInstitutionDomains(institution);
     try {
       return institutionDAO.insertFullInstitution(institution, userId);
     } catch (SQLException e) {
@@ -37,6 +39,7 @@ public class InstitutionService {
       Integer userId) throws SQLException {
     Institution targetInstitution = institutionDAO.findInstitutionById(id);
     isInstitutionNull(targetInstitution);
+    InstitutionUtil.validateInstitutionDomains(institutionPayload);
     checkUserId(userId);
     checkForEmptyName(institutionPayload);
     return institutionDAO.updateFullInstitution(institutionPayload, userId);

--- a/src/main/java/org/broadinstitute/consent/http/service/InstitutionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/InstitutionService.java
@@ -28,7 +28,7 @@ public class InstitutionService {
     checkForEmptyName(institution);
     checkUserId(userId);
     InstitutionUtil.validateInstitutionDomains(institution);
-    checkForDomainConflicts(institution, null);
+    checkDomainUniqueness(institution);
     try {
       return institutionDAO.insertFullInstitution(institution, userId);
     } catch (SQLException e) {
@@ -43,7 +43,7 @@ public class InstitutionService {
     InstitutionUtil.validateInstitutionDomains(institutionPayload);
     checkUserId(userId);
     checkForEmptyName(institutionPayload);
-    checkForDomainConflicts(institutionPayload, id);
+    checkDomainUniqueness(institutionPayload);
     return institutionDAO.updateFullInstitution(institutionPayload, userId);
   }
 
@@ -120,27 +120,28 @@ public class InstitutionService {
     }
   }
 
-  private void checkForDomainConflicts(Institution institution, Integer institutionId) {
+  private void checkDomainUniqueness(Institution institution) {
     if (institution.getDomains() == null || institution.getDomains().isEmpty()) {
       return;
     }
 
-    //TODO make this more efficient?
     List<String> conflictingDomains = institution.getDomains().stream()
         .map(domain -> {
-          Institution existingInstitution = institutionDAO.findInstitutionByDomain(domain);
-          if (existingInstitution != null &&
-              (!existingInstitution.getId().equals(institutionId))) {
+          Integer existingInstitutionId = institutionDAO.findInstitutionIdByDomain(domain);
+          if (existingInstitutionId != null && !existingInstitutionId.equals(institution.getId())) {
+            // Return the domain if it conflicts with another institution.
+            // If the domain is already associated with the institution being updated, it's not a conflict.
             return domain;
           }
-          return null;
+          return null; // No conflict
         })
         .filter(Objects::nonNull)
         .toList();
 
     if (!conflictingDomains.isEmpty()) {
       throw new IllegalArgumentException(
-          "Domain(s) already associated with another institution: " + String.join(", ", conflictingDomains));
+          "Domain(s) already associated with another institution: " + String.join(", ",
+              conflictingDomains));
     }
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/util/InstitutionUtil.java
+++ b/src/main/java/org/broadinstitute/consent/http/util/InstitutionUtil.java
@@ -4,6 +4,11 @@ import com.google.gson.ExclusionStrategy;
 import com.google.gson.FieldAttributes;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.validator.routines.DomainValidator;
+import org.broadinstitute.consent.http.models.Institution;
 import org.broadinstitute.consent.http.util.gson.GsonUtil;
 
 public class InstitutionUtil implements ConsentLogger {
@@ -54,5 +59,43 @@ public class InstitutionUtil implements ConsentLogger {
         return false;
       }
     };
+  }
+
+  /**
+   * Validates that a given domain is valid
+   *
+   * @param domain The domain string to validate
+   * @return true if the domain is valid and is not a subdomain, false otherwise
+   */
+  public static boolean isValidInstitutionDomain(String domain) {
+    if (StringUtils.isBlank(domain)) {
+      return false;
+    }
+
+    DomainValidator validator = DomainValidator.getInstance();
+    if (!validator.isValid(domain)) {
+      return false;
+    }
+
+    // todo: use a better way to check for subdomains
+    long dotCount = domain.chars().filter(ch -> ch == '.').count();
+    return dotCount == 1;
+  }
+
+  public static String canonicalizeDomain(String domain) {
+    //todo
+    return domain.toLowerCase().trim();
+  }
+
+  /**
+   * Validates all domains in this institution's domain list and returns invalid ones.
+   *
+   * @param institution The institution to validate domains for.
+   * @return List of invalid domains.
+   */
+  public static List<String> getInvalidInstitutionDomains(Institution institution) {
+    return institution.getDomains().stream()
+        .filter(domain -> !isValidInstitutionDomain(domain))
+        .collect(java.util.stream.Collectors.toList());
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/util/InstitutionUtil.java
+++ b/src/main/java/org/broadinstitute/consent/http/util/InstitutionUtil.java
@@ -103,7 +103,7 @@ public class InstitutionUtil implements ConsentLogger {
 
     return institution.getDomains().stream()
         .filter(domain -> !validator.isValid(domain))
-        .collect(java.util.stream.Collectors.toList());
+        .toList();
   }
 
   public static void validateInstitutionDomains(Institution institution) {

--- a/src/main/java/org/broadinstitute/consent/http/util/InstitutionUtil.java
+++ b/src/main/java/org/broadinstitute/consent/http/util/InstitutionUtil.java
@@ -4,7 +4,6 @@ import com.google.gson.ExclusionStrategy;
 import com.google.gson.FieldAttributes;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import java.util.ArrayList;
 import java.util.List;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.validator.routines.DomainValidator;
@@ -80,17 +79,44 @@ public class InstitutionUtil implements ConsentLogger {
     }
 
     // Validate that the domain is not a subdomain
-    if (domain.split("\\.").length > 1) {
+    if (domain.split("\\.").length > 2) {
       return false;
     }
 
     return true;
   }
 
+  /**
+   * Canonicalizes an institution name by normalizing quotes and handling UTF-8 characters.
+   * - Replaces curly quotes with straight quotes
+   * - Replaces double quotes with single quotes
+   * - Handles UTF-8 characters properly
+   * - Name is required (cannot be null or blank)
+   *
+   * @param name The institution name to canonicalize
+   * @return The canonicalized name, or null if input is invalid
+   */
   public static String canonicalizeName(String name) {
-    //replace
+    // Validate that name is not null or blank
+    if (StringUtils.isBlank(name)) {
+      return null;
+    }
 
-    return null;
+    String canonicalized = name.trim();
+
+    // Replace curly/smart quotes with straight quotes
+    canonicalized = canonicalized
+        .replace("\u201C", "'")  // Left double quotation mark
+        .replace("\u201D", "'")  // Right double quotation mark
+        .replace("\u2018", "'")  // Left single quotation mark
+        .replace("\u2019", "'")  // Right single quotation mark
+        .replace("\u201A", "'")  // Single low-9 quotation mark
+        .replace("\u201E", "'"); // Double low-9 quotation mark
+
+    // Replace double quotes with single quotes
+    canonicalized = canonicalized.replace("\"", "'");
+
+    return canonicalized;
   }
 
   /**

--- a/src/main/java/org/broadinstitute/consent/http/util/InstitutionUtil.java
+++ b/src/main/java/org/broadinstitute/consent/http/util/InstitutionUtil.java
@@ -68,23 +68,29 @@ public class InstitutionUtil implements ConsentLogger {
    * @return true if the domain is valid and is not a subdomain, false otherwise
    */
   public static boolean isValidInstitutionDomain(String domain) {
+    // Validate that the domain is not null or empty
     if (StringUtils.isBlank(domain)) {
       return false;
     }
 
+    // Validate the domain format
     DomainValidator validator = DomainValidator.getInstance();
     if (!validator.isValid(domain)) {
       return false;
     }
 
-    // todo: use a better way to check for subdomains
-    long dotCount = domain.chars().filter(ch -> ch == '.').count();
-    return dotCount == 1;
+    // Validate that the domain is not a subdomain
+    if (domain.split("\\.").length > 1) {
+      return false;
+    }
+
+    return true;
   }
 
-  public static String canonicalizeDomain(String domain) {
-    //todo
-    return domain.toLowerCase().trim();
+  public static String canonicalizeName(String name) {
+    //replace
+
+    return null;
   }
 
   /**

--- a/src/main/java/org/broadinstitute/consent/http/util/InstitutionUtil.java
+++ b/src/main/java/org/broadinstitute/consent/http/util/InstitutionUtil.java
@@ -95,7 +95,6 @@ public class InstitutionUtil implements ConsentLogger {
    * @return List of invalid domains.
    */
   public static List<String> getInvalidInstitutionDomains(Institution institution) {
-    //TODO: also check for duplicates in the domain list
     if (institution.getDomains() == null) {
       return List.of();
     }

--- a/src/main/java/org/broadinstitute/consent/http/util/InstitutionUtil.java
+++ b/src/main/java/org/broadinstitute/consent/http/util/InstitutionUtil.java
@@ -1,10 +1,10 @@
 package org.broadinstitute.consent.http.util;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.gson.ExclusionStrategy;
 import com.google.gson.FieldAttributes;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import jakarta.ws.rs.BadRequestException;
 import java.util.List;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.validator.routines.DomainValidator;
@@ -117,10 +117,18 @@ public class InstitutionUtil implements ConsentLogger {
    * @param institution The institution to validate domains for.
    * @return List of invalid domains.
    */
-  public static List<String> validateInstitutionDomains(Institution institution) {
+  public static List<String> getInvalidInstitutionDomains(Institution institution) {
     //TODO: also check for duplicates in the domain list
     return institution.getDomains().stream()
         .filter(domain -> !isValidInstitutionDomain(domain))
         .collect(java.util.stream.Collectors.toList());
+  }
+
+  public static void validateInstitutionDomains(Institution institution) {
+    List<String> invalidDomains = getInvalidInstitutionDomains(institution);
+    if (!invalidDomains.isEmpty()) {
+      throw new BadRequestException(
+          "Invalid domain(s) provided for institution: " + String.join(", ", invalidDomains));
+    }
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/util/InstitutionUtil.java
+++ b/src/main/java/org/broadinstitute/consent/http/util/InstitutionUtil.java
@@ -62,53 +62,30 @@ public class InstitutionUtil implements ConsentLogger {
   }
 
   /**
-   * Canonicalizes an institution name by normalizing quotes and handling UTF-8 characters.
-   * - Replaces curly quotes with straight quotes
-   * - Replaces double quotes with single quotes
-   * - Handles UTF-8 characters properly
-   * - Name is required (cannot be null or blank)
+   * Canonicalizes an institution name by normalizing quotes and trimming whitespace.
    *
    * @param name The institution name to canonicalize
-   * @return The canonicalized name, or null if input is invalid
+   * @return The canonicalized name
    */
   public static String canonicalizeInstitutionName(String name) {
     // Validate that name is not null or blank
     if (StringUtils.isBlank(name)) {
-      return null;
+      throw new BadRequestException("Institution name cannot be null or blank");
     }
 
     String canonicalized = name.trim();
 
-    // Replace curly/smart quotes with straight quotes
-    canonicalized = canonicalized
-        .replace("\u201C", "'")  // Left double quotation mark
-        .replace("\u201D", "'")  // Right double quotation mark
-        .replace("\u2018", "'")  // Left single quotation mark
-        .replace("\u2019", "'")  // Right single quotation mark
-        .replace("\u201A", "'")  // Single low-9 quotation mark
-        .replace("\u201E", "'"); // Double low-9 quotation mark
-
-    // Replace double quotes with single quotes
-    canonicalized = canonicalized.replace("\"", "'");
+    // Replace curly and double quotes with single straight quotes
+    // u201C (Left double quotation mark)
+    // u201D (Right double quotation mark)
+    // u2018 (Left single quotation mark)
+    // u2019 (Right single quotation mark)
+    // u201A (Single low-9 quotation mark)
+    // u201E (Double low-9 quotation mark)
+    // " (Straight double quote)
+    canonicalized = canonicalized.replaceAll("[\u201C\u201D\u2018\u2019\u201A\u201E\"]", "'");
 
     return canonicalized;
-  }
-
-  /**
-   * Validates that a given domain is valid
-   *
-   * @param domain The domain string to validate
-   * @return true if the domain is valid, false otherwise
-   */
-  protected static boolean isValidInstitutionDomain(String domain) {
-    // Validate that the domain is not null or empty
-    if (StringUtils.isBlank(domain)) {
-      return false;
-    }
-
-    // Validate the domain format
-    DomainValidator validator = DomainValidator.getInstance();
-    return validator.isValid(domain);
   }
 
   /**
@@ -119,8 +96,14 @@ public class InstitutionUtil implements ConsentLogger {
    */
   public static List<String> getInvalidInstitutionDomains(Institution institution) {
     //TODO: also check for duplicates in the domain list
+    if (institution.getDomains() == null) {
+      return List.of();
+    }
+
+    DomainValidator validator = DomainValidator.getInstance();
+
     return institution.getDomains().stream()
-        .filter(domain -> !isValidInstitutionDomain(domain))
+        .filter(domain -> !validator.isValid(domain))
         .collect(java.util.stream.Collectors.toList());
   }
 

--- a/src/main/java/org/broadinstitute/consent/http/util/InstitutionUtil.java
+++ b/src/main/java/org/broadinstitute/consent/http/util/InstitutionUtil.java
@@ -68,21 +68,16 @@ public class InstitutionUtil implements ConsentLogger {
    * @return The canonicalized name
    */
   public static String canonicalizeInstitutionName(String name) {
-    // Validate that name is not null or blank
-    if (StringUtils.isBlank(name)) {
-      throw new BadRequestException("Institution name cannot be null or blank");
-    }
-
     String canonicalized = name.trim();
 
-    // Replace curly and double quotes with single straight quotes
-    // u201C (Left double quotation mark)
-    // u201D (Right double quotation mark)
-    // u2018 (Left single quotation mark)
-    // u2019 (Right single quotation mark)
-    // u201A (Single low-9 quotation mark)
-    // u201E (Double low-9 quotation mark)
-    // " (Straight double quote)
+    // Replace the following characters with a single quote:
+    // u201C (Left double quotation)
+    // u201D (Right double quotation)
+    // u2018 (Left single quotation)
+    // u2019 (Right single quotation)
+    // u201A (Single low-9 quotation)
+    // u201E (Double low-9 quotation)
+    // "     (Straight double quotation)
     canonicalized = canonicalized.replaceAll("[\u201C\u201D\u2018\u2019\u201A\u201E\"]", "'");
 
     return canonicalized;
@@ -94,7 +89,7 @@ public class InstitutionUtil implements ConsentLogger {
    * @param institution The institution to validate domains for.
    * @return List of invalid domains.
    */
-  public static List<String> getInvalidInstitutionDomains(Institution institution) {
+  protected static List<String> getInvalidInstitutionDomains(Institution institution) {
     if (institution.getDomains() == null) {
       return List.of();
     }

--- a/src/main/java/org/broadinstitute/consent/http/util/InstitutionUtil.java
+++ b/src/main/java/org/broadinstitute/consent/http/util/InstitutionUtil.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.consent.http.util;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.gson.ExclusionStrategy;
 import com.google.gson.FieldAttributes;
 import com.google.gson.Gson;
@@ -61,32 +62,6 @@ public class InstitutionUtil implements ConsentLogger {
   }
 
   /**
-   * Validates that a given domain is valid
-   *
-   * @param domain The domain string to validate
-   * @return true if the domain is valid and is not a subdomain, false otherwise
-   */
-  public static boolean isValidInstitutionDomain(String domain) {
-    // Validate that the domain is not null or empty
-    if (StringUtils.isBlank(domain)) {
-      return false;
-    }
-
-    // Validate the domain format
-    DomainValidator validator = DomainValidator.getInstance();
-    if (!validator.isValid(domain)) {
-      return false;
-    }
-
-    // Validate that the domain is not a subdomain
-    if (domain.split("\\.").length > 2) {
-      return false;
-    }
-
-    return true;
-  }
-
-  /**
    * Canonicalizes an institution name by normalizing quotes and handling UTF-8 characters.
    * - Replaces curly quotes with straight quotes
    * - Replaces double quotes with single quotes
@@ -96,7 +71,7 @@ public class InstitutionUtil implements ConsentLogger {
    * @param name The institution name to canonicalize
    * @return The canonicalized name, or null if input is invalid
    */
-  public static String canonicalizeName(String name) {
+  public static String canonicalizeInstitutionName(String name) {
     // Validate that name is not null or blank
     if (StringUtils.isBlank(name)) {
       return null;
@@ -120,12 +95,30 @@ public class InstitutionUtil implements ConsentLogger {
   }
 
   /**
+   * Validates that a given domain is valid
+   *
+   * @param domain The domain string to validate
+   * @return true if the domain is valid, false otherwise
+   */
+  protected static boolean isValidInstitutionDomain(String domain) {
+    // Validate that the domain is not null or empty
+    if (StringUtils.isBlank(domain)) {
+      return false;
+    }
+
+    // Validate the domain format
+    DomainValidator validator = DomainValidator.getInstance();
+    return validator.isValid(domain);
+  }
+
+  /**
    * Validates all domains in this institution's domain list and returns invalid ones.
    *
    * @param institution The institution to validate domains for.
    * @return List of invalid domains.
    */
-  public static List<String> getInvalidInstitutionDomains(Institution institution) {
+  public static List<String> validateInstitutionDomains(Institution institution) {
+    //TODO: also check for duplicates in the domain list
     return institution.getDomains().stream()
         .filter(domain -> !isValidInstitutionDomain(domain))
         .collect(java.util.stream.Collectors.toList());

--- a/src/test/java/org/broadinstitute/consent/http/resources/InstitutionResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/InstitutionResourceTest.java
@@ -15,7 +15,6 @@ import static org.mockito.Mockito.when;
 import com.google.api.client.http.HttpStatusCodes;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.ServerErrorException;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -25,7 +24,6 @@ import org.broadinstitute.consent.http.models.Institution;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.service.InstitutionService;
 import org.broadinstitute.consent.http.util.gson.GsonUtil;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -226,33 +224,6 @@ class InstitutionResourceTest {
         GsonUtil.getInstance().toJson(mockInstitution))) {
       assertEquals(HttpStatusCodes.STATUS_CODE_SERVER_ERROR, response.getStatus());
       assertNotNull(response.getEntity().toString());
-    }
-  }
-
-  @Test
-  void testPatchInstitutionInvalidDomains() {
-    List<String> invalidDomains = List.of("invalid-domain", "foo_bar.com");
-    List<String> validDomains = List.of("valid-domain.com", "baz.com");
-    List<String> allDomains = new ArrayList<>();
-    allDomains.addAll(validDomains);
-    allDomains.addAll(invalidDomains);
-
-    Institution mockInstitution = mockInstitutionSetup();
-    mockInstitution.setId(1);
-    when(institutionService.findInstitutionById(mockInstitution.getId())).thenReturn(
-        mockInstitution);
-    mockInstitution.setDomains(allDomains);
-
-    try (var response = resource.patchInstitution(duosUser, 1,
-        GsonUtil.getInstance().toJson(mockInstitution))) {
-      assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
-      assertTrue(
-          response.getEntity().toString().contains("Invalid domain(s) provided for institution"));
-
-      invalidDomains.forEach(
-          domain -> assertTrue(response.getEntity().toString().contains(domain)));
-      validDomains.forEach(
-          domain -> Assertions.assertFalse(response.getEntity().toString().contains(domain)));
     }
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/resources/InstitutionResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/InstitutionResourceTest.java
@@ -231,7 +231,7 @@ class InstitutionResourceTest {
 
   @Test
   void testPatchInstitutionInvalidDomains() {
-    List<String> invalidDomains = List.of("invalid-domain", "foo.bar.com");
+    List<String> invalidDomains = List.of("invalid-domain", "foo_bar.com");
     List<String> validDomains = List.of("valid-domain.com", "baz.com");
     List<String> allDomains = new ArrayList<>();
     allDomains.addAll(validDomains);

--- a/src/test/java/org/broadinstitute/consent/http/resources/InstitutionResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/InstitutionResourceTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.when;
 import com.google.api.client.http.HttpStatusCodes;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.ServerErrorException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -24,6 +25,7 @@ import org.broadinstitute.consent.http.models.Institution;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.service.InstitutionService;
 import org.broadinstitute.consent.http.util.gson.GsonUtil;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -224,6 +226,33 @@ class InstitutionResourceTest {
         GsonUtil.getInstance().toJson(mockInstitution))) {
       assertEquals(HttpStatusCodes.STATUS_CODE_SERVER_ERROR, response.getStatus());
       assertNotNull(response.getEntity().toString());
+    }
+  }
+
+  @Test
+  void testPatchInstitutionInvalidDomains() {
+    List<String> invalidDomains = List.of("invalid-domain", "foo.bar.com");
+    List<String> validDomains = List.of("valid-domain.com", "baz.com");
+    List<String> allDomains = new ArrayList<>();
+    allDomains.addAll(validDomains);
+    allDomains.addAll(invalidDomains);
+
+    Institution mockInstitution = mockInstitutionSetup();
+    mockInstitution.setId(1);
+    when(institutionService.findInstitutionById(mockInstitution.getId())).thenReturn(
+        mockInstitution);
+    mockInstitution.setDomains(allDomains);
+
+    try (var response = resource.patchInstitution(duosUser, 1,
+        GsonUtil.getInstance().toJson(mockInstitution))) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_CONFLICT, response.getStatus());
+      assertTrue(
+          response.getEntity().toString().contains("Invalid domain(s) provided for institution"));
+
+      invalidDomains.forEach(
+          domain -> assertTrue(response.getEntity().toString().contains(domain)));
+      validDomains.forEach(
+          domain -> Assertions.assertFalse(response.getEntity().toString().contains(domain)));
     }
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/resources/InstitutionResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/InstitutionResourceTest.java
@@ -245,7 +245,7 @@ class InstitutionResourceTest {
 
     try (var response = resource.patchInstitution(duosUser, 1,
         GsonUtil.getInstance().toJson(mockInstitution))) {
-      assertEquals(HttpStatusCodes.STATUS_CODE_CONFLICT, response.getStatus());
+      assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
       assertTrue(
           response.getEntity().toString().contains("Invalid domain(s) provided for institution"));
 

--- a/src/test/java/org/broadinstitute/consent/http/resources/InstitutionResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/InstitutionResourceTest.java
@@ -18,6 +18,7 @@ import jakarta.ws.rs.ServerErrorException;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
+import org.broadinstitute.consent.http.exceptions.ConsentConflictException;
 import org.broadinstitute.consent.http.models.AuthUser;
 import org.broadinstitute.consent.http.models.DuosUser;
 import org.broadinstitute.consent.http.models.Institution;
@@ -158,7 +159,9 @@ class InstitutionResourceTest {
   @Test
   void testCreateInstitutionDuplicate() {
     Institution mockInstitution = mockInstitutionSetup();
-    when(institutionService.findAllInstitutionsByName(any())).thenReturn(List.of(mockInstitution));
+    ConsentConflictException conflictException = new ConsentConflictException(
+        "An institution exists with the name of '" + mockInstitution.getName() + "'");
+    when(institutionService.createInstitution(any(), anyInt())).thenThrow(conflictException);
 
     try (var response = resource.createInstitution(duosUser,
         GsonUtil.getInstance().toJson(mockInstitution))) {

--- a/src/test/java/org/broadinstitute/consent/http/service/InstitutionServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/InstitutionServiceTest.java
@@ -1,11 +1,14 @@
 package org.broadinstitute.consent.http.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
 import jakarta.ws.rs.NotFoundException;
@@ -191,6 +194,93 @@ class InstitutionServiceTest {
     assertTrue(service.findAllInstitutions().isEmpty());
   }
 
+  @Test
+  void testCreateInstitutionDomainUniquenessAllUnique() {
+    Institution mockInstitution = initMockModel();
+    mockInstitution.setDomains(List.of("broadinstitute.org", "broad.mit.edu"));
+
+    when(institutionDAO.findInstitutionIdByDomain("broadinstitute.org")).thenReturn(null);
+    when(institutionDAO.findInstitutionIdByDomain("broad.mit.edu")).thenReturn(null);
+
+    initService();
+
+    assertDoesNotThrow(() -> {
+      service.createInstitution(mockInstitution, 1);
+    });
+  }
+
+  @Test
+  void testCreateInstitutionDomainUniquenessSomeUnique() {
+    Institution mockInstitution = initMockModel();
+    mockInstitution.setDomains(List.of("broadinstitute.org", "broad.mit.edu"));
+
+    when(institutionDAO.findInstitutionIdByDomain("broadinstitute.org")).thenReturn(2);
+    when(institutionDAO.findInstitutionIdByDomain("broad.mit.edu")).thenReturn(null);
+
+    initService();
+
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+      service.createInstitution(mockInstitution, 1);
+    });
+
+    assertTrue(exception.getMessage().contains("broadinstitute.org"));
+    assertFalse(exception.getMessage().contains("broad.mit.edu"));
+  }
+
+  @Test
+  void testCreateInstitutionDomainUniquenessNoneUnique() {
+    Institution mockInstitution = initMockModel();
+    mockInstitution.setDomains(List.of("broadinstitute.org", "broad.mit.edu"));
+
+    when(institutionDAO.findInstitutionIdByDomain("broadinstitute.org")).thenReturn(2);
+    when(institutionDAO.findInstitutionIdByDomain("broad.mit.edu")).thenReturn(2);
+
+    initService();
+
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+      service.createInstitution(mockInstitution, 1);
+    });
+
+    assertTrue(exception.getMessage().contains("broadinstitute.org"));
+    assertTrue(exception.getMessage().contains("broad.mit.edu"));
+  }
+
+  @Test
+  void testCheckDomainUniquenessUpdateSameInstitution() throws Exception {
+    Institution mockInstitution = initMockModel();
+    mockInstitution.setId(1);
+    mockInstitution.setDomains(List.of("broadinstitute.org"));
+
+    // If we're updating the same institution, it should not throw an error
+    when(institutionDAO.findInstitutionIdByDomain("broadinstitute.org")).thenReturn(1);
+    when(institutionDAO.findInstitutionById(1)).thenReturn(mockInstitution);
+    when(institutionDAO.updateFullInstitution(mockInstitution, 1)).thenReturn(mockInstitution);
+
+    initService();
+
+    assertDoesNotThrow(() -> {
+      service.updateInstitutionById(mockInstitution, 1, 1);
+    });
+  }
+
+  @Test
+  void testCheckDomainUniquenessUpdateDifferentInstitution() {
+    Institution mockInstitution = initMockModel();
+    mockInstitution.setId(1);
+    mockInstitution.setDomains(List.of("broadinstitute.org"));
+
+    when(institutionDAO.findInstitutionIdByDomain("broadinstitute.org")).thenReturn(2);
+    when(institutionDAO.findInstitutionById(1)).thenReturn(mockInstitution);
+
+    initService();
+
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+      service.updateInstitutionById(mockInstitution, 1, 1);
+    });
+
+    assertEquals("Domain(s) already associated with another institution: broadinstitute.org",
+        exception.getMessage());
+  }
 
   /**
    * @return A list of 5 dacs

--- a/src/test/java/org/broadinstitute/consent/http/service/InstitutionServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/InstitutionServiceTest.java
@@ -8,7 +8,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
 import jakarta.ws.rs.NotFoundException;
@@ -21,6 +20,7 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.RandomUtils;
 import org.broadinstitute.consent.http.db.InstitutionDAO;
 import org.broadinstitute.consent.http.db.UserDAO;
+import org.broadinstitute.consent.http.exceptions.ConsentConflictException;
 import org.broadinstitute.consent.http.models.Institution;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.service.UserService.SimplifiedUser;
@@ -281,6 +281,79 @@ class InstitutionServiceTest {
 
     assertEquals("Domain(s) already associated with another institution: broadinstitute.org",
         exception.getMessage());
+  }
+
+  @Test
+  void testCreateInstitutionNameUniqueness() {
+    Institution newInstitution = initMockModel();
+    newInstitution.setName("Broad Institute");
+
+    when(institutionDAO.findInstitutionsByName("Broad Institute")).thenReturn(Collections.emptyList());
+
+    initService();
+
+    assertDoesNotThrow(() -> {
+      service.createInstitution(newInstitution, 1);
+    });
+  }
+
+  @Test
+  void testCreateInstitutionNameUniquenessConflict() {
+    Institution newInstitution = initMockModel();
+    newInstitution.setName("Broad Institute");
+
+    Institution existingConflictingInstitution = new Institution();
+    existingConflictingInstitution.setId(2);
+    existingConflictingInstitution.setName("Broad Institute");
+
+    when(institutionDAO.findInstitutionsByName("Broad Institute")).thenReturn(List.of(existingConflictingInstitution));
+
+    initService();
+
+    ConsentConflictException exception = assertThrows(ConsentConflictException.class, () -> {
+      service.createInstitution(newInstitution, 1);
+    });
+
+    assertTrue(exception.getMessage().contains("An institution exists with the name of 'Broad Institute'"));
+  }
+
+  @Test
+  void testUpdateInstitutionNameUniqueness() throws Exception {
+    Institution updatedInstitution = initMockModel();
+    updatedInstitution.setId(1);
+    updatedInstitution.setName("Broad Institute");
+
+    when(institutionDAO.findInstitutionById(1)).thenReturn(updatedInstitution);
+    when(institutionDAO.findInstitutionsByName("Broad Institute")).thenReturn(Collections.emptyList());
+    when(institutionDAO.updateFullInstitution(updatedInstitution, 1)).thenReturn(updatedInstitution);
+
+    initService();
+
+    assertDoesNotThrow(() -> {
+      service.updateInstitutionById(updatedInstitution, 1, 1);
+    });
+  }
+
+  @Test
+  void testUpdateInstitutionNameUniquenessConflict() {
+    Institution updatedInstitution = initMockModel();
+    updatedInstitution.setId(1);
+    updatedInstitution.setName("Broad Institute");
+
+    Institution existingConflictingInstitution = new Institution();
+    existingConflictingInstitution.setId(2);
+    existingConflictingInstitution.setName("Broad Institute");
+
+    when(institutionDAO.findInstitutionById(1)).thenReturn(updatedInstitution);
+    when(institutionDAO.findInstitutionsByName("Broad Institute")).thenReturn(List.of(existingConflictingInstitution));
+
+    initService();
+
+    ConsentConflictException exception = assertThrows(ConsentConflictException.class, () -> {
+      service.updateInstitutionById(updatedInstitution, 1, 1);
+    });
+
+    assertTrue(exception.getMessage().contains("An institution exists with the name of 'Broad Institute'"));
   }
 
   /**

--- a/src/test/java/org/broadinstitute/consent/http/service/InstitutionServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/InstitutionServiceTest.java
@@ -197,7 +197,7 @@ class InstitutionServiceTest {
   @Test
   void testCreateInstitutionDomainUniquenessAllUnique() {
     Institution mockInstitution = initMockModel();
-    mockInstitution.setDomains(List.of("broadinstitute.org", "broad.mit.edu"));
+    mockInstitution.setDomains(List.of("broadinstitute.org", "broad.mit.edu", "café.com"));
 
     when(institutionDAO.findInstitutionIdByDomain("broadinstitute.org")).thenReturn(null);
     when(institutionDAO.findInstitutionIdByDomain("broad.mit.edu")).thenReturn(null);

--- a/src/test/java/org/broadinstitute/consent/http/service/InstitutionServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/InstitutionServiceTest.java
@@ -201,6 +201,7 @@ class InstitutionServiceTest {
 
     when(institutionDAO.findInstitutionIdByDomain("broadinstitute.org")).thenReturn(null);
     when(institutionDAO.findInstitutionIdByDomain("broad.mit.edu")).thenReturn(null);
+    when(institutionDAO.findInstitutionIdByDomain("café.com")).thenReturn(null);
 
     initService();
 

--- a/src/test/java/org/broadinstitute/consent/http/service/InstitutionServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/InstitutionServiceTest.java
@@ -356,6 +356,23 @@ class InstitutionServiceTest {
     assertTrue(exception.getMessage().contains("An institution exists with the name of 'Broad Institute'"));
   }
 
+  @Test
+  void testCreateInstitutionDuplicateDomainsInPayload() {
+    Institution newInstitution = initMockModel();
+    newInstitution.setName("Broad Institute");
+    newInstitution.setDomains(List.of("broadinstitute.org", "broadinstitute.org"));
+
+    when(institutionDAO.findInstitutionsByName("Broad Institute")).thenReturn(Collections.emptyList());
+
+    initService();
+
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+      service.createInstitution(newInstitution, 1);
+    });
+
+    assertEquals("Institution domains must be unique", exception.getMessage());
+  }
+
   /**
    * @return A list of 5 dacs
    */

--- a/src/test/java/org/broadinstitute/consent/http/util/InstitutionUtilTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/util/InstitutionUtilTest.java
@@ -1,11 +1,15 @@
 package org.broadinstitute.consent.http.util;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.gson.Gson;
+import jakarta.ws.rs.BadRequestException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
@@ -63,37 +67,7 @@ class InstitutionUtilTest {
   }
 
   @Test
-  void testIsValidInstitutionDomainValidDomains() {
-    assertTrue(InstitutionUtil.isValidInstitutionDomain("foo.com"));
-    assertTrue(InstitutionUtil.isValidInstitutionDomain("bar.org"));
-    assertTrue(InstitutionUtil.isValidInstitutionDomain("baz.edu"));
-    assertTrue(InstitutionUtil.isValidInstitutionDomain("foo.bar.dev"));
-    assertTrue(InstitutionUtil.isValidInstitutionDomain("nih.gov"));
-    assertTrue(InstitutionUtil.isValidInstitutionDomain("broadinstitute.org"));
-    assertTrue(InstitutionUtil.isValidInstitutionDomain("with-some-dashes.com"));
-  }
-
-  @Test
-  void testIsValidInstitutionDomainInvalidDomains() {
-    // Invalid domains
-    assertFalse(InstitutionUtil.isValidInstitutionDomain("invalid"));
-    assertFalse(InstitutionUtil.isValidInstitutionDomain("test."));
-    assertFalse(InstitutionUtil.isValidInstitutionDomain(".com"));
-
-    // Empty or null
-    assertFalse(InstitutionUtil.isValidInstitutionDomain(""));
-    assertFalse(InstitutionUtil.isValidInstitutionDomain("   "));
-    assertFalse(InstitutionUtil.isValidInstitutionDomain(null));
-
-    // Invalid characters
-    assertFalse(InstitutionUtil.isValidInstitutionDomain("test@domain.com"));
-    assertFalse(InstitutionUtil.isValidInstitutionDomain("domain withaspace.com"));
-    assertFalse(InstitutionUtil.isValidInstitutionDomain("domain_with_underscores.com"));
-  }
-
-  @Test
   void testGetInvalidInstitutionDomainsAllValid() {
-    initUtil();
     Institution institution = new Institution();
     institution.setDomains(Arrays.asList("example.com", "test.edu", "google.org"));
 
@@ -103,16 +77,15 @@ class InstitutionUtilTest {
 
   @Test
   void testGetInvalidInstitutionDomainsMixedValidity() {
-    initUtil();
     Institution institution = new Institution();
     institution.setDomains(Arrays.asList(
         "broadinstitute.org", // valid
         "uconn.edu",          // valid
-        "sub.example.com",    // valid (subdomain)
-        "www.test.edu",       // valid (subdomain)
-        "invalid",            // invalid (no TLD)
-        "",                   // invalid (empty)
-        null                  // invalid (null)
+        "sub.example.com",    // valid
+        "www.test.edu",       // valid
+        "invalid",            // invalid
+        "",                   // invalid
+        null                  // invalid
     ));
 
     List<String> invalidDomains = InstitutionUtil.getInvalidInstitutionDomains(institution);
@@ -124,12 +97,43 @@ class InstitutionUtilTest {
 
   @Test
   void testGetInvalidInstitutionDomainsEmptyList() {
-    initUtil();
     Institution institution = new Institution();
     institution.setDomains(Collections.emptyList());
 
     List<String> invalidDomains = InstitutionUtil.getInvalidInstitutionDomains(institution);
     assertTrue(invalidDomains.isEmpty());
+  }
+
+  @Test
+  void testValidateInstitutionDomainsAllValid() {
+    Institution institution = new Institution();
+    institution.setDomains(Arrays.asList("example.com", "test.edu", "broadinstitute.org"));
+
+    assertDoesNotThrow(() -> InstitutionUtil.validateInstitutionDomains(institution));
+  }
+
+  @Test
+  void testValidateInstitutionDomainsContainsInvalid() {
+    Institution institution = new Institution();
+    institution.setDomains(Arrays.asList(
+        "broadinstitute.org", // valid
+        "uconn.edu",          // valid
+        "sub.example.com",    // valid
+        "www.test.edu",       // valid
+        "invalid",            // invalid
+        "",                   // invalid
+        null                  // invalid
+    ));
+
+    Exception exception = null;
+    try {
+      InstitutionUtil.validateInstitutionDomains(institution);
+    } catch (Exception e) {
+      exception = e;
+    }
+
+    assertInstanceOf(BadRequestException.class, exception);
+    assertEquals("Invalid domain(s) provided for institution: invalid, , null", exception.getMessage());
   }
 
   @Test
@@ -139,35 +143,35 @@ class InstitutionUtilTest {
   }
 
   @Test
-  void testCanonicalizeInstitutionNameCurlyQuotes() {
+  void testCanonicalizeInstitutionNameQuotes() {
     // Test left/right double quotation marks
     assertEquals("A 'Real' University", InstitutionUtil.canonicalizeInstitutionName("A \"Real\" University"));
 
     // Test left/right single quotation marks
     assertEquals("St. John's University", InstitutionUtil.canonicalizeInstitutionName("St. John’s University"));
-    assertEquals("Mount St. Mary's College", InstitutionUtil.canonicalizeInstitutionName("Mount St. Mary's College"));
+    assertEquals("Mount St. Mary's College", InstitutionUtil.canonicalizeInstitutionName("Mount St. Mary‘s College"));
 
     // Test low-9 quotation marks
-    assertEquals("Test 'Quote' School", InstitutionUtil.canonicalizeInstitutionName("Test ‚Quote„ School"));
+    assertEquals("A 'Real' University", InstitutionUtil.canonicalizeInstitutionName("A ‚Real„ University"));
   }
 
   @Test
   void testCanonicalizeInstitutionNameDoubleToSingleQuotes() {
-    assertEquals("The 'Elite' University", InstitutionUtil.canonicalizeInstitutionName("The \"Elite\" University"));
-    assertEquals("Harvard 'School' of Medicine", InstitutionUtil.canonicalizeInstitutionName("Harvard \"School\" of Medicine"));
+    assertEquals("A 'Real' University", InstitutionUtil.canonicalizeInstitutionName("A \"Real\" University"));
+    assertEquals("Matt's University", InstitutionUtil.canonicalizeInstitutionName("Matt\"s University"));
   }
 
   @Test
   void testCanonicalizeInstitutionNameInvalidInput() {
-    assertNull(InstitutionUtil.canonicalizeInstitutionName(null));
-    assertNull(InstitutionUtil.canonicalizeInstitutionName(""));
-    assertNull(InstitutionUtil.canonicalizeInstitutionName("   "));
-    assertNull(InstitutionUtil.canonicalizeInstitutionName("\t\n"));
+    assertThrows(BadRequestException.class, () -> InstitutionUtil.canonicalizeInstitutionName(null));
+    assertThrows(BadRequestException.class, () -> InstitutionUtil.canonicalizeInstitutionName(""));
+    assertThrows(BadRequestException.class, () -> InstitutionUtil.canonicalizeInstitutionName("   "));
+    assertThrows(BadRequestException.class, () -> InstitutionUtil.canonicalizeInstitutionName("\t\n"));
   }
 
   @Test
   void testCanonicalizeInstitutionNameWhitespace() {
-    assertEquals("Trimmed University", InstitutionUtil.canonicalizeInstitutionName("  Trimmed University  "));
-    assertEquals("Spaced College", InstitutionUtil.canonicalizeInstitutionName("\t Spaced College \n"));
+    assertEquals("Harvard University", InstitutionUtil.canonicalizeInstitutionName("  Harvard University  "));
+    assertEquals("Connecticut College", InstitutionUtil.canonicalizeInstitutionName("\t Connecticut College \n"));
   }
 }

--- a/src/test/java/org/broadinstitute/consent/http/util/InstitutionUtilTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/util/InstitutionUtilTest.java
@@ -67,6 +67,7 @@ class InstitutionUtilTest {
     assertTrue(InstitutionUtil.isValidInstitutionDomain("foo.com"));
     assertTrue(InstitutionUtil.isValidInstitutionDomain("bar.org"));
     assertTrue(InstitutionUtil.isValidInstitutionDomain("baz.edu"));
+    assertTrue(InstitutionUtil.isValidInstitutionDomain("foo.bar.dev"));
     assertTrue(InstitutionUtil.isValidInstitutionDomain("nih.gov"));
     assertTrue(InstitutionUtil.isValidInstitutionDomain("broadinstitute.org"));
     assertTrue(InstitutionUtil.isValidInstitutionDomain("with-some-dashes.com"));
@@ -74,11 +75,6 @@ class InstitutionUtilTest {
 
   @Test
   void testIsValidInstitutionDomainInvalidDomains() {
-    // Subdomains
-    assertFalse(InstitutionUtil.isValidInstitutionDomain("foo.bar.baz"));
-    assertFalse(InstitutionUtil.isValidInstitutionDomain("mail.google.com"));
-    assertFalse(InstitutionUtil.isValidInstitutionDomain("www.broadinstitute.org"));
-
     // Invalid domains
     assertFalse(InstitutionUtil.isValidInstitutionDomain("invalid"));
     assertFalse(InstitutionUtil.isValidInstitutionDomain("test."));
@@ -92,87 +88,86 @@ class InstitutionUtilTest {
     // Invalid characters
     assertFalse(InstitutionUtil.isValidInstitutionDomain("test@domain.com"));
     assertFalse(InstitutionUtil.isValidInstitutionDomain("domain withaspace.com"));
+    assertFalse(InstitutionUtil.isValidInstitutionDomain("domain_with_underscores.com"));
   }
 
   @Test
-  void testGetInvalidInstitutionDomainsAllValid() {
+  void testValidateInstitutionDomainsAllValid() {
     initUtil();
     Institution institution = new Institution();
     institution.setDomains(Arrays.asList("example.com", "test.edu", "google.org"));
 
-    List<String> invalidDomains = InstitutionUtil.getInvalidInstitutionDomains(institution);
+    List<String> invalidDomains = InstitutionUtil.validateInstitutionDomains(institution);
     assertTrue(invalidDomains.isEmpty());
   }
 
   @Test
-  void testGetInvalidInstitutionDomainsMixedValidity() {
+  void testValidateInstitutionDomainsMixedValidity() {
     initUtil();
     Institution institution = new Institution();
     institution.setDomains(Arrays.asList(
         "broadinstitute.org", // valid
         "uconn.edu",          // valid
-        "sub.example.com",    // invalid (subdomain)
-        "www.test.edu",       // invalid (subdomain)
+        "sub.example.com",    // valid (subdomain)
+        "www.test.edu",       // valid (subdomain)
         "invalid",            // invalid (no TLD)
         "",                   // invalid (empty)
         null                  // invalid (null)
     ));
 
-    List<String> invalidDomains = InstitutionUtil.getInvalidInstitutionDomains(institution);
-    assertEquals(5, invalidDomains.size());
-    assertTrue(invalidDomains.contains("sub.example.com"));
+    List<String> invalidDomains = InstitutionUtil.validateInstitutionDomains(institution);
+    assertEquals(3, invalidDomains.size());
     assertTrue(invalidDomains.contains("invalid"));
     assertTrue(invalidDomains.contains(""));
-    assertTrue(invalidDomains.contains("www.test.edu"));
     assertTrue(invalidDomains.contains(null));
   }
 
   @Test
-  void testGetInvalidInstitutionDomainsEmptyList() {
+  void testValidateInstitutionDomainsEmptyList() {
     initUtil();
     Institution institution = new Institution();
     institution.setDomains(Collections.emptyList());
 
-    List<String> invalidDomains = InstitutionUtil.getInvalidInstitutionDomains(institution);
+    List<String> invalidDomains = InstitutionUtil.validateInstitutionDomains(institution);
     assertTrue(invalidDomains.isEmpty());
   }
 
   @Test
-  void testCanonicalizeNameValidInput() {
-    assertEquals("Harvard University", InstitutionUtil.canonicalizeName("Harvard University"));
-    assertEquals("University of Connecticut", InstitutionUtil.canonicalizeName("  University of Connecticut  "));
+  void testCanonicalizeInstitutionNameValidInput() {
+    assertEquals("Harvard University", InstitutionUtil.canonicalizeInstitutionName("Harvard University"));
+    assertEquals("University of Connecticut", InstitutionUtil.canonicalizeInstitutionName("  University of Connecticut  "));
   }
 
   @Test
-  void testCanonicalizeNameCurlyQuotes() {
+  void testCanonicalizeInstitutionNameCurlyQuotes() {
     // Test left/right double quotation marks
-    assertEquals("A 'Real' University", InstitutionUtil.canonicalizeName("A \"Real\" University"));
+    assertEquals("A 'Real' University", InstitutionUtil.canonicalizeInstitutionName("A \"Real\" University"));
 
     // Test left/right single quotation marks
-    assertEquals("St. John's University", InstitutionUtil.canonicalizeName("St. John’s University"));
-    assertEquals("Mount St. Mary's College", InstitutionUtil.canonicalizeName("Mount St. Mary's College"));
+    assertEquals("St. John's University", InstitutionUtil.canonicalizeInstitutionName("St. John’s University"));
+    assertEquals("Mount St. Mary's College", InstitutionUtil.canonicalizeInstitutionName("Mount St. Mary's College"));
 
     // Test low-9 quotation marks
-    assertEquals("Test 'Quote' School", InstitutionUtil.canonicalizeName("Test ‚Quote„ School"));
+    assertEquals("Test 'Quote' School", InstitutionUtil.canonicalizeInstitutionName("Test ‚Quote„ School"));
   }
 
   @Test
-  void testCanonicalizeNameDoubleToSingleQuotes() {
-    assertEquals("The 'Elite' University", InstitutionUtil.canonicalizeName("The \"Elite\" University"));
-    assertEquals("Harvard 'School' of Medicine", InstitutionUtil.canonicalizeName("Harvard \"School\" of Medicine"));
+  void testCanonicalizeInstitutionNameDoubleToSingleQuotes() {
+    assertEquals("The 'Elite' University", InstitutionUtil.canonicalizeInstitutionName("The \"Elite\" University"));
+    assertEquals("Harvard 'School' of Medicine", InstitutionUtil.canonicalizeInstitutionName("Harvard \"School\" of Medicine"));
   }
 
   @Test
-  void testCanonicalizeNameInvalidInput() {
-    assertNull(InstitutionUtil.canonicalizeName(null));
-    assertNull(InstitutionUtil.canonicalizeName(""));
-    assertNull(InstitutionUtil.canonicalizeName("   "));
-    assertNull(InstitutionUtil.canonicalizeName("\t\n"));
+  void testCanonicalizeInstitutionNameInvalidInput() {
+    assertNull(InstitutionUtil.canonicalizeInstitutionName(null));
+    assertNull(InstitutionUtil.canonicalizeInstitutionName(""));
+    assertNull(InstitutionUtil.canonicalizeInstitutionName("   "));
+    assertNull(InstitutionUtil.canonicalizeInstitutionName("\t\n"));
   }
 
   @Test
-  void testCanonicalizeNameWhitespace() {
-    assertEquals("Trimmed University", InstitutionUtil.canonicalizeName("  Trimmed University  "));
-    assertEquals("Spaced College", InstitutionUtil.canonicalizeName("\t Spaced College \n"));
+  void testCanonicalizeInstitutionNameWhitespace() {
+    assertEquals("Trimmed University", InstitutionUtil.canonicalizeInstitutionName("  Trimmed University  "));
+    assertEquals("Spaced College", InstitutionUtil.canonicalizeInstitutionName("\t Spaced College \n"));
   }
 }

--- a/src/test/java/org/broadinstitute/consent/http/util/InstitutionUtilTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/util/InstitutionUtilTest.java
@@ -2,6 +2,7 @@ package org.broadinstitute.consent.http.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.gson.Gson;
@@ -93,21 +94,13 @@ class InstitutionUtilTest {
     assertFalse(InstitutionUtil.isValidInstitutionDomain("domain withaspace.com"));
   }
 
-//  @Test
-//  void testCanonicalizeDomain() {
-//    assertEquals("example.com", InstitutionUtil.canonicalizeDomain("EXAMPLE.COM"));
-//    assertEquals("test.edu", InstitutionUtil.canonicalizeDomain("Test.Edu"));
-//    assertEquals("google.org", InstitutionUtil.canonicalizeDomain("  google.org  "));
-//    assertEquals("university.net", InstitutionUtil.canonicalizeDomain("  UNIVERSITY.NET  "));
-//  }
-
   @Test
   void testGetInvalidInstitutionDomainsAllValid() {
     initUtil();
     Institution institution = new Institution();
     institution.setDomains(Arrays.asList("example.com", "test.edu", "google.org"));
 
-    List<String> invalidDomains = util.getInvalidInstitutionDomains(institution);
+    List<String> invalidDomains = InstitutionUtil.getInvalidInstitutionDomains(institution);
     assertTrue(invalidDomains.isEmpty());
   }
 
@@ -116,21 +109,22 @@ class InstitutionUtilTest {
     initUtil();
     Institution institution = new Institution();
     institution.setDomains(Arrays.asList(
-        "example.com",        // valid
+        "broadinstitute.org", // valid
+        "uconn.edu",          // valid
         "sub.example.com",    // invalid (subdomain)
-        "test.edu",           // valid
+        "www.test.edu",       // invalid (subdomain)
         "invalid",            // invalid (no TLD)
-        "google.org",         // valid
         "",                   // invalid (empty)
-        "www.test.edu"        // invalid (subdomain)
+        null                  // invalid (null)
     ));
 
     List<String> invalidDomains = InstitutionUtil.getInvalidInstitutionDomains(institution);
-    assertEquals(4, invalidDomains.size());
+    assertEquals(5, invalidDomains.size());
     assertTrue(invalidDomains.contains("sub.example.com"));
     assertTrue(invalidDomains.contains("invalid"));
     assertTrue(invalidDomains.contains(""));
     assertTrue(invalidDomains.contains("www.test.edu"));
+    assertTrue(invalidDomains.contains(null));
   }
 
   @Test
@@ -141,5 +135,44 @@ class InstitutionUtilTest {
 
     List<String> invalidDomains = InstitutionUtil.getInvalidInstitutionDomains(institution);
     assertTrue(invalidDomains.isEmpty());
+  }
+
+  @Test
+  void testCanonicalizeNameValidInput() {
+    assertEquals("Harvard University", InstitutionUtil.canonicalizeName("Harvard University"));
+    assertEquals("University of Connecticut", InstitutionUtil.canonicalizeName("  University of Connecticut  "));
+  }
+
+  @Test
+  void testCanonicalizeNameCurlyQuotes() {
+    // Test left/right double quotation marks
+    assertEquals("A 'Real' University", InstitutionUtil.canonicalizeName("A \"Real\" University"));
+
+    // Test left/right single quotation marks
+    assertEquals("St. John's University", InstitutionUtil.canonicalizeName("St. John’s University"));
+    assertEquals("Mount St. Mary's College", InstitutionUtil.canonicalizeName("Mount St. Mary's College"));
+
+    // Test low-9 quotation marks
+    assertEquals("Test 'Quote' School", InstitutionUtil.canonicalizeName("Test ‚Quote„ School"));
+  }
+
+  @Test
+  void testCanonicalizeNameDoubleToSingleQuotes() {
+    assertEquals("The 'Elite' University", InstitutionUtil.canonicalizeName("The \"Elite\" University"));
+    assertEquals("Harvard 'School' of Medicine", InstitutionUtil.canonicalizeName("Harvard \"School\" of Medicine"));
+  }
+
+  @Test
+  void testCanonicalizeNameInvalidInput() {
+    assertNull(InstitutionUtil.canonicalizeName(null));
+    assertNull(InstitutionUtil.canonicalizeName(""));
+    assertNull(InstitutionUtil.canonicalizeName("   "));
+    assertNull(InstitutionUtil.canonicalizeName("\t\n"));
+  }
+
+  @Test
+  void testCanonicalizeNameWhitespace() {
+    assertEquals("Trimmed University", InstitutionUtil.canonicalizeName("  Trimmed University  "));
+    assertEquals("Spaced College", InstitutionUtil.canonicalizeName("\t Spaced College \n"));
   }
 }

--- a/src/test/java/org/broadinstitute/consent/http/util/InstitutionUtilTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/util/InstitutionUtilTest.java
@@ -2,14 +2,12 @@ package org.broadinstitute.consent.http.util;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.gson.Gson;
 import jakarta.ws.rs.BadRequestException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
@@ -22,6 +20,25 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class InstitutionUtilTest {
+
+  private static final List<String> VALID_DOMAINS = Arrays.asList(
+      "café.com",
+      "broad.mit.edu",
+      "broadinstitute.org",
+      "mail.google.com",
+      "www.broadinstitute.org"
+  );
+
+  private static final List<String> INVALID_DOMAINS = Arrays.asList(
+      "invalid",
+      "",
+      null
+  );
+
+  private static final List<String> MIXED_VALIDITY_DOMAINS = new ArrayList<String>() {{
+    addAll(VALID_DOMAINS);
+    addAll(INVALID_DOMAINS);
+  }};
 
   private InstitutionUtil util;
 
@@ -69,7 +86,7 @@ class InstitutionUtilTest {
   @Test
   void testGetInvalidInstitutionDomainsAllValid() {
     Institution institution = new Institution();
-    institution.setDomains(Arrays.asList("google.com", "broad.mit.edu", "broadinstitute.org"));
+    institution.setDomains(VALID_DOMAINS);
 
     List<String> invalidDomains = InstitutionUtil.getInvalidInstitutionDomains(institution);
     assertTrue(invalidDomains.isEmpty());
@@ -78,22 +95,13 @@ class InstitutionUtilTest {
   @Test
   void testGetInvalidInstitutionDomainsMixedValidity() {
     Institution institution = new Institution();
-    institution.setDomains(Arrays.asList(
-        "broadinstitute.org", // valid
-        "uconn.edu",          // valid
-        "mail.google.com",    // valid
-        "www.uconn.edu",      // valid
-        "café.com",           // valid
-        "invalid",            // invalid
-        "",                   // invalid
-        null                  // invalid
-    ));
+    institution.setDomains(MIXED_VALIDITY_DOMAINS);
 
     List<String> invalidDomains = InstitutionUtil.getInvalidInstitutionDomains(institution);
     assertEquals(3, invalidDomains.size());
-    assertTrue(invalidDomains.contains("invalid"));
-    assertTrue(invalidDomains.contains(""));
-    assertTrue(invalidDomains.contains(null));
+    INVALID_DOMAINS.forEach(domain -> {
+      assertTrue(invalidDomains.contains(domain));
+    });
   }
 
   @Test
@@ -108,7 +116,7 @@ class InstitutionUtilTest {
   @Test
   void testValidateInstitutionDomainsAllValid() {
     Institution institution = new Institution();
-    institution.setDomains(Arrays.asList("google.com", "broad.mit.edu", "broadinstitute.org"));
+    institution.setDomains(VALID_DOMAINS);
 
     assertDoesNotThrow(() -> InstitutionUtil.validateInstitutionDomains(institution));
   }
@@ -116,16 +124,7 @@ class InstitutionUtilTest {
   @Test
   void testValidateInstitutionDomainsContainsInvalid() {
     Institution institution = new Institution();
-    institution.setDomains(Arrays.asList(
-        "broadinstitute.org", // valid
-        "uconn.edu",          // valid
-        "sub.example.com",    // valid
-        "www.test.edu",       // valid
-        "café.com",           // valid
-        "invalid",            // invalid
-        "",                   // invalid
-        null                  // invalid
-    ));
+    institution.setDomains(MIXED_VALIDITY_DOMAINS);
 
     Exception exception = null;
     try {

--- a/src/test/java/org/broadinstitute/consent/http/util/InstitutionUtilTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/util/InstitutionUtilTest.java
@@ -69,7 +69,7 @@ class InstitutionUtilTest {
   @Test
   void testGetInvalidInstitutionDomainsAllValid() {
     Institution institution = new Institution();
-    institution.setDomains(Arrays.asList("example.com", "test.edu", "google.org"));
+    institution.setDomains(Arrays.asList("google.com", "broad.mit.edu", "broadinstitute.org"));
 
     List<String> invalidDomains = InstitutionUtil.getInvalidInstitutionDomains(institution);
     assertTrue(invalidDomains.isEmpty());
@@ -81,8 +81,8 @@ class InstitutionUtilTest {
     institution.setDomains(Arrays.asList(
         "broadinstitute.org", // valid
         "uconn.edu",          // valid
-        "sub.example.com",    // valid
-        "www.test.edu",       // valid
+        "mail.google.com",    // valid
+        "www.uconn.edu",      // valid
         "invalid",            // invalid
         "",                   // invalid
         null                  // invalid
@@ -107,7 +107,7 @@ class InstitutionUtilTest {
   @Test
   void testValidateInstitutionDomainsAllValid() {
     Institution institution = new Institution();
-    institution.setDomains(Arrays.asList("example.com", "test.edu", "broadinstitute.org"));
+    institution.setDomains(Arrays.asList("google.com", "broad.mit.edu", "broadinstitute.org"));
 
     assertDoesNotThrow(() -> InstitutionUtil.validateInstitutionDomains(institution));
   }
@@ -153,20 +153,6 @@ class InstitutionUtilTest {
 
     // Test low-9 quotation marks
     assertEquals("A 'Real' University", InstitutionUtil.canonicalizeInstitutionName("A ‚Real„ University"));
-  }
-
-  @Test
-  void testCanonicalizeInstitutionNameDoubleToSingleQuotes() {
-    assertEquals("A 'Real' University", InstitutionUtil.canonicalizeInstitutionName("A \"Real\" University"));
-    assertEquals("Matt's University", InstitutionUtil.canonicalizeInstitutionName("Matt\"s University"));
-  }
-
-  @Test
-  void testCanonicalizeInstitutionNameInvalidInput() {
-    assertThrows(BadRequestException.class, () -> InstitutionUtil.canonicalizeInstitutionName(null));
-    assertThrows(BadRequestException.class, () -> InstitutionUtil.canonicalizeInstitutionName(""));
-    assertThrows(BadRequestException.class, () -> InstitutionUtil.canonicalizeInstitutionName("   "));
-    assertThrows(BadRequestException.class, () -> InstitutionUtil.canonicalizeInstitutionName("\t\n"));
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/util/InstitutionUtilTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/util/InstitutionUtilTest.java
@@ -121,6 +121,7 @@ class InstitutionUtilTest {
         "uconn.edu",          // valid
         "sub.example.com",    // valid
         "www.test.edu",       // valid
+        "café.com",     //valid
         "invalid",            // invalid
         "",                   // invalid
         null                  // invalid

--- a/src/test/java/org/broadinstitute/consent/http/util/InstitutionUtilTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/util/InstitutionUtilTest.java
@@ -92,17 +92,17 @@ class InstitutionUtilTest {
   }
 
   @Test
-  void testValidateInstitutionDomainsAllValid() {
+  void testGetInvalidInstitutionDomainsAllValid() {
     initUtil();
     Institution institution = new Institution();
     institution.setDomains(Arrays.asList("example.com", "test.edu", "google.org"));
 
-    List<String> invalidDomains = InstitutionUtil.validateInstitutionDomains(institution);
+    List<String> invalidDomains = InstitutionUtil.getInvalidInstitutionDomains(institution);
     assertTrue(invalidDomains.isEmpty());
   }
 
   @Test
-  void testValidateInstitutionDomainsMixedValidity() {
+  void testGetInvalidInstitutionDomainsMixedValidity() {
     initUtil();
     Institution institution = new Institution();
     institution.setDomains(Arrays.asList(
@@ -115,7 +115,7 @@ class InstitutionUtilTest {
         null                  // invalid (null)
     ));
 
-    List<String> invalidDomains = InstitutionUtil.validateInstitutionDomains(institution);
+    List<String> invalidDomains = InstitutionUtil.getInvalidInstitutionDomains(institution);
     assertEquals(3, invalidDomains.size());
     assertTrue(invalidDomains.contains("invalid"));
     assertTrue(invalidDomains.contains(""));
@@ -123,12 +123,12 @@ class InstitutionUtilTest {
   }
 
   @Test
-  void testValidateInstitutionDomainsEmptyList() {
+  void testGetInvalidInstitutionDomainsEmptyList() {
     initUtil();
     Institution institution = new Institution();
     institution.setDomains(Collections.emptyList());
 
-    List<String> invalidDomains = InstitutionUtil.validateInstitutionDomains(institution);
+    List<String> invalidDomains = InstitutionUtil.getInvalidInstitutionDomains(institution);
     assertTrue(invalidDomains.isEmpty());
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/util/InstitutionUtilTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/util/InstitutionUtilTest.java
@@ -61,27 +61,25 @@ class InstitutionUtilTest {
     assertEquals("{\"id\":1,\"name\":\"Test Name\"}", json);
   }
 
-  // Domain validation tests
-
   @Test
-  void testIsValidInstitutionDomain_ValidDomains() {
-    assertTrue(InstitutionUtil.isValidInstitutionDomain("example.com"));
-    assertTrue(InstitutionUtil.isValidInstitutionDomain("google.org"));
-    assertTrue(InstitutionUtil.isValidInstitutionDomain("test.edu"));
-    assertTrue(InstitutionUtil.isValidInstitutionDomain("institution.gov"));
-    assertTrue(InstitutionUtil.isValidInstitutionDomain("university.net"));
+  void testIsValidInstitutionDomainValidDomains() {
+    assertTrue(InstitutionUtil.isValidInstitutionDomain("foo.com"));
+    assertTrue(InstitutionUtil.isValidInstitutionDomain("bar.org"));
+    assertTrue(InstitutionUtil.isValidInstitutionDomain("baz.edu"));
+    assertTrue(InstitutionUtil.isValidInstitutionDomain("nih.gov"));
+    assertTrue(InstitutionUtil.isValidInstitutionDomain("broadinstitute.org"));
+    assertTrue(InstitutionUtil.isValidInstitutionDomain("with-some-dashes.com"));
   }
 
   @Test
-  void testIsValidInstitutionDomain_InvalidDomains() {
-    // Subdomains (more than one dot)
-    assertFalse(InstitutionUtil.isValidInstitutionDomain("sub.example.com"));
+  void testIsValidInstitutionDomainInvalidDomains() {
+    // Subdomains
+    assertFalse(InstitutionUtil.isValidInstitutionDomain("foo.bar.baz"));
     assertFalse(InstitutionUtil.isValidInstitutionDomain("mail.google.com"));
-    assertFalse(InstitutionUtil.isValidInstitutionDomain("www.test.edu"));
+    assertFalse(InstitutionUtil.isValidInstitutionDomain("www.broadinstitute.org"));
 
-    // Invalid format
+    // Invalid domains
     assertFalse(InstitutionUtil.isValidInstitutionDomain("invalid"));
-    assertFalse(InstitutionUtil.isValidInstitutionDomain("example"));
     assertFalse(InstitutionUtil.isValidInstitutionDomain("test."));
     assertFalse(InstitutionUtil.isValidInstitutionDomain(".com"));
 
@@ -92,19 +90,19 @@ class InstitutionUtilTest {
 
     // Invalid characters
     assertFalse(InstitutionUtil.isValidInstitutionDomain("test@domain.com"));
-    assertFalse(InstitutionUtil.isValidInstitutionDomain("domain space.com"));
+    assertFalse(InstitutionUtil.isValidInstitutionDomain("domain withaspace.com"));
   }
 
-  @Test
-  void testCanonicalizeDomain() {
-    assertEquals("example.com", InstitutionUtil.canonicalizeDomain("EXAMPLE.COM"));
-    assertEquals("test.edu", InstitutionUtil.canonicalizeDomain("Test.Edu"));
-    assertEquals("google.org", InstitutionUtil.canonicalizeDomain("  google.org  "));
-    assertEquals("university.net", InstitutionUtil.canonicalizeDomain("  UNIVERSITY.NET  "));
-  }
+//  @Test
+//  void testCanonicalizeDomain() {
+//    assertEquals("example.com", InstitutionUtil.canonicalizeDomain("EXAMPLE.COM"));
+//    assertEquals("test.edu", InstitutionUtil.canonicalizeDomain("Test.Edu"));
+//    assertEquals("google.org", InstitutionUtil.canonicalizeDomain("  google.org  "));
+//    assertEquals("university.net", InstitutionUtil.canonicalizeDomain("  UNIVERSITY.NET  "));
+//  }
 
   @Test
-  void testGetInvalidInstitutionDomains_AllValid() {
+  void testGetInvalidInstitutionDomainsAllValid() {
     initUtil();
     Institution institution = new Institution();
     institution.setDomains(Arrays.asList("example.com", "test.edu", "google.org"));
@@ -114,7 +112,7 @@ class InstitutionUtilTest {
   }
 
   @Test
-  void testGetInvalidInstitutionDomains_SomeInvalid() {
+  void testGetInvalidInstitutionDomainsMixedValidity() {
     initUtil();
     Institution institution = new Institution();
     institution.setDomains(Arrays.asList(
@@ -136,17 +134,7 @@ class InstitutionUtilTest {
   }
 
   @Test
-  void testGetInvalidInstitutionDomains_AllInvalid() {
-    initUtil();
-    Institution institution = new Institution();
-    institution.setDomains(Arrays.asList("sub.example.com", "invalid", "", "www.test.edu"));
-
-    List<String> invalidDomains = InstitutionUtil.getInvalidInstitutionDomains(institution);
-    assertEquals(4, invalidDomains.size());
-  }
-
-  @Test
-  void testGetInvalidInstitutionDomains_EmptyList() {
+  void testGetInvalidInstitutionDomainsEmptyList() {
     initUtil();
     Institution institution = new Institution();
     institution.setDomains(Collections.emptyList());

--- a/src/test/java/org/broadinstitute/consent/http/util/InstitutionUtilTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/util/InstitutionUtilTest.java
@@ -83,7 +83,7 @@ class InstitutionUtilTest {
         "uconn.edu",          // valid
         "mail.google.com",    // valid
         "www.uconn.edu",      // valid
-        "café.com",      //valid
+        "café.com",           // valid
         "invalid",            // invalid
         "",                   // invalid
         null                  // invalid
@@ -121,7 +121,7 @@ class InstitutionUtilTest {
         "uconn.edu",          // valid
         "sub.example.com",    // valid
         "www.test.edu",       // valid
-        "café.com",     //valid
+        "café.com",           // valid
         "invalid",            // invalid
         "",                   // invalid
         null                  // invalid

--- a/src/test/java/org/broadinstitute/consent/http/util/InstitutionUtilTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/util/InstitutionUtilTest.java
@@ -83,6 +83,7 @@ class InstitutionUtilTest {
         "uconn.edu",          // valid
         "mail.google.com",    // valid
         "www.uconn.edu",      // valid
+        "café.com",      //valid
         "invalid",            // invalid
         "",                   // invalid
         null                  // invalid

--- a/src/test/java/org/broadinstitute/consent/http/util/InstitutionUtilTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/util/InstitutionUtilTest.java
@@ -1,9 +1,14 @@
 package org.broadinstitute.consent.http.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.gson.Gson;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
+import java.util.List;
 import org.broadinstitute.consent.http.models.Institution;
 import org.broadinstitute.consent.http.util.gson.GsonUtil;
 import org.junit.jupiter.api.Test;
@@ -54,5 +59,99 @@ class InstitutionUtilTest {
     Gson builder = util.getGsonBuilder(false);
     String json = builder.toJson(mockInstitution);
     assertEquals("{\"id\":1,\"name\":\"Test Name\"}", json);
+  }
+
+  // Domain validation tests
+
+  @Test
+  void testIsValidInstitutionDomain_ValidDomains() {
+    assertTrue(InstitutionUtil.isValidInstitutionDomain("example.com"));
+    assertTrue(InstitutionUtil.isValidInstitutionDomain("google.org"));
+    assertTrue(InstitutionUtil.isValidInstitutionDomain("test.edu"));
+    assertTrue(InstitutionUtil.isValidInstitutionDomain("institution.gov"));
+    assertTrue(InstitutionUtil.isValidInstitutionDomain("university.net"));
+  }
+
+  @Test
+  void testIsValidInstitutionDomain_InvalidDomains() {
+    // Subdomains (more than one dot)
+    assertFalse(InstitutionUtil.isValidInstitutionDomain("sub.example.com"));
+    assertFalse(InstitutionUtil.isValidInstitutionDomain("mail.google.com"));
+    assertFalse(InstitutionUtil.isValidInstitutionDomain("www.test.edu"));
+
+    // Invalid format
+    assertFalse(InstitutionUtil.isValidInstitutionDomain("invalid"));
+    assertFalse(InstitutionUtil.isValidInstitutionDomain("example"));
+    assertFalse(InstitutionUtil.isValidInstitutionDomain("test."));
+    assertFalse(InstitutionUtil.isValidInstitutionDomain(".com"));
+
+    // Empty or null
+    assertFalse(InstitutionUtil.isValidInstitutionDomain(""));
+    assertFalse(InstitutionUtil.isValidInstitutionDomain("   "));
+    assertFalse(InstitutionUtil.isValidInstitutionDomain(null));
+
+    // Invalid characters
+    assertFalse(InstitutionUtil.isValidInstitutionDomain("test@domain.com"));
+    assertFalse(InstitutionUtil.isValidInstitutionDomain("domain space.com"));
+  }
+
+  @Test
+  void testCanonicalizeDomain() {
+    assertEquals("example.com", InstitutionUtil.canonicalizeDomain("EXAMPLE.COM"));
+    assertEquals("test.edu", InstitutionUtil.canonicalizeDomain("Test.Edu"));
+    assertEquals("google.org", InstitutionUtil.canonicalizeDomain("  google.org  "));
+    assertEquals("university.net", InstitutionUtil.canonicalizeDomain("  UNIVERSITY.NET  "));
+  }
+
+  @Test
+  void testGetInvalidInstitutionDomains_AllValid() {
+    initUtil();
+    Institution institution = new Institution();
+    institution.setDomains(Arrays.asList("example.com", "test.edu", "google.org"));
+
+    List<String> invalidDomains = util.getInvalidInstitutionDomains(institution);
+    assertTrue(invalidDomains.isEmpty());
+  }
+
+  @Test
+  void testGetInvalidInstitutionDomains_SomeInvalid() {
+    initUtil();
+    Institution institution = new Institution();
+    institution.setDomains(Arrays.asList(
+        "example.com",        // valid
+        "sub.example.com",    // invalid (subdomain)
+        "test.edu",           // valid
+        "invalid",            // invalid (no TLD)
+        "google.org",         // valid
+        "",                   // invalid (empty)
+        "www.test.edu"        // invalid (subdomain)
+    ));
+
+    List<String> invalidDomains = InstitutionUtil.getInvalidInstitutionDomains(institution);
+    assertEquals(4, invalidDomains.size());
+    assertTrue(invalidDomains.contains("sub.example.com"));
+    assertTrue(invalidDomains.contains("invalid"));
+    assertTrue(invalidDomains.contains(""));
+    assertTrue(invalidDomains.contains("www.test.edu"));
+  }
+
+  @Test
+  void testGetInvalidInstitutionDomains_AllInvalid() {
+    initUtil();
+    Institution institution = new Institution();
+    institution.setDomains(Arrays.asList("sub.example.com", "invalid", "", "www.test.edu"));
+
+    List<String> invalidDomains = InstitutionUtil.getInvalidInstitutionDomains(institution);
+    assertEquals(4, invalidDomains.size());
+  }
+
+  @Test
+  void testGetInvalidInstitutionDomains_EmptyList() {
+    initUtil();
+    Institution institution = new Institution();
+    institution.setDomains(Collections.emptyList());
+
+    List<String> invalidDomains = InstitutionUtil.getInvalidInstitutionDomains(institution);
+    assertTrue(invalidDomains.isEmpty());
   }
 }


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-1991

### Summary

Adds institution name validation/sanitization:

* Trims whitespace
* Replaces many different types of quotations with straight single quotes
* There was existing validation in place to make sure that names were non-empty and unique -- this is moved into the service layer, but the logic remains the same

Adds institution domain validation:

* Checks validity of domains
* Checks for global uniqueness of domains

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
