### PR TITLE
[DT-2916] Only validate result window size on `v2` endpoint.

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
@@ -193,7 +193,7 @@ public class ElasticSearchService implements ConsentLogger {
   }
 
   public InputStream searchDatasetsStream(String query) throws IOException {
-    if (!validateQuery(query)) {
+    if (invalidResultWindow(query)) {
       throw new IOException("Invalid Elasticsearch query");
     }
     Request searchRequest =


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2916

### Summary

The query validation that we do in the v2 endpoint does not work with aggregations or pagination. Only validate the query length.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
