### PR TITLE
DT-2289: Update to Dropwizard 5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <maven.compiler.source>21</maven.compiler.source>
     <maven.compiler.target>21</maven.compiler.target>
     <liquibase.version>4.33.0</liquibase.version>
-    <dropwizard.version>4.0.16</dropwizard.version>
+    <dropwizard.version>5.0.0</dropwizard.version>
     <logback.version>1.5.18</logback.version>
     <postgres.version>42.7.8</postgres.version>
     <surefire.version>3.5.4</surefire.version>
@@ -487,12 +487,6 @@
       <groupId>io.dropwizard</groupId>
       <artifactId>dropwizard-http2</artifactId>
       <version>${dropwizard.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.eclipse.jetty.http2</groupId>
-          <artifactId>http2-common</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
 
     <dependency>

--- a/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
@@ -80,7 +80,7 @@ import org.broadinstitute.consent.http.resources.UserResource;
 import org.broadinstitute.consent.http.resources.VersionResource;
 import org.broadinstitute.consent.http.resources.VoteResource;
 import org.broadinstitute.consent.http.util.gson.JerseyGsonProvider;
-import org.eclipse.jetty.servlet.ErrorPageErrorHandler;
+import org.eclipse.jetty.ee10.servlet.ErrorPageErrorHandler;
 import org.glassfish.jersey.internal.inject.AbstractBinder;
 import org.glassfish.jersey.server.filter.RolesAllowedDynamicFeature;
 import org.slf4j.Logger;

--- a/src/main/java/org/broadinstitute/consent/http/resources/ErrorResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/ErrorResource.java
@@ -1,6 +1,8 @@
 package org.broadinstitute.consent.http.resources;
 
+import jakarta.servlet.ServletRequest;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
@@ -9,18 +11,38 @@ import jakarta.ws.rs.core.Response;
 import java.net.URLDecoder;
 import java.nio.charset.Charset;
 import org.broadinstitute.consent.http.models.Error;
+import org.eclipse.jetty.ee10.servlet.ServletApiRequest;
+import org.eclipse.jetty.ee10.servlet.ServletContextHandler.ServletRequestInfo;
 
 @Path("error")
 public class ErrorResource {
 
+  /**
+   * Explanatory note about this 404 handler:
+   * In order to provide the original URI that resulted in a 404, we need to access the underlying
+   * request information. The HttpServletRequest passed to this method is actually a wrapper around
+   * the original request. By unwrapping it to get to the ServletApiRequest, we can retrieve the
+   * original URI that was requested. This allows us to construct a more informative error message
+   * for the client.
+   * @param httpServletRequest The HttpServletRequest
+   * @return Response
+   */
   @GET
   @Path("404")
   @Produces("application/json")
-  public Response notFound(@Context HttpServletRequest request) {
-    String originalUri = request.getRequestURI();
-    String decodedUri = URLDecoder.decode(originalUri, Charset.defaultCharset());
-    String msg = String.format("Unable to find requested path: '%s'", decodedUri);
-    Error error = new Error(msg, 404);
-    return Response.status(error.code()).entity(error).build();
+  public Response notFound(@Context HttpServletRequest httpServletRequest) {
+    try {
+      HttpServletRequestWrapper requestWrapper = (HttpServletRequestWrapper) httpServletRequest;
+      ServletRequest servletRequest = requestWrapper.getRequest();
+      ServletApiRequest servletApiRequest = (ServletApiRequest) servletRequest;
+      ServletRequestInfo servletRequestInfo = servletApiRequest.getServletRequestInfo();
+      String originalUri = servletRequestInfo.getDecodedPathInContext();
+      String decodedUri = URLDecoder.decode(originalUri, Charset.defaultCharset());
+      String msg = String.format("Unable to find requested path: %s", decodedUri);
+      Error error = new Error(msg, 404);
+      return Response.status(error.code()).entity(error).build();
+    } catch (Exception e) {
+      return Response.status(Response.Status.NOT_FOUND).build();
+    }
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/resources/ErrorResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/ErrorResource.java
@@ -9,7 +9,6 @@ import jakarta.ws.rs.core.Response;
 import java.net.URLDecoder;
 import java.nio.charset.Charset;
 import org.broadinstitute.consent.http.models.Error;
-import org.eclipse.jetty.server.Request;
 
 @Path("error")
 public class ErrorResource {
@@ -18,7 +17,7 @@ public class ErrorResource {
   @Path("404")
   @Produces("application/json")
   public Response notFound(@Context HttpServletRequest request) {
-    String originalUri = ((Request) request).getOriginalURI();
+    String originalUri = request.getRequestURI();
     String decodedUri = URLDecoder.decode(originalUri, Charset.defaultCharset());
     String msg = String.format("Unable to find requested path: '%s'", decodedUri);
     Error error = new Error(msg, 404);

--- a/src/main/java/org/broadinstitute/consent/http/resources/ErrorResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/ErrorResource.java
@@ -39,8 +39,8 @@ public class ErrorResource {
       String originalUri = servletRequestInfo.getDecodedPathInContext();
       String decodedUri = URLDecoder.decode(originalUri, Charset.defaultCharset());
       String msg = String.format("Unable to find requested path: %s", decodedUri);
-      Error error = new Error(msg, 404);
-      return Response.status(error.code()).entity(error).build();
+      Error error = new Error(msg, Response.Status.NOT_FOUND.getStatusCode());
+      return Response.status(Response.Status.NOT_FOUND).entity(error).build();
     } catch (Exception e) {
       return Response.status(Response.Status.NOT_FOUND).build();
     }

--- a/src/test/java/org/broadinstitute/consent/http/resources/ErrorResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/ErrorResourceTest.java
@@ -5,10 +5,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
 import com.google.api.client.http.HttpStatusCodes;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.ws.rs.core.Response;
 import java.net.URLEncoder;
 import java.nio.charset.Charset;
-import org.eclipse.jetty.server.Request;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -18,12 +18,12 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class ErrorResourceTest {
 
   @Mock
-  private Request request;
+  private HttpServletRequest request;
 
   @Test
   void testNotFound() {
     ErrorResource resource = new ErrorResource();
-    when(request.getOriginalURI()).thenReturn("not_found");
+    when(request.getRequestURI()).thenReturn("not_found");
     try (Response response = resource.notFound(request)) {
       assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
     }
@@ -34,7 +34,7 @@ class ErrorResourceTest {
     String unicode = "¥";
     String encoded = URLEncoder.encode(unicode, Charset.defaultCharset());
     ErrorResource resource = new ErrorResource();
-    when(request.getOriginalURI()).thenReturn(encoded);
+    when(request.getRequestURI()).thenReturn(encoded);
     try (Response response = resource.notFound(request)) {
       assertTrue(response.getEntity().toString().contains(unicode));
     }

--- a/src/test/java/org/broadinstitute/consent/http/resources/ErrorResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/ErrorResourceTest.java
@@ -5,12 +5,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
 import com.google.api.client.http.HttpStatusCodes;
-import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
 import jakarta.ws.rs.core.Response;
-import java.net.URLEncoder;
-import java.nio.charset.Charset;
-import org.junit.jupiter.api.Test;
+import org.eclipse.jetty.ee10.servlet.ServletApiRequest;
+import org.eclipse.jetty.ee10.servlet.ServletContextHandler.ServletRequestInfo;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -18,26 +19,22 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class ErrorResourceTest {
 
   @Mock
-  private HttpServletRequest request;
+  private HttpServletRequestWrapper mockRequest;
+  @Mock
+  private ServletApiRequest mockServletRequest;
+  @Mock
+  private ServletRequestInfo servletRequestInfo;
 
-  @Test
-  void testNotFound() {
+  @ParameterizedTest
+  @ValueSource(strings = {"/not_found", "/context/¥"})
+  void testNotFound(String path) {
     ErrorResource resource = new ErrorResource();
-    when(request.getRequestURI()).thenReturn("not_found");
-    try (Response response = resource.notFound(request)) {
+    when(mockRequest.getRequest()).thenReturn(mockServletRequest);
+    when(mockServletRequest.getServletRequestInfo()).thenReturn(servletRequestInfo);
+    when(servletRequestInfo.getDecodedPathInContext()).thenReturn(path);
+    try (Response response = resource.notFound(mockRequest)) {
       assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
+      assertTrue(response.getEntity().toString().contains(path));
     }
   }
-
-  @Test
-  void testNotFoundDecoded() {
-    String unicode = "¥";
-    String encoded = URLEncoder.encode(unicode, Charset.defaultCharset());
-    ErrorResource resource = new ErrorResource();
-    when(request.getRequestURI()).thenReturn(encoded);
-    try (Response response = resource.notFound(request)) {
-      assertTrue(response.getEntity().toString().contains(unicode));
-    }
-  }
-
 }

--- a/src/test/java/org/broadinstitute/consent/http/resources/ErrorResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/ErrorResourceTest.java
@@ -19,9 +19,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class ErrorResourceTest {
 
   @Mock
-  private HttpServletRequestWrapper mockRequest;
+  private HttpServletRequestWrapper request;
   @Mock
-  private ServletApiRequest mockServletRequest;
+  private ServletApiRequest servletRequest;
   @Mock
   private ServletRequestInfo servletRequestInfo;
 
@@ -29,10 +29,10 @@ class ErrorResourceTest {
   @ValueSource(strings = {"/not_found", "/context/¥"})
   void testNotFound(String path) {
     ErrorResource resource = new ErrorResource();
-    when(mockRequest.getRequest()).thenReturn(mockServletRequest);
-    when(mockServletRequest.getServletRequestInfo()).thenReturn(servletRequestInfo);
+    when(request.getRequest()).thenReturn(servletRequest);
+    when(servletRequest.getServletRequestInfo()).thenReturn(servletRequestInfo);
     when(servletRequestInfo.getDecodedPathInContext()).thenReturn(path);
-    try (Response response = resource.notFound(mockRequest)) {
+    try (Response response = resource.notFound(request)) {
       assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
       assertTrue(response.getEntity().toString().contains(path));
     }


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-2289

### Summary
Update Dropwizard framework to the latest version, 5.0. There were [major version updates to several libraries](https://www.dropwizard.io/en/stable/manual/upgrade-notes/upgrade-notes-5_0_x.html), but the only one that affected us was the Jetty update which we used in our custom 404 handler. This required some extra unwrapping of the request to get to the original request that triggered the 404.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
