### PR TITLE
[DT-2345] Persist `assets` in Postgres

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/models/dataset_registration_v1/builder/DatasetRegistrationSchemaV1Builder.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/dataset_registration_v1/builder/DatasetRegistrationSchemaV1Builder.java
@@ -37,6 +37,7 @@ public class DatasetRegistrationSchemaV1Builder {
   public static final String alternativeDataSharingPlanTargetDeliveryDate = "alternativeDataSharingPlanTargetDeliveryDate";
   public static final String alternativeDataSharingPlanTargetPublicReleaseDate = "alternativeDataSharingPlanTargetPublicReleaseDate";
   public static final String alternativeDataSharingPlanAccessManagement = "alternativeDataSharingPlanAccessManagement";
+  public static final String assets = "assets";
   public static final String accessManagement = "accessManagement";
   public static final String generalResearchUse = "generalResearchUse";
   public static final String hmb = "hmb";

--- a/src/main/java/org/broadinstitute/consent/http/models/dataset_registration_v1/builder/SchemaFromStudy.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/dataset_registration_v1/builder/SchemaFromStudy.java
@@ -8,6 +8,7 @@ import static org.broadinstitute.consent.http.models.dataset_registration_v1.bui
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.alternativeDataSharingPlanReasons;
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.alternativeDataSharingPlanTargetDeliveryDate;
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.alternativeDataSharingPlanTargetPublicReleaseDate;
+import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.assets;
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.collaboratingSites;
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.controlledAccessRequiredForGenomicSummaryResultsGSR;
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.controlledAccessRequiredForGenomicSummaryResultsGSRRequiredExplanation;
@@ -131,6 +132,7 @@ public class SchemaFromStudy {
             AlternativeDataSharingPlanAccessManagement.fromValue(
                 alternativeDataSharingPlanAccessManagementVal));
       }
+      schemaV1.setAssets(findMapPropValue(study.getProperties(), assets));
     }
 
     return schemaV1;
@@ -227,6 +229,21 @@ public class SchemaFromStudy {
           .map(StudyProperty::getValue)
           .map(Object::toString)
           .map(Integer::valueOf)
+          .findFirst()
+          .orElse(null);
+    }
+    return null;
+  }
+
+  @Nullable
+  private java.util.Map<String, Object> findMapPropValue(Set<StudyProperty> props, String propName) {
+    if (Objects.nonNull(props) && !props.isEmpty()) {
+      return props
+          .stream()
+          .filter(p -> p.getKey().equalsIgnoreCase(propName))
+          .map(StudyProperty::getValue)
+          .map(p -> (java.util.Map<String, Object>) GsonUtil.getInstance().fromJson(p.toString(), 
+              new com.google.gson.reflect.TypeToken<java.util.Map<String, Object>>(){}.getType()))
           .findFirst()
           .orElse(null);
     }

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetRegistrationService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetRegistrationService.java
@@ -677,6 +677,14 @@ public class DatasetRegistrationService implements ConsentLogger {
               return registration.getAlternativeDataSharingPlanAccessManagement().value();
             }
             return null;
+          }),
+      new StudyPropertyExtractor(
+          "assets", PropertyType.Json,
+          (registration) -> {
+            if (Objects.nonNull(registration.getAssets()) && !registration.getAssets().isEmpty()) {
+              return GsonUtil.getInstance().toJson(registration.getAssets());
+            }
+            return null;
           })
   );
 

--- a/src/test/java/org/broadinstitute/consent/http/service/DatasetRegistrationServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DatasetRegistrationServiceTest.java
@@ -226,6 +226,8 @@ class DatasetRegistrationServiceTest {
         PropertyType.Date.coerce(schema.getAlternativeDataSharingPlanTargetPublicReleaseDate()));
     assertContainsStudyProperty(studyProps, "alternativeDataSharingPlanAccessManagement",
         schema.getAlternativeDataSharingPlanAccessManagement().value());
+    assertContainsStudyProperty(studyProps, "assets",
+        PropertyType.coerceToJson(GsonUtil.getInstance().toJson(schema.getAssets())));
 
     List<DatasetProperty> datasetProps = inserts.get(0).props();
     assertContainsDatasetProperty(datasetProps, "dataLocation",
@@ -862,7 +864,15 @@ class DatasetRegistrationServiceTest {
     consentGroup.setAccessManagement(AccessManagement.CONTROLLED);
     consentGroup.setDataLocation(ConsentGroup.DataLocation.TDR_LOCATION);
     consentGroup.setDataAccessCommitteeId(new Random().nextInt());
-
+    schemaV1.setAssets(Map.of(
+        "workspace_id", "c7b96ac5-5568-441c-a3f4-2e82e45e3e6d", 
+        "name", "Cardiometabolic GWAS Analysis Workspace", 
+        "platform", "Terra",
+        "authors", List.of(
+            Map.of("user", "john", "email", "john@example.com"),
+            Map.of("user", "emma", "email", "emma@example.com")
+        ),
+        "tags", List.of("GWAS", "Terra", "featured")));
     schemaV1.setConsentGroups(List.of(consentGroup));
     return schemaV1;
   }


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2345

### Summary

Persist `assets` in Postgres, and added `assets` to our existing de/serialization tests.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
