### PR TITLE
[DT-2561] Rename `intellectualProperty` to `intellectualProperties`

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequest.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequest.java
@@ -353,7 +353,7 @@ public class DataAccessRequest {
     originalDataCopy.setExternalCollaborators(newData.getExternalCollaborators());
     originalDataCopy.setLabCollaborators(newData.getLabCollaborators());
     originalDataCopy.setProgressReportSummary(newData.getProgressReportSummary());
-    originalDataCopy.setIntellectualProperty(newData.getIntellectualProperty());
+    originalDataCopy.setIntellectualProperties(newData.getIntellectualProperties());
     originalDataCopy.setPublications(newData.getPublications());
     originalDataCopy.setPresentations(newData.getPresentations());
     originalDataCopy.setDmi(newData.getDmi());

--- a/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequestData.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequestData.java
@@ -124,7 +124,7 @@ public class DataAccessRequestData {
 
   // Progress Report/Closeout Fields
   private String progressReportSummary;
-  private List<IntellectualProperty> intellectualProperty;
+  private List<IntellectualProperty> intellectualProperties;
   private List<Publication> publications;
   private List<Presentation> presentations;
   private DataManagementIncident dmi;
@@ -709,12 +709,12 @@ public class DataAccessRequestData {
     this.progressReportSummary = progressReportSummary;
   }
 
-  public List<IntellectualProperty> getIntellectualProperty() {
-    return intellectualProperty;
+  public List<IntellectualProperty> getIntellectualProperties() {
+    return intellectualProperties;
   }
 
-  public void setIntellectualProperty(List<IntellectualProperty> intellectualProperty) {
-    this.intellectualProperty = intellectualProperty;
+  public void setIntellectualProperties(List<IntellectualProperty> intellectualProperties) {
+    this.intellectualProperties = intellectualProperties;
   }
 
   public List<Publication> getPublications() {

--- a/src/main/java/org/broadinstitute/consent/http/models/IntellectualProperty.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/IntellectualProperty.java
@@ -5,10 +5,9 @@ import java.util.List;
 public record IntellectualProperty(
     String type,
     String title,
-    String date,
     String assignee,
     String patentNumber,
-    Boolean filingDate,
+    String filingDate,
     String status,
     String url,
     String contact,

--- a/src/main/resources/changelog-master.xml
+++ b/src/main/resources/changelog-master.xml
@@ -216,4 +216,6 @@
     relativeToChangelogFile="true" />
   <include file="changesets/changelog-consent-2025-12-05-migrate-ip-presentations-publications.xml"
            relativeToChangelogFile="true" />
+  <include file="changesets/changelog-consent-2025-12-11-rename-intellectual-property-to-properties.xml"
+           relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/src/main/resources/changesets/changelog-consent-2025-12-11-rename-intellectual-property-to-properties.xml
+++ b/src/main/resources/changesets/changelog-consent-2025-12-11-rename-intellectual-property-to-properties.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+  <changeSet id="changelog-consent-2025-12-11-rename-intellectual-property-to-properties" author="kevinmarete">
+    <comment>
+      Rename intellectualProperty field to intellectualProperties in data_access_request table.
+      Transforms the singular field name to plural form.
+    </comment>
+    <sql>
+      UPDATE data_access_request
+      SET data = jsonb_set(
+        data #- '{intellectualProperty}',
+        '{intellectualProperties}',
+        data -> 'intellectualProperty'
+                 )
+      WHERE parent_id IS NOT NULL
+        AND data -> 'intellectualProperty' IS NOT NULL
+        AND data -> 'intellectualProperties' IS NULL;
+    </sql>
+  </changeSet>
+</databaseChangeLog>

--- a/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
@@ -901,7 +901,7 @@ institution or library cards issued: Internal Collaborator member:  \
     progressReport.getData().setProgressReportSummary("Progress Report Summary");
     progressReport
         .getData()
-        .setIntellectualProperty(
+        .setIntellectualProperties(
             List.of(
                 new IntellectualProperty(
                     "Patent",

--- a/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
@@ -906,10 +906,9 @@ institution or library cards issued: Internal Collaborator member:  \
                 new IntellectualProperty(
                     "Patent",
                     "Description of patent",
-                    "2024-01-01",
                     "Test Assignee",
                     "US12345678",
-                    true,
+                    "2024-01-01",
                     "Active",
                     "https://example.com",
                     "contact@example.com",


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2561

### Summary

This PR standardizes the use of the attribute intellectualProperty in DARs. There has been inconsistent use of both `intellectualProperty` and `intellectualProperties`. We have settled on `intellectualProperties`. 

It also fixes the `IntellectualProperty` model by removing the `date` attribute and changing the `filingDate` attribute from `Boolean` to `String`.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
