### PR TITLE
DT-2959: Consolidate dataset data use updates to a single transaction

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
@@ -428,11 +428,6 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
   @SqlUpdate("UPDATE dataset SET dac_id = :dacId WHERE dataset_id = :datasetId")
   void updateDatasetDacId(@Bind("datasetId") Integer datasetId, @Bind("dacId") Integer dacId);
 
-  @SqlUpdate(
-      "UPDATE dataset SET translated_data_use = :translatedDataUse WHERE dataset_id = :datasetId")
-  void updateDatasetTranslatedDataUse(
-      @Bind("datasetId") Integer datasetId, @Bind("translatedDataUse") String translatedDataUse);
-
   @SqlUpdate("UPDATE dataset SET name = :name WHERE dataset_id = :datasetId")
   void updateDatasetName(@Bind("datasetId") Integer datasetId, @Bind("name") String name);
 
@@ -514,10 +509,17 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
   @SqlUpdate(
       """
       UPDATE dataset
-      SET data_use = :dataUse
+      SET data_use = :dataUse,
+          translated_data_use = :translation,
+          update_date = current_timestamp,
+          update_user_id = :updateUserId
       WHERE dataset_id = :datasetId
       """)
-  void updateDatasetDataUse(@Bind("datasetId") Integer datasetId, @Bind("dataUse") String dataUse);
+  void updateDatasetDataUse(
+      @Bind("datasetId") Integer datasetId,
+      @Bind("dataUse") String dataUse,
+      @Bind("translation") String translation,
+      @Bind("updateUserId") Integer updateUserId);
 
   @SqlUpdate(
       """

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -402,8 +402,7 @@ public class DatasetService implements ConsentLogger {
 
   public List<ApprovedDataset> getApprovedDatasets(User user) {
     try {
-      List<ApprovedDataset> approvedDatasets = datasetDAO.getApprovedDatasets(user.getUserId());
-      return approvedDatasets;
+      return datasetDAO.getApprovedDatasets(user.getUserId());
     } catch (Exception e) {
       logException(e);
       throw e;

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -266,7 +266,8 @@ public class DatasetService implements ConsentLogger {
     if (!user.hasUserRole(UserRoles.ADMIN)) {
       throw new IllegalArgumentException("Admin use only");
     }
-    datasetDAO.updateDatasetDataUse(datasetId, dataUse.toString());
+    String translation = ontologyService.translateDataUse(dataUse, DataUseTranslationType.DATASET);
+    datasetServiceDAO.updateDatasetDataUse(user, d, dataUse, translation);
     elasticSearchService.synchronizeDatasetInESIndex(d, user, false);
     return datasetDAO.findDatasetById(datasetId);
   }
@@ -279,7 +280,7 @@ public class DatasetService implements ConsentLogger {
 
     String translation =
         ontologyService.translateDataUse(dataset.getDataUse(), DataUseTranslationType.DATASET);
-    datasetDAO.updateDatasetTranslatedDataUse(datasetId, translation);
+    datasetServiceDAO.updateDatasetDataUse(user, dataset, dataset.getDataUse(), translation);
     elasticSearchService.synchronizeDatasetInESIndex(dataset, user, false);
     return datasetDAO.findDatasetById(datasetId);
   }
@@ -429,14 +430,11 @@ public class DatasetService implements ConsentLogger {
       datasetDAO.updateDatasetDacId(dataset.getDatasetId(), studyConversion.getDacId());
     }
     if (studyConversion.getDataUse() != null) {
-      datasetDAO.updateDatasetDataUse(
-          dataset.getDatasetId(), studyConversion.getDataUse().toString());
-    }
-    if (studyConversion.getDataUse() != null) {
       String translation =
           ontologyService.translateDataUse(
               studyConversion.getDataUse(), DataUseTranslationType.DATASET);
-      datasetDAO.updateDatasetTranslatedDataUse(dataset.getDatasetId(), translation);
+      datasetServiceDAO.updateDatasetDataUse(
+          user, dataset, studyConversion.getDataUse(), translation);
     }
     if (studyConversion.getDatasetName() != null) {
       datasetDAO.updateDatasetName(dataset.getDatasetId(), studyConversion.getDatasetName());

--- a/src/main/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAO.java
@@ -216,10 +216,10 @@ public class DatasetServiceDAO implements ConsentLogger {
   }
 
   private Integer executeInsertStudy(Handle handle, StudyInsert insert) {
-    StudyDAO studyDAO = handle.attach(StudyDAO.class);
+    StudyDAO studyDAOLocal = handle.attach(StudyDAO.class);
     UUID uuid = UUID.randomUUID();
     Integer studyId =
-        studyDAO.insertStudy(
+        studyDAOLocal.insertStudy(
             insert.name,
             insert.description,
             insert.piName,
@@ -230,7 +230,7 @@ public class DatasetServiceDAO implements ConsentLogger {
             uuid);
 
     for (StudyProperty prop : insert.props) {
-      studyDAO.insertStudyProperty(
+      studyDAOLocal.insertStudyProperty(
           studyId, prop.getKey(), prop.getType().toString(), prop.getValue().toString());
     }
 
@@ -284,9 +284,9 @@ public class DatasetServiceDAO implements ConsentLogger {
   }
 
   private void executeUpdateStudy(Handle handle, StudyUpdate update, boolean replaceProps) {
-    StudyDAO studyDAO = handle.attach(StudyDAO.class);
-    Study study = studyDAO.findStudyById(update.studyId);
-    studyDAO.updateStudy(
+    StudyDAO studyDAOLocal = handle.attach(StudyDAO.class);
+    Study study = studyDAOLocal.findStudyById(update.studyId);
+    studyDAOLocal.updateStudy(
         update.studyId,
         update.name,
         update.description,
@@ -297,15 +297,15 @@ public class DatasetServiceDAO implements ConsentLogger {
         Instant.now());
 
     if (replaceProps) {
-      studyDAO.deleteStudyPropertiesByStudyId(update.studyId);
+      studyDAOLocal.deleteStudyPropertiesByStudyId(update.studyId);
       update.props.forEach(
           p ->
-              studyDAO.insertStudyProperty(
+              studyDAOLocal.insertStudyProperty(
                   update.studyId, p.getKey(), p.getType().toString(), p.getValue().toString()));
     } else {
       // Handle property inserts and updates
       Set<StudyProperty> existingStudyProperties =
-          studyDAO.findStudyById(update.studyId).getProperties();
+          studyDAOLocal.findStudyById(update.studyId).getProperties();
       update.props.forEach(
           p -> {
             Optional<StudyProperty> existingProp =
@@ -315,11 +315,11 @@ public class DatasetServiceDAO implements ConsentLogger {
                     .findFirst();
             if (existingProp.isPresent()) {
               // Update existing study prop:
-              studyDAO.updateStudyProperty(
+              studyDAOLocal.updateStudyProperty(
                   update.studyId, p.getKey(), p.getType().toString(), p.getValue().toString());
             } else {
               // Add new study prop:
-              studyDAO.insertStudyProperty(
+              studyDAOLocal.insertStudyProperty(
                   update.studyId, p.getKey(), p.getType().toString(), p.getValue().toString());
             }
           });
@@ -615,15 +615,13 @@ public class DatasetServiceDAO implements ConsentLogger {
                     prop.getPropertyName(), datasetId));
           }
           matchingProps.forEach(
-              existingProp -> {
-                updates.add(
-                    createPropertyUpdate(
-                        handle,
-                        datasetId,
-                        prop.getPropertyValueAsString(),
-                        existingProp.getPropertyKey(),
-                        existingProp.getPropertyId()));
-              });
+              existingProp -> updates.add(
+                  createPropertyUpdate(
+                      handle,
+                      datasetId,
+                      prop.getPropertyValueAsString(),
+                      existingProp.getPropertyKey(),
+                      existingProp.getPropertyId())));
         });
     return updates;
   }
@@ -681,7 +679,7 @@ public class DatasetServiceDAO implements ConsentLogger {
   public void updateDatasetDataUse(
       User user, Dataset dataset, DataUse dataUse, String translation) {
     jdbi.useTransaction(
-        handle -> {
+        _ -> {
           datasetDAO.updateDatasetDataUse(
               dataset.getDatasetId(), dataUse.toString(), translation, user.getUserId());
           addAuditRecord(

--- a/src/main/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAO.java
@@ -615,13 +615,14 @@ public class DatasetServiceDAO implements ConsentLogger {
                     prop.getPropertyName(), datasetId));
           }
           matchingProps.forEach(
-              existingProp -> updates.add(
-                  createPropertyUpdate(
-                      handle,
-                      datasetId,
-                      prop.getPropertyValueAsString(),
-                      existingProp.getPropertyKey(),
-                      existingProp.getPropertyId())));
+              existingProp ->
+                  updates.add(
+                      createPropertyUpdate(
+                          handle,
+                          datasetId,
+                          prop.getPropertyValueAsString(),
+                          existingProp.getPropertyKey(),
+                          existingProp.getPropertyId())));
         });
     return updates;
   }

--- a/src/main/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAO.java
@@ -678,6 +678,20 @@ public class DatasetServiceDAO implements ConsentLogger {
     return insert;
   }
 
+  public void updateDatasetDataUse(
+      User user, Dataset dataset, DataUse dataUse, String translation) {
+    jdbi.useTransaction(
+        handle -> {
+          datasetDAO.updateDatasetDataUse(
+              dataset.getDatasetId(), dataUse.toString(), translation, user.getUserId());
+          addAuditRecord(
+              dataset.getDatasetId(),
+              dataset.getDatasetName(),
+              user.getUserId(),
+              AuditActions.UPDATE);
+        });
+  }
+
   // Helper methods to generate DatasetProperty updates
 
   public record StudyInsert(

--- a/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
@@ -162,18 +162,6 @@ class DatasetDAOTest extends DAOTestHelper {
   }
 
   @Test
-  void testTranslatedDataUse() {
-    Dataset d1 = insertDataset();
-
-    String tdu = randomAlphabetic(10);
-    datasetDAO.updateDatasetTranslatedDataUse(d1.getDatasetId(), tdu);
-
-    d1 = datasetDAO.findDatasetById(d1.getDatasetId());
-
-    assertEquals(tdu, d1.getTranslatedDataUse());
-  }
-
-  @Test
   void testUpdateDatasetName() {
     Dataset dataset = insertDataset();
     String newName = randomAlphabetic(25);
@@ -782,10 +770,12 @@ class DatasetDAOTest extends DAOTestHelper {
             .setDiseaseRestrictions(List.of("DOID_1"))
             .build();
 
-    datasetDAO.updateDatasetDataUse(dataset.getDatasetId(), newDataUse.toString());
+    datasetDAO.updateDatasetDataUse(
+        dataset.getDatasetId(), newDataUse.toString(), "translation", dataset.getCreateUserId());
     Dataset updated = datasetDAO.findDatasetById(dataset.getDatasetId());
     assertEquals(newDataUse, updated.getDataUse());
     assertNotEquals(oldDataUse, updated.getDataUse());
+    assertEquals("translation", dataset.getTranslatedDataUse());
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
@@ -775,7 +775,7 @@ class DatasetDAOTest extends DAOTestHelper {
     Dataset updated = datasetDAO.findDatasetById(dataset.getDatasetId());
     assertEquals(newDataUse, updated.getDataUse());
     assertNotEquals(oldDataUse, updated.getDataUse());
-    assertEquals("translation", dataset.getTranslatedDataUse());
+    assertEquals("translation", updated.getTranslatedDataUse());
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.when;
 import com.google.gson.Gson;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.core.Response;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.Collections;
@@ -31,7 +32,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
-import jakarta.ws.rs.core.Response;
 import org.broadinstitute.consent.http.AbstractTestHelper;
 import org.broadinstitute.consent.http.db.DaaDAO;
 import org.broadinstitute.consent.http.db.DacDAO;
@@ -191,7 +191,9 @@ class DatasetServiceTest extends AbstractTestHelper {
     study.setPublicVisibility(Boolean.TRUE);
     dataset.setStudy(study);
     when(datasetDAO.findMinimalDatasetByAlias(dataset.getAlias())).thenReturn(dataset);
-    Dataset found = datasetService.findMinimalDatasetByIdentifier(mockUser, dataset.getDatasetIdentifier(), false);
+    Dataset found =
+        datasetService.findMinimalDatasetByIdentifier(
+            mockUser, dataset.getDatasetIdentifier(), false);
     assertNotNull(found);
   }
 
@@ -207,7 +209,9 @@ class DatasetServiceTest extends AbstractTestHelper {
     dataset.setStudyId(study.getStudyId());
     when(datasetDAO.findMinimalDatasetByAlias(dataset.getAlias())).thenReturn(dataset);
     when(studyDAO.findStudyById(study.getStudyId())).thenReturn(study);
-    Dataset found = datasetService.findMinimalDatasetByIdentifier(mockUser, dataset.getDatasetIdentifier(), true);
+    Dataset found =
+        datasetService.findMinimalDatasetByIdentifier(
+            mockUser, dataset.getDatasetIdentifier(), true);
     assertNotNull(found);
   }
 
@@ -218,7 +222,11 @@ class DatasetServiceTest extends AbstractTestHelper {
     dataset.setAlias(1);
     dataset.setDatasetIdentifier();
     when(datasetDAO.findMinimalDatasetByAlias(dataset.getAlias())).thenReturn(null);
-    assertThrows(NotFoundException.class, () -> datasetService.findMinimalDatasetByIdentifier(mockUser, dataset.getDatasetIdentifier(), false));
+    assertThrows(
+        NotFoundException.class,
+        () ->
+            datasetService.findMinimalDatasetByIdentifier(
+                mockUser, dataset.getDatasetIdentifier(), false));
   }
 
   @Test
@@ -271,7 +279,9 @@ class DatasetServiceTest extends AbstractTestHelper {
   @SuppressWarnings({"java:S5778"})
   void testUpdateDatasetDataUseNullDataset() {
     when(datasetDAO.findDatasetById(any())).thenReturn(null);
-    assertThrows(NotFoundException.class, () -> datasetService.updateDatasetDataUse(mockUser, 1, new DataUse()));
+    assertThrows(
+        NotFoundException.class,
+        () -> datasetService.updateDatasetDataUse(mockUser, 1, new DataUse()));
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
@@ -116,13 +116,13 @@ class DatasetServiceTest extends AbstractTestHelper {
 
   @Test
   void testGetDatasetByName() {
-    when(datasetDAO.getDatasetByName(getDatasets().get(0).getName().toLowerCase()))
-        .thenReturn(getDatasets().get(0));
+    when(datasetDAO.getDatasetByName(getDatasets().getFirst().getName().toLowerCase()))
+        .thenReturn(getDatasets().getFirst());
 
     Dataset dataset = datasetService.getDatasetByName("Test Dataset 1");
 
     assertNotNull(dataset);
-    assertEquals(dataset.getDatasetId(), getDatasets().get(0).getDatasetId());
+    assertEquals(dataset.getDatasetId(), getDatasets().getFirst().getDatasetId());
   }
 
   @Test
@@ -137,13 +137,13 @@ class DatasetServiceTest extends AbstractTestHelper {
 
   @Test
   void testFindDatasetById() {
-    when(datasetDAO.findDatasetById(getDatasets().get(0).getDatasetId()))
-        .thenReturn(getDatasets().get(0));
+    when(datasetDAO.findDatasetById(getDatasets().getFirst().getDatasetId()))
+        .thenReturn(getDatasets().getFirst());
 
     Dataset dataset = datasetService.findDatasetById(mockUser, 1);
 
     assertNotNull(dataset);
-    assertEquals(dataset.getName(), getDatasets().get(0).getName());
+    assertEquals(dataset.getName(), getDatasets().getFirst().getName());
   }
 
   @Test
@@ -207,7 +207,7 @@ class DatasetServiceTest extends AbstractTestHelper {
     try {
       datasetService.updateDatasetDataUse(u, 1, dataUse);
       fail("Should have thrown an exception on datasetService.updateDatasetDataUse()");
-    } catch (IllegalArgumentException e) {
+    } catch (IllegalArgumentException _) {
       assertTrue(true);
     }
   }
@@ -386,7 +386,7 @@ class DatasetServiceTest extends AbstractTestHelper {
                     Instant.now().toEpochMilli() + DataAccessRequest.EXPIRATION_DURATION_MILLIS)));
     when(datasetDAO.getApprovedDatasets(anyInt())).thenReturn(List.of(example));
     assertEquals(1, datasetService.getApprovedDatasets(user).size());
-    assertTrue(datasetService.getApprovedDatasets(user).get(0).isApprovedDatasetEqual(example));
+    assertTrue(datasetService.getApprovedDatasets(user).getFirst().isApprovedDatasetEqual(example));
   }
 
   @Test
@@ -452,7 +452,7 @@ class DatasetServiceTest extends AbstractTestHelper {
     List<DatasetStudySummary> authorizedSummaries =
         datasetService.findAllDatasetStudySummaries(user);
     assertEquals(1, authorizedSummaries.size());
-    assertEquals(summary, authorizedSummaries.get(0));
+    assertEquals(summary, authorizedSummaries.getFirst());
   }
 
   @Test
@@ -464,7 +464,7 @@ class DatasetServiceTest extends AbstractTestHelper {
     List<DatasetStudySummary> authorizedSummaries =
         datasetService.verifyPublicVisibilityAccess(List.of(summary), admin);
     assertEquals(1, authorizedSummaries.size());
-    assertEquals(summary, authorizedSummaries.get(0));
+    assertEquals(summary, authorizedSummaries.getFirst());
   }
 
   @Test
@@ -476,7 +476,7 @@ class DatasetServiceTest extends AbstractTestHelper {
     List<DatasetStudySummary> authorizedSummaries =
         datasetService.verifyPublicVisibilityAccess(List.of(summary), admin);
     assertEquals(1, authorizedSummaries.size());
-    assertEquals(summary, authorizedSummaries.get(0));
+    assertEquals(summary, authorizedSummaries.getFirst());
   }
 
   @Test
@@ -501,7 +501,7 @@ class DatasetServiceTest extends AbstractTestHelper {
     List<DatasetStudySummary> authorizedSummaries =
         datasetService.verifyPublicVisibilityAccess(List.of(summary), user);
     assertEquals(1, authorizedSummaries.size());
-    assertEquals(summary, authorizedSummaries.get(0));
+    assertEquals(summary, authorizedSummaries.getFirst());
   }
 
   @Test
@@ -514,7 +514,7 @@ class DatasetServiceTest extends AbstractTestHelper {
     List<DatasetStudySummary> authorizedSummaries =
         datasetService.verifyPublicVisibilityAccess(List.of(summary), user);
     assertEquals(1, authorizedSummaries.size());
-    assertEquals(summary, authorizedSummaries.get(0));
+    assertEquals(summary, authorizedSummaries.getFirst());
   }
 
   @Test
@@ -534,7 +534,7 @@ class DatasetServiceTest extends AbstractTestHelper {
     List<DatasetStudySummary> authorizedSummaries =
         datasetService.verifyPublicVisibilityAccess(List.of(summary), user);
     assertEquals(1, authorizedSummaries.size());
-    assertEquals(summary, authorizedSummaries.get(0));
+    assertEquals(summary, authorizedSummaries.getFirst());
   }
 
   @Test
@@ -567,7 +567,7 @@ class DatasetServiceTest extends AbstractTestHelper {
     List<DatasetStudySummary> authorizedSummaries =
         datasetService.verifyPublicVisibilityAccess(List.of(summary), custodian);
     assertEquals(1, authorizedSummaries.size());
-    assertEquals(summary, authorizedSummaries.get(0));
+    assertEquals(summary, authorizedSummaries.getFirst());
   }
 
   @Test
@@ -614,7 +614,7 @@ class DatasetServiceTest extends AbstractTestHelper {
     List<DatasetStudySummary> authorizedSummaries =
         datasetService.findAllDatasetStudySummaries(user);
     assertEquals(1, authorizedSummaries.size());
-    assertEquals(summary, authorizedSummaries.get(0));
+    assertEquals(summary, authorizedSummaries.getFirst());
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
@@ -178,6 +178,57 @@ class DatasetServiceTest extends AbstractTestHelper {
   }
 
   @Test
+  void testFindMinimalDatasetByIdentifierVisible() {
+    Dataset dataset = new Dataset();
+    dataset.setAlias(1);
+    dataset.setDatasetIdentifier();
+    Study study = new Study();
+    study.setStudyId(1);
+    study.setPublicVisibility(Boolean.TRUE);
+    dataset.setStudy(study);
+    when(datasetDAO.findMinimalDatasetByAlias(dataset.getAlias())).thenReturn(dataset);
+    Dataset found = datasetService.findMinimalDatasetByIdentifier(mockUser, dataset.getDatasetIdentifier(), false);
+    assertNotNull(found);
+  }
+
+  @Test
+  void testFindMinimalDatasetByIdentifierVisible2() {
+    Dataset dataset = new Dataset();
+    dataset.setAlias(1);
+    dataset.setDatasetIdentifier();
+    Study study = new Study();
+    study.setStudyId(1);
+    study.setPublicVisibility(Boolean.TRUE);
+    dataset.setStudy(study);
+    dataset.setStudyId(study.getStudyId());
+    when(datasetDAO.findMinimalDatasetByAlias(dataset.getAlias())).thenReturn(dataset);
+    when(studyDAO.findStudyById(study.getStudyId())).thenReturn(study);
+    Dataset found = datasetService.findMinimalDatasetByIdentifier(mockUser, dataset.getDatasetIdentifier(), true);
+    assertNotNull(found);
+  }
+
+  @Test
+  @SuppressWarnings({"java:S5778"})
+  void testFindMinimalDatasetByIdentifierNotFound() {
+    Dataset dataset = new Dataset();
+    dataset.setAlias(1);
+    dataset.setDatasetIdentifier();
+    when(datasetDAO.findMinimalDatasetByAlias(dataset.getAlias())).thenReturn(null);
+    assertThrows(NotFoundException.class, () -> datasetService.findMinimalDatasetByIdentifier(mockUser, dataset.getDatasetIdentifier(), false));
+  }
+
+  @Test
+  @SuppressWarnings({"java:S5778"})
+  void testFindMinimalDatasetByIdentifierIncorrectIdentifier() {
+    Dataset dataset = new Dataset();
+    dataset.setAlias(1);
+    dataset.setDatasetIdentifier();
+    when(datasetDAO.findMinimalDatasetByAlias(2)).thenReturn(dataset);
+    Dataset found = datasetService.findMinimalDatasetByIdentifier(mockUser, "DUOS-000002", false);
+    assertNull(found);
+  }
+
+  @Test
   void testUpdateDatasetDataUseAdmin() {
     when(datasetDAO.findDatasetById(any())).thenReturn(new Dataset());
     User u = new User();

--- a/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
@@ -14,6 +14,7 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -30,6 +31,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
+import jakarta.ws.rs.core.Response;
 import org.broadinstitute.consent.http.AbstractTestHelper;
 import org.broadinstitute.consent.http.db.DaaDAO;
 import org.broadinstitute.consent.http.db.DacDAO;
@@ -59,6 +61,8 @@ import org.broadinstitute.consent.http.util.gson.GsonUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -264,6 +268,13 @@ class DatasetServiceTest extends AbstractTestHelper {
   }
 
   @Test
+  @SuppressWarnings({"java:S5778"})
+  void testUpdateDatasetDataUseNullDataset() {
+    when(datasetDAO.findDatasetById(any())).thenReturn(null);
+    assertThrows(NotFoundException.class, () -> datasetService.updateDatasetDataUse(mockUser, 1, new DataUse()));
+  }
+
+  @Test
   void testApproveDataset_AlreadyApproved_TrueSubmission() throws Exception {
     Dataset dataset = new Dataset();
     User user = new User();
@@ -397,10 +408,49 @@ class DatasetServiceTest extends AbstractTestHelper {
   }
 
   @Test
+  void testSyncDataUseTranslation() {
+    Dataset dataset = new Dataset();
+    dataset.setDatasetId(1);
+    when(datasetDAO.findDatasetById(1)).thenReturn(dataset);
+
+    Dataset updated = datasetService.syncDatasetDataUseTranslation(1, mockUser);
+    assertNotNull(updated);
+    assertEquals(dataset.getDatasetId(), updated.getDatasetId());
+  }
+
+  @Test
   void testSyncDataUseTranslationNotFound() {
     when(datasetDAO.findDatasetById(1)).thenReturn(null);
     assertThrows(
         NotFoundException.class, () -> datasetService.syncDatasetDataUseTranslation(1, mockUser));
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {200, 500})
+  void testDeleteDataset(int status) throws Exception {
+    Dataset dataset = new Dataset();
+    dataset.setDatasetId(1);
+    when(datasetDAO.findDatasetById(1)).thenReturn(dataset);
+    Response response = mock(Response.class);
+    when(response.getStatus()).thenReturn(status);
+    when(elasticSearchService.deleteIndex(any(), any())).thenReturn(response);
+
+    datasetService.deleteDataset(dataset.getDatasetId(), mockUser.getUserId());
+    verify(datasetServiceDAO).deleteDataset(dataset, mockUser.getUserId());
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {200, 500})
+  void testDeleteStudy(int status) throws Exception {
+    Study study = new Study();
+    study.setStudyId(1);
+    study.addDatasetIds(Set.of(1));
+    Response response = mock(Response.class);
+    when(response.getStatus()).thenReturn(status);
+    when(elasticSearchService.deleteIndex(any(), any())).thenReturn(response);
+
+    datasetService.deleteStudy(study, mockUser);
+    verify(datasetServiceDAO).deleteStudy(study, mockUser);
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
@@ -37,7 +37,6 @@ import org.broadinstitute.consent.http.db.DatasetAuthorizationReaderDAO;
 import org.broadinstitute.consent.http.db.DatasetDAO;
 import org.broadinstitute.consent.http.db.StudyDAO;
 import org.broadinstitute.consent.http.db.UserDAO;
-import org.broadinstitute.consent.http.enumeration.DataUseTranslationType;
 import org.broadinstitute.consent.http.enumeration.PropertyType;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.ApprovedDataset;
@@ -180,7 +179,6 @@ class DatasetServiceTest extends AbstractTestHelper {
 
   @Test
   void testUpdateDatasetDataUseAdmin() {
-    doNothing().when(datasetDAO).updateDatasetDataUse(any(), any());
     when(datasetDAO.findDatasetById(any())).thenReturn(new Dataset());
     User u = new User();
     u.setAdminRole();
@@ -345,29 +343,6 @@ class DatasetServiceTest extends AbstractTestHelper {
 
     // do not send denied email
     verify(emailService, times(0)).sendDatasetDeniedMessage(user, "DAC NAME", "DUOS-000001", "");
-  }
-
-  @Test
-  void testSyncDataUseTranslation() {
-    Dataset ds = new Dataset();
-    ds.setDataUse(new DataUseBuilder().setGeneralUse(true).build());
-
-    when(datasetDAO.findDatasetById(1)).thenReturn(ds);
-    String translation =
-        """
-        Samples are restricted for use under the following conditions:
-        Data is limited for health/medical/biomedical research. [HMB]
-        Data use is limited for studying: cancerophobia [DS]
-        Commercial use is not prohibited.
-        Data use for methods development research irrespective of the specified data use limitations is not prohibited.
-        Restrictions for use as a control set for diseases other than those defined were not specified.
-        """;
-    when(ontologyService.translateDataUse(ds.getDataUse(), DataUseTranslationType.DATASET))
-        .thenReturn(translation);
-
-    datasetService.syncDatasetDataUseTranslation(1, mockUser);
-
-    verify(datasetDAO, times(1)).updateDatasetTranslatedDataUse(1, translation);
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAOTest.java
@@ -626,7 +626,8 @@ class DatasetServiceDAOTest extends DAOTestHelper {
   @Test
   void testUpdateStudyWithDatasetUpdates() throws Exception {
     Study study = createStudy(null, null, null);
-    Dataset dataset = datasetDAO.findDatasetsByIdList(List.copyOf(study.getDatasetIds())).getFirst();
+    Dataset dataset =
+        datasetDAO.findDatasetsByIdList(List.copyOf(study.getDatasetIds())).getFirst();
 
     StudyUpdate studyUpdate =
         new StudyUpdate(
@@ -1589,7 +1590,9 @@ class DatasetServiceDAOTest extends DAOTestHelper {
     Dataset dataset = createDataset();
     User user = userDAO.findUserById(dataset.getCreateUserId());
     DataUse newDataUse = new DataUseBuilder().setGeneralUse(true).setHmbResearch(true).build();
-    String translatedDataUse = new TranslationUtil(ontologyDAO).translate(dataset.getDataUse(), DataUseTranslationType.DATASET);
+    String translatedDataUse =
+        new TranslationUtil(ontologyDAO)
+            .translate(dataset.getDataUse(), DataUseTranslationType.DATASET);
     serviceDAO.updateDatasetDataUse(user, dataset, newDataUse, translatedDataUse);
     Dataset updatedDataset = datasetDAO.findDatasetById(dataset.getDatasetId());
     assertEquals(translatedDataUse, updatedDataset.getTranslatedDataUse());

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAOTest.java
@@ -1592,7 +1592,7 @@ class DatasetServiceDAOTest extends DAOTestHelper {
     DataUse newDataUse = new DataUseBuilder().setGeneralUse(true).setHmbResearch(true).build();
     String translatedDataUse =
         new TranslationUtil(ontologyDAO)
-            .translate(dataset.getDataUse(), DataUseTranslationType.DATASET);
+            .translate(newDataUse, DataUseTranslationType.DATASET);
     serviceDAO.updateDatasetDataUse(user, dataset, newDataUse, translatedDataUse);
     Dataset updatedDataset = datasetDAO.findDatasetById(dataset.getDatasetId());
     assertEquals(translatedDataUse, updatedDataset.getTranslatedDataUse());

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAOTest.java
@@ -25,8 +25,10 @@ import java.util.Random;
 import java.util.Set;
 import org.broadinstitute.consent.http.db.DAOTestHelper;
 import org.broadinstitute.consent.http.enumeration.AuditActions;
+import org.broadinstitute.consent.http.enumeration.DataUseTranslationType;
 import org.broadinstitute.consent.http.enumeration.FileCategory;
 import org.broadinstitute.consent.http.enumeration.PropertyType;
+import org.broadinstitute.consent.http.matching.TranslationUtil;
 import org.broadinstitute.consent.http.models.Dac;
 import org.broadinstitute.consent.http.models.DataUse;
 import org.broadinstitute.consent.http.models.DataUseBuilder;
@@ -49,6 +51,9 @@ import org.broadinstitute.consent.http.util.gson.GsonUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -57,7 +62,7 @@ class DatasetServiceDAOTest extends DAOTestHelper {
   private DatasetServiceDAO serviceDAO;
 
   @BeforeEach
-  public void setUp() {
+  void setUp() {
     serviceDAO = new DatasetServiceDAO(jdbi, datasetDAO, studyDAO, datasetAuthorizationReaderDAO);
   }
 
@@ -73,7 +78,7 @@ class DatasetServiceDAOTest extends DAOTestHelper {
     // Validate that an audit record was added:
     List<DatasetAudit> audits = datasetDAO.findAuditsByDatasetId(dataset.getDatasetId());
     assertEquals(1, audits.size());
-    assertEquals(AuditActions.DELETE.name(), audits.get(0).getAction());
+    assertEquals(AuditActions.DELETE.name(), audits.getFirst().getAction());
   }
 
   @Test
@@ -113,7 +118,7 @@ class DatasetServiceDAOTest extends DAOTestHelper {
 
     assertEquals(1, createdIds.size());
 
-    Dataset created = datasetDAO.findDatasetById(createdIds.get(0));
+    Dataset created = datasetDAO.findDatasetById(createdIds.getFirst());
 
     assertEquals(insert.name(), created.getName());
     assertEquals(insert.dacId(), created.getDacId());
@@ -122,19 +127,21 @@ class DatasetServiceDAOTest extends DAOTestHelper {
 
     DatasetProperty createdProp1 =
         created.getProperties().stream()
-            .filter((p) -> p.getPropertyName().equals(prop1.getPropertyName()))
+            .filter(p -> p.getPropertyName().equals(prop1.getPropertyName()))
             .findFirst()
-            .get();
+            .orElse(null);
     DatasetProperty createdProp2 =
         created.getProperties().stream()
-            .filter((p) -> p.getPropertyName().equals(prop2.getPropertyName()))
+            .filter(p -> p.getPropertyName().equals(prop2.getPropertyName()))
             .findFirst()
-            .get();
+            .orElse(null);
 
+    assertNotNull(createdProp1);
     assertEquals(created.getDatasetId(), createdProp1.getDatasetId());
     assertEquals(prop1.getPropertyValue(), createdProp1.getPropertyValue());
     assertEquals(prop1.getPropertyType(), createdProp1.getPropertyType());
 
+    assertNotNull(createdProp2);
     assertEquals(created.getDatasetId(), createdProp2.getDatasetId());
     assertEquals(prop2.getPropertyValue(), createdProp2.getPropertyValue());
     assertEquals(prop2.getPropertyType(), createdProp2.getPropertyType());
@@ -237,7 +244,7 @@ class DatasetServiceDAOTest extends DAOTestHelper {
 
     assertEquals(1, datasets.size());
 
-    Dataset dataset1 = datasetDAO.findDatasetById(createdIds.get(0));
+    Dataset dataset1 = datasetDAO.findDatasetById(createdIds.getFirst());
 
     assertNotNull(dataset1.getStudy());
     Study s = dataset1.getStudy();
@@ -295,7 +302,7 @@ class DatasetServiceDAOTest extends DAOTestHelper {
 
     assertEquals(1, datasets.size());
 
-    Dataset dataset1 = datasetDAO.findDatasetById(createdIds.get(0));
+    Dataset dataset1 = datasetDAO.findDatasetById(createdIds.getFirst());
 
     assertNotNull(dataset1.getStudy());
     Study s = dataset1.getStudy();
@@ -309,17 +316,19 @@ class DatasetServiceDAOTest extends DAOTestHelper {
 
     StudyProperty createdProp1 =
         dataset1.getStudy().getProperties().stream()
-            .filter((p) -> p.getKey().equals(prop1.getKey()))
+            .filter(p -> p.getKey().equals(prop1.getKey()))
             .findFirst()
-            .get();
+            .orElse(null);
     StudyProperty createdProp2 =
         dataset1.getStudy().getProperties().stream()
-            .filter((p) -> p.getKey().equals(prop2.getKey()))
+            .filter(p -> p.getKey().equals(prop2.getKey()))
             .findFirst()
-            .get();
+            .orElse(null);
 
+    assertNotNull(createdProp1);
     assertEquals(prop1.getType(), createdProp1.getType());
     assertEquals(prop1.getValue(), createdProp1.getValue());
+    assertNotNull(createdProp2);
     assertEquals(prop2.getType(), createdProp2.getType());
     assertEquals(prop2.getValue(), createdProp2.getValue());
 
@@ -374,7 +383,7 @@ class DatasetServiceDAOTest extends DAOTestHelper {
 
     assertEquals(1, datasets.size());
 
-    Dataset dataset1 = datasetDAO.findDatasetById(createdIds.get(0));
+    Dataset dataset1 = datasetDAO.findDatasetById(createdIds.getFirst());
 
     assertNotNull(dataset1.getStudy());
     Study s = dataset1.getStudy();
@@ -388,17 +397,19 @@ class DatasetServiceDAOTest extends DAOTestHelper {
 
     StudyProperty createdProp1 =
         dataset1.getStudy().getProperties().stream()
-            .filter((p) -> p.getKey().equals(prop1.getKey()))
+            .filter(p -> p.getKey().equals(prop1.getKey()))
             .findFirst()
-            .get();
+            .orElse(null);
     StudyProperty createdProp2 =
         dataset1.getStudy().getProperties().stream()
-            .filter((p) -> p.getKey().equals(prop2.getKey()))
+            .filter(p -> p.getKey().equals(prop2.getKey()))
             .findFirst()
-            .get();
+            .orElse(null);
 
+    assertNotNull(createdProp1);
     assertEquals(prop1.getType(), createdProp1.getType());
     assertEquals(prop1.getValue(), createdProp1.getValue());
+    assertNotNull(createdProp2);
     assertEquals(prop2.getType(), createdProp2.getType());
     assertEquals(prop2.getValue(), createdProp2.getValue());
 
@@ -413,7 +424,7 @@ class DatasetServiceDAOTest extends DAOTestHelper {
         d -> {
           List<DatasetAudit> audits = datasetDAO.findAuditsByDatasetId(d.getDatasetId());
           assertEquals(1, audits.size());
-          assertEquals(AuditActions.CREATE.name(), audits.get(0).getAction());
+          assertEquals(AuditActions.CREATE.name(), audits.getFirst().getAction());
         });
   }
 
@@ -515,7 +526,7 @@ class DatasetServiceDAOTest extends DAOTestHelper {
     // Validate that an audit record was added:
     List<DatasetAudit> audits = datasetDAO.findAuditsByDatasetId(dataset.getDatasetId());
     assertEquals(1, audits.size());
-    assertEquals(AuditActions.UPDATE.name(), audits.get(0).getAction());
+    assertEquals(AuditActions.UPDATE.name(), audits.getFirst().getAction());
   }
 
   @Test
@@ -568,7 +579,7 @@ class DatasetServiceDAOTest extends DAOTestHelper {
     newProp.setValue(randomAlphabetic(10));
 
     String newPropValue = "New Study Prop Value";
-    StudyProperty prop1 = props.get(0);
+    StudyProperty prop1 = props.getFirst();
     prop1.setValue(newPropValue);
 
     // Create a study update with a changed prop, a new prop, and a to-be-deleted prop
@@ -615,7 +626,7 @@ class DatasetServiceDAOTest extends DAOTestHelper {
   @Test
   void testUpdateStudyWithDatasetUpdates() throws Exception {
     Study study = createStudy(null, null, null);
-    Dataset dataset = datasetDAO.findDatasetsByIdList(List.copyOf(study.getDatasetIds())).get(0);
+    Dataset dataset = datasetDAO.findDatasetsByIdList(List.copyOf(study.getDatasetIds())).getFirst();
 
     StudyUpdate studyUpdate =
         new StudyUpdate(
@@ -706,12 +717,6 @@ class DatasetServiceDAOTest extends DAOTestHelper {
     updatedFso2.setCategory(FileCategory.NIH_INSTITUTIONAL_CERTIFICATION);
     updatedFso2.setBlobId(BlobId.of(randomAlphabetic(10), randomAlphabetic(10)));
     updatedFso2.setFileName(randomAlphabetic(10));
-
-    FileStorageObject updatedFso3 = new FileStorageObject();
-    updatedFso3.setMediaType(randomAlphabetic(20));
-    updatedFso3.setCategory(FileCategory.NIH_INSTITUTIONAL_CERTIFICATION);
-    updatedFso3.setBlobId(BlobId.of(randomAlphabetic(10), randomAlphabetic(10)));
-    updatedFso3.setFileName(randomAlphabetic(10));
 
     StudyUpdate studyUpdate =
         new StudyUpdate(
@@ -913,7 +918,7 @@ class DatasetServiceDAOTest extends DAOTestHelper {
     // This creates a study with a single dataset:
     Study study = createStudy(null, null, null);
     List<Dataset> datasets = datasetDAO.findDatasetsByIdList(study.getDatasetIds());
-    Dataset dataset = datasets.get(0);
+    Dataset dataset = datasets.getFirst();
     jdbi.useHandle(
         handle ->
             serviceDAO.executeUpdateDatasetWithFiles(
@@ -937,7 +942,7 @@ class DatasetServiceDAOTest extends DAOTestHelper {
     Study study = createStudy(null, null, null);
     List<Dataset> datasets =
         datasetDAO.findDatasetsByIdList(study.getDatasetIds().stream().toList());
-    Dataset dataset = datasets.get(0);
+    Dataset dataset = datasets.getFirst();
     jdbi.useHandle(
         handle ->
             serviceDAO.executeUpdateDatasetWithFiles(
@@ -961,7 +966,7 @@ class DatasetServiceDAOTest extends DAOTestHelper {
     Study study = createStudy(null, null, null);
     List<Dataset> datasets =
         datasetDAO.findDatasetsByIdList(study.getDatasetIds().stream().toList());
-    Dataset dataset = datasets.get(0);
+    Dataset dataset = datasets.getFirst();
     String newName = randomAlphabetic(dataset.getName().length() + 10);
     jdbi.useHandle(
         handle ->
@@ -1082,51 +1087,17 @@ class DatasetServiceDAOTest extends DAOTestHelper {
         audits.stream().anyMatch(a -> a.getAction().equalsIgnoreCase(AuditActions.UPDATE.name())));
   }
 
-  @Test
-  void testPatchDatasetWithNullName() throws Exception {
+  @ParameterizedTest
+  @NullAndEmptySource
+  @ValueSource(strings = {"   "})
+  void testPatchDatasetWithNullAndEmptyNames(String input) throws Exception {
     Dataset dataset = createDataset();
     User user = userDAO.findUserById(dataset.getCreateUserId());
-    DatasetPatch patch = new DatasetPatch(null, List.of());
+    DatasetPatch patch = new DatasetPatch(input, List.of());
     serviceDAO.patchDataset(dataset.getDatasetId(), user, patch);
     Dataset patched = datasetDAO.findDatasetById(dataset.getDatasetId());
 
     // Validate that the name is NOT updated to a null value
-    assertEquals(dataset.getName(), patched.getDatasetName());
-
-    // Validate that an update audit record was added:
-    List<DatasetAudit> audits = datasetDAO.findAuditsByDatasetId(dataset.getDatasetId());
-    assertFalse(audits.isEmpty());
-    assertTrue(
-        audits.stream().anyMatch(a -> a.getAction().equalsIgnoreCase(AuditActions.UPDATE.name())));
-  }
-
-  @Test
-  void testPatchDatasetWithEmptyName() throws Exception {
-    Dataset dataset = createDataset();
-    User user = userDAO.findUserById(dataset.getCreateUserId());
-    DatasetPatch patch = new DatasetPatch("", List.of());
-    serviceDAO.patchDataset(dataset.getDatasetId(), user, patch);
-    Dataset patched = datasetDAO.findDatasetById(dataset.getDatasetId());
-
-    // Validate that the name is NOT updated with an empty value
-    assertEquals(dataset.getName(), patched.getDatasetName());
-
-    // Validate that an update audit record was added:
-    List<DatasetAudit> audits = datasetDAO.findAuditsByDatasetId(dataset.getDatasetId());
-    assertFalse(audits.isEmpty());
-    assertTrue(
-        audits.stream().anyMatch(a -> a.getAction().equalsIgnoreCase(AuditActions.UPDATE.name())));
-  }
-
-  @Test
-  void testPatchDatasetWithBlankName() throws Exception {
-    Dataset dataset = createDataset();
-    User user = userDAO.findUserById(dataset.getCreateUserId());
-    DatasetPatch patch = new DatasetPatch("   ", List.of());
-    serviceDAO.patchDataset(dataset.getDatasetId(), user, patch);
-    Dataset patched = datasetDAO.findDatasetById(dataset.getDatasetId());
-
-    // Validate that the name is NOT updated with an empty value
     assertEquals(dataset.getName(), patched.getDatasetName());
 
     // Validate that an update audit record was added:
@@ -1613,6 +1584,28 @@ class DatasetServiceDAOTest extends DAOTestHelper {
             .getValue());
   }
 
+  @Test
+  void testUpdateDatasetDataUse() {
+    Dataset dataset = createDataset();
+    User user = userDAO.findUserById(dataset.getCreateUserId());
+    DataUse newDataUse = new DataUseBuilder().setGeneralUse(true).setHmbResearch(true).build();
+    String translatedDataUse = new TranslationUtil(ontologyDAO).translate(dataset.getDataUse(), DataUseTranslationType.DATASET);
+    serviceDAO.updateDatasetDataUse(user, dataset, newDataUse, translatedDataUse);
+    Dataset updatedDataset = datasetDAO.findDatasetById(dataset.getDatasetId());
+    assertEquals(translatedDataUse, updatedDataset.getTranslatedDataUse());
+    assertEquals(newDataUse, updatedDataset.getDataUse());
+    assertNotNull(updatedDataset.getUpdateDate());
+    assertEquals(user.getUserId(), updatedDataset.getUpdateUserId());
+    List<DatasetAudit> audits = datasetDAO.findAuditsByDatasetId(dataset.getDatasetId());
+    assertFalse(audits.isEmpty());
+    Optional<DatasetAudit> updateAudit =
+        audits.stream()
+            .filter(a -> a.getAction().equalsIgnoreCase(AuditActions.UPDATE.getValue()))
+            .findFirst();
+    assertTrue(updateAudit.isPresent());
+    assertEquals(user.getUserId(), updateAudit.get().getUser());
+  }
+
   /**
    * Helper method to create a study with two props and one dataset
    *
@@ -1686,7 +1679,7 @@ class DatasetServiceDAOTest extends DAOTestHelper {
     List<Integer> createdIds =
         serviceDAO.insertDatasetRegistration(studyInsert, List.of(datasetInsert1, datasetInsert2));
 
-    Dataset createdDataset = datasetDAO.findDatasetById(createdIds.get(0));
+    Dataset createdDataset = datasetDAO.findDatasetById(createdIds.getFirst());
     Study studyFromFirstDatasetCreated = createdDataset.getStudy();
     return studyDAO.findStudyById(studyFromFirstDatasetCreated.getStudyId());
   }

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAOTest.java
@@ -1591,8 +1591,7 @@ class DatasetServiceDAOTest extends DAOTestHelper {
     User user = userDAO.findUserById(dataset.getCreateUserId());
     DataUse newDataUse = new DataUseBuilder().setGeneralUse(true).setHmbResearch(true).build();
     String translatedDataUse =
-        new TranslationUtil(ontologyDAO)
-            .translate(newDataUse, DataUseTranslationType.DATASET);
+        new TranslationUtil(ontologyDAO).translate(newDataUse, DataUseTranslationType.DATASET);
     serviceDAO.updateDatasetDataUse(user, dataset, newDataUse, translatedDataUse);
     Dataset updatedDataset = datasetDAO.findDatasetById(dataset.getDatasetId());
     assertEquals(translatedDataUse, updatedDataset.getTranslatedDataUse());


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-2959

### Summary
This PR groups the updates to a dataset's `data_use` and `translated_data_use` fields to a single db call and also adds an audit record. 

Most of the ancillary changes are sonar suggestions and boosts to test coverage since there are large areas of uncovered code in `DatasetService`

### Testing
Can be tested by updating a dataset's data use object via the `PUT /api/dataset/{id}/datause` API. There will be updates to all of the following:
* the data use object
* the translation
* audit record for the update
* audit record for the re-index in ES

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
