### PR TITLE
[DT-2958] Do not require data location on update.

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/models/dataset_registration_v1/DatasetRegistrationSchemaV1UpdateValidator.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/dataset_registration_v1/DatasetRegistrationSchemaV1UpdateValidator.java
@@ -172,15 +172,6 @@ public class DatasetRegistrationSchemaV1UpdateValidator {
       throw new BadRequestException("Invalid Name changes to existing Consent Groups");
     }
 
-    // Data Location required for all consent groups
-    List<ConsentGroup> missingDataLocationConsentGroups =
-        registration.getConsentGroups().stream()
-            .filter(cg -> Objects.isNull(cg.getDataLocation()))
-            .toList();
-    if (!missingDataLocationConsentGroups.isEmpty()) {
-      throw new BadRequestException("Missing Data Location for Consent Groups");
-    }
-
     // Validate that we're not trying to delete any datasets in the registration payload.
     // The list of non-null dataset ids in the consent groups MUST be the same as the list of
     // existing dataset ids.

--- a/src/test/java/org/broadinstitute/consent/http/models/dataset_registration_v1/DatasetRegistrationSchemaV1UpdateValidatorTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/dataset_registration_v1/DatasetRegistrationSchemaV1UpdateValidatorTest.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.consent.http.models.dataset_registration_v1;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -296,8 +297,7 @@ class DatasetRegistrationSchemaV1UpdateValidatorTest {
               cg.setDataLocation(null);
             });
 
-    assertThrows(
-        BadRequestException.class,
+    assertDoesNotThrow(
         () -> {
           validator.validate(study, registration);
         });

--- a/src/test/java/org/broadinstitute/consent/http/models/dataset_registration_v1/DatasetRegistrationSchemaV1UpdateValidatorTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/dataset_registration_v1/DatasetRegistrationSchemaV1UpdateValidatorTest.java
@@ -287,7 +287,7 @@ class DatasetRegistrationSchemaV1UpdateValidatorTest {
   }
 
   @Test
-  void testValidation_consent_group_data_location_required() {
+  void testValidation_consent_group_data_not_required() {
     Study study = createMockStudy();
     DatasetRegistrationSchemaV1 registration = createMockRegistration(study);
     registration


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-2958](https://broadworkbench.atlassian.net/browse/DT-2958)

### Summary

Data locations are no longer required in the front end, but the backend was still requiring a value to be present in an update.  This removes the backend requirement that an update include a data location.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
