### PR TITLE
DT-2433: Stream ES results directly to client

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
@@ -438,6 +438,22 @@ public class DatasetResource extends Resource {
     }
   }
 
+  @POST
+  @Path("/search/index/v2")
+  @Consumes("application/json")
+  @Produces("application/json")
+  @PermitAll
+  @Timed
+  public Response searchDatasetIndexStream(@Auth DuosUser duosUser, String query) {
+    try {
+      InputStream inputStream = elasticSearchService.searchDatasetsStream(query);
+      StreamingOutput stream = createStreamingOutput(inputStream);
+      return Response.ok(stream).build();
+    } catch (Exception e) {
+      return createExceptionResponse(e);
+    }
+  }
+
   @PUT
   @Produces("application/json")
   @RolesAllowed(ADMIN)

--- a/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
@@ -12,6 +12,7 @@ import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.Response.Status;
 import jakarta.ws.rs.core.StreamingOutput;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
 import java.time.Instant;
@@ -189,6 +190,21 @@ public class ElasticSearchService implements ConsentLogger {
     var hits = json.getHits();
 
     return Response.ok().entity(hits).build();
+  }
+
+  public InputStream searchDatasetsStream(String query) throws IOException {
+    if (!validateQuery(query)) {
+      throw new IOException("Invalid Elasticsearch query");
+    }
+    Request searchRequest =
+        new Request(HttpMethod.GET, "/" + esConfig.getDatasetIndexName() + "/_search");
+    searchRequest.setEntity(new NStringEntity(query, ContentType.APPLICATION_JSON));
+    var response = esClient.performRequest(searchRequest);
+    var status = response.getStatusLine().getStatusCode();
+    if (status != 200) {
+      throw new IOException("Invalid Elasticsearch query");
+    }
+    return response.getEntity().getContent();
   }
 
   public StudyTerm toStudyTerm(Study study) {

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -511,6 +511,8 @@ paths:
     $ref: './paths/datasetIndexById.yaml'
   /api/dataset/search/index:
     $ref: './paths/datasetSearchIndex.yaml'
+  /api/dataset/search/index/v2:
+    $ref: './paths/datasetSearchIndexV2.yaml'
   /api/dataset/{id}/authorizedAccessReaders:
     $ref: './paths/datasetAuthorizedReaders.yaml'
   /api/dataset/{id}/authorizedAccessReaders/{userId}:

--- a/src/main/resources/assets/paths/datasetSearchIndexV2.yaml
+++ b/src/main/resources/assets/paths/datasetSearchIndexV2.yaml
@@ -1,0 +1,98 @@
+post:
+  summary: Search the dataset index
+  operationId: searchDatasetIndexV2
+  description: |
+    Returns all results matching a search query in a streaming format. Includes full ElasticSearch
+    response that includes timing, shards, hits:total, hits:max_score, and hits:hits which contains
+    the actual results.
+  requestBody:
+    description: Search query
+    required: true
+    content:
+      application/json:
+        schema:
+          type: object
+          description: Elasticsearch query object
+          additionalProperties: true
+        examples:
+          example1:
+            summary: Search request 1
+            value:
+              query:
+                bool:
+                  must:
+                    - match:
+                        _type: dataset
+                    - match:
+                        _id: 1440
+          example2:
+            summary: Search request 2
+            value:
+              from: 0
+              size: 10000
+              query:
+                bool:
+                  must:
+                    - match:
+                        _type: dataset
+                    - exists:
+                        field: study
+  tags:
+    - Dataset
+  responses:
+    200:
+      description: ElasticSearch response of results matching the search query
+      content:
+        application/json:
+          schema:
+            type: object
+          examples:
+            example1:
+              summary: Search response 1
+              value:
+                - took: 181
+                  timed_out: false
+                  _shards:
+                    total: 5
+                    successful: 5
+                    failed: 0
+                  hits:
+                    total: 15
+                    max_score: 1.0
+                    hits:
+                      - _index: datasets
+                        _type: dataset
+                        _id: 1440
+                        _score: 1.0
+                        _source:
+                          datasetId: 1440
+                          createUserId: 1
+                          datasetIdentifier: DUOS-000xxx
+                          deletable: false
+                          datasetName: Dataset 000xxx
+                          participantCount: 45
+                          dataUse:
+                            primary:
+                              - code: NPOA
+                                description: Future use for population origins or ancestry research is prohibited.
+                            secondary:
+                              - code: NCU
+                          dacId: 2
+                          dacApproval: true
+                          approvedUserIds: [1,2,3]
+                          submitter:
+                            userId: 10
+                            displayName: Jane Doe
+                            institution:
+                              id: 100
+                              name: Broad Institute
+                          updateUser:
+                            userId: 10
+                            displayName: Jane Doe
+                            institution:
+                              id: 100
+                              name: Broad Institute
+                          dac:
+                            dacId: 2
+                            name: Example DAC
+                            dacEmail: dac_email@test.org

--- a/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
@@ -29,6 +29,7 @@ import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.StreamingOutput;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.time.Instant;
@@ -38,6 +39,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import org.apache.commons.io.IOUtils;
 import org.broadinstitute.consent.http.AbstractTestHelper;
 import org.broadinstitute.consent.http.cloudstore.GCSService;
 import org.broadinstitute.consent.http.enumeration.PropertyType;
@@ -552,6 +554,17 @@ class DatasetResourceTest extends AbstractTestHelper {
     when(elasticSearchService.searchDatasets(any())).thenReturn(mockResponse);
 
     try (var response = resource.searchDatasetIndex(duosUser, query)) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+      assertTrue(response.getEntity().toString().length() > 2);
+    }
+  }
+
+  @Test
+  void testSearchDatasetIndexStream() throws IOException {
+    String query = "{ \"dataUse\": [\"HMB\"] }";
+    when(elasticSearchService.searchDatasetsStream(any()))
+        .thenReturn(IOUtils.toInputStream(query, Charset.defaultCharset()));
+    try (var response = resource.searchDatasetIndexStream(duosUser, query)) {
       assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
       assertTrue(response.getEntity().toString().length() > 2);
     }

--- a/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
@@ -25,6 +25,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.lang.reflect.Type;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -32,6 +33,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpVersion;
 import org.apache.http.StatusLine;
@@ -592,6 +594,17 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
 
     try (var response = service.searchDatasets(query)) {
       assertEquals(200, response.getStatus());
+    }
+  }
+
+  @Test
+  void testSearchDatasetsStream() throws IOException {
+    String query = "{ \"query\": { \"query_string\": { \"query\": \"(GRU) AND (HMB)\" } } }";
+    String mockResponse = "{\"valid\":true,\"hits\":{\"hits\":[]}}";
+    mockElasticSearchResponse(mockResponse);
+    try (var inputStream = service.searchDatasetsStream(query)) {
+      String received = IOUtils.toString(inputStream, Charset.defaultCharset());
+      assertEquals(mockResponse, received);
     }
   }
 


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-2433

### Summary
New `/api/dataset/search/index/v2` API to pass the response stream from ES to the calling client. This is a separate endpoint because clients will need to adjust how they parse the response. The input is unchanged, but the response now includes full elastic search results in the form of:

```
{
  "took": 181,
  "timed_out": false,
  "_shards": {
    "total": 5,
    "successful": 5,
    "failed": 0
  },
  "hits": {
    "total": 15,
    "max_score": 1.0,
    "hits": [
      {
        "_index": "dataset",
        "_type": "dataset",
        "_id": "452",
        "_score": 1.0,
        "_source": {
        "datasetId": 452,
        ...
```

The original version of this endpoint parse out the `hits.hits` array and returns only that. 

Local comparison data when matching on:

| Query | V1 | V 2 | % |
| :------- | :------- | :------ | :------ |
|`"_id": 1447` | 956 ms | 631 ms | ~34% |
|`"_id": 1448` | 1141 ms | 952 ms | ~16% |
|`"term": {"study.publicVisibility": true}`| 678 ms | 459 ms | ~32% |


----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
