### PR TITLE
[DT-3086] Remove validation enum for centers list

### DIFF
--- a/src/main/resources/dataset-registration-schema_v1.json
+++ b/src/main/resources/dataset-registration-schema_v1.json
@@ -333,36 +333,7 @@
         "nihInstitutionCenterSubmission" : {
           "type" : "string",
           "label" : "NIH Institution/Center for Submission",
-          "description" : "NIH Institution/Center for Submission",
-          "enum" : [
-            "NCI",
-            "NEI",
-            "NHLBI",
-            "NHGRI",
-            "NIA",
-            "NIAAA",
-            "NIAID",
-            "NIAMS",
-            "NIBIB",
-            "NICHD",
-            "NIDCD",
-            "NIDCR",
-            "NIDDK",
-            "NIDA",
-            "NIEHS",
-            "NIGMS",
-            "NIMH",
-            "NIMHD",
-            "NINDS",
-            "NINR",
-            "NLM",
-            "CC",
-            "CIT",
-            "CSR",
-            "FIC",
-            "NCATS",
-            "NCCIH"
-          ]
+          "description" : "NIH Institution/Center for Submission"
         },
         "nihGenomicProgramAdministratorName" : {
           "type" : "string",


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-3086

### Summary

This PR removes the validation enum for centers list which now allows any string to be submitted.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
