### PR TITLE
[DT-2824] Feature flags

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
@@ -60,6 +60,7 @@ import org.broadinstitute.consent.http.resources.DatasetResource;
 import org.broadinstitute.consent.http.resources.DraftResource;
 import org.broadinstitute.consent.http.resources.EmailNotifierResource;
 import org.broadinstitute.consent.http.resources.ErrorResource;
+import org.broadinstitute.consent.http.resources.FeatureFlagResource;
 import org.broadinstitute.consent.http.resources.InstitutionResource;
 import org.broadinstitute.consent.http.resources.LibraryCardResource;
 import org.broadinstitute.consent.http.resources.LivenessResource;
@@ -167,6 +168,7 @@ public class ConsentApplication extends Application<ConsentConfiguration> {
     env.jersey().register(injector.getInstance(DatasetResource.class));
     env.jersey().register(injector.getInstance(DraftResource.class));
     env.jersey().register(injector.getInstance(EmailNotifierResource.class));
+    env.jersey().register(injector.getInstance(FeatureFlagResource.class));
     env.jersey().register(injector.getInstance(InstitutionResource.class));
     env.jersey().register(injector.getInstance(LibraryCardResource.class));
     env.jersey().register(injector.getInstance(LivenessResource.class));

--- a/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
@@ -31,6 +31,7 @@ import org.broadinstitute.consent.http.db.DatasetAuthorizationReaderDAO;
 import org.broadinstitute.consent.http.db.DatasetDAO;
 import org.broadinstitute.consent.http.db.DraftDAO;
 import org.broadinstitute.consent.http.db.ElectionDAO;
+import org.broadinstitute.consent.http.db.FeatureFlagDAO;
 import org.broadinstitute.consent.http.db.FileStorageObjectDAO;
 import org.broadinstitute.consent.http.db.InstitutionDAO;
 import org.broadinstitute.consent.http.db.LibraryCardDAO;
@@ -57,6 +58,7 @@ import org.broadinstitute.consent.http.service.DatasetService;
 import org.broadinstitute.consent.http.service.ElasticSearchService;
 import org.broadinstitute.consent.http.service.ElectionService;
 import org.broadinstitute.consent.http.service.EmailService;
+import org.broadinstitute.consent.http.service.FeatureFlagService;
 import org.broadinstitute.consent.http.service.FileStorageObjectService;
 import org.broadinstitute.consent.http.service.InstitutionService;
 import org.broadinstitute.consent.http.service.LibraryCardService;
@@ -119,6 +121,7 @@ public class ConsentModule extends AbstractModule {
   private final AcknowledgementDAO acknowledgementDAO;
   private final DraftDAO draftDAO;
   private final DACAutomationRuleDAO rulesDAO;
+  private final FeatureFlagDAO featureFlagDAO;
 
   ConsentModule(ConsentConfiguration consentConfiguration, Environment environment) {
     this.config = consentConfiguration;
@@ -156,6 +159,7 @@ public class ConsentModule extends AbstractModule {
     this.acknowledgementDAO = this.jdbi.onDemand((AcknowledgementDAO.class));
     this.draftDAO = this.jdbi.onDemand(DraftDAO.class);
     this.rulesDAO = this.jdbi.onDemand(DACAutomationRuleDAO.class);
+    this.featureFlagDAO = this.jdbi.onDemand(FeatureFlagDAO.class);
   }
 
   @Override
@@ -348,6 +352,11 @@ public class ConsentModule extends AbstractModule {
         providesSendGridAPI(),
         providesFreeMarkerTemplateHelper(),
         config);
+  }
+
+  @Provides
+  FeatureFlagService providesFeatureFlagService() {
+    return new FeatureFlagService(providesFeatureFlagDAO());
   }
 
   @Provides
@@ -678,5 +687,10 @@ public class ConsentModule extends AbstractModule {
   @Provides
   DACAutomationRuleDAO providesDACAutomationRuleDAO() {
     return rulesDAO;
+  }
+
+  @Provides
+  FeatureFlagDAO providesFeatureFlagDAO() {
+    return featureFlagDAO;
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/db/FeatureFlagDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/FeatureFlagDAO.java
@@ -67,4 +67,21 @@ public interface FeatureFlagDAO extends Transactional<FeatureFlagDAO> {
    */
   @SqlQuery("SELECT COUNT(*) > 0 FROM feature_flag WHERE id = :id")
   boolean exists(@Bind("id") String id);
+
+  /**
+   * Insert an audit record for a feature flag action
+   *
+   * @param userId The user id who performed the action
+   * @param featureFlagId The feature flag id
+   * @param action The action performed (e.g., 'CREATE', 'UPDATE', 'DELETE')
+   */
+  @SqlUpdate(
+      """
+      INSERT INTO feature_flag_audit (user_id, feature_flag_id, action, action_date)
+      VALUES (:userId, :featureFlagId, :action, NOW())
+      """)
+  void insertAudit(
+      @Bind("userId") Integer userId,
+      @Bind("featureFlagId") String featureFlagId,
+      @Bind("action") String action);
 }

--- a/src/main/java/org/broadinstitute/consent/http/db/FeatureFlagDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/FeatureFlagDAO.java
@@ -1,0 +1,70 @@
+package org.broadinstitute.consent.http.db;
+
+import java.util.List;
+import org.broadinstitute.consent.http.db.mapper.FeatureFlagMapper;
+import org.broadinstitute.consent.http.models.FeatureFlag;
+import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
+import org.jdbi.v3.sqlobject.customizer.Bind;
+import org.jdbi.v3.sqlobject.statement.SqlQuery;
+import org.jdbi.v3.sqlobject.statement.SqlUpdate;
+import org.jdbi.v3.sqlobject.transaction.Transactional;
+
+@RegisterRowMapper(FeatureFlagMapper.class)
+public interface FeatureFlagDAO extends Transactional<FeatureFlagDAO> {
+
+  /**
+   * Find all feature flags
+   *
+   * @return List<FeatureFlag>
+   */
+  @SqlQuery("SELECT id, value, create_date, update_date FROM feature_flag ORDER BY id")
+  List<FeatureFlag> findAll();
+
+  /**
+   * Find a feature flag by id
+   *
+   * @param id The feature flag id
+   * @return FeatureFlag or null if not found
+   */
+  @SqlQuery("SELECT id, value, create_date, update_date FROM feature_flag WHERE id = :id")
+  FeatureFlag findById(@Bind("id") String id);
+
+  /**
+   * Insert a new feature flag
+   *
+   * @param id The feature flag id
+   * @param value The feature flag value
+   */
+  @SqlUpdate(
+      """
+      INSERT INTO feature_flag (id, value, create_date, update_date)
+      VALUES (:id, :value, NOW(), NOW())
+      """)
+  void insert(@Bind("id") String id, @Bind("value") String value);
+
+  /**
+   * Update an existing feature flag
+   *
+   * @param id The feature flag id
+   * @param value The new feature flag value
+   */
+  @SqlUpdate("UPDATE feature_flag SET value = :value, update_date = NOW() WHERE id = :id")
+  void update(@Bind("id") String id, @Bind("value") String value);
+
+  /**
+   * Delete a feature flag by id
+   *
+   * @param id The feature flag id
+   */
+  @SqlUpdate("DELETE FROM feature_flag WHERE id = :id")
+  void deleteById(@Bind("id") String id);
+
+  /**
+   * Check if a feature flag exists
+   *
+   * @param id The feature flag id
+   * @return true if exists, false otherwise
+   */
+  @SqlQuery("SELECT COUNT(*) > 0 FROM feature_flag WHERE id = :id")
+  boolean exists(@Bind("id") String id);
+}

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/FeatureFlagMapper.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/FeatureFlagMapper.java
@@ -1,0 +1,19 @@
+package org.broadinstitute.consent.http.db.mapper;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import org.broadinstitute.consent.http.models.FeatureFlag;
+import org.jdbi.v3.core.mapper.RowMapper;
+import org.jdbi.v3.core.statement.StatementContext;
+
+public class FeatureFlagMapper implements RowMapper<FeatureFlag> {
+
+  @Override
+  public FeatureFlag map(ResultSet rs, StatementContext ctx) throws SQLException {
+    return new FeatureFlag(
+        rs.getString("id"),
+        rs.getString("value"),
+        rs.getTimestamp("create_date").toInstant(),
+        rs.getTimestamp("update_date").toInstant());
+  }
+}

--- a/src/main/java/org/broadinstitute/consent/http/models/FeatureFlag.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/FeatureFlag.java
@@ -1,0 +1,57 @@
+package org.broadinstitute.consent.http.models;
+
+import java.time.Instant;
+
+public class FeatureFlag {
+
+  private String id;
+  private String value;
+  private Instant createDate;
+  private Instant updateDate;
+
+  public FeatureFlag() {}
+
+  public FeatureFlag(String id, String value) {
+    this.id = id;
+    this.value = value;
+  }
+
+  public FeatureFlag(String id, String value, Instant createDate, Instant updateDate) {
+    this.id = id;
+    this.value = value;
+    this.createDate = createDate;
+    this.updateDate = updateDate;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(String id) {
+    this.id = id;
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+  public void setValue(String value) {
+    this.value = value;
+  }
+
+  public Instant getCreateDate() {
+    return createDate;
+  }
+
+  public void setCreateDate(Instant createDate) {
+    this.createDate = createDate;
+  }
+
+  public Instant getUpdateDate() {
+    return updateDate;
+  }
+
+  public void setUpdateDate(Instant updateDate) {
+    this.updateDate = updateDate;
+  }
+}

--- a/src/main/java/org/broadinstitute/consent/http/resources/FeatureFlagResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/FeatureFlagResource.java
@@ -1,0 +1,130 @@
+package org.broadinstitute.consent.http.resources;
+
+import com.google.inject.Inject;
+import io.dropwizard.auth.Auth;
+import jakarta.annotation.security.PermitAll;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriInfo;
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import org.broadinstitute.consent.http.models.AuthUser;
+import org.broadinstitute.consent.http.models.FeatureFlag;
+import org.broadinstitute.consent.http.service.FeatureFlagService;
+
+@Path("api/feature")
+public class FeatureFlagResource extends Resource {
+
+  private final FeatureFlagService featureFlagService;
+
+  @Inject
+  public FeatureFlagResource(FeatureFlagService featureFlagService) {
+    this.featureFlagService = featureFlagService;
+  }
+
+  /**
+   * Get all feature flags
+   *
+   * @return List of all feature flags
+   */
+  @GET
+  @Produces(MediaType.APPLICATION_JSON)
+  @PermitAll
+  public Response getAllFeatureFlags() {
+    try {
+      List<FeatureFlag> flags = featureFlagService.getAllFeatureFlags();
+      return Response.ok(flags).build();
+    } catch (Exception e) {
+      return createExceptionResponse(e);
+    }
+  }
+
+  /**
+   * Get a specific feature flag by id
+   *
+   * @param id The feature flag id
+   * @return The feature flag
+   */
+  @GET
+  @Path("/{id}")
+  @Produces(MediaType.APPLICATION_JSON)
+  @PermitAll
+  public Response getFeatureFlagById(@PathParam("id") String id) {
+    try {
+      FeatureFlag flag = featureFlagService.getFeatureFlagById(id);
+      return Response.ok(flag).build();
+    } catch (Exception e) {
+      return createExceptionResponse(e);
+    }
+  }
+
+  /**
+   * Create or update a feature flag (admin only)
+   *
+   * @param info URI information
+   * @param authUser The authenticated user
+   * @param id The feature flag id
+   * @param body Request body containing the value
+   * @return The created or updated feature flag
+   */
+  @POST
+  @Path("/{id}")
+  @Consumes(MediaType.APPLICATION_JSON)
+  @Produces(MediaType.APPLICATION_JSON)
+  @RolesAllowed({ADMIN})
+  public Response createOrUpdateFeatureFlag(
+      @Context UriInfo info,
+      @Auth AuthUser authUser,
+      @PathParam("id") String id,
+      Map<String, String> body) {
+    try {
+      String value = body.get("value");
+      if (value == null) {
+        return Response.status(Response.Status.BAD_REQUEST)
+            .entity(Map.of("error", "Missing 'value' in request body"))
+            .build();
+      }
+
+      boolean existed = featureFlagService.exists(id);
+      FeatureFlag flag = featureFlagService.createOrUpdateFeatureFlag(id, value);
+
+      if (existed) {
+        return Response.ok(flag).build();
+      } else {
+        URI uri = info.getAbsolutePathBuilder().path(id).build();
+        return Response.created(uri).entity(flag).build();
+      }
+    } catch (Exception e) {
+      return createExceptionResponse(e);
+    }
+  }
+
+  /**
+   * Delete a feature flag (admin only)
+   *
+   * @param authUser The authenticated user
+   * @param id The feature flag id
+   * @return No content response
+   */
+  @DELETE
+  @Path("/{id}")
+  @RolesAllowed({ADMIN})
+  public Response deleteFeatureFlag(@Auth AuthUser authUser, @PathParam("id") String id) {
+    try {
+      featureFlagService.deleteFeatureFlag(id);
+      return Response.noContent().build();
+    } catch (Exception e) {
+      return createExceptionResponse(e);
+    }
+  }
+}

--- a/src/main/java/org/broadinstitute/consent/http/resources/FeatureFlagResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/FeatureFlagResource.java
@@ -20,16 +20,20 @@ import java.util.List;
 import java.util.Map;
 import org.broadinstitute.consent.http.models.AuthUser;
 import org.broadinstitute.consent.http.models.FeatureFlag;
+import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.service.FeatureFlagService;
+import org.broadinstitute.consent.http.service.UserService;
 
 @Path("api/feature")
 public class FeatureFlagResource extends Resource {
 
   private final FeatureFlagService featureFlagService;
+  private final UserService userService;
 
   @Inject
-  public FeatureFlagResource(FeatureFlagService featureFlagService) {
+  public FeatureFlagResource(FeatureFlagService featureFlagService, UserService userService) {
     this.featureFlagService = featureFlagService;
+    this.userService = userService;
   }
 
   /**
@@ -95,8 +99,9 @@ public class FeatureFlagResource extends Resource {
             .build();
       }
 
+      User user = userService.findUserByEmail(authUser.getEmail());
       boolean existed = featureFlagService.exists(id);
-      FeatureFlag flag = featureFlagService.createOrUpdateFeatureFlag(id, value);
+      FeatureFlag flag = featureFlagService.createOrUpdateFeatureFlag(id, value, user.getUserId());
 
       if (existed) {
         return Response.ok(flag).build();
@@ -121,7 +126,8 @@ public class FeatureFlagResource extends Resource {
   @RolesAllowed({ADMIN})
   public Response deleteFeatureFlag(@Auth AuthUser authUser, @PathParam("id") String id) {
     try {
-      featureFlagService.deleteFeatureFlag(id);
+      User user = userService.findUserByEmail(authUser.getEmail());
+      featureFlagService.deleteFeatureFlag(id, user.getUserId());
       return Response.noContent().build();
     } catch (Exception e) {
       return createExceptionResponse(e);

--- a/src/main/java/org/broadinstitute/consent/http/service/FeatureFlagService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/FeatureFlagService.java
@@ -81,9 +81,10 @@ public class FeatureFlagService implements ConsentLogger {
    *
    * @param id The feature flag id
    * @param value The feature flag value
+   * @param userId The user id performing the action
    * @return The created or updated feature flag
    */
-  public FeatureFlag createOrUpdateFeatureFlag(String id, String value) {
+  public FeatureFlag createOrUpdateFeatureFlag(String id, String value, Integer userId) {
     if (id == null || id.trim().isEmpty()) {
       throw new IllegalArgumentException("Feature flag id cannot be empty");
     }
@@ -93,8 +94,10 @@ public class FeatureFlagService implements ConsentLogger {
 
     if (featureFlagDAO.exists(id)) {
       featureFlagDAO.update(id, value);
+      featureFlagDAO.insertAudit(userId, id, "UPDATE");
     } else {
       featureFlagDAO.insert(id, value);
+      featureFlagDAO.insertAudit(userId, id, "CREATE");
     }
     return featureFlagDAO.findById(id);
   }
@@ -103,13 +106,15 @@ public class FeatureFlagService implements ConsentLogger {
    * Delete a feature flag by id
    *
    * @param id The feature flag id
+   * @param userId The user id performing the action
    * @throws NotFoundException if the feature flag does not exist
    */
-  public void deleteFeatureFlag(String id) {
+  public void deleteFeatureFlag(String id, Integer userId) {
     if (!featureFlagDAO.exists(id)) {
       throw new NotFoundException("Feature flag with id '" + id + "' not found");
     }
     featureFlagDAO.deleteById(id);
+    featureFlagDAO.insertAudit(userId, id, "DELETE");
   }
 
   /**

--- a/src/main/java/org/broadinstitute/consent/http/service/FeatureFlagService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/FeatureFlagService.java
@@ -92,13 +92,16 @@ public class FeatureFlagService implements ConsentLogger {
       throw new IllegalArgumentException("Feature flag value cannot be null");
     }
 
-    if (featureFlagDAO.exists(id)) {
-      featureFlagDAO.update(id, value);
-      featureFlagDAO.insertAudit(userId, id, "UPDATE");
-    } else {
-      featureFlagDAO.insert(id, value);
-      featureFlagDAO.insertAudit(userId, id, "CREATE");
-    }
+    featureFlagDAO.useTransaction(
+        dao -> {
+          if (dao.exists(id)) {
+            dao.update(id, value);
+            dao.insertAudit(userId, id, "UPDATE");
+          } else {
+            dao.insert(id, value);
+            dao.insertAudit(userId, id, "CREATE");
+          }
+        });
     return featureFlagDAO.findById(id);
   }
 
@@ -110,11 +113,14 @@ public class FeatureFlagService implements ConsentLogger {
    * @throws NotFoundException if the feature flag does not exist
    */
   public void deleteFeatureFlag(String id, Integer userId) {
-    if (!featureFlagDAO.exists(id)) {
-      throw new NotFoundException("Feature flag with id '" + id + "' not found");
-    }
-    featureFlagDAO.deleteById(id);
-    featureFlagDAO.insertAudit(userId, id, "DELETE");
+    featureFlagDAO.useTransaction(
+        dao -> {
+          if (!dao.exists(id)) {
+            throw new NotFoundException("Feature flag with id '" + id + "' not found");
+          }
+          dao.deleteById(id);
+          dao.insertAudit(userId, id, "DELETE");
+        });
   }
 
   /**

--- a/src/main/java/org/broadinstitute/consent/http/service/FeatureFlagService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/FeatureFlagService.java
@@ -1,0 +1,124 @@
+package org.broadinstitute.consent.http.service;
+
+import com.google.inject.Inject;
+import jakarta.ws.rs.NotFoundException;
+import java.util.List;
+import org.broadinstitute.consent.http.db.FeatureFlagDAO;
+import org.broadinstitute.consent.http.models.FeatureFlag;
+import org.broadinstitute.consent.http.util.ConsentLogger;
+
+public class FeatureFlagService implements ConsentLogger {
+
+  private final FeatureFlagDAO featureFlagDAO;
+
+  @Inject
+  public FeatureFlagService(FeatureFlagDAO featureFlagDAO) {
+    this.featureFlagDAO = featureFlagDAO;
+  }
+
+  /**
+   * Get all feature flags
+   *
+   * @return List of all feature flags
+   */
+  public List<FeatureFlag> getAllFeatureFlags() {
+    return featureFlagDAO.findAll();
+  }
+
+  /**
+   * Get a feature flag by id
+   *
+   * @param id The feature flag id
+   * @return The feature flag
+   * @throws NotFoundException if the feature flag does not exist
+   */
+  public FeatureFlag getFeatureFlagById(String id) {
+    FeatureFlag flag = featureFlagDAO.findById(id);
+    if (flag == null) {
+      throw new NotFoundException("Feature flag with id '" + id + "' not found");
+    }
+    return flag;
+  }
+
+  /**
+   * Get the value of a feature flag by id, or return null if not found This is a helper method for
+   * other services
+   *
+   * @param id The feature flag id
+   * @return The feature flag value, or null if not found
+   */
+  public String getFeatureFlagValue(String id) {
+    FeatureFlag flag = featureFlagDAO.findById(id);
+    return flag != null ? flag.getValue() : null;
+  }
+
+  /**
+   * Get the value of a feature flag by id, or return a default value if not found This is a helper
+   * method for other services
+   *
+   * @param id The feature flag id
+   * @param defaultValue The default value to return if not found
+   * @return The feature flag value, or the default value if not found
+   */
+  public String getFeatureFlagValue(String id, String defaultValue) {
+    FeatureFlag flag = featureFlagDAO.findById(id);
+    return flag != null ? flag.getValue() : defaultValue;
+  }
+
+  /**
+   * Check if a feature flag is enabled (value is "true") This is a helper method for other services
+   *
+   * @param id The feature flag id
+   * @return true if the flag exists and its value is "true", false otherwise
+   */
+  public boolean isFeatureEnabled(String id) {
+    String value = getFeatureFlagValue(id);
+    return "true".equalsIgnoreCase(value);
+  }
+
+  /**
+   * Create or update a feature flag
+   *
+   * @param id The feature flag id
+   * @param value The feature flag value
+   * @return The created or updated feature flag
+   */
+  public FeatureFlag createOrUpdateFeatureFlag(String id, String value) {
+    if (id == null || id.trim().isEmpty()) {
+      throw new IllegalArgumentException("Feature flag id cannot be empty");
+    }
+    if (value == null) {
+      throw new IllegalArgumentException("Feature flag value cannot be null");
+    }
+
+    if (featureFlagDAO.exists(id)) {
+      featureFlagDAO.update(id, value);
+    } else {
+      featureFlagDAO.insert(id, value);
+    }
+    return featureFlagDAO.findById(id);
+  }
+
+  /**
+   * Delete a feature flag by id
+   *
+   * @param id The feature flag id
+   * @throws NotFoundException if the feature flag does not exist
+   */
+  public void deleteFeatureFlag(String id) {
+    if (!featureFlagDAO.exists(id)) {
+      throw new NotFoundException("Feature flag with id '" + id + "' not found");
+    }
+    featureFlagDAO.deleteById(id);
+  }
+
+  /**
+   * Check if a feature flag exists
+   *
+   * @param id The feature flag id
+   * @return true if the feature flag exists, false otherwise
+   */
+  public boolean exists(String id) {
+    return featureFlagDAO.exists(id);
+  }
+}

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -553,6 +553,10 @@ paths:
           description: Server error.
   /api/emailNotifier/darExpirationNotices:
     $ref: './paths/darExpirationNotices.yaml'
+  /api/feature:
+    $ref: './paths/feature.yaml'
+  /api/feature/{id}:
+    $ref: './paths/featureById.yaml'
   /api/institutions:
     $ref: './paths/institutions.yaml'
   /api/institutions/{id}:

--- a/src/main/resources/assets/paths/feature.yaml
+++ b/src/main/resources/assets/paths/feature.yaml
@@ -1,0 +1,21 @@
+get:
+  summary: Get all feature flags
+  operationId: getAllFeatureFlags
+  description: Retrieve all feature flags in the system
+  tags:
+    - Feature Flags
+  responses:
+    200:
+      description: List of all feature flags
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: '../schemas/FeatureFlag.yaml'
+    500:
+      description: Internal Server Error
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'

--- a/src/main/resources/assets/paths/featureById.yaml
+++ b/src/main/resources/assets/paths/featureById.yaml
@@ -1,0 +1,142 @@
+get:
+  summary: Get feature flag by ID
+  operationId: getFeatureFlagById
+  description: Retrieve a specific feature flag by its ID
+  tags:
+    - Feature Flags
+  parameters:
+    - name: id
+      in: path
+      description: The feature flag ID
+      required: true
+      schema:
+        type: string
+  responses:
+    200:
+      description: Feature flag found
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/FeatureFlag.yaml'
+    404:
+      description: Feature flag not found
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
+    500:
+      description: Internal Server Error
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
+
+post:
+  summary: Create or update feature flag
+  operationId: createOrUpdateFeatureFlag
+  description: |
+    Create a new feature flag or update an existing one. 
+    Requires Admin role.
+  tags:
+    - Feature Flags
+  parameters:
+    - name: id
+      in: path
+      description: The feature flag ID
+      required: true
+      schema:
+        type: string
+  requestBody:
+    description: Feature flag value
+    required: true
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            value:
+              type: string
+              description: The value to set for the feature flag
+          required:
+            - value
+        examples:
+          enableFeature:
+            summary: Enable a feature
+            value:
+              value: "true"
+          disableFeature:
+            summary: Disable a feature
+            value:
+              value: "false"
+          customValue:
+            summary: Custom configuration value
+            value:
+              value: "custom-config-value"
+  responses:
+    200:
+      description: Feature flag updated successfully
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/FeatureFlag.yaml'
+    201:
+      description: Feature flag created successfully
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/FeatureFlag.yaml'
+    400:
+      description: Bad Request - Invalid input
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
+    403:
+      description: Forbidden - Admin role required
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
+    500:
+      description: Internal Server Error
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
+
+delete:
+  summary: Delete feature flag
+  operationId: deleteFeatureFlag
+  description: |
+    Delete a feature flag by its ID.
+    Requires Admin role.
+  tags:
+    - Feature Flags
+  parameters:
+    - name: id
+      in: path
+      description: The feature flag ID
+      required: true
+      schema:
+        type: string
+  responses:
+    204:
+      description: Feature flag deleted successfully
+    403:
+      description: Forbidden - Admin role required
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
+    404:
+      description: Feature flag not found
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
+    500:
+      description: Internal Server Error
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'

--- a/src/main/resources/assets/schemas/FeatureFlag.yaml
+++ b/src/main/resources/assets/schemas/FeatureFlag.yaml
@@ -1,0 +1,21 @@
+type: object
+properties:
+  id:
+    type: string
+    description: Unique identifier for the feature flag
+    example: "enable-new-dar-workflow"
+  value:
+    type: string
+    description: Value of the feature flag
+    example: "true"
+  createDate:
+    type: string
+    format: date-time
+    description: Timestamp when the feature flag was created
+  updateDate:
+    type: string
+    format: date-time
+    description: Timestamp when the feature flag was last updated
+required:
+  - id
+  - value

--- a/src/main/resources/changelog-master.xml
+++ b/src/main/resources/changelog-master.xml
@@ -228,4 +228,6 @@
            relativeToChangelogFile="true" />
   <include file="changesets/changelog-consent-2026-01-22-feature-flags.xml"
            relativeToChangelogFile="true" />
+  <include file="changesets/changelog-consent-2026-01-26-feature-flag-audit.xml"
+           relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/src/main/resources/changelog-master.xml
+++ b/src/main/resources/changelog-master.xml
@@ -226,4 +226,6 @@
            relativeToChangelogFile="true" />
   <include file="changesets/changelog-consent-2026-01-22-update-so-approval-rule-desc.xml"
            relativeToChangelogFile="true" />
+  <include file="changesets/changelog-consent-2026-01-22-feature-flags.xml"
+           relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/src/main/resources/changesets/changelog-consent-2026-01-22-feature-flags.xml
+++ b/src/main/resources/changesets/changelog-consent-2026-01-22-feature-flags.xml
@@ -1,0 +1,20 @@
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+  <changeSet id="changelog-consent-2026-01-22-feature-flags.xml" author="consent">
+    <createTable tableName="feature_flag">
+      <column name="id" type="varchar(255)">
+        <constraints primaryKey="true" nullable="false"/>
+      </column>
+      <column name="value" type="text">
+        <constraints nullable="false"/>
+      </column>
+      <column name="create_date" type="timestamp">
+        <constraints nullable="false"/>
+      </column>
+      <column name="update_date" type="timestamp">
+        <constraints nullable="false"/>
+      </column>
+    </createTable>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/changesets/changelog-consent-2026-01-26-feature-flag-audit.xml
+++ b/src/main/resources/changesets/changelog-consent-2026-01-26-feature-flag-audit.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+  <changeSet id="2026-01-26-feature-flag-audit" author="consent">
+    <createTable tableName="feature_flag_audit">
+      <column name="id" type="bigint" autoIncrement="true">
+        <constraints primaryKey="true" nullable="false"/>
+      </column>
+      <column name="user_id" type="bigint">
+        <constraints nullable="false"/>
+      </column>
+      <column name="feature_flag_id" type="varchar(255)">
+        <constraints nullable="false"/>
+      </column>
+      <column name="action" type="varchar(255)">
+        <constraints nullable="false"/>
+      </column>
+      <column name="action_date" type="timestamp" defaultValueDate="current_timestamp">
+        <constraints nullable="false"/>
+      </column>
+    </createTable>
+    <addForeignKeyConstraint baseTableName="feature_flag_audit"
+                             baseColumnNames="user_id"
+                             constraintName="fk_feature_flag_audit_user"
+                             referencedTableName="users"
+                             referencedColumnNames="user_id"/>
+  </changeSet>
+</databaseChangeLog>

--- a/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
@@ -62,6 +62,7 @@ public class DAOTestHelper extends AbstractTestHelper implements TestExecutionLi
   protected static AcknowledgementDAO acknowledgementDAO;
   protected static DraftDAO draftDAO;
   protected static DACAutomationRuleDAO dacAutomationRuleDAO;
+  protected static FeatureFlagDAO featureFlagDAO;
   private static DropwizardTestSupport<ConsentConfiguration> testApp;
   // This is a test-only DAO class where we manage the deletion
   // of all records between test runs.
@@ -152,6 +153,7 @@ public class DAOTestHelper extends AbstractTestHelper implements TestExecutionLi
     acknowledgementDAO = jdbi.onDemand(AcknowledgementDAO.class);
     draftDAO = jdbi.onDemand(DraftDAO.class);
     dacAutomationRuleDAO = jdbi.onDemand(DACAutomationRuleDAO.class);
+    featureFlagDAO = jdbi.onDemand(FeatureFlagDAO.class);
     testingDAO = jdbi.onDemand(TestingDAO.class);
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/db/FeatureFlagDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/FeatureFlagDAOTest.java
@@ -1,0 +1,135 @@
+package org.broadinstitute.consent.http.db;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.broadinstitute.consent.http.models.FeatureFlag;
+import org.junit.jupiter.api.Test;
+
+class FeatureFlagDAOTest extends DAOTestHelper {
+
+  @Test
+  void testInsertAndFindById() {
+    String id = "test-feature-" + RandomStringUtils.secureStrong().nextAlphanumeric(10);
+    String value = "test-value";
+    featureFlagDAO.insert(id, value);
+
+    FeatureFlag flag = featureFlagDAO.findById(id);
+    assertNotNull(flag);
+    assertEquals(id, flag.getId());
+    assertEquals(value, flag.getValue());
+    assertNotNull(flag.getCreateDate());
+    assertNotNull(flag.getUpdateDate());
+  }
+
+  @Test
+  void testFindById_NotFound() {
+    String id = "non-existent-" + RandomStringUtils.secureStrong().nextAlphanumeric(10);
+    FeatureFlag flag = featureFlagDAO.findById(id);
+    assertNull(flag);
+  }
+
+  @Test
+  void testFindAll() {
+    String id1 = "feature-1-" + RandomStringUtils.secureStrong().nextAlphanumeric(10);
+    String id2 = "feature-2-" + RandomStringUtils.secureStrong().nextAlphanumeric(10);
+    featureFlagDAO.insert(id1, "value1");
+    featureFlagDAO.insert(id2, "value2");
+
+    List<FeatureFlag> flags = featureFlagDAO.findAll();
+    assertNotNull(flags);
+    assertTrue(flags.size() >= 2);
+    assertTrue(flags.stream().anyMatch(f -> f.getId().equals(id1)));
+    assertTrue(flags.stream().anyMatch(f -> f.getId().equals(id2)));
+  }
+
+  @Test
+  void testUpdate() {
+    String id = "update-test-" + RandomStringUtils.secureStrong().nextAlphanumeric(10);
+    String originalValue = "original";
+    String updatedValue = "updated";
+
+    featureFlagDAO.insert(id, originalValue);
+    FeatureFlag flag = featureFlagDAO.findById(id);
+    assertEquals(originalValue, flag.getValue());
+
+    featureFlagDAO.update(id, updatedValue);
+    FeatureFlag updatedFlag = featureFlagDAO.findById(id);
+    assertEquals(updatedValue, updatedFlag.getValue());
+    assertTrue(
+        updatedFlag.getUpdateDate().isAfter(flag.getUpdateDate())
+            || updatedFlag.getUpdateDate().equals(flag.getUpdateDate()));
+  }
+
+  @Test
+  void testDeleteById() {
+    String id = "delete-test-" + RandomStringUtils.secureStrong().nextAlphanumeric(10);
+    featureFlagDAO.insert(id, "value");
+
+    assertTrue(featureFlagDAO.exists(id));
+    featureFlagDAO.deleteById(id);
+    assertFalse(featureFlagDAO.exists(id));
+    assertNull(featureFlagDAO.findById(id));
+  }
+
+  @Test
+  void testExists() {
+    String id = "exists-test-" + RandomStringUtils.secureStrong().nextAlphanumeric(10);
+    assertFalse(featureFlagDAO.exists(id));
+
+    featureFlagDAO.insert(id, "value");
+    assertTrue(featureFlagDAO.exists(id));
+
+    featureFlagDAO.deleteById(id);
+    assertFalse(featureFlagDAO.exists(id));
+  }
+
+  @Test
+  void testMultipleOperations() {
+    String id = "multi-test-" + RandomStringUtils.secureStrong().nextAlphanumeric(10);
+
+    // Insert
+    featureFlagDAO.insert(id, "initial");
+    assertTrue(featureFlagDAO.exists(id));
+
+    // Update multiple times
+    featureFlagDAO.update(id, "updated1");
+    assertEquals("updated1", featureFlagDAO.findById(id).getValue());
+
+    featureFlagDAO.update(id, "updated2");
+    assertEquals("updated2", featureFlagDAO.findById(id).getValue());
+
+    // Delete
+    featureFlagDAO.deleteById(id);
+    assertFalse(featureFlagDAO.exists(id));
+  }
+
+  @Test
+  void testFindAllOrdering() {
+    String id1 = "aaa-" + RandomStringUtils.secureStrong().nextAlphanumeric(10);
+    String id2 = "zzz-" + RandomStringUtils.secureStrong().nextAlphanumeric(10);
+    String id3 = "mmm-" + RandomStringUtils.secureStrong().nextAlphanumeric(10);
+
+    featureFlagDAO.insert(id2, "value2");
+    featureFlagDAO.insert(id1, "value1");
+    featureFlagDAO.insert(id3, "value3");
+
+    List<FeatureFlag> flags = featureFlagDAO.findAll();
+    assertNotNull(flags);
+
+    // Verify ordering (should be alphabetical by id)
+    int idx1 = -1, idx2 = -1, idx3 = -1;
+    for (int i = 0; i < flags.size(); i++) {
+      if (flags.get(i).getId().equals(id1)) idx1 = i;
+      if (flags.get(i).getId().equals(id2)) idx2 = i;
+      if (flags.get(i).getId().equals(id3)) idx3 = i;
+    }
+    assertTrue(idx1 < idx3);
+    assertTrue(idx3 < idx2);
+  }
+}

--- a/src/test/java/org/broadinstitute/consent/http/db/FeatureFlagDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/FeatureFlagDAOTest.java
@@ -7,7 +7,9 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
+import java.util.Map;
 import org.broadinstitute.consent.http.models.FeatureFlag;
+import org.broadinstitute.consent.http.models.User;
 import org.junit.jupiter.api.Test;
 
 class FeatureFlagDAOTest extends DAOTestHelper {
@@ -130,5 +132,27 @@ class FeatureFlagDAOTest extends DAOTestHelper {
     }
     assertTrue(idx1 < idx3);
     assertTrue(idx3 < idx2);
+  }
+
+  @Test
+  void testInsertAudit() {
+    User user = createUser();
+    String id = "audit-test-" + randomAlphanumeric(10);
+    featureFlagDAO.insertAudit(user.getUserId(), id, "CREATE");
+
+    jdbi.useHandle(
+        handle -> {
+          List<Map<String, Object>> results =
+              handle
+                  .createQuery("SELECT * FROM feature_flag_audit WHERE feature_flag_id = :id")
+                  .bind("id", id)
+                  .mapToMap()
+                  .list();
+          assertEquals(1, results.size());
+          // The database returns a Long for bigint, so we compare with user.getUserId().longValue()
+          assertEquals(user.getUserId().longValue(), results.get(0).get("user_id"));
+          assertEquals("CREATE", results.get(0).get("action"));
+          assertNotNull(results.get(0).get("action_date"));
+        });
   }
 }

--- a/src/test/java/org/broadinstitute/consent/http/db/FeatureFlagDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/FeatureFlagDAOTest.java
@@ -7,7 +7,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.broadinstitute.consent.http.models.FeatureFlag;
 import org.junit.jupiter.api.Test;
 
@@ -15,7 +14,7 @@ class FeatureFlagDAOTest extends DAOTestHelper {
 
   @Test
   void testInsertAndFindById() {
-    String id = "test-feature-" + RandomStringUtils.secureStrong().nextAlphanumeric(10);
+    String id = "test-feature-" + randomAlphanumeric(10);
     String value = "test-value";
     featureFlagDAO.insert(id, value);
 
@@ -29,15 +28,15 @@ class FeatureFlagDAOTest extends DAOTestHelper {
 
   @Test
   void testFindById_NotFound() {
-    String id = "non-existent-" + RandomStringUtils.secureStrong().nextAlphanumeric(10);
+    String id = "non-existent-" + randomAlphanumeric(10);
     FeatureFlag flag = featureFlagDAO.findById(id);
     assertNull(flag);
   }
 
   @Test
   void testFindAll() {
-    String id1 = "feature-1-" + RandomStringUtils.secureStrong().nextAlphanumeric(10);
-    String id2 = "feature-2-" + RandomStringUtils.secureStrong().nextAlphanumeric(10);
+    String id1 = "feature-1-" + randomAlphanumeric(10);
+    String id2 = "feature-2-" + randomAlphanumeric(10);
     featureFlagDAO.insert(id1, "value1");
     featureFlagDAO.insert(id2, "value2");
 
@@ -50,7 +49,7 @@ class FeatureFlagDAOTest extends DAOTestHelper {
 
   @Test
   void testUpdate() {
-    String id = "update-test-" + RandomStringUtils.secureStrong().nextAlphanumeric(10);
+    String id = "update-test-" + randomAlphanumeric(10);
     String originalValue = "original";
     String updatedValue = "updated";
 
@@ -68,7 +67,7 @@ class FeatureFlagDAOTest extends DAOTestHelper {
 
   @Test
   void testDeleteById() {
-    String id = "delete-test-" + RandomStringUtils.secureStrong().nextAlphanumeric(10);
+    String id = "delete-test-" + randomAlphanumeric(10);
     featureFlagDAO.insert(id, "value");
 
     assertTrue(featureFlagDAO.exists(id));
@@ -79,7 +78,7 @@ class FeatureFlagDAOTest extends DAOTestHelper {
 
   @Test
   void testExists() {
-    String id = "exists-test-" + RandomStringUtils.secureStrong().nextAlphanumeric(10);
+    String id = "exists-test-" + randomAlphanumeric(10);
     assertFalse(featureFlagDAO.exists(id));
 
     featureFlagDAO.insert(id, "value");
@@ -91,7 +90,7 @@ class FeatureFlagDAOTest extends DAOTestHelper {
 
   @Test
   void testMultipleOperations() {
-    String id = "multi-test-" + RandomStringUtils.secureStrong().nextAlphanumeric(10);
+    String id = "multi-test-" + randomAlphanumeric(10);
 
     // Insert
     featureFlagDAO.insert(id, "initial");
@@ -111,9 +110,9 @@ class FeatureFlagDAOTest extends DAOTestHelper {
 
   @Test
   void testFindAllOrdering() {
-    String id1 = "aaa-" + RandomStringUtils.secureStrong().nextAlphanumeric(10);
-    String id2 = "zzz-" + RandomStringUtils.secureStrong().nextAlphanumeric(10);
-    String id3 = "mmm-" + RandomStringUtils.secureStrong().nextAlphanumeric(10);
+    String id1 = "aaa-" + randomAlphanumeric(10);
+    String id2 = "zzz-" + randomAlphanumeric(10);
+    String id3 = "mmm-" + randomAlphanumeric(10);
 
     featureFlagDAO.insert(id2, "value2");
     featureFlagDAO.insert(id1, "value1");

--- a/src/test/java/org/broadinstitute/consent/http/resources/FeatureFlagResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/FeatureFlagResourceTest.java
@@ -1,0 +1,183 @@
+package org.broadinstitute.consent.http.resources;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriBuilder;
+import jakarta.ws.rs.core.UriInfo;
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import org.broadinstitute.consent.http.AbstractTestHelper;
+import org.broadinstitute.consent.http.models.AuthUser;
+import org.broadinstitute.consent.http.models.FeatureFlag;
+import org.broadinstitute.consent.http.service.FeatureFlagService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class FeatureFlagResourceTest extends AbstractTestHelper {
+
+  @Mock private FeatureFlagService featureFlagService;
+
+  private FeatureFlagResource resource;
+  private final AuthUser authUser = new AuthUser("admin@test.com");
+
+  @BeforeEach
+  void setUp() {
+    resource = new FeatureFlagResource(featureFlagService);
+  }
+
+  @Test
+  void testGetAllFeatureFlags() {
+    FeatureFlag flag1 = new FeatureFlag("feature1", "value1");
+    FeatureFlag flag2 = new FeatureFlag("feature2", "value2");
+    when(featureFlagService.getAllFeatureFlags()).thenReturn(List.of(flag1, flag2));
+
+    Response response = resource.getAllFeatureFlags();
+    assertEquals(200, response.getStatus());
+    assertNotNull(response.getEntity());
+    verify(featureFlagService).getAllFeatureFlags();
+  }
+
+  @Test
+  void testGetAllFeatureFlags_Empty() {
+    when(featureFlagService.getAllFeatureFlags()).thenReturn(List.of());
+
+    Response response = resource.getAllFeatureFlags();
+    assertEquals(200, response.getStatus());
+    verify(featureFlagService).getAllFeatureFlags();
+  }
+
+  @Test
+  void testGetFeatureFlagById_Found() {
+    FeatureFlag flag = new FeatureFlag("test-feature", "test-value");
+    when(featureFlagService.getFeatureFlagById("test-feature")).thenReturn(flag);
+
+    Response response = resource.getFeatureFlagById("test-feature");
+    assertEquals(200, response.getStatus());
+    assertNotNull(response.getEntity());
+    verify(featureFlagService).getFeatureFlagById("test-feature");
+  }
+
+  @Test
+  void testGetFeatureFlagById_NotFound() {
+    when(featureFlagService.getFeatureFlagById("non-existent"))
+        .thenThrow(new NotFoundException("Feature flag with id 'non-existent' not found"));
+
+    Response response = resource.getFeatureFlagById("non-existent");
+    assertEquals(404, response.getStatus());
+    verify(featureFlagService).getFeatureFlagById("non-existent");
+  }
+
+  @Test
+  void testCreateOrUpdateFeatureFlag_Create() {
+    UriInfo uriInfo = mock(UriInfo.class);
+    UriBuilder uriBuilder = mock(UriBuilder.class);
+    when(uriInfo.getAbsolutePathBuilder()).thenReturn(uriBuilder);
+    when(uriBuilder.path(anyString())).thenReturn(uriBuilder);
+    when(uriBuilder.build()).thenReturn(URI.create("http://localhost/api/feature/new-feature"));
+
+    FeatureFlag createdFlag = new FeatureFlag("new-feature", "new-value");
+    when(featureFlagService.exists("new-feature")).thenReturn(false);
+    when(featureFlagService.createOrUpdateFeatureFlag("new-feature", "new-value"))
+        .thenReturn(createdFlag);
+
+    Map<String, String> body = Map.of("value", "new-value");
+    Response response = resource.createOrUpdateFeatureFlag(uriInfo, authUser, "new-feature", body);
+
+    assertEquals(201, response.getStatus());
+    assertNotNull(response.getEntity());
+    verify(featureFlagService).exists("new-feature");
+    verify(featureFlagService).createOrUpdateFeatureFlag("new-feature", "new-value");
+  }
+
+  @Test
+  void testCreateOrUpdateFeatureFlag_Update() {
+    UriInfo uriInfo = mock(UriInfo.class);
+    FeatureFlag updatedFlag = new FeatureFlag("existing-feature", "updated-value");
+    when(featureFlagService.exists("existing-feature")).thenReturn(true);
+    when(featureFlagService.createOrUpdateFeatureFlag("existing-feature", "updated-value"))
+        .thenReturn(updatedFlag);
+
+    Map<String, String> body = Map.of("value", "updated-value");
+    Response response =
+        resource.createOrUpdateFeatureFlag(uriInfo, authUser, "existing-feature", body);
+
+    assertEquals(200, response.getStatus());
+    assertNotNull(response.getEntity());
+    verify(featureFlagService).exists("existing-feature");
+    verify(featureFlagService).createOrUpdateFeatureFlag("existing-feature", "updated-value");
+  }
+
+  @Test
+  void testCreateOrUpdateFeatureFlag_MissingValue() {
+    UriInfo uriInfo = mock(UriInfo.class);
+    Map<String, String> body = Map.of();
+
+    Response response = resource.createOrUpdateFeatureFlag(uriInfo, authUser, "test-id", body);
+
+    assertEquals(400, response.getStatus());
+    assertNotNull(response.getEntity());
+  }
+
+  @Test
+  void testCreateOrUpdateFeatureFlag_ServiceError() {
+    UriInfo uriInfo = mock(UriInfo.class);
+    when(featureFlagService.exists("test-id")).thenReturn(false);
+    when(featureFlagService.createOrUpdateFeatureFlag("test-id", "value"))
+        .thenThrow(new RuntimeException("Database error"));
+
+    Map<String, String> body = Map.of("value", "value");
+    Response response = resource.createOrUpdateFeatureFlag(uriInfo, authUser, "test-id", body);
+
+    assertEquals(500, response.getStatus());
+    verify(featureFlagService).exists("test-id");
+    verify(featureFlagService).createOrUpdateFeatureFlag("test-id", "value");
+  }
+
+  @Test
+  void testDeleteFeatureFlag_Success() {
+    doNothing().when(featureFlagService).deleteFeatureFlag("test-id");
+
+    Response response = resource.deleteFeatureFlag(authUser, "test-id");
+
+    assertEquals(204, response.getStatus());
+    verify(featureFlagService).deleteFeatureFlag("test-id");
+  }
+
+  @Test
+  void testDeleteFeatureFlag_NotFound() {
+    doThrow(new NotFoundException("Feature flag with id 'non-existent' not found"))
+        .when(featureFlagService)
+        .deleteFeatureFlag("non-existent");
+
+    Response response = resource.deleteFeatureFlag(authUser, "non-existent");
+
+    assertEquals(404, response.getStatus());
+    verify(featureFlagService).deleteFeatureFlag("non-existent");
+  }
+
+  @Test
+  void testDeleteFeatureFlag_ServiceError() {
+    doThrow(new RuntimeException("Database error"))
+        .when(featureFlagService)
+        .deleteFeatureFlag("test-id");
+
+    Response response = resource.deleteFeatureFlag(authUser, "test-id");
+
+    assertEquals(500, response.getStatus());
+    verify(featureFlagService).deleteFeatureFlag("test-id");
+  }
+}

--- a/src/test/java/org/broadinstitute/consent/http/resources/FeatureFlagResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/FeatureFlagResourceTest.java
@@ -19,7 +19,9 @@ import java.util.Map;
 import org.broadinstitute.consent.http.AbstractTestHelper;
 import org.broadinstitute.consent.http.models.AuthUser;
 import org.broadinstitute.consent.http.models.FeatureFlag;
+import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.service.FeatureFlagService;
+import org.broadinstitute.consent.http.service.UserService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -30,13 +32,15 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class FeatureFlagResourceTest extends AbstractTestHelper {
 
   @Mock private FeatureFlagService featureFlagService;
+  @Mock private UserService userService;
 
   private FeatureFlagResource resource;
   private final AuthUser authUser = new AuthUser("admin@test.com");
+  private final User user = new User(1, "admin@test.com", "Admin", new java.util.Date());
 
   @BeforeEach
   void setUp() {
-    resource = new FeatureFlagResource(featureFlagService);
+    resource = new FeatureFlagResource(featureFlagService, userService);
   }
 
   @Test
@@ -89,9 +93,10 @@ class FeatureFlagResourceTest extends AbstractTestHelper {
     when(uriBuilder.path(anyString())).thenReturn(uriBuilder);
     when(uriBuilder.build()).thenReturn(URI.create("http://localhost/api/feature/new-feature"));
 
+    when(userService.findUserByEmail(authUser.getEmail())).thenReturn(user);
     FeatureFlag createdFlag = new FeatureFlag("new-feature", "new-value");
     when(featureFlagService.exists("new-feature")).thenReturn(false);
-    when(featureFlagService.createOrUpdateFeatureFlag("new-feature", "new-value"))
+    when(featureFlagService.createOrUpdateFeatureFlag("new-feature", "new-value", user.getUserId()))
         .thenReturn(createdFlag);
 
     Map<String, String> body = Map.of("value", "new-value");
@@ -99,16 +104,20 @@ class FeatureFlagResourceTest extends AbstractTestHelper {
 
     assertEquals(201, response.getStatus());
     assertNotNull(response.getEntity());
+    verify(userService).findUserByEmail(authUser.getEmail());
     verify(featureFlagService).exists("new-feature");
-    verify(featureFlagService).createOrUpdateFeatureFlag("new-feature", "new-value");
+    verify(featureFlagService)
+        .createOrUpdateFeatureFlag("new-feature", "new-value", user.getUserId());
   }
 
   @Test
   void testCreateOrUpdateFeatureFlag_Update() {
     UriInfo uriInfo = mock(UriInfo.class);
+    when(userService.findUserByEmail(authUser.getEmail())).thenReturn(user);
     FeatureFlag updatedFlag = new FeatureFlag("existing-feature", "updated-value");
     when(featureFlagService.exists("existing-feature")).thenReturn(true);
-    when(featureFlagService.createOrUpdateFeatureFlag("existing-feature", "updated-value"))
+    when(featureFlagService.createOrUpdateFeatureFlag(
+            "existing-feature", "updated-value", user.getUserId()))
         .thenReturn(updatedFlag);
 
     Map<String, String> body = Map.of("value", "updated-value");
@@ -117,8 +126,10 @@ class FeatureFlagResourceTest extends AbstractTestHelper {
 
     assertEquals(200, response.getStatus());
     assertNotNull(response.getEntity());
+    verify(userService).findUserByEmail(authUser.getEmail());
     verify(featureFlagService).exists("existing-feature");
-    verify(featureFlagService).createOrUpdateFeatureFlag("existing-feature", "updated-value");
+    verify(featureFlagService)
+        .createOrUpdateFeatureFlag("existing-feature", "updated-value", user.getUserId());
   }
 
   @Test
@@ -135,49 +146,57 @@ class FeatureFlagResourceTest extends AbstractTestHelper {
   @Test
   void testCreateOrUpdateFeatureFlag_ServiceError() {
     UriInfo uriInfo = mock(UriInfo.class);
+    when(userService.findUserByEmail(authUser.getEmail())).thenReturn(user);
     when(featureFlagService.exists("test-id")).thenReturn(false);
-    when(featureFlagService.createOrUpdateFeatureFlag("test-id", "value"))
+    when(featureFlagService.createOrUpdateFeatureFlag("test-id", "value", user.getUserId()))
         .thenThrow(new RuntimeException("Database error"));
 
     Map<String, String> body = Map.of("value", "value");
     Response response = resource.createOrUpdateFeatureFlag(uriInfo, authUser, "test-id", body);
 
     assertEquals(500, response.getStatus());
+    verify(userService).findUserByEmail(authUser.getEmail());
     verify(featureFlagService).exists("test-id");
-    verify(featureFlagService).createOrUpdateFeatureFlag("test-id", "value");
+    verify(featureFlagService).createOrUpdateFeatureFlag("test-id", "value", user.getUserId());
   }
 
   @Test
   void testDeleteFeatureFlag_Success() {
-    doNothing().when(featureFlagService).deleteFeatureFlag("test-id");
+    when(userService.findUserByEmail(authUser.getEmail())).thenReturn(user);
+    doNothing().when(featureFlagService).deleteFeatureFlag("test-id", user.getUserId());
 
     Response response = resource.deleteFeatureFlag(authUser, "test-id");
 
     assertEquals(204, response.getStatus());
-    verify(featureFlagService).deleteFeatureFlag("test-id");
+    verify(userService).findUserByEmail(authUser.getEmail());
+    verify(featureFlagService).deleteFeatureFlag("test-id", user.getUserId());
   }
 
   @Test
   void testDeleteFeatureFlag_NotFound() {
+    when(userService.findUserByEmail(authUser.getEmail())).thenReturn(user);
     doThrow(new NotFoundException("Feature flag with id 'non-existent' not found"))
         .when(featureFlagService)
-        .deleteFeatureFlag("non-existent");
+        .deleteFeatureFlag("non-existent", user.getUserId());
 
     Response response = resource.deleteFeatureFlag(authUser, "non-existent");
 
     assertEquals(404, response.getStatus());
-    verify(featureFlagService).deleteFeatureFlag("non-existent");
+    verify(userService).findUserByEmail(authUser.getEmail());
+    verify(featureFlagService).deleteFeatureFlag("non-existent", user.getUserId());
   }
 
   @Test
   void testDeleteFeatureFlag_ServiceError() {
+    when(userService.findUserByEmail(authUser.getEmail())).thenReturn(user);
     doThrow(new RuntimeException("Database error"))
         .when(featureFlagService)
-        .deleteFeatureFlag("test-id");
+        .deleteFeatureFlag("test-id", user.getUserId());
 
     Response response = resource.deleteFeatureFlag(authUser, "test-id");
 
     assertEquals(500, response.getStatus());
-    verify(featureFlagService).deleteFeatureFlag("test-id");
+    verify(userService).findUserByEmail(authUser.getEmail());
+    verify(featureFlagService).deleteFeatureFlag("test-id", user.getUserId());
   }
 }

--- a/src/test/java/org/broadinstitute/consent/http/service/FeatureFlagServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/FeatureFlagServiceTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.never;
@@ -144,34 +145,41 @@ class FeatureFlagServiceTest extends AbstractTestHelper {
 
   @Test
   void testCreateOrUpdateFeatureFlag_Create() {
+    Integer userId = 1;
     FeatureFlag createdFlag = new FeatureFlag("new-feature", "new-value");
     when(featureFlagDAO.exists("new-feature")).thenReturn(false);
     doNothing().when(featureFlagDAO).insert(anyString(), anyString());
+    doNothing().when(featureFlagDAO).insertAudit(userId, "new-feature", "CREATE");
     when(featureFlagDAO.findById("new-feature")).thenReturn(createdFlag);
 
-    FeatureFlag result = service.createOrUpdateFeatureFlag("new-feature", "new-value");
+    FeatureFlag result = service.createOrUpdateFeatureFlag("new-feature", "new-value", userId);
     assertNotNull(result);
     assertEquals("new-feature", result.getId());
     assertEquals("new-value", result.getValue());
     verify(featureFlagDAO).exists("new-feature");
     verify(featureFlagDAO).insert("new-feature", "new-value");
+    verify(featureFlagDAO).insertAudit(userId, "new-feature", "CREATE");
     verify(featureFlagDAO, never()).update(anyString(), anyString());
     verify(featureFlagDAO).findById("new-feature");
   }
 
   @Test
   void testCreateOrUpdateFeatureFlag_Update() {
+    Integer userId = 1;
     FeatureFlag updatedFlag = new FeatureFlag("existing-feature", "updated-value");
     when(featureFlagDAO.exists("existing-feature")).thenReturn(true);
     doNothing().when(featureFlagDAO).update(anyString(), anyString());
+    doNothing().when(featureFlagDAO).insertAudit(userId, "existing-feature", "UPDATE");
     when(featureFlagDAO.findById("existing-feature")).thenReturn(updatedFlag);
 
-    FeatureFlag result = service.createOrUpdateFeatureFlag("existing-feature", "updated-value");
+    FeatureFlag result =
+        service.createOrUpdateFeatureFlag("existing-feature", "updated-value", userId);
     assertNotNull(result);
     assertEquals("existing-feature", result.getId());
     assertEquals("updated-value", result.getValue());
     verify(featureFlagDAO).exists("existing-feature");
     verify(featureFlagDAO).update("existing-feature", "updated-value");
+    verify(featureFlagDAO).insertAudit(userId, "existing-feature", "UPDATE");
     verify(featureFlagDAO, never()).insert(anyString(), anyString());
     verify(featureFlagDAO).findById("existing-feature");
   }
@@ -179,36 +187,40 @@ class FeatureFlagServiceTest extends AbstractTestHelper {
   @Test
   void testCreateOrUpdateFeatureFlag_EmptyId() {
     assertThrows(
-        IllegalArgumentException.class, () -> service.createOrUpdateFeatureFlag("", "value"));
+        IllegalArgumentException.class, () -> service.createOrUpdateFeatureFlag("", "value", 1));
     assertThrows(
-        IllegalArgumentException.class, () -> service.createOrUpdateFeatureFlag("   ", "value"));
+        IllegalArgumentException.class, () -> service.createOrUpdateFeatureFlag("   ", "value", 1));
     assertThrows(
-        IllegalArgumentException.class, () -> service.createOrUpdateFeatureFlag(null, "value"));
+        IllegalArgumentException.class, () -> service.createOrUpdateFeatureFlag(null, "value", 1));
   }
 
   @Test
   void testCreateOrUpdateFeatureFlag_NullValue() {
     assertThrows(
-        IllegalArgumentException.class, () -> service.createOrUpdateFeatureFlag("id", null));
+        IllegalArgumentException.class, () -> service.createOrUpdateFeatureFlag("id", null, 1));
   }
 
   @Test
   void testDeleteFeatureFlag_Success() {
+    Integer userId = 1;
     when(featureFlagDAO.exists("test-id")).thenReturn(true);
     doNothing().when(featureFlagDAO).deleteById("test-id");
+    doNothing().when(featureFlagDAO).insertAudit(userId, "test-id", "DELETE");
 
-    service.deleteFeatureFlag("test-id");
+    service.deleteFeatureFlag("test-id", userId);
     verify(featureFlagDAO).exists("test-id");
     verify(featureFlagDAO).deleteById("test-id");
+    verify(featureFlagDAO).insertAudit(userId, "test-id", "DELETE");
   }
 
   @Test
   void testDeleteFeatureFlag_NotFound() {
     when(featureFlagDAO.exists("non-existent")).thenReturn(false);
 
-    assertThrows(NotFoundException.class, () -> service.deleteFeatureFlag("non-existent"));
+    assertThrows(NotFoundException.class, () -> service.deleteFeatureFlag("non-existent", 1));
     verify(featureFlagDAO).exists("non-existent");
     verify(featureFlagDAO, never()).deleteById(anyString());
+    verify(featureFlagDAO, never()).insertAudit(any(), anyString(), anyString());
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/FeatureFlagServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/FeatureFlagServiceTest.java
@@ -1,0 +1,231 @@
+package org.broadinstitute.consent.http.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import jakarta.ws.rs.NotFoundException;
+import org.broadinstitute.consent.http.AbstractTestHelper;
+import org.broadinstitute.consent.http.db.FeatureFlagDAO;
+import org.broadinstitute.consent.http.models.FeatureFlag;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class FeatureFlagServiceTest extends AbstractTestHelper {
+
+  @Mock private FeatureFlagDAO featureFlagDAO;
+
+  private FeatureFlagService service;
+
+  @BeforeEach
+  void setUp() {
+    service = new FeatureFlagService(featureFlagDAO);
+  }
+
+  @Test
+  void testGetAllFeatureFlags() {
+    FeatureFlag flag1 = new FeatureFlag("feature1", "value1");
+    FeatureFlag flag2 = new FeatureFlag("feature2", "value2");
+    when(featureFlagDAO.findAll()).thenReturn(java.util.List.of(flag1, flag2));
+
+    var flags = service.getAllFeatureFlags();
+    assertNotNull(flags);
+    assertEquals(2, flags.size());
+    verify(featureFlagDAO).findAll();
+  }
+
+  @Test
+  void testGetFeatureFlagById_Found() {
+    FeatureFlag flag = new FeatureFlag("test-id", "test-value");
+    when(featureFlagDAO.findById("test-id")).thenReturn(flag);
+
+    FeatureFlag result = service.getFeatureFlagById("test-id");
+    assertNotNull(result);
+    assertEquals("test-id", result.getId());
+    assertEquals("test-value", result.getValue());
+    verify(featureFlagDAO).findById("test-id");
+  }
+
+  @Test
+  void testGetFeatureFlagById_NotFound() {
+    when(featureFlagDAO.findById("non-existent")).thenReturn(null);
+
+    assertThrows(NotFoundException.class, () -> service.getFeatureFlagById("non-existent"));
+    verify(featureFlagDAO).findById("non-existent");
+  }
+
+  @Test
+  void testGetFeatureFlagValue_Found() {
+    FeatureFlag flag = new FeatureFlag("test-id", "test-value");
+    when(featureFlagDAO.findById("test-id")).thenReturn(flag);
+
+    String value = service.getFeatureFlagValue("test-id");
+    assertEquals("test-value", value);
+    verify(featureFlagDAO).findById("test-id");
+  }
+
+  @Test
+  void testGetFeatureFlagValue_NotFound() {
+    when(featureFlagDAO.findById("non-existent")).thenReturn(null);
+
+    String value = service.getFeatureFlagValue("non-existent");
+    assertNull(value);
+    verify(featureFlagDAO).findById("non-existent");
+  }
+
+  @Test
+  void testGetFeatureFlagValue_WithDefault_Found() {
+    FeatureFlag flag = new FeatureFlag("test-id", "test-value");
+    when(featureFlagDAO.findById("test-id")).thenReturn(flag);
+
+    String value = service.getFeatureFlagValue("test-id", "default");
+    assertEquals("test-value", value);
+    verify(featureFlagDAO).findById("test-id");
+  }
+
+  @Test
+  void testGetFeatureFlagValue_WithDefault_NotFound() {
+    when(featureFlagDAO.findById("non-existent")).thenReturn(null);
+
+    String value = service.getFeatureFlagValue("non-existent", "default-value");
+    assertEquals("default-value", value);
+    verify(featureFlagDAO).findById("non-existent");
+  }
+
+  @Test
+  void testIsFeatureEnabled_True() {
+    FeatureFlag flag = new FeatureFlag("enabled-feature", "true");
+    when(featureFlagDAO.findById("enabled-feature")).thenReturn(flag);
+
+    boolean enabled = service.isFeatureEnabled("enabled-feature");
+    assertTrue(enabled);
+    verify(featureFlagDAO).findById("enabled-feature");
+  }
+
+  @Test
+  void testIsFeatureEnabled_False() {
+    FeatureFlag flag = new FeatureFlag("disabled-feature", "false");
+    when(featureFlagDAO.findById("disabled-feature")).thenReturn(flag);
+
+    boolean enabled = service.isFeatureEnabled("disabled-feature");
+    assertFalse(enabled);
+    verify(featureFlagDAO).findById("disabled-feature");
+  }
+
+  @Test
+  void testIsFeatureEnabled_NotFound() {
+    when(featureFlagDAO.findById("non-existent")).thenReturn(null);
+
+    boolean enabled = service.isFeatureEnabled("non-existent");
+    assertFalse(enabled);
+    verify(featureFlagDAO).findById("non-existent");
+  }
+
+  @Test
+  void testIsFeatureEnabled_CaseInsensitive() {
+    FeatureFlag flag = new FeatureFlag("feature", "TRUE");
+    when(featureFlagDAO.findById("feature")).thenReturn(flag);
+
+    boolean enabled = service.isFeatureEnabled("feature");
+    assertTrue(enabled);
+  }
+
+  @Test
+  void testCreateOrUpdateFeatureFlag_Create() {
+    FeatureFlag createdFlag = new FeatureFlag("new-feature", "new-value");
+    when(featureFlagDAO.exists("new-feature")).thenReturn(false);
+    doNothing().when(featureFlagDAO).insert(anyString(), anyString());
+    when(featureFlagDAO.findById("new-feature")).thenReturn(createdFlag);
+
+    FeatureFlag result = service.createOrUpdateFeatureFlag("new-feature", "new-value");
+    assertNotNull(result);
+    assertEquals("new-feature", result.getId());
+    assertEquals("new-value", result.getValue());
+    verify(featureFlagDAO).exists("new-feature");
+    verify(featureFlagDAO).insert("new-feature", "new-value");
+    verify(featureFlagDAO, never()).update(anyString(), anyString());
+    verify(featureFlagDAO).findById("new-feature");
+  }
+
+  @Test
+  void testCreateOrUpdateFeatureFlag_Update() {
+    FeatureFlag updatedFlag = new FeatureFlag("existing-feature", "updated-value");
+    when(featureFlagDAO.exists("existing-feature")).thenReturn(true);
+    doNothing().when(featureFlagDAO).update(anyString(), anyString());
+    when(featureFlagDAO.findById("existing-feature")).thenReturn(updatedFlag);
+
+    FeatureFlag result = service.createOrUpdateFeatureFlag("existing-feature", "updated-value");
+    assertNotNull(result);
+    assertEquals("existing-feature", result.getId());
+    assertEquals("updated-value", result.getValue());
+    verify(featureFlagDAO).exists("existing-feature");
+    verify(featureFlagDAO).update("existing-feature", "updated-value");
+    verify(featureFlagDAO, never()).insert(anyString(), anyString());
+    verify(featureFlagDAO).findById("existing-feature");
+  }
+
+  @Test
+  void testCreateOrUpdateFeatureFlag_EmptyId() {
+    assertThrows(
+        IllegalArgumentException.class, () -> service.createOrUpdateFeatureFlag("", "value"));
+    assertThrows(
+        IllegalArgumentException.class, () -> service.createOrUpdateFeatureFlag("   ", "value"));
+    assertThrows(
+        IllegalArgumentException.class, () -> service.createOrUpdateFeatureFlag(null, "value"));
+  }
+
+  @Test
+  void testCreateOrUpdateFeatureFlag_NullValue() {
+    assertThrows(
+        IllegalArgumentException.class, () -> service.createOrUpdateFeatureFlag("id", null));
+  }
+
+  @Test
+  void testDeleteFeatureFlag_Success() {
+    when(featureFlagDAO.exists("test-id")).thenReturn(true);
+    doNothing().when(featureFlagDAO).deleteById("test-id");
+
+    service.deleteFeatureFlag("test-id");
+    verify(featureFlagDAO).exists("test-id");
+    verify(featureFlagDAO).deleteById("test-id");
+  }
+
+  @Test
+  void testDeleteFeatureFlag_NotFound() {
+    when(featureFlagDAO.exists("non-existent")).thenReturn(false);
+
+    assertThrows(NotFoundException.class, () -> service.deleteFeatureFlag("non-existent"));
+    verify(featureFlagDAO).exists("non-existent");
+    verify(featureFlagDAO, never()).deleteById(anyString());
+  }
+
+  @Test
+  void testExists_True() {
+    when(featureFlagDAO.exists("test-id")).thenReturn(true);
+
+    boolean exists = service.exists("test-id");
+    assertTrue(exists);
+    verify(featureFlagDAO).exists("test-id");
+  }
+
+  @Test
+  void testExists_False() {
+    when(featureFlagDAO.exists("test-id")).thenReturn(false);
+
+    boolean exists = service.exists("test-id");
+    assertFalse(exists);
+    verify(featureFlagDAO).exists("test-id");
+  }
+}

--- a/src/test/java/org/broadinstitute/consent/http/service/FeatureFlagServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/FeatureFlagServiceTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -17,6 +18,7 @@ import jakarta.ws.rs.NotFoundException;
 import org.broadinstitute.consent.http.AbstractTestHelper;
 import org.broadinstitute.consent.http.db.FeatureFlagDAO;
 import org.broadinstitute.consent.http.models.FeatureFlag;
+import org.jdbi.v3.sqlobject.transaction.TransactionalConsumer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -31,8 +33,17 @@ class FeatureFlagServiceTest extends AbstractTestHelper {
   private FeatureFlagService service;
 
   @BeforeEach
-  void setUp() {
+  void setUp() throws Exception {
     service = new FeatureFlagService(featureFlagDAO);
+    lenient()
+        .doAnswer(
+            invocation -> {
+              TransactionalConsumer<FeatureFlagDAO, Exception> consumer = invocation.getArgument(0);
+              consumer.useTransaction(featureFlagDAO);
+              return null;
+            })
+        .when(featureFlagDAO)
+        .useTransaction(any());
   }
 
   @Test


### PR DESCRIPTION
### Addresses

### Summary

Adds feature flags to Consent. The API is:

* `GET /api/feature` - List all feature flags (unauthenticated)
* `GET /api/feature/id` - Get a specific flag (unauthenticated)
* `POST /api/feature/id` - Create/update value (admin-only), body: `{"value": "..."}`
* `DELETE /api/feature/id` - Delete a feature flag (admin-only)

Some helper methods exist that consent itself can use to determine if a feature flag is enabled. I kept the `value` as a string, as we may want multiple states beyond enabled or disabled.

Unit tests cover all functionality.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
