### PR TITLE
[DT-3002] Add DAC usage support request option

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/enumeration/SupportRequestType.java
+++ b/src/main/java/org/broadinstitute/consent/http/enumeration/SupportRequestType.java
@@ -4,5 +4,6 @@ public enum SupportRequestType {
   QUESTION,
   BUG,
   FEATURE_REQUEST,
-  TASK
+  TASK,
+  DAC_USAGE
 }

--- a/src/main/resources/assets/schemas/TicketFields.yaml
+++ b/src/main/resources/assets/schemas/TicketFields.yaml
@@ -12,7 +12,7 @@ properties:
     description: The name of the user requesting support
   type:
     type: string
-    enum: ["QUESTION", "BUG", "FEATURE_REQUEST", "TASK"]
+    enum: ["QUESTION", "BUG", "FEATURE_REQUEST", "TASK", "DAC_USAGE"]
   email:
     type: string
     description: The email of the user requesting support


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-3002

See also https://github.com/DataBiosphere/duos-ui/pull/3380

### Summary

Adds a new `DAC_USAGE` support option. The tests are already parametrized.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
