### PR TITLE
DT-2288: Standardize class injection in main application

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -33,6 +33,7 @@ jobs:
           MAVEN_OPTS: -Dorg.slf4j.simpleLogger.defaultLogLevel=warn -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
         run: mvn clean test  --batch-mode
       - name: Test Report
+        continue-on-error: true
         if: github.actor != 'dependabot[bot]'
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
@@ -40,7 +40,6 @@ import org.broadinstitute.consent.http.authentication.AuthorizationHelper;
 import org.broadinstitute.consent.http.authentication.DuosUserAuthenticator;
 import org.broadinstitute.consent.http.authentication.OAuthAuthenticator;
 import org.broadinstitute.consent.http.authentication.OAuthCustomAuthFilter;
-import org.broadinstitute.consent.http.cloudstore.GCSService;
 import org.broadinstitute.consent.http.configurations.ConsentConfiguration;
 import org.broadinstitute.consent.http.filters.RequestHeaderCacheFilter;
 import org.broadinstitute.consent.http.filters.ResponseServerFilter;
@@ -80,26 +79,6 @@ import org.broadinstitute.consent.http.resources.TosResource;
 import org.broadinstitute.consent.http.resources.UserResource;
 import org.broadinstitute.consent.http.resources.VersionResource;
 import org.broadinstitute.consent.http.resources.VoteResource;
-import org.broadinstitute.consent.http.service.AcknowledgementService;
-import org.broadinstitute.consent.http.service.DarCollectionService;
-import org.broadinstitute.consent.http.service.DataAccessRequestService;
-import org.broadinstitute.consent.http.service.DatasetRegistrationService;
-import org.broadinstitute.consent.http.service.DatasetService;
-import org.broadinstitute.consent.http.service.DraftService;
-import org.broadinstitute.consent.http.service.ElasticSearchService;
-import org.broadinstitute.consent.http.service.ElectionService;
-import org.broadinstitute.consent.http.service.EmailService;
-import org.broadinstitute.consent.http.service.InstitutionService;
-import org.broadinstitute.consent.http.service.LibraryCardService;
-import org.broadinstitute.consent.http.service.MatchService;
-import org.broadinstitute.consent.http.service.MetricsService;
-import org.broadinstitute.consent.http.service.NihService;
-import org.broadinstitute.consent.http.service.OidcService;
-import org.broadinstitute.consent.http.service.TDRService;
-import org.broadinstitute.consent.http.service.UserService;
-import org.broadinstitute.consent.http.service.VoteService;
-import org.broadinstitute.consent.http.service.sam.SamService;
-import org.broadinstitute.consent.http.util.HttpClientUtil;
 import org.broadinstitute.consent.http.util.gson.JerseyGsonProvider;
 import org.eclipse.jetty.servlet.ErrorPageErrorHandler;
 import org.glassfish.jersey.internal.inject.AbstractBinder;
@@ -154,42 +133,8 @@ public class ConsentApplication extends Application<ConsentConfiguration> {
       LOGGER.error(MessageFormat.format("Exception initializing liquibase: {0}", e));
     }
 
-    // Previously, this code was working around a dropwizard+Guice issue with singletons and JDBI.
     final Injector injector = Guice.createInjector(new ConsentModule(config, env));
-
-    // Clients
-    final HttpClientUtil clientUtil = new HttpClientUtil(config.getServicesConfiguration());
-
-    // Services
-    final DarCollectionService darCollectionService = injector.getProvider(
-        DarCollectionService.class).get();
-    final DataAccessRequestService dataAccessRequestService = injector.getProvider(DataAccessRequestService.class).get();
-    final DatasetService datasetService = injector.getProvider(DatasetService.class).get();
-    final ElectionService electionService = injector.getProvider(ElectionService.class).get();
-    final EmailService emailService = injector.getProvider(EmailService.class).get();
-    final GCSService gcsService = injector.getProvider(GCSService.class).get();
-    final InstitutionService institutionService = injector.getProvider(InstitutionService.class)
-        .get();
-    final MetricsService metricsService = injector.getProvider(MetricsService.class).get();
-    final UserService userService = injector.getProvider(UserService.class).get();
-    final VoteService voteService = injector.getProvider(VoteService.class).get();
-    final MatchService matchService = injector.getProvider(MatchService.class).get();
-    final LibraryCardService libraryCardService = injector.getProvider(LibraryCardService.class)
-        .get();
-    final SamService samService = injector.getProvider(SamService.class).get();
-    final TDRService tdrService = injector.getProvider(TDRService.class).get();
-    final AcknowledgementService acknowledgementService = injector.getProvider(
-        AcknowledgementService.class).get();
-    final DatasetRegistrationService datasetRegistrationService = injector.getProvider(
-        DatasetRegistrationService.class).get();
-    final ElasticSearchService elasticSearchService = injector.getProvider(
-        ElasticSearchService.class).get();
-    final OidcService oidcService = injector.getProvider(OidcService.class).get();
-    final DraftService draftService = injector.getProvider(
-        DraftService.class).get();
-
     System.setProperty("sun.net.http.allowRestrictedHeaders", "true");
-
     env.jersey().register(JerseyGsonProvider.class);
 
     // Metric Registry
@@ -197,17 +142,12 @@ public class ConsentApplication extends Application<ConsentConfiguration> {
     env.jersey().register(new InstrumentedResourceMethodApplicationListener(metricRegistry));
 
     // Health Checks
-    env.healthChecks().register(GCS_CHECK, new GCSHealthCheck(gcsService));
-    env.healthChecks()
-        .register(ES_CHECK, new ElasticSearchHealthCheck(config.getElasticSearchConfiguration()));
-    env.healthChecks().register(ONTOLOGY_CHECK,
-        new OntologyHealthCheck(clientUtil, config.getServicesConfiguration()));
-    env.healthChecks()
-        .register(SAM_CHECK, new SamHealthCheck(clientUtil, config.getServicesConfiguration()));
-    env.healthChecks()
-        .register(SG_CHECK, new SendGridHealthCheck(clientUtil, config.getMailConfiguration()));
+    env.healthChecks().register(GCS_CHECK, injector.getInstance(GCSHealthCheck.class));
+    env.healthChecks().register(ES_CHECK, injector.getInstance(ElasticSearchHealthCheck.class));
+    env.healthChecks().register(ONTOLOGY_CHECK, injector.getInstance(OntologyHealthCheck.class));
+    env.healthChecks().register(SAM_CHECK, injector.getInstance(SamHealthCheck.class));
+    env.healthChecks().register(SG_CHECK, injector.getInstance(SendGridHealthCheck.class));
 
-    final NihService nihService = injector.getProvider(NihService.class).get();
     // Custom Error handling. Expand to include other codes when necessary
     final ErrorPageErrorHandler errorHandler = new ErrorPageErrorHandler();
     errorHandler.addErrorPage(404, "/error/404");
@@ -217,37 +157,33 @@ public class ConsentApplication extends Application<ConsentConfiguration> {
 
     // Register standard application resources.
     env.jersey().register(injector.getInstance(DaaResource.class));
-    env.jersey().register(injector.getInstance(DataAccessRequestResource.class));
-    env.jersey().register(new DatasetResource(datasetService, userService,
-        datasetRegistrationService, elasticSearchService, tdrService, gcsService));
-    env.jersey().register(injector.getInstance(DacResource.class));
     env.jersey().register(injector.getInstance(DACAutomationRuleResource.class));
-    env.jersey().register(new DACUserResource(userService));
-    env.jersey().register(
-        new DarCollectionResource(darCollectionService));
-    env.jersey().register(new EmailNotifierResource(dataAccessRequestService));
-    env.jersey().register(new InstitutionResource(institutionService));
-    env.jersey().register(new LibraryCardResource(userService, libraryCardService));
-    env.jersey().register(new MatchResource(matchService));
-    env.jersey().register(new MetricsResource(metricsService));
-    env.jersey().register(new NihAccountResource(nihService));
-    env.jersey().register(new SamResource(samService, userService));
-    env.jersey().register(new SchemaResource());
-    env.jersey().register(new SwaggerResource(config.getGoogleAuthentication()));
-    env.jersey().register(new StatusResource(env.healthChecks()));
-    env.jersey().register(injector.getInstance(SupportResource.class));
-    env.jersey().register(
-        new UserResource(samService, userService, datasetService, acknowledgementService, nihService));
-    env.jersey().register(new TosResource(samService));
-    env.jersey().register(injector.getInstance(VersionResource.class));
-    env.jersey().register(new VoteResource(userService, voteService, electionService));
-    env.jersey().register(new LivenessResource());
-    env.jersey().register(
-        new TDRResource(tdrService, datasetService));
-    env.jersey().register(new MailResource(emailService));
+    env.jersey().register(injector.getInstance(DacResource.class));
+    env.jersey().register(injector.getInstance(DACUserResource.class));
+    env.jersey().register(injector.getInstance(DarCollectionResource.class));
+    env.jersey().register(injector.getInstance(DataAccessRequestResource.class));
+    env.jersey().register(injector.getInstance(DatasetResource.class));
+    env.jersey().register(injector.getInstance(DraftResource.class));
+    env.jersey().register(injector.getInstance(EmailNotifierResource.class));
+    env.jersey().register(injector.getInstance(InstitutionResource.class));
+    env.jersey().register(injector.getInstance(LibraryCardResource.class));
+    env.jersey().register(injector.getInstance(LivenessResource.class));
+    env.jersey().register(injector.getInstance(MailResource.class));
+    env.jersey().register(injector.getInstance(MatchResource.class));
+    env.jersey().register(injector.getInstance(MetricsResource.class));
+    env.jersey().register(injector.getInstance(NihAccountResource.class));
+    env.jersey().register(injector.getInstance(OAuth2Resource.class));
+    env.jersey().register(injector.getInstance(SamResource.class));
+    env.jersey().register(injector.getInstance(SchemaResource.class));
+    env.jersey().register(injector.getInstance(SwaggerResource.class));
+    env.jersey().register(injector.getInstance(StatusResource.class));
     env.jersey().register(injector.getInstance(StudyResource.class));
-    env.jersey().register(new OAuth2Resource(oidcService));
-    env.jersey().register(new DraftResource(userService, draftService));
+    env.jersey().register(injector.getInstance(SupportResource.class));
+    env.jersey().register(injector.getInstance(TDRResource.class));
+    env.jersey().register(injector.getInstance(TosResource.class));
+    env.jersey().register(injector.getInstance(UserResource.class));
+    env.jersey().register(injector.getInstance(VersionResource.class));
+    env.jersey().register(injector.getInstance(VoteResource.class));
 
     // Authentication filters
     final OAuthAuthenticator authenticator = injector.getProvider(OAuthAuthenticator.class).get();

--- a/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.consent.http;
 
+import com.codahale.metrics.health.HealthCheckRegistry;
 import com.google.inject.AbstractModule;
 import com.google.inject.Inject;
 import com.google.inject.Provides;
@@ -13,6 +14,10 @@ import org.broadinstitute.consent.http.authentication.DuosUserAuthenticator;
 import org.broadinstitute.consent.http.authentication.OAuthAuthenticator;
 import org.broadinstitute.consent.http.cloudstore.GCSService;
 import org.broadinstitute.consent.http.configurations.ConsentConfiguration;
+import org.broadinstitute.consent.http.configurations.ElasticSearchConfiguration;
+import org.broadinstitute.consent.http.configurations.GoogleOAuth2Config;
+import org.broadinstitute.consent.http.configurations.MailConfiguration;
+import org.broadinstitute.consent.http.configurations.ServicesConfiguration;
 import org.broadinstitute.consent.http.db.AcknowledgementDAO;
 import org.broadinstitute.consent.http.db.CounterDAO;
 import org.broadinstitute.consent.http.db.DACAutomationRuleDAO;
@@ -196,6 +201,31 @@ public class ConsentModule extends AbstractModule {
   @Provides
   Jdbi providesJdbi() {
     return jdbi;
+  }
+
+  @Provides
+  ElasticSearchConfiguration providesElasticSearchConfiguration() {
+    return config.getElasticSearchConfiguration();
+  }
+
+  @Provides
+  MailConfiguration providesMailConfiguration() {
+    return config.getMailConfiguration();
+  }
+
+  @Provides
+  ServicesConfiguration providesServicesConfiguration() {
+    return config.getServicesConfiguration();
+  }
+
+  @Provides
+  GoogleOAuth2Config providesGoogleOAuth2Config() {
+    return config.getGoogleAuthentication();
+  }
+
+  @Provides
+  HealthCheckRegistry providesHealthCheckRegistry() {
+    return environment.healthChecks();
   }
 
   @Provides

--- a/src/main/java/org/broadinstitute/consent/http/health/ElasticSearchHealthCheck.java
+++ b/src/main/java/org/broadinstitute/consent/http/health/ElasticSearchHealthCheck.java
@@ -5,6 +5,7 @@ import static org.broadinstitute.consent.http.service.ontology.ElasticSearchSupp
 import com.codahale.metrics.health.HealthCheck;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import com.google.inject.Inject;
 import io.dropwizard.lifecycle.Managed;
 import java.io.IOException;
 import java.nio.charset.Charset;
@@ -31,6 +32,7 @@ public class ElasticSearchHealthCheck extends HealthCheck implements Managed {
     }
   }
 
+  @Inject
   public ElasticSearchHealthCheck(ElasticSearchConfiguration config) {
     this.client = ElasticSearchSupport.createRestClient(config);
   }

--- a/src/main/java/org/broadinstitute/consent/http/health/GCSHealthCheck.java
+++ b/src/main/java/org/broadinstitute/consent/http/health/GCSHealthCheck.java
@@ -2,12 +2,14 @@ package org.broadinstitute.consent.http.health;
 
 import com.codahale.metrics.health.HealthCheck;
 import com.google.cloud.storage.Bucket;
+import com.google.inject.Inject;
 import org.broadinstitute.consent.http.cloudstore.GCSService;
 
 public class GCSHealthCheck extends HealthCheck {
 
   private final GCSService store;
 
+  @Inject
   public GCSHealthCheck(GCSService store) {
     this.store = store;
   }

--- a/src/main/java/org/broadinstitute/consent/http/health/OntologyHealthCheck.java
+++ b/src/main/java/org/broadinstitute/consent/http/health/OntologyHealthCheck.java
@@ -3,6 +3,7 @@ package org.broadinstitute.consent.http.health;
 import com.codahale.metrics.health.HealthCheck;
 import com.google.api.client.http.HttpStatusCodes;
 import com.google.gson.Gson;
+import com.google.inject.Inject;
 import io.dropwizard.lifecycle.Managed;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.broadinstitute.consent.http.configurations.ServicesConfiguration;
@@ -15,6 +16,7 @@ public class OntologyHealthCheck extends HealthCheck implements Managed {
   private final HttpClientUtil clientUtil;
   private final ServicesConfiguration servicesConfiguration;
 
+  @Inject
   public OntologyHealthCheck(
       HttpClientUtil clientUtil, ServicesConfiguration servicesConfiguration) {
     this.clientUtil = clientUtil;

--- a/src/main/java/org/broadinstitute/consent/http/health/SamHealthCheck.java
+++ b/src/main/java/org/broadinstitute/consent/http/health/SamHealthCheck.java
@@ -3,6 +3,7 @@ package org.broadinstitute.consent.http.health;
 import com.codahale.metrics.health.HealthCheck;
 import com.google.api.client.http.HttpStatusCodes;
 import com.google.gson.Gson;
+import com.google.inject.Inject;
 import io.dropwizard.lifecycle.Managed;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.broadinstitute.consent.http.configurations.ServicesConfiguration;
@@ -15,6 +16,7 @@ public class SamHealthCheck extends HealthCheck implements Managed {
   private final HttpClientUtil clientUtil;
   private final ServicesConfiguration configuration;
 
+  @Inject
   public SamHealthCheck(HttpClientUtil clientUtil, ServicesConfiguration configuration) {
     this.clientUtil = clientUtil;
     this.configuration = configuration;

--- a/src/main/java/org/broadinstitute/consent/http/health/SendGridHealthCheck.java
+++ b/src/main/java/org/broadinstitute/consent/http/health/SendGridHealthCheck.java
@@ -3,6 +3,7 @@ package org.broadinstitute.consent.http.health;
 import com.codahale.metrics.health.HealthCheck;
 import com.google.api.client.http.HttpStatusCodes;
 import com.google.gson.Gson;
+import com.google.inject.Inject;
 import io.dropwizard.lifecycle.Managed;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.broadinstitute.consent.http.configurations.MailConfiguration;
@@ -14,6 +15,7 @@ public class SendGridHealthCheck extends HealthCheck implements Managed {
   private final HttpClientUtil clientUtil;
   private final MailConfiguration configuration;
 
+  @Inject
   public SendGridHealthCheck(HttpClientUtil clientUtil, MailConfiguration configuration) {
     this.clientUtil = clientUtil;
     this.configuration = configuration;

--- a/src/main/java/org/broadinstitute/consent/http/resources/LivenessResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/LivenessResource.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.consent.http.resources;
 
+import com.google.inject.Inject;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
@@ -7,6 +8,11 @@ import jakarta.ws.rs.core.Response;
 
 @Path("liveness")
 public class LivenessResource {
+
+  @Inject
+  public LivenessResource() {
+    // For injection
+  }
 
   @GET
   @Produces("text/plain")

--- a/src/main/java/org/broadinstitute/consent/http/resources/StatusResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/StatusResource.java
@@ -4,6 +4,7 @@ import static org.broadinstitute.consent.http.ConsentModule.DB_ENV;
 
 import com.codahale.metrics.health.HealthCheck;
 import com.codahale.metrics.health.HealthCheckRegistry;
+import com.google.inject.Inject;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
@@ -21,6 +22,7 @@ public class StatusResource extends Resource {
 
   private final HealthCheckRegistry healthChecks;
 
+  @Inject
   public StatusResource(HealthCheckRegistry healthChecks) {
     this.healthChecks = healthChecks;
   }

--- a/src/main/java/org/broadinstitute/consent/http/resources/SwaggerResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/SwaggerResource.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.consent.http.resources;
 
+import com.google.inject.Inject;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
@@ -27,6 +28,7 @@ public class SwaggerResource {
 
   private final GoogleOAuth2Config config;
 
+  @Inject
   public SwaggerResource(GoogleOAuth2Config config) {
     this.config = config;
   }

--- a/src/main/java/org/broadinstitute/consent/http/resources/VersionResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/VersionResource.java
@@ -4,6 +4,7 @@ import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
+import com.google.inject.Inject;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
@@ -15,6 +16,11 @@ import org.apache.commons.io.IOUtils;
 
 @Path("/version")
 public class VersionResource extends Resource {
+
+  @Inject
+  public VersionResource() {
+    // For injection
+  }
 
   @GET
   @Produces("application/json")

--- a/src/main/java/org/broadinstitute/consent/http/resources/VoteResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/VoteResource.java
@@ -2,6 +2,7 @@ package org.broadinstitute.consent.http.resources;
 
 
 import com.google.gson.Gson;
+import com.google.inject.Inject;
 import io.dropwizard.auth.Auth;
 import jakarta.annotation.security.RolesAllowed;
 import jakarta.ws.rs.BadRequestException;
@@ -35,6 +36,7 @@ public class VoteResource extends Resource {
   private final ElectionService electionService;
   private final Gson gson = new Gson();
 
+  @Inject
   public VoteResource(UserService userService, VoteService voteService,
       ElectionService electionService) {
     this.userService = userService;


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-2288

### Summary
Standardize resource construction in `ConsentApplication`

Note: This contains the one-line change in https://github.com/DataBiosphere/consent/pull/2688 for CI/CD purposes. I will rebase this PR once that one merges.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
