### PR TITLE
[DT-2250] Remove sortDate

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DarCollectionDAO.java
@@ -88,7 +88,7 @@ public interface DarCollectionDAO extends Transactional<DarCollectionDAO> {
           "dar.id AS dar_id, dar.reference_id AS dar_reference_id, dar.collection_id AS dar_collection_id, "
           +
           "dar.parent_id AS dar_parent_id, dar.user_id AS dar_userId, " +
-          "dar.create_date AS dar_create_date, dar.sort_date AS dar_sort_date, dar.submission_date AS dar_submission_date, " +
+          "dar.create_date AS dar_create_date, dar.submission_date AS dar_submission_date, " +
           "dar.closeout_so_approval_timestamp AS dar_closeout_signing_official_approved_date, "+
           "dar.closeout_approving_so_id AS dar_closeout_signing_official_approved_user_id, " +
           "dar.update_date AS dar_update_date, (dar.data #>> '{}')::jsonb AS data " +
@@ -136,7 +136,7 @@ public interface DarCollectionDAO extends Transactional<DarCollectionDAO> {
         dar.parent_id AS dar_parent_id, dar.user_id AS dar_userId, dar.era_commons_id AS dar_era_commons_id,
         dar.closeout_so_approval_timestamp AS dar_closeout_signing_official_approved_date,
         dar.closeout_approving_so_id AS dar_closeout_signing_official_approved_user_id,
-        dar.create_date AS dar_create_date, dar.sort_date AS dar_sort_date, dar.submission_date AS dar_submission_date,
+        dar.create_date AS dar_create_date, dar.submission_date AS dar_submission_date,
         dar.update_date AS dar_update_date, dar.data AS data, dd.dataset_id
         FROM dar_collection c
         INNER JOIN users u ON c.create_user_id = u.user_id
@@ -173,7 +173,7 @@ public interface DarCollectionDAO extends Transactional<DarCollectionDAO> {
           + "dd.dataset_id, "
           + "dar.id AS dar_id, dar.reference_id AS dar_reference_id, dar.collection_id AS dar_collection_id, "
           + "dar.parent_id AS dar_parent_id, dar.user_id AS dar_userId, dar.era_commons_id AS dar_era_commons_id, "
-          + "dar.create_date AS dar_create_date, dar.sort_date AS dar_sort_date, dar.submission_date AS dar_submission_date, "
+          + "dar.create_date AS dar_create_date, dar.submission_date AS dar_submission_date, "
           + "dar.update_date AS dar_update_date, dar.data AS data, "
           + "dar.closeout_so_approval_timestamp AS dar_closeout_signing_official_approved_date, "
           + "dar.closeout_approving_so_id AS dar_closeout_signing_official_approved_user_id, "
@@ -229,7 +229,7 @@ public interface DarCollectionDAO extends Transactional<DarCollectionDAO> {
        dd.dataset_id,
        dar.id AS dar_id, dar.reference_id AS dar_reference_id, dar.collection_id AS dar_collection_id,
        dar.parent_id AS dar_parent_id, dar.user_id AS dar_userId, dar.era_commons_id AS dar_era_commons_id,
-       dar.create_date AS dar_create_date, dar.sort_date AS dar_sort_date, dar.submission_date AS dar_submission_date,
+       dar.create_date AS dar_create_date, dar.submission_date AS dar_submission_date,
        dar.update_date AS dar_update_date, (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data,
        dar.closeout_so_approval_timestamp AS dar_closeout_signing_official_approved_date,
        dar.closeout_approving_so_id AS dar_closeout_signing_official_approved_user_id,
@@ -283,7 +283,7 @@ public interface DarCollectionDAO extends Transactional<DarCollectionDAO> {
        dd.dataset_id,
        dar.id AS dar_id, dar.reference_id AS dar_reference_id, dar.collection_id AS dar_collection_id,
        dar.parent_id AS dar_parent_id, dar.user_id AS dar_userId, dar.era_commons_id AS dar_era_commons_id,
-       dar.create_date AS dar_create_date, dar.sort_date AS dar_sort_date, dar.submission_date AS dar_submission_date,
+       dar.create_date AS dar_create_date, dar.submission_date AS dar_submission_date,
        dar.update_date AS dar_update_date, (regexp_replace(dar.data #>> '{}', '\\\\u0000', '', 'g'))::jsonb AS data,
        dar.closeout_so_approval_timestamp AS dar_closeout_signing_official_approved_date,
        dar.closeout_approving_so_id AS dar_closeout_signing_official_approved_user_id,

--- a/src/main/java/org/broadinstitute/consent/http/db/DataAccessRequestDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DataAccessRequestDAO.java
@@ -39,7 +39,7 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
   @SqlQuery(
       """
           SELECT collection.dar_code, dd.dataset_id, dar.id, dar.reference_id, dar.collection_id,
-            dar.parent_id, dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date,
+            dar.parent_id, dar.user_id, dar.create_date, dar.submission_date, dar.update_date,
             dar.data, dar.era_commons_id,
             dar.closeout_so_approval_timestamp, dar.closeout_approving_so_id
           FROM data_access_request dar
@@ -66,7 +66,7 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
   @UseRowReducer(DataAccessRequestReducer.class)
   @SqlQuery("""
       SELECT dar.id, dar.reference_id, dar.collection_id, dar.parent_id,
-        dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date,
+        dar.user_id, dar.create_date, dar.submission_date, dar.update_date,
         dar.data,
         dd.dataset_id, collection.dar_code, dar.era_commons_id,
         dar.closeout_so_approval_timestamp, dar.closeout_approving_so_id
@@ -156,7 +156,7 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
   @SqlQuery(
       """
               SELECT dar.id, dar.reference_id, dar.collection_id, dar.parent_id,
-                dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date,
+                dar.user_id, dar.create_date, dar.submission_date, dar.update_date,
                 data,
                 dd.dataset_id, collection.dar_code, dar.era_commons_id,
                 dar.closeout_so_approval_timestamp, dar.closeout_approving_so_id
@@ -181,7 +181,7 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
   @SqlQuery(
       """
               SELECT dd.dataset_id, dar.id, dar.reference_id, dar.collection_id, dar.parent_id,
-              dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date,
+              dar.user_id, dar.create_date, dar.submission_date, dar.update_date,
               dar.data, collection.dar_code,
               dar.era_commons_id, dar.closeout_so_approval_timestamp, dar.closeout_approving_so_id
               FROM data_access_request dar
@@ -202,7 +202,7 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
   @SqlQuery(
       """
               SELECT dd.dataset_id, dar.id, dar.reference_id, dar.collection_id, dar.parent_id,
-              dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date,
+              dar.user_id, dar.create_date, dar.submission_date, dar.update_date,
               dar.data,
               collection.dar_code, dar.era_commons_id, dar.closeout_so_approval_timestamp,
               dar.closeout_approving_so_id
@@ -212,7 +212,7 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
               WHERE dar.submission_date is null
                 AND (LOWER(dar.data->>'status') != 'archived' OR dar.data->>'status' IS NULL)
                 AND dar.user_id = :userId
-              ORDER BY dar.sort_date DESC
+              ORDER BY dar.update_date DESC
           """)
   List<DataAccessRequest> findAllDraftsByUserId(@Bind("userId") Integer userId);
 
@@ -226,7 +226,7 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
   @SqlQuery(
       """
               SELECT dd.dataset_id, dar.id, dar.reference_id, dar.collection_id, dar.parent_id,
-                dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date,
+                dar.user_id, dar.create_date, dar.submission_date, dar.update_date,
                 dar.data,
                 collection.dar_code, dar.era_commons_id, dar.closeout_so_approval_timestamp,
                 dar.closeout_approving_so_id
@@ -247,7 +247,7 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
   @UseRowReducer(DataAccessRequestReducer.class)
   @SqlQuery(
       """
-          SELECT dd.dataset_id, dar.id, dar.reference_id, dar.collection_id, dar.parent_id, dar.user_id, dar.create_date, dar.sort_date, dar.submission_date, dar.update_date,
+          SELECT dd.dataset_id, dar.id, dar.reference_id, dar.collection_id, dar.parent_id, dar.user_id, dar.create_date, dar.submission_date, dar.update_date,
             dar.data, collection.dar_code,
             dar.era_commons_id, dar.closeout_so_approval_timestamp, dar.closeout_approving_so_id
           FROM data_access_request dar
@@ -263,7 +263,6 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
    *
    * @param referenceId    String
    * @param userId         Integer User
-   * @param sortDate       Date Sorting Date
    * @param submissionDate Date Submission Date
    * @param updateDate     Date Update Date
    * @param data           DataAccessRequestData DAR Properties
@@ -273,14 +272,13 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
   @SqlUpdate(
       """
           UPDATE data_access_request
-          SET data = regexp_replace(:data, '\\\\u0000', '', 'g')::jsonb, user_id = :userId, sort_date = :sortDate,
+          SET data = regexp_replace(:data, '\\\\u0000', '', 'g')::jsonb, user_id = :userId,
             submission_date = :submissionDate, update_date = :updateDate, era_commons_id = :eraCommonsId
           WHERE reference_id = :referenceId
       """)
   void updateDataByReferenceId(
       @Bind("referenceId") String referenceId,
       @Bind("userId") Integer userId,
-      @Bind("sortDate") Date sortDate,
       @Bind("submissionDate") Date submissionDate,
       @Bind("updateDate") Date updateDate,
       @Bind("data") @Json DataAccessRequestData data,
@@ -326,7 +324,6 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
    * @param referenceId String
    * @param userId      Integer User
    * @param createDate  Date Creation Date
-   * @param sortDate    Date Sorting Date
    * @param updateDate  Date Update Date
    * @param data        DataAccessRequestData DAR Properties
    */
@@ -334,15 +331,14 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
   @SqlUpdate(
       """
           INSERT INTO data_access_request
-            (reference_id, user_id, create_date, sort_date, update_date, data)
-          VALUES (:referenceId, :userId, :createDate, :sortDate,
+            (reference_id, user_id, create_date, update_date, data)
+          VALUES (:referenceId, :userId, :createDate,
             :updateDate, regexp_replace(:data, '\\\\u0000', '', 'g')::jsonb)
       """)
   void insertDraftDataAccessRequest(
       @Bind("referenceId") String referenceId,
       @Bind("userId") Integer userId,
       @Bind("createDate") Date createDate,
-      @Bind("sortDate") Date sortDate,
       @Bind("updateDate") Date updateDate,
       @Bind("data") @Json DataAccessRequestData data);
 
@@ -353,7 +349,6 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
    * @param referenceId    String
    * @param userId         Integer User
    * @param createDate     Date Creation Date
-   * @param sortDate       Date Sorting Date
    * @param submissionDate Date Submission Date
    * @param updateDate     Date Update Date
    * @param data           DataAccessRequestData DAR Properties
@@ -362,8 +357,8 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
   @SqlUpdate(
       """
           INSERT INTO data_access_request
-            (collection_id, reference_id, user_id, create_date, sort_date, submission_date, update_date, data, era_commons_id)
-          VALUES (:collectionId, :referenceId, :userId, :createDate, :sortDate,
+            (collection_id, reference_id, user_id, create_date, submission_date, update_date, data, era_commons_id)
+          VALUES (:collectionId, :referenceId, :userId, :createDate,
             :submissionDate, :updateDate, regexp_replace(:data, '\\\\u0000', '', 'g')::jsonb, :eraCommonsId)
       """)
   void insertDataAccessRequest(
@@ -371,7 +366,6 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
       @Bind("referenceId") String referenceId,
       @Bind("userId") Integer userId,
       @Bind("createDate") Date createDate,
-      @Bind("sortDate") Date sortDate,
       @Bind("submissionDate") Date submissionDate,
       @Bind("updateDate") Date updateDate,
       @Bind("data") @Json DataAccessRequestData data,
@@ -390,8 +384,8 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
   @SqlUpdate(
       """
           INSERT INTO data_access_request
-            (parent_id, collection_id, reference_id, user_id, create_date, sort_date, submission_date, update_date, data, era_commons_id)
-          VALUES (:parentId, :collectionId, :referenceId, :userId, now(), now(), now(), now(), regexp_replace(:data, '\\\\u0000', '', 'g')::jsonb, :eraCommonsId)
+            (parent_id, collection_id, reference_id, user_id, create_date, submission_date, update_date, data, era_commons_id)
+          VALUES (:parentId, :collectionId, :referenceId, :userId, now(), now(), now(), regexp_replace(:data, '\\\\u0000', '', 'g')::jsonb, :eraCommonsId)
       """)
   void insertProgressReport(
       @Bind("parentId") Integer parentId,

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DataAccessRequestMapper.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DataAccessRequestMapper.java
@@ -35,7 +35,6 @@ public class DataAccessRequestMapper implements RowMapper<DataAccessRequest>, Ro
     }
 
     dar.setCreateDate(resultSet.getTimestamp("create_date"));
-    dar.setSortDate(resultSet.getTimestamp("sort_date"));
     dar.setSubmissionDate(resultSet.getTimestamp("submission_date"));
     dar.setUpdateDate(resultSet.getTimestamp("update_date"));
     String darDataString = resultSet.getObject("data", PGobject.class).getValue();

--- a/src/main/java/org/broadinstitute/consent/http/models/DarCollection.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DarCollection.java
@@ -20,7 +20,7 @@ public class DarCollection {
       "dar.id AS dar_id, dar.reference_id AS dar_reference_id, dar.collection_id AS dar_collection_id, "
           +
           "dar.parent_id AS dar_parent_id, dar.user_id AS dar_userId, " +
-          "dar.create_date AS dar_create_date, dar.sort_date AS dar_sort_date, dar.submission_date AS dar_submission_date, "
+          "dar.create_date AS dar_create_date, dar.submission_date AS dar_submission_date, "
           +
           "dar.update_date AS dar_update_date, dar.data AS data, "
           +

--- a/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequest.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequest.java
@@ -439,9 +439,6 @@ public class DataAccessRequest {
     if (Objects.nonNull(dar.getReferenceId())) {
       copy.put("referenceId", dar.getReferenceId());
     }
-    if (Objects.nonNull(dar.getSortDate())) {
-      copy.put("sortDate", dar.getSortDate().getTime());
-    }
     if (Objects.nonNull(dar.getSubmissionDate())) {
       copy.put("submissionDate", dar.getSubmissionDate().getTime());
     }

--- a/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequest.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequest.java
@@ -66,13 +66,6 @@ public class DataAccessRequest {
   @JsonProperty
   public Timestamp createDate;
 
-  /*
-   * Legacy property on DARs. Used to display the sort order for a DAR. In practice, this also
-   * functions as the Update Date. See also https://broadinstitute.atlassian.net/browse/DUOS-728
-   */
-  @JsonProperty
-  public Timestamp sortDate;
-
   @JsonProperty
   public Timestamp submissionDate;
 
@@ -170,14 +163,6 @@ public class DataAccessRequest {
 
   public void setCreateDate(Timestamp createDate) {
     this.createDate = createDate;
-  }
-
-  public Date getSortDate() {
-    return sortDate;
-  }
-
-  public void setSortDate(Timestamp sortDate) {
-    this.sortDate = sortDate;
   }
 
   public Timestamp getSubmissionDate() {

--- a/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
@@ -435,7 +435,6 @@ public class DarCollectionService implements ConsentLogger {
       dataAccessRequestDAO.updateDataByReferenceId(
           d.getReferenceId(),
           d.getUserId(),
-          now,
           null,
           now,
           newData,

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessReportsParser.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessReportsParser.java
@@ -69,7 +69,7 @@ public class DataAccessReportsParser implements ConsentLogger {
     String electionDate = (Objects.nonNull(election.getFinalVoteDate())) ? formatTimeToDate(
         election.getFinalVoteDate().getTime()) : "";
     String content2 = rusSummary + DEFAULT_SEPARATOR +
-        formatTimeToDate(dar.getSortDate().getTime()) + DEFAULT_SEPARATOR +
+        formatTimeToDate(dar.getUpdateDate().getTime()) + DEFAULT_SEPARATOR +
         electionDate + DEFAULT_SEPARATOR +
         "--";
     addDARLine(darWriter, dar, darCode, content1, content2, consentName, translatedUseRestriction);

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessReportsParser.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessReportsParser.java
@@ -68,8 +68,10 @@ public class DataAccessReportsParser implements ConsentLogger {
     String content1 = profileName + DEFAULT_SEPARATOR + institution + DEFAULT_SEPARATOR;
     String electionDate = (Objects.nonNull(election.getFinalVoteDate())) ? formatTimeToDate(
         election.getFinalVoteDate().getTime()) : "";
+    String updateDate = (Objects.nonNull(dar.getUpdateDate())) ? formatTimeToDate(
+        dar.getUpdateDate().getTime()) : "";
     String content2 = rusSummary + DEFAULT_SEPARATOR +
-        formatTimeToDate(dar.getUpdateDate().getTime()) + DEFAULT_SEPARATOR +
+        updateDate + DEFAULT_SEPARATOR +
         electionDate + DEFAULT_SEPARATOR +
         "--";
     addDARLine(darWriter, dar, darCode, content1, content2, consentName, translatedUseRestriction);

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
@@ -158,7 +158,6 @@ public class DataAccessRequestService implements ConsentLogger {
         user.getUserId(),
         now,
         now,
-        now,
         dar.getData()
     );
     syncDataAccessRequestDatasets(dar.getDatasetIds(), dar.getReferenceId());
@@ -233,7 +232,6 @@ public class DataAccessRequestService implements ConsentLogger {
           user.getUserId(),
           now,
           now,
-          now,
           darData,
           user.getEraCommonsId());
     } else {
@@ -242,7 +240,6 @@ public class DataAccessRequestService implements ConsentLogger {
           collectionId,
           referenceId,
           user.getUserId(),
-          now,
           now,
           now,
           now,

--- a/src/main/java/org/broadinstitute/consent/http/service/dao/DataAccessRequestServiceDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/dao/DataAccessRequestServiceDAO.java
@@ -33,7 +33,7 @@ public class DataAccessRequestServiceDAO {
     String referenceId = dar.getReferenceId();
     final String updateDataByReferenceId = """
           UPDATE data_access_request
-          SET data = regexp_replace(:data, '\\\\u0000', '', 'g')::jsonb, user_id = :userId, sort_date = :sortDate,
+          SET data = regexp_replace(:data, '\\\\u0000', '', 'g')::jsonb, user_id = :userId,
           submission_date = :submissionDate, update_date = :updateDate
           WHERE reference_id = :referenceId
         """;
@@ -52,7 +52,6 @@ public class DataAccessRequestServiceDAO {
         Update darUpdate = h.createUpdate(updateDataByReferenceId);
         darUpdate.bind("referenceId", referenceId);
         darUpdate.bind("userId", user.getUserId());
-        darUpdate.bind("sortDate", now);
         darUpdate.bind("updateDate", now);
         darUpdate.bind("data", dar.getData().toString());
         darUpdate.bind("submissionDate", dar.getSubmissionDate());

--- a/src/main/resources/assets/schemas/DataAccessRequest.yaml
+++ b/src/main/resources/assets/schemas/DataAccessRequest.yaml
@@ -10,9 +10,6 @@ properties:
   createDate:
     type: number
     description: Creation Date
-  sortDate:
-    type: number
-    description: Sort Date
   submissionDate:
     type: number
     description: Submission Date

--- a/src/main/resources/changelog-master.xml
+++ b/src/main/resources/changelog-master.xml
@@ -208,4 +208,6 @@
     relativeToChangelogFile="true" />
   <include file="changesets/changelog-consent-2025-10-14-clear-nih-statuses.xml"
     relativeToChangelogFile="true" />
+  <include file="changesets/changelog-consent-2025-11-03-drop-sort-date-column.xml"
+    relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/src/main/resources/changesets/changelog-consent-2025-11-03-drop-sort-date-column.xml
+++ b/src/main/resources/changesets/changelog-consent-2025-11-03-drop-sort-date-column.xml
@@ -1,0 +1,11 @@
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+  <changeSet id="changelog-consent-2025-11-03-drop-sort-date-column" author="kevinmarete">
+    <comment>
+      Drop sort_date column from data_access_request table as part of consolidating
+      sort_date and update_date fields.
+    </comment>
+    <dropColumn tableName="data_access_request" columnName="sort_date"/>
+  </changeSet>
+</databaseChangeLog>

--- a/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
@@ -205,7 +205,7 @@ public class DAOTestHelper extends AbstractTestHelper implements TestExecutionLi
         collectionId,
         referenceId,
         userId,
-        now, now, now, now,
+        now, now, now,
         data,
         randomAlphabetic(10));
     return dataAccessRequestDAO.findByReferenceId(referenceId);

--- a/src/test/java/org/broadinstitute/consent/http/db/DacDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DacDAOTest.java
@@ -457,7 +457,7 @@ class DacDAOTest extends DAOTestHelper {
         collectionId,
         referenceId,
         userId,
-        now, now, now, now,
+        now, now, now,
         data,
         randomAlphabetic(10));
     return dataAccessRequestDAO.findByReferenceId(referenceId);
@@ -473,7 +473,6 @@ class DacDAOTest extends DAOTestHelper {
         collection.getDarCollectionId(),
         randomUUID,
         user.getUserId(),
-        new Date(),
         new Date(),
         new Date(),
         new Date(),

--- a/src/test/java/org/broadinstitute/consent/http/db/DarCollectionDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DarCollectionDAOTest.java
@@ -515,7 +515,6 @@ class DarCollectionDAOTest extends DAOTestHelper {
     testDar.setReferenceId(UUID.randomUUID().toString());
     testDar.setUserId(user.getUserId());
     testDar.setCreateDate(now);
-    testDar.setSortDate(now);
     testDar.setSubmissionDate(now);
     testDar.setUpdateDate(now);
     testDar.setEraCommonsId(user.getEraCommonsId());
@@ -527,7 +526,6 @@ class DarCollectionDAOTest extends DAOTestHelper {
         testDar.getReferenceId(),
         testDar.getUserId(),
         testDar.getCreateDate(),
-        testDar.getSortDate(),
         testDar.getSubmissionDate(),
         testDar.getUpdateDate(),
         testDar.getData(),

--- a/src/test/java/org/broadinstitute/consent/http/db/DarCollectionDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DarCollectionDAOTest.java
@@ -690,7 +690,7 @@ class DarCollectionDAOTest extends DAOTestHelper {
         collectionId,
         referenceId,
         userId,
-        now, now, now, now,
+        now, now, now,
         data,
         randomAlphabetic(10));
     return dataAccessRequestDAO.findByReferenceId(referenceId);
@@ -823,7 +823,6 @@ class DarCollectionDAOTest extends DAOTestHelper {
     dataAccessRequestDAO.insertDraftDataAccessRequest(
         referenceId,
         user.getUserId(),
-        now,
         now,
         now,
         data

--- a/src/test/java/org/broadinstitute/consent/http/db/DarCollectionSummaryDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DarCollectionSummaryDAOTest.java
@@ -44,7 +44,7 @@ class DarCollectionSummaryDAOTest extends DAOTestHelper {
     data.setProjectTitle(randomAlphabetic(20));
     data.setStatus("test");
     dataAccessRequestDAO.insertDataAccessRequest(collectionId, referenceId, userId, createDate,
-        new Date(), submissionDate, new Date(), data, randomAlphabetic(10));
+        submissionDate, new Date(), data, randomAlphabetic(10));
     return dataAccessRequestDAO.findByReferenceId(referenceId);
   }
 
@@ -559,7 +559,7 @@ class DarCollectionSummaryDAOTest extends DAOTestHelper {
     DataAccessRequest dar = createDataAccessRequest(collectionId, userId);
 
     dataAccessRequestDAO.insertDARDatasetRelation(dar.getReferenceId(), dataset.getDatasetId());
-    dataAccessRequestDAO.updateDataByReferenceId(dar.getReferenceId(), dar.userId, new Date(), null,
+    dataAccessRequestDAO.updateDataByReferenceId(dar.getReferenceId(), dar.userId, null,
         new Date(), dar.getData(), randomAlphabetic(10)); // draft DAR
 
     List<DarCollectionSummary> summaries = darCollectionSummaryDAO.getDarCollectionSummariesForResearcher(

--- a/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
@@ -410,7 +410,6 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
     testDar.setReferenceId(UUID.randomUUID().toString());
     testDar.setUserId(user.getUserId());
     testDar.setCreateDate(now);
-    testDar
     testDar.setSubmissionDate(submissionDate);
     testDar.setUpdateDate(now);
     DataAccessRequestData contents = new DataAccessRequestData();

--- a/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
@@ -112,7 +112,7 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
     assertEquals(1, draftDars1.size());
     DataAccessRequestData darData = draftDars1.get(0).getData();
     dataAccessRequestDAO.updateDataByReferenceId(dar.referenceId, dar.userId, new Date(),
-        new Date(), new Date(), darData, randomAlphabetic(10));
+        new Date(), darData, randomAlphabetic(10));
     List<DataAccessRequest> draftDars2 = dataAccessRequestDAO.findAllDraftDataAccessRequests();
     assertTrue(draftDars2.isEmpty());
   }
@@ -124,7 +124,7 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
     List<DataAccessRequest> draftDars1 = dataAccessRequestDAO.findAllDraftDataAccessRequests();
     assertTrue(draftDars1.isEmpty());
 
-    dataAccessRequestDAO.updateDataByReferenceId(dar.getReferenceId(), dar.userId, new Date(), null,
+    dataAccessRequestDAO.updateDataByReferenceId(dar.getReferenceId(), dar.userId, null,
         new Date(), dar.getData(), randomAlphabetic(10));
     List<DataAccessRequest> draftDars2 = dataAccessRequestDAO.findAllDraftDataAccessRequests();
     assertFalse(draftDars2.isEmpty());
@@ -137,12 +137,12 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
     DarCollection darColl = createDarCollection();
     DataAccessRequest dar = new ArrayList<>(darColl.getDars().values()).get(0);
 
-    dataAccessRequestDAO.updateDataByReferenceId(dar.referenceId, dar.userId, new Date(), null,
+    dataAccessRequestDAO.updateDataByReferenceId(dar.referenceId, dar.userId, null,
         new Date(), dar.getData(), randomAlphabetic(10));
     dar = dataAccessRequestDAO.findByReferenceId(dar.getReferenceId());
     DataAccessRequestData darData = dar.getData();
     dataAccessRequestDAO.updateDataByReferenceId(dar.referenceId, dar.userId, new Date(),
-        new Date(), new Date(), darData, randomAlphabetic(10));
+        new Date(), darData, randomAlphabetic(10));
     dar = dataAccessRequestDAO.findByReferenceId(dar.getReferenceId());
     assertFalse(dar.getDraft());
     Timestamp expectedTimestamp = new Timestamp(
@@ -156,7 +156,7 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
     DarCollection darColl = createDarCollection();
     DataAccessRequest dar = new ArrayList<>(darColl.getDars().values()).get(0);
 
-    dataAccessRequestDAO.updateDataByReferenceId(dar.referenceId, dar.userId, new Date(), null,
+    dataAccessRequestDAO.updateDataByReferenceId(dar.referenceId, dar.userId, null,
         new Date(), dar.getData(), randomAlphabetic(10));
     dar = dataAccessRequestDAO.findByReferenceId(dar.getReferenceId());
     assertNull(dar.getSubmissionDate());
@@ -171,7 +171,6 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
     DataAccessRequest dar = new ArrayList<>(darColl.getDars().values()).get(0);
 
     dataAccessRequestDAO.updateDataByReferenceId(dar.referenceId, dar.userId, new Date(),
-        new Date(),
         new Date(), dar.getData(), randomAlphabetic(10));
     dar = dataAccessRequestDAO.findByReferenceId(dar.getReferenceId());
     assertFalse(dar.getDraft());
@@ -188,7 +187,7 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
 
     dar = dataAccessRequestDAO.findByReferenceId(dar.getReferenceId());
     assertFalse(dar.getDraft());
-    dataAccessRequestDAO.updateDataByReferenceId(dar.referenceId, dar.userId, new Date(), null,
+    dataAccessRequestDAO.updateDataByReferenceId(dar.referenceId, dar.userId, null,
         new Date(), dar.getData(), randomAlphabetic(10));
     dar = dataAccessRequestDAO.findByReferenceId(dar.getReferenceId());
     assertTrue(dar.getDraft());
@@ -239,7 +238,7 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
     String rus = randomAlphabetic(10);
     dar.getData().setRus(rus);
     dar.getData().setValidRestriction(false);
-    dataAccessRequestDAO.updateDataByReferenceId(dar.getReferenceId(), user.getUserId(), now, now,
+    dataAccessRequestDAO.updateDataByReferenceId(dar.getReferenceId(), user.getUserId(), now,
         now, dar.getData(), randomAlphabetic(10));
     DataAccessRequest updatedDar = dataAccessRequestDAO.findByReferenceId(dar.getReferenceId());
     assertEquals(rus, updatedDar.getData().getRus());
@@ -258,7 +257,7 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
         collection.getDarCollectionId(),
         referenceId,
         collection.getCreateUserId(),
-        now, now, now, now,
+        now, now, now,
         data,
         randomAlphabetic(10));
     DataAccessRequest dar = dataAccessRequestDAO.findByReferenceId(referenceId);
@@ -277,8 +276,7 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
     String rus = randomAlphabetic(10);
     dar.getData().setRus(rus + String.format(" %s ", unsupportedUnicode));
     dataAccessRequestDAO.updateDataByReferenceId(dar.getReferenceId(), collection.getCreateUserId(),
-        now, now,
-        now, dar.getData(), randomAlphabetic(10));
+        now, now, dar.getData(), randomAlphabetic(10));
 
     DataAccessRequest updatedDar = dataAccessRequestDAO.findByReferenceId(dar.getReferenceId());
     assertNotNull(updatedDar);
@@ -296,7 +294,6 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
     dataAccessRequestDAO.insertDraftDataAccessRequest(
         referenceId,
         user.getUserId(),
-        now,
         now,
         now,
         data
@@ -436,7 +433,6 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
     dataAccessRequestDAO.insertDraftDataAccessRequest(
         referenceId,
         user.getUserId(),
-        now,
         now,
         now,
         contents
@@ -760,7 +756,6 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
         user.getUserId(),
         now,
         now,
-        now,
         closeoutDAR.getData(),
         randomAlphabetic(10)
     );
@@ -920,7 +915,6 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
     dataAccessRequestDAO.updateDataByReferenceId(
         closeoutDAR.getReferenceId(),
         user.getUserId(),
-        now,
         now,
         now,
         closeoutDAR.getData(),
@@ -1282,7 +1276,7 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
         collectionId,
         referenceId,
         userId,
-        now, now, now, now,
+        now, now, now,
         data,
         randomAlphabetic(10));
     return dataAccessRequestDAO.findByReferenceId(referenceId);
@@ -1311,7 +1305,7 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
     data.setProjectTitle("Project Title: " + randomAlphabetic(50));
     data.setStatus("test");
     dataAccessRequestDAO.insertDataAccessRequest(collectionId, referenceId, userId, createDate,
-        new Date(), submissionDate, new Date(), data, randomAlphabetic(10));
+        submissionDate, new Date(), data, randomAlphabetic(10));
     return dataAccessRequestDAO.findByReferenceId(referenceId);
   }
 
@@ -1388,7 +1382,6 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
     dataAccessRequestDAO.insertDraftDataAccessRequest(
         referenceId,
         user.getUserId(),
-        now,
         now,
         now,
         data

--- a/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
@@ -410,7 +410,7 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
     testDar.setReferenceId(UUID.randomUUID().toString());
     testDar.setUserId(user.getUserId());
     testDar.setCreateDate(now);
-    testDar.setSortDate(now);
+    testDar
     testDar.setSubmissionDate(submissionDate);
     testDar.setUpdateDate(now);
     DataAccessRequestData contents = new DataAccessRequestData();
@@ -420,7 +420,6 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
         testDar.getReferenceId(),
         testDar.getUserId(),
         testDar.getCreateDate(),
-        testDar.getSortDate(),
         testDar.getSubmissionDate(),
         testDar.getUpdateDate(),
         testDar.getData(),
@@ -1008,7 +1007,6 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
     assertEquals(dar.getUserId(), progressReport.getUserId());
     assertNotNull(progressReport.getData());
     assertNotNull(progressReport.getCreateDate());
-    assertNotNull(progressReport.getSortDate());
     assertNotNull(progressReport.getSubmissionDate());
     assertNotNull(progressReport.getUpdateDate());
     assertNotEquals(dar.getReferenceId(), progressReport.getReferenceId());

--- a/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
@@ -1352,7 +1352,7 @@ class DatasetDAOTest extends DAOTestHelper {
     data.setProjectTitle(randomAlphabetic(10));
     String referenceId = randomAlphanumeric(20);
     dataAccessRequestDAO.insertDataAccessRequest(collectionId, referenceId, userId, new Date(),
-        new Date(), new Date(), new Date(), data, randomAlphabetic(10));
+        new Date(), new Date(), data, randomAlphabetic(10));
     dataAccessRequestDAO.insertDARDatasetRelation(referenceId, datasetId);
   }
 
@@ -1361,7 +1361,7 @@ class DatasetDAOTest extends DAOTestHelper {
     data.setProjectTitle(randomAlphabetic(10));
     String referenceId = randomAlphabetic(20);
     Date now = new Date();
-    dataAccessRequestDAO.insertDataAccessRequest(collectionId, referenceId, userId, now, now, now, now, data, randomAlphabetic(10));
+    dataAccessRequestDAO.insertDataAccessRequest(collectionId, referenceId, userId, now, now, now, data, randomAlphabetic(10));
     datasetIds.forEach(
         datasetId -> dataAccessRequestDAO.insertDARDatasetRelation(referenceId, datasetId));
   }

--- a/src/test/java/org/broadinstitute/consent/http/db/ElectionDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/ElectionDAOTest.java
@@ -703,7 +703,7 @@ class ElectionDAOTest extends DAOTestHelper {
         collectionId,
         referenceId,
         userId,
-        now, now, now, now,
+        now, now, now,
         data,
         randomAlphabetic(10));
     return dataAccessRequestDAO.findByReferenceId(referenceId);

--- a/src/test/java/org/broadinstitute/consent/http/db/VoteDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/VoteDAOTest.java
@@ -475,7 +475,7 @@ class VoteDAOTest extends DAOTestHelper {
     data.setProjectTitle(randomAlphabetic(10));
     String referenceId = randomAlphanumeric(20);
     dataAccessRequestDAO.insertDataAccessRequest(collectionId, referenceId, userId, new Date(),
-        new Date(), new Date(), new Date(), data, randomAlphabetic(10));
+        new Date(), new Date(), data, randomAlphabetic(10));
     dataAccessRequestDAO.insertDARDatasetRelation(referenceId, datasetId);
     return dataAccessRequestDAO.findByReferenceId(referenceId);
   }

--- a/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceTest.java
@@ -811,7 +811,6 @@ class DataAccessRequestResourceTest extends AbstractTestHelper {
     dar.setUserId(user.getUserId());
     dar.setCreateDate(now);
     dar.setUpdateDate(now);
-    dar.setSortDate(now);
     return dar;
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/service/DataAccessReportsParserTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DataAccessReportsParserTest.java
@@ -9,11 +9,9 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.sql.Timestamp;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
-import java.util.stream.Stream;
 import org.broadinstitute.consent.http.db.DatasetDAO;
 import org.broadinstitute.consent.http.enumeration.HeaderDAR;
 import org.broadinstitute.consent.http.models.DataAccessRequest;
@@ -69,7 +67,7 @@ class DataAccessReportsParserTest {
     File file = File.createTempFile("ApprovedDataAccessRequests.tsv", ".tsv");
     Date currentDate = new Date();
     Election election = createElection(currentDate);
-    DataAccessRequest dar = createDAR(currentDate);
+    DataAccessRequest dar = createDAR();
     FileWriter darWriter = new FileWriter(file);
     parser.setApprovedDARHeader(darWriter);
     String REQUESTER = "Wesley";
@@ -120,7 +118,7 @@ class DataAccessReportsParserTest {
     File file = File.createTempFile("ApprovedDataAccessRequests.tsv", ".tsv");
     Date currentDate = new Date();
     Election election = createElection(currentDate);
-    DataAccessRequest dar = createDAR(currentDate);
+    DataAccessRequest dar = createDAR();
     FileWriter darWriter = new FileWriter(file);
     parser.setReviewedDARHeader(darWriter);
     parser.addReviewedDARLine(darWriter, election, dar, DAR_CODE, CONSENT_NAME, sDUL);
@@ -160,10 +158,9 @@ class DataAccessReportsParserTest {
   @Test
   void testDataAccessReviewedReportNullElectionDate() throws IOException {
     File file = File.createTempFile("ApprovedDataAccessRequests.tsv", ".tsv");
-    Date currentDate = new Date();
     Election election = new Election();
     election.setFinalVote(true);
-    DataAccessRequest dar = createDAR(currentDate);
+    DataAccessRequest dar = createDAR();
     FileWriter darWriter = new FileWriter(file);
     parser.setReviewedDARHeader(darWriter);
     parser.addReviewedDARLine(darWriter, election, dar, DAR_CODE, CONSENT_NAME, sDUL);
@@ -207,7 +204,7 @@ class DataAccessReportsParserTest {
     return election;
   }
 
-  private DataAccessRequest createDAR(Date currentDate) {
+  private DataAccessRequest createDAR() {
     DataAccessRequest dar = new DataAccessRequest();
     dar.setDatasetIds(List.of(1));
     DataAccessRequestData data = new DataAccessRequestData();

--- a/src/test/java/org/broadinstitute/consent/http/service/DataAccessReportsParserTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DataAccessReportsParserTest.java
@@ -213,7 +213,6 @@ class DataAccessReportsParserTest {
     DataAccessRequestData data = new DataAccessRequestData();
     data.setNonTechRus(RUS_SUMMARY);
     dar.setData(data);
-    dar.setSortDate(new Timestamp(currentDate.getTime()));
     return dar;
   }
 }

--- a/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
@@ -208,7 +208,6 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     DataAccessRequest dar = generateDataAccessRequest();
     dar.addDatasetIds(List.of(1, 2, 3));
     dar.setCreateDate(new Timestamp(1000));
-    dar.setSortDate(new Timestamp(1000));
     dar.setReferenceId("id");
     User user = createUserWithPrerequisites();
     when(institutionService.findInstitutionForEmail(any())).thenReturn(user.getInstitution());
@@ -229,7 +228,6 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     DataAccessRequest dar = generateDataAccessRequest();
     dar.addDatasetIds(List.of(1, 2, 3));
     dar.setCreateDate(new Timestamp(1000));
-    dar.setSortDate(new Timestamp(1000));
     dar.setReferenceId("id");
     dar.setSubmissionDate(Timestamp.from(Instant.now()));
     User user = createUserWithPrerequisites();
@@ -264,7 +262,6 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     DataAccessRequest dar = generateDataAccessRequest();
     dar.addDatasetIds(List.of(1, 2, 3));
     dar.setCreateDate(new Timestamp(1000));
-    dar.setSortDate(new Timestamp(1000));
     dar.setReferenceId("id");
     User user = new User(1, "email@test.org", "Display Name", new Date());
     assertThrows(NIHComplianceRuleException.class,

--- a/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
@@ -198,7 +198,7 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     when(counterService.getNextDarSequence()).thenReturn(1);
     when(dataAccessRequestDAO.findByReferenceId(any())).thenReturn(dar);
     doNothing().when(dataAccessRequestDAO)
-        .updateDataByReferenceId(any(), any(), any(), any(), any(), any(), any());
+        .updateDataByReferenceId(any(), any(), any(), any(), any(), any());
     DataAccessRequest newDar = service.createDataAccessRequest(user, dar, request);
     assertNotNull(newDar);
   }
@@ -218,7 +218,7 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
         randomInt(1, 100));
     doNothing().when(dataAccessRequestDAO)
         .insertDataAccessRequest(anyInt(), anyString(), anyInt(), any(Date.class), any(Date.class),
-            any(Date.class), any(Date.class), any(DataAccessRequestData.class), anyString());
+            any(Date.class), any(DataAccessRequestData.class), anyString());
     DataAccessRequest newDar = service.createDataAccessRequest(user, dar, request);
     assertNotNull(newDar);
   }
@@ -842,7 +842,7 @@ institution or library cards issued: Internal Collaborator member:  \
     DataAccessRequest draft = generateDataAccessRequest();
     doNothing()
         .when(dataAccessRequestDAO)
-        .insertDraftDataAccessRequest(any(), any(), any(), any(), any(), any());
+        .insertDraftDataAccessRequest(any(), any(), any(), any(), any());
     when(dataAccessRequestDAO.findByReferenceId(any())).thenReturn(draft);
     DataAccessRequest dar = service.insertDraftDataAccessRequest(user, draft);
     assertNotNull(dar);

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DarCollectionServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DarCollectionServiceDAOTest.java
@@ -447,7 +447,7 @@ class DarCollectionServiceDAOTest extends DAOTestHelper {
     dataAccessRequestDAO.insertDARDatasetRelation(dar.getReferenceId(), dacAndDataset2.dataset.getDatasetId());
     Date now = new Date();
     dataAccessRequestDAO.updateDataByReferenceId(
-        dar.getReferenceId(), dar.getUserId(), now, now, now, dar.getData(), user.getEraCommonsId());
+        dar.getReferenceId(), dar.getUserId(), now, now, dar.getData(), user.getEraCommonsId());
     return darCollectionDAO.findDARCollectionByReferenceId(dar.getReferenceId());
   }
 
@@ -488,10 +488,10 @@ class DarCollectionServiceDAOTest extends DAOTestHelper {
     DataAccessRequestData data = new DataAccessRequestData();
     dar.setData(data);
     dataAccessRequestDAO.insertDraftDataAccessRequest(dar.getReferenceId(), user.getUserId(), now,
-        now, now, data);
+        now, data);
     dataAccessRequestDAO.updateDraftToSubmittedForCollection(collectionId, dar.getReferenceId());
     dataAccessRequestDAO.updateDataByReferenceId(dar.referenceId, dar.userId, new Date(),
-        new Date(), new Date(), data, user.getEraCommonsId());
+        new Date(), data, user.getEraCommonsId());
     dataAccessRequestDAO.insertDARDatasetRelation(dar.getReferenceId(), dataset.getDatasetId());
     return dataAccessRequestDAO.findByReferenceId(dar.getReferenceId());
   }

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DataAccessRequestServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DataAccessRequestServiceDAOTest.java
@@ -58,7 +58,7 @@ class DataAccessRequestServiceDAOTest extends DAOTestHelper {
     DarCollection collection = createDarCollection();
     Integer collectionId = collection.getDarCollectionId();
     dataAccessRequestDAO.insertDataAccessRequest(collectionId, referenceId, user.getUserId(), old,
-        old, old, old, new DataAccessRequestData(), user.getEraCommonsId());
+        old, old, new DataAccessRequestData(), user.getEraCommonsId());
     dataAccessRequestDAO.insertAllDarDatasets(List.of(oldDarDataset, oldDarDatasetTwo));
 
     DataAccessRequest dar = new DataAccessRequest();
@@ -155,7 +155,7 @@ class DataAccessRequestServiceDAOTest extends DAOTestHelper {
         collectionId,
         referenceId,
         userId,
-        now, now, now, now,
+        now, now, now,
         data,
         randomAlphabetic(10));
     return dataAccessRequestDAO.findByReferenceId(referenceId);

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DataAccessRequestServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DataAccessRequestServiceDAOTest.java
@@ -2,7 +2,6 @@ package org.broadinstitute.consent.http.service.dao;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import java.sql.Timestamp;
 import java.util.ArrayList;

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DataAccessRequestServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DataAccessRequestServiceDAOTest.java
@@ -75,7 +75,6 @@ class DataAccessRequestServiceDAOTest extends DAOTestHelper {
     DataAccessRequest updatedDar = serviceDAO.updateByReferenceId(user, dar);
 
     Timestamp oldTimestamp = new Timestamp(old.getTime());
-    assertNotEquals(oldTimestamp, updatedDar.getSortDate());
     assertFalse(oldTimestamp.equals(updatedDar.getUpdateDate()));
     assertEquals(newDatasetIds, updatedDar.getDatasetIds());
     DataAccessRequestData updatedData = updatedDar.getData();


### PR DESCRIPTION
### Addresses
http://broadworkbench.atlassian.net/browse/DT-2250
### Summary
Remove the redundant `sortDate` field from DataAccessRequest. It was duplicating the functionality of `updateDate` and has no UI usage.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
