### PR TITLE
[DT-2839] Allow open after approval.

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
@@ -276,7 +276,8 @@ public class DarCollectionService implements ConsentLogger {
         s -> {
           Map<String, Integer> statusCount = new HashMap<>();
           Map<Integer, Election> elections = s.getElections();
-          if (!s.requiresSOApproval() && elections.size() < s.getDatasetCount()) {
+          if ((!s.requiresSOApproval() || s.getSOApprover() != null)
+              && elections.size() < s.getDatasetCount()) {
             s.addAction(DarCollectionActions.OPEN);
           }
           elections
@@ -310,7 +311,8 @@ public class DarCollectionService implements ConsentLogger {
     }
 
     // If there are no elections, only show open
-    if (!summary.requiresSOApproval() && summary.getElections().isEmpty()) {
+    if ((!summary.requiresSOApproval() || summary.getSOApprover() != null)
+        && summary.getElections().isEmpty()) {
       summary.addAction(DarCollectionActions.OPEN);
     }
 

--- a/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
@@ -1701,6 +1701,28 @@ class DarCollectionServiceTest extends AbstractTestHelper {
   }
 
   @Test
+  void testProcessDarCollectionSummariesForChairWithSOApprovalRequired_And_Granted() {
+    User user = new User();
+    user.setUserId(1);
+    user.addRole(UserRoles.Chairperson());
+    DarCollectionSummary summary = new DarCollectionSummary();
+    summary.setLatestReferenceId(UUID.randomUUID().toString());
+    summary.setRequiresSOApproval(true);
+    summary.setSOApprover(1);
+    summary.addDatasetId(1);
+    when(darCollectionSummaryDAO.getDarCollectionSummariesForDACRole(
+            user.getUserId(), UserRoles.CHAIRPERSON.getRoleId()))
+        .thenReturn(List.of(summary));
+
+    List<DarCollectionSummary> summaries = service.getSummariesForRole(user, UserRoles.CHAIRPERSON);
+
+    assertNotNull(summaries);
+    assertEquals(1, summaries.size());
+    // Chair summary should not have any actions
+    assertTrue(summaries.getFirst().getActions().contains(DarCollectionActions.OPEN.getValue()));
+  }
+
+  @Test
   void testGetSummaryForRoleByCollectionId_SO() {
     User user = new User();
     user.setUserId(1);

--- a/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
@@ -1718,7 +1718,7 @@ class DarCollectionServiceTest extends AbstractTestHelper {
 
     assertNotNull(summaries);
     assertEquals(1, summaries.size());
-    // Chair summary should not have any actions
+    // Chair summary have the open action after it is approved by the SO.
     assertTrue(summaries.getFirst().getActions().contains(DarCollectionActions.OPEN.getValue()));
   }
 


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-2839](https://broadworkbench.atlassian.net/browse/DT-2839)

### Summary

Allows a chair to have the open action on a DAR that needs elections open after an SO approves the DAR.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
