### PR TITLE
DT-2160: Enforce creator or custodian when updating a study

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/resources/StudyResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/StudyResource.java
@@ -215,6 +215,11 @@ public class StudyResource extends Resource {
     try {
       User user = userService.findUserByEmail(authUser.getEmail());
       Study existingStudy = datasetRegistrationService.findStudyById(studyId);
+      boolean canUpdateStudy = user.hasUserRole(UserRoles.ADMIN) ||
+          datasetService.isCreatorOrCustodian(user, existingStudy);
+      if (!canUpdateStudy) {
+        throw new NotFoundException("Study with ID " + studyId + " is not found");
+      }
 
       // Manually validate the schema from an editing context. Validation with the schema tools
       // enforces it in a creation context but doesn't work for editing purposes.

--- a/src/main/java/org/broadinstitute/consent/http/resources/StudyResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/StudyResource.java
@@ -10,6 +10,7 @@ import jakarta.annotation.security.RolesAllowed;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.ForbiddenException;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.PUT;
@@ -218,7 +219,7 @@ public class StudyResource extends Resource {
       boolean canUpdateStudy = user.hasUserRole(UserRoles.ADMIN) ||
           datasetService.isCreatorOrCustodian(user, existingStudy);
       if (!canUpdateStudy) {
-        throw new NotFoundException("Study with ID " + studyId + " is not found");
+        throw new ForbiddenException("Study with ID " + studyId + " is not updatable");
       }
 
       // Manually validate the schema from an editing context. Validation with the schema tools

--- a/src/main/resources/assets/paths/studyById.yaml
+++ b/src/main/resources/assets/paths/studyById.yaml
@@ -42,6 +42,7 @@ put:
       See [/api/dataset/studyNames](#/Study/findAllStudyNames) for a list of existing study names.
       Data Use fields can only be modified using Admin permissions. See 
       [/api/dataset/{id}/datause](#/Admin/updateDatasetDataUse) to update a dataset's Data Use.
+      Studies are updatable by Admins, Creators, and Datat Custodians
       
       The following fields are not modifiable:
       * Data Submitter Name/Email
@@ -58,8 +59,6 @@ put:
           type: object
           properties:
             dataset:
-              description: Required dataset registration json schema instance
-              type: object
               $ref: '../schemas/DatasetRegistrationSchemaV1.yaml'
             alternativeDataSharingPlan:
               description: Optional alternative data sharing plan

--- a/src/main/resources/assets/paths/studyById.yaml
+++ b/src/main/resources/assets/paths/studyById.yaml
@@ -77,6 +77,8 @@ put:
             $ref: '../schemas/Study.yaml'
     400:
       description: Bad Request when schema is invalid or the required consent groups are not provided.
+    403:
+      description: Forbidden
     404:
       description: Not Found
     500:

--- a/src/test/java/org/broadinstitute/consent/http/resources/StudyResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/StudyResourceTest.java
@@ -359,7 +359,7 @@ class StudyResourceTest extends AbstractTestHelper {
     when(datasetService.isCreatorOrCustodian(createUser, study)).thenReturn(false);
 
     try (var response = resource.updateStudyByRegistration(authUser, null, study.getStudyId(), input)) {
-      assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
+      assertEquals(HttpStatusCodes.STATUS_CODE_FORBIDDEN, response.getStatus());
     }
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/resources/StudyResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/StudyResourceTest.java
@@ -19,6 +19,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.broadinstitute.consent.http.AbstractTestHelper;
 import org.broadinstitute.consent.http.enumeration.PropertyType;
+import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.AuthUser;
 import org.broadinstitute.consent.http.models.DataUse;
 import org.broadinstitute.consent.http.models.Dataset;
@@ -254,7 +255,7 @@ class StudyResourceTest extends AbstractTestHelper {
       DataResourceTestData.registrationWithExistingCGDataUse,
       DataResourceTestData.registrationWithExistingCG
   })
-  void testUpdateStudyByRegistrationInvalid(String input) {
+  void testUpdateStudyByRegistrationInvalidInput(String input) {
     Study study = createMockStudy();
     // for DataResourceTestData.registrationWithExistingCG, manipulate the dataset ids to simulate
     // a dataset deletion
@@ -267,7 +268,13 @@ class StudyResourceTest extends AbstractTestHelper {
       study.addDatasetIds(Set.of(datasetIds.get(0) + 1));
     }
     when(userService.findUserByEmail(any())).thenReturn(user);
+    User createUser = new User();
+    createUser.setUserId(study.getCreateUserId());
+    createUser.setEmail("creator@test.com");
+    when(authUser.getEmail()).thenReturn(createUser.getEmail());
+    when(userService.findUserByEmail(createUser.getEmail())).thenReturn(createUser);
     when(datasetRegistrationService.findStudyById(study.getStudyId())).thenReturn(study);
+    when(datasetService.isCreatorOrCustodian(createUser, study)).thenReturn(true);
 
     try (var response = resource.updateStudyByRegistration(authUser, null, study.getStudyId(), input)) {
       assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
@@ -275,7 +282,7 @@ class StudyResourceTest extends AbstractTestHelper {
   }
 
   @Test
-  void testUpdateStudyByRegistration() {
+  void testUpdateStudyByRegistrationCreatorOrCustodian() {
     String input = DataResourceTestData.validRegistration;
     Study study = createMockStudy();
     Gson gson = GsonUtil.gsonBuilderWithAdapters().create();
@@ -288,11 +295,71 @@ class StudyResourceTest extends AbstractTestHelper {
         .collect(Collectors.toSet());
     study.getDatasetIds().clear();
     study.addDatasetIds(datasetIds);
-    when(userService.findUserByEmail(any())).thenReturn(user);
-    when(datasetRegistrationService.findStudyById(any())).thenReturn(study);
+    User createUser = new User();
+    createUser.setUserId(study.getCreateUserId());
+    createUser.setEmail("creator@test.com");
+    when(authUser.getEmail()).thenReturn(createUser.getEmail());
+    when(userService.findUserByEmail(createUser.getEmail())).thenReturn(createUser);
+    when(datasetRegistrationService.findStudyById(study.getStudyId())).thenReturn(study);
+    when(datasetService.isCreatorOrCustodian(createUser, study)).thenReturn(true);
 
-    try (var response = resource.updateStudyByRegistration(authUser, null, 1, input)) {
+    try (var response = resource.updateStudyByRegistration(authUser, null, study.getStudyId(), input)) {
       assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+    }
+  }
+
+  @Test
+  void testUpdateStudyByRegistrationAdmin() {
+    String input = DataResourceTestData.validRegistration;
+    Study study = createMockStudy();
+    Gson gson = GsonUtil.gsonBuilderWithAdapters().create();
+    DatasetRegistrationSchemaV1 schemaV1 = gson.fromJson(input, DatasetRegistrationSchemaV1.class);
+    Set<Integer> datasetIds = schemaV1
+        .getConsentGroups()
+        .stream()
+        .map(ConsentGroup::getDatasetId)
+        .filter(Objects::nonNull)
+        .collect(Collectors.toSet());
+    study.getDatasetIds().clear();
+    study.addDatasetIds(datasetIds);
+    User createUser = new User();
+    createUser.setUserId(study.getCreateUserId());
+    createUser.setEmail("creator@test.com");
+    createUser.addRole(UserRoles.Admin());
+    when(authUser.getEmail()).thenReturn(createUser.getEmail());
+    when(userService.findUserByEmail(createUser.getEmail())).thenReturn(createUser);
+    when(datasetRegistrationService.findStudyById(study.getStudyId())).thenReturn(study);
+
+    try (var response = resource.updateStudyByRegistration(authUser, null, study.getStudyId(), input)) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+    }
+  }
+
+  @Test
+  void testUpdateStudyByRegistrationNotCreatorOrAdmin() {
+    String input = DataResourceTestData.validRegistration;
+    Study study = createMockStudy();
+    Gson gson = GsonUtil.gsonBuilderWithAdapters().create();
+    DatasetRegistrationSchemaV1 schemaV1 = gson.fromJson(input, DatasetRegistrationSchemaV1.class);
+    Set<Integer> datasetIds = schemaV1
+        .getConsentGroups()
+        .stream()
+        .map(ConsentGroup::getDatasetId)
+        .filter(Objects::nonNull)
+        .collect(Collectors.toSet());
+    study.getDatasetIds().clear();
+    study.addDatasetIds(datasetIds);
+    User createUser = new User();
+    createUser.setUserId(study.getCreateUserId() + 100);
+    createUser.setEmail("chair@test.com");
+    createUser.addRole(UserRoles.Chairperson());
+    when(authUser.getEmail()).thenReturn(createUser.getEmail());
+    when(userService.findUserByEmail(createUser.getEmail())).thenReturn(createUser);
+    when(datasetRegistrationService.findStudyById(study.getStudyId())).thenReturn(study);
+    when(datasetService.isCreatorOrCustodian(createUser, study)).thenReturn(false);
+
+    try (var response = resource.updateStudyByRegistration(authUser, null, study.getStudyId(), input)) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
     }
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
@@ -10,6 +10,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -264,7 +265,7 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
     // Call the async method ...
     elasticSearchSpy.asyncDatasetInESIndex(datasetRecord.dataset.getDatasetId(), datasetRecord.createUser, true);
     // Ensure that the synchronous method was called with the expected parameters
-    verify(elasticSearchSpy).synchronizeDatasetInESIndex(datasetRecord.dataset, datasetRecord.dataset.getCreateUser(), true);
+    verify(elasticSearchSpy, timeout(1000)).synchronizeDatasetInESIndex(datasetRecord.dataset, datasetRecord.dataset.getCreateUser(), true);
   }
 
   @Test


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-2160

### Summary
Enforce that the authenticated user is an admin, creator, or custodian of the study being updated.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
