### PR TITLE
[DT-1983] Trigger RuleService on Progress Reports

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequest.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequest.java
@@ -507,4 +507,11 @@ public class DataAccessRequest {
     return this.getCloseoutSigningOfficialApprovedDate() != null
         && this.getCloseoutSigningOfficialApprovedUserId() != null;
   }
+
+  public boolean getHasDMI() {
+    return this.getData() != null
+        && this.getData().getDmi() != null
+        && this.getData().getDmi().incidents() != null
+        && !this.getData().getDmi().incidents().isEmpty();
+  }
 }

--- a/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
@@ -423,6 +423,7 @@ public class DataAccessRequestResource extends Resource {
   @RolesAllowed({RESEARCHER})
   public Response postProgressReport(
       @Auth AuthUser authUser,
+      @Context Request request,
       @PathParam("parentReferenceId") String parentReferenceId,
       @FormDataParam("dar") String dar,
       @FormDataParam("collaboratorRequiredFile") InputStream collabInputStream,
@@ -452,10 +453,13 @@ public class DataAccessRequestResource extends Resource {
       populateProgressReportWithDocuments(collabInputStream, collabFileDetails, ethicsInputStream,
           ethicsFileDetails, payload, parentDar);
       DataAccessRequest progressReport = dataAccessRequestService.createProgressReport(user,
-          payload, parentDar);
+          payload, parentDar, (ContainerRequest) request);
       if (Objects.nonNull(progressReport) && !progressReport.getIsCloseoutProgressReport()) {
         sendNewDarCollectionMessage(parentDar.getCollectionId());
       }
+      List<Dataset> datasets = datasetService.findDatasetsByIds(progressReport.getDatasetIds());
+      ComplianceLogger.logDARSubmission(user, datasets, ((ContainerRequest) request),
+          HttpStatusCodes.STATUS_CODE_CREATED);
       return Response.ok(progressReport.convertToSimplifiedDar()).build();
     } catch (Exception e) {
       return createExceptionResponse(e);

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
@@ -264,7 +264,7 @@ public class DataAccessRequestService implements ConsentLogger {
    * @param parentDar         The parent DataAccessRequest
    * @return The created progress report.
    */
-  public DataAccessRequest createProgressReport(User user, DataAccessRequest progressReport, DataAccessRequest parentDar) {
+  public DataAccessRequest createProgressReport(User user, DataAccessRequest progressReport, DataAccessRequest parentDar, ContainerRequest request) {
     validateProgressReport(user, progressReport, parentDar);
 
     String referenceId = progressReport.getReferenceId();
@@ -296,6 +296,10 @@ public class DataAccessRequestService implements ConsentLogger {
       } catch (TemplateException | IOException e) {
         throw new InternalServerErrorException(e);
       }
+    }
+
+    if (!progressReport.getIsCloseoutProgressReport() && !progressReport.getHasDMI()) {
+      ruleService.triggerDACRuleSettings(user, progressReportDatasetIds, referenceId, request);
     }
 
     syncDataAccessRequestDatasets(progressReportDatasetIds, referenceId);

--- a/src/test/java/org/broadinstitute/consent/http/models/DataAccessRequestTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/DataAccessRequestTest.java
@@ -116,6 +116,50 @@ class DataAccessRequestTest {
   }
 
   @Test
+  void testGetHasDMI_NoData() {
+    DataAccessRequest dar = new DataAccessRequest();
+    assertFalse(dar.getHasDMI());
+  }
+
+  @Test
+  void testGetHasDMI_NoDMI() {
+    DataAccessRequest dar = new DataAccessRequest();
+    DataAccessRequestData data = new DataAccessRequestData();
+    dar.setData(data);
+    assertFalse(dar.getHasDMI());
+  }
+
+  @Test
+  void testGetHasDMI_NullIncidents() {
+    DataAccessRequest dar = new DataAccessRequest();
+    DataAccessRequestData data = new DataAccessRequestData();
+    DataManagementIncident dmi = new DataManagementIncident(null, null);
+    data.setDmi(dmi);
+    dar.setData(data);
+    assertFalse(dar.getHasDMI());
+  }
+
+  @Test
+  void testGetHasDMI_EmptyIncidents() {
+    DataAccessRequest dar = new DataAccessRequest();
+    DataAccessRequestData data = new DataAccessRequestData();
+    DataManagementIncident dmi = new DataManagementIncident(List.of(), null);
+    data.setDmi(dmi);
+    dar.setData(data);
+    assertFalse(dar.getHasDMI());
+  }
+
+  @Test
+  void testGetHasDMI_HasIncidents() {
+    DataAccessRequest dar = new DataAccessRequest();
+    DataAccessRequestData data = new DataAccessRequestData();
+    DataManagementIncident dmi = new DataManagementIncident(List.of("Incident 1"), null);
+    data.setDmi(dmi);
+    dar.setData(data);
+    assertTrue(dar.getHasDMI());
+  }
+
+  @Test
   void testValidateCloseoutSupplement_Unset() {
     DataAccessRequest dar = new DataAccessRequest();
     DataAccessRequestData darData = new DataAccessRequestData();

--- a/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceTest.java
@@ -424,12 +424,14 @@ class DataAccessRequestResourceTest extends AbstractTestHelper {
     DataAccessRequest parentDar = generateDataAccessRequest();
     when(dataAccessRequestService.findByReferenceId(any())).thenReturn(parentDar);
     DataAccessRequest childDar = generateDataAccessRequest();
-    when(dataAccessRequestService.createProgressReport(eq(user), any(), eq(parentDar))).thenReturn(
+    when(dataAccessRequestService.createProgressReport(eq(user), any(), eq(parentDar), eq(request))).thenReturn(
         childDar);
+    // datasets retrieved for the compliance logger
+    when(datasetService.findDatasetsByIds(childDar.getDatasetIds())).thenReturn(List.of());
     Pair<InputStream, FormDataContentDisposition> collabFile = mockFormDataMultiPart("collab.txt");
     Pair<InputStream, FormDataContentDisposition> ethicsFile = mockFormDataMultiPart("ethics.txt");
 
-    try (var response = resource.postProgressReport(authUser, "", "", collabFile.getLeft(),
+    try (var response = resource.postProgressReport(authUser, request, "", "", collabFile.getLeft(),
         collabFile.getRight(), ethicsFile.getLeft(), ethicsFile.getRight())) {
       assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
     }
@@ -444,7 +446,7 @@ class DataAccessRequestResourceTest extends AbstractTestHelper {
     Pair<InputStream, FormDataContentDisposition> collabFile = mockFormDataMultiPart("collab.txt");
     Pair<InputStream, FormDataContentDisposition> ethicsFile = mockFormDataMultiPart("ethics.txt");
 
-    Response response = resource.postProgressReport(authUser, "", "", collabFile.getLeft(),
+    Response response = resource.postProgressReport(authUser, request,"", "", collabFile.getLeft(),
         collabFile.getRight(), ethicsFile.getLeft(), ethicsFile.getRight());
     assertEquals(HttpStatusCodes.STATUS_CODE_FORBIDDEN, response.getStatus());
   }
@@ -456,7 +458,7 @@ class DataAccessRequestResourceTest extends AbstractTestHelper {
     Pair<InputStream, FormDataContentDisposition> collabFile = mockFormDataMultiPart("collab.txt");
     Pair<InputStream, FormDataContentDisposition> ethicsFile = mockFormDataMultiPart("ethics.txt");
 
-    try (var response = resource.postProgressReport(authUser, "", "", collabFile.getLeft(),
+    try (var response = resource.postProgressReport(authUser, request,"", "", collabFile.getLeft(),
         collabFile.getRight(), ethicsFile.getLeft(), ethicsFile.getRight())) {
       assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
     }
@@ -471,7 +473,7 @@ class DataAccessRequestResourceTest extends AbstractTestHelper {
     var collabFile = mockFormDataMultiPart("collab.txt");
     var ethicsFile = mockFormDataMultiPart("ethics.txt");
 
-    try (var response = resource.postProgressReport(authUser, "", invalidDar,
+    try (var response = resource.postProgressReport(authUser, request,"", invalidDar,
         collabFile.getLeft(), collabFile.getRight(), ethicsFile.getLeft(), ethicsFile.getRight())) {
       assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
       assertTrue(response.getEntity().toString().contains("Unable to parse DAR from JSON string"));
@@ -483,7 +485,7 @@ class DataAccessRequestResourceTest extends AbstractTestHelper {
     when(userService.findUserByEmail(user.getEmail())).thenReturn(user);
     doThrow(BadRequestException.class).when(userService).validateActiveERACredentials(user);
 
-    try (var response = resource.postProgressReport(authUser, "", "",
+    try (var response = resource.postProgressReport(authUser, request,"", "",
         null, null, null, null)) {
       assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
     }
@@ -502,7 +504,7 @@ class DataAccessRequestResourceTest extends AbstractTestHelper {
     var collabFile = mockFormDataMultiPart("collab.txt");
     var ethicsFile = mockFormDataMultiPart("ethics.txt");
 
-    try (var response = resource.postProgressReport(authUser, "", "",
+    try (var response = resource.postProgressReport(authUser, request,"", "",
         collabFile.getLeft(), collabFile.getRight(), ethicsFile.getLeft(), ethicsFile.getRight())) {
       assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
       assertTrue(response.getEntity().toString().contains("Cannot create a progress report for a DAR with an open election"));

--- a/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
@@ -16,6 +16,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -282,12 +283,13 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     when(dataAccessRequestDAO.findByReferenceId(progressReport.getReferenceId())).thenReturn(progressReport);
     when(dataAccessRequestDAO.findDatasetApprovalsByDar(parentDar.getReferenceId())).thenReturn(
         Set.copyOf(progressReport.getDatasetIds()));
-    DataAccessRequest newDar = service.createProgressReport(user, progressReport, parentDar);
+    DataAccessRequest newDar = service.createProgressReport(user, progressReport, parentDar, request);
     assertNotNull(newDar);
     verify(dataAccessRequestDAO)
         .insertProgressReport(parentDar.getId(), progressReport.getCollectionId(),
             progressReport.getReferenceId(), user.getUserId(),
             progressReport.getData(), user.getEraCommonsId());
+    verify(ruleService).triggerDACRuleSettings(user, progressReport.getDatasetIds(), progressReport.getReferenceId(), request);
     verify(dataAccessRequestDAO).insertAllDarDatasets(
         argThat(new DarDatasetMatcher(progressReport)));
   }
@@ -315,7 +317,7 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     when(dataAccessRequestDAO.findDatasetApprovalsByDar(parentDar.getReferenceId()))
         .thenReturn(Set.copyOf(progressReport.getDatasetIds()));
 
-    DataAccessRequest newDar = service.createProgressReport(user, progressReport, parentDar);
+    DataAccessRequest newDar = service.createProgressReport(user, progressReport, parentDar, request);
 
     assertNotNull(newDar);
     verify(emailService)
@@ -332,6 +334,7 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
             user.getUserId(),
             progressReport.getData(),
             user.getEraCommonsId());
+    verify(ruleService, never()).triggerDACRuleSettings(any(), any(), any(), any());
     verify(dataAccessRequestDAO)
         .insertAllDarDatasets(argThat(new DarDatasetMatcher(progressReport)));
   }
@@ -346,7 +349,7 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     User user = createUserWithPrerequisites();
     parentDar.setUserId(user.getUserId());
     when(dataAccessRequestDAO.findDatasetApprovalsByDar(parentDar.getReferenceId())).thenReturn(Set.of());
-    assertThrows(BadRequestException.class, () -> service.createProgressReport(user, progressReport, parentDar));
+    assertThrows(BadRequestException.class, () -> service.createProgressReport(user, progressReport, parentDar, request));
   }
 
   @Test
@@ -369,7 +372,7 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
             user.getUserId(),
             progressReport.data,
             user.getEraCommonsId());
-    assertThrows(BadRequestException.class, () -> service.createProgressReport(user, progressReport, parentDar));
+    assertThrows(BadRequestException.class, () -> service.createProgressReport(user, progressReport, parentDar, request));
   }
 
   private User createRequestingUser() {


### PR DESCRIPTION
### Addresses
1. https://broadworkbench.atlassian.net/browse/DT-1983
2. And additional fix: adding compliance logging for Progress Report Submission. Continuing the work done here: https://github.com/DataBiosphere/consent/pull/2497

### Summary
1. add call to radar for progress reports in service layer 
-  only if the PR is not a closeout nor a DMI
- Updates tests to check for ruleService call
2. add compliance logging for progress report submission
- Updates tests 

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
