### PR TITLE
DT-2519: Patch API for selected study fields

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/models/StudyPatch.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/StudyPatch.java
@@ -71,8 +71,8 @@ public record StudyPatch(
     }
   }
 
-  // Jackson, by default, allows coercion from numbers to strings.
-  // This custom deserializer forbids that behavior for all String fields.
+  // Jackson, by default, allows coercion from strings to booleans.
+  // This custom deserializer forbids that behavior for all Boolean fields.
   private static class ForceBooleanDeserializer extends JsonDeserializer<Boolean> {
     @Override
     public Boolean deserialize(JsonParser jsonParser, DeserializationContext deserializationContext)

--- a/src/main/java/org/broadinstitute/consent/http/models/StudyPatch.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/StudyPatch.java
@@ -1,0 +1,10 @@
+package org.broadinstitute.consent.http.models;
+
+import java.util.List;
+
+public record StudyPatch(
+    String name,
+    String description,
+    List<String> dataTypes,
+    String piName,
+    Boolean publicVisibility) {}

--- a/src/main/java/org/broadinstitute/consent/http/models/StudyPatch.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/StudyPatch.java
@@ -21,65 +21,88 @@ public record StudyPatch(
     String alternativeDataSharingPlanTargetPublicReleaseDate,
     Boolean publicVisibility) {
 
+  public static final String STUDY_TYPE = "studyType";
+  public static final String PHENOTYPE_INDICATION = "phenotypeIndication";
+  public static final String SPECIES_TYPE = "species";
+  public static final String DATA_CUSTODIAN_EMAIL = "dataCustodianEmail";
+  public static final String ALTERNATIVE_DATA_SHARING_PLAN_TARGET_DELIVERY_DATE = "alternativeDataSharingPlanTargetDeliveryDate";
+  public static final String ALTERNATIVE_DATA_SHARING_PLAN_TARGET_PUBLIC_RELEASE_DATE = "alternativeDataSharingPlanTargetPublicReleaseDate";
+
   // Utility method to determine if any patch values differ from the provided Study entity
   public boolean isPatchable(Study study) {
-    if (name() != null && !name().equals(study.getName()) && !name().isBlank()) {
-      return true;
-    }
+    List<Boolean> checks = new ArrayList<>();
+    checks.add(checkName(study));
+    checks.add(checkStudyType(study));
+    checks.add(checkDescription(study));
+    checks.add(checkDataTypes(study));
+    checks.add(checkPhenotypeIndication(study));
+    checks.add(checkSpecies(study));
+    checks.add(checkPiName(study));
+    checks.add(checkDataCustodians(study));
+    checks.add(checkTargetDate(study));
+    checks.add(checkTargetReleaseDate(study));
+    checks.add(checkPublicVisibility(study));
+    return checks.stream().anyMatch(Boolean::booleanValue);
+  }
 
+  private boolean checkName(Study study) {
+    return name() != null && !name().equals(study.getName()) && !name().isBlank();
+  }
+
+  private boolean checkStudyType(Study study) {
     Optional<StudyProperty> studyTypeProp =
-        study.getProperties().stream().filter(p -> p.getKey().equals("studyType")).findFirst();
+        study.getProperties().stream().filter(p -> p.getKey().equals(STUDY_TYPE)).findFirst();
     if (studyType() != null) {
-      if (studyTypeProp.isEmpty()) {
-        return true;
-      }
-      if (!studyType().value().equals(studyTypeProp.get().getValue())) {
-        return true;
-      }
+      return studyTypeProp
+          .map(studyProperty -> !studyType().value().equals(studyProperty.getValue()))
+          .orElse(true);
     }
+    return false;
+  }
 
-    if (description() != null
+  private boolean checkDescription(Study study) {
+    return description() != null
         && !description().equals(study.getDescription())
-        && !description().isBlank()) {
-      return true;
-    }
+        && !description().isBlank();
+  }
 
-    if (dataTypes() != null
-        && !CollectionUtils.isEqualCollection(dataTypes(), study.getDataTypes())) {
-      return true;
-    }
+  private boolean checkDataTypes(Study study) {
+    return dataTypes() != null
+        && !CollectionUtils.isEqualCollection(dataTypes(), study.getDataTypes());
+  }
 
+  private boolean checkPhenotypeIndication(Study study) {
     Optional<StudyProperty> phenoProp =
         study.getProperties().stream()
-            .filter(p -> p.getKey().equals("phenotypeIndication"))
+            .filter(p -> p.getKey().equals(PHENOTYPE_INDICATION))
             .findFirst();
     if (phenotypeIndication() != null) {
-      if (phenoProp.isEmpty()) {
-        return true;
-      }
-      if (!phenotypeIndication().equals(phenoProp.get().getValue())) {
-        return true;
-      }
+      return phenoProp
+          .map(studyProperty -> !phenotypeIndication().equals(studyProperty.getValue()))
+          .orElse(true);
     }
+    return false;
+  }
 
+  private boolean checkSpecies(Study study) {
     Optional<StudyProperty> speciesProp =
-        study.getProperties().stream().filter(p -> p.getKey().equals("species")).findFirst();
+        study.getProperties().stream().filter(p -> p.getKey().equals(SPECIES_TYPE)).findFirst();
     if (species() != null) {
-      if (speciesProp.isEmpty()) {
-        return true;
-      }
-      if (!species().equals(speciesProp.get().getValue())) {
-        return true;
-      }
+      return speciesProp
+          .map(studyProperty -> !species().equals(studyProperty.getValue()))
+          .orElse(true);
     }
+    return false;
+  }
 
-    if (piName() != null && !piName().equals(study.getPiName()) && !piName().isBlank()) {
-      return true;
-    }
+  private boolean checkPiName(Study study) {
+    return piName() != null && !piName().equals(study.getPiName()) && !piName().isBlank();
+  }
 
+  private boolean checkDataCustodians(Study study) {
     Optional<StudyProperty> custodiansProp =
         study.getProperties().stream()
-            .filter(p -> p.getKey().equals("dataCustodianEmail"))
+            .filter(p -> p.getKey().equals(DATA_CUSTODIAN_EMAIL))
             .findFirst();
     if (dataCustodianEmail() != null) {
       if (custodiansProp.isEmpty()) {
@@ -90,38 +113,43 @@ public record StudyPatch(
               .fromJson(
                   custodiansProp.get().getValue().toString(),
                   new TypeToken<ArrayList<String>>() {}.getType());
-      if (!CollectionUtils.isEqualCollection(dataCustodianEmail(), existingCustodians)) {
-        return true;
-      }
+      return !CollectionUtils.isEqualCollection(dataCustodianEmail(), existingCustodians);
     }
+    return false;
+  }
 
+  private boolean checkTargetDate(Study study) {
     Optional<StudyProperty> targetDateProp =
         study.getProperties().stream()
-            .filter(p -> p.getKey().equals("alternativeDataSharingPlanTargetDeliveryDate"))
+            .filter(p -> p.getKey().equals(ALTERNATIVE_DATA_SHARING_PLAN_TARGET_DELIVERY_DATE))
             .findFirst();
     if (alternativeDataSharingPlanTargetDeliveryDate() != null) {
-      if (targetDateProp.isEmpty()) {
-        return true;
-      }
-      if (!alternativeDataSharingPlanTargetDeliveryDate().equals(targetDateProp.get().getValue())) {
-        return true;
-      }
+      return targetDateProp
+          .map(
+              studyProperty ->
+                  !alternativeDataSharingPlanTargetDeliveryDate().equals(studyProperty.getValue()))
+          .orElse(true);
     }
+    return false;
+  }
 
+  private boolean checkTargetReleaseDate(Study study) {
     Optional<StudyProperty> targetReleaseProp =
         study.getProperties().stream()
-            .filter(p -> p.getKey().equals("alternativeDataSharingPlanTargetPublicReleaseDate"))
+            .filter(p -> p.getKey().equals(ALTERNATIVE_DATA_SHARING_PLAN_TARGET_PUBLIC_RELEASE_DATE))
             .findFirst();
     if (alternativeDataSharingPlanTargetPublicReleaseDate() != null) {
-      if (targetReleaseProp.isEmpty()) {
-        return true;
-      }
-      if (!alternativeDataSharingPlanTargetPublicReleaseDate()
-          .equals(targetReleaseProp.get().getValue())) {
-        return true;
-      }
+      return targetReleaseProp
+          .map(
+              studyProperty ->
+                  !alternativeDataSharingPlanTargetPublicReleaseDate()
+                      .equals(studyProperty.getValue()))
+          .orElse(true);
     }
+    return false;
+  }
 
+  private boolean checkPublicVisibility(Study study) {
     return publicVisibility() != null && !publicVisibility().equals(study.getPublicVisibility());
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/models/StudyPatch.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/StudyPatch.java
@@ -1,7 +1,12 @@
 package org.broadinstitute.consent.http.models;
 
+import com.google.gson.reflect.TypeToken;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
+import org.apache.commons.collections4.CollectionUtils;
 import org.broadinstitute.consent.http.models.dataset_registration_v1.DatasetRegistrationSchemaV1.StudyType;
+import org.broadinstitute.consent.http.util.gson.GsonUtil;
 
 public record StudyPatch(
     String name,
@@ -14,4 +19,109 @@ public record StudyPatch(
     List<String> dataCustodianEmail,
     String alternativeDataSharingPlanTargetDeliveryDate,
     String alternativeDataSharingPlanTargetPublicReleaseDate,
-    Boolean publicVisibility) {}
+    Boolean publicVisibility) {
+
+  // Utility method to determine if any patch values differ from the provided Study entity
+  public boolean isPatchable(Study study) {
+    if (name() != null && !name().equals(study.getName()) && !name().isBlank()) {
+      return true;
+    }
+
+    Optional<StudyProperty> studyTypeProp =
+        study.getProperties().stream().filter(p -> p.getKey().equals("studyType")).findFirst();
+    if (studyType() != null) {
+      if (studyTypeProp.isEmpty()) {
+        return true;
+      }
+      if (!studyType().value().equals(studyTypeProp.get().getValue())) {
+        return true;
+      }
+    }
+
+    if (description() != null
+        && !description().equals(study.getDescription())
+        && !description().isBlank()) {
+      return true;
+    }
+
+    if (dataTypes() != null
+        && !CollectionUtils.isEqualCollection(dataTypes(), study.getDataTypes())) {
+      return true;
+    }
+
+    Optional<StudyProperty> phenoProp =
+        study.getProperties().stream()
+            .filter(p -> p.getKey().equals("phenotypeIndication"))
+            .findFirst();
+    if (phenotypeIndication() != null) {
+      if (phenoProp.isEmpty()) {
+        return true;
+      }
+      if (!phenotypeIndication().equals(phenoProp.get().getValue())) {
+        return true;
+      }
+    }
+
+    Optional<StudyProperty> speciesProp =
+        study.getProperties().stream().filter(p -> p.getKey().equals("species")).findFirst();
+    if (species() != null) {
+      if (speciesProp.isEmpty()) {
+        return true;
+      }
+      if (!species().equals(speciesProp.get().getValue())) {
+        return true;
+      }
+    }
+
+    if (piName() != null && !piName().equals(study.getPiName()) && !piName().isBlank()) {
+      return true;
+    }
+
+    Optional<StudyProperty> custodiansProp =
+        study.getProperties().stream()
+            .filter(p -> p.getKey().equals("dataCustodianEmail"))
+            .findFirst();
+    if (dataCustodianEmail() != null) {
+      if (custodiansProp.isEmpty()) {
+        return true;
+      }
+      List<String> existingCustodians =
+          GsonUtil.getInstance()
+              .fromJson(
+                  custodiansProp.get().getValue().toString(),
+                  new TypeToken<ArrayList<String>>() {}.getType());
+      if (!CollectionUtils.isEqualCollection(dataCustodianEmail(), existingCustodians)) {
+        return true;
+      }
+    }
+
+    Optional<StudyProperty> targetDateProp =
+        study.getProperties().stream()
+            .filter(p -> p.getKey().equals("alternativeDataSharingPlanTargetDeliveryDate"))
+            .findFirst();
+    if (alternativeDataSharingPlanTargetDeliveryDate() != null) {
+      if (targetDateProp.isEmpty()) {
+        return true;
+      }
+      if (!alternativeDataSharingPlanTargetDeliveryDate().equals(targetDateProp.get().getValue())) {
+        return true;
+      }
+    }
+
+    Optional<StudyProperty> targetReleaseProp =
+        study.getProperties().stream()
+            .filter(p -> p.getKey().equals("alternativeDataSharingPlanTargetPublicReleaseDate"))
+            .findFirst();
+    if (alternativeDataSharingPlanTargetPublicReleaseDate() != null) {
+      if (targetReleaseProp.isEmpty()) {
+        return true;
+      }
+      if (!alternativeDataSharingPlanTargetPublicReleaseDate()
+          .equals(targetReleaseProp.get().getValue())) {
+        return true;
+      }
+    }
+
+    return publicVisibility() != null && !publicVisibility().equals(study.getPublicVisibility());
+  }
+}

--- a/src/main/java/org/broadinstitute/consent/http/models/StudyPatch.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/StudyPatch.java
@@ -23,6 +23,7 @@ public record StudyPatch(
 
   public static final String STUDY_TYPE = "studyType";
   public static final String PHENOTYPE_INDICATION = "phenotypeIndication";
+  // nosemgrep
   public static final String SPECIES_KEY = "species";
   public static final String DATA_CUSTODIAN_EMAIL = "dataCustodianEmail";
   public static final String ALTERNATIVE_DATA_SHARING_PLAN_TARGET_DELIVERY_DATE =

--- a/src/main/java/org/broadinstitute/consent/http/models/StudyPatch.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/StudyPatch.java
@@ -1,6 +1,14 @@
 package org.broadinstitute.consent.http.models;
 
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.google.gson.reflect.TypeToken;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -30,6 +38,37 @@ public record StudyPatch(
       "alternativeDataSharingPlanTargetDeliveryDate";
   public static final String ALTERNATIVE_DATA_SHARING_PLAN_TARGET_PUBLIC_RELEASE_DATE =
       "alternativeDataSharingPlanTargetPublicReleaseDate";
+
+  public static StudyPatch fromJson(String json) {
+    ObjectMapper mapper = new ObjectMapper();
+    mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true);
+    mapper.configure(DeserializationFeature.FAIL_ON_INVALID_SUBTYPE, true);
+    SimpleModule module = new SimpleModule();
+    module.addDeserializer(String.class, new ForceStringDeserializer());
+    mapper.registerModule(module);
+    try {
+      return mapper.readValue(json, StudyPatch.class);
+    } catch (Exception e) {
+      throw new IllegalArgumentException(e.getMessage());
+    }
+  }
+
+  // Jackson, by default, allows coercion from numbers to strings.
+  // This custom deserializer forbids that behavior for all String fields.
+  private static class ForceStringDeserializer extends JsonDeserializer<String> {
+    @Override
+    public String deserialize(JsonParser jsonParser, DeserializationContext deserializationContext)
+        throws IOException {
+      if (jsonParser.getCurrentToken() == JsonToken.VALUE_NUMBER_INT) {
+        throw deserializationContext.wrongTokenException(
+            jsonParser,
+            String.class,
+            JsonToken.VALUE_STRING,
+            "Attempted to parse int to string but this is not allowed");
+      }
+      return jsonParser.getValueAsString();
+    }
+  }
 
   // Utility method to determine if any patch values differ from the provided Study entity
   public boolean isPatchable(Study study) {

--- a/src/main/java/org/broadinstitute/consent/http/models/StudyPatch.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/StudyPatch.java
@@ -45,6 +45,7 @@ public record StudyPatch(
     mapper.configure(DeserializationFeature.FAIL_ON_INVALID_SUBTYPE, true);
     SimpleModule module = new SimpleModule();
     module.addDeserializer(String.class, new ForceStringDeserializer());
+    module.addDeserializer(Boolean.class, new ForceBooleanDeserializer());
     mapper.registerModule(module);
     try {
       return mapper.readValue(json, StudyPatch.class);
@@ -67,6 +68,23 @@ public record StudyPatch(
             "Attempted to parse int to string but this is not allowed");
       }
       return jsonParser.getValueAsString();
+    }
+  }
+
+  // Jackson, by default, allows coercion from numbers to strings.
+  // This custom deserializer forbids that behavior for all String fields.
+  private static class ForceBooleanDeserializer extends JsonDeserializer<Boolean> {
+    @Override
+    public Boolean deserialize(JsonParser jsonParser, DeserializationContext deserializationContext)
+        throws IOException {
+      if (jsonParser.getCurrentToken() == JsonToken.VALUE_STRING) {
+        throw deserializationContext.wrongTokenException(
+            jsonParser,
+            String.class,
+            JsonToken.NOT_AVAILABLE,
+            "Attempted to parse string to boolean but this is not allowed");
+      }
+      return jsonParser.getBooleanValue();
     }
   }
 

--- a/src/main/java/org/broadinstitute/consent/http/models/StudyPatch.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/StudyPatch.java
@@ -23,10 +23,12 @@ public record StudyPatch(
 
   public static final String STUDY_TYPE = "studyType";
   public static final String PHENOTYPE_INDICATION = "phenotypeIndication";
-  public static final String SPECIES_TYPE = "species";
+  public static final String SPECIES_KEY = "species";
   public static final String DATA_CUSTODIAN_EMAIL = "dataCustodianEmail";
-  public static final String ALTERNATIVE_DATA_SHARING_PLAN_TARGET_DELIVERY_DATE = "alternativeDataSharingPlanTargetDeliveryDate";
-  public static final String ALTERNATIVE_DATA_SHARING_PLAN_TARGET_PUBLIC_RELEASE_DATE = "alternativeDataSharingPlanTargetPublicReleaseDate";
+  public static final String ALTERNATIVE_DATA_SHARING_PLAN_TARGET_DELIVERY_DATE =
+      "alternativeDataSharingPlanTargetDeliveryDate";
+  public static final String ALTERNATIVE_DATA_SHARING_PLAN_TARGET_PUBLIC_RELEASE_DATE =
+      "alternativeDataSharingPlanTargetPublicReleaseDate";
 
   // Utility method to determine if any patch values differ from the provided Study entity
   public boolean isPatchable(Study study) {
@@ -86,7 +88,7 @@ public record StudyPatch(
 
   private boolean checkSpecies(Study study) {
     Optional<StudyProperty> speciesProp =
-        study.getProperties().stream().filter(p -> p.getKey().equals(SPECIES_TYPE)).findFirst();
+        study.getProperties().stream().filter(p -> p.getKey().equals(SPECIES_KEY)).findFirst();
     if (species() != null) {
       return speciesProp
           .map(studyProperty -> !species().equals(studyProperty.getValue()))
@@ -136,7 +138,8 @@ public record StudyPatch(
   private boolean checkTargetReleaseDate(Study study) {
     Optional<StudyProperty> targetReleaseProp =
         study.getProperties().stream()
-            .filter(p -> p.getKey().equals(ALTERNATIVE_DATA_SHARING_PLAN_TARGET_PUBLIC_RELEASE_DATE))
+            .filter(
+                p -> p.getKey().equals(ALTERNATIVE_DATA_SHARING_PLAN_TARGET_PUBLIC_RELEASE_DATE))
             .findFirst();
     if (alternativeDataSharingPlanTargetPublicReleaseDate() != null) {
       return targetReleaseProp

--- a/src/main/java/org/broadinstitute/consent/http/models/StudyPatch.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/StudyPatch.java
@@ -1,10 +1,17 @@
 package org.broadinstitute.consent.http.models;
 
 import java.util.List;
+import org.broadinstitute.consent.http.models.dataset_registration_v1.DatasetRegistrationSchemaV1.StudyType;
 
 public record StudyPatch(
     String name,
+    StudyType studyType,
     String description,
     List<String> dataTypes,
+    String phenotypeIndication,
+    String species,
     String piName,
+    List<String> dataCustodianEmail,
+    String alternativeDataSharingPlanTargetDeliveryDate,
+    String alternativeDataSharingPlanTargetPublicReleaseDate,
     Boolean publicVisibility) {}

--- a/src/main/java/org/broadinstitute/consent/http/resources/StudyResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/StudyResource.java
@@ -152,6 +152,9 @@ public class StudyResource extends Resource {
       }
       checkPublicVisibilityForUser(study, duosUser.getUser());
       StudyPatch studyPatch = GsonUtil.getInstance().fromJson(json, StudyPatch.class);
+      if (!studyPatch.isPatchable(study)) {
+        return Response.status(Status.NOT_MODIFIED).entity(study).build();
+      }
       Study patchedStudy = datasetService.patchStudy(studyId, duosUser.getUser(), studyPatch);
       return Response.ok(patchedStudy).build();
     } catch (Exception e) {

--- a/src/main/java/org/broadinstitute/consent/http/resources/StudyResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/StudyResource.java
@@ -147,6 +147,9 @@ public class StudyResource extends Resource {
       @Auth DuosUser duosUser, @PathParam("studyId") Integer studyId, String json) {
     try {
       Study study = datasetService.findStudy(studyId);
+      if (study == null) {
+        throw new NotFoundException("Study not found");
+      }
       checkPublicVisibilityForUser(study, duosUser.getUser());
       StudyPatch studyPatch = GsonUtil.getInstance().fromJson(json, StudyPatch.class);
       Study patchedStudy = datasetService.patchStudy(studyId, duosUser.getUser(), studyPatch);

--- a/src/main/java/org/broadinstitute/consent/http/resources/StudyResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/StudyResource.java
@@ -13,6 +13,7 @@ import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.ForbiddenException;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.PATCH;
 import jakarta.ws.rs.PUT;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
@@ -34,6 +35,7 @@ import org.broadinstitute.consent.http.models.Dataset;
 import org.broadinstitute.consent.http.models.DuosUser;
 import org.broadinstitute.consent.http.models.Study;
 import org.broadinstitute.consent.http.models.StudyConversion;
+import org.broadinstitute.consent.http.models.StudyPatch;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.dataset_registration_v1.DatasetRegistrationSchemaV1;
 import org.broadinstitute.consent.http.models.dataset_registration_v1.DatasetRegistrationSchemaV1UpdateValidator;
@@ -131,6 +133,24 @@ public class StudyResource extends Resource {
       Study study = datasetService.getStudyWithDatasetsById(duosUser.getUser(), studyId);
       checkPublicVisibilityForUser(study, duosUser.getUser());
       return Response.ok(study).build();
+    } catch (Exception e) {
+      return createExceptionResponse(e);
+    }
+  }
+
+  @PATCH
+  @Path("/{studyId}")
+  @Consumes({MediaType.APPLICATION_JSON})
+  @Produces({MediaType.APPLICATION_JSON})
+  @RolesAllowed({ADMIN, CHAIRPERSON, DATASUBMITTER})
+  public Response patchStudyById(
+      @Auth DuosUser duosUser, @PathParam("studyId") Integer studyId, String json) {
+    try {
+      Study study = datasetService.getStudyWithDatasetsById(duosUser.getUser(), studyId);
+      checkPublicVisibilityForUser(study, duosUser.getUser());
+      StudyPatch studyPatch = GsonUtil.getInstance().fromJson(json, StudyPatch.class);
+      Study patchedStudy = datasetService.patchStudy(studyId, duosUser.getUser(), studyPatch);
+      return Response.ok(patchedStudy).build();
     } catch (Exception e) {
       return createExceptionResponse(e);
     }

--- a/src/main/java/org/broadinstitute/consent/http/resources/StudyResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/StudyResource.java
@@ -151,7 +151,7 @@ public class StudyResource extends Resource {
         throw new NotFoundException("Study not found");
       }
       checkPublicVisibilityForUser(study, duosUser.getUser());
-      StudyPatch studyPatch = GsonUtil.getInstance().fromJson(json, StudyPatch.class);
+      StudyPatch studyPatch = StudyPatch.fromJson(json);
       if (!studyPatch.isPatchable(study)) {
         return Response.status(Status.NOT_MODIFIED).entity(study).build();
       }

--- a/src/main/java/org/broadinstitute/consent/http/resources/StudyResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/StudyResource.java
@@ -146,7 +146,7 @@ public class StudyResource extends Resource {
   public Response patchStudyById(
       @Auth DuosUser duosUser, @PathParam("studyId") Integer studyId, String json) {
     try {
-      Study study = datasetService.getStudyWithDatasetsById(duosUser.getUser(), studyId);
+      Study study = datasetService.findStudy(studyId);
       checkPublicVisibilityForUser(study, duosUser.getUser());
       StudyPatch studyPatch = GsonUtil.getInstance().fromJson(json, StudyPatch.class);
       Study patchedStudy = datasetService.patchStudy(studyId, duosUser.getUser(), studyPatch);

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -720,15 +720,7 @@ public class DatasetService implements ConsentLogger {
   public Study patchStudy(Integer studyId, User user, StudyPatch patch) {
     try {
       Study study = studyDAO.findStudyById(studyId);
-      studyDAO.updateStudy(
-          studyId,
-          patch.name() != null ? patch.name() : study.getName(),
-          patch.description() != null ? patch.description() : study.getDescription(),
-          patch.piName() != null ? patch.piName() : study.getPiName(),
-          patch.dataTypes() != null ? patch.dataTypes() : study.getDataTypes(),
-          patch.publicVisibility() != null ? patch.publicVisibility() : study.getPublicVisibility(),
-          user.getUserId(),
-          Instant.now());
+      datasetServiceDAO.patchStudy(study, user, patch);
       study
           .getDatasetIds()
           .forEach(datasetId -> elasticSearchService.asyncDatasetInESIndex(datasetId, user, true));

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -7,6 +7,7 @@ import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import com.google.inject.Inject;
 import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.InternalServerErrorException;
 import jakarta.ws.rs.NotAuthorizedException;
 import jakarta.ws.rs.NotFoundException;
 import java.io.IOException;
@@ -39,6 +40,7 @@ import org.broadinstitute.consent.http.models.DatasetStudySummary;
 import org.broadinstitute.consent.http.models.Dictionary;
 import org.broadinstitute.consent.http.models.Study;
 import org.broadinstitute.consent.http.models.StudyConversion;
+import org.broadinstitute.consent.http.models.StudyPatch;
 import org.broadinstitute.consent.http.models.StudyProperty;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.service.dao.DatasetServiceDAO;
@@ -713,5 +715,28 @@ public class DatasetService implements ConsentLogger {
 
   public void removeAuthorizedAccessReader(long datasetId, long userId) {
     datasetAuthorizationReaderDAO.deleteByDatasetAndUserId(datasetId, userId);
+  }
+
+  public Study patchStudy(Integer studyId, User user, StudyPatch patch) {
+    try {
+      Study study = studyDAO.findStudyById(studyId);
+      studyDAO.updateStudy(
+          studyId,
+          patch.name() != null ? patch.name() : study.getName(),
+          patch.description() != null ? patch.description() : study.getDescription(),
+          patch.piName() != null ? patch.piName() : study.getPiName(),
+          patch.dataTypes() != null ? patch.dataTypes() : study.getDataTypes(),
+          patch.publicVisibility() != null ? patch.publicVisibility() : study.getPublicVisibility(),
+          user.getUserId(),
+          Instant.now());
+      study
+          .getDatasetIds()
+          .forEach(datasetId -> elasticSearchService.asyncDatasetInESIndex(datasetId, user, true));
+      return studyDAO.findStudyById(studyId);
+    } catch (Exception ex) {
+      logException(ex);
+      throw new InternalServerErrorException(
+          "An error occurred patching study %s".formatted(studyId));
+    }
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAO.java
@@ -1,11 +1,11 @@
 package org.broadinstitute.consent.http.service.dao;
 
-import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.alternativeDataSharingPlanTargetDeliveryDate;
-import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.alternativeDataSharingPlanTargetPublicReleaseDate;
-import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.dataCustodianEmail;
-import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.phenotypeIndication;
-import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.species;
-import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.studyType;
+import static org.broadinstitute.consent.http.models.StudyPatch.ALTERNATIVE_DATA_SHARING_PLAN_TARGET_DELIVERY_DATE;
+import static org.broadinstitute.consent.http.models.StudyPatch.ALTERNATIVE_DATA_SHARING_PLAN_TARGET_PUBLIC_RELEASE_DATE;
+import static org.broadinstitute.consent.http.models.StudyPatch.DATA_CUSTODIAN_EMAIL;
+import static org.broadinstitute.consent.http.models.StudyPatch.PHENOTYPE_INDICATION;
+import static org.broadinstitute.consent.http.models.StudyPatch.SPECIES_KEY;
+import static org.broadinstitute.consent.http.models.StudyPatch.STUDY_TYPE;
 
 import com.google.inject.Inject;
 import java.sql.SQLException;
@@ -450,33 +450,34 @@ public class DatasetServiceDAO implements ConsentLogger {
             new ArrayList<>(),
             new ArrayList<>());
     if (patch.studyType() != null) {
-      studyUpdate.props.add(new StudyProperty(studyType, patch.studyType(), PropertyType.String));
+      studyUpdate.props.add(new StudyProperty(STUDY_TYPE, patch.studyType(), PropertyType.String));
     }
     if (patch.phenotypeIndication() != null) {
       studyUpdate.props.add(
-          new StudyProperty(phenotypeIndication, patch.phenotypeIndication(), PropertyType.String));
+          new StudyProperty(
+              PHENOTYPE_INDICATION, patch.phenotypeIndication(), PropertyType.String));
     }
     if (patch.species() != null) {
-      studyUpdate.props.add(new StudyProperty(species, patch.species(), PropertyType.String));
+      studyUpdate.props.add(new StudyProperty(SPECIES_KEY, patch.species(), PropertyType.String));
     }
     if (patch.dataCustodianEmail() != null) {
       studyUpdate.props.add(
           new StudyProperty(
-              dataCustodianEmail,
+              DATA_CUSTODIAN_EMAIL,
               GsonUtil.getInstance().toJson(patch.dataCustodianEmail()),
               PropertyType.Json));
     }
     if (patch.alternativeDataSharingPlanTargetDeliveryDate() != null) {
       studyUpdate.props.add(
           new StudyProperty(
-              alternativeDataSharingPlanTargetDeliveryDate,
+              ALTERNATIVE_DATA_SHARING_PLAN_TARGET_DELIVERY_DATE,
               patch.alternativeDataSharingPlanTargetDeliveryDate(),
               PropertyType.String));
     }
     if (patch.alternativeDataSharingPlanTargetPublicReleaseDate() != null) {
       studyUpdate.props.add(
           new StudyProperty(
-              alternativeDataSharingPlanTargetPublicReleaseDate,
+              ALTERNATIVE_DATA_SHARING_PLAN_TARGET_PUBLIC_RELEASE_DATE,
               patch.alternativeDataSharingPlanTargetPublicReleaseDate(),
               PropertyType.String));
     }

--- a/src/main/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAO.java
@@ -1,5 +1,12 @@
 package org.broadinstitute.consent.http.service.dao;
 
+import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.alternativeDataSharingPlanTargetDeliveryDate;
+import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.alternativeDataSharingPlanTargetPublicReleaseDate;
+import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.dataCustodianEmail;
+import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.phenotypeIndication;
+import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.species;
+import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.studyType;
+
 import com.google.inject.Inject;
 import java.sql.SQLException;
 import java.sql.Timestamp;
@@ -18,6 +25,7 @@ import org.broadinstitute.consent.http.db.DatasetDAO;
 import org.broadinstitute.consent.http.db.FileStorageObjectDAO;
 import org.broadinstitute.consent.http.db.StudyDAO;
 import org.broadinstitute.consent.http.enumeration.AuditActions;
+import org.broadinstitute.consent.http.enumeration.PropertyType;
 import org.broadinstitute.consent.http.models.DataUse;
 import org.broadinstitute.consent.http.models.Dataset;
 import org.broadinstitute.consent.http.models.DatasetAudit;
@@ -26,9 +34,11 @@ import org.broadinstitute.consent.http.models.DatasetProperty;
 import org.broadinstitute.consent.http.models.Dictionary;
 import org.broadinstitute.consent.http.models.FileStorageObject;
 import org.broadinstitute.consent.http.models.Study;
+import org.broadinstitute.consent.http.models.StudyPatch;
 import org.broadinstitute.consent.http.models.StudyProperty;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.util.ConsentLogger;
+import org.broadinstitute.consent.http.util.gson.GsonUtil;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.statement.Update;
@@ -404,6 +414,73 @@ public class DatasetServiceDAO implements ConsentLogger {
     }
     // insert properties
     executeSynchronizeDatasetProperties(handle, datasetId, properties, false);
+  }
+
+  public Study patchStudy(Study study, User user, StudyPatch patch) throws SQLException {
+    jdbi.useHandle(
+        handle -> {
+          handle.getConnection().setAutoCommit(false);
+          // Convert the patch to a StudyUpdate for reuse of existing methods
+          StudyUpdate studyUpdate = convertToStudyUpdate(study, user, patch);
+          try {
+            executeUpdateStudy(handle, studyUpdate);
+          } catch (Exception e) {
+            handle.rollback();
+            logException(e);
+            throw e;
+          }
+          handle.commit();
+        });
+    return studyDAO.findStudyById(study.getStudyId());
+  }
+
+  // Helper method to convert StudyPatch to StudyUpdate
+  private StudyUpdate convertToStudyUpdate(Study study, User user, StudyPatch patch) {
+    StudyUpdate studyUpdate =
+        new StudyUpdate(
+            patch.name() != null ? patch.name() : study.getName(),
+            study.getStudyId(),
+            patch.description() != null ? patch.description() : study.getDescription(),
+            patch.dataTypes() != null ? patch.dataTypes() : study.getDataTypes(),
+            patch.piName() != null ? patch.piName() : study.getPiName(),
+            patch.publicVisibility() != null
+                ? patch.publicVisibility()
+                : study.getPublicVisibility(),
+            user.getUserId(),
+            new ArrayList<>(),
+            new ArrayList<>());
+    if (patch.studyType() != null) {
+      studyUpdate.props.add(new StudyProperty(studyType, patch.studyType(), PropertyType.String));
+    }
+    if (patch.phenotypeIndication() != null) {
+      studyUpdate.props.add(
+          new StudyProperty(phenotypeIndication, patch.phenotypeIndication(), PropertyType.String));
+    }
+    if (patch.species() != null) {
+      studyUpdate.props.add(new StudyProperty(species, patch.species(), PropertyType.String));
+    }
+    if (patch.dataCustodianEmail() != null) {
+      studyUpdate.props.add(
+          new StudyProperty(
+              dataCustodianEmail,
+              GsonUtil.getInstance().toJson(patch.dataCustodianEmail()),
+              PropertyType.Json));
+    }
+    if (patch.alternativeDataSharingPlanTargetDeliveryDate() != null) {
+      studyUpdate.props.add(
+          new StudyProperty(
+              alternativeDataSharingPlanTargetDeliveryDate,
+              patch.alternativeDataSharingPlanTargetDeliveryDate(),
+              PropertyType.String));
+    }
+    if (patch.alternativeDataSharingPlanTargetPublicReleaseDate() != null) {
+      studyUpdate.props.add(
+          new StudyProperty(
+              alternativeDataSharingPlanTargetPublicReleaseDate,
+              patch.alternativeDataSharingPlanTargetPublicReleaseDate(),
+              PropertyType.String));
+    }
+    return studyUpdate;
   }
 
   private void addAuditRecord(Integer datasetId, String name, Integer userId, AuditActions action) {

--- a/src/main/resources/assets/paths/studyById.yaml
+++ b/src/main/resources/assets/paths/studyById.yaml
@@ -107,3 +107,40 @@ delete:
       description: Not Found
     500:
       description: Server error
+patch:
+  summary: Patch Study
+  description: |
+    This API allows Admins, Chairpersons, and Data Submitters to patch a limited set of study
+    properties. All fields are optional and if not provided, will be ignored.
+      * Study name
+      * Study description
+      * Study datatypes (list of strings)
+      * Study PI Name
+      * Study public visibility (boolean)
+  parameters:
+    - name: studyId
+      in: path
+      description: ID of the Study
+      required: true
+      schema:
+        type: integer
+  tags:
+    - Study
+  requestBody:
+    description: StudyPatch object
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: '../schemas/StudyPatch.yaml'
+  responses:
+    200:
+      description: Study Patch applied successfully
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/Study.yaml'
+    404:
+      description: Not Found
+    500:
+      description: Server error.

--- a/src/main/resources/assets/paths/studyById.yaml
+++ b/src/main/resources/assets/paths/studyById.yaml
@@ -113,8 +113,13 @@ patch:
     This API allows Admins, Chairpersons, and Data Submitters to patch a limited set of study
     properties. All fields are optional and if not provided, will be ignored.
       * Study name
+      * Study type
       * Study description
       * Study datatypes (list of strings)
+      * Study Phenotype/Indication
+      * Study Species
+      * Study Target Delivery Date
+      * Study Target Public Release Date
       * Study PI Name
       * Study public visibility (boolean)
   parameters:

--- a/src/main/resources/assets/paths/studyById.yaml
+++ b/src/main/resources/assets/paths/studyById.yaml
@@ -145,6 +145,8 @@ patch:
         application/json:
           schema:
             $ref: '../schemas/Study.yaml'
+    304:
+      description: Not Modified
     404:
       description: Not Found
     500:

--- a/src/main/resources/assets/schemas/DatasetRegistrationSchemaV1.yaml
+++ b/src/main/resources/assets/schemas/DatasetRegistrationSchemaV1.yaml
@@ -4,19 +4,7 @@ properties:
     type: string
     description: The study name
   studyType:
-    type: string
-    enum:
-      - Observational
-      - Interventional
-      - Descriptive
-      - Analytical
-      - Prospective
-      - Retrospective
-      - Case report
-      - Case series
-      - Cross-sectional
-      - Cohort study
-    description: The study type
+    $ref: './StudyType.yaml'
   studyDescription:
     type: string
     description: Description of the study

--- a/src/main/resources/assets/schemas/StudyPatch.yaml
+++ b/src/main/resources/assets/schemas/StudyPatch.yaml
@@ -7,19 +7,7 @@ properties:
     type: string
     description: A human-readable description of the study.
   studyType:
-    type: string
-    enum:
-      - Observational
-      - Interventional
-      - Descriptive
-      - Analytical
-      - Prospective
-      - Retrospective
-      - Case report
-      - Case series
-      - Cross-sectional
-      - Cohort study
-    description: The study type
+    $ref: './StudyType.yaml'
   dataTypes:
     type: array
     items:

--- a/src/main/resources/assets/schemas/StudyPatch.yaml
+++ b/src/main/resources/assets/schemas/StudyPatch.yaml
@@ -6,14 +6,45 @@ properties:
   description:
     type: string
     description: A human-readable description of the study.
+  studyType:
+    type: string
+    enum:
+      - Observational
+      - Interventional
+      - Descriptive
+      - Analytical
+      - Prospective
+      - Retrospective
+      - Case report
+      - Case series
+      - Cross-sectional
+      - Cohort study
+    description: The study type
   dataTypes:
     type: array
     items:
       type: string
     description: The data types included in the study's dataset.
+  phenotypeIndication:
+    type: string
+    description: The phenotype indication for the study.
+  species:
+    type: string
+    description: The species for the study.
   piName:
     type: string
     description: The name of the PI of the study.
+  dataCustodianEmail:
+    type: array
+    items:
+      type: string
+    description: The data custodian email(s) for the study.
+  alternativeDataSharingPlanTargetDeliveryDate:
+    type: string
+    description: The target delivery date for the alternative data sharing plan.
+  alternativeDataSharingPlanTargetPublicReleaseDate:
+    type: string
+    description: The target delivery public release date for the alternative data sharing plan.
   publicVisibility:
     type: boolean
     description: Whether this study is publicly visible or not.

--- a/src/main/resources/assets/schemas/StudyPatch.yaml
+++ b/src/main/resources/assets/schemas/StudyPatch.yaml
@@ -1,0 +1,19 @@
+type: object
+properties:
+  name:
+    type: string
+    description: The name of the study.
+  description:
+    type: string
+    description: A human-readable description of the study.
+  dataTypes:
+    type: array
+    items:
+      type: string
+    description: The data types included in the study's dataset.
+  piName:
+    type: string
+    description: The name of the PI of the study.
+  publicVisibility:
+    type: boolean
+    description: Whether this study is publicly visible or not.

--- a/src/main/resources/assets/schemas/StudyType.yaml
+++ b/src/main/resources/assets/schemas/StudyType.yaml
@@ -1,0 +1,13 @@
+type: string
+enum:
+  - Observational
+  - Interventional
+  - Descriptive
+  - Analytical
+  - Prospective
+  - Retrospective
+  - Case report
+  - Case series
+  - Cross-sectional
+  - Cohort study
+description: The study type

--- a/src/test/java/org/broadinstitute/consent/http/models/StudyPatchTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/StudyPatchTest.java
@@ -31,7 +31,9 @@ class StudyPatchTest extends AbstractTestHelper {
         "{ \"unknownField\": \"some value\" }",
         "{ \"name\": 12345 }",
         "{ \"studyType\": \"not a study type\" }",
-        "{ \"publicVisibility\": \"not a boolean\" }"
+        "{ \"publicVisibility\": \"not a boolean\" }",
+        "{ \"publicVisibility\": \"true\" }",
+        "{ \"publicVisibility\": \"false\" }"
       })
   void testFromJson(String json) {
     assertThrows(Exception.class, () -> StudyPatch.fromJson(json));

--- a/src/test/java/org/broadinstitute/consent/http/models/StudyPatchTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/StudyPatchTest.java
@@ -1,0 +1,169 @@
+package org.broadinstitute.consent.http.models;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import org.broadinstitute.consent.http.AbstractTestHelper;
+import org.broadinstitute.consent.http.enumeration.PropertyType;
+import org.broadinstitute.consent.http.models.dataset_registration_v1.DatasetRegistrationSchemaV1.StudyType;
+import org.broadinstitute.consent.http.util.gson.GsonUtil;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class StudyPatchTest extends AbstractTestHelper {
+
+  @Test
+  void testIsPatchableNoValues() {
+    Study study = mockStudy();
+    StudyPatch patch =
+        new StudyPatch(null, null, null, null, null, null, null, null, null, null, null);
+    assertFalse(patch.isPatchable(study));
+  }
+
+  @Test
+  void testIsPatchableSameValues() {
+    Study study = mockStudy();
+    StudyPatch patch =
+        new StudyPatch(
+            study.getName(),
+            StudyType.OBSERVATIONAL,
+            study.getDescription(),
+            study.getDataTypes(),
+            "CANCER",
+            "HUMAN",
+            study.getPiName(),
+            List.of("EMAIL1", "EMAIL2"),
+            "01/01/2020",
+            "01/01/2020",
+            study.getPublicVisibility());
+    assertFalse(patch.isPatchable(study));
+  }
+
+  @Test
+  void testIsPatchableName() {
+    Study study = mockStudy();
+    StudyPatch patch =
+        new StudyPatch("Name", null, null, null, null, null, null, null, null, null, null);
+    assertTrue(patch.isPatchable(study));
+  }
+
+  @Test
+  void testIsPatchableStudyType() {
+    Study study = mockStudy();
+    StudyPatch patch =
+        new StudyPatch(
+            null, StudyType.ANALYTICAL, null, null, null, null, null, null, null, null, null);
+    assertTrue(patch.isPatchable(study));
+  }
+
+  @Test
+  void testIsPatchableDescription() {
+    Study study = mockStudy();
+    StudyPatch patch =
+        new StudyPatch(null, null, "Description", null, null, null, null, null, null, null, null);
+    assertTrue(patch.isPatchable(study));
+  }
+
+  @Test
+  void testIsPatchableDataTypes() {
+    Study study = mockStudy();
+    StudyPatch patch =
+        new StudyPatch(
+            null, null, null, List.of("type1", "type2"), null, null, null, null, null, null, null);
+    assertTrue(patch.isPatchable(study));
+  }
+
+  @Test
+  void testIsPatchablePhenotype() {
+    Study study = mockStudy();
+    StudyPatch patch =
+        new StudyPatch(null, null, null, null, "New Phenotype", null, null, null, null, null, null);
+    assertTrue(patch.isPatchable(study));
+  }
+
+  @Test
+  void testIsPatchableSpecies() {
+    Study study = mockStudy();
+    StudyPatch patch =
+        new StudyPatch(null, null, null, null, null, "New Species", null, null, null, null, null);
+    assertTrue(patch.isPatchable(study));
+  }
+
+  @Test
+  void testIsPatchablePIName() {
+    Study study = mockStudy();
+    StudyPatch patch =
+        new StudyPatch(null, null, null, null, null, null, "New PI Name", null, null, null, null);
+    assertTrue(patch.isPatchable(study));
+  }
+
+  @Test
+  void testIsPatchableDataCustodians() {
+    Study study = mockStudy();
+    StudyPatch patch =
+        new StudyPatch(
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            List.of("new_email1", "new_email2"),
+            null,
+            null,
+            null);
+    assertTrue(patch.isPatchable(study));
+  }
+
+  @Test
+  void testIsPatchableTargetDeliveryDate() {
+    Study study = mockStudy();
+    StudyPatch patch =
+        new StudyPatch(null, null, null, null, null, null, null, null, "New Date", null, null);
+    assertTrue(patch.isPatchable(study));
+  }
+
+  @Test
+  void testIsPatchableTargetReleaseDate() {
+    Study study = mockStudy();
+    StudyPatch patch =
+        new StudyPatch(null, null, null, null, null, null, null, null, null, "New Date", null);
+    assertTrue(patch.isPatchable(study));
+  }
+
+  @Test
+  void testIsPatchablePublicVisibility() {
+    Study study = mockStudy();
+    StudyPatch patch =
+        new StudyPatch(null, null, null, null, null, null, null, null, null, null, false);
+    assertTrue(patch.isPatchable(study));
+  }
+
+  private Study mockStudy() {
+    Study study = new Study();
+    study.setName(randomAlphabetic(20));
+    study.setDescription(randomAlphabetic(20));
+    study.setDataTypes(List.of(randomAlphabetic(20), randomAlphabetic(20)));
+    study.setPiName(randomAlphabetic(20));
+    study.setPublicVisibility(true);
+    study.addProperties(
+        new StudyProperty("studyType", StudyType.OBSERVATIONAL.value(), PropertyType.String),
+        new StudyProperty("phenotypeIndication", "CANCER", PropertyType.String),
+        new StudyProperty("species", "HUMAN", PropertyType.String),
+        new StudyProperty(
+            "dataCustodianEmail",
+            GsonUtil.getInstance().toJson(List.of("EMAIL1", "EMAIL2")),
+            PropertyType.Json),
+        new StudyProperty(
+            "alternativeDataSharingPlanTargetDeliveryDate", "01/01/2020", PropertyType.String),
+        new StudyProperty(
+            "alternativeDataSharingPlanTargetPublicReleaseDate",
+            "01/01/2020",
+            PropertyType.String));
+    return study;
+  }
+}

--- a/src/test/java/org/broadinstitute/consent/http/models/StudyPatchTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/StudyPatchTest.java
@@ -1,5 +1,11 @@
 package org.broadinstitute.consent.http.models;
 
+import static org.broadinstitute.consent.http.models.StudyPatch.ALTERNATIVE_DATA_SHARING_PLAN_TARGET_DELIVERY_DATE;
+import static org.broadinstitute.consent.http.models.StudyPatch.ALTERNATIVE_DATA_SHARING_PLAN_TARGET_PUBLIC_RELEASE_DATE;
+import static org.broadinstitute.consent.http.models.StudyPatch.DATA_CUSTODIAN_EMAIL;
+import static org.broadinstitute.consent.http.models.StudyPatch.PHENOTYPE_INDICATION;
+import static org.broadinstitute.consent.http.models.StudyPatch.SPECIES_KEY;
+import static org.broadinstitute.consent.http.models.StudyPatch.STUDY_TYPE;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -151,17 +157,17 @@ class StudyPatchTest extends AbstractTestHelper {
     study.setPiName(randomAlphabetic(20));
     study.setPublicVisibility(true);
     study.addProperties(
-        new StudyProperty("studyType", StudyType.OBSERVATIONAL.value(), PropertyType.String),
-        new StudyProperty("phenotypeIndication", "CANCER", PropertyType.String),
-        new StudyProperty("species", "HUMAN", PropertyType.String),
+        new StudyProperty(STUDY_TYPE, StudyType.OBSERVATIONAL.value(), PropertyType.String),
+        new StudyProperty(PHENOTYPE_INDICATION, "CANCER", PropertyType.String),
+        new StudyProperty(SPECIES_KEY, "HUMAN", PropertyType.String),
         new StudyProperty(
-            "dataCustodianEmail",
+            DATA_CUSTODIAN_EMAIL,
             GsonUtil.getInstance().toJson(List.of("EMAIL1", "EMAIL2")),
             PropertyType.Json),
         new StudyProperty(
-            "alternativeDataSharingPlanTargetDeliveryDate", "01/01/2020", PropertyType.String),
+            ALTERNATIVE_DATA_SHARING_PLAN_TARGET_DELIVERY_DATE, "01/01/2020", PropertyType.String),
         new StudyProperty(
-            "alternativeDataSharingPlanTargetPublicReleaseDate",
+            ALTERNATIVE_DATA_SHARING_PLAN_TARGET_PUBLIC_RELEASE_DATE,
             "01/01/2020",
             PropertyType.String));
     return study;

--- a/src/test/java/org/broadinstitute/consent/http/models/StudyPatchTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/StudyPatchTest.java
@@ -7,6 +7,7 @@ import static org.broadinstitute.consent.http.models.StudyPatch.PHENOTYPE_INDICA
 import static org.broadinstitute.consent.http.models.StudyPatch.SPECIES_KEY;
 import static org.broadinstitute.consent.http.models.StudyPatch.STUDY_TYPE;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
@@ -16,10 +17,25 @@ import org.broadinstitute.consent.http.models.dataset_registration_v1.DatasetReg
 import org.broadinstitute.consent.http.util.gson.GsonUtil;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class StudyPatchTest extends AbstractTestHelper {
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "{ invalid json }",
+        "{ \"unknownField\": \"some value\" }",
+        "{ \"name\": 12345 }",
+        "{ \"studyType\": \"not a study type\" }",
+        "{ \"publicVisibility\": \"not a boolean\" }"
+      })
+  void testFromJson(String json) {
+    assertThrows(Exception.class, () -> StudyPatch.fromJson(json));
+  }
 
   @Test
   void testIsPatchableNoValues() {

--- a/src/test/java/org/broadinstitute/consent/http/resources/StudyResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/StudyResourceTest.java
@@ -698,4 +698,24 @@ class StudyResourceTest extends AbstractTestHelper {
       assertEquals(HttpStatusCodes.STATUS_CODE_NOT_MODIFIED, response.getStatus());
     }
   }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "{ invalid json }",
+        "{ \"unknownField\": \"some value\" }",
+        "{ \"name\": 12345 }",
+        "{ \"studyType\": \"not a study type\" }",
+        "{ \"publicVisibility\": \"not a boolean\" }"
+      })
+  void testPatchStudyByIdInvalidPatch(String json) {
+    Study study = createMockStudy();
+    User admin = new User();
+    admin.setAdminRole();
+    admin.setUserId(study.getCreateUserId());
+    when(datasetService.findStudy(study.getStudyId())).thenReturn(study);
+    try (var response = resource.patchStudyById(duosUser, study.getStudyId(), json)) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
+    }
+  }
 }

--- a/src/test/java/org/broadinstitute/consent/http/resources/StudyResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/StudyResourceTest.java
@@ -26,6 +26,7 @@ import org.broadinstitute.consent.http.models.Dataset;
 import org.broadinstitute.consent.http.models.DatasetProperty;
 import org.broadinstitute.consent.http.models.DuosUser;
 import org.broadinstitute.consent.http.models.Study;
+import org.broadinstitute.consent.http.models.StudyPatch;
 import org.broadinstitute.consent.http.models.StudyProperty;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.dataset_registration_v1.ConsentGroup;
@@ -649,6 +650,40 @@ class StudyResourceTest extends AbstractTestHelper {
 
     try (var response = resource.getStudyById(duosUser, study.getStudyId())) {
       assertEquals(HttpStatusCodes.STATUS_CODE_SERVER_ERROR, response.getStatus());
+    }
+  }
+
+  @Test
+  void testPatchStudyById() {
+    Study study = createMockStudy();
+    User admin = new User();
+    admin.setAdminRole();
+    admin.setUserId(study.getCreateUserId());
+    when(datasetService.findStudy(study.getStudyId())).thenReturn(study);
+    when(duosUser.getUser()).thenReturn(admin);
+    String patchJson =
+        """
+            {
+              "name": "Updated Study Name"
+            }
+            """;
+    StudyPatch studyPatch = GsonUtil.getInstance().fromJson(patchJson, StudyPatch.class);
+    when(datasetService.patchStudy(study.getStudyId(), duosUser.getUser(), studyPatch))
+        .thenReturn(study);
+    try (var response = resource.patchStudyById(duosUser, study.getStudyId(), patchJson)) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+    }
+  }
+
+  @Test
+  void testPatchStudyByIdNotFound() {
+    Study study = createMockStudy();
+    User admin = new User();
+    admin.setAdminRole();
+    admin.setUserId(study.getCreateUserId());
+    when(datasetService.findStudy(study.getStudyId())).thenReturn(null);
+    try (var response = resource.patchStudyById(duosUser, study.getStudyId(), "{}")) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
     }
   }
 }

--- a/src/test/java/org/broadinstitute/consent/http/resources/StudyResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/StudyResourceTest.java
@@ -686,4 +686,16 @@ class StudyResourceTest extends AbstractTestHelper {
       assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
     }
   }
+
+  @Test
+  void testPatchStudyByIdNotModified() {
+    Study study = createMockStudy();
+    User admin = new User();
+    admin.setAdminRole();
+    admin.setUserId(study.getCreateUserId());
+    when(datasetService.findStudy(study.getStudyId())).thenReturn(study);
+    try (var response = resource.patchStudyById(duosUser, study.getStudyId(), "{}")) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_NOT_MODIFIED, response.getStatus());
+    }
+  }
 }

--- a/src/test/java/org/broadinstitute/consent/http/resources/StudyResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/StudyResourceTest.java
@@ -706,7 +706,9 @@ class StudyResourceTest extends AbstractTestHelper {
         "{ \"unknownField\": \"some value\" }",
         "{ \"name\": 12345 }",
         "{ \"studyType\": \"not a study type\" }",
-        "{ \"publicVisibility\": \"not a boolean\" }"
+        "{ \"publicVisibility\": \"not a boolean\" }",
+        "{ \"publicVisibility\": \"true\" }",
+        "{ \"publicVisibility\": \"false\" }"
       })
   void testPatchStudyByIdInvalidPatch(String json) {
     Study study = createMockStudy();

--- a/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
@@ -13,6 +13,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -49,6 +50,7 @@ import org.broadinstitute.consent.http.models.Dataset;
 import org.broadinstitute.consent.http.models.DatasetAuthorizationReader;
 import org.broadinstitute.consent.http.models.DatasetStudySummary;
 import org.broadinstitute.consent.http.models.Study;
+import org.broadinstitute.consent.http.models.StudyPatch;
 import org.broadinstitute.consent.http.models.StudyProperty;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.UserRole;
@@ -863,7 +865,158 @@ class DatasetServiceTest extends AbstractTestHelper {
     assertDoesNotThrow(() -> datasetAuthorizationReaderDAO.deleteByDatasetAndUserId(1, 1));
   }
 
+  @Test
+  void testPatchStudy() {
+    Study study = mockStudy();
+    StudyPatch patch =
+        new StudyPatch(
+            randomAlphabetic(10),
+            randomAlphabetic(10),
+            List.of("tag1", "tag2"),
+            randomAlphabetic(10),
+            true);
+    User user = new User();
+    user.setUserId(1);
+    when(studyDAO.findStudyById(study.getStudyId())).thenReturn(study);
+    datasetService.patchStudy(study.getStudyId(), user, patch);
+    verify(studyDAO)
+        .updateStudy(
+            eq(study.getStudyId()),
+            eq(patch.name()),
+            eq(patch.description()),
+            eq(patch.piName()),
+            eq(patch.dataTypes()),
+            eq(patch.publicVisibility()),
+            eq(user.getUserId()),
+            any(Instant.class));
+  }
+
+  @Test
+  void testPatchStudyUnchangedName() {
+    Study study = mockStudy();
+    StudyPatch patch =
+        new StudyPatch(
+            null, randomAlphabetic(10), List.of("tag1", "tag2"), randomAlphabetic(10), true);
+    User user = new User();
+    user.setUserId(1);
+    when(studyDAO.findStudyById(study.getStudyId())).thenReturn(study);
+    datasetService.patchStudy(study.getStudyId(), user, patch);
+    verify(studyDAO)
+        .updateStudy(
+            eq(study.getStudyId()),
+            eq(study.getName()),
+            eq(patch.description()),
+            eq(patch.piName()),
+            eq(patch.dataTypes()),
+            eq(patch.publicVisibility()),
+            eq(user.getUserId()),
+            any(Instant.class));
+  }
+
+  @Test
+  void testPatchStudyUnchangedDescription() {
+    Study study = mockStudy();
+    StudyPatch patch =
+        new StudyPatch(
+            randomAlphabetic(10), null, List.of("tag1", "tag2"), randomAlphabetic(10), true);
+    User user = new User();
+    user.setUserId(1);
+    when(studyDAO.findStudyById(study.getStudyId())).thenReturn(study);
+    datasetService.patchStudy(study.getStudyId(), user, patch);
+    verify(studyDAO)
+        .updateStudy(
+            eq(study.getStudyId()),
+            eq(patch.name()),
+            eq(study.getDescription()),
+            eq(patch.piName()),
+            eq(patch.dataTypes()),
+            eq(patch.publicVisibility()),
+            eq(user.getUserId()),
+            any(Instant.class));
+  }
+
+  @Test
+  void testPatchStudyUnchangedDatatypes() {
+    Study study = mockStudy();
+    StudyPatch patch =
+        new StudyPatch(
+            randomAlphabetic(10), randomAlphabetic(10), null, randomAlphabetic(10), true);
+    User user = new User();
+    user.setUserId(1);
+    when(studyDAO.findStudyById(study.getStudyId())).thenReturn(study);
+    datasetService.patchStudy(study.getStudyId(), user, patch);
+    verify(studyDAO)
+        .updateStudy(
+            eq(study.getStudyId()),
+            eq(patch.name()),
+            eq(patch.description()),
+            eq(patch.piName()),
+            eq(study.getDataTypes()),
+            eq(patch.publicVisibility()),
+            eq(user.getUserId()),
+            any(Instant.class));
+  }
+
+  @Test
+  void testPatchStudyUnchangedPIName() {
+    Study study = mockStudy();
+    StudyPatch patch =
+        new StudyPatch(
+            randomAlphabetic(10), randomAlphabetic(10), List.of("tag3", "tag4"), null, true);
+    User user = new User();
+    user.setUserId(1);
+    when(studyDAO.findStudyById(study.getStudyId())).thenReturn(study);
+    datasetService.patchStudy(study.getStudyId(), user, patch);
+    verify(studyDAO)
+        .updateStudy(
+            eq(study.getStudyId()),
+            eq(patch.name()),
+            eq(patch.description()),
+            eq(study.getPiName()),
+            eq(patch.dataTypes()),
+            eq(patch.publicVisibility()),
+            eq(user.getUserId()),
+            any(Instant.class));
+  }
+
+  @Test
+  void testPatchStudyUnchangedVisibility() {
+    Study study = mockStudy();
+    StudyPatch patch =
+        new StudyPatch(
+            randomAlphabetic(10),
+            randomAlphabetic(10),
+            List.of("tag3", "tag4"),
+            randomAlphabetic(10),
+            null);
+    User user = new User();
+    user.setUserId(1);
+    when(studyDAO.findStudyById(study.getStudyId())).thenReturn(study);
+    datasetService.patchStudy(study.getStudyId(), user, patch);
+    verify(studyDAO)
+        .updateStudy(
+            eq(study.getStudyId()),
+            eq(patch.name()),
+            eq(patch.description()),
+            eq(patch.piName()),
+            eq(patch.dataTypes()),
+            eq(study.getPublicVisibility()),
+            eq(user.getUserId()),
+            any(Instant.class));
+  }
+
   /* Helper functions */
+
+  private Study mockStudy() {
+    Study study = new Study();
+    study.setStudyId(1);
+    study.setName("Original Study Name");
+    study.setDescription("Original Study Description");
+    study.setDataTypes(List.of("tag1", "tag2"));
+    study.setPiName("Original PI Name");
+    study.setPublicVisibility(true);
+    return study;
+  }
 
   private List<Dataset> getDatasets() {
     return IntStream.range(1, 3)

--- a/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
@@ -13,7 +13,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -54,6 +53,7 @@ import org.broadinstitute.consent.http.models.StudyPatch;
 import org.broadinstitute.consent.http.models.StudyProperty;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.UserRole;
+import org.broadinstitute.consent.http.models.dataset_registration_v1.DatasetRegistrationSchemaV1.StudyType;
 import org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder;
 import org.broadinstitute.consent.http.service.dao.DatasetServiceDAO;
 import org.broadinstitute.consent.http.util.gson.GsonUtil;
@@ -866,156 +866,28 @@ class DatasetServiceTest extends AbstractTestHelper {
   }
 
   @Test
-  void testPatchStudy() {
-    Study study = mockStudy();
-    StudyPatch patch =
-        new StudyPatch(
-            randomAlphabetic(10),
-            randomAlphabetic(10),
-            List.of("tag1", "tag2"),
-            randomAlphabetic(10),
-            true);
-    User user = new User();
-    user.setUserId(1);
-    when(studyDAO.findStudyById(study.getStudyId())).thenReturn(study);
-    datasetService.patchStudy(study.getStudyId(), user, patch);
-    verify(studyDAO)
-        .updateStudy(
-            eq(study.getStudyId()),
-            eq(patch.name()),
-            eq(patch.description()),
-            eq(patch.piName()),
-            eq(patch.dataTypes()),
-            eq(patch.publicVisibility()),
-            eq(user.getUserId()),
-            any(Instant.class));
-  }
-
-  @Test
-  void testPatchStudyUnchangedName() {
-    Study study = mockStudy();
-    StudyPatch patch =
-        new StudyPatch(
-            null, randomAlphabetic(10), List.of("tag1", "tag2"), randomAlphabetic(10), true);
-    User user = new User();
-    user.setUserId(1);
-    when(studyDAO.findStudyById(study.getStudyId())).thenReturn(study);
-    datasetService.patchStudy(study.getStudyId(), user, patch);
-    verify(studyDAO)
-        .updateStudy(
-            eq(study.getStudyId()),
-            eq(study.getName()),
-            eq(patch.description()),
-            eq(patch.piName()),
-            eq(patch.dataTypes()),
-            eq(patch.publicVisibility()),
-            eq(user.getUserId()),
-            any(Instant.class));
-  }
-
-  @Test
-  void testPatchStudyUnchangedDescription() {
-    Study study = mockStudy();
-    StudyPatch patch =
-        new StudyPatch(
-            randomAlphabetic(10), null, List.of("tag1", "tag2"), randomAlphabetic(10), true);
-    User user = new User();
-    user.setUserId(1);
-    when(studyDAO.findStudyById(study.getStudyId())).thenReturn(study);
-    datasetService.patchStudy(study.getStudyId(), user, patch);
-    verify(studyDAO)
-        .updateStudy(
-            eq(study.getStudyId()),
-            eq(patch.name()),
-            eq(study.getDescription()),
-            eq(patch.piName()),
-            eq(patch.dataTypes()),
-            eq(patch.publicVisibility()),
-            eq(user.getUserId()),
-            any(Instant.class));
-  }
-
-  @Test
-  void testPatchStudyUnchangedDatatypes() {
-    Study study = mockStudy();
-    StudyPatch patch =
-        new StudyPatch(
-            randomAlphabetic(10), randomAlphabetic(10), null, randomAlphabetic(10), true);
-    User user = new User();
-    user.setUserId(1);
-    when(studyDAO.findStudyById(study.getStudyId())).thenReturn(study);
-    datasetService.patchStudy(study.getStudyId(), user, patch);
-    verify(studyDAO)
-        .updateStudy(
-            eq(study.getStudyId()),
-            eq(patch.name()),
-            eq(patch.description()),
-            eq(patch.piName()),
-            eq(study.getDataTypes()),
-            eq(patch.publicVisibility()),
-            eq(user.getUserId()),
-            any(Instant.class));
-  }
-
-  @Test
-  void testPatchStudyUnchangedPIName() {
-    Study study = mockStudy();
-    StudyPatch patch =
-        new StudyPatch(
-            randomAlphabetic(10), randomAlphabetic(10), List.of("tag3", "tag4"), null, true);
-    User user = new User();
-    user.setUserId(1);
-    when(studyDAO.findStudyById(study.getStudyId())).thenReturn(study);
-    datasetService.patchStudy(study.getStudyId(), user, patch);
-    verify(studyDAO)
-        .updateStudy(
-            eq(study.getStudyId()),
-            eq(patch.name()),
-            eq(patch.description()),
-            eq(study.getPiName()),
-            eq(patch.dataTypes()),
-            eq(patch.publicVisibility()),
-            eq(user.getUserId()),
-            any(Instant.class));
-  }
-
-  @Test
-  void testPatchStudyUnchangedVisibility() {
-    Study study = mockStudy();
-    StudyPatch patch =
-        new StudyPatch(
-            randomAlphabetic(10),
-            randomAlphabetic(10),
-            List.of("tag3", "tag4"),
-            randomAlphabetic(10),
-            null);
-    User user = new User();
-    user.setUserId(1);
-    when(studyDAO.findStudyById(study.getStudyId())).thenReturn(study);
-    datasetService.patchStudy(study.getStudyId(), user, patch);
-    verify(studyDAO)
-        .updateStudy(
-            eq(study.getStudyId()),
-            eq(patch.name()),
-            eq(patch.description()),
-            eq(patch.piName()),
-            eq(patch.dataTypes()),
-            eq(study.getPublicVisibility()),
-            eq(user.getUserId()),
-            any(Instant.class));
-  }
-
-  /* Helper functions */
-
-  private Study mockStudy() {
+  void testPatchStudy() throws Exception {
     Study study = new Study();
     study.setStudyId(1);
-    study.setName("Original Study Name");
-    study.setDescription("Original Study Description");
-    study.setDataTypes(List.of("tag1", "tag2"));
-    study.setPiName("Original PI Name");
-    study.setPublicVisibility(true);
-    return study;
+    study.setName("Study Name");
+    User user = new User();
+    user.setUserId(1);
+    StudyPatch patch =
+        new StudyPatch(
+            "New Study Name",
+            StudyType.OBSERVATIONAL,
+            "New Description",
+            null,
+            "New Phenotype",
+            "New Species",
+            "New PI",
+            null,
+            null,
+            null,
+            true);
+    when(datasetServiceDAO.patchStudy(study, user, patch)).thenReturn(study);
+    when(studyDAO.findStudyById(study.getStudyId())).thenReturn(study);
+    assertDoesNotThrow(() -> datasetService.patchStudy(study.getStudyId(), user, patch));
   }
 
   private List<Dataset> getDatasets() {

--- a/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
@@ -890,6 +890,8 @@ class DatasetServiceTest extends AbstractTestHelper {
     assertDoesNotThrow(() -> datasetService.patchStudy(study.getStudyId(), user, patch));
   }
 
+  /* Helper functions */
+
   private List<Dataset> getDatasets() {
     return IntStream.range(1, 3)
         .mapToObj(

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAOTest.java
@@ -1,5 +1,11 @@
 package org.broadinstitute.consent.http.service.dao;
 
+import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.alternativeDataSharingPlanTargetDeliveryDate;
+import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.alternativeDataSharingPlanTargetPublicReleaseDate;
+import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.dataCustodianEmail;
+import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.phenotypeIndication;
+import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.species;
+import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.studyType;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -30,11 +36,14 @@ import org.broadinstitute.consent.http.models.DatasetProperty;
 import org.broadinstitute.consent.http.models.Dictionary;
 import org.broadinstitute.consent.http.models.FileStorageObject;
 import org.broadinstitute.consent.http.models.Study;
+import org.broadinstitute.consent.http.models.StudyPatch;
 import org.broadinstitute.consent.http.models.StudyProperty;
 import org.broadinstitute.consent.http.models.User;
+import org.broadinstitute.consent.http.models.dataset_registration_v1.DatasetRegistrationSchemaV1.StudyType;
 import org.broadinstitute.consent.http.service.dao.DatasetServiceDAO.DatasetInsert;
 import org.broadinstitute.consent.http.service.dao.DatasetServiceDAO.DatasetUpdate;
 import org.broadinstitute.consent.http.service.dao.DatasetServiceDAO.StudyUpdate;
+import org.broadinstitute.consent.http.util.gson.GsonUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -1039,6 +1048,411 @@ class DatasetServiceDAOTest extends DAOTestHelper {
     assertTrue(
         audits.stream()
             .anyMatch(a -> a.getAction().equalsIgnoreCase(AuditActions.DEINDEXED.name())));
+  }
+
+  @Test
+  void testPatchStudyAllProperties() throws Exception {
+    Study study = createStudy(null);
+    User user = userDAO.findUserById(study.getCreateUserId());
+    StudyPatch patch =
+        new StudyPatch(
+            randomAlphabetic(10),
+            StudyType.OBSERVATIONAL,
+            randomAlphabetic(10),
+            List.of("tag1", "tag2"),
+            randomAlphabetic(10),
+            randomAlphabetic(10),
+            randomAlphabetic(10),
+            List.of("email1", "email2"),
+            randomAlphabetic(10),
+            randomAlphabetic(10),
+            true);
+    Study patched = serviceDAO.patchStudy(study, user, patch);
+    assertEquals(patch.name(), patched.getName());
+    assertEquals(patch.description(), patched.getDescription());
+    assertEquals(patch.dataTypes(), patched.getDataTypes());
+    assertEquals(patch.piName(), patched.getPiName());
+    assertEquals(patch.publicVisibility(), patched.getPublicVisibility());
+    assertEquals(
+        patch.studyType().value(),
+        patched.getProperties().stream()
+            .filter(p -> p.getKey().equals(studyType))
+            .findFirst()
+            .orElseThrow()
+            .getValue());
+    assertEquals(
+        patch.phenotypeIndication(),
+        patched.getProperties().stream()
+            .filter(p -> p.getKey().equals(phenotypeIndication))
+            .findFirst()
+            .orElseThrow()
+            .getValue());
+    assertEquals(
+        patch.species(),
+        patched.getProperties().stream()
+            .filter(p -> p.getKey().equals(species))
+            .findFirst()
+            .orElseThrow()
+            .getValue());
+    assertEquals(
+        GsonUtil.getInstance().toJson(patch.dataCustodianEmail()),
+        patched.getProperties().stream()
+            .filter(p -> p.getKey().equals(dataCustodianEmail))
+            .findFirst()
+            .orElseThrow()
+            .getValue()
+            .toString());
+    assertEquals(
+        patch.alternativeDataSharingPlanTargetDeliveryDate(),
+        patched.getProperties().stream()
+            .filter(p -> p.getKey().equals(alternativeDataSharingPlanTargetDeliveryDate))
+            .findFirst()
+            .orElseThrow()
+            .getValue());
+    assertEquals(
+        patch.alternativeDataSharingPlanTargetPublicReleaseDate(),
+        patched.getProperties().stream()
+            .filter(p -> p.getKey().equals(alternativeDataSharingPlanTargetPublicReleaseDate))
+            .findFirst()
+            .orElseThrow()
+            .getValue());
+  }
+
+  @Test
+  void testPatchStudyName() throws Exception {
+    Study study = createStudy(null);
+    User user = userDAO.findUserById(study.getCreateUserId());
+    StudyPatch patch =
+        new StudyPatch(
+            randomAlphabetic(10), null, null, null, null, null, null, null, null, null, null);
+    Study patched = serviceDAO.patchStudy(study, user, patch);
+    assertEquals(patch.name(), patched.getName());
+    assertEquals(study.getDescription(), patched.getDescription());
+    assertEquals(study.getDataTypes(), patched.getDataTypes());
+    assertEquals(study.getPiName(), patched.getPiName());
+    assertEquals(study.getPublicVisibility(), patched.getPublicVisibility());
+    assertTrue(study.getProperties().stream().noneMatch(p -> p.getKey().equals(studyType)));
+    assertTrue(
+        study.getProperties().stream().noneMatch(p -> p.getKey().equals(phenotypeIndication)));
+    assertTrue(study.getProperties().stream().noneMatch(p -> p.getKey().equals(species)));
+    assertTrue(
+        study.getProperties().stream().noneMatch(p -> p.getKey().equals(dataCustodianEmail)));
+    assertTrue(
+        study.getProperties().stream()
+            .noneMatch(p -> p.getKey().equals(alternativeDataSharingPlanTargetDeliveryDate)));
+    assertTrue(
+        study.getProperties().stream()
+            .noneMatch(p -> p.getKey().equals(alternativeDataSharingPlanTargetPublicReleaseDate)));
+  }
+
+  @Test
+  void testPatchStudyDescription() throws Exception {
+    Study study = createStudy(null);
+    User user = userDAO.findUserById(study.getCreateUserId());
+    StudyPatch patch =
+        new StudyPatch(
+            null, null, randomAlphabetic(10), null, null, null, null, null, null, null, null);
+    Study patched = serviceDAO.patchStudy(study, user, patch);
+    assertEquals(study.getName(), patched.getName());
+    assertEquals(patch.description(), patched.getDescription());
+    assertEquals(study.getDataTypes(), patched.getDataTypes());
+    assertEquals(study.getPiName(), patched.getPiName());
+    assertEquals(study.getPublicVisibility(), patched.getPublicVisibility());
+    assertTrue(study.getProperties().stream().noneMatch(p -> p.getKey().equals(studyType)));
+    assertTrue(
+        study.getProperties().stream().noneMatch(p -> p.getKey().equals(phenotypeIndication)));
+    assertTrue(study.getProperties().stream().noneMatch(p -> p.getKey().equals(species)));
+    assertTrue(
+        study.getProperties().stream().noneMatch(p -> p.getKey().equals(dataCustodianEmail)));
+    assertTrue(
+        study.getProperties().stream()
+            .noneMatch(p -> p.getKey().equals(alternativeDataSharingPlanTargetDeliveryDate)));
+    assertTrue(
+        study.getProperties().stream()
+            .noneMatch(p -> p.getKey().equals(alternativeDataSharingPlanTargetPublicReleaseDate)));
+  }
+
+  @Test
+  void testPatchStudyDataTypes() throws Exception {
+    Study study = createStudy(null);
+    User user = userDAO.findUserById(study.getCreateUserId());
+    StudyPatch patch =
+        new StudyPatch(
+            null, null, null, List.of("tag1", "tag2"), null, null, null, null, null, null, null);
+    Study patched = serviceDAO.patchStudy(study, user, patch);
+    assertEquals(study.getName(), patched.getName());
+    assertEquals(study.getDescription(), patched.getDescription());
+    assertEquals(patch.dataTypes(), patched.getDataTypes());
+    assertEquals(study.getPiName(), patched.getPiName());
+    assertEquals(study.getPublicVisibility(), patched.getPublicVisibility());
+    assertTrue(study.getProperties().stream().noneMatch(p -> p.getKey().equals(studyType)));
+    assertTrue(
+        study.getProperties().stream().noneMatch(p -> p.getKey().equals(phenotypeIndication)));
+    assertTrue(study.getProperties().stream().noneMatch(p -> p.getKey().equals(species)));
+    assertTrue(
+        study.getProperties().stream().noneMatch(p -> p.getKey().equals(dataCustodianEmail)));
+    assertTrue(
+        study.getProperties().stream()
+            .noneMatch(p -> p.getKey().equals(alternativeDataSharingPlanTargetDeliveryDate)));
+    assertTrue(
+        study.getProperties().stream()
+            .noneMatch(p -> p.getKey().equals(alternativeDataSharingPlanTargetPublicReleaseDate)));
+  }
+
+  @Test
+  void testPatchStudyPIName() throws Exception {
+    Study study = createStudy(null);
+    User user = userDAO.findUserById(study.getCreateUserId());
+    StudyPatch patch =
+        new StudyPatch(
+            null, null, null, null, null, null, randomAlphabetic(10), null, null, null, null);
+    Study patched = serviceDAO.patchStudy(study, user, patch);
+    assertEquals(study.getName(), patched.getName());
+    assertEquals(study.getDescription(), patched.getDescription());
+    assertEquals(study.getDataTypes(), patched.getDataTypes());
+    assertEquals(patch.piName(), patched.getPiName());
+    assertEquals(study.getPublicVisibility(), patched.getPublicVisibility());
+    assertTrue(study.getProperties().stream().noneMatch(p -> p.getKey().equals(studyType)));
+    assertTrue(
+        study.getProperties().stream().noneMatch(p -> p.getKey().equals(phenotypeIndication)));
+    assertTrue(study.getProperties().stream().noneMatch(p -> p.getKey().equals(species)));
+    assertTrue(
+        study.getProperties().stream().noneMatch(p -> p.getKey().equals(dataCustodianEmail)));
+    assertTrue(
+        study.getProperties().stream()
+            .noneMatch(p -> p.getKey().equals(alternativeDataSharingPlanTargetDeliveryDate)));
+    assertTrue(
+        study.getProperties().stream()
+            .noneMatch(p -> p.getKey().equals(alternativeDataSharingPlanTargetPublicReleaseDate)));
+  }
+
+  @Test
+  void testPatchStudyPublicVisibility() throws Exception {
+    Study study = createStudy(null);
+    User user = userDAO.findUserById(study.getCreateUserId());
+    StudyPatch patch =
+        new StudyPatch(null, null, null, null, null, null, null, null, null, null, false);
+    Study patched = serviceDAO.patchStudy(study, user, patch);
+    assertEquals(study.getName(), patched.getName());
+    assertEquals(study.getDescription(), patched.getDescription());
+    assertEquals(study.getDataTypes(), patched.getDataTypes());
+    assertEquals(study.getPiName(), patched.getPiName());
+    assertEquals(patch.publicVisibility(), patched.getPublicVisibility());
+    assertTrue(study.getProperties().stream().noneMatch(p -> p.getKey().equals(studyType)));
+    assertTrue(
+        study.getProperties().stream().noneMatch(p -> p.getKey().equals(phenotypeIndication)));
+    assertTrue(study.getProperties().stream().noneMatch(p -> p.getKey().equals(species)));
+    assertTrue(
+        study.getProperties().stream().noneMatch(p -> p.getKey().equals(dataCustodianEmail)));
+    assertTrue(
+        study.getProperties().stream()
+            .noneMatch(p -> p.getKey().equals(alternativeDataSharingPlanTargetDeliveryDate)));
+    assertTrue(
+        study.getProperties().stream()
+            .noneMatch(p -> p.getKey().equals(alternativeDataSharingPlanTargetPublicReleaseDate)));
+  }
+
+  @Test
+  void testPatchStudyStudyType() throws Exception {
+    Study study = createStudy(null);
+    User user = userDAO.findUserById(study.getCreateUserId());
+    StudyPatch patch =
+        new StudyPatch(
+            null, StudyType.COHORT_STUDY, null, null, null, null, null, null, null, null, null);
+    Study patched = serviceDAO.patchStudy(study, user, patch);
+    assertEquals(study.getName(), patched.getName());
+    assertEquals(study.getDescription(), patched.getDescription());
+    assertEquals(study.getDataTypes(), patched.getDataTypes());
+    assertEquals(study.getPiName(), patched.getPiName());
+    assertEquals(study.getPublicVisibility(), patched.getPublicVisibility());
+    assertEquals(
+        patch.studyType().value(),
+        patched.getProperties().stream()
+            .filter(p -> p.getKey().equals(studyType))
+            .findFirst()
+            .orElseThrow()
+            .getValue());
+    assertTrue(
+        study.getProperties().stream().noneMatch(p -> p.getKey().equals(phenotypeIndication)));
+    assertTrue(study.getProperties().stream().noneMatch(p -> p.getKey().equals(species)));
+    assertTrue(
+        study.getProperties().stream().noneMatch(p -> p.getKey().equals(dataCustodianEmail)));
+    assertTrue(
+        study.getProperties().stream()
+            .noneMatch(p -> p.getKey().equals(alternativeDataSharingPlanTargetDeliveryDate)));
+    assertTrue(
+        study.getProperties().stream()
+            .noneMatch(p -> p.getKey().equals(alternativeDataSharingPlanTargetPublicReleaseDate)));
+  }
+
+  @Test
+  void testPatchStudyPhenotypeIndication() throws Exception {
+    Study study = createStudy(null);
+    User user = userDAO.findUserById(study.getCreateUserId());
+    StudyPatch patch =
+        new StudyPatch(
+            null, null, null, null, randomAlphabetic(10), null, null, null, null, null, null);
+    Study patched = serviceDAO.patchStudy(study, user, patch);
+    assertEquals(study.getName(), patched.getName());
+    assertEquals(study.getDescription(), patched.getDescription());
+    assertEquals(study.getDataTypes(), patched.getDataTypes());
+    assertEquals(study.getPiName(), patched.getPiName());
+    assertEquals(study.getPublicVisibility(), patched.getPublicVisibility());
+    assertTrue(patched.getProperties().stream().noneMatch(p -> p.getKey().equals(studyType)));
+    assertEquals(
+        patch.phenotypeIndication(),
+        patched.getProperties().stream()
+            .filter(p -> p.getKey().equals(phenotypeIndication))
+            .findFirst()
+            .orElseThrow()
+            .getValue());
+    assertTrue(study.getProperties().stream().noneMatch(p -> p.getKey().equals(species)));
+    assertTrue(
+        study.getProperties().stream().noneMatch(p -> p.getKey().equals(dataCustodianEmail)));
+    assertTrue(
+        study.getProperties().stream()
+            .noneMatch(p -> p.getKey().equals(alternativeDataSharingPlanTargetDeliveryDate)));
+    assertTrue(
+        study.getProperties().stream()
+            .noneMatch(p -> p.getKey().equals(alternativeDataSharingPlanTargetPublicReleaseDate)));
+  }
+
+  @Test
+  void testPatchStudySpecies() throws Exception {
+    Study study = createStudy(null);
+    User user = userDAO.findUserById(study.getCreateUserId());
+    StudyPatch patch =
+        new StudyPatch(
+            null, null, null, null, null, randomAlphabetic(10), null, null, null, null, null);
+    Study patched = serviceDAO.patchStudy(study, user, patch);
+    assertEquals(study.getName(), patched.getName());
+    assertEquals(study.getDescription(), patched.getDescription());
+    assertEquals(study.getDataTypes(), patched.getDataTypes());
+    assertEquals(study.getPiName(), patched.getPiName());
+    assertEquals(study.getPublicVisibility(), patched.getPublicVisibility());
+    assertTrue(patched.getProperties().stream().noneMatch(p -> p.getKey().equals(studyType)));
+    assertTrue(
+        study.getProperties().stream().noneMatch(p -> p.getKey().equals(phenotypeIndication)));
+    assertEquals(
+        patch.species(),
+        patched.getProperties().stream()
+            .filter(p -> p.getKey().equals(species))
+            .findFirst()
+            .orElseThrow()
+            .getValue());
+    assertTrue(
+        study.getProperties().stream().noneMatch(p -> p.getKey().equals(dataCustodianEmail)));
+    assertTrue(
+        study.getProperties().stream()
+            .noneMatch(p -> p.getKey().equals(alternativeDataSharingPlanTargetDeliveryDate)));
+    assertTrue(
+        study.getProperties().stream()
+            .noneMatch(p -> p.getKey().equals(alternativeDataSharingPlanTargetPublicReleaseDate)));
+  }
+
+  @Test
+  void testPatchStudyDataCustodianEmail() throws Exception {
+    Study study = createStudy(null);
+    User user = userDAO.findUserById(study.getCreateUserId());
+    StudyPatch patch =
+        new StudyPatch(
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            List.of("email1", "email2"),
+            null,
+            null,
+            null);
+    Study patched = serviceDAO.patchStudy(study, user, patch);
+    assertEquals(study.getName(), patched.getName());
+    assertEquals(study.getDescription(), patched.getDescription());
+    assertEquals(study.getDataTypes(), patched.getDataTypes());
+    assertEquals(study.getPiName(), patched.getPiName());
+    assertEquals(study.getPublicVisibility(), patched.getPublicVisibility());
+    assertTrue(patched.getProperties().stream().noneMatch(p -> p.getKey().equals(studyType)));
+    assertTrue(
+        study.getProperties().stream().noneMatch(p -> p.getKey().equals(phenotypeIndication)));
+    assertTrue(study.getProperties().stream().noneMatch(p -> p.getKey().equals(species)));
+    assertEquals(
+        GsonUtil.getInstance().toJson(patch.dataCustodianEmail()),
+        patched.getProperties().stream()
+            .filter(p -> p.getKey().equals(dataCustodianEmail))
+            .findFirst()
+            .orElseThrow()
+            .getValue()
+            .toString());
+    assertTrue(
+        study.getProperties().stream()
+            .noneMatch(p -> p.getKey().equals(alternativeDataSharingPlanTargetDeliveryDate)));
+    assertTrue(
+        study.getProperties().stream()
+            .noneMatch(p -> p.getKey().equals(alternativeDataSharingPlanTargetPublicReleaseDate)));
+  }
+
+  @Test
+  void testPatchStudyAlternativeDataSharingPlanTargetDeliveryDate() throws Exception {
+    Study study = createStudy(null);
+    User user = userDAO.findUserById(study.getCreateUserId());
+    StudyPatch patch =
+        new StudyPatch(
+            null, null, null, null, null, null, null, null, randomAlphabetic(10), null, null);
+    Study patched = serviceDAO.patchStudy(study, user, patch);
+    assertEquals(study.getName(), patched.getName());
+    assertEquals(study.getDescription(), patched.getDescription());
+    assertEquals(study.getDataTypes(), patched.getDataTypes());
+    assertEquals(study.getPiName(), patched.getPiName());
+    assertEquals(study.getPublicVisibility(), patched.getPublicVisibility());
+    assertTrue(patched.getProperties().stream().noneMatch(p -> p.getKey().equals(studyType)));
+    assertTrue(
+        study.getProperties().stream().noneMatch(p -> p.getKey().equals(phenotypeIndication)));
+    assertTrue(study.getProperties().stream().noneMatch(p -> p.getKey().equals(species)));
+    assertTrue(
+        study.getProperties().stream().noneMatch(p -> p.getKey().equals(dataCustodianEmail)));
+    assertEquals(
+        patch.alternativeDataSharingPlanTargetDeliveryDate(),
+        patched.getProperties().stream()
+            .filter(p -> p.getKey().equals(alternativeDataSharingPlanTargetDeliveryDate))
+            .findFirst()
+            .orElseThrow()
+            .getValue());
+    assertTrue(
+        study.getProperties().stream()
+            .noneMatch(p -> p.getKey().equals(alternativeDataSharingPlanTargetPublicReleaseDate)));
+  }
+
+  @Test
+  void testPatchStudyAlternativeDataSharingPlanTargetPublicReleaseDate() throws Exception {
+    Study study = createStudy(null);
+    User user = userDAO.findUserById(study.getCreateUserId());
+    StudyPatch patch =
+        new StudyPatch(
+            null, null, null, null, null, null, null, null, null, randomAlphabetic(10), null);
+    Study patched = serviceDAO.patchStudy(study, user, patch);
+    assertEquals(study.getName(), patched.getName());
+    assertEquals(study.getDescription(), patched.getDescription());
+    assertEquals(study.getDataTypes(), patched.getDataTypes());
+    assertEquals(study.getPiName(), patched.getPiName());
+    assertEquals(study.getPublicVisibility(), patched.getPublicVisibility());
+    assertTrue(patched.getProperties().stream().noneMatch(p -> p.getKey().equals(studyType)));
+    assertTrue(
+        study.getProperties().stream().noneMatch(p -> p.getKey().equals(phenotypeIndication)));
+    assertTrue(study.getProperties().stream().noneMatch(p -> p.getKey().equals(species)));
+    assertTrue(
+        study.getProperties().stream().noneMatch(p -> p.getKey().equals(dataCustodianEmail)));
+    assertTrue(
+        study.getProperties().stream()
+            .noneMatch(p -> p.getKey().equals(alternativeDataSharingPlanTargetDeliveryDate)));
+    assertEquals(
+        patch.alternativeDataSharingPlanTargetPublicReleaseDate(),
+        patched.getProperties().stream()
+            .filter(p -> p.getKey().equals(alternativeDataSharingPlanTargetPublicReleaseDate))
+            .findFirst()
+            .orElseThrow()
+            .getValue());
   }
 
   /**

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAOTest.java
@@ -1119,6 +1119,33 @@ class DatasetServiceDAOTest extends DAOTestHelper {
   }
 
   @Test
+  void testPatchStudyNoChanges() throws Exception {
+    Study study = createStudy(null);
+    User user = userDAO.findUserById(study.getCreateUserId());
+    StudyPatch patch =
+        new StudyPatch(
+            null, null, null, null, null, null, null, null, null, null, null);
+    Study patched = serviceDAO.patchStudy(study, user, patch);
+    assertEquals(study.getName(), patched.getName());
+    assertEquals(study.getDescription(), patched.getDescription());
+    assertEquals(study.getDataTypes(), patched.getDataTypes());
+    assertEquals(study.getPiName(), patched.getPiName());
+    assertEquals(study.getPublicVisibility(), patched.getPublicVisibility());
+    assertTrue(study.getProperties().stream().noneMatch(p -> p.getKey().equals(studyType)));
+    assertTrue(
+        study.getProperties().stream().noneMatch(p -> p.getKey().equals(phenotypeIndication)));
+    assertTrue(study.getProperties().stream().noneMatch(p -> p.getKey().equals(species)));
+    assertTrue(
+        study.getProperties().stream().noneMatch(p -> p.getKey().equals(dataCustodianEmail)));
+    assertTrue(
+        study.getProperties().stream()
+            .noneMatch(p -> p.getKey().equals(alternativeDataSharingPlanTargetDeliveryDate)));
+    assertTrue(
+        study.getProperties().stream()
+            .noneMatch(p -> p.getKey().equals(alternativeDataSharingPlanTargetPublicReleaseDate)));
+  }
+
+  @Test
   void testPatchStudyName() throws Exception {
     Study study = createStudy(null);
     User user = userDAO.findUserById(study.getCreateUserId());

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAOTest.java
@@ -1,11 +1,11 @@
 package org.broadinstitute.consent.http.service.dao;
 
-import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.alternativeDataSharingPlanTargetDeliveryDate;
-import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.alternativeDataSharingPlanTargetPublicReleaseDate;
-import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.dataCustodianEmail;
-import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.phenotypeIndication;
-import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.species;
-import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.studyType;
+import static org.broadinstitute.consent.http.models.StudyPatch.ALTERNATIVE_DATA_SHARING_PLAN_TARGET_DELIVERY_DATE;
+import static org.broadinstitute.consent.http.models.StudyPatch.ALTERNATIVE_DATA_SHARING_PLAN_TARGET_PUBLIC_RELEASE_DATE;
+import static org.broadinstitute.consent.http.models.StudyPatch.DATA_CUSTODIAN_EMAIL;
+import static org.broadinstitute.consent.http.models.StudyPatch.PHENOTYPE_INDICATION;
+import static org.broadinstitute.consent.http.models.StudyPatch.SPECIES_KEY;
+import static org.broadinstitute.consent.http.models.StudyPatch.STUDY_TYPE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -1076,28 +1076,28 @@ class DatasetServiceDAOTest extends DAOTestHelper {
     assertEquals(
         patch.studyType().value(),
         patched.getProperties().stream()
-            .filter(p -> p.getKey().equals(studyType))
+            .filter(p -> p.getKey().equals(STUDY_TYPE))
             .findFirst()
             .orElseThrow()
             .getValue());
     assertEquals(
         patch.phenotypeIndication(),
         patched.getProperties().stream()
-            .filter(p -> p.getKey().equals(phenotypeIndication))
+            .filter(p -> p.getKey().equals(PHENOTYPE_INDICATION))
             .findFirst()
             .orElseThrow()
             .getValue());
     assertEquals(
         patch.species(),
         patched.getProperties().stream()
-            .filter(p -> p.getKey().equals(species))
+            .filter(p -> p.getKey().equals(SPECIES_KEY))
             .findFirst()
             .orElseThrow()
             .getValue());
     assertEquals(
         GsonUtil.getInstance().toJson(patch.dataCustodianEmail()),
         patched.getProperties().stream()
-            .filter(p -> p.getKey().equals(dataCustodianEmail))
+            .filter(p -> p.getKey().equals(DATA_CUSTODIAN_EMAIL))
             .findFirst()
             .orElseThrow()
             .getValue()
@@ -1105,14 +1105,15 @@ class DatasetServiceDAOTest extends DAOTestHelper {
     assertEquals(
         patch.alternativeDataSharingPlanTargetDeliveryDate(),
         patched.getProperties().stream()
-            .filter(p -> p.getKey().equals(alternativeDataSharingPlanTargetDeliveryDate))
+            .filter(p -> p.getKey().equals(ALTERNATIVE_DATA_SHARING_PLAN_TARGET_DELIVERY_DATE))
             .findFirst()
             .orElseThrow()
             .getValue());
     assertEquals(
         patch.alternativeDataSharingPlanTargetPublicReleaseDate(),
         patched.getProperties().stream()
-            .filter(p -> p.getKey().equals(alternativeDataSharingPlanTargetPublicReleaseDate))
+            .filter(
+                p -> p.getKey().equals(ALTERNATIVE_DATA_SHARING_PLAN_TARGET_PUBLIC_RELEASE_DATE))
             .findFirst()
             .orElseThrow()
             .getValue());
@@ -1130,18 +1131,19 @@ class DatasetServiceDAOTest extends DAOTestHelper {
     assertEquals(study.getDataTypes(), patched.getDataTypes());
     assertEquals(study.getPiName(), patched.getPiName());
     assertEquals(study.getPublicVisibility(), patched.getPublicVisibility());
-    assertTrue(study.getProperties().stream().noneMatch(p -> p.getKey().equals(studyType)));
+    assertTrue(study.getProperties().stream().noneMatch(p -> p.getKey().equals(STUDY_TYPE)));
     assertTrue(
-        study.getProperties().stream().noneMatch(p -> p.getKey().equals(phenotypeIndication)));
-    assertTrue(study.getProperties().stream().noneMatch(p -> p.getKey().equals(species)));
+        study.getProperties().stream().noneMatch(p -> p.getKey().equals(PHENOTYPE_INDICATION)));
+    assertTrue(study.getProperties().stream().noneMatch(p -> p.getKey().equals(SPECIES_KEY)));
     assertTrue(
-        study.getProperties().stream().noneMatch(p -> p.getKey().equals(dataCustodianEmail)));
-    assertTrue(
-        study.getProperties().stream()
-            .noneMatch(p -> p.getKey().equals(alternativeDataSharingPlanTargetDeliveryDate)));
+        study.getProperties().stream().noneMatch(p -> p.getKey().equals(DATA_CUSTODIAN_EMAIL)));
     assertTrue(
         study.getProperties().stream()
-            .noneMatch(p -> p.getKey().equals(alternativeDataSharingPlanTargetPublicReleaseDate)));
+            .noneMatch(p -> p.getKey().equals(ALTERNATIVE_DATA_SHARING_PLAN_TARGET_DELIVERY_DATE)));
+    assertTrue(
+        study.getProperties().stream()
+            .noneMatch(
+                p -> p.getKey().equals(ALTERNATIVE_DATA_SHARING_PLAN_TARGET_PUBLIC_RELEASE_DATE)));
   }
 
   @Test
@@ -1157,18 +1159,19 @@ class DatasetServiceDAOTest extends DAOTestHelper {
     assertEquals(study.getDataTypes(), patched.getDataTypes());
     assertEquals(study.getPiName(), patched.getPiName());
     assertEquals(study.getPublicVisibility(), patched.getPublicVisibility());
-    assertTrue(study.getProperties().stream().noneMatch(p -> p.getKey().equals(studyType)));
+    assertTrue(study.getProperties().stream().noneMatch(p -> p.getKey().equals(STUDY_TYPE)));
     assertTrue(
-        study.getProperties().stream().noneMatch(p -> p.getKey().equals(phenotypeIndication)));
-    assertTrue(study.getProperties().stream().noneMatch(p -> p.getKey().equals(species)));
+        study.getProperties().stream().noneMatch(p -> p.getKey().equals(PHENOTYPE_INDICATION)));
+    assertTrue(study.getProperties().stream().noneMatch(p -> p.getKey().equals(SPECIES_KEY)));
     assertTrue(
-        study.getProperties().stream().noneMatch(p -> p.getKey().equals(dataCustodianEmail)));
-    assertTrue(
-        study.getProperties().stream()
-            .noneMatch(p -> p.getKey().equals(alternativeDataSharingPlanTargetDeliveryDate)));
+        study.getProperties().stream().noneMatch(p -> p.getKey().equals(DATA_CUSTODIAN_EMAIL)));
     assertTrue(
         study.getProperties().stream()
-            .noneMatch(p -> p.getKey().equals(alternativeDataSharingPlanTargetPublicReleaseDate)));
+            .noneMatch(p -> p.getKey().equals(ALTERNATIVE_DATA_SHARING_PLAN_TARGET_DELIVERY_DATE)));
+    assertTrue(
+        study.getProperties().stream()
+            .noneMatch(
+                p -> p.getKey().equals(ALTERNATIVE_DATA_SHARING_PLAN_TARGET_PUBLIC_RELEASE_DATE)));
   }
 
   @Test
@@ -1184,18 +1187,19 @@ class DatasetServiceDAOTest extends DAOTestHelper {
     assertEquals(study.getDataTypes(), patched.getDataTypes());
     assertEquals(study.getPiName(), patched.getPiName());
     assertEquals(study.getPublicVisibility(), patched.getPublicVisibility());
-    assertTrue(study.getProperties().stream().noneMatch(p -> p.getKey().equals(studyType)));
+    assertTrue(study.getProperties().stream().noneMatch(p -> p.getKey().equals(STUDY_TYPE)));
     assertTrue(
-        study.getProperties().stream().noneMatch(p -> p.getKey().equals(phenotypeIndication)));
-    assertTrue(study.getProperties().stream().noneMatch(p -> p.getKey().equals(species)));
+        study.getProperties().stream().noneMatch(p -> p.getKey().equals(PHENOTYPE_INDICATION)));
+    assertTrue(study.getProperties().stream().noneMatch(p -> p.getKey().equals(SPECIES_KEY)));
     assertTrue(
-        study.getProperties().stream().noneMatch(p -> p.getKey().equals(dataCustodianEmail)));
-    assertTrue(
-        study.getProperties().stream()
-            .noneMatch(p -> p.getKey().equals(alternativeDataSharingPlanTargetDeliveryDate)));
+        study.getProperties().stream().noneMatch(p -> p.getKey().equals(DATA_CUSTODIAN_EMAIL)));
     assertTrue(
         study.getProperties().stream()
-            .noneMatch(p -> p.getKey().equals(alternativeDataSharingPlanTargetPublicReleaseDate)));
+            .noneMatch(p -> p.getKey().equals(ALTERNATIVE_DATA_SHARING_PLAN_TARGET_DELIVERY_DATE)));
+    assertTrue(
+        study.getProperties().stream()
+            .noneMatch(
+                p -> p.getKey().equals(ALTERNATIVE_DATA_SHARING_PLAN_TARGET_PUBLIC_RELEASE_DATE)));
   }
 
   @Test
@@ -1211,18 +1215,19 @@ class DatasetServiceDAOTest extends DAOTestHelper {
     assertEquals(patch.dataTypes(), patched.getDataTypes());
     assertEquals(study.getPiName(), patched.getPiName());
     assertEquals(study.getPublicVisibility(), patched.getPublicVisibility());
-    assertTrue(study.getProperties().stream().noneMatch(p -> p.getKey().equals(studyType)));
+    assertTrue(study.getProperties().stream().noneMatch(p -> p.getKey().equals(STUDY_TYPE)));
     assertTrue(
-        study.getProperties().stream().noneMatch(p -> p.getKey().equals(phenotypeIndication)));
-    assertTrue(study.getProperties().stream().noneMatch(p -> p.getKey().equals(species)));
+        study.getProperties().stream().noneMatch(p -> p.getKey().equals(PHENOTYPE_INDICATION)));
+    assertTrue(study.getProperties().stream().noneMatch(p -> p.getKey().equals(SPECIES_KEY)));
     assertTrue(
-        study.getProperties().stream().noneMatch(p -> p.getKey().equals(dataCustodianEmail)));
-    assertTrue(
-        study.getProperties().stream()
-            .noneMatch(p -> p.getKey().equals(alternativeDataSharingPlanTargetDeliveryDate)));
+        study.getProperties().stream().noneMatch(p -> p.getKey().equals(DATA_CUSTODIAN_EMAIL)));
     assertTrue(
         study.getProperties().stream()
-            .noneMatch(p -> p.getKey().equals(alternativeDataSharingPlanTargetPublicReleaseDate)));
+            .noneMatch(p -> p.getKey().equals(ALTERNATIVE_DATA_SHARING_PLAN_TARGET_DELIVERY_DATE)));
+    assertTrue(
+        study.getProperties().stream()
+            .noneMatch(
+                p -> p.getKey().equals(ALTERNATIVE_DATA_SHARING_PLAN_TARGET_PUBLIC_RELEASE_DATE)));
   }
 
   @Test
@@ -1238,18 +1243,19 @@ class DatasetServiceDAOTest extends DAOTestHelper {
     assertEquals(study.getDataTypes(), patched.getDataTypes());
     assertEquals(patch.piName(), patched.getPiName());
     assertEquals(study.getPublicVisibility(), patched.getPublicVisibility());
-    assertTrue(study.getProperties().stream().noneMatch(p -> p.getKey().equals(studyType)));
+    assertTrue(study.getProperties().stream().noneMatch(p -> p.getKey().equals(STUDY_TYPE)));
     assertTrue(
-        study.getProperties().stream().noneMatch(p -> p.getKey().equals(phenotypeIndication)));
-    assertTrue(study.getProperties().stream().noneMatch(p -> p.getKey().equals(species)));
+        study.getProperties().stream().noneMatch(p -> p.getKey().equals(PHENOTYPE_INDICATION)));
+    assertTrue(study.getProperties().stream().noneMatch(p -> p.getKey().equals(SPECIES_KEY)));
     assertTrue(
-        study.getProperties().stream().noneMatch(p -> p.getKey().equals(dataCustodianEmail)));
-    assertTrue(
-        study.getProperties().stream()
-            .noneMatch(p -> p.getKey().equals(alternativeDataSharingPlanTargetDeliveryDate)));
+        study.getProperties().stream().noneMatch(p -> p.getKey().equals(DATA_CUSTODIAN_EMAIL)));
     assertTrue(
         study.getProperties().stream()
-            .noneMatch(p -> p.getKey().equals(alternativeDataSharingPlanTargetPublicReleaseDate)));
+            .noneMatch(p -> p.getKey().equals(ALTERNATIVE_DATA_SHARING_PLAN_TARGET_DELIVERY_DATE)));
+    assertTrue(
+        study.getProperties().stream()
+            .noneMatch(
+                p -> p.getKey().equals(ALTERNATIVE_DATA_SHARING_PLAN_TARGET_PUBLIC_RELEASE_DATE)));
   }
 
   @Test
@@ -1264,18 +1270,19 @@ class DatasetServiceDAOTest extends DAOTestHelper {
     assertEquals(study.getDataTypes(), patched.getDataTypes());
     assertEquals(study.getPiName(), patched.getPiName());
     assertEquals(patch.publicVisibility(), patched.getPublicVisibility());
-    assertTrue(study.getProperties().stream().noneMatch(p -> p.getKey().equals(studyType)));
+    assertTrue(study.getProperties().stream().noneMatch(p -> p.getKey().equals(STUDY_TYPE)));
     assertTrue(
-        study.getProperties().stream().noneMatch(p -> p.getKey().equals(phenotypeIndication)));
-    assertTrue(study.getProperties().stream().noneMatch(p -> p.getKey().equals(species)));
+        study.getProperties().stream().noneMatch(p -> p.getKey().equals(PHENOTYPE_INDICATION)));
+    assertTrue(study.getProperties().stream().noneMatch(p -> p.getKey().equals(SPECIES_KEY)));
     assertTrue(
-        study.getProperties().stream().noneMatch(p -> p.getKey().equals(dataCustodianEmail)));
-    assertTrue(
-        study.getProperties().stream()
-            .noneMatch(p -> p.getKey().equals(alternativeDataSharingPlanTargetDeliveryDate)));
+        study.getProperties().stream().noneMatch(p -> p.getKey().equals(DATA_CUSTODIAN_EMAIL)));
     assertTrue(
         study.getProperties().stream()
-            .noneMatch(p -> p.getKey().equals(alternativeDataSharingPlanTargetPublicReleaseDate)));
+            .noneMatch(p -> p.getKey().equals(ALTERNATIVE_DATA_SHARING_PLAN_TARGET_DELIVERY_DATE)));
+    assertTrue(
+        study.getProperties().stream()
+            .noneMatch(
+                p -> p.getKey().equals(ALTERNATIVE_DATA_SHARING_PLAN_TARGET_PUBLIC_RELEASE_DATE)));
   }
 
   @Test
@@ -1294,21 +1301,22 @@ class DatasetServiceDAOTest extends DAOTestHelper {
     assertEquals(
         patch.studyType().value(),
         patched.getProperties().stream()
-            .filter(p -> p.getKey().equals(studyType))
+            .filter(p -> p.getKey().equals(STUDY_TYPE))
             .findFirst()
             .orElseThrow()
             .getValue());
     assertTrue(
-        study.getProperties().stream().noneMatch(p -> p.getKey().equals(phenotypeIndication)));
-    assertTrue(study.getProperties().stream().noneMatch(p -> p.getKey().equals(species)));
+        study.getProperties().stream().noneMatch(p -> p.getKey().equals(PHENOTYPE_INDICATION)));
+    assertTrue(study.getProperties().stream().noneMatch(p -> p.getKey().equals(SPECIES_KEY)));
     assertTrue(
-        study.getProperties().stream().noneMatch(p -> p.getKey().equals(dataCustodianEmail)));
-    assertTrue(
-        study.getProperties().stream()
-            .noneMatch(p -> p.getKey().equals(alternativeDataSharingPlanTargetDeliveryDate)));
+        study.getProperties().stream().noneMatch(p -> p.getKey().equals(DATA_CUSTODIAN_EMAIL)));
     assertTrue(
         study.getProperties().stream()
-            .noneMatch(p -> p.getKey().equals(alternativeDataSharingPlanTargetPublicReleaseDate)));
+            .noneMatch(p -> p.getKey().equals(ALTERNATIVE_DATA_SHARING_PLAN_TARGET_DELIVERY_DATE)));
+    assertTrue(
+        study.getProperties().stream()
+            .noneMatch(
+                p -> p.getKey().equals(ALTERNATIVE_DATA_SHARING_PLAN_TARGET_PUBLIC_RELEASE_DATE)));
   }
 
   @Test
@@ -1324,23 +1332,24 @@ class DatasetServiceDAOTest extends DAOTestHelper {
     assertEquals(study.getDataTypes(), patched.getDataTypes());
     assertEquals(study.getPiName(), patched.getPiName());
     assertEquals(study.getPublicVisibility(), patched.getPublicVisibility());
-    assertTrue(patched.getProperties().stream().noneMatch(p -> p.getKey().equals(studyType)));
+    assertTrue(patched.getProperties().stream().noneMatch(p -> p.getKey().equals(STUDY_TYPE)));
     assertEquals(
         patch.phenotypeIndication(),
         patched.getProperties().stream()
-            .filter(p -> p.getKey().equals(phenotypeIndication))
+            .filter(p -> p.getKey().equals(PHENOTYPE_INDICATION))
             .findFirst()
             .orElseThrow()
             .getValue());
-    assertTrue(study.getProperties().stream().noneMatch(p -> p.getKey().equals(species)));
+    assertTrue(study.getProperties().stream().noneMatch(p -> p.getKey().equals(SPECIES_KEY)));
     assertTrue(
-        study.getProperties().stream().noneMatch(p -> p.getKey().equals(dataCustodianEmail)));
-    assertTrue(
-        study.getProperties().stream()
-            .noneMatch(p -> p.getKey().equals(alternativeDataSharingPlanTargetDeliveryDate)));
+        study.getProperties().stream().noneMatch(p -> p.getKey().equals(DATA_CUSTODIAN_EMAIL)));
     assertTrue(
         study.getProperties().stream()
-            .noneMatch(p -> p.getKey().equals(alternativeDataSharingPlanTargetPublicReleaseDate)));
+            .noneMatch(p -> p.getKey().equals(ALTERNATIVE_DATA_SHARING_PLAN_TARGET_DELIVERY_DATE)));
+    assertTrue(
+        study.getProperties().stream()
+            .noneMatch(
+                p -> p.getKey().equals(ALTERNATIVE_DATA_SHARING_PLAN_TARGET_PUBLIC_RELEASE_DATE)));
   }
 
   @Test
@@ -1356,24 +1365,25 @@ class DatasetServiceDAOTest extends DAOTestHelper {
     assertEquals(study.getDataTypes(), patched.getDataTypes());
     assertEquals(study.getPiName(), patched.getPiName());
     assertEquals(study.getPublicVisibility(), patched.getPublicVisibility());
-    assertTrue(patched.getProperties().stream().noneMatch(p -> p.getKey().equals(studyType)));
+    assertTrue(patched.getProperties().stream().noneMatch(p -> p.getKey().equals(STUDY_TYPE)));
     assertTrue(
-        study.getProperties().stream().noneMatch(p -> p.getKey().equals(phenotypeIndication)));
+        study.getProperties().stream().noneMatch(p -> p.getKey().equals(PHENOTYPE_INDICATION)));
     assertEquals(
         patch.species(),
         patched.getProperties().stream()
-            .filter(p -> p.getKey().equals(species))
+            .filter(p -> p.getKey().equals(SPECIES_KEY))
             .findFirst()
             .orElseThrow()
             .getValue());
     assertTrue(
-        study.getProperties().stream().noneMatch(p -> p.getKey().equals(dataCustodianEmail)));
+        study.getProperties().stream().noneMatch(p -> p.getKey().equals(DATA_CUSTODIAN_EMAIL)));
     assertTrue(
         study.getProperties().stream()
-            .noneMatch(p -> p.getKey().equals(alternativeDataSharingPlanTargetDeliveryDate)));
+            .noneMatch(p -> p.getKey().equals(ALTERNATIVE_DATA_SHARING_PLAN_TARGET_DELIVERY_DATE)));
     assertTrue(
         study.getProperties().stream()
-            .noneMatch(p -> p.getKey().equals(alternativeDataSharingPlanTargetPublicReleaseDate)));
+            .noneMatch(
+                p -> p.getKey().equals(ALTERNATIVE_DATA_SHARING_PLAN_TARGET_PUBLIC_RELEASE_DATE)));
   }
 
   @Test
@@ -1399,24 +1409,25 @@ class DatasetServiceDAOTest extends DAOTestHelper {
     assertEquals(study.getDataTypes(), patched.getDataTypes());
     assertEquals(study.getPiName(), patched.getPiName());
     assertEquals(study.getPublicVisibility(), patched.getPublicVisibility());
-    assertTrue(patched.getProperties().stream().noneMatch(p -> p.getKey().equals(studyType)));
+    assertTrue(patched.getProperties().stream().noneMatch(p -> p.getKey().equals(STUDY_TYPE)));
     assertTrue(
-        study.getProperties().stream().noneMatch(p -> p.getKey().equals(phenotypeIndication)));
-    assertTrue(study.getProperties().stream().noneMatch(p -> p.getKey().equals(species)));
+        study.getProperties().stream().noneMatch(p -> p.getKey().equals(PHENOTYPE_INDICATION)));
+    assertTrue(study.getProperties().stream().noneMatch(p -> p.getKey().equals(SPECIES_KEY)));
     assertEquals(
         GsonUtil.getInstance().toJson(patch.dataCustodianEmail()),
         patched.getProperties().stream()
-            .filter(p -> p.getKey().equals(dataCustodianEmail))
+            .filter(p -> p.getKey().equals(DATA_CUSTODIAN_EMAIL))
             .findFirst()
             .orElseThrow()
             .getValue()
             .toString());
     assertTrue(
         study.getProperties().stream()
-            .noneMatch(p -> p.getKey().equals(alternativeDataSharingPlanTargetDeliveryDate)));
+            .noneMatch(p -> p.getKey().equals(ALTERNATIVE_DATA_SHARING_PLAN_TARGET_DELIVERY_DATE)));
     assertTrue(
         study.getProperties().stream()
-            .noneMatch(p -> p.getKey().equals(alternativeDataSharingPlanTargetPublicReleaseDate)));
+            .noneMatch(
+                p -> p.getKey().equals(ALTERNATIVE_DATA_SHARING_PLAN_TARGET_PUBLIC_RELEASE_DATE)));
   }
 
   @Test
@@ -1432,22 +1443,23 @@ class DatasetServiceDAOTest extends DAOTestHelper {
     assertEquals(study.getDataTypes(), patched.getDataTypes());
     assertEquals(study.getPiName(), patched.getPiName());
     assertEquals(study.getPublicVisibility(), patched.getPublicVisibility());
-    assertTrue(patched.getProperties().stream().noneMatch(p -> p.getKey().equals(studyType)));
+    assertTrue(patched.getProperties().stream().noneMatch(p -> p.getKey().equals(STUDY_TYPE)));
     assertTrue(
-        study.getProperties().stream().noneMatch(p -> p.getKey().equals(phenotypeIndication)));
-    assertTrue(study.getProperties().stream().noneMatch(p -> p.getKey().equals(species)));
+        study.getProperties().stream().noneMatch(p -> p.getKey().equals(PHENOTYPE_INDICATION)));
+    assertTrue(study.getProperties().stream().noneMatch(p -> p.getKey().equals(SPECIES_KEY)));
     assertTrue(
-        study.getProperties().stream().noneMatch(p -> p.getKey().equals(dataCustodianEmail)));
+        study.getProperties().stream().noneMatch(p -> p.getKey().equals(DATA_CUSTODIAN_EMAIL)));
     assertEquals(
         patch.alternativeDataSharingPlanTargetDeliveryDate(),
         patched.getProperties().stream()
-            .filter(p -> p.getKey().equals(alternativeDataSharingPlanTargetDeliveryDate))
+            .filter(p -> p.getKey().equals(ALTERNATIVE_DATA_SHARING_PLAN_TARGET_DELIVERY_DATE))
             .findFirst()
             .orElseThrow()
             .getValue());
     assertTrue(
         study.getProperties().stream()
-            .noneMatch(p -> p.getKey().equals(alternativeDataSharingPlanTargetPublicReleaseDate)));
+            .noneMatch(
+                p -> p.getKey().equals(ALTERNATIVE_DATA_SHARING_PLAN_TARGET_PUBLIC_RELEASE_DATE)));
   }
 
   @Test
@@ -1463,19 +1475,20 @@ class DatasetServiceDAOTest extends DAOTestHelper {
     assertEquals(study.getDataTypes(), patched.getDataTypes());
     assertEquals(study.getPiName(), patched.getPiName());
     assertEquals(study.getPublicVisibility(), patched.getPublicVisibility());
-    assertTrue(patched.getProperties().stream().noneMatch(p -> p.getKey().equals(studyType)));
+    assertTrue(patched.getProperties().stream().noneMatch(p -> p.getKey().equals(STUDY_TYPE)));
     assertTrue(
-        study.getProperties().stream().noneMatch(p -> p.getKey().equals(phenotypeIndication)));
-    assertTrue(study.getProperties().stream().noneMatch(p -> p.getKey().equals(species)));
+        study.getProperties().stream().noneMatch(p -> p.getKey().equals(PHENOTYPE_INDICATION)));
+    assertTrue(study.getProperties().stream().noneMatch(p -> p.getKey().equals(SPECIES_KEY)));
     assertTrue(
-        study.getProperties().stream().noneMatch(p -> p.getKey().equals(dataCustodianEmail)));
+        study.getProperties().stream().noneMatch(p -> p.getKey().equals(DATA_CUSTODIAN_EMAIL)));
     assertTrue(
         study.getProperties().stream()
-            .noneMatch(p -> p.getKey().equals(alternativeDataSharingPlanTargetDeliveryDate)));
+            .noneMatch(p -> p.getKey().equals(ALTERNATIVE_DATA_SHARING_PLAN_TARGET_DELIVERY_DATE)));
     assertEquals(
         patch.alternativeDataSharingPlanTargetPublicReleaseDate(),
         patched.getProperties().stream()
-            .filter(p -> p.getKey().equals(alternativeDataSharingPlanTargetPublicReleaseDate))
+            .filter(
+                p -> p.getKey().equals(ALTERNATIVE_DATA_SHARING_PLAN_TARGET_PUBLIC_RELEASE_DATE))
             .findFirst()
             .orElseThrow()
             .getValue());

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAOTest.java
@@ -1123,8 +1123,7 @@ class DatasetServiceDAOTest extends DAOTestHelper {
     Study study = createStudy(null);
     User user = userDAO.findUserById(study.getCreateUserId());
     StudyPatch patch =
-        new StudyPatch(
-            null, null, null, null, null, null, null, null, null, null, null);
+        new StudyPatch(null, null, null, null, null, null, null, null, null, null, null);
     Study patched = serviceDAO.patchStudy(study, user, patch);
     assertEquals(study.getName(), patched.getName());
     assertEquals(study.getDescription(), patched.getDescription());


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DT-2519

## Summary
  This PATCH API allows for admins, chairs, and data submitters to patch a set of selected values on a study. The top level field values patchable are:
* Study name
* Study description
* Study datatypes (list of strings)
* Study PI Name
* Study public visibility (boolean)

Additionally, these study properties can be modified:
* Study Type (enum that must match a value in the current [schema](https://github.com/DataBiosphere/consent/blob/develop/src/main/resources/dataset-registration-schema_v1.json#L113))
* Phenotype Indication
* Data Custodian Email (this replicates and makes redundant `PUT /api/dataset/study/{studyId}/custodians`)
* Target Delivery Date
* Target Public Release Date

### Reviewer Notes
* I chose to use Jackson to strictly validate the input json because similar configuration functionality is missing from Gson.
* The current UI shows the two target dates as unrelated to alternative data file sharing plan, but the fields are saved as `alternativeDataSharingPlanTargetDeliveryDate` and `alternativeDataSharingPlanTargetPublicReleaseDate`:
<img width="1721" height="881" alt="Screenshot 2025-12-03 at 9 48 02 AM" src="https://github.com/user-attachments/assets/771194cc-dc8c-49fa-8ab3-7ac76b1755e1" />


----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
