### PR TITLE
[DT-2128] Fix electionHistory endpoint to only show DAC 1 elections for requesting user in DAC 1

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
@@ -309,7 +309,7 @@ public interface DarCollectionDAO extends Transactional<DarCollectionDAO> {
     AND (LOWER(data->>'status') != 'archived' OR data->>'status' IS NULL )
     """
   )
-  DarCollection findCollectionWithElectionsByCollectionIdAndDatasetIds(@BindList(value = "datasetIds") List<Integer> datasetIds, @Bind("collectionId") Integer collectionId);
+  DarCollection findCollectionWithElectionsByCollectionIdAndDatasetIds(@BindList(value = "datasetIds", onEmpty = EmptyHandling.NULL_STRING) List<Integer> datasetIds, @Bind("collectionId") Integer collectionId);
 
   /**
    * Create a new DAR Collection with the given dar code, create user ID, and create date

--- a/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
@@ -256,6 +256,61 @@ public interface DarCollectionDAO extends Transactional<DarCollectionDAO> {
   )
   DarCollection findCollectionWithAllElectionsByCollectionId(@Bind("collectionId") Integer collectionId);
 
+
+  /**
+   * Find the DARCollection and all of its Data Access Requests that has the given collectionId
+   * Instead of including all elections for each DAR like findCollectionWithAllElectionsByCollectionId
+   * this query returns only elections for the datasets in the given datasetIds list
+   *
+   * @return DarCollection
+   */
+  @RegisterBeanMapper(value = User.class, prefix = "u")
+  @RegisterBeanMapper(value = Institution.class, prefix = "i")
+  @RegisterBeanMapper(value = DarCollection.class)
+  @RegisterBeanMapper(value = DataAccessRequest.class, prefix = "dar")
+  @RegisterBeanMapper(value = Election.class, prefix = "e")
+  @RegisterBeanMapper(value = Vote.class, prefix = "v")
+  @RegisterBeanMapper(value = UserProperty.class, prefix = "up")
+  @RegisterBeanMapper(value = LibraryCard.class, prefix = "lc")
+  @UseRowReducer(DarCollectionReducer.class)
+  @SqlQuery(
+      """
+    SELECT c.*,
+       u.user_id as u_user_id, u.email as u_email, u.display_name as u_display_name, u.create_date as u_create_date, u.email_preference as u_email_preference, u.institution_id as u_institution_id, u.era_commons_id as u_era_commons_id,
+       i.institution_id as i_id, i.institution_name as i_name, i.it_director_name as i_it_director_name, i.it_director_email as i_it_director_email, i.create_date as i_create_date, i.update_date as i_update_date,
+       up.property_id AS up_property_id, up.user_id AS up_user_id, up.property_key as up_property_key, up.property_value AS up_property_value,
+       lc.id as lc_id, lc.user_id as lc_user_id, lc.user_name as lc_user_name, lc.user_email as lc_user_email, lc.create_user_id as lc_create_user_id, lc.create_date as lc_create_date, lc.update_date as lc_update_date, lc.update_user_id as lc_update_user_id,
+       dd.dataset_id,
+       dar.id AS dar_id, dar.reference_id AS dar_reference_id, dar.collection_id AS dar_collection_id,
+       dar.parent_id AS dar_parent_id, dar.user_id AS dar_userId, dar.era_commons_id AS dar_era_commons_id,
+       dar.create_date AS dar_create_date, dar.sort_date AS dar_sort_date, dar.submission_date AS dar_submission_date,
+       dar.update_date AS dar_update_date, (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data,
+       dar.closeout_so_approval_timestamp AS dar_closeout_signing_official_approved_date,
+       dar.closeout_approving_so_id AS dar_closeout_signing_official_approved_user_id,
+       e.election_id AS e_election_id, e.reference_id AS e_reference_id, e.status AS e_status, e.create_date AS e_create_date,
+       e.last_update AS e_last_update, e.dataset_id AS e_dataset_id, e.election_type AS e_election_type,
+       v.voteid as v_vote_id, v.vote as v_vote, v.user_id as v_user_id, v.rationale as v_rationale, v.electionid as v_election_id,
+       v.createdate as v_create_date, v.updatedate as v_update_date, v.type as v_type, du.display_name as v_display_name
+    FROM dar_collection c
+    INNER JOIN users u ON c.create_user_id = u.user_id
+    LEFT JOIN user_property up ON u.user_id = up.user_id
+    LEFT JOIN institution i ON i.institution_id = u.institution_id
+    LEFT JOIN library_card lc ON u.user_id = lc.user_id
+    INNER JOIN data_access_request dar ON c.collection_id = dar.collection_id
+    LEFT JOIN dar_dataset dd
+      ON (dd.reference_id = dar.reference_id AND dd.dataset_id IN (<datasetIds>))
+    LEFT JOIN election e
+      ON (dar.reference_id = e.reference_id AND dd.dataset_id = e.dataset_id)
+    LEFT JOIN vote v
+      ON v.electionid = e.election_id
+    LEFT JOIN users du
+      ON du.user_id = v.user_id
+    WHERE c.collection_id = :collectionId
+    AND (LOWER(data->>'status') != 'archived' OR data->>'status' IS NULL )
+    """
+  )
+  DarCollection findCollectionWithElectionsByCollectionIdAndDatasetIds(@BindList(value = "datasetIds") List<Integer> datasetIds, @Bind("collectionId") Integer collectionId);
+
   /**
    * Create a new DAR Collection with the given dar code, create user ID, and create date
    *

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DatasetMapper.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DatasetMapper.java
@@ -22,7 +22,7 @@ public class DatasetMapper implements RowMapper<Dataset>, RowMapperHelper {
     dataset.setObjectId(r.getString("object_id"));
     dataset.setName(r.getString("name"));
     if (hasColumn(r, "create_date")) {
-      dataset.setCreateDate(r.getDate("create_date"));
+      dataset.setCreateDate(r.getTimestamp("create_date"));
     }
     if (hasNonZeroColumn(r, "create_user_id")) {
       dataset.setCreateUserId(r.getInt("create_user_id"));

--- a/src/main/java/org/broadinstitute/consent/http/resources/DarCollectionResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DarCollectionResource.java
@@ -9,7 +9,6 @@ import jakarta.annotation.security.PermitAll;
 import jakarta.annotation.security.RolesAllowed;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.Consumes;
-import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.POST;
@@ -31,6 +30,7 @@ import org.broadinstitute.consent.http.models.DarCollectionSummary;
 import org.broadinstitute.consent.http.models.Dataset;
 import org.broadinstitute.consent.http.models.DuosUser;
 import org.broadinstitute.consent.http.models.User;
+import org.broadinstitute.consent.http.models.UserRole;
 import org.broadinstitute.consent.http.service.DarCollectionService;
 import org.broadinstitute.consent.http.service.UserService;
 import org.broadinstitute.consent.http.util.ComplianceLogger;
@@ -135,8 +135,16 @@ public class DarCollectionResource extends Resource {
       @Auth DuosUser authUser,
       @PathParam("collectionId") Integer collectionId) {
     try {
-      DarCollection collection = darCollectionService.getCollectionWithAllElectionsByCollectionId(collectionId);
-      validateRequestingUserForElectionHistory(authUser, collection);
+      List<UserRole> roles = authUser.getUser().getRoles();
+      boolean isAdmin = roles.stream().anyMatch(r -> r.getName().equals(UserRoles.ADMIN.name()));
+      if (isAdmin) {
+        DarCollection collection = darCollectionService.getCollectionWithAllElectionsByCollectionId(collectionId);
+        return Response.ok().entity(collection).build();
+      }
+      // if user is only a member or chair, get the list of datasets they have access to
+      // this will be used to filter the collection's elections
+      List<Integer> userDatasetIds = darCollectionService.findDatasetIdsByDACUser(authUser.getUser());
+      DarCollection collection = darCollectionService.getCollectionWithElectionsByCollectionIdAndDatasetIds(userDatasetIds, collectionId);
       return Response.ok().entity(collection).build();
     } catch (Exception e) {
       return createExceptionResponse(e);

--- a/src/main/java/org/broadinstitute/consent/http/resources/DarCollectionResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DarCollectionResource.java
@@ -1,7 +1,6 @@
 package org.broadinstitute.consent.http.resources;
 
 import com.codahale.metrics.annotation.Timed;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.gson.Gson;
 import com.google.inject.Inject;
 import io.dropwizard.auth.Auth;
@@ -30,7 +29,6 @@ import org.broadinstitute.consent.http.models.DarCollectionSummary;
 import org.broadinstitute.consent.http.models.Dataset;
 import org.broadinstitute.consent.http.models.DuosUser;
 import org.broadinstitute.consent.http.models.User;
-import org.broadinstitute.consent.http.models.UserRole;
 import org.broadinstitute.consent.http.service.DarCollectionService;
 import org.broadinstitute.consent.http.service.UserService;
 import org.broadinstitute.consent.http.util.ComplianceLogger;
@@ -135,9 +133,7 @@ public class DarCollectionResource extends Resource {
       @Auth DuosUser authUser,
       @PathParam("collectionId") Integer collectionId) {
     try {
-      List<UserRole> roles = authUser.getUser().getRoles();
-      boolean isAdmin = roles.stream().anyMatch(r -> r.getName().equals(UserRoles.ADMIN.name()));
-      if (isAdmin) {
+      if (authUser.getUser().hasUserRole(UserRoles.ADMIN)) {
         DarCollection collection = darCollectionService.getCollectionWithAllElectionsByCollectionId(collectionId);
         return Response.ok().entity(collection).build();
       }
@@ -145,17 +141,12 @@ public class DarCollectionResource extends Resource {
       // this will be used to filter the collection's elections
       List<Integer> userDatasetIds = darCollectionService.findDatasetIdsByDACUser(authUser.getUser());
       DarCollection collection = darCollectionService.getCollectionWithElectionsByCollectionIdAndDatasetIds(userDatasetIds, collectionId);
+      if (!checkDacPermissionsForCollection(authUser.getUser(), collection)) {
+        throw new NotFoundException();
+      }
       return Response.ok().entity(collection).build();
     } catch (Exception e) {
       return createExceptionResponse(e);
-    }
-  }
-
-  @VisibleForTesting
-  protected void validateRequestingUserForElectionHistory(DuosUser duosUser, DarCollection collection) {
-    User user = duosUser.getUser();
-    if (!user.hasUserRole(UserRoles.ADMIN) && !checkDacPermissionsForCollection(user, collection)) {
-      throw new NotFoundException();
     }
   }
 

--- a/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
@@ -524,9 +524,8 @@ public class DarCollectionService implements ConsentLogger {
             .map(datasetMap::get)
             .filter(Objects::nonNull) // filtering out nulls which were getting captured by map
             .collect(Collectors.toSet());
-        DarCollection copy = collection.deepCopy();
-        copy.setDatasets(collectionDatasets);
-        return copy;
+        collection.setDatasets(collectionDatasets);
+        return collection.deepCopy();
     }
     // There were no datasets to add, so we return the original list
     return collection;

--- a/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
@@ -1,15 +1,11 @@
 package org.broadinstitute.consent.http.service;
 
-import static java.util.stream.Collectors.toList;
-
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Streams;
 import com.google.gson.Gson;
 import com.google.inject.Inject;
 import freemarker.template.TemplateException;
 import jakarta.ws.rs.BadRequestException;
-import jakarta.ws.rs.NotAcceptableException;
-import jakarta.ws.rs.NotAuthorizedException;
 import jakarta.ws.rs.NotFoundException;
 import java.io.IOException;
 import java.text.SimpleDateFormat;
@@ -488,6 +484,15 @@ public class DarCollectionService implements ConsentLogger {
 
   public DarCollection getCollectionWithAllElectionsByCollectionId(Integer collectionId) {
     DarCollection collection = darCollectionDAO.findCollectionWithAllElectionsByCollectionId(collectionId);
+    if (Objects.isNull(collection)) {
+      throw new NotFoundException(
+          "Collection with the collection id of " + collectionId + " was not found");
+    }
+    return addDatasetsToCollection(collection);
+  }
+
+  public DarCollection getCollectionWithElectionsByCollectionIdAndDatasetIds(List<Integer> datasetIds, Integer collectionId) {
+    DarCollection collection = darCollectionDAO.findCollectionWithElectionsByCollectionIdAndDatasetIds(datasetIds, collectionId);
     if (Objects.isNull(collection)) {
       throw new NotFoundException(
           "Collection with the collection id of " + collectionId + " was not found");

--- a/src/test/java/org/broadinstitute/consent/http/db/DarCollectionDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DarCollectionDAOTest.java
@@ -13,6 +13,7 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -198,7 +199,8 @@ class DarCollectionDAOTest extends DAOTestHelper {
     DataAccessRequest testDar2 = createDAR(user, dataset, testDar1.getCollectionId());
     dataAccessRequestDAO.updateDarCloseoutSO(user.getUserId(), testDar2.getReferenceId());
 
-    DataAccessRequest testDar2Stored = dataAccessRequestDAO.findByReferenceId(testDar2.getReferenceId());
+    DataAccessRequest testDar2Stored = dataAccessRequestDAO.findByReferenceId(
+        testDar2.getReferenceId());
     assertNotNull(testDar2Stored.getCloseoutSigningOfficialApprovedUserId());
     assertNotNull(testDar2Stored.getCloseoutSigningOfficialApprovedDate());
 
@@ -206,21 +208,30 @@ class DarCollectionDAOTest extends DAOTestHelper {
         testDar2.getCollectionId());
 
     assertNotNull(darCollection.getMostRecentDar().getCloseoutSigningOfficialApprovedDate());
-    assertEquals(user.getUserId(), darCollection.getMostRecentDar().getCloseoutSigningOfficialApprovedUserId());
+    assertEquals(user.getUserId(),
+        darCollection.getMostRecentDar().getCloseoutSigningOfficialApprovedUserId());
 
-    DarCollection darCollectionByReferenceId = darCollectionDAO.findDARCollectionByReferenceId(testDar2.getReferenceId());
-    assertNotNull(darCollectionByReferenceId.getMostRecentDar().getCloseoutSigningOfficialApprovedDate());
-    assertEquals(user.getUserId(), darCollectionByReferenceId.getMostRecentDar().getCloseoutSigningOfficialApprovedUserId());
+    DarCollection darCollectionByReferenceId = darCollectionDAO.findDARCollectionByReferenceId(
+        testDar2.getReferenceId());
+    assertNotNull(
+        darCollectionByReferenceId.getMostRecentDar().getCloseoutSigningOfficialApprovedDate());
+    assertEquals(user.getUserId(),
+        darCollectionByReferenceId.getMostRecentDar().getCloseoutSigningOfficialApprovedUserId());
 
     DarCollection darCollectionWithElectionsById = darCollectionDAO.findCollectionWithAllElectionsByCollectionId(
         testDar2.getCollectionId());
-    assertNotNull(darCollectionWithElectionsById.getMostRecentDar().getCloseoutSigningOfficialApprovedDate());
-    assertEquals(user.getUserId(), darCollectionWithElectionsById.getMostRecentDar().getCloseoutSigningOfficialApprovedUserId());
+    assertNotNull(
+        darCollectionWithElectionsById.getMostRecentDar().getCloseoutSigningOfficialApprovedDate());
+    assertEquals(user.getUserId(), darCollectionWithElectionsById.getMostRecentDar()
+        .getCloseoutSigningOfficialApprovedUserId());
 
-    List<DarCollection> darCollectionList = darCollectionDAO.findDARCollectionByCollectionIds(List.of(testDar2.getCollectionId()));
+    List<DarCollection> darCollectionList = darCollectionDAO.findDARCollectionByCollectionIds(
+        List.of(testDar2.getCollectionId()));
     assertEquals(1, darCollectionList.size());
-    assertNotNull(darCollectionList.get(0).getMostRecentDar().getCloseoutSigningOfficialApprovedDate());
-    assertEquals(user.getUserId(), darCollectionList.get(0).getMostRecentDar().getCloseoutSigningOfficialApprovedUserId());
+    assertNotNull(
+        darCollectionList.get(0).getMostRecentDar().getCloseoutSigningOfficialApprovedDate());
+    assertEquals(user.getUserId(),
+        darCollectionList.get(0).getMostRecentDar().getCloseoutSigningOfficialApprovedUserId());
   }
 
   @Test
@@ -264,7 +275,8 @@ class DarCollectionDAOTest extends DAOTestHelper {
         new Date());
     createDataAccessRequest(updatedUser.getUserId(), collectionId);
 
-    DarCollection collection = darCollectionDAO.findCollectionWithAllElectionsByCollectionId(collectionId);
+    DarCollection collection = darCollectionDAO.findCollectionWithAllElectionsByCollectionId(
+        collectionId);
     User returnedUser = collection.getCreateUser();
     assertEquals(updatedUser, returnedUser);
 
@@ -276,6 +288,161 @@ class DarCollectionDAOTest extends DAOTestHelper {
   @Test
   void testFindCollectionWithAllElectionsByCollectionIdNegative() {
     DarCollection returned = darCollectionDAO.findCollectionWithAllElectionsByCollectionId(
+        randomInt(1000, 2000));
+    assertNull(returned);
+  }
+
+  @Test
+  void testFindCollectionWithElectionsByCollectionIdAndDatasetIds() {
+    // creates 3 dars, one dar has 2 datasets, each with 2 elections, one cancelled, one open,
+    // the other two dars in the collections have no elections
+    // each election has one vote (final)
+    // uses findDarCollectionById internally
+    DarCollection collection = createDarCollectionMultipleDatasetElections();
+    List<Integer> datasetIds = collection.getDatasets().stream()
+        .sorted(Comparator.comparing(Dataset::getDatasetId))
+        .map(Dataset::getDatasetId).toList();
+    DarCollection returnedAll = darCollectionDAO.findCollectionWithElectionsByCollectionIdAndDatasetIds(
+        datasetIds, collection.getDarCollectionId());
+    assertNotNull(returnedAll);
+    // all values should be the same as the collection returned by findDarCollectionById
+    // except the collection returned by findCollectionWithDataAccessElectionsByCollectionIdAndDatasetIds will include
+    // all the created elections for the specified datasets in the collection
+    assertCollectionEqualExceptForElections(collection, returnedAll);
+    List<Election> elections = getElectionsFromCollection(returnedAll)
+        .stream()
+        .sorted(Comparator.comparing(Election::getCreateDate))
+        .toList();
+    assertEquals(4, elections.size());
+    Election firstElection = elections.get(0);
+    assertEquals(datasetIds.get(0), firstElection.getDatasetId());
+    assertExpectedElection(firstElection, ElectionStatus.CANCELED.getValue());
+    Election secondElection = elections.get(1);
+    assertEquals(datasetIds.get(0), secondElection.getDatasetId());
+    assertExpectedElection(secondElection, ElectionStatus.OPEN.getValue());
+    Election thirdElection = elections.get(2);
+    assertEquals(datasetIds.get(1), thirdElection.getDatasetId());
+    assertExpectedElection(thirdElection, ElectionStatus.CANCELED.getValue());
+    Election fourthElection = elections.get(3);
+    assertEquals(datasetIds.get(1), fourthElection.getDatasetId());
+    assertExpectedElection(fourthElection, ElectionStatus.OPEN.getValue());
+
+    List<UserProperty> userProperties = returnedAll.getCreateUser().getProperties();
+    assertFalse(userProperties.isEmpty());
+    userProperties.forEach(p -> assertEquals(collection.getCreateUserId(),
+        p.getUserId()));
+
+    assertNull(returnedAll.getCreateUser().getLibraryCard());
+  }
+
+  @Test
+  void testFindCollectionWithElectionsByCollectionIdAndDatasetIdsOneDataset() {
+    // creates 3 dars, one dar has 2 datasets, each with 2 elections, one cancelled, one open,
+    // the other two dars in the collections have no elections
+    // each election has one vote (final)
+    // uses findDarCollectionById internally
+    DarCollection collection = createDarCollectionMultipleDatasetElections();
+    List<Integer> datasetId = List.of(collection.getDatasets().stream()
+        .map(Dataset::getDatasetId).toList().get(0));
+    DarCollection returnedAll = darCollectionDAO.findCollectionWithElectionsByCollectionIdAndDatasetIds(
+        datasetId, collection.getDarCollectionId());
+    assertNotNull(returnedAll);
+    // all values should be the same as the collection returned by findDarCollectionById
+    // except the collection returned by findCollectionWithAllDataAccessElectionsByCollectionIdAndDatasetIds
+    // will include all the created elections for the specified datasets in the collection
+    assertCollectionEqualExceptForElections(collection, returnedAll);
+    List<Election> elections = getElectionsFromCollection(returnedAll)
+        .stream()
+        .sorted(Comparator.comparing(Election::getCreateDate))
+        .toList();
+    assertEquals(2, elections.size());
+    Election firstElection = elections.get(0);
+    assertEquals(datasetId.get(0), firstElection.getDatasetId());
+    assertExpectedElection(firstElection, ElectionStatus.CANCELED.getValue());
+    Election secondElection = elections.get(1);
+    assertEquals(datasetId.get(0), secondElection.getDatasetId());
+    assertExpectedElection(secondElection, ElectionStatus.OPEN.getValue());
+
+    List<UserProperty> userProperties = returnedAll.getCreateUser().getProperties();
+    assertFalse(userProperties.isEmpty());
+    userProperties.forEach(p -> assertEquals(collection.getCreateUserId(),
+        p.getUserId()));
+
+    assertNull(returnedAll.getCreateUser().getLibraryCard());
+  }
+
+  @Test
+  void testFindCollectionWithElectionsByCollectionIdAndDatasetIdsNoDataset() {
+    // creates 3 dars, one dar has 2 datasets, each with 2 elections, one cancelled, one open,
+    // the other two dars in the collections have no elections
+    // each election has one vote (final)
+    // uses findDarCollectionById internally
+    DarCollection collection = createDarCollectionMultipleDatasetElections();
+    List<Integer> datasetIds = List.of();
+    DarCollection returnedAll = darCollectionDAO.findCollectionWithElectionsByCollectionIdAndDatasetIds(
+        datasetIds, collection.getDarCollectionId());
+    assertNotNull(returnedAll);
+    // all values should be the same as the collection returned by findDarCollectionById
+    // except the collection returned by findCollectionWithDataAccessElectionsByCollectionIdAndDatasetIds will include
+    // no elections because no dataset was specified
+    assertCollectionEqualExceptForElections(collection, returnedAll);
+    List<Election> elections = getElectionsFromCollection(returnedAll);
+    assertEquals(0, elections.size());
+    List<UserProperty> userProperties = returnedAll.getCreateUser().getProperties();
+    assertFalse(userProperties.isEmpty());
+    userProperties.forEach(p -> assertEquals(collection.getCreateUserId(),
+        p.getUserId()));
+
+    assertNull(returnedAll.getCreateUser().getLibraryCard());
+  }
+
+  @Test
+  void testFindCollectionWithElectionsByCollectionIdAndDatasetIdsOtherDataset() {
+    // creates 3 dars, one dar has 2 datasets, each with 2 elections, one cancelled, one open,
+    // the other two dars in the collections have no elections
+    // each election has one vote (final)
+    // uses findDarCollectionById internally
+    DarCollection collection = createDarCollectionMultipleDatasetElections();
+    List<Integer> datasetIds = List.of(randomInt(1000, 2000));
+    DarCollection returnedAll = darCollectionDAO.findCollectionWithElectionsByCollectionIdAndDatasetIds(
+        datasetIds, collection.getDarCollectionId());
+    assertNotNull(returnedAll);
+    // all values should be the same as the collection returned by findDarCollectionById
+    // except the collection returned by findCollectionWithDataAccessElectionsByCollectionIdAndDatasetIds will include
+    // no elections since the specified dataset is not in the collection
+    assertCollectionEqualExceptForElections(collection, returnedAll);
+    List<Election> elections = getElectionsFromCollection(returnedAll);
+    assertEquals(0, elections.size());
+    List<UserProperty> userProperties = returnedAll.getCreateUser().getProperties();
+    assertFalse(userProperties.isEmpty());
+    userProperties.forEach(p -> assertEquals(collection.getCreateUserId(),
+        p.getUserId()));
+
+    assertNull(returnedAll.getCreateUser().getLibraryCard());
+  }
+
+  @Test
+  void testFindCollectionWithElectionsByCollectionIdAndDatasetsLC() {
+    User user = createUser();
+    createLibraryCard(user);
+    User updatedUser = userDAO.findUserById(user.getUserId());
+    String darCode = "DAR-" + randomInt(100, 1000);
+    Integer collectionId = darCollectionDAO.insertDarCollection(darCode, updatedUser.getUserId(),
+        new Date());
+    createDataAccessRequest(updatedUser.getUserId(), collectionId);
+
+    DarCollection collection = darCollectionDAO.findCollectionWithElectionsByCollectionIdAndDatasetIds(List.of(), collectionId);
+    User returnedUser = collection.getCreateUser();
+    assertEquals(updatedUser, returnedUser);
+
+    LibraryCard returnedLibraryCard = returnedUser.getLibraryCard();
+    assertNotNull(returnedLibraryCard);
+    assertEquals(updatedUser.getLibraryCard(), returnedLibraryCard);
+  }
+
+  @Test
+  void testFindCollectionWithElectionsByCollectionIdAndDatasetsNegative() {
+    DarCollection returned = darCollectionDAO.findCollectionWithElectionsByCollectionIdAndDatasetIds(List.of(1),
         randomInt(1000, 2000));
     assertNull(returned);
   }
@@ -586,6 +753,38 @@ class DarCollectionDAOTest extends DAOTestHelper {
     return darCollectionDAO.findDARCollectionByCollectionId(collectionId);
   }
 
+  private DarCollection createDarCollectionMultipleDatasetElections() {
+    User user = createUser();
+    Integer userId = user.getUserId();
+    createUserProperty(userId, UserFields.ERA_STATUS.getValue());
+    String darCode = "DAR-" + randomInt(100, 1000);
+    Integer collectionId = darCollectionDAO.insertDarCollection(darCode, user.getUserId(),
+        new Date());
+    DataAccessRequest dar = createDataAccessRequest(user.getUserId(), collectionId);
+
+    Dataset dataset1 = createDataset();
+    dataAccessRequestDAO.insertDARDatasetRelation(dar.getReferenceId(), dataset1.getDatasetId());
+    Election cancelled1 = createCancelledAccessElection(dar.getReferenceId(),
+        dataset1.getDatasetId());
+    Election access1 = createDataAccessElection(dar.getReferenceId(), dataset1.getDatasetId());
+    createFinalVote(user.getUserId(), cancelled1.getElectionId());
+    createFinalVote(user.getUserId(), access1.getElectionId());
+
+    Dataset dataset2 = createDataset();
+    dataAccessRequestDAO.insertDARDatasetRelation(dar.getReferenceId(), dataset2.getDatasetId());
+    Election cancelled2 = createCancelledAccessElection(dar.getReferenceId(),
+        dataset2.getDatasetId());
+    Election access2 = createDataAccessElection(dar.getReferenceId(), dataset2.getDatasetId());
+    createFinalVote(user.getUserId(), cancelled2.getElectionId());
+    createFinalVote(user.getUserId(), access2.getElectionId());
+
+    createDataAccessRequest(user.getUserId(), collectionId);
+    createDataAccessRequest(user.getUserId(), collectionId);
+    DarCollection darCollection = darCollectionDAO.findDARCollectionByCollectionId(collectionId);
+    darCollection.setDatasets(new HashSet<>(List.of(dataset1, dataset2)));
+    return darCollection;
+  }
+
   private void createUserProperty(Integer userId, String field) {
     UserProperty property = new UserProperty();
     property.setPropertyKey(field);
@@ -673,8 +872,10 @@ class DarCollectionDAOTest extends DAOTestHelper {
   }
 
   private void assertCollectionEqualExceptForElections(DarCollection collection, DarCollection returned) {
-    collection.deepCopy().getDars().values().forEach(dar -> dar.setElections(new HashMap<>()));
-    returned.deepCopy().getDars().values().forEach(dar -> dar.setElections(new HashMap<>()));
-    assertEquals(collection, returned);
+    DarCollection collectionCopy = collection.deepCopy();
+    collectionCopy.getDars().values().forEach(dar -> dar.setElections(new HashMap<>()));
+    DarCollection returnedCopy = returned.deepCopy();
+    returnedCopy.getDars().values().forEach(dar -> dar.setElections(new HashMap<>()));
+    assertEquals(collectionCopy, returnedCopy);
   }
 }

--- a/src/test/java/org/broadinstitute/consent/http/db/DarCollectionDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DarCollectionDAOTest.java
@@ -16,6 +16,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import org.broadinstitute.consent.http.enumeration.ElectionStatus;
 import org.broadinstitute.consent.http.enumeration.ElectionType;
@@ -872,10 +873,21 @@ class DarCollectionDAOTest extends DAOTestHelper {
   }
 
   private void assertCollectionEqualExceptForElections(DarCollection collection, DarCollection returned) {
+    // datasets cannot be serialized by deepCopy
+    Set<Dataset> collectionDatasets = collection.getDatasets();
+    collection.setDatasets(null);
     DarCollection collectionCopy = collection.deepCopy();
     collectionCopy.getDars().values().forEach(dar -> dar.setElections(new HashMap<>()));
+    collection.setDatasets(collectionDatasets);
+    collectionCopy.setDatasets(collectionDatasets);
+
+    Set<Dataset> returnedDatasets = returned.getDatasets();
+    returned.setDatasets(null);
     DarCollection returnedCopy = returned.deepCopy();
     returnedCopy.getDars().values().forEach(dar -> dar.setElections(new HashMap<>()));
+    returned.setDatasets(returnedDatasets);
+    returnedCopy.setDatasets(returnedDatasets);
+
     assertEquals(collectionCopy, returnedCopy);
   }
 }

--- a/src/test/java/org/broadinstitute/consent/http/db/DarCollectionDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DarCollectionDAOTest.java
@@ -16,7 +16,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.UUID;
 import org.broadinstitute.consent.http.enumeration.ElectionStatus;
 import org.broadinstitute.consent.http.enumeration.ElectionType;
@@ -873,21 +872,10 @@ class DarCollectionDAOTest extends DAOTestHelper {
   }
 
   private void assertCollectionEqualExceptForElections(DarCollection collection, DarCollection returned) {
-    // datasets cannot be serialized by deepCopy
-    Set<Dataset> collectionDatasets = collection.getDatasets();
-    collection.setDatasets(null);
     DarCollection collectionCopy = collection.deepCopy();
     collectionCopy.getDars().values().forEach(dar -> dar.setElections(new HashMap<>()));
-    collection.setDatasets(collectionDatasets);
-    collectionCopy.setDatasets(collectionDatasets);
-
-    Set<Dataset> returnedDatasets = returned.getDatasets();
-    returned.setDatasets(null);
     DarCollection returnedCopy = returned.deepCopy();
     returnedCopy.getDars().values().forEach(dar -> dar.setElections(new HashMap<>()));
-    returned.setDatasets(returnedDatasets);
-    returnedCopy.setDatasets(returnedDatasets);
-
     assertEquals(collectionCopy, returnedCopy);
   }
 }

--- a/src/test/java/org/broadinstitute/consent/http/resources/DarCollectionResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DarCollectionResourceTest.java
@@ -264,7 +264,7 @@ class DarCollectionResourceTest extends AbstractTestHelper {
   }
 
   @Test
-  void testGetCollectionWithAllElectionsByCollectionId() {
+  void testGetCollectionWithAllElectionsByCollectionIdAdmin() {
     DarCollection collection = mockDarCollection();
     User admin = new User(2, authUser.getEmail(), "Admin User", new Date(),
         List.of(UserRoles.Admin()));
@@ -273,6 +273,23 @@ class DarCollectionResourceTest extends AbstractTestHelper {
     collection.setCreateUserId(researcher.getUserId());
 
     when(darCollectionService.getCollectionWithAllElectionsByCollectionId(collection.getDarCollectionId())).thenReturn(collection);
+
+    Response response = resource.getCollectionWithAllElectionsByCollectionId(duosAdmin, collection.getDarCollectionId());
+    assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+  }
+
+  @Test
+  void testGetCollectionWithAllElectionsByCollectionIdDacMember() {
+    DarCollection collection = mockDarCollection();
+    List<Integer> userDatasetIds = List.of(1, 2);
+    User admin = new User(2, authUser.getEmail(), "Dac Member User", new Date(),
+        List.of(UserRoles.Member()));
+    DuosUser duosAdmin = new DuosUser(authUser, admin);
+    collection.setCreateUser(researcher);
+    collection.setCreateUserId(researcher.getUserId());
+
+    when(darCollectionService.findDatasetIdsByDACUser(any())).thenReturn(userDatasetIds);
+    when(darCollectionService.getCollectionWithElectionsByCollectionIdAndDatasetIds(userDatasetIds, collection.getDarCollectionId())).thenReturn(collection);
 
     Response response = resource.getCollectionWithAllElectionsByCollectionId(duosAdmin, collection.getDarCollectionId());
     assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());

--- a/src/test/java/org/broadinstitute/consent/http/resources/DarCollectionResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DarCollectionResourceTest.java
@@ -1,12 +1,10 @@
 package org.broadinstitute.consent.http.resources;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.api.client.http.HttpStatusCodes;
@@ -282,22 +280,27 @@ class DarCollectionResourceTest extends AbstractTestHelper {
   void testGetCollectionWithAllElectionsByCollectionIdDacMember() {
     DarCollection collection = mockDarCollection();
     List<Integer> userDatasetIds = List.of(1, 2);
-    User admin = new User(2, authUser.getEmail(), "Dac Member User", new Date(),
+    User member = new User(2, authUser.getEmail(), "Dac Member User", new Date(),
         List.of(UserRoles.Member()));
-    DuosUser duosAdmin = new DuosUser(authUser, admin);
+    DuosUser duosMember = new DuosUser(authUser, member);
     collection.setCreateUser(researcher);
     collection.setCreateUserId(researcher.getUserId());
+    Dataset dataset1 = new Dataset();
+    dataset1.setDatasetId(1);
+    collection.setDatasets(Set.of(dataset1));
 
-    when(darCollectionService.findDatasetIdsByDACUser(any())).thenReturn(userDatasetIds);
+    when(darCollectionService.findDatasetIdsByDACUser(member)).thenReturn(userDatasetIds);
     when(darCollectionService.getCollectionWithElectionsByCollectionIdAndDatasetIds(userDatasetIds, collection.getDarCollectionId())).thenReturn(collection);
 
-    Response response = resource.getCollectionWithAllElectionsByCollectionId(duosAdmin, collection.getDarCollectionId());
+    Response response = resource.getCollectionWithAllElectionsByCollectionId(duosMember, collection.getDarCollectionId());
     assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
   }
 
   @Test
   void testGetCollectionWithAllElectionsById_CollectionNotFoundCollection() {
-    when(darCollectionService.getCollectionWithAllElectionsByCollectionId(anyInt())).thenThrow(new NotFoundException("Collection not found"));
+    when(darCollectionService.findDatasetIdsByDACUser(duosResearcher.getUser())).thenReturn(List.of());
+    when(darCollectionService.getCollectionWithElectionsByCollectionIdAndDatasetIds(List.of(), 1))
+        .thenThrow(new NotFoundException("Collection not found"));
 
     Response response = resource.getCollectionWithAllElectionsByCollectionId(duosResearcher, 1);
     assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
@@ -305,7 +308,8 @@ class DarCollectionResourceTest extends AbstractTestHelper {
 
   @Test
   void testGetCollectionWithAllElectionsByCollectionId_ServiceException() {
-    when(darCollectionService.getCollectionWithAllElectionsByCollectionId(anyInt()))
+    when(darCollectionService.findDatasetIdsByDACUser(duosResearcher.getUser())).thenReturn(List.of());
+    when(darCollectionService.getCollectionWithElectionsByCollectionIdAndDatasetIds(List.of(), 1))
         .thenThrow(new RuntimeException("Service error"));
 
     Response response = resource.getCollectionWithAllElectionsByCollectionId(duosResearcher, 1);
@@ -318,55 +322,13 @@ class DarCollectionResourceTest extends AbstractTestHelper {
     collection.setCreateUser(researcher);
     collection.setCreateUserId(researcher.getUserId());
 
-    when(darCollectionService.getCollectionWithAllElectionsByCollectionId(
+    when(darCollectionService.findDatasetIdsByDACUser(researcher)).thenReturn(List.of());
+    when(darCollectionService.getCollectionWithElectionsByCollectionIdAndDatasetIds(List.of(),
         collection.getDarCollectionId())).thenReturn(collection);
-    when(darCollectionService.findDatasetIdsByDACUser(researcher)).thenReturn(List.of()); // No datasets
 
     Response response = resource.getCollectionWithAllElectionsByCollectionId(duosResearcher,
         collection.getDarCollectionId());
     assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
-  }
-
-  @Test
-  void testValidateRequestingUserForElectionHistory_Admin() {
-    DarCollection collection = new DarCollection();
-    collection.setCreateUserId(1); // Different from admin's ID
-    User admin = new User(2, authUser.getEmail(), "Admin User", new Date(),
-        List.of(UserRoles.Admin()));
-    DuosUser duosAdmin = new DuosUser(authUser, admin);
-
-    resource.validateRequestingUserForElectionHistory(duosAdmin, collection);
-  }
-
-  @Test
-  void testValidateRequestingUserForElectionHistory_DacMember() {
-    User dacMember = new User(1, authUser.getEmail(), "DAC Member", new Date(),
-        List.of(UserRoles.Member()));
-    DuosUser duosMember = new DuosUser(authUser, dacMember);
-    DarCollection collection = new DarCollection();
-    User creator = new User(2, "creator@example.com", "Create User", new Date(),
-        List.of(UserRoles.Researcher()));
-    collection.setCreateUser(creator); // Different from DAC member's ID
-    Dataset dataset = new Dataset();
-    dataset.setDatasetId(42);
-    collection.addDataset(dataset);
-
-    when(darCollectionService.findDatasetIdsByDACUser(dacMember)).thenReturn(List.of(42, 43));
-
-    resource.validateRequestingUserForElectionHistory(duosMember, collection);
-    verify(darCollectionService).findDatasetIdsByDACUser(dacMember);
-  }
-
-  @Test
-  void testValidateRequestingUserForElectionHistory_Unauthorized() {
-    DarCollection collection = new DarCollection();
-    collection.setCreateUser(researcher);
-    collection.setCreateUserId(1);
-
-    when(darCollectionService.findDatasetIdsByDACUser(researcher)).thenReturn(List.of());
-
-    assertThrows(NotFoundException.class, () ->
-        resource.validateRequestingUserForElectionHistory(duosResearcher, collection));
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
@@ -157,7 +157,6 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     assertEquals(expectedException, exception);
   }
 
-
   @Test
   void testGetCollectionWithAllElectionsByCollectionId() {
     Integer collectionId = 1;
@@ -188,6 +187,43 @@ class DarCollectionServiceTest extends AbstractTestHelper {
 
     RuntimeException exception = assertThrows(RuntimeException.class, () ->
         service.getCollectionWithAllElectionsByCollectionId(collectionId));
+    assertEquals(expectedException, exception);
+  }
+
+
+  @Test
+  void testGetCollectionWithElectionsByCollectionIdAndDatasetIds() {
+    Integer collectionId = 1;
+    DarCollection collection = new DarCollection();
+    collection.setDarCollectionId(collectionId);
+    List<Integer> datasetIds = List.of(1, 2, 3);
+    when(darCollectionDAO.findCollectionWithElectionsByCollectionIdAndDatasetIds(datasetIds, collectionId)).thenReturn(collection);
+
+    DarCollection result = service.getCollectionWithElectionsByCollectionIdAndDatasetIds(datasetIds, collectionId);
+    assertNotNull(result);
+    assertEquals(collectionId, result.getDarCollectionId());
+  }
+
+  @Test
+  void testGetCollectionWithElectionsByCollectionIdAndDatasetIds_NotFound() {
+    Integer collectionId = 1;
+    List<Integer> datasetIds = List.of(1, 2, 3);
+    when(darCollectionDAO.findCollectionWithElectionsByCollectionIdAndDatasetIds(datasetIds, collectionId)).thenReturn(null);
+
+    assertThrows(NotFoundException.class, () ->
+        service.getCollectionWithElectionsByCollectionIdAndDatasetIds(datasetIds, collectionId));
+  }
+
+  @Test
+  void testGetCollectionWithElectionsByCollectionIdAndDatasetIds_ServiceException() {
+    Integer collectionId = 1;
+    List<Integer> datasetIds = List.of(1, 2, 3);
+    RuntimeException expectedException = new RuntimeException("Test exception");
+    when(darCollectionDAO.findCollectionWithElectionsByCollectionIdAndDatasetIds(datasetIds, collectionId))
+        .thenThrow(expectedException);
+
+    RuntimeException exception = assertThrows(RuntimeException.class, () ->
+        service.getCollectionWithElectionsByCollectionIdAndDatasetIds(datasetIds, collectionId));
     assertEquals(expectedException, exception);
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
@@ -10,6 +10,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -264,7 +265,7 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
     // Call the async method ...
     elasticSearchSpy.asyncDatasetInESIndex(datasetRecord.dataset.getDatasetId(), datasetRecord.createUser, true);
     // Ensure that the synchronous method was called with the expected parameters
-    verify(elasticSearchSpy).synchronizeDatasetInESIndex(datasetRecord.dataset, datasetRecord.dataset.getCreateUser(), true);
+    verify(elasticSearchSpy, timeout(1000)).synchronizeDatasetInESIndex(datasetRecord.dataset, datasetRecord.dataset.getCreateUser(), true);
   }
 
   @Test


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-2128
Drive by fix: https://broadworkbench.atlassian.net/browse/DT-2151

### Summary
getCollectionWithAllElectionsByCollectionId endpoint
The modified endpoint is for Admins, Chairs, and Members only. The functionality for Admins remains unchanged. For DAC members and chairs, the endpoint is modified to filter elections by DAC (by datasets that belong to the DACs the user is a part of).
This involves a new DAO query and service method with unit tests.

Also fixes serialization issue with dataset create date. In the mapper it was being retrieved as a SQL date instead of a timestamp to be converted into a java util date. 

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
