### PR TITLE
DT-2531: Replicate the Translate feature from Ontology to Consent

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/matching/DataUseUtil.java
+++ b/src/main/java/org/broadinstitute/consent/http/matching/DataUseUtil.java
@@ -3,7 +3,6 @@ package org.broadinstitute.consent.http.matching;
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonParser;
-import com.google.inject.Inject;
 import jakarta.ws.rs.core.StreamingOutput;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -22,7 +21,6 @@ public final class DataUseUtil {
 
   private final OntologyService ontologyService;
 
-  @Inject
   public DataUseUtil(OntologyService ontologyService) {
     this.ontologyService = ontologyService;
   }

--- a/src/main/java/org/broadinstitute/consent/http/matching/TranslationUtil.java
+++ b/src/main/java/org/broadinstitute/consent/http/matching/TranslationUtil.java
@@ -67,14 +67,15 @@ public class TranslationUtil implements ConsentLogger {
    * @param dataUse The DataUse object
    * @return Summary list of restrictions in string format
    */
-  // Suppress warning for method complexity: due for reevaluation after initial migration
-  @SuppressWarnings("java:S3776")
-  public String translate(DataUse dataUse, DataUseTranslationType translateFor) {
+  // Suppress warning for method complexity (S3776). Due for reevaluation after initial migration
+  // Suppress warning for switch statement (S1301). This is more readable as a switch than if/else
+  // statements.
+  @SuppressWarnings({"java:S3776", "java:S1301"})
+  public String translate(DataUse dataUse, DataUseTranslationType type) {
     List<String> summary = new ArrayList<>();
-    if (translateFor.equals(DataUseTranslationType.DATASET)) {
-      summary.add(DATASET_HEADER);
-    } else if (translateFor.equals(DataUseTranslationType.PURPOSE)) {
-      summary.add(PURPOSE_HEADER);
+    switch (type) {
+      case DATASET -> summary.add(DATASET_HEADER);
+      case PURPOSE -> summary.add(PURPOSE_HEADER);
     }
 
     if (dataUse == null) {

--- a/src/main/java/org/broadinstitute/consent/http/matching/TranslationUtil.java
+++ b/src/main/java/org/broadinstitute/consent/http/matching/TranslationUtil.java
@@ -76,6 +76,7 @@ public class TranslationUtil implements ConsentLogger {
     switch (type) {
       case DATASET -> summary.add(DATASET_HEADER);
       case PURPOSE -> summary.add(PURPOSE_HEADER);
+      case null -> throw new IllegalArgumentException("Translation type is required");
     }
 
     if (dataUse == null) {

--- a/src/main/java/org/broadinstitute/consent/http/matching/TranslationUtil.java
+++ b/src/main/java/org/broadinstitute/consent/http/matching/TranslationUtil.java
@@ -4,7 +4,6 @@ import com.google.gson.Gson;
 import com.google.gson.JsonParser;
 import jakarta.ws.rs.core.StreamingOutput;
 import java.io.ByteArrayOutputStream;
-import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
@@ -187,7 +186,7 @@ public class TranslationUtil implements ConsentLogger {
     return String.join("\n", summary);
   }
 
-  private List<OntologyTerm> findTermsByIds(List<String> ids) {
+  protected List<OntologyTerm> findTermsByIds(List<String> ids) {
     try {
       String[] idArray = ids.toArray(new String[0]);
       StreamingOutput output = ontologyService.findByTermIds(idArray);
@@ -197,7 +196,7 @@ public class TranslationUtil implements ConsentLogger {
       return JsonParser.parseString(jsonString).getAsJsonArray().asList().stream()
           .map(t -> gson.fromJson(t, OntologyTerm.class))
           .toList();
-    } catch (IOException e) {
+    } catch (Exception e) {
       logException("Unable to retrieve term ids: " + String.join(", ", ids), e);
       return List.of();
     }

--- a/src/main/java/org/broadinstitute/consent/http/matching/TranslationUtil.java
+++ b/src/main/java/org/broadinstitute/consent/http/matching/TranslationUtil.java
@@ -21,9 +21,9 @@ import org.broadinstitute.consent.http.util.gson.GsonUtil;
 
 public class TranslationUtil implements ConsentLogger {
 
-  protected static final String DATASET_HEADER =
+  public static final String DATASET_HEADER =
       "Samples are restricted for use under the following conditions:";
-  protected static final String PURPOSE_HEADER =
+  public static final String PURPOSE_HEADER =
       "Research is limited to samples restricted for use under the following conditions:";
   protected static final String FEMALE = "Female";
   protected static final String MALE = "Male";
@@ -59,26 +59,6 @@ public class TranslationUtil implements ConsentLogger {
 
   public TranslationUtil(OntologyDAO ontologyDAO) {
     this.ontologyDAO = ontologyDAO;
-  }
-
-  public String translateDataset(String dataUseString) {
-    try {
-      DataUse dataUse = gson.fromJson(dataUseString, DataUse.class);
-      return translate(dataUse, DataUseTranslationType.DATASET);
-    } catch (Exception e) {
-      throw new IllegalArgumentException(
-          "Error translating: " + dataUseString + " - " + e.getMessage());
-    }
-  }
-
-  public String translatePurpose(String dataUseString) {
-    try {
-      DataUse dataUse = gson.fromJson(dataUseString, DataUse.class);
-      return translate(dataUse, DataUseTranslationType.PURPOSE);
-    } catch (Exception e) {
-      throw new IllegalArgumentException(
-          "Error translating: " + dataUseString + " - " + e.getMessage());
-    }
   }
 
   /**

--- a/src/main/java/org/broadinstitute/consent/http/matching/TranslationUtil.java
+++ b/src/main/java/org/broadinstitute/consent/http/matching/TranslationUtil.java
@@ -21,8 +21,10 @@ import org.broadinstitute.consent.http.util.gson.GsonUtil;
 
 public class TranslationUtil implements ConsentLogger {
 
-  protected static final String DATASET_HEADER = "Samples are restricted for use under the following conditions:";
-  protected static final String PURPOSE_HEADER = "Research is limited to samples restricted for use under the following conditions:";
+  protected static final String DATASET_HEADER =
+      "Samples are restricted for use under the following conditions:";
+  protected static final String PURPOSE_HEADER =
+      "Research is limited to samples restricted for use under the following conditions:";
   protected static final String FEMALE = "Female";
   protected static final String MALE = "Male";
   private static final String GRU = "Data is available for general research use. [GRU]";

--- a/src/main/java/org/broadinstitute/consent/http/matching/TranslationUtil.java
+++ b/src/main/java/org/broadinstitute/consent/http/matching/TranslationUtil.java
@@ -14,7 +14,7 @@ import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.consent.http.enumeration.DataUseTranslationType;
 import org.broadinstitute.consent.http.models.DataUse;
-import org.broadinstitute.consent.http.service.OntologyService;
+import org.broadinstitute.consent.http.service.ontology.OntologyDAO;
 import org.broadinstitute.consent.http.service.ontology.OntologyTerm;
 import org.broadinstitute.consent.http.util.ConsentLogger;
 import org.broadinstitute.consent.http.util.gson.GsonUtil;
@@ -24,13 +24,13 @@ public class TranslationUtil implements ConsentLogger {
   protected static final String FEMALE = "Female";
   protected static final String MALE = "Male";
   private static final String GRU = "Data is available for general research use. [GRU]";
-  private static final String DS = "Data use is limited for studying: %s [DS]";
-  private static final String HMB = "Data is limited for health/medical/biomedical research. [HMB]";
+  public static final String DS = "Data use is limited for studying: %s [DS]";
+  public static final String HMB = "Data is limited for health/medical/biomedical research. [HMB]";
   private static final String POA =
       "Future use for population origins or ancestry research is prohibited. [POA]";
-  private static final String NMDS =
+  public static final String NMDS =
       "Data use for methods development research ONLY within the bounds of other data use limitations. [NMDS]";
-  private static final String NCU = "Commercial use prohibited. [NCU]";
+  public static final String NCU = "Commercial use prohibited. [NCU]";
   private static final String OTHER = "Other restrictions: %s.";
   private static final String SECONDARY_OTHER = "Secondary other restrictions: %s.";
   private static final String ETHICS_APPROVAL = "Local ethics committee approval is required.";
@@ -42,7 +42,7 @@ public class TranslationUtil implements ConsentLogger {
       "Publishing results of studies using the data available to the larger scientific community is required";
   private static final String PUB_MORATORIUM =
       "Publishing moratorium until '%s' is in effect. [MOR]";
-  private static final String NCTRL =
+  public static final String NCTRL =
       "Future use as a control set for diseases other than those specified is prohibited. [NCTRL]";
   private static final String RS_M = "Data use is limited to research on males. [RS-M]";
   private static final String RS_FM = "Data use is limited to research on females. [RS-FM]";
@@ -50,11 +50,11 @@ public class TranslationUtil implements ConsentLogger {
   private static final String POP =
       "Future use for study variation in the general population (e.g. calling variants and/or studying their distribution). [POP]";
 
-  private final OntologyService ontologyService;
+  private final OntologyDAO ontologyDAO;
   private final Gson gson = GsonUtil.getInstance();
 
-  public TranslationUtil(OntologyService ontologyService) {
-    this.ontologyService = ontologyService;
+  public TranslationUtil(OntologyDAO ontologyDAO) {
+    this.ontologyDAO = ontologyDAO;
   }
 
   public String translateDataset(String dataUseString) {
@@ -189,7 +189,7 @@ public class TranslationUtil implements ConsentLogger {
   protected List<OntologyTerm> findTermsByIds(List<String> ids) {
     try {
       String[] idArray = ids.toArray(new String[0]);
-      StreamingOutput output = ontologyService.findByTermIds(idArray);
+      StreamingOutput output = ontologyDAO.findByTermIds(idArray);
       ByteArrayOutputStream baos = new ByteArrayOutputStream();
       output.write(baos);
       String jsonString = baos.toString(StandardCharsets.UTF_8);

--- a/src/main/java/org/broadinstitute/consent/http/matching/TranslationUtil.java
+++ b/src/main/java/org/broadinstitute/consent/http/matching/TranslationUtil.java
@@ -21,6 +21,8 @@ import org.broadinstitute.consent.http.util.gson.GsonUtil;
 
 public class TranslationUtil implements ConsentLogger {
 
+  protected static final String DATASET_HEADER = "Samples are restricted for use under the following conditions:";
+  protected static final String PURPOSE_HEADER = "Research is limited to samples restricted for use under the following conditions:";
   protected static final String FEMALE = "Female";
   protected static final String MALE = "Male";
   private static final String GRU = "Data is available for general research use. [GRU]";
@@ -83,16 +85,14 @@ public class TranslationUtil implements ConsentLogger {
    * @param dataUse The DataUse object
    * @return Summary list of restrictions in string format
    */
-  @SuppressWarnings(
-      "java:S3776") // Suppress warning for method complexity: due for reevaluation after initial
-  // migration
+  // Suppress warning for method complexity: due for reevaluation after initial migration
+  @SuppressWarnings("java:S3776")
   public String translate(DataUse dataUse, DataUseTranslationType translateFor) {
     List<String> summary = new ArrayList<>();
     if (translateFor.equals(DataUseTranslationType.DATASET)) {
-      summary.add("Samples are restricted for use under the following conditions:");
+      summary.add(DATASET_HEADER);
     } else if (translateFor.equals(DataUseTranslationType.PURPOSE)) {
-      summary.add(
-          "Research is limited to samples restricted for use under the following conditions:");
+      summary.add(PURPOSE_HEADER);
     }
 
     if (dataUse == null) {

--- a/src/main/java/org/broadinstitute/consent/http/matching/TranslationUtil.java
+++ b/src/main/java/org/broadinstitute/consent/http/matching/TranslationUtil.java
@@ -1,0 +1,205 @@
+package org.broadinstitute.consent.http.matching;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonParser;
+import jakarta.ws.rs.core.StreamingOutput;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.BooleanUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.broadinstitute.consent.http.enumeration.DataUseTranslationType;
+import org.broadinstitute.consent.http.models.DataUse;
+import org.broadinstitute.consent.http.service.OntologyService;
+import org.broadinstitute.consent.http.service.ontology.OntologyTerm;
+import org.broadinstitute.consent.http.util.ConsentLogger;
+import org.broadinstitute.consent.http.util.gson.GsonUtil;
+
+public class TranslationUtil implements ConsentLogger {
+
+  protected static final String FEMALE = "Female";
+  protected static final String MALE = "Male";
+  private static final String GRU = "Data is available for general research use. [GRU]";
+  private static final String DS = "Data use is limited for studying: %s [DS]";
+  private static final String HMB = "Data is limited for health/medical/biomedical research. [HMB]";
+  private static final String POA =
+      "Future use for population origins or ancestry research is prohibited. [POA]";
+  private static final String NMDS =
+      "Data use for methods development research ONLY within the bounds of other data use limitations. [NMDS]";
+  private static final String NCU = "Commercial use prohibited. [NCU]";
+  private static final String OTHER = "Other restrictions: %s.";
+  private static final String SECONDARY_OTHER = "Secondary other restrictions: %s.";
+  private static final String ETHICS_APPROVAL = "Local ethics committee approval is required.";
+  private static final String COLLABORATION_REQUIRED =
+      "Collaboration with the primary study investigators required. [COL]";
+  private static final String GEO_RESTRICTION = "Geographical restrictions: %s.";
+  private static final String GSO = "Future use is limited to genetic studies only [GSO]";
+  private static final String PUB_REQUIRED =
+      "Publishing results of studies using the data available to the larger scientific community is required";
+  private static final String PUB_MORATORIUM =
+      "Publishing moratorium until '%s' is in effect. [MOR]";
+  private static final String NCTRL =
+      "Future use as a control set for diseases other than those specified is prohibited. [NCTRL]";
+  private static final String RS_M = "Data use is limited to research on males. [RS-M]";
+  private static final String RS_FM = "Data use is limited to research on females. [RS-FM]";
+  private static final String RS_PD = "Data use is limited to pediatric research. [RS-PD]";
+  private static final String POP =
+      "Future use for study variation in the general population (e.g. calling variants and/or studying their distribution). [POP]";
+
+  private final OntologyService ontologyService;
+  private final Gson gson = GsonUtil.getInstance();
+
+  public TranslationUtil(OntologyService ontologyService) {
+    this.ontologyService = ontologyService;
+  }
+
+  public String translateDataset(String dataUseString) {
+    try {
+      DataUse dataUse = gson.fromJson(dataUseString, DataUse.class);
+      return translate(dataUse, DataUseTranslationType.DATASET);
+    } catch (Exception e) {
+      throw new IllegalArgumentException(
+          "Error translating: " + dataUseString + " - " + e.getMessage());
+    }
+  }
+
+  public String translatePurpose(String dataUseString) {
+    try {
+      DataUse dataUse = gson.fromJson(dataUseString, DataUse.class);
+      return translate(dataUse, DataUseTranslationType.PURPOSE);
+    } catch (Exception e) {
+      throw new IllegalArgumentException(
+          "Error translating: " + dataUseString + " - " + e.getMessage());
+    }
+  }
+
+  /**
+   * Generate a textual summary that consists of an ordered list of restrictions.
+   *
+   * @param dataUse The DataUse object
+   * @return Summary list of restrictions in string format
+   */
+  @SuppressWarnings(
+      "java:S3776") // Suppress warning for method complexity: due for reevaluation after initial
+  // migration
+  public String translate(DataUse dataUse, DataUseTranslationType translateFor) {
+    List<String> summary = new ArrayList<>();
+    if (translateFor.equals(DataUseTranslationType.DATASET)) {
+      summary.add("Samples are restricted for use under the following conditions:");
+    } else if (translateFor.equals(DataUseTranslationType.PURPOSE)) {
+      summary.add(
+          "Research is limited to samples restricted for use under the following conditions:");
+    }
+
+    if (dataUse == null) {
+      return String.join("\n", summary);
+    }
+    if (BooleanUtils.isTrue(dataUse.getGeneralUse())) {
+      summary.add(GRU);
+    }
+
+    if (dataUse.getDiseaseRestrictions() != null && !dataUse.getDiseaseRestrictions().isEmpty()) {
+      List<OntologyTerm> terms = findTermsByIds(dataUse.getDiseaseRestrictions());
+      List<String> labels = new ArrayList<>(terms.stream().map(OntologyTerm::label).toList());
+      if (!labels.isEmpty()) {
+        String dsRestrictions =
+            labels.stream()
+                .filter(Objects::nonNull)
+                .filter(r -> !r.isEmpty())
+                .collect(Collectors.joining(", "));
+        summary.add(String.format(DS, dsRestrictions));
+      }
+    }
+
+    if (BooleanUtils.isTrue(dataUse.getHmbResearch())) {
+      summary.add(HMB);
+    }
+
+    if (BooleanUtils.isTrue(dataUse.getPopulationOriginsAncestry())) {
+      summary.add(POA);
+    }
+
+    if (BooleanUtils.isTrue(dataUse.getMethodsResearch())) {
+      summary.add(NMDS);
+    }
+
+    if (BooleanUtils.isTrue(dataUse.getNonProfitUse())) {
+      summary.add(NCU);
+    }
+
+    if (StringUtils.isNotBlank(dataUse.getOther())) {
+      summary.add(String.format(OTHER, dataUse.getOther()));
+    }
+
+    if (StringUtils.isNotBlank(dataUse.getSecondaryOther())) {
+      summary.add(String.format(SECONDARY_OTHER, dataUse.getSecondaryOther()));
+    }
+
+    if (BooleanUtils.isTrue(dataUse.getEthicsApprovalRequired())) {
+      summary.add(ETHICS_APPROVAL);
+    }
+
+    if (BooleanUtils.isTrue(dataUse.getCollaboratorRequired())) {
+      summary.add(COLLABORATION_REQUIRED);
+    }
+
+    if (StringUtils.isNotBlank(dataUse.getGeographicalRestrictions())) {
+      summary.add(String.format(GEO_RESTRICTION, dataUse.getGeographicalRestrictions()));
+    }
+
+    if (BooleanUtils.isTrue(dataUse.getGeneticStudiesOnly())) {
+      summary.add(GSO);
+    }
+
+    if (BooleanUtils.isTrue(dataUse.getPublicationResults())) {
+      summary.add(PUB_REQUIRED);
+    }
+
+    if (StringUtils.isNotBlank(dataUse.getPublicationMoratorium())) {
+      summary.add(String.format(PUB_MORATORIUM, dataUse.getPublicationMoratorium()));
+    }
+
+    if (BooleanUtils.isTrue(dataUse.getControls())) {
+      summary.add(NCTRL);
+    }
+
+    if (Optional.ofNullable(dataUse.getGender()).orElse("na").equalsIgnoreCase(MALE)) {
+      summary.add(RS_M);
+    }
+
+    if (Optional.ofNullable(dataUse.getGender()).orElse("na").equalsIgnoreCase(FEMALE)) {
+      summary.add(RS_FM);
+    }
+
+    if (BooleanUtils.isTrue(dataUse.getPediatric())) {
+      summary.add(RS_PD);
+    }
+
+    if (BooleanUtils.isTrue(dataUse.getPopulation())) {
+      summary.add(POP);
+    }
+
+    return String.join("\n", summary);
+  }
+
+  private List<OntologyTerm> findTermsByIds(List<String> ids) {
+    try {
+      String[] idArray = ids.toArray(new String[0]);
+      StreamingOutput output = ontologyService.findByTermIds(idArray);
+      ByteArrayOutputStream baos = new ByteArrayOutputStream();
+      output.write(baos);
+      String jsonString = baos.toString(StandardCharsets.UTF_8);
+      return JsonParser.parseString(jsonString).getAsJsonArray().asList().stream()
+          .map(t -> gson.fromJson(t, OntologyTerm.class))
+          .toList();
+    } catch (IOException e) {
+      logException("Unable to retrieve term ids: " + String.join(", ", ids), e);
+      return List.of();
+    }
+  }
+}

--- a/src/main/java/org/broadinstitute/consent/http/service/OntologyService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/OntologyService.java
@@ -66,13 +66,10 @@ public class OntologyService implements ConsentLogger {
   }
 
   public String translateDataUse(DataUse dataUse, DataUseTranslationType type) {
-    if (type.equals(DataUseTranslationType.DATASET)) {
-      return translationUtil.translateDataset(dataUse.toString());
-    }
-    if (type.equals(DataUseTranslationType.PURPOSE)) {
-      return translationUtil.translatePurpose(dataUse.toString());
-    }
-    throw new IllegalArgumentException("Unsupported translation type: " + type);
+    return switch (type) {
+      case DATASET -> translationUtil.translateDataset(dataUse.toString());
+      case PURPOSE -> translationUtil.translatePurpose(dataUse.toString());
+    };
   }
 
   public void deleteOntologyTerms(OntologyType ontologyType) {

--- a/src/main/java/org/broadinstitute/consent/http/service/OntologyService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/OntologyService.java
@@ -66,10 +66,7 @@ public class OntologyService implements ConsentLogger {
   }
 
   public String translateDataUse(DataUse dataUse, DataUseTranslationType type) {
-    return switch (type) {
-      case DATASET -> translationUtil.translateDataset(dataUse.toString());
-      case PURPOSE -> translationUtil.translatePurpose(dataUse.toString());
-    };
+    return translationUtil.translate(dataUse, type);
   }
 
   public void deleteOntologyTerms(OntologyType ontologyType) {

--- a/src/main/java/org/broadinstitute/consent/http/service/OntologyService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/OntologyService.java
@@ -17,6 +17,7 @@ import java.util.concurrent.ExecutorService;
 import org.broadinstitute.consent.http.configurations.ServicesConfiguration;
 import org.broadinstitute.consent.http.enumeration.DataUseTranslationType;
 import org.broadinstitute.consent.http.enumeration.OntologyType;
+import org.broadinstitute.consent.http.matching.TranslationUtil;
 import org.broadinstitute.consent.http.models.DataUse;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.ontology.DataUseSummary;
@@ -35,6 +36,7 @@ public class OntologyService implements ConsentLogger {
   private final Client client;
   private final OntologyDAO ontologyDAO;
   private final OntologyIndexService indexService;
+  private final TranslationUtil translationUtil;
 
   @Inject
   public OntologyService(
@@ -46,6 +48,7 @@ public class OntologyService implements ConsentLogger {
     this.servicesConfiguration = config;
     this.ontologyDAO = ontologyDAO;
     this.indexService = indexService;
+    this.translationUtil = new TranslationUtil(ontologyDAO);
   }
 
   public DataUseSummary translateDataUseSummary(DataUse dataUse) {
@@ -63,20 +66,13 @@ public class OntologyService implements ConsentLogger {
   }
 
   public String translateDataUse(DataUse dataUse, DataUseTranslationType type) {
-    WebTarget target =
-        client.target(servicesConfiguration.getOntologyURL() + "translate?for=" + type.getValue());
-    try (Response response =
-        target.request(MediaType.TEXT_PLAIN).post(Entity.json(dataUse.toString()))) {
-      if (response.getStatus() == 200) {
-        return response.readEntity(String.class);
-      }
-
-      throw new RuntimeException(
-          "Error response from Ontology service: " + response.readEntity(String.class));
-    } catch (Exception e) {
-      logWarn("Error parsing response from Ontology service: " + e);
-      throw e;
+    if (type.equals(DataUseTranslationType.DATASET)) {
+      return translationUtil.translateDataset(dataUse.toString());
     }
+    if (type.equals(DataUseTranslationType.PURPOSE)) {
+      return translationUtil.translatePurpose(dataUse.toString());
+    }
+    throw new IllegalArgumentException("Unsupported translation type: " + type);
   }
 
   public void deleteOntologyTerms(OntologyType ontologyType) {

--- a/src/main/resources/assets/paths/datasetReprocessDataUse.yaml
+++ b/src/main/resources/assets/paths/datasetReprocessDataUse.yaml
@@ -1,6 +1,9 @@
 put:
-  summary: Admin Only API to sync the Dataset's Data Use with Ontology
-  description: This endpoint calls ontology with the dataset's DataUse and updates its `dataUseTranslation`
+  summary: Admin Only API to update a Dataset's Translated Data Use
+  description: | 
+    This endpoint allows an admin to update the translated data use for a dataset. This is used 
+    when the data use has changed and the dataset needs to be reprocessed to update the translated 
+    data use.
   parameters:
     - name: id
       in: path

--- a/src/test/java/org/broadinstitute/consent/http/matching/TranslationUtilTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/matching/TranslationUtilTest.java
@@ -2,13 +2,16 @@ package org.broadinstitute.consent.http.matching;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import com.google.gson.Gson;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import org.broadinstitute.consent.http.AbstractTestHelper;
+import org.broadinstitute.consent.http.enumeration.DataUseTranslationType;
 import org.broadinstitute.consent.http.models.DataUse;
 import org.broadinstitute.consent.http.models.DataUseBuilder;
 import org.broadinstitute.consent.http.service.OntologyService;
@@ -132,6 +135,33 @@ class TranslationUtilTest extends AbstractTestHelper {
     String translation = service.translatePurpose(datasetString);
     assertNotNull(translation);
     assertFalse(translation.contains("[GRU]"));
+  }
+
+  @Test
+  void tesTranslateDatasetInvalidJson() {
+    String invalidJson = "{invalid json}";
+    assertThrows(IllegalArgumentException.class, () -> service.translateDataset(invalidJson));
+  }
+
+  @Test
+  void tesTranslatePurposeInvalidJson() {
+    String invalidJson = "{invalid json}";
+    assertThrows(IllegalArgumentException.class, () -> service.translatePurpose(invalidJson));
+  }
+
+  @Test
+  void testTranslateNull() {
+    String translation = service.translate(null, DataUseTranslationType.DATASET);
+    assertNotNull(translation);
+  }
+
+  @Test
+  void testFindTermsByIdsError() {
+    when(ontologyService.findByTermIds(any()))
+        .thenThrow(new RuntimeException("Ontology service error"));
+    List<OntologyTerm> terms = service.findTermsByIds(List.of("DOID_1"));
+    assertNotNull(terms);
+    assertTrue(terms.isEmpty());
   }
 
   private OntologyTerm initializeDiseaseTerm() {

--- a/src/test/java/org/broadinstitute/consent/http/matching/TranslationUtilTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/matching/TranslationUtilTest.java
@@ -2,12 +2,10 @@ package org.broadinstitute.consent.http.matching;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
-import com.google.gson.Gson;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import org.broadinstitute.consent.http.AbstractTestHelper;
@@ -29,7 +27,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class TranslationUtilTest extends AbstractTestHelper {
 
   private TranslationUtil service;
-  private final Gson gson = GsonUtil.getInstance();
 
   @Mock private OntologyDAO ontologyDAO;
 
@@ -42,8 +39,7 @@ class TranslationUtilTest extends AbstractTestHelper {
   void testDiseaseLookup() {
     OntologyTerm term = initializeDiseaseTerm();
     DataUse dataUse = new DataUseBuilder().setDiseaseRestrictions(List.of(term.id())).build();
-    String dataUseJson = gson.toJson(dataUse);
-    String translation = service.translateDataset(dataUseJson);
+    String translation = service.translate(dataUse, DataUseTranslationType.DATASET);
     assertNotNull(translation);
     assertTrue(translation.contains(term.label()));
     assertTrue(translation.contains("[DS]"));
@@ -52,8 +48,7 @@ class TranslationUtilTest extends AbstractTestHelper {
   @Test
   void testTranslateDataset() {
     DataUse dataUse = new DataUseBuilder().setGeneralUse(true).build();
-    String datasetString = gson.toJson(dataUse);
-    String translation = service.translateDataset(datasetString);
+    String translation = service.translate(dataUse, DataUseTranslationType.DATASET);
     assertNotNull(translation);
     assertTrue(translation.contains(TranslationUtil.DATASET_HEADER));
     assertTrue(translation.contains("[GRU]"));
@@ -62,8 +57,7 @@ class TranslationUtilTest extends AbstractTestHelper {
   @Test
   void testTranslatePurpose() {
     DataUse dataUse = new DataUseBuilder().setGeneralUse(true).build();
-    String datasetString = gson.toJson(dataUse);
-    String translation = service.translatePurpose(datasetString);
+    String translation = service.translate(dataUse, DataUseTranslationType.PURPOSE);
     assertNotNull(translation);
     assertTrue(translation.contains(TranslationUtil.PURPOSE_HEADER));
     assertTrue(translation.contains("[GRU]"));
@@ -99,8 +93,7 @@ class TranslationUtilTest extends AbstractTestHelper {
             .setStigmatizeDiseases(true)
             .setVulnerablePopulations(true)
             .build();
-    String datasetString = gson.toJson(dataUse);
-    String translation = service.translatePurpose(datasetString);
+    String translation = service.translate(dataUse, DataUseTranslationType.PURPOSE);
     assertNotNull(translation);
     assertTrue(translation.contains("[GRU]"));
   }
@@ -135,22 +128,9 @@ class TranslationUtilTest extends AbstractTestHelper {
             .setStigmatizeDiseases(false)
             .setVulnerablePopulations(false)
             .build();
-    String datasetString = gson.toJson(dataUse);
-    String translation = service.translatePurpose(datasetString);
+    String translation = service.translate(dataUse, DataUseTranslationType.PURPOSE);
     assertNotNull(translation);
     assertFalse(translation.contains("[GRU]"));
-  }
-
-  @Test
-  void tesTranslateDatasetInvalidJson() {
-    String invalidJson = "{invalid json}";
-    assertThrows(IllegalArgumentException.class, () -> service.translateDataset(invalidJson));
-  }
-
-  @Test
-  void tesTranslatePurposeInvalidJson() {
-    String invalidJson = "{invalid json}";
-    assertThrows(IllegalArgumentException.class, () -> service.translatePurpose(invalidJson));
   }
 
   @ParameterizedTest

--- a/src/test/java/org/broadinstitute/consent/http/matching/TranslationUtilTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/matching/TranslationUtilTest.java
@@ -2,6 +2,7 @@ package org.broadinstitute.consent.http.matching;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
@@ -165,6 +166,12 @@ class TranslationUtilTest extends AbstractTestHelper {
     List<OntologyTerm> terms = service.findTermsByIds(List.of("DOID_1"));
     assertNotNull(terms);
     assertTrue(terms.isEmpty());
+  }
+
+  @Test
+  void testTranslateNullType() {
+    DataUse dataUse = new DataUseBuilder().setGeneralUse(false).build();
+    assertThrows(IllegalArgumentException.class, () -> service.translate(dataUse, null));
   }
 
   private OntologyTerm initializeDiseaseTerm() {

--- a/src/test/java/org/broadinstitute/consent/http/matching/TranslationUtilTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/matching/TranslationUtilTest.java
@@ -31,8 +31,7 @@ class TranslationUtilTest extends AbstractTestHelper {
   private TranslationUtil service;
   private final Gson gson = GsonUtil.getInstance();
 
-  @Mock
-  private OntologyDAO ontologyDAO;
+  @Mock private OntologyDAO ontologyDAO;
 
   @BeforeEach
   void setUpClass() {
@@ -194,7 +193,7 @@ class TranslationUtilTest extends AbstractTestHelper {
     // Label is the value we use for a disease translation.
     term.setLabel(term.id());
     String json = GsonUtil.getInstance().toJson(List.of(term));
-    when(ontologyDAO.findByTermIds(new String[]{term.id()}))
+    when(ontologyDAO.findByTermIds(new String[] {term.id()}))
         .thenReturn(output -> output.write(json.getBytes(StandardCharsets.UTF_8)));
     return term;
   }

--- a/src/test/java/org/broadinstitute/consent/http/matching/TranslationUtilTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/matching/TranslationUtilTest.java
@@ -20,6 +20,8 @@ import org.broadinstitute.consent.http.util.gson.GsonUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -29,7 +31,8 @@ class TranslationUtilTest extends AbstractTestHelper {
   private TranslationUtil service;
   private final Gson gson = GsonUtil.getInstance();
 
-  @Mock private OntologyDAO ontologyDAO;
+  @Mock
+  private OntologyDAO ontologyDAO;
 
   @BeforeEach
   void setUpClass() {
@@ -49,26 +52,28 @@ class TranslationUtilTest extends AbstractTestHelper {
 
   @Test
   void testTranslateDataset() {
-    DataUse dataset = new DataUseBuilder().setGeneralUse(true).build();
-    String datasetString = gson.toJson(dataset);
+    DataUse dataUse = new DataUseBuilder().setGeneralUse(true).build();
+    String datasetString = gson.toJson(dataUse);
     String translation = service.translateDataset(datasetString);
     assertNotNull(translation);
+    assertTrue(translation.contains(TranslationUtil.DATASET_HEADER));
     assertTrue(translation.contains("[GRU]"));
   }
 
   @Test
   void testTranslatePurpose() {
-    DataUse dataset = new DataUseBuilder().setGeneralUse(true).build();
-    String datasetString = gson.toJson(dataset);
+    DataUse dataUse = new DataUseBuilder().setGeneralUse(true).build();
+    String datasetString = gson.toJson(dataUse);
     String translation = service.translatePurpose(datasetString);
     assertNotNull(translation);
+    assertTrue(translation.contains(TranslationUtil.PURPOSE_HEADER));
     assertTrue(translation.contains("[GRU]"));
   }
 
   @Test
   void testTranslateCoverageTrue() {
     OntologyTerm term = initializeDiseaseTerm();
-    DataUse dataset =
+    DataUse dataUse =
         new DataUseBuilder()
             .setGeneralUse(true)
             .setHmbResearch(true)
@@ -95,7 +100,7 @@ class TranslationUtilTest extends AbstractTestHelper {
             .setStigmatizeDiseases(true)
             .setVulnerablePopulations(true)
             .build();
-    String datasetString = gson.toJson(dataset);
+    String datasetString = gson.toJson(dataUse);
     String translation = service.translatePurpose(datasetString);
     assertNotNull(translation);
     assertTrue(translation.contains("[GRU]"));
@@ -104,7 +109,7 @@ class TranslationUtilTest extends AbstractTestHelper {
   @Test
   void testTranslateCoverageFalse() {
     OntologyTerm term = initializeDiseaseTerm();
-    DataUse dataset =
+    DataUse dataUse =
         new DataUseBuilder()
             .setGeneralUse(false)
             .setHmbResearch(false)
@@ -131,7 +136,7 @@ class TranslationUtilTest extends AbstractTestHelper {
             .setStigmatizeDiseases(false)
             .setVulnerablePopulations(false)
             .build();
-    String datasetString = gson.toJson(dataset);
+    String datasetString = gson.toJson(dataUse);
     String translation = service.translatePurpose(datasetString);
     assertNotNull(translation);
     assertFalse(translation.contains("[GRU]"));
@@ -149,9 +154,28 @@ class TranslationUtilTest extends AbstractTestHelper {
     assertThrows(IllegalArgumentException.class, () -> service.translatePurpose(invalidJson));
   }
 
-  @Test
-  void testTranslateNull() {
-    String translation = service.translate(null, DataUseTranslationType.DATASET);
+  @ParameterizedTest
+  @EnumSource(DataUseTranslationType.class)
+  void testTranslateNullDataUse(DataUseTranslationType type) {
+    String translation = service.translate(null, type);
+    assertNotNull(translation);
+  }
+
+  @ParameterizedTest
+  @EnumSource(DataUseTranslationType.class)
+  void testTranslateNullDiseases(DataUseTranslationType type) {
+    DataUse dataUse = new DataUseBuilder().setGeneralUse(false).build();
+    dataUse.setDiseaseRestrictions(null);
+    String translation = service.translate(dataUse, type);
+    assertNotNull(translation);
+  }
+
+  @ParameterizedTest
+  @EnumSource(DataUseTranslationType.class)
+  void testTranslateEmptyDiseases(DataUseTranslationType type) {
+    DataUse dataUse = new DataUseBuilder().setGeneralUse(false).build();
+    dataUse.setDiseaseRestrictions(List.of());
+    String translation = service.translate(dataUse, type);
     assertNotNull(translation);
   }
 
@@ -170,7 +194,7 @@ class TranslationUtilTest extends AbstractTestHelper {
     // Label is the value we use for a disease translation.
     term.setLabel(term.id());
     String json = GsonUtil.getInstance().toJson(List.of(term));
-    when(ontologyDAO.findByTermIds(new String[] {term.id()}))
+    when(ontologyDAO.findByTermIds(new String[]{term.id()}))
         .thenReturn(output -> output.write(json.getBytes(StandardCharsets.UTF_8)));
     return term;
   }

--- a/src/test/java/org/broadinstitute/consent/http/matching/TranslationUtilTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/matching/TranslationUtilTest.java
@@ -14,7 +14,7 @@ import org.broadinstitute.consent.http.AbstractTestHelper;
 import org.broadinstitute.consent.http.enumeration.DataUseTranslationType;
 import org.broadinstitute.consent.http.models.DataUse;
 import org.broadinstitute.consent.http.models.DataUseBuilder;
-import org.broadinstitute.consent.http.service.OntologyService;
+import org.broadinstitute.consent.http.service.ontology.OntologyDAO;
 import org.broadinstitute.consent.http.service.ontology.OntologyTerm;
 import org.broadinstitute.consent.http.util.gson.GsonUtil;
 import org.junit.jupiter.api.BeforeEach;
@@ -29,11 +29,11 @@ class TranslationUtilTest extends AbstractTestHelper {
   private TranslationUtil service;
   private final Gson gson = GsonUtil.getInstance();
 
-  @Mock private OntologyService ontologyService;
+  @Mock private OntologyDAO ontologyDAO;
 
   @BeforeEach
   void setUpClass() {
-    service = new TranslationUtil(ontologyService);
+    service = new TranslationUtil(ontologyDAO);
   }
 
   @Test
@@ -157,7 +157,7 @@ class TranslationUtilTest extends AbstractTestHelper {
 
   @Test
   void testFindTermsByIdsError() {
-    when(ontologyService.findByTermIds(any()))
+    when(ontologyDAO.findByTermIds(any()))
         .thenThrow(new RuntimeException("Ontology service error"));
     List<OntologyTerm> terms = service.findTermsByIds(List.of("DOID_1"));
     assertNotNull(terms);
@@ -170,7 +170,7 @@ class TranslationUtilTest extends AbstractTestHelper {
     // Label is the value we use for a disease translation.
     term.setLabel(term.id());
     String json = GsonUtil.getInstance().toJson(List.of(term));
-    when(ontologyService.findByTermIds(new String[] {term.id()}))
+    when(ontologyDAO.findByTermIds(new String[] {term.id()}))
         .thenReturn(output -> output.write(json.getBytes(StandardCharsets.UTF_8)));
     return term;
   }

--- a/src/test/java/org/broadinstitute/consent/http/matching/TranslationUtilTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/matching/TranslationUtilTest.java
@@ -1,0 +1,147 @@
+package org.broadinstitute.consent.http.matching;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import com.google.gson.Gson;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import org.broadinstitute.consent.http.AbstractTestHelper;
+import org.broadinstitute.consent.http.models.DataUse;
+import org.broadinstitute.consent.http.models.DataUseBuilder;
+import org.broadinstitute.consent.http.service.OntologyService;
+import org.broadinstitute.consent.http.service.ontology.OntologyTerm;
+import org.broadinstitute.consent.http.util.gson.GsonUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class TranslationUtilTest extends AbstractTestHelper {
+
+  private TranslationUtil service;
+  private final Gson gson = GsonUtil.getInstance();
+
+  @Mock private OntologyService ontologyService;
+
+  @BeforeEach
+  void setUpClass() {
+    service = new TranslationUtil(ontologyService);
+  }
+
+  @Test
+  void testDiseaseLookup() {
+    OntologyTerm term = initializeDiseaseTerm();
+    DataUse dataUse = new DataUseBuilder().setDiseaseRestrictions(List.of(term.id())).build();
+    String dataUseJson = gson.toJson(dataUse);
+    String translation = service.translateDataset(dataUseJson);
+    assertNotNull(translation);
+    assertTrue(translation.contains(term.label()));
+    assertTrue(translation.contains("[DS]"));
+  }
+
+  @Test
+  void testTranslateDataset() {
+    DataUse dataset = new DataUseBuilder().setGeneralUse(true).build();
+    String datasetString = gson.toJson(dataset);
+    String translation = service.translateDataset(datasetString);
+    assertNotNull(translation);
+    assertTrue(translation.contains("[GRU]"));
+  }
+
+  @Test
+  void testTranslatePurpose() {
+    DataUse dataset = new DataUseBuilder().setGeneralUse(true).build();
+    String datasetString = gson.toJson(dataset);
+    String translation = service.translatePurpose(datasetString);
+    assertNotNull(translation);
+    assertTrue(translation.contains("[GRU]"));
+  }
+
+  @Test
+  void testTranslateCoverageTrue() {
+    OntologyTerm term = initializeDiseaseTerm();
+    DataUse dataset =
+        new DataUseBuilder()
+            .setGeneralUse(true)
+            .setHmbResearch(true)
+            .setDiseaseRestrictions(List.of(term.id()))
+            .setMethodsResearch(true)
+            .setControl(true)
+            .setNonProfitUse(true)
+            .setGender(TranslationUtil.MALE)
+            .setPediatric(true)
+            .setEthicsApprovalRequired(true)
+            .setCollaboratorRequired(true)
+            .setIllegalBehavior(true)
+            .setNotHealth(true)
+            .setOther("Other")
+            .setSecondaryOther("Secondary other")
+            .setGeographicalRestrictions("Geographical restriction")
+            .setGeneticStudiesOnly(true)
+            .setPublicationResults(true)
+            .setPublicationMoratorium("2025-01-01")
+            .setPopulationOriginsAncestry(true)
+            .setPopulation(true)
+            .setPsychologicalTraits(true)
+            .setSexualDiseases(true)
+            .setStigmatizeDiseases(true)
+            .setVulnerablePopulations(true)
+            .build();
+    String datasetString = gson.toJson(dataset);
+    String translation = service.translatePurpose(datasetString);
+    assertNotNull(translation);
+    assertTrue(translation.contains("[GRU]"));
+  }
+
+  @Test
+  void testTranslateCoverageFalse() {
+    OntologyTerm term = initializeDiseaseTerm();
+    DataUse dataset =
+        new DataUseBuilder()
+            .setGeneralUse(false)
+            .setHmbResearch(false)
+            .setDiseaseRestrictions(List.of(term.id()))
+            .setMethodsResearch(false)
+            .setControl(true)
+            .setNonProfitUse(false)
+            .setGender(TranslationUtil.FEMALE)
+            .setPediatric(false)
+            .setEthicsApprovalRequired(false)
+            .setCollaboratorRequired(false)
+            .setIllegalBehavior(false)
+            .setNotHealth(false)
+            .setOther("Other")
+            .setSecondaryOther("Secondary other")
+            .setGeographicalRestrictions("Geographical restriction")
+            .setGeneticStudiesOnly(false)
+            .setPublicationResults(false)
+            .setPublicationMoratorium("2025-01-01")
+            .setPopulationOriginsAncestry(false)
+            .setPopulation(false)
+            .setPsychologicalTraits(false)
+            .setSexualDiseases(false)
+            .setStigmatizeDiseases(false)
+            .setVulnerablePopulations(false)
+            .build();
+    String datasetString = gson.toJson(dataset);
+    String translation = service.translatePurpose(datasetString);
+    assertNotNull(translation);
+    assertFalse(translation.contains("[GRU]"));
+  }
+
+  private OntologyTerm initializeDiseaseTerm() {
+    OntologyTerm term =
+        new OntologyTerm("DOID_" + randomInt(1, 100), "term label", "term definition");
+    // Label is the value we use for a disease translation.
+    term.setLabel(term.id());
+    String json = GsonUtil.getInstance().toJson(List.of(term));
+    when(ontologyService.findByTermIds(new String[] {term.id()}))
+        .thenReturn(output -> output.write(json.getBytes(StandardCharsets.UTF_8)));
+    return term;
+  }
+}

--- a/src/test/java/org/broadinstitute/consent/http/service/OntologyServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/OntologyServiceTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
@@ -176,6 +177,12 @@ class OntologyServiceTest extends MockServerTestHelper {
     }
     assertTrue(translation.contains(HMB));
     assertFalse(translation.contains(DS.formatted("")));
+  }
+
+  @Test
+  void testTranslateNullType() {
+    DataUse dataUse = new DataUseBuilder().setGeneralUse(false).build();
+    assertThrows(IllegalArgumentException.class, () -> service.translateDataUse(dataUse, null));
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/OntologyServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/OntologyServiceTest.java
@@ -32,6 +32,7 @@ import org.broadinstitute.consent.http.MockServerTestHelper;
 import org.broadinstitute.consent.http.configurations.ServicesConfiguration;
 import org.broadinstitute.consent.http.enumeration.DataUseTranslationType;
 import org.broadinstitute.consent.http.enumeration.OntologyType;
+import org.broadinstitute.consent.http.matching.TranslationUtil;
 import org.broadinstitute.consent.http.models.DataUse;
 import org.broadinstitute.consent.http.models.DataUseBuilder;
 import org.broadinstitute.consent.http.models.User;
@@ -151,14 +152,9 @@ class OntologyServiceTest extends MockServerTestHelper {
 
     String translation = service.translateDataUse(dataUse, type);
     assertNotNull(translation);
-    if (type == DataUseTranslationType.DATASET) {
-      assertTrue(
-          translation.contains("Samples are restricted for use under the following conditions:"));
-    }
-    if (type == DataUseTranslationType.PURPOSE) {
-      assertTrue(
-          translation.contains(
-              "Research is limited to samples restricted for use under the following conditions:"));
+    switch (type) {
+      case DATASET -> assertTrue(translation.contains(TranslationUtil.DATASET_HEADER));
+      case PURPOSE -> assertTrue(translation.contains(TranslationUtil.PURPOSE_HEADER));
     }
     assertTrue(translation.contains(HMB));
     assertTrue(translation.contains(DS.formatted(term.label())));
@@ -174,17 +170,12 @@ class OntologyServiceTest extends MockServerTestHelper {
 
     String translation = service.translateDataUse(dataUse, type);
     assertNotNull(translation);
-    if (type == DataUseTranslationType.DATASET) {
-      assertTrue(
-          translation.contains("Samples are restricted for use under the following conditions:"));
+    switch (type) {
+      case DATASET -> assertTrue(translation.contains(TranslationUtil.DATASET_HEADER));
+      case PURPOSE -> assertTrue(translation.contains(TranslationUtil.PURPOSE_HEADER));
     }
-    if (type == DataUseTranslationType.PURPOSE) {
-      assertTrue(
-          translation.contains(
-              "Research is limited to samples restricted for use under the following conditions:"));
-      assertTrue(translation.contains(HMB));
-      assertFalse(translation.contains(DS.formatted("")));
-    }
+    assertTrue(translation.contains(HMB));
+    assertFalse(translation.contains(DS.formatted("")));
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/OntologyServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/OntologyServiceTest.java
@@ -1,5 +1,7 @@
 package org.broadinstitute.consent.http.service;
 
+import static org.broadinstitute.consent.http.matching.TranslationUtil.DS;
+import static org.broadinstitute.consent.http.matching.TranslationUtil.HMB;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -7,7 +9,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 import static org.mockserver.model.HttpRequest.request;
@@ -17,6 +20,7 @@ import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.spi.ILoggingEvent;
+import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.client.ClientBuilder;
@@ -34,10 +38,14 @@ import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.ontology.DataUseSummary;
 import org.broadinstitute.consent.http.service.ontology.OntologyDAO;
 import org.broadinstitute.consent.http.service.ontology.OntologyIndexService;
+import org.broadinstitute.consent.http.service.ontology.OntologyTerm;
 import org.broadinstitute.consent.http.util.TestAppender;
+import org.broadinstitute.consent.http.util.gson.GsonUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockserver.model.Header;
@@ -48,6 +56,7 @@ class OntologyServiceTest extends MockServerTestHelper {
 
   private OntologyService service;
   private TestAppender testAppender;
+  private final Gson gson = GsonUtil.getInstance();
   @Mock private OntologyDAO ontologyDAO;
   @Mock private OntologyIndexService indexService;
 
@@ -126,48 +135,56 @@ class OntologyServiceTest extends MockServerTestHelper {
         containsString("Error parsing response from Ontology service:"));
   }
 
-  @Test
-  void testTranslateDataUse() {
-    mockDataUseTranslateSuccess();
-
+  @ParameterizedTest
+  @EnumSource(DataUseTranslationType.class)
+  void testTranslateDataUse(DataUseTranslationType type) {
+    OntologyTerm term = new OntologyTerm("DOID_1", "v1", "DOID");
+    term.setLabel("cancerophobia");
     DataUse dataUse =
-        new DataUseBuilder().setHmbResearch(true).setDiseaseRestrictions(List.of("")).build();
-    String translation = service.translateDataUse(dataUse, DataUseTranslationType.DATASET);
+        new DataUseBuilder()
+            .setHmbResearch(true)
+            .setDiseaseRestrictions(List.of(term.id()))
+            .build();
+    String responseJson = gson.toJson(List.of(term));
+    when(ontologyDAO.findByTermIds(new String[] {term.id()}))
+        .thenReturn(output -> output.write(responseJson.getBytes(StandardCharsets.UTF_8)));
 
-    assertEquals(
-        """
-            Samples are restricted for use under the following conditions:
-            Data is limited for health/medical/biomedical research. [HMB]
-            Data use is limited for studying: cancerophobia [DS]
-            Commercial use is not prohibited.
-            Data use for methods development research irrespective of the specified data use limitations is not prohibited.
-            Restrictions for use as a control set for diseases other than those defined were not specified.
-            """,
-        translation);
+    String translation = service.translateDataUse(dataUse, type);
+    assertNotNull(translation);
+    if (type == DataUseTranslationType.DATASET) {
+      assertTrue(
+          translation.contains("Samples are restricted for use under the following conditions:"));
+    }
+    if (type == DataUseTranslationType.PURPOSE) {
+      assertTrue(
+          translation.contains(
+              "Research is limited to samples restricted for use under the following conditions:"));
+    }
+    assertTrue(translation.contains(HMB));
+    assertTrue(translation.contains(DS.formatted(term.label())));
   }
 
-  @Test
-  void testTranslateDataUseError() {
-    mockServerClient
-        .when(request().withMethod("POST").withPath("/translate"))
-        .respond(
-            response()
-                .withStatusCode(500)
-                .withHeaders(new Header("Content-Type", MediaType.TEXT_PLAIN))
-                .withBody("Internal Server Error"));
-
+  @ParameterizedTest
+  @EnumSource(DataUseTranslationType.class)
+  void testTranslateDataUseOntologyError(DataUseTranslationType type) {
     DataUse dataUse =
         new DataUseBuilder().setHmbResearch(true).setDiseaseRestrictions(List.of("")).build();
+    when(ontologyDAO.findByTermIds(any()))
+        .thenThrow(new RuntimeException("Ontology service error"));
 
-    Exception exception =
-        assertThrows(
-            RuntimeException.class,
-            () -> service.translateDataUse(dataUse, DataUseTranslationType.DATASET));
-
-    String expectedMessage = "Error response from Ontology service: Internal Server Error";
-    String actualMessage = exception.getMessage();
-
-    assertEquals(expectedMessage, actualMessage);
+    String translation = service.translateDataUse(dataUse, type);
+    assertNotNull(translation);
+    if (type == DataUseTranslationType.DATASET) {
+      assertTrue(
+          translation.contains("Samples are restricted for use under the following conditions:"));
+    }
+    if (type == DataUseTranslationType.PURPOSE) {
+      assertTrue(
+          translation.contains(
+              "Research is limited to samples restricted for use under the following conditions:"));
+      assertTrue(translation.contains(HMB));
+      assertFalse(translation.contains(DS.formatted("")));
+    }
   }
 
   @Test
@@ -271,24 +288,6 @@ class OntologyServiceTest extends MockServerTestHelper {
                             }
                           ]
                         }
-                        """));
-  }
-
-  private void mockDataUseTranslateSuccess() {
-    mockServerClient
-        .when(request().withMethod("POST").withPath("/translate"))
-        .respond(
-            response()
-                .withStatusCode(200)
-                .withHeaders(new Header("Content-Type", MediaType.TEXT_PLAIN))
-                .withBody(
-                    """
-                        Samples are restricted for use under the following conditions:
-                        Data is limited for health/medical/biomedical research. [HMB]
-                        Data use is limited for studying: cancerophobia [DS]
-                        Commercial use is not prohibited.
-                        Data use for methods development research irrespective of the specified data use limitations is not prohibited.
-                        Restrictions for use as a control set for diseases other than those defined were not specified.
                         """));
   }
 }


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DT-2531

## Summary
This PR replicates the current [Ontology Translate](https://consent-ontology.dsde-prod.broadinstitute.org/#/Translate/post_translate) functionality internally to Consent. Usages of this feature described in the Testing section. There is an additional translation feature, `/translate/summary` that will be addressed in a separate ticket. 

### TranslationUtil
This class is a partial copy of [`TextTranslationServiceImpl`](https://github.com/DataBiosphere/consent-ontology/blob/3c0c70804f692424733d8725d23596107fb1a64a/src/main/java/org/broadinstitute/dsde/consent/ontology/datause/services/TextTranslationServiceImpl.java). The functions brought over are:
1. [`translate`](https://github.com/DataBiosphere/consent-ontology/blob/3c0c70804f692424733d8725d23596107fb1a64a/src/main/java/org/broadinstitute/dsde/consent/ontology/datause/services/TextTranslationServiceImpl.java#L269C17-L269C26)
2. [`translatePurpose`](https://github.com/DataBiosphere/consent-ontology/blob/3c0c70804f692424733d8725d23596107fb1a64a/src/main/java/org/broadinstitute/dsde/consent/ontology/datause/services/TextTranslationServiceImpl.java#L117C17-L117C33) is fully replaced by `translate`
3. [`translateDataset`](https://github.com/DataBiosphere/consent-ontology/blob/3c0c70804f692424733d8725d23596107fb1a64a/src/main/java/org/broadinstitute/dsde/consent/ontology/datause/services/TextTranslationServiceImpl.java#L76C17-L76C33) is fully replaced by `translate`

There are some `DataUse` conditions in current Consent code that are NOT covered in this code. New tickets will be generated for that work.

### TranslationUtilTest
This class is a partial copy of [`TextTranslationServiceImplTest`](https://github.com/DataBiosphere/consent-ontology/blob/3c0c70804f692424733d8725d23596107fb1a64a/src/test/java/org/broadinstitute/dsde/consent/ontology/datause/services/TextTranslationServiceImplTest.java#L38). There are some additional tests to cover cases not originally covered, but all existing logic tests are mostly unchanged aside from minor syntax and variable updates.

### Testing
This code path can be tested in these ways:
- Update a dataset's data use via the Admin API: `/api/dataset/{id}/datause`
  - Then reprocess the dataset's data use via the admin API: `/api/dataset/{id}/reprocess/datause`. Note that this is no longer calling Ontology as the original swagger docs suggest. It should be slated for removal once `/api/dataset/{id}/datause` is updated to handle the translation.
- Convert a dataset to a study via the Admin API: `/api/dataset/study/convert/{datasetIdentifier}`

### TODO
The following work is has been uncovered during this migration:
* New ticket to determine translation handling the following `DataUse` cases:
  * `aiLlmUse`
  * `illegalBehavior`
  * `sexualDiseases`
  * `stigmatizeDiseases`
  * `vulnerablePopulations`
  * `psychologicalTraits`
  * `notHealth`
* The `DatasetService.updateDatasetDataUse` code path does NOT update the `translated_data_use` field when updating a dataset's `DataUse` object. This code path should be updated to ensure all data use related values are updated accordingly.
* Remove `/api/dataset/{id}/reprocess/datause` API once `DatasetService.updateDatasetDataUse` is fixed.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
