### PR TITLE
[DT-2344] Add study registration assets

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/models/dataset_registration_v1/DatasetRegistrationSchemaV1.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/dataset_registration_v1/DatasetRegistrationSchemaV1.java
@@ -1171,6 +1171,7 @@ public class DatasetRegistrationSchemaV1 {
     result = ((result * 31) + ((this.controlledAccessRequiredForGenomicSummaryResultsGSR == null)
         ? 0 : this.controlledAccessRequiredForGenomicSummaryResultsGSR.hashCode()));
     result = ((result * 31) + ((this.piInstitution == null) ? 0 : this.piInstitution.hashCode()));
+    result = ((result * 31) + ((this.assets == null) ? 0 : this.assets.hashCode()));
     return result;
   }
 
@@ -1288,7 +1289,8 @@ public class DatasetRegistrationSchemaV1 {
             && this.controlledAccessRequiredForGenomicSummaryResultsGSR.equals(
             rhs.controlledAccessRequiredForGenomicSummaryResultsGSR)))) && (
         (this.piInstitution == rhs.piInstitution) || ((this.piInstitution != null)
-            && this.piInstitution.equals(rhs.piInstitution))));
+            && this.piInstitution.equals(rhs.piInstitution)))) && ((this.assets == rhs.assets)
+        || ((this.assets != null) && this.assets.equals(rhs.assets)));
   }
 
 

--- a/src/main/java/org/broadinstitute/consent/http/models/dataset_registration_v1/DatasetRegistrationSchemaV1.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/dataset_registration_v1/DatasetRegistrationSchemaV1.java
@@ -61,7 +61,8 @@ import java.util.Map;
     "alternativeDataSharingPlanTargetDeliveryDate",
     "alternativeDataSharingPlanTargetPublicReleaseDate",
     "alternativeDataSharingPlanAccessManagement",
-    "consentGroups"
+    "consentGroups",
+    "assets"
 })
 public class DatasetRegistrationSchemaV1 {
 
@@ -291,6 +292,13 @@ public class DatasetRegistrationSchemaV1 {
   @JsonProperty("consentGroups")
   @JsonPropertyDescription("Consent Groups")
   private List<ConsentGroup> consentGroups = new ArrayList<ConsentGroup>();
+
+  /**
+   * Additional assets or metadata associated with this study registration
+   */
+  @JsonProperty("assets")
+  @JsonPropertyDescription("Additional assets or metadata associated with this study registration")
+  private Map<String, Object> assets = new HashMap<>();
 
   /**
    * The study id
@@ -900,6 +908,22 @@ public class DatasetRegistrationSchemaV1 {
     this.consentGroups = consentGroups;
   }
 
+  /**
+   * Additional assets or metadata associated with this study registration
+   */
+  @JsonProperty("assets")
+  public Map<String, Object> getAssets() {
+    return assets;
+  }
+
+  /**
+   * Additional assets or metadata associated with this study registration
+   */
+  @JsonProperty("assets")
+  public void setAssets(Map<String, Object> assets) {
+    this.assets = assets;
+  }
+
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
@@ -1066,6 +1090,10 @@ public class DatasetRegistrationSchemaV1 {
     sb.append("consentGroups");
     sb.append('=');
     sb.append(((this.consentGroups == null) ? "<null>" : this.consentGroups));
+    sb.append(',');
+    sb.append("assets");
+    sb.append('=');
+    sb.append(((this.assets == null) ? "<null>" : this.assets));
     sb.append(',');
     if (sb.charAt((sb.length() - 1)) == ',') {
       sb.setCharAt((sb.length() - 1), ']');

--- a/src/main/resources/dataset-registration-schema_v1.json
+++ b/src/main/resources/dataset-registration-schema_v1.json
@@ -208,6 +208,12 @@
       "items" : {
         "$ref" : "#/$defs/consentGroup"
       }
+    },
+    "assets" : {
+      "type" : "object",
+      "label" : "Assets",
+      "description" : "Additional assets or metadata associated with this study registration",
+      "additionalProperties" : true
     }
   },
   "$defs" : {

--- a/src/test/java/org/broadinstitute/consent/http/models/DatasetRegistrationSchemaV1AssetsTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/DatasetRegistrationSchemaV1AssetsTest.java
@@ -1,0 +1,175 @@
+package org.broadinstitute.consent.http.models;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.google.gson.Gson;
+import java.util.HashMap;
+import java.util.Map;
+import org.broadinstitute.consent.http.models.dataset_registration_v1.DatasetRegistrationSchemaV1;
+import org.broadinstitute.consent.http.util.JsonSchemaUtil;
+import org.junit.jupiter.api.Test;
+
+class DatasetRegistrationSchemaV1AssetsTest {
+
+  @Test
+  void testAssetsFieldCanBeSetAndRetrieved() {
+    // Create a DatasetRegistrationSchemaV1 instance
+    DatasetRegistrationSchemaV1 registration = new DatasetRegistrationSchemaV1();
+    
+    // Create a sample assets object
+    Map<String, Object> assets = new HashMap<>();
+    assets.put("workspaces", Map.of("workspace_id", "c7b96ac5-5568-441c-a3f4-2e82e45e3e6d", "name", "Cardiometabolic GWAS Analysis Workspace", "platform", "Terra"));
+    assets.put("funding", Map.of("funding_id", "fund-0001",  "funder_name", "NIH", "grant_number", "R01HG012345"));
+    
+    // Set the assets
+    registration.setAssets(assets);
+    
+    // Verify the assets can be retrieved
+    Map<String, Object> retrievedAssets = registration.getAssets();
+    assertNotNull(retrievedAssets);
+    assertEquals(2, retrievedAssets.size());
+    assertNotNull(retrievedAssets.get("workspaces"));
+  }
+
+  @Test
+  void testAssetsFieldSerializationWithGson() {
+    // Create a DatasetRegistrationSchemaV1 instance with assets
+    DatasetRegistrationSchemaV1 registration = new DatasetRegistrationSchemaV1();
+    registration.setStudyName("Test Study");
+    
+    Map<String, Object> assets = new HashMap<>();
+    assets.put("customField", "customValue");
+    assets.put("nestedObject", Map.of("key1", "value1", "key2", 123));
+    registration.setAssets(assets);
+    
+    // Serialize to JSON
+    Gson gson = new Gson();
+    String json = gson.toJson(registration);
+    
+    // Verify JSON contains assets
+    assertTrue(json.contains("\"assets\""));
+    assertTrue(json.contains("\"customField\""));
+    assertTrue(json.contains("\"customValue\""));
+    
+    // Deserialize back
+    DatasetRegistrationSchemaV1 deserialized = gson.fromJson(json, DatasetRegistrationSchemaV1.class);
+    assertNotNull(deserialized.getAssets());
+    assertEquals("customValue", deserialized.getAssets().get("customField"));
+  }
+
+  @Test
+  void testAssetsFieldIsOptional() {
+    // Create a DatasetRegistrationSchemaV1 instance without setting assets
+    DatasetRegistrationSchemaV1 registration = new DatasetRegistrationSchemaV1();
+    registration.setStudyName("Test Study");
+    
+    // Verify assets is initialized as empty map
+    Map<String, Object> assets = registration.getAssets();
+    assertNotNull(assets);
+    assertTrue(assets.isEmpty());
+  }
+
+  @Test
+  void testJsonSchemaValidationAcceptsAssets() {
+    JsonSchemaUtil jsonSchemaUtil = new JsonSchemaUtil();
+    
+    // Create a minimal valid JSON with assets
+    String json = """
+        {
+          "studyName": "Test Study",
+          "studyDescription": "Test Description",
+          "dataTypes": ["Genomic"],
+          "dataSubmitterUserId": 1,
+          "publicVisibility": true,
+          "nihAnvilUse": "I am not NHGRI funded and do not plan to store data in AnVIL",
+          "piName": "Dr. Test",
+          "consentGroups": [
+            {
+              "consentGroupName": "Group 1",
+              "numberOfParticipants": 100,
+              "accessManagement": "open"
+            }
+          ],
+          "assets": {
+            "customField": "value",
+            "anotherField": 123,
+            "complexObject": {
+              "nested": "data"
+            }
+          }
+        }
+        """;
+    
+    // Validate the schema
+    var errors = jsonSchemaUtil.validateSchema_v1(json);
+    
+    // Verify no validation errors
+    assertTrue(errors.isEmpty(), 
+        "Schema validation should pass with assets field. Errors: " + errors);
+  }
+
+  @Test
+  void testEmptyAssetsObjectIsValid() {
+    JsonSchemaUtil jsonSchemaUtil = new JsonSchemaUtil();
+    
+    // Create a minimal valid JSON with empty assets
+    String json = """
+        {
+          "studyName": "Test Study",
+          "studyDescription": "Test Description",
+          "dataTypes": ["Genomic"],
+          "dataSubmitterUserId": 1,
+          "publicVisibility": true,
+          "nihAnvilUse": "I am not NHGRI funded and do not plan to store data in AnVIL",
+          "piName": "Dr. Test",
+          "consentGroups": [
+            {
+              "consentGroupName": "Group 1",
+              "numberOfParticipants": 100,
+              "accessManagement": "open"
+            }
+          ],
+          "assets": {}
+        }
+        """;
+    
+    // Validate the schema
+    var errors = jsonSchemaUtil.validateSchema_v1(json);
+    
+    // Verify no validation errors
+    assertTrue(errors.isEmpty(), 
+        "Schema validation should pass with empty assets field. Errors: " + errors);
+  }
+
+  @Test
+  void testMissingAssetsFieldIsValid() {
+    JsonSchemaUtil jsonSchemaUtil = new JsonSchemaUtil();
+    
+    // Create a minimal valid JSON without assets field
+    String json = """
+        {
+          "studyName": "Test Study",
+          "studyDescription": "Test Description",
+          "dataTypes": ["Genomic"],
+          "dataSubmitterUserId": 1,
+          "publicVisibility": true,
+          "nihAnvilUse": "I am not NHGRI funded and do not plan to store data in AnVIL",
+          "piName": "Dr. Test",
+          "consentGroups": [
+            {
+              "consentGroupName": "Group 1",
+              "numberOfParticipants": 100,
+              "accessManagement": "open"
+            }
+          ]
+        }
+        """;
+    
+    // Validate the schema
+    var errors = jsonSchemaUtil.validateSchema_v1(json);
+    
+    // Verify no validation errors
+    assertTrue(errors.isEmpty(), 
+        "Schema validation should pass without assets field. Errors: " + errors);
+  }
+}


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2344

### Summary

Extends the Study Registration API to allow assets, and ensures that they are not tightly bound to the schema. Unit tests confirm this behavior is fulfilled.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
