### PR TITLE
[DT-2104] RADAR progress report emails.

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/mail/message/ResearcherApprovedProgressReportMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/ResearcherApprovedProgressReportMessage.java
@@ -13,13 +13,15 @@ public class ResearcherApprovedProgressReportMessage extends MailMessage {
   private final String darCode;
   private final List<DatasetMailDTO> datasets;
   private final String dataUseRestriction;
+  private final String radarText;
 
   public ResearcherApprovedProgressReportMessage(User toUser, String darCode, List<DatasetMailDTO> datasets,
-      String dataUseRestriction) {
+      String dataUseRestriction, boolean radarApproved) {
     super(toUser, EmailType.RESEARCHER_PROGRESS_REPORT_APPROVED);
     this.darCode = darCode;
     this.datasets = datasets;
     this.dataUseRestriction = dataUseRestriction;
+    this.radarText = radarApproved ? "Rule Automated DAR (RADAR) " : "";
   }
 
   @Override
@@ -33,6 +35,7 @@ public class ResearcherApprovedProgressReportMessage extends MailMessage {
         "darCode", darCode,
         "datasets", datasets,
         "dataUseRestriction", dataUseRestriction,
+        "radarText", radarText,
         "researcherEmail", toUser.getEmail());
   }
 

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
@@ -297,11 +297,12 @@ public class DataAccessRequestService implements ConsentLogger {
       }
     }
 
+    syncDataAccessRequestDatasets(progressReportDatasetIds, referenceId);
+
     if (!progressReport.getIsCloseoutProgressReport() && !progressReport.getHasDMI()) {
       ruleService.triggerDACRuleSettings(user, progressReportDatasetIds, referenceId, request);
     }
 
-    syncDataAccessRequestDatasets(progressReportDatasetIds, referenceId);
     return findByReferenceId(referenceId);
   }
 

--- a/src/main/java/org/broadinstitute/consent/http/service/EmailService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/EmailService.java
@@ -157,11 +157,12 @@ public class EmailService implements ConsentLogger {
       String darCode,
       Integer researcherId,
       List<DatasetMailDTO> datasets,
-      String dataUseRestriction)
+      String dataUseRestriction,
+      boolean radarApproved)
       throws TemplateException, IOException {
     User user = userDAO.findUserById(researcherId);
     sendMessage(
-        new ResearcherApprovedProgressReportMessage(user, darCode, datasets, dataUseRestriction), researcherId);
+        new ResearcherApprovedProgressReportMessage(user, darCode, datasets, dataUseRestriction, radarApproved), researcherId);
   }
 
   public void sendDataCustodianApprovalMessage(

--- a/src/main/java/org/broadinstitute/consent/http/service/VoteService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/VoteService.java
@@ -298,7 +298,7 @@ public class VoteService implements ConsentLogger {
             try {
               if (dar.getProgressReport()) {
                 emailService.sendResearcherProgressReportApproved(
-                    darCode, researcherId, datasetMailDTOs, translation);
+                    darCode, researcherId, datasetMailDTOs, translation, radarApproved);
               } else {
                 emailService.sendResearcherDarApproved(
                     darCode, researcherId, datasetMailDTOs, translation, radarApproved);

--- a/src/main/resources/freemarker/researcher-progress-report-approved.html
+++ b/src/main/resources/freemarker/researcher-progress-report-approved.html
@@ -3,7 +3,7 @@
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Broad Data Use Oversight System - Researcher - Your access to a dataset was approved</title>
+    <title>Broad Data Use Oversight System - Researcher - Your access to a dataset was ${radarText}approved</title>
 </head>
 
 <body style="text-align: center; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none; width: 100%; height: 100%; margin: 0; padding: 0;">
@@ -22,7 +22,7 @@
         <tr>
             <td style="padding: 0px 15px; font-family: 'Montserrat', sans-serif; font-size: 16px; color: #1F3B50; text-align: justify; line-height: 25px;">
                 <p>
-                    Your progress report application ${darCode} was approved for the following dataset(s) with the corresponding data use limitations:
+                    Your progress report application ${darCode} was ${radarText}approved for the following dataset(s) with the corresponding data use limitations:
                 </p>
                 <table style="margin: 15px 0 10px 0; border-collapse: collapse; width: 600px;">
                     <tr>

--- a/src/test/java/org/broadinstitute/consent/http/mail/message/ResearcherProgressReportApprovedMessageTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mail/message/ResearcherProgressReportApprovedMessageTest.java
@@ -36,7 +36,7 @@ class ResearcherProgressReportApprovedMessageTest extends AbstractTestHelper {
 
   @Test
   void testMessageSubject() {
-    var message = new ResearcherApprovedProgressReportMessage(new User(), "DAR-123", List.of(), "");
+    var message = new ResearcherApprovedProgressReportMessage(new User(), "DAR-123", List.of(), "", false);
     assertEquals("Your DUOS Progress Report Results", message.createSubject());
   }
 
@@ -53,7 +53,7 @@ class ResearcherProgressReportApprovedMessageTest extends AbstractTestHelper {
 
     var message =
         new ResearcherApprovedProgressReportMessage(
-            researcher, darCode, List.of(new DatasetMailDTO(datasetName, datasetId)), "");
+            researcher, darCode, List.of(new DatasetMailDTO(datasetName, datasetId)), "", false);
     assertEquals(darCode, message.getEntityReferenceId());
 
     Template template = helper.getTemplate(message.getTemplateName());
@@ -68,6 +68,39 @@ class ResearcherProgressReportApprovedMessageTest extends AbstractTestHelper {
     assertEquals(
         "Hello " + researcherUserName + ",", getElementTextById(parsedTemplate, "userName"));
     assertTrue(templateString.contains("Your progress report application " + darCode + " was approved"));
+    assertTrue(templateString.contains(datasetId));
+    assertTrue(templateString.contains(datasetName));
+    assertTrue(templateString.contains(researcherEmail));
+  }
+
+  @Test
+  void testGetResearcherRADARApprovedTemplate() throws Exception {
+    String researcherUserName = randomAlphabetic(10);
+    String researcherEmail = randomAlphabetic(10);
+    String darCode = randomAlphabetic(10);
+    String datasetName = randomAlphabetic(10);
+    String datasetId = randomAlphabetic(10);
+    User researcher = new User();
+    researcher.setDisplayName(researcherUserName);
+    researcher.setEmail(researcherEmail);
+
+    var message =
+        new ResearcherApprovedProgressReportMessage(
+            researcher, darCode, List.of(new DatasetMailDTO(datasetName, datasetId)), "", true);
+    assertEquals(darCode, message.getEntityReferenceId());
+
+    Template template = helper.getTemplate(message.getTemplateName());
+    Writer out = new StringWriter();
+    template.process(message.createModel(""), out);
+    String templateString = out.toString();
+    Document parsedTemplate = Jsoup.parse(templateString);
+
+    assertEquals(
+        "Broad Data Use Oversight System - Researcher - Your access to a dataset was Rule Automated DAR (RADAR) approved",
+        parsedTemplate.title());
+    assertEquals(
+        "Hello " + researcherUserName + ",", getElementTextById(parsedTemplate, "userName"));
+    assertTrue(templateString.contains("Your progress report application " + darCode + " was Rule Automated DAR (RADAR) approved"));
     assertTrue(templateString.contains(datasetId));
     assertTrue(templateString.contains(datasetName));
     assertTrue(templateString.contains(researcherEmail));

--- a/src/test/java/org/broadinstitute/consent/http/service/VoteServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/VoteServiceTest.java
@@ -438,7 +438,7 @@ class VoteServiceTest extends AbstractTestHelper {
 
     service.sendDatasetApprovalNotifications(List.of(v1), researcher);
 
-    verify(emailService).sendResearcherProgressReportApproved(any(), any(), anyList(), any());
+    verify(emailService).sendResearcherProgressReportApproved(any(), any(), anyList(), any(), anyBoolean());
   }
 
   @Test


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-2104](https://broadworkbench.atlassian.net/browse/DT-2104)

### Summary

- Fixes order of operations when progress report is submitted so that database values are recorded before RADAR rules are applied.  This was preventing existing email logic from being triggered.
- Updates the email template for progress report approvals to add our standard language for RADAR invoked approvals.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
