### PR TITLE
[DT-2873] Switch _type to _index

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
@@ -91,12 +91,12 @@ public class ElasticSearchService implements ConsentLogger {
 
   private static final String BULK_HEADER =
       """
-      { "index": {"_type": "dataset", "_id": "%d"} }
+      { "index": {"_index": "dataset", "_id": "%d"} }
       """;
 
   private static final String DELETE_QUERY =
       """
-      { "query": { "bool": { "must": [ { "match": { "_type": "dataset" } }, { "match": { "_id": "%d" } } ] } } }
+      { "query": { "bool": { "must": [ { "match": { "_index": "dataset" } }, { "match": { "_id": "%d" } } ] } } }
       """;
 
   private Response performRequest(Request request) throws IOException {

--- a/src/main/resources/assets/paths/datasetSearchIndex.yaml
+++ b/src/main/resources/assets/paths/datasetSearchIndex.yaml
@@ -19,7 +19,7 @@ post:
                 bool:
                   must:
                     - match:
-                        _type: dataset
+                        _index: dataset
                     - match:
                         _id: 1440
           example2:
@@ -31,7 +31,7 @@ post:
                 bool:
                   must:
                     - match:
-                        _type: dataset
+                        _index: dataset
                     - exists:
                         field: study
   tags:

--- a/src/main/resources/assets/paths/datasetSearchIndexV2.yaml
+++ b/src/main/resources/assets/paths/datasetSearchIndexV2.yaml
@@ -22,7 +22,7 @@ post:
                 bool:
                   must:
                     - match:
-                        _type: dataset
+                        _index: dataset
                     - match:
                         _id: 1440
           example2:
@@ -34,7 +34,7 @@ post:
                 bool:
                   must:
                     - match:
-                        _type: dataset
+                        _index: dataset
                     - exists:
                         field: study
   tags:

--- a/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
@@ -536,9 +536,9 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
       assertEquals("PUT", capturedRequest.getMethod());
       assertEquals(
           """
-              { "index": {"_type": "dataset", "_id": "1"} }
+              { "index": {"_index": "dataset", "_id": "1"} }
               {"datasetId":1}
-              { "index": {"_type": "dataset", "_id": "2"} }
+              { "index": {"_index": "dataset", "_id": "2"} }
               {"datasetId":2}
 
               """,


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2873

### Summary

Now that we changed the name of the index from `duos-dataset` to `dataset`, this simplifies how we can extract information out of the search index. This also prepares us for future use of Elasticsearch 9 or OpenSearch 3.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
