### PR TITLE
[DT-1279] Liquibase issue in cloudsql that isn't visible locally

### DIFF
--- a/src/main/resources/changesets/changelog-consent-2026-02-03-email-entity-refererence-id-idx.xml
+++ b/src/main/resources/changesets/changelog-consent-2026-02-03-email-entity-refererence-id-idx.xml
@@ -6,22 +6,22 @@
   <changeSet id="changelog-consent-2026-02-03-email-entity-refererence-id-idx" author="otchet">
     <preConditions onFail="MARK_RAN">
       <not>
-        <indexExists indexName="idx_entity_reference_id" tableName="email_entity"/>
-        <indexExists indexName="idx_email_type" tableName="email_entity"/>
-        <indexExists indexName="idx_user" tableName="email_entity"/>
-        <indexExists indexName="idx_user_type_ref" tableName="email_entity"/>
+        <indexExists indexName="idx_email_entity_entity_reference_id" tableName="email_entity"/>
+        <indexExists indexName="idx_email_entity_email_type" tableName="email_entity"/>
+        <indexExists indexName="idx_email_entity_user" tableName="email_entity"/>
+        <indexExists indexName="idx_email_entity_user_type_ref" tableName="email_entity"/>
       </not>
     </preConditions>
-    <createIndex tableName="email_entity" indexName="idx_entity_reference_id">
+    <createIndex tableName="email_entity" indexName="idx_email_entity_entity_reference_id">
       <column name="entity_reference_id"/>
     </createIndex>
-    <createIndex tableName="email_entity" indexName="idx_email_type">
+    <createIndex tableName="email_entity" indexName="idx_email_entity_email_type">
       <column name="email_type"/>
     </createIndex>
-    <createIndex tableName="email_entity" indexName="idx_user">
+    <createIndex tableName="email_entity" indexName="idx_email_entity_user">
       <column name="user_id"/>
     </createIndex>
-    <createIndex tableName="email_entity" indexName="idx_user_type_ref">
+    <createIndex tableName="email_entity" indexName="idx_email_entity_user_type_ref">
       <column name="user_id" />
       <column name="email_type"/>
       <column name="entity_reference_id"/>


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-1279](https://broadworkbench.atlassian.net/browse/DT-1279)

### Summary

This is a follow-up to the PR to address an issue with index names in the Google CloudSQL environment that isn't happening locally with index name conflicts.  The precondition verifies the index doesn't exist on the table, but it does exist elsewhere so CloudSQL is taking the stand that the name cannot be used and index creation is failing.


----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
