### PR TITLE
[DT-2528] Removes the attribute from the list of required fields.

### DIFF
--- a/src/main/resources/dataset-registration-schema_v1.json
+++ b/src/main/resources/dataset-registration-schema_v1.json
@@ -8,7 +8,6 @@
     "studyName",
     "studyDescription",
     "dataTypes",
-    "dataSubmitterUserId",
     "publicVisibility",
     "nihAnvilUse",
     "piName",


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-2528](https://broadworkbench.atlassian.net/browse/DT-2528)

### Summary

This attribute should not be required from the client since the value is determined by the user performing the action in the backend.  Removing this from the 'required' lists doesn't change that it can still be provided and ignored for backwards compatibility.


----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
