### PR TITLE
[DT-1799] Allow Signing Officials to Create users in Same Institution

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
@@ -40,11 +40,13 @@ import org.broadinstitute.consent.http.models.CreateDuosUserRequest;
 import org.broadinstitute.consent.http.models.Dataset;
 import org.broadinstitute.consent.http.models.DuosUser;
 import org.broadinstitute.consent.http.models.Error;
+import org.broadinstitute.consent.http.models.Institution;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.UserRole;
 import org.broadinstitute.consent.http.models.UserUpdateFields;
 import org.broadinstitute.consent.http.service.AcknowledgementService;
 import org.broadinstitute.consent.http.service.DatasetService;
+import org.broadinstitute.consent.http.service.InstitutionService;
 import org.broadinstitute.consent.http.service.NihService;
 import org.broadinstitute.consent.http.service.UserService;
 import org.broadinstitute.consent.http.service.UserService.SimplifiedUser;
@@ -61,6 +63,7 @@ public class UserResource extends Resource {
   private final AcknowledgementService acknowledgementService;
   private final NihService nihService;
   private final ServicesConfiguration servicesConfiguration;
+  private final InstitutionService institutionService;
 
   @Inject
   public UserResource(
@@ -69,13 +72,15 @@ public class UserResource extends Resource {
       DatasetService datasetService,
       AcknowledgementService acknowledgementService,
       NihService nihService,
-      ServicesConfiguration servicesConfiguration) {
+      ServicesConfiguration servicesConfiguration,
+      InstitutionService institutionService) {
     this.samService = samService;
     this.userService = userService;
     this.datasetService = datasetService;
     this.acknowledgementService = acknowledgementService;
     this.nihService = nihService;
     this.servicesConfiguration = servicesConfiguration;
+    this.institutionService = institutionService;
   }
 
   @GET
@@ -489,28 +494,37 @@ public class UserResource extends Resource {
       CreateDuosUserRequest createDuosUserRequest =
           gson.fromJson(json, CreateDuosUserRequest.class);
       createDuosUserRequest.validate();
-      // Non-admins can only create users with emails from the same institution
-      // Non-admins can only create users with the Researcher role
+
+      // Non-admins have additional restrictions when creating new users
       if (!duosUser.getUser().hasUserRole(UserRoles.ADMIN)) {
+        Integer userInstitutionId = duosUser.getUser().getInstitutionId();
+        if (userInstitutionId == null) {
+          throw new ForbiddenException(
+              "You must be associated with an institution to create new users.");
+        }
+        Institution institution = institutionService.findInstitutionById(userInstitutionId);
+        List<String> institutionDomains = institution.getDomains();
 
-        String authenticatedEmail = duosUser.getUser().getEmail();
         String newUserEmail = createDuosUserRequest.newUser().getEmail();
-
-        String authenticatedDomain = authenticatedEmail.substring(authenticatedEmail.indexOf("@"));
         String newUserDomain = newUserEmail.substring(newUserEmail.indexOf("@"));
 
-        if (!authenticatedDomain.equals(newUserDomain)) {
+        // Non-admins can only create users with emails from their institutional domains
+        if (institutionDomains != null
+            && !institutionDomains.isEmpty()
+            && !institutionDomains.contains(newUserDomain)) {
           throw new ForbiddenException(
-              "You can only create users with email addresses from your institution domain.");
+              "You can only create users with email addresses from your institutional domains: "
+                  + institutionDomains);
         }
 
+        // Non-admins can only create users with the Researcher role
         createDuosUserRequest
             .roles()
             .forEach(
                 role -> {
                   if (!role.getName().equals(UserRoles.RESEARCHER.getRoleName())) {
                     throw new ForbiddenException(
-                        "Chairs can only create users with the Researcher role.");
+                        "You can only create users with the Researcher role.");
                   }
                 });
       }

--- a/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
@@ -40,16 +40,15 @@ import org.broadinstitute.consent.http.models.CreateDuosUserRequest;
 import org.broadinstitute.consent.http.models.Dataset;
 import org.broadinstitute.consent.http.models.DuosUser;
 import org.broadinstitute.consent.http.models.Error;
-import org.broadinstitute.consent.http.models.Institution;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.UserRole;
 import org.broadinstitute.consent.http.models.UserUpdateFields;
 import org.broadinstitute.consent.http.service.AcknowledgementService;
 import org.broadinstitute.consent.http.service.DatasetService;
-import org.broadinstitute.consent.http.service.InstitutionService;
 import org.broadinstitute.consent.http.service.NihService;
 import org.broadinstitute.consent.http.service.UserService;
 import org.broadinstitute.consent.http.service.UserService.SimplifiedUser;
+import org.broadinstitute.consent.http.service.feature.InstitutionAndLibraryCardEnforcement;
 import org.broadinstitute.consent.http.service.sam.SamService;
 import org.broadinstitute.consent.http.util.gson.GsonUtil;
 
@@ -63,7 +62,7 @@ public class UserResource extends Resource {
   private final AcknowledgementService acknowledgementService;
   private final NihService nihService;
   private final ServicesConfiguration servicesConfiguration;
-  private final InstitutionService institutionService;
+  private final InstitutionAndLibraryCardEnforcement institutionAndLibraryCardEnforcement;
 
   @Inject
   public UserResource(
@@ -73,14 +72,14 @@ public class UserResource extends Resource {
       AcknowledgementService acknowledgementService,
       NihService nihService,
       ServicesConfiguration servicesConfiguration,
-      InstitutionService institutionService) {
+      InstitutionAndLibraryCardEnforcement institutionAndLibraryCardEnforcement) {
     this.samService = samService;
     this.userService = userService;
     this.datasetService = datasetService;
     this.acknowledgementService = acknowledgementService;
     this.nihService = nihService;
     this.servicesConfiguration = servicesConfiguration;
-    this.institutionService = institutionService;
+    this.institutionAndLibraryCardEnforcement = institutionAndLibraryCardEnforcement;
   }
 
   @GET
@@ -497,25 +496,12 @@ public class UserResource extends Resource {
 
       // Non-admins have additional restrictions when creating new users
       if (!duosUser.getUser().hasUserRole(UserRoles.ADMIN)) {
-        Integer userInstitutionId = duosUser.getUser().getInstitutionId();
-        if (userInstitutionId == null) {
-          throw new ForbiddenException(
-              "You must be associated with an institution to create new users.");
-        }
-        Institution institution = institutionService.findInstitutionById(userInstitutionId);
-        List<String> institutionDomains = institution.getDomains();
-
+        String existingUserEmail = duosUser.getUser().getEmail();
         String newUserEmail = createDuosUserRequest.newUser().getEmail();
-        String newUserDomain = newUserEmail.substring(newUserEmail.indexOf("@"));
 
-        // Non-admins can only create users with emails from their institutional domains
-        if (institutionDomains != null
-            && !institutionDomains.isEmpty()
-            && !institutionDomains.contains(newUserDomain)) {
-          throw new ForbiddenException(
-              "You can only create users with email addresses from your institutional domains: "
-                  + institutionDomains);
-        }
+        // Enforce that the new user email domain matches the creator's institution domains
+        institutionAndLibraryCardEnforcement.validateEmailsFromSameInstitution(
+            newUserEmail, existingUserEmail);
 
         // Non-admins can only create users with the Researcher role
         createDuosUserRequest

--- a/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
@@ -483,14 +483,27 @@ public class UserResource extends Resource {
   @Consumes(MediaType.APPLICATION_JSON)
   @Produces(MediaType.APPLICATION_JSON)
   @Path("/create")
-  @RolesAllowed({ADMIN, CHAIRPERSON})
+  @RolesAllowed({ADMIN, CHAIRPERSON, SIGNINGOFFICIAL})
   public Response createNewUser(@Auth DuosUser duosUser, String json) {
     try {
       CreateDuosUserRequest createDuosUserRequest =
           gson.fromJson(json, CreateDuosUserRequest.class);
       createDuosUserRequest.validate();
+      // Non-admins can only create users with emails from the same institution
       // Non-admins can only create users with the Researcher role
       if (!duosUser.getUser().hasUserRole(UserRoles.ADMIN)) {
+
+        String authenticatedEmail = duosUser.getUser().getEmail();
+        String newUserEmail = createDuosUserRequest.newUser().getEmail();
+
+        String authenticatedDomain = authenticatedEmail.substring(authenticatedEmail.indexOf("@"));
+        String newUserDomain = newUserEmail.substring(newUserEmail.indexOf("@"));
+
+        if (!authenticatedDomain.equals(newUserDomain)) {
+          throw new ForbiddenException(
+              "You can only create users with email addresses from your institution domain.");
+        }
+
         createDuosUserRequest
             .roles()
             .forEach(

--- a/src/main/java/org/broadinstitute/consent/http/service/feature/InstitutionAndLibraryCardEnforcement.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/feature/InstitutionAndLibraryCardEnforcement.java
@@ -7,6 +7,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.inject.Inject;
+import jakarta.ws.rs.ForbiddenException;
 import jakarta.ws.rs.NotFoundException;
 import java.util.concurrent.ExecutorService;
 import org.broadinstitute.consent.http.db.InstitutionDAO;
@@ -94,6 +95,25 @@ public class InstitutionAndLibraryCardEnforcement implements ConsentLogger {
   public String trimmedEmailDomain(String email) {
     String trimmedEmail = email.trim();
     return trimmedEmail.substring(trimmedEmail.indexOf('@') + 1);
+  }
+
+  /**
+   * Method to validate that two email addresses belong to the same institution based on their
+   * domain. This is used to enforce the rule that a user must have an email from the same
+   * institution as the issuer of their library card.
+   *
+   * @param existingEmail The email address currently associated with the user in our system.
+   * @param newEmail The new email address being evaluated for association with the user.
+   */
+  public void validateEmailsFromSameInstitution(String existingEmail, String newEmail) {
+    Institution institutionForExistingEmail = findInstitutionForEmail(existingEmail);
+    Institution institutionForNewEmail = findInstitutionForEmail(newEmail);
+
+    if (!hasMatchingInstitutionInDatabase(institutionForExistingEmail, institutionForNewEmail)) {
+      throw new ForbiddenException(
+          "You can only create users with email addresses from your institutional domains: "
+              + institutionForExistingEmail.getDomains());
+    }
   }
 
   /**

--- a/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
@@ -16,6 +16,7 @@ import static org.mockito.Mockito.when;
 import com.google.api.client.http.HttpStatusCodes;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
+import jakarta.ws.rs.ForbiddenException;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.Response.Status;
@@ -48,9 +49,9 @@ import org.broadinstitute.consent.http.models.UserUpdateFields;
 import org.broadinstitute.consent.http.models.sam.UserStatusInfo;
 import org.broadinstitute.consent.http.service.AcknowledgementService;
 import org.broadinstitute.consent.http.service.DatasetService;
-import org.broadinstitute.consent.http.service.InstitutionService;
 import org.broadinstitute.consent.http.service.NihService;
 import org.broadinstitute.consent.http.service.UserService;
+import org.broadinstitute.consent.http.service.feature.InstitutionAndLibraryCardEnforcement;
 import org.broadinstitute.consent.http.service.sam.SamService;
 import org.broadinstitute.consent.http.util.gson.GsonUtil;
 import org.jdbi.v3.core.statement.StatementContext;
@@ -90,7 +91,7 @@ class UserResourceTest extends AbstractTestHelper {
 
   @Mock private ServicesConfiguration servicesConfiguration;
 
-  @Mock private InstitutionService institutionService;
+  @Mock private InstitutionAndLibraryCardEnforcement institutionAndLibraryCardEnforcement;
 
   private static final String TEST_EMAIL = "test@gmail.com";
 
@@ -117,7 +118,7 @@ class UserResourceTest extends AbstractTestHelper {
             acknowledgementService,
             nihService,
             servicesConfiguration,
-            institutionService);
+            institutionAndLibraryCardEnforcement);
   }
 
   @Test
@@ -418,7 +419,7 @@ class UserResourceTest extends AbstractTestHelper {
     assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
     var body = (List<UserService.SimplifiedUser>) response.getEntity();
     assertFalse(body.isEmpty());
-    assertEquals(so.getDisplayName(), body.get(0).getDisplayName());
+    assertEquals(so.getDisplayName(), body.getFirst().getDisplayName());
   }
 
   @SuppressWarnings("rawtypes")
@@ -1028,8 +1029,6 @@ class UserResourceTest extends AbstractTestHelper {
     institution.setId(nonAdminUser.getInstitutionId());
     institution.setDomains(List.of("@example.com"));
 
-    when(institutionService.findInstitutionById(nonAdminUser.getInstitutionId()))
-        .thenReturn(institution);
     when(userService.createUser(request.newUser())).thenReturn(createdUser);
     when(servicesConfiguration.getLocalURL()).thenReturn("http://localhost:8080");
 
@@ -1046,12 +1045,17 @@ class UserResourceTest extends AbstractTestHelper {
     User nonAdminUser = createUserWithInstitution();
     DuosUser nonAdminDuosUser = new DuosUser(authUser, nonAdminUser);
 
+    List<String> allowedDomains = List.of("@example.com");
     Institution institution = new Institution();
     institution.setId(nonAdminUser.getInstitutionId());
-    institution.setDomains(List.of("@example.com"));
+    institution.setDomains(allowedDomains);
 
-    when(institutionService.findInstitutionById(nonAdminUser.getInstitutionId()))
-        .thenReturn(institution);
+    doThrow(
+            new ForbiddenException(
+                "You can only create users with email addresses from your institutional domains: "
+                    + allowedDomains))
+        .when(institutionAndLibraryCardEnforcement)
+        .validateEmailsFromSameInstitution(anyString(), anyString());
 
     try (var response = userResource.createNewUser(nonAdminDuosUser, gson.toJson(request))) {
       assertEquals(Status.FORBIDDEN.getStatusCode(), response.getStatus());

--- a/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
@@ -41,12 +41,14 @@ import org.broadinstitute.consent.http.models.CreateDuosUserRequest;
 import org.broadinstitute.consent.http.models.DataAccessRequest;
 import org.broadinstitute.consent.http.models.Dataset;
 import org.broadinstitute.consent.http.models.DuosUser;
+import org.broadinstitute.consent.http.models.Institution;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.UserRole;
 import org.broadinstitute.consent.http.models.UserUpdateFields;
 import org.broadinstitute.consent.http.models.sam.UserStatusInfo;
 import org.broadinstitute.consent.http.service.AcknowledgementService;
 import org.broadinstitute.consent.http.service.DatasetService;
+import org.broadinstitute.consent.http.service.InstitutionService;
 import org.broadinstitute.consent.http.service.NihService;
 import org.broadinstitute.consent.http.service.UserService;
 import org.broadinstitute.consent.http.service.sam.SamService;
@@ -88,6 +90,8 @@ class UserResourceTest extends AbstractTestHelper {
 
   @Mock private ServicesConfiguration servicesConfiguration;
 
+  @Mock private InstitutionService institutionService;
+
   private static final String TEST_EMAIL = "test@gmail.com";
 
   private final Gson gson = GsonUtil.getInstance();
@@ -112,7 +116,8 @@ class UserResourceTest extends AbstractTestHelper {
             datasetService,
             acknowledgementService,
             nihService,
-            servicesConfiguration);
+            servicesConfiguration,
+            institutionService);
   }
 
   @Test
@@ -991,16 +996,65 @@ class UserResourceTest extends AbstractTestHelper {
   }
 
   @Test
-  void testCreateNewUser() {
+  void testCreateNewUserAsAdmin() {
     CreateDuosUserRequest request =
         new CreateDuosUserRequest(
             "New User", "test@test.com", true, List.of(UserRoles.Researcher()));
     User createdUser =
         new User(1, request.email(), request.displayName(), new Date(), request.roles());
+    User adminUser = createUserWithRole();
+    adminUser.setAdminRole();
+    DuosUser adminDuosUser = new DuosUser(authUser, adminUser);
+
     when(userService.createUser(request.newUser())).thenReturn(createdUser);
     when(servicesConfiguration.getLocalURL()).thenReturn("http://localhost:8080");
-    try (var response = userResource.createNewUser(duosUser, gson.toJson(request))) {
+
+    try (var response = userResource.createNewUser(adminDuosUser, gson.toJson(request))) {
       assertEquals(Status.CREATED.getStatusCode(), response.getStatus());
+    }
+  }
+
+  @Test
+  void testCreateNewUserAsNonAdminWithValidDomain() {
+    CreateDuosUserRequest request =
+        new CreateDuosUserRequest(
+            "New User", "test@example.com", true, List.of(UserRoles.Researcher()));
+    User createdUser =
+        new User(1, request.email(), request.displayName(), new Date(), request.roles());
+    User nonAdminUser = createUserWithInstitution();
+    DuosUser nonAdminDuosUser = new DuosUser(authUser, nonAdminUser);
+
+    Institution institution = new Institution();
+    institution.setId(nonAdminUser.getInstitutionId());
+    institution.setDomains(List.of("@example.com"));
+
+    when(institutionService.findInstitutionById(nonAdminUser.getInstitutionId()))
+        .thenReturn(institution);
+    when(userService.createUser(request.newUser())).thenReturn(createdUser);
+    when(servicesConfiguration.getLocalURL()).thenReturn("http://localhost:8080");
+
+    try (var response = userResource.createNewUser(nonAdminDuosUser, gson.toJson(request))) {
+      assertEquals(Status.CREATED.getStatusCode(), response.getStatus());
+    }
+  }
+
+  @Test
+  void testCreateNewUserAsNonAdminWithInvalidDomain() {
+    CreateDuosUserRequest request =
+        new CreateDuosUserRequest(
+            "New User", "test@invalid.com", true, List.of(UserRoles.Researcher()));
+    User nonAdminUser = createUserWithInstitution();
+    DuosUser nonAdminDuosUser = new DuosUser(authUser, nonAdminUser);
+
+    Institution institution = new Institution();
+    institution.setId(nonAdminUser.getInstitutionId());
+    institution.setDomains(List.of("@example.com"));
+
+    when(institutionService.findInstitutionById(nonAdminUser.getInstitutionId()))
+        .thenReturn(institution);
+
+    try (var response = userResource.createNewUser(nonAdminDuosUser, gson.toJson(request))) {
+      assertEquals(Status.FORBIDDEN.getStatusCode(), response.getStatus());
     }
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/service/feature/InstitutionAndLibraryCardEnforcementTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/feature/InstitutionAndLibraryCardEnforcementTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import jakarta.ws.rs.ForbiddenException;
 import jakarta.ws.rs.NotFoundException;
 import java.util.List;
 import java.util.stream.IntStream;
@@ -162,12 +163,12 @@ public class InstitutionAndLibraryCardEnforcementTest extends AbstractTestHelper
     testUser.setLibraryCard(lc);
 
     Institution institutionFromEmail = new Institution();
-    institutionFromEmail.setId(Integer.valueOf(1));
+    institutionFromEmail.setId(1);
     institutionFromEmail.setName("Institution One");
     testUser.setInstitution(institutionFromEmail);
 
     Institution institutionFromDatabase = new Institution();
-    institutionFromDatabase.setId(Integer.valueOf(2));
+    institutionFromDatabase.setId(2);
     institutionFromDatabase.setName("Institution Two");
 
     // Mock SO not found
@@ -257,6 +258,52 @@ public class InstitutionAndLibraryCardEnforcementTest extends AbstractTestHelper
     when(userDAO.findUserById(signingOfficial.getUserId())).thenReturn(signingOfficial);
     when(institutionDAO.findInstitutionByDomain(soDomain)).thenReturn(soInstitution);
     assertTrue(service.needsLibraryCardRemovedForUser(testUser, institutionFromEmail.getId()));
+  }
+
+  @Test
+  void validateEmailsFromSameInstitution_SameInstitution() {
+    Institution institution = new Institution();
+    institution.setId(1);
+    institution.setName("Test Institution");
+
+    String existingEmail = "user1@example.com";
+    String newEmail = "user2@example.com";
+
+    when(institutionDAO.findInstitutionByDomain("example.com")).thenReturn(institution);
+
+    // Should not throw exception
+    service.validateEmailsFromSameInstitution(existingEmail, newEmail);
+  }
+
+  @Test
+  void validateEmailsFromSameInstitution_DifferentInstitutions() {
+    Institution institution1 = new Institution();
+    institution1.setId(1);
+    institution1.setName("Institution One");
+    institution1.setDomains(List.of("example.com"));
+
+    Institution institution2 = new Institution();
+    institution2.setId(2);
+    institution2.setName("Institution Two");
+    institution2.setDomains(List.of("different.com"));
+
+    String existingEmail = "user1@example.com";
+    String newEmail = "user2@different.com";
+
+    when(institutionDAO.findInstitutionByDomain("example.com")).thenReturn(institution1);
+    when(institutionDAO.findInstitutionByDomain("different.com")).thenReturn(institution2);
+
+    ForbiddenException exception =
+        assertThrows(
+            ForbiddenException.class,
+            () -> service.validateEmailsFromSameInstitution(existingEmail, newEmail));
+
+    assertTrue(
+        exception
+            .getMessage()
+            .contains(
+                "You can only create users with email addresses from your institutional domains: "
+                    + institution1.getDomains()));
   }
 
   public static Stream<Arguments> testEnforceInstitutionAndLibraryCardVariations() {


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-1799

### Summary

This PR enables Signing Officials (SOs) to create users (researchers) within their own institution, allowing them to assign Library Cards to new users without accounts.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
