### PR TITLE
[DT-3052] Deprecate endpoints bypassing DAA enforcement

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
@@ -254,6 +254,9 @@ public class DataAccessRequestResource extends Resource {
     }
   }
 
+  /**
+   * @deprecated Use {@link #createDraftDataAccessRequestWithDAARestrictions()} instead.
+   */
   @Deprecated(forRemoval = true) // Use v3 endpoint, to be removed in DT-3054
   @POST
   @Consumes("application/json")
@@ -295,6 +298,9 @@ public class DataAccessRequestResource extends Resource {
     }
   }
 
+  /**
+   * @deprecated Use {@link #updatePartialDataAccessRequestWithDAARestrictions()} instead.
+   */
   @Deprecated(forRemoval = true) // Use v3 endpoint, to be removed in DT-3054
   @PUT
   @Consumes("application/json")
@@ -418,6 +424,10 @@ public class DataAccessRequestResource extends Resource {
     }
   }
 
+  /**
+   * @deprecated This method will be replaced by {@code postProgressReportWithDAARestrictions()} (to
+   *     be introduced in DT-3051).
+   */
   @Deprecated(forRemoval = true) // Use v3 endpoint implemented in DT-3051, to be removed in DT-3054
   @POST
   @Consumes(MediaType.MULTIPART_FORM_DATA)

--- a/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
@@ -254,6 +254,7 @@ public class DataAccessRequestResource extends Resource {
     }
   }
 
+  @Deprecated(forRemoval = true) // Use v3 endpoint, to be removed in DT-3054
   @POST
   @Consumes("application/json")
   @Produces("application/json")
@@ -294,6 +295,7 @@ public class DataAccessRequestResource extends Resource {
     }
   }
 
+  @Deprecated(forRemoval = true) // Use v3 endpoint, to be removed in DT-3054
   @PUT
   @Consumes("application/json")
   @Produces("application/json")
@@ -416,6 +418,7 @@ public class DataAccessRequestResource extends Resource {
     }
   }
 
+  @Deprecated(forRemoval = true) // Use v3 endpoint implemented in DT-3051, to be removed in DT-3054
   @POST
   @Consumes(MediaType.MULTIPART_FORM_DATA)
   @Produces(MediaType.APPLICATION_JSON)

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -287,8 +287,13 @@ paths:
 
   /api/dar/v2/draft/{referenceId}:
     put:
-      summary: Update Draft Data Access Request
-      description: Update Draft Data Access Request
+      deprecated: true
+      summary: |
+        Update Draft Data Access Request
+        See /api/dar/v3/draft/{referenceId} for replacement
+      description: |
+        Update Draft Data Access Request
+        Deprecated in favor of /api/dar/v3/draft/{referenceId}
       parameters:
         - name: referenceId
           in: path

--- a/src/main/resources/assets/paths/progressReport.yaml
+++ b/src/main/resources/assets/paths/progressReport.yaml
@@ -1,6 +1,11 @@
 post:
-  summary: Create a new DAR progress report
-  description: Create a new DAR progress report
+  deprecated: true
+  summary: |
+    Create a new DAR progress report
+    See /api/dar/v3/progress_report/{parentReferenceId} for replacement
+  description: |
+    Create a new DAR progress report
+    Deprecated in favor of /api/dar/v3/progress_report/{parentReferenceId}
   tags:
     - Data Access Request
   parameters:


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-3052

### Summary

This PR deprecates legacy endpoints that bypass Data Access Authorization (DAA) enforcement and do not use the new DAA mechanism. These endpoints are now marked as deprecated to guide consumers toward compliant alternatives.

<img width="1438" height="222" alt="After" src="https://github.com/user-attachments/assets/1de6b2c9-032d-4f09-ae6b-7e2e7ccac949" />

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
