### PR TITLE
DT-2797: Remove Admin ability to create elections

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/resources/DarCollectionResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DarCollectionResource.java
@@ -246,7 +246,7 @@ public class DarCollectionResource extends Resource {
   @POST
   @Path("{collectionId}/election")
   @Consumes("application/json")
-  @RolesAllowed({ADMIN, CHAIRPERSON})
+  @RolesAllowed({CHAIRPERSON})
   public Response createElectionsForCollection(
       @Auth DuosUser duosUser, @PathParam("collectionId") Integer collectionId) {
     try {

--- a/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
@@ -127,7 +127,6 @@ public class DarCollectionService implements ConsentLogger {
           Map<String, Integer> statusCount = new HashMap<>();
           Map<Integer, Election> elections = s.getElections();
           if (elections.isEmpty()) {
-            s.addAction(DarCollectionActions.OPEN);
             s.setStatus(DarCollectionStatus.SUBMITTED.getValue());
           } else {
             elections
@@ -138,8 +137,6 @@ public class DarCollectionService implements ConsentLogger {
                       updateStatusCount(statusCount, status);
                       if (status.equals(ElectionStatus.OPEN.getValue())) {
                         s.addAction(DarCollectionActions.CANCEL);
-                      } else {
-                        s.addAction(DarCollectionActions.OPEN);
                       }
                     });
             determineCollectionStatus(s, statusCount, s.getDatasetCount(), s.getElections().size());

--- a/src/main/java/org/broadinstitute/consent/http/service/dao/DarCollectionServiceDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/dao/DarCollectionServiceDAO.java
@@ -37,8 +37,8 @@ public class DarCollectionServiceDAO {
   }
 
   /**
-   * Find all Dar + Dataset combinations that are available to the user. - Admins have all available
-   * to them - Chairs can only create elections for datasets in their DACs
+   * Find all Dar + Dataset combinations that are available to the user. Chairs can only create
+   * elections for datasets in their DACs
    *
    * <p>DataAccessRequests with no elections, or with previously canceled elections, are valid for
    * initiating a new set of elections. Any DAR elections in open state should be ignored.
@@ -49,11 +49,9 @@ public class DarCollectionServiceDAO {
    */
   public List<String> createElectionsForDarByUser(User user, DataAccessRequest dar)
       throws SQLException {
-    boolean isAdmin = user.hasUserRole(UserRoles.ADMIN);
     List<String> createdElectionReferenceIds = new ArrayList<>();
     // If the user is not an admin, we need to know what datasets they have access to.
-    List<Integer> dacUserDatasetIds =
-        isAdmin ? List.of() : datasetDAO.findDatasetIdsByDACUserId(user.getUserId());
+    List<Integer> dacUserDatasetIds = datasetDAO.findDatasetIdsByDACUserId(user.getUserId());
     jdbi.useHandle(
         handle -> {
           // By default, new connections are set to auto-commit which breaks our rollback strategy.
@@ -88,10 +86,9 @@ public class DarCollectionServiceDAO {
                                 .getStatus()
                                 .equalsIgnoreCase(ElectionStatus.OPEN.getValue());
 
-                    // If the user is not an admin, then the dataset must be in the list of the
-                    // user's DAC Datasets
+                    // The dataset must be in the list of the user's DAC Datasets
                     // Otherwise, we need to skip election creation for this DAR as well.
-                    if (!isAdmin && !dacUserDatasetIds.contains(datasetId)) {
+                    if (!dacUserDatasetIds.contains(datasetId)) {
                       ignore = true;
                     }
                     if (!ignore) {

--- a/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
@@ -351,7 +351,7 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     dar.setReferenceId(UUID.randomUUID().toString());
     DataAccessRequestData data = new DataAccessRequestData();
     dar.setData(data);
-    DarCollection collection = createMockCollections().get(0);
+    DarCollection collection = createMockCollections().getFirst();
     collection.addDar(dar);
     when(electionDAO.findLastElectionsByReferenceIds(anyList())).thenReturn(List.of());
     when(darCollectionDAO.findDARCollectionByCollectionId(any())).thenReturn(collection);
@@ -376,7 +376,7 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     dar.setReferenceId(UUID.randomUUID().toString());
     DataAccessRequestData data = new DataAccessRequestData();
     dar.setData(data);
-    DarCollection collection = createMockCollections().get(0);
+    DarCollection collection = createMockCollections().getFirst();
     collection.addDar(dar);
     Election election = createMockElection();
     election.setReferenceId(dar.getReferenceId());
@@ -401,7 +401,7 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     dar.setReferenceId(UUID.randomUUID().toString());
     DataAccessRequestData data = new DataAccessRequestData();
     dar.setData(data);
-    DarCollection collection = createMockCollections().get(0);
+    DarCollection collection = createMockCollections().getFirst();
     collection.addDar(dar);
     Election election = createMockElection();
     election.setReferenceId(dar.getReferenceId());
@@ -430,7 +430,7 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     DataAccessRequestData data = new DataAccessRequestData();
     dar.addDatasetId(dataset.getDatasetId());
     dar.setData(data);
-    DarCollection collection = createMockCollections().get(0);
+    DarCollection collection = createMockCollections().getFirst();
     collection.addDar(dar);
     Election election = createMockElection();
     election.setReferenceId(dar.getReferenceId());
@@ -462,7 +462,7 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     DataAccessRequestData data = new DataAccessRequestData();
     dar.addDatasetId(dataset.getDatasetId());
     dar.setData(data);
-    DarCollection collection = createMockCollections().get(0);
+    DarCollection collection = createMockCollections().getFirst();
     collection.addDar(dar);
     Election election = createMockElection();
     election.setReferenceId(dar.getReferenceId());
@@ -479,7 +479,7 @@ class DarCollectionServiceTest extends AbstractTestHelper {
 
   @Test
   void cancelDarCollectionByRole_ProgressReport() {
-    DarCollection collection = createMockCollections().get(0);
+    DarCollection collection = createMockCollections().getFirst();
     collection.addDar(new DataAccessRequest());
     DarCollectionSummary summary = new DarCollectionSummary();
     summary.addParentChildRelationship(123, "456");
@@ -509,7 +509,7 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     user.setEmail("email");
     DataAccessRequest dar = new DataAccessRequest();
     dar.setReferenceId(UUID.randomUUID().toString());
-    DarCollection collection = createMockCollections().get(0);
+    DarCollection collection = createMockCollections().getFirst();
     collection.addDar(dar);
     when(darCollectionServiceDAO.createElectionsForDarByUser(any(), any()))
         .thenReturn(List.of("electionId"));
@@ -536,7 +536,7 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     progressReport.setReferenceId(UUID.randomUUID().toString());
     progressReport.setParentId(dar.getId());
     progressReport.setSubmissionDate(Timestamp.from(Instant.now()));
-    DarCollection collection = createMockCollections().get(0);
+    DarCollection collection = createMockCollections().getFirst();
     collection.addDar(dar);
     collection.addDar(progressReport);
 
@@ -562,7 +562,7 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     user.setEmail("email");
     DataAccessRequest dar = new DataAccessRequest();
     dar.setReferenceId(UUID.randomUUID().toString());
-    DarCollection collection = createMockCollections().get(0);
+    DarCollection collection = createMockCollections().getFirst();
     collection.addDar(dar);
 
     assertThrows(
@@ -576,7 +576,7 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     user.setEmail("email");
     DataAccessRequest dar = new DataAccessRequest();
     dar.setReferenceId(UUID.randomUUID().toString());
-    DarCollection collection = createMockCollections().get(0);
+    DarCollection collection = createMockCollections().getFirst();
     collection.addDar(dar);
     List<String> electionIds = List.of("electionId");
     when(darCollectionServiceDAO.createElectionsForDarByUser(user, dar)).thenReturn(electionIds);
@@ -611,7 +611,7 @@ class DarCollectionServiceTest extends AbstractTestHelper {
         service.getSummariesForRole(user, UserRoles.SIGNINGOFFICIAL);
     assertNotNull(summaries);
     assertEquals(1, summaries.size());
-    DarCollectionSummary s = summaries.get(0);
+    DarCollectionSummary s = summaries.getFirst();
     assertTrue(s.getStatus().equalsIgnoreCase(DarCollectionStatus.IN_PROCESS.getValue()));
   }
 
@@ -641,7 +641,7 @@ class DarCollectionServiceTest extends AbstractTestHelper {
         service.getSummariesForRole(user, UserRoles.SIGNINGOFFICIAL);
     assertNotNull(summaries);
     assertEquals(1, summaries.size());
-    DarCollectionSummary s = summaries.get(0);
+    DarCollectionSummary s = summaries.getFirst();
     assertTrue(s.getStatus().equalsIgnoreCase(DarCollectionStatus.COMPLETE.getValue()));
   }
 
@@ -663,7 +663,7 @@ class DarCollectionServiceTest extends AbstractTestHelper {
         service.getSummariesForRole(user, UserRoles.SIGNINGOFFICIAL);
     assertNotNull(summaries);
     assertEquals(1, summaries.size());
-    DarCollectionSummary s = summaries.get(0);
+    DarCollectionSummary s = summaries.getFirst();
     assertTrue(s.getStatus().equalsIgnoreCase(DarCollectionStatus.SUBMITTED.getValue()));
   }
 
@@ -681,7 +681,7 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     assertNotNull(summaries);
     assertEquals(1, summaries.size());
     // Admin summary should not have any actions
-    assertTrue(summaries.get(0).getActions().isEmpty());
+    assertTrue(summaries.getFirst().getActions().isEmpty());
   }
 
   @Test
@@ -697,7 +697,7 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     assertNotNull(summaries);
     assertEquals(1, summaries.size());
     // With no elections, there should be an Open action
-    assertTrue(summaries.get(0).getActions().contains(DarCollectionActions.OPEN.getValue()));
+    assertFalse(summaries.getFirst().getActions().contains(DarCollectionActions.OPEN.getValue()));
   }
 
   @Test
@@ -779,7 +779,7 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     assertNotNull(summaries);
     assertEquals(6, summaries.size());
 
-    DarCollectionSummary testOne = summaries.get(0);
+    DarCollectionSummary testOne = summaries.getFirst();
     Set<String> expectedOneActions = Set.of(DarCollectionActions.REVIEW.getValue());
     assertTrue(testOne.getStatus().equalsIgnoreCase(DarCollectionStatus.IN_PROCESS.getValue()));
     assertEquals(expectedOneActions, testOne.getActions());
@@ -832,11 +832,11 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     assertNotNull(summaries);
     assertEquals(1, summaries.size());
     // All summaries should have the REVIEW action
-    assertTrue(summaries.get(0).getActions().contains(DarCollectionActions.REVIEW.getValue()));
+    assertTrue(summaries.getFirst().getActions().contains(DarCollectionActions.REVIEW.getValue()));
     // Summaries with closeout should not have the CREATE_PROGRESS_REPORT action
     assertFalse(
         summaries
-            .get(0)
+            .getFirst()
             .getActions()
             .contains(DarCollectionActions.CREATE_PROGRESS_REPORT.getValue()));
   }
@@ -857,11 +857,11 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     assertNotNull(summaries);
     assertEquals(1, summaries.size());
     // All summaries should have the REVIEW action
-    assertTrue(summaries.get(0).getActions().contains(DarCollectionActions.REVIEW.getValue()));
+    assertTrue(summaries.getFirst().getActions().contains(DarCollectionActions.REVIEW.getValue()));
     // Summaries without a closeout should have the CREATE_PROGRESS_REPORT action
     assertTrue(
         summaries
-            .get(0)
+            .getFirst()
             .getActions()
             .contains(DarCollectionActions.CREATE_PROGRESS_REPORT.getValue()));
   }
@@ -891,7 +891,7 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     assertNotNull(summaries);
     assertEquals(1, summaries.size());
     Set<String> expectedActions = Set.of(DarCollectionActions.REVIEW_PROGRESS_REPORT.getValue());
-    assertEquals(expectedActions, summaries.get(0).getActions());
+    assertEquals(expectedActions, summaries.getFirst().getActions());
   }
 
   @Test
@@ -918,7 +918,7 @@ class DarCollectionServiceTest extends AbstractTestHelper {
 
     assertNotNull(summaries);
     assertEquals(1, summaries.size());
-    assertEquals(Set.of(), summaries.get(0).getActions());
+    assertEquals(Set.of(), summaries.getFirst().getActions());
   }
 
   @Test
@@ -945,7 +945,7 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     assertNotNull(summaries);
     assertEquals(1, summaries.size());
     Set<String> expectedActions = Set.of(DarCollectionActions.REVIEW_PROGRESS_REPORT.getValue());
-    assertEquals(expectedActions, summaries.get(0).getActions());
+    assertEquals(expectedActions, summaries.getFirst().getActions());
   }
 
   @Test
@@ -1012,26 +1012,25 @@ class DarCollectionServiceTest extends AbstractTestHelper {
 
     List<DarCollectionSummary> summaries = service.getSummariesForRole(user, UserRoles.ADMIN);
 
-    DarCollectionSummary testOne = summaries.get(0);
+    DarCollectionSummary testOne = summaries.getFirst();
     Set<String> expectedOneActions = Set.of(DarCollectionActions.CANCEL.getValue());
     assertTrue(testOne.getStatus().equalsIgnoreCase(DarCollectionStatus.IN_PROCESS.getValue()));
-    assertEquals(testOne.getActions(), expectedOneActions);
+    assertEquals(expectedOneActions, testOne.getActions());
 
     DarCollectionSummary testTwo = summaries.get(1);
-    Set<String> expectedTwoActions =
-        Set.of(DarCollectionActions.CANCEL.getValue(), DarCollectionActions.OPEN.getValue());
+    Set<String> expectedTwoActions = Set.of(DarCollectionActions.CANCEL.getValue());
     assertTrue(testTwo.getStatus().equalsIgnoreCase(DarCollectionStatus.IN_PROCESS.getValue()));
-    assertEquals(testTwo.getActions(), expectedTwoActions);
+    assertEquals(expectedTwoActions, testTwo.getActions());
 
     DarCollectionSummary testThree = summaries.get(2);
-    Set<String> expectedThreeActions = Set.of(DarCollectionActions.OPEN.getValue());
+    Set<String> expectedThreeActions = Set.of();
     assertTrue(testThree.getStatus().equalsIgnoreCase(DarCollectionStatus.COMPLETE.getValue()));
-    assertEquals(testThree.getActions(), expectedThreeActions);
+    assertEquals(expectedThreeActions, testThree.getActions());
 
     DarCollectionSummary testFour = summaries.get(3);
-    Set<String> expectedFourActions = Set.of(DarCollectionActions.OPEN.getValue());
+    Set<String> expectedFourActions = Set.of();
     assertTrue(testFour.getStatus().equalsIgnoreCase(DarCollectionStatus.SUBMITTED.getValue()));
-    assertEquals(testFour.getActions(), expectedFourActions);
+    assertEquals(expectedFourActions, testFour.getActions());
   }
 
   @Test
@@ -1144,7 +1143,7 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     assertNotNull(summaries);
     assertEquals(4, summaries.size());
 
-    DarCollectionSummary testOne = summaries.get(0);
+    DarCollectionSummary testOne = summaries.getFirst();
     Set<String> expectedOneActions = Set.of();
     assertEquals(testOne.getActions(), expectedOneActions);
     assertEquals(DarCollectionStatus.COMPLETE.getValue(), testOne.getStatus());
@@ -1262,7 +1261,7 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     List<DarCollectionSummary> summaries = service.getSummariesForRole(user, UserRoles.CHAIRPERSON);
     assertEquals(6, summaries.size());
 
-    DarCollectionSummary testOne = summaries.get(0);
+    DarCollectionSummary testOne = summaries.getFirst();
     Set<String> expectedOneActions =
         Set.of(DarCollectionActions.VOTE.getValue(), DarCollectionActions.CANCEL.getValue());
     assertTrue(testOne.getStatus().equalsIgnoreCase(DarCollectionStatus.IN_PROCESS.getValue()));
@@ -1316,7 +1315,7 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     assertNotNull(summaries);
     assertEquals(1, summaries.size());
     // Chair summary should not have any actions
-    assertTrue(summaries.get(0).getActions().isEmpty());
+    assertTrue(summaries.getFirst().getActions().isEmpty());
   }
 
   @Test
@@ -1335,7 +1334,7 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     assertNotNull(summaries);
     assertEquals(1, summaries.size());
     // With no elections, there should be an Open action
-    assertTrue(summaries.get(0).getActions().contains(DarCollectionActions.OPEN.getValue()));
+    assertTrue(summaries.getFirst().getActions().contains(DarCollectionActions.OPEN.getValue()));
   }
 
   @Test
@@ -1397,7 +1396,7 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     assertNotNull(summaryResult);
 
     Set<String> expectedActions =
-        Set.of(DarCollectionActions.CANCEL.getValue(), DarCollectionActions.OPEN.getValue());
+        Set.of(DarCollectionActions.CANCEL.getValue());
     assertTrue(
         summaryResult.getStatus().equalsIgnoreCase(DarCollectionStatus.IN_PROCESS.getValue()));
     assertEquals(expectedActions, summaryResult.getActions());
@@ -1413,9 +1412,7 @@ class DarCollectionServiceTest extends AbstractTestHelper {
         .getElections()
         .values()
         .forEach(
-            election -> {
-              election.setStatus(ElectionStatus.CLOSED.getValue());
-            });
+            election -> election.setStatus(ElectionStatus.CLOSED.getValue()));
     summary.setLatestReferenceId("ref1");
     Integer collectionId = summary.getDarCollectionId();
 
@@ -1449,9 +1446,7 @@ class DarCollectionServiceTest extends AbstractTestHelper {
         .getElections()
         .values()
         .forEach(
-            election -> {
-              election.setStatus(ElectionStatus.OPEN.getValue());
-            });
+            election -> election.setStatus(ElectionStatus.OPEN.getValue()));
     summary.setLatestReferenceId("ref1");
     Integer collectionId = summary.getDarCollectionId();
 
@@ -1793,10 +1788,10 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     dar.setDatasetIds(List.of(dataset.getDatasetId()));
     collection.addDar(dar);
 
-    User researcher = createUserWithRole(UserRoles.RESEARCHER, null);
+    User researcher = createUserWithRole(UserRoles.RESEARCHER);
     collection.setCreateUserId(researcher.getUserId());
     researcher.setInstitutionId(1);
-    User signingOfficial = createUserWithRole(UserRoles.SIGNINGOFFICIAL, null);
+    User signingOfficial = createUserWithRole(UserRoles.SIGNINGOFFICIAL);
     signingOfficial.setEmailPreference(true);
     when(userDAO.getSOsByInstitution(researcher.getInstitutionId()))
         .thenReturn(List.of(signingOfficial));
@@ -1835,10 +1830,10 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     child.setDatasetIds(List.of(dataset.getDatasetId()));
     collection.addDar(child);
 
-    User researcher = createUserWithRole(UserRoles.RESEARCHER, null);
+    User researcher = createUserWithRole(UserRoles.RESEARCHER);
     collection.setCreateUserId(researcher.getUserId());
     researcher.setInstitutionId(1);
-    User signingOfficial = createUserWithRole(UserRoles.SIGNINGOFFICIAL, null);
+    User signingOfficial = createUserWithRole(UserRoles.SIGNINGOFFICIAL);
     signingOfficial.setEmailPreference(true);
     when(userDAO.getSOsByInstitution(researcher.getInstitutionId()))
         .thenReturn(List.of(signingOfficial));
@@ -1865,7 +1860,7 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     dar.setDatasetIds(List.of(dataset.getDatasetId()));
     collection.addDar(dar);
 
-    User researcher = createUserWithRole(UserRoles.RESEARCHER, null);
+    User researcher = createUserWithRole(UserRoles.RESEARCHER);
     collection.setCreateUserId(researcher.getUserId());
 
     service.notifySigningOfficialsOfDARSubmission(
@@ -1915,15 +1910,12 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     return election;
   }
 
-  private User createUserWithRole(UserRoles userRoles, Integer dacId) {
+  private User createUserWithRole(UserRoles userRoles) {
     User user = new User();
     user.setUserId(randomInt(1, 100000));
     user.setDisplayName(String.format("%s - %s", userRoles.getRoleName(), user.getUserId()));
     user.setEmail(String.format("%s@test.com", userRoles.getRoleName()));
     UserRole role = new UserRole(userRoles.getRoleId(), userRoles.getRoleName());
-    if (dacId != null) {
-      role.setDacId(dacId);
-    }
     user.setRoles(List.of(role));
     user.setEmailPreference(Boolean.TRUE);
     return user;

--- a/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
@@ -1395,8 +1395,7 @@ class DarCollectionServiceTest extends AbstractTestHelper {
         service.getSummaryForRoleByCollectionId(user, UserRoles.ADMIN, collectionId);
     assertNotNull(summaryResult);
 
-    Set<String> expectedActions =
-        Set.of(DarCollectionActions.CANCEL.getValue());
+    Set<String> expectedActions = Set.of(DarCollectionActions.CANCEL.getValue());
     assertTrue(
         summaryResult.getStatus().equalsIgnoreCase(DarCollectionStatus.IN_PROCESS.getValue()));
     assertEquals(expectedActions, summaryResult.getActions());
@@ -1411,8 +1410,7 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     summary
         .getElections()
         .values()
-        .forEach(
-            election -> election.setStatus(ElectionStatus.CLOSED.getValue()));
+        .forEach(election -> election.setStatus(ElectionStatus.CLOSED.getValue()));
     summary.setLatestReferenceId("ref1");
     Integer collectionId = summary.getDarCollectionId();
 
@@ -1445,8 +1443,7 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     summary
         .getElections()
         .values()
-        .forEach(
-            election -> election.setStatus(ElectionStatus.OPEN.getValue()));
+        .forEach(election -> election.setStatus(ElectionStatus.OPEN.getValue()));
     summary.setLatestReferenceId("ref1");
     Integer collectionId = summary.getDarCollectionId();
 

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DarCollectionServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DarCollectionServiceDAOTest.java
@@ -12,9 +12,6 @@ import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.stream.Collectors;
-import org.apache.commons.lang3.RandomStringUtils;
-import org.apache.commons.lang3.RandomUtils;
 import org.broadinstitute.consent.http.db.DAOTestHelper;
 import org.broadinstitute.consent.http.enumeration.ElectionStatus;
 import org.broadinstitute.consent.http.enumeration.ElectionType;
@@ -47,112 +44,6 @@ class DarCollectionServiceDAOTest extends DAOTestHelper {
   }
 
   /**
-   * This test covers the case where: - User is an admin - Collection has 1 DAR/Dataset combinations
-   * - Elections created should be for the DAR/Dataset for the user
-   */
-  @Test
-  void testCreateElectionsForDarByUserAdmin() throws Exception {
-    User user = new User();
-    user.setAdminRole();
-    DarCollection collection = setUpDarCollectionWithDacDataset();
-    DataAccessRequest dar = collection.getDars().values().stream().findFirst().orElse(null);
-    assertNotNull(dar);
-
-    List<String> referenceIds = serviceDAO.createElectionsForDarByUser(user, dar);
-
-    List<Election> createdElections =
-        electionDAO.findLastElectionsByReferenceIds(List.of(dar.getReferenceId()));
-    List<Vote> createdVotes =
-        voteDAO.findVotesByElectionIds(
-            createdElections.stream().map(Election::getElectionId).collect(Collectors.toList()));
-
-    assertTrue(referenceIds.contains(dar.getReferenceId()));
-    assertFalse(createdElections.isEmpty());
-    assertFalse(createdVotes.isEmpty());
-
-    // Ensure that we have all primary vote types for each election type
-    // Data Access Elections have Chair, Dac, Final, and Agreement votes
-    Optional<Election> daElectionOption =
-        createdElections.stream()
-            .filter(e -> ElectionType.DATA_ACCESS.getValue().equals(e.getElectionType()))
-            .findFirst();
-    assertTrue(daElectionOption.isPresent());
-    assertTrue(
-        createdVotes.stream()
-            .filter(v -> v.getElectionId().equals(daElectionOption.get().getElectionId()))
-            .anyMatch(v -> v.getType().equals(VoteType.CHAIRPERSON.getValue())));
-    assertTrue(
-        createdVotes.stream()
-            .filter(v -> v.getElectionId().equals(daElectionOption.get().getElectionId()))
-            .anyMatch(v -> v.getType().equals(VoteType.DAC.getValue())));
-    assertTrue(
-        createdVotes.stream()
-            .filter(v -> v.getElectionId().equals(daElectionOption.get().getElectionId()))
-            .anyMatch(v -> v.getType().equals(VoteType.FINAL.getValue())));
-    assertTrue(
-        createdVotes.stream()
-            .filter(v -> v.getElectionId().equals(daElectionOption.get().getElectionId()))
-            .anyMatch(v -> v.getType().equals(VoteType.AGREEMENT.getValue())));
-
-    // RP Elections have Chair and Dac votes
-    Optional<Election> rpElectionOption =
-        createdElections.stream()
-            .filter(e -> ElectionType.RP.getValue().equals(e.getElectionType()))
-            .findFirst();
-    assertTrue(rpElectionOption.isPresent());
-    assertTrue(
-        createdVotes.stream()
-            .filter(v -> v.getElectionId().equals(rpElectionOption.get().getElectionId()))
-            .anyMatch(v -> v.getType().equals(VoteType.CHAIRPERSON.getValue())));
-    assertTrue(
-        createdVotes.stream()
-            .filter(v -> v.getElectionId().equals(rpElectionOption.get().getElectionId()))
-            .anyMatch(v -> v.getType().equals(VoteType.DAC.getValue())));
-  }
-
-  /**
-   * This test covers the case where: - User is an admin - Collection has 2 DAR/Dataset combinations
-   * - User is an Admin - Elections created should only be for ALL the DAR/Dataset combinations
-   */
-  @Test
-  void testCreateElectionsForDarCollectionWithMultipleDatasetsForAdminBy() throws Exception {
-    User user = new User();
-    user.setAdminRole();
-    DarCollection collection = setUpDarCollectionWithDacDataset();
-    DataAccessRequest dar = collection.getDars().values().stream().findFirst().orElse(null);
-    assertNotNull(dar);
-
-    // refresh the collection
-    collection = darCollectionDAO.findDARCollectionByCollectionId(collection.getDarCollectionId());
-
-    List<String> referenceIds = serviceDAO.createElectionsForDarByUser(user, dar);
-
-    List<Election> createdElections =
-        electionDAO.findLastElectionsByReferenceIds(List.of(dar.getReferenceId()));
-    List<Vote> createdVotes =
-        voteDAO.findVotesByElectionIds(
-            createdElections.stream().map(Election::getElectionId).collect(Collectors.toList()));
-
-    assertTrue(referenceIds.contains(dar.getReferenceId()));
-    // Ensure that we have an access and rp election
-    assertFalse(createdElections.isEmpty());
-    assertTrue(
-        createdElections.stream()
-            .anyMatch(e -> e.getElectionType().equals(ElectionType.DATA_ACCESS.getValue())));
-    assertTrue(
-        createdElections.stream()
-            .anyMatch(e -> e.getElectionType().equals(ElectionType.RP.getValue())));
-    // Ensure that we have primary vote types
-    assertFalse(createdVotes.isEmpty());
-    assertTrue(
-        createdVotes.stream().anyMatch(v -> v.getType().equals(VoteType.CHAIRPERSON.getValue())));
-    assertTrue(createdVotes.stream().anyMatch(v -> v.getType().equals(VoteType.FINAL.getValue())));
-    assertTrue(createdVotes.stream().anyMatch(v -> v.getType().equals(VoteType.DAC.getValue())));
-    assertTrue(
-        createdVotes.stream().anyMatch(v -> v.getType().equals(VoteType.AGREEMENT.getValue())));
-  }
-
-  /**
    * This test covers the case where: - User is a chairperson - Collection has 1 DAR/Dataset
    * combinations - Elections created should be for the DAR/Dataset for the user
    */
@@ -160,7 +51,7 @@ class DarCollectionServiceDAOTest extends DAOTestHelper {
   void testCreateElectionsForDarByUserChair() throws Exception {
     DarCollection collection = setUpDarCollectionWithDacDataset();
     DataAccessRequest dar = collection.getDars().values().stream().findFirst().orElseThrow();
-    Integer datasetId = dar.getDatasetIds().get(0);
+    Integer datasetId = dar.getDatasetIds().getFirst();
     assertNotNull(datasetId);
     Optional<Dac> dac = dacDAO.findDacsForDatasetIds(List.of(datasetId)).stream().findFirst();
     assertTrue(dac.isPresent());
@@ -175,7 +66,7 @@ class DarCollectionServiceDAOTest extends DAOTestHelper {
         electionDAO.findLastElectionsByReferenceIds(List.of(dar.getReferenceId()));
     List<Vote> createdVotes =
         voteDAO.findVotesByElectionIds(
-            createdElections.stream().map(Election::getElectionId).collect(Collectors.toList()));
+            createdElections.stream().map(Election::getElectionId).toList());
 
     assertTrue(referenceIds.contains(dar.getReferenceId()));
     // Ensure that we have an access and rp election
@@ -208,7 +99,7 @@ class DarCollectionServiceDAOTest extends DAOTestHelper {
     DataAccessRequest dar = collection.getMostRecentDar();
     assertNotNull(dar);
     assertFalse(dar.getDatasetIds().isEmpty());
-    Integer datasetId1 = dar.getDatasetIds().get(0);
+    Integer datasetId1 = dar.getDatasetIds().getFirst();
     Integer datasetId2 = dar.getDatasetIds().get(1);
     assertEquals(2, dar.getDatasetIds().size());
 
@@ -223,7 +114,7 @@ class DarCollectionServiceDAOTest extends DAOTestHelper {
             .orElseThrow();
 
     // refresh the collection
-    collection = darCollectionDAO.findDARCollectionByCollectionId(collection.getDarCollectionId());
+    darCollectionDAO.findDARCollectionByCollectionId(collection.getDarCollectionId());
 
     List<String> referenceIds = serviceDAO.createElectionsForDarByUser(chair, dar);
 
@@ -231,7 +122,7 @@ class DarCollectionServiceDAOTest extends DAOTestHelper {
         electionDAO.findLastElectionsByReferenceIds(List.of(dar.getReferenceId()));
     List<Vote> createdVotes =
         voteDAO.findVotesByElectionIds(
-            createdElections.stream().map(Election::getElectionId).collect(Collectors.toList()));
+            createdElections.stream().map(Election::getElectionId).toList());
 
     assertTrue(referenceIds.contains(dar.getReferenceId()));
     assertEquals(2, createdElections.size()); //
@@ -275,10 +166,10 @@ class DarCollectionServiceDAOTest extends DAOTestHelper {
     // Verify we have elections for both DACs
     assertTrue(
         createdElections.stream()
-            .anyMatch(e -> e.getDatasetId().equals(dac.getDatasetIds().get(0))));
+            .anyMatch(e -> e.getDatasetId().equals(dac.getDatasetIds().getFirst())));
     assertTrue(
         createdElections.stream()
-            .anyMatch(e -> e.getDatasetId().equals(dac2.getDatasetIds().get(0))));
+            .anyMatch(e -> e.getDatasetId().equals(dac2.getDatasetIds().getFirst())));
 
     // Verify we have open votes for both datasets on the DAR.
     createdVotes =
@@ -296,7 +187,7 @@ class DarCollectionServiceDAOTest extends DAOTestHelper {
     DarCollection collection = setUpDarCollectionWithDacDataset();
     DataAccessRequest dar = collection.getDars().values().stream().findFirst().orElseThrow();
     assertFalse(dar.getDatasetIds().isEmpty());
-    Integer datasetId = dar.getDatasetIds().get(0);
+    Integer datasetId = dar.getDatasetIds().getFirst();
 
     // Find the dac chairperson for the current DAR/Dataset combination
     Dac dac = dacDAO.findDacsForDatasetIds(List.of(datasetId)).stream().findFirst().orElseThrow();
@@ -323,58 +214,6 @@ class DarCollectionServiceDAOTest extends DAOTestHelper {
   }
 
   /**
-   * This test covers the case where: - User is an admin - Elections have been created for a
-   * Collection - Elections are then canceled - Elections re-created correctly - Previous canceled
-   * elections are correctly archived
-   */
-  @Test
-  void testCreateElectionsForDarCollectionAfterCancelingEarlierElectionsAsAdminBy()
-      throws Exception {
-    User user = new User();
-    user.setAdminRole();
-    DarCollection collection = setUpDarCollectionWithDacDataset();
-    DataAccessRequest dar = collection.getDars().values().stream().findFirst().orElse(null);
-    assertNotNull(dar);
-
-    // create elections & votes:
-    List<String> referenceIds = serviceDAO.createElectionsForDarByUser(user, dar);
-
-    // cancel those elections:
-    List<Integer> canceledElectionIds =
-        electionDAO.findLastElectionsByReferenceIds(List.of(dar.getReferenceId())).stream()
-            .map(Election::getElectionId)
-            .toList();
-    canceledElectionIds.forEach(
-        id -> electionDAO.updateElectionById(id, ElectionStatus.CANCELED.getValue(), new Date()));
-
-    // re-create elections & new votes:
-    referenceIds.addAll(serviceDAO.createElectionsForDarByUser(user, dar));
-
-    List<Election> createdElections =
-        electionDAO.findLastElectionsByReferenceIds(List.of(dar.getReferenceId()));
-
-    assertTrue(referenceIds.contains(dar.getReferenceId()));
-
-    // Ensure that we have the right number of access and rp elections, i.e. 1 each
-    assertFalse(createdElections.isEmpty());
-    assertEquals(2, createdElections.size());
-    assertEquals(
-        1,
-        createdElections.stream()
-            .filter(e -> e.getElectionType().equals(ElectionType.DATA_ACCESS.getValue()))
-            .count());
-    assertEquals(
-        1,
-        createdElections.stream()
-            .filter(e -> e.getElectionType().equals(ElectionType.RP.getValue()))
-            .count());
-
-    // Check that the canceled elections are archived
-    List<Election> canceledElections = electionDAO.findElectionsByIds(canceledElectionIds);
-    canceledElections.forEach(e -> assertTrue(e.getArchived()));
-  }
-
-  /**
    * This test covers the case where: - User is a chair - Collection has 2 DAR/Dataset combinations
    * - Elections have been created for a Collection - User is a DAC chair for only one of the
    * DAR/Dataset combinations - All elections are canceled - Chair specific elections are re-created
@@ -388,7 +227,7 @@ class DarCollectionServiceDAOTest extends DAOTestHelper {
     DataAccessRequest dar = collection.getDars().values().stream().findFirst().orElse(null);
     assertNotNull(dar);
     assertFalse(dar.getDatasetIds().isEmpty());
-    Integer datasetId = dar.getDatasetIds().get(0);
+    Integer datasetId = dar.getDatasetIds().getFirst();
     assertNotNull(datasetId);
 
     // Find the dac chairperson for the current DAR/Dataset combination
@@ -468,7 +307,7 @@ class DarCollectionServiceDAOTest extends DAOTestHelper {
   /** Helper method to generate a DarCollection with a Dac, a Dataset, and a create User */
   private DarCollection setUpDarCollectionWithDacDataset() {
     User user = createUser();
-    String darCode = "DAR-" + RandomUtils.nextInt(100, 1000);
+    String darCode = "DAR-" + randomInt(100, 1000);
     DacAndDataset dacAndDataset = createDacAndDataset();
     DacAndDataset dacAndDataset2 = createDacAndDataset();
     Integer collectionId =
@@ -500,9 +339,7 @@ class DarCollectionServiceDAOTest extends DAOTestHelper {
   private Dac createDac() {
     Integer id =
         dacDAO.createDac(
-            "Test_" + RandomStringUtils.random(20, true, true),
-            "Test_" + RandomStringUtils.random(20, true, true),
-            new Date());
+            "Test_" + randomAlphabetic(20), "Test_" + randomAlphabetic(20), new Date());
     return dacDAO.findById(id);
   }
 
@@ -517,8 +354,7 @@ class DarCollectionServiceDAOTest extends DAOTestHelper {
     datasetDAO.insertDatasetProperties(list);
   }
 
-  private DataAccessRequest createDarForCollection(
-      User user, Integer collectionId, Dataset dataset) {
+  private void createDarForCollection(User user, Integer collectionId, Dataset dataset) {
     Date now = new Date();
     DataAccessRequest dar = new DataAccessRequest();
     dar.setReferenceId(UUID.randomUUID().toString());
@@ -530,14 +366,13 @@ class DarCollectionServiceDAOTest extends DAOTestHelper {
     dataAccessRequestDAO.updateDataByReferenceId(
         dar.referenceId, dar.userId, new Date(), new Date(), data, user.getEraCommonsId());
     dataAccessRequestDAO.insertDARDatasetRelation(dar.getReferenceId(), dataset.getDatasetId());
-    return dataAccessRequestDAO.findByReferenceId(dar.getReferenceId());
   }
 
   private Dataset createDatasetWithDac(Integer dacId) {
     User user = createUser();
-    String name = "Name_" + RandomStringUtils.random(20, true, true);
+    String name = "Name_" + randomAlphabetic(20);
     Timestamp now = new Timestamp(new Date().getTime());
-    String objectId = "Object ID_" + RandomStringUtils.random(20, true, true);
+    String objectId = "Object ID_" + randomAlphabetic(20);
     DataUse dataUse = new DataUseBuilder().setGeneralUse(true).build();
     Integer id =
         datasetDAO.insertDataset(name, now, user.getUserId(), objectId, dataUse.toString(), dacId);


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-2797

### Summary
- Removes the ability for Admins to create elections
- Does NOT remove the ability to cancel.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
