### PR TITLE
[DT-3051] Add v3 progress report endpoint with DAA enforcement

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
@@ -501,7 +501,7 @@ public class DataAccessRequestResource extends Resource {
   @Path("/v3/progress_report/{parentReferenceId}")
   @RolesAllowed({RESEARCHER})
   public Response postProgressReportWithDAARestrictions(
-      @Auth AuthUser authUser,
+      @Auth DuosUser duoUser,
       @Context Request request,
       @PathParam("parentReferenceId") String parentReferenceId,
       @FormDataParam("dar") String dar,
@@ -510,7 +510,7 @@ public class DataAccessRequestResource extends Resource {
       @FormDataParam("ethicsApprovalRequiredFile") InputStream ethicsInputStream,
       @FormDataParam("ethicsApprovalRequiredFile") FormDataContentDisposition ethicsFileDetails) {
     try {
-      User user = userService.findUserByEmail(authUser.getEmail());
+      User user = duoUser.getUser();
       // added here because other dataAccessRequestServices calls are invoked that do not normally
       // require this sequence.  hasValidActiveERACredentials will also check for a LC so no
       // additional LC check needed.
@@ -532,7 +532,9 @@ public class DataAccessRequestResource extends Resource {
                           .equalsIgnoreCase(ElectionType.DATA_ACCESS.getValue()));
       if (hasOpenDataAccessElections) {
         throw new BadRequestException(
-            "Cannot create a progress report for a DAR with an open election: "
+            "Cannot create a progress report for a DAR: "
+                + parentDar.darCode
+                + " with an open election: "
                 + parentDar.getReferenceId());
       }
       DataAccessRequest payload =

--- a/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
@@ -495,6 +495,76 @@ public class DataAccessRequestResource extends Resource {
     }
   }
 
+  @POST
+  @Consumes(MediaType.MULTIPART_FORM_DATA)
+  @Produces(MediaType.APPLICATION_JSON)
+  @Path("/v3/progress_report/{parentReferenceId}")
+  @RolesAllowed({RESEARCHER})
+  public Response postProgressReportWithDAARestrictions(
+      @Auth AuthUser authUser,
+      @Context Request request,
+      @PathParam("parentReferenceId") String parentReferenceId,
+      @FormDataParam("dar") String dar,
+      @FormDataParam("collaboratorRequiredFile") InputStream collabInputStream,
+      @FormDataParam("collaboratorRequiredFile") FormDataContentDisposition collabFileDetails,
+      @FormDataParam("ethicsApprovalRequiredFile") InputStream ethicsInputStream,
+      @FormDataParam("ethicsApprovalRequiredFile") FormDataContentDisposition ethicsFileDetails) {
+    try {
+      User user = userService.findUserByEmail(authUser.getEmail());
+      // added here because other dataAccessRequestServices calls are invoked that do not normally
+      // require this sequence.  hasValidActiveERACredentials will also check for a LC so no
+      // additional LC check needed.
+      userService.validateActiveERACredentials(user);
+      DataAccessRequest parentDar = dataAccessRequestService.findByReferenceId(parentReferenceId);
+      // needs to happen before docs are uploaded
+      if (!user.getUserId().equals(parentDar.getUserId())) {
+        throw new ForbiddenException("User not authorized to update this Data Access Request");
+      }
+      // Prevent creation if there are open DataAccess elections for the parent DAR
+      List<Election> openElections =
+          dataAccessRequestService.findOpenElectionsByReferenceId(parentDar.getReferenceId());
+      boolean hasOpenDataAccessElections =
+          openElections.stream()
+              .anyMatch(
+                  election ->
+                      election
+                          .getElectionType()
+                          .equalsIgnoreCase(ElectionType.DATA_ACCESS.getValue()));
+      if (hasOpenDataAccessElections) {
+        throw new BadRequestException(
+            "Cannot create a progress report for a DAR with an open election: "
+                + parentDar.getReferenceId());
+      }
+      DataAccessRequest payload =
+          DataAccessRequest.populateProgressReportFromJsonString(dar, parentDar);
+      populateProgressReportWithDocuments(
+          user,
+          collabInputStream,
+          collabFileDetails,
+          ethicsInputStream,
+          ethicsFileDetails,
+          payload,
+          parentDar);
+
+      // DAA Enforcement
+      datasetService.enforceDAARestrictions(user, payload.getDatasetIds());
+
+      DataAccessRequest progressReport =
+          dataAccessRequestService.createProgressReport(
+              user, payload, parentDar, (ContainerRequest) request);
+      if (Objects.nonNull(progressReport) && !progressReport.getIsCloseoutProgressReport()) {
+        processNewDarCollection(parentDar.getCollectionId());
+      }
+      List<Dataset> datasets =
+          datasetService.findDatasetsByIds(user, progressReport.getDatasetIds());
+      ComplianceLogger.logDARSubmission(
+          user, datasets, ((ContainerRequest) request), HttpStatusCodes.STATUS_CODE_CREATED);
+      return Response.ok(progressReport.convertToSimplifiedDar()).build();
+    } catch (Exception e) {
+      return createExceptionResponse(e);
+    }
+  }
+
   private void processNewDarCollection(Integer collectionId) {
     try {
       // This service method knows how to distinguish between a DAR and a Progress Report.

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -342,6 +342,9 @@ paths:
   /api/dar/v3/draft/{referenceId}:
     $ref: './paths/darV3DraftByReferenceId.yaml'
 
+  /api/dar/v3/progress_report/{parentReferenceId}:
+    $ref: './paths/progressReportV3.yaml'
+
   /api/dar/v2/{referenceId}/irbDocument:
     get:
       summary: Retrieve DAR IRB Document

--- a/src/main/resources/assets/paths/progressReportV3.yaml
+++ b/src/main/resources/assets/paths/progressReportV3.yaml
@@ -1,0 +1,59 @@
+post:
+  summary: Create a new DAR progress report
+  description: Create a new DAR progress report
+  tags:
+    - Data Access Request
+  parameters:
+    - name: parentReferenceId
+      in: path
+      description: The referenceId of the Data Access Request
+      required: true
+      schema:
+        type: string
+  requestBody:
+    required: true
+    content:
+      multipart/form-data:
+        schema:
+          type: object
+          properties:
+            dar:
+              type: object
+              description: An object that follows the Data Access Request schema
+            collaboratorRequiredFile:
+              type: string
+              format: binary
+            ethicsApprovalRequiredFile:
+              type: string
+              format: binary
+  responses:
+    200:
+      description: Returns the Data Access Request with progress report
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/DataAccessRequest.yaml'
+    400:
+      description: Bad request
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
+    403:
+      description: Forbidden
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
+    404:
+      description: Not found
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
+    500:
+      description: Internal server error
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'

--- a/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceTest.java
@@ -414,7 +414,6 @@ class DataAccessRequestResourceTest extends AbstractTestHelper {
 
   @Test
   void testPostProgressReportCollabAndEthicsFiles() {
-    when(userService.findUserByEmail(user.getEmail())).thenReturn(user);
     DataAccessRequest parentDar = generateDataAccessRequest();
     when(dataAccessRequestService.findByReferenceId(any())).thenReturn(parentDar);
     DataAccessRequest childDar = generateDataAccessRequest();
@@ -427,7 +426,7 @@ class DataAccessRequestResourceTest extends AbstractTestHelper {
 
     try (var response =
         resource.postProgressReportWithDAARestrictions(
-            authUser,
+            duosUser,
             request,
             "",
             "",
@@ -441,7 +440,6 @@ class DataAccessRequestResourceTest extends AbstractTestHelper {
 
   @Test
   void testPostProgressReportDifferentUser() {
-    when(userService.findUserByEmail(user.getEmail())).thenReturn(user);
     DataAccessRequest parentDar = generateDataAccessRequest();
     parentDar.setUserId(2);
     when(dataAccessRequestService.findByReferenceId(any())).thenReturn(parentDar);
@@ -450,7 +448,7 @@ class DataAccessRequestResourceTest extends AbstractTestHelper {
 
     Response response =
         resource.postProgressReportWithDAARestrictions(
-            authUser,
+            duosUser,
             request,
             "",
             "",
@@ -463,14 +461,13 @@ class DataAccessRequestResourceTest extends AbstractTestHelper {
 
   @Test
   void testPostProgressReportMissingParentDar() {
-    when(userService.findUserByEmail(user.getEmail())).thenReturn(user);
     when(dataAccessRequestService.findByReferenceId(any())).thenThrow(NotFoundException.class);
     Pair<InputStream, FormDataContentDisposition> collabFile = mockFormDataMultiPart("collab.txt");
     Pair<InputStream, FormDataContentDisposition> ethicsFile = mockFormDataMultiPart("ethics.txt");
 
     try (var response =
         resource.postProgressReportWithDAARestrictions(
-            authUser,
+            duosUser,
             request,
             "",
             "",
@@ -485,7 +482,6 @@ class DataAccessRequestResourceTest extends AbstractTestHelper {
   @Test
   void testPostProgressReportInvalidJson() {
     String invalidDar = "{\"projectTitle\": \"test\", \"datasetIds\": \"invalid\"}";
-    when(userService.findUserByEmail(user.getEmail())).thenReturn(user);
     DataAccessRequest parentDar = generateDataAccessRequest();
     when(dataAccessRequestService.findByReferenceId(any())).thenReturn(parentDar);
     var collabFile = mockFormDataMultiPart("collab.txt");
@@ -493,7 +489,7 @@ class DataAccessRequestResourceTest extends AbstractTestHelper {
 
     try (var response =
         resource.postProgressReportWithDAARestrictions(
-            authUser,
+            duosUser,
             request,
             "",
             invalidDar,
@@ -508,19 +504,17 @@ class DataAccessRequestResourceTest extends AbstractTestHelper {
 
   @Test
   void testPostProgressReportThrowsWhenNoERACommonsID() {
-    when(userService.findUserByEmail(user.getEmail())).thenReturn(user);
     doThrow(BadRequestException.class).when(userService).validateActiveERACredentials(user);
 
     try (var response =
         resource.postProgressReportWithDAARestrictions(
-            authUser, request, "", "", null, null, null, null)) {
+            duosUser, request, "", "", null, null, null, null)) {
       assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
     }
   }
 
   @Test
   void testPostProgressReportWithOpenElections() {
-    when(userService.findUserByEmail(user.getEmail())).thenReturn(user);
     DataAccessRequest parentDar = generateDataAccessRequest();
     when(dataAccessRequestService.findByReferenceId(any())).thenReturn(parentDar);
     Election election = new Election();
@@ -534,7 +528,7 @@ class DataAccessRequestResourceTest extends AbstractTestHelper {
 
     try (var response =
         resource.postProgressReportWithDAARestrictions(
-            authUser,
+            duosUser,
             request,
             "",
             "",
@@ -547,14 +541,15 @@ class DataAccessRequestResourceTest extends AbstractTestHelper {
           response
               .getEntity()
               .toString()
-              .contains("Cannot create a progress report for a DAR with an open election"));
+              .contains(
+                  "Cannot create a progress report for a DAR: "
+                      + parentDar.getDarCode()
+                      + " with an open election"));
     }
   }
 
   @Test
   void testPostProgressReportFailsWhenDAARestricted() {
-    when(userService.findUserByEmail(user.getEmail())).thenReturn(user);
-
     DataAccessRequest parentDar = generateDataAccessRequest();
     when(dataAccessRequestService.findByReferenceId(any())).thenReturn(parentDar);
 
@@ -568,7 +563,7 @@ class DataAccessRequestResourceTest extends AbstractTestHelper {
 
     try (var response =
         resource.postProgressReportWithDAARestrictions(
-            authUser,
+            duosUser,
             request,
             "",
             "",
@@ -587,8 +582,6 @@ class DataAccessRequestResourceTest extends AbstractTestHelper {
 
   @Test
   void testPostProgressReportInvokesDAAEnforcement() {
-    when(userService.findUserByEmail(user.getEmail())).thenReturn(user);
-
     DataAccessRequest parentDar = generateDataAccessRequest();
     when(dataAccessRequestService.findByReferenceId(any())).thenReturn(parentDar);
 
@@ -603,7 +596,7 @@ class DataAccessRequestResourceTest extends AbstractTestHelper {
 
     try (var response =
         resource.postProgressReportWithDAARestrictions(
-            authUser,
+            duosUser,
             request,
             "",
             "",
@@ -946,6 +939,7 @@ class DataAccessRequestResourceTest extends AbstractTestHelper {
     DataAccessRequestData data = new DataAccessRequestData();
     dar.setReferenceId(UUID.randomUUID().toString());
     data.setReferenceId(dar.getReferenceId());
+    dar.setDarCode("DAR-" + randomInt(100, 500));
     dar.setId(new Random().nextInt());
     dar.setDatasetIds(Arrays.asList(1, 2));
     dar.setData(data);

--- a/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceTest.java
@@ -12,6 +12,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -425,7 +426,7 @@ class DataAccessRequestResourceTest extends AbstractTestHelper {
     Pair<InputStream, FormDataContentDisposition> ethicsFile = mockFormDataMultiPart("ethics.txt");
 
     try (var response =
-        resource.postProgressReport(
+        resource.postProgressReportWithDAARestrictions(
             authUser,
             request,
             "",
@@ -448,7 +449,7 @@ class DataAccessRequestResourceTest extends AbstractTestHelper {
     Pair<InputStream, FormDataContentDisposition> ethicsFile = mockFormDataMultiPart("ethics.txt");
 
     Response response =
-        resource.postProgressReport(
+        resource.postProgressReportWithDAARestrictions(
             authUser,
             request,
             "",
@@ -468,7 +469,7 @@ class DataAccessRequestResourceTest extends AbstractTestHelper {
     Pair<InputStream, FormDataContentDisposition> ethicsFile = mockFormDataMultiPart("ethics.txt");
 
     try (var response =
-        resource.postProgressReport(
+        resource.postProgressReportWithDAARestrictions(
             authUser,
             request,
             "",
@@ -491,7 +492,7 @@ class DataAccessRequestResourceTest extends AbstractTestHelper {
     var ethicsFile = mockFormDataMultiPart("ethics.txt");
 
     try (var response =
-        resource.postProgressReport(
+        resource.postProgressReportWithDAARestrictions(
             authUser,
             request,
             "",
@@ -511,7 +512,8 @@ class DataAccessRequestResourceTest extends AbstractTestHelper {
     doThrow(BadRequestException.class).when(userService).validateActiveERACredentials(user);
 
     try (var response =
-        resource.postProgressReport(authUser, request, "", "", null, null, null, null)) {
+        resource.postProgressReportWithDAARestrictions(
+            authUser, request, "", "", null, null, null, null)) {
       assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
     }
   }
@@ -531,7 +533,7 @@ class DataAccessRequestResourceTest extends AbstractTestHelper {
     var ethicsFile = mockFormDataMultiPart("ethics.txt");
 
     try (var response =
-        resource.postProgressReport(
+        resource.postProgressReportWithDAARestrictions(
             authUser,
             request,
             "",
@@ -547,6 +549,73 @@ class DataAccessRequestResourceTest extends AbstractTestHelper {
               .toString()
               .contains("Cannot create a progress report for a DAR with an open election"));
     }
+  }
+
+  @Test
+  void testPostProgressReportFailsWhenDAARestricted() {
+    when(userService.findUserByEmail(user.getEmail())).thenReturn(user);
+
+    DataAccessRequest parentDar = generateDataAccessRequest();
+    when(dataAccessRequestService.findByReferenceId(any())).thenReturn(parentDar);
+
+    // Mock enforcement to fail
+    doThrow(new ForbiddenException("DAA restriction violated"))
+        .when(datasetService)
+        .enforceDAARestrictions(eq(user), any());
+
+    var collabFile = mockFormDataMultiPart("collab.txt");
+    var ethicsFile = mockFormDataMultiPart("ethics.txt");
+
+    try (var response =
+        resource.postProgressReportWithDAARestrictions(
+            authUser,
+            request,
+            "",
+            "",
+            collabFile.getLeft(),
+            collabFile.getRight(),
+            ethicsFile.getLeft(),
+            ethicsFile.getRight())) {
+
+      assertEquals(HttpStatusCodes.STATUS_CODE_FORBIDDEN, response.getStatus());
+    }
+
+    // Ensure persistence never happens
+    verify(dataAccessRequestService, never())
+        .createProgressReport(eq(user), any(), eq(parentDar), eq(request));
+  }
+
+  @Test
+  void testPostProgressReportInvokesDAAEnforcement() {
+    when(userService.findUserByEmail(user.getEmail())).thenReturn(user);
+
+    DataAccessRequest parentDar = generateDataAccessRequest();
+    when(dataAccessRequestService.findByReferenceId(any())).thenReturn(parentDar);
+
+    DataAccessRequest childDar = generateDataAccessRequest();
+    when(dataAccessRequestService.createProgressReport(eq(user), any(), eq(parentDar), eq(request)))
+        .thenReturn(childDar);
+
+    when(datasetService.findDatasetsByIds(user, childDar.getDatasetIds())).thenReturn(List.of());
+
+    var collabFile = mockFormDataMultiPart("collab.txt");
+    var ethicsFile = mockFormDataMultiPart("ethics.txt");
+
+    try (var response =
+        resource.postProgressReportWithDAARestrictions(
+            authUser,
+            request,
+            "",
+            "",
+            collabFile.getLeft(),
+            collabFile.getRight(),
+            ethicsFile.getLeft(),
+            ethicsFile.getRight())) {
+
+      assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+    }
+
+    verify(datasetService).enforceDAARestrictions(eq(user), any());
   }
 
   @Test


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-3051

### Summary

Adds a new v3 endpoint for submitting progress reports with DAA enforcement.
Validates dataset access before creating the progress report.

<img width="1142" height="885" alt="After" src="https://github.com/user-attachments/assets/8640332e-ddc5-40d1-b13a-9f9e8492dd94" />

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
