### PR TITLE
[DT-3043] Records when a dataset was approved by a DAC.  

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
@@ -592,6 +592,7 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
   @SqlUpdate(
       "UPDATE dataset "
           + "SET dac_approval = :dacApproval, "
+          + "dac_approval_date = now(), "
           + "update_date = :updateDate, "
           + "update_user_id = :updateUserId "
           + "WHERE dataset_id = :datasetId")

--- a/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
@@ -590,7 +590,7 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
       @BindList(value = "dacIds", onEmpty = EmptyHandling.NULL_STRING) List<Integer> dacIds);
 
   @SqlUpdate(
-  """
+      """
   UPDATE dataset
   SET
     dac_approval = :dacApproval,

--- a/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
@@ -590,12 +590,15 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
       @BindList(value = "dacIds", onEmpty = EmptyHandling.NULL_STRING) List<Integer> dacIds);
 
   @SqlUpdate(
-      "UPDATE dataset "
-          + "SET dac_approval = :dacApproval, "
-          + "dac_approval_date = now(), "
-          + "update_date = :updateDate, "
-          + "update_user_id = :updateUserId "
-          + "WHERE dataset_id = :datasetId")
+  """
+  UPDATE dataset
+  SET
+    dac_approval = :dacApproval,
+    dac_approval_date = now(),
+    update_date = :updateDate,
+    update_user_id = :updateUserId
+  WHERE dataset_id = :datasetId
+  """)
   void updateDatasetApproval(
       @Bind("dacApproval") Boolean dacApproved,
       @Bind("updateDate") Instant updateDate,

--- a/src/main/resources/changelog-master.xml
+++ b/src/main/resources/changelog-master.xml
@@ -236,4 +236,6 @@
   <include file="changesets/changelog-consent-2026-02-05-fix-dataset-access-control.xml" relativeToChangelogFile="true" />
   <include file="changesets/changelog-consent-2026-02-11-new-dataset-property-dictionary-entry.xml"
            relativeToChangelogFile="true"/>
+  <include file="changesets/changelog-consent-2026-03-03-dac-dataset-approval-time.xml"
+           relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/src/main/resources/changesets/changelog-consent-2026-03-03-dac-dataset-approval-time.xml
+++ b/src/main/resources/changesets/changelog-consent-2026-03-03-dac-dataset-approval-time.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+  <changeSet id="changelog-consent-2026-03-03-dac-dataset-approval-time" author="otchet">
+    <addColumn tableName="dataset">
+      <column name="dac_approval_date" type="timestamp">
+        <constraints nullable="true"/>
+      </column>
+    </addColumn>
+    <createIndex tableName="dataset" indexName="idx_dac_approval_date">
+      <column name="dac_approval_date"/>
+    </createIndex>
+  </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-3043](https://broadworkbench.atlassian.net/browse/DT-3043)

Needed for new dataset approved digest messages in DT-1832


### Summary

Adds:
* A new column to store the timestamp of when a dataset was approved by a DAC.
* Memorialization on the update (only called by setting the approved to True)
* A new index that will be used in queries needed by DT-1832.


----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
