### PR TITLE
DT-2945: Handle null datasets and return 404 if none found

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
@@ -367,7 +367,14 @@ public class ElasticSearchService implements ConsentLogger {
     // Datasets in list context may not have their study populated, so we need to ensure that is
     // true before trying to index them in ES.
     List<DatasetTerm> datasetTerms =
-        datasetIds.stream().map(datasetDAO::findDatasetById).map(this::toDatasetTerm).toList();
+        datasetIds.stream()
+            .map(datasetDAO::findDatasetById)
+            .filter(Objects::nonNull)
+            .map(this::toDatasetTerm)
+            .toList();
+    if (datasetTerms.isEmpty()) {
+      return Response.status(Status.NOT_FOUND).build();
+    }
     return indexDatasetTerms(datasetTerms, user);
   }
 

--- a/src/main/resources/assets/paths/datasetIndex.yaml
+++ b/src/main/resources/assets/paths/datasetIndex.yaml
@@ -7,3 +7,5 @@ post:
   responses:
     200:
       description: All datasets have been indexed
+    404:
+      description: No datasets found to index

--- a/src/main/resources/assets/paths/datasetIndexById.yaml
+++ b/src/main/resources/assets/paths/datasetIndexById.yaml
@@ -14,6 +14,8 @@ post:
   responses:
     200:
       description: The dataset has been indexed
+    404:
+      description: Dataset not found
 delete:
   summary: Delete dataset index by id
   description: Delete a specific dataset index in the system

--- a/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -580,13 +581,40 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
   }
 
   @Test
-  void testIndexDatasetsHandleNullDatasets() throws Exception {
+  void testIndexDatasetsHandleSingleNullDataset() throws Exception {
     User user = createUser(1, 100);
     when(datasetDAO.findDatasetById(1)).thenReturn(null);
     try (var response = service.indexDatasets(List.of(1), user)) {
       verify(datasetDAO).findDatasetById(1);
       verify(esClient, never()).performRequest(any());
       assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
+    }
+  }
+
+  @Test
+  void testIndexDatasetsHandleNullDatasetInBatch() throws Exception {
+    User user = createUser(1, 100);
+    Dataset d1 = createDataset(user, user, new DataUse(), createDac());
+    Dataset d2 = createDataset(user, user, new DataUse(), createDac());
+    // List of IDs includes two valid datasets and a third ID that does not correspond to an
+    // existing dataset
+    List<Integer> datasetIds =
+        List.of(d1.getDatasetId(), d2.getDatasetId(), d1.getDatasetId() + d2.getDatasetId());
+    when(datasetDAO.findDatasetById(d1.getDatasetId())).thenReturn(d1);
+    when(datasetDAO.findDatasetById(d2.getDatasetId())).thenReturn(d2);
+    when(datasetDAO.findDatasetById(d1.getDatasetId() + d2.getDatasetId())).thenReturn(null);
+    when(userDao.findUserById(user.getUserId())).thenReturn(user);
+    org.elasticsearch.client.Response mockResponse = mock();
+    when(esClient.performRequest(any())).thenReturn(mockResponse);
+    when(mockResponse.getEntity()).thenReturn(new StringEntity("response body"));
+    StatusLine statusLine = mock();
+    when(mockResponse.getStatusLine()).thenReturn(statusLine);
+    when(statusLine.getStatusCode()).thenReturn(200);
+    try (var response = service.indexDatasets(datasetIds, user)) {
+      verify(datasetDAO, atLeastOnce()).findDatasetById(d1.getDatasetId());
+      verify(datasetDAO, atLeastOnce()).findDatasetById(d2.getDatasetId());
+      verify(datasetDAO).findDatasetById(d1.getDatasetId() + d2.getDatasetId());
+      assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
     }
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
@@ -580,6 +580,16 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
   }
 
   @Test
+  void testIndexDatasetsHandleNullDatasets() throws Exception {
+    User user = createUser(1, 100);
+    when(datasetDAO.findDatasetById(1)).thenReturn(null);
+    try (var response = service.indexDatasets(List.of(1), user)) {
+      verify(datasetDAO, times(1)).findDatasetById(1);
+      assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
+    }
+  }
+
+  @Test
   void testSearchDatasets() throws IOException {
     String query = "{ \"query\": { \"query_string\": { \"query\": \"(GRU) AND (HMB)\" } } }";
 

--- a/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
@@ -584,7 +584,8 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
     User user = createUser(1, 100);
     when(datasetDAO.findDatasetById(1)).thenReturn(null);
     try (var response = service.indexDatasets(List.of(1), user)) {
-      verify(datasetDAO, times(1)).findDatasetById(1);
+      verify(datasetDAO).findDatasetById(1);
+      verify(esClient, never()).performRequest(any());
       assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
     }
   }


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-2945

### Summary
In the case where there are no datasets found to index, return a 404 instead of throwing an NPE when attempting to convert to a `DatasetTerm`

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
