### PR TITLE
DT-2118: Remove the approved user ids from indexed dataset terms

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
@@ -469,14 +469,12 @@ public class ConsentModule extends AbstractModule {
         ElasticSearchSupport.createRestClient(config.getElasticSearchConfiguration()),
         config.getElasticSearchConfiguration(),
         providesDacDAO(),
-        providesDataAccessRequestDAO(),
         providesUserDAO(),
         providesOntologyService(),
         providesInstitutionDAO(),
         providesDatasetDAO(),
         providesDatasetServiceDAO(),
-        providesStudyDAO(),
-        providesLibraryCardDAO()
+        providesStudyDAO()
     );
   }
 

--- a/src/main/java/org/broadinstitute/consent/http/models/elastic_search/DatasetTerm.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/elastic_search/DatasetTerm.java
@@ -1,6 +1,5 @@
 package org.broadinstitute.consent.http.models.elastic_search;
 
-import java.util.List;
 import org.broadinstitute.consent.http.models.ontology.DataUseSummary;
 
 public class DatasetTerm {
@@ -19,7 +18,6 @@ public class DatasetTerm {
   private Integer dacId;
   private Boolean dacApproval;
   private String accessManagement;
-  private List<Integer> approvedUserIds;
   private StudyTerm study;
   private UserTerm submitter;
   private UserTerm updateUser;
@@ -127,14 +125,6 @@ public class DatasetTerm {
 
   public void setAccessManagement(String accessManagement) {
     this.accessManagement = accessManagement;
-  }
-
-  public List<Integer> getApprovedUserIds() {
-    return approvedUserIds;
-  }
-
-  public void setApprovedUserIds(List<Integer> approvedUsers) {
-    this.approvedUserIds = approvedUsers;
   }
 
   public StudyTerm getStudy() {

--- a/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
@@ -20,18 +20,14 @@ import org.apache.http.entity.ContentType;
 import org.apache.http.nio.entity.NStringEntity;
 import org.broadinstitute.consent.http.configurations.ElasticSearchConfiguration;
 import org.broadinstitute.consent.http.db.DacDAO;
-import org.broadinstitute.consent.http.db.DataAccessRequestDAO;
 import org.broadinstitute.consent.http.db.DatasetDAO;
 import org.broadinstitute.consent.http.db.InstitutionDAO;
-import org.broadinstitute.consent.http.db.LibraryCardDAO;
 import org.broadinstitute.consent.http.db.StudyDAO;
 import org.broadinstitute.consent.http.db.UserDAO;
 import org.broadinstitute.consent.http.models.Dac;
-import org.broadinstitute.consent.http.models.DataAccessRequest;
 import org.broadinstitute.consent.http.models.Dataset;
 import org.broadinstitute.consent.http.models.DatasetProperty;
 import org.broadinstitute.consent.http.models.Institution;
-import org.broadinstitute.consent.http.models.LibraryCard;
 import org.broadinstitute.consent.http.models.Study;
 import org.broadinstitute.consent.http.models.StudyProperty;
 import org.broadinstitute.consent.http.models.User;
@@ -53,38 +49,32 @@ public class ElasticSearchService implements ConsentLogger {
   private final RestClient esClient;
   private final ElasticSearchConfiguration esConfig;
   private final DacDAO dacDAO;
-  private final DataAccessRequestDAO dataAccessRequestDAO;
   private final UserDAO userDAO;
   private final OntologyService ontologyService;
   private final InstitutionDAO institutionDAO;
   private final DatasetDAO datasetDAO;
   private final DatasetServiceDAO datasetServiceDAO;
   private final StudyDAO studyDAO;
-  private final LibraryCardDAO libraryCardDAO;
 
   public ElasticSearchService(
       RestClient esClient,
       ElasticSearchConfiguration esConfig,
       DacDAO dacDAO,
-      DataAccessRequestDAO dataAccessRequestDAO,
       UserDAO userDao,
       OntologyService ontologyService,
       InstitutionDAO institutionDAO,
       DatasetDAO datasetDAO,
       DatasetServiceDAO datasetServiceDAO,
-      StudyDAO studyDAO,
-      LibraryCardDAO libraryCardDAO) {
+      StudyDAO studyDAO) {
     this.esClient = esClient;
     this.esConfig = esConfig;
     this.dacDAO = dacDAO;
-    this.dataAccessRequestDAO = dataAccessRequestDAO;
     this.userDAO = userDao;
     this.ontologyService = ontologyService;
     this.institutionDAO = institutionDAO;
     this.datasetDAO = datasetDAO;
     this.datasetServiceDAO = datasetServiceDAO;
     this.studyDAO = studyDAO;
-    this.libraryCardDAO = libraryCardDAO;
   }
 
 
@@ -367,20 +357,6 @@ public class ElasticSearchService implements ConsentLogger {
       }
       term.setDac(toDacTerm(dac));
     });
-
-    List<Integer> approvedUserIds = dataAccessRequestDAO
-        .findApprovedDARsByDatasetId(dataset.getDatasetId())
-        .stream()
-        .map(DataAccessRequest::getUserId)
-        .toList();
-
-    if (!approvedUserIds.isEmpty()) {
-      List<Integer> approvedLCUserIds = libraryCardDAO.findLibraryCardsByUserIds(approvedUserIds)
-          .stream()
-          .map(LibraryCard::getUserId)
-          .toList();
-      term.setApprovedUserIds(approvedLCUserIds);
-    }
 
     if (Objects.nonNull(dataset.getDataUse())) {
       DataUseSummary summary = ontologyService.translateDataUseSummary(dataset.getDataUse());

--- a/src/main/resources/assets/paths/datasetSearchIndex.yaml
+++ b/src/main/resources/assets/paths/datasetSearchIndex.yaml
@@ -65,10 +65,6 @@ post:
                   dataLocation: Not Determined
                   dacId: 3
                   accessManagement: controlled
-                  approvedUserIds:
-                    - 1
-                    - 2
-                    - 3
                   study:
                     description: Test study details
                     studyName: Test Dataset

--- a/src/main/resources/assets/schemas/DatasetSearch.yaml
+++ b/src/main/resources/assets/schemas/DatasetSearch.yaml
@@ -23,11 +23,6 @@ properties:
   dacId:
     type: integer
     description: The unique identifier for a DAC
-  approvedUserIds:
-    type: array
-    description: The list of users who have been approved to access the dataset
-    items:
-      type: integer
   study:
     type: object
     description: The study associated with the dataset

--- a/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
@@ -39,10 +39,8 @@ import org.apache.http.nio.entity.NStringEntity;
 import org.broadinstitute.consent.http.AbstractTestHelper;
 import org.broadinstitute.consent.http.configurations.ElasticSearchConfiguration;
 import org.broadinstitute.consent.http.db.DacDAO;
-import org.broadinstitute.consent.http.db.DataAccessRequestDAO;
 import org.broadinstitute.consent.http.db.DatasetDAO;
 import org.broadinstitute.consent.http.db.InstitutionDAO;
-import org.broadinstitute.consent.http.db.LibraryCardDAO;
 import org.broadinstitute.consent.http.db.StudyDAO;
 import org.broadinstitute.consent.http.db.UserDAO;
 import org.broadinstitute.consent.http.enumeration.PropertyType;
@@ -91,9 +89,6 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
   private DacDAO dacDAO;
 
   @Mock
-  private DataAccessRequestDAO dataAccessRequestDAO;
-
-  @Mock
   private UserDAO userDao;
 
   @Mock
@@ -108,23 +103,18 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
   @Mock
   private StudyDAO studyDAO;
 
-  @Mock
-  private LibraryCardDAO libraryCardDAO;
-
   @BeforeEach
   void initService() {
     service = new ElasticSearchService(
         esClient,
         esConfig,
         dacDAO,
-        dataAccessRequestDAO,
         userDao,
         ontologyService,
         institutionDAO,
         datasetDAO,
         datasetServiceDAO,
-        studyDAO,
-        libraryCardDAO);
+        studyDAO);
   }
 
   private void mockElasticSearchResponse(String body) throws IOException {
@@ -337,7 +327,6 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
     dar1.setUserId(1);
     DataAccessRequest dar2 = new DataAccessRequest();
     dar2.setUserId(2);
-    List<Integer> approvedUserIds = List.of(dar1.getUserId(), dar2.getUserId());
     DataUseSummary dataUseSummary = createDataUseSummary();
     DatasetRecord datasetRecord = createDatasetRecord();
     when(userDao.findUserById(datasetRecord.createUser.getUserId())).thenReturn(
@@ -348,11 +337,8 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
     card1.setUserId(dar1.getUserId());
     LibraryCard card2 = new LibraryCard();
     card2.setUserId(dar2.getUserId());
-    when(libraryCardDAO.findLibraryCardsByUserIds(
-        List.of(dar1.getUserId(), dar2.getUserId()))).thenReturn(List.of(card1, card2));
     when(dacDAO.findById(any())).thenReturn(datasetRecord.dac);
     when(ontologyService.translateDataUseSummary(any())).thenReturn(dataUseSummary);
-    when(dataAccessRequestDAO.findApprovedDARsByDatasetId(any())).thenReturn(List.of(dar1, dar2));
     DatasetTerm term = service.toDatasetTerm(datasetRecord.dataset);
 
     assertEquals(datasetRecord.dataset.getDatasetId(), term.getDatasetId());
@@ -381,7 +367,6 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
     assertTrue(accessManagementProp.isPresent());
     assertEquals(accessManagementProp.get().getPropertyValue().toString(),
         term.getAccessManagement());
-    assertEquals(approvedUserIds, term.getApprovedUserIds());
   }
 
   @Test
@@ -431,9 +416,6 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
     dataset.setAlias(10);
     dataset.setDatasetIdentifier();
     dataset.setProperties(Set.of());
-
-    when(dataAccessRequestDAO.findApprovedDARsByDatasetId(any())).thenReturn(
-        List.of());
 
     DatasetTerm term = service.toDatasetTerm(dataset);
 


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-2118

### Summary
Approved user ids is not a necessary feature of the ES indexed dataset terms. This PR removes it.

A follow on task will be required to manually re-index datasets.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
