### PR TITLE
DT-1769: Send completed closeout email after Chair approval

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
@@ -562,7 +562,9 @@ public class ConsentModule extends AbstractModule {
   @Provides
   AcknowledgementService providesAcknowledgementService() {
     return new AcknowledgementService(
-        providesAcknowledgementDAO()
+        providesAcknowledgementDAO(),
+        providesDataAccessRequestDAO(),
+        providesEmailService()
     );
   }
 

--- a/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
@@ -24,8 +24,8 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.Status;
 import jakarta.ws.rs.core.UriInfo;
-import java.lang.reflect.Type;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -38,6 +38,7 @@ import org.broadinstitute.consent.http.models.Acknowledgement;
 import org.broadinstitute.consent.http.models.ApprovedDataset;
 import org.broadinstitute.consent.http.models.AuthUser;
 import org.broadinstitute.consent.http.models.Dataset;
+import org.broadinstitute.consent.http.models.DuosUser;
 import org.broadinstitute.consent.http.models.Error;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.UserRole;
@@ -271,7 +272,8 @@ public class UserResource extends Resource {
     return activeUser.hasUserRole(UserRoles.SIGNINGOFFICIAL)
         && activeUser.getInstitutionId() != null
         && UserRoles.isValidSoAdjustableRoleId(role)
-        && (user.getInstitutionId() == null || user.getInstitutionId().equals(activeUser.getInstitutionId()));
+        && (user.getInstitutionId() == null || user.getInstitutionId()
+        .equals(activeUser.getInstitutionId()));
   }
 
   private Response getUserResponse(AuthUser authUser, Integer userId) {
@@ -344,7 +346,8 @@ public class UserResource extends Resource {
           entity(new Error("Unable to verify google identity",
               Response.Status.BAD_REQUEST.getStatusCode())).
           build();
-    }    try {
+    }
+    try {
       if (userService.findUserByEmail(authUser.getEmail()) != null) {
         return Response.
             status(Response.Status.CONFLICT).
@@ -444,12 +447,11 @@ public class UserResource extends Resource {
   @Produces(MediaType.APPLICATION_JSON)
   @Path("/acknowledgements")
   @PermitAll
-  public Response postAcknowledgements(@Auth AuthUser authUser, String json) {
+  public Response postAcknowledgements(@Auth DuosUser duosUser, String json) {
+    User user = duosUser.getUser();
     ArrayList<String> keys;
     try {
-      Type listOfStringsType = new TypeToken<ArrayList<String>>() {
-      }.getType();
-      keys = gson.fromJson(json, listOfStringsType);
+      keys = gson.fromJson(json, new TypeToken<>() {});
       if (keys == null || keys.isEmpty()) {
         return Response.status(Response.Status.BAD_REQUEST).build();
       }
@@ -457,8 +459,14 @@ public class UserResource extends Resource {
       return Response.status(Response.Status.BAD_REQUEST).build();
     }
 
+    if (keys.stream().anyMatch(k -> k.startsWith(AcknowledgementService.DAR_CLOSEOUT_CHAIR_REF))
+        && !user.hasUserRole(UserRoles.CHAIRPERSON)) {
+      return Response.status(Status.BAD_REQUEST)
+          .entity(new Error("Invalid acknowledgement", HttpStatusCodes.STATUS_CODE_BAD_REQUEST))
+          .build();
+    }
+
     try {
-      User user = userService.findUserByEmail(authUser.getEmail());
       Map<String, Acknowledgement> acknowledgementMap = acknowledgementService.makeAcknowledgements(
           keys, user);
       return Response.ok().entity(acknowledgementMap).build();

--- a/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
@@ -461,8 +461,8 @@ public class UserResource extends Resource {
 
     if (keys.stream().anyMatch(k -> k.startsWith(AcknowledgementService.DAR_CLOSEOUT_CHAIR_REF))
         && !user.hasUserRole(UserRoles.CHAIRPERSON)) {
-      return Response.status(Status.BAD_REQUEST)
-          .entity(new Error("Invalid acknowledgement", HttpStatusCodes.STATUS_CODE_BAD_REQUEST))
+      return Response.status(Status.UNAUTHORIZED)
+          .entity(new Error("Invalid acknowledgement", HttpStatusCodes.STATUS_CODE_UNAUTHORIZED))
           .build();
     }
 

--- a/src/main/java/org/broadinstitute/consent/http/service/AcknowledgementService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/AcknowledgementService.java
@@ -51,7 +51,6 @@ public class AcknowledgementService implements ConsentLogger {
     if (key.startsWith(DAR_CLOSEOUT_CHAIR_REF)) {
       String referenceId = key.replace(DAR_CLOSEOUT_CHAIR_REF, "");
       DataAccessRequest dar = dataAccessRequestDAO.findByReferenceId(referenceId);
-      // Is this acknowledged already?
       Acknowledgement existingAck = acknowledgementDAO.findAcknowledgementsByKeyForUser(key, user.getUserId());
       if (existingAck != null) {
         throw new BadRequestException("Closeout acknowledgement already exists for %s".formatted(dar.getDarCode()));

--- a/src/main/java/org/broadinstitute/consent/http/service/AcknowledgementService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/AcknowledgementService.java
@@ -1,19 +1,29 @@
 package org.broadinstitute.consent.http.service;
 
+import freemarker.template.TemplateException;
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.broadinstitute.consent.http.db.AcknowledgementDAO;
+import org.broadinstitute.consent.http.db.DataAccessRequestDAO;
 import org.broadinstitute.consent.http.models.Acknowledgement;
+import org.broadinstitute.consent.http.models.DataAccessRequest;
 import org.broadinstitute.consent.http.models.User;
+import org.broadinstitute.consent.http.util.ConsentLogger;
 
-public class AcknowledgementService {
+public class AcknowledgementService implements ConsentLogger {
 
+  public static final String DAR_CLOSEOUT_CHAIR_REF = "dar_closeout_chair_ref_";
   private final AcknowledgementDAO acknowledgementDAO;
+  private final DataAccessRequestDAO dataAccessRequestDAO;
+  private final EmailService emailService;
 
-  public AcknowledgementService(AcknowledgementDAO acknowledgementDAO) {
+  public AcknowledgementService(AcknowledgementDAO acknowledgementDAO, DataAccessRequestDAO dataAccessRequestDAO, EmailService emailService) {
     this.acknowledgementDAO = acknowledgementDAO;
+    this.dataAccessRequestDAO = dataAccessRequestDAO;
+    this.emailService = emailService;
   }
 
   public Map<String, Acknowledgement> findAcknowledgementsForUser(User user) {
@@ -32,6 +42,20 @@ public class AcknowledgementService {
     }
     List<Acknowledgement> acknowledgementList = acknowledgementDAO.findAcknowledgementsForUser(keys,
         userId);
+    acknowledgementList.forEach(
+        ack -> {
+          if (ack.getAckKey().startsWith(DAR_CLOSEOUT_CHAIR_REF)) {
+            String referenceId = ack.getAckKey().replace(DAR_CLOSEOUT_CHAIR_REF, "");
+            DataAccessRequest dar = dataAccessRequestDAO.findByReferenceId(referenceId);
+            try {
+              emailService.sendResearcherCloseoutCompletedMessage(user, dar.getDarCode(), referenceId);
+            } catch (IOException | TemplateException e) {
+              // Log the error but do not fail the acknowledgement creation
+              logException("Unable to send researcher closeout completed message for DAR %s".formatted(dar.getDarCode()), e);
+            }
+          }
+        }
+    );
     return acknowledgementListToMap(acknowledgementList);
   }
 

--- a/src/main/java/org/broadinstitute/consent/http/service/AcknowledgementService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/AcknowledgementService.java
@@ -1,6 +1,7 @@
 package org.broadinstitute.consent.http.service;
 
 import freemarker.template.TemplateException;
+import jakarta.ws.rs.BadRequestException;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
@@ -37,26 +38,33 @@ public class AcknowledgementService implements ConsentLogger {
 
   public Map<String, Acknowledgement> makeAcknowledgements(List<String> keys, User user) {
     Integer userId = user.getUserId();
+    keys.forEach(key -> handleCloseoutAcknowledgement(key, user));
     for (String key : keys) {
       acknowledgementDAO.upsertAcknowledgement(key, userId);
     }
     List<Acknowledgement> acknowledgementList = acknowledgementDAO.findAcknowledgementsForUser(keys,
         userId);
-    acknowledgementList.forEach(
-        ack -> {
-          if (ack.getAckKey().startsWith(DAR_CLOSEOUT_CHAIR_REF)) {
-            String referenceId = ack.getAckKey().replace(DAR_CLOSEOUT_CHAIR_REF, "");
-            DataAccessRequest dar = dataAccessRequestDAO.findByReferenceId(referenceId);
-            try {
-              emailService.sendResearcherCloseoutCompletedMessage(user, dar.getDarCode(), referenceId);
-            } catch (IOException | TemplateException e) {
-              // Log the error but do not fail the acknowledgement creation
-              logException("Unable to send researcher closeout completed message for DAR %s".formatted(dar.getDarCode()), e);
-            }
-          }
-        }
-    );
     return acknowledgementListToMap(acknowledgementList);
+  }
+
+  private void handleCloseoutAcknowledgement(String key, User user) {
+    if (key.startsWith(DAR_CLOSEOUT_CHAIR_REF)) {
+      String referenceId = key.replace(DAR_CLOSEOUT_CHAIR_REF, "");
+      DataAccessRequest dar = dataAccessRequestDAO.findByReferenceId(referenceId);
+      // Is this acknowledged already?
+      Acknowledgement existingAck = acknowledgementDAO.findAcknowledgementsByKeyForUser(key, user.getUserId());
+      if (existingAck != null) {
+        throw new BadRequestException("Closeout acknowledgement already exists for %s".formatted(dar.getDarCode()));
+      }
+      if (!dar.getIsCloseoutProgressReport()) {
+        throw new BadRequestException("Closeout acknowledgement is only valid for closeout progress reports for DAR %s".formatted(dar.getDarCode()));
+      }
+      try {
+        emailService.sendResearcherCloseoutCompletedMessage(user, dar.getDarCode(), referenceId);
+      } catch (IOException | TemplateException e) {
+        logException("Unable to send researcher closeout completed message for DAR %s".formatted(dar.getDarCode()), e);
+      }
+    }
   }
 
   private Map<String, Acknowledgement> acknowledgementListToMap(

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -872,7 +872,9 @@ paths:
         400:
           description: The request isn't in the proper format.
         401:
-          description: Unauthorized, log in and try the operation again.
+          description: |
+            Unauthorized, log in and try the operation again.
+            Closeout Acknowledgements can only be submitted by Chairpersons
         500:
           description: Error processing the request.
     get:

--- a/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
@@ -851,7 +851,7 @@ class UserResourceTest extends AbstractTestHelper {
 
     String jsonString = userResource.unmarshal(List.of(acknowledgementKey));
     try (Response response = userResource.postAcknowledgements(duosUser, jsonString)) {
-      assertEquals(Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+      assertEquals(Status.UNAUTHORIZED.getStatusCode(), response.getStatus());
     }
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
@@ -35,6 +35,7 @@ import org.broadinstitute.consent.http.models.ApprovedDataset;
 import org.broadinstitute.consent.http.models.AuthUser;
 import org.broadinstitute.consent.http.models.DataAccessRequest;
 import org.broadinstitute.consent.http.models.Dataset;
+import org.broadinstitute.consent.http.models.DuosUser;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.UserUpdateFields;
 import org.broadinstitute.consent.http.models.sam.UserStatusInfo;
@@ -89,6 +90,9 @@ class UserResourceTest extends AbstractTestHelper {
       .setName("Test User")
       .setEmail(TEST_EMAIL)
       .setUserStatusInfo(userStatusInfo);
+
+  private final DuosUser duosUser = new DuosUser(authUser,
+      new User(1, TEST_EMAIL, "Test User", new Date(), Collections.emptyList()));
 
   @BeforeEach
   void initResource() {
@@ -176,7 +180,6 @@ class UserResourceTest extends AbstractTestHelper {
   void testGetUsers_InvalidRole() {
     User user = createUserWithRole();
     when(userService.findUserByEmail(any())).thenReturn(user);
-
 
     Response response = userResource.getUsers(authUser, "BadRequest");
     assertEquals(Status.BAD_REQUEST.getStatusCode(), response.getStatus());
@@ -775,7 +778,6 @@ class UserResourceTest extends AbstractTestHelper {
     when(datasetService.findDatasetListByDacIds(anyList())).thenReturn(List.of());
     when(userService.findUserByEmail(anyString())).thenReturn(user);
 
-
     Response response = userResource.getDatasetsFromUserDacsV2(authUser);
     assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
   }
@@ -784,7 +786,6 @@ class UserResourceTest extends AbstractTestHelper {
   void testGetDatasetsFromUserDacsV2UserNotFound() {
     when(userService.findUserByEmail(anyString())).thenThrow(
         new NotFoundException("User not found"));
-
 
     Response response = userResource.getDatasetsFromUserDacsV2(authUser);
     assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
@@ -799,9 +800,8 @@ class UserResourceTest extends AbstractTestHelper {
     when(acknowledgementService.makeAcknowledgements(anyList(), any())).thenReturn(
         acknowledgementMap);
 
-
     String jsonString = userResource.unmarshal(List.of(acknowledgementKey));
-    try (Response response = userResource.postAcknowledgements(authUser, jsonString)) {
+    try (Response response = userResource.postAcknowledgements(duosUser, jsonString)) {
       assertEquals(Status.OK.getStatusCode(), response.getStatus());
     }
   }
@@ -814,7 +814,7 @@ class UserResourceTest extends AbstractTestHelper {
 
     String jsonString = userResource.unmarshal(List.of(acknowledgementKey));
 
-    try (Response response = userResource.postAcknowledgements(authUser, jsonString)) {
+    try (Response response = userResource.postAcknowledgements(duosUser, jsonString)) {
       assertEquals(Status.INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatus());
     }
   }
@@ -823,21 +823,48 @@ class UserResourceTest extends AbstractTestHelper {
   void testPostAcknowledgementBadJson() {
     String jsonString = "The quick brown fox jumped over the lazy dog.";
 
-    try (Response response = userResource.postAcknowledgements(authUser, jsonString)) {
+    try (Response response = userResource.postAcknowledgements(duosUser, jsonString)) {
+      assertEquals(Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+    }
+  }
+
+  @Test
+  void testPostCloseoutAcknowledgementSuccess() {
+    User user = createUserWithRole();
+    user.addRole(UserRoles.Chairperson());
+    DuosUser chairUser = new DuosUser(authUser, user);
+    String acknowledgementKey = AcknowledgementService.DAR_CLOSEOUT_CHAIR_REF + "12345";
+    Map<String, Acknowledgement> acknowledgementMap = getDefaultAcknowledgementForUser(user,
+        acknowledgementKey);
+    when(acknowledgementService.makeAcknowledgements(anyList(), any())).thenReturn(
+        acknowledgementMap);
+
+    String jsonString = userResource.unmarshal(List.of(acknowledgementKey));
+    try (Response response = userResource.postAcknowledgements(chairUser, jsonString)) {
+      assertEquals(Status.OK.getStatusCode(), response.getStatus());
+    }
+  }
+
+  @Test
+  void testPostCloseoutAcknowledgementFailure() {
+    String acknowledgementKey = AcknowledgementService.DAR_CLOSEOUT_CHAIR_REF + "12345";
+
+    String jsonString = userResource.unmarshal(List.of(acknowledgementKey));
+    try (Response response = userResource.postAcknowledgements(duosUser, jsonString)) {
       assertEquals(Status.BAD_REQUEST.getStatusCode(), response.getStatus());
     }
   }
 
   @Test
   void testPostAcknowledgementEmptyJson() {
-    try (Response response = userResource.postAcknowledgements(authUser, "")) {
+    try (Response response = userResource.postAcknowledgements(duosUser, "")) {
       assertEquals(Status.BAD_REQUEST.getStatusCode(), response.getStatus());
     }
   }
 
   @Test
   void testPostAcknowledgementEmptyJsonList() {
-    try (Response response = userResource.postAcknowledgements(authUser, "[]")) {
+    try (Response response = userResource.postAcknowledgements(duosUser, "[]")) {
       assertEquals(Status.BAD_REQUEST.getStatusCode(), response.getStatus());
     }
   }
@@ -846,7 +873,6 @@ class UserResourceTest extends AbstractTestHelper {
   void testMissingAcknowledgement() {
     String acknowledgementKey = "key1";
     when(acknowledgementService.findAcknowledgementForUserByKey(any(), any())).thenReturn(null);
-
 
     Response response = userResource.getUserAcknowledgement(authUser, acknowledgementKey);
     assertEquals(Status.NOT_FOUND.getStatusCode(), response.getStatus());
@@ -858,7 +884,6 @@ class UserResourceTest extends AbstractTestHelper {
     doThrow(new RuntimeException("some exception during get.")).when(acknowledgementService)
         .findAcknowledgementForUserByKey(any(), any());
 
-
     Response response = userResource.getUserAcknowledgement(authUser, acknowledgementKey);
     assertEquals(Status.INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatus());
   }
@@ -866,7 +891,6 @@ class UserResourceTest extends AbstractTestHelper {
   @Test
   void testGetAcknowledgementNull() {
     when(acknowledgementService.findAcknowledgementForUserByKey(any(), any())).thenReturn(null);
-
 
     Response response = userResource.getUserAcknowledgement(authUser, null);
     assertEquals(Status.NOT_FOUND.getStatusCode(), response.getStatus());
@@ -876,7 +900,6 @@ class UserResourceTest extends AbstractTestHelper {
   void testGetUnsetAcknowledgementsForUser() {
     when(acknowledgementService.findAcknowledgementsForUser(any())).thenReturn(null);
 
-
     Response response = userResource.getUserAcknowledgements(authUser);
     assertEquals(Status.OK.getStatusCode(), response.getStatus());
   }
@@ -885,7 +908,6 @@ class UserResourceTest extends AbstractTestHelper {
   void testGetAcknowledgementsForUserException() {
     doThrow(new RuntimeException("some get exception")).when(acknowledgementService)
         .findAcknowledgementsForUser(any());
-
 
     Response response = userResource.getUserAcknowledgements(authUser);
     assertEquals(Status.INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatus());
@@ -899,7 +921,6 @@ class UserResourceTest extends AbstractTestHelper {
         acknowledgementKey);
     when(acknowledgementService.findAcknowledgementForUserByKey(any(), any())).thenReturn(
         acknowledgementMap.get(acknowledgementKey));
-
 
     Response response = userResource.getUserAcknowledgement(authUser, acknowledgementKey);
     assertEquals(Status.OK.getStatusCode(), response.getStatus());

--- a/src/test/java/org/broadinstitute/consent/http/service/AcknowledgementServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/AcknowledgementServiceTest.java
@@ -2,14 +2,17 @@ package org.broadinstitute.consent.http.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import jakarta.ws.rs.BadRequestException;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Date;
@@ -21,7 +24,9 @@ import org.broadinstitute.consent.http.db.AcknowledgementDAO;
 import org.broadinstitute.consent.http.db.DataAccessRequestDAO;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.Acknowledgement;
+import org.broadinstitute.consent.http.models.CloseoutSupplement;
 import org.broadinstitute.consent.http.models.DataAccessRequest;
+import org.broadinstitute.consent.http.models.DataAccessRequestData;
 import org.broadinstitute.consent.http.models.User;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -99,15 +104,21 @@ class AcknowledgementServiceTest extends AbstractTestHelper {
   }
 
   @Test
-  void testMakeAcknowledgementWithCloseout() throws Exception {
+  void testMakeCloseoutAcknowledgement() throws Exception {
+    DataAccessRequestData data = new DataAccessRequestData();
+    data.setCloseoutSupplement(new CloseoutSupplement(List.of("reason"), "details", 1));
     User user = new User(3, "test@domain.com", "Test User", new Date(),
         List.of(UserRoles.Chairperson()));
     DataAccessRequest dar1 = new DataAccessRequest();
     dar1.setReferenceId(UUID.randomUUID().toString());
     dar1.setDarCode("DAR-" + randomInt(100, 1000));
+    dar1.setData(data);
+    dar1.setParentId(1);
     DataAccessRequest dar2 = new DataAccessRequest();
     dar2.setReferenceId(UUID.randomUUID().toString());
     dar2.setDarCode("DAR-" + randomInt(1001, 2000));
+    dar2.setData(data);
+    dar2.setParentId(1);
     Timestamp timestamp = new Timestamp(new Date().getTime());
 
     // Expect an email to go out for this
@@ -130,6 +141,9 @@ class AcknowledgementServiceTest extends AbstractTestHelper {
 
     when(dataAccessRequestDAO.findByReferenceId(dar1.getReferenceId())).thenReturn(dar1);
     when(dataAccessRequestDAO.findByReferenceId(dar2.getReferenceId())).thenReturn(dar2);
+    // Neither DAR has been acknowledged yet
+    when(acknowledgementDAO.findAcknowledgementsByKeyForUser(ack1.getAckKey(), user.getUserId())).thenReturn(null);
+    when(acknowledgementDAO.findAcknowledgementsByKeyForUser(ack3.getAckKey(), user.getUserId())).thenReturn(null);
     when(acknowledgementDAO.findAcknowledgementsForUser(
         List.of(ack1.getAckKey(), ack2.getAckKey(), ack3.getAckKey()),
         user.getUserId())).thenReturn(List.of(ack1, ack2, ack3));
@@ -141,5 +155,47 @@ class AcknowledgementServiceTest extends AbstractTestHelper {
         dar1.getReferenceId());
     verify(emailService).sendResearcherCloseoutCompletedMessage(user, dar2.getDarCode(),
         dar2.getReferenceId());
+  }
+
+  @Test
+  void testMakeCloseoutAcknowledgementPreviouslyAcknowledged() throws Exception {
+    User user = new User(3, "test@domain.com", "Test User", new Date(),
+        List.of(UserRoles.Chairperson()));
+    DataAccessRequest dar1 = new DataAccessRequest();
+    dar1.setReferenceId(UUID.randomUUID().toString());
+    dar1.setDarCode("DAR-" + randomInt(100, 1000));
+    Timestamp timestamp = new Timestamp(new Date().getTime());
+
+    Acknowledgement ack1 = new Acknowledgement();
+    ack1.setUserId(user.getUserId());
+    ack1.setAckKey(AcknowledgementService.DAR_CLOSEOUT_CHAIR_REF + dar1.getReferenceId());
+    ack1.setFirstAcknowledged(timestamp);
+
+    // Ensures that this DAR closeout has already been acknowledged
+    when(acknowledgementDAO.findAcknowledgementsByKeyForUser(ack1.getAckKey(), user.getUserId())).thenReturn(ack1);
+    when(dataAccessRequestDAO.findByReferenceId(dar1.getReferenceId())).thenReturn(dar1);
+
+    List<String> keys = List.of(ack1.getAckKey());
+    assertThrows(BadRequestException.class, () -> acknowledgementService.makeAcknowledgements(keys, user));
+    verify(emailService, never()).sendResearcherCloseoutCompletedMessage(any(), anyString(), anyString());
+  }
+
+  @Test
+  void testMakeCloseoutAcknowledgementNotACloseout() throws Exception {
+    User user = new User(3, "test@domain.com", "Test User", new Date(),
+        List.of(UserRoles.Chairperson()));
+    // Note that this DAR does not have a closeout
+    DataAccessRequest dar1 = new DataAccessRequest();
+    dar1.setReferenceId(UUID.randomUUID().toString());
+    dar1.setDarCode("DAR-" + randomInt(100, 1000));
+    String key = AcknowledgementService.DAR_CLOSEOUT_CHAIR_REF + dar1.getReferenceId();
+
+    // Ensures that this DAR closeout has NOT already been acknowledged
+    when(acknowledgementDAO.findAcknowledgementsByKeyForUser(key, user.getUserId())).thenReturn(null);
+    when(dataAccessRequestDAO.findByReferenceId(dar1.getReferenceId())).thenReturn(dar1);
+
+    List<String> keys = List.of(key);
+    assertThrows(BadRequestException.class, () -> acknowledgementService.makeAcknowledgements(keys, user));
+    verify(emailService, never()).sendResearcherCloseoutCompletedMessage(any(), anyString(), anyString());
   }
 }

--- a/src/test/java/org/broadinstitute/consent/http/service/AcknowledgementServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/AcknowledgementServiceTest.java
@@ -28,6 +28,7 @@ import org.broadinstitute.consent.http.models.CloseoutSupplement;
 import org.broadinstitute.consent.http.models.DataAccessRequest;
 import org.broadinstitute.consent.http.models.DataAccessRequestData;
 import org.broadinstitute.consent.http.models.User;
+import org.broadinstitute.consent.http.models.UserRole;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -178,6 +179,37 @@ class AcknowledgementServiceTest extends AbstractTestHelper {
     List<String> keys = List.of(ack1.getAckKey());
     assertThrows(BadRequestException.class, () -> acknowledgementService.makeAcknowledgements(keys, user));
     verify(emailService, never()).sendResearcherCloseoutCompletedMessage(any(), anyString(), anyString());
+  }
+
+  @Test
+  void testMakeCloseoutAcknowledgementPreviouslyAcknowledgedByDifferentChair() throws Exception {
+    Date now = new Date();
+    Timestamp timestamp = new Timestamp(now.getTime());
+    List<UserRole> roles = List.of(UserRoles.Chairperson());
+    User chair1 = new User(3, "chair1@domain.com", "Chair 1", now, roles);
+    User chair2 = new User(4, "chair2@domain.com", "Chair 2", now, roles);
+    DataAccessRequest dar1 = new DataAccessRequest();
+    DataAccessRequestData data = new DataAccessRequestData();
+    data.setCloseoutSupplement(new CloseoutSupplement(List.of("reason"), "details", 1));
+    dar1.setReferenceId(UUID.randomUUID().toString());
+    dar1.setDarCode("DAR-" + randomInt(100, 1000));
+    dar1.setData(data);
+    dar1.setParentId(1);
+
+    // Record acknowledgement for chair1, but not Chair 2.
+    // Chair 2 can re-use the same key for the same DAR.
+    String ackKey = AcknowledgementService.DAR_CLOSEOUT_CHAIR_REF + dar1.getReferenceId();
+    Acknowledgement ack1 = new Acknowledgement();
+    ack1.setUserId(chair1.getUserId());
+    ack1.setAckKey(ackKey);
+    ack1.setFirstAcknowledged(timestamp);
+    // This is technically a no-op, but we want to document a chair1 ack for test clarity
+    acknowledgementDAO.upsertAcknowledgement(ack1.getAckKey(), chair1.getUserId());
+    when(acknowledgementDAO.findAcknowledgementsByKeyForUser(ackKey, chair2.getUserId())).thenReturn(null);
+    when(dataAccessRequestDAO.findByReferenceId(dar1.getReferenceId())).thenReturn(dar1);
+
+    acknowledgementService.makeAcknowledgements(List.of(ackKey), chair2);
+    verify(emailService).sendResearcherCloseoutCompletedMessage(chair2, dar1.getDarCode(), dar1.getReferenceId());
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/AcknowledgementServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/AcknowledgementServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.sql.Timestamp;
@@ -14,24 +15,36 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
+import org.broadinstitute.consent.http.AbstractTestHelper;
 import org.broadinstitute.consent.http.db.AcknowledgementDAO;
+import org.broadinstitute.consent.http.db.DataAccessRequestDAO;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.Acknowledgement;
+import org.broadinstitute.consent.http.models.DataAccessRequest;
 import org.broadinstitute.consent.http.models.User;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-class AcknowledgementServiceTest {
+class AcknowledgementServiceTest extends AbstractTestHelper {
 
   @Mock
   private static AcknowledgementDAO acknowledgementDAO;
+  @Mock
+  private static DataAccessRequestDAO dataAccessRequestDAO;
+  @Mock
+  private static EmailService emailService;
+
   private AcknowledgementService acknowledgementService;
 
-  private void initService() {
-    acknowledgementService = new AcknowledgementService(acknowledgementDAO);
+  @BeforeEach
+  void setUp() {
+    acknowledgementService = new AcknowledgementService(acknowledgementDAO, dataAccessRequestDAO,
+        emailService);
   }
 
   @Test
@@ -41,7 +54,7 @@ class AcknowledgementServiceTest {
     when(acknowledgementDAO.findAcknowledgementsForUser(anyInt())).thenReturn(new ArrayList<>());
     when(acknowledgementDAO.findAcknowledgementsByKeyForUser(anyString(), anyInt())).thenReturn(
         null);
-    initService();
+
     assertTrue(acknowledgementService.findAcknowledgementsForUser(user).isEmpty());
     assertNull(acknowledgementService.findAcknowledgementForUserByKey(user, "key1"));
   }
@@ -65,7 +78,6 @@ class AcknowledgementServiceTest {
     when(acknowledgementDAO.findAcknowledgementsByKeyForUser(anyString(), anyInt())).thenReturn(
         key2Acknowledgement);
     doNothing().when(acknowledgementDAO).deleteAcknowledgement(anyString(), anyInt());
-    initService();
 
     Map<String, Acknowledgement> makeResponse = acknowledgementService.makeAcknowledgements(keys,
         user);
@@ -84,5 +96,50 @@ class AcknowledgementServiceTest {
     assertEquals(singleLookupResponse, key2Acknowledgement);
 
     acknowledgementService.deleteAcknowledgementForUserByKey(user, key);
+  }
+
+  @Test
+  void testMakeAcknowledgementWithCloseout() throws Exception {
+    User user = new User(3, "test@domain.com", "Test User", new Date(),
+        List.of(UserRoles.Chairperson()));
+    DataAccessRequest dar1 = new DataAccessRequest();
+    dar1.setReferenceId(UUID.randomUUID().toString());
+    dar1.setDarCode("DAR-" + randomInt(100, 1000));
+    DataAccessRequest dar2 = new DataAccessRequest();
+    dar2.setReferenceId(UUID.randomUUID().toString());
+    dar2.setDarCode("DAR-" + randomInt(1001, 2000));
+    Timestamp timestamp = new Timestamp(new Date().getTime());
+
+    // Expect an email to go out for this
+    Acknowledgement ack1 = new Acknowledgement();
+    ack1.setUserId(user.getUserId());
+    ack1.setAckKey(AcknowledgementService.DAR_CLOSEOUT_CHAIR_REF + dar1.getReferenceId());
+    ack1.setFirstAcknowledged(timestamp);
+
+    // Expect NO email for this acknowledgement
+    Acknowledgement ack2 = new Acknowledgement();
+    ack2.setUserId(user.getUserId());
+    ack2.setAckKey(randomAlphabetic(10));
+    ack2.setFirstAcknowledged(timestamp);
+
+    // Expect an email to go out for this
+    Acknowledgement ack3 = new Acknowledgement();
+    ack3.setUserId(user.getUserId());
+    ack3.setAckKey(AcknowledgementService.DAR_CLOSEOUT_CHAIR_REF + dar2.getReferenceId());
+    ack3.setFirstAcknowledged(timestamp);
+
+    when(dataAccessRequestDAO.findByReferenceId(dar1.getReferenceId())).thenReturn(dar1);
+    when(dataAccessRequestDAO.findByReferenceId(dar2.getReferenceId())).thenReturn(dar2);
+    when(acknowledgementDAO.findAcknowledgementsForUser(
+        List.of(ack1.getAckKey(), ack2.getAckKey(), ack3.getAckKey()),
+        user.getUserId())).thenReturn(List.of(ack1, ack2, ack3));
+
+    acknowledgementService.makeAcknowledgements(
+        List.of(ack1.getAckKey(), ack2.getAckKey(), ack3.getAckKey()), user);
+    // Only two acknowledgements are closeouts, so only two emails should be sent
+    verify(emailService).sendResearcherCloseoutCompletedMessage(user, dar1.getDarCode(),
+        dar1.getReferenceId());
+    verify(emailService).sendResearcherCloseoutCompletedMessage(user, dar2.getDarCode(),
+        dar2.getReferenceId());
   }
 }


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-1769

### Summary
Trigger an email to researchers when a closeout is approved by a DAC Chairperson. The email template was completed in https://github.com/DataBiosphere/consent/pull/2549.

This PR closes some problematic code paths that were previously possible:
1. Anyone could submit a closeout acknowledgement because the base API is annotated with `@PermitAll`. This PR adds logic to `UserResource.postAcknowledgements` to ensure that only chairpersons can post a closeout approval.
2. The approval code in `AcknowledgementService.makeAcknowledgements` allowed for two improper acknowledgements.
    - Additional acknowledgements could be made for a DAR that was previously acknowledged by the same user
    - An acknowledgement could be made for a DAR that was not a closeout
    - Both of these cases now throw an exception


----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
