### PR TITLE
DT-2279: Allow Sort in ES Queries

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
@@ -157,8 +157,9 @@ public class ElasticSearchService implements ConsentLogger {
       return false;
     }
 
-    // Remove `size` and `from` parameters from query, otherwise validation will fail
+    // Remove `sort`, `size` and `from` parameters from query, otherwise validation will fail
     var modifiedQuery = query
+        .replaceAll("\"sort\": ?\\[(.*?)\\],?", "")
         .replaceAll("\"size\": ?\\d+,?", "")
         .replaceAll("\"from\": ?\\d+,?", "");
 

--- a/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
@@ -69,6 +69,8 @@ import org.elasticsearch.client.RestClient;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -559,21 +561,15 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
     }
   }
 
-  @Test
-  void testValidateQuery() throws IOException {
-    String query = "{ \"query\": { \"query_string\": { \"query\": \"(GRU) AND (HMB)\" } } }";
-
+  @ParameterizedTest
+  @ValueSource(strings = {
+      "{ \"query\": { \"query_string\": { \"query\": \"(GRU) AND (HMB)\" } } }",
+      "{ \"from\": 0, \"size\": 100, \"query\": { \"query_string\": { \"query\": \"(GRU) AND (HMB)\" } } }",
+      "{ \"sort\": [\"datasetIdentifier\"], \"query\": { \"query_string\": { \"query\": \"(GRU) AND (HMB)\" } } }",
+      "{ \"from\": 0, \"size\": 100, \"sort\": [\"datasetIdentifier\"], \"query\": { \"query_string\": { \"query\": \"(GRU) AND (HMB)\" } } }",
+  })
+  void testValidateQuerySuccess(String query) throws IOException {
     mockElasticSearchResponse("{\"valid\":true}");
-
-    assertTrue(service.validateQuery(query));
-  }
-
-  @Test
-  void testValidateQueryWithFromAndSize() throws IOException {
-    String query = "{ \"from\": 0, \"size\": 100, \"query\": { \"query_string\": { \"query\": \"(GRU) AND (HMB)\" } } }";
-
-    mockElasticSearchResponse("{\"valid\":true}");
-
     assertTrue(service.validateQuery(query));
   }
 


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-2279

### Summary
Filter out the `sort` field from provided ES queries when validating the query. Like `from` and `size`, `sort` triggers a failure in the built-in ES validate function.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
