### PR TITLE
[DT-2832] Move GET methods to `/feature`

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
@@ -69,6 +69,7 @@ import org.broadinstitute.consent.http.resources.MatchResource;
 import org.broadinstitute.consent.http.resources.MetricsResource;
 import org.broadinstitute.consent.http.resources.NihAccountResource;
 import org.broadinstitute.consent.http.resources.OAuth2Resource;
+import org.broadinstitute.consent.http.resources.PublicFeatureFlagResource;
 import org.broadinstitute.consent.http.resources.SamResource;
 import org.broadinstitute.consent.http.resources.SchemaResource;
 import org.broadinstitute.consent.http.resources.StatusResource;
@@ -169,6 +170,7 @@ public class ConsentApplication extends Application<ConsentConfiguration> {
     env.jersey().register(injector.getInstance(DraftResource.class));
     env.jersey().register(injector.getInstance(EmailNotifierResource.class));
     env.jersey().register(injector.getInstance(FeatureFlagResource.class));
+    env.jersey().register(injector.getInstance(PublicFeatureFlagResource.class));
     env.jersey().register(injector.getInstance(InstitutionResource.class));
     env.jersey().register(injector.getInstance(LibraryCardResource.class));
     env.jersey().register(injector.getInstance(LivenessResource.class));

--- a/src/main/java/org/broadinstitute/consent/http/resources/FeatureFlagResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/FeatureFlagResource.java
@@ -2,11 +2,9 @@ package org.broadinstitute.consent.http.resources;
 
 import com.google.inject.Inject;
 import io.dropwizard.auth.Auth;
-import jakarta.annotation.security.PermitAll;
 import jakarta.annotation.security.RolesAllowed;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
-import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
@@ -16,7 +14,6 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriInfo;
 import java.net.URI;
-import java.util.List;
 import java.util.Map;
 import org.broadinstitute.consent.http.models.AuthUser;
 import org.broadinstitute.consent.http.models.FeatureFlag;
@@ -34,42 +31,6 @@ public class FeatureFlagResource extends Resource {
   public FeatureFlagResource(FeatureFlagService featureFlagService, UserService userService) {
     this.featureFlagService = featureFlagService;
     this.userService = userService;
-  }
-
-  /**
-   * Get all feature flags
-   *
-   * @return List of all feature flags
-   */
-  @GET
-  @Produces(MediaType.APPLICATION_JSON)
-  @PermitAll
-  public Response getAllFeatureFlags() {
-    try {
-      List<FeatureFlag> flags = featureFlagService.getAllFeatureFlags();
-      return Response.ok(flags).build();
-    } catch (Exception e) {
-      return createExceptionResponse(e);
-    }
-  }
-
-  /**
-   * Get a specific feature flag by id
-   *
-   * @param id The feature flag id
-   * @return The feature flag
-   */
-  @GET
-  @Path("/{id}")
-  @Produces(MediaType.APPLICATION_JSON)
-  @PermitAll
-  public Response getFeatureFlagById(@PathParam("id") String id) {
-    try {
-      FeatureFlag flag = featureFlagService.getFeatureFlagById(id);
-      return Response.ok(flag).build();
-    } catch (Exception e) {
-      return createExceptionResponse(e);
-    }
   }
 
   /**
@@ -106,7 +67,7 @@ public class FeatureFlagResource extends Resource {
       if (existed) {
         return Response.ok(flag).build();
       } else {
-        URI uri = info.getAbsolutePathBuilder().path(id).build();
+        URI uri = info.getBaseUriBuilder().path("feature").path(id).build();
         return Response.created(uri).entity(flag).build();
       }
     } catch (Exception e) {

--- a/src/main/java/org/broadinstitute/consent/http/resources/PublicFeatureFlagResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/PublicFeatureFlagResource.java
@@ -1,0 +1,60 @@
+package org.broadinstitute.consent.http.resources;
+
+import com.google.inject.Inject;
+import jakarta.annotation.security.PermitAll;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import java.util.List;
+import org.broadinstitute.consent.http.models.FeatureFlag;
+import org.broadinstitute.consent.http.service.FeatureFlagService;
+
+@Path("feature")
+public class PublicFeatureFlagResource extends Resource {
+
+  private final FeatureFlagService featureFlagService;
+
+  @Inject
+  public PublicFeatureFlagResource(FeatureFlagService featureFlagService) {
+    this.featureFlagService = featureFlagService;
+  }
+
+  /**
+   * Get all feature flags
+   *
+   * @return List of all feature flags
+   */
+  @GET
+  @Produces(MediaType.APPLICATION_JSON)
+  @PermitAll
+  public Response getAllFeatureFlags() {
+    try {
+      List<FeatureFlag> flags = featureFlagService.getAllFeatureFlags();
+      return Response.ok(flags).build();
+    } catch (Exception e) {
+      return createExceptionResponse(e);
+    }
+  }
+
+  /**
+   * Get a specific feature flag by id
+   *
+   * @param id The feature flag id
+   * @return The feature flag
+   */
+  @GET
+  @Path("/{id}")
+  @Produces(MediaType.APPLICATION_JSON)
+  @PermitAll
+  public Response getFeatureFlagById(@PathParam("id") String id) {
+    try {
+      FeatureFlag flag = featureFlagService.getFeatureFlagById(id);
+      return Response.ok(flag).build();
+    } catch (Exception e) {
+      return createExceptionResponse(e);
+    }
+  }
+}

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -553,10 +553,12 @@ paths:
           description: Server error.
   /api/emailNotifier/darExpirationNotices:
     $ref: './paths/darExpirationNotices.yaml'
-  /api/feature:
+  /feature:
     $ref: './paths/feature.yaml'
+  /feature/{id}:
+    $ref: './paths/publicFeatureById.yaml'
   /api/feature/{id}:
-    $ref: './paths/featureById.yaml'
+    $ref: './paths/adminFeatureById.yaml'
   /api/institutions:
     $ref: './paths/institutions.yaml'
   /api/institutions/{id}:

--- a/src/main/resources/assets/paths/adminFeatureById.yaml
+++ b/src/main/resources/assets/paths/adminFeatureById.yaml
@@ -1,36 +1,3 @@
-get:
-  summary: Get feature flag by ID
-  operationId: getFeatureFlagById
-  description: Retrieve a specific feature flag by its ID
-  tags:
-    - Feature Flags
-  parameters:
-    - name: id
-      in: path
-      description: The feature flag ID
-      required: true
-      schema:
-        type: string
-  responses:
-    200:
-      description: Feature flag found
-      content:
-        application/json:
-          schema:
-            $ref: '../schemas/FeatureFlag.yaml'
-    404:
-      description: Feature flag not found
-      content:
-        application/json:
-          schema:
-            $ref: '../schemas/ErrorResponse.yaml'
-    500:
-      description: Internal Server Error
-      content:
-        application/json:
-          schema:
-            $ref: '../schemas/ErrorResponse.yaml'
-
 post:
   summary: Create or update feature flag
   operationId: createOrUpdateFeatureFlag

--- a/src/main/resources/assets/paths/publicFeatureById.yaml
+++ b/src/main/resources/assets/paths/publicFeatureById.yaml
@@ -1,0 +1,32 @@
+get:
+  summary: Get feature flag by ID
+  operationId: getFeatureFlagById
+  description: Retrieve a specific feature flag by its ID
+  tags:
+    - Feature Flags
+  parameters:
+    - name: id
+      in: path
+      description: The feature flag ID
+      required: true
+      schema:
+        type: string
+  responses:
+    200:
+      description: Feature flag found
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/FeatureFlag.yaml'
+    404:
+      description: Feature flag not found
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
+    500:
+      description: Internal Server Error
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'

--- a/src/test/java/org/broadinstitute/consent/http/resources/FeatureFlagResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/FeatureFlagResourceTest.java
@@ -14,7 +14,6 @@ import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriBuilder;
 import jakarta.ws.rs.core.UriInfo;
 import java.net.URI;
-import java.util.List;
 import java.util.Map;
 import org.broadinstitute.consent.http.AbstractTestHelper;
 import org.broadinstitute.consent.http.models.AuthUser;
@@ -44,54 +43,12 @@ class FeatureFlagResourceTest extends AbstractTestHelper {
   }
 
   @Test
-  void testGetAllFeatureFlags() {
-    FeatureFlag flag1 = new FeatureFlag("feature1", "value1");
-    FeatureFlag flag2 = new FeatureFlag("feature2", "value2");
-    when(featureFlagService.getAllFeatureFlags()).thenReturn(List.of(flag1, flag2));
-
-    Response response = resource.getAllFeatureFlags();
-    assertEquals(200, response.getStatus());
-    assertNotNull(response.getEntity());
-    verify(featureFlagService).getAllFeatureFlags();
-  }
-
-  @Test
-  void testGetAllFeatureFlags_Empty() {
-    when(featureFlagService.getAllFeatureFlags()).thenReturn(List.of());
-
-    Response response = resource.getAllFeatureFlags();
-    assertEquals(200, response.getStatus());
-    verify(featureFlagService).getAllFeatureFlags();
-  }
-
-  @Test
-  void testGetFeatureFlagById_Found() {
-    FeatureFlag flag = new FeatureFlag("test-feature", "test-value");
-    when(featureFlagService.getFeatureFlagById("test-feature")).thenReturn(flag);
-
-    Response response = resource.getFeatureFlagById("test-feature");
-    assertEquals(200, response.getStatus());
-    assertNotNull(response.getEntity());
-    verify(featureFlagService).getFeatureFlagById("test-feature");
-  }
-
-  @Test
-  void testGetFeatureFlagById_NotFound() {
-    when(featureFlagService.getFeatureFlagById("non-existent"))
-        .thenThrow(new NotFoundException("Feature flag with id 'non-existent' not found"));
-
-    Response response = resource.getFeatureFlagById("non-existent");
-    assertEquals(404, response.getStatus());
-    verify(featureFlagService).getFeatureFlagById("non-existent");
-  }
-
-  @Test
   void testCreateOrUpdateFeatureFlag_Create() {
     UriInfo uriInfo = mock(UriInfo.class);
     UriBuilder uriBuilder = mock(UriBuilder.class);
-    when(uriInfo.getAbsolutePathBuilder()).thenReturn(uriBuilder);
+    when(uriInfo.getBaseUriBuilder()).thenReturn(uriBuilder);
     when(uriBuilder.path(anyString())).thenReturn(uriBuilder);
-    when(uriBuilder.build()).thenReturn(URI.create("http://localhost/api/feature/new-feature"));
+    when(uriBuilder.build()).thenReturn(URI.create("http://localhost/feature/new-feature"));
 
     when(userService.findUserByEmail(authUser.getEmail())).thenReturn(user);
     FeatureFlag createdFlag = new FeatureFlag("new-feature", "new-value");

--- a/src/test/java/org/broadinstitute/consent/http/resources/PublicFeatureFlagResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/PublicFeatureFlagResourceTest.java
@@ -1,0 +1,73 @@
+package org.broadinstitute.consent.http.resources;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.core.Response;
+import java.util.List;
+import org.broadinstitute.consent.http.AbstractTestHelper;
+import org.broadinstitute.consent.http.models.FeatureFlag;
+import org.broadinstitute.consent.http.service.FeatureFlagService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PublicFeatureFlagResourceTest extends AbstractTestHelper {
+
+  @Mock private FeatureFlagService featureFlagService;
+
+  private PublicFeatureFlagResource resource;
+
+  @BeforeEach
+  void setUp() {
+    resource = new PublicFeatureFlagResource(featureFlagService);
+  }
+
+  @Test
+  void testGetAllFeatureFlags() {
+    FeatureFlag flag1 = new FeatureFlag("feature1", "value1");
+    FeatureFlag flag2 = new FeatureFlag("feature2", "value2");
+    when(featureFlagService.getAllFeatureFlags()).thenReturn(List.of(flag1, flag2));
+
+    Response response = resource.getAllFeatureFlags();
+    assertEquals(200, response.getStatus());
+    assertNotNull(response.getEntity());
+    verify(featureFlagService).getAllFeatureFlags();
+  }
+
+  @Test
+  void testGetAllFeatureFlags_Empty() {
+    when(featureFlagService.getAllFeatureFlags()).thenReturn(List.of());
+
+    Response response = resource.getAllFeatureFlags();
+    assertEquals(200, response.getStatus());
+    verify(featureFlagService).getAllFeatureFlags();
+  }
+
+  @Test
+  void testGetFeatureFlagById_Found() {
+    FeatureFlag flag = new FeatureFlag("test-feature", "test-value");
+    when(featureFlagService.getFeatureFlagById("test-feature")).thenReturn(flag);
+
+    Response response = resource.getFeatureFlagById("test-feature");
+    assertEquals(200, response.getStatus());
+    assertNotNull(response.getEntity());
+    verify(featureFlagService).getFeatureFlagById("test-feature");
+  }
+
+  @Test
+  void testGetFeatureFlagById_NotFound() {
+    when(featureFlagService.getFeatureFlagById("non-existent"))
+        .thenThrow(new NotFoundException("Feature flag with id 'non-existent' not found"));
+
+    Response response = resource.getFeatureFlagById("non-existent");
+    assertEquals(404, response.getStatus());
+    verify(featureFlagService).getFeatureFlagById("non-existent");
+  }
+}


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2832

### Summary

Per previous discussion, moves the GET methods from `/api/feature` to `/feature` , so they can be used fully unauthenticated.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
