### PR TITLE
[DT-2983] Make adjustments to template for using methods on getting Java Record values.

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/mail/freemarker/FreeMarkerTemplateHelper.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/freemarker/FreeMarkerTemplateHelper.java
@@ -11,7 +11,7 @@ public class FreeMarkerTemplateHelper {
   private final Configuration freeMarkerConfig;
 
   public FreeMarkerTemplateHelper(FreeMarkerConfiguration config) {
-    freeMarkerConfig = new Configuration(Configuration.VERSION_2_3_33);
+    freeMarkerConfig = new Configuration(Configuration.VERSION_2_3_34);
     freeMarkerConfig.setTemplateExceptionHandler(TemplateExceptionHandler.RETHROW_HANDLER);
     freeMarkerConfig.setClassForTemplateLoading(this.getClass(), config.getTemplateDirectory());
     freeMarkerConfig.setDefaultEncoding(config.getDefaultEncoding());

--- a/src/main/resources/freemarker/vote-digest.ftl
+++ b/src/main/resources/freemarker/vote-digest.ftl
@@ -27,19 +27,19 @@
     <#if openedThisWeek?has_content>
       <tr></br><td id="submittedThisWeek" style="padding: 15px 15px 0px; font-family: 'Montserrat', sans-serif; font-size: 16px; color: #1F3B50; text-align: justify; line-height: 25px;"></br>Submitted this week:</td></tr>
       <#list openedThisWeek as item>
-        <tr><td style="padding: 15px 15px 0px; font-family: 'Montserrat', sans-serif; font-size: 16px; color: #1F3B50; text-align: justify; line-height: 25px;">${item.darCode}</td></tr>
+        <tr><td style="padding: 15px 15px 0px; font-family: 'Montserrat', sans-serif; font-size: 16px; color: #1F3B50; text-align: justify; line-height: 25px;">${item.darCode()}</td></tr>
       </#list>
     </#if>
     <#if openedLastWeek?has_content>
       <tr><td id="submittedLastWeek" style="padding: 15px 15px 0px; font-family: 'Montserrat', sans-serif; font-size: 16px; color: #1F3B50; text-align: justify; line-height: 25px;" ></br>Submitted last week:</td></tr>
       <#list openedLastWeek as item>
-        <tr><td style="padding: 15px 15px 0px; font-family: 'Montserrat', sans-serif; font-size: 16px; color: #1F3B50; text-align: justify; line-height: 25px;">${item.darCode}</td></tr>
+        <tr><td style="padding: 15px 15px 0px; font-family: 'Montserrat', sans-serif; font-size: 16px; color: #1F3B50; text-align: justify; line-height: 25px;">${item.darCode()}</td></tr>
       </#list>
     </#if>
     <#if olderRequests?has_content>
       <tr><td id="olderRequests" style="padding: 15px 15px 0px; font-family: 'Montserrat', sans-serif; font-size: 16px; color: #1F3B50; text-align: justify; line-height: 25px;" ></br>Submitted more than 2 weeks ago:</td></tr>
       <#list olderRequests as item>
-        <tr><td style="padding: 15px 15px 0px; font-family: 'Montserrat', sans-serif; font-size: 16px; color: #1F3B50; text-align: justify; line-height: 25px;">${item.darCode}</td></tr>
+        <tr><td style="padding: 15px 15px 0px; font-family: 'Montserrat', sans-serif; font-size: 16px; color: #1F3B50; text-align: justify; line-height: 25px;">${item.darCode()}</td></tr>
       </#list>
     </#if>
       <td style="padding: 15px 15px 0px; font-family: 'Montserrat', sans-serif; font-size: 16px; color: #1F3B50; text-align: left; line-height: 25px; display: block; font-weight: 500;">

--- a/src/test/java/org/broadinstitute/consent/http/mail/message/DacVoteDigestMessageTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mail/message/DacVoteDigestMessageTest.java
@@ -1,5 +1,7 @@
 package org.broadinstitute.consent.http.mail.message;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -194,6 +196,29 @@ class DacVoteDigestMessageTest {
     assertFalse(hasElementWithId(parsedTemplate, "submittedThisWeek"));
     assertFalse(hasElementWithId(parsedTemplate, "submittedLastWeek"));
     assertTrue(hasElementWithId(parsedTemplate, "olderRequests"));
+  }
+
+  @Test
+  void testReminderInTemplate() throws IOException, TemplateException {
+    User toUser = new User();
+    toUser.setUserId(1);
+    toUser.setDisplayName("Reminder User");
+    Instant timeBasis = Instant.now().minus(48, ChronoUnit.HOURS);
+    Reminder reminder = new Reminder(1, "DAR-1", 2, timeBasis);
+    String refId = timeBasis.toString();
+
+    var message = new DacVoteDigestMessage(toUser, List.of(reminder), refId, timeBasis);
+
+    var template = helper.getTemplate(message.getTemplateName());
+    var out = new StringWriter();
+    template.process(message.createModel("localhost:8080"), out);
+    var templateString = out.toString();
+
+    assertEquals(1, reminder.userId());
+    assertEquals("DAR-1", reminder.darCode());
+    assertEquals(2, reminder.collectionId());
+    assertEquals(timeBasis, reminder.createDate());
+    assertThat(templateString, containsString("DAR-1"));
   }
 
   String getElementTextById(Document document, String id) {


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-2983](https://broadworkbench.atlassian.net/browse/DT-2983)

### Summary

The stack trace values in production logs indicates an issue with obtaining values from Java Records.  This seems counter to the Freemarker release notes here: [https://freemarker.apache.org/docs/versions_2_3_33.html](https://freemarker.apache.org/docs/versions_2_3_33.html).  These release notes indicate that Java Record values can be obtained as if they were bean values as long as the configuration is updated to point to v_2_3_33 (ours is!).

This PR:
* Updates the Freemarker configuration to v_2_3_34
* Adds parens to darCode accessor so that we don't assume magic in freemarker is working
* Adds a test to verify the darCode value appears in the template output.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
