### PR TITLE
[DT-2750] Erase old study properties before applying new registration to a study.

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/StudyDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/StudyDAO.java
@@ -133,6 +133,12 @@ public interface StudyDAO extends Transactional<StudyDAO> {
       """)
   void deleteStudyByStudyId(@Bind("studyId") Integer studyId);
 
+  @SqlUpdate(
+      """
+      DELETE FROM public.study_property where study_id = :studyId
+      """)
+  void deleteStudyPropertiesByStudyId(@Bind("studyId") Integer studyId);
+
   @UseRowReducer(StudyReducer.class)
   @SqlQuery(
       """

--- a/src/main/java/org/broadinstitute/consent/http/db/StudyDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/StudyDAO.java
@@ -135,7 +135,7 @@ public interface StudyDAO extends Transactional<StudyDAO> {
 
   @SqlUpdate(
       """
-      DELETE FROM public.study_property where study_id = :studyId
+      DELETE FROM study_property where study_id = :studyId
       """)
   void deleteStudyPropertiesByStudyId(@Bind("studyId") Integer studyId);
 

--- a/src/main/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAO.java
@@ -247,7 +247,7 @@ public class DatasetServiceDAO implements ConsentLogger {
     jdbi.useHandle(
         handle -> {
           handle.getConnection().setAutoCommit(false);
-          executeUpdateStudy(handle, studyUpdate);
+          executeUpdateStudyReplaceProps(handle, studyUpdate);
           for (DatasetUpdate datasetUpdate : datasetUpdates) {
             executeUpdateDatasetWithFiles(
                 handle,
@@ -275,7 +275,15 @@ public class DatasetServiceDAO implements ConsentLogger {
     return studyDAO.findStudyById(studyUpdate.studyId);
   }
 
-  private void executeUpdateStudy(Handle handle, StudyUpdate update) {
+  private void executeUpdateStudyReplaceProps(Handle handle, StudyUpdate update) {
+    executeUpdateStudy(handle, update, true);
+  }
+
+  private void executeUpdateStudyKeepProps(Handle handle, StudyUpdate update) {
+    executeUpdateStudy(handle, update, false);
+  }
+
+  private void executeUpdateStudy(Handle handle, StudyUpdate update, boolean replaceProps) {
     StudyDAO studyDAO = handle.attach(StudyDAO.class);
     Study study = studyDAO.findStudyById(update.studyId);
     studyDAO.updateStudy(
@@ -288,26 +296,34 @@ public class DatasetServiceDAO implements ConsentLogger {
         update.userId,
         Instant.now());
 
-    // Handle property inserts and updates
-    Set<StudyProperty> existingStudyProperties =
-        studyDAO.findStudyById(update.studyId).getProperties();
-    update.props.forEach(
-        p -> {
-          Optional<StudyProperty> existingProp =
-              existingStudyProperties.stream()
-                  .filter(ep -> p.getKey().equals(ep.getKey()) && p.getType().equals(ep.getType()))
-                  .findFirst();
-          if (existingProp.isPresent()) {
-            // Update existing study prop:
-            studyDAO.updateStudyProperty(
-                update.studyId, p.getKey(), p.getType().toString(), p.getValue().toString());
-          } else {
-            // Add new study prop:
-            studyDAO.insertStudyProperty(
-                update.studyId, p.getKey(), p.getType().toString(), p.getValue().toString());
-          }
-        });
-
+    if (replaceProps) {
+      studyDAO.deleteStudyPropertiesByStudyId(update.studyId);
+      update.props.forEach(
+          p ->
+              studyDAO.insertStudyProperty(
+                  update.studyId, p.getKey(), p.getType().toString(), p.getValue().toString()));
+    } else {
+      // Handle property inserts and updates
+      Set<StudyProperty> existingStudyProperties =
+          studyDAO.findStudyById(update.studyId).getProperties();
+      update.props.forEach(
+          p -> {
+            Optional<StudyProperty> existingProp =
+                existingStudyProperties.stream()
+                    .filter(
+                        ep -> p.getKey().equals(ep.getKey()) && p.getType().equals(ep.getType()))
+                    .findFirst();
+            if (existingProp.isPresent()) {
+              // Update existing study prop:
+              studyDAO.updateStudyProperty(
+                  update.studyId, p.getKey(), p.getType().toString(), p.getValue().toString());
+            } else {
+              // Add new study prop:
+              studyDAO.insertStudyProperty(
+                  update.studyId, p.getKey(), p.getType().toString(), p.getValue().toString());
+            }
+          });
+    }
     executeInsertFiles(handle, update.files, update.userId, study.getUuid().toString());
   }
 
@@ -423,7 +439,7 @@ public class DatasetServiceDAO implements ConsentLogger {
           // Convert the patch to a StudyUpdate for reuse of existing methods
           StudyUpdate studyUpdate = convertToStudyUpdate(study, user, patch);
           try {
-            executeUpdateStudy(handle, studyUpdate);
+            executeUpdateStudyKeepProps(handle, studyUpdate);
           } catch (Exception e) {
             handle.rollback();
             logException(e);

--- a/src/test/java/org/broadinstitute/consent/http/db/StudyDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/StudyDAOTest.java
@@ -344,6 +344,19 @@ class StudyDAOTest extends DAOTestHelper {
   }
 
   @Test
+  void testDeleteStudyPropertiesById() {
+    Study study = insertStudyWithProperties();
+    Integer id = study.getStudyId();
+    int propertyCount = study.getProperties().size();
+    assertTrue(propertyCount > 0);
+
+    studyDAO.deleteStudyPropertiesByStudyId(id);
+
+    Study foundStudy = studyDAO.findStudyById(id);
+    assertEquals(0, foundStudy.getProperties().size());
+  }
+
+  @Test
   void testFindStudyByName() {
     Study study = insertStudyWithProperties();
     Study foundStudy = studyDAO.findStudyByName(study.getName());

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAOTest.java
@@ -586,7 +586,7 @@ class DatasetServiceDAOTest extends DAOTestHelper {
     // Updated prop
     Optional<StudyProperty> updatedProp1 =
         updatedStudy.getProperties().stream()
-            .filter(p -> p.getStudyPropertyId().equals(prop1.getStudyPropertyId()))
+            .filter(p -> p.getKey().equals(prop1.getKey()))
             .findFirst();
     assertTrue(updatedProp1.isPresent());
     assertEquals(newPropValue, updatedProp1.get().getValue());


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-2750](https://broadworkbench.atlassian.net/browse/DT-2750)

### Summary

Removes all study properties when receiving a new registration for a study.  This allows patching to work for a particular study property through the new patch endpoint, but cleans up old study properties that may no longer be relevant when submitting a new registration and applying it to an existing study.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
