### PR TITLE
[DT-2873][DT-2947] Use `_type` on old versions of elasticsearch

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/models/elastic_search/ElasticSearchInfo.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/elastic_search/ElasticSearchInfo.java
@@ -1,0 +1,10 @@
+package org.broadinstitute.consent.http.models.elastic_search;
+
+import com.google.gson.annotations.SerializedName;
+
+public record ElasticSearchInfo(
+    String name,
+    @SerializedName("cluster_name") String clusterName,
+    @SerializedName("cluster_uuid") String clusterUuid,
+    ElasticSearchVersion version,
+    String tagline) {}

--- a/src/main/java/org/broadinstitute/consent/http/models/elastic_search/ElasticSearchVersion.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/elastic_search/ElasticSearchVersion.java
@@ -1,0 +1,15 @@
+package org.broadinstitute.consent.http.models.elastic_search;
+
+import com.google.gson.annotations.SerializedName;
+
+public record ElasticSearchVersion(
+    String number,
+    @SerializedName("build_flavor") String buildFlavor,
+    @SerializedName("build_type") String buildType,
+    @SerializedName("build_hash") String buildHash,
+    @SerializedName("build_date") String buildDate,
+    @SerializedName("build_snapshot") Boolean buildSnapshot,
+    @SerializedName("lucene_version") String luceneVersion,
+    @SerializedName("minimum_wire_compatibility_version") String minimumWireCompatibilityVersion,
+    @SerializedName("minimum_index_compatibility_version") String minimumIndexCompatibilityVersion,
+    String distribution) {}

--- a/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
@@ -41,6 +41,8 @@ import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.elastic_search.DacTerm;
 import org.broadinstitute.consent.http.models.elastic_search.DatasetTerm;
 import org.broadinstitute.consent.http.models.elastic_search.ElasticSearchHits;
+import org.broadinstitute.consent.http.models.elastic_search.ElasticSearchInfo;
+import org.broadinstitute.consent.http.models.elastic_search.ElasticSearchVersion;
 import org.broadinstitute.consent.http.models.elastic_search.InstitutionTerm;
 import org.broadinstitute.consent.http.models.elastic_search.StudyTerm;
 import org.broadinstitute.consent.http.models.elastic_search.UserTerm;
@@ -65,6 +67,8 @@ public class ElasticSearchService implements ConsentLogger {
   private final DatasetDAO datasetDAO;
   private final DatasetServiceDAO datasetServiceDAO;
   private final StudyDAO studyDAO;
+
+  private String indexKey;
 
   public ElasticSearchService(
       RestClient esClient,
@@ -91,7 +95,7 @@ public class ElasticSearchService implements ConsentLogger {
 
   private static final String BULK_HEADER =
       """
-      { "index": {"_index": "dataset", "_id": "%d"} }
+      { "index": {"%s": "dataset", "_id": "%d"} }
       """;
 
   private static final String DELETE_QUERY =
@@ -109,12 +113,46 @@ public class ElasticSearchService implements ConsentLogger {
     return Response.status(status).entity(body).build();
   }
 
+  public String getIndexKey() {
+    if (this.indexKey != null) {
+      return this.indexKey;
+    }
+    // nosemgrep
+    String defaultKey = "_index";
+    try {
+      Request request = new Request(HttpMethod.GET, "/");
+      Response response = performRequest(request);
+      ElasticSearchInfo info =
+          GsonUtil.getInstance().fromJson(response.getEntity().toString(), ElasticSearchInfo.class);
+      if (info != null && info.version() != null && info.version().number() != null) {
+        ElasticSearchVersion version = info.version();
+        int majorVersion = Integer.parseInt(version.number().split("\\.")[0]);
+        String distribution = version.distribution();
+        if (distribution == null && majorVersion < 7) {
+          defaultKey = "_type";
+        }
+      }
+    } catch (Exception e) {
+      logWarn(
+          "Unable to get Elasticsearch index key, defaulting to "
+              + defaultKey
+              + ": "
+              + e.getMessage());
+    }
+    return setIndexKey(defaultKey);
+  }
+
+  String setIndexKey(String indexKey) {
+    this.indexKey = indexKey;
+    return this.indexKey;
+  }
+
   public Response indexDatasetTerms(List<DatasetTerm> datasets, User user) throws IOException {
     List<String> bulkApiCall = new ArrayList<>();
 
     datasets.forEach(
         dsTerm -> {
-          bulkApiCall.add(BULK_HEADER.formatted(dsTerm.getDatasetId()));
+          bulkApiCall.add(BULK_HEADER.formatted(getIndexKey(), dsTerm.getDatasetId()));
           bulkApiCall.add(GsonUtil.getInstance().toJson(dsTerm) + "\n");
           updateDatasetIndexDate(dsTerm.getDatasetId(), user.getUserId(), Instant.now());
         });

--- a/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
@@ -115,6 +115,7 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
             datasetDAO,
             datasetServiceDAO,
             studyDAO);
+    service.setIndexKey("_index");
   }
 
   private void mockElasticSearchResponse(String body) throws IOException {
@@ -855,5 +856,49 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
   void testInvalidResultWindow_ExtraFieldsInQuery() {
     String query = "{\"size\": 100, \"from\": 50, \"query\": {\"match_all\": {}}}";
     assertFalse(service.invalidResultWindow(query));
+  }
+
+  @Test
+  void testGetIndexKey_SetKey() {
+    service.setIndexKey("custom-key");
+    assertEquals("custom-key", service.getIndexKey());
+  }
+
+  @Test
+  void testGetIndexKey_DefaultIndex() throws IOException {
+    service.setIndexKey(null);
+    String body = "{ \"version\": { \"number\": \"7.10.2\" } }";
+    mockElasticSearchResponse(body);
+    assertEquals("_index", service.getIndexKey());
+  }
+
+  @Test
+  void testGetIndexKey_LegacyType() throws IOException {
+    service.setIndexKey(null);
+    String body = "{ \"version\": { \"number\": \"6.8.0\" } }";
+    mockElasticSearchResponse(body);
+    assertEquals("_type", service.getIndexKey());
+  }
+
+  @Test
+  void testGetIndexKey_OpenSearch() throws IOException {
+    service.setIndexKey(null);
+    String body = "{ \"version\": { \"number\": \"3.3.0\", \"distribution\": \"opensearch\" } }";
+    mockElasticSearchResponse(body);
+    assertEquals("_index", service.getIndexKey());
+  }
+
+  @Test
+  void testGetIndexKey_ExceptionDefaultsToIndex() throws IOException {
+    service.setIndexKey(null);
+    when(esClient.performRequest(any())).thenThrow(new IOException("Connection failed"));
+    assertEquals("_index", service.getIndexKey());
+  }
+
+  @Test
+  void testGetIndexKey_NullInfoDefaultsToIndex() throws IOException {
+    service.setIndexKey(null);
+    mockElasticSearchResponse("{}");
+    assertEquals("_index", service.getIndexKey());
   }
 }


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2947

### Summary

Use of `_index` in bulk index update throws a `Validation Failed: 1: type is missing` error in staging and prod.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
