### PR TITLE
DT-2276: Update version references to hashes

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -60,7 +60,7 @@ jobs:
           service_account: 'dsp-artifact-registry-push@dsp-artifact-registry.iam.gserviceaccount.com'
       # authenticate to GAR docker repo
       - name: Docker Login
-        uses: 'docker/login-action@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093'
+        uses: 'docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1'
         with:
           registry: 'us-central1-docker.pkg.dev'
           username: 'oauth2accesstoken'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -52,7 +52,7 @@ jobs:
           ENVIRONMENT_TAG: ${{ steps.construct-tags.outputs.environment-tag }}
       - id: 'auth'
         name: 'Authenticate to Google Cloud'
-        uses: 'google-github-actions/auth@v3'
+        uses: 'google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093'
         with:
           # Centralized in dsp-tools-k8s; ask in #dsp-devops-champions for help troubleshooting
           token_format: 'access_token'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,7 +28,7 @@ jobs:
         id: short-sha
         run: echo "sha=$(git rev-parse --short=12 HEAD)" >> $GITHUB_OUTPUT
       - name: 'Set up Cloud SDK'
-        uses: 'google-github-actions/setup-gcloud@v3'
+        uses: 'google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db'
       - name: Construct tags
         id: construct-tags
         run: |
@@ -60,7 +60,7 @@ jobs:
           service_account: 'dsp-artifact-registry-push@dsp-artifact-registry.iam.gserviceaccount.com'
       # authenticate to GAR docker repo
       - name: Docker Login
-        uses: 'docker/login-action@v3'
+        uses: 'docker/login-action@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093'
         with:
           registry: 'us-central1-docker.pkg.dev'
           username: 'oauth2accesstoken'


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-2276

### Summary
Updates version references to exact hashes for the following GHAs:
* https://github.com/google-github-actions/setup-gcloud/releases/tag/v3.0.1
* https://github.com/google-github-actions/auth/pull/510
* https://github.com/docker/login-action/releases/tag/v3.5.0

This addresses a Sonar warning that calls this out as a security hotspot: https://sonarcloud.io/organizations/broad-databiosphere/rules?open=githubactions%3AS7637&rule_key=githubactions%3AS7637

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
