### PR TITLE
DT-1696: Remove unused library cards field

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/service/UserService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/UserService.java
@@ -52,7 +52,6 @@ import org.broadinstitute.consent.http.util.gson.GsonUtil;
 public class UserService implements ConsentLogger {
 
   public static final String LIBRARY_CARD_FIELD = "libraryCard";
-  public static final String LIBRARY_CARDS_FIELD = "libraryCards";
   public static final String USER_PROPERTIES_FIELD = "properties";
   public static final String USER_STATUS_INFO_FIELD = "userStatusInfo";
 
@@ -345,8 +344,6 @@ public class UserService implements ConsentLogger {
     if (user.getLibraryCard() != null) {
       JsonObject libraryCardJson = gson.toJsonTree(user.getLibraryCard()).getAsJsonObject();
       userJson.add(LIBRARY_CARD_FIELD, libraryCardJson);
-      // Note that this is provided for backwards compatibility with the UI and will be removed
-      userJson.add(LIBRARY_CARDS_FIELD, gson.toJsonTree(List.of(libraryCardJson)));
     }
     if (authUser.getEmail().equalsIgnoreCase(user.getEmail()) && Objects.nonNull(
         authUser.getUserStatusInfo())) {

--- a/src/main/resources/assets/schemas/User.yaml
+++ b/src/main/resources/assets/schemas/User.yaml
@@ -24,8 +24,3 @@ properties:
     $ref: './UserProperties.yaml'
   libraryCard:
     $ref: './LibraryCard.yaml'
-  libraryCards:
-    deprecated: true
-    type: array
-    items:
-      $ref: './LibraryCard.yaml'

--- a/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
@@ -686,7 +686,6 @@ class UserServiceTest extends AbstractTestHelper {
         user.getUserId());
     assertNotNull(userJson);
     assertTrue(userJson.get(UserService.LIBRARY_CARD_FIELD).getAsJsonObject().isJsonObject());
-    assertTrue(userJson.get(UserService.LIBRARY_CARDS_FIELD).getAsJsonArray().isJsonArray());
     assertTrue(
         userJson.get(UserService.USER_PROPERTIES_FIELD).getAsJsonArray().isJsonArray());
     assertTrue(userJson.get(UserService.USER_STATUS_INFO_FIELD).getAsJsonObject().isJsonObject());
@@ -708,7 +707,6 @@ class UserServiceTest extends AbstractTestHelper {
         user.getUserId());
     assertNotNull(userJson);
     assertTrue(userJson.get(UserService.LIBRARY_CARD_FIELD).getAsJsonObject().isJsonObject());
-    assertTrue(userJson.get(UserService.LIBRARY_CARDS_FIELD).getAsJsonArray().isJsonArray());
     assertTrue(
         userJson.get(UserService.USER_PROPERTIES_FIELD).getAsJsonArray().isJsonArray());
     assertNull(userJson.get(UserService.USER_STATUS_INFO_FIELD));


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-1696

### Summary
Since https://github.com/DataBiosphere/duos-ui/pull/2888, the UI no longer uses the plural `libraryCards` field on user, so we can remove this from the back end code.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
