### PR TITLE
DT-2258: Improve query by alias performance

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
@@ -47,7 +47,7 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
   String CHAIRPERSON = Resource.CHAIRPERSON;
 
   /**
-   * Find a for Dataset Approval by id.
+   * Find a Dataset by id.
    * @param datasetId The dataset id
    * @return Dataset
    */
@@ -86,6 +86,30 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
       WHERE d.dataset_id = :datasetId
       """)
   Dataset findDatasetWithoutFSOInformation(@Bind("datasetId") Integer datasetId);
+
+  /**
+   * Find a minimal version of a Dataset by alias. This query excludes file and study information
+   * which is often not necessary for many operations.
+   * @param alias The dataset alias
+   * @return Dataset
+   */
+  @UseRowReducer(DatasetReducer.class)
+  @SqlQuery("""
+          SELECT d.dataset_id, d.name, d.create_date, d.create_user_id, d.update_date,
+              d.update_user_id, d.object_id, d.dac_id, d.alias, d.data_use, d.translated_data_use,
+              d.dac_approval, d.study_id, d.indexed_date,
+              u.user_id AS u_user_id, u.email AS u_email, u.display_name AS u_display_name,
+              u.create_date AS u_create_date, u.email_preference AS u_email_preference,
+              u.institution_id AS u_institution_id, u.era_commons_id AS u_era_commons_id,
+              k.key, dp.property_value, dp.property_key, dp.property_type, dp.schema_property,
+              dp.property_id
+      FROM dataset d
+      LEFT JOIN users u on d.create_user_id = u.user_id
+      LEFT JOIN dataset_property dp ON dp.dataset_id = d.dataset_id
+      LEFT JOIN dictionary k ON k.key_id = dp.property_key
+      WHERE d.alias = :alias
+      """)
+  Dataset findMinimalDatasetByAlias(@Bind("alias") Integer alias);
 
   @UseRowMapper(DatasetStudySummaryMapper.class)
   @SqlQuery("""

--- a/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
@@ -95,14 +95,14 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
    */
   @UseRowReducer(DatasetReducer.class)
   @SqlQuery("""
-          SELECT d.dataset_id, d.name, d.create_date, d.create_user_id, d.update_date,
-              d.update_user_id, d.object_id, d.dac_id, d.alias, d.data_use, d.translated_data_use,
-              d.dac_approval, d.study_id, d.indexed_date,
-              u.user_id AS u_user_id, u.email AS u_email, u.display_name AS u_display_name,
-              u.create_date AS u_create_date, u.email_preference AS u_email_preference,
-              u.institution_id AS u_institution_id, u.era_commons_id AS u_era_commons_id,
-              k.key, dp.property_value, dp.property_key, dp.property_type, dp.schema_property,
-              dp.property_id
+      SELECT d.dataset_id, d.name, d.create_date, d.create_user_id, d.update_date,
+          d.update_user_id, d.object_id, d.dac_id, d.alias, d.data_use, d.translated_data_use,
+          d.dac_approval, d.study_id, d.indexed_date,
+          u.user_id AS u_user_id, u.email AS u_email, u.display_name AS u_display_name,
+          u.create_date AS u_create_date, u.email_preference AS u_email_preference,
+          u.institution_id AS u_institution_id, u.era_commons_id AS u_era_commons_id,
+          k.key, dp.property_value, dp.property_key, dp.property_type, dp.schema_property,
+          dp.property_id
       FROM dataset d
       LEFT JOIN users u on d.create_user_id = u.user_id
       LEFT JOIN dataset_property dp ON dp.dataset_id = d.dataset_id

--- a/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
@@ -560,7 +560,7 @@ public class DatasetResource extends Resource {
   @Path("/{identifier}/approvedUsers")
   public Response getApprovedUsers(@Auth DuosUser duosUser, @PathParam("identifier") String datasetIdentifier) {
     try {
-      Dataset dataset = datasetService.findMinimalDatasetByIdentifier(duosUser.getUser(), datasetIdentifier);
+      Dataset dataset = datasetService.findMinimalDatasetByIdentifier(duosUser.getUser(), datasetIdentifier, false);
       if (Objects.isNull(dataset)) {
         return Response.status(Response.Status.NOT_FOUND).build();
       }

--- a/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
@@ -560,7 +560,7 @@ public class DatasetResource extends Resource {
   @Path("/{identifier}/approvedUsers")
   public Response getApprovedUsers(@Auth DuosUser duosUser, @PathParam("identifier") String datasetIdentifier) {
     try {
-      Dataset dataset = datasetService.findDatasetByIdentifier(duosUser.getUser(), datasetIdentifier);
+      Dataset dataset = datasetService.findMinimalDatasetByIdentifier(duosUser.getUser(), datasetIdentifier);
       if (Objects.isNull(dataset)) {
         return Response.status(Response.Status.NOT_FOUND).build();
       }

--- a/src/main/java/org/broadinstitute/consent/http/resources/TDRResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/TDRResource.java
@@ -40,7 +40,7 @@ public class TDRResource extends Resource {
   public Response getApprovedUsers(@Auth DuosUser duosUser,
       @PathParam("identifier") String identifier) {
     try {
-      Dataset dataset = datasetService.findMinimalDatasetByIdentifier(duosUser.getUser(), identifier);
+      Dataset dataset = datasetService.findMinimalDatasetByIdentifier(duosUser.getUser(), identifier, false);
       if (Objects.isNull(dataset)) {
         throw new NotFoundException("Could not find dataset " + identifier);
       }
@@ -60,7 +60,7 @@ public class TDRResource extends Resource {
   public Response getDatasetByIdentifier(@Auth DuosUser duosUser,
       @PathParam("identifier") String identifier) {
     try {
-      Dataset dataset = datasetService.findMinimalDatasetByIdentifier(duosUser.getUser(), identifier);
+      Dataset dataset = datasetService.findMinimalDatasetByIdentifier(duosUser.getUser(), identifier, true);
       if (Objects.isNull(dataset)) {
         throw new NotFoundException("Could not find dataset " + identifier);
       }

--- a/src/main/java/org/broadinstitute/consent/http/resources/TDRResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/TDRResource.java
@@ -40,7 +40,7 @@ public class TDRResource extends Resource {
   public Response getApprovedUsers(@Auth DuosUser duosUser,
       @PathParam("identifier") String identifier) {
     try {
-      Dataset dataset = datasetService.findDatasetByIdentifier(duosUser.getUser(), identifier);
+      Dataset dataset = datasetService.findMinimalDatasetByIdentifier(duosUser.getUser(), identifier);
       if (Objects.isNull(dataset)) {
         throw new NotFoundException("Could not find dataset " + identifier);
       }
@@ -60,7 +60,7 @@ public class TDRResource extends Resource {
   public Response getDatasetByIdentifier(@Auth DuosUser duosUser,
       @PathParam("identifier") String identifier) {
     try {
-      Dataset dataset = datasetService.findDatasetByIdentifier(duosUser.getUser(), identifier);
+      Dataset dataset = datasetService.findMinimalDatasetByIdentifier(duosUser.getUser(), identifier);
       if (Objects.isNull(dataset)) {
         throw new NotFoundException("Could not find dataset " + identifier);
       }

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -113,6 +113,29 @@ public class DatasetService implements ConsentLogger {
     return verifyPublicVisibilityAccess(d, user);
   }
 
+  /**
+   * Finds a minimal version of a Dataset by a formatted dataset identifier.
+   *
+   * @param datasetIdentifier The formatted identifier, e.g. DUOS-123456
+   * @return the Dataset with the given identifier, if found.
+   * @throws IllegalArgumentException if datasetIdentifier is invalid
+   */
+  public Dataset findMinimalDatasetByIdentifier(User user, String datasetIdentifier)
+      throws IllegalArgumentException {
+    Integer alias = Dataset.parseIdentifierToAlias(datasetIdentifier);
+    Dataset d = datasetDAO.findMinimalDatasetByAlias(alias);
+    if (d == null) {
+      throw new NotFoundException("Dataset not found");
+    }
+    // technically, it is possible to have two dataset identifiers which
+    // have the same alias but are not the same: e.g., DUOS-5 and DUOS-00005
+    if (!Objects.equals(d.getDatasetIdentifier(), datasetIdentifier)) {
+      return null;
+    }
+    // Verification will populate study if necessary.
+    return verifyPublicVisibilityAccess(d, user);
+  }
+
   protected Dataset verifyPublicVisibilityAccess(Dataset dataset, User user) {
     // Admins
     if (user.hasUserRole(UserRoles.ADMIN)) {

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -117,10 +117,11 @@ public class DatasetService implements ConsentLogger {
    * Finds a minimal version of a Dataset by a formatted dataset identifier.
    *
    * @param datasetIdentifier The formatted identifier, e.g. DUOS-123456
+   * @param populateStudy Whether to populate the study object in the returned dataset
    * @return the Dataset with the given identifier, if found.
    * @throws IllegalArgumentException if datasetIdentifier is invalid
    */
-  public Dataset findMinimalDatasetByIdentifier(User user, String datasetIdentifier)
+  public Dataset findMinimalDatasetByIdentifier(User user, String datasetIdentifier, boolean populateStudy)
       throws IllegalArgumentException {
     Integer alias = Dataset.parseIdentifierToAlias(datasetIdentifier);
     Dataset d = datasetDAO.findMinimalDatasetByAlias(alias);
@@ -132,7 +133,10 @@ public class DatasetService implements ConsentLogger {
     if (!Objects.equals(d.getDatasetIdentifier(), datasetIdentifier)) {
       return null;
     }
-    // Verification will populate study if necessary.
+    // It is faster to populate the study separately than in a single query with the dataset
+    if (d.getStudyId() != null && populateStudy) {
+      d.setStudy(studyDAO.findStudyById(d.getStudyId()));
+    }
     return verifyPublicVisibilityAccess(d, user);
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
@@ -80,6 +80,30 @@ class DatasetDAOTest extends DAOTestHelper {
   }
 
   @Test
+  void testFindMinimalDatasetByAlias() {
+    // The query under test specifically excludes FSO and study information
+    // and INCLUDES User and Dataset Properties information
+    Dataset dataset = insertDataset();
+    Study study = insertStudyWithProperties();
+    datasetDAO.updateStudyId(dataset.getDatasetId(), study.getStudyId());
+    createFileStorageObject(study.getUuid().toString(),
+        FileCategory.ALTERNATIVE_DATA_SHARING_PLAN);
+    createFileStorageObject(
+        dataset.getDatasetId().toString(),
+        FileCategory.NIH_INSTITUTIONAL_CERTIFICATION
+    );
+    Dataset foundDataset = datasetDAO.findMinimalDatasetByAlias(dataset.getAlias());
+    // Explicitly check queried entities
+    assertNotNull(foundDataset.getProperties());
+    assertEquals(study.getStudyId(), foundDataset.getStudyId());
+    assertEquals(dataset.getCreateUserId(), foundDataset.getCreateUser().getUserId());
+    // Explicitly check un-queried entities
+    assertNull(foundDataset.getNihInstitutionalCertificationFile());
+    assertNull(foundDataset.getStudy());
+    assertNull(foundDataset.getStudy());
+  }
+
+  @Test
   void testFindAllDatasetStudySummariesDatasetAndStudy() {
     Dataset dataset = insertDataset();
     Study study = insertStudyWithProperties();

--- a/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
@@ -1088,7 +1088,7 @@ class DatasetResourceTest extends AbstractTestHelper {
   void testGetApprovedUsers() {
     Dataset dataset = new Dataset();
     dataset.setDatasetId(1);
-    when(datasetService.findDatasetByIdentifier(any(), any())).thenReturn(dataset);
+    when(datasetService.findMinimalDatasetByIdentifier(any(), any())).thenReturn(dataset);
     when(datasetService.isAuthorizedToListUsers(any(), any())).thenReturn(true);
     when(tdrService.getApprovedUsersForDataset(any(), any())).thenReturn(new ApprovedUsers(List.of()));
     Response response = resource.getApprovedUsers(duosUser, "ABC");
@@ -1098,7 +1098,7 @@ class DatasetResourceTest extends AbstractTestHelper {
 
   @Test
   void testGetApprovedUsersDatasetNotFound() {
-    when(datasetService.findDatasetByIdentifier(any(), any())).thenReturn(null);
+    when(datasetService.findMinimalDatasetByIdentifier(any(), any())).thenReturn(null);
     Response response = resource.getApprovedUsers(duosUser, "ABC");
     assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
   }
@@ -1107,7 +1107,7 @@ class DatasetResourceTest extends AbstractTestHelper {
   void testGetAuthorizedUsersNotApproved() {
     Dataset dataset = new Dataset();
     dataset.setDatasetId(1);
-    when(datasetService.findDatasetByIdentifier(any(), any())).thenReturn(dataset);
+    when(datasetService.findMinimalDatasetByIdentifier(any(), any())).thenReturn(dataset);
     when(datasetService.isAuthorizedToListUsers(any(), any())).thenReturn(false);
     Response response = resource.getApprovedUsers(duosUser, "ABC");
     assertEquals(HttpStatusCodes.STATUS_CODE_FORBIDDEN, response.getStatus());
@@ -1116,7 +1116,7 @@ class DatasetResourceTest extends AbstractTestHelper {
   @Test
   void testGetApprovedUsersDatasetThrows() {
     doThrow(new RuntimeException("Some exception"))
-        .when(datasetService).findDatasetByIdentifier(any(), any());
+        .when(datasetService).findMinimalDatasetByIdentifier(any(), any());
     Response response = resource.getApprovedUsers(duosUser, "ABC");
     assertEquals(HttpStatusCodes.STATUS_CODE_SERVER_ERROR, response.getStatus());
   }

--- a/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
@@ -1088,7 +1088,7 @@ class DatasetResourceTest extends AbstractTestHelper {
   void testGetApprovedUsers() {
     Dataset dataset = new Dataset();
     dataset.setDatasetId(1);
-    when(datasetService.findMinimalDatasetByIdentifier(any(), any())).thenReturn(dataset);
+    when(datasetService.findMinimalDatasetByIdentifier(duosUser.getUser(), "ABC", false)).thenReturn(dataset);
     when(datasetService.isAuthorizedToListUsers(any(), any())).thenReturn(true);
     when(tdrService.getApprovedUsersForDataset(any(), any())).thenReturn(new ApprovedUsers(List.of()));
     Response response = resource.getApprovedUsers(duosUser, "ABC");
@@ -1098,7 +1098,7 @@ class DatasetResourceTest extends AbstractTestHelper {
 
   @Test
   void testGetApprovedUsersDatasetNotFound() {
-    when(datasetService.findMinimalDatasetByIdentifier(any(), any())).thenReturn(null);
+    when(datasetService.findMinimalDatasetByIdentifier(duosUser.getUser(), "ABC", false)).thenReturn(null);
     Response response = resource.getApprovedUsers(duosUser, "ABC");
     assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
   }
@@ -1107,7 +1107,7 @@ class DatasetResourceTest extends AbstractTestHelper {
   void testGetAuthorizedUsersNotApproved() {
     Dataset dataset = new Dataset();
     dataset.setDatasetId(1);
-    when(datasetService.findMinimalDatasetByIdentifier(any(), any())).thenReturn(dataset);
+    when(datasetService.findMinimalDatasetByIdentifier(duosUser.getUser(), "ABC", false)).thenReturn(dataset);
     when(datasetService.isAuthorizedToListUsers(any(), any())).thenReturn(false);
     Response response = resource.getApprovedUsers(duosUser, "ABC");
     assertEquals(HttpStatusCodes.STATUS_CODE_FORBIDDEN, response.getStatus());
@@ -1116,7 +1116,7 @@ class DatasetResourceTest extends AbstractTestHelper {
   @Test
   void testGetApprovedUsersDatasetThrows() {
     doThrow(new RuntimeException("Some exception"))
-        .when(datasetService).findMinimalDatasetByIdentifier(any(), any());
+        .when(datasetService).findMinimalDatasetByIdentifier(duosUser.getUser(), "ABC", false);
     Response response = resource.getApprovedUsers(duosUser, "ABC");
     assertEquals(HttpStatusCodes.STATUS_CODE_SERVER_ERROR, response.getStatus());
   }

--- a/src/test/java/org/broadinstitute/consent/http/resources/TDRResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/TDRResourceTest.java
@@ -58,7 +58,7 @@ class TDRResourceTest {
     d.setStudy(study);
 
     when(tdrService.getApprovedUsersForDataset(any(), any())).thenReturn(approvedUsers);
-    when(datasetService.findMinimalDatasetByIdentifier(user, ds)).thenReturn(d);
+    when(datasetService.findMinimalDatasetByIdentifier(user, ds, false)).thenReturn(d);
     when(duosUser.getUser()).thenReturn(user);
 
     initResource();
@@ -71,7 +71,7 @@ class TDRResourceTest {
   @Test
   void testGetApprovedUsersForDataset404() {
     when(duosUser.getUser()).thenReturn(user);
-    when(datasetService.findMinimalDatasetByIdentifier(user, "DUOS-00003")).thenReturn(null);
+    when(datasetService.findMinimalDatasetByIdentifier(user, "DUOS-00003", false)).thenReturn(null);
 
     initResource();
 
@@ -87,7 +87,7 @@ class TDRResourceTest {
     d.setName("test");
 
     when(duosUser.getUser()).thenReturn(user);
-    when(datasetService.findMinimalDatasetByIdentifier(user, "DUOS-00003")).thenReturn(d);
+    when(datasetService.findMinimalDatasetByIdentifier(user, "DUOS-00003", true)).thenReturn(d);
 
     initResource();
 
@@ -101,7 +101,7 @@ class TDRResourceTest {
   @Test
   void testGetDatasetByIdentifier404() {
     when(duosUser.getUser()).thenReturn(user);
-    when(datasetService.findMinimalDatasetByIdentifier(user, "DUOS-00003")).thenReturn(null);
+    when(datasetService.findMinimalDatasetByIdentifier(user, "DUOS-00003", true)).thenReturn(null);
 
     initResource();
 

--- a/src/test/java/org/broadinstitute/consent/http/resources/TDRResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/TDRResourceTest.java
@@ -58,7 +58,7 @@ class TDRResourceTest {
     d.setStudy(study);
 
     when(tdrService.getApprovedUsersForDataset(any(), any())).thenReturn(approvedUsers);
-    when(datasetService.findDatasetByIdentifier(user, ds)).thenReturn(d);
+    when(datasetService.findMinimalDatasetByIdentifier(user, ds)).thenReturn(d);
     when(duosUser.getUser()).thenReturn(user);
 
     initResource();
@@ -71,7 +71,7 @@ class TDRResourceTest {
   @Test
   void testGetApprovedUsersForDataset404() {
     when(duosUser.getUser()).thenReturn(user);
-    when(datasetService.findDatasetByIdentifier(user, "DUOS-00003")).thenReturn(null);
+    when(datasetService.findMinimalDatasetByIdentifier(user, "DUOS-00003")).thenReturn(null);
 
     initResource();
 
@@ -87,7 +87,7 @@ class TDRResourceTest {
     d.setName("test");
 
     when(duosUser.getUser()).thenReturn(user);
-    when(datasetService.findDatasetByIdentifier(user, "DUOS-00003")).thenReturn(d);
+    when(datasetService.findMinimalDatasetByIdentifier(user, "DUOS-00003")).thenReturn(d);
 
     initResource();
 
@@ -101,7 +101,7 @@ class TDRResourceTest {
   @Test
   void testGetDatasetByIdentifier404() {
     when(duosUser.getUser()).thenReturn(user);
-    when(datasetService.findDatasetByIdentifier(user, "DUOS-00003")).thenReturn(null);
+    when(datasetService.findMinimalDatasetByIdentifier(user, "DUOS-00003")).thenReturn(null);
 
     initResource();
 


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-2258

### Summary
This PR makes two primary changes:
1. Minimize/optimize the data returned by the following endpoint:
  - `GET /api/tdr/{identifier}`
2. Streamline the query for approved users by calling the minimized dataset call before querying for approved users:
  - `GET /api/dataset/{identifier}/approvedUsers`
  - `GET /api/tdr/{identifier}/approvedUsers`

> [!CAUTION]
> The response payload for `GET /api/tdr/{identifier}` no longer includes file related information and only returns dataset, dataset property, study, study property, and dataset creator information. 

Some prod vs local timings that all use the same dataset identifier (`DUOS-000203`):
| API | Prod | This PR | % Improvement |
| -------- | ------- | ------- | ------- |
|` GET /api/tdr/{identifier} `| 6599 ms | 1126 ms | ~83% |
| `GET /api/dataset/{identifier}/approvedUsers` | 6675 ms | 530 ms | ~92% |
| `GET /api/tdr/{identifier}/approvedUsers` | 6600 ms | 730 ms | ~89% |


----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
