### PR TITLE
[DT-2202] Add hint for presence of NIH Institutional Certification in Elasticsearch contents.

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/models/elastic_search/DatasetTerm.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/elastic_search/DatasetTerm.java
@@ -22,6 +22,7 @@ public class DatasetTerm {
   private UserTerm submitter;
   private UserTerm updateUser;
   private DacTerm dac;
+  private Boolean hasInstitutionCertification;
 
   public Integer getDatasetId() {
     return datasetId;
@@ -157,5 +158,13 @@ public class DatasetTerm {
 
   public void setDac(DacTerm dac) {
     this.dac = dac;
+  }
+
+  public Boolean getHasInstitutionCertification() {
+    return hasInstitutionCertification;
+  }
+
+  public void setHasInstitutionCertification(Boolean hasInstitutionCertification) {
+    this.hasInstitutionCertification = hasInstitutionCertification;
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
@@ -404,6 +404,9 @@ public class ElasticSearchService implements ConsentLogger {
       }
     }
 
+    Optional.ofNullable(dataset.getNihInstitutionalCertificationFile()).ifPresent(
+    obj -> term.setHasInstitutionCertification(true));
+
     findDatasetProperty(
         dataset.getProperties(), "accessManagement"
     ).ifPresent(

--- a/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
@@ -52,6 +52,7 @@ import org.broadinstitute.consent.http.models.DataUse;
 import org.broadinstitute.consent.http.models.DataUseBuilder;
 import org.broadinstitute.consent.http.models.Dataset;
 import org.broadinstitute.consent.http.models.DatasetProperty;
+import org.broadinstitute.consent.http.models.FileStorageObject;
 import org.broadinstitute.consent.http.models.Institution;
 import org.broadinstitute.consent.http.models.LibraryCard;
 import org.broadinstitute.consent.http.models.Study;
@@ -161,6 +162,7 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
     dataset.setCreateUser(user);
     dataset.setUpdateUserId(updateUser.getUserId());
     dataset.setCreateUserId(user.getUserId());
+    dataset.setNihInstitutionalCertificationFile(new FileStorageObject());
     return dataset;
   }
 
@@ -398,6 +400,28 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
     assertEquals(datasetRecord.dac.getDacId(), term.getDacId());
     assertEquals(datasetRecord.dac.getDacId(), term.getDac().dacId());
     assertEquals(datasetRecord.dac.getName(), term.getDac().dacName());
+  }
+
+  @Test
+  void testToDatasetTerm_NIHInstitutionalCertification() {
+    DatasetRecord datasetRecord = createDatasetRecord();
+    when(dacDAO.findById(any())).thenReturn(datasetRecord.dac);
+    when(userDao.findUserById(datasetRecord.createUser.getUserId())).thenReturn(
+        datasetRecord.createUser);
+    DatasetTerm term = service.toDatasetTerm(datasetRecord.dataset);
+    assertEquals(datasetRecord.dataset.getNihInstitutionalCertificationFile() != null, term.getHasInstitutionCertification());
+  }
+
+
+  @Test
+  void testToDatasetTerm_Missing_NIHInstitutionalCertification() {
+    DatasetRecord datasetRecord = createDatasetRecord();
+    when(dacDAO.findById(any())).thenReturn(datasetRecord.dac);
+    when(userDao.findUserById(datasetRecord.createUser.getUserId())).thenReturn(
+        datasetRecord.createUser);
+    datasetRecord.dataset.setNihInstitutionalCertificationFile(null);
+    DatasetTerm term = service.toDatasetTerm(datasetRecord.dataset);
+    assertEquals(null, term.getHasInstitutionCertification());
   }
 
   @Test


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-2202](https://broadworkbench.atlassian.net/browse/DT-2202)

### Summary

Adds hint of presence of NIH Institutional Certification in Elastic data so the UI doesn't need to make additional calls to the backend to get this information.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
