### PR TITLE
DT-1668: Remove coveralls in favor of sonar coverage reporting

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -1,9 +1,4 @@
-# Note that the token used for this action is manually maintained via Google Secrets Manager
-# To update the value, regenerate a new token in Coveralls: https://coveralls.io/github/DataBiosphere/consent
-# and save it in a data file: coveralls.txt
-# Update the value in GSM:
-# gcloud secrets versions add consent-coveralls-token --data-file="coveralls.txt" --project broad-dsde-dev
-# That value will be automatically synced to `secrets.COVERALLS_TOKEN`
+# Note that the sonar token used for this action is maintained in Google Secrets Manager by Devops
 name: Coverage
 on:
   push:
@@ -40,9 +35,8 @@ jobs:
       - name: Test Report
         if: github.actor != 'dependabot[bot]'
         env:
-          COVERALLS_TOKEN: ${{ secrets.COVERALLS_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           MAVEN_OPTS: -Dorg.slf4j.simpleLogger.defaultLogLevel=warn -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
         run: |
           mvn -v
-          mvn clean jacoco:prepare-agent test jacoco:report coveralls:report org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -DrepoToken=$COVERALLS_TOKEN --batch-mode
+          mvn clean jacoco:prepare-agent test jacoco:report org.sonarsource.scanner.maven:sonar-maven-plugin:sonar --batch-mode

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Consent Web Services
 ====================
 
 [![Build Status](https://circleci.com/gh/DataBiosphere/consent.svg?style=svg)](https://circleci.com/gh/DataBiosphere/consent)
-[![Coverage Status](https://coveralls.io/repos/github/DataBiosphere/consent/badge.svg?branch=develop)](https://coveralls.io/github/DataBiosphere/consent?branch=develop)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=DataBiosphere_consent&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=DataBiosphere_consent)
 
 # Consent Web Services API
 

--- a/pom.xml
+++ b/pom.xml
@@ -229,20 +229,6 @@
       </plugin>
 
       <plugin>
-        <groupId>org.eluder.coveralls</groupId>
-        <artifactId>coveralls-maven-plugin</artifactId>
-        <version>4.3.0</version>
-        <!-- java 11 requirement for coveralls support-->
-        <dependencies>
-          <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-            <version>2.3.1</version>
-          </dependency>
-        </dependencies>
-      </plugin>
-
-      <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
         <version>0.8.13</version>


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-1668

### Summary
Fully remove coveralls in favor of Sonar coverage reporting

See https://sonarcloud.io/project/overview?id=DataBiosphere_consent for this project's details in Sonarcloud

See also: https://github.com/DataBiosphere/consent-ontology/pull/1039

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
