### PR TITLE
[DT-2795] AC # 2: Ensure we have Rule Implementations 

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/rules/AutoOpenDARForAllMembers.java
+++ b/src/main/java/org/broadinstitute/consent/http/rules/AutoOpenDARForAllMembers.java
@@ -1,0 +1,17 @@
+package org.broadinstitute.consent.http.rules;
+
+import org.broadinstitute.consent.http.models.DataAccessRequest;
+import org.broadinstitute.consent.http.models.Dataset;
+
+public class AutoOpenDARForAllMembers implements RuleImplementationInterface {
+
+  @Override
+  public DACAutomationRuleType getRuleType() {
+    return DACAutomationRuleType.AUTO_OPEN_DAR_FOR_ALL_MEMBERS;
+  }
+
+  @Override
+  public boolean compare(Dataset dataset, DataAccessRequest dataAccessRequest) {
+    return false;
+  }
+}

--- a/src/main/java/org/broadinstitute/consent/http/rules/Rules.java
+++ b/src/main/java/org/broadinstitute/consent/http/rules/Rules.java
@@ -6,6 +6,10 @@ public class Rules {
 
   public static List<RuleImplementationInterface> implementationList =
       List.of(
-          new GeneralResearchUseV1(), new GeneralResearchUseWithDiseaseSpecificV1(),
-          new HealthMedicalBioMedicalV1(), new HealthMedicalBioMedicalWithDiseaseSpecificV1());
+          new GeneralResearchUseV1(),
+          new GeneralResearchUseWithDiseaseSpecificV1(),
+          new HealthMedicalBioMedicalV1(),
+          new HealthMedicalBioMedicalWithDiseaseSpecificV1(),
+          new AutoOpenDARForAllMembers(),
+          new SOApprovalForNewDARRequired());
 }

--- a/src/main/java/org/broadinstitute/consent/http/rules/SOApprovalForNewDARRequired.java
+++ b/src/main/java/org/broadinstitute/consent/http/rules/SOApprovalForNewDARRequired.java
@@ -1,0 +1,17 @@
+package org.broadinstitute.consent.http.rules;
+
+import org.broadinstitute.consent.http.models.DataAccessRequest;
+import org.broadinstitute.consent.http.models.Dataset;
+
+public class SOApprovalForNewDARRequired implements RuleImplementationInterface {
+
+  @Override
+  public DACAutomationRuleType getRuleType() {
+    return DACAutomationRuleType.REQUIRE_SO_DAR_APPROVAL;
+  }
+
+  @Override
+  public boolean compare(Dataset dataset, DataAccessRequest dataAccessRequest) {
+    return false;
+  }
+}

--- a/src/test/java/org/broadinstitute/consent/http/rules/AutoOpenDARForAllMembersTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/rules/AutoOpenDARForAllMembersTest.java
@@ -1,0 +1,15 @@
+package org.broadinstitute.consent.http.rules;
+
+import org.broadinstitute.consent.http.models.DataAccessRequest;
+import org.broadinstitute.consent.http.models.Dataset;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+class AutoOpenDARForAllMembersTest {
+  @Test
+  void ensureRuleReturnsFalse() {
+    AutoOpenDARForAllMembers rule = new AutoOpenDARForAllMembers();
+    assertFalse(rule.compare(new Dataset(), new DataAccessRequest()));
+  }
+}

--- a/src/test/java/org/broadinstitute/consent/http/rules/AutoOpenDARForAllMembersTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/rules/AutoOpenDARForAllMembersTest.java
@@ -1,10 +1,10 @@
 package org.broadinstitute.consent.http.rules;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
 import org.broadinstitute.consent.http.models.DataAccessRequest;
 import org.broadinstitute.consent.http.models.Dataset;
 import org.junit.jupiter.api.Test;
-
-import static org.junit.jupiter.api.Assertions.assertFalse;
 
 class AutoOpenDARForAllMembersTest {
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/rules/RuleImplementationInterfaceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/rules/RuleImplementationInterfaceTest.java
@@ -1,5 +1,8 @@
 package org.broadinstitute.consent.http.rules;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.core.IsNot.not;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -78,5 +81,14 @@ class RuleImplementationInterfaceTest {
 
     data.setAiLlmUse(true);
     assertFalse(rule.requestHasDiseases(data));
+  }
+
+  @Test
+  void testEnsureEachRuleHasImplementation() {
+    for (DACAutomationRuleType value : DACAutomationRuleType.values()) {
+      assertThat(
+          Rules.implementationList.stream().filter(r -> r.getRuleType() == value).toList(),
+          not(empty()));
+    }
   }
 }

--- a/src/test/java/org/broadinstitute/consent/http/rules/SOApprovalForNewDARRequiredTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/rules/SOApprovalForNewDARRequiredTest.java
@@ -1,14 +1,14 @@
 package org.broadinstitute.consent.http.rules;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
 import org.broadinstitute.consent.http.models.DataAccessRequest;
 import org.broadinstitute.consent.http.models.Dataset;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-
 class SOApprovalForNewDARRequiredTest {
   @Test
-  void ensureRuleReturnsFalse () {
+  void ensureRuleReturnsFalse() {
     SOApprovalForNewDARRequired rule = new SOApprovalForNewDARRequired();
     assertFalse(rule.compare(new Dataset(), new DataAccessRequest()));
   }

--- a/src/test/java/org/broadinstitute/consent/http/rules/SOApprovalForNewDARRequiredTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/rules/SOApprovalForNewDARRequiredTest.java
@@ -1,0 +1,15 @@
+package org.broadinstitute.consent.http.rules;
+
+import org.broadinstitute.consent.http.models.DataAccessRequest;
+import org.broadinstitute.consent.http.models.Dataset;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+class SOApprovalForNewDARRequiredTest {
+  @Test
+  void ensureRuleReturnsFalse () {
+    SOApprovalForNewDARRequired rule = new SOApprovalForNewDARRequired();
+    assertFalse(rule.compare(new Dataset(), new DataAccessRequest()));
+  }
+}


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-2795](https://broadworkbench.atlassian.net/browse/DT-2795)

### Summary

Covers AC # 2 in the ticket by:

- Creating rule implementations for all of the RADAR DACAutomationRuleType enum values because code expects them.
- Adding test to verify one exists so that we catch this in the future.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
