### PR TITLE
[DT-2771] Remove unused `UserResource.getUnassignedUsers`

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/UserDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/UserDAO.java
@@ -388,23 +388,6 @@ public interface UserDAO extends Transactional<UserDAO> {
         """)
   List<User> getUsersWithCardsByDaaId(@Bind("daaId") Integer daaId);
 
-  // SO only endpoint (so far)
-  // Meant to pull in users that have not yet been assigned an institution
-  // (SOs can assign LCs to these users as well)
-  @RegisterBeanMapper(value = User.class, prefix = "u")
-  @RegisterBeanMapper(value = UserRole.class)
-  @UseRowReducer(UserWithRolesReducer.class)
-  @SqlQuery(
-      " SELECT "
-          + User.QUERY_FIELDS_WITH_U_PREFIX
-          + QUERY_FIELD_SEPARATOR
-          + " r.name, ur.role_id, ur.user_role_id, ur.dac_id, ur.user_id "
-          + " FROM users u "
-          + " LEFT JOIN user_role ur ON ur.user_id = u.user_id "
-          + " LEFT JOIN roles r ON r.role_id = ur.role_id "
-          + " WHERE u.institution_id IS NULL")
-  List<User> getUsersWithNoInstitution();
-
   @RegisterBeanMapper(value = User.class)
   @SqlQuery(
       "SELECT u.user_id, u.display_name, u.email FROM users u "

--- a/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
@@ -166,19 +166,6 @@ public class UserResource extends Resource {
   }
 
   @GET
-  @Path("/institution/unassigned")
-  @Produces("application/json")
-  @RolesAllowed({ADMIN, SIGNINGOFFICIAL})
-  public Response getUnassignedUsers(@Auth AuthUser user) {
-    try {
-      List<User> unassignedUsers = userService.findUsersWithNoInstitution();
-      return Response.ok().entity(unassignedUsers).build();
-    } catch (Exception e) {
-      return createExceptionResponse(e);
-    }
-  }
-
-  @GET
   @Path("/institution/{institutionId}")
   @Produces("application/json")
   @RolesAllowed({ADMIN})

--- a/src/main/java/org/broadinstitute/consent/http/service/UserService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/UserService.java
@@ -338,10 +338,6 @@ public class UserService implements ConsentLogger {
             .formatted(authUser.getDisplayName(), roleId, userId));
   }
 
-  public List<User> findUsersWithNoInstitution() {
-    return userDAO.getUsersWithNoInstitution();
-  }
-
   /**
    * Convenience method to return a response-friendly json object of the user.
    *

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -733,23 +733,6 @@ paths:
     $ref: './paths/getApprovedDatasets.yaml'
   /api/user/institution/{institutionId}:
     $ref: './paths/userInstitutionByInstitutionId.yaml'
-  /api/user/institution/unassigned:
-    get:
-      summary: Find users that do not belong to an institution
-      description: Find users that do not belong to an institution
-      tags:
-        - User
-      responses:
-        200:
-          description: An array of users that do not belong to an institution
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/User'
-        500:
-          description: Internal Server Error
   /api/user/signing-officials:
     get:
       summary: Find SOs for currently authenticated user's institution

--- a/src/test/java/org/broadinstitute/consent/http/db/UserDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/UserDAOTest.java
@@ -434,16 +434,6 @@ class UserDAOTest extends DAOTestHelper {
   }
 
   @Test
-  void testGetUsersWithNoInstitution() {
-    createUserWithInstitution();
-    User user = createUser();
-    List<User> users = userDAO.getUsersWithNoInstitution();
-    // One user we created just now, one is the admin user for the institution.
-    assertEquals(2, users.size());
-    assertTrue(users.stream().anyMatch(u -> u.getUserId().equals(user.getUserId())));
-  }
-
-  @Test
   void testUpdateEraCommonsId() {
     User u = createUser();
     String era = u.getEraCommonsId();

--- a/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
@@ -437,15 +437,6 @@ class UserResourceTest extends AbstractTestHelper {
   }
 
   @Test
-  void testGetUnassignedUsers() {
-    List<User> users = Collections.singletonList(createUserWithRole());
-    when(userService.findUsersWithNoInstitution()).thenReturn(users);
-
-    Response response = userResource.getUnassignedUsers(authUser);
-    assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
-  }
-
-  @Test
   void testGetUsersByInstitutionNoInstitution() {
     Integer institutionId = 1;
     doThrow(new NotFoundException()).when(userService).findUsersByInstitutionId(institutionId);

--- a/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
@@ -627,16 +627,6 @@ class UserServiceTest extends AbstractTestHelper {
   }
 
   @Test
-  void testFindUsersWithNoInstitution() {
-    User user = generateUser();
-    when(userDAO.getUsersWithNoInstitution()).thenReturn(List.of(user));
-    List<User> users = service.findUsersWithNoInstitution();
-    assertNotNull(users);
-    assertEquals(1, users.size());
-    assertEquals(user.getUserId(), users.get(0).getUserId());
-  }
-
-  @Test
   void testFindUserWithPropertiesAsJsonObjectById() {
     User user = generateUser();
     user.setLibraryCard(new LibraryCard());


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2771

### Summary

This PR removes `UserResource.getUnassignedUsers`, which is no longer necessary. The logic it supported is no longer used, and eliminating it simplifies the User API and reduces dead code.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
