### PR TITLE
[DT-2028] Address TODO in DacAutomationRuleResource.

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/models/User.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/User.java
@@ -9,7 +9,6 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 import net.gcardone.junidecode.Junidecode;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -335,7 +334,7 @@ public class User {
     if (Objects.isNull(this.getRoles())) {
       return false;
     } else {
-      return this.getRoles().stream().anyMatch((r) -> r.getRoleId().equals(role.getRoleId()));
+      return this.getRoles().stream().anyMatch(r -> r.getRoleId().equals(role.getRoleId()));
     }
   }
 
@@ -347,20 +346,21 @@ public class User {
     return this.getRoles()
         .stream()
         .map(UserRole::getRoleId)
-        .collect(Collectors.toList());
+        .toList();
   }
 
   @Transient
-  public Boolean checkIfUserHasRole(String roleName, Integer dacId) {
+  public boolean verifyDACRole(String roleName, Integer dacId) {
     UserRoles role = UserRoles.getUserRoleFromName(roleName);
-    List<UserRole> roles = getRoles();
-    List<UserRole> targetRoles = roles.stream()
-        .filter((r) -> {
-          return r.getName().equals(role.getRoleName())
-              && r.getRoleId().equals(role.getRoleId())
-              && Objects.equals(r.getDacId(), dacId);
-        })
-        .collect(Collectors.toList());
+    List<UserRole> currentRoles = getRoles();
+    if (Objects.isNull(currentRoles) || Objects.isNull(role)) {
+      return false;
+    }
+    List<UserRole> targetRoles = currentRoles.stream()
+        .filter(r -> r.getName().equals(role.getRoleName())
+            && r.getRoleId().equals(role.getRoleId())
+            && Objects.equals(r.getDacId(), dacId))
+        .toList();
     return !targetRoles.isEmpty();
 
   }

--- a/src/main/java/org/broadinstitute/consent/http/resources/DACAutomationRuleResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DACAutomationRuleResource.java
@@ -118,7 +118,6 @@ public class DACAutomationRuleResource extends Resource {
   }
 
   private void validateAdminOrChairForDAC(User user, Integer dacId) {
-    //TODO: harmonize this with the logic in the DACResource so we're consistent.
     boolean isAdminOrChair = user.hasUserRole(UserRoles.ADMIN) || isChairOfDAC(user, dacId);
     if (!isAdminOrChair) {
       throw new ForbiddenException("User does not have access to the specified DAC ID");
@@ -143,11 +142,7 @@ public class DACAutomationRuleResource extends Resource {
   }
 
   private boolean isChairOfDAC(User user, Integer dacId) {
-    return Stream.ofNullable(user.getRoles())
-        .flatMap(List::stream)
-        .filter(r -> r.getRoleId().equals(UserRoles.Chairperson().getRoleId()))
-        .map(UserRole::getDacId)
-        .anyMatch(id -> Objects.equals(id, dacId));
+    return user.checkIfUserHasRole(UserRoles.CHAIRPERSON.getRoleName(), dacId);
   }
 
 }

--- a/src/main/java/org/broadinstitute/consent/http/resources/DACAutomationRuleResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DACAutomationRuleResource.java
@@ -118,14 +118,16 @@ public class DACAutomationRuleResource extends Resource {
   }
 
   private void validateAdminOrChairForDAC(User user, Integer dacId) {
-    boolean isAdminOrChair = user.hasUserRole(UserRoles.ADMIN) || isChairOfDAC(user, dacId);
+    boolean isAdminOrChair =
+        user.hasUserRole(UserRoles.ADMIN)
+            || user.checkIfUserHasRole(UserRoles.CHAIRPERSON.getRoleName(), dacId);
     if (!isAdminOrChair) {
       throw new ForbiddenException("User does not have access to the specified DAC ID");
     }
   }
 
   private void validateIsChairOfDAC(User user, Integer dacId) {
-    if (!isChairOfDAC(user, dacId)) {
+    if (Boolean.FALSE.equals(user.checkIfUserHasRole(UserRoles.CHAIRPERSON.getRoleName(), dacId))) {
       throw new ForbiddenException("User does not have access to the specified DAC ID");
     }
   }
@@ -139,10 +141,6 @@ public class DACAutomationRuleResource extends Resource {
       throw new IllegalArgumentException("PageSize must be less than or equal to 100");
     }
 
-  }
-
-  private boolean isChairOfDAC(User user, Integer dacId) {
-    return user.checkIfUserHasRole(UserRoles.CHAIRPERSON.getRoleName(), dacId);
   }
 
 }

--- a/src/main/java/org/broadinstitute/consent/http/resources/DACAutomationRuleResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DACAutomationRuleResource.java
@@ -13,13 +13,10 @@ import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import java.util.List;
-import java.util.Objects;
-import java.util.stream.Stream;
 import javax.annotation.security.RolesAllowed;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.AuthUser;
 import org.broadinstitute.consent.http.models.User;
-import org.broadinstitute.consent.http.models.UserRole;
 import org.broadinstitute.consent.http.rules.AuditPageResults;
 import org.broadinstitute.consent.http.rules.DACAutomationRule;
 import org.broadinstitute.consent.http.service.DACAutomationRuleService;
@@ -120,14 +117,14 @@ public class DACAutomationRuleResource extends Resource {
   private void validateAdminOrChairForDAC(User user, Integer dacId) {
     boolean isAdminOrChair =
         user.hasUserRole(UserRoles.ADMIN)
-            || user.checkIfUserHasRole(UserRoles.CHAIRPERSON.getRoleName(), dacId);
+            || user.verifyDACRole(UserRoles.CHAIRPERSON.getRoleName(), dacId);
     if (!isAdminOrChair) {
       throw new ForbiddenException("User does not have access to the specified DAC ID");
     }
   }
 
   private void validateIsChairOfDAC(User user, Integer dacId) {
-    if (Boolean.FALSE.equals(user.checkIfUserHasRole(UserRoles.CHAIRPERSON.getRoleName(), dacId))) {
+    if (!user.verifyDACRole(UserRoles.CHAIRPERSON.getRoleName(), dacId)) {
       throw new ForbiddenException("User does not have access to the specified DAC ID");
     }
   }

--- a/src/main/java/org/broadinstitute/consent/http/resources/DacResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DacResource.java
@@ -106,7 +106,7 @@ public class DacResource extends Resource {
       }
       // Ensure that the user can only update a DAC they're a chairperson for.
       if (!user.hasUserRole(UserRoles.ADMIN)) {
-        if (!user.checkIfUserHasRole(UserRoles.CHAIRPERSON.getRoleName(), dac.getDacId())) {
+        if (!user.verifyDACRole(UserRoles.CHAIRPERSON.getRoleName(), dac.getDacId())) {
           throw new NotAuthorizedException(
               "You do not have the required permissions to update DAC");
         }
@@ -261,7 +261,7 @@ public class DacResource extends Resource {
         //Vague message is intentional, don't want to reveal too much info
         throw new NotFoundException("Dataset not found");
       }
-      Boolean userHasRole = user.checkIfUserHasRole(UserRoles.CHAIRPERSON.getRoleName(), dacId);
+      boolean userHasRole = user.verifyDACRole(UserRoles.CHAIRPERSON.getRoleName(), dacId);
       if (!userHasRole) {
         throw new NotFoundException("User role not found");
       }

--- a/src/test/java/org/broadinstitute/consent/http/models/UserCheckRoleInDacTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/UserCheckRoleInDacTest.java
@@ -13,30 +13,30 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class UserCheckRoleInDacTest {
 
   @Test
-  void testCheckIfUserHasRole_RoleNotFound() {
+  void testVerifyDACRole_RoleNotFound() {
     User user = new User();
     user.setAdminRole();
-    Boolean isUserChair = user.checkIfUserHasRole(UserRoles.CHAIRPERSON.getRoleName(), 2);
+    boolean isUserChair = user.verifyDACRole(UserRoles.CHAIRPERSON.getRoleName(), 2);
     assertFalse(isUserChair);
   }
 
   @Test
-  void testCheckIfUserHasRole_RoleTypeFoundDifferentDacId() {
+  void testVerifyDACRole_RoleTypeFoundDifferentDacId() {
     User user = new User();
     user.setChairpersonRoleWithDAC(1);
-    Boolean isUserChair = user.checkIfUserHasRole(UserRoles.CHAIRPERSON.getRoleName(), 2);
+    boolean isUserChair = user.verifyDACRole(UserRoles.CHAIRPERSON.getRoleName(), 2);
     assertFalse(isUserChair);
   }
 
   @Test
-  void testCheckIfUserHasRole() {
+  void testVerifyDACRole() {
     User user = new User();
     UserRole chairRole = UserRoles.Chairperson();
     chairRole.setDacId(1);
     UserRole adminRole = UserRoles.Admin();
     user.setRoles(List.of(chairRole, adminRole));
-    Boolean isUserChair = user.checkIfUserHasRole(UserRoles.CHAIRPERSON.getRoleName(), 1);
-    Boolean isUserAdmin = user.checkIfUserHasRole(UserRoles.ADMIN.getRoleName(), null);
+    boolean isUserChair = user.verifyDACRole(UserRoles.CHAIRPERSON.getRoleName(), 1);
+    boolean isUserAdmin = user.verifyDACRole(UserRoles.ADMIN.getRoleName(), null);
     assertTrue(isUserChair);
     assertTrue(isUserAdmin);
   }


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-2028](https://broadworkbench.atlassian.net/browse/DT-2028)

### Summary

Uses already tested feature in User class to determine if the user is a chair of the specified DAC.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
