### PR TITLE
[DT-2116] Remove ERA commons registration

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/resources/NihAccountResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/NihAccountResource.java
@@ -3,19 +3,14 @@ package org.broadinstitute.consent.http.resources;
 import com.google.inject.Inject;
 import io.dropwizard.auth.Auth;
 import jakarta.annotation.security.PermitAll;
-import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
-import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
-import java.util.List;
 import org.broadinstitute.consent.http.models.DuosUser;
-import org.broadinstitute.consent.http.models.NIHUserAccount;
 import org.broadinstitute.consent.http.models.User;
-import org.broadinstitute.consent.http.models.UserProperty;
 import org.broadinstitute.consent.http.service.NihService;
 
 @Path("api/nih")
@@ -36,22 +31,6 @@ public class NihAccountResource extends Resource {
     try {
       User user = nihService.syncAccount(duosUser);
       return Response.ok(user).build();
-    } catch (Exception e) {
-      return createExceptionResponse(e);
-    }
-  }
-
-  @POST
-  @Produces(MediaType.APPLICATION_JSON)
-  @Consumes(MediaType.APPLICATION_JSON)
-  @PermitAll
-  public Response registerResearcher(@Auth DuosUser duosUser, NIHUserAccount nihAccount) {
-    try {
-      nihService.validateNihUserAccount(nihAccount, duosUser);
-      User user = duosUser.getUser();
-      List<UserProperty> authUserProps = nihService.authenticateNih(nihAccount, duosUser,
-          user.getUserId());
-      return Response.ok(authUserProps).build();
     } catch (Exception e) {
       return createExceptionResponse(e);
     }

--- a/src/main/java/org/broadinstitute/consent/http/service/NihService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/NihService.java
@@ -5,24 +5,16 @@ import com.google.api.client.http.HttpRequest;
 import com.google.api.client.http.HttpResponse;
 import com.google.api.client.http.HttpStatusCodes;
 import com.google.inject.Inject;
-import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.ServerErrorException;
 import java.time.Instant;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.List;
-import java.util.Objects;
-import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.consent.http.configurations.ServicesConfiguration;
 import org.broadinstitute.consent.http.db.UserDAO;
 import org.broadinstitute.consent.http.db.UserPropertyDAO;
 import org.broadinstitute.consent.http.enumeration.UserFields;
-import org.broadinstitute.consent.http.models.AuthUser;
 import org.broadinstitute.consent.http.models.DuosUser;
 import org.broadinstitute.consent.http.models.NIHUserAccount;
 import org.broadinstitute.consent.http.models.User;
-import org.broadinstitute.consent.http.models.UserProperty;
 import org.broadinstitute.consent.http.models.ecm.LinkInfo;
 import org.broadinstitute.consent.http.service.dao.NihServiceDAO;
 import org.broadinstitute.consent.http.util.ConsentLogger;
@@ -65,38 +57,6 @@ public class NihService implements ConsentLogger {
     return userDAO.findUserWithPropertiesById(user.getUserId(), UserFields.getValues());
   }
 
-  public void validateNihUserAccount(NIHUserAccount nihAccount, AuthUser authUser)
-      throws BadRequestException {
-    if (Objects.isNull(nihAccount) || Objects.isNull(nihAccount.getEraExpiration())) {
-      logWarn("Invalid NIH Account for user: " + authUser.getEmail());
-      throw new BadRequestException("Invalid NIH Authentication for user : " + authUser.getEmail());
-    }
-  }
-
-  public List<UserProperty> authenticateNih(NIHUserAccount nihAccount, AuthUser authUser,
-      Integer userId) throws BadRequestException {
-    // fail fast
-    validateNihUserAccount(nihAccount, authUser);
-    User user = userDAO.findUserById(userId);
-    if (Objects.isNull(user)) {
-      throw new NotFoundException("User not found: " + authUser.getEmail());
-    }
-    if (StringUtils.isNotEmpty(nihAccount.getNihUsername()) && !nihAccount.getNihUsername()
-        .isEmpty()) {
-      nihAccount.setEraExpiration(generateEraExpirationDates());
-      nihAccount.setStatus(true);
-      try {
-        serviceDAO.updateUserNihStatus(user, nihAccount);
-      } catch (IllegalArgumentException e) {
-        logException(e);
-      }
-      return userPropertyDAO.findUserPropertiesByUserIdAndPropertyKeys(userId,
-          UserFields.getValues());
-    } else {
-      throw new BadRequestException("Invalid NIH UserName for user : " + authUser.getEmail());
-    }
-  }
-
   public void deleteNihAccountById(DuosUser duosUser) {
     User user = duosUser.getUser();
     // Delete linkage locally
@@ -122,16 +82,6 @@ public class NihService implements ConsentLogger {
           HttpStatusCodes.STATUS_CODE_SERVER_ERROR, e);
     }
 
-  }
-
-
-  private String generateEraExpirationDates() {
-    Date currentDate = new Date();
-    Calendar c = Calendar.getInstance();
-    c.setTime(currentDate);
-    c.add(Calendar.DATE, 30);
-    Date expires = c.getTime();
-    return String.valueOf(expires.getTime());
   }
 
   private NIHUserAccount parseNihUserAccount(String body) {

--- a/src/main/resources/assets/paths/nih.yaml
+++ b/src/main/resources/assets/paths/nih.yaml
@@ -7,22 +7,3 @@ delete:
   responses:
     200:
       description: Returns an empty response if the operation was successful
-post:
-  deprecated: true
-  summary: Store eRA Commons information
-  description: Save user's eRA Commons account
-  requestBody:
-    description: The eRA Commons account information to be stored
-    required: true
-    content:
-      application/json:
-        schema:
-          $ref: '../schemas/NIHUserAccount.yaml'
-  tags:
-    - User
-    - Nih
-  responses:
-    200:
-      description: Returns eRA Commons Account information.
-    404:
-      description: The user doesn't exist in the system

--- a/src/test/java/org/broadinstitute/consent/http/resources/NihAccountResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/NihAccountResourceTest.java
@@ -1,12 +1,10 @@
 package org.broadinstitute.consent.http.resources;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 
 import com.google.api.client.http.HttpStatusCodes;
-import jakarta.ws.rs.BadRequestException;
 import java.util.Date;
 import java.util.List;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
@@ -53,32 +51,6 @@ class NihAccountResourceTest {
     resource = new NihAccountResource(nihService);
     try (var response = resource.syncAccount(duosUser)) {
       assertEquals(HttpStatusCodes.STATUS_CODE_SERVER_ERROR, response.getStatus());
-    }
-  }
-
-  @Test
-  void testRegisterResearcherSuccess() {
-    resource = new NihAccountResource(nihService);
-    try (var response = resource.registerResearcher(duosUser, nihAccount)) {
-      assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
-    }
-  }
-
-  @Test
-  void testRegisterResearcherError() {
-    doThrow(new RuntimeException()).when(nihService).authenticateNih(any(), any(), any());
-    resource = new NihAccountResource(nihService);
-    try (var response = resource.registerResearcher(duosUser, nihAccount)) {
-      assertEquals(HttpStatusCodes.STATUS_CODE_SERVER_ERROR, response.getStatus());
-    }
-  }
-
-  @Test
-  void testRegisterResearcherNullAccountError() {
-    doThrow(new BadRequestException()).when(nihService).validateNihUserAccount(any(), any());
-    resource = new NihAccountResource(nihService);
-    try (var response = resource.registerResearcher(duosUser,null)) {
-      assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
     }
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/service/NihServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/NihServiceTest.java
@@ -2,7 +2,6 @@ package org.broadinstitute.consent.http.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockserver.model.HttpRequest.request;
@@ -10,12 +9,9 @@ import static org.mockserver.model.HttpResponse.response;
 
 import com.google.api.client.http.HttpStatusCodes;
 import jakarta.ws.rs.BadRequestException;
-import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.ServerErrorException;
 import java.time.Instant;
-import java.util.Collections;
 import java.util.Date;
-import java.util.List;
 import org.broadinstitute.consent.http.MockServerTestHelper;
 import org.broadinstitute.consent.http.configurations.ServicesConfiguration;
 import org.broadinstitute.consent.http.db.UserDAO;
@@ -25,7 +21,6 @@ import org.broadinstitute.consent.http.models.AuthUser;
 import org.broadinstitute.consent.http.models.DuosUser;
 import org.broadinstitute.consent.http.models.NIHUserAccount;
 import org.broadinstitute.consent.http.models.User;
-import org.broadinstitute.consent.http.models.UserProperty;
 import org.broadinstitute.consent.http.models.ecm.LinkInfo;
 import org.broadinstitute.consent.http.service.dao.NihServiceDAO;
 import org.broadinstitute.consent.http.util.HttpClientUtil;
@@ -140,79 +135,6 @@ class NihServiceTest extends MockServerTestHelper {
             .withStatusCode(HttpStatusCodes.STATUS_CODE_NOT_FOUND));
     User syncedUser = service.syncAccount(duosUser);
     assertEquals(user.getUserId(), syncedUser.getUserId());
-    verify(nihServiceDAO).deleteNihAccountById(user.getUserId());
-  }
-
-  @Test
-  void testAuthenticateNih_InvalidUser() {
-    AuthUser testUser = new AuthUser("test@test.com");
-    assertThrows(NotFoundException.class,
-        () -> service.authenticateNih(nihUserAccount, testUser, 1));
-  }
-
-  @Test
-  void testAuthenticateNih() {
-    List<UserProperty> props = Collections.singletonList(new UserProperty(1, 1, "test", "value"));
-    when(userPropertyDAO.findUserPropertiesByUserIdAndPropertyKeys(any(), any())).thenReturn(props);
-    User user = new User();
-    user.setUserId(1);
-    when(userDAO.findUserById(any())).thenReturn(user);
-    try {
-      List<UserProperty> properties = service.authenticateNih(nihUserAccount, authUser,
-          user.getUserId());
-      assertEquals(1, properties.size());
-      assertEquals(Integer.valueOf(1), properties.get(0).getPropertyId());
-      verify(nihServiceDAO).updateUserNihStatus(user, nihUserAccount);
-    } catch (BadRequestException bre) {
-      assert false;
-    }
-  }
-
-  @Test
-  void testAuthenticateNih_BadRequest() {
-    User user = new User();
-    user.setUserId(1);
-    when(userDAO.findUserById(any())).thenReturn(user);
-    nihUserAccount.setNihUsername("");
-    assertThrows(BadRequestException.class,
-        () -> service.authenticateNih(nihUserAccount, authUser, 1));
-  }
-
-  @Test
-  void testAuthenticateNih_BadRequestNullAccount() {
-    assertThrows(BadRequestException.class, () -> service.authenticateNih(null, authUser, 1));
-  }
-
-  @Test
-  void testAuthenticateNih_BadRequestNullAccountExpiration() {
-    NIHUserAccount account = new NIHUserAccount();
-    account.setStatus(true);
-    assertThrows(BadRequestException.class, () -> service.authenticateNih(account, authUser, 1));
-  }
-
-  @Test
-  void testDeleteNihAccountByIdECMSuccess() {
-    User user = new User();
-    user.setUserId(1);
-    when(duosUser.getUser()).thenReturn(user);
-    mockServerClient.when(request())
-        .respond(response()
-            .withStatusCode(HttpStatusCodes.STATUS_CODE_OK));
-    service.deleteNihAccountById(duosUser);
-    verify(nihServiceDAO).deleteNihAccountById(user.getUserId());
-  }
-
-  @Test
-  void testDeleteNihAccountByIdECMNotFound() {
-    User user = new User();
-    user.setUserId(1);
-    user.setEmail("email");
-    when(duosUser.getUser()).thenReturn(user);
-    when(duosUser.getAuthToken()).thenReturn("Token");
-    mockServerClient.when(request())
-        .respond(response()
-            .withStatusCode(HttpStatusCodes.STATUS_CODE_NOT_FOUND));
-    service.deleteNihAccountById(duosUser);
     verify(nihServiceDAO).deleteNihAccountById(user.getUserId());
   }
 }


### PR DESCRIPTION
> [!WARNING]
> DO NOT MERGE UNTIL 2025-10-02.

### Addresses

https://broadworkbench.atlassian.net/browse/DT-2116

### Summary

Cleans up `NihAccountResource.registerResearcher` and associated methods.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
