### PR TITLE
DT-1563: Update how we're storing and retrieving jsonb data in Data Access Requests

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
@@ -137,7 +137,7 @@ public interface DarCollectionDAO extends Transactional<DarCollectionDAO> {
         dar.closeout_so_approval_timestamp AS dar_closeout_signing_official_approved_date,
         dar.closeout_approving_so_id AS dar_closeout_signing_official_approved_user_id,
         dar.create_date AS dar_create_date, dar.sort_date AS dar_sort_date, dar.submission_date AS dar_submission_date,
-        dar.update_date AS dar_update_date, dar.data as data, dd.dataset_id
+        dar.update_date AS dar_update_date, dar.data AS data, dd.dataset_id
         FROM dar_collection c
         INNER JOIN users u ON c.create_user_id = u.user_id
         LEFT JOIN user_property up ON u.user_id = up.user_id

--- a/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
@@ -137,7 +137,7 @@ public interface DarCollectionDAO extends Transactional<DarCollectionDAO> {
         dar.closeout_so_approval_timestamp AS dar_closeout_signing_official_approved_date,
         dar.closeout_approving_so_id AS dar_closeout_signing_official_approved_user_id,
         dar.create_date AS dar_create_date, dar.sort_date AS dar_sort_date, dar.submission_date AS dar_submission_date,
-        dar.update_date AS dar_update_date, (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data, dd.dataset_id
+        dar.update_date AS dar_update_date, dar.data as data, dd.dataset_id
         FROM dar_collection c
         INNER JOIN users u ON c.create_user_id = u.user_id
         LEFT JOIN user_property up ON u.user_id = up.user_id
@@ -174,7 +174,7 @@ public interface DarCollectionDAO extends Transactional<DarCollectionDAO> {
           + "dar.id AS dar_id, dar.reference_id AS dar_reference_id, dar.collection_id AS dar_collection_id, "
           + "dar.parent_id AS dar_parent_id, dar.user_id AS dar_userId, dar.era_commons_id AS dar_era_commons_id, "
           + "dar.create_date AS dar_create_date, dar.sort_date AS dar_sort_date, dar.submission_date AS dar_submission_date, "
-          + "dar.update_date AS dar_update_date, (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data, "
+          + "dar.update_date AS dar_update_date, dar.data AS data, "
           + "dar.closeout_so_approval_timestamp AS dar_closeout_signing_official_approved_date, "
           + "dar.closeout_approving_so_id AS dar_closeout_signing_official_approved_user_id, "
           + "e.election_id AS e_election_id, e.reference_id AS e_reference_id, e.status AS e_status, e.create_date AS e_create_date, "

--- a/src/main/java/org/broadinstitute/consent/http/db/DarCollectionSummaryDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DarCollectionSummaryDAO.java
@@ -32,9 +32,9 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
         v.voteid as v_vote_id, dd.dataset_id as dd_datasetid,
         v.user_id as v_user_id, v.vote as v_vote, v.electionid as v_election_id,
         v.createdate as v_create_date,v.updatedate as v_update_date, v.type as v_type,
-        (regexp_replace(latest_dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb ->> 'projectTitle' AS name,
-        (regexp_replace(latest_dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb ->> 'status' AS dar_status,
-        (regexp_replace(latest_dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb ->> 'closeoutSupplement' AS closeout,
+        latest_dar.data ->> 'projectTitle' AS name,
+        latest_dar.data ->> 'status' AS dar_status,
+        latest_dar.data ->> 'closeoutSupplement' AS closeout,
         ARRAY_AGG(dar_all.reference_id) AS reference_ids
       FROM dar_collection c
       -- DAR Collection Researcher join
@@ -114,9 +114,9 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
                e.dataset_id,
                e.reference_id,
                dd.dataset_id as dd_datasetid,
-               (regexp_replace(latest_dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb ->> 'projectTitle' AS name,
-               (regexp_replace(latest_dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb ->> 'status' AS dar_status,
-               (regexp_replace(latest_dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb ->> 'closeoutSupplement' AS closeout,
+               latest_dar.data ->> 'projectTitle' AS name,
+               latest_dar.data ->> 'status' AS dar_status,
+               latest_dar.data ->> 'closeoutSupplement' AS closeout,
                ARRAY_AGG(dar_all.reference_id) AS reference_ids
               FROM dar_collection c
               INNER JOIN users u
@@ -173,9 +173,9 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
               e.status,
               e.dataset_id,
               dd.dataset_id AS dd_datasetid,
-              (regexp_replace(latest_dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb ->> 'projectTitle' AS name,
-              (regexp_replace(latest_dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb ->> 'status' AS dar_status,
-              (regexp_replace(latest_dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb ->> 'closeoutSupplement' AS closeout,
+              latest_dar.data ->> 'projectTitle' AS name,
+              latest_dar.data ->> 'status' AS dar_status,
+              latest_dar.data ->> 'closeoutSupplement' AS closeout,
               dac.name AS dac_name,
               ARRAY_AGG(dar_all.reference_id) AS reference_ids
           FROM dar_collection c
@@ -229,9 +229,9 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
               e.dataset_id,
               e.reference_id AS election_reference_id,
               dd.dataset_id AS dd_datasetid,
-              (regexp_replace(latest_dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb ->> 'projectTitle' AS name,
-              (regexp_replace(latest_dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb ->> 'status' AS dar_status,
-              (regexp_replace(latest_dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb ->> 'closeoutSupplement' AS closeout,
+              latest_dar.data ->> 'projectTitle' AS name,
+              latest_dar.data ->> 'status' AS dar_status,
+              latest_dar.data ->> 'closeoutSupplement' AS closeout,
               ARRAY_AGG(dar_all.reference_id) AS reference_ids
           FROM
               dar_collection c
@@ -281,9 +281,9 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
         u.display_name as researcher_name, u.user_id as researcher_id,
         i.institution_name, i.institution_id, e.election_id, e.status, e.dataset_id, e.reference_id, v.voteid as v_vote_id, dd.dataset_id as dd_datasetid,
         v.user_id as v_user_id, v.vote as v_vote, v.electionid as v_election_id, v.createdate as v_create_date, v.updatedate as v_update_date, v.type as v_type,
-        (regexp_replace(latest_dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb ->> 'projectTitle' AS name,
-        (regexp_replace(latest_dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb ->> 'status' AS dar_status,
-        (regexp_replace(latest_dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb ->> 'closeoutSupplement' AS closeout,
+        latest_dar.data ->> 'projectTitle' AS name,
+        latest_dar.data ->> 'status' AS dar_status,
+        latest_dar.data ->> 'closeoutSupplement' AS closeout,
         ARRAY_AGG(dar_all.reference_id) AS reference_ids
       FROM dar_collection c
       INNER JOIN users u
@@ -342,9 +342,9 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
                 latest_dar.closeout_so_approval_timestamp as latest_dar_closeout_so_approval_timestamp,
                 u.display_name as researcher_name,
                 u.user_id as researcher_id, i.institution_name, i.institution_id, e.election_id, e.status, e.dataset_id, e.reference_id, dd.dataset_id as dd_datasetid,
-                (regexp_replace(latest_dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb ->> 'projectTitle' AS name,
-                (regexp_replace(latest_dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb ->> 'status' AS dar_status,
-                (regexp_replace(latest_dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb ->> 'closeoutSupplement' AS closeout,
+                latest_dar.data ->> 'projectTitle' AS name,
+                latest_dar.data ->> 'status' AS dar_status,
+                latest_dar.data ->> 'closeoutSupplement' AS closeout,
                 ARRAY_AGG(dar_all.reference_id) AS reference_ids
               FROM dar_collection c
               INNER JOIN users u

--- a/src/main/java/org/broadinstitute/consent/http/db/DataAccessRequestDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DataAccessRequestDAO.java
@@ -40,7 +40,7 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
       """
           SELECT collection.dar_code, dd.dataset_id, dar.id, dar.reference_id, dar.collection_id,
             dar.parent_id, dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date,
-            (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data, dar.era_commons_id,
+            dar.data, dar.era_commons_id,
             dar.closeout_so_approval_timestamp, dar.closeout_approving_so_id
           FROM data_access_request dar
           LEFT JOIN dar_dataset dd on dd.reference_id = dar.reference_id
@@ -67,7 +67,7 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
   @SqlQuery("""
       SELECT dar.id, dar.reference_id, dar.collection_id, dar.parent_id,
         dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date,
-        (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data,
+        dar.data,
         dd.dataset_id, collection.dar_code, dar.era_commons_id,
         dar.closeout_so_approval_timestamp, dar.closeout_approving_so_id
       FROM data_access_request dar
@@ -94,7 +94,7 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
       AND dar.collection_id NOT IN (
         SELECT DISTINCT collection_id
         FROM data_access_request
-        WHERE (regexp_replace(data #>> '{}', '\\\\u0000', '', 'g'))::jsonb ->> 'closeoutSupplement' IS NOT NULL)
+        WHERE data ->> 'closeoutSupplement' IS NOT NULL)
       """)
   List<DataAccessRequest> findApprovedDARsByDatasetId(@Bind("datasetId") Integer datasetId);
 
@@ -140,7 +140,7 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
         AND dar.collection_id NOT IN (
           SELECT DISTINCT collection_id
           FROM data_access_request
-          WHERE (regexp_replace(data #>> '{}', '\\\\u0000', '', 'g'))::jsonb ->> 'closeoutSupplement' IS NOT NULL)
+          WHERE data ->> 'closeoutSupplement' IS NOT NULL)
       """)
   Set<Integer> findDatasetApprovalsByDar(@Bind("darReferenceId") String darReferenceId);
 
@@ -157,7 +157,7 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
       """
               SELECT dar.id, dar.reference_id, dar.collection_id, dar.parent_id,
                 dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date,
-                (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data,
+                data,
                 dd.dataset_id, collection.dar_code, dar.era_commons_id,
                 dar.closeout_so_approval_timestamp, dar.closeout_approving_so_id
               FROM data_access_request dar
@@ -182,7 +182,7 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
       """
               SELECT dd.dataset_id, dar.id, dar.reference_id, dar.collection_id, dar.parent_id,
               dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date,
-              (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data, collection.dar_code,
+              dar.data, collection.dar_code,
               dar.era_commons_id, dar.closeout_so_approval_timestamp, dar.closeout_approving_so_id
               FROM data_access_request dar
               LEFT JOIN dar_collection collection on collection.collection_id = dar.collection_id
@@ -203,7 +203,7 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
       """
               SELECT dd.dataset_id, dar.id, dar.reference_id, dar.collection_id, dar.parent_id,
               dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date,
-              (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data,
+              dar.data,
               collection.dar_code, dar.era_commons_id, dar.closeout_so_approval_timestamp,
               dar.closeout_approving_so_id
               FROM data_access_request dar
@@ -227,7 +227,7 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
       """
               SELECT dd.dataset_id, dar.id, dar.reference_id, dar.collection_id, dar.parent_id,
                 dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date,
-                (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data,
+                dar.data,
                 collection.dar_code, dar.era_commons_id, dar.closeout_so_approval_timestamp,
                 dar.closeout_approving_so_id
               FROM data_access_request dar
@@ -248,7 +248,7 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
   @SqlQuery(
       """
           SELECT dd.dataset_id, dar.id, dar.reference_id, dar.collection_id, dar.parent_id, dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date,
-            (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data, collection.dar_code,
+            dar.data, collection.dar_code,
             dar.era_commons_id, dar.closeout_so_approval_timestamp, dar.closeout_approving_so_id
           FROM data_access_request dar
           LEFT JOIN dar_collection collection on collection.collection_id = dar.collection_id
@@ -273,7 +273,7 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
   @SqlUpdate(
       """
           UPDATE data_access_request
-          SET data = to_jsonb(regexp_replace(:data, '\\\\u0000', '', 'g')), user_id = :userId, sort_date = :sortDate,
+          SET data = regexp_replace(:data, '\\\\u0000', '', 'g')::jsonb, user_id = :userId, sort_date = :sortDate,
             submission_date = :submissionDate, update_date = :updateDate, era_commons_id = :eraCommonsId
           WHERE reference_id = :referenceId
       """)
@@ -303,8 +303,8 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
 
   @SqlUpdate(
       """
-          UPDATE data_access_request dar
-          SET data=jsonb_set((regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb, '{status}', '"Canceled"')
+          UPDATE data_access_request
+          SET data = jsonb_set(data, '{status}', '"Canceled"'::jsonb)
           WHERE reference_id IN (<referenceIds>)
       """)
   void cancelByReferenceIds(@BindList(value = "referenceIds", onEmpty = EmptyHandling.NULL_STRING) List<String> referenceIds);
@@ -336,7 +336,7 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
           INSERT INTO data_access_request
             (reference_id, user_id, create_date, sort_date, update_date, data)
           VALUES (:referenceId, :userId, :createDate, :sortDate,
-            :updateDate, to_jsonb(:data))
+            :updateDate, regexp_replace(:data, '\\\\u0000', '', 'g')::jsonb)
       """)
   void insertDraftDataAccessRequest(
       @Bind("referenceId") String referenceId,
@@ -364,7 +364,7 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
           INSERT INTO data_access_request
             (collection_id, reference_id, user_id, create_date, sort_date, submission_date, update_date, data, era_commons_id)
           VALUES (:collectionId, :referenceId, :userId, :createDate, :sortDate,
-            :submissionDate, :updateDate, to_jsonb(:data), :eraCommonsId)
+            :submissionDate, :updateDate, regexp_replace(:data, '\\\\u0000', '', 'g')::jsonb, :eraCommonsId)
       """)
   void insertDataAccessRequest(
       @Bind("collectionId") Integer collectionId,
@@ -391,7 +391,7 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
       """
           INSERT INTO data_access_request
             (parent_id, collection_id, reference_id, user_id, create_date, sort_date, submission_date, update_date, data, era_commons_id)
-          VALUES (:parentId, :collectionId, :referenceId, :userId, now(), now(), now(), now(), to_jsonb(:data), :eraCommonsId)
+          VALUES (:parentId, :collectionId, :referenceId, :userId, now(), now(), now(), now(), regexp_replace(:data, '\\\\u0000', '', 'g')::jsonb, :eraCommonsId)
       """)
   void insertProgressReport(
       @Bind("parentId") Integer parentId,

--- a/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
@@ -527,7 +527,7 @@ WHERE dar.submission_date > now() - interval '1 year'
   AND dar.collection_id NOT IN (
     SELECT DISTINCT collection_id
     FROM data_access_request
-    WHERE (regexp_replace(data #>> '{}', '\\\\u0000', '', 'g'))::jsonb ->> 'closeoutSupplement' IS NOT NULL)
+    WHERE data ->> 'closeoutSupplement' IS NOT NULL)
   """)
   List<ApprovedDataset> getApprovedDatasets(@Bind("userId") Integer userId);
 

--- a/src/main/java/org/broadinstitute/consent/http/models/DarCollection.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DarCollection.java
@@ -22,13 +22,13 @@ public class DarCollection {
           "dar.parent_id AS dar_parent_id, dar.user_id AS dar_userId, " +
           "dar.create_date AS dar_create_date, dar.sort_date AS dar_sort_date, dar.submission_date AS dar_submission_date, "
           +
-          "dar.update_date AS dar_update_date, (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data, "
+          "dar.update_date AS dar_update_date, dar.data AS data, "
           +
           "dar.closeout_so_approval_timestamp AS dar_closeout_signing_official_approved_date, "
           +
           "dar.closeout_approving_so_id AS dar_closeout_signing_official_approved_user_id, "
           +
-          "(regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb ->> 'projectTitle' as projectTitle ";
+          "dar.data ->> 'projectTitle' as projectTitle ";
 
   @JsonProperty
   private Integer darCollectionId;

--- a/src/main/java/org/broadinstitute/consent/http/service/dao/DataAccessRequestServiceDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/dao/DataAccessRequestServiceDAO.java
@@ -33,7 +33,7 @@ public class DataAccessRequestServiceDAO {
     String referenceId = dar.getReferenceId();
     final String updateDataByReferenceId = """
           UPDATE data_access_request
-          SET data = regexp_replace(:data, '\\\\\\\\u0000', '', 'g')::jsonb, user_id = :userId, sort_date = :sortDate,
+          SET data = regexp_replace(:data, '\\\\u0000', '', 'g')::jsonb, user_id = :userId, sort_date = :sortDate,
           submission_date = :submissionDate, update_date = :updateDate
           WHERE reference_id = :referenceId
         """;

--- a/src/main/java/org/broadinstitute/consent/http/service/dao/DataAccessRequestServiceDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/dao/DataAccessRequestServiceDAO.java
@@ -31,18 +31,23 @@ public class DataAccessRequestServiceDAO {
       throws SQLException {
     Instant now = Instant.now();
     String referenceId = dar.getReferenceId();
+    final String updateDataByReferenceId = """
+          UPDATE data_access_request
+          SET data = regexp_replace(:data, '\\\\\\\\u0000', '', 'g')::jsonb, user_id = :userId, sort_date = :sortDate,
+          submission_date = :submissionDate, update_date = :updateDate
+          WHERE reference_id = :referenceId
+        """;
+    final String deleteDarDatasetRelationByReferenceId = """
+          DELETE FROM dar_dataset WHERE reference_id = :referenceId
+        """;
+    final String insertDarDataset = """
+          INSERT INTO dar_dataset (reference_id, dataset_id)
+          VALUES (:referenceId, :datasetId)
+          ON CONFLICT DO NOTHING
+        """;
     jdbi.useHandle(handle -> {
       handle.getConnection().setAutoCommit(false);
       handle.useTransaction(h -> {
-
-        final String updateDataByReferenceId = "UPDATE data_access_request "
-            + "SET data = to_jsonb(regexp_replace(:data, '\\\\u0000', '', 'g')), user_id = :userId, sort_date = :sortDate, "
-            + "submission_date = :submissionDate, update_date = :updateDate "
-            + "WHERE reference_id = :referenceId";
-        final String deleteDarDatasetRelationByReferenceId = "DELETE FROM dar_dataset WHERE reference_id = :referenceId";
-        final String insertDarDataset = "INSERT INTO dar_dataset (reference_id, dataset_id) "
-            + "VALUES (:referenceId, :datasetId) "
-            + "ON CONFLICT DO NOTHING";
 
         Update darUpdate = h.createUpdate(updateDataByReferenceId);
         darUpdate.bind("referenceId", referenceId);

--- a/src/main/resources/changelog-master.xml
+++ b/src/main/resources/changelog-master.xml
@@ -198,4 +198,6 @@
     relativeToChangelogFile="true" />
   <include file="changesets/changelog-consent-2025-07-31-vote-create-date-index.xml"
     relativeToChangelogFile="true" />
+  <include file="changesets/changelog-consent-2025-08-07-2025-jsonb-data.xml"
+    relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/src/main/resources/changesets/changelog-consent-2025-08-07-2025-jsonb-data.xml
+++ b/src/main/resources/changesets/changelog-consent-2025-08-07-2025-jsonb-data.xml
@@ -11,6 +11,10 @@
       -- Previously, we selected these values out of the response.
       -- Going forward, we'll be preventing inserts and updates with problematic values
       UPDATE data_access_request SET data = (SELECT (regexp_replace(data #>> '{}', '\\\\u0000', '', 'g'))::jsonb);
+      -- Create indexes on commonly queried fields
+      CREATE INDEX idx_dar_data_project_title ON data_access_request USING GIN ((data -> 'projectTitle'));
+      CREATE INDEX idx_dar_data_status ON data_access_request USING GIN ((data -> 'status'));
+      CREATE INDEX idx_dar_data_closeout ON data_access_request USING GIN ((data -> 'closeoutSupplement'));
     </sql>
   </changeSet>
 </databaseChangeLog>

--- a/src/main/resources/changesets/changelog-consent-2025-08-07-2025-jsonb-data.xml
+++ b/src/main/resources/changesets/changelog-consent-2025-08-07-2025-jsonb-data.xml
@@ -1,0 +1,16 @@
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+  <changeSet id="changelog-consent-2025-07-31-vote-create-date-index" author="grushton">
+    <addColumn tableName="data_access_request">
+      <column name="data_bak" type="jsonb"/>
+    </addColumn>
+    <sql>
+      UPDATE data_access_request SET data_bak = data;
+      -- Existing data has unsupported characters.
+      -- Previously, we selected these values out of the response.
+      -- Going forward, we'll be preventing inserts and updates with problematic values
+      UPDATE data_access_request SET data = (SELECT (regexp_replace(data #>> '{}', '\\\\u0000', '', 'g'))::jsonb);
+    </sql>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/changesets/changelog-consent-2025-08-07-2025-jsonb-data.xml
+++ b/src/main/resources/changesets/changelog-consent-2025-08-07-2025-jsonb-data.xml
@@ -1,20 +1,42 @@
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
          http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
-  <changeSet id="changelog-consent-2025-07-31-vote-create-date-index" author="grushton">
+  <changeSet id="changelog-consent-2025-07-31-vote-create-date-index_part_1" author="grushton">
     <addColumn tableName="data_access_request">
       <column name="data_bak" type="jsonb"/>
     </addColumn>
     <sql>
       UPDATE data_access_request SET data_bak = data;
+    </sql>
+    <rollback>
+      <dropColumn tableName="data_access_request" columnName="data_bak"/>
+    </rollback>
+  </changeSet>
+  <changeSet id="changelog-consent-2025-07-31-vote-create-date-index_part_2" author="grushton">
+    <sql>
       -- Existing data has unsupported characters.
       -- Previously, we selected these values out of the response.
       -- Going forward, we'll be preventing inserts and updates with problematic values
-      UPDATE data_access_request SET data = (SELECT (regexp_replace(data #>> '{}', '\\\\u0000', '', 'g'))::jsonb);
-      -- Create indexes on commonly queried fields
+      UPDATE data_access_request SET data = (SELECT (regexp_replace(data #>> '{}', '\\u0000', '', 'g'))::jsonb);
+    </sql>
+    <rollback>
+      <sql>
+        UPDATE data_access_request SET data = data_bak;
+      </sql>
+    </rollback>
+  </changeSet>
+  <changeSet id="changelog-consent-2025-07-31-vote-create-date-index_part_3" author="grushton">
+    <sql>
       CREATE INDEX idx_dar_data_project_title ON data_access_request USING GIN ((data -> 'projectTitle'));
       CREATE INDEX idx_dar_data_status ON data_access_request USING GIN ((data -> 'status'));
       CREATE INDEX idx_dar_data_closeout ON data_access_request USING GIN ((data -> 'closeoutSupplement'));
     </sql>
+    <rollback>
+      <sql>
+        DROP INDEX idx_dar_data_project_title;
+        DROP INDEX idx_dar_data_status;
+        DROP INDEX idx_dar_data_closeout;
+      </sql>
+    </rollback>
   </changeSet>
 </databaseChangeLog>

--- a/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
@@ -19,8 +19,6 @@ import static org.mockito.Mockito.when;
 
 import freemarker.template.TemplateException;
 import jakarta.ws.rs.BadRequestException;
-import jakarta.ws.rs.NotAcceptableException;
-import jakarta.ws.rs.NotAuthorizedException;
 import jakarta.ws.rs.NotFoundException;
 import java.io.IOException;
 import java.sql.Timestamp;


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DT-1563

## Summary
This PR updates how we're storing jsonb data for `DataAccessRequestData` objects. Previously, we were doing two things that made the underlying data difficult to work with:
* Using `to_jsonb` in inserts/updates. This had the effect of double encoding the json being passed into the sql
* Using `regexp_replace` when querying for fields due to unsupported characters in the data. This made deserialization complicated.

Instead, we take a slightly different approach now.
* Prevent double encoding by removing `to_jsonb` usages.
* Prevent unsupported characters on insert/update. This makes it possible to query the json data more naturally using standard postgres json operators.

Additional work includes:
* Updating all queries on jsonb fields to use standard postgres json operators
* Adding indexes for the fields we commonly query on

As of 8/11, tested against latest dev, staging, and prod databases.

### Examples
You can see the before and after in these db views. In both cases, the `data` column now contains clean data and the `data_bak` column contains the original value for reference. A future PR/story will remove this column.
<img width="1344" height="806" alt="Screenshot 2025-08-08 at 12 31 18 PM" src="https://github.com/user-attachments/assets/4ddb71c4-29f0-40aa-9a71-0dd14bad675f" />

Note that now we can use standard postgres json operators on the raw `data` column:
<img width="1344" height="806" alt="Screenshot 2025-08-08 at 12 31 09 PM" src="https://github.com/user-attachments/assets/beb3cfee-02e2-4857-be58-e673335029a8" />

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
