### PR TITLE
[DT-2775] Improve Data Submission Error Messaging

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
@@ -105,7 +105,7 @@ public class DatasetResource extends Resource {
   public Response createDatasetRegistration(
       @Auth AuthUser authUser, FormDataMultiPart multipart, @FormDataParam("dataset") String json) {
     try {
-      Set<String> errors = jsonSchemaUtil.validateSchemaMessages_v1(json);
+      Set<String> errors = jsonSchemaUtil.validateSchemaMessagesV1(json);
       if (!errors.isEmpty()) {
         throw new BadRequestException(
             "Please correct the following fields:\n"

--- a/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
@@ -5,7 +5,6 @@ import com.google.api.client.http.HttpStatusCodes;
 import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
 import com.google.inject.Inject;
-import com.networknt.schema.ValidationMessage;
 import io.dropwizard.auth.Auth;
 import jakarta.annotation.security.PermitAll;
 import jakarta.annotation.security.RolesAllowed;
@@ -100,17 +99,17 @@ public class DatasetResource extends Resource {
   @RolesAllowed({ADMIN, CHAIRPERSON, DATASUBMITTER})
   @Timed
   /*
-   * This endpoint accepts a json instance of a dataset-registration-schema_v1.json schema.
+   * This endpoint accepts a JSON instance of a dataset-registration-schema_v1.json schema.
    * With that object, we can fully create datasets from the provided values.
    */
   public Response createDatasetRegistration(
       @Auth AuthUser authUser, FormDataMultiPart multipart, @FormDataParam("dataset") String json) {
     try {
-      Set<ValidationMessage> errors = jsonSchemaUtil.validateSchema_v1(json);
+      Set<String> errors = jsonSchemaUtil.validateSchemaMessages_v1(json);
       if (!errors.isEmpty()) {
         throw new BadRequestException(
-            "Invalid schema:\n"
-                + String.join("\n", errors.stream().map(ValidationMessage::getMessage).toList()));
+            "Please correct the following fields:\n"
+                + errors.stream().map(error -> " - " + error + "\n").collect(Collectors.joining()));
       }
 
       DatasetRegistrationSchemaV1 registration =
@@ -123,7 +122,7 @@ public class DatasetResource extends Resource {
       // Generate datasets from registration
       List<Dataset> datasets =
           datasetRegistrationService.createDatasetsFromRegistration(registration, user, files);
-      Integer studyId = datasets.get(0).getStudyId();
+      Integer studyId = datasets.getFirst().getStudyId();
       Study study = datasetService.findStudy(studyId);
       DatasetRegistrationSchemaV1Builder builder = new DatasetRegistrationSchemaV1Builder();
       DatasetRegistrationSchemaV1 createdRegistration = builder.build(study, datasets);

--- a/src/main/java/org/broadinstitute/consent/http/util/JsonSchemaUtil.java
+++ b/src/main/java/org/broadinstitute/consent/http/util/JsonSchemaUtil.java
@@ -104,7 +104,7 @@ public class JsonSchemaUtil implements ConsentLogger {
    * @param json The string instance of a dataset registration object
    * @return Set of human-readable validation error messages, or an empty list if valid.
    */
-  public Set<String> validateSchemaMessages_v1(String json) {
+  public Set<String> validateSchemaMessagesV1(String json) {
     return validateSchema_v1(json).stream()
         .map(this::formatMessage)
         .collect(Collectors.toCollection(LinkedHashSet::new));

--- a/src/main/java/org/broadinstitute/consent/http/util/JsonSchemaUtil.java
+++ b/src/main/java/org/broadinstitute/consent/http/util/JsonSchemaUtil.java
@@ -13,16 +13,23 @@ import com.networknt.schema.SpecVersion;
 import com.networknt.schema.ValidationMessage;
 import jakarta.ws.rs.BadRequestException;
 import java.nio.charset.Charset;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
 import org.apache.commons.io.IOUtils;
 import org.broadinstitute.consent.http.models.dataset_registration_v1.DatasetRegistrationSchemaV1;
 
 public class JsonSchemaUtil implements ConsentLogger {
 
   private final LoadingCache<String, String> cache;
-  private final String datasetRegistrationSchemaV1 = "/dataset-registration-schema_v1.json";
-  private JsonSchemaFactory factory;
+  private final JsonSchemaFactory factory;
+  Map<String, String> fieldLabels = new HashMap<>();
+  Map<String, String> fieldDescriptions = new HashMap<>();
+  private static final Map<String, String> FIELD_NAME_OVERRIDES =
+      Map.of("consentGroups", "Datasets");
 
   public JsonSchemaUtil() {
     factory = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V201909);
@@ -36,8 +43,14 @@ public class JsonSchemaUtil implements ConsentLogger {
     this.cache = CacheBuilder.newBuilder().build(loader);
   }
 
+  /**
+   * Loads the dataset registration schema v1 as a string
+   *
+   * @return The schema as a string
+   */
   public String getDatasetRegistrationSchemaV1() {
     try {
+      String datasetRegistrationSchemaV1 = "/dataset-registration-schema_v1.json";
       return cache.get(datasetRegistrationSchemaV1);
     } catch (ExecutionException ee) {
       logException("Unable to load the data submitter schema: %s".formatted(ee.getMessage()), ee);
@@ -51,12 +64,17 @@ public class JsonSchemaUtil implements ConsentLogger {
    * @return Schema The Schema
    * @throws ExecutionException Error reading from cache
    */
-  private JsonSchema getDatasetRegistrationSchema() throws ExecutionException {
+  JsonSchema getDatasetRegistrationSchema() throws ExecutionException {
     String schemaString = getDatasetRegistrationSchemaV1();
+
+    // Extract labels and descriptions for error messages
+    extractLabelsAndDescriptions(schemaString);
+
     SchemaValidatorsConfig config = new SchemaValidatorsConfig();
     config.setHandleNullableField(false);
     config.setTypeLoose(false);
     config.setFormatAssertionsEnabled(true);
+
     return factory.getSchema(schemaString, config);
   }
 
@@ -64,7 +82,7 @@ public class JsonSchemaUtil implements ConsentLogger {
    * Compares an instance of a dataset registration object to the dataset registration schema
    *
    * @param datasetRegistrationInstance The string instance of a dataset registration object
-   * @return List of human-readable validation errors, or an empty list if valid.
+   * @return Set of human-readable validation errors, or an empty list if valid.
    */
   public Set<ValidationMessage> validateSchema_v1(String datasetRegistrationInstance) {
     try {
@@ -80,6 +98,24 @@ public class JsonSchemaUtil implements ConsentLogger {
     }
   }
 
+  /**
+   * Compares an instance of a dataset registration object to the dataset registration schema
+   *
+   * @param json The string instance of a dataset registration object
+   * @return Set of human-readable validation error messages, or an empty list if valid.
+   */
+  public Set<String> validateSchemaMessages_v1(String json) {
+    return validateSchema_v1(json).stream()
+        .map(this::formatMessage)
+        .collect(Collectors.toCollection(LinkedHashSet::new));
+  }
+
+  /**
+   * Deserializes a dataset registration instance into a DatasetRegistrationSchemaV1 object
+   *
+   * @param datasetRegistrationInstance The string instance of a dataset registration object
+   * @return The deserialized DatasetRegistrationSchemaV1 object, or null if invalid
+   */
   public DatasetRegistrationSchemaV1 deserializeDatasetRegistration(
       String datasetRegistrationInstance) {
     try {
@@ -94,5 +130,109 @@ public class JsonSchemaUtil implements ConsentLogger {
       logException("Unable to load the data submitter schema: %s".formatted(ee.getMessage()), ee);
       return null;
     }
+  }
+
+  /**
+   * Extracts field labels and descriptions from the schema for use in error messages and tooltips
+   *
+   * @param schemaString The schema as a string
+   */
+  private void extractLabelsAndDescriptions(String schemaString) {
+    try {
+      ObjectMapper mapper = new ObjectMapper();
+      JsonNode schemaNode = mapper.readTree(schemaString);
+      JsonNode properties = schemaNode.path("properties");
+
+      properties
+          .fields()
+          .forEachRemaining(
+              entry -> {
+                String field = entry.getKey();
+
+                JsonNode labelNode = entry.getValue().path("label");
+                if (labelNode.isTextual()) {
+                  fieldLabels.put(field, labelNode.asText());
+                }
+
+                JsonNode descNode = entry.getValue().path("description");
+                if (descNode.isTextual()) {
+                  fieldDescriptions.put(field, descNode.asText());
+                }
+              });
+    } catch (Exception e) {
+      fieldLabels = Map.of();
+      fieldDescriptions = Map.of();
+    }
+  }
+
+  /**
+   * Formats a validation message into a human-readable string
+   *
+   * @param vm The validation message
+   * @return The formatted message
+   */
+  String formatMessage(ValidationMessage vm) {
+    String field = fieldFromMessage(vm);
+    String name = displayName(field);
+
+    return switch (vm.getType()) {
+      case "required" -> name + " is required";
+      case "minLength" -> name + " must not be empty";
+      case "minItems" -> name + " must have at least one item";
+      case "enum" -> name + " must be one of the allowed options";
+      case "type" -> name + " has an invalid value";
+      default -> vm.getMessage(); // fallback to default message
+    };
+  }
+
+  /**
+   * Derives the field name from the schema location in a validation message
+   *
+   * @param vm The validation message
+   * @return The field name, or null if not found
+   */
+  private String fieldFromMessage(ValidationMessage vm) {
+    // REQUIRED → field name comes from arguments
+    if ("required".equals(vm.getType())) {
+      Object[] args = vm.getArguments();
+      return (args != null && args.length > 0) ? args[0].toString() : null;
+    }
+
+    // ALL OTHERS → derive from schema location
+    String loc = vm.getSchemaLocation().toString();
+    if (loc == null) return null;
+
+    String marker = "#/properties/";
+    int idx = loc.indexOf(marker);
+    if (idx < 0) return null;
+
+    String rest = loc.substring(idx + marker.length());
+    int slash = rest.indexOf('/');
+
+    return slash > 0 ? rest.substring(0, slash) : rest;
+  }
+
+  /**
+   * Gets the display name for a field, using label or description if available
+   *
+   * @param field The field name
+   * @return The display name
+   */
+  String displayName(String field) {
+    if (field == null) return "Field";
+
+    if (FIELD_NAME_OVERRIDES.containsKey(field)) {
+      return FIELD_NAME_OVERRIDES.get(field);
+    }
+
+    if (fieldLabels.containsKey(field)) {
+      return fieldLabels.get(field);
+    }
+
+    if (fieldDescriptions.containsKey(field)) {
+      return fieldDescriptions.get(field);
+    }
+
+    return field;
   }
 }

--- a/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
@@ -768,6 +768,32 @@ class DatasetResourceTest extends AbstractTestHelper {
   }
 
   @Test
+  void testCreateDatasetRegistration_invalidSchema_errorMessages() {
+    // Invalid JSON: missing required fields
+    String invalidJson =
+        """
+      {
+        "dataTypes": [],
+        "consentGroups": []
+      }
+      """;
+    try (var response = resource.createDatasetRegistration(authUser, null, invalidJson)) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
+      String entity = response.getEntity().toString();
+
+      // Check for specific user-facing error messages
+      assertTrue(entity.contains("Please correct the following fields:"));
+      assertTrue(entity.contains("Study Name is required"));
+      assertTrue(entity.contains("Study Description is required"));
+      assertTrue(entity.contains("Data Types must have at least one item"));
+      assertTrue(entity.contains("Datasets must have at least one item"));
+      assertTrue(entity.contains("NIH Anvil Use is required"));
+      assertTrue(entity.contains("Principal Investigator Name is required"));
+      assertTrue(entity.contains("Public Visibility is required"));
+    }
+  }
+
+  @Test
   void testCreateDatasetRegistration_validSchema() throws SQLException, IOException {
     when(userService.findUserByEmail(any())).thenReturn(user);
     user.setUserId(1);

--- a/src/test/java/org/broadinstitute/consent/http/util/JsonSchemaUtilTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/util/JsonSchemaUtilTest.java
@@ -1,11 +1,15 @@
 package org.broadinstitute.consent.http.util;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.networknt.schema.ValidationMessage;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
 import org.broadinstitute.consent.http.models.dataset_registration_v1.DatasetRegistrationSchemaV1;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -79,8 +83,8 @@ class JsonSchemaUtilTest {
     assertFalse(instance.getDataCustodianEmail().isEmpty());
     assertNotNull(instance.getPublicVisibility());
     assertFalse(instance.getConsentGroups().isEmpty());
-    assertFalse(instance.getConsentGroups().get(0).getFileTypes().isEmpty());
-    assertNotNull(instance.getConsentGroups().get(0).getDataAccessCommitteeId());
+    assertFalse(instance.getConsentGroups().getFirst().getFileTypes().isEmpty());
+    assertNotNull(instance.getConsentGroups().getFirst().getDataAccessCommitteeId());
   }
 
   @Test
@@ -764,7 +768,6 @@ class JsonSchemaUtilTest {
           }]
         }
         """;
-    ;
     String tdrLocationNoUrl =
         """
         {
@@ -845,6 +848,44 @@ class JsonSchemaUtilTest {
     assertFieldHasError(errors, "nihGrantContractNumber");
     assertFieldHasError(errors, "consentGroupName");
     assertFieldHasError(errors, "url");
+  }
+
+  @Test
+  void testExtractLabelsAndDescriptions() throws ExecutionException {
+    JsonSchemaUtil util = new JsonSchemaUtil();
+
+    // Ensure schema is loaded and labels/descriptions are extracted
+    util.getDatasetRegistrationSchema();
+
+    assertTrue(util.fieldLabels.containsKey("studyName"));
+    assertEquals("Study Name", util.fieldLabels.get("studyName"));
+    assertTrue(util.fieldDescriptions.containsKey("studyName"));
+    assertEquals("The study name", util.fieldDescriptions.get("studyName"));
+  }
+
+  @Test
+  void testFormatMessageRequired() {
+    JsonSchemaUtil util = new JsonSchemaUtil();
+    ValidationMessage vm = mock(ValidationMessage.class);
+    when(vm.getType()).thenReturn("required");
+    when(vm.getArguments()).thenReturn(new Object[] {"studyName"});
+
+    String msg = util.formatMessage(vm);
+    assertTrue(msg.contains("is required"));
+  }
+
+  @Test
+  void testDisplayNameOverrides() {
+    JsonSchemaUtil util = new JsonSchemaUtil();
+    String name = util.displayName("consentGroups");
+    assertEquals("Datasets", name);
+  }
+
+  @Test
+  void testDisplayNameFallback() {
+    JsonSchemaUtil util = new JsonSchemaUtil();
+    String name = util.displayName("nonexistentField");
+    assertEquals("nonexistentField", name);
   }
 
   private void assertNoErrors(Set<ValidationMessage> errors) {


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2775

### Summary

This PR and the ([UI part](https://github.com/DataBiosphere/consent/pull/2790)) improve submission validation errors so users can easily understand what’s missing and where to fix it. Instead of showing internal schema paths and raw validation output, error messages now use user-facing field names.

https://github.com/user-attachments/assets/ecd0ea5c-121e-4d4c-8def-5e5820e84958

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
