### PR TITLE
[DT-2779] Remove validation for data location fields

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/models/dataset_registration_v1/ConsentGroup.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/dataset_registration_v1/ConsentGroup.java
@@ -716,7 +716,8 @@ public class ConsentGroup {
     AN_VIL_WORKSPACE("AnVIL Workspace"),
     TERRA_WORKSPACE("Terra Workspace"),
     TDR_LOCATION("TDR Location"),
-    NOT_DETERMINED("Not Determined");
+    NOT_DETERMINED("Not Determined"),
+    OTHER("Other");
     private final String value;
     private static final Map<String, ConsentGroup.DataLocation> CONSTANTS =
         new HashMap<String, ConsentGroup.DataLocation>();

--- a/src/main/resources/assets/schemas/ConsentGroup.yaml
+++ b/src/main/resources/assets/schemas/ConsentGroup.yaml
@@ -79,6 +79,7 @@ properties:
       - Terra Workspace
       - TDR Location
       - Not Determined
+      - Other
   url:
     type: string
     format: uri

--- a/src/main/resources/dataset-registration-schema_v1.json
+++ b/src/main/resources/dataset-registration-schema_v1.json
@@ -669,6 +669,7 @@
           "format" : "uri",
           "label" : "Free text field for entering URL of data",
           "description" : "Free text field for entering URL of data",
+          "minLength" : 1
         },
         "numberOfParticipants" : {
           "type" : "integer",

--- a/src/main/resources/dataset-registration-schema_v1.json
+++ b/src/main/resources/dataset-registration-schema_v1.json
@@ -684,7 +684,6 @@
           "format" : "uri",
           "label" : "Free text field for entering URL of data",
           "description" : "Free text field for entering URL of data",
-          "minLength" : 1
         },
         "numberOfParticipants" : {
           "type" : "integer",

--- a/src/main/resources/dataset-registration-schema_v1.json
+++ b/src/main/resources/dataset-registration-schema_v1.json
@@ -460,21 +460,6 @@
       ],
       "allOf" : [
         {
-          "if" : {
-            "properties" : {
-              "dataLocation" : {
-                "const" : "Not Determined"
-              }
-            }
-          },
-          "then" : {},
-          "else" : {
-            "required" : [
-              "url"
-            ]
-          }
-        },
-        {
           "$comment" : "if accessManagement is controlled OR not present, then require dac id & add secondary consent fields",
           "if" : {
             "properties" : {

--- a/src/main/resources/dataset-registration-schema_v1.json
+++ b/src/main/resources/dataset-registration-schema_v1.json
@@ -673,7 +673,8 @@
             "AnVIL Workspace",
             "Terra Workspace",
             "TDR Location",
-            "Not Determined"
+            "Not Determined",
+            "Other"
           ],
           "label" : "Please provide the location of your data resource for this consent group",
           "description" : "Data Location"

--- a/src/test/java/org/broadinstitute/consent/http/util/JsonSchemaUtilTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/util/JsonSchemaUtilTest.java
@@ -736,7 +736,7 @@ class JsonSchemaUtilTest {
   }
 
   @Test
-  void testValidateDatasetRegistrationObject_v1_url_not_required_if_data_loc_not_determined() {
+  void testValidateDatasetRegistrationObject_v1_url_not_required_for_any_data_loc() {
     String notDeterminedNoURL =
         """
         {
@@ -797,7 +797,7 @@ class JsonSchemaUtilTest {
     assertNoErrors(errors);
 
     errors = schemaUtil.validateSchema_v1(tdrLocationNoUrl);
-    assertFieldHasError(errors, "url");
+    assertNoErrors(errors);
   }
 
   @Test


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2779

### Summary

This PR adds support for an `Other` Data Location option and removes the requirements and validation for the Data Location dropdown and the URL fields, making both optional. 

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
