### PR TITLE
DT-2318: Allow any user to delete their own acknowledgement by key

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
@@ -421,7 +421,7 @@ public class UserResource extends Resource {
   @DELETE
   @Produces(MediaType.APPLICATION_JSON)
   @Path("/acknowledgements/{key}")
-  @RolesAllowed(ADMIN)
+  @PermitAll
   public Response deleteUserAcknowledgement(@Auth AuthUser authUser, @PathParam("key") String key) {
     try {
       User user = userService.findUserByEmail(authUser.getEmail());


### PR DESCRIPTION
### Addresses
Required for https://broadworkbench.atlassian.net/browse/DT-2318

### Summary
Allow any user to delete their own acknowledgement. Necessary to support the ability of a user to remove their acceptance of a class of cookies that DUOS uses.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
