### PR TITLE
[DT-2992] Only look back one year and don't bring back DARs where the user has been deleted.

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/ElectionDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/ElectionDAO.java
@@ -285,10 +285,12 @@ public interface ElectionDAO extends Transactional<ElectionDAO> {
                INNER JOIN dar_collection dc ON dc.collection_id = dar.collection_id
                INNER JOIN vote v ON v.election_id = e_sub.election_id
                INNER JOIN users u ON u.user_id = v.user_id
+               INNER JOIN users dar_u ON dar_u.user_id = dar.user_id
                LEFT OUTER JOIN email_entity ee ON ee.user_id = u.user_id AND ee.email_type = :emailType AND ee.entity_reference_id = :referenceId
       WHERE v.vote IS NULL
         AND dc.dar_code IS NOT NULL
         AND ee.entity_reference_id IS NULL
+        AND dar.submission_date > NOW() - make_interval(years => 1)
       GROUP BY u.user_id, dc.dar_code, dc.collection_id
 """)
   List<UserVoteReminder> findElectionReminders(


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-2992](https://broadworkbench.atlassian.net/browse/DT-2992)

### Summary

This PR mitigates unexpected state issues with the reminder queries.  Additional tickets have been created to address one of the core issues: users could be deleted but the elections on DARs they may have had open were not cancelled.
Older Data Access Requests followed a different lifecycle model that is no longer in code but could be found by the query that triggers reminders.  Those are now filtered out - reminders will only be sent for DARs created in the last year.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
