### PR TITLE
DT-2052, DT-2054: Move test only method to test helper

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/VoteDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/VoteDAO.java
@@ -57,18 +57,6 @@ public interface VoteDAO extends Transactional<VoteDAO> {
   @SqlUpdate("DELETE FROM vote v WHERE electionId IN (SELECT election_id FROM election WHERE reference_id IN (<referenceIds>)) ")
   void deleteVotesByReferenceIds(@BindList(value = "referenceIds", onEmpty = EmptyHandling.NULL_STRING) List<String> referenceIds);
 
-
-  @SqlUpdate("update vote set vote = :vote, updateDate = :updateDate, rationale = :rationale, reminderSent = :reminderSent, createDate = :createDate, has_concerns = :hasConcerns where voteId = :voteId")
-  void updateVote(@Bind("vote") Boolean vote,
-      @Bind("rationale") String rationale,
-      @Bind("updateDate") Date updateDate,
-      @Bind("voteId") Integer voteId,
-      @Bind("reminderSent") boolean reminder,
-      @Bind("electionId") Integer electionId,
-      @Bind("createDate") Date createDate,
-      @Bind("hasConcerns") Boolean hasConcerns);
-
-
   @SqlUpdate("update vote set reminderSent = :reminderSent where voteId = :voteId")
   void updateVoteReminderFlag(@Bind("voteId") Integer voteId,
       @Bind("reminderSent") boolean reminderSent);

--- a/src/main/java/org/broadinstitute/consent/http/db/VoteDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/VoteDAO.java
@@ -1,6 +1,5 @@
 package org.broadinstitute.consent.http.db;
 
-import java.util.Date;
 import java.util.List;
 import org.broadinstitute.consent.http.db.mapper.VoteMapper;
 import org.broadinstitute.consent.http.models.User;

--- a/src/main/java/org/broadinstitute/consent/http/db/VoteDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/VoteDAO.java
@@ -44,7 +44,7 @@ public interface VoteDAO extends Transactional<VoteDAO> {
   Integer checkVoteById(@Bind("referenceId") String referenceId,
       @Bind("voteId") Integer voteId);
 
-  @SqlUpdate("insert into vote (user_id, electionId, type, reminderSent) values (:userId, :electionId, :type, false)")
+  @SqlUpdate("INSERT INTO vote (user_id, electionid, type, remindersent, createdate) VALUES (:userId, :electionId, :type, false, current_timestamp)")
   @GetGeneratedKeys
   Integer insertVote(@Bind("userId") Integer userId,
       @Bind("electionId") Integer electionId,

--- a/src/main/java/org/broadinstitute/consent/http/service/dao/DarCollectionServiceDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/dao/DarCollectionServiceDAO.java
@@ -49,7 +49,6 @@ public class DarCollectionServiceDAO {
    */
   public List<String> createElectionsForDarByUser(User user, DataAccessRequest dar)
       throws SQLException {
-    final Date now = new Date();
     boolean isAdmin = user.hasUserRole(UserRoles.ADMIN);
     List<String> createdElectionReferenceIds = new ArrayList<>();
     // If the user is not an admin, we need to know what datasets they have access to.
@@ -97,20 +96,20 @@ public class DarCollectionServiceDAO {
                     .stream().map(Election::getElectionId)
                     .toList();
                 if (!oldElectionIds.isEmpty()) {
-                  electionDAO.archiveElectionByIds(oldElectionIds, now);
+                  electionDAO.archiveElectionByIds(oldElectionIds, new Date());
                 }
                 List<User> voteUsers = findVoteUsersForDataset(datasetId);
                 inserts.add(createElectionInsert(handle, ElectionType.DATA_ACCESS.getValue(),
-                    dar.getReferenceId(), now, datasetId));
+                    dar.getReferenceId(), datasetId));
                 inserts.addAll(createVoteInsertsForUsers(handle, voteUsers,
-                    ElectionType.DATA_ACCESS.getValue(), dar.getReferenceId(), datasetId, now,
+                    ElectionType.DATA_ACCESS.getValue(), dar.getReferenceId(), datasetId,
                     dar.requiresManualReview()));
                 inserts.add(
                     createElectionInsert(handle, ElectionType.RP.getValue(), dar.getReferenceId(),
-                        now, datasetId));
+                        datasetId));
                 inserts.addAll(
                     createVoteInsertsForUsers(handle, voteUsers, ElectionType.RP.getValue(),
-                        dar.getReferenceId(), datasetId, now,
+                        dar.getReferenceId(), datasetId,
                         dar.requiresManualReview()));
                 createdElectionReferenceIds.add(dar.getReferenceId());
               }
@@ -122,26 +121,25 @@ public class DarCollectionServiceDAO {
   }
 
   private List<Update> createVoteInsertsForUsers(Handle handle, List<User> voteUsers,
-      String electionType, String referenceId, Integer datasetId, Date now,
-      Boolean isManualReview) {
+      String electionType, String referenceId, Integer datasetId, Boolean isManualReview) {
     List<Update> userVotes = new ArrayList<>();
     voteUsers.forEach(
         u -> {
           // All users get a minimum of one DAC vote type for both RP and DataAccess election types
           userVotes.add(createVoteInsert(handle, VoteType.DAC.getValue(), electionType, referenceId,
-              datasetId, now, u.getUserId()));
+              datasetId, u.getUserId()));
           // Chairpersons get a Chairperson vote for both RP and DataAccess election types
           if (u.hasUserRole(UserRoles.CHAIRPERSON)) {
             userVotes.add(
                 createVoteInsert(handle, VoteType.CHAIRPERSON.getValue(), electionType, referenceId,
-                    datasetId, now, u.getUserId()));
+                    datasetId, u.getUserId()));
             // Chairpersons get Final and Agreement votes for DataAccess elections
             if (ElectionType.DATA_ACCESS.getValue().equals(electionType)) {
               userVotes.add(createVoteInsert(handle, VoteType.FINAL.getValue(),
-                  ElectionType.DATA_ACCESS.getValue(), referenceId, datasetId, now, u.getUserId()));
+                  ElectionType.DATA_ACCESS.getValue(), referenceId, datasetId, u.getUserId()));
               if (!isManualReview) {
                 userVotes.add(createVoteInsert(handle, VoteType.AGREEMENT.getValue(),
-                    ElectionType.DATA_ACCESS.getValue(), referenceId, datasetId, now,
+                    ElectionType.DATA_ACCESS.getValue(), referenceId, datasetId,
                     u.getUserId()));
               }
             }
@@ -151,10 +149,10 @@ public class DarCollectionServiceDAO {
   }
 
   private Update createVoteInsert(Handle handle, String voteType, String electionType,
-      String referenceId, Integer datasetId, Date now, Integer userId) {
+      String referenceId, Integer datasetId, Integer userId) {
     final String sql =
         " INSERT INTO vote (createdate, user_id, electionid, type, remindersent) "
-            + " (SELECT :createDate, :userId, election_id, :voteType, false "
+            + " (SELECT current_timestamp, :userId, election_id, :voteType, false "
             + "  FROM election "
             + "  WHERE election_type = :electionType "
             + "  AND reference_id = :referenceId "
@@ -162,7 +160,6 @@ public class DarCollectionServiceDAO {
             + "  ORDER BY create_date desc "
             + "  LIMIT 1) ";
     Update insert = handle.createUpdate(sql);
-    insert.bind("createDate", now);
     insert.bind("userId", userId);
     insert.bind("voteType", voteType);
     insert.bind("electionType", electionType);
@@ -182,11 +179,11 @@ public class DarCollectionServiceDAO {
   }
 
   private Update createElectionInsert(
-      Handle handle, String electionType, String referenceId, Date now, Integer datasetId) {
+      Handle handle, String electionType, String referenceId, Integer datasetId) {
     final String sql =
         " INSERT INTO election "
             + "        (election_type, status, create_date, reference_id, dataset_id, version) "
-            + " VALUES (:electionType, :status, :createDate, :referenceId, :datasetId, "
+            + " VALUES (:electionType, :status, current_timestamp, :referenceId, :datasetId, "
             + "         (SELECT coalesce (MAX(version), 0) + 1 "
             + "          FROM election AS election_version "
             + "          WHERE reference_id = :referenceId "
@@ -196,7 +193,6 @@ public class DarCollectionServiceDAO {
     Update insert = handle.createUpdate(sql);
     insert.bind("electionType", electionType);
     insert.bind("referenceId", referenceId);
-    insert.bind("createDate", now);
     insert.bind("datasetId", datasetId);
     insert.bind("status", ElectionStatus.OPEN.getValue());
     return insert;

--- a/src/main/resources/changelog-master.xml
+++ b/src/main/resources/changelog-master.xml
@@ -196,4 +196,6 @@
     relativeToChangelogFile="true" />
   <include file="changesets/changelog-consent-2025-07-23-vote-type-election-type-indices.xml"
     relativeToChangelogFile="true" />
+  <include file="changesets/changelog-consent-2025-07-31-vote-create-date-index.xml"
+    relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/src/main/resources/changesets/changelog-consent-2025-07-31-vote-create-date-index.xml
+++ b/src/main/resources/changesets/changelog-consent-2025-07-31-vote-create-date-index.xml
@@ -1,0 +1,9 @@
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+  <changeSet id="changelog-consent-2025-07-31-vote-create-date-index" author="grushton">
+    <createIndex tableName="vote" indexName="idx_vote_create_date">
+      <column name="createdate"/>
+    </createIndex>
+  </changeSet>
+</databaseChangeLog>

--- a/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
@@ -263,7 +263,7 @@ public class DAOTestHelper extends AbstractTestHelper implements TestExecutionLi
     jdbi.useHandle(handle -> {
       String sql = """
               UPDATE vote
-              SET vote = :vote, updateDate = :updateDate, rationale = :rationale, reminderSent = :reminderSent, createDate = :createDate, has_concerns = :hasConcerns
+              SET vote = :vote, updatedate = :updateDate, rationale = :rationale, remindersent = :reminderSent, createdate = :createDate, has_concerns = :hasConcerns
               WHERE voteId = :voteId
           """;
       handle.createUpdate(sql)

--- a/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
@@ -28,8 +28,6 @@ import org.jdbi.v3.gson2.Gson2Config;
 import org.jdbi.v3.gson2.Gson2Plugin;
 import org.jdbi.v3.guava.GuavaPlugin;
 import org.jdbi.v3.sqlobject.SqlObjectPlugin;
-import org.jdbi.v3.sqlobject.customizer.Bind;
-import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.platform.launcher.TestExecutionListener;
 import org.junit.platform.launcher.TestPlan;
@@ -260,17 +258,13 @@ public class DAOTestHelper extends AbstractTestHelper implements TestExecutionLi
     return institutionDAO.findInstitutionById(user.getInstitutionId());
   }
 
-  protected void updateVote(@Bind("vote") Boolean vote,
-      @Bind("rationale") String rationale,
-      @Bind("updateDate") Date updateDate,
-      @Bind("voteId") Integer voteId,
-      @Bind("reminderSent") boolean reminder,
-      @Bind("electionId") Integer electionId,
-      @Bind("createDate") Date createDate,
-      @Bind("hasConcerns") Boolean hasConcerns) {
+  protected void updateVote(Boolean vote, String rationale, Date updateDate, Integer voteId,
+      boolean reminder, Integer electionId, Date createDate, Boolean hasConcerns) {
     jdbi.useHandle(handle -> {
       String sql = """
-          update vote set vote = :vote, updateDate = :updateDate, rationale = :rationale, reminderSent = :reminderSent, createDate = :createDate, has_concerns = :hasConcerns where voteId = :voteId
+              UPDATE vote
+              SET vote = :vote, updateDate = :updateDate, rationale = :rationale, reminderSent = :reminderSent, createDate = :createDate, has_concerns = :hasConcerns
+              WHERE voteId = :voteId
           """;
       handle.createUpdate(sql)
           .bind("vote", vote)

--- a/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
@@ -28,6 +28,8 @@ import org.jdbi.v3.gson2.Gson2Config;
 import org.jdbi.v3.gson2.Gson2Plugin;
 import org.jdbi.v3.guava.GuavaPlugin;
 import org.jdbi.v3.sqlobject.SqlObjectPlugin;
+import org.jdbi.v3.sqlobject.customizer.Bind;
+import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.platform.launcher.TestExecutionListener;
 import org.junit.platform.launcher.TestPlan;
@@ -257,4 +259,30 @@ public class DAOTestHelper extends AbstractTestHelper implements TestExecutionLi
   protected Institution getUserInstitution(User user) {
     return institutionDAO.findInstitutionById(user.getInstitutionId());
   }
+
+  protected void updateVote(@Bind("vote") Boolean vote,
+      @Bind("rationale") String rationale,
+      @Bind("updateDate") Date updateDate,
+      @Bind("voteId") Integer voteId,
+      @Bind("reminderSent") boolean reminder,
+      @Bind("electionId") Integer electionId,
+      @Bind("createDate") Date createDate,
+      @Bind("hasConcerns") Boolean hasConcerns) {
+    jdbi.useHandle(handle -> {
+      String sql = """
+          update vote set vote = :vote, updateDate = :updateDate, rationale = :rationale, reminderSent = :reminderSent, createDate = :createDate, has_concerns = :hasConcerns where voteId = :voteId
+          """;
+      handle.createUpdate(sql)
+          .bind("vote", vote)
+          .bind("rationale", rationale)
+          .bind("updateDate", updateDate)
+          .bind("voteId", voteId)
+          .bind("reminderSent", reminder)
+          .bind("electionId", electionId)
+          .bind("createDate", createDate)
+          .bind("hasConcerns", hasConcerns)
+          .execute();
+    });
+  }
+
 }

--- a/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
@@ -501,7 +501,7 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
     Election e1 = createDataAccessElection(testDar1.getReferenceId(), dataset1.getDatasetId());
     Vote v1 = createFinalVote(dataset1.getCreateUserId(), e1.getElectionId());
     Date now = new Date();
-    voteDAO.updateVote(true,
+    updateVote(true,
         "",
         now,
         v1.getVoteId(),
@@ -513,7 +513,7 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
     Election e2 = createDataAccessElection(testDar2.getReferenceId(), dataset2.getDatasetId());
     Vote v2 = createVote(dataset2.getCreateUserId(), e2.getElectionId(), VoteType.RADAR_APPROVE);
     now = new Date();
-    voteDAO.updateVote(true,
+    updateVote(true,
         "",
         now,
         v2.getVoteId(),
@@ -570,7 +570,7 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
     Election e1 = createDataAccessElection(testDar1.getReferenceId(), dataset1.getDatasetId());
     Vote v1 = createFinalVote(dataset1.getCreateUserId(), e1.getElectionId());
     Date now = new Date();
-    voteDAO.updateVote(true,
+    updateVote(true,
         "",
         now,
         v1.getVoteId(),
@@ -582,7 +582,7 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
     Election e2 = createDataAccessElection(testDar2.getReferenceId(), dataset2.getDatasetId());
     Vote v2 = createFinalVote(dataset2.getCreateUserId(), e2.getElectionId());
     now = new Date();
-    voteDAO.updateVote(true,
+    updateVote(true,
         "",
         now,
         v2.getVoteId(),
@@ -607,7 +607,7 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
     Election e3 = createDataAccessElection(testDar3.getReferenceId(), dataset2.getDatasetId());
     Vote v3 = createFinalVote(dataset2.getCreateUserId(), e3.getElectionId());
     now = new Date();
-    voteDAO.updateVote(true,
+    updateVote(true,
         "",
         now,
         v3.getVoteId(),
@@ -652,7 +652,7 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
         dataAccessRequestDAO.findDatasetApprovalsByDar(testDar1.getReferenceId())
             .isEmpty());
 
-    voteDAO.updateVote(true,
+    updateVote(true,
         "",
         now,
         v1.getVoteId(),
@@ -666,7 +666,7 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
     assertEquals(1, approvedDatasetIds.size());
     assertTrue(approvedDatasetIds.contains(dataset1.getDatasetId()));
 
-    voteDAO.updateVote(true,
+    updateVote(true,
         "",
         now,
         v2.getVoteId(),
@@ -682,7 +682,7 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
     assertTrue(approvedDatasetIds.contains(dataset2.getDatasetId()));
 
 
-    voteDAO.updateVote(false,
+    updateVote(false,
         "",
         now,
         v3.getVoteId(),
@@ -712,7 +712,7 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
 
     Date now = new Date();
 
-    voteDAO.updateVote(true,
+    updateVote(true,
         "",
         now,
         v1.getVoteId(),
@@ -744,7 +744,7 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
         dataset.getDatasetId());
     Vote vote = createFinalVote(dataset.getCreateUserId(), election.getElectionId());
     Date now = new Date();
-    voteDAO.updateVote(true,
+    updateVote(true,
         "",
         now,
         vote.getVoteId(),
@@ -800,7 +800,7 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
     Election e1 = createDataAccessElection(testDar1.getReferenceId(), dataset1.getDatasetId());
     Vote v1 = createFinalVote(dataset1.getCreateUserId(), e1.getElectionId());
     Date now = new Date();
-    voteDAO.updateVote(true,
+    updateVote(true,
         "",
         now,
         v1.getVoteId(),
@@ -816,7 +816,7 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
     Election e2 = createDataAccessElection(testDar1.getReferenceId(), dataset1.getDatasetId());
     Vote v2 = createFinalVote(dataset1.getCreateUserId(), e2.getElectionId());
     now = new Date();
-    voteDAO.updateVote(false,
+    updateVote(false,
         "",
         now,
         v2.getVoteId(),
@@ -843,7 +843,7 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
     Election e1 = createDataAccessElection(testDar1.getReferenceId(), dataset1.getDatasetId());
     Vote v1 = createFinalVote(dataset1.getCreateUserId(), e1.getElectionId());
     Date now = new Date();
-    voteDAO.updateVote(true,
+    updateVote(true,
         "",
         now,
         v1.getVoteId(),
@@ -873,7 +873,7 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
     Election e1 = createDataAccessElection(testDar1.getReferenceId(), dataset1.getDatasetId());
     Vote v1 = createFinalVote(dataset1.getCreateUserId(), e1.getElectionId());
     Date now = new Date();
-    voteDAO.updateVote(true,
+    updateVote(true,
         "",
         now,
         v1.getVoteId(),
@@ -905,7 +905,7 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
         dataset.getDatasetId());
     Vote vote = createFinalVote(dataset.getCreateUserId(), election.getElectionId());
     Date now = new Date();
-    voteDAO.updateVote(true,
+    updateVote(true,
         "",
         now,
         vote.getVoteId(),

--- a/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
@@ -1036,7 +1036,7 @@ class DatasetDAOTest extends DAOTestHelper {
         dataset1.getDatasetId()
     );
     Integer voteId1 = voteDAO.insertVote(chairperson1.getUserId(), electionId1, VoteType.FINAL.getValue());
-    voteDAO.updateVote(true, "rationale", yesterday, voteId1, false, electionId1, yesterday, false);
+    updateVote(true, "rationale", yesterday, voteId1, false, electionId1, yesterday, false);
     electionDAO.updateElectionById(electionId1, ElectionStatus.CLOSED.getValue(), yesterday);
     List<ApprovedDataset> approvedDatasets = datasetDAO.getApprovedDatasets(user.getUserId());
     assertEquals(1, approvedDatasets.size());
@@ -1051,7 +1051,7 @@ class DatasetDAOTest extends DAOTestHelper {
         dataset2.getDatasetId()
     );
     Integer voteId2 = voteDAO.insertVote(chairperson1.getUserId(), electionId2, VoteType.FINAL.getValue());
-    voteDAO.updateVote(true, "rationale", yesterday, voteId2, false, electionId1, yesterday, false);
+    updateVote(true, "rationale", yesterday, voteId2, false, electionId1, yesterday, false);
     electionDAO.updateElectionById(electionId2, ElectionStatus.CLOSED.getValue(), yesterday);
     assertEquals(2, datasetDAO.getApprovedDatasets(user.getUserId()).size());
 
@@ -1065,7 +1065,7 @@ class DatasetDAOTest extends DAOTestHelper {
         dataset3.getDatasetId()
     );
     Integer voteId3 = voteDAO.insertVote(chairperson2.getUserId(), electionId3, VoteType.FINAL.getValue());
-    voteDAO.updateVote(true, "rationale", today, voteId3, false, electionId3, today, false);
+    updateVote(true, "rationale", today, voteId3, false, electionId3, today, false);
     electionDAO.updateElectionById(electionId3, ElectionStatus.CLOSED.getValue(), today);
     assertEquals(3, datasetDAO.getApprovedDatasets(user.getUserId()).size());
 
@@ -1077,7 +1077,7 @@ class DatasetDAOTest extends DAOTestHelper {
         dataset4.getDatasetId()
     );
     Integer voteId4 = voteDAO.insertVote(chairperson2.getUserId(), electionId4, VoteType.FINAL.getValue());
-    voteDAO.updateVote(true, "rationale", today, voteId4, false, electionId4, today, false);
+    updateVote(true, "rationale", today, voteId4, false, electionId4, today, false);
     electionDAO.updateElectionById(electionId4, ElectionStatus.CLOSED.getValue(), today);
 
     List<ApprovedDataset> approvedDatasets2 = datasetDAO.getApprovedDatasets(user.getUserId());
@@ -1116,7 +1116,7 @@ class DatasetDAOTest extends DAOTestHelper {
         dataset3.getDatasetId()
     );
     Integer voteId5 = voteDAO.insertVote(chairperson2.getUserId(), electionId5, VoteType.FINAL.getValue());
-    voteDAO.updateVote(true, "rationale", today, voteId5, false, electionId5, today, false);
+    updateVote(true, "rationale", today, voteId5, false, electionId5, today, false);
     electionDAO.updateElectionById(electionId5, ElectionStatus.CLOSED.getValue(), today);
     List<ApprovedDataset> approvedDatasets5 = datasetDAO.getApprovedDatasets(user.getUserId());
     assertEquals(1, approvedDatasets5.size());
@@ -1131,7 +1131,7 @@ class DatasetDAOTest extends DAOTestHelper {
     );
     Integer voteId6 = voteDAO.insertVote(chairperson2.getUserId(), electionId6, VoteType.FINAL.getValue());
     // vote no on dataset 4
-    voteDAO.updateVote(false, "rationale", today, voteId6, false, electionId6, today, false);
+    updateVote(false, "rationale", today, voteId6, false, electionId6, today, false);
     electionDAO.updateElectionById(electionId6, ElectionStatus.CLOSED.getValue(), today);
 
     List<ApprovedDataset> approvedDatasets6 = datasetDAO.getApprovedDatasets(user.getUserId());
@@ -1154,7 +1154,7 @@ class DatasetDAOTest extends DAOTestHelper {
         dataset3.getDatasetId()
     );
     Integer voteId7 = voteDAO.insertVote(chairperson2.getUserId(), electionId7, VoteType.FINAL.getValue());
-    voteDAO.updateVote(false, "rationale", today, voteId7, false, electionId7, today, false);
+    updateVote(false, "rationale", today, voteId7, false, electionId7, today, false);
     electionDAO.updateElectionById(electionId7, ElectionStatus.CLOSED.getValue(), today);
     assertEquals(0, datasetDAO.getApprovedDatasets(user.getUserId()).size());
 
@@ -1435,7 +1435,7 @@ class DatasetDAOTest extends DAOTestHelper {
         datasetId
     );
     Integer voteId = voteDAO.insertVote(userId, electionId, voteType.getValue());
-    voteDAO.updateVote(finalVoteApproval, "rationale", new Date(), voteId, false, electionId,
+    updateVote(finalVoteApproval, "rationale", new Date(), voteId, false, electionId,
         new Date(), false);
     electionDAO.updateElectionById(electionId, ElectionStatus.CLOSED.getValue(), new Date());
     datasetDAO.updateDatasetApproval(finalVoteApproval, Instant.now(), userId, datasetId);

--- a/src/test/java/org/broadinstitute/consent/http/db/ElectionDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/ElectionDAOTest.java
@@ -26,7 +26,6 @@ import org.broadinstitute.consent.http.models.Dataset;
 import org.broadinstitute.consent.http.models.DatasetEntry;
 import org.broadinstitute.consent.http.models.DatasetProperty;
 import org.broadinstitute.consent.http.models.Election;
-import org.broadinstitute.consent.http.models.LibraryCard;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.Vote;
 import org.junit.jupiter.api.Test;
@@ -254,7 +253,7 @@ class ElectionDAOTest extends DAOTestHelper {
     Election e = createDataAccessElection(dar.getReferenceId(), d.getDatasetId());
     Integer voteId = voteDAO.insertVote(u.getUserId(), e.getElectionId(),
         VoteType.FINAL.getValue());
-    voteDAO.updateVote(true, "rationale", new Date(), voteId, false, e.getElectionId(), new Date(),
+    updateVote(true, "rationale", new Date(), voteId, false, e.getElectionId(), new Date(),
         false);
     Vote v = voteDAO.findVoteById(voteId);
 
@@ -692,7 +691,7 @@ class ElectionDAOTest extends DAOTestHelper {
 
   private Vote createPopulatedChairpersonVote(Integer userId, Integer electionId) {
     Integer voteId = voteDAO.insertVote(userId, electionId, VoteType.CHAIRPERSON.getValue());
-    voteDAO.updateVote(true, "rationale", new Date(), voteId, false, electionId, new Date(), false);
+    updateVote(true, "rationale", new Date(), voteId, false, electionId, new Date(), false);
     return voteDAO.findVoteById(voteId);
   }
 
@@ -767,15 +766,15 @@ class ElectionDAOTest extends DAOTestHelper {
     datasetDAO.insertDatasetProperties(list);
   }
 
-  private LibraryCard createLibraryCard(User user) {
+  private void createLibraryCard(User user) {
     Integer id = libraryCardDAO.insertLibraryCard(user.getUserId(),
         user.getDisplayName(), user.getEmail(), user.getUserId(), new Date());
-    return libraryCardDAO.findLibraryCardById(id);
+    libraryCardDAO.findLibraryCardById(id);
   }
 
-  private Vote createFinalVote(Integer userId, Integer electionId) {
+  private void createFinalVote(Integer userId, Integer electionId) {
     Integer voteId = voteDAO.insertVote(userId, electionId, VoteType.FINAL.getValue());
-    return voteDAO.findVoteById(voteId);
+    voteDAO.findVoteById(voteId);
   }
 
   private Dataset createDatasetWithDac(Integer dacId) {

--- a/src/test/java/org/broadinstitute/consent/http/db/VoteDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/VoteDAOTest.java
@@ -50,6 +50,10 @@ class VoteDAOTest extends DAOTestHelper {
 
     Vote foundVote = voteDAO.findVoteById(vote.getVoteId());
     assertNotNull(foundVote);
+    assertNotNull(foundVote.getCreateDate());
+    assertEquals(user.getUserId(), foundVote.getUserId());
+    assertEquals(election.getElectionId(), foundVote.getElectionId());
+    assertEquals(VoteType.DAC.getValue(), foundVote.getType());
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/db/VoteDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/VoteDAOTest.java
@@ -14,8 +14,6 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
-import org.apache.commons.lang3.RandomStringUtils;
-import org.apache.commons.lang3.RandomUtils;
 import org.broadinstitute.consent.http.enumeration.ElectionStatus;
 import org.broadinstitute.consent.http.enumeration.ElectionType;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
@@ -43,9 +41,9 @@ class VoteDAOTest extends DAOTestHelper {
     User user = createUserWithRole(UserRoles.CHAIRPERSON.getRoleId());
     Dataset dataset = createDataset();
     String darCode = "DAR-1234567890";
-    Integer collection_id = darCollectionDAO.insertDarCollection(darCode, user.getUserId(),
+    Integer collectionId = darCollectionDAO.insertDarCollection(darCode, user.getUserId(),
         new Date());
-    DataAccessRequest dar = createDataAccessRequestWithDatasetAndCollectionInfo(collection_id,
+    DataAccessRequest dar = createDataAccessRequestWithDatasetAndCollectionInfo(collectionId,
         dataset.getDatasetId(), user.getUserId());
     Election election = createDataAccessElection(dar.getReferenceId(), dataset.getDatasetId());
     Vote vote = createDacVote(user.getUserId(), election.getElectionId());
@@ -62,9 +60,9 @@ class VoteDAOTest extends DAOTestHelper {
     User user4 = createUserWithRole(UserRoles.MEMBER.getRoleId());
     Dataset dataset = createDataset();
     String darCode = "DAR-1234567890";
-    Integer collection_id = darCollectionDAO.insertDarCollection(darCode, user.getUserId(),
+    Integer collectionId = darCollectionDAO.insertDarCollection(darCode, user.getUserId(),
         new Date());
-    DataAccessRequest dar = createDataAccessRequestWithDatasetAndCollectionInfo(collection_id,
+    DataAccessRequest dar = createDataAccessRequestWithDatasetAndCollectionInfo(collectionId,
         dataset.getDatasetId(), user.getUserId());
     Election election = createDataAccessElection(dar.getReferenceId(), dataset.getDatasetId());
     Vote vote = createDacVote(user.getUserId(), election.getElectionId());
@@ -86,18 +84,18 @@ class VoteDAOTest extends DAOTestHelper {
     User user = createUserWithRole(UserRoles.CHAIRPERSON.getRoleId());
     Dataset dataset = createDataset();
     String darCode = "DAR-12345";
-    Integer collection_id = darCollectionDAO.insertDarCollection(darCode, user.getUserId(),
+    Integer collectionId = darCollectionDAO.insertDarCollection(darCode, user.getUserId(),
         new Date());
-    DataAccessRequest dar = createDataAccessRequestWithDatasetAndCollectionInfo(collection_id,
+    DataAccessRequest dar = createDataAccessRequestWithDatasetAndCollectionInfo(collectionId,
         dataset.getDatasetId(), user.getUserId());
     Election election = createDataAccessElection(dar.getReferenceId(), dataset.getDatasetId());
     createDacVote(user.getUserId(), election.getElectionId());
 
     Dataset dataset2 = createDataset();
     String darCode2 = "DAR-67890";
-    Integer collection_id2 = darCollectionDAO.insertDarCollection(darCode2, user.getUserId(),
+    Integer collectionId2 = darCollectionDAO.insertDarCollection(darCode2, user.getUserId(),
         new Date());
-    DataAccessRequest dar2 = createDataAccessRequestWithDatasetAndCollectionInfo(collection_id2,
+    DataAccessRequest dar2 = createDataAccessRequestWithDatasetAndCollectionInfo(collectionId2,
         dataset.getDatasetId(), user.getUserId());
     Election election2 = createDataAccessElection(dar2.getReferenceId(), dataset2.getDatasetId());
     createDacVote(user.getUserId(), election2.getElectionId());
@@ -114,9 +112,9 @@ class VoteDAOTest extends DAOTestHelper {
     User user = createUserWithRole(UserRoles.CHAIRPERSON.getRoleId());
     Dataset dataset = createDataset();
     String darCode = "DAR-1234567890";
-    Integer collection_id = darCollectionDAO.insertDarCollection(darCode, user.getUserId(),
+    Integer collectionId = darCollectionDAO.insertDarCollection(darCode, user.getUserId(),
         new Date());
-    DataAccessRequest dar = createDataAccessRequestWithDatasetAndCollectionInfo(collection_id,
+    DataAccessRequest dar = createDataAccessRequestWithDatasetAndCollectionInfo(collectionId,
         dataset.getDatasetId(), user.getUserId());
     Election election = createDataAccessElection(dar.getReferenceId(), dataset.getDatasetId());
     Vote vote = createDacVote(user.getUserId(), election.getElectionId());
@@ -145,9 +143,9 @@ class VoteDAOTest extends DAOTestHelper {
     User user = createUserWithRole(UserRoles.CHAIRPERSON.getRoleId());
     Dataset dataset = createDataset();
     String darCode = "DAR-1234567890";
-    Integer collection_id = darCollectionDAO.insertDarCollection(darCode, user.getUserId(),
+    Integer collectionId = darCollectionDAO.insertDarCollection(darCode, user.getUserId(),
         new Date());
-    DataAccessRequest dar = createDataAccessRequestWithDatasetAndCollectionInfo(collection_id,
+    DataAccessRequest dar = createDataAccessRequestWithDatasetAndCollectionInfo(collectionId,
         dataset.getDatasetId(), user.getUserId());
     Election election = createDataAccessElection(dar.getReferenceId(), dataset.getDatasetId());
     Vote vote = createDacVote(user.getUserId(), election.getElectionId());
@@ -163,9 +161,9 @@ class VoteDAOTest extends DAOTestHelper {
     User user = createUserWithRole(UserRoles.CHAIRPERSON.getRoleId());
     Dataset dataset = createDataset();
     String darCode = "DAR-1234567890";
-    Integer collection_id = darCollectionDAO.insertDarCollection(darCode, user.getUserId(),
+    Integer collectionId = darCollectionDAO.insertDarCollection(darCode, user.getUserId(),
         new Date());
-    DataAccessRequest dar = createDataAccessRequestWithDatasetAndCollectionInfo(collection_id,
+    DataAccessRequest dar = createDataAccessRequestWithDatasetAndCollectionInfo(collectionId,
         dataset.getDatasetId(), user.getUserId());
     Election election = createDataAccessElection(dar.getReferenceId(), dataset.getDatasetId());
     Vote vote = createDacVote(user.getUserId(), election.getElectionId());
@@ -176,20 +174,15 @@ class VoteDAOTest extends DAOTestHelper {
   }
 
   @Test
-  void testInsertVote() {
-    // no-op ... tested by `createDacVote` and `createFinalVote`
-  }
-
-  @Test
   void testCreateVote() {
     User user = createUser();
     Dataset dataset = createDataset();
     Dac dac = createDac();
     datasetDAO.updateDatasetDacId(dataset.getDatasetId(), dac.getDacId());
     String darCode = "DAR-1234567890";
-    Integer collection_id = darCollectionDAO.insertDarCollection(darCode, user.getUserId(),
+    Integer collectionId = darCollectionDAO.insertDarCollection(darCode, user.getUserId(),
         new Date());
-    DataAccessRequest dar = createDataAccessRequestWithDatasetAndCollectionInfo(collection_id,
+    DataAccessRequest dar = createDataAccessRequestWithDatasetAndCollectionInfo(collectionId,
         dataset.getDatasetId(), user.getUserId());
     Election election = createDataAccessElection(dar.getReferenceId(), dataset.getDatasetId());
     Vote v = createDacVote(user.getUserId(), election.getElectionId());
@@ -206,30 +199,25 @@ class VoteDAOTest extends DAOTestHelper {
     Dac dac = createDac();
     datasetDAO.updateDatasetDacId(dataset.getDatasetId(), dac.getDacId());
     String darCode = "DAR-1234567890";
-    Integer collection_id = darCollectionDAO.insertDarCollection(darCode, user.getUserId(),
+    Integer collectionId = darCollectionDAO.insertDarCollection(darCode, user.getUserId(),
         new Date());
-    DataAccessRequest dar = createDataAccessRequestWithDatasetAndCollectionInfo(collection_id,
+    DataAccessRequest dar = createDataAccessRequestWithDatasetAndCollectionInfo(collectionId,
         dataset.getDatasetId(), user.getUserId());
     Election election = createDataAccessElection(dar.getReferenceId(), dataset.getDatasetId());
     Vote v = createDacVote(user.getUserId(), election.getElectionId());
 
     String rationale = "rationale";
     Date now = new Date();
-    voteDAO.updateVote(true, rationale, now, v.getVoteId(), true,
+    updateVote(true, rationale, now, v.getVoteId(), true,
         election.getElectionId(), now, true);
     Vote vote = voteDAO.findVoteById(v.getVoteId());
     assertTrue(vote.getVote());
     assertTrue(vote.getHasConcerns());
     assertTrue(vote.getIsReminderSent());
-    assertEquals(vote.getRationale(), rationale);
+    assertEquals(rationale, vote.getRationale());
     SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
     assertEquals(sdf.format(vote.getCreateDate()), sdf.format(now));
     assertEquals(sdf.format(vote.getUpdateDate()), sdf.format(now));
-  }
-
-  @Test
-  void testDeleteVotes() {
-    // No-op ... tested by `tearDown()`
   }
 
   @Test
@@ -239,9 +227,9 @@ class VoteDAOTest extends DAOTestHelper {
     Dac dac = createDac();
     datasetDAO.updateDatasetDacId(dataset.getDatasetId(), dac.getDacId());
     String darCode = "DAR-1234567890";
-    Integer collection_id = darCollectionDAO.insertDarCollection(darCode, user.getUserId(),
+    Integer collectionId = darCollectionDAO.insertDarCollection(darCode, user.getUserId(),
         new Date());
-    DataAccessRequest dar = createDataAccessRequestWithDatasetAndCollectionInfo(collection_id,
+    DataAccessRequest dar = createDataAccessRequestWithDatasetAndCollectionInfo(collectionId,
         dataset.getDatasetId(), user.getUserId());
     Election election = createDataAccessElection(dar.getReferenceId(), dataset.getDatasetId());
     Vote v = createDacVote(user.getUserId(), election.getElectionId());
@@ -261,9 +249,9 @@ class VoteDAOTest extends DAOTestHelper {
     Dac dac = createDac();
     Dataset dataset = createDatasetWithDac(dac.getDacId());
     String darCode = "DAR-1234567890";
-    Integer collection_id = darCollectionDAO.insertDarCollection(darCode, user.getUserId(),
+    Integer collectionId = darCollectionDAO.insertDarCollection(darCode, user.getUserId(),
         new Date());
-    DataAccessRequest dar = createDataAccessRequestWithDatasetAndCollectionInfo(collection_id,
+    DataAccessRequest dar = createDataAccessRequestWithDatasetAndCollectionInfo(collectionId,
         dataset.getDatasetId(), user.getUserId());
     Election election = createDataAccessElection(dar.getReferenceId(), dataset.getDatasetId());
     electionDAO.updateElectionById(
@@ -272,9 +260,9 @@ class VoteDAOTest extends DAOTestHelper {
         new Date());
     Vote v = createFinalVote(user.getUserId(), election.getElectionId());
     boolean voteValue = true;
-    voteDAO.updateVote(
+    updateVote(
         voteValue,
-        RandomStringUtils.randomAlphabetic(10),
+        randomAlphabetic(10),
         new Date(),
         v.getVoteId(),
         false,
@@ -303,9 +291,9 @@ class VoteDAOTest extends DAOTestHelper {
     Dac dac = createDac();
     datasetDAO.updateDatasetDacId(dataset.getDatasetId(), dac.getDacId());
     String darCode = "DAR-1234567890";
-    Integer collection_id = darCollectionDAO.insertDarCollection(darCode, user.getUserId(),
+    Integer collectionId = darCollectionDAO.insertDarCollection(darCode, user.getUserId(),
         new Date());
-    DataAccessRequest dar = createDataAccessRequestWithDatasetAndCollectionInfo(collection_id,
+    DataAccessRequest dar = createDataAccessRequestWithDatasetAndCollectionInfo(collectionId,
         dataset.getDatasetId(), user.getUserId());
     Election election = createDataAccessElection(dar.getReferenceId(), dataset.getDatasetId());
     electionDAO.updateElectionById(
@@ -314,9 +302,9 @@ class VoteDAOTest extends DAOTestHelper {
         new Date());
     Vote v = createDacVote(user.getUserId(), election.getElectionId());
     boolean voteValue = true;
-    voteDAO.updateVote(
+    updateVote(
         voteValue,
-        RandomStringUtils.random(10),
+        randomAlphanumeric(10),
         new Date(),
         v.getVoteId(),
         false,
@@ -340,9 +328,9 @@ class VoteDAOTest extends DAOTestHelper {
     datasetDAO.updateDatasetDacId(dataset.getDatasetId(), dac.getDacId());
     User user4 = createUser();
     String darCode = "DAR-1234567890";
-    Integer collection_id = darCollectionDAO.insertDarCollection(darCode, user4.getUserId(),
+    Integer collectionId = darCollectionDAO.insertDarCollection(darCode, user4.getUserId(),
         new Date());
-    DataAccessRequest dar = createDataAccessRequestWithDatasetAndCollectionInfo(collection_id,
+    DataAccessRequest dar = createDataAccessRequestWithDatasetAndCollectionInfo(collectionId,
         dataset.getDatasetId(), user4.getUserId());
     Election election = createDataAccessElection(dar.getReferenceId(), dataset.getDatasetId());
     List<Integer> userIds = Arrays.asList(user1.getUserId(), user2.getUserId(), user3.getUserId());
@@ -362,9 +350,9 @@ class VoteDAOTest extends DAOTestHelper {
     Dac dac = createDac();
     datasetDAO.updateDatasetDacId(dataset.getDatasetId(), dac.getDacId());
     String darCode = "DAR-1234567890";
-    Integer collection_id = darCollectionDAO.insertDarCollection(darCode, user.getUserId(),
+    Integer collectionId = darCollectionDAO.insertDarCollection(darCode, user.getUserId(),
         new Date());
-    DataAccessRequest dar = createDataAccessRequestWithDatasetAndCollectionInfo(collection_id,
+    DataAccessRequest dar = createDataAccessRequestWithDatasetAndCollectionInfo(collectionId,
         dataset.getDatasetId(), user.getUserId());
     Election election = createDataAccessElection(dar.getReferenceId(), dataset.getDatasetId());
     Vote vote = createDacVote(user.getUserId(), election.getElectionId());
@@ -381,9 +369,9 @@ class VoteDAOTest extends DAOTestHelper {
     Dac dac = createDac();
     datasetDAO.updateDatasetDacId(dataset.getDatasetId(), dac.getDacId());
     String darCode = "DAR-1234567890";
-    Integer collection_id = darCollectionDAO.insertDarCollection(darCode, user.getUserId(),
+    Integer collectionId = darCollectionDAO.insertDarCollection(darCode, user.getUserId(),
         new Date());
-    DataAccessRequest dar = createDataAccessRequestWithDatasetAndCollectionInfo(collection_id,
+    DataAccessRequest dar = createDataAccessRequestWithDatasetAndCollectionInfo(collectionId,
         dataset.getDatasetId(), user.getUserId());
     Election election = createDataAccessElection(dar.getReferenceId(), dataset.getDatasetId());
     createChairpersonVote(user.getUserId(), election.getElectionId());
@@ -403,7 +391,7 @@ class VoteDAOTest extends DAOTestHelper {
     Vote dacVote = createDacVote(user.getUserId(), election.getElectionId());
     assertNull(dacVote.getRationale());
 
-    String rationale = RandomStringUtils.random(10, true, false);
+    String rationale = randomAlphabetic(10);
     voteDAO.updateRationaleByVoteIds(List.of(dacVote.getVoteId()), rationale);
 
     Vote updatedVote = voteDAO.findVoteById(dacVote.getVoteId());
@@ -454,14 +442,14 @@ class VoteDAOTest extends DAOTestHelper {
     assertEquals(chair.getUserId(), voteUsers.get(0).getUserId());
   }
 
-  private Vote createChairpersonVote(Integer userId, Integer electionId) {
+  private void createChairpersonVote(Integer userId, Integer electionId) {
     Integer voteId = voteDAO.insertVote(userId, electionId, VoteType.CHAIRPERSON.getValue());
-    return voteDAO.findVoteById(voteId);
+    voteDAO.findVoteById(voteId);
   }
 
   private DarCollection createDarCollectionWithDatasets(User user,
       List<Dataset> datasets) {
-    String darCode = "DAR-" + RandomUtils.nextInt(100, 1000);
+    String darCode = "DAR-" + randomInt(100, 1000);
     Integer collectionId = darCollectionDAO.insertDarCollection(darCode, user.getUserId(),
         new Date());
     datasets
@@ -480,8 +468,8 @@ class VoteDAOTest extends DAOTestHelper {
   private DataAccessRequest createDataAccessRequestWithDatasetAndCollectionInfo(int collectionId,
       int datasetId, int userId) {
     DataAccessRequestData data = new DataAccessRequestData();
-    data.setProjectTitle(RandomStringUtils.randomAlphabetic(10));
-    String referenceId = RandomStringUtils.randomAlphanumeric(20);
+    data.setProjectTitle(randomAlphabetic(10));
+    String referenceId = randomAlphanumeric(20);
     dataAccessRequestDAO.insertDataAccessRequest(collectionId, referenceId, userId, new Date(),
         new Date(), new Date(), new Date(), data, randomAlphabetic(10));
     dataAccessRequestDAO.insertDARDatasetRelation(referenceId, datasetId);
@@ -501,17 +489,17 @@ class VoteDAOTest extends DAOTestHelper {
 
   private Dac createDac() {
     Integer id = dacDAO.createDac(
-        "Test_" + RandomStringUtils.random(20, true, true),
-        "Test_" + RandomStringUtils.random(20, true, true),
+        "Test_" + randomAlphanumeric(20),
+        "Test_" + randomAlphanumeric(20),
         new Date());
     return dacDAO.findById(id);
   }
 
   private Dataset createDataset() {
     User user = createUser();
-    String name = "Name_" + RandomStringUtils.random(20, true, true);
+    String name = "Name_" + randomAlphanumeric(20);
     Timestamp now = new Timestamp(new Date().getTime());
-    String objectId = "Object ID_" + RandomStringUtils.random(20, true, true);
+    String objectId = "Object ID_" + randomAlphanumeric(20);
     DataUse dataUse = new DataUseBuilder().setGeneralUse(true).build();
     Integer id = datasetDAO.insertDataset(name, now, user.getUserId(), objectId,
         dataUse.toString(), null);
@@ -542,9 +530,9 @@ class VoteDAOTest extends DAOTestHelper {
 
   private Dataset createDatasetWithDac(Integer dacId) {
     User user = createUser();
-    String name = "Name_" + RandomStringUtils.random(20, true, true);
+    String name = "Name_" + randomAlphanumeric(20);
     Timestamp now = new Timestamp(new Date().getTime());
-    String objectId = "Object ID_" + RandomStringUtils.random(20, true, true);
+    String objectId = "Object ID_" + randomAlphanumeric(20);
     DataUse dataUse = new DataUseBuilder().setGeneralUse(true).build();
     Integer id = datasetDAO.insertDataset(name, now, user.getUserId(), objectId,
         dataUse.toString(), dacId);


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-2052
https://broadworkbench.atlassian.net/browse/DT-2054

### Summary
* `VoteDAO.updateVote` is only used in tests but is necessary as a helper function. This PR moves it out of application code into test infrastructure.
* Includes some sonarqube cleanup to `VoteDAOTest`
* Drive by cleanup to ensure that vote inserts get a default create date
* Make the same changes in `DarCollectionServiceDAO` to be consistent with `VoteDAO`
* Added index on vote create date so the approved datasets is more efficient
* Addresses an issue where approved datasets query was returning incorrect values due to null vote create dates

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
