### PR TITLE
[DT-2115] Delegate checking authorization of a dataset - proof of concept.

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
@@ -219,7 +219,7 @@ public class ConsentApplication extends Application<ConsentConfiguration> {
     env.jersey().register(injector.getInstance(DaaResource.class));
     env.jersey().register(injector.getInstance(DataAccessRequestResource.class));
     env.jersey().register(new DatasetResource(datasetService, userService,
-        datasetRegistrationService, elasticSearchService));
+        datasetRegistrationService, elasticSearchService, tdrService));
     env.jersey().register(injector.getInstance(DacResource.class));
     env.jersey().register(injector.getInstance(DACAutomationRuleResource.class));
     env.jersey().register(new DACUserResource(userService));

--- a/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
@@ -22,6 +22,7 @@ import org.broadinstitute.consent.http.db.DacDAO;
 import org.broadinstitute.consent.http.db.DarCollectionDAO;
 import org.broadinstitute.consent.http.db.DarCollectionSummaryDAO;
 import org.broadinstitute.consent.http.db.DataAccessRequestDAO;
+import org.broadinstitute.consent.http.db.DatasetAuthorizationReaderDAO;
 import org.broadinstitute.consent.http.db.DatasetDAO;
 import org.broadinstitute.consent.http.db.DraftDAO;
 import org.broadinstitute.consent.http.db.ElectionDAO;
@@ -97,6 +98,7 @@ public class ConsentModule extends AbstractModule {
   private final VoteDAO voteDAO;
   private final StudyDAO studyDAO;
   private final DatasetDAO datasetDAO;
+  private final DatasetAuthorizationReaderDAO datasetAuthorizationReaderDAO;
   private final DaaDAO daaDAO;
   private final DacDAO dacDAO;
   private final UserDAO userDAO;
@@ -131,6 +133,7 @@ public class ConsentModule extends AbstractModule {
     this.electionDAO = this.jdbi.onDemand(ElectionDAO.class);
     this.voteDAO = this.jdbi.onDemand(VoteDAO.class);
     this.studyDAO = this.jdbi.onDemand(StudyDAO.class);
+    this.datasetAuthorizationReaderDAO = this.jdbi.onDemand(DatasetAuthorizationReaderDAO.class);
     this.datasetDAO = this.jdbi.onDemand(DatasetDAO.class);
     this.daaDAO = this.jdbi.onDemand(DaaDAO.class);
     this.dacDAO = this.jdbi.onDemand(DacDAO.class);
@@ -164,6 +167,7 @@ public class ConsentModule extends AbstractModule {
     container.setDataAccessRequestDAO(providesDataAccessRequestDAO());
     container.setDarCollectionDAO(providesDARCollectionDAO());
     container.setDarCollectionSummaryDAO(providesDarCollectionSummaryDAO());
+    container.setDatasetAuthorizationReaderDAO(providesDatasetAuthorizationReaderDAO());
     container.setDatasetDAO(providesDatasetDAO());
     container.setElectionDAO(providesElectionDAO());
     container.setMailMessageDAO(providesMailMessageDAO());
@@ -293,12 +297,14 @@ public class ConsentModule extends AbstractModule {
     return new DatasetServiceDAO(
         jdbi,
         providesDatasetDAO(),
-        providesStudyDAO());
+        providesStudyDAO(),
+        providesDatasetAuthorizationReaderDAO());
   }
 
   @Provides
   DatasetService providesDatasetService() {
     return new DatasetService(
+        providesDatasetAuthorizationReaderDAO(),
         providesDatasetDAO(),
         providesDaaDAO(),
         providesDacDAO(),
@@ -407,6 +413,11 @@ public class ConsentModule extends AbstractModule {
         providesUseRestrictionConverter(),
         providesVoteDAO(),
         providesVoteServiceDAO());
+  }
+
+  @Provides
+  DatasetAuthorizationReaderDAO providesDatasetAuthorizationReaderDAO() {
+    return datasetAuthorizationReaderDAO;
   }
 
   @Provides
@@ -607,7 +618,8 @@ public class ConsentModule extends AbstractModule {
         providesDaaDAO(),
         providesDraftService(),
         providesInstitutionService(),
-        providesDACAutomationRuleDAO());
+        providesDACAutomationRuleDAO(),
+        providesDatasetAuthorizationReaderDAO());
   }
 
   @Provides

--- a/src/main/java/org/broadinstitute/consent/http/db/DAOContainer.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DAOContainer.java
@@ -14,6 +14,7 @@ public class DAOContainer {
   private DataAccessRequestDAO dataAccessRequestDAO;
   private DarCollectionDAO darCollectionDAO;
   private DarCollectionSummaryDAO darCollectionSummaryDAO;
+  private DatasetAuthorizationReaderDAO datasetAuthorizationReaderDAO;
   private DatasetDAO datasetDAO;
   private ElectionDAO electionDAO;
   private MailMessageDAO mailMessageDAO;
@@ -77,6 +78,14 @@ public class DAOContainer {
 
   public void setDatasetDAO(DatasetDAO datasetDAO) {
     this.datasetDAO = datasetDAO;
+  }
+
+  public void setDatasetAuthorizationReaderDAO(DatasetAuthorizationReaderDAO datasetAuthorizationReaderDAO) {
+    this.datasetAuthorizationReaderDAO = datasetAuthorizationReaderDAO;
+  }
+
+  public DatasetAuthorizationReaderDAO getDatasetAuthorizationReaderDAO() {
+    return datasetAuthorizationReaderDAO;
   }
 
   public ElectionDAO getElectionDAO() {

--- a/src/main/java/org/broadinstitute/consent/http/db/DatasetAuthorizationReaderDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DatasetAuthorizationReaderDAO.java
@@ -3,7 +3,6 @@ package org.broadinstitute.consent.http.db;
 import java.util.List;
 import org.broadinstitute.consent.http.models.DatasetAuthorizationReader;
 import org.jdbi.v3.sqlobject.config.RegisterConstructorMapper;
-import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
 import org.jdbi.v3.sqlobject.customizer.Bind;
 import org.jdbi.v3.sqlobject.statement.GetGeneratedKeys;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;

--- a/src/main/java/org/broadinstitute/consent/http/db/DatasetAuthorizationReaderDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DatasetAuthorizationReaderDAO.java
@@ -38,9 +38,9 @@ INSERT INTO dataset_authorized_readers (dataset_id, user_id, created_by) VALUES 
 """)
   @GetGeneratedKeys
   long addAuthorizedReaderToDataset(
-      @Bind("datasetId") int datasetId,
-      @Bind("userId") int userId,
-      @Bind("operatorId") int operatorId);
+      @Bind("datasetId") long datasetId,
+      @Bind("userId") long userId,
+      @Bind("operatorId") long operatorId);
 
   @SqlUpdate(
 """

--- a/src/main/java/org/broadinstitute/consent/http/db/DatasetAuthorizationReaderDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DatasetAuthorizationReaderDAO.java
@@ -1,0 +1,63 @@
+package org.broadinstitute.consent.http.db;
+
+import java.util.List;
+import org.broadinstitute.consent.http.models.DatasetAuthorizationReader;
+import org.jdbi.v3.sqlobject.config.RegisterConstructorMapper;
+import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
+import org.jdbi.v3.sqlobject.customizer.Bind;
+import org.jdbi.v3.sqlobject.statement.GetGeneratedKeys;
+import org.jdbi.v3.sqlobject.statement.SqlQuery;
+import org.jdbi.v3.sqlobject.statement.SqlUpdate;
+import org.jdbi.v3.sqlobject.transaction.Transactional;
+
+@RegisterConstructorMapper(DatasetAuthorizationReader.class)
+public interface DatasetAuthorizationReaderDAO
+    extends Transactional<DatasetAuthorizationReaderDAO> {
+  @SqlQuery(
+"""
+SELECT * from dataset_authorized_readers WHERE dataset_id = :datasetId
+""")
+  List<DatasetAuthorizationReader> findAuthorizedReadersByDatasetId(
+      @Bind("datasetId") long datasetId);
+
+  @SqlQuery(
+"""
+SELECT * from dataset_authorized_readers WHERE dataset_id = :datasetId AND user_id = :userId
+""")
+  DatasetAuthorizationReader findAuthorizedReadersByDatasetIdAndUserId(
+      @Bind("datasetId") long datasetId, @Bind("userId") long userId);
+
+  @SqlQuery(
+"""
+SELECT * from dataset_authorized_readers WHERE id = :recordId
+""")
+  DatasetAuthorizationReader findAuthorizedReaderByRecordId(@Bind("recordId") long recordId);
+
+  @SqlUpdate(
+"""
+INSERT INTO dataset_authorized_readers (dataset_id, user_id, created_by) VALUES (:datasetId, :userId, :operatorId)
+""")
+  @GetGeneratedKeys
+  long addAuthorizedReaderToDataset(
+      @Bind("datasetId") int datasetId,
+      @Bind("userId") int userId,
+      @Bind("operatorId") int operatorId);
+
+  @SqlUpdate(
+"""
+DELETE FROM dataset_authorized_readers WHERE dataset_id = :datasetId
+""")
+  void deleteByDatasetId(@Bind("datasetId") int datasetId);
+
+  @SqlUpdate(
+"""
+DELETE FROM dataset_authorized_readers WHERE user_id = :userId
+""")
+  void deleteByUserId(@Bind("userId") int userId);
+
+  @SqlUpdate(
+"""
+DELETE FROM dataset_authorized_readers WHERE dataset_id =:datasetId AND user_id = :userId
+""")
+  void deleteByDatasetAndUserId(@Bind("datasetId") long datasetId, @Bind("userId") long userId);
+}

--- a/src/main/java/org/broadinstitute/consent/http/models/DatasetAuthorizationReader.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DatasetAuthorizationReader.java
@@ -1,0 +1,6 @@
+package org.broadinstitute.consent.http.models;
+
+import java.sql.Timestamp;
+
+public record DatasetAuthorizationReader(
+    long id, long datasetId, long userId, long createdBy, Timestamp createdDate) {}

--- a/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
@@ -529,7 +529,11 @@ public class DatasetResource extends Resource {
   @RolesAllowed(ADMIN)
   @Path("/{id}/authorizedAccessReaders")
   public Response getAuthorizedReaders(@Auth DuosUser duosUser, @PathParam("id") Long id) {
-    return Response.ok(datasetService.getAuthorizationReaders(id)).build();
+    try{
+      return Response.ok(datasetService.getAuthorizationReaders(id)).build();
+    } catch (Exception e) {
+     return createExceptionResponse(e);
+    }
   }
 
   @PUT
@@ -538,15 +542,20 @@ public class DatasetResource extends Resource {
   @Path("/{id}/authorizedAccessReaders/{userId}")
   public Response addAuthorizedReaders(
       @Auth DuosUser duosUser,
-      @PathParam("id") int datasetId,
-      @PathParam("userId") Integer userId) {
-    User targetUser = userService.findUserById(userId);
-    if (!targetUser.hasUserRole(UserRoles.SERVICE_ACCOUNT)) {
-      return Response.status(Status.CONFLICT).build();
+      @PathParam("id") long datasetId,
+      @PathParam("userId") int userId) {
+    try {
+      User targetUser = userService.findUserById(userId);
+      if (targetUser == null || !targetUser.hasUserRole(UserRoles.SERVICE_ACCOUNT)) {
+        return Response.status(Status.CONFLICT).build();
+      }
+      return Response.ok(
+              datasetService.addAuthorizedReader(datasetId, userId, duosUser.getUser().getUserId()))
+          .build();
+    } catch (Exception e) {
+      return createExceptionResponse(e);
     }
-    return Response.ok(
-            datasetService.addAuthorizedReader(datasetId, userId, duosUser.getUser().getUserId()))
-        .build();
+
   }
 
   @DELETE
@@ -555,8 +564,8 @@ public class DatasetResource extends Resource {
   @Path("/{id}/authorizedAccessReaders/{userId}")
   public Response removeAuthorizedReaders(
       @Auth DuosUser duosUser,
-      @PathParam("id") int datasetId,
-      @PathParam("userId") Integer userId) {
+      @PathParam("id") long datasetId,
+      @PathParam("userId") long userId) {
     try {
       datasetService.removeAuthorizedAccessReader(datasetId, userId);
       return Response.ok().build();
@@ -570,13 +579,17 @@ public class DatasetResource extends Resource {
   @RolesAllowed(SERVICE_ACCOUNT)
   @Path("/{identifier}/authorizedUsers")
   public Response getAuthorizedUsers(@Auth DuosUser duosUser, @PathParam("identifier") String datasetIdentifier) {
-    Dataset dataset = datasetService.findDatasetByIdentifier(duosUser.getUser(), datasetIdentifier);
-    if (Objects.isNull(dataset)) {
-      return Response.status(Response.Status.NOT_FOUND).build();
+    try {
+      Dataset dataset = datasetService.findDatasetByIdentifier(duosUser.getUser(), datasetIdentifier);
+      if (Objects.isNull(dataset)) {
+        return Response.status(Response.Status.NOT_FOUND).build();
+      }
+      if (!datasetService.isAuthorizedToListUsers(dataset.getDatasetId(), duosUser.getUser().getUserId())) {
+        return Response.status(Response.Status.FORBIDDEN).build();
+      }
+      return Response.ok(tdrService.getApprovedUsersForDataset(duosUser, dataset)).build();
+    } catch (Exception e) {
+      return createExceptionResponse(e);
     }
-    if (!datasetService.isAuthorizedToListUsers(dataset.getDatasetId(), duosUser.getUser().getUserId())) {
-      return Response.status(Response.Status.FORBIDDEN).build();
-    }
-    return Response.ok(tdrService.getApprovedUsersForDataset(duosUser, dataset)).build();
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
@@ -577,8 +577,8 @@ public class DatasetResource extends Resource {
   @GET
   @Produces("application/json")
   @RolesAllowed(SERVICE_ACCOUNT)
-  @Path("/{identifier}/authorizedUsers")
-  public Response getAuthorizedUsers(@Auth DuosUser duosUser, @PathParam("identifier") String datasetIdentifier) {
+  @Path("/{identifier}/approvedUsers")
+  public Response getApprovedUsers(@Auth DuosUser duosUser, @PathParam("identifier") String datasetIdentifier) {
     try {
       Dataset dataset = datasetService.findDatasetByIdentifier(duosUser.getUser(), datasetIdentifier);
       if (Objects.isNull(dataset)) {

--- a/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
@@ -24,6 +24,7 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.Status;
 import jakarta.ws.rs.core.StreamingOutput;
 import jakarta.ws.rs.core.UriBuilder;
 import java.net.URI;
@@ -51,6 +52,7 @@ import org.broadinstitute.consent.http.models.dataset_registration_v1.builder.Da
 import org.broadinstitute.consent.http.service.DatasetRegistrationService;
 import org.broadinstitute.consent.http.service.DatasetService;
 import org.broadinstitute.consent.http.service.ElasticSearchService;
+import org.broadinstitute.consent.http.service.TDRService;
 import org.broadinstitute.consent.http.service.UserService;
 import org.broadinstitute.consent.http.util.JsonSchemaUtil;
 import org.broadinstitute.consent.http.util.gson.GsonUtil;
@@ -64,6 +66,7 @@ public class DatasetResource extends Resource {
 
   private final DatasetService datasetService;
   private final DatasetRegistrationService datasetRegistrationService;
+  private final TDRService tdrService;
   private final UserService userService;
   private final ElasticSearchService elasticSearchService;
 
@@ -72,11 +75,13 @@ public class DatasetResource extends Resource {
   @Inject
   public DatasetResource(DatasetService datasetService, UserService userService,
       DatasetRegistrationService datasetRegistrationService,
-      ElasticSearchService elasticSearchService) {
+      ElasticSearchService elasticSearchService,
+      TDRService tdrService) {
     this.datasetService = datasetService;
     this.userService = userService;
     this.datasetRegistrationService = datasetRegistrationService;
     this.elasticSearchService = elasticSearchService;
+    this.tdrService = tdrService;
     this.jsonSchemaUtil = new JsonSchemaUtil();
   }
 
@@ -519,4 +524,59 @@ public class DatasetResource extends Resource {
     }
   }
 
+  @GET
+  @Produces("application/json")
+  @RolesAllowed(ADMIN)
+  @Path("/{id}/authorizedAccessReaders")
+  public Response getAuthorizedReaders(@Auth DuosUser duosUser, @PathParam("id") Long id) {
+    return Response.ok(datasetService.getAuthorizationReaders(id)).build();
+  }
+
+  @PUT
+  @Produces("application/json")
+  @RolesAllowed(ADMIN)
+  @Path("/{id}/authorizedAccessReaders/{userId}")
+  public Response addAuthorizedReaders(
+      @Auth DuosUser duosUser,
+      @PathParam("id") int datasetId,
+      @PathParam("userId") Integer userId) {
+    User targetUser = userService.findUserById(userId);
+    if (!targetUser.hasUserRole(UserRoles.SERVICE_ACCOUNT)) {
+      return Response.status(Status.CONFLICT).build();
+    }
+    return Response.ok(
+            datasetService.addAuthorizedReader(datasetId, userId, duosUser.getUser().getUserId()))
+        .build();
+  }
+
+  @DELETE
+  @Produces("application/json")
+  @RolesAllowed(ADMIN)
+  @Path("/{id}/authorizedAccessReaders/{userId}")
+  public Response removeAuthorizedReaders(
+      @Auth DuosUser duosUser,
+      @PathParam("id") int datasetId,
+      @PathParam("userId") Integer userId) {
+    try {
+      datasetService.removeAuthorizedAccessReader(datasetId, userId);
+      return Response.ok().build();
+    } catch (Exception e) {
+      return createExceptionResponse(e);
+    }
+  }
+
+  @GET
+  @Produces("application/json")
+  @RolesAllowed(SERVICE_ACCOUNT)
+  @Path("/{identifier}/authorizedUsers")
+  public Response getAuthorizedUsers(@Auth DuosUser duosUser, @PathParam("identifier") String datasetIdentifier) {
+    Dataset dataset = datasetService.findDatasetByIdentifier(duosUser.getUser(), datasetIdentifier);
+    if (Objects.isNull(dataset)) {
+      return Response.status(Response.Status.NOT_FOUND).build();
+    }
+    if (!datasetService.isAuthorizedToListUsers(dataset.getDatasetId(), duosUser.getUser().getUserId())) {
+      return Response.status(Response.Status.FORBIDDEN).build();
+    }
+    return Response.ok(tdrService.getApprovedUsersForDataset(duosUser, dataset)).build();
+  }
 }

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -22,6 +22,7 @@ import java.util.UUID;
 import org.apache.commons.collections4.CollectionUtils;
 import org.broadinstitute.consent.http.db.DaaDAO;
 import org.broadinstitute.consent.http.db.DacDAO;
+import org.broadinstitute.consent.http.db.DatasetAuthorizationReaderDAO;
 import org.broadinstitute.consent.http.db.DatasetDAO;
 import org.broadinstitute.consent.http.db.StudyDAO;
 import org.broadinstitute.consent.http.db.UserDAO;
@@ -32,6 +33,7 @@ import org.broadinstitute.consent.http.models.ApprovedDataset;
 import org.broadinstitute.consent.http.models.Dac;
 import org.broadinstitute.consent.http.models.DataUse;
 import org.broadinstitute.consent.http.models.Dataset;
+import org.broadinstitute.consent.http.models.DatasetAuthorizationReader;
 import org.broadinstitute.consent.http.models.DatasetProperty;
 import org.broadinstitute.consent.http.models.DatasetStudySummary;
 import org.broadinstitute.consent.http.models.DatasetSummary;
@@ -46,6 +48,7 @@ import org.broadinstitute.consent.http.util.gson.GsonUtil;
 
 public class DatasetService implements ConsentLogger {
 
+  private final DatasetAuthorizationReaderDAO datasetAuthorizationReaderDAO;
   private final DatasetDAO datasetDAO;
   private final DaaDAO daaDAO;
   private final DacDAO dacDAO;
@@ -57,9 +60,18 @@ public class DatasetService implements ConsentLogger {
   private final UserDAO userDAO;
 
   @Inject
-  public DatasetService(DatasetDAO dataSetDAO, DaaDAO daaDAO, DacDAO dacDAO, ElasticSearchService
-      elasticSearchService, EmailService emailService, OntologyService ontologyService, StudyDAO
-      studyDAO, DatasetServiceDAO datasetServiceDAO, UserDAO userDAO) {
+  public DatasetService(
+      DatasetAuthorizationReaderDAO datasetAuthorizationReaderDAO,
+      DatasetDAO dataSetDAO,
+      DaaDAO daaDAO,
+      DacDAO dacDAO,
+      ElasticSearchService elasticSearchService,
+      EmailService emailService,
+      OntologyService ontologyService,
+      StudyDAO studyDAO,
+      DatasetServiceDAO datasetServiceDAO,
+      UserDAO userDAO) {
+    this.datasetAuthorizationReaderDAO = datasetAuthorizationReaderDAO;
     this.datasetDAO = dataSetDAO;
     this.daaDAO = daaDAO;
     this.dacDAO = dacDAO;
@@ -79,8 +91,8 @@ public class DatasetService implements ConsentLogger {
   }
 
   /**
-   * TODO: Refactor this to throw a NotFoundException instead of returning null
-   * Finds a Dataset by a formatted dataset identifier.
+   * TODO: Refactor this to throw a NotFoundException instead of returning null Finds a Dataset by a
+   * formatted dataset identifier.
    *
    * @param datasetIdentifier The formatted identifier, e.g. DUOS-123456
    * @return the Dataset with the given identifier, if found.
@@ -141,13 +153,15 @@ public class DatasetService implements ConsentLogger {
     if (study.getCreateUserId().equals(user.getUserId())) {
       return true;
     }
-    Optional<StudyProperty> custodianProp = study.getProperties().stream()
-        .filter(p -> p.getKey().equals(dataCustodianEmail))
-        .findFirst();
+    Optional<StudyProperty> custodianProp =
+        study.getProperties().stream()
+            .filter(p -> p.getKey().equals(dataCustodianEmail))
+            .findFirst();
     if (custodianProp.isPresent()) {
       Gson gson = GsonUtil.getInstance();
       // prop is a JsonArray of Strings
-      List<String> custodians = gson.fromJson(custodianProp.get().getValue().toString(), new TypeToken<>(){}.getType());
+      List<String> custodians =
+          gson.fromJson(custodianProp.get().getValue().toString(), new TypeToken<>() {}.getType());
       for (String custodian : custodians) {
         if (user.getEmail().equals(custodian.trim())) {
           return true;
@@ -205,8 +219,8 @@ public class DatasetService implements ConsentLogger {
       throw new NotFoundException("Dataset not found");
     }
 
-    String translation = ontologyService.translateDataUse(dataset.getDataUse(),
-        DataUseTranslationType.DATASET);
+    String translation =
+        ontologyService.translateDataUse(dataset.getDataUse(), DataUseTranslationType.DATASET);
     datasetDAO.updateDatasetTranslatedDataUse(datasetId, translation);
     elasticSearchService.synchronizeDatasetInESIndex(dataset, user, false);
     return datasetDAO.findDatasetById(datasetId);
@@ -225,15 +239,20 @@ public class DatasetService implements ConsentLogger {
   }
 
   public void deleteStudy(Study study, User user) throws Exception {
-    study.getDatasetIds().forEach(datasetId -> {
-      try (var response = elasticSearchService.deleteIndex(datasetId, user.getUserId())) {
-        if (!HttpStatusCodes.isSuccess(response.getStatus())) {
-          logWarn("Response error, unable to delete dataset from index: %s".formatted(datasetId));
-        }
-      } catch (IOException e) {
-        throw new RuntimeException(e);
-      }
-    });
+    study
+        .getDatasetIds()
+        .forEach(
+            datasetId -> {
+              try (var response = elasticSearchService.deleteIndex(datasetId, user.getUserId())) {
+                if (!HttpStatusCodes.isSuccess(response.getStatus())) {
+                  logWarn(
+                      "Response error, unable to delete dataset from index: %s"
+                          .formatted(datasetId));
+                }
+              } catch (IOException e) {
+                throw new RuntimeException(e);
+              }
+            });
     datasetServiceDAO.deleteStudy(study, user);
   }
 
@@ -249,8 +268,9 @@ public class DatasetService implements ConsentLogger {
     Boolean currentApprovalState = dataset.getDacApproval();
     Integer datasetId = dataset.getDatasetId();
     Dataset datasetReturn = dataset;
-    //Only update and fetch the dataset if it hasn't already been approved
-    //If it has, simply returned the dataset in the argument (which was already queried for in the resource)
+    // Only update and fetch the dataset if it hasn't already been approved
+    // If it has, simply returned the dataset in the argument (which was already queried for in the
+    // resource)
     if (currentApprovalState == null || !currentApprovalState) {
       datasetDAO.updateDatasetApproval(approval, Instant.now(), user.getUserId(), datasetId);
       elasticSearchService.asyncDatasetInESIndex(datasetId, user, true);
@@ -267,8 +287,10 @@ public class DatasetService implements ConsentLogger {
         sendDatasetApprovalNotificationEmail(dataset, user, approval);
       }
     } catch (Exception e) {
-      logException("Unable to notifier Data Submitter of dataset approval status: %s".formatted(
-          dataset.getDatasetIdentifier()), e);
+      logException(
+          "Unable to notifier Data Submitter of dataset approval status: %s"
+              .formatted(dataset.getDatasetIdentifier()),
+          e);
     }
     return datasetReturn;
   }
@@ -277,29 +299,22 @@ public class DatasetService implements ConsentLogger {
       throws Exception {
     Dac dac = dacDAO.findById(dataset.getDacId());
     if (approval) {
-      emailService.sendDatasetApprovedMessage(
-          user,
-          dac.getName(),
-          dataset.getDatasetIdentifier());
+      emailService.sendDatasetApprovedMessage(user, dac.getName(), dataset.getDatasetIdentifier());
     } else {
       if (dac.getEmail() != null) {
         String dacEmail = dac.getEmail();
         emailService.sendDatasetDeniedMessage(
-            user,
-            dac.getName(),
-            dataset.getDatasetIdentifier(),
-            dacEmail);
+            user, dac.getName(), dataset.getDatasetIdentifier(), dacEmail);
       } else {
         logWarn("Unable to send dataset denied email to DAC: " + dac.getDacId());
       }
     }
-
   }
 
   public List<Dataset> findDatasetsByIds(User user, List<Integer> datasetIds) {
-    return datasetDAO.findDatasetsByIdList(datasetIds).stream().filter(
-        d -> verifyPublicVisibilityAccess(d, user) != null
-    ).toList();
+    return datasetDAO.findDatasetsByIdList(datasetIds).stream()
+        .filter(d -> verifyPublicVisibilityAccess(d, user) != null)
+        .toList();
   }
 
   public List<Integer> findAllDatasetIds() {
@@ -339,7 +354,7 @@ public class DatasetService implements ConsentLogger {
    * This method is used to convert a dataset into a study if none exist, or if one does, to update
    * the dataset, study, and associated properties with new values. This is an admin function only.
    *
-   * @param dataset         The dataset
+   * @param dataset The dataset
    * @param studyConversion Study Conversion object
    * @return Updated/created study
    */
@@ -355,12 +370,13 @@ public class DatasetService implements ConsentLogger {
       datasetDAO.updateDatasetDacId(dataset.getDatasetId(), studyConversion.getDacId());
     }
     if (studyConversion.getDataUse() != null) {
-      datasetDAO.updateDatasetDataUse(dataset.getDatasetId(),
-          studyConversion.getDataUse().toString());
+      datasetDAO.updateDatasetDataUse(
+          dataset.getDatasetId(), studyConversion.getDataUse().toString());
     }
     if (studyConversion.getDataUse() != null) {
-      String translation = ontologyService.translateDataUse(studyConversion.getDataUse(),
-          DataUseTranslationType.DATASET);
+      String translation =
+          ontologyService.translateDataUse(
+              studyConversion.getDataUse(), DataUseTranslationType.DATASET);
       datasetDAO.updateDatasetTranslatedDataUse(dataset.getDatasetId(), translation);
     }
     if (studyConversion.getDatasetName() != null) {
@@ -370,33 +386,52 @@ public class DatasetService implements ConsentLogger {
     List<Dictionary> dictionaries = datasetDAO.getDictionaryTerms();
     // Handle "Phenotype/Indication"
     if (studyConversion.getPhenotype() != null) {
-      legacyPropConversion(dictionaries, dataset, "Phenotype/Indication", null, PropertyType.String,
+      legacyPropConversion(
+          dictionaries,
+          dataset,
+          "Phenotype/Indication",
+          null,
+          PropertyType.String,
           studyConversion.getPhenotype());
     }
 
     // Handle "Species"
     if (studyConversion.getSpecies() != null) {
-      legacyPropConversion(dictionaries, dataset, "Species", null, PropertyType.String,
+      legacyPropConversion(
+          dictionaries,
+          dataset,
+          "Species",
+          null,
+          PropertyType.String,
           studyConversion.getSpecies());
     }
 
     if (studyConversion.getNumberOfParticipants() != null) {
       // Handle "# of participants"
-      legacyPropConversion(dictionaries, dataset, "# of participants", "numberOfParticipants",
+      legacyPropConversion(
+          dictionaries,
+          dataset,
+          "# of participants",
+          "numberOfParticipants",
           PropertyType.Number,
           studyConversion.getNumberOfParticipants().toString());
     }
 
     // Handle "Data Location"
     if (studyConversion.getDataLocation() != null) {
-      newPropConversion(dictionaries, dataset, "Data Location", "dataLocation", PropertyType.String,
+      newPropConversion(
+          dictionaries,
+          dataset,
+          "Data Location",
+          "dataLocation",
+          PropertyType.String,
           studyConversion.getDataLocation());
     }
 
     if (studyConversion.getUrl() != null) {
       // Handle "URL"
-      newPropConversion(dictionaries, dataset, "URL", "url", PropertyType.String,
-          studyConversion.getUrl());
+      newPropConversion(
+          dictionaries, dataset, "URL", "url", PropertyType.String, studyConversion.getUrl());
     }
 
     // Handle "Data Submitter User ID"
@@ -411,20 +446,22 @@ public class DatasetService implements ConsentLogger {
   }
 
   public Study updateStudyCustodians(User user, Integer studyId, String custodians) {
-    logInfo(String.format("User %s is updating custodians for study id: %s; custodians: %s",
-        user.getEmail(), studyId, custodians));
+    logInfo(
+        String.format(
+            "User %s is updating custodians for study id: %s; custodians: %s",
+            user.getEmail(), studyId, custodians));
     Study study = studyDAO.findStudyById(studyId);
     if (study == null) {
       throw new NotFoundException("Study not found");
     }
-    boolean propPresent = study.getProperties().stream()
-        .anyMatch(prop -> prop.getKey().equals(dataCustodianEmail));
+    boolean propPresent =
+        study.getProperties().stream().anyMatch(prop -> prop.getKey().equals(dataCustodianEmail));
     if (propPresent) {
-      studyDAO.updateStudyProperty(studyId, dataCustodianEmail, PropertyType.Json.toString(),
-          custodians);
+      studyDAO.updateStudyProperty(
+          studyId, dataCustodianEmail, PropertyType.Json.toString(), custodians);
     } else {
-      studyDAO.insertStudyProperty(studyId, dataCustodianEmail, PropertyType.Json.toString(),
-          custodians);
+      studyDAO.insertStudyProperty(
+          studyId, dataCustodianEmail, PropertyType.Json.toString(), custodians);
     }
     List<Dataset> datasets = datasetDAO.findDatasetsByIdList(study.getDatasetIds());
     datasets.forEach(
@@ -435,7 +472,7 @@ public class DatasetService implements ConsentLogger {
   /**
    * Ensure that all requested datasetIds exist in the user's list of accepted DAAs
    *
-   * @param user       The requesting User
+   * @param user The requesting User
    * @param datasetIds The list of dataset ids the user is requesting access to
    */
   public void enforceDAARestrictions(User user, List<Integer> datasetIds) {
@@ -447,40 +484,50 @@ public class DatasetService implements ConsentLogger {
     }
   }
 
+  public List<DatasetAuthorizationReader> getAuthorizationReaders(long datasetId) {
+    return datasetAuthorizationReaderDAO.findAuthorizedReadersByDatasetId(datasetId);
+  }
+
   /**
-   * This method is used to synchronize a new dataset property with values from the study
-   * conversion
+   * This method is used to synchronize a new dataset property with values from the study conversion
    *
-   * @param dictionaries   List<Dictionary>
-   * @param dataset        Dataset
+   * @param dictionaries List<Dictionary>
+   * @param dataset Dataset
    * @param dictionaryName Name to look for in dictionaries
    * @param schemaProperty Schema Property to look for in properties
-   * @param propertyType   Property Type of new value
-   * @param propValue      New property value
+   * @param propertyType Property Type of new value
+   * @param propValue New property value
    */
-  private void newPropConversion(List<Dictionary> dictionaries, Dataset dataset,
-      String dictionaryName, String schemaProperty, PropertyType propertyType, String propValue) {
-    Optional<DatasetProperty> maybeProp = dataset.getProperties().stream()
-        .filter(p -> Objects.nonNull(p.getSchemaProperty()))
-        .filter(p -> p.getSchemaProperty().equals(schemaProperty))
-        .findFirst();
+  private void newPropConversion(
+      List<Dictionary> dictionaries,
+      Dataset dataset,
+      String dictionaryName,
+      String schemaProperty,
+      PropertyType propertyType,
+      String propValue) {
+    Optional<DatasetProperty> maybeProp =
+        dataset.getProperties().stream()
+            .filter(p -> Objects.nonNull(p.getSchemaProperty()))
+            .filter(p -> p.getSchemaProperty().equals(schemaProperty))
+            .findFirst();
     if (maybeProp.isPresent()) {
-      datasetDAO.updateDatasetProperty(dataset.getDatasetId(), maybeProp.get().getPropertyKey(),
-          propValue);
+      datasetDAO.updateDatasetProperty(
+          dataset.getDatasetId(), maybeProp.get().getPropertyKey(), propValue);
     } else {
       dictionaries.stream()
           .filter(d -> d.getKey().equals(dictionaryName))
           .findFirst()
-          .ifPresent(dictionary -> {
-            DatasetProperty prop = new DatasetProperty();
-            prop.setDatasetId(dataset.getDatasetId());
-            prop.setPropertyKey(dictionary.getKeyId());
-            prop.setSchemaProperty(schemaProperty);
-            prop.setPropertyValue(propValue);
-            prop.setPropertyType(propertyType);
-            prop.setCreateDate(new Date());
-            datasetDAO.insertDatasetProperties(List.of(prop));
-          });
+          .ifPresent(
+              dictionary -> {
+                DatasetProperty prop = new DatasetProperty();
+                prop.setDatasetId(dataset.getDatasetId());
+                prop.setPropertyKey(dictionary.getKeyId());
+                prop.setSchemaProperty(schemaProperty);
+                prop.setPropertyValue(propValue);
+                prop.setPropertyType(propertyType);
+                prop.setCreateDate(new Date());
+                datasetDAO.insertDatasetProperties(List.of(prop));
+              });
     }
   }
 
@@ -488,25 +535,30 @@ public class DatasetService implements ConsentLogger {
    * This method is used to synchronize a legacy dataset property with values from the study
    * conversion
    *
-   * @param dictionaries   List<Dictionary>
-   * @param dataset        Dataset
+   * @param dictionaries List<Dictionary>
+   * @param dataset Dataset
    * @param dictionaryName Name to look for in dictionaries
    * @param schemaProperty Schema Property to update if necessary
-   * @param propertyType   Property Type of new value
-   * @param propValue      New property value
+   * @param propertyType Property Type of new value
+   * @param propValue New property value
    */
-  private void legacyPropConversion(List<Dictionary> dictionaries, Dataset dataset,
-      String dictionaryName, String schemaProperty, PropertyType propertyType, String propValue) {
-    Optional<DatasetProperty> maybeProp = dataset.getProperties().stream()
-        .filter(p -> p.getPropertyName().equals(dictionaryName))
-        .findFirst();
-    Optional<Dictionary> dictionary = dictionaries.stream()
-        .filter(d -> d.getKey().equals(dictionaryName))
-        .findFirst();
+  private void legacyPropConversion(
+      List<Dictionary> dictionaries,
+      Dataset dataset,
+      String dictionaryName,
+      String schemaProperty,
+      PropertyType propertyType,
+      String propValue) {
+    Optional<DatasetProperty> maybeProp =
+        dataset.getProperties().stream()
+            .filter(p -> p.getPropertyName().equals(dictionaryName))
+            .findFirst();
+    Optional<Dictionary> dictionary =
+        dictionaries.stream().filter(d -> d.getKey().equals(dictionaryName)).findFirst();
     // Legacy property exists, update it.
     if (dictionary.isPresent() && maybeProp.isPresent()) {
-      datasetDAO.updateDatasetProperty(dataset.getDatasetId(), dictionary.get().getKeyId(),
-          propValue);
+      datasetDAO.updateDatasetProperty(
+          dataset.getDatasetId(), dictionary.get().getKeyId(), propValue);
     }
     // Legacy property does not exist, but we have a valid dictionary term, so create it.
     else if (dictionary.isPresent()) {
@@ -525,8 +577,8 @@ public class DatasetService implements ConsentLogger {
     }
   }
 
-  private Integer updateStudyFromConversion(User user, Dataset dataset,
-      StudyConversion studyConversion) {
+  private Integer updateStudyFromConversion(
+      User user, Dataset dataset, StudyConversion studyConversion) {
     // Ensure that we are not trying to create a new study with an existing name
     Study study = studyDAO.findStudyByName(studyConversion.getName());
     Integer studyId;
@@ -535,15 +587,27 @@ public class DatasetService implements ConsentLogger {
     // Create or update the study:
     if (study == null) {
       study = studyConversion.createNewStudyStub();
-      studyId = studyDAO.insertStudy(study.getName(), study.getDescription(), study.getPiName(),
-          study.getDataTypes(), study.getPublicVisibility(), userId, Instant.now(),
-          UUID.randomUUID());
+      studyId =
+          studyDAO.insertStudy(
+              study.getName(),
+              study.getDescription(),
+              study.getPiName(),
+              study.getDataTypes(),
+              study.getPublicVisibility(),
+              userId,
+              Instant.now(),
+              UUID.randomUUID());
       study.setStudyId(studyId);
     } else {
       studyId = study.getStudyId();
-      studyDAO.updateStudy(study.getStudyId(), studyConversion.getName(),
-          studyConversion.getDescription(), studyConversion.getPiName(),
-          studyConversion.getDataTypes(), studyConversion.getPublicVisibility(), userId,
+      studyDAO.updateStudy(
+          study.getStudyId(),
+          studyConversion.getName(),
+          studyConversion.getDescription(),
+          studyConversion.getPiName(),
+          studyConversion.getDataTypes(),
+          studyConversion.getPublicVisibility(),
+          userId,
           Instant.now());
     }
     datasetDAO.updateStudyId(dataset.getDatasetId(), studyId);
@@ -554,23 +618,44 @@ public class DatasetService implements ConsentLogger {
     if (existingProps == null || existingProps.isEmpty()) {
       studyConversion.getStudyProperties().stream()
           .filter(Objects::nonNull)
-          .forEach(p -> studyDAO.insertStudyProperty(studyId, p.getKey(), p.getType().toString(),
-              p.getValue().toString()));
+          .forEach(
+              p ->
+                  studyDAO.insertStudyProperty(
+                      studyId, p.getKey(), p.getType().toString(), p.getValue().toString()));
     } else {
       // Study props to add:
       studyConversion.getStudyProperties().stream()
           .filter(Objects::nonNull)
           .filter(p -> existingProps.stream().noneMatch(ep -> ep.getKey().equals(p.getKey())))
-          .forEach(p -> studyDAO.insertStudyProperty(studyId, p.getKey(), p.getType().toString(),
-              p.getValue().toString()));
+          .forEach(
+              p ->
+                  studyDAO.insertStudyProperty(
+                      studyId, p.getKey(), p.getType().toString(), p.getValue().toString()));
       // Study props to update:
       studyConversion.getStudyProperties().stream()
           .filter(Objects::nonNull)
           .filter(p -> existingProps.stream().anyMatch(ep -> ep.equals(p)))
-          .forEach(p -> studyDAO.updateStudyProperty(studyId, p.getKey(), p.getType().toString(),
-              p.getValue().toString()));
+          .forEach(
+              p ->
+                  studyDAO.updateStudyProperty(
+                      studyId, p.getKey(), p.getType().toString(), p.getValue().toString()));
     }
     return studyId;
   }
 
+  public DatasetAuthorizationReader addAuthorizedReader(
+      int id, Integer userId, Integer operatorId) {
+    long recordId =
+        datasetAuthorizationReaderDAO.addAuthorizedReaderToDataset(id, userId, operatorId);
+    return datasetAuthorizationReaderDAO.findAuthorizedReaderByRecordId(recordId);
+  }
+
+  public boolean isAuthorizedToListUsers(Integer datasetId, Integer userId) {
+    return !Objects.isNull(
+        datasetAuthorizationReaderDAO.findAuthorizedReadersByDatasetIdAndUserId(datasetId, userId));
+  }
+
+  public void removeAuthorizedAccessReader(int datasetId, Integer userId) {
+    datasetAuthorizationReaderDAO.deleteByDatasetAndUserId(datasetId, userId);
+  }
 }

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -644,7 +644,7 @@ public class DatasetService implements ConsentLogger {
   }
 
   public DatasetAuthorizationReader addAuthorizedReader(
-      int id, Integer userId, Integer operatorId) {
+      long id, long userId, long operatorId) {
     long recordId =
         datasetAuthorizationReaderDAO.addAuthorizedReaderToDataset(id, userId, operatorId);
     return datasetAuthorizationReaderDAO.findAuthorizedReaderByRecordId(recordId);
@@ -655,7 +655,7 @@ public class DatasetService implements ConsentLogger {
         datasetAuthorizationReaderDAO.findAuthorizedReadersByDatasetIdAndUserId(datasetId, userId));
   }
 
-  public void removeAuthorizedAccessReader(int datasetId, Integer userId) {
+  public void removeAuthorizedAccessReader(long datasetId, long userId) {
     datasetAuthorizationReaderDAO.deleteByDatasetAndUserId(datasetId, userId);
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -91,8 +91,8 @@ public class DatasetService implements ConsentLogger {
   }
 
   /**
-   * TODO: Refactor this to throw a NotFoundException instead of returning null Finds a Dataset by a
-   * formatted dataset identifier.
+   * TODO: Refactor this to throw a NotFoundException instead of returning null
+   * Finds a Dataset by a formatted dataset identifier.
    *
    * @param datasetIdentifier The formatted identifier, e.g. DUOS-123456
    * @return the Dataset with the given identifier, if found.

--- a/src/main/java/org/broadinstitute/consent/http/service/UserService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/UserService.java
@@ -37,7 +37,6 @@ import org.broadinstitute.consent.http.exceptions.ConsentConflictException;
 import org.broadinstitute.consent.http.exceptions.LibraryCardRequiredException;
 import org.broadinstitute.consent.http.models.AuthUser;
 import org.broadinstitute.consent.http.models.DataAccessAgreement;
-import org.broadinstitute.consent.http.models.DatasetAuthorizationReader;
 import org.broadinstitute.consent.http.models.Institution;
 import org.broadinstitute.consent.http.models.LibraryCard;
 import org.broadinstitute.consent.http.models.User;

--- a/src/main/java/org/broadinstitute/consent/http/service/UserService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/UserService.java
@@ -22,6 +22,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.consent.http.db.AcknowledgementDAO;
 import org.broadinstitute.consent.http.db.DACAutomationRuleDAO;
 import org.broadinstitute.consent.http.db.DaaDAO;
+import org.broadinstitute.consent.http.db.DatasetAuthorizationReaderDAO;
 import org.broadinstitute.consent.http.db.FileStorageObjectDAO;
 import org.broadinstitute.consent.http.db.InstitutionDAO;
 import org.broadinstitute.consent.http.db.LibraryCardDAO;
@@ -36,6 +37,7 @@ import org.broadinstitute.consent.http.exceptions.ConsentConflictException;
 import org.broadinstitute.consent.http.exceptions.LibraryCardRequiredException;
 import org.broadinstitute.consent.http.models.AuthUser;
 import org.broadinstitute.consent.http.models.DataAccessAgreement;
+import org.broadinstitute.consent.http.models.DatasetAuthorizationReader;
 import org.broadinstitute.consent.http.models.Institution;
 import org.broadinstitute.consent.http.models.LibraryCard;
 import org.broadinstitute.consent.http.models.User;
@@ -69,13 +71,25 @@ public class UserService implements ConsentLogger {
   private final DraftServiceDAO draftServiceDAO;
   private final InstitutionService institutionService;
   private final DACAutomationRuleDAO ruleDAO;
+  private final DatasetAuthorizationReaderDAO datasetAuthorizationReaderDAO;
 
   @Inject
-  public UserService(UserDAO userDAO, UserPropertyDAO userPropertyDAO, UserRoleDAO userRoleDAO,
-      VoteDAO voteDAO, InstitutionDAO institutionDAO, LibraryCardDAO libraryCardDAO,
-      AcknowledgementDAO acknowledgementDAO, FileStorageObjectDAO fileStorageObjectDAO,
-      SamDAO samDAO, UserServiceDAO userServiceDAO, DaaDAO daaDAO, DraftServiceDAO draftServiceDAO,
-      InstitutionService institutionService, DACAutomationRuleDAO ruleDAO) {
+  public UserService(
+      UserDAO userDAO,
+      UserPropertyDAO userPropertyDAO,
+      UserRoleDAO userRoleDAO,
+      VoteDAO voteDAO,
+      InstitutionDAO institutionDAO,
+      LibraryCardDAO libraryCardDAO,
+      AcknowledgementDAO acknowledgementDAO,
+      FileStorageObjectDAO fileStorageObjectDAO,
+      SamDAO samDAO,
+      UserServiceDAO userServiceDAO,
+      DaaDAO daaDAO,
+      DraftServiceDAO draftServiceDAO,
+      InstitutionService institutionService,
+      DACAutomationRuleDAO ruleDAO,
+      DatasetAuthorizationReaderDAO datasetAuthorizationReaderDAO) {
     this.userDAO = userDAO;
     this.userPropertyDAO = userPropertyDAO;
     this.userRoleDAO = userRoleDAO;
@@ -88,6 +102,7 @@ public class UserService implements ConsentLogger {
     this.userServiceDAO = userServiceDAO;
     this.daaDAO = daaDAO;
     this.draftServiceDAO = draftServiceDAO;
+    this.datasetAuthorizationReaderDAO = datasetAuthorizationReaderDAO;
     this.institutionService = institutionService;
     this.ruleDAO = ruleDAO;
   }
@@ -283,6 +298,7 @@ public class UserService implements ConsentLogger {
     acknowledgementDAO.deleteAllAcknowledgementsByUser(userId);
     fileStorageObjectDAO.deleteAllUserFiles(userId);
     ruleDAO.auditedDeleteAllDACRuleSettingForUser(userId, auditUserId);
+    datasetAuthorizationReaderDAO.deleteByUserId(userId);
     userDAO.deleteUserById(userId);
   }
 

--- a/src/main/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAO.java
@@ -13,6 +13,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import org.apache.commons.lang3.StringUtils;
+import org.broadinstitute.consent.http.db.DatasetAuthorizationReaderDAO;
 import org.broadinstitute.consent.http.db.DatasetDAO;
 import org.broadinstitute.consent.http.db.FileStorageObjectDAO;
 import org.broadinstitute.consent.http.db.StudyDAO;
@@ -35,14 +36,20 @@ import org.jdbi.v3.core.statement.Update;
 public class DatasetServiceDAO implements ConsentLogger {
 
   private final Jdbi jdbi;
+  private final DatasetAuthorizationReaderDAO datasetAuthorizationReaderDAO;
   private final DatasetDAO datasetDAO;
   private final StudyDAO studyDAO;
 
   @Inject
-  public DatasetServiceDAO(Jdbi jdbi, DatasetDAO datasetDAO, StudyDAO studyDAO) {
+  public DatasetServiceDAO(
+      Jdbi jdbi,
+      DatasetDAO datasetDAO,
+      StudyDAO studyDAO,
+      DatasetAuthorizationReaderDAO datasetAuthorizationReaderDAO) {
     this.jdbi = jdbi;
     this.datasetDAO = datasetDAO;
     this.studyDAO = studyDAO;
+    this.datasetAuthorizationReaderDAO = datasetAuthorizationReaderDAO;
   }
 
   public void deleteDataset(Dataset dataset, Integer userId) throws Exception {
@@ -53,6 +60,7 @@ public class DatasetServiceDAO implements ConsentLogger {
           Objects.nonNull(dataset.getName()) ? dataset.getName() : dataset.getDatasetIdentifier();
       try {
         addAuditRecord(dataset.getDatasetId(), dsAuditName, userId, AuditActions.DELETE);
+        datasetAuthorizationReaderDAO.deleteByDatasetId(dataset.getDatasetId());
         datasetDAO.deleteDatasetPropertiesByDatasetId(dataset.getDatasetId());
         datasetDAO.deleteDatasetById(dataset.getDatasetId());
       } catch (Exception e) {
@@ -85,47 +93,6 @@ public class DatasetServiceDAO implements ConsentLogger {
       }
       handle.commit();
     });
-  }
-
-  public record StudyInsert(String name,
-                            String description,
-                            List<String> dataTypes,
-                            String piName,
-                            Boolean publicVisibility,
-                            Integer userId,
-                            List<StudyProperty> props,
-                            List<FileStorageObject> files) {
-
-  }
-
-  public record StudyUpdate(String name,
-                            Integer studyId,
-                            String description,
-                            List<String> dataTypes,
-                            String piName,
-                            Boolean publicVisibility,
-                            Integer userId,
-                            List<StudyProperty> props,
-                            List<FileStorageObject> files) {
-
-  }
-
-  public record DatasetInsert(String name,
-                              Integer dacId,
-                              DataUse dataUse,
-                              Integer userId,
-                              List<DatasetProperty> props,
-                              List<FileStorageObject> files) {
-
-  }
-
-  public record DatasetUpdate(Integer datasetId,
-                              String name,
-                              Integer userId,
-                              Integer dacId,
-                              List<DatasetProperty> props,
-                              List<FileStorageObject> files) {
-
   }
 
   /**
@@ -521,8 +488,6 @@ public class DatasetServiceDAO implements ConsentLogger {
     return insert;
   }
 
-  // Helper methods to generate DatasetProperty inserts
-
   private List<Update> generatePropertyInserts(Handle handle, Integer datasetId,
       List<DatasetProperty> properties, Set<DatasetProperty> existingProps) {
     Timestamp now = new Timestamp(new Date().getTime());
@@ -557,8 +522,6 @@ public class DatasetServiceDAO implements ConsentLogger {
     insert.bind("createDate", now);
     return insert;
   }
-
-  // Helper methods to generate DatasetProperty updates
 
   private List<Update> generatePropertyUpdates(Handle handle, Integer datasetId,
       List<DatasetProperty> properties, Set<DatasetProperty> existingProps) {
@@ -602,7 +565,7 @@ public class DatasetServiceDAO implements ConsentLogger {
     return insert;
   }
 
-  // Helper methods to generate DatasetProperty deletes
+  // Helper methods to generate DatasetProperty inserts
 
   private List<Update> generatePropertyDeletes(Handle handle, List<DatasetProperty> properties,
       Set<DatasetProperty> existingProps) {
@@ -630,5 +593,50 @@ public class DatasetServiceDAO implements ConsentLogger {
     insert.bind("propertyKey", property.getPropertyKey());
     insert.bind("propertyId", property.getPropertyId());
     return insert;
+  }
+
+  // Helper methods to generate DatasetProperty updates
+
+  public record StudyInsert(String name,
+                            String description,
+                            List<String> dataTypes,
+                            String piName,
+                            Boolean publicVisibility,
+                            Integer userId,
+                            List<StudyProperty> props,
+                            List<FileStorageObject> files) {
+
+  }
+
+  public record StudyUpdate(String name,
+                            Integer studyId,
+                            String description,
+                            List<String> dataTypes,
+                            String piName,
+                            Boolean publicVisibility,
+                            Integer userId,
+                            List<StudyProperty> props,
+                            List<FileStorageObject> files) {
+
+  }
+
+  // Helper methods to generate DatasetProperty deletes
+
+  public record DatasetInsert(String name,
+                              Integer dacId,
+                              DataUse dataUse,
+                              Integer userId,
+                              List<DatasetProperty> props,
+                              List<FileStorageObject> files) {
+
+  }
+
+  public record DatasetUpdate(Integer datasetId,
+                              String name,
+                              Integer userId,
+                              Integer dacId,
+                              List<DatasetProperty> props,
+                              List<FileStorageObject> files) {
+
   }
 }

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -511,6 +511,12 @@ paths:
     $ref: './paths/datasetSummaryAutocomplete.yaml'
   /api/dataset/search/index:
     $ref: './paths/datasetSearchIndex.yaml'
+  /api/dataset/{id}/authorizedAccessReaders:
+    $ref: './paths/datasetAuthorizedReaders.yaml'
+  /api/dataset/{id}/authorizedAccessReaders/{userId}:
+    $ref: './paths/datasetAuthorizedReadersAddDelete.yaml'
+  /api/dataset/{identifier}/authorizedUsers:
+    $ref: './paths/datasetAuthorizedUsers.yaml'
   /api/draft/v1:
     $ref: './paths/draftIndex.yaml'
   /api/draft/v1/{draftUUID}:

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -515,7 +515,7 @@ paths:
     $ref: './paths/datasetAuthorizedReaders.yaml'
   /api/dataset/{id}/authorizedAccessReaders/{userId}:
     $ref: './paths/datasetAuthorizedReadersAddDelete.yaml'
-  /api/dataset/{identifier}/authorizedUsers:
+  /api/dataset/{identifier}/approvedUsers:
     $ref: './paths/datasetAuthorizedUsers.yaml'
   /api/draft/v1:
     $ref: './paths/draftIndex.yaml'

--- a/src/main/resources/assets/paths/datasetAuthorizedReaders.yaml
+++ b/src/main/resources/assets/paths/datasetAuthorizedReaders.yaml
@@ -1,0 +1,22 @@
+get:
+  summary: List authorized access readers for a dataset
+  description: |
+    Endpoint allows administrators to list the authorized access readers of a dataset
+  tags:
+    - Admin
+    - Dataset
+  parameters:
+    - name: id
+      in: path
+      required: true
+      schema:
+        type: integer
+  responses:
+    200:
+      description: Returns the list of authorized access readers
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: '../schemas/DatasetAuthorizedReader.yaml'

--- a/src/main/resources/assets/paths/datasetAuthorizedUsers.yaml
+++ b/src/main/resources/assets/paths/datasetAuthorizedUsers.yaml
@@ -1,0 +1,25 @@
+get:
+  summary: Find approved users by dataset identifier
+  description: Endpoint for authorized SERVICE ACCOUNT users to call that finds all users who have been approved access to this dataset with an accepted DAR.
+  parameters:
+    - name: identifier
+      in: path
+      description: Dataset identifier, e.g. DUOS-123456
+      required: true
+      schema:
+        type: string
+  tags:
+    - Dataset
+  responses:
+    200:
+      description: Returns a simplified view of all of the users.
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ApprovedUsers.yaml'
+    400:
+      description: Invalid dataset identifier.
+    404:
+      description: Could not find dataset with given identifier.
+    500:
+      description: Server error.

--- a/src/main/resources/assets/paths/datasetAuthorizedreadersAddDelete.yaml
+++ b/src/main/resources/assets/paths/datasetAuthorizedreadersAddDelete.yaml
@@ -1,0 +1,48 @@
+put:
+  summary: Add authorized access reader
+  description: |
+    Endpoint allows administrators to add an authorized access reader to a dataset
+  tags:
+    - Admin
+    - Dataset
+  parameters:
+    - name: id
+      in: path
+      required: true
+      schema:
+        type: integer
+    - name: userId
+      in: path
+      required: true
+      schema:
+        type: integer
+  responses:
+    200:
+      description: The addition of the user was successful
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/DatasetAuthorizedReader.yaml'
+    409:
+      description: The user is missing the SERVICE_ACCOUNT role required to check access.
+delete:
+  summary: Remove authorized access reader
+  description: |
+    Endpoint allows administrators to remove an authorized access reader to a dataset
+  tags:
+    - Admin
+    - Dataset
+  parameters:
+    - name: id
+      in: path
+      required: true
+      schema:
+        type: integer
+    - name: userId
+      in: path
+      required: true
+      schema:
+        type: integer
+  responses:
+    200:
+      description: The removal of the user was successful

--- a/src/main/resources/assets/schemas/DatasetAuthorizedReader.yaml
+++ b/src/main/resources/assets/schemas/DatasetAuthorizedReader.yaml
@@ -1,0 +1,17 @@
+type: object
+properties:
+  id:
+    type: number
+    description: The identifying number of this entry
+  datasetId:
+    type: number
+    description: The identifying number of the dataset
+  userId:
+    type: number
+    description: The identifying number of the user allowed to check access
+  createdBy:
+    type: number
+    description: The identifying number of the user granting this authorization
+  createdDate:
+    type: number
+    description: When this rule was created in, milliseconds since the epoch

--- a/src/main/resources/assets/schemas/DatasetAuthorizedReader.yaml
+++ b/src/main/resources/assets/schemas/DatasetAuthorizedReader.yaml
@@ -14,4 +14,4 @@ properties:
     description: The identifying number of the user granting this authorization
   createdDate:
     type: number
-    description: When this rule was created in, milliseconds since the epoch
+    description: When this rule was created, in milliseconds since the epoch

--- a/src/main/resources/changelog-master.xml
+++ b/src/main/resources/changelog-master.xml
@@ -200,4 +200,6 @@
     relativeToChangelogFile="true" />
   <include file="changesets/changelog-consent-2025-08-07-2025-jsonb-data.xml"
     relativeToChangelogFile="true" />
+  <include file="changesets/changelog-consent-2025-08-29-2025-dataset-authorization-readers.xml"
+    relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/src/main/resources/changesets/changelog-consent-2025-08-29-2025-dataset-authorization-readers.xml
+++ b/src/main/resources/changesets/changelog-consent-2025-08-29-2025-dataset-authorization-readers.xml
@@ -1,0 +1,18 @@
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+  <changeSet id="changelog-consent-2025-08-29-2025-dataset-authorized-readers" author="otchet-broad">
+  <createTable tableName="dataset_authorized_readers">
+    <column name="id" autoIncrement="true" type="bigint"/>
+    <column name="dataset_id" type="bigint"/>
+    <column name="user_id" type="bigint" />
+    <column name="created_by" type="bigint" />
+    <column name="created_date" type="timestamp" defaultValue="now()"/>
+  </createTable>
+    <addForeignKeyConstraint baseTableName="dataset_authorized_readers" baseColumnNames="dataset_id" constraintName="fkAuthorizedReadersDatasetId"
+      referencedTableName="dataset" referencedColumnNames="dataset_id"/>
+    <addForeignKeyConstraint baseTableName="dataset_authorized_readers" baseColumnNames="user_id" constraintName="fkAuthorizedReadersUserId"
+      referencedTableName="users" referencedColumnNames="user_id" />
+    <addUniqueConstraint tableName="dataset_authorized_readers" columnNames="dataset_id, user_id" />
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/changesets/changelog-consent-2025-08-29-2025-dataset-authorization-readers.xml
+++ b/src/main/resources/changesets/changelog-consent-2025-08-29-2025-dataset-authorization-readers.xml
@@ -14,5 +14,19 @@
     <addForeignKeyConstraint baseTableName="dataset_authorized_readers" baseColumnNames="user_id" constraintName="fkAuthorizedReadersUserId"
       referencedTableName="users" referencedColumnNames="user_id" />
     <addUniqueConstraint tableName="dataset_authorized_readers" columnNames="dataset_id, user_id" />
+    <addPrimaryKey tableName="dataset_authorized_readers" columnNames="id"/>
+    <createIndex tableName="dataset_authorized_readers" indexName="idx_dataset_id">
+      <column name="dataset_id"/>
+    </createIndex>
+    <createIndex tableName="dataset_authorized_readers" indexName="idx_dataset_id_user_id">
+      <column name="dataset_id"/>
+      <column name="user_id"/>
+    </createIndex>
+    <createIndex tableName="dataset_authorized_readers" indexName="idx_user_id">
+      <column name="user_id"/>
+    </createIndex>
+    <createIndex tableName="dataset_authorized_readers" indexName="idx_id">
+      <column name="id"/>
+    </createIndex>
   </changeSet>
 </databaseChangeLog>

--- a/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
@@ -46,6 +46,7 @@ public class DAOTestHelper extends AbstractTestHelper implements TestExecutionLi
   protected static DacDAO dacDAO;
   protected static DaaDAO daaDAO;
   protected static UserDAO userDAO;
+  protected static DatasetAuthorizationReaderDAO datasetAuthorizationReaderDAO;
   protected static DatasetDAO datasetDAO;
   protected static ElectionDAO electionDAO;
   protected static UserRoleDAO userRoleDAO;
@@ -132,6 +133,7 @@ public class DAOTestHelper extends AbstractTestHelper implements TestExecutionLi
     dacDAO = jdbi.onDemand(DacDAO.class);
     daaDAO = jdbi.onDemand(DaaDAO.class);
     userDAO = jdbi.onDemand(UserDAO.class);
+    datasetAuthorizationReaderDAO = jdbi.onDemand(DatasetAuthorizationReaderDAO.class);
     datasetDAO = jdbi.onDemand(DatasetDAO.class);
     electionDAO = jdbi.onDemand(ElectionDAO.class);
     userRoleDAO = jdbi.onDemand(UserRoleDAO.class);

--- a/src/test/java/org/broadinstitute/consent/http/db/DatasetAuthorizationReaderDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DatasetAuthorizationReaderDAOTest.java
@@ -1,0 +1,131 @@
+package org.broadinstitute.consent.http.db;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import org.broadinstitute.consent.http.models.DataUse;
+import org.broadinstitute.consent.http.models.DataUseBuilder;
+import org.broadinstitute.consent.http.models.DatasetAuthorizationReader;
+import org.broadinstitute.consent.http.models.DatasetProperty;
+import org.broadinstitute.consent.http.models.User;
+import org.junit.jupiter.api.Test;
+
+public class DatasetAuthorizationReaderDAOTest extends DAOTestHelper {
+
+  @Test
+  void testInsertDatasetAuthorizationRecord() {
+    User testUser = createUserWithInstitution();
+    User operator = createUserWithInstitution();
+    int datasetId = createDataset(testUser);
+    long authRecordId = datasetAuthorizationReaderDAO.addAuthorizedReaderToDataset(datasetId, testUser.getUserId(), operator.getUserId());
+    assertTrue(authRecordId > 0);
+    List<DatasetAuthorizationReader> authorizationReaderList = datasetAuthorizationReaderDAO.findAuthorizedReadersByDatasetId(datasetId);
+    assertNotNull(authorizationReaderList);
+    assertEquals(1, authorizationReaderList.size());
+    DatasetAuthorizationReader authorizationReader = authorizationReaderList.get(0);
+    assertEquals(datasetId, authorizationReader.datasetId());
+    assertEquals(testUser.getUserId().intValue(), authorizationReader.userId());
+    assertEquals(operator.getUserId().intValue(), authorizationReader.createdBy());
+    datasetAuthorizationReaderDAO.deleteByDatasetId(datasetId);
+    List<DatasetAuthorizationReader> authorizationReaderList2 = datasetAuthorizationReaderDAO.findAuthorizedReadersByDatasetId(datasetId);
+    assertNotNull(authorizationReaderList2);
+    assertEquals(0, authorizationReaderList2.size());
+  }
+
+  @Test
+  void testDeleteByDatasetAndUserId() {
+    User testUser = createUserWithInstitution();
+    User operator = createUserWithInstitution();
+    int datasetId1 = createDataset(testUser);
+    int datasetId2 = createDataset(testUser);
+    datasetAuthorizationReaderDAO.addAuthorizedReaderToDataset(datasetId1, testUser.getUserId(), operator.getUserId());
+    datasetAuthorizationReaderDAO.addAuthorizedReaderToDataset(datasetId2, testUser.getUserId(), operator.getUserId());
+    assertEquals(1, datasetAuthorizationReaderDAO.findAuthorizedReadersByDatasetId(datasetId1).size());
+    assertEquals(1, datasetAuthorizationReaderDAO.findAuthorizedReadersByDatasetId(datasetId2).size());
+
+    datasetAuthorizationReaderDAO.deleteByDatasetAndUserId(datasetId1, testUser.getUserId());
+    assertEquals(0, datasetAuthorizationReaderDAO.findAuthorizedReadersByDatasetId(datasetId1).size());
+    assertEquals(1, datasetAuthorizationReaderDAO.findAuthorizedReadersByDatasetId(datasetId2).size());
+
+    datasetAuthorizationReaderDAO.deleteByDatasetAndUserId(datasetId2, testUser.getUserId());
+    assertEquals(0, datasetAuthorizationReaderDAO.findAuthorizedReadersByDatasetId(datasetId1).size());
+    assertEquals(0, datasetAuthorizationReaderDAO.findAuthorizedReadersByDatasetId(datasetId2).size());
+  }
+
+  @Test
+  void testDeleteByDatasetId() {
+    User testUser = createUserWithInstitution();
+    User testUser2 = createUserWithInstitution();
+    User operator = createUserWithInstitution();
+    int datasetId1 = createDataset(testUser);
+    int datasetId2 = createDataset(testUser);
+    long record1 = datasetAuthorizationReaderDAO.addAuthorizedReaderToDataset(datasetId1, testUser.getUserId(), operator.getUserId());
+    datasetAuthorizationReaderDAO.addAuthorizedReaderToDataset(datasetId2, testUser.getUserId(), operator.getUserId());
+    datasetAuthorizationReaderDAO.addAuthorizedReaderToDataset(datasetId1, testUser2.getUserId(), operator.getUserId());
+
+    DatasetAuthorizationReader authReader = datasetAuthorizationReaderDAO.findAuthorizedReaderByRecordId(record1);
+    assertNotNull(authReader);
+    assertEquals(record1, authReader.id());
+    assertEquals(datasetId1, authReader.datasetId());
+    assertEquals(testUser.getUserId().intValue(), authReader.userId());
+    assertEquals(operator.getUserId().intValue(), authReader.createdBy());
+    assertEquals(2, datasetAuthorizationReaderDAO.findAuthorizedReadersByDatasetId(datasetId1).size());
+    DatasetAuthorizationReader reader = datasetAuthorizationReaderDAO.findAuthorizedReadersByDatasetIdAndUserId(datasetId1, testUser.getUserId());
+    assertNotNull(reader);
+    assertEquals(record1, reader.id());
+    assertEquals(datasetId1, reader.datasetId());
+    assertEquals(testUser.getUserId().intValue(), reader.userId());
+    assertEquals(operator.getUserId().intValue(), reader.createdBy());
+    datasetAuthorizationReaderDAO.deleteByDatasetId(datasetId1);
+    assertEquals(0, datasetAuthorizationReaderDAO.findAuthorizedReadersByDatasetId(datasetId1).size());
+
+    assertEquals(1, datasetAuthorizationReaderDAO.findAuthorizedReadersByDatasetId(datasetId2).size());
+  }
+
+  @Test
+  void testDeleteByUserId() {
+    User testUser1 = createUserWithInstitution();
+    User testUser2 = createUserWithInstitution();
+    User operator = createUserWithInstitution();
+    int datasetId1 = createDataset(testUser1);
+    int datasetId2 = createDataset(testUser2);
+
+    datasetAuthorizationReaderDAO.addAuthorizedReaderToDataset(datasetId1, testUser1.getUserId(), operator.getUserId());
+    datasetAuthorizationReaderDAO.addAuthorizedReaderToDataset(datasetId2, testUser1.getUserId(), operator.getUserId());
+    datasetAuthorizationReaderDAO.addAuthorizedReaderToDataset(datasetId2, testUser2.getUserId(), operator.getUserId());
+
+    assertEquals(1,datasetAuthorizationReaderDAO.findAuthorizedReadersByDatasetId(datasetId1).size());
+    assertEquals(2,datasetAuthorizationReaderDAO.findAuthorizedReadersByDatasetId(datasetId2).size());
+    datasetAuthorizationReaderDAO.deleteByUserId(testUser1.getUserId());
+    assertEquals(0,datasetAuthorizationReaderDAO.findAuthorizedReadersByDatasetId(datasetId1).size());
+    assertEquals(1,datasetAuthorizationReaderDAO.findAuthorizedReadersByDatasetId(datasetId2).size());
+
+  }
+
+  private int createDataset(User user) {
+    String name = "Name_" + randomAlphanumeric(20);
+    Timestamp now = new Timestamp(new Date().getTime());
+    String objectId = "Object ID_" + randomAlphanumeric(20);
+    DataUse dataUse = new DataUseBuilder().setGeneralUse(true).build();
+    Integer id = datasetDAO.insertDataset(name, now, user.getUserId(), objectId,
+        dataUse.toString(), null);
+    createDatasetProperties(id);
+    return id;
+  }
+
+  private void createDatasetProperties(Integer datasetId) {
+    List<DatasetProperty> list = new ArrayList<>();
+    DatasetProperty dsp = new DatasetProperty();
+    dsp.setDatasetId(datasetId);
+    dsp.setPropertyKey(1);
+    dsp.setPropertyValue("Test_PropertyValue");
+    dsp.setCreateDate(new Date());
+    list.add(dsp);
+    datasetDAO.insertDatasetProperties(list);
+  }
+}

--- a/src/test/java/org/broadinstitute/consent/http/db/DatasetAuthorizationReaderDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DatasetAuthorizationReaderDAOTest.java
@@ -15,7 +15,7 @@ import org.broadinstitute.consent.http.models.DatasetProperty;
 import org.broadinstitute.consent.http.models.User;
 import org.junit.jupiter.api.Test;
 
-public class DatasetAuthorizationReaderDAOTest extends DAOTestHelper {
+class DatasetAuthorizationReaderDAOTest extends DAOTestHelper {
 
   @Test
   void testInsertDatasetAuthorizationRecord() {

--- a/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
@@ -58,6 +58,7 @@ import org.broadinstitute.consent.http.models.dataset_registration_v1.ConsentGro
 import org.broadinstitute.consent.http.models.dataset_registration_v1.ConsentGroup.DataLocation;
 import org.broadinstitute.consent.http.models.dataset_registration_v1.DatasetRegistrationSchemaV1;
 import org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder;
+import org.broadinstitute.consent.http.models.tdr.ApprovedUsers;
 import org.broadinstitute.consent.http.service.DatasetRegistrationService;
 import org.broadinstitute.consent.http.service.DatasetService;
 import org.broadinstitute.consent.http.service.ElasticSearchService;
@@ -1088,9 +1089,46 @@ class DatasetResourceTest extends AbstractTestHelper {
   }
 
   @Test
-  void testRemoveAuthorizedReadersThrowns(){
+  void testRemoveAuthorizedReadersThrows(){
     doThrow(new RuntimeException("Some Exception")).when(datasetService).removeAuthorizedAccessReader(anyLong(), anyLong());
     Response response = resource.removeAuthorizedReaders(duosUser, 1, 1);
+    assertEquals(HttpStatusCodes.STATUS_CODE_SERVER_ERROR, response.getStatus());
+  }
+
+  @Test
+  void testGetAuthorizedUsers() {
+    Dataset dataset = new Dataset();
+    dataset.setDatasetId(1);
+    when(datasetService.findDatasetByIdentifier(any(), any())).thenReturn(dataset);
+    when(datasetService.isAuthorizedToListUsers(any(), any())).thenReturn(true);
+    when(tdrService.getApprovedUsersForDataset(any(), any())).thenReturn(new ApprovedUsers(List.of()));
+    Response response = resource.getAuthorizedUsers(duosUser, "ABC");
+    assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+  }
+
+
+  @Test
+  void testGetAuthorizedUsersDatasetNotFound() {
+    when(datasetService.findDatasetByIdentifier(any(), any())).thenReturn(null);
+    Response response = resource.getAuthorizedUsers(duosUser, "ABC");
+    assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
+  }
+
+  @Test
+  void testGetAuthorizedUsersNotAuthorized() {
+    Dataset dataset = new Dataset();
+    dataset.setDatasetId(1);
+    when(datasetService.findDatasetByIdentifier(any(), any())).thenReturn(dataset);
+    when(datasetService.isAuthorizedToListUsers(any(), any())).thenReturn(false);
+    Response response = resource.getAuthorizedUsers(duosUser, "ABC");
+    assertEquals(HttpStatusCodes.STATUS_CODE_FORBIDDEN, response.getStatus());
+  }
+
+  @Test
+  void testGetAuthorizedUsersDatasetThrows() {
+    doThrow(new RuntimeException("Some exception"))
+        .when(datasetService).findDatasetByIdentifier(any(), any());
+    Response response = resource.getAuthorizedUsers(duosUser, "ABC");
     assertEquals(HttpStatusCodes.STATUS_CODE_SERVER_ERROR, response.getStatus());
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
@@ -55,6 +55,7 @@ import org.broadinstitute.consent.http.models.dataset_registration_v1.builder.Da
 import org.broadinstitute.consent.http.service.DatasetRegistrationService;
 import org.broadinstitute.consent.http.service.DatasetService;
 import org.broadinstitute.consent.http.service.ElasticSearchService;
+import org.broadinstitute.consent.http.service.TDRService;
 import org.broadinstitute.consent.http.service.UserService;
 import org.broadinstitute.consent.http.util.gson.GsonUtil;
 import org.glassfish.jersey.media.multipart.FormDataBodyPart;
@@ -78,6 +79,9 @@ class DatasetResourceTest extends AbstractTestHelper {
   private ElasticSearchService elasticSearchService;
 
   @Mock
+  private TDRService tdrService;
+
+  @Mock
   private UserService userService;
 
   @Mock
@@ -91,7 +95,7 @@ class DatasetResourceTest extends AbstractTestHelper {
   @BeforeEach
   void initResource() {
     resource = new DatasetResource(datasetService, userService,
-        datasetRegistrationService, elasticSearchService);
+        datasetRegistrationService, elasticSearchService, tdrService);
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
@@ -8,7 +8,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -26,6 +29,8 @@ import jakarta.ws.rs.core.StreamingOutput;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -39,6 +44,7 @@ import org.broadinstitute.consent.http.models.AuthUser;
 import org.broadinstitute.consent.http.models.DataUse;
 import org.broadinstitute.consent.http.models.DataUseBuilder;
 import org.broadinstitute.consent.http.models.Dataset;
+import org.broadinstitute.consent.http.models.DatasetAuthorizationReader;
 import org.broadinstitute.consent.http.models.DatasetPatch;
 import org.broadinstitute.consent.http.models.DatasetProperty;
 import org.broadinstitute.consent.http.models.DatasetSummary;
@@ -1017,6 +1023,75 @@ class DatasetResourceTest extends AbstractTestHelper {
     try (var response = resource.syncDataUseTranslation(authUser, 1)) {
       assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
     }
+  }
+
+  @Test
+  void testGetAuthorizedReadersOK() {
+    when(datasetService.getAuthorizationReaders(anyLong())).thenReturn(new ArrayList<>());
+    Response response = resource.getAuthorizedReaders(duosUser,1L);
+    assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+  }
+
+
+  @Test
+  void testGetAuthorizedReadersError() {
+    doThrow(new RuntimeException("Some Exception"))
+        .when(datasetService)
+        .getAuthorizationReaders(anyLong());
+    Response response = resource.getAuthorizedReaders(duosUser,1L);
+    assertEquals(HttpStatusCodes.STATUS_CODE_SERVER_ERROR, response.getStatus());
+  }
+
+  @Test
+  void testAddAuthorizedReadersNotServiceAccount(){
+    User user = new User();
+    user.setUserId(1);
+    user.addRole(
+        new UserRole(UserRoles.CHAIRPERSON.getRoleId(), UserRoles.CHAIRPERSON.getRoleName()));
+    when(userService.findUserById(any())).thenReturn(user);
+    Response response = resource.addAuthorizedReaders(duosUser, 1, 1);
+    assertEquals(HttpStatusCodes.STATUS_CODE_CONFLICT, response.getStatus());
+  }
+
+  @Test
+  void testAddAuthorizedReaders(){
+    User readerUser = new User();
+    readerUser.setUserId(1);
+    readerUser.addRole(
+        new UserRole(UserRoles.SERVICE_ACCOUNT.getRoleId(), UserRoles.SERVICE_ACCOUNT.getRoleName()));
+    user.setUserId(1);
+    DatasetAuthorizationReader reader = new DatasetAuthorizationReader(1,1,1, 1, Timestamp.from(
+        Instant.now()));
+    when(userService.findUserById(any())).thenReturn(readerUser);
+    when(datasetService.addAuthorizedReader(anyLong(), anyLong(), anyLong())).thenReturn(reader);
+    Response response = resource.addAuthorizedReaders(duosUser, 1, 1);
+    assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+  }
+
+  @Test
+  void testAddAuthorizedReadersThrows(){
+    User readerUser = new User();
+    readerUser.setUserId(1);
+    readerUser.addRole(
+        new UserRole(UserRoles.SERVICE_ACCOUNT.getRoleId(), UserRoles.SERVICE_ACCOUNT.getRoleName()));
+    user.setUserId(1);
+    doThrow(new RuntimeException("Some exception")).when(userService).findUserById(any());
+    Response response = resource.addAuthorizedReaders(duosUser, 1, 1);
+    assertEquals(HttpStatusCodes.STATUS_CODE_SERVER_ERROR, response.getStatus());
+  }
+
+  @Test
+  void testRemoveAuthorizedReaders(){
+    doNothing().when(datasetService).removeAuthorizedAccessReader(anyLong(), anyLong());
+    Response response = resource.removeAuthorizedReaders(duosUser, 1, 1);
+    assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+  }
+
+  @Test
+  void testRemoveAuthorizedReadersThrowns(){
+    doThrow(new RuntimeException("Some Exception")).when(datasetService).removeAuthorizedAccessReader(anyLong(), anyLong());
+    Response response = resource.removeAuthorizedReaders(duosUser, 1, 1);
+    assertEquals(HttpStatusCodes.STATUS_CODE_SERVER_ERROR, response.getStatus());
   }
 
   /**

--- a/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
@@ -1044,11 +1044,11 @@ class DatasetResourceTest extends AbstractTestHelper {
 
   @Test
   void testAddAuthorizedReadersNotServiceAccount(){
-    User user = new User();
-    user.setUserId(1);
-    user.addRole(
+    User readerUser = new User();
+    readerUser.setUserId(1);
+    readerUser.addRole(
         new UserRole(UserRoles.CHAIRPERSON.getRoleId(), UserRoles.CHAIRPERSON.getRoleName()));
-    when(userService.findUserById(any())).thenReturn(user);
+    when(userService.findUserById(any())).thenReturn(readerUser);
     Response response = resource.addAuthorizedReaders(duosUser, 1, 1);
     assertEquals(HttpStatusCodes.STATUS_CODE_CONFLICT, response.getStatus());
   }

--- a/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
@@ -1096,39 +1096,39 @@ class DatasetResourceTest extends AbstractTestHelper {
   }
 
   @Test
-  void testGetAuthorizedUsers() {
+  void testGetApprovedUsers() {
     Dataset dataset = new Dataset();
     dataset.setDatasetId(1);
     when(datasetService.findDatasetByIdentifier(any(), any())).thenReturn(dataset);
     when(datasetService.isAuthorizedToListUsers(any(), any())).thenReturn(true);
     when(tdrService.getApprovedUsersForDataset(any(), any())).thenReturn(new ApprovedUsers(List.of()));
-    Response response = resource.getAuthorizedUsers(duosUser, "ABC");
+    Response response = resource.getApprovedUsers(duosUser, "ABC");
     assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
   }
 
 
   @Test
-  void testGetAuthorizedUsersDatasetNotFound() {
+  void testGetApprovedUsersDatasetNotFound() {
     when(datasetService.findDatasetByIdentifier(any(), any())).thenReturn(null);
-    Response response = resource.getAuthorizedUsers(duosUser, "ABC");
+    Response response = resource.getApprovedUsers(duosUser, "ABC");
     assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
   }
 
   @Test
-  void testGetAuthorizedUsersNotAuthorized() {
+  void testGetAuthorizedUsersNotApproved() {
     Dataset dataset = new Dataset();
     dataset.setDatasetId(1);
     when(datasetService.findDatasetByIdentifier(any(), any())).thenReturn(dataset);
     when(datasetService.isAuthorizedToListUsers(any(), any())).thenReturn(false);
-    Response response = resource.getAuthorizedUsers(duosUser, "ABC");
+    Response response = resource.getApprovedUsers(duosUser, "ABC");
     assertEquals(HttpStatusCodes.STATUS_CODE_FORBIDDEN, response.getStatus());
   }
 
   @Test
-  void testGetAuthorizedUsersDatasetThrows() {
+  void testGetApprovedUsersDatasetThrows() {
     doThrow(new RuntimeException("Some exception"))
         .when(datasetService).findDatasetByIdentifier(any(), any());
-    Response response = resource.getAuthorizedUsers(duosUser, "ABC");
+    Response response = resource.getApprovedUsers(duosUser, "ABC");
     assertEquals(HttpStatusCodes.STATUS_CODE_SERVER_ERROR, response.getStatus());
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
@@ -660,7 +660,7 @@ class DatasetServiceTest extends AbstractTestHelper {
   void testAddAuthorizedReader() {
     DatasetAuthorizationReader dauthr =
         new DatasetAuthorizationReader(1, 1, 1, 1, Timestamp.from(Instant.now()));
-    when(datasetAuthorizationReaderDAO.addAuthorizedReaderToDataset(anyInt(), anyInt(), anyInt()))
+    when(datasetAuthorizationReaderDAO.addAuthorizedReaderToDataset(anyLong(), anyLong(), anyLong()))
         .thenReturn(dauthr.id());
     when(datasetAuthorizationReaderDAO.findAuthorizedReaderByRecordId(anyLong()))
         .thenReturn(dauthr);

--- a/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
@@ -12,6 +12,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -32,6 +33,7 @@ import java.util.stream.Stream;
 import org.broadinstitute.consent.http.AbstractTestHelper;
 import org.broadinstitute.consent.http.db.DaaDAO;
 import org.broadinstitute.consent.http.db.DacDAO;
+import org.broadinstitute.consent.http.db.DatasetAuthorizationReaderDAO;
 import org.broadinstitute.consent.http.db.DatasetDAO;
 import org.broadinstitute.consent.http.db.StudyDAO;
 import org.broadinstitute.consent.http.db.UserDAO;
@@ -44,6 +46,7 @@ import org.broadinstitute.consent.http.models.DataAccessRequest;
 import org.broadinstitute.consent.http.models.DataUse;
 import org.broadinstitute.consent.http.models.DataUseBuilder;
 import org.broadinstitute.consent.http.models.Dataset;
+import org.broadinstitute.consent.http.models.DatasetAuthorizationReader;
 import org.broadinstitute.consent.http.models.Study;
 import org.broadinstitute.consent.http.models.StudyProperty;
 import org.broadinstitute.consent.http.models.User;
@@ -62,31 +65,32 @@ class DatasetServiceTest extends AbstractTestHelper {
 
   private DatasetService datasetService;
 
-  @Mock
-  private DatasetDAO datasetDAO;
-  @Mock
-  private DaaDAO daaDAO;
-  @Mock
-  private DacDAO dacDAO;
-  @Mock
-  private ElasticSearchService elasticSearchService;
-  @Mock
-  private EmailService emailService;
-  @Mock
-  private OntologyService ontologyService;
-  @Mock
-  private StudyDAO studyDAO;
-  @Mock
-  private DatasetServiceDAO datasetServiceDAO;
-  @Mock
-  private UserDAO userDAO;
-  @Mock
-  private User mockUser;
+  @Mock private DatasetAuthorizationReaderDAO datasetAuthorizationReaderDAO;
+  @Mock private DatasetDAO datasetDAO;
+  @Mock private DaaDAO daaDAO;
+  @Mock private DacDAO dacDAO;
+  @Mock private ElasticSearchService elasticSearchService;
+  @Mock private EmailService emailService;
+  @Mock private OntologyService ontologyService;
+  @Mock private StudyDAO studyDAO;
+  @Mock private DatasetServiceDAO datasetServiceDAO;
+  @Mock private UserDAO userDAO;
+  @Mock private User mockUser;
 
   @BeforeEach
   void initService() {
-    datasetService = new DatasetService(datasetDAO, daaDAO, dacDAO, elasticSearchService,
-        emailService, ontologyService, studyDAO, datasetServiceDAO, userDAO);
+    datasetService =
+        new DatasetService(
+            datasetAuthorizationReaderDAO,
+            datasetDAO,
+            daaDAO,
+            dacDAO,
+            elasticSearchService,
+            emailService,
+            ontologyService,
+            studyDAO,
+            datasetServiceDAO,
+            userDAO);
   }
 
   @Test
@@ -99,8 +103,8 @@ class DatasetServiceTest extends AbstractTestHelper {
   @Test
   void testFindDatasetListByDacIdsEmptyList() {
     List<Integer> emptyList = Collections.emptyList();
-    assertThrows(BadRequestException.class,
-        () -> datasetService.findDatasetListByDacIds(emptyList));
+    assertThrows(
+        BadRequestException.class, () -> datasetService.findDatasetListByDacIds(emptyList));
   }
 
   @Test
@@ -121,8 +125,7 @@ class DatasetServiceTest extends AbstractTestHelper {
 
   @Test
   void testFindStudyNames() {
-    when(datasetDAO.findAllStudyNames())
-        .thenReturn(Set.of("Hi", "Hello"));
+    when(datasetDAO.findAllStudyNames()).thenReturn(Set.of("Hi", "Hello"));
 
     Set<String> returned = datasetService.findAllStudyNames();
 
@@ -191,19 +194,18 @@ class DatasetServiceTest extends AbstractTestHelper {
     when(datasetDAO.findDatasetById(any())).thenReturn(new Dataset());
     User u = new User();
     Stream.of(
-        UserRoles.CHAIRPERSON,
-        UserRoles.MEMBER,
-        UserRoles.RESEARCHER,
-        UserRoles.SIGNINGOFFICIAL,
-        UserRoles.DATASUBMITTER,
-        UserRoles.ITDIRECTOR,
-        UserRoles.ALUMNI
-    ).forEach(r -> u.addRole(new UserRole(r.getRoleId(), r.getRoleName())));
+            UserRoles.CHAIRPERSON,
+            UserRoles.MEMBER,
+            UserRoles.RESEARCHER,
+            UserRoles.SIGNINGOFFICIAL,
+            UserRoles.DATASUBMITTER,
+            UserRoles.ITDIRECTOR,
+            UserRoles.ALUMNI)
+        .forEach(r -> u.addRole(new UserRole(r.getRoleId(), r.getRoleName())));
     DataUse dataUse = new DataUseBuilder().setGeneralUse(true).build();
     try {
       datasetService.updateDatasetDataUse(u, 1, dataUse);
-      fail(
-          "Should have thrown an exception on datasetService.updateDatasetDataUse()");
+      fail("Should have thrown an exception on datasetService.updateDatasetDataUse()");
     } catch (IllegalArgumentException e) {
       assertTrue(true);
     }
@@ -230,11 +232,7 @@ class DatasetServiceTest extends AbstractTestHelper {
     assertEquals(dataset.getUpdateUserId(), datasetResult.getUpdateUserId());
     assertEquals(dataset.getDacApproval(), datasetResult.getDacApproval());
     assertEquals(dataset.getUpdateDate(), datasetResult.getUpdateDate());
-    verify(emailService, times(0)).sendDatasetApprovedMessage(
-        any(),
-        any(),
-        any()
-    );
+    verify(emailService, times(0)).sendDatasetApprovedMessage(any(), any(), any());
   }
 
   @Test
@@ -243,8 +241,8 @@ class DatasetServiceTest extends AbstractTestHelper {
     User user = new User();
     dataset.setDacApproval(true);
 
-    assertThrows(IllegalArgumentException.class,
-        () -> datasetService.approveDataset(dataset, user, false));
+    assertThrows(
+        IllegalArgumentException.class, () -> datasetService.approveDataset(dataset, user, false));
   }
 
   @Test
@@ -253,8 +251,8 @@ class DatasetServiceTest extends AbstractTestHelper {
     User user = new User();
     dataset.setDacApproval(true);
 
-    assertThrows(IllegalArgumentException.class,
-        () -> datasetService.approveDataset(dataset, user, null));
+    assertThrows(
+        IllegalArgumentException.class, () -> datasetService.approveDataset(dataset, user, null));
   }
 
   @Test
@@ -270,7 +268,8 @@ class DatasetServiceTest extends AbstractTestHelper {
     updatedDataset.setDatasetId(1);
     updatedDataset.setDacApproval(payloadBool);
 
-    when(datasetDAO.findDatasetWithoutFSOInformation(dataset.getDatasetId())).thenReturn(updatedDataset);
+    when(datasetDAO.findDatasetWithoutFSOInformation(dataset.getDatasetId()))
+        .thenReturn(updatedDataset);
     dataset.setAlias(1);
     dataset.setDacId(3);
     Dac dac = new Dac();
@@ -282,11 +281,7 @@ class DatasetServiceTest extends AbstractTestHelper {
     assertTrue(returnedDataset.getDacApproval());
 
     // send approved email
-    verify(emailService, times(1)).sendDatasetApprovedMessage(
-        user,
-        "DAC NAME",
-        "DUOS-000001"
-    );
+    verify(emailService, times(1)).sendDatasetApprovedMessage(user, "DAC NAME", "DUOS-000001");
   }
 
   @Test
@@ -302,7 +297,8 @@ class DatasetServiceTest extends AbstractTestHelper {
     updatedDataset.setDatasetId(1);
     updatedDataset.setDacApproval(payloadBool);
 
-    when(datasetDAO.findDatasetWithoutFSOInformation(dataset.getDatasetId())).thenReturn(updatedDataset);
+    when(datasetDAO.findDatasetWithoutFSOInformation(dataset.getDatasetId()))
+        .thenReturn(updatedDataset);
     dataset.setAlias(1);
     dataset.setDacId(3);
     Dac dac = new Dac();
@@ -315,12 +311,8 @@ class DatasetServiceTest extends AbstractTestHelper {
     assertFalse(returnedDataset.getDacApproval());
 
     // send denied email
-    verify(emailService, times(1)).sendDatasetDeniedMessage(
-        user,
-        "DAC NAME",
-        "DUOS-000001",
-        "dacEmail@gmail.com"
-    );
+    verify(emailService, times(1))
+        .sendDatasetDeniedMessage(user, "DAC NAME", "DUOS-000001", "dacEmail@gmail.com");
   }
 
   @Test
@@ -336,7 +328,8 @@ class DatasetServiceTest extends AbstractTestHelper {
     updatedDataset.setDatasetId(1);
     updatedDataset.setDacApproval(payloadBool);
 
-    when(datasetDAO.findDatasetWithoutFSOInformation(dataset.getDatasetId())).thenReturn(updatedDataset);
+    when(datasetDAO.findDatasetWithoutFSOInformation(dataset.getDatasetId()))
+        .thenReturn(updatedDataset);
     dataset.setAlias(1);
     dataset.setDacId(3);
     Dac dac = new Dac();
@@ -348,13 +341,7 @@ class DatasetServiceTest extends AbstractTestHelper {
     assertFalse(returnedDataset.getDacApproval());
 
     // do not send denied email
-    verify(emailService, times(0)).sendDatasetDeniedMessage(
-        user,
-        "DAC NAME",
-        "DUOS-000001",
-        ""
-    );
-
+    verify(emailService, times(0)).sendDatasetDeniedMessage(user, "DAC NAME", "DUOS-000001", "");
   }
 
   @Test
@@ -363,7 +350,8 @@ class DatasetServiceTest extends AbstractTestHelper {
     ds.setDataUse(new DataUseBuilder().setGeneralUse(true).build());
 
     when(datasetDAO.findDatasetById(1)).thenReturn(ds);
-    String translation = """
+    String translation =
+        """
         Samples are restricted for use under the following conditions:
         Data is limited for health/medical/biomedical research. [HMB]
         Data use is limited for studying: cancerophobia [DS]
@@ -371,8 +359,8 @@ class DatasetServiceTest extends AbstractTestHelper {
         Data use for methods development research irrespective of the specified data use limitations is not prohibited.
         Restrictions for use as a control set for diseases other than those defined were not specified.
         """;
-    when(ontologyService.translateDataUse(ds.getDataUse(),
-        DataUseTranslationType.DATASET)).thenReturn(translation);
+    when(ontologyService.translateDataUse(ds.getDataUse(), DataUseTranslationType.DATASET))
+        .thenReturn(translation);
 
     datasetService.syncDatasetDataUseTranslation(1, mockUser);
 
@@ -382,8 +370,8 @@ class DatasetServiceTest extends AbstractTestHelper {
   @Test
   void testSyncDataUseTranslationNotFound() {
     when(datasetDAO.findDatasetById(1)).thenReturn(null);
-    assertThrows(NotFoundException.class,
-        () -> datasetService.syncDatasetDataUseTranslation(1, mockUser));
+    assertThrows(
+        NotFoundException.class, () -> datasetService.syncDatasetDataUseTranslation(1, mockUser));
   }
 
   @Test
@@ -395,7 +383,8 @@ class DatasetServiceTest extends AbstractTestHelper {
   @Test
   void testGetStudyWithDatasetsByIdNFE() {
     when(studyDAO.findStudyById(anyInt())).thenReturn(null);
-    assertThrows(NotFoundException.class, () -> datasetService.getStudyWithDatasetsById(mockUser, 1));
+    assertThrows(
+        NotFoundException.class, () -> datasetService.getStudyWithDatasetsById(mockUser, 1));
   }
 
   @Test
@@ -406,8 +395,8 @@ class DatasetServiceTest extends AbstractTestHelper {
 
   @Test
   void testGetApprovedDatasets() {
-    User user = new User(1, "test@domain.com", "Test User", new Date(),
-        List.of(UserRoles.Researcher()));
+    User user =
+        new User(1, "test@domain.com", "Test User", new Date(), List.of(UserRoles.Researcher()));
     ApprovedDataset example =
         new ApprovedDataset(
             1,
@@ -456,18 +445,20 @@ class DatasetServiceTest extends AbstractTestHelper {
 
   @Test
   void testEnforceDAARestrictions() {
-    final User user = new User(1, "test@domain.com", "Test User", new Date(),
-        List.of(UserRoles.Researcher()));
+    final User user =
+        new User(1, "test@domain.com", "Test User", new Date(), List.of(UserRoles.Researcher()));
     when(daaDAO.findDaaDatasetIdsByUserId(any())).thenReturn(List.of(1, 2, 3));
 
     assertDoesNotThrow(() -> datasetService.enforceDAARestrictions(user, List.of(1)));
     assertDoesNotThrow(() -> datasetService.enforceDAARestrictions(user, List.of(1, 2)));
     assertDoesNotThrow(() -> datasetService.enforceDAARestrictions(user, List.of(1, 2, 3)));
     List<Integer> firstExpectedList = List.of(1, 2, 3, 4);
-    assertThrows(BadRequestException.class,
+    assertThrows(
+        BadRequestException.class,
         () -> datasetService.enforceDAARestrictions(user, firstExpectedList));
     List<Integer> secondExpectedList = List.of(2, 3, 4, 5);
-    assertThrows(BadRequestException.class,
+    assertThrows(
+        BadRequestException.class,
         () -> datasetService.enforceDAARestrictions(user, secondExpectedList));
   }
 
@@ -653,16 +644,31 @@ class DatasetServiceTest extends AbstractTestHelper {
     assertTrue(isCustodian);
   }
 
+  @Test
+  void testIsAuthorizedToListUsers() {
+    when(datasetAuthorizationReaderDAO.findAuthorizedReadersByDatasetIdAndUserId(anyLong(), anyLong())).thenReturn(new DatasetAuthorizationReader(1, 1, 1, 1, Timestamp.from(Instant.now())));
+    assertTrue(datasetService.isAuthorizedToListUsers(1, 1));
+  }
+
+  @Test
+  void testIsAuthorizedToListUsersNotFound() {
+    when(datasetAuthorizationReaderDAO.findAuthorizedReadersByDatasetIdAndUserId(anyLong(), anyLong())).thenReturn(null);
+    assertFalse(datasetService.isAuthorizedToListUsers(1, 1));
+  }
+
+
   /* Helper functions */
 
   private List<Dataset> getDatasets() {
     return IntStream.range(1, 3)
-        .mapToObj(i -> {
-          Dataset dataset = new Dataset();
-          dataset.setDatasetId(i);
-          dataset.setName("Test Dataset " + i);
-          dataset.setProperties(Collections.emptySet());
-          return dataset;
-        }).toList();
+        .mapToObj(
+            i -> {
+              Dataset dataset = new Dataset();
+              dataset.setDatasetId(i);
+              dataset.setName("Test Dataset " + i);
+              dataset.setProperties(Collections.emptySet());
+              return dataset;
+            })
+        .toList();
   }
 }

--- a/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
@@ -656,6 +656,24 @@ class DatasetServiceTest extends AbstractTestHelper {
     assertFalse(datasetService.isAuthorizedToListUsers(1, 1));
   }
 
+  @Test
+  void testAddAuthorizedReader() {
+    DatasetAuthorizationReader dauthr =
+        new DatasetAuthorizationReader(1, 1, 1, 1, Timestamp.from(Instant.now()));
+    when(datasetAuthorizationReaderDAO.addAuthorizedReaderToDataset(anyInt(), anyInt(), anyInt()))
+        .thenReturn(dauthr.id());
+    when(datasetAuthorizationReaderDAO.findAuthorizedReaderByRecordId(anyLong()))
+        .thenReturn(dauthr);
+    DatasetAuthorizationReader response = datasetService.addAuthorizedReader(1, 1, 1);
+    assertNotNull(response);
+    assertEquals(dauthr, response);
+  }
+
+  @Test
+  void testRemoveAuthorizedAccessReader() {
+    doNothing().when(datasetAuthorizationReaderDAO).deleteByDatasetAndUserId(anyLong(), anyLong());
+    datasetAuthorizationReaderDAO.deleteByDatasetAndUserId(1, 1);
+  }
 
   /* Helper functions */
 

--- a/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
@@ -672,7 +672,7 @@ class DatasetServiceTest extends AbstractTestHelper {
   @Test
   void testRemoveAuthorizedAccessReader() {
     doNothing().when(datasetAuthorizationReaderDAO).deleteByDatasetAndUserId(anyLong(), anyLong());
-    datasetAuthorizationReaderDAO.deleteByDatasetAndUserId(1, 1);
+    assertDoesNotThrow(() -> datasetAuthorizationReaderDAO.deleteByDatasetAndUserId(1, 1));
   }
 
   /* Helper functions */

--- a/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
@@ -38,6 +38,7 @@ import org.broadinstitute.consent.http.AbstractTestHelper;
 import org.broadinstitute.consent.http.db.AcknowledgementDAO;
 import org.broadinstitute.consent.http.db.DACAutomationRuleDAO;
 import org.broadinstitute.consent.http.db.DaaDAO;
+import org.broadinstitute.consent.http.db.DatasetAuthorizationReaderDAO;
 import org.broadinstitute.consent.http.db.FileStorageObjectDAO;
 import org.broadinstitute.consent.http.db.InstitutionDAO;
 import org.broadinstitute.consent.http.db.LibraryCardDAO;
@@ -116,6 +117,8 @@ class UserServiceTest extends AbstractTestHelper {
   private InstitutionService institutionService;
   @Mock
   private DACAutomationRuleDAO ruleDAO;
+  @Mock
+  private DatasetAuthorizationReaderDAO datasetAuthorizationReaderDAO;
 
 
   private UserService service;
@@ -124,7 +127,7 @@ class UserServiceTest extends AbstractTestHelper {
   void initService() {
     service = new UserService(userDAO, userPropertyDAO, userRoleDAO, voteDAO, institutionDAO,
         libraryCardDAO, acknowledgementDAO, fileStorageObjectDAO, samDAO, userServiceDAO, daaDAO,
-        draftServiceDAO, institutionService, ruleDAO);
+        draftServiceDAO, institutionService, ruleDAO, datasetAuthorizationReaderDAO);
   }
 
   @Test
@@ -457,6 +460,7 @@ class UserServiceTest extends AbstractTestHelper {
       service.deleteUserByEmail(randomAlphabetic(10), randomInt(1,100));
       verify(draftServiceDAO).deleteDraftsByUser(u);
       verify(ruleDAO, atLeastOnce()).auditedDeleteAllDACRuleSettingForUser(anyInt(), anyInt());
+      verify(datasetAuthorizationReaderDAO, atLeastOnce()).deleteByUserId(u.getUserId());
     } catch (Exception e) {
       fail("Should not fail: " + e.getMessage());
     }

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAOTest.java
@@ -47,7 +47,7 @@ class DatasetServiceDAOTest extends DAOTestHelper {
 
   @BeforeEach
   public void setUp() {
-    serviceDAO = new DatasetServiceDAO(jdbi, datasetDAO, studyDAO);
+    serviceDAO = new DatasetServiceDAO(jdbi, datasetDAO, studyDAO, datasetAuthorizationReaderDAO);
   }
 
   @Test


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-2115](https://broadworkbench.atlassian.net/browse/DT-2115)

### Summary

This proof of concept adds a new table to hold the list of authorized access checkers for each individual dataset so that we can allow "SERVICE ACCOUNT" users to check to see which users are authorized for a given dataset.  The code adds new endpoints to facilitate adding and removing authorizations along with an endpoint to invoke the same business logic authorization check as performed by our TDRResource.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
