### PR TITLE
[DT-2276] Fix flaky UserServiceTest by using fixed values instead of random ones

### DIFF
--- a/src/test/java/org/broadinstitute/consent/http/service/feature/InstitutionAndLibraryCardEnforcementTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/feature/InstitutionAndLibraryCardEnforcementTest.java
@@ -149,17 +149,31 @@ public class InstitutionAndLibraryCardEnforcementTest extends AbstractTestHelper
 
   @Test
   void handleUserWithInstitutionInMap_DifferentInDatabaseWithLibraryCard_SO_NFE() {
-    User testUser = generateUser(1);
-    User signingOfficial = generateUser(2);
+    User testUser = new User();
+    testUser.setUserId(1);
+    testUser.setEmail("user1@example.org");
+    testUser.setDisplayName("User One");
+    testUser.setInstitutionId(2);
+
+    User signingOfficial = new User();
+    signingOfficial.setUserId(2);
+    signingOfficial.setEmail("so@example.org");
+    signingOfficial.setDisplayName("Signing Official");
+
     LibraryCard lc = new LibraryCard();
     lc.setCreateUserId(signingOfficial.getUserId());
     testUser.setLibraryCard(lc);
-    Institution institutionFromEmail = new Institution();
-    institutionFromEmail.setId(1);
-    testUser.setInstitution(institutionFromEmail);
-    Institution institutionFromDatabase = new Institution();
-    institutionFromDatabase.setId(2);
 
+    Institution institutionFromEmail = new Institution();
+    institutionFromEmail.setId(Integer.valueOf(1));
+    institutionFromEmail.setName("Institution One");
+    testUser.setInstitution(institutionFromEmail);
+
+    Institution institutionFromDatabase = new Institution();
+    institutionFromDatabase.setId(Integer.valueOf(2));
+    institutionFromDatabase.setName("Institution Two");
+
+    // Mock SO not found
     when(userDAO.findUserById(signingOfficial.getUserId())).thenReturn(null);
 
     assertTrue(service.handleUserWithInstitutionInMap(testUser, institutionFromEmail.getId()));


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2278

### Summary

The test `UserServiceTest.handleUserWithInstitutionInMap_DifferentInDatabaseWithLibraryCard_SO_NFE` was failing intermittently due to randomly generated object values causing inconsistent database state comparisons. This update replaces random values with fixed, deterministic ones to ensure consistent behavior and eliminate flakiness across test runs.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
