### PR TITLE
[DT-2266] Prevent Admins from Editing Auto-Assigned User Institution

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/models/UserUpdateFields.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/UserUpdateFields.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 import org.broadinstitute.consent.http.enumeration.UserFields;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
 
@@ -20,13 +19,13 @@ public class UserUpdateFields {
   private static final List<Integer> VALID_ROLE_IDS = Arrays.stream(UserRoles.values())
       .map(UserRoles::getRoleId).toList();
   private String displayName;
-  private Integer institutionId;
   private Boolean emailPreference;
   private List<Integer> userRoleIds;
   private String eraCommonsId;
   private Boolean daaAcceptance;
 
   public UserUpdateFields() {
+    // Default constructor
   }
 
   public String getDisplayName() {
@@ -35,14 +34,6 @@ public class UserUpdateFields {
 
   public void setDisplayName(String displayName) {
     this.displayName = displayName;
-  }
-
-  public Integer getInstitutionId() {
-    return institutionId;
-  }
-
-  public void setInstitutionId(Integer institutionId) {
-    this.institutionId = institutionId;
   }
 
   public Boolean getEmailPreference() {
@@ -100,12 +91,12 @@ public class UserUpdateFields {
   public List<Integer> getRoleIdsToAdd(List<Integer> currentUserRoleIds) {
     return this.getUserRoleIds().stream()
         .filter(
-            id -> {
-              return !currentUserRoleIds.contains(id) && // Don't add any that already exist
+            id ->
+              !currentUserRoleIds.contains(id) && // Don't add any that already exist
                   !IGNORE_ROLE_IDS.contains(id) &&    // Never add ignorable roles
-                  VALID_ROLE_IDS.contains(id);        // Only add roles we know about
-            })
-        .collect(Collectors.toList());
+                  VALID_ROLE_IDS.contains(id)        // Only add roles we know about
+            )
+        .toList();
   }
 
   /**
@@ -119,16 +110,15 @@ public class UserUpdateFields {
   public List<Integer> getRoleIdsToRemove(List<Integer> currentUserRoleIds) {
     return currentUserRoleIds.stream()
         .filter(
-            id -> {
-              return !getUserRoleIds().contains(id) &&
+            id -> !getUserRoleIds().contains(id) &&
                   // Remove roles that are NOT in the new role id list
                   !Objects.equals(id, UserRoles.RESEARCHER.getRoleId()) &&
                   // Never remove the researcher role
                   !IGNORE_ROLE_IDS.contains(id) &&
                   // Never remove ignorable roles
                   VALID_ROLE_IDS.contains(
-                      id);                            // Only remove roles we know about
-            })
+                      id)                            // Only remove roles we know about
+            )
         .toList();
   }
 
@@ -139,15 +129,14 @@ public class UserUpdateFields {
     }
 
     UserUpdateFields that = (UserUpdateFields) o;
-    return Objects.equals(displayName, that.displayName) && Objects.equals(institutionId,
-        that.institutionId) && Objects.equals(emailPreference, that.emailPreference)
+    return Objects.equals(displayName, that.displayName) && Objects.equals(emailPreference, that.emailPreference)
         && Objects.equals(userRoleIds, that.userRoleIds) && Objects.equals(eraCommonsId,
         that.eraCommonsId) && Objects.equals(daaAcceptance, that.daaAcceptance);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(displayName, institutionId, emailPreference, userRoleIds, eraCommonsId,
+    return Objects.hash(displayName, emailPreference, userRoleIds, eraCommonsId,
         daaAcceptance);
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
@@ -195,12 +195,6 @@ public class UserResource extends Resource {
       UserUpdateFields userUpdateFields = gson.fromJson(json, UserUpdateFields.class);
       // Ensure that we have a real user with this ID, fail if we do not.
       userService.findUserById(userId);
-
-      // Admins cannot update institutions
-      if (userUpdateFields.getInstitutionId() != null) {
-        throw new BadRequestException("Institution ID should not be updated");
-      }
-
       User updatedUser = userService.updateUserFieldsById(userUpdateFields, userId);
       Gson gson = new Gson();
       JsonObject jsonUser = userService.findUserWithPropertiesByIdAsJsonObject(duosUser,
@@ -219,11 +213,6 @@ public class UserResource extends Resource {
     try {
       User user = duosUser.getUser();
       UserUpdateFields userUpdateFields = gson.fromJson(json, UserUpdateFields.class);
-
-      // Users cannot update their own institution id through this service
-      if (userUpdateFields.getInstitutionId() != null) {
-        throw new BadRequestException("Institution ID is not updatable");
-      }
 
       if (Objects.nonNull(userUpdateFields.getUserRoleIds()) && !user.hasUserRole(
           UserRoles.ADMIN)) {

--- a/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
@@ -195,6 +195,12 @@ public class UserResource extends Resource {
       UserUpdateFields userUpdateFields = gson.fromJson(json, UserUpdateFields.class);
       // Ensure that we have a real user with this ID, fail if we do not.
       userService.findUserById(userId);
+
+      // Admins cannot update institutions
+      if (userUpdateFields.getInstitutionId() != null) {
+        throw new BadRequestException("Institution ID should not be updated");
+      }
+
       User updatedUser = userService.updateUserFieldsById(userUpdateFields, userId);
       Gson gson = new Gson();
       JsonObject jsonUser = userService.findUserWithPropertiesByIdAsJsonObject(duosUser,

--- a/src/main/java/org/broadinstitute/consent/http/service/UserService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/UserService.java
@@ -110,12 +110,15 @@ public class UserService implements ConsentLogger {
    */
   public User updateUserFieldsById(UserUpdateFields userUpdateFields, Integer userId) {
     if (Objects.nonNull(userUpdateFields)) {
+
+      // Institutions cannot be updated
+      if (Objects.nonNull(userUpdateFields.getInstitutionId())) {
+        throw new BadRequestException("Institution ID is not updatable");
+      }
+
       // Update Primary User Fields
       if (Objects.nonNull(userUpdateFields.getDisplayName())) {
         userDAO.updateDisplayName(userId, userUpdateFields.getDisplayName());
-      }
-      if (Objects.nonNull(userUpdateFields.getInstitutionId())) {
-        userDAO.updateInstitutionId(userId, userUpdateFields.getInstitutionId());
       }
       if (Objects.nonNull(userUpdateFields.getEmailPreference())) {
         userDAO.updateEmailPreference(userId, userUpdateFields.getEmailPreference());

--- a/src/main/java/org/broadinstitute/consent/http/service/UserService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/UserService.java
@@ -111,11 +111,6 @@ public class UserService implements ConsentLogger {
   public User updateUserFieldsById(UserUpdateFields userUpdateFields, Integer userId) {
     if (Objects.nonNull(userUpdateFields)) {
 
-      // Institutions cannot be updated
-      if (Objects.nonNull(userUpdateFields.getInstitutionId())) {
-        throw new BadRequestException("Institution ID is not updatable");
-      }
-
       // Update Primary User Fields
       if (Objects.nonNull(userUpdateFields.getDisplayName())) {
         userDAO.updateDisplayName(userId, userUpdateFields.getDisplayName());

--- a/src/main/resources/assets/paths/userByIdv2.yaml
+++ b/src/main/resources/assets/paths/userByIdv2.yaml
@@ -46,9 +46,6 @@ put:
             displayName:
               description: The display name for the user
               type: string
-            institutionId:
-              description: The institution id for the user
-              type: number
             emailPreference:
               description: True for receiving email, false for disabling all email
               type: boolean

--- a/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.when;
 import com.google.api.client.http.HttpStatusCodes;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
+import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.Response.Status;
@@ -508,6 +509,9 @@ class UserResourceTest extends AbstractTestHelper {
     UserUpdateFields userUpdateFields = new UserUpdateFields();
     userUpdateFields.setInstitutionId(20);
 
+    BadRequestException badRequestException = new BadRequestException("Institution ID is not updatable");
+    when(userService.updateUserFieldsById(userUpdateFields, user.getUserId())).thenThrow(badRequestException);
+
     try (var response = userResource.updateSelf(new DuosUser(authUser, user), uriInfo, gson.toJson(userUpdateFields))) {
       assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
     }
@@ -545,6 +549,9 @@ class UserResourceTest extends AbstractTestHelper {
 
     UserUpdateFields userUpdateFields = new UserUpdateFields();
     userUpdateFields.setInstitutionId(123);
+
+    BadRequestException badRequestException = new BadRequestException("Institution ID is not updatable");
+    when(userService.updateUserFieldsById(userUpdateFields, user.getUserId())).thenThrow(badRequestException);
 
     try (Response response = userResource.update(duosUser, uriInfo, user.getUserId(), gson.toJson(userUpdateFields))) {
       assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());

--- a/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
@@ -14,7 +14,6 @@ import static org.mockito.Mockito.when;
 import com.google.api.client.http.HttpStatusCodes;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
-import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.Response.Status;
@@ -502,22 +501,6 @@ class UserResourceTest extends AbstractTestHelper {
   }
 
   @Test
-  void testUpdateSelfShouldNotPassInstitutionId() {
-    User user = createUserWithRole();
-    user.setITDirectorRole();
-    user.setInstitutionId(10);
-    UserUpdateFields userUpdateFields = new UserUpdateFields();
-    userUpdateFields.setInstitutionId(20);
-
-    BadRequestException badRequestException = new BadRequestException("Institution ID is not updatable");
-    when(userService.updateUserFieldsById(userUpdateFields, user.getUserId())).thenThrow(badRequestException);
-
-    try (var response = userResource.updateSelf(new DuosUser(authUser, user), uriInfo, gson.toJson(userUpdateFields))) {
-      assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
-    }
-  }
-
-  @Test
   void testUpdate() {
     User user = createUserWithRole();
     UserUpdateFields userUpdateFields = new UserUpdateFields();
@@ -539,22 +522,6 @@ class UserResourceTest extends AbstractTestHelper {
 
     try (Response response = userResource.update(duosUser, uriInfo, user.getUserId(), "")) {
       assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
-    }
-  }
-
-  @Test
-  void testUpdateUserWithInstitutionIdShouldFail() {
-    User user = createUserWithRole();
-    when(userService.findUserById(any())).thenReturn(user);
-
-    UserUpdateFields userUpdateFields = new UserUpdateFields();
-    userUpdateFields.setInstitutionId(123);
-
-    BadRequestException badRequestException = new BadRequestException("Institution ID is not updatable");
-    when(userService.updateUserFieldsById(userUpdateFields, user.getUserId())).thenThrow(badRequestException);
-
-    try (Response response = userResource.update(duosUser, uriInfo, user.getUserId(), gson.toJson(userUpdateFields))) {
-      assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
     }
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
@@ -539,6 +539,19 @@ class UserResourceTest extends AbstractTestHelper {
   }
 
   @Test
+  void testUpdateUserWithInstitutionIdShouldFail() {
+    User user = createUserWithRole();
+    when(userService.findUserById(any())).thenReturn(user);
+
+    UserUpdateFields userUpdateFields = new UserUpdateFields();
+    userUpdateFields.setInstitutionId(123);
+
+    try (Response response = userResource.update(duosUser, uriInfo, user.getUserId(), gson.toJson(userUpdateFields))) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
+    }
+  }
+
+  @Test
   void testUpdateUserInvalidJson() {
     User user = createUserWithRole();
 

--- a/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
@@ -18,6 +18,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -149,7 +150,7 @@ class UserServiceTest extends AbstractTestHelper {
     // both the Researcher and Chairperson roles, but remove the Admin role.
     fields.setUserRoleIds(List.of(so.getRoleId()));
     fields.setDisplayName(randomAlphabetic(10));
-    fields.setInstitutionId(1);
+    //fields.setInstitutionId(1);
     fields.setEmailPreference(true);
     fields.setEraCommonsId(randomAlphabetic(10));
     fields.setDaaAcceptance(true);
@@ -164,6 +165,34 @@ class UserServiceTest extends AbstractTestHelper {
     // Verify role additions/deletions.
     verify(userRoleDAO, times(1)).insertUserRoles(List.of(so), 1);
     verify(userRoleDAO, times(1)).removeUserRoles(1, List.of(admin.getRoleId()));
+  }
+
+  @Test
+  void testUpdateUserFieldsByIdShouldNotPassInstitutionId() {
+    UserRole so = UserRoles.SigningOfficial();
+
+    User user = new User();
+    user.setUserId(1);
+
+    UserUpdateFields fields = new UserUpdateFields();
+    fields.setUserRoleIds(List.of(so.getRoleId()));
+    fields.setDisplayName(randomAlphabetic(10));
+    fields.setInstitutionId(1);
+    fields.setEmailPreference(true);
+    fields.setEraCommonsId(randomAlphabetic(10));
+    fields.setDaaAcceptance(true);
+
+    assertEquals(1, fields.buildUserProperties(user.getUserId()).size());
+
+    assertThrows(BadRequestException.class, () -> service.updateUserFieldsById(fields, user.getUserId()));
+
+    // Ensure that no update methods are called due to the exception
+    verify(userDAO, never()).updateDisplayName(any(), any());
+    verify(userDAO, never()).updateEmailPreference(any(), any());
+    verify(userDAO, never()).updateEraCommonsId(any(), any());
+    verify(userPropertyDAO, never()).insertAll(any());
+    verify(userRoleDAO, never()).insertUserRoles(any(), anyInt());
+    verify(userRoleDAO, never()).removeUserRoles(anyInt(), any());
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
@@ -18,7 +18,6 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -164,35 +163,6 @@ class UserServiceTest extends AbstractTestHelper {
     // Verify role additions/deletions.
     verify(userRoleDAO, times(1)).insertUserRoles(List.of(so), 1);
     verify(userRoleDAO, times(1)).removeUserRoles(1, List.of(admin.getRoleId()));
-  }
-
-  @Test
-  void testUpdateUserFieldsByIdShouldNotPassInstitutionId() {
-    UserRole so = UserRoles.SigningOfficial();
-
-    User user = new User();
-    user.setUserId(1);
-
-    UserUpdateFields fields = new UserUpdateFields();
-    fields.setUserRoleIds(List.of(so.getRoleId()));
-    fields.setDisplayName(randomAlphabetic(10));
-    fields.setInstitutionId(1);
-    fields.setEmailPreference(true);
-    fields.setEraCommonsId(randomAlphabetic(10));
-    fields.setDaaAcceptance(true);
-
-    assertEquals(1, fields.buildUserProperties(user.getUserId()).size());
-
-    int userId = user.getUserId();
-    assertThrows(BadRequestException.class, () -> service.updateUserFieldsById(fields, userId));
-
-    // Ensure that no update methods are called due to the exception
-    verify(userDAO, never()).updateDisplayName(any(), any());
-    verify(userDAO, never()).updateEmailPreference(any(), any());
-    verify(userDAO, never()).updateEraCommonsId(any(), any());
-    verify(userPropertyDAO, never()).insertAll(any());
-    verify(userRoleDAO, never()).insertUserRoles(any(), anyInt());
-    verify(userRoleDAO, never()).removeUserRoles(anyInt(), any());
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
@@ -150,7 +150,6 @@ class UserServiceTest extends AbstractTestHelper {
     // both the Researcher and Chairperson roles, but remove the Admin role.
     fields.setUserRoleIds(List.of(so.getRoleId()));
     fields.setDisplayName(randomAlphabetic(10));
-    //fields.setInstitutionId(1);
     fields.setEmailPreference(true);
     fields.setEraCommonsId(randomAlphabetic(10));
     fields.setDaaAcceptance(true);
@@ -184,7 +183,8 @@ class UserServiceTest extends AbstractTestHelper {
 
     assertEquals(1, fields.buildUserProperties(user.getUserId()).size());
 
-    assertThrows(BadRequestException.class, () -> service.updateUserFieldsById(fields, user.getUserId()));
+    int userId = user.getUserId();
+    assertThrows(BadRequestException.class, () -> service.updateUserFieldsById(fields, userId));
 
     // Ensure that no update methods are called due to the exception
     verify(userDAO, never()).updateDisplayName(any(), any());


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2266

### Summary

This change blocks updates to a user’s institution. Attempts to update will return an error.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
