### PR TITLE
DT-1636: Sync User Linked Account Status with ECM

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
@@ -615,7 +615,9 @@ public class ConsentModule extends AbstractModule {
     return new NihService(
         providesUserDAO(),
         providesUserPropertyDAO(),
-        providesNIHServiceDAO());
+        providesNIHServiceDAO(),
+        providesHttpClientUtil(),
+        config.getServicesConfiguration());
   }
 
   @Provides

--- a/src/main/java/org/broadinstitute/consent/http/configurations/ServicesConfiguration.java
+++ b/src/main/java/org/broadinstitute/consent/http/configurations/ServicesConfiguration.java
@@ -17,6 +17,7 @@ public class ServicesConfiguration {
   public static final String ACCEPT_TOS_PATH = "api/termsOfService/v1/user/self/accept";
   public static final String REJECT_TOS_PATH = "api/termsOfService/v1/user/self/reject";
   public static final String SAM_V1_USER_EMAIL = "api/users/v1";
+  public static final String ECM_RAS_PROVIDER = "/api/oauth/v1/ras";
   // nosemgrep
   public static final String BROAD_ZENDESK_URL = "https://broadinstitute.zendesk.com";
 
@@ -91,6 +92,10 @@ public class ServicesConfiguration {
 
   public void setEcmUrl(String ecmUrl) {
     this.ecmUrl = ecmUrl;
+  }
+
+  public String getEcmRasProviderUrl() {
+    return getEcmUrl() + ECM_RAS_PROVIDER;
   }
 
   public String getV1ResourceTypesUrl() {

--- a/src/main/java/org/broadinstitute/consent/http/configurations/ServicesConfiguration.java
+++ b/src/main/java/org/broadinstitute/consent/http/configurations/ServicesConfiguration.java
@@ -29,6 +29,9 @@ public class ServicesConfiguration {
   @NotNull
   private String samUrl;
 
+  @NotNull
+  private String ecmUrl;
+
   /**
    * This represents the max time we'll wait for an external status check to return. If it does not
    * return, we assume a degradation in the overall service. This can be overridden in local
@@ -80,6 +83,14 @@ public class ServicesConfiguration {
 
   public void setSamUrl(String samUrl) {
     this.samUrl = samUrl;
+  }
+
+  public String getEcmUrl() {
+    return ecmUrl;
+  }
+
+  public void setEcmUrl(String ecmUrl) {
+    this.ecmUrl = ecmUrl;
   }
 
   public String getV1ResourceTypesUrl() {

--- a/src/main/java/org/broadinstitute/consent/http/db/UserDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/UserDAO.java
@@ -9,6 +9,7 @@ import org.broadinstitute.consent.http.db.mapper.UserWithRolesReducer;
 import org.broadinstitute.consent.http.models.Institution;
 import org.broadinstitute.consent.http.models.LibraryCard;
 import org.broadinstitute.consent.http.models.User;
+import org.broadinstitute.consent.http.models.UserProperty;
 import org.broadinstitute.consent.http.models.UserRole;
 import org.jdbi.v3.sqlobject.config.RegisterBeanMapper;
 import org.jdbi.v3.sqlobject.customizer.Bind;
@@ -61,6 +62,47 @@ public interface UserDAO extends Transactional<UserDAO> {
       WHERE u.user_id = :userId
       """)
   User findUserById(@Bind("userId") Integer userId);
+
+  @RegisterBeanMapper(value = User.class, prefix = "u")
+  @RegisterBeanMapper(value = UserRole.class)
+  @RegisterBeanMapper(value = Institution.class, prefix = "i")
+  @RegisterBeanMapper(value = LibraryCard.class, prefix = "lc")
+  @RegisterBeanMapper(value = UserProperty.class, prefix = "up")
+  @UseRowReducer(UserWithRolesReducer.class)
+  @SqlQuery("""
+      SELECT
+          u.user_id as u_user_id,
+          u.email as u_email,
+          u.display_name as u_display_name,
+          u.create_date as u_create_date,
+          u.email_preference as u_email_preference,
+          u.institution_id as u_institution_id,
+          u.era_commons_id as u_era_commons_id,
+          i.institution_id as i_id,
+          i.institution_name as i_name,
+          i.it_director_name as i_it_director_name,
+          i.it_director_email as i_it_director_email,
+          i.create_date as i_create_date,
+          i.update_date as i_update_date,
+          ur.user_role_id as ur_user_role_id, ur.user_id as ur_user_id,
+          ur.role_id as ur_role_id, ur.dac_id as ur_dac_id, r.name as ur_name,
+          lc.id AS lc_id, lc.user_id AS lc_user_id,
+          lc.user_name AS lc_user_name, lc.user_email AS lc_user_email,
+          lc.create_user_id AS lc_create_user_id, lc.create_date AS lc_create_date,
+          lc.update_user_id AS lc_update_user_id,
+          ld.daa_id as lc_daa_id,
+          up.property_id as up_property_id, up.property_key as up_property_key,
+          up.property_value as up_property_value
+      FROM users u
+      LEFT JOIN user_role ur ON ur.user_id = u.user_id
+      LEFT JOIN roles r ON r.role_id = ur.role_id
+      LEFT JOIN institution i ON u.institution_id = i.institution_id
+      LEFT JOIN library_card lc ON lc.user_id = u.user_id
+      LEFT JOIN lc_daa ld ON lc.id = ld.lc_id
+      INNER JOIN user_property up ON up.user_id = u.user_id AND up.property_key IN (<keys>)
+      WHERE u.user_id = :userId
+      """)
+  User findUserWithPropertiesById(@Bind("userId") Integer userId, @BindList(value = "keys", onEmpty = EmptyHandling.NULL_STRING) List<String> keys);
 
   @RegisterBeanMapper(value = User.class, prefix = "u")
   @UseRowReducer(UserWithRolesReducer.class)

--- a/src/main/java/org/broadinstitute/consent/http/db/UserDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/UserDAO.java
@@ -99,7 +99,7 @@ public interface UserDAO extends Transactional<UserDAO> {
       LEFT JOIN institution i ON u.institution_id = i.institution_id
       LEFT JOIN library_card lc ON lc.user_id = u.user_id
       LEFT JOIN lc_daa ld ON lc.id = ld.lc_id
-      INNER JOIN user_property up ON up.user_id = u.user_id AND up.property_key IN (<keys>)
+      LEFT JOIN user_property up ON up.user_id = u.user_id AND up.property_key IN (<keys>)
       WHERE u.user_id = :userId
       """)
   User findUserWithPropertiesById(@Bind("userId") Integer userId, @BindList(value = "keys", onEmpty = EmptyHandling.NULL_STRING) List<String> keys);

--- a/src/main/java/org/broadinstitute/consent/http/models/NIHUserAccount.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/NIHUserAccount.java
@@ -1,6 +1,7 @@
 package org.broadinstitute.consent.http.models;
 
 import com.google.gson.annotations.SerializedName;
+import java.util.Objects;
 
 public class NIHUserAccount {
 
@@ -45,4 +46,17 @@ public class NIHUserAccount {
     this.status = status;
   }
 
+  @Override
+  public boolean equals(Object o) {
+    if (!(o instanceof NIHUserAccount that)) {
+      return false;
+    }
+    return Objects.equals(nihUsername, that.nihUsername) && Objects.equals(
+        eraExpiration, that.eraExpiration) && Objects.equals(status, that.status);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(nihUsername, eraExpiration, status);
+  }
 }

--- a/src/main/java/org/broadinstitute/consent/http/models/ecm/LinkInfo.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/ecm/LinkInfo.java
@@ -1,0 +1,4 @@
+package org.broadinstitute.consent.http.models.ecm;
+
+public record LinkInfo(String externalUserId, String expirationTimestamp, Boolean authenticated) {
+}

--- a/src/main/java/org/broadinstitute/consent/http/resources/NihAccountResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/NihAccountResource.java
@@ -63,10 +63,9 @@ public class NihAccountResource extends Resource {
   @DELETE
   @Produces(MediaType.APPLICATION_JSON)
   @PermitAll
-  public Response deleteNihAccount(@Auth AuthUser user) {
+  public Response deleteNihAccount(@Auth AuthUser authUser) {
     try {
-      User dacUser = userService.findUserByEmail(user.getEmail());
-      nihService.deleteNihAccountById(dacUser.getUserId());
+      nihService.deleteNihAccountById(authUser);
       return Response.ok().build();
     } catch (Exception e) {
       return createExceptionResponse(e);

--- a/src/main/java/org/broadinstitute/consent/http/resources/NihAccountResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/NihAccountResource.java
@@ -13,6 +13,7 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import java.util.List;
 import org.broadinstitute.consent.http.models.AuthUser;
+import org.broadinstitute.consent.http.models.DuosUser;
 import org.broadinstitute.consent.http.models.NIHUserAccount;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.UserProperty;
@@ -35,9 +36,9 @@ public class NihAccountResource extends Resource {
   @Produces(MediaType.APPLICATION_JSON)
   @Path("sync")
   @PermitAll
-  public Response syncAccount(@Auth AuthUser authUser) {
+  public Response syncAccount(@Auth DuosUser duosUser) {
     try {
-      User user = nihService.syncAccount(authUser);
+      User user = nihService.syncAccount(duosUser);
       return Response.ok(user).build();
     } catch (Exception e) {
       return createExceptionResponse(e);
@@ -63,9 +64,9 @@ public class NihAccountResource extends Resource {
   @DELETE
   @Produces(MediaType.APPLICATION_JSON)
   @PermitAll
-  public Response deleteNihAccount(@Auth AuthUser authUser) {
+  public Response deleteNihAccount(@Auth DuosUser duosUser) {
     try {
-      nihService.deleteNihAccountById(authUser);
+      nihService.deleteNihAccountById(duosUser);
       return Response.ok().build();
     } catch (Exception e) {
       return createExceptionResponse(e);

--- a/src/main/java/org/broadinstitute/consent/http/resources/NihAccountResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/NihAccountResource.java
@@ -5,6 +5,7 @@ import io.dropwizard.auth.Auth;
 import jakarta.annotation.security.PermitAll;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
@@ -28,6 +29,19 @@ public class NihAccountResource extends Resource {
   public NihAccountResource(NihService nihService, UserService userService) {
     this.nihService = nihService;
     this.userService = userService;
+  }
+
+  @GET
+  @Produces(MediaType.APPLICATION_JSON)
+  @Path("sync")
+  @PermitAll
+  public Response syncAccount(@Auth AuthUser authUser) {
+    try {
+      User user = nihService.syncAccount(authUser);
+      return Response.ok(user).build();
+    } catch (Exception e) {
+      return createExceptionResponse(e);
+    }
   }
 
   @POST

--- a/src/main/java/org/broadinstitute/consent/http/service/NihService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/NihService.java
@@ -1,14 +1,19 @@
 package org.broadinstitute.consent.http.service;
 
+import com.google.api.client.http.GenericUrl;
+import com.google.api.client.http.HttpRequest;
+import com.google.api.client.http.HttpResponse;
 import com.google.inject.Inject;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.ServerErrorException;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 import org.apache.commons.lang3.StringUtils;
+import org.broadinstitute.consent.http.configurations.ServicesConfiguration;
 import org.broadinstitute.consent.http.db.UserDAO;
 import org.broadinstitute.consent.http.db.UserPropertyDAO;
 import org.broadinstitute.consent.http.enumeration.UserFields;
@@ -16,21 +21,44 @@ import org.broadinstitute.consent.http.models.AuthUser;
 import org.broadinstitute.consent.http.models.NIHUserAccount;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.UserProperty;
+import org.broadinstitute.consent.http.models.ecm.LinkInfo;
 import org.broadinstitute.consent.http.service.dao.NihServiceDAO;
 import org.broadinstitute.consent.http.util.ConsentLogger;
+import org.broadinstitute.consent.http.util.HttpClientUtil;
+import org.broadinstitute.consent.http.util.gson.GsonUtil;
 
 public class NihService implements ConsentLogger {
 
   private final UserDAO userDAO;
   private final UserPropertyDAO userPropertyDAO;
   private final NihServiceDAO serviceDAO;
+  private final HttpClientUtil clientUtil;
+  private final ServicesConfiguration configuration;
 
   @Inject
-  public NihService(UserDAO userDAO, UserPropertyDAO userPropertyDAO,
-      NihServiceDAO serviceDAO) {
+  public NihService(UserDAO userDAO, UserPropertyDAO userPropertyDAO, NihServiceDAO serviceDAO,
+      HttpClientUtil clientUtil, ServicesConfiguration configuration) {
     this.userDAO = userDAO;
     this.userPropertyDAO = userPropertyDAO;
     this.serviceDAO = serviceDAO;
+    this.clientUtil = clientUtil;
+    this.configuration = configuration;
+  }
+
+  public User syncAccount(AuthUser authUser) throws Exception {
+    User user = userDAO.findUserByEmail(authUser.getEmail());
+    GenericUrl ecmRasProviderUrl = new GenericUrl(configuration.getEcmRasProviderUrl());
+    HttpRequest request = clientUtil.buildGetRequest(ecmRasProviderUrl, authUser);
+    HttpResponse response = clientUtil.handleHttpRequest(request);
+    if (!response.isSuccessStatusCode()) {
+      throw new ServerErrorException(response.getStatusMessage(), response.getStatusCode());
+    }
+    String body = response.parseAsString();
+    LinkInfo linkInfo = GsonUtil.getInstance().fromJson(body, LinkInfo.class);
+    NIHUserAccount nihAccount = new NIHUserAccount(
+        linkInfo.externalUserId(), linkInfo.expirationTimestamp(), linkInfo.authenticated());
+    serviceDAO.updateUserNihStatus(user, nihAccount);
+    return userDAO.findUserWithPropertiesById(user.getUserId(), UserFields.getValues());
   }
 
   public void validateNihUserAccount(NIHUserAccount nihAccount, AuthUser authUser)

--- a/src/main/java/org/broadinstitute/consent/http/service/NihService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/NihService.java
@@ -19,6 +19,7 @@ import org.broadinstitute.consent.http.db.UserDAO;
 import org.broadinstitute.consent.http.db.UserPropertyDAO;
 import org.broadinstitute.consent.http.enumeration.UserFields;
 import org.broadinstitute.consent.http.models.AuthUser;
+import org.broadinstitute.consent.http.models.DuosUser;
 import org.broadinstitute.consent.http.models.NIHUserAccount;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.UserProperty;
@@ -46,10 +47,10 @@ public class NihService implements ConsentLogger {
     this.configuration = configuration;
   }
 
-  public User syncAccount(AuthUser authUser) throws Exception {
-    User user = userDAO.findUserByEmail(authUser.getEmail());
+  public  User syncAccount(DuosUser duosUser) throws Exception {
+    User user = duosUser.getUser();
     GenericUrl ecmRasProviderUrl = new GenericUrl(configuration.getEcmRasProviderUrl());
-    HttpRequest request = clientUtil.buildGetRequest(ecmRasProviderUrl, authUser);
+    HttpRequest request = clientUtil.buildGetRequest(ecmRasProviderUrl, duosUser);
     try {
       HttpResponse response = clientUtil.handleHttpRequest(request);
       if (!response.isSuccessStatusCode()) {
@@ -96,23 +97,23 @@ public class NihService implements ConsentLogger {
     }
   }
 
-  public void deleteNihAccountById(AuthUser authUser) {
-    User user = userDAO.findUserByEmail(authUser.getEmail());
+  public void deleteNihAccountById(DuosUser duosUser) {
+    User user = duosUser.getUser();
     // Delete linkage locally
     serviceDAO.deleteNihAccountById(user.getUserId());
     try {
       // Delete linkage from ECM
       GenericUrl ecmRasProviderUrl = new GenericUrl(configuration.getEcmRasProviderUrl());
-      HttpRequest request = clientUtil.buildDeleteRequest(ecmRasProviderUrl, authUser);
+      HttpRequest request = clientUtil.buildDeleteRequest(ecmRasProviderUrl, duosUser);
       HttpResponse response = clientUtil.handleHttpRequest(request);
       if (!response.isSuccessStatusCode()) {
         throw new ServerErrorException(response.getStatusMessage(), response.getStatusCode());
       }
     } catch (Exception e) {
       logWarn(
-          "Failed to delete NIH account for user: " + authUser.getEmail() + " - " + e.getMessage());
+          "Failed to delete NIH account for user: " + duosUser.getEmail() + " - " + e.getMessage());
       throw new ServerErrorException(
-          "Failed to delete NIH account for user: " + authUser.getEmail(),
+          "Failed to delete NIH account for user: " + duosUser.getEmail(),
           HttpStatusCodes.STATUS_CODE_SERVER_ERROR, e);
     }
 

--- a/src/main/java/org/broadinstitute/consent/http/service/NihService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/NihService.java
@@ -8,7 +8,6 @@ import com.google.inject.Inject;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.ServerErrorException;
-import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
@@ -99,14 +98,7 @@ public class NihService implements ConsentLogger {
   }
 
   public void deleteNihAccountById(Integer userId) {
-    List<UserProperty> properties = new ArrayList<>();
-    properties.add(new UserProperty(userId, UserFields.ERA_EXPIRATION_DATE.getValue()));
-    properties.add(new UserProperty(userId, UserFields.ERA_STATUS.getValue()));
-    if (userDAO.findUserById(userId) == null) {
-      throw new NotFoundException("User with id: " + userId + " does not exist");
-    }
-    userDAO.updateEraCommonsId(userId, null);
-    userPropertyDAO.deletePropertiesByUserAndKey(properties);
+    serviceDAO.deleteNihAccountById(userId);
   }
 
 

--- a/src/main/java/org/broadinstitute/consent/http/service/NihService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/NihService.java
@@ -19,7 +19,6 @@ import org.broadinstitute.consent.http.db.UserDAO;
 import org.broadinstitute.consent.http.db.UserPropertyDAO;
 import org.broadinstitute.consent.http.enumeration.UserFields;
 import org.broadinstitute.consent.http.models.AuthUser;
-import org.broadinstitute.consent.http.models.Error;
 import org.broadinstitute.consent.http.models.NIHUserAccount;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.UserProperty;

--- a/src/main/java/org/broadinstitute/consent/http/service/NihService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/NihService.java
@@ -8,6 +8,7 @@ import com.google.inject.Inject;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.ServerErrorException;
+import java.time.Instant;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
@@ -55,12 +56,10 @@ public class NihService implements ConsentLogger {
         throw new ServerErrorException(response.getStatusMessage(), response.getStatusCode());
       }
       String body = response.parseAsString();
-      LinkInfo linkInfo = parseLinkInfo(body);
-      NIHUserAccount nihAccount = new NIHUserAccount(
-          linkInfo.externalUserId(), linkInfo.expirationTimestamp(), linkInfo.authenticated());
+      NIHUserAccount nihAccount = parseNihUserAccount(body);
       serviceDAO.updateUserNihStatus(user, nihAccount);
     } catch (NotFoundException e) {
-      deleteNihAccountById(user.getUserId());
+      serviceDAO.deleteNihAccountById(user.getUserId());
     }
     return userDAO.findUserWithPropertiesById(user.getUserId(), UserFields.getValues());
   }
@@ -97,8 +96,26 @@ public class NihService implements ConsentLogger {
     }
   }
 
-  public void deleteNihAccountById(Integer userId) {
-    serviceDAO.deleteNihAccountById(userId);
+  public void deleteNihAccountById(AuthUser authUser) {
+    User user = userDAO.findUserByEmail(authUser.getEmail());
+    // Delete linkage locally
+    serviceDAO.deleteNihAccountById(user.getUserId());
+    try {
+      // Delete linkage from ECM
+      GenericUrl ecmRasProviderUrl = new GenericUrl(configuration.getEcmRasProviderUrl());
+      HttpRequest request = clientUtil.buildDeleteRequest(ecmRasProviderUrl, authUser);
+      HttpResponse response = clientUtil.handleHttpRequest(request);
+      if (!response.isSuccessStatusCode()) {
+        throw new ServerErrorException(response.getStatusMessage(), response.getStatusCode());
+      }
+    } catch (Exception e) {
+      logWarn(
+          "Failed to delete NIH account for user: " + authUser.getEmail() + " - " + e.getMessage());
+      throw new ServerErrorException(
+          "Failed to delete NIH account for user: " + authUser.getEmail(),
+          HttpStatusCodes.STATUS_CODE_SERVER_ERROR, e);
+    }
+
   }
 
 
@@ -111,9 +128,14 @@ public class NihService implements ConsentLogger {
     return String.valueOf(expires.getTime());
   }
 
-  private LinkInfo parseLinkInfo(String body) {
+  private NIHUserAccount parseNihUserAccount(String body) {
     try {
-      return GsonUtil.getInstance().fromJson(body, LinkInfo.class);
+      LinkInfo linkInfo = GsonUtil.getInstance().fromJson(body, LinkInfo.class);
+      // LinkInfo expirationTimestamp is in a date string.
+      // Historically, we store this value as epoch milliseconds
+      Instant instant = Instant.parse(linkInfo.expirationTimestamp());
+      return new NIHUserAccount(
+          linkInfo.externalUserId(), String.valueOf(instant.toEpochMilli()), linkInfo.authenticated());
     } catch (Exception e) {
       logWarn("Failed to parse ECM response: " + body);
       throw new ServerErrorException("Invalid response from ECM RAS Provider",

--- a/src/main/java/org/broadinstitute/consent/http/service/NihService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/NihService.java
@@ -3,6 +3,7 @@ package org.broadinstitute.consent.http.service;
 import com.google.api.client.http.GenericUrl;
 import com.google.api.client.http.HttpRequest;
 import com.google.api.client.http.HttpResponse;
+import com.google.api.client.http.HttpStatusCodes;
 import com.google.inject.Inject;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.NotFoundException;
@@ -18,6 +19,7 @@ import org.broadinstitute.consent.http.db.UserDAO;
 import org.broadinstitute.consent.http.db.UserPropertyDAO;
 import org.broadinstitute.consent.http.enumeration.UserFields;
 import org.broadinstitute.consent.http.models.AuthUser;
+import org.broadinstitute.consent.http.models.Error;
 import org.broadinstitute.consent.http.models.NIHUserAccount;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.UserProperty;
@@ -54,7 +56,14 @@ public class NihService implements ConsentLogger {
       throw new ServerErrorException(response.getStatusMessage(), response.getStatusCode());
     }
     String body = response.parseAsString();
-    LinkInfo linkInfo = GsonUtil.getInstance().fromJson(body, LinkInfo.class);
+    LinkInfo linkInfo;
+    try {
+      linkInfo = GsonUtil.getInstance().fromJson(body, LinkInfo.class);
+    } catch (Exception e) {
+      logWarn("Failed to parse ECM response: " + body);
+      throw new ServerErrorException("Invalid response from ECM RAS Provider",
+          HttpStatusCodes.STATUS_CODE_SERVER_ERROR);
+    }
     NIHUserAccount nihAccount = new NIHUserAccount(
         linkInfo.externalUserId(), linkInfo.expirationTimestamp(), linkInfo.authenticated());
     serviceDAO.updateUserNihStatus(user, nihAccount);

--- a/src/main/java/org/broadinstitute/consent/http/service/NihService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/NihService.java
@@ -50,22 +50,19 @@ public class NihService implements ConsentLogger {
     User user = userDAO.findUserByEmail(authUser.getEmail());
     GenericUrl ecmRasProviderUrl = new GenericUrl(configuration.getEcmRasProviderUrl());
     HttpRequest request = clientUtil.buildGetRequest(ecmRasProviderUrl, authUser);
-    HttpResponse response = clientUtil.handleHttpRequest(request);
-    if (!response.isSuccessStatusCode()) {
-      throw new ServerErrorException(response.getStatusMessage(), response.getStatusCode());
-    }
-    String body = response.parseAsString();
-    LinkInfo linkInfo;
     try {
-      linkInfo = GsonUtil.getInstance().fromJson(body, LinkInfo.class);
-    } catch (Exception e) {
-      logWarn("Failed to parse ECM response: " + body);
-      throw new ServerErrorException("Invalid response from ECM RAS Provider",
-          HttpStatusCodes.STATUS_CODE_SERVER_ERROR);
+      HttpResponse response = clientUtil.handleHttpRequest(request);
+      if (!response.isSuccessStatusCode()) {
+        throw new ServerErrorException(response.getStatusMessage(), response.getStatusCode());
+      }
+      String body = response.parseAsString();
+      LinkInfo linkInfo = parseLinkInfo(body);
+      NIHUserAccount nihAccount = new NIHUserAccount(
+          linkInfo.externalUserId(), linkInfo.expirationTimestamp(), linkInfo.authenticated());
+      serviceDAO.updateUserNihStatus(user, nihAccount);
+    } catch (NotFoundException e) {
+      deleteNihAccountById(user.getUserId());
     }
-    NIHUserAccount nihAccount = new NIHUserAccount(
-        linkInfo.externalUserId(), linkInfo.expirationTimestamp(), linkInfo.authenticated());
-    serviceDAO.updateUserNihStatus(user, nihAccount);
     return userDAO.findUserWithPropertiesById(user.getUserId(), UserFields.getValues());
   }
 
@@ -108,6 +105,7 @@ public class NihService implements ConsentLogger {
     if (userDAO.findUserById(userId) == null) {
       throw new NotFoundException("User with id: " + userId + " does not exist");
     }
+    userDAO.updateEraCommonsId(userId, null);
     userPropertyDAO.deletePropertiesByUserAndKey(properties);
   }
 
@@ -121,4 +119,13 @@ public class NihService implements ConsentLogger {
     return String.valueOf(expires.getTime());
   }
 
+  private LinkInfo parseLinkInfo(String body) {
+    try {
+      return GsonUtil.getInstance().fromJson(body, LinkInfo.class);
+    } catch (Exception e) {
+      logWarn("Failed to parse ECM response: " + body);
+      throw new ServerErrorException("Invalid response from ECM RAS Provider",
+          HttpStatusCodes.STATUS_CODE_SERVER_ERROR);
+    }
+  }
 }

--- a/src/main/java/org/broadinstitute/consent/http/service/dao/NihServiceDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/dao/NihServiceDAO.java
@@ -42,4 +42,17 @@ public class NihServiceDAO implements ConsentLogger {
       userDAO.updateEraCommonsId(user.getUserId(), nihAccount.getNihUsername());
     });
   }
+
+  public void deleteNihAccountById(Integer userId) {
+    jdbi.useTransaction(handler -> {
+      UserDAO userDAO = handler.attach(UserDAO.class);
+      UserPropertyDAO userPropertyDAO = handler.attach(UserPropertyDAO.class);
+      Collection<UserProperty> properties = List.of(
+          new UserProperty(userId, UserFields.ERA_EXPIRATION_DATE.getValue()),
+          new UserProperty(userId, UserFields.ERA_STATUS.getValue())
+      );
+      userDAO.updateEraCommonsId(userId, null);
+      userPropertyDAO.deletePropertiesByUserAndKey(properties);
+    });
+  }
 }

--- a/src/main/java/org/broadinstitute/consent/http/util/HttpClientUtil.java
+++ b/src/main/java/org/broadinstitute/consent/http/util/HttpClientUtil.java
@@ -105,6 +105,13 @@ public class HttpClientUtil implements ConsentLogger {
     return request;
   }
 
+  public HttpRequest buildDeleteRequest(GenericUrl genericUrl, AuthUser authUser) throws Exception {
+    HttpTransport transport = new NetHttpTransport();
+    HttpRequest request = transport.createRequestFactory().buildDeleteRequest(genericUrl);
+    request.setHeaders(buildHeaders(authUser));
+    return request;
+  }
+
   public HttpRequest buildUnAuthedGetRequest(GenericUrl genericUrl) throws Exception {
     HttpTransport transport = new NetHttpTransport();
     HttpRequest request = transport.createRequestFactory().buildGetRequest(genericUrl);

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -893,6 +893,8 @@ paths:
           description: Error processing the request.
   /api/nih:
     $ref: './paths/nih.yaml'
+  /api/nih/sync:
+    $ref: './paths/nihSync.yaml'
   /api/sam/register/self:
     $ref: './paths/samRegisterSelf.yaml'
   /api/sam/register/self/diagnostics:

--- a/src/main/resources/assets/paths/nih.yaml
+++ b/src/main/resources/assets/paths/nih.yaml
@@ -1,6 +1,6 @@
 delete:
   summary: Delete eRA Commons Account
-  description: Removes only eRA Commons Account related information from the authenticated user requesting this action
+  description: Removes Linked Account information for the authenticated user
   tags:
     - User
     - Nih
@@ -8,6 +8,7 @@ delete:
     200:
       description: Returns an empty response if the operation was successful
 post:
+  deprecated: true
   summary: Store eRA Commons information
   description: Save user's eRA Commons account
   requestBody:

--- a/src/main/resources/assets/paths/nih.yaml
+++ b/src/main/resources/assets/paths/nih.yaml
@@ -3,7 +3,6 @@ delete:
   description: Removes only eRA Commons Account related information from the authenticated user requesting this action
   tags:
     - User
-    - eRA Commons
     - Nih
   responses:
     200:
@@ -20,7 +19,6 @@ post:
           $ref: '../schemas/NIHUserAccount.yaml'
   tags:
     - User
-    - eRA Commons
     - Nih
   responses:
     200:

--- a/src/main/resources/assets/paths/nihSync.yaml
+++ b/src/main/resources/assets/paths/nihSync.yaml
@@ -1,6 +1,6 @@
 get:
-  summary: Synchronize NIH Account
-  description: Synchronizes the user's account with known NIH linked account
+  summary: Get Synchronized User NIH Account
+  description: Get a synchronized user account fetches known linked accounts
   tags:
     - User
     - Nih

--- a/src/main/resources/assets/paths/nihSync.yaml
+++ b/src/main/resources/assets/paths/nihSync.yaml
@@ -1,0 +1,18 @@
+get:
+  summary: Synchronize NIH Account
+  description: Synchronizes the user's account with known NIH linked account
+  tags:
+    - User
+    - eRA Commons
+    - Nih
+  responses:
+    200:
+      description: Returns the synchronized user.
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/User.yaml'
+    400:
+      description: Unable to validate the user's google identity.
+    500:
+      description: Server error.

--- a/src/main/resources/assets/paths/nihSync.yaml
+++ b/src/main/resources/assets/paths/nihSync.yaml
@@ -3,7 +3,6 @@ get:
   description: Synchronizes the user's account with known NIH linked account
   tags:
     - User
-    - eRA Commons
     - Nih
   responses:
     200:
@@ -12,7 +11,5 @@ get:
         application/json:
           schema:
             $ref: '../schemas/User.yaml'
-    400:
-      description: Unable to validate the user's google identity.
     500:
       description: Server error.

--- a/src/test/java/org/broadinstitute/consent/http/db/UserDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/UserDAOTest.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import org.apache.commons.lang3.RandomStringUtils;
+import org.broadinstitute.consent.http.enumeration.UserFields;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.Dac;
 import org.broadinstitute.consent.http.models.DataUse;
@@ -26,6 +27,7 @@ import org.broadinstitute.consent.http.models.Dataset;
 import org.broadinstitute.consent.http.models.DatasetProperty;
 import org.broadinstitute.consent.http.models.LibraryCard;
 import org.broadinstitute.consent.http.models.User;
+import org.broadinstitute.consent.http.models.UserProperty;
 import org.broadinstitute.consent.http.models.UserRole;
 import org.jdbi.v3.core.statement.UnableToExecuteStatementException;
 import org.junit.jupiter.api.Test;
@@ -63,6 +65,37 @@ class UserDAOTest extends DAOTestHelper {
     assertNotNull(queriedUser3.getInstitutionId());
     assert (queriedUser3.getInstitution().getId()).equals(user3.getInstitution().getId());
   }
+
+  @Test
+  void testFindUserWithPropertiesById() {
+    User user = createUserWithInstitution();
+    int lcId = libraryCardDAO.insertLibraryCard(user.getUserId(), user.getDisplayName(),
+        user.getEmail(), user.getUserId(), new Date());
+    UserProperty eraExpProp = new UserProperty();
+    eraExpProp.setPropertyKey(UserFields.ERA_EXPIRATION_DATE.getValue());
+    eraExpProp.setPropertyValue(Instant.now().toString());
+    eraExpProp.setUserId(user.getUserId());
+    UserProperty eraAuthProp = new UserProperty();
+    eraAuthProp.setPropertyKey(UserFields.ERA_STATUS.getValue());
+    eraAuthProp.setPropertyValue("true");
+    eraAuthProp.setUserId(user.getUserId());
+    userPropertyDAO.insertAll(List.of(eraExpProp, eraAuthProp));
+
+    User foundUser = userDAO.findUserWithPropertiesById(user.getUserId(),
+        UserFields.getValues());
+    assertNotNull(foundUser);
+    assertFalse(foundUser.getRoles().isEmpty());
+    assertEquals(lcId, foundUser.getLibraryCard().getId());
+    assertEquals(user.getInstitutionId(), foundUser.getInstitutionId());
+    assertFalse(foundUser.getProperties().isEmpty());
+    assertTrue(foundUser.getProperties().stream()
+        .anyMatch(p -> p.getPropertyKey().equals(UserFields.ERA_EXPIRATION_DATE.getValue())
+            && p.getPropertyValue().equals(eraExpProp.getPropertyValue())));
+    assertTrue(foundUser.getProperties().stream()
+        .anyMatch(p -> p.getPropertyKey().equals(UserFields.ERA_STATUS.getValue())
+            && p.getPropertyValue().equals(eraAuthProp.getPropertyValue())));
+  }
+
 
   @Test
   void testFindUserByIdWithLibraryCard() {

--- a/src/test/java/org/broadinstitute/consent/http/resources/NihAccountResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/NihAccountResourceTest.java
@@ -112,7 +112,7 @@ class NihAccountResourceTest {
   @Test
   void testDeleteNihAccountError() {
     when(userService.findUserByEmail(any())).thenReturn(user);
-    doThrow(new RuntimeException()).when(nihService).deleteNihAccountById(any());
+    doThrow(new RuntimeException()).when(nihService).deleteNihAccountById(authUser);
     resource = new NihAccountResource(nihService, userService);
     try (var response = resource.deleteNihAccount(authUser)) {
       assertEquals(HttpStatusCodes.STATUS_CODE_SERVER_ERROR, response.getStatus());

--- a/src/test/java/org/broadinstitute/consent/http/resources/NihAccountResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/NihAccountResourceTest.java
@@ -93,7 +93,6 @@ class NihAccountResourceTest {
 
   @Test
   void testDeleteNihAccountSuccess() {
-    when(userService.findUserByEmail(any())).thenReturn(user);
     resource = new NihAccountResource(nihService, userService);
     try (var response = resource.deleteNihAccount(authUser)) {
       assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
@@ -102,7 +101,7 @@ class NihAccountResourceTest {
 
   @Test
   void testDeleteNihAccountNoAuth() {
-    when(userService.findUserByEmail(any())).thenReturn(null);
+    doThrow(new RuntimeException()).when(nihService).deleteNihAccountById(authUser);
     resource = new NihAccountResource(nihService, userService);
     try (var response = resource.deleteNihAccount(authUser)) {
       assertEquals(HttpStatusCodes.STATUS_CODE_SERVER_ERROR, response.getStatus());
@@ -111,7 +110,6 @@ class NihAccountResourceTest {
 
   @Test
   void testDeleteNihAccountError() {
-    when(userService.findUserByEmail(any())).thenReturn(user);
     doThrow(new RuntimeException()).when(nihService).deleteNihAccountById(authUser);
     resource = new NihAccountResource(nihService, userService);
     try (var response = resource.deleteNihAccount(authUser)) {

--- a/src/test/java/org/broadinstitute/consent/http/resources/NihAccountResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/NihAccountResourceTest.java
@@ -38,11 +38,28 @@ class NihAccountResourceTest {
   private NihAccountResource resource;
 
   @Test
+  void testSyncAccountSuccess() {
+    resource = new NihAccountResource(nihService, userService);
+    try (var response = resource.syncAccount(authUser)) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+    }
+  }
+
+  @Test
+  void testSyncAccountNoAuth() throws Exception {
+    when(nihService.syncAccount(authUser)).thenThrow(new RuntimeException());
+    resource = new NihAccountResource(nihService, userService);
+    try (var response = resource.syncAccount(authUser)) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_SERVER_ERROR, response.getStatus());
+    }
+  }
+
+  @Test
   void testRegisterResearcherSuccess() {
     when(userService.findUserByEmail(any())).thenReturn(user);
     resource = new NihAccountResource(nihService, userService);
     try (var response = resource.registerResearcher(authUser, nihAccount)) {
-      assertEquals(200, response.getStatus());
+      assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
     }
   }
 
@@ -51,7 +68,7 @@ class NihAccountResourceTest {
     when(userService.findUserByEmail(any())).thenReturn(null);
     resource = new NihAccountResource(nihService, userService);
     try (var response = resource.registerResearcher(authUser, nihAccount)) {
-      assertEquals(500, response.getStatus());
+      assertEquals(HttpStatusCodes.STATUS_CODE_SERVER_ERROR, response.getStatus());
     }
   }
 
@@ -61,7 +78,7 @@ class NihAccountResourceTest {
     doThrow(new RuntimeException()).when(nihService).authenticateNih(any(), any(), any());
     resource = new NihAccountResource(nihService, userService);
     try (var response = resource.registerResearcher(authUser, nihAccount)) {
-      assertEquals(500, response.getStatus());
+      assertEquals(HttpStatusCodes.STATUS_CODE_SERVER_ERROR, response.getStatus());
     }
   }
 
@@ -79,7 +96,7 @@ class NihAccountResourceTest {
     when(userService.findUserByEmail(any())).thenReturn(user);
     resource = new NihAccountResource(nihService, userService);
     try (var response = resource.deleteNihAccount(authUser)) {
-      assertEquals(200, response.getStatus());
+      assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
     }
   }
 
@@ -88,7 +105,7 @@ class NihAccountResourceTest {
     when(userService.findUserByEmail(any())).thenReturn(null);
     resource = new NihAccountResource(nihService, userService);
     try (var response = resource.deleteNihAccount(authUser)) {
-      assertEquals(500, response.getStatus());
+      assertEquals(HttpStatusCodes.STATUS_CODE_SERVER_ERROR, response.getStatus());
     }
   }
 
@@ -98,7 +115,7 @@ class NihAccountResourceTest {
     doThrow(new RuntimeException()).when(nihService).deleteNihAccountById(any());
     resource = new NihAccountResource(nihService, userService);
     try (var response = resource.deleteNihAccount(authUser)) {
-      assertEquals(500, response.getStatus());
+      assertEquals(HttpStatusCodes.STATUS_CODE_SERVER_ERROR, response.getStatus());
     }
   }
 }

--- a/src/test/java/org/broadinstitute/consent/http/resources/NihAccountResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/NihAccountResourceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.when;
 import com.google.api.client.http.HttpStatusCodes;
 import jakarta.ws.rs.BadRequestException;
 import org.broadinstitute.consent.http.models.AuthUser;
+import org.broadinstitute.consent.http.models.DuosUser;
 import org.broadinstitute.consent.http.models.NIHUserAccount;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.service.NihService;
@@ -35,21 +36,24 @@ class NihAccountResourceTest {
   @Mock
   private AuthUser authUser;
 
+  @Mock
+  private DuosUser duosUser;
+
   private NihAccountResource resource;
 
   @Test
   void testSyncAccountSuccess() {
     resource = new NihAccountResource(nihService, userService);
-    try (var response = resource.syncAccount(authUser)) {
+    try (var response = resource.syncAccount(duosUser)) {
       assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
     }
   }
 
   @Test
   void testSyncAccountNoAuth() throws Exception {
-    when(nihService.syncAccount(authUser)).thenThrow(new RuntimeException());
+    when(nihService.syncAccount(duosUser)).thenThrow(new RuntimeException());
     resource = new NihAccountResource(nihService, userService);
-    try (var response = resource.syncAccount(authUser)) {
+    try (var response = resource.syncAccount(duosUser)) {
       assertEquals(HttpStatusCodes.STATUS_CODE_SERVER_ERROR, response.getStatus());
     }
   }
@@ -94,25 +98,25 @@ class NihAccountResourceTest {
   @Test
   void testDeleteNihAccountSuccess() {
     resource = new NihAccountResource(nihService, userService);
-    try (var response = resource.deleteNihAccount(authUser)) {
+    try (var response = resource.deleteNihAccount(duosUser)) {
       assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
     }
   }
 
   @Test
   void testDeleteNihAccountNoAuth() {
-    doThrow(new RuntimeException()).when(nihService).deleteNihAccountById(authUser);
+    doThrow(new RuntimeException()).when(nihService).deleteNihAccountById(duosUser);
     resource = new NihAccountResource(nihService, userService);
-    try (var response = resource.deleteNihAccount(authUser)) {
+    try (var response = resource.deleteNihAccount(duosUser)) {
       assertEquals(HttpStatusCodes.STATUS_CODE_SERVER_ERROR, response.getStatus());
     }
   }
 
   @Test
   void testDeleteNihAccountError() {
-    doThrow(new RuntimeException()).when(nihService).deleteNihAccountById(authUser);
+    doThrow(new RuntimeException()).when(nihService).deleteNihAccountById(duosUser);
     resource = new NihAccountResource(nihService, userService);
-    try (var response = resource.deleteNihAccount(authUser)) {
+    try (var response = resource.deleteNihAccount(duosUser)) {
       assertEquals(HttpStatusCodes.STATUS_CODE_SERVER_ERROR, response.getStatus());
     }
   }

--- a/src/test/java/org/broadinstitute/consent/http/resources/NihAccountResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/NihAccountResourceTest.java
@@ -104,15 +104,6 @@ class NihAccountResourceTest {
   }
 
   @Test
-  void testDeleteNihAccountNoAuth() {
-    doThrow(new RuntimeException()).when(nihService).deleteNihAccountById(duosUser);
-    resource = new NihAccountResource(nihService, userService);
-    try (var response = resource.deleteNihAccount(duosUser)) {
-      assertEquals(HttpStatusCodes.STATUS_CODE_SERVER_ERROR, response.getStatus());
-    }
-  }
-
-  @Test
   void testDeleteNihAccountError() {
     doThrow(new RuntimeException()).when(nihService).deleteNihAccountById(duosUser);
     resource = new NihAccountResource(nihService, userService);

--- a/src/test/java/org/broadinstitute/consent/http/service/NihServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/NihServiceTest.java
@@ -22,6 +22,7 @@ import org.broadinstitute.consent.http.db.UserDAO;
 import org.broadinstitute.consent.http.db.UserPropertyDAO;
 import org.broadinstitute.consent.http.enumeration.UserFields;
 import org.broadinstitute.consent.http.models.AuthUser;
+import org.broadinstitute.consent.http.models.DuosUser;
 import org.broadinstitute.consent.http.models.NIHUserAccount;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.UserProperty;
@@ -47,6 +48,9 @@ class NihServiceTest extends MockServerTestHelper {
   @Mock
   private NihServiceDAO nihServiceDAO;
 
+  @Mock
+  private DuosUser duosUser;
+
   private NihService service;
   private NIHUserAccount nihUserAccount;
   private AuthUser authUser;
@@ -68,7 +72,7 @@ class NihServiceTest extends MockServerTestHelper {
   void testSyncAccount() throws Exception {
     User user = new User();
     user.setUserId(1);
-    when(userDAO.findUserByEmail(authUser.getEmail())).thenReturn(user);
+    when(duosUser.getUser()).thenReturn(user);
     when(userDAO.findUserWithPropertiesById(user.getUserId(), UserFields.getValues())).thenReturn(
         user);
     String timestamp = "2025-08-28T16:54:22.064+00:00";
@@ -81,7 +85,7 @@ class NihServiceTest extends MockServerTestHelper {
         .respond(response()
             .withStatusCode(HttpStatusCodes.STATUS_CODE_OK)
             .withBody(GsonUtil.getInstance().toJson(ecmResponse)));
-    User syncedUser = service.syncAccount(authUser);
+    User syncedUser = service.syncAccount(duosUser);
     assertEquals(user.getUserId(), syncedUser.getUserId());
     verify(nihServiceDAO).updateUserNihStatus(user, nihAccount);
   }
@@ -90,51 +94,51 @@ class NihServiceTest extends MockServerTestHelper {
   void testSyncAccountBadRequestError() {
     User user = new User();
     user.setUserId(1);
-    when(userDAO.findUserByEmail(authUser.getEmail())).thenReturn(user);
+    when(duosUser.getUser()).thenReturn(user);
     LinkInfo ecmResponse = new LinkInfo("test", "test", true);
     mockServerClient.when(request())
         .respond(response()
             .withStatusCode(HttpStatusCodes.STATUS_CODE_BAD_REQUEST)
             .withBody(GsonUtil.getInstance().toJson(ecmResponse)));
-    assertThrows(BadRequestException.class, () -> service.syncAccount(authUser));
+    assertThrows(BadRequestException.class, () -> service.syncAccount(duosUser));
   }
 
   @Test
   void testSyncAccountServerError() {
     User user = new User();
     user.setUserId(1);
-    when(userDAO.findUserByEmail(authUser.getEmail())).thenReturn(user);
+    when(duosUser.getUser()).thenReturn(user);
     LinkInfo ecmResponse = new LinkInfo("test", "test", true);
     mockServerClient.when(request())
         .respond(response()
             .withStatusCode(HttpStatusCodes.STATUS_CODE_SERVER_ERROR)
             .withBody(GsonUtil.getInstance().toJson(ecmResponse)));
-    assertThrows(ServerErrorException.class, () -> service.syncAccount(authUser));
+    assertThrows(ServerErrorException.class, () -> service.syncAccount(duosUser));
   }
 
   @Test
   void testSyncAccountInvalidECMResponse() {
     User user = new User();
     user.setUserId(1);
-    when(userDAO.findUserByEmail(authUser.getEmail())).thenReturn(user);
+    when(duosUser.getUser()).thenReturn(user);
     mockServerClient.when(request())
         .respond(response()
             .withStatusCode(HttpStatusCodes.STATUS_CODE_OK)
             .withBody(GsonUtil.getInstance().toJson("bad response")));
-    assertThrows(ServerErrorException.class, () -> service.syncAccount(authUser));
+    assertThrows(ServerErrorException.class, () -> service.syncAccount(duosUser));
   }
 
   @Test
   void testSyncAccountECMNotFound() throws Exception {
     User user = new User();
     user.setUserId(1);
-    when(userDAO.findUserByEmail(authUser.getEmail())).thenReturn(user);
+    when(duosUser.getUser()).thenReturn(user);
     when(userDAO.findUserWithPropertiesById(user.getUserId(), UserFields.getValues())).thenReturn(
         user);
     mockServerClient.when(request())
         .respond(response()
             .withStatusCode(HttpStatusCodes.STATUS_CODE_NOT_FOUND));
-    User syncedUser = service.syncAccount(authUser);
+    User syncedUser = service.syncAccount(duosUser);
     assertEquals(user.getUserId(), syncedUser.getUserId());
     verify(nihServiceDAO).deleteNihAccountById(user.getUserId());
   }

--- a/src/test/java/org/broadinstitute/consent/http/service/NihServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/NihServiceTest.java
@@ -12,7 +12,6 @@ import com.google.api.client.http.HttpStatusCodes;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.ServerErrorException;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -69,10 +68,12 @@ class NihServiceTest extends MockServerTestHelper {
     User user = new User();
     user.setUserId(1);
     when(userDAO.findUserByEmail(authUser.getEmail())).thenReturn(user);
-    when(userDAO.findUserWithPropertiesById(user.getUserId(), UserFields.getValues())).thenReturn(user);
+    when(userDAO.findUserWithPropertiesById(user.getUserId(), UserFields.getValues())).thenReturn(
+        user);
     LinkInfo ecmResponse = new LinkInfo("test", "test", true);
     NIHUserAccount nihAccount = new NIHUserAccount(
-        ecmResponse.externalUserId(), ecmResponse.expirationTimestamp(), ecmResponse.authenticated());
+        ecmResponse.externalUserId(), ecmResponse.expirationTimestamp(),
+        ecmResponse.authenticated());
     mockServerClient.when(request())
         .respond(response()
             .withStatusCode(HttpStatusCodes.STATUS_CODE_OK)
@@ -125,18 +126,14 @@ class NihServiceTest extends MockServerTestHelper {
     User user = new User();
     user.setUserId(1);
     when(userDAO.findUserByEmail(authUser.getEmail())).thenReturn(user);
-    when(userDAO.findUserById(user.getUserId())).thenReturn(user);
-    when(userDAO.findUserWithPropertiesById(user.getUserId(), UserFields.getValues())).thenReturn(user);
+    when(userDAO.findUserWithPropertiesById(user.getUserId(), UserFields.getValues())).thenReturn(
+        user);
     mockServerClient.when(request())
         .respond(response()
             .withStatusCode(HttpStatusCodes.STATUS_CODE_NOT_FOUND));
     User syncedUser = service.syncAccount(authUser);
     assertEquals(user.getUserId(), syncedUser.getUserId());
-    verify(userDAO).updateEraCommonsId(user.getUserId(), null);
-    List<UserProperty> properties = new ArrayList<>();
-    properties.add(new UserProperty(user.getUserId(), UserFields.ERA_EXPIRATION_DATE.getValue()));
-    properties.add(new UserProperty(user.getUserId(), UserFields.ERA_STATUS.getValue()));
-    verify(userPropertyDAO).deletePropertiesByUserAndKey(properties);
+    verify(nihServiceDAO).deleteNihAccountById(user.getUserId());
   }
 
   @Test
@@ -184,23 +181,5 @@ class NihServiceTest extends MockServerTestHelper {
     NIHUserAccount account = new NIHUserAccount();
     account.setStatus(true);
     assertThrows(BadRequestException.class, () -> service.authenticateNih(account, authUser, 1));
-  }
-
-  @Test
-  void testDeleteNihAccountById() {
-    User user = new User();
-    user.setUserId(1);
-    when(userDAO.findUserById(any())).thenReturn(user);
-    service.deleteNihAccountById(1);
-    verify(userDAO).updateEraCommonsId(user.getUserId(), null);
-    List<UserProperty> properties = new ArrayList<>();
-    properties.add(new UserProperty(user.getUserId(), UserFields.ERA_EXPIRATION_DATE.getValue()));
-    properties.add(new UserProperty(user.getUserId(), UserFields.ERA_STATUS.getValue()));
-    verify(userPropertyDAO).deletePropertiesByUserAndKey(properties);
-  }
-
-  @Test
-  void testDeleteNihAccountByIdNotFound() {
-    assertThrows(NotFoundException.class, () -> service.deleteNihAccountById(1));
   }
 }

--- a/src/test/java/org/broadinstitute/consent/http/service/NihServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/NihServiceTest.java
@@ -110,6 +110,18 @@ class NihServiceTest extends MockServerTestHelper {
   }
 
   @Test
+  void testSyncAccountInvalidECMResponse() {
+    User user = new User();
+    user.setUserId(1);
+    when(userDAO.findUserByEmail(authUser.getEmail())).thenReturn(user);
+    mockServerClient.when(request())
+        .respond(response()
+            .withStatusCode(HttpStatusCodes.STATUS_CODE_OK)
+            .withBody(GsonUtil.getInstance().toJson("bad response")));
+    assertThrows(ServerErrorException.class, () -> service.syncAccount(authUser));
+  }
+
+  @Test
   void testAuthenticateNih_InvalidUser() {
     AuthUser testUser = new AuthUser("test@test.com");
     assertThrows(NotFoundException.class,

--- a/src/test/java/org/broadinstitute/consent/http/service/NihServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/NihServiceTest.java
@@ -3,7 +3,6 @@ package org.broadinstitute.consent.http.service;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;

--- a/src/test/java/org/broadinstitute/consent/http/service/NihServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/NihServiceTest.java
@@ -3,22 +3,33 @@ package org.broadinstitute.consent.http.service;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockserver.model.HttpRequest.request;
+import static org.mockserver.model.HttpResponse.response;
 
+import com.google.api.client.http.HttpStatusCodes;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.ServerErrorException;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
+import org.broadinstitute.consent.http.MockServerTestHelper;
+import org.broadinstitute.consent.http.configurations.ServicesConfiguration;
 import org.broadinstitute.consent.http.db.UserDAO;
 import org.broadinstitute.consent.http.db.UserPropertyDAO;
+import org.broadinstitute.consent.http.enumeration.UserFields;
 import org.broadinstitute.consent.http.models.AuthUser;
 import org.broadinstitute.consent.http.models.NIHUserAccount;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.UserProperty;
+import org.broadinstitute.consent.http.models.ecm.LinkInfo;
 import org.broadinstitute.consent.http.service.dao.NihServiceDAO;
+import org.broadinstitute.consent.http.util.HttpClientUtil;
+import org.broadinstitute.consent.http.util.gson.GsonUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -26,7 +37,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-class NihServiceTest {
+class NihServiceTest extends MockServerTestHelper {
 
   @Mock
   private UserDAO userDAO;
@@ -43,18 +54,66 @@ class NihServiceTest {
 
   @BeforeEach
   void setUp() {
+    ServicesConfiguration servicesConfig = new ServicesConfiguration();
+    servicesConfig.setTimeoutSeconds(1);
+    servicesConfig.setEcmUrl(
+        "http://" + CONTAINER.getHost() + ":" + CONTAINER.getServerPort() + "/");
     nihUserAccount = new NIHUserAccount("nih username", new Date().toString(), true);
     authUser = new AuthUser("test@test.com");
+    service = new NihService(userDAO, userPropertyDAO, nihServiceDAO,
+        new HttpClientUtil(servicesConfig), servicesConfig);
+    mockServerClient.reset();
   }
 
-  private void initService() {
-    service = new NihService(userDAO, userPropertyDAO, nihServiceDAO);
+  @Test
+  void testSyncAccount() throws Exception {
+    User user = new User();
+    user.setUserId(1);
+    when(userDAO.findUserByEmail(authUser.getEmail())).thenReturn(user);
+    when(userDAO.findUserWithPropertiesById(user.getUserId(), UserFields.getValues())).thenReturn(user);
+    LinkInfo ecmResponse = new LinkInfo("test", "test", true);
+    NIHUserAccount nihAccount = new NIHUserAccount(
+        ecmResponse.externalUserId(), ecmResponse.expirationTimestamp(), ecmResponse.authenticated());
+    mockServerClient.when(request())
+        .respond(response()
+            .withStatusCode(200)
+            .withBody(GsonUtil.getInstance().toJson(ecmResponse)));
+    User syncedUser = service.syncAccount(authUser);
+    assertEquals(user.getUserId(), syncedUser.getUserId());
+    verify(nihServiceDAO).updateUserNihStatus(user, nihAccount);
+  }
+
+  @Test
+  void testSyncAccountBadRequestError() {
+    User user = new User();
+    user.setUserId(1);
+    when(userDAO.findUserByEmail(authUser.getEmail())).thenReturn(user);
+    LinkInfo ecmResponse = new LinkInfo("test", "test", true);
+    mockServerClient.when(request())
+        .respond(response()
+            .withStatusCode(HttpStatusCodes.STATUS_CODE_BAD_REQUEST)
+            .withBody(GsonUtil.getInstance().toJson(ecmResponse)));
+    assertThrows(BadRequestException.class, () -> service.syncAccount(authUser));
+  }
+
+  @Test
+  void testSyncAccountServerError() {
+    User user = new User();
+    user.setUserId(1);
+    when(userDAO.findUserByEmail(authUser.getEmail())).thenReturn(user);
+    LinkInfo ecmResponse = new LinkInfo("test", "test", true);
+    mockServerClient.when(request())
+        .respond(response()
+            .withStatusCode(HttpStatusCodes.STATUS_CODE_SERVER_ERROR)
+            .withBody(GsonUtil.getInstance().toJson(ecmResponse)));
+    assertThrows(ServerErrorException.class, () -> service.syncAccount(authUser));
   }
 
   @Test
   void testAuthenticateNih_InvalidUser() {
-    initService();
-    assertThrows(NotFoundException.class, () -> service.authenticateNih(nihUserAccount, new AuthUser("test@test.com"), 1));
+    AuthUser testUser = new AuthUser("test@test.com");
+    assertThrows(NotFoundException.class,
+        () -> service.authenticateNih(nihUserAccount, testUser, 1));
   }
 
   @Test
@@ -64,7 +123,6 @@ class NihServiceTest {
     User user = new User();
     user.setUserId(1);
     when(userDAO.findUserById(any())).thenReturn(user);
-    initService();
     try {
       List<UserProperty> properties = service.authenticateNih(nihUserAccount, authUser,
           user.getUserId());
@@ -82,14 +140,12 @@ class NihServiceTest {
     user.setUserId(1);
     when(userDAO.findUserById(any())).thenReturn(user);
     nihUserAccount.setNihUsername("");
-    initService();
     assertThrows(BadRequestException.class,
         () -> service.authenticateNih(nihUserAccount, authUser, 1));
   }
 
   @Test
   void testAuthenticateNih_BadRequestNullAccount() {
-    initService();
     assertThrows(BadRequestException.class, () -> service.authenticateNih(null, authUser, 1));
   }
 
@@ -97,7 +153,6 @@ class NihServiceTest {
   void testAuthenticateNih_BadRequestNullAccountExpiration() {
     NIHUserAccount account = new NIHUserAccount();
     account.setStatus(true);
-    initService();
     assertThrows(BadRequestException.class, () -> service.authenticateNih(account, authUser, 1));
   }
 
@@ -106,14 +161,12 @@ class NihServiceTest {
     User user = new User();
     user.setUserId(1);
     when(userDAO.findUserById(any())).thenReturn(user);
-    initService();
     service.deleteNihAccountById(1);
     verify(userPropertyDAO, times(1)).deletePropertiesByUserAndKey(any());
   }
 
   @Test
   void testDeleteNihAccountByIdNotFound() {
-    initService();
     assertThrows(NotFoundException.class, () -> service.deleteNihAccountById(1));
   }
 }

--- a/src/test/java/org/broadinstitute/consent/http/service/NihServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/NihServiceTest.java
@@ -12,6 +12,7 @@ import com.google.api.client.http.HttpStatusCodes;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.ServerErrorException;
+import java.time.Instant;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -70,9 +71,11 @@ class NihServiceTest extends MockServerTestHelper {
     when(userDAO.findUserByEmail(authUser.getEmail())).thenReturn(user);
     when(userDAO.findUserWithPropertiesById(user.getUserId(), UserFields.getValues())).thenReturn(
         user);
-    LinkInfo ecmResponse = new LinkInfo("test", "test", true);
+    String timestamp = "2025-08-28T16:54:22.064+00:00";
+    LinkInfo ecmResponse = new LinkInfo("test", timestamp, true);
     NIHUserAccount nihAccount = new NIHUserAccount(
-        ecmResponse.externalUserId(), ecmResponse.expirationTimestamp(),
+        ecmResponse.externalUserId(),
+        String.valueOf(Instant.parse(timestamp).toEpochMilli()),
         ecmResponse.authenticated());
     mockServerClient.when(request())
         .respond(response()

--- a/src/test/java/org/broadinstitute/consent/http/service/NihServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/NihServiceTest.java
@@ -3,7 +3,6 @@ package org.broadinstitute.consent.http.service;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockserver.model.HttpRequest.request;
@@ -13,6 +12,7 @@ import com.google.api.client.http.HttpStatusCodes;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.ServerErrorException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -75,7 +75,7 @@ class NihServiceTest extends MockServerTestHelper {
         ecmResponse.externalUserId(), ecmResponse.expirationTimestamp(), ecmResponse.authenticated());
     mockServerClient.when(request())
         .respond(response()
-            .withStatusCode(200)
+            .withStatusCode(HttpStatusCodes.STATUS_CODE_OK)
             .withBody(GsonUtil.getInstance().toJson(ecmResponse)));
     User syncedUser = service.syncAccount(authUser);
     assertEquals(user.getUserId(), syncedUser.getUserId());
@@ -121,6 +121,25 @@ class NihServiceTest extends MockServerTestHelper {
   }
 
   @Test
+  void testSyncAccountECMNotFound() throws Exception {
+    User user = new User();
+    user.setUserId(1);
+    when(userDAO.findUserByEmail(authUser.getEmail())).thenReturn(user);
+    when(userDAO.findUserById(user.getUserId())).thenReturn(user);
+    when(userDAO.findUserWithPropertiesById(user.getUserId(), UserFields.getValues())).thenReturn(user);
+    mockServerClient.when(request())
+        .respond(response()
+            .withStatusCode(HttpStatusCodes.STATUS_CODE_NOT_FOUND));
+    User syncedUser = service.syncAccount(authUser);
+    assertEquals(user.getUserId(), syncedUser.getUserId());
+    verify(userDAO).updateEraCommonsId(user.getUserId(), null);
+    List<UserProperty> properties = new ArrayList<>();
+    properties.add(new UserProperty(user.getUserId(), UserFields.ERA_EXPIRATION_DATE.getValue()));
+    properties.add(new UserProperty(user.getUserId(), UserFields.ERA_STATUS.getValue()));
+    verify(userPropertyDAO).deletePropertiesByUserAndKey(properties);
+  }
+
+  @Test
   void testAuthenticateNih_InvalidUser() {
     AuthUser testUser = new AuthUser("test@test.com");
     assertThrows(NotFoundException.class,
@@ -139,7 +158,7 @@ class NihServiceTest extends MockServerTestHelper {
           user.getUserId());
       assertEquals(1, properties.size());
       assertEquals(Integer.valueOf(1), properties.get(0).getPropertyId());
-      verify(nihServiceDAO, times(1)).updateUserNihStatus(user, nihUserAccount);
+      verify(nihServiceDAO).updateUserNihStatus(user, nihUserAccount);
     } catch (BadRequestException bre) {
       assert false;
     }
@@ -173,7 +192,11 @@ class NihServiceTest extends MockServerTestHelper {
     user.setUserId(1);
     when(userDAO.findUserById(any())).thenReturn(user);
     service.deleteNihAccountById(1);
-    verify(userPropertyDAO, times(1)).deletePropertiesByUserAndKey(any());
+    verify(userDAO).updateEraCommonsId(user.getUserId(), null);
+    List<UserProperty> properties = new ArrayList<>();
+    properties.add(new UserProperty(user.getUserId(), UserFields.ERA_EXPIRATION_DATE.getValue()));
+    properties.add(new UserProperty(user.getUserId(), UserFields.ERA_STATUS.getValue()));
+    verify(userPropertyDAO).deletePropertiesByUserAndKey(properties);
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/NihServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/NihServiceDAOTest.java
@@ -141,9 +141,7 @@ class NihServiceDAOTest extends DAOTestHelper {
   @Test
   void testUpdateUserNihStatus_nullAccount() {
     User user = createUser();
-    assertThrows(IllegalArgumentException.class, () -> {
-      serviceDAO.updateUserNihStatus(user, null);
-    });
+    assertThrows(IllegalArgumentException.class, () -> serviceDAO.updateUserNihStatus(user, null));
   }
 
   @Test
@@ -157,9 +155,46 @@ class NihServiceDAOTest extends DAOTestHelper {
     userAccount.setStatus(true);
     userAccount.setNihUsername("NEW_ID");
     userAccount.setEraExpiration("new expiration");
-    assertThrows(Exception.class, () -> {
-      serviceDAO.updateUserNihStatus(user, userAccount);
-    });
+    assertThrows(Exception.class, () -> serviceDAO.updateUserNihStatus(user, userAccount));
   }
 
+  @Test
+  void testDeleteNihAccountById() {
+    User user = createUser();
+    UserProperty prop1 = new UserProperty(
+        user.getUserId(),
+        UserFields.ERA_STATUS.getValue(),
+        Boolean.TRUE.toString()
+    );
+    UserProperty prop2 = new UserProperty(
+        user.getUserId(),
+        UserFields.ERA_EXPIRATION_DATE.getValue(),
+        new Date().toString()
+    );
+    String commonsId = "COMMONS_ID";
+    userDAO.updateEraCommonsId(user.getUserId(), commonsId);
+    userPropertyDAO.insertAll(List.of(prop1, prop2));
+
+    serviceDAO.deleteNihAccountById(user.getUserId());
+
+    // assert that props are deleted
+    List<UserProperty> updatedProps = userPropertyDAO.findUserPropertiesByUserIdAndPropertyKeys(
+        user.getUserId(),
+        List.of(UserFields.ERA_STATUS.getValue(), UserFields.ERA_EXPIRATION_DATE.getValue()));
+    assertTrue(updatedProps.isEmpty());
+
+    // assert that era commons id is null
+    User updatedUser = userDAO.findUserById(user.getUserId());
+    assertNull(updatedUser.getEraCommonsId());
+  }
+
+  @Test
+  void testDeleteNihStatus_jdbiError() {
+    // superclass jdbi is not a mock, we need to mock it locally to simulate an exception
+    Jdbi jdbi = mock(Jdbi.class);
+    serviceDAO = new NihServiceDAO(jdbi);
+    doThrow(new Exception()).when(jdbi).useTransaction(any());
+    User user = createUser();
+    assertThrows(Exception.class, () -> serviceDAO.deleteNihAccountById(user.getUserId()));
+  }
 }

--- a/src/test/resources/consent-config.yml
+++ b/src/test/resources/consent-config.yml
@@ -40,6 +40,7 @@ services:
   localURL: http://localhost:8000/#/
   ontologyURL: http://localhost:8180/
   samUrl: https://localhost:8181/
+  ecmUrl: http://localhost:8182/
 mailConfiguration:
   activateEmailNotifications: false
   googleAccount: test@gmail.com


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DT-1636

## Summary
New API to synchronize a user's RAS state in Consent with what is known in ECM. This returns a full user object with properties that will include the updated values from ECM. NOTE: This syncs in both directions with ECM so that a linked account can be created and removed in ECM. Since DUOS and Terra both use ECM as a source of truth, a user link/de-link in Terra affects DUOS and vice-versa.

For example (actual values redacted for demonstration):

```
{
  "userId": 1,
  "email": "my email",
  "displayName": "my display name",
  "createDate": 1,
  "roles": [...],
  "properties": [
    {
      "propertyId": 1,
      "propertyKey": "eraAuthorized",
      "propertyValue": "<Synced value from ECM>"
    },
    {
      "propertyId": 2,
      "propertyKey": "eraExpiration",
      "propertyValue": "<Synced value from ECM>"
    }
  ],
  "emailPreference": true,
  "institutionId": 1,
  "eraCommonsId": "<Synced value from ECM>",
  "institution": {...},
  "libraryCard": {...}
}
```

This is the required information that the UI needs to do any work necessary to update a user's RAS display status.

Under the hood, we re-purpose the [ECM `LinkInfo`](https://externalcreds.dsde-prod.broadinstitute.org/#/oauth/getLink) object to how we've been storing this [locally in `NIHUserAccount`](https://github.com/DataBiosphere/consent/blob/fde9d35395dd9ddbfa086f4709dbd391e25c341d/src/main/java/org/broadinstitute/consent/http/models/NIHUserAccount.java) so all existing functionality that relied on the existing data should be preserved without need for changes.

This PR also fixes a bug in the delete NIH Account Information code path. Previously, if a user chose to delete their linked account, we only deleted the properties, not the 

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
