### PR TITLE
[DT-2112] Adjust SO PR notification when RADAR approved.

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/mail/message/SoPRApproved.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/SoPRApproved.java
@@ -8,25 +8,27 @@ import org.broadinstitute.consent.http.models.User;
 
 public class SoPRApproved extends MailMessage {
 
-  private static final String SUBJECT = "Broad Data Use Oversight System - Signing Official - Your Institutional Researcher's Progress Report %s is Approved";
+  private static final String SUBJECT = "Broad Data Use Oversight System - Signing Official - Your Institutional Researcher's Progress Report %s is %sApproved";
   private final String darCode;
   private final User researcher;
   private final String referenceId;
   private final List<Dataset> datasets;
   private final String dataUseRestriction;
+  private final String radarText;
 
-  public SoPRApproved(User toUser, String darCode, User researcher, String referenceId, List<Dataset> datasets, String dataUseRestriction) {
+  public SoPRApproved(User toUser, String darCode, User researcher, String referenceId, List<Dataset> datasets, String dataUseRestriction,  boolean radarApproved) {
     super(toUser, EmailType.SO_PROGRESS_REPORT_APPROVED);
     this.darCode = darCode;
     this.researcher = researcher;
     this.referenceId = referenceId;
     this.datasets = datasets;
     this.dataUseRestriction = dataUseRestriction;
+    this.radarText = radarApproved ? "Rule Automated DAR (RADAR) " : "";
   }
 
   @Override
   public String createSubject() {
-    return String.format(SUBJECT, darCode);
+    return String.format(SUBJECT, darCode, radarText);
   }
 
   @Override
@@ -34,6 +36,7 @@ public class SoPRApproved extends MailMessage {
     return Map.of(
         "userName", toUser.getDisplayName(),
         "darCode", darCode,
+        "radarText", radarText,
         "researcherUserName", researcher.getDisplayName(),
         "researcherEmail", researcher.getEmail(),
         "datasets", datasets,

--- a/src/main/java/org/broadinstitute/consent/http/service/EmailService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/EmailService.java
@@ -326,9 +326,9 @@ public class EmailService implements ConsentLogger {
    * @throws TemplateException Template processing exception
    * @throws IOException IOException when processing the template or sending the email
    */
-  public void sendNewSoProgressReportApprovedEmail(User user, String darCode, User researcher, String referenceId, List<Dataset> datasets, String dataUseRestriction)
+  public void sendNewSoProgressReportApprovedEmail(User user, String darCode, User researcher, String referenceId, List<Dataset> datasets, String dataUseRestriction, boolean radarApproved)
       throws TemplateException, IOException {
-      sendMessage(new SoPRApproved(user, darCode, researcher, referenceId, datasets, dataUseRestriction),
+      sendMessage(new SoPRApproved(user, darCode, researcher, referenceId, datasets, dataUseRestriction, radarApproved),
         user.getUserId());
   }
 

--- a/src/main/java/org/broadinstitute/consent/http/service/VoteService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/VoteService.java
@@ -388,7 +388,7 @@ public class VoteService implements ConsentLogger {
     for (User so : signingOfficials) {
       if (dar.getProgressReport()) {
         emailService.sendNewSoProgressReportApprovedEmail(
-            so, darCode, researcher, dar.getReferenceId(), datasets, translation);
+            so, darCode, researcher, dar.getReferenceId(), datasets, translation, radarApproved);
       } else {
         emailService.sendNewSoDARApprovedEmail(
             so, darCode, researcher, dar.getReferenceId(), datasets, translation, radarApproved);

--- a/src/main/resources/freemarker/so-progress-report-approved.html
+++ b/src/main/resources/freemarker/so-progress-report-approved.html
@@ -4,7 +4,7 @@
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Broad Data Use Oversight System - Signing Official - Access to a dataset was approved to
+  <title>Broad Data Use Oversight System - Signing Official - Access to a dataset was ${radarText}approved to
     your institution</title>
 </head>
 
@@ -31,7 +31,7 @@
         <td
           style="padding: 0px 15px; font-family: 'Montserrat', sans-serif; font-size: 16px; color: #1F3B50; text-align: justify; line-height: 25px;">
           <p>
-            A Progress Report ${darCode}, submitted by ${researcherUserName}, was approved for the
+            A Progress Report ${darCode}, submitted by ${researcherUserName}, was ${radarText}approved for the
             following dataset(s) with the corresponding data use limitations:
           </p>
           <table style="margin: 15px 0 10px 0; border-collapse: collapse; width: 600px;">

--- a/src/test/java/org/broadinstitute/consent/http/mail/message/SigningOfficialMessagesTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mail/message/SigningOfficialMessagesTest.java
@@ -40,7 +40,9 @@ class SigningOfficialMessagesTest extends AbstractTestHelper {
         Arguments.of(new SoDARApproved(toUser, DAR_CODE, researcher, REFERENCE_ID, datasets,
             TRANSLATION, true)),
         Arguments.of(new SoPRApproved(toUser, DAR_CODE, researcher, REFERENCE_ID, datasets,
-            TRANSLATION)),
+            TRANSLATION, false)),
+        Arguments.of(new SoPRApproved(toUser, DAR_CODE, researcher, REFERENCE_ID, datasets,
+            TRANSLATION, true)),
         Arguments.of(new SoDARSubmitted(toUser, DAR_CODE, researcher, REFERENCE_ID, datasets)),
         Arguments.of(new SoPRSubmitted(toUser, DAR_CODE, researcher, REFERENCE_ID, datasets))
     );
@@ -96,7 +98,7 @@ class SigningOfficialMessagesTest extends AbstractTestHelper {
   }
 
   @Test
-  void testRADARReferences() throws Exception {
+  void testDARApprovedRADARReferences() throws Exception {
     MailMessage message = new SoDARApproved(toUser, DAR_CODE, researcher, REFERENCE_ID, datasets,
         TRANSLATION, true);
     var linkUrl = "http://testServerUrl";
@@ -110,9 +112,40 @@ class SigningOfficialMessagesTest extends AbstractTestHelper {
   }
 
   @Test
-  void testNORADARReferences() throws Exception {
+  void testDARNORADARReferences() throws Exception {
     MailMessage message = new SoDARApproved(toUser, DAR_CODE, researcher, REFERENCE_ID, datasets,
         TRANSLATION, false);
+    var linkUrl = "http://testServerUrl";
+    var template = helper.getTemplate(message.getTemplateName());
+    var out = new StringWriter();
+    template.process(message.createModel(linkUrl), out);
+    String templateString = out.toString();
+
+    assertFalse(templateString.toLowerCase().contains("radar"));
+  }
+
+  @Test
+  void testPRApprovedRADARReferences() throws Exception {
+    MailMessage message =
+        new SoPRApproved(toUser, DAR_CODE, researcher, REFERENCE_ID, datasets, TRANSLATION, true);
+    var linkUrl = "http://testServerUrl";
+    var template = helper.getTemplate(message.getTemplateName());
+    var out = new StringWriter();
+    template.process(message.createModel(linkUrl), out);
+    String templateString = out.toString();
+
+    assertEquals(2, StringUtils.countMatches(templateString," Rule Automated DAR (RADAR) "));
+    assertFalse(templateString.contains("radarText"));
+
+    String subject = message.createSubject();
+    assertFalse(subject.contains("radarText"));
+    assertTrue(subject.contains(" Rule Automated DAR (RADAR) "));
+  }
+
+  @Test
+  void testPRNORADARReferences() throws Exception {
+    MailMessage message =
+        new SoPRApproved(toUser, DAR_CODE, researcher, REFERENCE_ID, datasets, TRANSLATION, false);
     var linkUrl = "http://testServerUrl";
     var template = helper.getTemplate(message.getTemplateName());
     var out = new StringWriter();

--- a/src/test/java/org/broadinstitute/consent/http/service/VoteServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/VoteServiceTest.java
@@ -1079,7 +1079,7 @@ class VoteServiceTest extends AbstractTestHelper {
     service.notifySigningOfficialsOfApprovedDatasets(
         List.of(dataset), researcher, dar, "DAR-000123", "translation", false);
     verify(emailService, never())
-        .sendNewSoProgressReportApprovedEmail(any(), any(), any(), any(), any(), any());
+        .sendNewSoProgressReportApprovedEmail(any(), any(), any(), any(), any(), any(), anyBoolean());
     verify(emailService, times(1))
         .sendNewSoDARApprovedEmail(any(), any(), any(), any(), any(), any(), eq(false));
   }
@@ -1105,7 +1105,7 @@ class VoteServiceTest extends AbstractTestHelper {
     service.notifySigningOfficialsOfApprovedDatasets(
         List.of(dataset), researcher, dar, "DAR-000123", "translation", true);
     verify(emailService, never())
-        .sendNewSoProgressReportApprovedEmail(any(), any(), any(), any(), any(), any());
+        .sendNewSoProgressReportApprovedEmail(any(), any(), any(), any(), any(), any(), anyBoolean());
     verify(emailService, times(1))
         .sendNewSoDARApprovedEmail(any(), any(), any(), any(), any(), any(), eq(true));
   }
@@ -1204,7 +1204,7 @@ class VoteServiceTest extends AbstractTestHelper {
     service.notifySigningOfficialsOfApprovedDatasets(
         List.of(dataset), researcher, child, "DAR-000123", "translation", false);
     verify(emailService, times(1))
-        .sendNewSoProgressReportApprovedEmail(any(), any(), any(), any(), any(), any());
+        .sendNewSoProgressReportApprovedEmail(any(), any(), any(), any(), any(), any(), anyBoolean());
     verify(emailService, never())
         .sendNewSoDARApprovedEmail(any(), any(), any(), any(), any(), any(), anyBoolean());
   }
@@ -1223,7 +1223,7 @@ class VoteServiceTest extends AbstractTestHelper {
     service.notifySigningOfficialsOfApprovedDatasets(
         List.of(dataset), null, dar, "DAR-000123", "translation", false);
     verify(emailService, never())
-        .sendNewSoProgressReportApprovedEmail(any(), any(), any(), any(), any(), any());
+        .sendNewSoProgressReportApprovedEmail(any(), any(), any(), any(), any(), any(), anyBoolean());
     verify(emailService, never())
         .sendNewSoDARApprovedEmail(any(), any(), any(), any(), any(), any(), anyBoolean());
   }
@@ -1244,7 +1244,7 @@ class VoteServiceTest extends AbstractTestHelper {
     service.notifySigningOfficialsOfApprovedDatasets(
         List.of(dataset), researcher, dar, "DAR-000123", "translation", false);
     verify(emailService, never())
-        .sendNewSoProgressReportApprovedEmail(any(), any(), any(), any(), any(), any());
+        .sendNewSoProgressReportApprovedEmail(any(), any(), any(), any(), any(), any(), anyBoolean());
     verify(emailService, never())
         .sendNewSoDARApprovedEmail(any(), any(), any(), any(), any(), any(), anyBoolean());
   }
@@ -1267,7 +1267,7 @@ class VoteServiceTest extends AbstractTestHelper {
     service.notifySigningOfficialsOfApprovedDatasets(
         List.of(dataset), researcher, dar, "DAR-000123", "translation", false);
     verify(emailService, never())
-        .sendNewSoProgressReportApprovedEmail(any(), any(), any(), any(), any(), any());
+        .sendNewSoProgressReportApprovedEmail(any(), any(), any(), any(), any(), any(), anyBoolean());
     verify(emailService, never())
         .sendNewSoDARApprovedEmail(any(), any(), any(), any(), any(), any(), anyBoolean());
   }


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-2112](https://broadworkbench.atlassian.net/browse/DT-2112)

### Summary

SO PR Approved email didn't include standard RADAR text when RADAR approved messages.  This adds our standard RADAR text, consistent with other messages.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
