### PR TITLE
DT-2468: Fix datasets missing access control

### DIFF
--- a/src/main/resources/changelog-master.xml
+++ b/src/main/resources/changelog-master.xml
@@ -231,4 +231,5 @@
   <include file="changesets/changelog-consent-2026-01-26-feature-flag-audit.xml"
            relativeToChangelogFile="true" />
   <include file="changesets/changelog-consent-2026-01-30-ontology-index.xml" relativeToChangelogFile="true" />
+  <include file="changesets/changelog-consent-2026-02-05-fix-dataset-access-control.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/src/main/resources/changesets/changelog-consent-2026-02-05-fix-dataset-access-control.xml
+++ b/src/main/resources/changesets/changelog-consent-2026-02-05-fix-dataset-access-control.xml
@@ -12,33 +12,26 @@
       WHERE dac_id IS NOT NULL
         AND dac_approval IS NULL
         -- No access management property set:
-        AND NOT EXISTS (
-        SELECT 1
-        FROM dataset_property dp
-        WHERE dp.dataset_id = dataset.dataset_id
-          AND dp.schema_property = 'accessManagement'
-      );
+        AND NOT EXISTS (SELECT 1
+                        FROM dataset_property dp
+                        WHERE dp.dataset_id = dataset.dataset_id
+                          AND dp.schema_property = 'accessManagement')
     </sql>
     <!-- Add access management prop for datasets with a DAC ID: -->
     <sql>
       INSERT INTO dataset_property
       (dataset_id, property_key, property_value, create_date, property_type, schema_property)
-      SELECT
-        d.dataset_id,
-        (SELECT key_id FROM dictionary WHERE key = 'Access Management'),
-        'controlled',
-        NOW(),
-        'String',
-        'accessManagement'
+      SELECT d.dataset_id,
+             (SELECT key_id FROM dictionary WHERE key = 'Access Management'), 'controlled', NOW(), 'String', 'accessManagement'
       FROM dataset d
       WHERE d.dac_id IS NOT NULL
-        -- No access management property set:
+      -- No access management property set:
         AND NOT EXISTS (
         SELECT 1
         FROM dataset_property dp
         WHERE dp.dataset_id = d.dataset_id
         AND dp.schema_property = 'accessManagement'
-        );
+        )
     </sql>
   </changeSet>
 </databaseChangeLog>

--- a/src/main/resources/changesets/changelog-consent-2026-02-05-fix-dataset-access-control.xml
+++ b/src/main/resources/changesets/changelog-consent-2026-02-05-fix-dataset-access-control.xml
@@ -5,18 +5,6 @@
          http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
   <changeSet id="changelog-consent-2026-02-05-fix-dataset-access-control" author="grushton">
-    <!-- Impute DAC Approval for datasets with a DAC ID but no access management prop or approval: -->
-    <sql>
-      UPDATE dataset
-      SET dac_approval = true
-      WHERE dac_id IS NOT NULL
-        AND dac_approval IS NULL
-        -- No access management property set:
-        AND NOT EXISTS (SELECT 1
-                        FROM dataset_property dp
-                        WHERE dp.dataset_id = dataset.dataset_id
-                          AND dp.schema_property = 'accessManagement')
-    </sql>
     <!-- Add access management prop for datasets with a DAC ID: -->
     <sql>
       INSERT INTO dataset_property
@@ -25,12 +13,12 @@
              (SELECT key_id FROM dictionary WHERE key = 'Access Management'), 'controlled', NOW(), 'String', 'accessManagement'
       FROM dataset d
       WHERE d.dac_id IS NOT NULL
-      -- No access management property set:
+        -- No access management property set:
         AND NOT EXISTS (
         SELECT 1
-        FROM dataset_property dp
+         FROM dataset_property dp
         WHERE dp.dataset_id = d.dataset_id
-        AND dp.schema_property = 'accessManagement'
+          AND dp.schema_property = 'accessManagement'
         )
     </sql>
   </changeSet>

--- a/src/main/resources/changesets/changelog-consent-2026-02-05-fix-dataset-access-control.xml
+++ b/src/main/resources/changesets/changelog-consent-2026-02-05-fix-dataset-access-control.xml
@@ -1,0 +1,44 @@
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+  <changeSet id="changelog-consent-2026-02-05-fix-dataset-access-control" author="grushton">
+    <!-- Impute DAC Approval for datasets with a DAC ID but no access management prop or approval: -->
+    <sql>
+      UPDATE dataset
+      SET dac_approval = true
+      WHERE dac_id IS NOT NULL
+        AND dac_approval IS NULL
+        -- No access management property set:
+        AND NOT EXISTS (
+        SELECT 1
+        FROM dataset_property dp
+        WHERE dp.dataset_id = dataset.dataset_id
+          AND dp.schema_property = 'accessManagement'
+      );
+    </sql>
+    <!-- Add access management prop for datasets with a DAC ID: -->
+    <sql>
+      INSERT INTO dataset_property
+      (dataset_id, property_key, property_value, create_date, property_type, schema_property)
+      SELECT
+        d.dataset_id,
+        (SELECT key_id FROM dictionary WHERE key = 'Access Management'),
+        'controlled',
+        NOW(),
+        'String',
+        'accessManagement'
+      FROM dataset d
+      WHERE d.dac_id IS NOT NULL
+        -- No access management property set:
+        AND NOT EXISTS (
+        SELECT 1
+        FROM dataset_property dp
+        WHERE dp.dataset_id = d.dataset_id
+        AND dp.schema_property = 'accessManagement'
+        );
+    </sql>
+  </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DT-2468

## Summary
This PR adds a missing property to datasets that are assigned a DAC ID but do not have an `Access Control` property indicating that the dataset is `controlled`

Follow on work is required to re-index the affected datasets. Those values have been captured in the referenced ticket.

### Testing notes
This sql update has been tested against copies of dev, staging, and prod databases as of 2/5/2026.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
