### PR TITLE
DT-2207: Ensure that email to admins show DACs and Dataset identifiers

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/UserDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/UserDAO.java
@@ -257,22 +257,28 @@ public interface UserDAO extends Transactional<UserDAO> {
   List<User> findUsersWithLCsAndInstitution();
 
   @UseRowMapper(UserWithRolesMapper.class)
-  @SqlQuery("select du.*, r.role_id, r.name, ur.user_role_id, ur.user_id, ur.role_id, ur.dac_id from users du inner join user_role ur on ur.user_id = du.user_id inner join roles r on r.role_id = ur.role_id where r.name = :roleName and du.email_preference = :emailPreference")
-  List<User> describeUsersByRoleAndEmailPreference(@Bind("roleName") String roleName,
-      @Bind("emailPreference") Boolean emailPreference);
+  @SqlQuery("""
+      SELECT u.*, r.role_id, r.name, ur.user_role_id, ur.user_id, ur.role_id, ur.dac_id
+      FROM users u
+      INNER JOIN user_role ur ON ur.user_id = u.user_id AND ur.role_id = :roleId
+      INNER JOIN roles r ON r.role_id = ur.role_id
+    """)
+  List<User> findUsersByRoleId(@Bind("roleId") Integer roleId);
 
   @UseRowMapper(UserWithRolesMapper.class)
-  @SqlQuery("select du.*, r.role_id, r.name, ur.user_role_id, ur.user_id, ur.role_id, ur.dac_id " +
-      " from users du " +
-      " inner join user_role ur on ur.user_id = du.user_id " +
-      " inner join roles r on r.role_id = ur.role_id and r.name in (<roleNames>) " +
-      " inner join dac d on d.dac_id = ur.dac_id " +
-      " inner join dataset ds on ds.dac_id = d.dac_id " +
-      " where ds.dataset_id in (<datasetIds>) "
+  @SqlQuery("""
+      SELECT u.*, r.role_id, r.name, ur.user_role_id, ur.user_id, ur.role_id, ur.dac_id
+      FROM users u
+      INNER JOIN user_role ur ON ur.user_id = u.user_id AND ur.role_id in (<roleIds>)
+      INNER JOIN roles r on r.role_id = ur.role_id
+      INNER JOIN dac d ON d.dac_id = ur.dac_id
+      INNER JOIN dataset ds ON ds.dac_id = d.dac_id
+      WHERE ds.dataset_id in (<datasetIds>)
+    """
   )
   Set<User> findUsersForDatasetsByRole(
       @BindList(value = "datasetIds", onEmpty = EmptyHandling.NULL_STRING) List<Integer> datasetIds,
-      @BindList(value = "roleNames", onEmpty = EmptyHandling.NULL_STRING) List<String> roleNames);
+      @BindList(value = "roleIds", onEmpty = EmptyHandling.NULL_STRING) List<Integer> roleIds);
 
   @RegisterBeanMapper(value = User.class)
   @RegisterBeanMapper(value = UserRole.class)

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/NewDARRequestMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/NewDARRequestMessage.java
@@ -10,14 +10,14 @@ public class NewDARRequestMessage extends MailMessage {
   private static final String NEW_DAR_REQUEST = "Create an election for Data Access Request id: %s.";
 
   private final String darCode;
-  private final Map<String, List<String>> sendList;
+  private final Map<String, List<String>> dacDatasetMap;
   private final String researcherName;
 
-  public NewDARRequestMessage(User toUser, String darCode, Map<String, List<String>> sendList,
+  public NewDARRequestMessage(User toUser, String darCode, Map<String, List<String>> dacDatasetMap,
       String researcherName) {
     super(toUser, EmailType.NEW_DAR);
     this.darCode = darCode;
-    this.sendList = sendList;
+    this.dacDatasetMap = dacDatasetMap;
     this.researcherName = researcherName;
   }
 
@@ -32,7 +32,7 @@ public class NewDARRequestMessage extends MailMessage {
     return Map.of(
         "serverUrl", serverUrl,
         "userName", toUser.getDisplayName(),
-        "dacDatasetGroups", sendList,
+        "dacDatasetGroups", dacDatasetMap,
         "researcherUserName", researcherName,
         "darID", darCode);
   }

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/NewProgressReportRequestMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/NewProgressReportRequestMessage.java
@@ -10,17 +10,17 @@ public class NewProgressReportRequestMessage extends MailMessage {
   private static final String NEW_PROGRESS_REPORT_REQUEST = "Create an election for Progress Report id: %s.";
 
   private final String darCode;
-  private final Map<String, List<String>> sendList;
+  private final Map<String, List<String>> dacDatasetMap;
   private final String researcherName;
   private final String referenceId;
 
 
-  public NewProgressReportRequestMessage(User toUser, String darCode, String referenceId, Map<String, List<String>> sendList,
+  public NewProgressReportRequestMessage(User toUser, String darCode, String referenceId, Map<String, List<String>> dacDatasetMap,
       String researcherName) {
     super(toUser, EmailType.NEW_PROGRESS_REPORT_REQUEST);
     this.darCode = darCode;
     this.referenceId = referenceId;
-    this.sendList = sendList;
+    this.dacDatasetMap = dacDatasetMap;
     this.researcherName = researcherName;
   }
 
@@ -35,7 +35,7 @@ public class NewProgressReportRequestMessage extends MailMessage {
     return Map.of(
         "serverUrl", serverUrl,
         "userName", toUser.getDisplayName(),
-        "dacDatasetGroups", sendList,
+        "dacDatasetGroups", dacDatasetMap,
         "researcherUserName", researcherName,
         "darID", darCode);
   }

--- a/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
@@ -754,23 +754,21 @@ public class DarCollectionService implements ConsentLogger {
     List<Dataset> datasetsInDAR =
         datasetIds.isEmpty() ? List.of() : datasetDAO.findDatasetsByIdList(datasetIds);
 
-    Map<String, List<String>> sendList = new HashMap<>();
+    Map<String, List<String>> dacDatasetMap = new HashMap<>();
     for (User user : distinctUsers) {
       List<Dac> matchingDacsForUser = getMatchingDacs(user, dacsInDAR);
       for (Dac dac : matchingDacsForUser) {
         List<String> matchingDatasetsForDac = getMatchingDatasets(dac, datasetsInDAR);
-        if (matchingDatasetsForDac != null) {
-          sendList.put(dac.getName(), matchingDatasetsForDac);
-        }
+        dacDatasetMap.put(dac.getName(), matchingDatasetsForDac);
       }
       // If the dar is not a progress report, use the DAR template else use the PR template.
       if (dar.getProgressReport()) {
         // Use the reference ID to link the fact that this progress report will have been noted.
         // the DAR Code at this point will be ambiguous.
-        emailService.sendNewProgressReportRequestEmail(user, sendList, researcherName,
+        emailService.sendNewProgressReportRequestEmail(user, dacDatasetMap, researcherName,
             collection.getDarCode(), dar.getReferenceId());
       } else {
-        emailService.sendNewDARRequestEmail(user, sendList, researcherName,
+        emailService.sendNewDARRequestEmail(user, dacDatasetMap, researcherName,
             collection.getDarCode());
       }
     }
@@ -811,19 +809,19 @@ public class DarCollectionService implements ConsentLogger {
   }
 
   private List<User> getDistinctAdminAndChairUsersForDatasetIds(List<Integer> datasetIds) {
-    List<User> admins = userDAO.describeUsersByRoleAndEmailPreference(UserRoles.ADMIN.getRoleName(),
-        true);
+    List<User> admins = userDAO.findUsersByRoleId(UserRoles.ADMIN.getRoleId());
     Set<User> chairPersons = userDAO.findUsersForDatasetsByRole(datasetIds,
-        Collections.singletonList(UserRoles.CHAIRPERSON.getRoleName()));
+        Collections.singletonList(UserRoles.CHAIRPERSON.getRoleId()));
     // Ensure that admins/chairs are not double emailed
-    // and filter users that don't want to receive email
     return Streams.concat(admins.stream(), chairPersons.stream())
-        .filter(u -> Boolean.TRUE.equals(u.getEmailPreference()))
         .distinct()
         .toList();
   }
 
   private List<Dac> getMatchingDacs(User user, Collection<Dac> dacsInDAR) {
+    if (user.hasUserRole(UserRoles.ADMIN)) {
+      return new ArrayList<>(dacsInDAR);
+    }
     List<Integer> dacIDs = user.getRoles().stream()
         .map(UserRole::getDacId)
         .filter(Objects::nonNull)

--- a/src/main/java/org/broadinstitute/consent/http/service/EmailService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/EmailService.java
@@ -113,6 +113,7 @@ public class EmailService implements ConsentLogger {
     String content = out.toString();
     Mail message = new Mail(new Email(fromAccount), mailMessage.createSubject(),
         new Email(mailMessage.toUser.getEmail()), new Content("text/html", content));
+    // Checks that the user has not disabled email before sending
     Response response = sendGridAPI.sendMessage(message, mailMessage.toUser.getEmail());
     saveEmailAndResponse(
         response,
@@ -249,16 +250,16 @@ public class EmailService implements ConsentLogger {
   }
 
   public void sendNewDARRequestEmail(
-      User user, Map<String, List<String>> sendList, String researcherName, String darCode)
+      User user, Map<String, List<String>> dacDatasetMap, String researcherName, String darCode)
       throws TemplateException, IOException {
-        sendMessage(new NewDARRequestMessage(user, darCode, sendList, researcherName),
+        sendMessage(new NewDARRequestMessage(user, darCode, dacDatasetMap, researcherName),
         user.getUserId());
   }
 
   public void sendNewProgressReportRequestEmail(
-      User user, Map<String, List<String>> sendList, String researcherName, String darCode, String referenceId)
+      User user, Map<String, List<String>> dacDatasetMap, String researcherName, String darCode, String referenceId)
       throws TemplateException, IOException {
-      sendMessage(new NewProgressReportRequestMessage(user, darCode, referenceId, sendList, researcherName),
+      sendMessage(new NewProgressReportRequestMessage(user, darCode, referenceId, dacDatasetMap, researcherName),
         user.getUserId());
   }
 

--- a/src/main/java/org/broadinstitute/consent/http/service/dao/DarCollectionServiceDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/dao/DarCollectionServiceDAO.java
@@ -172,7 +172,7 @@ public class DarCollectionServiceDAO {
     List<User> dacUsers =
         new ArrayList<>(userDAO.findUsersForDatasetsByRole(
             List.of(datasetId),
-            List.of(UserRoles.CHAIRPERSON.getRoleName(), UserRoles.MEMBER.getRoleName())));
+            List.of(UserRoles.CHAIRPERSON.getRoleId(), UserRoles.MEMBER.getRoleId())));
     return dacUsers.isEmpty() ?
         new ArrayList<>(userDAO.findNonDacUsersEnabledToVote()) :
         dacUsers;

--- a/src/test/java/org/broadinstitute/consent/http/db/UserDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/UserDAOTest.java
@@ -17,7 +17,6 @@ import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.broadinstitute.consent.http.enumeration.UserFields;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.Dac;
@@ -258,11 +257,10 @@ class UserDAOTest extends DAOTestHelper {
   }
 
   @Test
-  void testDescribeUsersByRoleAndEmailPreference() {
+  void testFindUsersByRoleId() {
     User researcher = createUser();
     userDAO.updateEmailPreference(researcher.getUserId(), true);
-    Collection<User> researchers = userDAO.describeUsersByRoleAndEmailPreference("Researcher",
-        true);
+    Collection<User> researchers = userDAO.findUsersByRoleId(UserRoles.RESEARCHER.getRoleId());
     assertFalse(researchers.isEmpty());
   }
 
@@ -291,7 +289,7 @@ class UserDAOTest extends DAOTestHelper {
   @Test
   void testUpdateDisplayName() {
     User researcher = createUser();
-    String newName = RandomStringUtils.random(10, true, false);
+    String newName = randomAlphabetic(10);
     userDAO.updateDisplayName(researcher.getUserId(), newName);
     User u1 = userDAO.findUserById(researcher.getUserId());
     assertEquals(newName, u1.getDisplayName());
@@ -314,7 +312,7 @@ class UserDAOTest extends DAOTestHelper {
 
     Set<User> users = userDAO.findUsersForDatasetsByRole(
         Collections.singletonList(dataset.getDatasetId()),
-        Collections.singletonList(UserRoles.CHAIRPERSON.getRoleName()));
+        Collections.singletonList(UserRoles.CHAIRPERSON.getRoleId()));
     Optional<User> foundUser = users.stream().findFirst();
     assertNotNull(users);
     assertFalse(users.isEmpty());
@@ -331,7 +329,7 @@ class UserDAOTest extends DAOTestHelper {
 
     Set<User> users = userDAO.findUsersForDatasetsByRole(
         Collections.singletonList(dataset.getDatasetId()),
-        Collections.singletonList(UserRoles.CHAIRPERSON.getRoleName()));
+        Collections.singletonList(UserRoles.CHAIRPERSON.getRoleId()));
     assertNotNull(users);
     assertTrue(users.isEmpty());
   }
@@ -449,7 +447,7 @@ class UserDAOTest extends DAOTestHelper {
     for (UserRoles role : roles) {
       // ensure that each role exists on user
       assertTrue(found.getRoles().stream().anyMatch(
-          (existingRole) -> (
+          existingRole -> (
               role.getRoleId().equals(existingRole.getRoleId())
                   && role.getRoleName().equals(existingRole.getName()))));
     }
@@ -487,17 +485,17 @@ class UserDAOTest extends DAOTestHelper {
 
   private Dac createDac() {
     Integer id = dacDAO.createDac(
-        "Test_" + RandomStringUtils.random(20, true, true),
-        "Test_" + RandomStringUtils.random(20, true, true),
+        "Test_" + randomAlphanumeric(20),
+        "Test_" + randomAlphanumeric(20),
         new Date());
     return dacDAO.findById(id);
   }
 
   private Dataset createDataset() {
     User user = createUser();
-    String name = "Name_" + RandomStringUtils.random(20, true, true);
+    String name = "Name_" + randomAlphanumeric(20);
     Timestamp now = new Timestamp(new Date().getTime());
-    String objectId = "Object ID_" + RandomStringUtils.random(20, true, true);
+    String objectId = "Object ID_" + randomAlphanumeric(20);
     DataUse dataUse = new DataUseBuilder().setGeneralUse(true).build();
     Integer id = datasetDAO.insertDataset(name, now, user.getUserId(), objectId,
         dataUse.toString(), null);

--- a/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
@@ -1624,7 +1624,7 @@ class DarCollectionServiceTest extends AbstractTestHelper {
         .thenReturn(collection);
     when(userDAO.findUserById(researcher.getUserId())).thenReturn(researcher);
     when(userDAO.findUsersForDatasetsByRole(dar.getDatasetIds(),
-        Collections.singletonList(UserRoles.CHAIRPERSON.getRoleName()))).thenReturn(
+        Collections.singletonList(UserRoles.CHAIRPERSON.getRoleId()))).thenReturn(
         Set.of(chairperson));
     when(dacDAO.findDacsForDatasetIds(dar.getDatasetIds())).thenReturn(Set.of(dac));
     when(datasetDAO.findDatasetsByIdList(dar.getDatasetIds())).thenReturn(List.of(d1, d2));


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-2207

### Summary
Primary fix:
* Populate all DACs and Dataset identifiers when user is an admin in `DarCollectionService`

Other fixes/optimizations:
* Rename confusing variable in email classes: `sendList` -> `dacDatasetMap`
* Update user queries to query on role id instead of role name
* Don't filter on email preference when generating the list of to-users. Email preference is checked just before sending and if we pre-filter users before sending, we miss the opportunity to record that we would have tried to send an email.
* Minor test updates

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
