### PR TITLE
[DT-2502] Require Dataset Names and Enforce Not-Null Constraint

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetRegistrationService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetRegistrationService.java
@@ -294,6 +294,11 @@ public class DatasetRegistrationService implements ConsentLogger {
       throws IOException {
     ConsentGroup consentGroup = registration.getConsentGroups().get(consentGroupIdx);
 
+    if (Objects.isNull(consentGroup.getConsentGroupName())
+        || consentGroup.getConsentGroupName().isBlank()) {
+      throw new BadRequestException("Consent Group Name is required");
+    }
+
     if (Objects.nonNull(consentGroup.getDataAccessCommitteeId())
         && Objects.isNull(dacDAO.findById(consentGroup.getDataAccessCommitteeId()))) {
       throw new NotFoundException("Could not find DAC");

--- a/src/main/resources/changelog-master.xml
+++ b/src/main/resources/changelog-master.xml
@@ -210,4 +210,6 @@
     relativeToChangelogFile="true" />
   <include file="changesets/changelog-consent-2025-11-03-drop-sort-date-column.xml"
     relativeToChangelogFile="true" />
+  <include file="changesets/changelog-consent-2025-12-02-alter-dataset-name-column.xml"
+    relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/src/main/resources/changesets/changelog-consent-2025-12-02-alter-dataset-name-column.xml
+++ b/src/main/resources/changesets/changelog-consent-2025-12-02-alter-dataset-name-column.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+  <changeSet id="changelog-consent-2025-12-02-alter-dataset-name-column" author="kevinmarete">
+    <comment>
+      Alter name column in dataset table to be not nullable.
+      The name field is a required property in the Dataset model.
+    </comment>
+    <addNotNullConstraint tableName="dataset" columnName="name" columnDataType="VARCHAR(255)"/>
+  </changeSet>
+</databaseChangeLog>

--- a/src/test/java/org/broadinstitute/consent/http/service/DatasetRegistrationServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DatasetRegistrationServiceTest.java
@@ -20,9 +20,11 @@ import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.ServerErrorException;
 import jakarta.ws.rs.core.MediaType;
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.sql.SQLException;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -939,11 +941,7 @@ class DatasetRegistrationServiceTest {
 
     initService();
 
-    assertThrows(
-        BadRequestException.class,
-        () -> {
-          datasetRegistrationService.createDatasetsFromRegistration(schema, user, Map.of());
-        });
+    assertThrows(BadRequestException.class, () -> invokeCreateRegistration(schema, user));
   }
 
   @Test
@@ -956,10 +954,11 @@ class DatasetRegistrationServiceTest {
 
     initService();
 
-    assertThrows(
-        BadRequestException.class,
-        () -> {
-          datasetRegistrationService.createDatasetsFromRegistration(schema, user, Map.of());
-        });
+    assertThrows(BadRequestException.class, () -> invokeCreateRegistration(schema, user));
+  }
+
+  private void invokeCreateRegistration(DatasetRegistrationSchemaV1 schema, User user)
+      throws SQLException, IOException {
+    datasetRegistrationService.createDatasetsFromRegistration(schema, user, Map.of());
   }
 }

--- a/src/test/java/org/broadinstitute/consent/http/service/DatasetRegistrationServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DatasetRegistrationServiceTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.cloud.storage.BlobId;
+import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.ServerErrorException;
 import jakarta.ws.rs.core.MediaType;
@@ -926,5 +927,39 @@ class DatasetRegistrationServiceTest {
     schemaV1.setAssets(Map.of("key", List.of("value1", "value2")));
     schemaV1.setConsentGroups(List.of(consentGroup));
     return schemaV1;
+  }
+
+  @Test
+  void testCreateDatasetRegistrationWithBlankConsentGroupName() {
+    User user = mock();
+    DatasetRegistrationSchemaV1 schema = createRandomMinimumDatasetRegistration(user);
+
+    // Set consent group name to blank
+    schema.getConsentGroups().getFirst().setConsentGroupName("");
+
+    initService();
+
+    assertThrows(
+        BadRequestException.class,
+        () -> {
+          datasetRegistrationService.createDatasetsFromRegistration(schema, user, Map.of());
+        });
+  }
+
+  @Test
+  void testCreateDatasetRegistrationWithNullConsentGroupName() {
+    User user = mock();
+    DatasetRegistrationSchemaV1 schema = createRandomMinimumDatasetRegistration(user);
+
+    // Set consent group name to null
+    schema.getConsentGroups().getFirst().setConsentGroupName(null);
+
+    initService();
+
+    assertThrows(
+        BadRequestException.class,
+        () -> {
+          datasetRegistrationService.createDatasetsFromRegistration(schema, user, Map.of());
+        });
   }
 }


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2502

### Summary

While working on [DT-2225](https://broadworkbench.atlassian.net/browse/DT-2225), we found datasets in dev without names. Although these have been fixed, the issue showed that the system allows creating datasets without a name.

This PR adds validation to ensure all datasets in Consent must have a name and updates the database schema to make the dataset name column non-nullable. This prevents nameless datasets from being created going forward.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment


[DT-2225]: https://broadworkbench.atlassian.net/browse/DT-2225?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ