### PR TITLE
[DT-2858] Add `Yes`, `No` options to `nihAnvilUse` enum

### DIFF
--- a/src/main/resources/dataset-registration-schema_v1.json
+++ b/src/main/resources/dataset-registration-schema_v1.json
@@ -183,7 +183,9 @@
         "I am NHGRI funded and I have a dbGaP PHS ID already",
         "I am NHGRI funded and I do not have a dbGaP PHS ID",
         "I am not NHGRI funded but I am seeking to submit data to AnVIL",
-        "I am not NHGRI funded and do not plan to store data in AnVIL"
+        "I am not NHGRI funded and do not plan to store data in AnVIL",
+        "Yes",
+        "No"
       ],
       "description" : "NIH Anvil Use"
     },


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2858

### Summary

This PR supports the work done here https://github.com/DataBiosphere/duos-ui/pull/3320 to simplify the NIH Registration Field to `Yes`/`No` Toggle by adding `Yes`/`No`  options to the`nihAnvilUse` enum.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
