### PR TITLE
[DT-2883] Add tags to study and consent groups, ensure they end up in elasticsearch

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/models/dataset_registration_v1/ConsentGroup.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/dataset_registration_v1/ConsentGroup.java
@@ -459,7 +459,6 @@ public class ConsentGroup {
   public Map<String, Object> getData() {
     return data;
   }
-  ;
 
   /** Data and metadata about this dataset. */
   @JsonProperty("data")

--- a/src/main/java/org/broadinstitute/consent/http/models/dataset_registration_v1/ConsentGroup.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/dataset_registration_v1/ConsentGroup.java
@@ -37,7 +37,8 @@ import java.util.Map;
   "dataLocation",
   "url",
   "numberOfParticipants",
-  "fileTypes"
+  "fileTypes",
+  "data"
 })
 public class ConsentGroup {
 
@@ -160,6 +161,10 @@ public class ConsentGroup {
   @JsonProperty("fileTypes")
   @JsonPropertyDescription("List of File Types")
   private List<FileTypeObject> fileTypes = new ArrayList<FileTypeObject>();
+
+  @JsonProperty("data")
+  @JsonPropertyDescription("Data and metadata about this dataset.")
+  private Map<String, Object> data = new HashMap<>();
 
   /** Dataset Id */
   @JsonProperty("datasetId")
@@ -449,6 +454,19 @@ public class ConsentGroup {
     this.fileTypes = fileTypes;
   }
 
+  /** Data and metadata about this dataset. */
+  @JsonProperty("data")
+  public Map<String, Object> getData() {
+    return data;
+  }
+  ;
+
+  /** Data and metadata about this dataset. */
+  @JsonProperty("data")
+  public void setData(Map<String, Object> data) {
+    this.data = data;
+  }
+
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
@@ -552,6 +570,10 @@ public class ConsentGroup {
     sb.append('=');
     sb.append(((this.fileTypes == null) ? "<null>" : this.fileTypes));
     sb.append(',');
+    sb.append("data");
+    sb.append('=');
+    sb.append(((this.data == null) ? "<null>" : this.data));
+    sb.append(',');
     if (sb.charAt((sb.length() - 1)) == ',') {
       sb.setCharAt((sb.length() - 1), ']');
     } else {
@@ -599,6 +621,7 @@ public class ConsentGroup {
     result = ((result * 31) + ((this.pub == null) ? 0 : this.pub.hashCode()));
     result = ((result * 31) + ((this.nmds == null) ? 0 : this.nmds.hashCode()));
     result = ((result * 31) + ((this.otherSecondary == null) ? 0 : this.otherSecondary.hashCode()));
+    result = ((result * 31) + ((this.data == null) ? 0 : this.data.hashCode()));
     return result;
   }
 
@@ -708,7 +731,8 @@ public class ConsentGroup {
                 && ((this.pub == rhs.pub) || ((this.pub != null) && this.pub.equals(rhs.pub))))
             && ((this.nmds == rhs.nmds) || ((this.nmds != null) && this.nmds.equals(rhs.nmds))))
         && ((this.otherSecondary == rhs.otherSecondary)
-            || ((this.otherSecondary != null) && this.otherSecondary.equals(rhs.otherSecondary))));
+            || ((this.otherSecondary != null) && this.otherSecondary.equals(rhs.otherSecondary)))
+        && ((this.data == rhs.data) || ((this.data != null) && this.data.equals(rhs.data))));
   }
 
   /** Data Location */

--- a/src/main/java/org/broadinstitute/consent/http/models/dataset_registration_v1/DatasetRegistrationSchemaV1.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/dataset_registration_v1/DatasetRegistrationSchemaV1.java
@@ -61,7 +61,8 @@ import java.util.Map;
   "alternativeDataSharingPlanTargetPublicReleaseDate",
   "alternativeDataSharingPlanAccessManagement",
   "consentGroups",
-  "assets"
+  "assets",
+  "data"
 })
 public class DatasetRegistrationSchemaV1 {
 
@@ -271,6 +272,10 @@ public class DatasetRegistrationSchemaV1 {
   @JsonProperty("assets")
   @JsonPropertyDescription("Additional assets or metadata associated with this study registration")
   private Map<String, Object> assets = new HashMap<>();
+
+  @JsonProperty
+  @JsonPropertyDescription("Additional data or metadata associated with this study registration")
+  private Map<String, Object> data = new HashMap<>();
 
   /** The study id */
   @JsonProperty("studyId")
@@ -765,6 +770,18 @@ public class DatasetRegistrationSchemaV1 {
     this.assets = assets;
   }
 
+  /** Additional data associated with this study registration */
+  @JsonProperty("data")
+  public Map<String, Object> getData() {
+    return data;
+  }
+
+  /** Additional data associated with this study registration */
+  @JsonProperty("data")
+  public void setData(Map<String, Object> data) {
+    this.data = data;
+  }
+
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
@@ -962,6 +979,10 @@ public class DatasetRegistrationSchemaV1 {
     sb.append('=');
     sb.append(((this.assets == null) ? "<null>" : this.assets));
     sb.append(',');
+    sb.append("data");
+    sb.append('=');
+    sb.append(((this.data == null) ? "<null>" : this.data));
+    sb.append(',');
     if (sb.charAt((sb.length() - 1)) == ',') {
       sb.setCharAt((sb.length() - 1), ']');
     } else {
@@ -1090,6 +1111,7 @@ public class DatasetRegistrationSchemaV1 {
                 : this.controlledAccessRequiredForGenomicSummaryResultsGSR.hashCode()));
     result = ((result * 31) + ((this.piInstitution == null) ? 0 : this.piInstitution.hashCode()));
     result = ((result * 31) + ((this.assets == null) ? 0 : this.assets.hashCode()));
+    result = ((result * 31) + ((this.data == null) ? 0 : this.data.hashCode()));
     return result;
   }
 
@@ -1390,7 +1412,9 @@ public class DatasetRegistrationSchemaV1 {
             && ((this.piInstitution == rhs.piInstitution)
                 || ((this.piInstitution != null) && this.piInstitution.equals(rhs.piInstitution))))
         && ((this.assets == rhs.assets)
-            || ((this.assets != null) && this.assets.equals(rhs.assets)));
+            || ((this.assets != null) && this.assets.equals(rhs.assets))
+                && ((this.data == rhs.data)
+                    || ((this.data != null) && this.data.equals(rhs.data))));
   }
 
   /** Does the data need to be managed under Controlled, Open, or External Access? */

--- a/src/main/java/org/broadinstitute/consent/http/models/dataset_registration_v1/builder/ConsentGroupFromDataset.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/dataset_registration_v1/builder/ConsentGroupFromDataset.java
@@ -1,6 +1,7 @@
 package org.broadinstitute.consent.http.models.dataset_registration_v1.builder;
 
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.accessManagement;
+import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.data;
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.dataLocation;
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.fileTypes;
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.numberOfParticipants;
@@ -9,7 +10,9 @@ import static org.broadinstitute.consent.http.models.dataset_registration_v1.bui
 import com.google.gson.JsonArray;
 import java.net.URI;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
@@ -20,6 +23,7 @@ import org.broadinstitute.consent.http.models.dataset_registration_v1.ConsentGro
 import org.broadinstitute.consent.http.models.dataset_registration_v1.ConsentGroup.AccessManagement;
 import org.broadinstitute.consent.http.models.dataset_registration_v1.ConsentGroup.DataLocation;
 import org.broadinstitute.consent.http.models.dataset_registration_v1.FileTypeObject;
+import org.broadinstitute.consent.http.service.ElasticSearchService;
 import org.broadinstitute.consent.http.util.gson.GsonUtil;
 
 public class ConsentGroupFromDataset {
@@ -69,6 +73,10 @@ public class ConsentGroupFromDataset {
       consentGroup.setNumberOfParticipants(
           findIntegerDSPropValue(dataset.getProperties(), numberOfParticipants));
       consentGroup.setFileTypes(findListFTSODSPropValue(dataset.getProperties()));
+      Map<String, Object> dataVal = findDataPropValue(dataset.getProperties());
+      if (Objects.nonNull(dataVal)) {
+        consentGroup.setData(dataVal);
+      }
       return consentGroup;
     }
     return null;
@@ -118,6 +126,22 @@ public class ConsentGroupFromDataset {
           .flatMap(List::stream)
           .map(p -> GsonUtil.getInstance().fromJson(p, FileTypeObject.class))
           .toList();
+    }
+    return null;
+  }
+
+  @Nullable
+  private Map<String, Object> findDataPropValue(Set<DatasetProperty> props) {
+    if (Objects.nonNull(props) && !props.isEmpty()) {
+      Optional<DatasetProperty> prop =
+          props.stream()
+              .filter(
+                  p ->
+                      p.getSchemaProperty() != null && p.getSchemaProperty().equalsIgnoreCase(data))
+              .findFirst();
+      if (prop.isPresent()) {
+        return ElasticSearchService.buildMapFromPropertyValue(prop.get().getPropertyValue());
+      }
     }
     return null;
   }

--- a/src/main/java/org/broadinstitute/consent/http/models/dataset_registration_v1/builder/DatasetRegistrationSchemaV1Builder.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/dataset_registration_v1/builder/DatasetRegistrationSchemaV1Builder.java
@@ -50,6 +50,7 @@ public class DatasetRegistrationSchemaV1Builder {
   public static final String alternativeDataSharingPlanAccessManagement =
       "alternativeDataSharingPlanAccessManagement";
   public static final String assets = "assets";
+  public static final String data = "data";
   public static final String accessManagement = "accessManagement";
   public static final String generalResearchUse = "generalResearchUse";
   public static final String hmb = "hmb";

--- a/src/main/java/org/broadinstitute/consent/http/models/dataset_registration_v1/builder/SchemaFromStudy.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/dataset_registration_v1/builder/SchemaFromStudy.java
@@ -12,6 +12,7 @@ import static org.broadinstitute.consent.http.models.dataset_registration_v1.bui
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.collaboratingSites;
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.controlledAccessRequiredForGenomicSummaryResultsGSR;
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.controlledAccessRequiredForGenomicSummaryResultsGSRRequiredExplanation;
+import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.data;
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.dataCustodianEmail;
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.dbGaPPhsID;
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.dbGaPStudyRegistrationName;
@@ -134,6 +135,7 @@ public class SchemaFromStudy {
                 alternativeDataSharingPlanAccessManagementVal));
       }
       schemaV1.setAssets(findMapPropValue(study.getProperties(), assets));
+      schemaV1.setData(findMapPropValue(study.getProperties(), data));
     }
 
     return schemaV1;

--- a/src/main/java/org/broadinstitute/consent/http/models/elastic_search/DatasetTerm.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/elastic_search/DatasetTerm.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.consent.http.models.elastic_search;
 
+import java.util.Map;
 import org.broadinstitute.consent.http.models.ontology.DataUseSummary;
 
 public class DatasetTerm {
@@ -23,6 +24,7 @@ public class DatasetTerm {
   private UserTerm updateUser;
   private DacTerm dac;
   private Boolean hasInstitutionCertification;
+  private Map<String, Object> data;
 
   public Integer getDatasetId() {
     return datasetId;
@@ -166,5 +168,13 @@ public class DatasetTerm {
 
   public void setHasInstitutionCertification(Boolean hasInstitutionCertification) {
     this.hasInstitutionCertification = hasInstitutionCertification;
+  }
+
+  public void setData(Map<String, Object> data) {
+    this.data = data;
+  }
+
+  public Map<String, Object> getData() {
+    return this.data;
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/models/elastic_search/StudyTerm.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/elastic_search/StudyTerm.java
@@ -18,6 +18,7 @@ public class StudyTerm {
   private Boolean publicVisibility;
   private List<String> dataTypes;
   private Map<String, Object> assets;
+  private Map<String, Object> data;
 
   public String getDescription() {
     return description;
@@ -121,5 +122,13 @@ public class StudyTerm {
 
   public void setAssets(Map<String, Object> assets) {
     this.assets = assets;
+  }
+
+  public Map<String, Object> getData() {
+    return data;
+  }
+
+  public void setData(Map<String, Object> data) {
+    this.data = data;
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetRegistrationService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetRegistrationService.java
@@ -568,7 +568,7 @@ public class DatasetRegistrationService implements ConsentLogger {
               new StudyPropertyExtractor(
                   "studyType",
                   PropertyType.String,
-                  (registration) -> {
+                  registration -> {
                     if (Objects.nonNull(registration.getStudyType())) {
                       return registration.getStudyType().value();
                     }
@@ -583,7 +583,7 @@ public class DatasetRegistrationService implements ConsentLogger {
               new StudyPropertyExtractor(
                   "dataCustodianEmail",
                   PropertyType.Json,
-                  (registration) -> {
+                  registration -> {
                     if (Objects.nonNull(registration.getDataCustodianEmail())) {
                       return GsonUtil.getInstance().toJson(registration.getDataCustodianEmail());
                     }
@@ -620,7 +620,7 @@ public class DatasetRegistrationService implements ConsentLogger {
               new StudyPropertyExtractor(
                   "nihICsSupportingStudy",
                   PropertyType.Json,
-                  (registration) -> {
+                  registration -> {
                     if (Objects.nonNull(registration.getNihICsSupportingStudy())) {
                       return GsonUtil.getInstance()
                           .toJson(
@@ -637,7 +637,7 @@ public class DatasetRegistrationService implements ConsentLogger {
               new StudyPropertyExtractor(
                   "nihInstitutionCenterSubmission",
                   PropertyType.String,
-                  (registration) -> {
+                  registration -> {
                     if (Objects.nonNull(registration.getNihInstitutionCenterSubmission())) {
                       return registration.getNihInstitutionCenterSubmission().value();
                     }
@@ -654,7 +654,7 @@ public class DatasetRegistrationService implements ConsentLogger {
               new StudyPropertyExtractor(
                   "collaboratingSites",
                   PropertyType.Json,
-                  (registration) -> {
+                  registration -> {
                     if (Objects.nonNull(registration.getCollaboratingSites())) {
                       return GsonUtil.getInstance().toJson(registration.getCollaboratingSites());
                     }
@@ -677,7 +677,7 @@ public class DatasetRegistrationService implements ConsentLogger {
               new StudyPropertyExtractor(
                   "alternativeDataSharingPlanReasons",
                   PropertyType.Json,
-                  (registration) -> {
+                  registration -> {
                     if (Objects.nonNull(registration.getAlternativeDataSharingPlanReasons())) {
                       return GsonUtil.getInstance()
                           .toJson(
@@ -698,7 +698,7 @@ public class DatasetRegistrationService implements ConsentLogger {
               new StudyPropertyExtractor(
                   "alternativeDataSharingPlanDataSubmitted",
                   PropertyType.String,
-                  (registration) -> {
+                  registration -> {
                     if (Objects.nonNull(
                         registration.getAlternativeDataSharingPlanDataSubmitted())) {
                       return registration.getAlternativeDataSharingPlanDataSubmitted().value();
@@ -721,7 +721,7 @@ public class DatasetRegistrationService implements ConsentLogger {
               new StudyPropertyExtractor(
                   "alternativeDataSharingPlanAccessManagement",
                   PropertyType.String,
-                  (registration) -> {
+                  registration -> {
                     if (Objects.nonNull(
                         registration.getAlternativeDataSharingPlanAccessManagement())) {
                       return registration.getAlternativeDataSharingPlanAccessManagement().value();
@@ -731,7 +731,7 @@ public class DatasetRegistrationService implements ConsentLogger {
               new StudyPropertyExtractor(
                   "assets",
                   PropertyType.Json,
-                  (registration) -> {
+                  registration -> {
                     if (Objects.nonNull(registration.getAssets())
                         && !registration.getAssets().isEmpty()) {
                       return GsonUtil.getInstance().toJson(registration.getAssets());
@@ -741,7 +741,7 @@ public class DatasetRegistrationService implements ConsentLogger {
               new StudyPropertyExtractor(
                   data,
                   PropertyType.Json,
-                  (registration) -> {
+                  registration -> {
                     if (Objects.nonNull(registration.getData())
                         && !registration.getData().isEmpty()) {
                       return GsonUtil.getInstance().toJson(registration.getData());
@@ -756,7 +756,7 @@ public class DatasetRegistrationService implements ConsentLogger {
                   "Data Location",
                   "dataLocation",
                   PropertyType.String,
-                  (consentGroup) -> {
+                  consentGroup -> {
                     if (Objects.nonNull(consentGroup.getDataLocation())) {
                       return consentGroup.getDataLocation().value();
                     }
@@ -771,7 +771,7 @@ public class DatasetRegistrationService implements ConsentLogger {
                   "File Types",
                   "fileTypes",
                   PropertyType.Json,
-                  (consentGroup) -> {
+                  consentGroup -> {
                     if (Objects.nonNull(consentGroup.getFileTypes())) {
                       return GsonUtil.getInstance().toJson(consentGroup.getFileTypes());
                     }
@@ -781,7 +781,7 @@ public class DatasetRegistrationService implements ConsentLogger {
                   "URL",
                   "url",
                   PropertyType.String,
-                  (consentGroup) -> {
+                  consentGroup -> {
                     if (Objects.nonNull(consentGroup.getUrl())) {
                       return consentGroup.getUrl();
                     }
@@ -791,7 +791,7 @@ public class DatasetRegistrationService implements ConsentLogger {
                   "Access Management",
                   "accessManagement",
                   PropertyType.String,
-                  (consentGroup) -> {
+                  consentGroup -> {
                     if (Objects.nonNull(consentGroup.getAccessManagement())) {
                       return consentGroup.getAccessManagement().value();
                     }
@@ -801,7 +801,7 @@ public class DatasetRegistrationService implements ConsentLogger {
                   data,
                   data,
                   PropertyType.Json,
-                  (consentGroup) -> {
+                  consentGroup -> {
                     if (Objects.nonNull(consentGroup.getData())) {
                       return GsonUtil.getInstance().toJson(consentGroup.getData());
                     }
@@ -812,7 +812,7 @@ public class DatasetRegistrationService implements ConsentLogger {
       DatasetRegistrationSchemaV1 registration) {
 
     return DATASET_REGISTRATION_V1_STUDY_PROPERTY_EXTRACTORS.stream()
-        .map((e) -> e.extract(registration))
+        .map(e -> e.extract(registration))
         .filter(Optional::isPresent)
         .map(Optional::get)
         .toList();

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetRegistrationService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetRegistrationService.java
@@ -1,5 +1,7 @@
 package org.broadinstitute.consent.http.service;
 
+import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.data;
+
 import com.google.cloud.storage.BlobId;
 import com.google.common.annotations.VisibleForTesting;
 import jakarta.ws.rs.BadRequestException;
@@ -735,6 +737,16 @@ public class DatasetRegistrationService implements ConsentLogger {
                       return GsonUtil.getInstance().toJson(registration.getAssets());
                     }
                     return null;
+                  }),
+              new StudyPropertyExtractor(
+                  data,
+                  PropertyType.Json,
+                  (registration) -> {
+                    if (Objects.nonNull(registration.getData())
+                        && !registration.getData().isEmpty()) {
+                      return GsonUtil.getInstance().toJson(registration.getData());
+                    }
+                    return null;
                   }));
 
   private static final List<DatasetPropertyExtractor>
@@ -782,6 +794,16 @@ public class DatasetRegistrationService implements ConsentLogger {
                   (consentGroup) -> {
                     if (Objects.nonNull(consentGroup.getAccessManagement())) {
                       return consentGroup.getAccessManagement().value();
+                    }
+                    return null;
+                  }),
+              new DatasetPropertyExtractor(
+                  data,
+                  data,
+                  PropertyType.Json,
+                  (consentGroup) -> {
+                    if (Objects.nonNull(consentGroup.getData())) {
+                      return GsonUtil.getInstance().toJson(consentGroup.getData());
                     }
                     return null;
                   }));

--- a/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
@@ -1,5 +1,8 @@
 package org.broadinstitute.consent.http.service;
 
+import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.assets;
+import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.data;
+
 import com.google.api.client.http.HttpStatusCodes;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
@@ -251,34 +254,10 @@ public class ElasticSearchService implements ConsentLogger {
       term.setDataSubmitterEmail(study.getCreateUserEmail());
     }
 
-    findStudyProperty(study.getProperties(), "assets")
-        .ifPresent(
-            prop -> {
-              Object value = prop.getValue();
-              Map<String, Object> assetsMap;
-              // When property is loaded from db it is deserialized as JsonObject
-              if (value instanceof com.google.gson.JsonElement) {
-                assetsMap =
-                    GsonUtil.getInstance()
-                        .fromJson(
-                            (com.google.gson.JsonElement) value,
-                            new com.google.gson.reflect.TypeToken<
-                                Map<String, Object>>() {}.getType());
-                // Otherwise Gson deserializes JSON and creates a LinkedTreeMap
-              } else if (value instanceof Map) {
-                assetsMap = (Map<String, Object>) value;
-                // Fallback: try to parse as JSON string
-              } else {
-                assetsMap =
-                    GsonUtil.getInstance()
-                        .fromJson(
-                            value.toString(),
-                            new com.google.gson.reflect.TypeToken<
-                                Map<String, Object>>() {}.getType());
-              }
-              term.setAssets(assetsMap);
-            });
-
+    findStudyProperty(study.getProperties(), assets)
+        .ifPresent(prop -> term.setAssets(buildMapFromPropertyValue(prop.getValue())));
+    findStudyProperty(study.getProperties(), data)
+        .ifPresent(prop -> term.setData(buildMapFromPropertyValue(prop.getValue())));
     return term;
   }
 
@@ -489,7 +468,10 @@ public class ElasticSearchService implements ConsentLogger {
     findDatasetProperty(dataset.getProperties(), "dataLocation")
         .ifPresent(
             datasetProperty -> term.setDataLocation(datasetProperty.getPropertyValueAsString()));
-
+    findDatasetProperty(dataset.getProperties(), "data")
+        .ifPresent(
+            datasetProperty ->
+                term.setData(buildMapFromPropertyValue(datasetProperty.getPropertyValue())));
     return term;
   }
 
@@ -529,5 +511,28 @@ public class ElasticSearchService implements ConsentLogger {
     return (props == null)
         ? Optional.empty()
         : props.stream().filter(p -> p.getKey().equals(key)).findFirst();
+  }
+
+  public static Map<String, Object> buildMapFromPropertyValue(Object value) {
+    Map<String, Object> objectMap;
+    // When property is loaded from db it is deserialized as JsonObject
+    if (value instanceof com.google.gson.JsonElement) {
+      objectMap =
+          GsonUtil.getInstance()
+              .fromJson(
+                  (com.google.gson.JsonElement) value,
+                  new com.google.gson.reflect.TypeToken<Map<String, Object>>() {}.getType());
+      // Otherwise Gson deserializes JSON and creates a LinkedTreeMap
+    } else if (value instanceof Map) {
+      objectMap = (Map<String, Object>) value;
+      // Fallback: try to parse as JSON string
+    } else {
+      objectMap =
+          GsonUtil.getInstance()
+              .fromJson(
+                  value.toString(),
+                  new com.google.gson.reflect.TypeToken<Map<String, Object>>() {}.getType());
+    }
+    return objectMap;
   }
 }

--- a/src/main/resources/changelog-master.xml
+++ b/src/main/resources/changelog-master.xml
@@ -234,4 +234,6 @@
   <include file="changesets/changelog-consent-2026-02-03-email-entity-refererence-id-idx.xml"
            relativeToChangelogFile="true" />
   <include file="changesets/changelog-consent-2026-02-05-fix-dataset-access-control.xml" relativeToChangelogFile="true" />
+  <include file="changesets/changelog-consent-2026-02-11-new-dataset-property-dictionary-entry.xml"
+           relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/changesets/changelog-consent-2026-02-11-new-dataset-property-dictionary-entry.xml
+++ b/src/main/resources/changesets/changelog-consent-2026-02-11-new-dataset-property-dictionary-entry.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+  <changeSet id="changelog-consent-2026-02-11-new-dataset-property-dictionary-entry" author="otchet">
+    <insert tableName="dictionary">
+      <column name="key" value="data"/>
+      <column name="required" value="false"/>
+    </insert>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/dataset-registration-schema_v1.json
+++ b/src/main/resources/dataset-registration-schema_v1.json
@@ -213,6 +213,12 @@
       "label" : "Assets",
       "description" : "Additional assets or metadata associated with this study registration",
       "additionalProperties" : true
+    },
+    "data" : {
+      "type" : "object",
+      "label" : "data",
+      "description" : "Additional data or metadata associated with this study registration",
+      "additionalProperties" : true
     }
   },
   "$defs" : {

--- a/src/test/java/org/broadinstitute/consent/http/models/DatasetRegistrationSchemaV1BuilderTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/DatasetRegistrationSchemaV1BuilderTest.java
@@ -12,6 +12,7 @@ import static org.broadinstitute.consent.http.models.dataset_registration_v1.bui
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.collaboratingSites;
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.controlledAccessRequiredForGenomicSummaryResultsGSR;
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.controlledAccessRequiredForGenomicSummaryResultsGSRRequiredExplanation;
+import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.data;
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.dataCustodianEmail;
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.dataLocation;
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.dbGaPPhsID;
@@ -43,6 +44,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
@@ -142,6 +144,8 @@ class DatasetRegistrationSchemaV1BuilderTest {
     assertNotNull(consentGroup.getNumberOfParticipants());
     assertNotNull(consentGroup.getFileTypes());
     assertFalse(consentGroup.getFileTypes().isEmpty());
+    assertNotNull(consentGroup.getData());
+    assertTrue(consentGroup.getData().isEmpty());
   }
 
   @Test
@@ -415,6 +419,8 @@ class DatasetRegistrationSchemaV1BuilderTest {
         createDatasetProperty(dataset, numberOfParticipants, PropertyType.Number, null));
     dataset.addProperty(
         createDatasetProperty(dataset, fileTypes, PropertyType.Json, new FileTypeObject()));
+    dataset.addProperty(
+        createDatasetProperty(dataset, data, PropertyType.Json, new HashMap<String, Object>()));
   }
 
   private DatasetProperty createDatasetProperty(
@@ -428,13 +434,17 @@ class DatasetRegistrationSchemaV1BuilderTest {
       case Boolean -> prop.setPropertyValue(Objects.nonNull(propValue) ? propValue : true);
       case Number -> prop.setPropertyValue(Objects.nonNull(propValue) ? propValue : randomInt());
       case Json -> {
-        List<Object> list = new ArrayList<>();
-        if (Objects.nonNull(propValue)) {
-          list.add(GsonUtil.getInstance().toJson(propValue));
+        if (propValue instanceof FileTypeObject) {
+          List<Object> list = new ArrayList<>();
+          if (Objects.nonNull(propValue)) {
+            list.add(GsonUtil.getInstance().toJson(propValue));
+          } else {
+            list.add(randomString());
+          }
+          prop.setPropertyValue(list);
         } else {
-          list.add(randomString());
+          prop.setPropertyValue(GsonUtil.getInstance().toJson(propValue));
         }
-        prop.setPropertyValue(list);
       }
       // Default to string
       default -> prop.setPropertyValue(Objects.nonNull(propValue) ? propValue : randomString());

--- a/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
@@ -1,6 +1,8 @@
 package org.broadinstitute.consent.http.service;
 
 import static jakarta.ws.rs.core.Response.Status.fromStatusCode;
+import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.assets;
+import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.data;
 import static org.junit.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -29,6 +31,8 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -343,17 +347,18 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
     assertEquals(datasetRecord.study.getDataTypes(), term.getStudy().getDataTypes());
   }
 
-  @Test
-  void testToDatasetTerm_StudyAssets() {
+  @ParameterizedTest
+  @ValueSource(strings = {assets, data})
+  void testToDatasetTerm_JsonBlobs(String propKey) {
     DatasetRecord datasetRecord = createDatasetRecord();
-    Map<String, Object> assetsMap = Map.of("key", List.of("value1", "value2"));
-    String assetsJson = GsonUtil.getInstance().toJson(assetsMap);
-    StudyProperty assetsProp = new StudyProperty();
-    assetsProp.setStudyId(datasetRecord.study.getStudyId());
-    assetsProp.setKey("assets");
-    assetsProp.setType(PropertyType.Json);
-    assetsProp.setValue(GsonUtil.getInstance().fromJson(assetsJson, Object.class));
-    datasetRecord.study.addProperty(assetsProp);
+    Map<String, Object> refMap = Map.of("key", List.of("value1", "value2"));
+    String refJson = GsonUtil.getInstance().toJson(refMap);
+    StudyProperty jsonBlob = new StudyProperty();
+    jsonBlob.setStudyId(datasetRecord.study.getStudyId());
+    jsonBlob.setKey(propKey);
+    jsonBlob.setType(PropertyType.Json);
+    jsonBlob.setValue(GsonUtil.getInstance().fromJson(refJson, Object.class));
+    datasetRecord.study.addProperty(jsonBlob);
 
     when(userDao.findUserById(datasetRecord.createUser.getUserId()))
         .thenReturn(datasetRecord.createUser);
@@ -362,8 +367,15 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
     when(dacDAO.findById(any())).thenReturn(datasetRecord.dac);
 
     DatasetTerm term = service.toDatasetTerm(datasetRecord.dataset);
-
-    assertEquals(assetsMap, term.getStudy().getAssets());
+    switch (propKey) {
+      case assets:
+        assertEquals(refMap, term.getStudy().getAssets());
+        return;
+      case data:
+        assertEquals(refMap, term.getStudy().getData());
+        return;
+      default:
+    }
   }
 
   @Test
@@ -420,6 +432,35 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
     assertTrue(accessManagementProp.isPresent());
     assertEquals(
         accessManagementProp.get().getPropertyValue().toString(), term.getAccessManagement());
+  }
+
+  @Test
+  void testToDatasetTerm_Data() {
+    Dataset dataset = new Dataset();
+    dataset.setDatasetId(1);
+    Set<DatasetProperty> datasetProperties = new HashSet<>();
+    Map<String, Object> refMap = Map.of("key", List.of("value1", "value2"));
+    DatasetProperty newProperty =
+        new DatasetProperty(
+            99,
+            dataset.getDatasetId(),
+            99,
+            data,
+            GsonUtil.getInstance().toJson(refMap),
+            PropertyType.Json,
+            new Date());
+    newProperty.setPropertyName(data);
+    newProperty.setSchemaProperty(data);
+    datasetProperties.add(newProperty);
+    dataset.setProperties(datasetProperties);
+
+    DatasetTerm term = service.toDatasetTerm(dataset);
+    Optional<DatasetProperty> dataProp =
+        dataset.getProperties().stream()
+            .filter(p -> p.getSchemaProperty().equals(data))
+            .findFirst();
+    assertTrue(dataProp.isPresent());
+    assertEquals(refMap, term.getData());
   }
 
   @Test


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-2883](https://broadworkbench.atlassian.net/browse/DT-2883)

### Summary

Adds optional dataset and study properties to support holding Json
Ensures Json values are stored in Elasticsearch index as well as in the relational database

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
