### PR TITLE
DT-2532: Replicate Translate Summary in Consent

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
@@ -243,11 +243,7 @@ public class ConsentModule extends AbstractModule {
 
   @Provides
   OntologyService providesOntologyService() {
-    return new OntologyService(
-        providesClient(),
-        config.getServicesConfiguration(),
-        providesOntologyDAO(),
-        providesOntologyIndexService());
+    return new OntologyService(providesOntologyDAO(), providesOntologyIndexService());
   }
 
   @Provides

--- a/src/main/java/org/broadinstitute/consent/http/matching/TranslationUtil.java
+++ b/src/main/java/org/broadinstitute/consent/http/matching/TranslationUtil.java
@@ -9,7 +9,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.consent.http.enumeration.DataUseTranslationType;
@@ -89,15 +88,9 @@ public class TranslationUtil implements ConsentLogger {
     }
 
     if (dataUse.getDiseaseRestrictions() != null && !dataUse.getDiseaseRestrictions().isEmpty()) {
-      List<OntologyTerm> terms = findTermsByIds(dataUse.getDiseaseRestrictions());
-      List<String> labels = new ArrayList<>(terms.stream().map(OntologyTerm::label).toList());
+      List<String> labels = findLabelsForTermIds(dataUse.getDiseaseRestrictions());
       if (!labels.isEmpty()) {
-        String dsRestrictions =
-            labels.stream()
-                .filter(Objects::nonNull)
-                .filter(r -> !r.isEmpty())
-                .collect(Collectors.joining(", "));
-        summary.add(String.format(DS, dsRestrictions));
+        summary.add(String.format(DS, String.join(", ", labels)));
       }
     }
 
@@ -193,15 +186,9 @@ public class TranslationUtil implements ConsentLogger {
     }
 
     if (dataUse.getDiseaseRestrictions() != null && !dataUse.getDiseaseRestrictions().isEmpty()) {
-      List<OntologyTerm> terms = findTermsByIds(dataUse.getDiseaseRestrictions());
-      List<String> labels = new ArrayList<>(terms.stream().map(OntologyTerm::label).toList());
+      List<String> labels = findLabelsForTermIds(dataUse.getDiseaseRestrictions());
       if (!labels.isEmpty()) {
-        String dsRestrictions =
-            labels.stream()
-                .filter(Objects::nonNull)
-                .filter(r -> !r.isEmpty())
-                .collect(Collectors.joining(", "));
-        primary.add(new DataUseTerm("DS", String.format(DS, dsRestrictions)));
+        primary.add(new DataUseTerm("DS", String.format(DS, String.join(", ", labels))));
       }
     }
 
@@ -297,5 +284,14 @@ public class TranslationUtil implements ConsentLogger {
       logException("Unable to retrieve term ids: " + String.join(", ", ids), e);
       return List.of();
     }
+  }
+
+  private List<String> findLabelsForTermIds(List<String> ids) {
+    List<OntologyTerm> terms = findTermsByIds(ids);
+    return terms.stream()
+        .map(OntologyTerm::label)
+        .filter(Objects::nonNull)
+        .filter(r -> !r.isBlank())
+        .toList();
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/matching/TranslationUtil.java
+++ b/src/main/java/org/broadinstitute/consent/http/matching/TranslationUtil.java
@@ -29,7 +29,7 @@ public class TranslationUtil implements ConsentLogger {
       "Research is limited to samples restricted for use under the following conditions:";
   protected static final String FEMALE = "Female";
   protected static final String MALE = "Male";
-  protected static final String GRU = "Data is available for general research use. [GRU]";
+  public static final String GRU = "Data is available for general research use. [GRU]";
   public static final String DS = "Data use is limited for studying: %s [DS]";
   public static final String HMB = "Data is limited for health/medical/biomedical research. [HMB]";
   protected static final String POA =
@@ -239,8 +239,9 @@ public class TranslationUtil implements ConsentLogger {
     }
 
     if (StringUtils.isNotBlank(dataUse.getGeographicalRestrictions())) {
-      secondary.add(new DataUseTerm("GS",
-          String.format(GEO_RESTRICTION, dataUse.getGeographicalRestrictions())));
+      secondary.add(
+          new DataUseTerm(
+              "GS", String.format(GEO_RESTRICTION, dataUse.getGeographicalRestrictions())));
     }
 
     if (BooleanUtils.isTrue(dataUse.getGeneticStudiesOnly())) {
@@ -252,8 +253,9 @@ public class TranslationUtil implements ConsentLogger {
     }
 
     if (StringUtils.isNotBlank(dataUse.getPublicationMoratorium())) {
-      secondary.add(new DataUseTerm("MOR",
-          String.format(PUB_MORATORIUM, dataUse.getPublicationMoratorium())));
+      secondary.add(
+          new DataUseTerm(
+              "MOR", String.format(PUB_MORATORIUM, dataUse.getPublicationMoratorium())));
     }
 
     if (BooleanUtils.isTrue(dataUse.getControls())) {

--- a/src/main/java/org/broadinstitute/consent/http/matching/TranslationUtil.java
+++ b/src/main/java/org/broadinstitute/consent/http/matching/TranslationUtil.java
@@ -14,6 +14,8 @@ import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.consent.http.enumeration.DataUseTranslationType;
 import org.broadinstitute.consent.http.models.DataUse;
+import org.broadinstitute.consent.http.models.ontology.DataUseSummary;
+import org.broadinstitute.consent.http.models.ontology.DataUseTerm;
 import org.broadinstitute.consent.http.service.ontology.OntologyDAO;
 import org.broadinstitute.consent.http.service.ontology.OntologyTerm;
 import org.broadinstitute.consent.http.util.ConsentLogger;
@@ -27,31 +29,31 @@ public class TranslationUtil implements ConsentLogger {
       "Research is limited to samples restricted for use under the following conditions:";
   protected static final String FEMALE = "Female";
   protected static final String MALE = "Male";
-  private static final String GRU = "Data is available for general research use. [GRU]";
+  protected static final String GRU = "Data is available for general research use. [GRU]";
   public static final String DS = "Data use is limited for studying: %s [DS]";
   public static final String HMB = "Data is limited for health/medical/biomedical research. [HMB]";
-  private static final String POA =
+  protected static final String POA =
       "Future use for population origins or ancestry research is prohibited. [POA]";
   public static final String NMDS =
       "Data use for methods development research ONLY within the bounds of other data use limitations. [NMDS]";
   public static final String NCU = "Commercial use prohibited. [NCU]";
-  private static final String OTHER = "Other restrictions: %s.";
-  private static final String SECONDARY_OTHER = "Secondary other restrictions: %s.";
-  private static final String ETHICS_APPROVAL = "Local ethics committee approval is required.";
-  private static final String COLLABORATION_REQUIRED =
+  protected static final String OTHER = "Other restrictions: %s.";
+  protected static final String SECONDARY_OTHER = "Secondary other restrictions: %s.";
+  protected static final String ETHICS_APPROVAL = "Local ethics committee approval is required.";
+  protected static final String COLLABORATION_REQUIRED =
       "Collaboration with the primary study investigators required. [COL]";
-  private static final String GEO_RESTRICTION = "Geographical restrictions: %s.";
-  private static final String GSO = "Future use is limited to genetic studies only [GSO]";
-  private static final String PUB_REQUIRED =
+  protected static final String GEO_RESTRICTION = "Geographical restrictions: %s.";
+  protected static final String GSO = "Future use is limited to genetic studies only [GSO]";
+  protected static final String PUB_REQUIRED =
       "Publishing results of studies using the data available to the larger scientific community is required";
-  private static final String PUB_MORATORIUM =
+  protected static final String PUB_MORATORIUM =
       "Publishing moratorium until '%s' is in effect. [MOR]";
   public static final String NCTRL =
       "Future use as a control set for diseases other than those specified is prohibited. [NCTRL]";
-  private static final String RS_M = "Data use is limited to research on males. [RS-M]";
-  private static final String RS_FM = "Data use is limited to research on females. [RS-FM]";
-  private static final String RS_PD = "Data use is limited to pediatric research. [RS-PD]";
-  private static final String POP =
+  protected static final String RS_M = "Data use is limited to research on males. [RS-M]";
+  protected static final String RS_FM = "Data use is limited to research on females. [RS-FM]";
+  protected static final String RS_PD = "Data use is limited to pediatric research. [RS-PD]";
+  protected static final String POP =
       "Future use for study variation in the general population (e.g. calling variants and/or studying their distribution). [POP]";
 
   private final OntologyDAO ontologyDAO;
@@ -168,6 +170,115 @@ public class TranslationUtil implements ConsentLogger {
     }
 
     return String.join("\n", summary);
+  }
+
+  /**
+   * Generate a structured summary of the data use. This method is Dataset specific.
+   *
+   * @param dataUse The DataUse
+   * @return DataUseSummary The structured summary
+   */
+  // Suppress warning for method complexity (S3776). Due for reevaluation after initial migration
+  @SuppressWarnings({"java:S3776"})
+  public DataUseSummary translateSummary(DataUse dataUse) {
+    DataUseSummary summary = new DataUseSummary();
+    List<DataUseTerm> primary = new ArrayList<>();
+    List<DataUseTerm> secondary = new ArrayList<>();
+    if (Objects.isNull(dataUse)) {
+      return summary;
+    }
+
+    if (BooleanUtils.isTrue(dataUse.getGeneralUse())) {
+      primary.add(new DataUseTerm("GRU", GRU));
+    }
+
+    if (dataUse.getDiseaseRestrictions() != null && !dataUse.getDiseaseRestrictions().isEmpty()) {
+      List<OntologyTerm> terms = findTermsByIds(dataUse.getDiseaseRestrictions());
+      List<String> labels = new ArrayList<>(terms.stream().map(OntologyTerm::label).toList());
+      if (!labels.isEmpty()) {
+        String dsRestrictions =
+            labels.stream()
+                .filter(Objects::nonNull)
+                .filter(r -> !r.isEmpty())
+                .collect(Collectors.joining(", "));
+        primary.add(new DataUseTerm("DS", String.format(DS, dsRestrictions)));
+      }
+    }
+
+    if (BooleanUtils.isTrue(dataUse.getHmbResearch())) {
+      primary.add(new DataUseTerm("HMB", HMB));
+    }
+
+    if (BooleanUtils.isTrue(dataUse.getPopulationOriginsAncestry())) {
+      primary.add(new DataUseTerm("NPOA", POA));
+    }
+
+    if (StringUtils.isNotBlank(dataUse.getOther())) {
+      primary.add(new DataUseTerm("OTHER", String.format(OTHER, dataUse.getOther())));
+    }
+
+    if (BooleanUtils.isTrue(dataUse.getMethodsResearch())) {
+      secondary.add(new DataUseTerm("NMDS", NMDS));
+    }
+
+    if (BooleanUtils.isTrue(dataUse.getNonProfitUse())) {
+      secondary.add(new DataUseTerm("NCU", NCU));
+    }
+
+    if (StringUtils.isNotBlank(dataUse.getSecondaryOther())) {
+      secondary.add(
+          new DataUseTerm("OTHER", String.format(SECONDARY_OTHER, dataUse.getSecondaryOther())));
+    }
+
+    if (BooleanUtils.isTrue(dataUse.getEthicsApprovalRequired())) {
+      secondary.add(new DataUseTerm("IRB", ETHICS_APPROVAL));
+    }
+
+    if (BooleanUtils.isTrue(dataUse.getCollaboratorRequired())) {
+      secondary.add(new DataUseTerm("COL", COLLABORATION_REQUIRED));
+    }
+
+    if (StringUtils.isNotBlank(dataUse.getGeographicalRestrictions())) {
+      secondary.add(new DataUseTerm("GS",
+          String.format(GEO_RESTRICTION, dataUse.getGeographicalRestrictions())));
+    }
+
+    if (BooleanUtils.isTrue(dataUse.getGeneticStudiesOnly())) {
+      secondary.add(new DataUseTerm("GSO", GSO));
+    }
+
+    if (BooleanUtils.isTrue(dataUse.getPublicationResults())) {
+      secondary.add(new DataUseTerm("PUB", PUB_REQUIRED));
+    }
+
+    if (StringUtils.isNotBlank(dataUse.getPublicationMoratorium())) {
+      secondary.add(new DataUseTerm("MOR",
+          String.format(PUB_MORATORIUM, dataUse.getPublicationMoratorium())));
+    }
+
+    if (BooleanUtils.isTrue(dataUse.getControls())) {
+      secondary.add(new DataUseTerm("NCTRL", NCTRL));
+    }
+
+    if (Optional.ofNullable(dataUse.getGender()).orElse("na").equalsIgnoreCase(MALE)) {
+      secondary.add(new DataUseTerm("POP-M", RS_M));
+    }
+
+    if (Optional.ofNullable(dataUse.getGender()).orElse("na").equalsIgnoreCase(FEMALE)) {
+      secondary.add(new DataUseTerm("POP-F", RS_FM));
+    }
+
+    if (BooleanUtils.isTrue(dataUse.getPediatric())) {
+      secondary.add(new DataUseTerm("POP-PD", RS_PD));
+    }
+
+    if (BooleanUtils.isTrue(dataUse.getPopulation())) {
+      secondary.add(new DataUseTerm("POP", POP));
+    }
+
+    summary.setPrimary(primary);
+    summary.setSecondary(secondary);
+    return summary;
   }
 
   protected List<OntologyTerm> findTermsByIds(List<String> ids) {

--- a/src/main/java/org/broadinstitute/consent/http/service/OntologyService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/OntologyService.java
@@ -6,15 +6,9 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.inject.Inject;
-import jakarta.ws.rs.client.Client;
-import jakarta.ws.rs.client.Entity;
-import jakarta.ws.rs.client.WebTarget;
-import jakarta.ws.rs.core.MediaType;
-import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.StreamingOutput;
 import java.util.Collection;
 import java.util.concurrent.ExecutorService;
-import org.broadinstitute.consent.http.configurations.ServicesConfiguration;
 import org.broadinstitute.consent.http.enumeration.DataUseTranslationType;
 import org.broadinstitute.consent.http.enumeration.OntologyType;
 import org.broadinstitute.consent.http.matching.TranslationUtil;
@@ -32,37 +26,19 @@ public class OntologyService implements ConsentLogger {
 
   private final ExecutorService executorService =
       new ThreadUtils().getExecutorService(OntologyService.class);
-  private final ServicesConfiguration servicesConfiguration;
-  private final Client client;
   private final OntologyDAO ontologyDAO;
   private final OntologyIndexService indexService;
   private final TranslationUtil translationUtil;
 
   @Inject
-  public OntologyService(
-      Client client,
-      ServicesConfiguration config,
-      OntologyDAO ontologyDAO,
-      OntologyIndexService indexService) {
-    this.client = client;
-    this.servicesConfiguration = config;
+  public OntologyService(OntologyDAO ontologyDAO, OntologyIndexService indexService) {
     this.ontologyDAO = ontologyDAO;
     this.indexService = indexService;
     this.translationUtil = new TranslationUtil(ontologyDAO);
   }
 
   public DataUseSummary translateDataUseSummary(DataUse dataUse) {
-    WebTarget target = client.target(servicesConfiguration.getOntologyURL() + "translate/summary");
-    try (Response response =
-        target.request(MediaType.APPLICATION_JSON).post(Entity.json(dataUse.toString()))) {
-      if (response.getStatus() >= 200 || response.getStatus() <= 299) {
-        return response.readEntity(DataUseSummary.class);
-      }
-      logWarn("Error response from Ontology service: " + response.readEntity(String.class));
-    } catch (Exception e) {
-      logWarn("Error parsing response from Ontology service: " + e);
-    }
-    return null;
+    return translationUtil.translateSummary(dataUse);
   }
 
   public String translateDataUse(DataUse dataUse, DataUseTranslationType type) {

--- a/src/test/java/org/broadinstitute/consent/http/matching/TranslationUtilTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/matching/TranslationUtilTest.java
@@ -8,10 +8,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
+import com.google.gson.Gson;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
-import java.util.stream.Stream;
-import com.google.gson.Gson;
 import org.broadinstitute.consent.http.AbstractTestHelper;
 import org.broadinstitute.consent.http.enumeration.DataUseTranslationType;
 import org.broadinstitute.consent.http.models.DataUse;
@@ -187,14 +186,14 @@ class TranslationUtilTest extends AbstractTestHelper {
     assertNull(summary.getSecondary());
   }
 
-
   @Test
   void testTranslateSummaryGRU() {
     DataUse dataUse = new DataUseBuilder().setGeneralUse(true).build();
     DataUseSummary summary = service.translateSummary(dataUse);
     assertFalse(summary.getPrimary().isEmpty());
     assertTrue(summary.getPrimary().getFirst().getCode().equalsIgnoreCase("GRU"));
-    assertTrue(summary.getPrimary().getFirst().getDescription().equalsIgnoreCase(TranslationUtil.GRU));
+    assertTrue(
+        summary.getPrimary().getFirst().getDescription().equalsIgnoreCase(TranslationUtil.GRU));
   }
 
   @Test
@@ -203,11 +202,18 @@ class TranslationUtilTest extends AbstractTestHelper {
     DataUse dataUse = new DataUseBuilder().setDiseaseRestrictions(List.of(cancer)).build();
     OntologyTerm term = new OntologyTerm("DOID_1", "v1", "term definition");
     term.setLabel(cancer);
-    when(ontologyDAO.findByTermIds(new String[] {cancer})).thenReturn(output -> output.write(gson.toJson(List.of(term)).getBytes(StandardCharsets.UTF_8)));
+    when(ontologyDAO.findByTermIds(new String[] {cancer}))
+        .thenReturn(
+            output -> output.write(gson.toJson(List.of(term)).getBytes(StandardCharsets.UTF_8)));
     DataUseSummary summary = service.translateSummary(dataUse);
     assertFalse(summary.getPrimary().isEmpty());
     assertTrue(summary.getPrimary().getFirst().getCode().equalsIgnoreCase("DS"));
-    assertTrue(summary.getPrimary().getFirst().getDescription().equalsIgnoreCase(TranslationUtil.DS.formatted(cancer)));
+    assertTrue(
+        summary
+            .getPrimary()
+            .getFirst()
+            .getDescription()
+            .equalsIgnoreCase(TranslationUtil.DS.formatted(cancer)));
   }
 
   @Test
@@ -216,7 +222,8 @@ class TranslationUtilTest extends AbstractTestHelper {
     DataUseSummary summary = service.translateSummary(dataUse);
     assertFalse(summary.getPrimary().isEmpty());
     assertTrue(summary.getPrimary().getFirst().getCode().equalsIgnoreCase("HMB"));
-    assertTrue(summary.getPrimary().getFirst().getDescription().equalsIgnoreCase(TranslationUtil.HMB));
+    assertTrue(
+        summary.getPrimary().getFirst().getDescription().equalsIgnoreCase(TranslationUtil.HMB));
   }
 
   @Test
@@ -225,7 +232,8 @@ class TranslationUtilTest extends AbstractTestHelper {
     DataUseSummary summary = service.translateSummary(dataUse);
     assertFalse(summary.getPrimary().isEmpty());
     assertTrue(summary.getPrimary().getFirst().getCode().equalsIgnoreCase("NPOA"));
-    assertTrue(summary.getPrimary().getFirst().getDescription().equalsIgnoreCase(TranslationUtil.POA));
+    assertTrue(
+        summary.getPrimary().getFirst().getDescription().equalsIgnoreCase(TranslationUtil.POA));
   }
 
   @Test
@@ -234,7 +242,12 @@ class TranslationUtilTest extends AbstractTestHelper {
     DataUseSummary summary = service.translateSummary(dataUse);
     assertFalse(summary.getPrimary().isEmpty());
     assertTrue(summary.getPrimary().getFirst().getCode().equalsIgnoreCase("OTHER"));
-    assertTrue(summary.getPrimary().getFirst().getDescription().equalsIgnoreCase(TranslationUtil.OTHER.formatted("Other")));
+    assertTrue(
+        summary
+            .getPrimary()
+            .getFirst()
+            .getDescription()
+            .equalsIgnoreCase(TranslationUtil.OTHER.formatted("Other")));
   }
 
   @Test
@@ -244,7 +257,8 @@ class TranslationUtilTest extends AbstractTestHelper {
     assertTrue(summary.getPrimary().isEmpty());
     assertFalse(summary.getSecondary().isEmpty());
     assertTrue(summary.getSecondary().getFirst().getCode().equalsIgnoreCase("NMDS"));
-    assertTrue(summary.getSecondary().getFirst().getDescription().equalsIgnoreCase(TranslationUtil.NMDS));
+    assertTrue(
+        summary.getSecondary().getFirst().getDescription().equalsIgnoreCase(TranslationUtil.NMDS));
   }
 
   @Test
@@ -254,7 +268,8 @@ class TranslationUtilTest extends AbstractTestHelper {
     assertTrue(summary.getPrimary().isEmpty());
     assertFalse(summary.getSecondary().isEmpty());
     assertTrue(summary.getSecondary().getFirst().getCode().equalsIgnoreCase("NCU"));
-    assertTrue(summary.getSecondary().getFirst().getDescription().equalsIgnoreCase(TranslationUtil.NCU));
+    assertTrue(
+        summary.getSecondary().getFirst().getDescription().equalsIgnoreCase(TranslationUtil.NCU));
   }
 
   @Test
@@ -264,7 +279,12 @@ class TranslationUtilTest extends AbstractTestHelper {
     assertTrue(summary.getPrimary().isEmpty());
     assertFalse(summary.getSecondary().isEmpty());
     assertTrue(summary.getSecondary().getFirst().getCode().equalsIgnoreCase("OTHER"));
-    assertTrue(summary.getSecondary().getFirst().getDescription().equalsIgnoreCase(TranslationUtil.SECONDARY_OTHER.formatted("Secondary other")));
+    assertTrue(
+        summary
+            .getSecondary()
+            .getFirst()
+            .getDescription()
+            .equalsIgnoreCase(TranslationUtil.SECONDARY_OTHER.formatted("Secondary other")));
   }
 
   @Test
@@ -274,7 +294,12 @@ class TranslationUtilTest extends AbstractTestHelper {
     assertTrue(summary.getPrimary().isEmpty());
     assertFalse(summary.getSecondary().isEmpty());
     assertTrue(summary.getSecondary().getFirst().getCode().equalsIgnoreCase("IRB"));
-    assertTrue(summary.getSecondary().getFirst().getDescription().equalsIgnoreCase(TranslationUtil.ETHICS_APPROVAL));
+    assertTrue(
+        summary
+            .getSecondary()
+            .getFirst()
+            .getDescription()
+            .equalsIgnoreCase(TranslationUtil.ETHICS_APPROVAL));
   }
 
   @Test
@@ -284,7 +309,12 @@ class TranslationUtilTest extends AbstractTestHelper {
     assertTrue(summary.getPrimary().isEmpty());
     assertFalse(summary.getSecondary().isEmpty());
     assertTrue(summary.getSecondary().getFirst().getCode().equalsIgnoreCase("COL"));
-    assertTrue(summary.getSecondary().getFirst().getDescription().equalsIgnoreCase(TranslationUtil.COLLABORATION_REQUIRED));
+    assertTrue(
+        summary
+            .getSecondary()
+            .getFirst()
+            .getDescription()
+            .equalsIgnoreCase(TranslationUtil.COLLABORATION_REQUIRED));
   }
 
   @Test
@@ -294,7 +324,12 @@ class TranslationUtilTest extends AbstractTestHelper {
     assertTrue(summary.getPrimary().isEmpty());
     assertFalse(summary.getSecondary().isEmpty());
     assertTrue(summary.getSecondary().getFirst().getCode().equalsIgnoreCase("GS"));
-    assertTrue(summary.getSecondary().getFirst().getDescription().equalsIgnoreCase(TranslationUtil.GEO_RESTRICTION.formatted("BOSTON")));
+    assertTrue(
+        summary
+            .getSecondary()
+            .getFirst()
+            .getDescription()
+            .equalsIgnoreCase(TranslationUtil.GEO_RESTRICTION.formatted("BOSTON")));
   }
 
   @Test
@@ -304,7 +339,8 @@ class TranslationUtilTest extends AbstractTestHelper {
     assertTrue(summary.getPrimary().isEmpty());
     assertFalse(summary.getSecondary().isEmpty());
     assertTrue(summary.getSecondary().getFirst().getCode().equalsIgnoreCase("GSO"));
-    assertTrue(summary.getSecondary().getFirst().getDescription().equalsIgnoreCase(TranslationUtil.GSO));
+    assertTrue(
+        summary.getSecondary().getFirst().getDescription().equalsIgnoreCase(TranslationUtil.GSO));
   }
 
   @Test
@@ -314,7 +350,12 @@ class TranslationUtilTest extends AbstractTestHelper {
     assertTrue(summary.getPrimary().isEmpty());
     assertFalse(summary.getSecondary().isEmpty());
     assertTrue(summary.getSecondary().getFirst().getCode().equalsIgnoreCase("PUB"));
-    assertTrue(summary.getSecondary().getFirst().getDescription().equalsIgnoreCase(TranslationUtil.PUB_REQUIRED));
+    assertTrue(
+        summary
+            .getSecondary()
+            .getFirst()
+            .getDescription()
+            .equalsIgnoreCase(TranslationUtil.PUB_REQUIRED));
   }
 
   @Test
@@ -324,7 +365,12 @@ class TranslationUtilTest extends AbstractTestHelper {
     assertTrue(summary.getPrimary().isEmpty());
     assertFalse(summary.getSecondary().isEmpty());
     assertTrue(summary.getSecondary().getFirst().getCode().equalsIgnoreCase("MOR"));
-    assertTrue(summary.getSecondary().getFirst().getDescription().equalsIgnoreCase(TranslationUtil.PUB_MORATORIUM.formatted("Moratorium")));
+    assertTrue(
+        summary
+            .getSecondary()
+            .getFirst()
+            .getDescription()
+            .equalsIgnoreCase(TranslationUtil.PUB_MORATORIUM.formatted("Moratorium")));
   }
 
   @Test
@@ -334,7 +380,8 @@ class TranslationUtilTest extends AbstractTestHelper {
     assertTrue(summary.getPrimary().isEmpty());
     assertFalse(summary.getSecondary().isEmpty());
     assertTrue(summary.getSecondary().getFirst().getCode().equalsIgnoreCase("NCTRL"));
-    assertTrue(summary.getSecondary().getFirst().getDescription().equalsIgnoreCase(TranslationUtil.NCTRL));
+    assertTrue(
+        summary.getSecondary().getFirst().getDescription().equalsIgnoreCase(TranslationUtil.NCTRL));
   }
 
   @Test
@@ -344,7 +391,8 @@ class TranslationUtilTest extends AbstractTestHelper {
     assertTrue(summary.getPrimary().isEmpty());
     assertFalse(summary.getSecondary().isEmpty());
     assertTrue(summary.getSecondary().getFirst().getCode().equalsIgnoreCase("POP-M"));
-    assertTrue(summary.getSecondary().getFirst().getDescription().equalsIgnoreCase(TranslationUtil.RS_M));
+    assertTrue(
+        summary.getSecondary().getFirst().getDescription().equalsIgnoreCase(TranslationUtil.RS_M));
   }
 
   @Test
@@ -354,7 +402,8 @@ class TranslationUtilTest extends AbstractTestHelper {
     assertTrue(summary.getPrimary().isEmpty());
     assertFalse(summary.getSecondary().isEmpty());
     assertTrue(summary.getSecondary().getFirst().getCode().equalsIgnoreCase("POP-F"));
-    assertTrue(summary.getSecondary().getFirst().getDescription().equalsIgnoreCase(TranslationUtil.RS_FM));
+    assertTrue(
+        summary.getSecondary().getFirst().getDescription().equalsIgnoreCase(TranslationUtil.RS_FM));
   }
 
   @Test
@@ -364,7 +413,8 @@ class TranslationUtilTest extends AbstractTestHelper {
     assertTrue(summary.getPrimary().isEmpty());
     assertFalse(summary.getSecondary().isEmpty());
     assertTrue(summary.getSecondary().getFirst().getCode().equalsIgnoreCase("POP-PD"));
-    assertTrue(summary.getSecondary().getFirst().getDescription().equalsIgnoreCase(TranslationUtil.RS_PD));
+    assertTrue(
+        summary.getSecondary().getFirst().getDescription().equalsIgnoreCase(TranslationUtil.RS_PD));
   }
 
   @Test
@@ -374,7 +424,8 @@ class TranslationUtilTest extends AbstractTestHelper {
     assertTrue(summary.getPrimary().isEmpty());
     assertFalse(summary.getSecondary().isEmpty());
     assertTrue(summary.getSecondary().getFirst().getCode().equalsIgnoreCase("POP"));
-    assertTrue(summary.getSecondary().getFirst().getDescription().equalsIgnoreCase(TranslationUtil.POP));
+    assertTrue(
+        summary.getSecondary().getFirst().getDescription().equalsIgnoreCase(TranslationUtil.POP));
   }
 
   private OntologyTerm initializeDiseaseTerm() {

--- a/src/test/java/org/broadinstitute/consent/http/matching/TranslationUtilTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/matching/TranslationUtilTest.java
@@ -2,6 +2,7 @@ package org.broadinstitute.consent.http.matching;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -9,10 +10,13 @@ import static org.mockito.Mockito.when;
 
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.stream.Stream;
+import com.google.gson.Gson;
 import org.broadinstitute.consent.http.AbstractTestHelper;
 import org.broadinstitute.consent.http.enumeration.DataUseTranslationType;
 import org.broadinstitute.consent.http.models.DataUse;
 import org.broadinstitute.consent.http.models.DataUseBuilder;
+import org.broadinstitute.consent.http.models.ontology.DataUseSummary;
 import org.broadinstitute.consent.http.service.ontology.OntologyDAO;
 import org.broadinstitute.consent.http.service.ontology.OntologyTerm;
 import org.broadinstitute.consent.http.util.gson.GsonUtil;
@@ -28,6 +32,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class TranslationUtilTest extends AbstractTestHelper {
 
   private TranslationUtil service;
+  private final Gson gson = GsonUtil.getInstance();
 
   @Mock private OntologyDAO ontologyDAO;
 
@@ -172,6 +177,204 @@ class TranslationUtilTest extends AbstractTestHelper {
   void testTranslateNullType() {
     DataUse dataUse = new DataUseBuilder().setGeneralUse(false).build();
     assertThrows(IllegalArgumentException.class, () -> service.translate(dataUse, null));
+  }
+
+  @Test
+  void testTranslateSummaryNull() {
+    DataUseSummary summary = service.translateSummary(null);
+    assertNotNull(summary);
+    assertNull(summary.getPrimary());
+    assertNull(summary.getSecondary());
+  }
+
+
+  @Test
+  void testTranslateSummaryGRU() {
+    DataUse dataUse = new DataUseBuilder().setGeneralUse(true).build();
+    DataUseSummary summary = service.translateSummary(dataUse);
+    assertFalse(summary.getPrimary().isEmpty());
+    assertTrue(summary.getPrimary().getFirst().getCode().equalsIgnoreCase("GRU"));
+    assertTrue(summary.getPrimary().getFirst().getDescription().equalsIgnoreCase(TranslationUtil.GRU));
+  }
+
+  @Test
+  void testTranslateSummaryDS() {
+    String cancer = "Cancer";
+    DataUse dataUse = new DataUseBuilder().setDiseaseRestrictions(List.of(cancer)).build();
+    OntologyTerm term = new OntologyTerm("DOID_1", "v1", "term definition");
+    term.setLabel(cancer);
+    when(ontologyDAO.findByTermIds(new String[] {cancer})).thenReturn(output -> output.write(gson.toJson(List.of(term)).getBytes(StandardCharsets.UTF_8)));
+    DataUseSummary summary = service.translateSummary(dataUse);
+    assertFalse(summary.getPrimary().isEmpty());
+    assertTrue(summary.getPrimary().getFirst().getCode().equalsIgnoreCase("DS"));
+    assertTrue(summary.getPrimary().getFirst().getDescription().equalsIgnoreCase(TranslationUtil.DS.formatted(cancer)));
+  }
+
+  @Test
+  void testTranslateSummaryHMB() {
+    DataUse dataUse = new DataUseBuilder().setHmbResearch(true).build();
+    DataUseSummary summary = service.translateSummary(dataUse);
+    assertFalse(summary.getPrimary().isEmpty());
+    assertTrue(summary.getPrimary().getFirst().getCode().equalsIgnoreCase("HMB"));
+    assertTrue(summary.getPrimary().getFirst().getDescription().equalsIgnoreCase(TranslationUtil.HMB));
+  }
+
+  @Test
+  void testTranslateSummaryPOA() {
+    DataUse dataUse = new DataUseBuilder().setPopulationOriginsAncestry(true).build();
+    DataUseSummary summary = service.translateSummary(dataUse);
+    assertFalse(summary.getPrimary().isEmpty());
+    assertTrue(summary.getPrimary().getFirst().getCode().equalsIgnoreCase("NPOA"));
+    assertTrue(summary.getPrimary().getFirst().getDescription().equalsIgnoreCase(TranslationUtil.POA));
+  }
+
+  @Test
+  void testTranslateSummaryOther() {
+    DataUse dataUse = new DataUseBuilder().setOther("Other").build();
+    DataUseSummary summary = service.translateSummary(dataUse);
+    assertFalse(summary.getPrimary().isEmpty());
+    assertTrue(summary.getPrimary().getFirst().getCode().equalsIgnoreCase("OTHER"));
+    assertTrue(summary.getPrimary().getFirst().getDescription().equalsIgnoreCase(TranslationUtil.OTHER.formatted("Other")));
+  }
+
+  @Test
+  void testTranslateSummaryNMDS() {
+    DataUse dataUse = new DataUseBuilder().setMethodsResearch(true).build();
+    DataUseSummary summary = service.translateSummary(dataUse);
+    assertTrue(summary.getPrimary().isEmpty());
+    assertFalse(summary.getSecondary().isEmpty());
+    assertTrue(summary.getSecondary().getFirst().getCode().equalsIgnoreCase("NMDS"));
+    assertTrue(summary.getSecondary().getFirst().getDescription().equalsIgnoreCase(TranslationUtil.NMDS));
+  }
+
+  @Test
+  void testTranslateSummaryNCU() {
+    DataUse dataUse = new DataUseBuilder().setNonProfitUse(true).build();
+    DataUseSummary summary = service.translateSummary(dataUse);
+    assertTrue(summary.getPrimary().isEmpty());
+    assertFalse(summary.getSecondary().isEmpty());
+    assertTrue(summary.getSecondary().getFirst().getCode().equalsIgnoreCase("NCU"));
+    assertTrue(summary.getSecondary().getFirst().getDescription().equalsIgnoreCase(TranslationUtil.NCU));
+  }
+
+  @Test
+  void testTranslateSummarySecondaryOther() {
+    DataUse dataUse = new DataUseBuilder().setSecondaryOther("Secondary other").build();
+    DataUseSummary summary = service.translateSummary(dataUse);
+    assertTrue(summary.getPrimary().isEmpty());
+    assertFalse(summary.getSecondary().isEmpty());
+    assertTrue(summary.getSecondary().getFirst().getCode().equalsIgnoreCase("OTHER"));
+    assertTrue(summary.getSecondary().getFirst().getDescription().equalsIgnoreCase(TranslationUtil.SECONDARY_OTHER.formatted("Secondary other")));
+  }
+
+  @Test
+  void testTranslateSummaryIRB() {
+    DataUse dataUse = new DataUseBuilder().setEthicsApprovalRequired(true).build();
+    DataUseSummary summary = service.translateSummary(dataUse);
+    assertTrue(summary.getPrimary().isEmpty());
+    assertFalse(summary.getSecondary().isEmpty());
+    assertTrue(summary.getSecondary().getFirst().getCode().equalsIgnoreCase("IRB"));
+    assertTrue(summary.getSecondary().getFirst().getDescription().equalsIgnoreCase(TranslationUtil.ETHICS_APPROVAL));
+  }
+
+  @Test
+  void testTranslateSummaryCollaborationRequired() {
+    DataUse dataUse = new DataUseBuilder().setCollaboratorRequired(true).build();
+    DataUseSummary summary = service.translateSummary(dataUse);
+    assertTrue(summary.getPrimary().isEmpty());
+    assertFalse(summary.getSecondary().isEmpty());
+    assertTrue(summary.getSecondary().getFirst().getCode().equalsIgnoreCase("COL"));
+    assertTrue(summary.getSecondary().getFirst().getDescription().equalsIgnoreCase(TranslationUtil.COLLABORATION_REQUIRED));
+  }
+
+  @Test
+  void testTranslateSummaryGeoGraphicalRestrictions() {
+    DataUse dataUse = new DataUseBuilder().setGeographicalRestrictions("BOSTON").build();
+    DataUseSummary summary = service.translateSummary(dataUse);
+    assertTrue(summary.getPrimary().isEmpty());
+    assertFalse(summary.getSecondary().isEmpty());
+    assertTrue(summary.getSecondary().getFirst().getCode().equalsIgnoreCase("GS"));
+    assertTrue(summary.getSecondary().getFirst().getDescription().equalsIgnoreCase(TranslationUtil.GEO_RESTRICTION.formatted("BOSTON")));
+  }
+
+  @Test
+  void testTranslateSummaryGSO() {
+    DataUse dataUse = new DataUseBuilder().setGeneticStudiesOnly(true).build();
+    DataUseSummary summary = service.translateSummary(dataUse);
+    assertTrue(summary.getPrimary().isEmpty());
+    assertFalse(summary.getSecondary().isEmpty());
+    assertTrue(summary.getSecondary().getFirst().getCode().equalsIgnoreCase("GSO"));
+    assertTrue(summary.getSecondary().getFirst().getDescription().equalsIgnoreCase(TranslationUtil.GSO));
+  }
+
+  @Test
+  void testTranslateSummaryPUB() {
+    DataUse dataUse = new DataUseBuilder().setPublicationResults(true).build();
+    DataUseSummary summary = service.translateSummary(dataUse);
+    assertTrue(summary.getPrimary().isEmpty());
+    assertFalse(summary.getSecondary().isEmpty());
+    assertTrue(summary.getSecondary().getFirst().getCode().equalsIgnoreCase("PUB"));
+    assertTrue(summary.getSecondary().getFirst().getDescription().equalsIgnoreCase(TranslationUtil.PUB_REQUIRED));
+  }
+
+  @Test
+  void testTranslateSummaryPubMoratorium() {
+    DataUse dataUse = new DataUseBuilder().setPublicationMoratorium("Moratorium").build();
+    DataUseSummary summary = service.translateSummary(dataUse);
+    assertTrue(summary.getPrimary().isEmpty());
+    assertFalse(summary.getSecondary().isEmpty());
+    assertTrue(summary.getSecondary().getFirst().getCode().equalsIgnoreCase("MOR"));
+    assertTrue(summary.getSecondary().getFirst().getDescription().equalsIgnoreCase(TranslationUtil.PUB_MORATORIUM.formatted("Moratorium")));
+  }
+
+  @Test
+  void testTranslateSummaryNCTRL() {
+    DataUse dataUse = new DataUseBuilder().setControl(true).build();
+    DataUseSummary summary = service.translateSummary(dataUse);
+    assertTrue(summary.getPrimary().isEmpty());
+    assertFalse(summary.getSecondary().isEmpty());
+    assertTrue(summary.getSecondary().getFirst().getCode().equalsIgnoreCase("NCTRL"));
+    assertTrue(summary.getSecondary().getFirst().getDescription().equalsIgnoreCase(TranslationUtil.NCTRL));
+  }
+
+  @Test
+  void testTranslateSummaryPOP_M() {
+    DataUse dataUse = new DataUseBuilder().setGender(TranslationUtil.MALE).build();
+    DataUseSummary summary = service.translateSummary(dataUse);
+    assertTrue(summary.getPrimary().isEmpty());
+    assertFalse(summary.getSecondary().isEmpty());
+    assertTrue(summary.getSecondary().getFirst().getCode().equalsIgnoreCase("POP-M"));
+    assertTrue(summary.getSecondary().getFirst().getDescription().equalsIgnoreCase(TranslationUtil.RS_M));
+  }
+
+  @Test
+  void testTranslateSummaryPOP_F() {
+    DataUse dataUse = new DataUseBuilder().setGender(TranslationUtil.FEMALE).build();
+    DataUseSummary summary = service.translateSummary(dataUse);
+    assertTrue(summary.getPrimary().isEmpty());
+    assertFalse(summary.getSecondary().isEmpty());
+    assertTrue(summary.getSecondary().getFirst().getCode().equalsIgnoreCase("POP-F"));
+    assertTrue(summary.getSecondary().getFirst().getDescription().equalsIgnoreCase(TranslationUtil.RS_FM));
+  }
+
+  @Test
+  void testTranslateSummaryPOP_PD() {
+    DataUse dataUse = new DataUseBuilder().setPediatric(true).build();
+    DataUseSummary summary = service.translateSummary(dataUse);
+    assertTrue(summary.getPrimary().isEmpty());
+    assertFalse(summary.getSecondary().isEmpty());
+    assertTrue(summary.getSecondary().getFirst().getCode().equalsIgnoreCase("POP-PD"));
+    assertTrue(summary.getSecondary().getFirst().getDescription().equalsIgnoreCase(TranslationUtil.RS_PD));
+  }
+
+  @Test
+  void testTranslateSummaryPOP() {
+    DataUse dataUse = new DataUseBuilder().setPopulation(true).build();
+    DataUseSummary summary = service.translateSummary(dataUse);
+    assertTrue(summary.getPrimary().isEmpty());
+    assertFalse(summary.getSecondary().isEmpty());
+    assertTrue(summary.getSecondary().getFirst().getCode().equalsIgnoreCase("POP"));
+    assertTrue(summary.getSecondary().getFirst().getDescription().equalsIgnoreCase(TranslationUtil.POP));
   }
 
   private OntologyTerm initializeDiseaseTerm() {

--- a/src/test/java/org/broadinstitute/consent/http/matching/TranslationUtilTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/matching/TranslationUtilTest.java
@@ -51,6 +51,20 @@ class TranslationUtilTest extends AbstractTestHelper {
   }
 
   @Test
+  void testTranslateDiseaseLookupWithEmptyLabels() {
+    OntologyTerm term =
+        new OntologyTerm("DOID_" + randomInt(1, 100), "term label", "term definition");
+    term.setLabel("");
+    String json = GsonUtil.getInstance().toJson(List.of(term));
+    when(ontologyDAO.findByTermIds(new String[] {term.id()}))
+        .thenReturn(output -> output.write(json.getBytes(StandardCharsets.UTF_8)));
+    DataUse dataUse = new DataUseBuilder().setDiseaseRestrictions(List.of(term.id())).build();
+    String translation = service.translate(dataUse, DataUseTranslationType.DATASET);
+    assertNotNull(translation);
+    assertFalse(translation.contains("[DS]"));
+  }
+
+  @Test
   void testTranslateDataset() {
     DataUse dataUse = new DataUseBuilder().setGeneralUse(true).build();
     String translation = service.translate(dataUse, DataUseTranslationType.DATASET);
@@ -214,6 +228,21 @@ class TranslationUtilTest extends AbstractTestHelper {
             .getFirst()
             .getDescription()
             .equalsIgnoreCase(TranslationUtil.DS.formatted(cancer)));
+  }
+
+  @Test
+  void testTranslateSummaryDiseaseLookupWithEmptyLabels() {
+    OntologyTerm term =
+        new OntologyTerm("DOID_" + randomInt(1, 100), "term label", "term definition");
+    term.setLabel("");
+    String json = GsonUtil.getInstance().toJson(List.of(term));
+    when(ontologyDAO.findByTermIds(new String[] {term.id()}))
+        .thenReturn(output -> output.write(json.getBytes(StandardCharsets.UTF_8)));
+    DataUse dataUse = new DataUseBuilder().setDiseaseRestrictions(List.of(term.id())).build();
+    DataUseSummary summary = service.translateSummary(dataUse);
+    assertNotNull(summary);
+    assertTrue(summary.getPrimary().isEmpty());
+    assertTrue(summary.getSecondary().isEmpty());
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/OntologyServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/OntologyServiceTest.java
@@ -8,14 +8,11 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
-import static org.mockserver.model.HttpRequest.request;
-import static org.mockserver.model.HttpResponse.response;
 
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
@@ -23,14 +20,10 @@ import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
-import jakarta.ws.rs.client.Client;
-import jakarta.ws.rs.client.ClientBuilder;
-import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.StreamingOutput;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import org.broadinstitute.consent.http.MockServerTestHelper;
-import org.broadinstitute.consent.http.configurations.ServicesConfiguration;
 import org.broadinstitute.consent.http.enumeration.DataUseTranslationType;
 import org.broadinstitute.consent.http.enumeration.OntologyType;
 import org.broadinstitute.consent.http.matching.TranslationUtil;
@@ -50,7 +43,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockserver.model.Header;
 import org.slf4j.LoggerFactory;
 
 @ExtendWith(MockitoExtension.class)
@@ -62,13 +54,6 @@ class OntologyServiceTest extends MockServerTestHelper {
   @Mock private OntologyDAO ontologyDAO;
   @Mock private OntologyIndexService indexService;
 
-  ServicesConfiguration config() {
-    ServicesConfiguration config = new ServicesConfiguration();
-    config.setLocalURL("http://localhost:8180/");
-    config.setOntologyURL(getRootUrl(CONTAINER));
-    return config;
-  }
-
   @BeforeEach
   void setUp() {
     Logger testLogger = (Logger) LoggerFactory.getLogger(OntologyService.class);
@@ -78,63 +63,20 @@ class OntologyServiceTest extends MockServerTestHelper {
     testLogger.addAppender(testAppender);
     testAppender.setContext((LoggerContext) LoggerFactory.getILoggerFactory());
     testAppender.start();
-    Client client = ClientBuilder.newClient();
-    service = new OntologyService(client, config(), ontologyDAO, indexService);
+    service = new OntologyService(ontologyDAO, indexService);
   }
 
   @Test
   void testTranslateDataUseSummary() {
-    mockDataUseTranslateSummarySuccess();
-
-    DataUse dataUse =
-        new DataUseBuilder().setHmbResearch(true).setDiseaseRestrictions(List.of("")).build();
-    DataUseSummary translation = service.translateDataUseSummary(dataUse);
-
-    assertNotNull(translation);
-
-    assertEquals(2, translation.getPrimary().size());
-
-    assertEquals("HMB", translation.getPrimary().get(0).getCode());
-    assertFalse(translation.getPrimary().get(0).getDescription().isEmpty());
-
-    assertEquals("DS", translation.getPrimary().get(1).getCode());
-    assertFalse(translation.getPrimary().get(1).getDescription().isEmpty());
-
-    assertEquals(4, translation.getSecondary().size());
-
-    assertEquals("NCU", translation.getSecondary().get(0).getCode());
-    assertFalse(translation.getSecondary().get(0).getDescription().isEmpty());
-
-    assertEquals("NMDS", translation.getSecondary().get(1).getCode());
-    assertFalse(translation.getSecondary().get(1).getDescription().isEmpty());
-
-    assertEquals("NCTRL", translation.getSecondary().get(2).getCode());
-    assertFalse(translation.getSecondary().get(2).getDescription().isEmpty());
-
-    assertEquals("OTHER", translation.getSecondary().get(3).getCode());
-    assertFalse(translation.getSecondary().get(3).getDescription().isEmpty());
-  }
-
-  @Test
-  void testTranslateDataUseSummaryErrorLogging() {
-    mockServerClient
-        .when(request().withMethod("POST").withPath("/translate/summary"))
-        .respond(
-            response()
-                .withStatusCode(500)
-                .withHeaders(new Header("Content-Type", MediaType.TEXT_PLAIN))
-                .withBody("Internal Server Error"));
-
-    DataUse dataUse =
-        new DataUseBuilder().setHmbResearch(true).setDiseaseRestrictions(List.of("")).build();
-
+    // Translations are more fully tested in TranslationUtilTest, so here we just verify that the
+    // summary is populated with expected values based on the input data use.
+    DataUse dataUse = new DataUseBuilder().setGeneralUse(true).build();
     DataUseSummary summary = service.translateDataUseSummary(dataUse);
-    assertNull(summary);
-    assertEquals(1, testAppender.getSize());
-    ILoggingEvent event = testAppender.getLoggedEvents().getFirst();
-    assertThat(
-        event.getFormattedMessage(),
-        containsString("Error parsing response from Ontology service:"));
+    assertNotNull(summary);
+    assertFalse(summary.getPrimary().isEmpty());
+    assertTrue(summary.getPrimary().getFirst().getCode().equalsIgnoreCase("GRU"));
+    assertTrue(
+        summary.getPrimary().getFirst().getDescription().equalsIgnoreCase(TranslationUtil.GRU));
   }
 
   @ParameterizedTest
@@ -245,47 +187,5 @@ class OntologyServiceTest extends MockServerTestHelper {
     assertNotNull(results);
     JsonArray jsonArray = getJsonArrayFromStreamingOutput(results);
     assertEquals(5, jsonArray.size());
-  }
-
-  private void mockDataUseTranslateSummarySuccess() {
-    mockServerClient
-        .when(request().withMethod("POST").withPath("/translate/summary"))
-        .respond(
-            response()
-                .withStatusCode(200)
-                .withHeaders(new Header("Content-Type", MediaType.APPLICATION_JSON))
-                .withBody(
-                    """
-                        {
-                          "primary": [
-                            {
-                              "code": "HMB",
-                              "description": "Data is limited for health/medical/biomedical research."
-                            },
-                            {
-                              "code": "DS",
-                              "description": "Data use is limited for studying: cancerophobia"
-                            }
-                          ],
-                          "secondary": [
-                            {
-                              "code": "NCU",
-                              "description": "Commercial use is not prohibited."
-                            },
-                            {
-                              "code": "NMDS",
-                              "description": "Data use for methods development research irrespective of the specified data use limitations is not prohibited."
-                            },
-                            {
-                              "code": "NCTRL",
-                              "description": "Restrictions for use as a control set for diseases other than those defined were not specified."
-                            },
-                            {
-                              "code": "OTHER",
-                              "description": "Genomic summary results from this study are available only through controlled-access"
-                            }
-                          ]
-                        }
-                        """));
   }
 }


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DT-2532

## Summary
This PR replicates the Translate Summary endpoint by copying over the [`translateSummary`](https://github.com/DataBiosphere/consent-ontology/blob/develop/src/main/java/org/broadinstitute/dsde/consent/ontology/datause/services/TextTranslationServiceImpl.java#L151) method to Consent. There were very few tests for this method so there are a large number of new tests in `TranslationUtilTest`

### Testing
This method is used when indexing a dataset to Elastic Search. Use the `POST /api/dataset/index/{datasetId}` API and this code path will be hit.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
