### PR TITLE
[DT-2470] Upgrade to ElasticSearch 9

### DIFF
--- a/DEVNOTES.md
+++ b/DEVNOTES.md
@@ -73,15 +73,15 @@ Update the compose file to include a new section for an ES instance:
 
 ```
 es:
-  image: docker.elastic.co/elasticsearch/elasticsearch:5.5.0
+  image: docker.elastic.co/elasticsearch/elasticsearch:9
   ports:
     - "9200:9200"
   volumes:
     - ../data:/usr/share/elasticsearch/data
   environment:
-    transport.host: 127.0.0.1
-    xpack.security.enabled: "false"
-    http.host: 0.0.0.0
+    - xpack.security.enabled=false
+    - discovery.type=single-node
+    - cluster.routing.allocation.disk.threshold_enabled=false
 ```
 
 Add a line to the `app` section to link to that:

--- a/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
@@ -91,12 +91,12 @@ public class ElasticSearchService implements ConsentLogger {
 
   private static final String BULK_HEADER =
       """
-      { "index": {"_type": "dataset", "_id": "%d"} }
+      { "index": {"_index": "dataset", "_id": "%d"} }
       """;
 
   private static final String DELETE_QUERY =
       """
-      { "query": { "bool": { "must": [ { "match": { "_type": "dataset" } }, { "match": { "_id": "%d" } } ] } } }
+      { "query": { "terms": { "_id": ["%d"] } } }
       """;
 
   private Response performRequest(Request request) throws IOException {

--- a/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
@@ -193,7 +193,7 @@ public class ElasticSearchService implements ConsentLogger {
   }
 
   public InputStream searchDatasetsStream(String query) throws IOException {
-    if (!validateQuery(query)) {
+    if (invalidResultWindow(query)) {
       throw new IOException("Invalid Elasticsearch query");
     }
     Request searchRequest =

--- a/src/main/resources/assets/paths/datasetSearchIndex.yaml
+++ b/src/main/resources/assets/paths/datasetSearchIndex.yaml
@@ -19,7 +19,7 @@ post:
                 bool:
                   must:
                     - match:
-                        _type: dataset
+                        _index: dataset
                     - match:
                         _id: 1440
           example2:
@@ -31,7 +31,7 @@ post:
                 bool:
                   must:
                     - match:
-                        _type: dataset
+                        _index: dataset
                     - exists:
                         field: study
   tags:

--- a/src/main/resources/assets/paths/datasetSearchIndexV2.yaml
+++ b/src/main/resources/assets/paths/datasetSearchIndexV2.yaml
@@ -22,7 +22,7 @@ post:
                 bool:
                   must:
                     - match:
-                        _type: dataset
+                        _index: dataset
                     - match:
                         _id: 1440
           example2:
@@ -34,7 +34,7 @@ post:
                 bool:
                   must:
                     - match:
-                        _type: dataset
+                        _index: dataset
                     - exists:
                         field: study
   tags:

--- a/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
@@ -536,9 +536,9 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
       assertEquals("PUT", capturedRequest.getMethod());
       assertEquals(
           """
-              { "index": {"_type": "dataset", "_id": "1"} }
+              { "index": {"_index": "dataset", "_id": "1"} }
               {"datasetId":1}
-              { "index": {"_type": "dataset", "_id": "2"} }
+              { "index": {"_index": "dataset", "_id": "2"} }
               {"datasetId":2}
 
               """,


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2470

### Summary

Similar to #2755 , using ElasticSearch instead. Here is what is needed in the `docker-compose.yaml`:

```
  elastic:
    image: elasticsearch:9.2.1
    ports:
      - "9200:9200"
    container_name: elastic
    volumes:
      - ./data:/usr/share/elasticsearch/data
    environment:
      - xpack.security.enabled=false
      - discovery.type=single-node
      - cluster.routing.allocation.disk.threshold_enabled=false
```

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
