### PR TITLE
DT-2241: Miscellaneous cleanup

### DIFF
--- a/src/test/java/org/broadinstitute/consent/http/db/DACAutomationRuleDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DACAutomationRuleDAOTest.java
@@ -1,5 +1,8 @@
 package org.broadinstitute.consent.http.db;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.time.Instant;
 import java.util.Date;
 import java.util.List;
@@ -22,7 +25,7 @@ class DACAutomationRuleDAOTest extends DAOTestHelper {
   void testFindAll() {
     List<DACAutomationRule> rules = dacAutomationRuleDAO.findAll();
     Assertions.assertFalse(rules.isEmpty());
-    Assertions.assertTrue(
+    assertTrue(
         rules.stream().anyMatch(rule -> rule.ruleType().equals(DACAutomationRuleType.GRU_V1)));
   }
 
@@ -93,11 +96,11 @@ class DACAutomationRuleDAOTest extends DAOTestHelper {
     Assertions.assertNotNull(settingId);
     List<DACAutomationRule> updatedRulesByDacId = dacAutomationRuleDAO.findAllDACAutomationRulesByDACId(
         dacId);
-    Assertions.assertTrue(updatedRulesByDacId.stream()
+    assertTrue(updatedRulesByDacId.stream()
         .anyMatch(r -> Objects.equals(r.enabledByUserId(), user.getUserId())));
-    Assertions.assertTrue(
+    assertTrue(
         updatedRulesByDacId.stream().anyMatch(r -> Objects.equals(r.userEmail(), user.getEmail())));
-    Assertions.assertTrue(updatedRulesByDacId.stream()
+    assertTrue(updatedRulesByDacId.stream()
         .anyMatch(r -> Objects.equals(r.displayName(), user.getDisplayName())));
   }
 
@@ -134,12 +137,16 @@ class DACAutomationRuleDAOTest extends DAOTestHelper {
     Assertions.assertEquals(2, auditRecords.size());
     Assertions.assertEquals(auditRecords.size(),
         dacAutomationRuleDAO.findCountOfAutomationAuditsForDac(dacId1));
-    Assertions.assertNotNull(auditRecords.get(0));
-    Assertions.assertEquals(RuleAuditAction.REMOVE, auditRecords.get(0).action());
-    Assertions.assertEquals(auditUser.getEmail(), auditRecords.get(0).email());
-    Assertions.assertNotNull(auditRecords.get(1));
-    Assertions.assertEquals(RuleAuditAction.ADD, auditRecords.get(1).action());
-    Assertions.assertEquals(user.getEmail(), auditRecords.get(1).email());
+    var remove = auditRecords.stream()
+        .filter(r -> r.action().equals(RuleAuditAction.REMOVE))
+        .findFirst();
+    assertTrue(remove.isPresent());
+    assertEquals(remove.get().email(), auditUser.getEmail());
+    var add = auditRecords.stream()
+        .filter(r -> r.action().equals(RuleAuditAction.ADD))
+        .findFirst();
+    assertTrue(add.isPresent());
+    assertEquals(add.get().email(), user.getEmail());
   }
 
   @Test
@@ -160,9 +167,11 @@ class DACAutomationRuleDAOTest extends DAOTestHelper {
     List<DACAutomationRuleAudit> auditRecords = dacAutomationRuleDAO.findAutomationAuditsForDac(
         dacId, 5, 0);
     Assertions.assertEquals(2, auditRecords.size());
-    Assertions.assertNotNull(auditRecords.get(0));
-    Assertions.assertEquals(RuleAuditAction.REMOVE, auditRecords.get(0).action());
-    Assertions.assertEquals(auditUser.getEmail(), auditRecords.get(0).email());
+    var remove = auditRecords.stream()
+        .filter(r -> r.action().equals(RuleAuditAction.REMOVE))
+        .findFirst();
+    assertTrue(remove.isPresent());
+    assertEquals(remove.get().email(), auditUser.getEmail());
   }
 
   @Test
@@ -198,19 +207,16 @@ class DACAutomationRuleDAOTest extends DAOTestHelper {
     User auditUser = createUser();
     Integer dacId1 = createRandomDAC();
     List<DACAutomationRule> rulesByDacId = dacAutomationRuleDAO.findAll();
-    rulesByDacId.forEach(r -> {
-      dacAutomationRuleDAO.auditedInsertDACRuleSetting(dacId1, r.id(), user.getUserId(),
-          Instant.now());
-    });
+    rulesByDacId.forEach(
+        r -> dacAutomationRuleDAO.auditedInsertDACRuleSetting(dacId1, r.id(), user.getUserId(),
+            Instant.now()));
     Integer deletedCount = dacAutomationRuleDAO.auditedDeleteDACRuleSettingByUser(dacId1,
         user.getUserId(), auditUser.getUserId());
     Assertions.assertEquals(rulesByDacId.size(), deletedCount);
     List<DACAutomationRuleAudit> deleteByUserAudits = dacAutomationRuleDAO.findAutomationAuditsForDac(
         dacId1, rulesByDacId.size(), 0);
     Assertions.assertEquals(rulesByDacId.size(), deleteByUserAudits.size());
-    deleteByUserAudits.forEach(r -> {
-      Assertions.assertEquals(RuleAuditAction.REMOVE, r.action());
-    });
+    deleteByUserAudits.forEach(r -> Assertions.assertEquals(RuleAuditAction.REMOVE, r.action()));
   }
 
   @Test
@@ -242,10 +248,9 @@ class DACAutomationRuleDAOTest extends DAOTestHelper {
     User user = createUser();
     Integer dacId1 = createRandomDAC();
     List<DACAutomationRule> rulesByDacId = dacAutomationRuleDAO.findAll();
-    rulesByDacId.forEach(r -> {
-      dacAutomationRuleDAO.auditedInsertDACRuleSetting(dacId1, r.id(), user.getUserId(),
-          Instant.now());
-    });
+    rulesByDacId.forEach(
+        r -> dacAutomationRuleDAO.auditedInsertDACRuleSetting(dacId1, r.id(), user.getUserId(),
+            Instant.now()));
     List<DACAutomationRuleAudit> auditRecords = dacAutomationRuleDAO.findAutomationAuditsForDac(
         dacId1, rulesByDacId.size(), 0);
     Assertions.assertEquals(rulesByDacId.size(), auditRecords.size());
@@ -254,7 +259,7 @@ class DACAutomationRuleDAOTest extends DAOTestHelper {
     Assertions.assertEquals(rulesByDacId.size() - 1, auditRecords.size());
     auditRecords = dacAutomationRuleDAO.findAutomationAuditsForDac(dacId1, 1,
         rulesByDacId.size() * 2);
-    Assertions.assertTrue(auditRecords.isEmpty());
+    assertTrue(auditRecords.isEmpty());
   }
 
   private Integer createRandomDAC() {


### PR DESCRIPTION
### Addresses
Partially addresses https://broadworkbench.atlassian.net/browse/DT-2241

### Summary
Fixes two small issues unrelated to the [main PR for DT-2241](https://github.com/DataBiosphere/consent/pull/2673) that can be addressed as cleanup
1. Address some test flakiness in `DACAutomationRuleDAOTest`
2. Removal of unused, empty file: `EmailNotifierService.class`

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
