### PR TITLE
[DT-2882] Support optional Through.Bio ID on Study Registration

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/models/dataset_registration_v1/DatasetRegistrationSchemaV1.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/dataset_registration_v1/DatasetRegistrationSchemaV1.java
@@ -35,6 +35,7 @@ import java.util.Map;
   "dataSubmitterUserId",
   "dataCustodianEmail",
   "publicVisibility",
+  "throughBioId",
   "nihAnvilUse",
   "submittingToAnvil",
   "dbGaPPhsID",
@@ -120,6 +121,11 @@ public class DatasetRegistrationSchemaV1 {
   @JsonProperty("publicVisibility")
   @JsonPropertyDescription("Public Visibility of this study")
   private Boolean publicVisibility;
+
+  /** Through.bio Identifier */
+  @JsonProperty("throughBioId")
+  @JsonPropertyDescription("Through.bio Identifier")
+  private String throughBioId;
 
   /** NIH Anvil Use (Required) */
   @JsonProperty("nihAnvilUse")
@@ -407,6 +413,18 @@ public class DatasetRegistrationSchemaV1 {
   @JsonProperty("publicVisibility")
   public void setPublicVisibility(Boolean publicVisibility) {
     this.publicVisibility = publicVisibility;
+  }
+
+  /** Through.bio Identifier */
+  @JsonProperty("throughBioId")
+  public String getThroughBioId() {
+    return throughBioId;
+  }
+
+  /** Through.bio Identifier */
+  @JsonProperty("throughBioId")
+  public void setThroughBioId(String throughBioId) {
+    this.throughBioId = throughBioId;
   }
 
   /** NIH Anvil Use (Required) */
@@ -833,6 +851,10 @@ public class DatasetRegistrationSchemaV1 {
     sb.append('=');
     sb.append(((this.publicVisibility == null) ? "<null>" : this.publicVisibility));
     sb.append(',');
+    sb.append("throughBioId");
+    sb.append('=');
+    sb.append(((this.throughBioId == null) ? "<null>" : this.throughBioId));
+    sb.append(',');
     sb.append("nihAnvilUse");
     sb.append('=');
     sb.append(((this.nihAnvilUse == null) ? "<null>" : this.nihAnvilUse));
@@ -1011,6 +1033,7 @@ public class DatasetRegistrationSchemaV1 {
             + ((this.dataSubmitterUserId == null) ? 0 : this.dataSubmitterUserId.hashCode()));
     result =
         ((result * 31) + ((this.publicVisibility == null) ? 0 : this.publicVisibility.hashCode()));
+    result = ((result * 31) + ((this.throughBioId == null) ? 0 : this.throughBioId.hashCode()));
     result =
         ((result * 31)
             + ((this.dataCustodianEmail == null) ? 0 : this.dataCustodianEmail.hashCode()));
@@ -1184,6 +1207,16 @@ public class DatasetRegistrationSchemaV1 {
                                                                                                                                                     .publicVisibility
                                                                                                                                                     .equals(
                                                                                                                                                         rhs.publicVisibility))))
+                                                                                                                                    && ((this
+                                                                                                                                                .throughBioId
+                                                                                                                                            == rhs.throughBioId)
+                                                                                                                                        || ((this
+                                                                                                                                                    .throughBioId
+                                                                                                                                                != null)
+                                                                                                                                            && this
+                                                                                                                                                .throughBioId
+                                                                                                                                                .equals(
+                                                                                                                                                    rhs.throughBioId)))
                                                                                                                                     && ((this
                                                                                                                                                 .dataCustodianEmail
                                                                                                                                             == rhs.dataCustodianEmail)

--- a/src/main/java/org/broadinstitute/consent/http/models/dataset_registration_v1/builder/DatasetRegistrationSchemaV1Builder.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/dataset_registration_v1/builder/DatasetRegistrationSchemaV1Builder.java
@@ -73,6 +73,7 @@ public class DatasetRegistrationSchemaV1Builder {
   public static final String url = "url";
   public static final String numberOfParticipants = "numberOfParticipants";
   public static final String fileTypes = "fileTypes";
+  public static final String throughBioId = "throughBioId";
 
   public DatasetRegistrationSchemaV1 build(Study study, List<Dataset> datasets) {
     DatasetRegistrationSchemaV1 schema = new SchemaFromStudy().build(study);

--- a/src/main/java/org/broadinstitute/consent/http/models/dataset_registration_v1/builder/SchemaFromStudy.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/dataset_registration_v1/builder/SchemaFromStudy.java
@@ -30,6 +30,7 @@ import static org.broadinstitute.consent.http.models.dataset_registration_v1.bui
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.species;
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.studyType;
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.submittingToAnvil;
+import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.throughBioId;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
@@ -70,6 +71,7 @@ public class SchemaFromStudy {
       schemaV1.setDataCustodianEmail(
           findListStringPropValue(study.getProperties(), dataCustodianEmail));
       schemaV1.setPublicVisibility(study.getPublicVisibility());
+      schemaV1.setThroughBioId(findStringPropValue(study.getProperties(), throughBioId));
       String nihAnvilUseVal = findStringPropValue(study.getProperties(), nihAnvilUse);
       if (Objects.nonNull(nihAnvilUseVal)) {
         schemaV1.setNihAnvilUse(NihAnvilUse.fromValue(nihAnvilUseVal));

--- a/src/main/java/org/broadinstitute/consent/http/models/elastic_search/StudyTerm.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/elastic_search/StudyTerm.java
@@ -16,6 +16,7 @@ public class StudyTerm {
   private Integer dataSubmitterId;
   private List<String> dataCustodianEmail;
   private Boolean publicVisibility;
+  private String throughBioId;
   private List<String> dataTypes;
   private Map<String, Object> assets;
   private Map<String, Object> data;
@@ -106,6 +107,14 @@ public class StudyTerm {
 
   public void setPublicVisibility(Boolean publicVisibility) {
     this.publicVisibility = publicVisibility;
+  }
+
+  public String getThroughBioId() {
+    return throughBioId;
+  }
+
+  public void setThroughBioId(String throughBioId) {
+    this.throughBioId = throughBioId;
   }
 
   public List<String> getDataTypes() {

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetRegistrationService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetRegistrationService.java
@@ -612,6 +612,10 @@ public class DatasetRegistrationService implements ConsentLogger {
                     return null;
                   }),
               new StudyPropertyExtractor(
+                  "throughBioId",
+                  PropertyType.String,
+                  DatasetRegistrationSchemaV1::getThroughBioId),
+              new StudyPropertyExtractor(
                   "nihAnvilUse", PropertyType.String, DatasetRegistrationSchemaV1::getNihAnvilUse),
               new StudyPropertyExtractor(
                   "submittingToAnvil",

--- a/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
@@ -262,6 +262,9 @@ public class ElasticSearchService implements ConsentLogger {
     term.setPiName(study.getPiName());
     term.setPublicVisibility(study.getPublicVisibility());
 
+    findStudyProperty(study.getProperties(), "throughBioId")
+        .ifPresent(prop -> term.setThroughBioId(prop.getValue().toString()));
+
     findStudyProperty(study.getProperties(), "dbGaPPhsID")
         .ifPresent(prop -> term.setPhsId(prop.getValue().toString()));
 

--- a/src/test/java/org/broadinstitute/consent/http/models/DatasetRegistrationSchemaV1BuilderTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/DatasetRegistrationSchemaV1BuilderTest.java
@@ -34,6 +34,7 @@ import static org.broadinstitute.consent.http.models.dataset_registration_v1.bui
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.species;
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.studyType;
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.submittingToAnvil;
+import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.throughBioId;
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.url;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -99,6 +100,7 @@ class DatasetRegistrationSchemaV1BuilderTest {
     assertNotNull(schemaV1.getDataSubmitterUserId());
     assertNotNull(schemaV1.getDataCustodianEmail());
     assertNotNull(schemaV1.getPublicVisibility());
+    assertNotNull(schemaV1.getThroughBioId());
     assertNotNull(schemaV1.getNihAnvilUse());
     assertNotNull(schemaV1.getSubmittingToAnvil());
     assertNotNull(schemaV1.getDbGaPPhsID());
@@ -360,6 +362,8 @@ class DatasetRegistrationSchemaV1BuilderTest {
             study.getStudyId(),
             AlternativeDataSharingPlanAccessManagement.OPEN_ACCESS.value(),
             PropertyType.String));
+    study.addProperty(
+        createStudyProperty(throughBioId, study.getStudyId(), randomString(), PropertyType.String));
   }
 
   private String randomString() {

--- a/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
@@ -241,7 +241,8 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
         createStudyProperty("dbGaPPhsID", PropertyType.String),
         createStudyProperty("phenotypeIndication", PropertyType.String),
         createStudyProperty("species", PropertyType.String),
-        createStudyProperty("dataCustodianEmail", PropertyType.Json));
+        createStudyProperty("dataCustodianEmail", PropertyType.Json),
+        createStudyProperty("throughBioId", PropertyType.String));
     Dataset dataset = createDataset(user, updateUser, new DataUse(), dac);
     dataset.setProperties(
         Set.of(
@@ -347,6 +348,11 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
     assertEquals(custodianProp.get().getValue().toString(), termCustodians);
     assertEquals(datasetRecord.study.getPublicVisibility(), term.getStudy().getPublicVisibility());
     assertEquals(datasetRecord.study.getDataTypes(), term.getStudy().getDataTypes());
+    Optional<StudyProperty> throughBioIdProp =
+        datasetRecord.study.getProperties().stream()
+            .filter(p -> p.getKey().equals("throughBioId"))
+            .findFirst();
+    assertTrue(throughBioIdProp.isPresent());
   }
 
   @ParameterizedTest


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2855

### Summary

This PR adds support for associating a Study with a `through.bio` page via the Study Registration form. Here is the frontend PR https://github.com/DataBiosphere/duos-ui/pull/3330

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
