### PR TITLE
[DT-2946] Switch to using election date from vote date in query + defense

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/ElectionDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/ElectionDAO.java
@@ -271,7 +271,7 @@ public interface ElectionDAO extends Transactional<ElectionDAO> {
           u.user_id,
           dc.dar_code,
           dc.collection_id,
-          v.create_date
+          max(e_sub.max_date) as create_date
       FROM (
                SELECT reference_id, MAX(create_date) max_date, election_id
                FROM election
@@ -279,7 +279,7 @@ public interface ElectionDAO extends Transactional<ElectionDAO> {
                  AND LOWER(election_type) = 'dataaccess'
                  AND create_date <= NOW() - make_interval(hours => :start)
                GROUP BY reference_id, election_id
-           ) e_sub
+           ) AS e_sub
                INNER JOIN data_access_request dar ON dar.reference_id = e_sub.reference_id
                INNER JOIN dar_dataset dar_ds ON dar_ds.reference_id = dar.reference_id
                INNER JOIN dar_collection dc ON dc.collection_id = dar.collection_id
@@ -289,6 +289,7 @@ public interface ElectionDAO extends Transactional<ElectionDAO> {
       WHERE v.vote IS NULL
         AND dc.dar_code IS NOT NULL
         AND ee.entity_reference_id IS NULL
+      GROUP BY u.user_id, dc.dar_code, dc.collection_id
 """)
   List<UserVoteReminder> findElectionReminders(
       @Bind("start") int start,

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/SimpleElectionMapper.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/SimpleElectionMapper.java
@@ -16,9 +16,9 @@ public class SimpleElectionMapper implements RowMapper<Election>, RowMapperHelpe
             r.getInt(ElectionFields.ID.getValue()),
             r.getString(ElectionFields.TYPE.getValue()),
             r.getString(ElectionFields.STATUS.getValue()),
-            r.getDate(ElectionFields.CREATE_DATE.getValue()),
+            r.getTimestamp(ElectionFields.CREATE_DATE.getValue()),
             r.getString(ElectionFields.REFERENCE_ID.getValue()),
-            r.getDate(ElectionFields.LAST_UPDATE.getValue()),
+            r.getTimestamp(ElectionFields.LAST_UPDATE.getValue()),
             (r.getString(ElectionFields.FINAL_ACCESS_VOTE.getValue()) == null)
                 ? null
                 : r.getBoolean(ElectionFields.FINAL_ACCESS_VOTE.getValue()),

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/DacVoteDigestMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/DacVoteDigestMessage.java
@@ -86,9 +86,9 @@ public class DacVoteDigestMessage extends MailMessage {
         .filter(
             reminder ->
                 reminder.darCode() != null
-                        && reminder.createDate() != null
-                        && (reminder.createDate().isBefore(twoWeeksAgo)
-                    || reminder.createDate().equals(twoWeeksAgo)))
+                    && reminder.createDate() != null
+                    && (reminder.createDate().isBefore(twoWeeksAgo)
+                        || reminder.createDate().equals(twoWeeksAgo)))
         .toList();
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/DacVoteDigestMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/DacVoteDigestMessage.java
@@ -33,6 +33,7 @@ public class DacVoteDigestMessage extends MailMessage {
   public Object createModel(String serverUrl) {
     List<Reminder> sortedReminderList =
         userReminderList.stream()
+            .filter(r -> r.createDate() != null)
             .sorted(Comparator.comparing(Reminder::createDate).reversed())
             .toList();
     List<Reminder> currentWeekReminders = getCurrentWeekReminders(sortedReminderList);
@@ -86,8 +87,8 @@ public class DacVoteDigestMessage extends MailMessage {
             reminder ->
                 reminder.darCode() != null
                         && reminder.createDate() != null
-                        && reminder.createDate().isBefore(twoWeeksAgo)
-                    || reminder.createDate().equals(twoWeeksAgo))
+                        && (reminder.createDate().isBefore(twoWeeksAgo)
+                    || reminder.createDate().equals(twoWeeksAgo)))
         .toList();
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/DacVoteDigestMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/DacVoteDigestMessage.java
@@ -55,7 +55,11 @@ public class DacVoteDigestMessage extends MailMessage {
   protected List<Reminder> getCurrentWeekReminders(List<Reminder> reminders) {
     Instant oneWeekAgo = timeBasis.minus(7, ChronoUnit.DAYS);
     return reminders.stream()
-        .filter(reminder -> reminder.createDate().isAfter(oneWeekAgo))
+        .filter(
+            reminder ->
+                reminder.darCode() != null
+                    && reminder.createDate() != null
+                    && reminder.createDate().isAfter(oneWeekAgo))
         .toList();
   }
 
@@ -66,7 +70,9 @@ public class DacVoteDigestMessage extends MailMessage {
     return reminders.stream()
         .filter(
             reminder ->
-                (reminder.createDate().equals(oneWeekAgo)
+                reminder.darCode() != null
+                    && reminder.createDate() != null
+                    && (reminder.createDate().equals(oneWeekAgo)
                         || reminder.createDate().isBefore(oneWeekAgo))
                     && reminder.createDate().isAfter(twoWeeksAgo))
         .toList();
@@ -78,7 +84,9 @@ public class DacVoteDigestMessage extends MailMessage {
     return reminders.stream()
         .filter(
             reminder ->
-                reminder.createDate().isBefore(twoWeeksAgo)
+                reminder.darCode() != null
+                        && reminder.createDate() != null
+                        && reminder.createDate().isBefore(twoWeeksAgo)
                     || reminder.createDate().equals(twoWeeksAgo))
         .toList();
   }

--- a/src/test/java/org/broadinstitute/consent/http/db/ElectionDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/ElectionDAOTest.java
@@ -673,6 +673,7 @@ class ElectionDAOTest extends DAOTestHelper {
   @Test
   void testFindVotesThatNeedReminders() {
     Vote vote = createElectionAndVote();
+    Election election = electionDAO.findElectionById(vote.getElectionId());
     // there's a timing issue in this test due to the precision of time in the column.
     // it's reliably resolved by setting the query start time early enough so that it
     // includes the SQL inserts contemplated by createElectionAndVote.
@@ -688,7 +689,7 @@ class ElectionDAOTest extends DAOTestHelper {
     assertNotNull(reminder.collectionId());
     assertNotNull(reminder.createDate());
     assertEquals(vote.getUserId(), reminder.userId());
-    assertEquals(vote.getCreateDate().toInstant(), reminder.createDate());
+    assertEquals(Instant.ofEpochMilli(election.getCreateDate().getTime()), reminder.createDate());
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/mail/message/DacVoteDigestMessageTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mail/message/DacVoteDigestMessageTest.java
@@ -140,6 +140,62 @@ class DacVoteDigestMessageTest {
     assertTrue(hasElementWithId(parsedTemplate, "olderRequests"));
   }
 
+  @Test
+  void testMessageTemplate_Reminders_template_missing_dar_code()
+      throws IOException, TemplateException {
+    User toUser = new User();
+    toUser.setUserId(1);
+    toUser.setDisplayName("Reminder User");
+    Instant timeBasis = Instant.now();
+    String refId = timeBasis.toString();
+    List<Reminder> olderReminders =
+        List.of(
+            new Reminder(toUser.getUserId(), "DAR-1", 2, timeBasis.minus(21, ChronoUnit.DAYS)),
+            new Reminder(toUser.getUserId(), null, 3, timeBasis.minus(14, ChronoUnit.DAYS)));
+
+    var message = new DacVoteDigestMessage(toUser, olderReminders, refId, timeBasis);
+
+    var template = helper.getTemplate(message.getTemplateName());
+    var out = new StringWriter();
+    template.process(message.createModel("localhost:8080"), out);
+    var templateString = out.toString();
+    Document parsedTemplate = Jsoup.parse(templateString);
+    assertEquals(
+        "Dear %s,".formatted(toUser.getDisplayName()),
+        getElementTextById(parsedTemplate, "userName"));
+    assertFalse(hasElementWithId(parsedTemplate, "submittedThisWeek"));
+    assertFalse(hasElementWithId(parsedTemplate, "submittedLastWeek"));
+    assertTrue(hasElementWithId(parsedTemplate, "olderRequests"));
+  }
+
+  @Test
+  void testMessageTemplate_Reminders_template_missing_create_date()
+      throws IOException, TemplateException {
+    User toUser = new User();
+    toUser.setUserId(1);
+    toUser.setDisplayName("Reminder User");
+    Instant timeBasis = Instant.now();
+    String refId = timeBasis.toString();
+    List<Reminder> olderReminders =
+        List.of(
+            new Reminder(toUser.getUserId(), "DAR-1", 2, timeBasis.minus(21, ChronoUnit.DAYS)),
+            new Reminder(toUser.getUserId(), "DAR-2", 3, null));
+
+    var message = new DacVoteDigestMessage(toUser, olderReminders, refId, timeBasis);
+
+    var template = helper.getTemplate(message.getTemplateName());
+    var out = new StringWriter();
+    template.process(message.createModel("localhost:8080"), out);
+    var templateString = out.toString();
+    Document parsedTemplate = Jsoup.parse(templateString);
+    assertEquals(
+        "Dear %s,".formatted(toUser.getDisplayName()),
+        getElementTextById(parsedTemplate, "userName"));
+    assertFalse(hasElementWithId(parsedTemplate, "submittedThisWeek"));
+    assertFalse(hasElementWithId(parsedTemplate, "submittedLastWeek"));
+    assertTrue(hasElementWithId(parsedTemplate, "olderRequests"));
+  }
+
   String getElementTextById(Document document, String id) {
     return Objects.requireNonNull(document.getElementById(id)).text();
   }


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-2946](https://broadworkbench.atlassian.net/browse/DT-2946)

### Summary

In production, it's observed that votes may not have 'create_date' set to a value, but it was confirmed that the election create date is always set.  This PR switches the query to use the election date.

Other changes:
Adds defensive logic to ensure that create date or dar code is present before passing a reminder to the template.
Ensures an election create_date has better resolution so that the underlying database value can be compared between queries

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
