### PR TITLE
Revert "DT-2276: Update version references to hashes"

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,7 +28,7 @@ jobs:
         id: short-sha
         run: echo "sha=$(git rev-parse --short=12 HEAD)" >> $GITHUB_OUTPUT
       - name: 'Set up Cloud SDK'
-        uses: 'google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db'
+        uses: 'google-github-actions/setup-gcloud@v3'
       - name: Construct tags
         id: construct-tags
         run: |
@@ -52,7 +52,7 @@ jobs:
           ENVIRONMENT_TAG: ${{ steps.construct-tags.outputs.environment-tag }}
       - id: 'auth'
         name: 'Authenticate to Google Cloud'
-        uses: 'google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093'
+        uses: 'google-github-actions/auth@v3'
         with:
           # Centralized in dsp-tools-k8s; ask in #dsp-devops-champions for help troubleshooting
           token_format: 'access_token'
@@ -60,7 +60,7 @@ jobs:
           service_account: 'dsp-artifact-registry-push@dsp-artifact-registry.iam.gserviceaccount.com'
       # authenticate to GAR docker repo
       - name: Docker Login
-        uses: 'docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1'
+        uses: 'docker/login-action@v3'
         with:
           registry: 'us-central1-docker.pkg.dev'
           username: 'oauth2accesstoken'


### PR DESCRIPTION
Reverts DataBiosphere/consent#2682

We received AppSec permissions to mark this sonar finding as safe so we can revert this change. I have logged into https://sonarcloud.io/project/security_hotspots?id=DataBiosphere_consent and marked them as safe.