### PR TITLE
[DT-2965] Share VOTE and TYPE attributes in Election Votes

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
@@ -551,8 +551,33 @@ public class DarCollectionService implements ConsentLogger {
         .getDars()
         .values()
         .forEach(
-            dar -> dar.getElections().values().forEach(election -> election.setVotes(Map.of())));
+            dar ->
+                dar.getElections()
+                    .values()
+                    .forEach(election -> election.setVotes(deIdentifyVotes(election.getVotes()))));
     return collection;
+  }
+
+  /**
+   * Given a map of votes, return a new map with the same keys but with de-identified votes (userId
+   * and vote value removed).
+   *
+   * @param votes The original map of votes to de-identify
+   * @return A new map of votes with all info removed except for the type of vote (DAC or RP) and
+   *     Vote Result (True/False/null)
+   */
+  private Map<Integer, Vote> deIdentifyVotes(Map<Integer, Vote> votes) {
+    return votes.entrySet().stream()
+        .collect(
+            Collectors.toMap(
+                Map.Entry::getKey,
+                entry -> {
+                  Vote v = entry.getValue();
+                  Vote deidentified = new Vote();
+                  deidentified.setVote(v.getVote());
+                  deidentified.setType(v.getType());
+                  return deidentified;
+                }));
   }
 
   public DarCollection getCollectionWithAllElectionsByCollectionId(

--- a/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -211,7 +212,20 @@ class DarCollectionServiceTest extends AbstractTestHelper {
             .map(Election::getVotes)
             .flatMap(v -> v.values().stream())
             .toList();
-    assertTrue(votes.isEmpty());
+
+    // For non-privileged roles, votes should only include type and vote, all identifying
+    // information removed
+    assertFalse(votes.isEmpty());
+    for (Vote v : votes) {
+      assertNull(v.getUserId(), "userId should be null for de-identified votes");
+      assertNull(v.getVoteId(), "voteId should be null for de-identified votes");
+      assertNull(v.getElectionId(), "electionId should be null for de-identified votes");
+      assertNotNull(v.getType(), "type should be retained for de-identified votes");
+      assertTrue(votes.contains(v), "vote should be present in de-identified votes");
+      // Vote outcome can be null or Boolean
+      assertTrue(
+          v.getVote() == null || v.getVote() != null, "vote should be present (null or Boolean)");
+    }
   }
 
   @Test


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2965

### Summary

This PR enables the sharing of the `vote` and `type` attributes for Election votes with non-privileged user roles like `Researcher`, which allows Progress Reports to show approved datasets for all users, since that is [determined by the vote information](https://github.com/DataBiosphere/duos-ui/blob/72f6851f97b7e2443b961e340894bf0390c02858/src/utils/DarUtils.ts#L28-L41), which had been missing for non-privileged users.

Related UI PR: https://github.com/DataBiosphere/duos-ui/pull/3338

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
