### PR TITLE
[DT-2962] Improve performance of study update

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
@@ -430,7 +430,6 @@ public class ConsentModule extends AbstractModule {
         providesDatasetDAO(),
         providesElectionDAO(),
         providesEmailService(),
-        providesElasticSearchService(),
         providesVoteDAO(),
         providesVoteServiceDAO(),
         providesOntologyService());

--- a/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
@@ -608,6 +608,14 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
   void updateDatasetIndexedDate(
       @Bind("datasetId") Integer datasetId, @Bind("indexedDate") Instant indexedDate);
 
+  @SqlUpdate(
+      """
+        UPDATE dataset
+        SET indexed_date = NOW()
+        WHERE dataset_id IN (<datasetIds>)
+    """)
+  void updateDatasetsIndexedDate(@BindList("datasetIds") Set<Integer> datasetIds);
+
   @RegisterRowMapper(ApprovedDatasetMapper.class)
   @UseRowReducer(ApprovedDatasetReducer.class)
   @SqlQuery(

--- a/src/main/java/org/broadinstitute/consent/http/models/dataset_registration_v1/DatasetRegistrationSchemaV1UpdateValidator.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/dataset_registration_v1/DatasetRegistrationSchemaV1UpdateValidator.java
@@ -135,11 +135,6 @@ public class DatasetRegistrationSchemaV1UpdateValidator {
       throw new BadRequestException("Invalid change to Data Submitter");
     }
 
-    // Minimum number of consent groups is 1
-    if (registration.getConsentGroups().isEmpty()) {
-      throw new BadRequestException("Invalid number of Consent Groups");
-    }
-
     // Ensure that all consent group changes are for datasets in the current study
     List<ConsentGroup> nonStudyConsentGroups =
         registration.getConsentGroups().stream()
@@ -185,7 +180,8 @@ public class DatasetRegistrationSchemaV1UpdateValidator {
                 .map(ConsentGroup::getDatasetId)
                 .filter(Objects::nonNull)
                 .toList());
-    if (!consentGroupDatasetIds.containsAll(existingDatasetIds)) {
+    if (!consentGroupDatasetIds.containsAll(existingDatasetIds)
+        && !registration.getConsentGroups().isEmpty()) {
       throw new BadRequestException("Invalid removal of Consent Groups");
     }
 

--- a/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
@@ -220,7 +220,7 @@ public class DatasetResource extends Resource {
         throw new BadRequestException("Properties are invalid");
       }
       Dataset patched = datasetRegistrationService.patchDataset(datasetId, user, patch);
-      elasticSearchService.synchronizeDatasetInESIndex(patched, user, false);
+      elasticSearchService.synchronizeDatasetInESIndex(patched, false);
       return Response.ok(patched).build();
     } catch (Exception e) {
       return createExceptionResponse(e);
@@ -389,9 +389,8 @@ public class DatasetResource extends Resource {
   @RolesAllowed(ADMIN)
   public Response indexDatasets(@Auth AuthUser authUser) {
     try {
-      User user = userService.findUserByEmail(authUser.getEmail());
       var datasetIds = datasetService.findAllDatasetIds();
-      StreamingOutput indexResponse = elasticSearchService.indexDatasetIds(datasetIds, user);
+      StreamingOutput indexResponse = elasticSearchService.indexDatasetIds(datasetIds);
       return Response.ok(indexResponse, MediaType.APPLICATION_JSON).build();
     } catch (Exception e) {
       return createExceptionResponse(e);
@@ -403,8 +402,7 @@ public class DatasetResource extends Resource {
   @RolesAllowed(ADMIN)
   public Response indexDataset(@Auth AuthUser authUser, @PathParam("datasetId") Integer datasetId) {
     try {
-      User user = userService.findUserByEmail(authUser.getEmail());
-      return elasticSearchService.indexDataset(datasetId, user);
+      return elasticSearchService.indexDataset(datasetId);
     } catch (Exception e) {
       return createExceptionResponse(e);
     }

--- a/src/main/java/org/broadinstitute/consent/http/resources/StudyResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/StudyResource.java
@@ -262,10 +262,8 @@ public class StudyResource extends Resource {
         Study updatedStudy =
             datasetRegistrationService.updateStudyFromRegistration(
                 studyId, registration, user, files);
-        try (Response indexResponse = elasticSearchService.indexStudy(studyId, user)) {
-          if (indexResponse.getStatus() >= Status.BAD_REQUEST.getStatusCode()) {
-            logWarn("Non-OK response when reindexing study with id: " + studyId);
-          }
+        try {
+          elasticSearchService.indexStudy(studyId);
         } catch (Exception e) {
           logException("Exception re-indexing datasets from study id: " + studyId, e);
         }

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetRegistrationService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetRegistrationService.java
@@ -130,7 +130,8 @@ public class DatasetRegistrationService implements ConsentLogger {
             idx -> {
               ConsentGroup cg = registration.getConsentGroups().get(idx);
               if (Objects.nonNull(cg.getDatasetId())) {
-                Dataset existingDataset = datasetDAO.findDatasetById(cg.getDatasetId());
+                Dataset existingDataset =
+                    datasetDAO.findDatasetsByIdList(List.of(cg.getDatasetId())).getFirst();
                 try {
                   DatasetUpdate datasetUpdate =
                       new DatasetUpdate(
@@ -213,7 +214,7 @@ public class DatasetRegistrationService implements ConsentLogger {
 
     List<Dataset> datasets = datasetDAO.findDatasetsByIdList(createdDatasetIds);
     sendDatasetSubmittedEmails(datasets);
-    try (Response response = elasticSearchService.indexDatasets(createdDatasetIds, user)) {
+    try (Response response = elasticSearchService.indexDatasets(createdDatasetIds)) {
       if (response.getStatus() >= 400) {
         logWarn(
             String.format(
@@ -290,7 +291,7 @@ public class DatasetRegistrationService implements ConsentLogger {
     }
 
     Dataset updatedDataset = datasetDAO.findDatasetById(datasetId);
-    elasticSearchService.synchronizeDatasetInESIndex(updatedDataset, user, false);
+    elasticSearchService.synchronizeDatasetInESIndex(updatedDataset, false);
     return updatedDataset;
   }
 

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -267,7 +267,7 @@ public class DatasetService implements ConsentLogger {
       throw new IllegalArgumentException("Admin use only");
     }
     datasetDAO.updateDatasetDataUse(datasetId, dataUse.toString());
-    elasticSearchService.synchronizeDatasetInESIndex(d, user, false);
+    elasticSearchService.synchronizeDatasetInESIndex(d, false);
     return datasetDAO.findDatasetById(datasetId);
   }
 
@@ -280,7 +280,7 @@ public class DatasetService implements ConsentLogger {
     String translation =
         ontologyService.translateDataUse(dataset.getDataUse(), DataUseTranslationType.DATASET);
     datasetDAO.updateDatasetTranslatedDataUse(datasetId, translation);
-    elasticSearchService.synchronizeDatasetInESIndex(dataset, user, false);
+    elasticSearchService.synchronizeDatasetInESIndex(dataset, false);
     return datasetDAO.findDatasetById(datasetId);
   }
 
@@ -332,7 +332,13 @@ public class DatasetService implements ConsentLogger {
     // resource)
     if (currentApprovalState == null || !currentApprovalState) {
       datasetDAO.updateDatasetApproval(approval, Instant.now(), user.getUserId(), datasetId);
-      elasticSearchService.asyncDatasetInESIndex(datasetId, user, true);
+      try {
+        elasticSearchService.indexDatasets(List.of(datasetId));
+      } catch (IOException ioException) {
+        logException(
+            "Error updating entry in ElasticSearch for dataset Id: %d".formatted(datasetId),
+            ioException);
+      }
       datasetReturn = datasetDAO.findDatasetWithoutFSOInformation(datasetId);
     } else {
       if (approval == null || !approval) {
@@ -441,7 +447,7 @@ public class DatasetService implements ConsentLogger {
     if (studyConversion.getDatasetName() != null) {
       datasetDAO.updateDatasetName(dataset.getDatasetId(), studyConversion.getDatasetName());
     }
-    elasticSearchService.synchronizeDatasetInESIndex(dataset, user, false);
+    elasticSearchService.synchronizeDatasetInESIndex(dataset, false);
     List<Dictionary> dictionaries = datasetDAO.getDictionaryTerms();
     // Handle "Phenotype/Indication"
     if (studyConversion.getPhenotype() != null) {
@@ -523,8 +529,7 @@ public class DatasetService implements ConsentLogger {
           studyId, dataCustodianEmail, PropertyType.Json.toString(), custodians);
     }
     List<Dataset> datasets = datasetDAO.findDatasetsByIdList(study.getDatasetIds());
-    datasets.forEach(
-        dataset -> elasticSearchService.synchronizeDatasetInESIndex(dataset, user, false));
+    datasets.forEach(dataset -> elasticSearchService.synchronizeDatasetInESIndex(dataset, false));
     return studyDAO.findStudyById(studyId);
   }
 
@@ -721,9 +726,7 @@ public class DatasetService implements ConsentLogger {
     try {
       Study study = studyDAO.findStudyById(studyId);
       datasetServiceDAO.patchStudy(study, user, patch);
-      study
-          .getDatasetIds()
-          .forEach(datasetId -> elasticSearchService.asyncDatasetInESIndex(datasetId, user, true));
+      elasticSearchService.indexStudy(studyId);
       return studyDAO.findStudyById(studyId);
     } catch (Exception ex) {
       logException(ex);

--- a/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
@@ -4,11 +4,6 @@ import static org.broadinstitute.consent.http.models.dataset_registration_v1.bui
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.data;
 
 import com.google.api.client.http.HttpStatusCodes;
-import com.google.common.util.concurrent.FutureCallback;
-import com.google.common.util.concurrent.Futures;
-import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.ListeningExecutorService;
-import com.google.common.util.concurrent.MoreExecutors;
 import com.google.gson.JsonArray;
 import jakarta.ws.rs.HttpMethod;
 import jakarta.ws.rs.core.Response;
@@ -21,11 +16,13 @@ import java.sql.SQLException;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.concurrent.ExecutorService;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.apache.http.entity.ContentType;
 import org.apache.http.nio.entity.NStringEntity;
 import org.broadinstitute.consent.http.configurations.ElasticSearchConfiguration;
@@ -52,15 +49,12 @@ import org.broadinstitute.consent.http.models.elastic_search.UserTerm;
 import org.broadinstitute.consent.http.models.ontology.DataUseSummary;
 import org.broadinstitute.consent.http.service.dao.DatasetServiceDAO;
 import org.broadinstitute.consent.http.util.ConsentLogger;
-import org.broadinstitute.consent.http.util.ThreadUtils;
 import org.broadinstitute.consent.http.util.gson.GsonUtil;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.RestClient;
 
 public class ElasticSearchService implements ConsentLogger {
 
-  private final ExecutorService executorService =
-      new ThreadUtils().getExecutorService(ElasticSearchService.class);
   private final RestClient esClient;
   private final ElasticSearchConfiguration esConfig;
   private final DacDAO dacDAO;
@@ -150,14 +144,13 @@ public class ElasticSearchService implements ConsentLogger {
     return this.indexKey;
   }
 
-  public Response indexDatasetTerms(List<DatasetTerm> datasets, User user) throws IOException {
+  public Response indexDatasetTerms(List<DatasetTerm> datasets) throws IOException {
     List<String> bulkApiCall = new ArrayList<>();
 
     datasets.forEach(
         dsTerm -> {
           bulkApiCall.add(BULK_HEADER.formatted(getIndexKey(), dsTerm.getDatasetId()));
           bulkApiCall.add(GsonUtil.getInstance().toJson(dsTerm) + "\n");
-          updateDatasetIndexDate(dsTerm.getDatasetId(), user.getUserId(), Instant.now());
         });
 
     Request bulkRequest =
@@ -165,7 +158,8 @@ public class ElasticSearchService implements ConsentLogger {
 
     bulkRequest.setEntity(
         new NStringEntity(String.join("", bulkApiCall) + "\n", ContentType.APPLICATION_JSON));
-
+    updateDatasetIndexDateForDatasets(
+        datasets.stream().map(DatasetTerm::getDatasetId).collect(Collectors.toSet()));
     return performRequest(bulkRequest);
   }
 
@@ -324,35 +318,21 @@ public class ElasticSearchService implements ConsentLogger {
     return new InstitutionTerm(institution.getId(), institution.getName());
   }
 
-  public void asyncDatasetInESIndex(Integer datasetId, User user, boolean force) {
-    ListeningExecutorService listeningExecutorService =
-        MoreExecutors.listeningDecorator(executorService);
-    ListenableFuture<Dataset> syncFuture =
-        listeningExecutorService.submit(
-            () -> {
-              Dataset dataset = datasetDAO.findDatasetById(datasetId);
-              synchronizeDatasetInESIndex(dataset, user, force);
-              return dataset;
-            });
-    Futures.addCallback(
-        syncFuture,
-        new FutureCallback<>() {
-          @Override
-          public void onSuccess(Dataset d) {
-            logInfo(
-                "Successfully synchronized dataset in ES index: %s"
-                    .formatted(d.getDatasetIdentifier()));
-          }
-
-          @Override
-          public void onFailure(Throwable t) {
-            logWarn(
-                "Failed to synchronize dataset in ES index: %s".formatted(datasetId)
-                    + ": "
-                    + t.getMessage());
-          }
-        },
-        listeningExecutorService);
+  public Response indexStudy(Integer studyId) {
+    Study study = studyDAO.findStudyById(studyId);
+    logWarn("Loading datasets for study: %d".formatted(studyId));
+    List<Dataset> datasets = datasetDAO.findDatasetsByIdList(study.getDatasetIds());
+    logWarn("Loaded %d datasets for study: %d".formatted(datasets.size(), studyId));
+    datasets.forEach(d -> d.setStudy(study));
+    if (datasets.isEmpty()) {
+      return Response.status(Status.NOT_FOUND).build();
+    }
+    try {
+      synchronizeDatasetListInESIndex(datasets);
+      return Response.ok().build();
+    } catch (Exception _) {
+      return Response.status(500, "Indexing failed.").build();
+    }
   }
 
   /**
@@ -361,12 +341,11 @@ public class ElasticSearchService implements ConsentLogger {
    * update the dataset's last indexed date value.
    *
    * @param dataset The Dataset
-   * @param user The User
    * @param force Boolean to force the index update regardless of dataset's indexed date status.
    */
-  public void synchronizeDatasetInESIndex(Dataset dataset, User user, boolean force) {
+  public void synchronizeDatasetInESIndex(Dataset dataset, boolean force) {
     if (force || dataset.getIndexedDate() != null) {
-      try (var response = indexDataset(dataset.getDatasetId(), user)) {
+      try (var response = indexDataset(dataset.getDatasetId())) {
         if (!HttpStatusCodes.isSuccess(response.getStatus())) {
           logWarn("Response error, unable to index dataset: %s".formatted(dataset.getDatasetId()));
         }
@@ -376,65 +355,72 @@ public class ElasticSearchService implements ConsentLogger {
     }
   }
 
-  public Response indexDataset(Integer datasetId, User user) throws IOException {
-    return indexDatasets(List.of(datasetId), user);
+  protected void synchronizeDatasetListInESIndex(List<Dataset> datasets) {
+    try (var response = indexDatasetList(datasets)) {
+      if (!HttpStatusCodes.isSuccess(response.getStatus())) {
+        logWarn("Response error, unable to index datasets");
+      }
+    } catch (IOException e) {
+      logWarn("Exception, unable to index datasets");
+    }
   }
 
-  public Response indexDatasets(List<Integer> datasetIds, User user) throws IOException {
+  public Response indexDataset(Integer datasetId) throws IOException {
+    return indexDatasets(List.of(datasetId));
+  }
+
+  public Response indexDatasets(List<Integer> datasetIds) throws IOException {
     // Datasets in list context may not have their study populated, so we need to ensure that is
     // true before trying to index them in ES.
+    logWarn("Fetching %d datasets from database".formatted(datasetIds.size()));
+    List<Dataset> datasets = datasetDAO.findDatasetsByIdList(datasetIds);
+    logWarn("Fetched %d datasets from database".formatted(datasetIds.size()));
+    Map<Integer, Study> studyCache = new HashMap<>();
+    datasets.forEach(
+        dataset -> {
+          if (dataset.getStudyId() != null) {
+            dataset.setStudy(
+                studyCache.computeIfAbsent(
+                    dataset.getStudyId(),
+                    k -> {
+                      logWarn("Fetching study id %d from database".formatted(k));
+                      Study study = studyDAO.findStudyById(k);
+                      logWarn("Study id %d fetched.".formatted(k));
+                      return study;
+                    }));
+          }
+        });
+    return indexDatasetList(datasets);
+  }
+
+  public Response indexDatasetList(List<Dataset> datasets) throws IOException {
     List<DatasetTerm> datasetTerms =
-        datasetIds.stream()
-            .map(datasetDAO::findDatasetById)
-            .filter(Objects::nonNull)
-            .map(this::toDatasetTerm)
-            .toList();
+        datasets.parallelStream().filter(Objects::nonNull).map(this::toDatasetTerm).toList();
     if (datasetTerms.isEmpty()) {
       return Response.status(Status.NOT_FOUND).build();
     }
-    return indexDatasetTerms(datasetTerms, user);
+    return indexDatasetTerms(datasetTerms);
   }
 
   /**
    * Sequentially index datasets to ElasticSearch by ID list. Note that this is intended for large
    * lists of dataset ids. For small sets of datasets (i.e. <~25), it is efficient to index them in
-   * bulk using the {@link #indexDatasets(List, User)} method.
+   * bulk using the {@link #indexDatasets(List)} method.
    *
    * @param datasetIds List of Dataset IDs to index
    * @return StreamingOutput of ElasticSearch responses from indexing datasets
    */
-  public StreamingOutput indexDatasetIds(List<Integer> datasetIds, User user) {
-    Integer lastDatasetId = datasetIds.get(datasetIds.size() - 1);
+  public StreamingOutput indexDatasetIds(List<Integer> datasetIds) {
     return output -> {
-      output.write("[".getBytes());
-      datasetIds.forEach(
-          id -> {
-            try (Response response = indexDataset(id, user)) {
-              output.write(response.getEntity().toString().getBytes());
-              if (!id.equals(lastDatasetId)) {
-                output.write(",".getBytes());
-              }
-              output.write("\n".getBytes());
-            } catch (IOException e) {
-              logException("Error indexing dataset term for dataset id: %d ".formatted(id), e);
-            }
-          });
-      output.write("]".getBytes());
-    };
-  }
-
-  public Response indexStudy(Integer studyId, User user) {
-    Study study = studyDAO.findStudyById(studyId);
-    // The dao call above does not populate its datasets so we need to check for datasetIds
-    if (study != null && !study.getDatasetIds().isEmpty()) {
-      try (Response response = indexDatasets(study.getDatasetIds().stream().toList(), user)) {
-        return response;
-      } catch (Exception e) {
-        logException(String.format("Failed to index datasets for study id: %d", studyId), e);
-        return Response.status(Status.INTERNAL_SERVER_ERROR).build();
+      try (Response response = indexDatasets(datasetIds)) {
+        output.write(response.getEntity().toString().getBytes());
+        output.write("\n".getBytes());
+      } catch (IOException e) {
+        logWarn("Error indexing datasets", e);
+        output.write("Error indexing datasets".getBytes());
+        output.write("\n".getBytes());
       }
-    }
-    return Response.status(Status.NOT_FOUND).build();
+    };
   }
 
   public DatasetTerm toDatasetTerm(Dataset dataset) {
@@ -530,6 +516,12 @@ public class ElasticSearchService implements ConsentLogger {
         // We don't want to send these to Sentry, but we do want to log them for follow up off cycle
         logWarn("Error updating dataset indexed date for dataset id: %d ".formatted(datasetId), e);
       }
+    }
+  }
+
+  protected void updateDatasetIndexDateForDatasets(Set<Integer> ids) {
+    if (ids != null && !ids.isEmpty()) {
+      datasetDAO.updateDatasetsIndexedDate(ids);
     }
   }
 

--- a/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
@@ -353,7 +353,7 @@ public class ElasticSearchService implements ConsentLogger {
           logWarn("Response error, unable to index dataset: %s".formatted(dataset.getDatasetId()));
         }
       } catch (IOException e) {
-        logWarn("Exception, unable to index dataset: %s".formatted(dataset.getDatasetId()));
+        logWarn("Exception, unable to index dataset: %s".formatted(dataset.getDatasetId()), e);
       }
     }
   }
@@ -364,7 +364,7 @@ public class ElasticSearchService implements ConsentLogger {
         logWarn("Response error, unable to index datasets");
       }
     } catch (IOException e) {
-      logWarn("Exception, unable to index datasets");
+      logWarn("Exception, unable to index datasets", e);
     }
   }
 
@@ -492,7 +492,8 @@ public class ElasticSearchService implements ConsentLogger {
                 logWarn(
                     String.format(
                         "Unable to coerce participant count to integer: %s for dataset: %s",
-                        value, dataset.getDatasetIdentifier()));
+                        value, dataset.getDatasetIdentifier()),
+                    e);
               }
             });
 
@@ -556,11 +557,11 @@ public class ElasticSearchService implements ConsentLogger {
   public static Map<String, Object> buildMapFromPropertyValue(Object value) {
     Map<String, Object> objectMap;
     // When property is loaded from db it is deserialized as JsonObject
-    if (value instanceof com.google.gson.JsonElement) {
+    if (value instanceof com.google.gson.JsonElement element) {
       objectMap =
           GsonUtil.getInstance()
               .fromJson(
-                  (com.google.gson.JsonElement) value,
+                  element,
                   new com.google.gson.reflect.TypeToken<Map<String, Object>>() {}.getType());
       // Otherwise Gson deserializes JSON and creates a LinkedTreeMap
     } else if (value instanceof Map) {

--- a/src/main/java/org/broadinstitute/consent/http/service/VoteService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/VoteService.java
@@ -258,12 +258,6 @@ public class VoteService implements ConsentLogger {
     List<Dataset> datasets =
         datasetIds.isEmpty() ? List.of() : datasetDAO.findDatasetsByIdList(datasetIds);
 
-    try {
-      elasticSearchService.indexDatasets(datasetIds, user);
-    } catch (Exception e) {
-      logException("Error indexing datasets for approved DARs: " + e.getMessage(), e);
-    }
-
     // For each dar, email the researcher summarizing the approved datasets in that dar
     dars.forEach(
         dar -> {

--- a/src/main/java/org/broadinstitute/consent/http/service/VoteService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/VoteService.java
@@ -56,7 +56,6 @@ public class VoteService implements ConsentLogger {
   private final DatasetDAO datasetDAO;
   private final ElectionDAO electionDAO;
   private final EmailService emailService;
-  private final ElasticSearchService elasticSearchService;
   private final VoteDAO voteDAO;
   private final VoteServiceDAO voteServiceDAO;
   private final OntologyService ontologyService;
@@ -69,7 +68,6 @@ public class VoteService implements ConsentLogger {
       DatasetDAO datasetDAO,
       ElectionDAO electionDAO,
       EmailService emailService,
-      ElasticSearchService elasticSearchService,
       VoteDAO voteDAO,
       VoteServiceDAO voteServiceDAO,
       OntologyService ontologyService) {
@@ -79,7 +77,6 @@ public class VoteService implements ConsentLogger {
     this.datasetDAO = datasetDAO;
     this.electionDAO = electionDAO;
     this.emailService = emailService;
-    this.elasticSearchService = elasticSearchService;
     this.voteDAO = voteDAO;
     this.voteServiceDAO = voteServiceDAO;
     this.ontologyService = ontologyService;

--- a/src/main/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAO.java
@@ -379,7 +379,7 @@ public class DatasetServiceDAO implements ConsentLogger {
       boolean executeDeletes) {
 
     // Don't update the name if it isn't provided
-    Dataset dataset = datasetDAO.findDatasetById(datasetId);
+    Dataset dataset = datasetDAO.findDatasetsByIdList(List.of(datasetId)).getFirst();
     String updateName = StringUtils.isBlank(datasetName) ? dataset.getName() : datasetName;
     addAuditRecord(datasetId, updateName, userId, AuditActions.UPDATE);
     // update dataset
@@ -420,7 +420,7 @@ public class DatasetServiceDAO implements ConsentLogger {
       logWarn(
           "Attempt to update dataset name with null or blank value: dataset id: %s; user id: %s"
               .formatted(datasetId, userId));
-      Dataset dataset = datasetDAO.findDatasetById(datasetId);
+      Dataset dataset = datasetDAO.findDatasetsByIdList(List.of(datasetId)).getFirst();
       addAuditRecord(datasetId, dataset.getDatasetName(), userId, AuditActions.UPDATE);
       datasetDAO.updateDatasetUpdateUser(datasetId, new Timestamp(new Date().getTime()), userId);
     } else {

--- a/src/main/java/org/broadinstitute/consent/http/util/ConsentLogger.java
+++ b/src/main/java/org/broadinstitute/consent/http/util/ConsentLogger.java
@@ -39,7 +39,7 @@ public interface ConsentLogger {
    * @param e Exception
    */
   default void logException(String message, Exception e) {
-    getLogger(this.getClass()).error(message + e.getMessage());
+    getLogger(this.getClass()).error("%s %s".formatted(message, e.getMessage()));
     Sentry.captureEvent(new SentryEvent(e));
   }
 

--- a/src/main/java/org/broadinstitute/consent/http/util/ThreadUtils.java
+++ b/src/main/java/org/broadinstitute/consent/http/util/ThreadUtils.java
@@ -13,8 +13,11 @@ public class ThreadUtils implements ConsentLogger {
    * @return A new ExecutorService instance.
    */
   public <T> ExecutorService getExecutorService(Class<T> clazz) {
-    ExecutorService executorService =
-        Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors());
+    int cpuCount = Math.max(1, Runtime.getRuntime().availableProcessors() - 1);
+    logWarn(
+        String.format(
+            "New thread pool requested for class: %s, size: %d", clazz.getSimpleName(), cpuCount));
+    ExecutorService executorService = Executors.newFixedThreadPool(cpuCount);
     Runtime.getRuntime()
         .addShutdownHook(
             new Thread(

--- a/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
@@ -16,6 +16,7 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -1352,6 +1353,19 @@ class DatasetDAOTest extends DAOTestHelper {
   void testUpdateDatasetIndexedDate() {
     Dataset dataset = insertDataset();
     datasetDAO.updateDatasetIndexedDate(dataset.getDatasetId(), Instant.now());
+    Dataset updatedDataset = datasetDAO.findDatasetById(dataset.getDatasetId());
+    assertNotNull(updatedDataset.getIndexedDate());
+    datasetDAO.updateDatasetIndexedDate(dataset.getDatasetId(), null);
+    Dataset updatedDataset2 = datasetDAO.findDatasetById(dataset.getDatasetId());
+    assertNull(updatedDataset2.getIndexedDate());
+  }
+
+  @Test
+  void testUpdateDatasetIdListIndexedDate() {
+    Dataset dataset = insertDataset();
+    Set<Integer> datasetIds = new HashSet<>();
+    datasetIds.add(dataset.getDatasetId());
+    datasetDAO.updateDatasetsIndexedDate(datasetIds);
     Dataset updatedDataset = datasetDAO.findDatasetById(dataset.getDatasetId());
     assertNotNull(updatedDataset.getIndexedDate());
     datasetDAO.updateDatasetIndexedDate(dataset.getDatasetId(), null);

--- a/src/test/java/org/broadinstitute/consent/http/models/dataset_registration_v1/DatasetRegistrationSchemaV1UpdateValidatorTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/dataset_registration_v1/DatasetRegistrationSchemaV1UpdateValidatorTest.java
@@ -227,13 +227,12 @@ class DatasetRegistrationSchemaV1UpdateValidatorTest {
   }
 
   @Test
-  void testValidation_empty_consent_groups() {
+  void testValidation_allow_empty_consent_groups() {
     Study study = createMockStudy();
     DatasetRegistrationSchemaV1 registration = createMockRegistration(study);
     registration.setConsentGroups(List.of());
 
-    assertThrows(
-        BadRequestException.class,
+    assertDoesNotThrow(
         () -> {
           validator.validate(study, registration);
         });

--- a/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
@@ -258,7 +258,7 @@ class DatasetResourceTest extends AbstractTestHelper {
     try (Response response =
         resource.patchByDatasetUpdate(duosUser, dataset.getDatasetId(), gson.toJson(patch))) {
       assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
-      verify(elasticSearchService, never()).indexDataset(dataset.getDatasetId(), user);
+      verify(elasticSearchService, never()).indexDataset(dataset.getDatasetId());
     }
   }
 
@@ -314,7 +314,7 @@ class DatasetResourceTest extends AbstractTestHelper {
 
     try (Response response =
         resource.patchByDatasetUpdate(duosUser, dataset.getDatasetId(), gson.toJson(patch))) {
-      verify(elasticSearchService).synchronizeDatasetInESIndex(dataset, user, false);
+      verify(elasticSearchService).synchronizeDatasetInESIndex(dataset, false);
       assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
     }
   }
@@ -502,9 +502,7 @@ class DatasetResourceTest extends AbstractTestHelper {
     StreamingOutput output =
         out -> out.write(esResponseArray.formatted(dataset.getDatasetId()).getBytes());
     when(datasetService.findAllDatasetIds()).thenReturn(List.of(dataset.getDatasetId()));
-    when(elasticSearchService.indexDatasetIds(List.of(dataset.getDatasetId()), user))
-        .thenReturn(output);
-    when(userService.findUserByEmail(duosUser.getEmail())).thenReturn(user);
+    when(elasticSearchService.indexDatasetIds(List.of(dataset.getDatasetId()))).thenReturn(output);
 
     try (Response response = resource.indexDatasets(duosUser)) {
       var entity = (StreamingOutput) response.getEntity();
@@ -526,8 +524,7 @@ class DatasetResourceTest extends AbstractTestHelper {
   void testIndexDataset() throws IOException {
     Dataset dataset = new Dataset();
     when(mockResponse.getStatus()).thenReturn(HttpStatusCodes.STATUS_CODE_OK);
-    when(elasticSearchService.indexDataset(dataset.getDatasetId(), user)).thenReturn(mockResponse);
-    when(userService.findUserByEmail(authUser.getEmail())).thenReturn(user);
+    when(elasticSearchService.indexDataset(dataset.getDatasetId())).thenReturn(mockResponse);
 
     try (var response = resource.indexDataset(authUser, dataset.getDatasetId())) {
       assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());

--- a/src/test/java/org/broadinstitute/consent/http/service/DatasetRegistrationServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DatasetRegistrationServiceTest.java
@@ -615,19 +615,19 @@ class DatasetRegistrationServiceTest extends AbstractTestHelper {
         () -> datasetRegistrationService.createDatasetsFromRegistration(schema, user, Map.of()));
   }
 
-    @Test
-    void testRegistrationSucceedsWithESError() throws Exception {
-      User user = mock();
-      DatasetRegistrationSchemaV1 schema = createRandomMinimumDatasetRegistration(user);
-      when(dacDAO.findById(any())).thenReturn(new Dac());
-      when(elasticSearchService.indexDatasets(any()))
-          .thenThrow(new ServerErrorException("Timeout connecting to [elasticsearch]", 500));
-      assertDoesNotThrow(
-          () -> {
-            datasetRegistrationService.createDatasetsFromRegistration(schema, user, Map.of());
-          },
-          "Registration Error");
-    }
+  @Test
+  void testRegistrationSucceedsWithESError() throws Exception {
+    User user = mock();
+    DatasetRegistrationSchemaV1 schema = createRandomMinimumDatasetRegistration(user);
+    when(dacDAO.findById(any())).thenReturn(new Dac());
+    when(elasticSearchService.indexDatasets(any()))
+        .thenThrow(new ServerErrorException("Timeout connecting to [elasticsearch]", 500));
+    assertDoesNotThrow(
+        () -> {
+          datasetRegistrationService.createDatasetsFromRegistration(schema, user, Map.of());
+        },
+        "Registration Error");
+  }
 
   @Test
   void testUpdateDatasetSucceedsWithESError() {

--- a/src/test/java/org/broadinstitute/consent/http/service/DatasetRegistrationServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DatasetRegistrationServiceTest.java
@@ -19,7 +19,6 @@ import static org.mockito.Mockito.when;
 import com.google.cloud.storage.BlobId;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.NotFoundException;
-import jakarta.ws.rs.ServerErrorException;
 import jakarta.ws.rs.core.MediaType;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -615,19 +614,19 @@ class DatasetRegistrationServiceTest extends AbstractTestHelper {
         () -> datasetRegistrationService.createDatasetsFromRegistration(schema, user, Map.of()));
   }
 
-  @Test
-  void testRegistrationSucceedsWithESError() throws Exception {
-    User user = mock();
-    DatasetRegistrationSchemaV1 schema = createRandomMinimumDatasetRegistration(user);
-    when(dacDAO.findById(any())).thenReturn(new Dac());
-    when(elasticSearchService.indexDatasets(any(), any()))
-        .thenThrow(new ServerErrorException("Timeout connecting to [elasticsearch]", 500));
-    assertDoesNotThrow(
-        () -> {
-          datasetRegistrationService.createDatasetsFromRegistration(schema, user, Map.of());
-        },
-        "Registration Error");
-  }
+  //  @Test
+  //  void testRegistrationSucceedsWithESError() throws Exception {
+  //    User user = mock();
+  //    DatasetRegistrationSchemaV1 schema = createRandomMinimumDatasetRegistration(user);
+  //    when(dacDAO.findById(any())).thenReturn(new Dac());
+  //    when(elasticSearchService.indexDatasets(any(), any()))
+  //        .thenThrow(new ServerErrorException("Timeout connecting to [elasticsearch]", 500));
+  //    assertDoesNotThrow(
+  //        () -> {
+  //          datasetRegistrationService.createDatasetsFromRegistration(schema, user, Map.of());
+  //        },
+  //        "Registration Error");
+  //  }
 
   @Test
   void testUpdateDatasetSucceedsWithESError() {

--- a/src/test/java/org/broadinstitute/consent/http/service/DatasetRegistrationServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DatasetRegistrationServiceTest.java
@@ -19,6 +19,7 @@ import static org.mockito.Mockito.when;
 import com.google.cloud.storage.BlobId;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.ServerErrorException;
 import jakarta.ws.rs.core.MediaType;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -614,19 +615,19 @@ class DatasetRegistrationServiceTest extends AbstractTestHelper {
         () -> datasetRegistrationService.createDatasetsFromRegistration(schema, user, Map.of()));
   }
 
-  //  @Test
-  //  void testRegistrationSucceedsWithESError() throws Exception {
-  //    User user = mock();
-  //    DatasetRegistrationSchemaV1 schema = createRandomMinimumDatasetRegistration(user);
-  //    when(dacDAO.findById(any())).thenReturn(new Dac());
-  //    when(elasticSearchService.indexDatasets(any(), any()))
-  //        .thenThrow(new ServerErrorException("Timeout connecting to [elasticsearch]", 500));
-  //    assertDoesNotThrow(
-  //        () -> {
-  //          datasetRegistrationService.createDatasetsFromRegistration(schema, user, Map.of());
-  //        },
-  //        "Registration Error");
-  //  }
+    @Test
+    void testRegistrationSucceedsWithESError() throws Exception {
+      User user = mock();
+      DatasetRegistrationSchemaV1 schema = createRandomMinimumDatasetRegistration(user);
+      when(dacDAO.findById(any())).thenReturn(new Dac());
+      when(elasticSearchService.indexDatasets(any()))
+          .thenThrow(new ServerErrorException("Timeout connecting to [elasticsearch]", 500));
+      assertDoesNotThrow(
+          () -> {
+            datasetRegistrationService.createDatasetsFromRegistration(schema, user, Map.of());
+          },
+          "Registration Error");
+    }
 
   @Test
   void testUpdateDatasetSucceedsWithESError() {

--- a/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
@@ -7,6 +7,7 @@ import static org.junit.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeastOnce;
@@ -19,15 +20,11 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.api.client.http.HttpStatusCodes;
-import com.google.gson.Gson;
 import com.google.gson.JsonArray;
-import com.google.gson.JsonObject;
-import com.google.gson.reflect.TypeToken;
 import jakarta.ws.rs.core.StreamingOutput;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.lang.reflect.Type;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
@@ -250,25 +247,34 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
             createDatasetProperty("url", PropertyType.String, "url"),
             createDatasetProperty("dataLocation", PropertyType.String, "dataLocation")));
     dataset.setStudy(study);
+    dataset.setStudyId(study.getStudyId());
+    study.addDatasetId(dataset.getDatasetId());
     return new DatasetRecord(user, updateUser, dac, dataset, study);
   }
 
   @Test
-  void testAsyncESIndexUpdate() {
+  void testIndexStudy() throws IOException {
     DatasetRecord datasetRecord = createDatasetRecord();
-    datasetRecord.dataset.setDataUse(new DataUseBuilder().setGeneralUse(true).build());
     when(userDao.findUserById(datasetRecord.createUser.getUserId()))
         .thenReturn(datasetRecord.createUser);
-    when(datasetDAO.findDatasetById(datasetRecord.dataset.getDatasetId()))
-        .thenReturn(datasetRecord.dataset);
+    when(datasetDAO.findDatasetsByIdList(datasetRecord.study.getDatasetIds()))
+        .thenReturn(List.of(datasetRecord.dataset));
+    when(studyDAO.findStudyById(datasetRecord.study.getStudyId())).thenReturn(datasetRecord.study);
+    org.elasticsearch.client.Response mockResponse = mock();
+    when(esClient.performRequest(any())).thenReturn(mockResponse);
+    when(mockResponse.getEntity()).thenReturn(new StringEntity("response body"));
+    StatusLine statusLine = mock();
+    when(mockResponse.getStatusLine()).thenReturn(statusLine);
+    when(statusLine.getStatusCode()).thenReturn(200);
+
     ElasticSearchService elasticSearchSpy = spy(service);
-    // Call the async method ...
-    elasticSearchSpy.asyncDatasetInESIndex(
-        datasetRecord.dataset.getDatasetId(), datasetRecord.createUser, true);
+
+    jakarta.ws.rs.core.Response response =
+        elasticSearchSpy.indexStudy(datasetRecord.study.getStudyId());
     // Ensure that the synchronous method was called with the expected parameters
     verify(elasticSearchSpy, timeout(1000))
-        .synchronizeDatasetInESIndex(
-            datasetRecord.dataset, datasetRecord.dataset.getCreateUser(), true);
+        .synchronizeDatasetListInESIndex(List.of(datasetRecord.dataset));
+    assertEquals(200, response.getStatus());
   }
 
   @Test
@@ -499,7 +505,7 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
         .thenReturn(datasetRecord.createUser);
     datasetRecord.dataset.setNihInstitutionalCertificationFile(null);
     DatasetTerm term = service.toDatasetTerm(datasetRecord.dataset);
-    assertEquals(null, term.getHasInstitutionCertification());
+    assertNull(term.getHasInstitutionCertification());
   }
 
   @Test
@@ -566,14 +572,12 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
     term1.setDatasetId(1);
     DatasetTerm term2 = new DatasetTerm();
     term2.setDatasetId(2);
-    User user = new User();
-    user.setUserId(1);
     String datasetIndexName = randomAlphabetic(10);
 
     when(esConfig.getDatasetIndexName()).thenReturn(datasetIndexName);
     mockElasticSearchResponse("");
 
-    try (var response = service.indexDatasetTerms(List.of(term1, term2), user)) {
+    try (var _ = service.indexDatasetTerms(List.of(term1, term2))) {
       verify(esClient).performRequest(request.capture());
       Request capturedRequest = request.getValue();
       assertEquals("PUT", capturedRequest.getMethod());
@@ -591,6 +595,26 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
   }
 
   @Test
+  void testIndexDataset() throws Exception {
+    DatasetRecord datasetRecord = createDatasetRecord();
+    Dataset dataset1 = datasetRecord.dataset;
+    when(datasetDAO.findDatasetsByIdList(List.of(dataset1.getDatasetId())))
+        .thenReturn(List.of(dataset1));
+    when(studyDAO.findStudyById(datasetRecord.study.getStudyId())).thenReturn(datasetRecord.study);
+    when(userDao.findUserById(dataset1.getCreateUserId())).thenReturn(datasetRecord.createUser);
+    org.elasticsearch.client.Response mockResponse = mock();
+    when(esClient.performRequest(any())).thenReturn(mockResponse);
+    when(mockResponse.getEntity()).thenReturn(new StringEntity("response body"));
+    StatusLine statusLine = mock();
+    when(mockResponse.getStatusLine()).thenReturn(statusLine);
+    when(statusLine.getStatusCode()).thenReturn(200);
+    try (var _ = service.indexDataset(dataset1.getDatasetId())) {
+      verify(datasetDAO, times(1)).findDatasetsByIdList(List.of(dataset1.getDatasetId()));
+      verify(studyDAO, times(1)).findStudyById(dataset1.getStudyId());
+    }
+  }
+
+  @Test
   void testIndexDatasets() throws Exception {
     DatasetRecord datasetRecord = createDatasetRecord();
     Dataset dataset1 = datasetRecord.dataset;
@@ -601,8 +625,10 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
             new DataUseBuilder().setGeneralUse(true).build(),
             datasetRecord.dac);
     dataset2.setStudy(datasetRecord.study);
-    when(datasetDAO.findDatasetById(dataset1.getDatasetId())).thenReturn(dataset1);
-    when(datasetDAO.findDatasetById(dataset2.getDatasetId())).thenReturn(dataset2);
+    dataset2.setStudyId(dataset1.getStudyId());
+    when(datasetDAO.findDatasetsByIdList(List.of(dataset1.getDatasetId(), dataset2.getDatasetId())))
+        .thenReturn(List.of(dataset1, dataset2));
+    when(studyDAO.findStudyById(datasetRecord.study.getStudyId())).thenReturn(datasetRecord.study);
     when(userDao.findUserById(dataset1.getCreateUserId())).thenReturn(datasetRecord.createUser);
     when(userDao.findUserById(dataset2.getCreateUserId())).thenReturn(datasetRecord.createUser);
     org.elasticsearch.client.Response mockResponse = mock();
@@ -612,22 +638,19 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
     when(mockResponse.getStatusLine()).thenReturn(statusLine);
     when(statusLine.getStatusCode()).thenReturn(200);
 
-    try (var ignored =
-        service.indexDatasets(
-            List.of(dataset1.getDatasetId(), dataset2.getDatasetId()), datasetRecord.createUser)) {
-      // Each dataset should be looked up once when defining the term and a second time
-      // when updating the indexed date.
-      verify(datasetDAO, times(2)).findDatasetById(dataset1.getDatasetId());
-      verify(datasetDAO, times(2)).findDatasetById(dataset2.getDatasetId());
+    try (var _ = service.indexDatasets(List.of(dataset1.getDatasetId(), dataset2.getDatasetId()))) {
+      verify(datasetDAO, times(1))
+          .findDatasetsByIdList(List.of(dataset1.getDatasetId(), dataset2.getDatasetId()));
+      assertEquals(dataset1.getStudyId(), dataset2.getStudyId());
+      verify(studyDAO, times(1)).findStudyById(dataset1.getStudyId());
     }
   }
 
   @Test
   void testIndexDatasetsHandleSingleNullDataset() throws Exception {
-    User user = createUser(1, 100);
-    when(datasetDAO.findDatasetById(1)).thenReturn(null);
-    try (var response = service.indexDatasets(List.of(1), user)) {
-      verify(datasetDAO).findDatasetById(1);
+    when(datasetDAO.findDatasetsByIdList(List.of(1))).thenReturn(List.of());
+    try (var response = service.indexDatasets(List.of(1))) {
+      verify(datasetDAO).findDatasetsByIdList(List.of(1));
       verify(esClient, never()).performRequest(any());
       assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
     }
@@ -642,9 +665,9 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
     // existing dataset
     List<Integer> datasetIds =
         List.of(d1.getDatasetId(), d2.getDatasetId(), d1.getDatasetId() + d2.getDatasetId());
-    when(datasetDAO.findDatasetById(d1.getDatasetId())).thenReturn(d1);
-    when(datasetDAO.findDatasetById(d2.getDatasetId())).thenReturn(d2);
-    when(datasetDAO.findDatasetById(d1.getDatasetId() + d2.getDatasetId())).thenReturn(null);
+    when(datasetDAO.findDatasetsByIdList(
+            List.of(d1.getDatasetId(), d2.getDatasetId(), d1.getDatasetId() + d2.getDatasetId())))
+        .thenReturn(List.of(d1, d2));
     when(userDao.findUserById(user.getUserId())).thenReturn(user);
     org.elasticsearch.client.Response mockResponse = mock();
     when(esClient.performRequest(any())).thenReturn(mockResponse);
@@ -652,10 +675,10 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
     StatusLine statusLine = mock();
     when(mockResponse.getStatusLine()).thenReturn(statusLine);
     when(statusLine.getStatusCode()).thenReturn(200);
-    try (var response = service.indexDatasets(datasetIds, user)) {
-      verify(datasetDAO, atLeastOnce()).findDatasetById(d1.getDatasetId());
-      verify(datasetDAO, atLeastOnce()).findDatasetById(d2.getDatasetId());
-      verify(datasetDAO).findDatasetById(d1.getDatasetId() + d2.getDatasetId());
+    try (var response = service.indexDatasets(datasetIds)) {
+      verify(datasetDAO, atLeastOnce())
+          .findDatasetsByIdList(
+              List.of(d1.getDatasetId(), d2.getDatasetId(), d1.getDatasetId() + d2.getDatasetId()));
       assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
     }
   }
@@ -725,69 +748,33 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
   }
 
   @Test
-  void testIndexDatasetIds() throws Exception {
-    User user = new User();
-    user.setUserId(1);
-    Gson gson = GsonUtil.buildGson();
+  void testIndexDatasetIdsErrors() throws Exception {
+    String mockErrorMessage = "error condition";
     Dataset dataset = new Dataset();
     dataset.setDatasetId(randomInt(10, 100));
-    String esResponseBody =
-        """
-          {
-            "took": 2,
-            "errors": false,
-            "items": [
-              {
-                "index": {
-                  "_index": "dataset",
-                  "_type": "dataset",
-                  "_id": "%d",
-                  "_version": 3,
-                  "result": "updated",
-                  "_shards": {
-                    "total": 2,
-                    "successful": 1,
-                    "failed": 0
-                  },
-                  "created": false,
-                  "status": 200
-                }
-              }
-            ]
-          }
-        """;
+    when(datasetDAO.findDatasetsByIdList(List.of(dataset.getDatasetId())))
+        .thenReturn(List.of(dataset));
+    mockESClientResponse(200, mockErrorMessage);
 
-    when(datasetDAO.findDatasetById(dataset.getDatasetId())).thenReturn(dataset);
-    mockESClientResponse(200, esResponseBody.formatted(dataset.getDatasetId()));
-    StreamingOutput output = service.indexDatasetIds(List.of(dataset.getDatasetId()), user);
+    StreamingOutput output = service.indexDatasetIds(List.of(dataset.getDatasetId()));
     var baos = new ByteArrayOutputStream();
     output.write(baos);
-    var entityString = baos.toString();
-    Type listOfEsResponses = new TypeToken<List<JsonObject>>() {}.getType();
-    List<JsonObject> responseList = gson.fromJson(entityString, listOfEsResponses);
-    assertEquals(1, responseList.size());
-    JsonArray items = responseList.get(0).getAsJsonArray("items");
-    assertEquals(1, items.size());
-    assertEquals(
-        dataset.getDatasetId(),
-        items.get(0).getAsJsonObject().getAsJsonObject("index").get("_id").getAsInt());
+    assertTrue(baos.toString().contains(mockErrorMessage));
   }
 
   @Test
-  void testIndexDatasetIdsErrors() throws Exception {
-    User user = new User();
-    user.setUserId(1);
-    Gson gson = GsonUtil.buildGson();
+  void testIndexDatasetIdsErrors_Not_200_response() throws Exception {
+    String mockErrorMessage = "error condition";
     Dataset dataset = new Dataset();
     dataset.setDatasetId(randomInt(10, 100));
-    when(datasetDAO.findDatasetById(dataset.getDatasetId())).thenReturn(dataset);
-    mockESClientResponse(500, "error condition");
+    when(datasetDAO.findDatasetsByIdList(List.of(dataset.getDatasetId())))
+        .thenReturn(List.of(dataset));
+    mockESClientResponse(500, mockErrorMessage);
 
-    StreamingOutput output = service.indexDatasetIds(List.of(dataset.getDatasetId()), user);
+    StreamingOutput output = service.indexDatasetIds(List.of(dataset.getDatasetId()));
     var baos = new ByteArrayOutputStream();
     output.write(baos);
-    JsonArray jsonArray = gson.fromJson(baos.toString(), JsonArray.class);
-    assertEquals(0, jsonArray.size());
+    assertTrue(baos.toString().contains("Error indexing datasets"));
   }
 
   // Helper method to mock an ElasticSearch Client response
@@ -807,8 +794,6 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
 
   @Test
   void testIndexStudyWithDatasets() {
-    User user = new User();
-    user.setUserId(1);
     Study study = new Study();
     study.setStudyId(1);
     Dataset d = new Dataset();
@@ -816,20 +801,18 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
     study.addDatasetId(d.getDatasetId());
     when(studyDAO.findStudyById(any())).thenReturn(study);
 
-    assertDoesNotThrow(() -> service.indexStudy(1, user));
+    assertDoesNotThrow(() -> service.indexStudy(1));
   }
 
   @Test
   void testIndexStudyWithNoDatasets() {
-    User user = new User();
-    user.setUserId(1);
     Study study = new Study();
     study.setStudyId(1);
     when(studyDAO.findStudyById(any())).thenReturn(study);
 
     assertDoesNotThrow(
         () -> {
-          try (var response = service.indexStudy(1, user)) {
+          try (var response = service.indexStudy(1)) {
             assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
           }
         });

--- a/src/test/java/org/broadinstitute/consent/http/service/VoteServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/VoteServiceTest.java
@@ -77,7 +77,6 @@ class VoteServiceTest extends AbstractTestHelper {
   @Mock private DatasetDAO datasetDAO;
   @Mock private ElectionDAO electionDAO;
   @Mock private EmailService emailService;
-  @Mock private ElasticSearchService elasticSearchService;
   @Mock private VoteDAO voteDAO;
   @Mock private VoteServiceDAO voteServiceDAO;
   @Mock private User user;
@@ -93,7 +92,6 @@ class VoteServiceTest extends AbstractTestHelper {
             datasetDAO,
             electionDAO,
             emailService,
-            elasticSearchService,
             voteDAO,
             voteServiceDAO,
             ontologyService);


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-2962](https://broadworkbench.atlassian.net/browse/DT-2962)

### Summary

Updates the core ElasticSearch code that generates documents for the index to use more efficient methods to retrieve these objects from the database AND to stop retrieving them multiple times in the same service code.

Updates the Study Update code so that it also uses more efficient object retrieval methods.

Stops updating Elasticsearch when dataset access is approved since access information is no longer published to the index.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
