### PR TITLE
[DT-2471] Upgrade to OpenSearch 3

### DIFF
--- a/DEVNOTES.md
+++ b/DEVNOTES.md
@@ -73,15 +73,16 @@ Update the compose file to include a new section for an ES instance:
 
 ```
 es:
-  image: docker.elastic.co/elasticsearch/elasticsearch:5.5.0
+  image: opensearchproject/opensearch:3
   ports:
     - "9200:9200"
+  container_name: elastic
   volumes:
-    - ../data:/usr/share/elasticsearch/data
+    - ./data:/usr/share/opensearch/data
   environment:
-    transport.host: 127.0.0.1
-    xpack.security.enabled: "false"
-    http.host: 0.0.0.0
+    - DISABLE_SECURITY_PLUGIN=true
+    - discovery.type=single-node
+    - cluster.routing.allocation.disk.threshold_enabled=false
 ```
 
 Add a line to the `app` section to link to that:

--- a/pom.xml
+++ b/pom.xml
@@ -804,9 +804,15 @@
     </dependency>
 
     <dependency>
-      <groupId>org.elasticsearch.client</groupId>
-      <artifactId>elasticsearch-rest-client</artifactId>
-      <version>9.2.1</version>
+      <groupId>org.opensearch.client</groupId>
+      <artifactId>opensearch-rest-client</artifactId>
+      <version>3.3.2</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.opensearch.client</groupId>
+      <artifactId>opensearch-java</artifactId>
+      <version>3.3.0</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/org/broadinstitute/consent/http/health/ElasticSearchHealthCheck.java
+++ b/src/main/java/org/broadinstitute/consent/http/health/ElasticSearchHealthCheck.java
@@ -12,10 +12,10 @@ import java.nio.charset.Charset;
 import org.apache.commons.io.IOUtils;
 import org.broadinstitute.consent.http.configurations.ElasticSearchConfiguration;
 import org.broadinstitute.consent.http.service.ontology.ElasticSearchSupport;
-import org.elasticsearch.client.Request;
-import org.elasticsearch.client.RequestOptions;
-import org.elasticsearch.client.Response;
-import org.elasticsearch.client.RestClient;
+import org.opensearch.client.Request;
+import org.opensearch.client.RequestOptions;
+import org.opensearch.client.Response;
+import org.opensearch.client.RestClient;
 
 public class ElasticSearchHealthCheck extends HealthCheck implements Managed {
 

--- a/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
@@ -23,8 +23,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
-import org.apache.http.entity.ContentType;
-import org.apache.http.nio.entity.NStringEntity;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.io.entity.StringEntity;
 import org.broadinstitute.consent.http.configurations.ElasticSearchConfiguration;
 import org.broadinstitute.consent.http.db.DacDAO;
 import org.broadinstitute.consent.http.db.DatasetDAO;
@@ -49,8 +49,8 @@ import org.broadinstitute.consent.http.service.dao.DatasetServiceDAO;
 import org.broadinstitute.consent.http.util.ConsentLogger;
 import org.broadinstitute.consent.http.util.ThreadUtils;
 import org.broadinstitute.consent.http.util.gson.GsonUtil;
-import org.elasticsearch.client.Request;
-import org.elasticsearch.client.RestClient;
+import org.opensearch.client.Request;
+import org.opensearch.client.RestClient;
 
 public class ElasticSearchService implements ConsentLogger {
 
@@ -91,12 +91,12 @@ public class ElasticSearchService implements ConsentLogger {
 
   private static final String BULK_HEADER =
       """
-      { "index": {"_type": "dataset", "_id": "%d"} }
+      { "index": { "_index": "dataset", "_id": "%d"} }
       """;
 
   private static final String DELETE_QUERY =
       """
-      { "query": { "bool": { "must": [ { "match": { "_type": "dataset" } }, { "match": { "_id": "%d" } } ] } } }
+      { "query": { "terms": { "_id": ["%d"] } } }
       """;
 
   private Response performRequest(Request request) throws IOException {
@@ -123,7 +123,7 @@ public class ElasticSearchService implements ConsentLogger {
         new Request(HttpMethod.PUT, "/" + esConfig.getDatasetIndexName() + "/_bulk");
 
     bulkRequest.setEntity(
-        new NStringEntity(String.join("", bulkApiCall) + "\n", ContentType.APPLICATION_JSON));
+        new StringEntity(String.join("", bulkApiCall) + "\n", ContentType.APPLICATION_JSON));
 
     return performRequest(bulkRequest);
   }
@@ -132,7 +132,7 @@ public class ElasticSearchService implements ConsentLogger {
     Request deleteRequest =
         new Request(HttpMethod.POST, "/" + esConfig.getDatasetIndexName() + "/_delete_by_query");
     deleteRequest.setEntity(
-        new NStringEntity(DELETE_QUERY.formatted(datasetId), ContentType.APPLICATION_JSON));
+        new StringEntity(DELETE_QUERY.formatted(datasetId), ContentType.APPLICATION_JSON));
     updateDatasetIndexDate(datasetId, userId, null);
     return performRequest(deleteRequest);
   }
@@ -165,7 +165,7 @@ public class ElasticSearchService implements ConsentLogger {
 
     Request validateRequest =
         new Request(HttpMethod.GET, "/" + esConfig.getDatasetIndexName() + "/_validate/query");
-    validateRequest.setEntity(new NStringEntity(modifiedQuery, ContentType.APPLICATION_JSON));
+    validateRequest.setEntity(new StringEntity(modifiedQuery, ContentType.APPLICATION_JSON));
     Response response = performRequest(validateRequest);
 
     var entity = response.getEntity().toString();
@@ -181,7 +181,7 @@ public class ElasticSearchService implements ConsentLogger {
 
     Request searchRequest =
         new Request(HttpMethod.GET, "/" + esConfig.getDatasetIndexName() + "/_search");
-    searchRequest.setEntity(new NStringEntity(query, ContentType.APPLICATION_JSON));
+    searchRequest.setEntity(new StringEntity(query, ContentType.APPLICATION_JSON));
 
     Response response = performRequest(searchRequest);
 
@@ -193,12 +193,12 @@ public class ElasticSearchService implements ConsentLogger {
   }
 
   public InputStream searchDatasetsStream(String query) throws IOException {
-    if (!validateQuery(query)) {
+    if (invalidResultWindow(query)) {
       throw new IOException("Invalid Elasticsearch query");
     }
     Request searchRequest =
         new Request(HttpMethod.GET, "/" + esConfig.getDatasetIndexName() + "/_search");
-    searchRequest.setEntity(new NStringEntity(query, ContentType.APPLICATION_JSON));
+    searchRequest.setEntity(new StringEntity(query, ContentType.APPLICATION_JSON));
     var response = esClient.performRequest(searchRequest);
     var status = response.getStatusLine().getStatusCode();
     if (status != 200) {

--- a/src/main/java/org/broadinstitute/consent/http/service/ontology/ElasticSearchSupport.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ontology/ElasticSearchSupport.java
@@ -1,10 +1,10 @@
 package org.broadinstitute.consent.http.service.ontology;
 
-import org.apache.http.Header;
-import org.apache.http.HttpHost;
-import org.apache.http.message.BasicHeader;
+import org.apache.hc.core5.http.Header;
+import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.http.message.BasicHeader;
 import org.broadinstitute.consent.http.configurations.ElasticSearchConfiguration;
-import org.elasticsearch.client.RestClient;
+import org.opensearch.client.RestClient;
 
 @SuppressWarnings("WeakerAccess")
 public class ElasticSearchSupport {
@@ -12,7 +12,7 @@ public class ElasticSearchSupport {
   public static RestClient createRestClient(ElasticSearchConfiguration configuration) {
     HttpHost[] hosts =
         configuration.getServers().stream()
-            .map(server -> new HttpHost(server, configuration.getPort(), "http"))
+            .map(server -> new HttpHost("http", server, configuration.getPort()))
             .toList()
             .toArray(new HttpHost[configuration.getServers().size()]);
     return RestClient.builder(hosts).build();

--- a/src/main/resources/assets/paths/datasetSearchIndex.yaml
+++ b/src/main/resources/assets/paths/datasetSearchIndex.yaml
@@ -19,7 +19,7 @@ post:
                 bool:
                   must:
                     - match:
-                        _type: dataset
+                        _index: dataset
                     - match:
                         _id: 1440
           example2:
@@ -31,7 +31,7 @@ post:
                 bool:
                   must:
                     - match:
-                        _type: dataset
+                        _index: dataset
                     - exists:
                         field: study
   tags:

--- a/src/main/resources/assets/paths/datasetSearchIndexV2.yaml
+++ b/src/main/resources/assets/paths/datasetSearchIndexV2.yaml
@@ -22,7 +22,7 @@ post:
                 bool:
                   must:
                     - match:
-                        _type: dataset
+                        _index: dataset
                     - match:
                         _id: 1440
           example2:
@@ -34,7 +34,7 @@ post:
                 bool:
                   must:
                     - match:
-                        _type: dataset
+                        _index: dataset
                     - exists:
                         field: study
   tags:

--- a/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
@@ -534,9 +534,9 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
       assertEquals("PUT", capturedRequest.getMethod());
       assertEquals(
           """
-              { "index": {"_index": "dataset", "_id": "1"} }
+              { "index": { "_index": "dataset", "_id": "1"} }
               {"datasetId":1}
-              { "index": {"_index": "dataset", "_id": "2"} }
+              { "index": { "_index": "dataset", "_id": "2"} }
               {"datasetId":2}
 
               """,

--- a/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
@@ -34,13 +34,11 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import org.apache.commons.io.IOUtils;
-import org.apache.http.HttpEntity;
-import org.apache.http.HttpVersion;
-import org.apache.http.StatusLine;
-import org.apache.http.entity.ContentType;
-import org.apache.http.entity.StringEntity;
-import org.apache.http.message.BasicStatusLine;
-import org.apache.http.nio.entity.NStringEntity;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.HttpEntity;
+import org.apache.hc.core5.http.io.entity.StringEntity;
+import org.apache.hc.core5.http.message.BasicHttpResponse;
+import org.apache.hc.core5.http.message.StatusLine;
 import org.broadinstitute.consent.http.AbstractTestHelper;
 import org.broadinstitute.consent.http.configurations.ElasticSearchConfiguration;
 import org.broadinstitute.consent.http.db.DacDAO;
@@ -66,9 +64,6 @@ import org.broadinstitute.consent.http.models.ontology.DataUseSummary;
 import org.broadinstitute.consent.http.models.ontology.DataUseTerm;
 import org.broadinstitute.consent.http.service.dao.DatasetServiceDAO;
 import org.broadinstitute.consent.http.util.gson.GsonUtil;
-import org.elasticsearch.client.Request;
-import org.elasticsearch.client.Response;
-import org.elasticsearch.client.RestClient;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -78,6 +73,9 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+import org.opensearch.client.RestClient;
 
 @ExtendWith(MockitoExtension.class)
 class ElasticSearchServiceTest extends AbstractTestHelper {
@@ -120,8 +118,8 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
   private void mockElasticSearchResponse(String body) throws IOException {
     Response response = mock(Response.class);
     String reasonPhrase = fromStatusCode(200).getReasonPhrase();
-    BasicStatusLine status = new BasicStatusLine(HttpVersion.HTTP_1_1, 200, reasonPhrase);
-    HttpEntity entity = new NStringEntity(body, ContentType.APPLICATION_JSON);
+    StatusLine status = new StatusLine(new BasicHttpResponse(200, reasonPhrase));
+    HttpEntity entity = new StringEntity(body, ContentType.APPLICATION_JSON);
 
     when(esClient.performRequest(any())).thenReturn(response);
     when(response.getStatusLine()).thenReturn(status);
@@ -536,9 +534,9 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
       assertEquals("PUT", capturedRequest.getMethod());
       assertEquals(
           """
-              { "index": {"_type": "dataset", "_id": "1"} }
+              { "index": {"_index": "dataset", "_id": "1"} }
               {"datasetId":1}
-              { "index": {"_type": "dataset", "_id": "2"} }
+              { "index": {"_index": "dataset", "_id": "2"} }
               {"datasetId":2}
 
               """,
@@ -562,7 +560,7 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
     when(datasetDAO.findDatasetById(dataset2.getDatasetId())).thenReturn(dataset2);
     when(userDao.findUserById(dataset1.getCreateUserId())).thenReturn(datasetRecord.createUser);
     when(userDao.findUserById(dataset2.getCreateUserId())).thenReturn(datasetRecord.createUser);
-    org.elasticsearch.client.Response mockResponse = mock();
+    org.opensearch.client.Response mockResponse = mock();
     when(esClient.performRequest(any())).thenReturn(mockResponse);
     when(mockResponse.getEntity()).thenReturn(new StringEntity("response body"));
     StatusLine statusLine = mock();
@@ -627,7 +625,7 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
 
     Response response = mock(Response.class);
     String reasonPhrase = fromStatusCode(400).getReasonPhrase();
-    BasicStatusLine status = new BasicStatusLine(HttpVersion.HTTP_1_1, 400, reasonPhrase);
+    StatusLine status = new StatusLine(new BasicHttpResponse(400, reasonPhrase));
     when(esClient.performRequest(any())).thenReturn(response);
     when(response.getStatusLine()).thenReturn(status);
 
@@ -709,9 +707,9 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
     assertEquals(0, jsonArray.size());
   }
 
-  // Helper method to mock an ElasticSearch Client response
+  // Helper method to mock an OpenSearch Client response
   private void mockESClientResponse(int status, String body) throws Exception {
-    var esClientResponse = mock(org.elasticsearch.client.Response.class);
+    var esClientResponse = mock(org.opensearch.client.Response.class);
     var statusLine = mock(StatusLine.class);
     when(esClientResponse.getStatusLine()).thenReturn(statusLine);
     when(statusLine.getStatusCode()).thenReturn(status);


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2471

### Summary

Upgrades from ElasticSearch 5 to OpenSearch 3. Here's what is needed in the `docker-compose.yaml`:

```
  elastic:
    image: opensearchproject/opensearch:3
    ports:
      - "9200:9200"
    container_name: elastic
    volumes:
      - ./data:/usr/share/opensearch/data
    environment:
      - DISABLE_SECURITY_PLUGIN=true
      - discovery.type=single-node
      - cluster.routing.allocation.disk.threshold_enabled=false
```

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
