### PR TITLE
[DT-2252] Fix to return correct user.

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/service/UserService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/UserService.java
@@ -340,13 +340,13 @@ public class UserService implements ConsentLogger {
   /**
    * Convenience method to return a response-friendly json object of the user.
    *
-   * @param authUser The AuthUser. Used to determine if we should return auth user properties
+   * @param duosUser The DuosUser. Used to determine if we should return auth user properties
    * @param userId   The User. This is the user we want to return properties for
    * @return JsonObject.
    */
   public JsonObject findUserWithPropertiesByIdAsJsonObject(DuosUser duosUser, Integer userId) {
     Gson gson = GsonUtil.getInstance();
-    User user = duosUser.getUser();
+    User user = findUserById(userId);
     List<UserProperty> props = findAllUserProperties(user.getUserId());
     JsonObject userJson = gson.toJsonTree(user).getAsJsonObject();
     JsonArray propsJson = gson.toJsonTree(props).getAsJsonArray();

--- a/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
@@ -681,6 +681,7 @@ class UserServiceTest extends AbstractTestHelper {
     DuosUser activeDuosUser = new DuosUser(authUser, user);
     when(userPropertyDAO.findUserPropertiesByUserIdAndPropertyKeys(anyInt(), any())).thenReturn(
         List.of(new UserProperty()));
+    when(userDAO.findUserById(user.getUserId())).thenReturn(user);
 
     JsonObject userJson = service.findUserWithPropertiesByIdAsJsonObject(activeDuosUser,
         user.getUserId());
@@ -702,6 +703,7 @@ class UserServiceTest extends AbstractTestHelper {
     DuosUser activeDuosUser = new DuosUser(authUser, user);
     when(userPropertyDAO.findUserPropertiesByUserIdAndPropertyKeys(anyInt(), any())).thenReturn(
         List.of(new UserProperty()));
+    when(userDAO.findUserById(user.getUserId())).thenReturn(user);
 
     JsonObject userJson = service.findUserWithPropertiesByIdAsJsonObject(activeDuosUser,
         user.getUserId());


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-2252](https://broadworkbench.atlassian.net/browse/DT-2252)

### Summary

findUserWithPropertiesByIdAsJsonObject was returning the current user, not the user the request was regarding.  This change restores the correct behavior.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
