### PR TITLE
[DT-2228] Validate query window size

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
@@ -86,6 +86,7 @@ public class ElasticSearchService implements ConsentLogger {
     this.studyDAO = studyDAO;
   }
 
+  private static final int MAX_RESULT_WINDOW = 10000;
 
   private static final String BULK_HEADER = """
       { "index": {"_type": "dataset", "_id": "%d"} }
@@ -137,7 +138,25 @@ public class ElasticSearchService implements ConsentLogger {
     return performRequest(deleteRequest);
   }
 
+  public boolean invalidResultWindow(String query) {
+    try {
+      var queryJson = GsonUtil.getInstance().fromJson(query, Map.class);
+
+      long size = (long) queryJson.getOrDefault("size", 10L);
+      long from = (long) queryJson.getOrDefault("from", 0L);
+
+      return from + size > MAX_RESULT_WINDOW;
+    } catch (Exception e) {
+      logWarn("Unable to parse query for result window validation: " + e.getMessage());
+      return true;
+    }
+  }
+
   public boolean validateQuery(String query) throws IOException {
+    if (invalidResultWindow(query)) {
+      return false;
+    }
+
     // Remove `size` and `from` parameters from query, otherwise validation will fail
     var modifiedQuery = query
         .replaceAll("\"size\": ?\\d+,?", "")

--- a/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
@@ -710,4 +710,87 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
     verify(datasetServiceDAO, never()).updateDatasetIndex(any(), any(), any());
   }
 
+  @Test
+  void testInvalidResultWindow_ValidQueryWithinLimits() {
+    String query = "{\"size\": 100, \"from\": 0}";
+    assertFalse(service.invalidResultWindow(query));
+  }
+
+  @Test
+  void testInvalidResultWindow_DoubleValuesThrowClassCastException() {
+    String query = "{\"size\": 100.0, \"from\": 0.0}";
+    assertTrue(service.invalidResultWindow(query));
+  }
+
+  @Test
+  void testInvalidResultWindow_StringValuesThrowClassCastException() {
+    String query = "{\"size\": \"100\", \"from\": \"0\"}";
+    assertTrue(service.invalidResultWindow(query));
+  }
+
+  @Test
+  void testInvalidResultWindow_ValidQueryAtLimit() {
+    String query = "{\"size\": 5000, \"from\": 5000}";
+    assertFalse(service.invalidResultWindow(query));
+  }
+
+  @Test
+  void testInvalidResultWindow_ExceedsMaxResultWindow() {
+    String query = "{\"size\": 5000, \"from\": 5001}";
+    assertTrue(service.invalidResultWindow(query));
+  }
+
+  @Test
+  void testInvalidResultWindow_ExceedsMaxResultWindowLargeValues() {
+    String query = "{\"size\": 10000, \"from\": 1}";
+    assertTrue(service.invalidResultWindow(query));
+  }
+
+  @Test
+  void testInvalidResultWindow_DefaultValues() {
+    String query = "{}";
+    assertFalse(service.invalidResultWindow(query));
+  }
+
+  @Test
+  void testInvalidResultWindow_OnlySizeProvided() {
+    String query = "{\"size\": 50}";
+    assertFalse(service.invalidResultWindow(query));
+  }
+
+  @Test
+  void testInvalidResultWindow_OnlyFromProvided() {
+    String query = "{\"from\": 100}";
+    assertFalse(service.invalidResultWindow(query));
+  }
+
+  @Test
+  void testInvalidResultWindow_InvalidJsonFormat() {
+    String query = "{invalid json}";
+    assertTrue(service.invalidResultWindow(query));
+  }
+
+  @Test
+  void testInvalidResultWindow_NullQuery() {
+    assertTrue(service.invalidResultWindow(null));
+  }
+
+  @Test
+  void testInvalidResultWindow_EmptyString() {
+    String query = "";
+    assertTrue(service.invalidResultWindow(query));
+  }
+
+  @Test
+  void testInvalidResultWindow_NonJsonString() {
+    String query = "not a json string";
+    assertTrue(service.invalidResultWindow(query));
+  }
+
+  @Test
+  void testInvalidResultWindow_ExtraFieldsInQuery() {
+    String query = "{\"size\": 100, \"from\": 50, \"query\": {\"match_all\": {}}}";
+    assertFalse(service.invalidResultWindow(query));
+  }
+
 }


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2228

### Summary

Prevents the following issue which crashes the service:

```
Caused by: org.elasticsearch.search.query.QueryPhaseExecutionException: Result window is too large, from + size must be less than or equal to: [10000] but was [1000000000]. See the scroll api for a more efficient way to request large data sets. This limit can be set by changing the [index.max_result_window] index level setting.
```

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
