### PR TITLE
DT-2918: Add user status info to the user in the GET /me call

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/authentication/AuthorizationHelper.java
+++ b/src/main/java/org/broadinstitute/consent/http/authentication/AuthorizationHelper.java
@@ -72,7 +72,7 @@ public class AuthorizationHelper implements ConsentLogger {
    */
   protected UserStatusInfo getUserStatusInfo(DuosUser duosUser) {
     try {
-      return samService.getRegistrationInfo(duosUser);
+      return samService.getCombinedUserStatusInfo(duosUser);
     } catch (NotFoundException e) {
       try {
         // Try to post the user to Sam if they have not registered previously

--- a/src/main/java/org/broadinstitute/consent/http/configurations/ServicesConfiguration.java
+++ b/src/main/java/org/broadinstitute/consent/http/configurations/ServicesConfiguration.java
@@ -12,6 +12,7 @@ public class ServicesConfiguration {
   public static final String REGISTER_SELF_INFO_PATH = "register/user/v2/self/info";
   public static final String REGISTER_SELF_DIAGNOSTICS_PATH = "register/user/v2/self/diagnostics";
   public static final String REGISTER_SELF_PATH = "register/user/v2/self";
+  public static final String COMBINED_STATE_PATH = "api/users/v2/self/combinedState";
   public static final String TOS_TEXT_PATH = "termsOfService/v1/docs";
   public static final String TOS_SELF_PATH = "api/termsOfService/v1/user/self";
   public static final String ACCEPT_TOS_PATH = "api/termsOfService/v1/user/self/accept";
@@ -103,6 +104,10 @@ public class ServicesConfiguration {
 
   public String postRegisterUserV2SelfUrl() {
     return getSamUrl() + REGISTER_SELF_PATH;
+  }
+
+  public String getCombinedStateUrl() {
+    return getSamUrl() + COMBINED_STATE_PATH;
   }
 
   public String getToSTextUrl() {

--- a/src/main/java/org/broadinstitute/consent/http/db/SamDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/SamDAO.java
@@ -4,6 +4,7 @@ import com.google.api.client.http.EmptyContent;
 import com.google.api.client.http.GenericUrl;
 import com.google.api.client.http.HttpRequest;
 import com.google.api.client.http.HttpResponse;
+import com.google.api.client.http.HttpStatusCodes;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -14,6 +15,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
 import com.google.gson.JsonSyntaxException;
 import com.google.gson.reflect.TypeToken;
+import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.ServerErrorException;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.MediaType;
@@ -24,6 +26,7 @@ import java.util.concurrent.ExecutorService;
 import org.broadinstitute.consent.http.configurations.ServicesConfiguration;
 import org.broadinstitute.consent.http.models.AuthUser;
 import org.broadinstitute.consent.http.models.DuosUser;
+import org.broadinstitute.consent.http.models.sam.CombinedState;
 import org.broadinstitute.consent.http.models.sam.EmailResponse;
 import org.broadinstitute.consent.http.models.sam.ResourceType;
 import org.broadinstitute.consent.http.models.sam.TosResponse;
@@ -33,6 +36,7 @@ import org.broadinstitute.consent.http.models.sam.UserStatusInfo;
 import org.broadinstitute.consent.http.util.ConsentLogger;
 import org.broadinstitute.consent.http.util.HttpClientUtil;
 import org.broadinstitute.consent.http.util.ThreadUtils;
+import org.broadinstitute.consent.http.util.gson.GsonUtil;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -44,6 +48,7 @@ public class SamDAO implements ConsentLogger {
   private final ServicesConfiguration configuration;
   private final Integer connectTimeoutMilliseconds;
   public final Integer readTimeoutMilliseconds;
+  private final Gson gson = GsonUtil.getInstance();
 
   public SamDAO(HttpClientUtil clientUtil, ServicesConfiguration configuration) {
     this.clientUtil = clientUtil;
@@ -65,7 +70,7 @@ public class SamDAO implements ConsentLogger {
     }
     String body = response.parseAsString();
     Type resourceTypesListType = new TypeToken<ArrayList<ResourceType>>() {}.getType();
-    return new Gson().fromJson(body, resourceTypesListType);
+    return gson.fromJson(body, resourceTypesListType);
   }
 
   public UserStatusInfo getRegistrationInfo(AuthUser authUser) throws Exception {
@@ -78,7 +83,7 @@ public class SamDAO implements ConsentLogger {
           new ServerErrorException(response.getStatusMessage(), response.getStatusCode()));
     }
     String body = response.parseAsString();
-    return new Gson().fromJson(body, UserStatusInfo.class);
+    return gson.fromJson(body, UserStatusInfo.class);
   }
 
   public UserStatusDiagnostics getSelfDiagnostics(DuosUser duosUser) throws Exception {
@@ -91,7 +96,7 @@ public class SamDAO implements ConsentLogger {
           new ServerErrorException(response.getStatusMessage(), response.getStatusCode()));
     }
     String body = response.parseAsString();
-    return new Gson().fromJson(body, UserStatusDiagnostics.class);
+    return gson.fromJson(body, UserStatusDiagnostics.class);
   }
 
   public UserStatus postRegistrationInfo(DuosUser duosUser) throws Exception {
@@ -106,6 +111,32 @@ public class SamDAO implements ConsentLogger {
       throw e;
     }
     return new Gson().fromJson(body, UserStatus.class);
+  }
+
+  public UserStatusInfo getCombinedUserStatusInfo(AuthUser authUser) throws Exception {
+    GenericUrl genericUrl = new GenericUrl(configuration.getCombinedStateUrl());
+    HttpRequest request = clientUtil.buildGetRequest(genericUrl, authUser);
+    HttpResponse response = executeRequest(request);
+    String body = response.parseAsString();
+    if (!response.isSuccessStatusCode()) {
+      // Sam throws a 403, not a 404, when the user is not found at this API
+      if (response.getStatusCode() == HttpStatusCodes.STATUS_CODE_FORBIDDEN) {
+        throw new NotFoundException("User not found in Sam.");
+      }
+      var errorMsg = getErrorMessage(new DuosUser(authUser, null), body);
+      Exception e = new WebApplicationException(errorMsg, response.getStatusCode());
+      logException(errorMsg, new Exception(body));
+      throw e;
+    }
+    CombinedState combinedState = gson.fromJson(body, CombinedState.class);
+    return new UserStatusInfo()
+        .setUserEmail(combinedState.getSamUser().email())
+        .setUserSubjectId(combinedState.getSamUser().googleSubjectId())
+        .setEnabled(combinedState.getSamUser().enabled())
+        // Ensure that the user has both accepted the ToS and that it is the most recent version.
+        .setTosAccepted(
+            combinedState.getTermsOfServiceDetails().permitsSystemUsage()
+                && combinedState.getTermsOfServiceDetails().isCurrentVersion());
   }
 
   public static String getErrorMessage(DuosUser duosUser, String body) {

--- a/src/main/java/org/broadinstitute/consent/http/db/SamDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/SamDAO.java
@@ -120,20 +120,28 @@ public class SamDAO implements ConsentLogger {
       HttpResponse response = executeRequest(request);
       String body = response.parseAsString();
       if (!response.isSuccessStatusCode()) {
-        var errorMsg = getErrorMessage(new DuosUser(authUser, null), body);
+        String errorMsg =
+            String.format(
+                "Error getting combined user status info for user %s: %s",
+                authUser.getEmail(), body);
         Exception e = new WebApplicationException(errorMsg, response.getStatusCode());
         logException(errorMsg, new Exception(body));
         throw e;
       }
       CombinedState combinedState = gson.fromJson(body, CombinedState.class);
+      var tosDetails = combinedState.getTermsOfServiceDetails();
+      boolean tosAccepted = false;
+      if (tosDetails != null) {
+        tosAccepted =
+            Boolean.TRUE.equals(tosDetails.permitsSystemUsage())
+                && Boolean.TRUE.equals(tosDetails.isCurrentVersion());
+      }
       return new UserStatusInfo()
           .setUserEmail(combinedState.getSamUser().email())
           .setUserSubjectId(combinedState.getSamUser().googleSubjectId())
           .setEnabled(combinedState.getSamUser().enabled())
           // Ensure that the user has both accepted the ToS and that it is the most recent version.
-          .setTosAccepted(
-              combinedState.getTermsOfServiceDetails().permitsSystemUsage()
-                  && combinedState.getTermsOfServiceDetails().isCurrentVersion());
+          .setTosAccepted(tosAccepted);
     } catch (ForbiddenException e) {
       // Sam throws a 403, not a 404, when the user is not found at this API
       // which is re-thrown in executeRequest

--- a/src/main/java/org/broadinstitute/consent/http/db/SamDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/SamDAO.java
@@ -4,7 +4,6 @@ import com.google.api.client.http.EmptyContent;
 import com.google.api.client.http.GenericUrl;
 import com.google.api.client.http.HttpRequest;
 import com.google.api.client.http.HttpResponse;
-import com.google.api.client.http.HttpStatusCodes;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -15,6 +14,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
 import com.google.gson.JsonSyntaxException;
 import com.google.gson.reflect.TypeToken;
+import jakarta.ws.rs.ForbiddenException;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.ServerErrorException;
 import jakarta.ws.rs.WebApplicationException;
@@ -116,27 +116,30 @@ public class SamDAO implements ConsentLogger {
   public UserStatusInfo getCombinedUserStatusInfo(AuthUser authUser) throws Exception {
     GenericUrl genericUrl = new GenericUrl(configuration.getCombinedStateUrl());
     HttpRequest request = clientUtil.buildGetRequest(genericUrl, authUser);
-    HttpResponse response = executeRequest(request);
-    String body = response.parseAsString();
-    if (!response.isSuccessStatusCode()) {
-      // Sam throws a 403, not a 404, when the user is not found at this API
-      if (response.getStatusCode() == HttpStatusCodes.STATUS_CODE_FORBIDDEN) {
-        throw new NotFoundException("User not found in Sam.");
+    try {
+      HttpResponse response = executeRequest(request);
+      String body = response.parseAsString();
+      if (!response.isSuccessStatusCode()) {
+        var errorMsg = getErrorMessage(new DuosUser(authUser, null), body);
+        Exception e = new WebApplicationException(errorMsg, response.getStatusCode());
+        logException(errorMsg, new Exception(body));
+        throw e;
       }
-      var errorMsg = getErrorMessage(new DuosUser(authUser, null), body);
-      Exception e = new WebApplicationException(errorMsg, response.getStatusCode());
-      logException(errorMsg, new Exception(body));
-      throw e;
+      CombinedState combinedState = gson.fromJson(body, CombinedState.class);
+      return new UserStatusInfo()
+          .setUserEmail(combinedState.getSamUser().email())
+          .setUserSubjectId(combinedState.getSamUser().googleSubjectId())
+          .setEnabled(combinedState.getSamUser().enabled())
+          // Ensure that the user has both accepted the ToS and that it is the most recent version.
+          .setTosAccepted(
+              combinedState.getTermsOfServiceDetails().permitsSystemUsage()
+                  && combinedState.getTermsOfServiceDetails().isCurrentVersion());
+    } catch (ForbiddenException e) {
+      // Sam throws a 403, not a 404, when the user is not found at this API
+      // which is re-thrown in executeRequest
+      throw new NotFoundException(
+          String.format("User %s not found in Sam: %s", authUser.getEmail(), e.getMessage()), e);
     }
-    CombinedState combinedState = gson.fromJson(body, CombinedState.class);
-    return new UserStatusInfo()
-        .setUserEmail(combinedState.getSamUser().email())
-        .setUserSubjectId(combinedState.getSamUser().googleSubjectId())
-        .setEnabled(combinedState.getSamUser().enabled())
-        // Ensure that the user has both accepted the ToS and that it is the most recent version.
-        .setTosAccepted(
-            combinedState.getTermsOfServiceDetails().permitsSystemUsage()
-                && combinedState.getTermsOfServiceDetails().isCurrentVersion());
   }
 
   public static String getErrorMessage(DuosUser duosUser, String body) {

--- a/src/main/java/org/broadinstitute/consent/http/models/User.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/User.java
@@ -16,6 +16,7 @@ import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
+import org.broadinstitute.consent.http.models.sam.UserStatusInfo;
 import org.broadinstitute.consent.http.util.gson.GsonUtil;
 
 public class User {
@@ -46,6 +47,8 @@ public class User {
   @JsonProperty private Integer institutionId;
 
   @JsonProperty private String eraCommonsId;
+
+  @JsonProperty private UserStatusInfo userStatusInfo;
 
   private Institution institution;
 
@@ -294,6 +297,14 @@ public class User {
     if (!this.getProperties().contains(userProp)) {
       this.getProperties().add(userProp);
     }
+  }
+
+  public UserStatusInfo getUserStatusInfo() {
+    return userStatusInfo;
+  }
+
+  public void setUserStatusInfo(UserStatusInfo userStatusInfo) {
+    this.userStatusInfo = userStatusInfo;
   }
 
   @Override

--- a/src/main/java/org/broadinstitute/consent/http/models/sam/CombinedState.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/sam/CombinedState.java
@@ -1,0 +1,67 @@
+package org.broadinstitute.consent.http.models.sam;
+
+/**
+ * This class is intended to be a wrapper for the various states that are returned by Sam. See
+ * original implementation in Sam: <a
+ * href="https://sam.dsde-prod.broadinstitute.org/#/Users/getSamUserCombinedState">
+ * https://sam.dsde-dev.broadinstitute.org/#/Users/getSamUserCombinedState</a> For the purposes of
+ * DUOS, we only need the `samUser` and `termsOfServiceDetails` fields, but we can add more fields
+ * as needed in the future. Note that the Sam swagger docs are not up to date with the actual
+ * implementation, so we are using the actual implementation.
+ */
+@SuppressWarnings("unused")
+public class CombinedState {
+
+  private SamUser samUser;
+  private TermsOfServiceDetails termsOfServiceDetails;
+
+  public SamUser getSamUser() {
+    return samUser;
+  }
+
+  public CombinedState setSamUser(SamUser samUser) {
+    this.samUser = samUser;
+    return this;
+  }
+
+  public TermsOfServiceDetails getTermsOfServiceDetails() {
+    return termsOfServiceDetails;
+  }
+
+  public CombinedState setTermsOfServiceDetails(TermsOfServiceDetails termsOfServiceDetails) {
+    this.termsOfServiceDetails = termsOfServiceDetails;
+    return this;
+  }
+
+  /// Example response from Sam:
+  /// "samUser": {
+  ///   "azureB2CId": "string",
+  ///   "createdAt": "2026-02-20T14:09:06.715Z",
+  ///   "email": "user@example.com",
+  ///   "enabled": true,
+  ///   "googleSubjectId": "string",
+  ///   "id": "string",
+  ///   "updatedAt": "2026-02-20T14:09:06.715Z"
+  /// }
+  public record SamUser(
+      String azureB2CId,
+      String createdAt,
+      String email,
+      Boolean enabled,
+      String googleSubjectId,
+      String id,
+      String updatedAt) {}
+
+  /// Example response from Sam:
+  /// "termsOfServiceDetails": {
+  ///   "acceptedOn": "2026-02-20T14:09:06.715Z",
+  ///   "isCurrentVersion": true,
+  ///   "latestAcceptedVersion": "string",
+  ///   "permitsSystemUsage": true,
+  /// }
+  public record TermsOfServiceDetails(
+      String acceptedOn,
+      Boolean isCurrentVersion,
+      String latestAcceptedVersion,
+      Boolean permitsSystemUsage) {}
+}

--- a/src/main/java/org/broadinstitute/consent/http/models/sam/UserStatusInfo.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/sam/UserStatusInfo.java
@@ -9,6 +9,7 @@ public class UserStatusInfo {
   private String userSubjectId;
   private String userEmail;
   private Boolean enabled;
+  private Boolean tosAccepted;
 
   public Boolean getAdminEnabled() {
     return adminEnabled;
@@ -43,6 +44,15 @@ public class UserStatusInfo {
 
   public UserStatusInfo setEnabled(Boolean enabled) {
     this.enabled = enabled;
+    return this;
+  }
+
+  public Boolean getTosAccepted() {
+    return tosAccepted;
+  }
+
+  public UserStatusInfo setTosAccepted(Boolean tosAccepted) {
+    this.tosAccepted = tosAccepted;
     return this;
   }
 

--- a/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
@@ -43,6 +43,7 @@ import org.broadinstitute.consent.http.models.Error;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.UserRole;
 import org.broadinstitute.consent.http.models.UserUpdateFields;
+import org.broadinstitute.consent.http.models.sam.UserStatusInfo;
 import org.broadinstitute.consent.http.service.AcknowledgementService;
 import org.broadinstitute.consent.http.service.DatasetService;
 import org.broadinstitute.consent.http.service.NihService;
@@ -117,11 +118,16 @@ public class UserResource extends Resource {
   @Timed
   public Response getUser(@Auth DuosUser duosUser) {
     try {
-      if (Objects.isNull(duosUser.getUserStatusInfo())) {
+      UserStatusInfo userStatusInfo = duosUser.getUserStatusInfo();
+      if (userStatusInfo == null) {
         samService.asyncPostRegistrationInfo(duosUser);
+        userStatusInfo = samService.getCombinedUserStatusInfo(duosUser);
       }
-      User syncedUser = nihService.syncAccount(duosUser);
-      return Response.ok(gson.toJson(syncedUser)).build();
+      User user = nihService.syncAccount(duosUser);
+      if (userStatusInfo != null) {
+        user.setUserStatusInfo(userStatusInfo);
+      }
+      return Response.ok(gson.toJson(user)).build();
     } catch (Exception e) {
       return createExceptionResponse(e);
     }

--- a/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
@@ -121,13 +121,8 @@ public class UserResource extends Resource {
       UserStatusInfo userStatusInfo = duosUser.getUserStatusInfo();
       if (userStatusInfo == null) {
         samService.asyncPostRegistrationInfo(duosUser);
-        try {
-          // Best-effort enrichment from Sam; proceed without status info on failure.
-          userStatusInfo = samService.getCombinedUserStatusInfo(duosUser);
-        } catch (Exception ex) {
-          // Intentionally ignore Sam errors here to avoid failing /me on transient outages.
-          userStatusInfo = null;
-        }
+        // Refresh the user status info after posting registration info to Sam
+        userStatusInfo = getUserStatusInfo(duosUser);
       }
       User user = nihService.syncAccount(duosUser);
       if (userStatusInfo != null) {
@@ -136,6 +131,16 @@ public class UserResource extends Resource {
       return Response.ok(gson.toJson(user)).build();
     } catch (Exception e) {
       return createExceptionResponse(e);
+    }
+  }
+
+  private UserStatusInfo getUserStatusInfo(DuosUser duosUser) {
+    try {
+      return samService.getCombinedUserStatusInfo(duosUser);
+    } catch (Exception ex) {
+      logWarn("Unable to retrieve user status info from Sam: " + ex.getMessage());
+      // Intentionally ignore Sam errors here to avoid failing /me on transient outages.
+      return null;
     }
   }
 

--- a/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
@@ -121,7 +121,13 @@ public class UserResource extends Resource {
       UserStatusInfo userStatusInfo = duosUser.getUserStatusInfo();
       if (userStatusInfo == null) {
         samService.asyncPostRegistrationInfo(duosUser);
-        userStatusInfo = samService.getCombinedUserStatusInfo(duosUser);
+        try {
+          // Best-effort enrichment from Sam; proceed without status info on failure.
+          userStatusInfo = samService.getCombinedUserStatusInfo(duosUser);
+        } catch (Exception ex) {
+          // Intentionally ignore Sam errors here to avoid failing /me on transient outages.
+          userStatusInfo = null;
+        }
       }
       User user = nihService.syncAccount(duosUser);
       if (userStatusInfo != null) {

--- a/src/main/java/org/broadinstitute/consent/http/service/sam/SamService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/sam/SamService.java
@@ -40,6 +40,10 @@ public class SamService implements ConsentLogger {
     samDAO.asyncPostRegistrationInfo(duosUser);
   }
 
+  public UserStatusInfo getCombinedUserStatusInfo(DuosUser duosUser) throws Exception {
+    return samDAO.getCombinedUserStatusInfo(duosUser);
+  }
+
   public String getToSText() throws Exception {
     return samDAO.getToSText();
   }

--- a/src/main/resources/assets/schemas/SamUserStatusInfo.yaml
+++ b/src/main/resources/assets/schemas/SamUserStatusInfo.yaml
@@ -1,0 +1,14 @@
+type: object
+properties:
+  userSubjectId:
+    type: string
+    description: User subject id
+  userEmail:
+    type: string
+    description: User email
+  enabled:
+    type: boolean
+    description: Enabled status
+  tosAcceptance:
+    type: boolean
+    description: Whether the user has accepted the most recent version of the Terms of Service

--- a/src/main/resources/assets/schemas/SamUserStatusInfo.yaml
+++ b/src/main/resources/assets/schemas/SamUserStatusInfo.yaml
@@ -9,6 +9,6 @@ properties:
   enabled:
     type: boolean
     description: Enabled status
-  tosAcceptance:
+  tosAccepted:
     type: boolean
     description: Whether the user has accepted the most recent version of the Terms of Service

--- a/src/main/resources/assets/schemas/User.yaml
+++ b/src/main/resources/assets/schemas/User.yaml
@@ -24,3 +24,5 @@ properties:
     $ref: './UserProperties.yaml'
   libraryCard:
     $ref: './LibraryCard.yaml'
+  userStatusInfo:
+    $ref: './SamUserStatusInfo.yaml'

--- a/src/test/java/org/broadinstitute/consent/http/AbstractTestHelper.java
+++ b/src/test/java/org/broadinstitute/consent/http/AbstractTestHelper.java
@@ -27,6 +27,10 @@ public abstract class AbstractTestHelper {
     return RandomUtils.secureStrong().randomInt(startInclusive, endExclusive);
   }
 
+  public static boolean randomBoolean() {
+    return RandomUtils.secureStrong().randomBoolean();
+  }
+
   public static int nextInt() {
     return RandomUtils.secure().randomInt();
   }

--- a/src/test/java/org/broadinstitute/consent/http/authentication/AuthorizationHelperTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/authentication/AuthorizationHelperTest.java
@@ -142,7 +142,7 @@ class AuthorizationHelperTest extends AbstractTestHelper {
     headerMap.put(ClaimsCache.OAUTH2_CLAIM_email, List.of("email"));
     headerMap.put(ClaimsCache.OAUTH2_CLAIM_name, List.of("name"));
     headerCache.loadCache(bearerToken, headerMap);
-    when(samService.getRegistrationInfo(any())).thenThrow(new NotFoundException());
+    when(samService.getCombinedUserStatusInfo(any())).thenThrow(new NotFoundException());
     when(samService.postRegistrationInfo(any()))
         .thenReturn(
             new UserStatus()
@@ -161,7 +161,7 @@ class AuthorizationHelperTest extends AbstractTestHelper {
   void testAuthenticateGetUserWithStatusInfoFailurePostUserFailureWebAppEx() throws Exception {
     headerMap.put(ClaimsCache.OAUTH2_CLAIM_email, List.of("email"));
     headerCache.loadCache(bearerToken, headerMap);
-    when(samService.getRegistrationInfo(any())).thenThrow(new NotFoundException());
+    when(samService.getCombinedUserStatusInfo(any())).thenThrow(new NotFoundException());
     when(samService.postRegistrationInfo(any())).thenThrow(new Exception("errorMessage"));
 
     WebApplicationException ex =

--- a/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
@@ -3,6 +3,7 @@ package org.broadinstitute.consent.http.resources;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -148,9 +149,26 @@ class UserResourceTest extends AbstractTestHelper {
     when(nihService.syncAccount(du)).thenReturn(user);
 
     Response response = userResource.getUser(du);
+    User responseUser = gson.fromJson(response.getEntity().toString(), User.class);
+    assertEquals(user.getEmail(), responseUser.getEmail());
+    assertNotNull(responseUser.getUserStatusInfo());
+    assertEquals(info.getUserSubjectId(), responseUser.getUserStatusInfo().getUserSubjectId());
+    assertTrue(responseUser.getUserStatusInfo().getEnabled());
+    assertTrue(responseUser.getUserStatusInfo().getTosAccepted());
     verify(samService, never()).asyncPostRegistrationInfo(du);
     assertEquals(Status.OK.getStatusCode(), response.getStatus());
   }
+
+  @Test
+  void testGetMeFailure() throws Exception {
+    User user = createUserWithRole();
+    DuosUser du = new DuosUser(authUser, user);
+    when(samService.getCombinedUserStatusInfo(du)).thenThrow(new RuntimeException("Sam failure"));
+
+    Response response = userResource.getUser(du);
+    assertEquals(Status.INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatus());
+  }
+
 
   @Test
   void testGetUserById() {

--- a/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
@@ -169,7 +169,6 @@ class UserResourceTest extends AbstractTestHelper {
     assertEquals(Status.INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatus());
   }
 
-
   @Test
   void testGetUserById() {
 

--- a/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
@@ -160,13 +160,14 @@ class UserResourceTest extends AbstractTestHelper {
   }
 
   @Test
-  void testGetMeFailure() throws Exception {
+  void testGetMeSamFailure() throws Exception {
     User user = createUserWithRole();
     DuosUser du = new DuosUser(authUser, user);
     when(samService.getCombinedUserStatusInfo(du)).thenThrow(new RuntimeException("Sam failure"));
 
     Response response = userResource.getUser(du);
-    assertEquals(Status.INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatus());
+    // Ensure that even if Sam fails, we still return the user information.
+    assertEquals(Status.OK.getStatusCode(), response.getStatus());
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
@@ -10,6 +10,7 @@ import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -128,7 +129,26 @@ class UserResourceTest extends AbstractTestHelper {
 
     Response response = userResource.getUser(du);
     verify(samService).asyncPostRegistrationInfo(du);
+    verify(samService).getCombinedUserStatusInfo(du);
     verify(nihService).syncAccount(du);
+    assertEquals(Status.OK.getStatusCode(), response.getStatus());
+  }
+
+  @Test
+  void testGetMeWithUserStatusInfo() throws Exception {
+    User user = createUserWithRole();
+    DuosUser du = new DuosUser(authUser, user);
+    UserStatusInfo info =
+        new UserStatusInfo()
+            .setUserEmail(user.getEmail())
+            .setUserSubjectId("test-subject-id")
+            .setEnabled(true)
+            .setTosAccepted(true);
+    du.setUserStatusInfo(info);
+    when(nihService.syncAccount(du)).thenReturn(user);
+
+    Response response = userResource.getUser(du);
+    verify(samService, never()).asyncPostRegistrationInfo(du);
     assertEquals(Status.OK.getStatusCode(), response.getStatus());
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/service/SamServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/SamServiceTest.java
@@ -1,0 +1,138 @@
+package org.broadinstitute.consent.http.service;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import org.broadinstitute.consent.http.db.SamDAO;
+import org.broadinstitute.consent.http.models.DuosUser;
+import org.broadinstitute.consent.http.models.sam.ResourceType;
+import org.broadinstitute.consent.http.models.sam.TosResponse;
+import org.broadinstitute.consent.http.models.sam.UserStatus;
+import org.broadinstitute.consent.http.models.sam.UserStatusDiagnostics;
+import org.broadinstitute.consent.http.models.sam.UserStatusInfo;
+import org.broadinstitute.consent.http.service.sam.SamService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class SamServiceTest {
+
+  @Mock private SamDAO samDAO;
+
+  @Mock private DuosUser duosUser;
+
+  private SamService service;
+
+  @BeforeEach
+  void setUp() {
+    service = new SamService(samDAO);
+  }
+
+  @Test
+  void getResourceTypes() throws Exception {
+    List<ResourceType> expected = List.of();
+    when(samDAO.getResourceTypes(duosUser)).thenReturn(expected);
+
+    List<ResourceType> result = service.getResourceTypes(duosUser);
+
+    assertSame(expected, result);
+    verify(samDAO).getResourceTypes(duosUser);
+  }
+
+  @Test
+  void getRegistrationInfo() throws Exception {
+    UserStatusInfo expected = new UserStatusInfo();
+    when(samDAO.getRegistrationInfo(duosUser)).thenReturn(expected);
+
+    UserStatusInfo result = service.getRegistrationInfo(duosUser);
+
+    assertSame(expected, result);
+    verify(samDAO).getRegistrationInfo(duosUser);
+  }
+
+  @Test
+  void getSelfDiagnostics() throws Exception {
+    UserStatusDiagnostics expected = new UserStatusDiagnostics();
+    when(samDAO.getSelfDiagnostics(duosUser)).thenReturn(expected);
+
+    UserStatusDiagnostics result = service.getSelfDiagnostics(duosUser);
+
+    assertSame(expected, result);
+    verify(samDAO).getSelfDiagnostics(duosUser);
+  }
+
+  @Test
+  void postRegistrationInfo() throws Exception {
+    UserStatus expected = new UserStatus();
+    when(samDAO.postRegistrationInfo(duosUser)).thenReturn(expected);
+
+    UserStatus result = service.postRegistrationInfo(duosUser);
+
+    assertSame(expected, result);
+    verify(samDAO).postRegistrationInfo(duosUser);
+  }
+
+  @Test
+  void asyncPostRegistrationInfo() {
+    service.asyncPostRegistrationInfo(duosUser);
+
+    verify(samDAO).asyncPostRegistrationInfo(duosUser);
+  }
+
+  @Test
+  void getCombinedUserStatusInfo() throws Exception {
+    UserStatusInfo expected = new UserStatusInfo();
+    when(samDAO.getCombinedUserStatusInfo(duosUser)).thenReturn(expected);
+
+    UserStatusInfo result = service.getCombinedUserStatusInfo(duosUser);
+
+    assertSame(expected, result);
+    verify(samDAO).getCombinedUserStatusInfo(duosUser);
+  }
+
+  @Test
+  void getToSText() throws Exception {
+    String expected = "tos-text";
+    when(samDAO.getToSText()).thenReturn(expected);
+
+    String result = service.getToSText();
+
+    assertSame(expected, result);
+    verify(samDAO).getToSText();
+  }
+
+  @Test
+  void postTosAcceptedStatus_callsAcceptThenFetchResponse() throws Exception {
+    TosResponse expected = new TosResponse("acceptedOn", true, "acceptedVersion", true);
+    when(samDAO.getTosResponse(duosUser)).thenReturn(expected);
+
+    TosResponse result = service.postTosAcceptedStatus(duosUser);
+
+    assertSame(expected, result);
+
+    InOrder order = inOrder(samDAO);
+    order.verify(samDAO).acceptTosStatus(duosUser);
+    order.verify(samDAO).getTosResponse(duosUser);
+  }
+
+  @Test
+  void removeTosAcceptedStatus_callsRejectThenFetchResponse() throws Exception {
+    TosResponse expected = new TosResponse("acceptedOn", true, "acceptedVersion", true);
+    when(samDAO.getTosResponse(duosUser)).thenReturn(expected);
+
+    TosResponse result = service.removeTosAcceptedStatus(duosUser);
+
+    assertSame(expected, result);
+
+    InOrder order = inOrder(samDAO);
+    order.verify(samDAO).rejectTosStatus(duosUser);
+    order.verify(samDAO).getTosResponse(duosUser);
+  }
+}

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/SamDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/SamDAOTest.java
@@ -21,6 +21,7 @@ import jakarta.ws.rs.WebApplicationException;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 import org.broadinstitute.consent.http.MockServerTestHelper;
 import org.broadinstitute.consent.http.configurations.ServicesConfiguration;
 import org.broadinstitute.consent.http.db.SamDAO;
@@ -39,7 +40,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockserver.model.Delay;
@@ -250,14 +252,26 @@ class SamDAOTest extends MockServerTestHelper {
     }
   }
 
+  // Provide all combinations of true/false for isCurrentVersion and permitsSystemUsage to test the
+  // logic in getCombinedUserStatusInfo
+  private static Stream<Arguments> provideBooleansForUserStatus() {
+    return Stream.of(
+        Arguments.of(false, false),
+        Arguments.of(false, true),
+        Arguments.of(true, false),
+        Arguments.of(true, true));
+  }
+
   @ParameterizedTest
-  @ValueSource(booleans = {true, false})
-  void testGetCombinedUserStatusInfo(boolean tos) throws Exception {
+  @MethodSource("provideBooleansForUserStatus")
+  void testGetCombinedUserStatusInfo(boolean isCurrentVersion, boolean permitsSystemUsage)
+      throws Exception {
     CombinedState.SamUser samUser =
         new CombinedState.SamUser(
             "azureB2CId", "createdAt", "email", true, "googleSubjectId", "id", "updatedAt");
     CombinedState.TermsOfServiceDetails tosDetails =
-        new CombinedState.TermsOfServiceDetails("acceptedOn", tos, "latestAcceptedVersion", tos);
+        new CombinedState.TermsOfServiceDetails(
+            "acceptedOn", isCurrentVersion, "latestAcceptedVersion", permitsSystemUsage);
     CombinedState combinedState =
         new CombinedState().setSamUser(samUser).setTermsOfServiceDetails(tosDetails);
     Gson gson = new Gson();

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/SamDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/SamDAOTest.java
@@ -21,13 +21,12 @@ import jakarta.ws.rs.WebApplicationException;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-import org.apache.commons.lang3.RandomStringUtils;
-import org.apache.commons.lang3.RandomUtils;
 import org.broadinstitute.consent.http.MockServerTestHelper;
 import org.broadinstitute.consent.http.configurations.ServicesConfiguration;
 import org.broadinstitute.consent.http.db.SamDAO;
 import org.broadinstitute.consent.http.exceptions.ConsentConflictException;
 import org.broadinstitute.consent.http.models.DuosUser;
+import org.broadinstitute.consent.http.models.sam.CombinedState;
 import org.broadinstitute.consent.http.models.sam.EmailResponse;
 import org.broadinstitute.consent.http.models.sam.ResourceType;
 import org.broadinstitute.consent.http.models.sam.UserStatus;
@@ -56,7 +55,7 @@ class SamDAOTest extends MockServerTestHelper {
   private UserStatus status;
 
   @BeforeAll
-  public static void setUp() {
+  static void setUp() {
     ServicesConfiguration servicesConfig = new ServicesConfiguration();
     servicesConfig.setTimeoutSeconds(1);
     servicesConfig.setSamUrl(
@@ -65,7 +64,7 @@ class SamDAOTest extends MockServerTestHelper {
   }
 
   @BeforeEach
-  public void init() {
+  void init() {
     UserStatus.UserInfo info =
         new UserStatus.UserInfo().setUserEmail("test@test.org").setUserSubjectId("subjectId");
     UserStatus.Enabled enabled =
@@ -76,9 +75,7 @@ class SamDAOTest extends MockServerTestHelper {
   @Test
   void testGetResourceTypes() throws Exception {
     ResourceType resourceType =
-        new ResourceType()
-            .setName(RandomStringUtils.random(10, true, true))
-            .setReuseIds(RandomUtils.nextBoolean());
+        new ResourceType().setName(randomAlphanumeric(10)).setReuseIds(randomBoolean());
     List<ResourceType> mockResponseList = Collections.singletonList(resourceType);
     Gson gson = new Gson();
     mockServerClient
@@ -97,10 +94,10 @@ class SamDAOTest extends MockServerTestHelper {
   void testGetRegistrationInfo() throws Exception {
     UserStatusInfo userInfo =
         new UserStatusInfo()
-            .setAdminEnabled(RandomUtils.nextBoolean())
+            .setAdminEnabled(randomBoolean())
             .setUserEmail("test@test.org")
-            .setUserSubjectId(RandomStringUtils.random(10, false, true))
-            .setEnabled(RandomUtils.nextBoolean());
+            .setUserSubjectId(randomAlphanumeric(10))
+            .setEnabled(randomBoolean());
     mockServerClient
         .when(request())
         .respond(
@@ -176,11 +173,11 @@ class SamDAOTest extends MockServerTestHelper {
   void testGetSelfDiagnostics() throws Exception {
     UserStatusDiagnostics diagnostics =
         new UserStatusDiagnostics()
-            .setAdminEnabled(RandomUtils.nextBoolean())
-            .setEnabled(RandomUtils.nextBoolean())
-            .setInAllUsersGroup(RandomUtils.nextBoolean())
-            .setInGoogleProxyGroup(RandomUtils.nextBoolean())
-            .setTosAccepted(RandomUtils.nextBoolean());
+            .setAdminEnabled(randomBoolean())
+            .setEnabled(randomBoolean())
+            .setInAllUsersGroup(randomBoolean())
+            .setInGoogleProxyGroup(randomBoolean())
+            .setTosAccepted(randomBoolean());
     mockServerClient
         .when(request())
         .respond(
@@ -249,6 +246,33 @@ class SamDAOTest extends MockServerTestHelper {
     } catch (Exception e) {
       fail(e.getMessage());
     }
+  }
+
+  @Test
+  void testGetCombinedUserStatusInfo() throws Exception {
+    CombinedState.SamUser samUser =
+        new CombinedState.SamUser(
+            "azureB2CId", "createdAt", "email", true, "googleSubjectId", "id", "updatedAt");
+    CombinedState.TermsOfServiceDetails tosDetails =
+        new CombinedState.TermsOfServiceDetails("acceptedOn", true, "latestAcceptedVersion", true);
+    CombinedState combinedState =
+        new CombinedState().setSamUser(samUser).setTermsOfServiceDetails(tosDetails);
+    Gson gson = new Gson();
+    mockServerClient
+        .when(request())
+        .respond(
+            response()
+                .withStatusCode(HttpStatusCodes.STATUS_CODE_OK)
+                .withBody(gson.toJson(combinedState)));
+
+    UserStatusInfo userStatusInfo = samDAO.getCombinedUserStatusInfo(duosUser);
+    assertNotNull(userStatusInfo);
+    assertEquals(samUser.email(), userStatusInfo.getUserEmail());
+    assertEquals(samUser.googleSubjectId(), userStatusInfo.getUserSubjectId());
+    assertEquals(samUser.enabled(), userStatusInfo.getEnabled());
+    assertEquals(
+        (tosDetails.permitsSystemUsage() && tosDetails.isCurrentVersion()),
+        userStatusInfo.getTosAccepted());
   }
 
   @Test
@@ -338,14 +362,15 @@ class SamDAOTest extends MockServerTestHelper {
   }
 
   @Test
+  @SuppressWarnings({"java:S5778"})
   void testConnectTimeout() {
     mockServerClient.when(request()).error(HttpError.error().withDropConnection(true));
     assertThrows(
-        ServerErrorException.class,
-        () -> samDAO.getV1UserByEmail(duosUser, RandomStringUtils.randomAlphabetic(10)));
+        ServerErrorException.class, () -> samDAO.getV1UserByEmail(duosUser, randomAlphabetic(10)));
   }
 
   @Test
+  @SuppressWarnings({"java:S5778"})
   void testReadTimeout() {
     // Increase the delay to push the response beyond the read timeout value
     int delayMilliseconds = samDAO.readTimeoutMilliseconds + 10;
@@ -357,8 +382,7 @@ class SamDAOTest extends MockServerTestHelper {
                 .withHeader(Header.header("Content-Type", "application/json"))
                 .withStatusCode(HttpStatusCodes.STATUS_CODE_OK));
     assertThrows(
-        ServerErrorException.class,
-        () -> samDAO.getV1UserByEmail(duosUser, RandomStringUtils.randomAlphabetic(10)));
+        ServerErrorException.class, () -> samDAO.getV1UserByEmail(duosUser, randomAlphabetic(10)));
   }
 
   @Test
@@ -366,7 +390,7 @@ class SamDAOTest extends MockServerTestHelper {
     when(duosUser.getEmail()).thenReturn("email@email.com");
     String body =
         """
-        {"code":500, "message": "Cannot update azureB2cId"}""";
+            {"code":500, "message": "Cannot update azureB2cId"}""";
     assertEquals(
         "Email: email@email.com. You may have previously signed in with a different authentication provider (Google or Microsoft). Please sign in with that provider. For more information visit: https://support.terra.bio/hc/en-us/community/posts/24089648317467-Cannot-update-azureB2cId-for-user",
         getErrorMessage(duosUser, body));
@@ -377,7 +401,7 @@ class SamDAOTest extends MockServerTestHelper {
     when(duosUser.getEmail()).thenReturn("email@email.com");
     String body =
         """
-        {"code":500, "message": "some other error"}""";
+            {"code":500, "message": "some other error"}""";
     assertEquals(
         "Error posting user registration information. Email: email@email.com. some other error.",
         getErrorMessage(duosUser, body));
@@ -388,7 +412,7 @@ class SamDAOTest extends MockServerTestHelper {
     when(duosUser.getEmail()).thenReturn("email@email.com");
     String body =
         """
-        {"code":500}""";
+            {"code":500}""";
     assertEquals(
         """
             Error posting user registration information. Email: email@email.com. {"code":500}.""",

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/SamDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/SamDAOTest.java
@@ -276,6 +276,15 @@ class SamDAOTest extends MockServerTestHelper {
   }
 
   @Test
+  void testGetCombinedUserStatusInfoNotFound() {
+    mockServerClient
+        .when(request())
+        .respond(response().withStatusCode(HttpStatusCodes.STATUS_CODE_FORBIDDEN));
+
+    assertThrows(NotFoundException.class, () -> samDAO.getCombinedUserStatusInfo(duosUser));
+  }
+
+  @Test
   void testGetToSText() {
     String mockText = "Plain Text";
     mockServerClient

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/SamDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/SamDAOTest.java
@@ -38,6 +38,8 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockserver.model.Delay;
@@ -248,13 +250,14 @@ class SamDAOTest extends MockServerTestHelper {
     }
   }
 
-  @Test
-  void testGetCombinedUserStatusInfo() throws Exception {
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void testGetCombinedUserStatusInfo(boolean tos) throws Exception {
     CombinedState.SamUser samUser =
         new CombinedState.SamUser(
             "azureB2CId", "createdAt", "email", true, "googleSubjectId", "id", "updatedAt");
     CombinedState.TermsOfServiceDetails tosDetails =
-        new CombinedState.TermsOfServiceDetails("acceptedOn", true, "latestAcceptedVersion", true);
+        new CombinedState.TermsOfServiceDetails("acceptedOn", tos, "latestAcceptedVersion", tos);
     CombinedState combinedState =
         new CombinedState().setSamUser(samUser).setTermsOfServiceDetails(tosDetails);
     Gson gson = new Gson();
@@ -282,6 +285,15 @@ class SamDAOTest extends MockServerTestHelper {
         .respond(response().withStatusCode(HttpStatusCodes.STATUS_CODE_FORBIDDEN));
 
     assertThrows(NotFoundException.class, () -> samDAO.getCombinedUserStatusInfo(duosUser));
+  }
+
+  @Test
+  void testGetCombinedUserStatusInfoNonSuccessStatus() {
+    mockServerClient
+        .when(request())
+        .respond(response().withStatusCode(HttpStatusCodes.STATUS_CODE_MOVED_PERMANENTLY));
+
+    assertThrows(WebApplicationException.class, () -> samDAO.getCombinedUserStatusInfo(duosUser));
   }
 
   @Test


### PR DESCRIPTION
### Addresses
Partially addresses https://broadworkbench.atlassian.net/browse/DT-2918
See front end PR here: https://github.com/DataBiosphere/duos-ui/pull/3337

### Summary
This PR makes a different call to Sam to get the user's combined state when any API call is made (during the initial OAuth filter process). It then tacks on an additional field to `UserStatusInfo` to reflect the current `tosAccepted` that we would normally get from the diagnostics call. The generated `userStatusInfo` is then added to the user response object in the current `GET /api/user/me` call.

Example response snippet from `GET /api/user/me`:
```
...
  "userStatusInfo": {
    "userSubjectId": "103..................318",
    "userEmail": "gr......@broadinstitute.org",
    "enabled": true,
    "tosAccepted": true
  },
...
```

The reason to do this is to reduce the number of API calls the UI has to make when a user signs in. Currently, it calls the me API and then after waiting for that, it makes a call to the diagnostics API which returns terms of service information:

<img width="1720" height="1031" alt="Screenshot 2026-02-20 at 1 01 28 PM" src="https://github.com/user-attachments/assets/becbfe9e-efaa-4d01-bcf8-a0b131b5e452" />

In a future UI PR, we can trim that down and skip the diagnostics API call altogether because we'll have terms of service information stored directly on the user.


----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
