### PR TITLE
[DT-2281] Update netty related dependencies.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,7 @@
     <io.grpc.version>1.58.0</io.grpc.version>
     <mockito.version>5.19.0</mockito.version>
     <sonar.plugin.version>5.2.0.4988</sonar.plugin.version>
+    <netty.override.version>4.1.127.Final</netty.override.version>
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -123,6 +124,7 @@
         <groupId>org.owasp</groupId>
         <artifactId>dependency-check-maven</artifactId>
         <configuration>
+          <nvdApiKeyEnvironmentVariable>NVD_API_KEY</nvdApiKeyEnvironmentVariable>
           <failBuildOnCVSS>1</failBuildOnCVSS>
           <suppressionFiles>
             <suppressionFile>owaspSuppression.xml</suppressionFile>
@@ -562,6 +564,37 @@
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-core</artifactId>
       <version>${logback.version}</version>
+    </dependency>
+    <!-- Security update. -->
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-codec-dns</artifactId>
+      <version>${netty.override.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-codec-http</artifactId>
+      <version>${netty.override.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-transport</artifactId>
+      <version>${netty.override.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-codec-socks</artifactId>
+      <version>${netty.override.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-resolver-dns</artifactId>
+      <version>${netty.override.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-handler-proxy</artifactId>
+      <version>${netty.override.version}</version>
     </dependency>
 
     <!--suppress VulnerableLibrariesLocal -->

--- a/pom.xml
+++ b/pom.xml
@@ -13,11 +13,11 @@
     <java.version>21</java.version>
     <maven.compiler.source>21</maven.compiler.source>
     <maven.compiler.target>21</maven.compiler.target>
-    <liquibase.version>4.30.0</liquibase.version>
-    <dropwizard.version>4.0.11</dropwizard.version>
-    <logback.version>1.5.16</logback.version>
+    <liquibase.version>4.33.0</liquibase.version>
+    <dropwizard.version>4.0.16</dropwizard.version>
+    <logback.version>1.5.18</logback.version>
     <pact.version>4.6.17</pact.version>
-    <postgres.version>42.7.7</postgres.version>
+    <postgres.version>42.7.8</postgres.version>
     <surefire.version>3.5.4</surefire.version>
     <swagger.ui.version>5.28.1</swagger.ui.version>
     <swagger.ui.path>META-INF/resources/webjars/swagger-ui/${swagger.ui.version}/</swagger.ui.path>
@@ -550,8 +550,8 @@
     <!-- Logback Access module moved to new location. See https://logback.qos.ch/news.html -->
     <dependency>
       <groupId>ch.qos.logback.access</groupId>
-      <artifactId>common</artifactId>
-      <version>2.0.3</version>
+      <artifactId>logback-access-common</artifactId>
+      <version>2.0.6</version>
     </dependency>
     <!-- Security update. See https://broadworkbench.atlassian.net/browse/DUOS-2826 -->
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,6 @@
     <swagger.ui.path>META-INF/resources/webjars/swagger-ui/${swagger.ui.version}/</swagger.ui.path>
     <mockserver.version>5.15.0</mockserver.version>
     <junit.version>5.13.4</junit.version>
-    <io.grpc.version>1.75.0</io.grpc.version>
     <mockito.version>5.19.0</mockito.version>
     <sonar.plugin.version>5.2.0.4988</sonar.plugin.version>
     <netty.override.version>4.1.127.Final</netty.override.version>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <swagger.ui.path>META-INF/resources/webjars/swagger-ui/${swagger.ui.version}/</swagger.ui.path>
     <mockserver.version>5.15.0</mockserver.version>
     <junit.version>5.13.4</junit.version>
-    <io.grpc.version>1.58.0</io.grpc.version>
+    <io.grpc.version>1.75.0</io.grpc.version>
     <mockito.version>5.19.0</mockito.version>
     <sonar.plugin.version>5.2.0.4988</sonar.plugin.version>
     <netty.override.version>4.1.127.Final</netty.override.version>

--- a/pom.xml
+++ b/pom.xml
@@ -682,7 +682,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>33.4.8-jre</version>
+      <version>33.5.0-jre</version>
     </dependency>
 
     <dependency>
@@ -725,7 +725,7 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-storage</artifactId>
-      <version>2.57.0</version>
+      <version>2.58.0</version>
     </dependency>
 
     <dependency>
@@ -761,13 +761,13 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <version>3.18.0</version>
+      <version>3.19.0</version>
     </dependency>
 
     <dependency>
       <groupId>org.elasticsearch.client</groupId>
       <artifactId>elasticsearch-rest-client</artifactId>
-      <version>9.1.3</version>
+      <version>9.1.4</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-2281](https://broadworkbench.atlassian.net/browse/DT-2281)

### Summary
[INFO] --- dependency:3.8.1:tree (default-cli) @ consent ---
[INFO] org.broadinstitute:consent:jar:1.0.1
[INFO] +- com.networknt:json-schema-validator:jar:1.5.9:compile
[INFO] |  +- com.ethlo.time:itu:jar:1.14.0:compile
[INFO] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.18.3:compile
[INFO] |  \- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:jar:2.18.3:compile
[INFO] +- com.fasterxml.jackson.core:jackson-core:jar:2.20.0:compile
[INFO] +- net.gcardone.junidecode:junidecode:jar:0.5.2:compile
[INFO] +- org.owasp:java-file-io:jar:1.0.0:compile
[INFO] +- org.jdbi:jdbi3-core:jar:3.49.5:compile
[INFO] |  \- io.leangen.geantyref:geantyref:jar:2.0.1:compile
[INFO] +- org.jdbi:jdbi3-sqlobject:jar:3.49.5:compile
[INFO] +- org.jdbi:jdbi3-gson2:jar:3.49.5:compile
[INFO] |  \- org.jdbi:jdbi3-json:jar:3.49.5:compile
[INFO] +- org.jdbi:jdbi3-guava:jar:3.49.5:compile
[INFO] +- com.fasterxml.jackson.core:jackson-annotations:jar:2.20:compile
[INFO] +- org.parboiled:parboiled-java:jar:1.4.1:compile
[INFO] |  +- org.parboiled:parboiled-core:jar:1.4.1:compile
[INFO] |  +- org.ow2.asm:asm:jar:9.2:compile
[INFO] |  +- org.ow2.asm:asm-tree:jar:9.2:compile
[INFO] |  +- org.ow2.asm:asm-analysis:jar:9.2:compile
[INFO] |  \- org.ow2.asm:asm-util:jar:9.2:compile
[INFO] +- com.sendgrid:sendgrid-java:jar:4.10.3:compile
[INFO] +- org.bouncycastle:bcprov-jdk18on:jar:1.81:compile
[INFO] +- org.apache.httpcomponents.client5:httpclient5:jar:5.5:compile
[INFO] |  +- org.apache.httpcomponents.core5:httpcore5:jar:5.3.4:compile
[INFO] |  \- org.apache.httpcomponents.core5:httpcore5-h2:jar:5.3.4:compile
[INFO] +- com.sendgrid:java-http-client:jar:4.5.1:compile
[INFO] |  +- org.apache.httpcomponents:httpcore:jar:4.4.15:compile
[INFO] |  \- org.apache.httpcomponents:httpclient:jar:4.5.13:compile
[INFO] +- io.sentry:sentry:jar:8.21.1:compile
[INFO] +- org.slf4j:slf4j-api:jar:2.0.17:compile
[INFO] +- io.dropwizard:dropwizard-json-logging:jar:4.0.16:compile
[INFO] |  +- io.dropwizard:dropwizard-jackson:jar:4.0.16:compile
[INFO] |  |  +- com.fasterxml.jackson.datatype:jackson-datatype-guava:jar:2.19.2:compile
[INFO] |  |  +- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:jar:2.19.2:compile
[INFO] |  |  +- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:jar:2.19.2:compile
[INFO] |  |  +- com.fasterxml.jackson.module:jackson-module-parameter-names:jar:2.19.2:compile
[INFO] |  |  \- com.fasterxml.jackson.module:jackson-module-blackbird:jar:2.19.2:compile
[INFO] |  +- io.dropwizard:dropwizard-logging:jar:4.0.16:compile
[INFO] |  |  +- io.dropwizard.metrics:metrics-logback:jar:4.2.34:compile
[INFO] |  |  +- org.slf4j:jul-to-slf4j:jar:2.0.17:compile
[INFO] |  |  +- io.dropwizard.logback:logback-throttling-appender:jar:1.5.1:compile
[INFO] |  |  +- org.slf4j:log4j-over-slf4j:jar:2.0.17:runtime
[INFO] |  |  \- org.slf4j:jcl-over-slf4j:jar:2.0.17:runtime
[INFO] |  +- org.checkerframework:checker-qual:jar:3.49.5:compile
[INFO] |  +- jakarta.servlet:jakarta.servlet-api:jar:5.0.0:compile
[INFO] |  \- jakarta.validation:jakarta.validation-api:jar:3.0.2:compile
[INFO] +- io.dropwizard:dropwizard-dependencies:pom:4.0.16:compile
[INFO] +- io.dropwizard:dropwizard-auth:jar:4.0.16:compile
[INFO] |  +- io.dropwizard:dropwizard-jersey:jar:4.0.16:compile
[INFO] |  |  +- org.glassfish.jersey.ext:jersey-metainf-services:jar:3.0.18:runtime
[INFO] |  |  +- org.glassfish.jersey.inject:jersey-hk2:jar:3.0.18:runtime
[INFO] |  |  |  \- org.glassfish.hk2:hk2-locator:jar:3.0.6:runtime
[INFO] |  |  +- org.javassist:javassist:jar:3.30.2-GA:compile
[INFO] |  |  +- io.dropwizard.metrics:metrics-jersey3:jar:4.2.34:compile
[INFO] |  |  +- com.fasterxml:classmate:jar:1.7.0:compile
[INFO] |  |  +- org.glassfish.hk2:hk2-api:jar:3.0.6:compile
[INFO] |  |  |  +- org.glassfish.hk2:hk2-utils:jar:3.0.6:compile
[INFO] |  |  |  \- org.glassfish.hk2.external:aopalliance-repackaged:jar:3.0.6:compile
[INFO] |  |  +- org.glassfish.jersey.containers:jersey-container-servlet:jar:3.0.18:runtime
[INFO] |  |  \- org.hibernate.validator:hibernate-validator:jar:7.0.5.Final:compile
[INFO] |  +- io.dropwizard.metrics:metrics-core:jar:4.2.34:compile
[INFO] |  +- io.dropwizard.metrics:metrics-caffeine:jar:4.2.34:compile
[INFO] |  +- com.github.ben-manes.caffeine:caffeine:jar:3.2.2:compile
[INFO] |  +- jakarta.annotation:jakarta.annotation-api:jar:2.0.0:compile
[INFO] |  +- jakarta.ws.rs:jakarta.ws.rs-api:jar:3.0.0:compile
[INFO] |  +- jakarta.inject:jakarta.inject-api:jar:2.0.1.MR:compile
[INFO] |  +- org.glassfish.jersey.core:jersey-common:jar:3.0.18:compile
[INFO] |  |  \- org.glassfish.hk2:osgi-resource-locator:jar:1.0.3:compile
[INFO] |  +- org.glassfish.jersey.core:jersey-server:jar:3.0.18:compile
[INFO] |  +- org.eclipse.jetty:jetty-security:jar:11.0.26:compile
[INFO] |  \- org.eclipse.jetty:jetty-server:jar:11.0.26:compile
[INFO] |     \- org.eclipse.jetty:jetty-http:jar:11.0.26:compile
[INFO] +- io.dropwizard:dropwizard-assets:jar:4.0.16:compile
[INFO] |  +- io.dropwizard:dropwizard-jetty:jar:4.0.16:compile
[INFO] |  |  \- org.eclipse.jetty:jetty-servlets:jar:11.0.26:compile
[INFO] |  \- io.dropwizard:dropwizard-servlets:jar:4.0.16:compile
[INFO] +- io.dropwizard:dropwizard-http2:jar:4.0.16:compile
[INFO] |  +- io.dropwizard.metrics:metrics-jetty11:jar:4.2.34:compile
[INFO] |  +- org.eclipse.jetty:jetty-alpn-server:jar:11.0.26:compile
[INFO] |  +- org.eclipse.jetty:jetty-io:jar:11.0.26:compile
[INFO] |  +- org.eclipse.jetty:jetty-util:jar:11.0.26:compile
[INFO] |  +- org.eclipse.jetty.http2:http2-server:jar:11.0.26:compile
[INFO] |  +- org.eclipse.jetty:jetty-alpn-java-server:jar:11.0.26:runtime
[INFO] |  \- org.eclipse.jetty:jetty-alpn-java-client:jar:11.0.26:runtime
[INFO] |     \- org.eclipse.jetty:jetty-alpn-client:jar:11.0.26:runtime
[INFO] +- org.eclipse.jetty.http2:http2-common:jar:11.0.26:compile
[INFO] |  \- org.eclipse.jetty.http2:http2-hpack:jar:11.0.26:compile
[INFO] +- io.dropwizard:dropwizard-client:jar:4.0.16:compile
[INFO] |  +- io.dropwizard:dropwizard-lifecycle:jar:4.0.16:compile
[INFO] |  +- io.dropwizard:dropwizard-util:jar:4.0.16:compile
[INFO] |  +- io.dropwizard:dropwizard-validation:jar:4.0.16:compile
[INFO] |  |  \- org.glassfish:jakarta.el:jar:4.0.2:compile
[INFO] |  |     \- jakarta.el:jakarta.el-api:jar:4.0.0:compile
[INFO] |  +- org.glassfish.jersey.core:jersey-client:jar:3.0.18:compile
[INFO] |  \- io.dropwizard.metrics:metrics-httpclient5:jar:4.2.34:compile
[INFO] +- io.dropwizard:dropwizard-core:jar:4.0.16:compile
[INFO] |  +- io.dropwizard:dropwizard-configuration:jar:4.0.16:compile
[INFO] |  +- io.dropwizard:dropwizard-metrics:jar:4.0.16:compile
[INFO] |  +- io.dropwizard:dropwizard-health:jar:4.0.16:compile
[INFO] |  +- io.dropwizard.metrics:metrics-annotation:jar:4.2.34:compile
[INFO] |  +- io.dropwizard.metrics:metrics-jvm:jar:4.2.34:compile
[INFO] |  +- io.dropwizard.metrics:metrics-jmx:jar:4.2.34:compile
[INFO] |  +- io.dropwizard.metrics:metrics-jakarta-servlets:jar:4.2.34:compile
[INFO] |  |  +- io.dropwizard.metrics:metrics-json:jar:4.2.34:compile
[INFO] |  |  \- com.helger:profiler:jar:1.1.1:compile
[INFO] |  +- io.dropwizard.metrics:metrics-healthchecks:jar:4.2.34:compile
[INFO] |  +- io.dropwizard:dropwizard-request-logging:jar:4.0.16:compile
[INFO] |  |  \- ch.qos.logback.access:logback-access-jetty11:jar:2.0.6:compile
[INFO] |  +- net.sourceforge.argparse4j:argparse4j:jar:0.9.0:compile
[INFO] |  +- org.eclipse.jetty:jetty-servlet:jar:11.0.26:compile
[INFO] |  +- org.eclipse.jetty.toolchain.setuid:jetty-setuid-java:jar:1.0.4:compile
[INFO] |  \- org.glassfish.jersey.ext:jersey-bean-validation:jar:3.0.18:compile
[INFO] |     \- org.jboss.logging:jboss-logging:jar:3.6.1.Final:compile
[INFO] +- io.dropwizard:dropwizard-jdbi3:jar:4.0.16:compile
[INFO] |  +- io.dropwizard:dropwizard-db:jar:4.0.16:compile
[INFO] |  |  \- org.apache.tomcat:tomcat-jdbc:jar:10.1.44:compile
[INFO] |  |     \- org.apache.tomcat:tomcat-juli:jar:10.1.44:compile
[INFO] |  \- io.dropwizard.metrics:metrics-jdbi3:jar:4.2.34:compile
[INFO] +- io.dropwizard:dropwizard-forms:jar:4.0.16:compile
[INFO] |  \- org.glassfish.jersey.media:jersey-media-multipart:jar:3.0.18:compile
[INFO] |     \- org.jvnet.mimepull:mimepull:jar:1.9.15:compile
[INFO] +- ch.qos.logback.access:logback-access-common:jar:2.0.6:compile
[INFO] +- ch.qos.logback:logback-classic:jar:1.5.18:compile
[INFO] +- ch.qos.logback:logback-core:jar:1.5.18:compile
[INFO] +- io.netty:netty-codec-dns:jar:4.1.127.Final:compile
[INFO] |  +- io.netty:netty-common:jar:4.1.127.Final:compile
[INFO] |  +- io.netty:netty-buffer:jar:4.1.127.Final:compile
[INFO] |  \- io.netty:netty-codec:jar:4.1.127.Final:compile
[INFO] +- io.netty:netty-codec-http:jar:4.1.127.Final:compile
[INFO] |  \- io.netty:netty-handler:jar:4.1.127.Final:compile
[INFO] |     \- io.netty:netty-transport-native-unix-common:jar:4.1.127.Final:compile
[INFO] +- io.netty:netty-transport:jar:4.1.127.Final:compile
[INFO] |  \- io.netty:netty-resolver:jar:4.1.127.Final:compile
[INFO] +- io.netty:netty-codec-socks:jar:4.1.127.Final:compile
[INFO] +- io.netty:netty-resolver-dns:jar:4.1.127.Final:compile
[INFO] +- io.netty:netty-handler-proxy:jar:4.1.127.Final:compile
[INFO] +- au.com.dius.pact:consumer:jar:4.6.17:test
[INFO] |  +- au.com.dius.pact.core:support:jar:4.6.17:test
[INFO] |  |  +- io.github.oshai:kotlin-logging-jvm:jar:5.1.4:test
[INFO] |  |  \- com.github.mifmif:generex:jar:1.0.2:test
[INFO] |  |     \- dk.brics.automaton:automaton:jar:1.11-8:test
[INFO] |  +- au.com.dius.pact.core:model:jar:4.6.17:test
[INFO] |  |  +- javax.mail:mail:jar:1.5.0-b01:test
[INFO] |  |  \- io.ktor:ktor-http-jvm:jar:2.3.8:test
[INFO] |  |     +- org.jetbrains.kotlin:kotlin-stdlib-jdk7:jar:1.8.22:test
[INFO] |  |     +- org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:jar:1.7.1:test
[INFO] |  |     +- org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:jar:1.7.1:test
[INFO] |  |     \- io.ktor:ktor-utils-jvm:jar:2.3.8:test
[INFO] |  |        \- io.ktor:ktor-io-jvm:jar:2.3.8:test
[INFO] |  +- au.com.dius.pact.core:matchers:jar:4.6.17:test
[INFO] |  |  +- io.github.java-diff-utils:java-diff-utils:jar:4.12:test
[INFO] |  |  +- org.atteo:evo-inflector:jar:1.3:test
[INFO] |  |  \- com.github.zafarkhaja:java-semver:jar:0.9.0:test
[INFO] |  +- org.json:json:jar:20240205:test
[INFO] |  +- org.jetbrains.kotlin:kotlin-stdlib:jar:1.8.22:test
[INFO] |  |  +- org.jetbrains.kotlin:kotlin-stdlib-common:jar:1.8.22:test
[INFO] |  |  \- org.jetbrains:annotations:jar:13.0:compile
[INFO] |  +- org.jetbrains.kotlin:kotlin-reflect:jar:1.8.22:test
[INFO] |  +- org.apache.httpcomponents.client5:httpclient5-fluent:jar:5.3.1:test
[INFO] |  +- com.googlecode.java-diff-utils:diffutils:jar:1.3.0:test
[INFO] |  +- io.ktor:ktor-server-netty:jar:2.3.8:test
[INFO] |  |  \- org.jetbrains.kotlinx:kotlinx-coroutines-core:jar:1.7.1:test
[INFO] |  +- io.ktor:ktor-network-tls-certificates:jar:2.3.8:test
[INFO] |  +- io.ktor:ktor-server-call-logging:jar:2.3.8:test
[INFO] |  |  \- io.ktor:ktor-server-core:jar:2.3.8:test
[INFO] |  |     +- org.jetbrains.kotlinx:atomicfu:jar:0.19.0:test
[INFO] |  |     |  \- org.jetbrains.kotlinx:atomicfu-jvm:jar:0.19.0:test
[INFO] |  |     +- io.ktor:ktor-utils:jar:2.3.8:test
[INFO] |  |     |  \- io.ktor:ktor-io:jar:2.3.8:test
[INFO] |  |     +- io.ktor:ktor-http:jar:2.3.8:test
[INFO] |  |     +- io.ktor:ktor-serialization:jar:2.3.8:test
[INFO] |  |     |  \- io.ktor:ktor-websockets:jar:2.3.8:test
[INFO] |  |     \- io.ktor:ktor-events:jar:2.3.8:test
[INFO] |  +- io.pact.plugin.driver:core:jar:0.5.1:test
[INFO] |  |  +- com.vdurmont:semver4j:jar:3.1.0:test
[INFO] |  |  +- io.hotmoka:toml4j:jar:0.7.3:test
[INFO] |  |  +- org.rauschig:jarchivelib:jar:1.2.0:test
[INFO] |  |  \- org.apache.commons:commons-compress:jar:1.26.1:test
[INFO] |  +- org.apache.commons:commons-text:jar:1.10.0:compile
[INFO] |  \- org.apache.tika:tika-core:jar:2.9.1:test
[INFO] +- au.com.dius.pact:provider:jar:4.6.17:test
[INFO] |  +- au.com.dius.pact.core:pactbroker:jar:4.6.17:test
[INFO] |  +- io.github.classgraph:classgraph:jar:4.8.129:test
[INFO] |  +- com.github.ajalt:mordant:jar:1.2.1:test
[INFO] |  |  \- com.github.ajalt:colormath:jar:1.2.0:test
[INFO] |  +- com.vladsch.flexmark:flexmark:jar:0.62.2:test
[INFO] |  |  +- com.vladsch.flexmark:flexmark-util-ast:jar:0.62.2:test
[INFO] |  |  +- com.vladsch.flexmark:flexmark-util-builder:jar:0.62.2:test
[INFO] |  |  +- com.vladsch.flexmark:flexmark-util-collection:jar:0.62.2:test
[INFO] |  |  +- com.vladsch.flexmark:flexmark-util-data:jar:0.62.2:test
[INFO] |  |  +- com.vladsch.flexmark:flexmark-util-dependency:jar:0.62.2:test
[INFO] |  |  +- com.vladsch.flexmark:flexmark-util-format:jar:0.62.2:test
[INFO] |  |  +- com.vladsch.flexmark:flexmark-util-html:jar:0.62.2:test
[INFO] |  |  +- com.vladsch.flexmark:flexmark-util-misc:jar:0.62.2:test
[INFO] |  |  +- com.vladsch.flexmark:flexmark-util-sequence:jar:0.62.2:test
[INFO] |  |  \- com.vladsch.flexmark:flexmark-util-visitor:jar:0.62.2:test
[INFO] |  +- com.vladsch.flexmark:flexmark-ext-tables:jar:0.62.2:test
[INFO] |  |  \- com.vladsch.flexmark:flexmark-util:jar:0.62.2:test
[INFO] |  |     \- com.vladsch.flexmark:flexmark-util-options:jar:0.62.2:test
[INFO] |  +- org.apache.groovy:groovy:jar:4.0.18:test
[INFO] |  \- com.michael-bull.kotlin-result:kotlin-result-jvm:jar:1.1.14:test
[INFO] |     \- org.jetbrains.kotlin:kotlin-stdlib-jdk8:jar:1.6.10:test
[INFO] +- au.com.dius.pact.consumer:junit5:jar:4.6.17:test
[INFO] |  \- org.junit.jupiter:junit-jupiter-api:jar:5.13.4:test
[INFO] |     +- org.opentest4j:opentest4j:jar:1.3.0:test
[INFO] |     \- org.junit.platform:junit-platform-commons:jar:1.13.4:test
[INFO] +- io.dropwizard:dropwizard-testing:jar:4.0.16:test
[INFO] |  +- com.fasterxml.jackson.jakarta.rs:jackson-jakarta-rs-json-provider:jar:2.19.2:compile
[INFO] |  |  +- com.fasterxml.jackson.jakarta.rs:jackson-jakarta-rs-base:jar:2.19.2:compile
[INFO] |  |  \- com.fasterxml.jackson.module:jackson-module-jakarta-xmlbind-annotations:jar:2.19.2:compile
[INFO] |  +- org.glassfish.jersey.containers:jersey-container-servlet-core:jar:3.0.18:compile
[INFO] |  +- org.glassfish.jersey.connectors:jersey-apache5-connector:jar:3.0.18:test
[INFO] |  +- org.glassfish.jersey.test-framework:jersey-test-framework-core:jar:3.0.18:test
[INFO] |  |  +- org.glassfish.jersey.media:jersey-media-jaxb:jar:3.0.18:test
[INFO] |  |  +- org.junit.jupiter:junit-jupiter:jar:5.13.4:test
[INFO] |  |  |  +- org.junit.jupiter:junit-jupiter-params:jar:5.13.4:test
[INFO] |  |  |  \- org.junit.jupiter:junit-jupiter-engine:jar:5.13.4:test
[INFO] |  |  \- org.hamcrest:hamcrest:jar:3.0:test
[INFO] |  +- org.glassfish.jersey.test-framework.providers:jersey-test-framework-provider-inmemory:jar:3.0.18:test
[INFO] |  +- jakarta.activation:jakarta.activation-api:jar:2.0.1:compile
[INFO] |  \- jakarta.xml.bind:jakarta.xml.bind-api:jar:3.0.1:compile
[INFO] |     \- com.sun.activation:jakarta.activation:jar:2.0.1:compile
[INFO] +- org.mockito:mockito-core:jar:5.19.0:test
[INFO] |  +- net.bytebuddy:byte-buddy:jar:1.17.6:test
[INFO] |  +- net.bytebuddy:byte-buddy-agent:jar:1.17.6:test
[INFO] |  \- org.objenesis:objenesis:jar:3.3:test
[INFO] +- org.mockito:mockito-junit-jupiter:jar:5.19.0:test
[INFO] +- org.junit.platform:junit-platform-launcher:jar:1.13.4:test
[INFO] |  +- org.junit.platform:junit-platform-engine:jar:1.13.4:test
[INFO] |  \- org.apiguardian:apiguardian-api:jar:1.1.2:test
[INFO] +- org.liquibase:liquibase-core:jar:4.33.0:compile
[INFO] |  +- com.opencsv:opencsv:jar:5.11.2:compile
[INFO] |  +- org.yaml:snakeyaml:jar:2.4:compile
[INFO] |  \- javax.xml.bind:jaxb-api:jar:2.3.1:compile
[INFO] +- com.sun.mail:javax.mail:jar:1.6.2:compile
[INFO] |  \- javax.activation:activation:jar:1.1:compile
[INFO] +- org.freemarker:freemarker:jar:2.3.34:compile
[INFO] +- org.jsoup:jsoup:jar:1.21.2:test
[INFO] +- com.google.guava:guava:jar:33.5.0-jre:compile
[INFO] |  +- com.google.guava:failureaccess:jar:1.0.3:compile
[INFO] |  +- com.google.guava:listenablefuture:jar:9999.0-empty-to-avoid-conflict-with-guava:compile
[INFO] |  +- org.jspecify:jspecify:jar:1.0.0:compile
[INFO] |  +- com.google.errorprone:error_prone_annotations:jar:2.41.0:compile
[INFO] |  \- com.google.j2objc:j2objc-annotations:jar:3.1:compile
[INFO] +- org.postgresql:postgresql:jar:42.7.8:compile
[INFO] +- org.testcontainers:postgresql:jar:1.21.3:test
[INFO] |  \- org.testcontainers:jdbc:jar:1.21.3:test
[INFO] |     \- org.testcontainers:database-commons:jar:1.21.3:test
[INFO] +- org.testcontainers:mockserver:jar:1.21.3:test
[INFO] |  \- org.testcontainers:testcontainers:jar:1.21.3:test
[INFO] |     +- junit:junit:jar:4.13.2:test
[INFO] |     |  \- org.hamcrest:hamcrest-core:jar:1.3:test
[INFO] |     +- org.rnorth.duct-tape:duct-tape:jar:1.0.8:test
[INFO] |     +- com.github.docker-java:docker-java-api:jar:3.4.2:test
[INFO] |     \- com.github.docker-java:docker-java-transport-zerodep:jar:3.4.2:test
[INFO] |        +- com.github.docker-java:docker-java-transport:jar:3.4.2:test
[INFO] |        \- net.java.dev.jna:jna:jar:5.13.0:test
[INFO] +- org.mock-server:mockserver-client-java:jar:5.15.0:test
[INFO] |  \- org.mock-server:mockserver-core:jar:5.15.0:test
[INFO] |     +- com.lmax:disruptor:jar:3.4.4:test
[INFO] |     +- javax.servlet:javax.servlet-api:jar:4.0.1:test
[INFO] |     +- io.netty:netty-codec-http2:jar:4.1.86.Final:test
[INFO] |     +- io.netty:netty-tcnative-boringssl-static:jar:2.0.56.Final:test
[INFO] |     |  +- io.netty:netty-tcnative-classes:jar:2.0.56.Final:test
[INFO] |     |  +- io.netty:netty-tcnative-boringssl-static:jar:linux-x86_64:2.0.56.Final:test
[INFO] |     |  +- io.netty:netty-tcnative-boringssl-static:jar:linux-aarch_64:2.0.56.Final:test
[INFO] |     |  +- io.netty:netty-tcnative-boringssl-static:jar:osx-x86_64:2.0.56.Final:test
[INFO] |     |  +- io.netty:netty-tcnative-boringssl-static:jar:osx-aarch_64:2.0.56.Final:test
[INFO] |     |  \- io.netty:netty-tcnative-boringssl-static:jar:windows-x86_64:2.0.56.Final:test
[INFO] |     +- com.jcraft:jzlib:jar:1.1.3:test
[INFO] |     +- com.fasterxml.uuid:java-uuid-generator:jar:4.1.0:test
[INFO] |     +- org.bouncycastle:bcpkix-jdk18on:jar:1.72:test
[INFO] |     |  \- org.bouncycastle:bcutil-jdk18on:jar:1.72:test
[INFO] |     +- com.nimbusds:nimbus-jose-jwt:jar:9.28:test
[INFO] |     |  \- com.github.stephenc.jcip:jcip-annotations:jar:1.0-1:test
[INFO] |     +- org.apache.velocity:velocity-engine-scripting:jar:2.3:test
[INFO] |     +- org.apache.velocity:velocity-engine-core:jar:2.3:test
[INFO] |     +- org.apache.velocity.tools:velocity-tools-generic:jar:3.1:test
[INFO] |     |  +- org.apache.commons:commons-digester3:jar:3.2:test
[INFO] |     |  \- com.github.cliftonlabs:json-simple:jar:3.0.2:test
[INFO] |     +- com.samskivert:jmustache:jar:1.15:test
[INFO] |     +- net.javacrumbs.json-unit:json-unit-core:jar:2.36.0:test
[INFO] |     +- com.jayway.jsonpath:json-path:jar:2.7.0:test
[INFO] |     |  \- net.minidev:json-smart:jar:2.4.7:test
[INFO] |     |     \- net.minidev:accessors-smart:jar:2.4.7:test
[INFO] |     +- io.swagger.parser.v3:swagger-parser:jar:2.1.10:test
[INFO] |     |  +- io.swagger.parser.v3:swagger-parser-v2-converter:jar:2.1.10:test
[INFO] |     |  |  +- io.swagger:swagger-core:jar:1.6.9:test
[INFO] |     |  |  |  \- io.swagger:swagger-models:jar:1.6.9:test
[INFO] |     |  |  |     \- io.swagger:swagger-annotations:jar:1.6.9:test
[INFO] |     |  |  +- io.swagger:swagger-parser:jar:1.0.64:test
[INFO] |     |  |  +- io.swagger:swagger-compat-spec-parser:jar:1.0.64:test
[INFO] |     |  |  |  +- com.github.java-json-tools:json-schema-validator:jar:2.2.14:test
[INFO] |     |  |  |  |  +- com.github.java-json-tools:jackson-coreutils-equivalence:jar:1.0:test
[INFO] |     |  |  |  |  +- com.github.java-json-tools:json-schema-core:jar:1.2.14:test
[INFO] |     |  |  |  |  |  +- com.github.java-json-tools:uri-template:jar:0.10:test
[INFO] |     |  |  |  |  |  \- org.mozilla:rhino:jar:1.7.7.2:test
[INFO] |     |  |  |  |  +- com.sun.mail:mailapi:jar:1.6.2:test
[INFO] |     |  |  |  |  +- com.googlecode.libphonenumber:libphonenumber:jar:8.11.1:test
[INFO] |     |  |  |  |  \- net.sf.jopt-simple:jopt-simple:jar:5.0.4:test
[INFO] |     |  |  |  \- com.github.java-json-tools:json-patch:jar:1.13:test
[INFO] |     |  |  |     +- com.github.java-json-tools:msg-simple:jar:1.2:test
[INFO] |     |  |  |     |  \- com.github.java-json-tools:btf:jar:1.3:test
[INFO] |     |  |  |     \- com.github.java-json-tools:jackson-coreutils:jar:2.0:test
[INFO] |     |  |  +- io.swagger.core.v3:swagger-models:jar:2.2.8:test
[INFO] |     |  |  \- io.swagger.parser.v3:swagger-parser-core:jar:2.1.10:test
[INFO] |     |  \- io.swagger.parser.v3:swagger-parser-v3:jar:2.1.10:test
[INFO] |     |     \- io.swagger.core.v3:swagger-core:jar:2.2.8:test
[INFO] |     |        \- io.swagger.core.v3:swagger-annotations:jar:2.2.8:test
[INFO] |     +- com.sun.xml.bind:jaxb-impl:jar:4.0.1:test
[INFO] |     |  \- com.sun.xml.bind:jaxb-core:jar:4.0.1:test
[INFO] |     |     \- org.eclipse.angus:angus-activation:jar:1.0.0:test
[INFO] |     +- org.xmlunit:xmlunit-core:jar:2.9.1:test
[INFO] |     +- org.xmlunit:xmlunit-placeholders:jar:2.9.1:test
[INFO] |     +- io.prometheus:simpleclient:jar:0.16.0:test
[INFO] |     |  +- io.prometheus:simpleclient_tracer_otel:jar:0.16.0:test
[INFO] |     |  |  \- io.prometheus:simpleclient_tracer_common:jar:0.16.0:test
[INFO] |     |  \- io.prometheus:simpleclient_tracer_otel_agent:jar:0.16.0:test
[INFO] |     \- io.prometheus:simpleclient_httpserver:jar:0.16.0:test
[INFO] |        \- io.prometheus:simpleclient_common:jar:0.16.0:test
[INFO] +- com.google.api-client:google-api-client:jar:2.8.1:compile
[INFO] |  +- commons-codec:commons-codec:jar:1.17.1:compile
[INFO] |  +- com.google.oauth-client:google-oauth-client:jar:1.36.0:compile
[INFO] |  +- com.google.auth:google-auth-library-credentials:jar:1.30.0:compile
[INFO] |  +- com.google.auth:google-auth-library-oauth2-http:jar:1.30.0:compile
[INFO] |  +- com.google.http-client:google-http-client-gson:jar:2.0.0:compile
[INFO] |  +- com.google.http-client:google-http-client-apache-v2:jar:2.0.0:compile
[INFO] |  \- com.google.http-client:google-http-client:jar:2.0.0:compile
[INFO] +- com.google.cloud:google-cloud-storage:jar:2.58.0:compile
[INFO] |  +- io.grpc:grpc-context:jar:1.71.0:compile
[INFO] |  +- io.opencensus:opencensus-contrib-http-util:jar:0.31.1:compile
[INFO] |  +- com.google.http-client:google-http-client-jackson2:jar:1.47.1:compile
[INFO] |  +- com.google.apis:google-api-services-storage:jar:v1-rev20250815-2.0.0:compile
[INFO] |  +- com.google.cloud:google-cloud-core:jar:2.60.2:compile
[INFO] |  +- com.google.auto.value:auto-value-annotations:jar:1.11.0:compile
[INFO] |  +- com.google.cloud:google-cloud-core-http:jar:2.60.2:compile
[INFO] |  +- com.google.http-client:google-http-client-appengine:jar:1.47.1:compile
[INFO] |  +- com.google.api:gax-httpjson:jar:2.70.2:compile
[INFO] |  +- com.google.cloud:google-cloud-core-grpc:jar:2.60.2:compile
[INFO] |  +- com.google.api:gax:jar:2.70.2:compile
[INFO] |  +- com.google.api:gax-grpc:jar:2.70.2:compile
[INFO] |  +- io.grpc:grpc-inprocess:jar:1.71.0:compile
[INFO] |  +- io.grpc:grpc-alts:jar:1.71.0:compile
[INFO] |  +- io.grpc:grpc-grpclb:jar:1.71.0:compile
[INFO] |  +- org.conscrypt:conscrypt-openjdk-uber:jar:2.5.2:compile
[INFO] |  +- io.grpc:grpc-auth:jar:1.71.0:compile
[INFO] |  +- com.google.api:api-common:jar:2.53.2:compile
[INFO] |  +- javax.annotation:javax.annotation-api:jar:1.3.2:compile
[INFO] |  +- io.opencensus:opencensus-api:jar:0.31.1:compile
[INFO] |  +- io.opentelemetry:opentelemetry-context:jar:1.47.0:compile
[INFO] |  +- com.google.api.grpc:proto-google-iam-v1:jar:1.56.2:compile
[INFO] |  +- com.google.protobuf:protobuf-java:jar:3.25.8:compile
[INFO] |  +- com.google.protobuf:protobuf-java-util:jar:3.25.8:compile
[INFO] |  +- io.grpc:grpc-core:jar:1.71.0:compile
[INFO] |  +- com.google.android:annotations:jar:4.1.1.4:runtime
[INFO] |  +- org.codehaus.mojo:animal-sniffer-annotations:jar:1.24:compile
[INFO] |  +- io.perfmark:perfmark-api:jar:0.27.0:runtime
[INFO] |  +- io.grpc:grpc-protobuf:jar:1.71.0:compile
[INFO] |  +- io.grpc:grpc-protobuf-lite:jar:1.71.0:runtime
[INFO] |  +- com.google.api.grpc:proto-google-common-protos:jar:2.61.2:compile
[INFO] |  +- org.threeten:threetenbp:jar:1.7.0:compile
[INFO] |  +- com.google.api.grpc:proto-google-cloud-storage-v2:jar:2.58.0:compile
[INFO] |  +- com.google.api.grpc:grpc-google-cloud-storage-v2:jar:2.58.0:compile
[INFO] |  +- com.google.api.grpc:gapic-google-cloud-storage-v2:jar:2.58.0:compile
[INFO] |  +- io.opentelemetry:opentelemetry-sdk:jar:1.47.0:compile
[INFO] |  +- io.opentelemetry:opentelemetry-sdk-trace:jar:1.47.0:compile
[INFO] |  +- io.opentelemetry:opentelemetry-sdk-logs:jar:1.47.0:compile
[INFO] |  +- io.grpc:grpc-opentelemetry:jar:1.71.0:compile
[INFO] |  +- io.opentelemetry:opentelemetry-api:jar:1.47.0:compile
[INFO] |  +- io.opentelemetry:opentelemetry-sdk-metrics:jar:1.47.0:compile
[INFO] |  +- io.opentelemetry:opentelemetry-sdk-common:jar:1.47.0:compile
[INFO] |  +- io.opentelemetry:opentelemetry-sdk-extension-autoconfigure-spi:jar:1.47.0:compile
[INFO] |  +- io.opentelemetry.semconv:opentelemetry-semconv:jar:1.29.0-alpha:compile
[INFO] |  +- com.google.cloud.opentelemetry:exporter-metrics:jar:0.33.0:compile
[INFO] |  +- com.google.cloud:google-cloud-monitoring:jar:3.52.0:compile
[INFO] |  +- com.google.api.grpc:proto-google-cloud-monitoring-v3:jar:3.52.0:compile
[INFO] |  +- com.google.cloud.opentelemetry:shared-resourcemapping:jar:0.33.0:runtime
[INFO] |  +- io.opentelemetry.contrib:opentelemetry-gcp-resources:jar:1.37.0-alpha:compile
[INFO] |  +- com.google.cloud.opentelemetry:detector-resources-support:jar:0.33.0:runtime
[INFO] |  +- com.google.code.findbugs:jsr305:jar:3.0.2:compile
[INFO] |  +- io.grpc:grpc-api:jar:1.71.0:compile
[INFO] |  +- io.grpc:grpc-netty-shaded:jar:1.71.0:runtime
[INFO] |  +- io.grpc:grpc-util:jar:1.71.0:runtime
[INFO] |  +- io.grpc:grpc-stub:jar:1.71.0:compile
[INFO] |  +- io.grpc:grpc-googleapis:jar:1.71.0:runtime
[INFO] |  +- io.grpc:grpc-xds:jar:1.71.0:runtime
[INFO] |  +- io.grpc:grpc-services:jar:1.71.0:runtime
[INFO] |  +- com.google.re2j:re2j:jar:1.8:runtime
[INFO] |  \- io.grpc:grpc-rls:jar:1.71.0:runtime
[INFO] +- commons-io:commons-io:jar:2.20.0:compile
[INFO] +- com.google.apis:google-api-services-oauth2:jar:v2-rev20200213-2.0.0:compile
[INFO] +- com.google.inject:guice:jar:7.0.0:compile
[INFO] |  \- aopalliance:aopalliance:jar:1.0:compile
[INFO] +- com.google.code.gson:gson:jar:2.13.2:compile
[INFO] +- org.apache.commons:commons-collections4:jar:4.5.0:compile
[INFO] +- org.apache.commons:commons-lang3:jar:3.19.0:compile
[INFO] +- org.elasticsearch.client:elasticsearch-rest-client:jar:9.1.4:compile
[INFO] |  +- org.apache.httpcomponents:httpasyncclient:jar:4.1.5:compile
[INFO] |  +- org.apache.httpcomponents:httpcore-nio:jar:4.4.16:compile
[INFO] |  \- commons-logging:commons-logging:jar:1.2:compile
[INFO] +- org.webjars:swagger-ui:jar:5.28.1:compile
[INFO] +- commons-validator:commons-validator:jar:1.10.0:compile
[INFO] |  +- commons-digester:commons-digester:jar:2.1:compile
[INFO] |  \- commons-collections:commons-collections:jar:3.2.2:compile
[INFO] +- commons-beanutils:commons-beanutils:jar:1.11.0:compile
[INFO] +- com.cloudbees.thirdparty:zendesk-java-client:jar:1.3.1:compile
[INFO] |  +- org.asynchttpclient:async-http-client:jar:3.0.1:compile
[INFO] |  \- com.damnhandy:handy-uri-templates:jar:2.1.8:compile
[INFO] |     \- joda-time:joda-time:jar:2.10.2:compile
[INFO] \- org.skyscreamer:jsonassert:jar:2.0-rc1:test

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
