### PR TITLE
[DT-2320] Verify the user has access to the study or dataset before responding.

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -28,13 +28,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
       - name: Test Only
-        if: github.actor == 'dependabot[bot]'
         env:
           MAVEN_OPTS: -Dorg.slf4j.simpleLogger.defaultLogLevel=warn -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
         run: mvn clean test  --batch-mode
       - name: Test Report
         continue-on-error: true
-        if: github.actor != 'dependabot[bot]'
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           MAVEN_OPTS: -Dorg.slf4j.simpleLogger.defaultLogLevel=warn -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Test Only
         env:
           MAVEN_OPTS: -Dorg.slf4j.simpleLogger.defaultLogLevel=warn -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
-        run: mvn clean test  --batch-mode
+        run: mvn clean jacoco:prepare-agent test jacoco:report --batch-mode
       - name: Test Report
         continue-on-error: true
         env:
@@ -38,4 +38,4 @@ jobs:
           MAVEN_OPTS: -Dorg.slf4j.simpleLogger.defaultLogLevel=warn -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
         run: |
           mvn -v
-          mvn clean jacoco:prepare-agent test jacoco:report org.sonarsource.scanner.maven:sonar-maven-plugin:sonar --batch-mode
+          mvn org.sonarsource.scanner.maven:sonar-maven-plugin:sonar --batch-mode

--- a/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
@@ -112,8 +112,11 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
   Dataset findMinimalDatasetByAlias(@Bind("alias") Integer alias);
 
   @UseRowMapper(DatasetStudySummaryMapper.class)
-  @SqlQuery("""
-      SELECT d.dataset_id, d.name AS dataset_name, d.alias, s.study_id, s.name AS study_name
+  @SqlQuery(
+      """
+      SELECT d.dataset_id, d.create_user_id AS dataset_create_user_id, d.name AS dataset_name,
+          d.alias, s.study_id, s.name AS study_name, s.public_visibility AS public_visibility,
+          s.create_user_id AS study_create_user_id
         FROM dataset d
         LEFT JOIN study s ON s.study_id = d.study_id
         ORDER BY dataset_id

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DatasetStudySummaryMapper.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DatasetStudySummaryMapper.java
@@ -12,11 +12,24 @@ public class DatasetStudySummaryMapper implements RowMapper<DatasetStudySummary>
   @Override
   public DatasetStudySummary map(ResultSet rs, StatementContext ctx) throws SQLException {
     Integer datasetId = hasNonZeroColumn(rs, "dataset_id") ? rs.getInt("dataset_id") : null;
+    Integer datasetCreateUserId =
+        hasNonZeroColumn(rs, "dataset_create_user_id") ? rs.getInt("dataset_create_user_id") : null;
     String datasetName = rs.getString("dataset_name");
     String studyName = rs.getString("study_name");
     Integer studyId = hasNonZeroColumn(rs, "study_id") ? rs.getInt("study_id") : null;
     Integer alias = hasNonZeroColumn(rs, "alias") ? rs.getInt("alias") : 0;
     String identifier = Dataset.parseAliasToIdentifier(alias);
-    return new DatasetStudySummary(datasetId, datasetName, identifier, studyId, studyName);
+    Integer studyCreateUserId =
+        hasNonZeroColumn(rs, "study_create_user_id") ? rs.getInt("study_create_user_id") : null;
+    Boolean publicVisibility = rs.getBoolean("public_visibility");
+    return new DatasetStudySummary(
+        datasetId,
+        datasetCreateUserId,
+        datasetName,
+        identifier,
+        studyId,
+        studyName,
+        studyCreateUserId,
+        publicVisibility);
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/models/DatasetStudySummary.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DatasetStudySummary.java
@@ -1,4 +1,11 @@
 package org.broadinstitute.consent.http.models;
 
-public record DatasetStudySummary(Integer dataset_id, String dataset_name, String identifier, Integer study_id, String study_name) {
-}
+public record DatasetStudySummary(
+    Integer dataset_id,
+    Integer dataset_create_user_id,
+    String dataset_name,
+    String identifier,
+    Integer study_id,
+    String study_name,
+    Integer study_create_user_id,
+    Boolean public_visibility) {}

--- a/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
@@ -239,7 +239,7 @@ public class DatasetResource extends Resource {
   @Path("/v3")
   public Response findAllDatasetStudySummaries(@Auth DuosUser duosUser) {
     try {
-      List<DatasetStudySummary> summaries = datasetService.findAllDatasetStudySummaries();
+      List<DatasetStudySummary> summaries = datasetService.findAllDatasetStudySummaries(duosUser.getUser());
       return Response.ok(summaries).build();
     } catch (Exception e) {
       return createExceptionResponse(e);

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -140,6 +140,30 @@ public class DatasetService implements ConsentLogger {
     return verifyPublicVisibilityAccess(d, user);
   }
 
+  protected List<DatasetStudySummary> verifyPublicVisibilityAccess(
+      List<DatasetStudySummary> summaries, User user) {
+    if (user.hasUserRole(UserRoles.ADMIN)) {
+      return summaries;
+    }
+    List<DatasetStudySummary> authorizedSummaries = new ArrayList<>();
+    for (DatasetStudySummary summary : summaries) {
+      if (Boolean.TRUE.equals(summary.public_visibility())) {
+        authorizedSummaries.add(summary);
+      } else if (summary.study_create_user_id().equals(user.getUserId())) {
+        authorizedSummaries.add(summary);
+      } else if (summary.dataset_create_user_id().equals(user.getUserId())) {
+        authorizedSummaries.add(summary);
+      } else {
+        // fetch study and see if the user is a custodian
+        Study study = studyDAO.findStudyById(summary.study_id());
+        if (study != null && isCreatorOrCustodian(user, study)) {
+          authorizedSummaries.add(summary);
+        }
+      }
+    }
+    return authorizedSummaries;
+  }
+
   protected Dataset verifyPublicVisibilityAccess(Dataset dataset, User user) {
     // Admins
     if (user.hasUserRole(UserRoles.ADMIN)) {
@@ -290,8 +314,9 @@ public class DatasetService implements ConsentLogger {
     return studyDAO.findStudyById(studyId);
   }
 
-  public List<DatasetStudySummary> findAllDatasetStudySummaries() {
-    return datasetDAO.findAllDatasetStudySummaries();
+  public List<DatasetStudySummary> findAllDatasetStudySummaries(User user) {
+    List<DatasetStudySummary> summaries = datasetDAO.findAllDatasetStudySummaries();
+    return verifyPublicVisibilityAccess(summaries, user);
   }
 
   public Dataset approveDataset(Dataset dataset, User user, Boolean approval) {

--- a/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
@@ -112,7 +112,10 @@ class DatasetDAOTest extends DAOTestHelper {
     List<DatasetStudySummary> summaries = datasetDAO.findAllDatasetStudySummaries();
     assertThat(summaries, hasSize(1));
     assertEquals(dataset.getDatasetId(), summaries.get(0).dataset_id());
+    assertEquals(dataset.getCreateUserId(), summaries.get(0).dataset_create_user_id());
     assertEquals(study.getStudyId(), summaries.get(0).study_id());
+    assertEquals(study.getCreateUserId(), summaries.get(0).study_create_user_id());
+    assertEquals(study.getPublicVisibility(), summaries.get(0).public_visibility());
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
@@ -732,7 +732,7 @@ class DatasetResourceTest extends AbstractTestHelper {
 
   @Test
   void testFindAllDatasetStudySummaries() {
-    when(datasetService.findAllDatasetStudySummaries()).thenReturn(List.of());
+    when(datasetService.findAllDatasetStudySummaries(user)).thenReturn(List.of());
 
     try (var response = resource.findAllDatasetStudySummaries(duosUser)) {
       assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());

--- a/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
@@ -47,6 +47,7 @@ import org.broadinstitute.consent.http.models.DataUse;
 import org.broadinstitute.consent.http.models.DataUseBuilder;
 import org.broadinstitute.consent.http.models.Dataset;
 import org.broadinstitute.consent.http.models.DatasetAuthorizationReader;
+import org.broadinstitute.consent.http.models.DatasetStudySummary;
 import org.broadinstitute.consent.http.models.Study;
 import org.broadinstitute.consent.http.models.StudyProperty;
 import org.broadinstitute.consent.http.models.User;
@@ -463,12 +464,170 @@ class DatasetServiceTest extends AbstractTestHelper {
   }
 
   @Test
+  void testFindAllDatasetStudySummaries() {
+    User user = new User();
+    user.setUserId(1);
+    DatasetStudySummary summary =
+        new DatasetStudySummary(
+            1, user.getUserId() + 1, "Dataset Name", "DUOS-123", 1, "Study Name", 1000, true);
+    when(datasetDAO.findAllDatasetStudySummaries()).thenReturn(List.of(summary));
+
+    List<DatasetStudySummary> authorizedSummaries =
+        datasetService.findAllDatasetStudySummaries(user);
+    assertEquals(1, authorizedSummaries.size());
+    assertEquals(summary, authorizedSummaries.get(0));
+  }
+
+  @Test
+  void testVerifyPublicVisibilitySummaries_Admin_PV_False() {
+    User admin = getAdmin();
+    DatasetStudySummary summary =
+        new DatasetStudySummary(
+            1, admin.getUserId() + 1, "Dataset Name", "DUOS-123", 1, "Study Name", 1000, false);
+    List<DatasetStudySummary> authorizedSummaries =
+        datasetService.verifyPublicVisibilityAccess(List.of(summary), admin);
+    assertEquals(1, authorizedSummaries.size());
+    assertEquals(summary, authorizedSummaries.get(0));
+  }
+
+  @Test
+  void testVerifyPublicVisibilitySummaries_Admin_PV_True() {
+    User admin = getAdmin();
+    DatasetStudySummary summary =
+        new DatasetStudySummary(
+            1, admin.getUserId() + 1, "Dataset Name", "DUOS-123", 1, "Study Name", 1000, true);
+    List<DatasetStudySummary> authorizedSummaries =
+        datasetService.verifyPublicVisibilityAccess(List.of(summary), admin);
+    assertEquals(1, authorizedSummaries.size());
+    assertEquals(summary, authorizedSummaries.get(0));
+  }
+
+  @Test
+  void testVerifyPublicVisibilitySummaries_User_HiddenStudy() {
+    User user = new User();
+    user.setUserId(1);
+    DatasetStudySummary summary =
+        new DatasetStudySummary(
+            1, user.getUserId() + 1, "Dataset Name", "DUOS-123", 1, "Study Name", 1000, false);
+    List<DatasetStudySummary> authorizedSummaries =
+        datasetService.verifyPublicVisibilityAccess(List.of(summary), user);
+    assertEquals(0, authorizedSummaries.size());
+  }
+
+  @Test
+  void testVerifyPublicVisibilitySummaries_User_PV_True() {
+    User user = new User();
+    user.setUserId(1);
+    DatasetStudySummary summary =
+        new DatasetStudySummary(
+            1, user.getUserId() + 1, "Dataset Name", "DUOS-123", 1, "Study Name", 1000, true);
+    List<DatasetStudySummary> authorizedSummaries =
+        datasetService.verifyPublicVisibilityAccess(List.of(summary), user);
+    assertEquals(1, authorizedSummaries.size());
+    assertEquals(summary, authorizedSummaries.get(0));
+  }
+
+  @Test
+  void testVerifyPublicVisibilitySummaries_User_Created_Dataset_PV_False() {
+    User user = new User();
+    user.setUserId(1);
+    DatasetStudySummary summary =
+        new DatasetStudySummary(
+            1, user.getUserId(), "Dataset Name", "DUOS-123", 1, "Study Name", 1000, false);
+    List<DatasetStudySummary> authorizedSummaries =
+        datasetService.verifyPublicVisibilityAccess(List.of(summary), user);
+    assertEquals(1, authorizedSummaries.size());
+    assertEquals(summary, authorizedSummaries.get(0));
+  }
+
+  @Test
+  void testVerifyPublicVisibilitySummaries_User_StudyCreator() {
+    User user = new User();
+    user.setUserId(1);
+    DatasetStudySummary summary =
+        new DatasetStudySummary(
+            1,
+            user.getUserId() + 1,
+            "Dataset Name",
+            "DUOS-123",
+            1,
+            "Study Name",
+            user.getUserId(),
+            false);
+    List<DatasetStudySummary> authorizedSummaries =
+        datasetService.verifyPublicVisibilityAccess(List.of(summary), user);
+    assertEquals(1, authorizedSummaries.size());
+    assertEquals(summary, authorizedSummaries.get(0));
+  }
+
+  @Test
+  void testVerifyPublicVisibilitySummaries_User_IS_StudyCustodian() {
+    Gson gson = GsonUtil.getInstance();
+    User custodian = new User();
+    custodian.setUserId(1);
+    custodian.setEmail("alice@custodiansRus.org");
+    Study study = new Study();
+    study.setStudyId(1);
+    study.setCreateUserId(custodian.getUserId() + 1);
+    study.setPublicVisibility(false);
+    StudyProperty prop = new StudyProperty();
+    prop.setKey(DatasetRegistrationSchemaV1Builder.dataCustodianEmail);
+    prop.setType(PropertyType.Json);
+    prop.setValue(gson.toJson(List.of(custodian.getEmail())));
+    study.addProperties(prop);
+    DatasetStudySummary summary =
+        new DatasetStudySummary(
+            1,
+            custodian.getUserId() + 1,
+            "Dataset Name",
+            "DUOS-123",
+            study.getStudyId(),
+            "Study Name",
+            study.getCreateUserId(),
+            false);
+    when(studyDAO.findStudyById(summary.study_id())).thenReturn(study);
+
+    List<DatasetStudySummary> authorizedSummaries =
+        datasetService.verifyPublicVisibilityAccess(List.of(summary), custodian);
+    assertEquals(1, authorizedSummaries.size());
+    assertEquals(summary, authorizedSummaries.get(0));
+  }
+
+  @Test
+  void testVerifyPublicVisibilitySummaries_User_NOT_StudyCustodian() {
+    Gson gson = GsonUtil.getInstance();
+    User custodian = new User();
+    custodian.setUserId(1);
+    custodian.setEmail("alice@custodiansRus.org");
+    Study study = new Study();
+    study.setStudyId(1);
+    study.setCreateUserId(custodian.getUserId() + 1);
+    study.setPublicVisibility(false);
+    StudyProperty prop = new StudyProperty();
+    prop.setKey(DatasetRegistrationSchemaV1Builder.dataCustodianEmail);
+    prop.setType(PropertyType.Json);
+    prop.setValue(gson.toJson(List.of("jane@custodiansRus.org")));
+    study.addProperties(prop);
+    DatasetStudySummary summary =
+        new DatasetStudySummary(
+            1,
+            custodian.getUserId() + 1,
+            "Dataset Name",
+            "DUOS-123",
+            study.getStudyId(),
+            "Study Name",
+            study.getCreateUserId(),
+            false);
+    when(studyDAO.findStudyById(summary.study_id())).thenReturn(study);
+
+    List<DatasetStudySummary> authorizedSummaries =
+        datasetService.verifyPublicVisibilityAccess(List.of(summary), custodian);
+    assertEquals(0, authorizedSummaries.size());
+  }
+
+  @Test
   void testVerifyPublicVisibilityAccess_Admin() {
-    User admin = new User();
-    admin.setUserId(1);
-    admin.setEmail("admin@email.com");
-    // Without the admin role this test condition would fail.
-    admin.setAdminRole();
+    User admin = getAdmin();
     Dataset dataset = new Dataset();
     dataset.setCreateUserId(2);
     User studyCreator = new User();
@@ -484,6 +643,15 @@ class DatasetServiceTest extends AbstractTestHelper {
 
     Dataset verfiedDataset = datasetService.verifyPublicVisibilityAccess(dataset, admin);
     assertEquals(dataset.getDatasetId(), verfiedDataset.getDatasetId());
+  }
+
+  private static User getAdmin() {
+    User admin = new User();
+    admin.setUserId(1);
+    admin.setEmail("admin@email.com");
+    // Without the admin role this test condition would fail.
+    admin.setAdminRole();
+    return admin;
   }
 
   @Test


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-2320](https://broadworkbench.atlassian.net/browse/DT-2320)

### Summary

If the user is an admin, always return the summary object;
If the study is marked public, return the summary object;
If the study is private and the user is the creator of the dataset, creator of the study, or a custodian of the study, return it;
In all other cases, don't return the summary.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
