### PR TITLE
DT-2875: Ontology indexing improvements

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/resources/OntologyResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/OntologyResource.java
@@ -3,6 +3,7 @@ package org.broadinstitute.consent.http.resources;
 import com.google.inject.Inject;
 import io.dropwizard.auth.Auth;
 import jakarta.annotation.security.RolesAllowed;
+import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
@@ -40,6 +41,22 @@ public class OntologyResource extends Resource {
         throw new IllegalArgumentException("Invalid ontology type: " + ontologyType);
       }
       ontologyService.indexOntology(duosUser.getUser(), type);
+      return Response.ok().build();
+    } catch (Exception e) {
+      return createExceptionResponse(e);
+    }
+  }
+
+  @DELETE
+  @RolesAllowed({ADMIN})
+  public Response deleteOntologyTerms(
+      @Auth DuosUser duosUser, @QueryParam("ontologyType") String ontologyType) {
+    try {
+      OntologyType type = OntologyType.getFromName(ontologyType);
+      if (type == null) {
+        throw new IllegalArgumentException("Invalid ontology type: " + ontologyType);
+      }
+      ontologyService.deleteOntologyTerms(type);
       return Response.ok().build();
     } catch (Exception e) {
       return createExceptionResponse(e);

--- a/src/main/java/org/broadinstitute/consent/http/service/OntologyService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/OntologyService.java
@@ -79,6 +79,11 @@ public class OntologyService implements ConsentLogger {
     }
   }
 
+  public void deleteOntologyTerms(OntologyType ontologyType) {
+    ontologyDAO.deleteByOntology(ontologyType.name());
+    logInfo("Deleted ontology terms for ontology: %s".formatted(ontologyType.name()));
+  }
+
   public void indexOntology(User user, OntologyType ontologyType) {
     ListeningExecutorService listeningExecutorService =
         MoreExecutors.listeningDecorator(executorService);
@@ -96,6 +101,7 @@ public class OntologyService implements ConsentLogger {
           public void onSuccess(Collection<OntologyTerm> terms) {
             logInfo("Successfully indexed %s ontology terms".formatted(terms.size()));
           }
+
           @Override
           public void onFailure(@NonNull Throwable t) {
             logThrowable(t);

--- a/src/main/java/org/broadinstitute/consent/http/service/OntologyService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/OntologyService.java
@@ -1,5 +1,10 @@
 package org.broadinstitute.consent.http.service;
 
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import com.google.common.util.concurrent.MoreExecutors;
 import com.google.inject.Inject;
 import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.client.Entity;
@@ -8,6 +13,7 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.StreamingOutput;
 import java.util.Collection;
+import java.util.concurrent.ExecutorService;
 import org.broadinstitute.consent.http.configurations.ServicesConfiguration;
 import org.broadinstitute.consent.http.enumeration.DataUseTranslationType;
 import org.broadinstitute.consent.http.enumeration.OntologyType;
@@ -18,10 +24,13 @@ import org.broadinstitute.consent.http.service.ontology.OntologyDAO;
 import org.broadinstitute.consent.http.service.ontology.OntologyIndexService;
 import org.broadinstitute.consent.http.service.ontology.OntologyTerm;
 import org.broadinstitute.consent.http.util.ConsentLogger;
-import org.semanticweb.owlapi.model.OWLOntologyCreationException;
+import org.broadinstitute.consent.http.util.ThreadUtils;
+import org.jspecify.annotations.NonNull;
 
 public class OntologyService implements ConsentLogger {
 
+  private final ExecutorService executorService =
+      new ThreadUtils().getExecutorService(OntologyService.class);
   private final ServicesConfiguration servicesConfiguration;
   private final Client client;
   private final OntologyDAO ontologyDAO;
@@ -70,10 +79,29 @@ public class OntologyService implements ConsentLogger {
     }
   }
 
-  public void indexOntology(User user, OntologyType ontologyType)
-      throws OWLOntologyCreationException {
-    Collection<OntologyTerm> terms = indexService.generateTerms(ontologyType);
-    ontologyDAO.batchInsertTerms(terms, user.getUserId());
+  public void indexOntology(User user, OntologyType ontologyType) {
+    ListeningExecutorService listeningExecutorService =
+        MoreExecutors.listeningDecorator(executorService);
+    ListenableFuture<Collection<OntologyTerm>> syncFuture =
+        listeningExecutorService.submit(
+            () -> {
+              Collection<OntologyTerm> terms = indexService.generateTerms(ontologyType);
+              ontologyDAO.batchInsertTerms(terms, user.getUserId());
+              return terms;
+            });
+    Futures.addCallback(
+        syncFuture,
+        new FutureCallback<>() {
+          @Override
+          public void onSuccess(Collection<OntologyTerm> terms) {
+            logInfo("Successfully indexed %s ontology terms".formatted(terms.size()));
+          }
+          @Override
+          public void onFailure(@NonNull Throwable t) {
+            logThrowable(t);
+          }
+        },
+        listeningExecutorService);
   }
 
   public StreamingOutput findByTermIds(String[] termIds) {

--- a/src/main/java/org/broadinstitute/consent/http/service/ontology/OntologyDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ontology/OntologyDAO.java
@@ -13,6 +13,7 @@ import org.jdbi.v3.sqlobject.customizer.BindMethods;
 import org.jdbi.v3.sqlobject.statement.BatchChunkSize;
 import org.jdbi.v3.sqlobject.statement.SqlBatch;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
+import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 import org.jdbi.v3.sqlobject.transaction.Transactional;
 
 public interface OntologyDAO extends Transactional<OntologyDAO> {
@@ -29,6 +30,9 @@ public interface OntologyDAO extends Transactional<OntologyDAO> {
 
   @SqlQuery("SELECT COUNT(*) FROM ontology_index")
   int countTerms();
+
+  @SqlUpdate("DELETE FROM ontology_index where ontology = :ontology")
+  void deleteByOntology(@Bind("ontology") String ontology);
 
   @Json
   default StreamingOutput findByTermIds(@Bind("ids") String[] ids) {

--- a/src/main/java/org/broadinstitute/consent/http/service/ontology/OntologyDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ontology/OntologyDAO.java
@@ -39,7 +39,8 @@ public interface OntologyDAO extends Transactional<OntologyDAO> {
             WHERE LOWER(id) = ANY (:ids)
                OR LOWER(obo_id) = ANY (:ids)
             """;
-    String[] lowerIds = Arrays.stream(ids).map(String::toLowerCase).toArray(String[]::new);
+    String[] lowerIds =
+        Arrays.stream(ids).map(String::toLowerCase).map(String::trim).toArray(String[]::new);
     return withHandle(
         handle -> {
           ResultIterable<JsonObject> results =

--- a/src/main/java/org/broadinstitute/consent/http/service/ontology/OntologyIndexService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ontology/OntologyIndexService.java
@@ -64,7 +64,7 @@ public class OntologyIndexService implements ConsentLogger {
     Optional<IRI> versionIRI = ontologyID.getVersionIRI();
     String version = versionIRI.map(IRI::toString).orElse("unknown_version");
     OWLReasonerFactory reasonerFactory = new StructuralReasonerFactory();
-    OWLReasoner reasoner = reasonerFactory.createNonBufferingReasoner(ontology);
+    OWLReasoner reasoner = reasonerFactory.createReasoner(ontology);
     Set<OWLClass> owlClasses = ontology.classesInSignature().collect(Collectors.toSet());
     owlClasses.addAll(
         ontology

--- a/src/main/resources/assets/paths/ontology.yaml
+++ b/src/main/resources/assets/paths/ontology.yaml
@@ -1,6 +1,10 @@
 post:
   summary: Index Ontology
-  description: Index Ontology
+  description: |
+    Index Ontology by type. The ontology file must exist in the configured
+    ontology file storage location. Note that this starts an async operation
+    that may take several minutes to complete depending on the size of the
+    ontology file.
   operationId: indexOntology
   parameters:
     - name: ontologyType
@@ -16,6 +20,26 @@ post:
     - Admin
   responses:
     200:
-      description: Ontology Query Results
+      description: Ontology Index Results
+    500:
+      description: Internal Server Error
+
+delete:
+  summary: Index Ontology Deletion
+  description: Index Ontology Deletion
+  operationId: indexOntologyDeletion
+  parameters:
+    - name: ontologyType
+      in: query
+      description: The type of the ontology file to remove
+      required: true
+      schema:
+        type: string
+        enum: [ DOID, DUO ]
+  tags:
+    - Admin
+  responses:
+    200:
+      description: Ontology Deletion Results
     500:
       description: Internal Server Error

--- a/src/test/java/org/broadinstitute/consent/http/db/OntologyDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/OntologyDAOTest.java
@@ -50,6 +50,7 @@ class OntologyDAOTest extends DAOTestHelper {
   @ValueSource(
       strings = {
         "DUO_0000006", // normalized obo id
+        " DUO_0000007 ", // normalized obo id with spaces
         "http://purl.obolibrary.org/obo/DUO_0000006" // full term_id
       })
   void testFindByIds(String id) throws Exception {

--- a/src/test/java/org/broadinstitute/consent/http/db/OntologyDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/OntologyDAOTest.java
@@ -46,6 +46,16 @@ class OntologyDAOTest extends DAOTestHelper {
     assertEquals(terms.size(), count);
   }
 
+  @Test
+  void testDeleteTerms() throws Exception {
+    Collection<OntologyTerm> terms = batchInsertTerms();
+    int count = ontologyDAO.countTerms();
+    assertEquals(terms.size(), count);
+    ontologyDAO.deleteByOntology(OntologyType.DUO.name());
+    int count2 = ontologyDAO.countTerms();
+    assertEquals(0, count2);
+  }
+
   @ParameterizedTest
   @ValueSource(
       strings = {

--- a/src/test/java/org/broadinstitute/consent/http/resources/OntologyResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/OntologyResourceTest.java
@@ -1,7 +1,6 @@
 package org.broadinstitute.consent.http.resources;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
@@ -31,12 +30,12 @@ class OntologyResourceTest extends AbstractTestHelper {
   private OntologyResource resource;
 
   @Test
-  void testIndexOntologyTermsSuccess() throws Exception {
+  void testIndexOntologyTermsSuccess() {
     User admin = new User();
     admin.setAdminRole();
     DuosUser duosUser = new DuosUser(authUser, admin);
 
-    doNothing().when(ontologyService).indexOntology(any(), any());
+    doNothing().when(ontologyService).indexOntology(duosUser.getUser(), OntologyType.DOID);
 
     resource = new OntologyResource(ontologyService);
     try (Response response = resource.indexOntologyTerms(duosUser, OntologyType.DOID.name())) {
@@ -57,15 +56,55 @@ class OntologyResourceTest extends AbstractTestHelper {
   }
 
   @Test
-  void testIndexOntologyTermsException() throws Exception {
+  void testIndexOntologyTermsException() {
     User admin = new User();
     admin.setAdminRole();
     DuosUser duosUser = new DuosUser(authUser, admin);
 
-    doThrow(new RuntimeException()).when(ontologyService).indexOntology(any(), any());
+    doThrow(new RuntimeException()).when(ontologyService).indexOntology(duosUser.getUser(), OntologyType.DOID);
 
     resource = new OntologyResource(ontologyService);
     try (Response response = resource.indexOntologyTerms(duosUser, OntologyType.DOID.name())) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_SERVER_ERROR, response.getStatus());
+    }
+  }
+
+  @Test
+  void testDeleteOntologyTermsSuccess() {
+    User admin = new User();
+    admin.setAdminRole();
+    DuosUser duosUser = new DuosUser(authUser, admin);
+
+    doNothing().when(ontologyService).deleteOntologyTerms(OntologyType.DOID);
+
+    resource = new OntologyResource(ontologyService);
+    try (Response response = resource.deleteOntologyTerms(duosUser, OntologyType.DOID.name())) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+    }
+  }
+
+  @Test
+  void testDeleteOntologyTermsInvalidType() {
+    User admin = new User();
+    admin.setAdminRole();
+    DuosUser duosUser = new DuosUser(authUser, admin);
+
+    resource = new OntologyResource(ontologyService);
+    try (Response response = resource.deleteOntologyTerms(duosUser, "INVALID_TYPE")) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
+    }
+  }
+
+  @Test
+  void testDeleteOntologyTermsException() {
+    User admin = new User();
+    admin.setAdminRole();
+    DuosUser duosUser = new DuosUser(authUser, admin);
+
+    doThrow(new RuntimeException()).when(ontologyService).deleteOntologyTerms(OntologyType.DOID);
+
+    resource = new OntologyResource(ontologyService);
+    try (Response response = resource.deleteOntologyTerms(duosUser, OntologyType.DOID.name())) {
       assertEquals(HttpStatusCodes.STATUS_CODE_SERVER_ERROR, response.getStatus());
     }
   }
@@ -82,7 +121,7 @@ class OntologyResourceTest extends AbstractTestHelper {
 
   @Test
   void testSearchByTermIdsException() {
-    when(ontologyService.findByTermIds(any())).thenThrow(new RuntimeException());
+    when(ontologyService.findByTermIds(new String[]{"DOID_1234"})).thenThrow(new RuntimeException());
 
     resource = new OntologyResource(ontologyService);
     try (Response response = resource.searchByTermIds("DOID_1234")) {

--- a/src/test/java/org/broadinstitute/consent/http/resources/OntologyResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/OntologyResourceTest.java
@@ -61,7 +61,9 @@ class OntologyResourceTest extends AbstractTestHelper {
     admin.setAdminRole();
     DuosUser duosUser = new DuosUser(authUser, admin);
 
-    doThrow(new RuntimeException()).when(ontologyService).indexOntology(duosUser.getUser(), OntologyType.DOID);
+    doThrow(new RuntimeException())
+        .when(ontologyService)
+        .indexOntology(duosUser.getUser(), OntologyType.DOID);
 
     resource = new OntologyResource(ontologyService);
     try (Response response = resource.indexOntologyTerms(duosUser, OntologyType.DOID.name())) {
@@ -121,7 +123,8 @@ class OntologyResourceTest extends AbstractTestHelper {
 
   @Test
   void testSearchByTermIdsException() {
-    when(ontologyService.findByTermIds(new String[]{"DOID_1234"})).thenThrow(new RuntimeException());
+    when(ontologyService.findByTermIds(new String[] {"DOID_1234"}))
+        .thenThrow(new RuntimeException());
 
     resource = new OntologyResource(ontologyService);
     try (Response response = resource.searchByTermIds("DOID_1234")) {

--- a/src/test/java/org/broadinstitute/consent/http/service/OntologyServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/OntologyServiceTest.java
@@ -183,6 +183,24 @@ class OntologyServiceTest extends MockServerTestHelper {
   }
 
   @Test
+  @SuppressWarnings("java:S2925") // Thread.sleep needed to wait for async callback
+  void testIndexOntologyFailure() throws Exception {
+    User user = new User();
+    user.setUserId(1);
+    String message = "Failed to generate terms";
+    when(indexService.generateTerms(OntologyType.DUO))
+        .thenThrow(new RuntimeException(message));
+
+    service.indexOntology(user, OntologyType.DUO);
+    // Wait a bit for the async callback to execute
+    Thread.sleep(100);
+    // Verify that the failure was logged
+    assertEquals(1, testAppender.getSize());
+    ILoggingEvent event = testAppender.getLoggedEvents().getFirst();
+    assertThat(event.getFormattedMessage(), containsString(message));
+  }
+
+  @Test
   void testFindByTermIds() throws Exception {
     String[] termIds = new String[] {"DUO_0000006", "DUO_0000007"};
     String json =

--- a/src/test/java/org/broadinstitute/consent/http/service/OntologyServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/OntologyServiceTest.java
@@ -176,8 +176,7 @@ class OntologyServiceTest extends MockServerTestHelper {
   }
 
   @Test
-  void testIndexOntology() throws Exception {
-    when(indexService.generateTerms(OntologyType.DUO)).thenReturn(List.of());
+  void testIndexOntology() {
     User user = new User();
     user.setUserId(1);
     assertDoesNotThrow(() -> service.indexOntology(user, OntologyType.DUO));

--- a/src/test/java/org/broadinstitute/consent/http/service/OntologyServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/OntologyServiceTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
@@ -166,6 +167,12 @@ class OntologyServiceTest extends MockServerTestHelper {
     String actualMessage = exception.getMessage();
 
     assertEquals(expectedMessage, actualMessage);
+  }
+
+  @Test
+  void testDeleteOntologyTerms() {
+    doNothing().when(ontologyDAO).deleteByOntology(OntologyType.DUO.name());
+    assertDoesNotThrow(() -> service.deleteOntologyTerms(OntologyType.DUO));
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/OntologyServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/OntologyServiceTest.java
@@ -188,8 +188,7 @@ class OntologyServiceTest extends MockServerTestHelper {
     User user = new User();
     user.setUserId(1);
     String message = "Failed to generate terms";
-    when(indexService.generateTerms(OntologyType.DUO))
-        .thenThrow(new RuntimeException(message));
+    when(indexService.generateTerms(OntologyType.DUO)).thenThrow(new RuntimeException(message));
 
     service.indexOntology(user, OntologyType.DUO);
     // Wait a bit for the async callback to execute


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DT-2875

## Summary
Addresses some minor bugs and adds a new feature to ontology indexing
* New admin feature to delete by ontology type. Useful for developer testing so an ontology can be re-indexed
* Use a different reasoner that is slightly (10-20%) faster which is necessary to find superclasses for terms
* Move indexing to an async service method. Indexing can be slow so return to the client once the index has been kicked off. Additional logging added for both success and failure cases
* Minor bug fix for searching on multiple terms to trim white space from terms before querying on them.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
