### PR TITLE
DT-3059: Add auditing for DAA creation and removal

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/DaaDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DaaDAO.java
@@ -265,4 +265,13 @@ public interface DaaDAO extends Transactional<DaaDAO> {
     ORDER BY action_date DESC
     """)
   List<DaaAudit> findAuditsByDaaId(@Bind("daaId") Integer daaId);
+
+  @RegisterRowMapper(DaaAuditMapper.class)
+  @SqlQuery(
+      """
+    SELECT *
+    FROM daa_audit
+    ORDER BY action_date DESC
+    """)
+  List<DaaAudit> findAllDaaAudits();
 }

--- a/src/main/java/org/broadinstitute/consent/http/db/DaaDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DaaDAO.java
@@ -171,11 +171,16 @@ public interface DaaDAO extends Transactional<DaaDAO> {
 
   @SqlUpdate(
       """
-    INSERT INTO dac_daa (dac_id, daa_id)
-    VALUES (:dacId, :daaId)
-    ON CONFLICT (dac_id) DO UPDATE SET daa_id = :daaId
-  """)
-  void createDacDaaRelation(@Bind("dacId") Integer dacId, @Bind("daaId") Integer daaId);
+      WITH audit AS (INSERT INTO daa_audit (daa_id, dac_id, user_id, action, action_date) VALUES (:daaId, :dacId, :userId, :action, NOW()))
+      INSERT INTO dac_daa (dac_id, daa_id)
+      VALUES (:dacId, :daaId)
+      ON CONFLICT (dac_id) DO UPDATE SET daa_id = :daaId
+      """)
+  void createDacDaaRelation(
+      @Bind("dacId") Integer dacId,
+      @Bind("daaId") Integer daaId,
+      @Bind("userId") Integer userId,
+      @Bind("action") String action);
 
   @SqlUpdate(
       """

--- a/src/main/java/org/broadinstitute/consent/http/db/DaaDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DaaDAO.java
@@ -12,7 +12,6 @@ import org.broadinstitute.consent.http.models.DataAccessAgreement;
 import org.jdbi.v3.sqlobject.config.RegisterBeanMapper;
 import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
 import org.jdbi.v3.sqlobject.customizer.Bind;
-import org.jdbi.v3.sqlobject.statement.GetGeneratedKeys;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 import org.jdbi.v3.sqlobject.statement.UseRowReducer;
@@ -156,12 +155,20 @@ public interface DaaDAO extends Transactional<DaaDAO> {
    * @param initialDacId The id for the initial DAC this DAA was created for
    * @return Integer
    */
-  @SqlUpdate(
+  @SqlQuery(
       """
-      INSERT INTO data_access_agreement (create_user_id, create_date, update_user_id, update_date, initial_dac_id)
-      VALUES (:createUserId, :createDate, :updateUserId, :updateDate, :initialDacId)
+      WITH new_daa AS (
+          INSERT INTO data_access_agreement (create_user_id, create_date, update_user_id, update_date, initial_dac_id)
+          VALUES (:createUserId, :createDate, :updateUserId, :updateDate, :initialDacId)
+          RETURNING daa_id
+      ),
+      audit AS (
+          INSERT INTO daa_audit (daa_id, dac_id, user_id, action, action_date)
+          SELECT daa_id, :initialDacId, :createUserId, 'CREATE', NOW()
+          FROM new_daa
+      )
+      SELECT daa_id FROM new_daa
       """)
-  @GetGeneratedKeys
   Integer createDaa(
       @Bind("createUserId") Integer createUserId,
       @Bind("createDate") Instant createDate,
@@ -248,17 +255,6 @@ public interface DaaDAO extends Transactional<DaaDAO> {
           WHERE dd.reference_id = :referenceId
       """)
   List<DataAccessAgreement> findByDarReferenceId(@Bind("referenceId") String referenceId);
-
-  @SqlUpdate(
-      """
-    INSERT INTO daa_audit (daa_id, dac_id, user_id, action, action_date)
-    VALUES (:daaId, :dacId, :userId, :action, NOW())
-    """)
-  void insertAudit(
-      @Bind("daaId") Integer daaId,
-      @Bind("dacId") Integer dacId,
-      @Bind("userId") Integer userId,
-      @Bind("action") String action);
 
   @RegisterRowMapper(DaaAuditMapper.class)
   @SqlQuery(

--- a/src/main/java/org/broadinstitute/consent/http/db/DaaDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DaaDAO.java
@@ -2,9 +2,11 @@ package org.broadinstitute.consent.http.db;
 
 import java.time.Instant;
 import java.util.List;
+import org.broadinstitute.consent.http.db.mapper.DaaAuditMapper;
 import org.broadinstitute.consent.http.db.mapper.DaaMapper;
 import org.broadinstitute.consent.http.db.mapper.DataAccessAgreementReducer;
 import org.broadinstitute.consent.http.db.mapper.FileStorageObjectMapper;
+import org.broadinstitute.consent.http.models.DaaAudit;
 import org.broadinstitute.consent.http.models.Dac;
 import org.broadinstitute.consent.http.models.DataAccessAgreement;
 import org.jdbi.v3.sqlobject.config.RegisterBeanMapper;
@@ -177,11 +179,14 @@ public interface DaaDAO extends Transactional<DaaDAO> {
 
   @SqlUpdate(
       """
-      DELETE FROM dac_daa
-      WHERE dac_id = :dacId
-      AND daa_id = :daaId
+      WITH audit AS (INSERT INTO daa_audit (daa_id, dac_id, user_id, action, action_date) VALUES (:daaId, :dacId, :userId, :action, NOW()))
+      DELETE FROM dac_daa WHERE daa_id = :daaId AND dac_id = :dacId
       """)
-  void deleteDacDaaRelation(@Bind("dacId") Integer dacId, @Bind("daaId") Integer daaId);
+  void deleteDacDaaRelation(
+      @Bind("daaId") Integer daaId,
+      @Bind("dacId") Integer dacId,
+      @Bind("userId") Integer userId,
+      @Bind("action") String action);
 
   /**
    * Relationship chain: User -> Library Card -> Data Access Agreement -> DAC -> Dataset
@@ -199,14 +204,6 @@ public interface DaaDAO extends Transactional<DaaDAO> {
       WHERE lc.user_id = :userId
       """)
   List<Integer> findDaaDatasetIdsByUserId(@Bind("userId") Integer userId);
-
-  @SqlUpdate(
-      """
-    WITH lc_deletes AS (DELETE FROM lc_daa WHERE lc_daa.daa_id = :daaId),
-    dac_delete AS (DELETE FROM dac_daa WHERE dac_daa.daa_id = :daaId)
-    DELETE FROM data_access_agreement WHERE daa_id = :daaId
-    """)
-  void deleteDaa(@Bind("daaId") Integer daaId);
 
   /**
    * Find all DAAs for a Data Access Request by Reference ID DAR -> dar dataset join table ->
@@ -252,4 +249,25 @@ public interface DaaDAO extends Transactional<DaaDAO> {
           WHERE dd.reference_id = :referenceId
       """)
   List<DataAccessAgreement> findByDarReferenceId(@Bind("referenceId") String referenceId);
+
+  @SqlUpdate(
+      """
+    INSERT INTO daa_audit (daa_id, dac_id, user_id, action, action_date)
+    VALUES (:daaId, :dacId, :userId, :action, NOW())
+    """)
+  void insertAudit(
+      @Bind("daaId") Integer daaId,
+      @Bind("dacId") Integer dacId,
+      @Bind("userId") Integer userId,
+      @Bind("action") String action);
+
+  @RegisterRowMapper(DaaAuditMapper.class)
+  @SqlQuery(
+      """
+    SELECT *
+    FROM daa_audit
+    WHERE daa_id = :daaId
+    ORDER BY action_date DESC
+    """)
+  List<DaaAudit> findAuditsByDaaId(@Bind("daaId") Integer daaId);
 }

--- a/src/main/java/org/broadinstitute/consent/http/db/DaaDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DaaDAO.java
@@ -171,27 +171,21 @@ public interface DaaDAO extends Transactional<DaaDAO> {
 
   @SqlUpdate(
       """
-      WITH audit AS (INSERT INTO daa_audit (daa_id, dac_id, user_id, action, action_date) VALUES (:daaId, :dacId, :userId, :action, NOW()))
+      WITH audit AS (INSERT INTO daa_audit (daa_id, dac_id, user_id, action, action_date) VALUES (:daaId, :dacId, :userId, 'ADD', NOW()))
       INSERT INTO dac_daa (dac_id, daa_id)
       VALUES (:dacId, :daaId)
       ON CONFLICT (dac_id) DO UPDATE SET daa_id = :daaId
       """)
   void createDacDaaRelation(
-      @Bind("dacId") Integer dacId,
-      @Bind("daaId") Integer daaId,
-      @Bind("userId") Integer userId,
-      @Bind("action") String action);
+      @Bind("dacId") Integer dacId, @Bind("daaId") Integer daaId, @Bind("userId") Integer userId);
 
   @SqlUpdate(
       """
-      WITH audit AS (INSERT INTO daa_audit (daa_id, dac_id, user_id, action, action_date) VALUES (:daaId, :dacId, :userId, :action, NOW()))
+      WITH audit AS (INSERT INTO daa_audit (daa_id, dac_id, user_id, action, action_date) VALUES (:daaId, :dacId, :userId, 'REMOVE', NOW()))
       DELETE FROM dac_daa WHERE daa_id = :daaId AND dac_id = :dacId
       """)
   void deleteDacDaaRelation(
-      @Bind("daaId") Integer daaId,
-      @Bind("dacId") Integer dacId,
-      @Bind("userId") Integer userId,
-      @Bind("action") String action);
+      @Bind("daaId") Integer daaId, @Bind("dacId") Integer dacId, @Bind("userId") Integer userId);
 
   /**
    * Relationship chain: User -> Library Card -> Data Access Agreement -> DAC -> Dataset

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DaaAuditMapper.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DaaAuditMapper.java
@@ -1,0 +1,21 @@
+package org.broadinstitute.consent.http.db.mapper;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import org.broadinstitute.consent.http.enumeration.AuditActions;
+import org.broadinstitute.consent.http.models.DaaAudit;
+import org.jdbi.v3.core.mapper.RowMapper;
+import org.jdbi.v3.core.statement.StatementContext;
+
+public class DaaAuditMapper implements RowMapper<DaaAudit>, RowMapperHelper {
+  @Override
+  public DaaAudit map(ResultSet rs, StatementContext ctx) throws SQLException {
+    return new DaaAudit(
+        rs.getLong("id"),
+        rs.getInt("daa_id"),
+        rs.getInt("dac_id"),
+        rs.getInt("user_id"),
+        AuditActions.valueOf(rs.getString("action").toUpperCase()),
+        rs.getTimestamp("action_date").toInstant());
+  }
+}

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DaaAuditMapper.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DaaAuditMapper.java
@@ -10,10 +10,11 @@ import org.jdbi.v3.core.statement.StatementContext;
 public class DaaAuditMapper implements RowMapper<DaaAudit>, RowMapperHelper {
   @Override
   public DaaAudit map(ResultSet rs, StatementContext ctx) throws SQLException {
+    int dacId = hasColumn(rs, "dac_id") ? rs.getInt("dac_id") : 0;
     return new DaaAudit(
         rs.getLong("id"),
         rs.getInt("daa_id"),
-        rs.getInt("dac_id"),
+        dacId > 0 ? dacId : null,
         rs.getInt("user_id"),
         AuditActions.valueOf(rs.getString("action").toUpperCase()),
         rs.getTimestamp("action_date").toInstant());

--- a/src/main/java/org/broadinstitute/consent/http/models/DaaAudit.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DaaAudit.java
@@ -1,0 +1,12 @@
+package org.broadinstitute.consent.http.models;
+
+import java.time.Instant;
+import org.broadinstitute.consent.http.enumeration.AuditActions;
+
+public record DaaAudit(
+    Long id,
+    Integer daaId,
+    Integer dacId,
+    Integer userId,
+    AuditActions action,
+    Instant actionDate) {}

--- a/src/main/java/org/broadinstitute/consent/http/resources/DaaResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DaaResource.java
@@ -320,7 +320,7 @@ public class DaaResource extends Resource implements ConsentLogger {
             daa.getDacs().stream().filter(dac -> Objects.equals(dac.getDacId(), dacId)).findFirst();
       }
       if (matchingDac.isEmpty()) {
-        daaService.addDacToDaa(dacId, daaId);
+        daaService.addDacToDaa(user.getUserId(), dacId, daaId);
       }
       DataAccessAgreement updatedDaa = daaService.findById(daaId);
       return Response.ok().entity(updatedDaa).build();

--- a/src/main/java/org/broadinstitute/consent/http/resources/DaaResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DaaResource.java
@@ -360,7 +360,7 @@ public class DaaResource extends Resource implements ConsentLogger {
       if (matchingDac.isEmpty()) {
         throw new BadRequestException("The given DAC is not associated with the provided DAA.");
       } else {
-        daaService.removeDacFromDaa(dacId, daaId);
+        daaService.removeDacFromDaa(user.getUserId(), dacId, daaId);
       }
       DataAccessAgreement updatedDaa = daaService.findById(daaId);
       return Response.ok().entity(updatedDaa).build();

--- a/src/main/java/org/broadinstitute/consent/http/service/DaaService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DaaService.java
@@ -19,7 +19,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.consent.http.cloudstore.GCSService;
 import org.broadinstitute.consent.http.db.DaaDAO;
 import org.broadinstitute.consent.http.db.DacDAO;
-import org.broadinstitute.consent.http.enumeration.AuditActions;
 import org.broadinstitute.consent.http.enumeration.FileCategory;
 import org.broadinstitute.consent.http.models.Dac;
 import org.broadinstitute.consent.http.models.DataAccessAgreement;
@@ -107,11 +106,11 @@ public class DaaService implements ConsentLogger {
   }
 
   public void addDacToDaa(Integer userId, Integer dacId, Integer daaId) {
-    daaDAO.createDacDaaRelation(dacId, daaId, userId, AuditActions.ADD.getValue().toUpperCase());
+    daaDAO.createDacDaaRelation(dacId, daaId, userId);
   }
 
   public void removeDacFromDaa(Integer userId, Integer dacId, Integer daaId) {
-    daaDAO.deleteDacDaaRelation(daaId, dacId, userId, AuditActions.REMOVE.getValue().toUpperCase());
+    daaDAO.deleteDacDaaRelation(daaId, dacId, userId);
   }
 
   // Note: This method/implementation is not the permanent solution to identifying the Broad DAA.

--- a/src/main/java/org/broadinstitute/consent/http/service/DaaService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DaaService.java
@@ -19,6 +19,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.consent.http.cloudstore.GCSService;
 import org.broadinstitute.consent.http.db.DaaDAO;
 import org.broadinstitute.consent.http.db.DacDAO;
+import org.broadinstitute.consent.http.enumeration.AuditActions;
 import org.broadinstitute.consent.http.enumeration.FileCategory;
 import org.broadinstitute.consent.http.models.Dac;
 import org.broadinstitute.consent.http.models.DataAccessAgreement;
@@ -109,8 +110,8 @@ public class DaaService implements ConsentLogger {
     daaDAO.createDacDaaRelation(dacId, daaId);
   }
 
-  public void removeDacFromDaa(Integer dacId, Integer daaId) {
-    daaDAO.deleteDacDaaRelation(dacId, daaId);
+  public void removeDacFromDaa(Integer userId, Integer dacId, Integer daaId) {
+    daaDAO.deleteDacDaaRelation(daaId, dacId, userId, AuditActions.REMOVE.getValue().toUpperCase());
   }
 
   // Note: This method/implementation is not the permanent solution to identifying the Broad DAA.
@@ -216,15 +217,6 @@ public class DaaService implements ConsentLogger {
       throw new BadRequestException("Invalid JSON or missing array with key: " + arrayKey);
     }
     return jsonElementList.stream().distinct().map(e -> findById(e.getAsInt())).toList();
-  }
-
-  public void deleteDaa(Integer daaId) {
-    DataAccessAgreement daa = daaDAO.findById(daaId);
-    if (daa != null) {
-      daaDAO.deleteDaa(daaId);
-    } else {
-      throw new NotFoundException("Could not find DAA with the provided ID: " + daaId);
-    }
   }
 
   public List<DataAccessAgreement> findByDarReferenceId(String referenceId) {

--- a/src/main/java/org/broadinstitute/consent/http/service/DaaService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DaaService.java
@@ -106,8 +106,8 @@ public class DaaService implements ConsentLogger {
     return daaDAO.findById(daaId);
   }
 
-  public void addDacToDaa(Integer dacId, Integer daaId) {
-    daaDAO.createDacDaaRelation(dacId, daaId);
+  public void addDacToDaa(Integer userId, Integer dacId, Integer daaId) {
+    daaDAO.createDacDaaRelation(dacId, daaId, userId, AuditActions.ADD.getValue().toUpperCase());
   }
 
   public void removeDacFromDaa(Integer userId, Integer dacId, Integer daaId) {

--- a/src/main/java/org/broadinstitute/consent/http/service/DacService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DacService.java
@@ -205,7 +205,7 @@ public class DacService implements ConsentLogger {
       throw new IllegalArgumentException("This is the Broad DAC, which can not be deleted.");
     }
     try {
-      dacServiceDAO.deleteDacAndDaas(user, fullDac);
+      dacServiceDAO.deleteDacAndRemoveDaaAssociation(user, fullDac);
     } catch (IllegalArgumentException e) {
       String logMessage = "Could not find DAC with the provided id: " + dacId;
       logException(logMessage, e);

--- a/src/main/java/org/broadinstitute/consent/http/service/DacService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DacService.java
@@ -5,7 +5,6 @@ import static java.util.stream.Collectors.groupingBy;
 import com.google.inject.Inject;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.NotFoundException;
-import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
@@ -198,7 +197,7 @@ public class DacService implements ConsentLogger {
     dacDAO.updateDac(name, description, email, updateDate, dacId);
   }
 
-  public void deleteDac(User user, Integer dacId) throws IllegalArgumentException, SQLException {
+  public void deleteDac(User user, Integer dacId) throws IllegalArgumentException {
     Dac fullDac = dacDAO.findById(dacId);
     // TODO: Broad DAC logic will be updated with DCJ-498 to not be reliant on name
     if (fullDac.getName().toLowerCase().contains("broad")) {

--- a/src/main/java/org/broadinstitute/consent/http/service/dao/DaaServiceDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/dao/DaaServiceDAO.java
@@ -36,7 +36,8 @@ public class DaaServiceDAO implements ConsentLogger {
             Integer daaId = daaDAO.createDaa(userId, now, userId, now, dacId);
             daaDAO.insertAudit(daaId, dacId, userId, AuditActions.CREATE.getValue().toUpperCase());
             createdDaaIds.add(daaId);
-            daaDAO.createDacDaaRelation(dacId, daaId);
+            daaDAO.createDacDaaRelation(
+                dacId, daaId, userId, AuditActions.ADD.getValue().toUpperCase());
             if (fso != null) {
               if (fso.getFileName() == null) {
                 throw new IllegalArgumentException("FileStorageObject must have a File Name");

--- a/src/main/java/org/broadinstitute/consent/http/service/dao/DaaServiceDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/dao/DaaServiceDAO.java
@@ -7,7 +7,6 @@ import java.util.ArrayList;
 import java.util.List;
 import org.broadinstitute.consent.http.db.DaaDAO;
 import org.broadinstitute.consent.http.db.FileStorageObjectDAO;
-import org.broadinstitute.consent.http.enumeration.AuditActions;
 import org.broadinstitute.consent.http.models.FileStorageObject;
 import org.broadinstitute.consent.http.util.ConsentLogger;
 import org.jdbi.v3.core.Jdbi;
@@ -36,7 +35,6 @@ public class DaaServiceDAO implements ConsentLogger {
             Integer daaId = daaDAO.createDaa(userId, now, userId, now, dacId);
             createdDaaIds.add(daaId);
             daaDAO.createDacDaaRelation(dacId, daaId, userId);
-            daaDAO.insertAudit(daaId, dacId, userId, AuditActions.CREATE.getValue().toUpperCase());
             if (fso != null) {
               if (fso.getFileName() == null) {
                 throw new IllegalArgumentException("FileStorageObject must have a File Name");

--- a/src/main/java/org/broadinstitute/consent/http/service/dao/DaaServiceDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/dao/DaaServiceDAO.java
@@ -36,8 +36,7 @@ public class DaaServiceDAO implements ConsentLogger {
             Integer daaId = daaDAO.createDaa(userId, now, userId, now, dacId);
             daaDAO.insertAudit(daaId, dacId, userId, AuditActions.CREATE.getValue().toUpperCase());
             createdDaaIds.add(daaId);
-            daaDAO.createDacDaaRelation(
-                dacId, daaId, userId, AuditActions.ADD.getValue().toUpperCase());
+            daaDAO.createDacDaaRelation(dacId, daaId, userId);
             if (fso != null) {
               if (fso.getFileName() == null) {
                 throw new IllegalArgumentException("FileStorageObject must have a File Name");

--- a/src/main/java/org/broadinstitute/consent/http/service/dao/DaaServiceDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/dao/DaaServiceDAO.java
@@ -34,9 +34,9 @@ public class DaaServiceDAO implements ConsentLogger {
           Instant now = Instant.now();
           try {
             Integer daaId = daaDAO.createDaa(userId, now, userId, now, dacId);
-            daaDAO.insertAudit(daaId, dacId, userId, AuditActions.CREATE.getValue().toUpperCase());
             createdDaaIds.add(daaId);
             daaDAO.createDacDaaRelation(dacId, daaId, userId);
+            daaDAO.insertAudit(daaId, dacId, userId, AuditActions.CREATE.getValue().toUpperCase());
             if (fso != null) {
               if (fso.getFileName() == null) {
                 throw new IllegalArgumentException("FileStorageObject must have a File Name");

--- a/src/main/java/org/broadinstitute/consent/http/service/dao/DaaServiceDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/dao/DaaServiceDAO.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.broadinstitute.consent.http.db.DaaDAO;
 import org.broadinstitute.consent.http.db.FileStorageObjectDAO;
+import org.broadinstitute.consent.http.enumeration.AuditActions;
 import org.broadinstitute.consent.http.models.FileStorageObject;
 import org.broadinstitute.consent.http.util.ConsentLogger;
 import org.jdbi.v3.core.Jdbi;
@@ -33,6 +34,7 @@ public class DaaServiceDAO implements ConsentLogger {
           Instant now = Instant.now();
           try {
             Integer daaId = daaDAO.createDaa(userId, now, userId, now, dacId);
+            daaDAO.insertAudit(daaId, dacId, userId, AuditActions.CREATE.getValue().toUpperCase());
             createdDaaIds.add(daaId);
             daaDAO.createDacDaaRelation(dacId, daaId);
             if (fso != null) {

--- a/src/main/java/org/broadinstitute/consent/http/service/dao/DacServiceDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/dao/DacServiceDAO.java
@@ -2,7 +2,9 @@ package org.broadinstitute.consent.http.service.dao;
 
 import com.google.inject.Inject;
 import java.sql.SQLException;
+import org.broadinstitute.consent.http.db.DaaDAO;
 import org.broadinstitute.consent.http.models.Dac;
+import org.broadinstitute.consent.http.models.DataAccessAgreement;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.util.ConsentLogger;
 import org.jdbi.v3.core.Jdbi;
@@ -11,13 +13,16 @@ import org.jdbi.v3.core.statement.Update;
 public class DacServiceDAO implements ConsentLogger {
 
   private final Jdbi jdbi;
+  private final DaaDAO daaDAO;
 
   @Inject
   public DacServiceDAO(Jdbi jdbi) {
     this.jdbi = jdbi;
+    daaDAO = jdbi.onDemand(DaaDAO.class);
   }
 
-  public void deleteDacAndDaas(User user, Dac dac) throws IllegalArgumentException, SQLException {
+  public void deleteDacAndRemoveDaaAssociation(User user, Dac dac)
+      throws IllegalArgumentException, SQLException {
     // fail fast
     if (dac == null) {
       throw new IllegalArgumentException("Invalid DAC");
@@ -28,11 +33,6 @@ public class DacServiceDAO implements ConsentLogger {
 
           jdbi.useTransaction(
               handler -> {
-                final String deleteFromLcDaa =
-                    "DELETE FROM lc_daa WHERE daa_id in (SELECT daa_id FROM data_access_agreement WHERE initial_dac_id = :dacId)";
-                final String deleteFromDacDaa = "DELETE FROM dac_daa WHERE dac_id = :dacId";
-                final String deleteFromDaa =
-                    "DELETE FROM data_access_agreement WHERE initial_dac_id = :dacId";
                 final String deleteMembers = "DELETE FROM user_role WHERE dac_id = :dacId";
                 final String updateDatasets =
                     "UPDATE dataset SET dac_id = null, dac_approval = null WHERE dac_id = :dacId";
@@ -47,17 +47,10 @@ public class DacServiceDAO implements ConsentLogger {
             """;
                 final String deleteDac = "DELETE FROM dac where dac_id = :dacId";
 
-                Update lcDaaDeletion = handler.createUpdate(deleteFromLcDaa);
-                lcDaaDeletion.bind("dacId", dac.getDacId());
-                lcDaaDeletion.execute();
-
-                Update dacDaaDeletion = handler.createUpdate(deleteFromDacDaa);
-                dacDaaDeletion.bind("dacId", dac.getDacId());
-                dacDaaDeletion.execute();
-
-                Update daaDeletion = handler.createUpdate(deleteFromDaa);
-                daaDeletion.bind("dacId", dac.getDacId());
-                daaDeletion.execute();
+                DataAccessAgreement daa = dac.getAssociatedDaa();
+                if (daa != null) {
+                  daaDAO.deleteDacDaaRelation(daa.getDaaId(), dac.getDacId(), user.getUserId());
+                }
 
                 Update memberDeletion = handler.createUpdate(deleteMembers);
                 memberDeletion.bind("dacId", dac.getDacId());

--- a/src/main/java/org/broadinstitute/consent/http/service/dao/DacServiceDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/dao/DacServiceDAO.java
@@ -14,6 +14,21 @@ public class DacServiceDAO implements ConsentLogger {
 
   private final Jdbi jdbi;
   private final DaaDAO daaDAO;
+  private static final String DAC_ID = "dacId";
+  private static final String USER_ID = "userId";
+  private static final String DELETE_ROLES_STATEMENT =
+      "DELETE FROM user_role WHERE dac_id = :dacId";
+  private static final String UPDATE_DATASET_STATEMENT =
+      "UPDATE dataset SET dac_id = null, dac_approval = null WHERE dac_id = :dacId";
+  private static final String DELETE_DAC_RULES_STATEMENT =
+      "DELETE FROM dac_rule_settings WHERE dac_id = :dacId ";
+  private static final String AUDIT_DAC_RULE_DELETION_STATEMENT =
+      """
+        INSERT INTO dac_rule_audit(action, dac_id, rule_id, user_id, action_date)
+        SELECT 'REMOVE', s.dac_id, s.rule_id, :userId, current_timestamp
+        FROM dac_rule_settings s
+        WHERE dac_id = :dacId
+      """;
 
   @Inject
   public DacServiceDAO(Jdbi jdbi) {
@@ -33,18 +48,6 @@ public class DacServiceDAO implements ConsentLogger {
 
           jdbi.useTransaction(
               handler -> {
-                final String deleteMembers = "DELETE FROM user_role WHERE dac_id = :dacId";
-                final String updateDatasets =
-                    "UPDATE dataset SET dac_id = null, dac_approval = null WHERE dac_id = :dacId";
-                final String deleteDacAutomationRules =
-                    "DELETE FROM dac_rule_settings WHERE dac_id = :dacId ";
-                final String deleteDacAutomationRulesDeletionAudit =
-                    """
-                    INSERT INTO dac_rule_audit(action, dac_id, rule_id, user_id, action_date)
-                    SELECT 'REMOVE', s.dac_id, s.rule_id, :userId, current_timestamp
-                    FROM dac_rule_settings s
-                    WHERE dac_id = :dacId
-            """;
                 final String deleteDac = "DELETE FROM dac where dac_id = :dacId";
 
                 DataAccessAgreement daa = dac.getAssociatedDaa();
@@ -52,26 +55,27 @@ public class DacServiceDAO implements ConsentLogger {
                   daaDAO.deleteDacDaaRelation(daa.getDaaId(), dac.getDacId(), user.getUserId());
                 }
 
-                Update memberDeletion = handler.createUpdate(deleteMembers);
-                memberDeletion.bind("dacId", dac.getDacId());
+                Update memberDeletion = handler.createUpdate(DELETE_ROLES_STATEMENT);
+                memberDeletion.bind(DAC_ID, dac.getDacId());
                 memberDeletion.execute();
 
-                Update datasetUpdate = handler.createUpdate(updateDatasets);
-                datasetUpdate.bind("dacId", dac.getDacId());
+                Update datasetUpdate = handler.createUpdate(UPDATE_DATASET_STATEMENT);
+                datasetUpdate.bind(DAC_ID, dac.getDacId());
                 datasetUpdate.execute();
 
                 Update dacAutomationRulesDeletionAudit =
-                    handler.createUpdate(deleteDacAutomationRulesDeletionAudit);
-                dacAutomationRulesDeletionAudit.bind("dacId", dac.getDacId());
-                dacAutomationRulesDeletionAudit.bind("userId", user.getUserId());
+                    handler.createUpdate(AUDIT_DAC_RULE_DELETION_STATEMENT);
+                dacAutomationRulesDeletionAudit.bind(DAC_ID, dac.getDacId());
+                dacAutomationRulesDeletionAudit.bind(USER_ID, user.getUserId());
                 dacAutomationRulesDeletionAudit.execute();
 
-                Update dacAutomationRulesDeletion = handler.createUpdate(deleteDacAutomationRules);
-                dacAutomationRulesDeletion.bind("dacId", dac.getDacId());
+                Update dacAutomationRulesDeletion =
+                    handler.createUpdate(DELETE_DAC_RULES_STATEMENT);
+                dacAutomationRulesDeletion.bind(DAC_ID, dac.getDacId());
                 dacAutomationRulesDeletion.execute();
 
                 Update dacDeletion = handler.createUpdate(deleteDac);
-                dacDeletion.bind("dacId", dac.getDacId());
+                dacDeletion.bind(DAC_ID, dac.getDacId());
                 dacDeletion.execute();
                 handler.commit();
               });

--- a/src/main/java/org/broadinstitute/consent/http/service/dao/DacServiceDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/dao/DacServiceDAO.java
@@ -1,7 +1,6 @@
 package org.broadinstitute.consent.http.service.dao;
 
 import com.google.inject.Inject;
-import java.sql.SQLException;
 import org.broadinstitute.consent.http.db.DaaDAO;
 import org.broadinstitute.consent.http.models.Dac;
 import org.broadinstitute.consent.http.models.DataAccessAgreement;
@@ -24,11 +23,12 @@ public class DacServiceDAO implements ConsentLogger {
       "DELETE FROM dac_rule_settings WHERE dac_id = :dacId ";
   private static final String AUDIT_DAC_RULE_DELETION_STATEMENT =
       """
-        INSERT INTO dac_rule_audit(action, dac_id, rule_id, user_id, action_date)
-        SELECT 'REMOVE', s.dac_id, s.rule_id, :userId, current_timestamp
-        FROM dac_rule_settings s
-        WHERE dac_id = :dacId
-      """;
+            INSERT INTO dac_rule_audit(action, dac_id, rule_id, user_id, action_date)
+            SELECT 'REMOVE', s.dac_id, s.rule_id, :userId, current_timestamp
+            FROM dac_rule_settings s
+            WHERE dac_id = :dacId
+          """;
+  private static final String DELETE_DAC_STATEMENT = "DELETE FROM dac where dac_id = :dacId";
 
   @Inject
   public DacServiceDAO(Jdbi jdbi) {
@@ -36,49 +36,40 @@ public class DacServiceDAO implements ConsentLogger {
     daaDAO = jdbi.onDemand(DaaDAO.class);
   }
 
-  public void deleteDacAndRemoveDaaAssociation(User user, Dac dac)
-      throws IllegalArgumentException, SQLException {
+  public void deleteDacAndRemoveDaaAssociation(User user, Dac dac) throws IllegalArgumentException {
     // fail fast
     if (dac == null) {
       throw new IllegalArgumentException("Invalid DAC");
     }
-    jdbi.useHandle(
+    jdbi.useTransaction(
         handle -> {
-          handle.getConnection().setAutoCommit(false);
+          DataAccessAgreement daa = dac.getAssociatedDaa();
+          if (daa != null) {
+            daaDAO.deleteDacDaaRelation(daa.getDaaId(), dac.getDacId(), user.getUserId());
+          }
 
-          jdbi.useTransaction(
-              handler -> {
-                final String deleteDac = "DELETE FROM dac where dac_id = :dacId";
+          Update memberDeletion = handle.createUpdate(DELETE_ROLES_STATEMENT);
+          memberDeletion.bind(DAC_ID, dac.getDacId());
+          memberDeletion.execute();
 
-                DataAccessAgreement daa = dac.getAssociatedDaa();
-                if (daa != null) {
-                  daaDAO.deleteDacDaaRelation(daa.getDaaId(), dac.getDacId(), user.getUserId());
-                }
+          Update datasetUpdate = handle.createUpdate(UPDATE_DATASET_STATEMENT);
+          datasetUpdate.bind(DAC_ID, dac.getDacId());
+          datasetUpdate.execute();
 
-                Update memberDeletion = handler.createUpdate(DELETE_ROLES_STATEMENT);
-                memberDeletion.bind(DAC_ID, dac.getDacId());
-                memberDeletion.execute();
+          Update dacAutomationRulesDeletionAudit =
+              handle.createUpdate(AUDIT_DAC_RULE_DELETION_STATEMENT);
+          dacAutomationRulesDeletionAudit.bind(DAC_ID, dac.getDacId());
+          dacAutomationRulesDeletionAudit.bind(USER_ID, user.getUserId());
+          dacAutomationRulesDeletionAudit.execute();
 
-                Update datasetUpdate = handler.createUpdate(UPDATE_DATASET_STATEMENT);
-                datasetUpdate.bind(DAC_ID, dac.getDacId());
-                datasetUpdate.execute();
+          Update dacAutomationRulesDeletion = handle.createUpdate(DELETE_DAC_RULES_STATEMENT);
+          dacAutomationRulesDeletion.bind(DAC_ID, dac.getDacId());
+          dacAutomationRulesDeletion.execute();
 
-                Update dacAutomationRulesDeletionAudit =
-                    handler.createUpdate(AUDIT_DAC_RULE_DELETION_STATEMENT);
-                dacAutomationRulesDeletionAudit.bind(DAC_ID, dac.getDacId());
-                dacAutomationRulesDeletionAudit.bind(USER_ID, user.getUserId());
-                dacAutomationRulesDeletionAudit.execute();
-
-                Update dacAutomationRulesDeletion =
-                    handler.createUpdate(DELETE_DAC_RULES_STATEMENT);
-                dacAutomationRulesDeletion.bind(DAC_ID, dac.getDacId());
-                dacAutomationRulesDeletion.execute();
-
-                Update dacDeletion = handler.createUpdate(deleteDac);
-                dacDeletion.bind(DAC_ID, dac.getDacId());
-                dacDeletion.execute();
-                handler.commit();
-              });
+          Update dacDeletion = handle.createUpdate(DELETE_DAC_STATEMENT);
+          dacDeletion.bind(DAC_ID, dac.getDacId());
+          dacDeletion.execute();
+          handle.commit();
         });
   }
 }

--- a/src/main/resources/changelog-master.xml
+++ b/src/main/resources/changelog-master.xml
@@ -240,4 +240,5 @@
            relativeToChangelogFile="true" />
   <include file="changesets/changelog-consent-2026-03-05-user-id-fks.xml" relativeToChangelogFile="true" />
   <include file="changesets/changelog-consent-2026-03-25-users-data.xml" relativeToChangelogFile="true" />
+  <include file="changesets/changelog-consent-2026-03-31-daa-audit.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/src/main/resources/changesets/changelog-consent-2026-03-31-daa-audit.xml
+++ b/src/main/resources/changesets/changelog-consent-2026-03-31-daa-audit.xml
@@ -2,7 +2,7 @@
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-                   https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+                   https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.33.xsd">
   <changeSet id="changelog-consent-2026-03-31-daa-audit" author="grushton">
     <createTable tableName="daa_audit">
       <column name="id" type="bigint" autoIncrement="true">

--- a/src/main/resources/changesets/changelog-consent-2026-03-31-daa-audit.xml
+++ b/src/main/resources/changesets/changelog-consent-2026-03-31-daa-audit.xml
@@ -25,6 +25,11 @@
         <constraints nullable="false"/>
       </column>
     </createTable>
+    <createIndex indexName="idx_daa_audit_daa_id_and_action_date_descending"
+                 tableName="daa_audit">
+      <column name="daa_id"/>
+      <column name="action_date" descending="true"/>
+    </createIndex>
     <!--
       Note that we are not including a FK to the DAC table since not all actions will be associated with a specific DAC.
      -->

--- a/src/main/resources/changesets/changelog-consent-2026-03-31-daa-audit.xml
+++ b/src/main/resources/changesets/changelog-consent-2026-03-31-daa-audit.xml
@@ -25,17 +25,22 @@
         <constraints nullable="false"/>
       </column>
     </createTable>
+    <!--
+      Note that we are not including a FK to the DAC table since not all actions will be associated with a specific DAC.
+     -->
     <addForeignKeyConstraint
       baseTableName="daa_audit" baseColumnNames="daa_id"
       constraintName="fk_daa_audit_daa_id"
       referencedTableName="data_access_agreement" referencedColumnNames="daa_id"/>
     <addForeignKeyConstraint
-      baseTableName="daa_audit" baseColumnNames="dac_id"
-      constraintName="fk_daa_audit_dac_id"
-      referencedTableName="dac" referencedColumnNames="dac_id"/>
-    <addForeignKeyConstraint
       baseTableName="daa_audit" baseColumnNames="user_id"
       constraintName="fk_daa_audit_user_id"
       referencedTableName="users" referencedColumnNames="user_id"/>
+    <!--
+      Note that existing DAC deletion functionality requires this FK to be dropped until we implement soft deletion for DACs.
+     -->
+    <dropForeignKeyConstraint
+      baseTableName="data_access_agreement"
+      constraintName="fk_daa_initial_dac_id"/>
   </changeSet>
 </databaseChangeLog>

--- a/src/main/resources/changesets/changelog-consent-2026-03-31-daa-audit.xml
+++ b/src/main/resources/changesets/changelog-consent-2026-03-31-daa-audit.xml
@@ -11,9 +11,10 @@
       <column name="daa_id" type="bigint">
         <constraints nullable="false"/>
       </column>
-      <column name="dac_id" type="bigint">
-        <constraints nullable="false"/>
-      </column>
+      <!--
+        Note that we're intentionally allowing dac_id to be nullable for future actions that may not be associated with a specific DAC.
+       -->
+      <column name="dac_id" type="bigint"/>
       <column name="user_id" type="bigint">
         <constraints nullable="false"/>
       </column>

--- a/src/main/resources/changesets/changelog-consent-2026-03-31-daa-audit.xml
+++ b/src/main/resources/changesets/changelog-consent-2026-03-31-daa-audit.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+  <changeSet id="changelog-consent-2026-03-31-daa-audit" author="grushton">
+    <createTable tableName="daa_audit">
+      <column name="id" type="bigint" autoIncrement="true">
+        <constraints primaryKey="true" nullable="false"/>
+      </column>
+      <column name="daa_id" type="bigint">
+        <constraints nullable="false"/>
+      </column>
+      <column name="dac_id" type="bigint">
+        <constraints nullable="false"/>
+      </column>
+      <column name="user_id" type="bigint">
+        <constraints nullable="false"/>
+      </column>
+      <column name="action" type="varchar(255)">
+        <constraints nullable="false"/>
+      </column>
+      <column name="action_date" type="timestamp" defaultValueDate="current_timestamp">
+        <constraints nullable="false"/>
+      </column>
+    </createTable>
+    <addForeignKeyConstraint
+      baseTableName="daa_audit" baseColumnNames="daa_id"
+      constraintName="fk_daa_audit_daa_id"
+      referencedTableName="data_access_agreement" referencedColumnNames="daa_id"/>
+    <addForeignKeyConstraint
+      baseTableName="daa_audit" baseColumnNames="dac_id"
+      constraintName="fk_daa_audit_dac_id"
+      referencedTableName="dac" referencedColumnNames="dac_id"/>
+    <addForeignKeyConstraint
+      baseTableName="daa_audit" baseColumnNames="user_id"
+      constraintName="fk_daa_audit_user_id"
+      referencedTableName="users" referencedColumnNames="user_id"/>
+  </changeSet>
+</databaseChangeLog>

--- a/src/test/java/org/broadinstitute/consent/http/db/DaaDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DaaDAOTest.java
@@ -162,12 +162,9 @@ class DaaDAOTest extends DAOTestHelper {
     assertNotNull(daa2);
     assertEquals(daa2.getInitialDacId(), dacId2);
 
-    daaDAO.createDacDaaRelation(
-        dacId, daa1.getDaaId(), userId, AuditActions.ADD.getValue().toUpperCase());
-    daaDAO.createDacDaaRelation(
-        dacId2, daa2.getDaaId(), userId, AuditActions.ADD.getValue().toUpperCase());
-    daaDAO.createDacDaaRelation(
-        dacId3, daa2.getDaaId(), userId, AuditActions.ADD.getValue().toUpperCase());
+    daaDAO.createDacDaaRelation(dacId, daa1.getDaaId(), userId);
+    daaDAO.createDacDaaRelation(dacId2, daa2.getDaaId(), userId);
+    daaDAO.createDacDaaRelation(dacId3, daa2.getDaaId(), userId);
 
     // Assert new relations exist
     DataAccessAgreement testDAA1 = daaDAO.findById(daa1.getDaaId());
@@ -209,15 +206,13 @@ class DaaDAOTest extends DAOTestHelper {
     assertNotNull(daa2);
     assertEquals(daa2.getInitialDacId(), dacId2);
 
-    daaDAO.createDacDaaRelation(dacId1, daaId1, userId, AuditActions.ADD.getValue().toUpperCase());
-    daaDAO.createDacDaaRelation(dacId2, daaId2, userId, AuditActions.ADD.getValue().toUpperCase());
-    daaDAO.createDacDaaRelation(dacId3, daaId2, userId, AuditActions.ADD.getValue().toUpperCase());
+    daaDAO.createDacDaaRelation(dacId1, daaId1, userId);
+    daaDAO.createDacDaaRelation(dacId2, daaId2, userId);
+    daaDAO.createDacDaaRelation(dacId3, daaId2, userId);
 
     // Delete DAC-DAA Relations
-    daaDAO.deleteDacDaaRelation(
-        daaId1, dacId1, userId, AuditActions.REMOVE.getValue().toUpperCase());
-    daaDAO.deleteDacDaaRelation(
-        daaId2, dacId2, userId, AuditActions.REMOVE.getValue().toUpperCase());
+    daaDAO.deleteDacDaaRelation(daaId1, dacId1, userId);
+    daaDAO.deleteDacDaaRelation(daaId2, dacId2, userId);
 
     // Assert that only 2 of the 3 DAC-DAA relations are removed
     DataAccessAgreement testDAA1 = daaDAO.findById(daa1.getDaaId());
@@ -277,9 +272,9 @@ class DaaDAOTest extends DAOTestHelper {
     Integer dacId3 =
         dacDAO.createDac(randomAlphabetic(5), "Dac 3", randomAlphabetic(15), new Date());
     Integer daaId = daaDAO.createDaa(userId, Instant.now(), userId, Instant.now(), dacId);
-    daaDAO.createDacDaaRelation(dacId, daaId, userId, AuditActions.ADD.getValue().toUpperCase());
-    daaDAO.createDacDaaRelation(dacId2, daaId, userId, AuditActions.ADD.getValue().toUpperCase());
-    daaDAO.createDacDaaRelation(dacId3, daaId, userId, AuditActions.ADD.getValue().toUpperCase());
+    daaDAO.createDacDaaRelation(dacId, daaId, userId);
+    daaDAO.createDacDaaRelation(dacId2, daaId, userId);
+    daaDAO.createDacDaaRelation(dacId3, daaId, userId);
     DataAccessAgreement daa = daaDAO.findById(daaId);
 
     assertNotNull(daa);
@@ -298,12 +293,8 @@ class DaaDAOTest extends DAOTestHelper {
     Dac dac2 = createRandomDac();
     DataAccessAgreement daa = createRandomDataAccessAgreement(user, dac1);
     // Associate the DAC to the Data Access Agreeement:
-    daaDAO.createDacDaaRelation(
-        dac1.getDacId(),
-        daa.getDaaId(),
-        user.getUserId(),
-        AuditActions.ADD.getValue().toUpperCase());
-    // Associate the user's Library Card to the Data Access Agreeement:
+    daaDAO.createDacDaaRelation(dac1.getDacId(), daa.getDaaId(), user.getUserId());
+    // Associate the user's Library Card to the Data Access Agreement:
     libraryCardDAO.createLibraryCardDaaRelation(lc.getId(), daa.getDaaId());
     // Create two datasets associated to the DAC and DAA
     Dataset dataset1 = createRandomDataset(user, dac1);
@@ -338,8 +329,7 @@ class DaaDAOTest extends DAOTestHelper {
     Dac dac1 = dacDAO.findById(dac1Id);
     Integer daaId1 =
         daaDAO.createDaa(dataSubmitterId, Instant.now(), dataSubmitterId, Instant.now(), dac1Id);
-    daaDAO.createDacDaaRelation(
-        dac1Id, daaId1, dataSubmitterId, AuditActions.ADD.getValue().toUpperCase());
+    daaDAO.createDacDaaRelation(dac1Id, daaId1, dataSubmitterId);
     DataAccessAgreement daa1 = daaDAO.findById(daaId1);
     Dataset d1 = createRandomDataset(dataSubmitter, dac1);
 
@@ -348,8 +338,7 @@ class DaaDAOTest extends DAOTestHelper {
     Dac dac2 = dacDAO.findById(dacId2);
     Integer daaId2 =
         daaDAO.createDaa(dataSubmitterId, Instant.now(), dataSubmitterId, Instant.now(), dacId2);
-    daaDAO.createDacDaaRelation(
-        dacId2, daaId2, dataSubmitterId, AuditActions.ADD.getValue().toUpperCase());
+    daaDAO.createDacDaaRelation(dacId2, daaId2, dataSubmitterId);
     DataAccessAgreement daa2 = daaDAO.findById(daaId2);
     Dataset d2 = createRandomDataset(dataSubmitter, dac2);
 
@@ -358,8 +347,7 @@ class DaaDAOTest extends DAOTestHelper {
     Dac dac3 = dacDAO.findById(dacId3);
     Integer daaId3 =
         daaDAO.createDaa(dataSubmitterId, Instant.now(), dataSubmitterId, Instant.now(), dacId3);
-    daaDAO.createDacDaaRelation(
-        dacId3, daaId3, dataSubmitterId, AuditActions.ADD.getValue().toUpperCase());
+    daaDAO.createDacDaaRelation(dacId3, daaId3, dataSubmitterId);
     DataAccessAgreement daa3 = daaDAO.findById(daaId3);
     createRandomDataset(dataSubmitter, dac3);
 

--- a/src/test/java/org/broadinstitute/consent/http/db/DaaDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DaaDAOTest.java
@@ -162,9 +162,33 @@ class DaaDAOTest extends DAOTestHelper {
     assertNotNull(daa2);
     assertEquals(daa2.getInitialDacId(), dacId2);
 
-    daaDAO.createDacDaaRelation(dacId, daa1.getDaaId());
-    daaDAO.createDacDaaRelation(dacId2, daa2.getDaaId());
-    daaDAO.createDacDaaRelation(dacId3, daa2.getDaaId());
+    daaDAO.createDacDaaRelation(
+        dacId, daa1.getDaaId(), userId, AuditActions.ADD.getValue().toUpperCase());
+    daaDAO.createDacDaaRelation(
+        dacId2, daa2.getDaaId(), userId, AuditActions.ADD.getValue().toUpperCase());
+    daaDAO.createDacDaaRelation(
+        dacId3, daa2.getDaaId(), userId, AuditActions.ADD.getValue().toUpperCase());
+
+    // Assert new relations exist
+    DataAccessAgreement testDAA1 = daaDAO.findById(daa1.getDaaId());
+    assertTrue(testDAA1.getDacs().stream().map(Dac::getDacId).toList().contains(dacId));
+    assertFalse(testDAA1.getDacs().stream().map(Dac::getDacId).toList().contains(dacId2));
+    assertFalse(testDAA1.getDacs().stream().map(Dac::getDacId).toList().contains(dacId3));
+    DataAccessAgreement testDAA2 = daaDAO.findById(daa2.getDaaId());
+    assertFalse(testDAA2.getDacs().stream().map(Dac::getDacId).toList().contains(dacId));
+    assertTrue(testDAA2.getDacs().stream().map(Dac::getDacId).toList().contains(dacId2));
+    assertTrue(testDAA2.getDacs().stream().map(Dac::getDacId).toList().contains(dacId3));
+
+    // Assert audit records exist
+    List<DaaAudit> daa1Audits = daaDAO.findAuditsByDaaId(daa1.getDaaId());
+    assertNotNull(daa1Audits);
+    assertFalse(daa1Audits.isEmpty());
+    assertEquals(AuditActions.ADD, daa1Audits.getFirst().action());
+
+    List<DaaAudit> daa2Audits = daaDAO.findAuditsByDaaId(daa2.getDaaId());
+    assertNotNull(daa2Audits);
+    assertFalse(daa1Audits.isEmpty());
+    assertEquals(AuditActions.ADD, daa2Audits.getFirst().action());
   }
 
   @Test
@@ -185,9 +209,9 @@ class DaaDAOTest extends DAOTestHelper {
     assertNotNull(daa2);
     assertEquals(daa2.getInitialDacId(), dacId2);
 
-    daaDAO.createDacDaaRelation(dacId1, daaId1);
-    daaDAO.createDacDaaRelation(dacId2, daaId2);
-    daaDAO.createDacDaaRelation(dacId3, daaId2);
+    daaDAO.createDacDaaRelation(dacId1, daaId1, userId, AuditActions.ADD.getValue().toUpperCase());
+    daaDAO.createDacDaaRelation(dacId2, daaId2, userId, AuditActions.ADD.getValue().toUpperCase());
+    daaDAO.createDacDaaRelation(dacId3, daaId2, userId, AuditActions.ADD.getValue().toUpperCase());
 
     // Delete DAC-DAA Relations
     daaDAO.deleteDacDaaRelation(
@@ -253,9 +277,9 @@ class DaaDAOTest extends DAOTestHelper {
     Integer dacId3 =
         dacDAO.createDac(randomAlphabetic(5), "Dac 3", randomAlphabetic(15), new Date());
     Integer daaId = daaDAO.createDaa(userId, Instant.now(), userId, Instant.now(), dacId);
-    daaDAO.createDacDaaRelation(dacId, daaId);
-    daaDAO.createDacDaaRelation(dacId2, daaId);
-    daaDAO.createDacDaaRelation(dacId3, daaId);
+    daaDAO.createDacDaaRelation(dacId, daaId, userId, AuditActions.ADD.getValue().toUpperCase());
+    daaDAO.createDacDaaRelation(dacId2, daaId, userId, AuditActions.ADD.getValue().toUpperCase());
+    daaDAO.createDacDaaRelation(dacId3, daaId, userId, AuditActions.ADD.getValue().toUpperCase());
     DataAccessAgreement daa = daaDAO.findById(daaId);
 
     assertNotNull(daa);
@@ -274,7 +298,11 @@ class DaaDAOTest extends DAOTestHelper {
     Dac dac2 = createRandomDac();
     DataAccessAgreement daa = createRandomDataAccessAgreement(user, dac1);
     // Associate the DAC to the Data Access Agreeement:
-    daaDAO.createDacDaaRelation(dac1.getDacId(), daa.getDaaId());
+    daaDAO.createDacDaaRelation(
+        dac1.getDacId(),
+        daa.getDaaId(),
+        user.getUserId(),
+        AuditActions.ADD.getValue().toUpperCase());
     // Associate the user's Library Card to the Data Access Agreeement:
     libraryCardDAO.createLibraryCardDaaRelation(lc.getId(), daa.getDaaId());
     // Create two datasets associated to the DAC and DAA
@@ -310,7 +338,8 @@ class DaaDAOTest extends DAOTestHelper {
     Dac dac1 = dacDAO.findById(dac1Id);
     Integer daaId1 =
         daaDAO.createDaa(dataSubmitterId, Instant.now(), dataSubmitterId, Instant.now(), dac1Id);
-    daaDAO.createDacDaaRelation(dac1Id, daaId1);
+    daaDAO.createDacDaaRelation(
+        dac1Id, daaId1, dataSubmitterId, AuditActions.ADD.getValue().toUpperCase());
     DataAccessAgreement daa1 = daaDAO.findById(daaId1);
     Dataset d1 = createRandomDataset(dataSubmitter, dac1);
 
@@ -319,7 +348,8 @@ class DaaDAOTest extends DAOTestHelper {
     Dac dac2 = dacDAO.findById(dacId2);
     Integer daaId2 =
         daaDAO.createDaa(dataSubmitterId, Instant.now(), dataSubmitterId, Instant.now(), dacId2);
-    daaDAO.createDacDaaRelation(dacId2, daaId2);
+    daaDAO.createDacDaaRelation(
+        dacId2, daaId2, dataSubmitterId, AuditActions.ADD.getValue().toUpperCase());
     DataAccessAgreement daa2 = daaDAO.findById(daaId2);
     Dataset d2 = createRandomDataset(dataSubmitter, dac2);
 
@@ -328,7 +358,8 @@ class DaaDAOTest extends DAOTestHelper {
     Dac dac3 = dacDAO.findById(dacId3);
     Integer daaId3 =
         daaDAO.createDaa(dataSubmitterId, Instant.now(), dataSubmitterId, Instant.now(), dacId3);
-    daaDAO.createDacDaaRelation(dacId3, daaId3);
+    daaDAO.createDacDaaRelation(
+        dacId3, daaId3, dataSubmitterId, AuditActions.ADD.getValue().toUpperCase());
     DataAccessAgreement daa3 = daaDAO.findById(daaId3);
     createRandomDataset(dataSubmitter, dac3);
 

--- a/src/test/java/org/broadinstitute/consent/http/db/DaaDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DaaDAOTest.java
@@ -38,6 +38,11 @@ class DaaDAOTest extends DAOTestHelper {
     Integer dacId = dacDAO.createDac(randomAlphabetic(5), randomAlphabetic(5), "", new Date());
     Integer daaId = daaDAO.createDaa(userId, Instant.now(), userId, Instant.now(), dacId);
     assertNotNull(daaId);
+    // Assert that CREATE audit records are created.
+    List<DaaAudit> daaAudits = daaDAO.findAuditsByDaaId(daaId);
+    assertNotNull(daaAudits);
+    assertFalse(daaAudits.isEmpty());
+    assertTrue(daaAudits.stream().anyMatch(a -> a.action().equals(AuditActions.CREATE)));
   }
 
   @Test
@@ -176,16 +181,16 @@ class DaaDAOTest extends DAOTestHelper {
     assertTrue(testDAA2.getDacs().stream().map(Dac::getDacId).toList().contains(dacId2));
     assertTrue(testDAA2.getDacs().stream().map(Dac::getDacId).toList().contains(dacId3));
 
-    // Assert audit records exist
+    // Assert that ADD audit records are created.
     List<DaaAudit> daa1Audits = daaDAO.findAuditsByDaaId(daa1.getDaaId());
     assertNotNull(daa1Audits);
     assertFalse(daa1Audits.isEmpty());
-    assertEquals(AuditActions.ADD, daa1Audits.getFirst().action());
+    assertTrue(daa1Audits.stream().anyMatch(a -> a.action().equals(AuditActions.ADD)));
 
     List<DaaAudit> daa2Audits = daaDAO.findAuditsByDaaId(daa2.getDaaId());
     assertNotNull(daa2Audits);
     assertFalse(daa1Audits.isEmpty());
-    assertEquals(AuditActions.ADD, daa2Audits.getFirst().action());
+    assertTrue(daa2Audits.stream().anyMatch(a -> a.action().equals(AuditActions.ADD)));
   }
 
   @Test
@@ -228,18 +233,17 @@ class DaaDAOTest extends DAOTestHelper {
     assertFalse(testDAA2.getDacs().stream().anyMatch(dac -> dac.getDacId().equals(dacId2)));
     assertTrue(testDAA2.getDacs().stream().anyMatch(dac -> dac.getDacId().equals(dacId3)));
 
-    // Assert that REMOVE audit records are created. Note that daaDAO.createDaa does not create
-    // audit records.
+    // Assert that REMOVE audit records are created.
     List<DaaAudit> daa1Audits = daaDAO.findAuditsByDaaId(daaId1);
     assertNotNull(daa1Audits);
     assertFalse(daa1Audits.isEmpty());
-    assertEquals(AuditActions.REMOVE, daa1Audits.getFirst().action());
+    assertTrue(daa1Audits.stream().anyMatch(a -> a.action().equals(AuditActions.REMOVE)));
 
     List<DaaAudit> daa2Audits = daaDAO.findAuditsByDaaId(daaId2);
     assertNotNull(daa2Audits);
 
     assertFalse(daa2Audits.isEmpty());
-    assertEquals(AuditActions.REMOVE, daa2Audits.getFirst().action());
+    assertTrue(daa2Audits.stream().anyMatch(a -> a.action().equals(AuditActions.REMOVE)));
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/db/DaaDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DaaDAOTest.java
@@ -189,7 +189,7 @@ class DaaDAOTest extends DAOTestHelper {
 
     List<DaaAudit> daa2Audits = daaDAO.findAuditsByDaaId(daa2.getDaaId());
     assertNotNull(daa2Audits);
-    assertFalse(daa1Audits.isEmpty());
+    assertFalse(daa2Audits.isEmpty());
     assertTrue(daa2Audits.stream().anyMatch(a -> a.action().equals(AuditActions.ADD)));
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/db/DaaDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DaaDAOTest.java
@@ -11,7 +11,9 @@ import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.Date;
 import java.util.List;
+import org.broadinstitute.consent.http.enumeration.AuditActions;
 import org.broadinstitute.consent.http.enumeration.FileCategory;
+import org.broadinstitute.consent.http.models.DaaAudit;
 import org.broadinstitute.consent.http.models.Dac;
 import org.broadinstitute.consent.http.models.DataAccessAgreement;
 import org.broadinstitute.consent.http.models.DataAccessRequest;
@@ -180,27 +182,56 @@ class DaaDAOTest extends DAOTestHelper {
   @Test
   void testDeleteDaaDacRelation() {
     Integer userId = createUserId();
-    Integer dacId = dacDAO.createDac(randomAlphabetic(5), randomAlphabetic(5), "", new Date());
+    Integer dacId1 = dacDAO.createDac(randomAlphabetic(5), randomAlphabetic(5), "", new Date());
     Integer dacId2 = dacDAO.createDac(randomAlphabetic(5), randomAlphabetic(5), "", new Date());
     Integer dacId3 = dacDAO.createDac(randomAlphabetic(5), randomAlphabetic(5), "", new Date());
     Integer daaId1 =
-        daaDAO.createDaa(userId, new Date().toInstant(), userId, new Date().toInstant(), dacId);
+        daaDAO.createDaa(userId, new Date().toInstant(), userId, new Date().toInstant(), dacId1);
     Integer daaId2 =
         daaDAO.createDaa(userId, new Date().toInstant(), userId, new Date().toInstant(), dacId2);
     assertNotNull(daaId1);
-    DataAccessAgreement daa1 = daaDAO.findByDacId(dacId);
+    DataAccessAgreement daa1 = daaDAO.findByDacId(dacId1);
     assertNotNull(daa1);
-    assertEquals(daa1.getInitialDacId(), dacId);
+    assertEquals(daa1.getInitialDacId(), dacId1);
     DataAccessAgreement daa2 = daaDAO.findByDacId(dacId2);
     assertNotNull(daa2);
     assertEquals(daa2.getInitialDacId(), dacId2);
 
-    daaDAO.createDacDaaRelation(dacId, daa1.getDaaId());
+    daaDAO.createDacDaaRelation(dacId1, daa1.getDaaId());
     daaDAO.createDacDaaRelation(dacId2, daa2.getDaaId());
     daaDAO.createDacDaaRelation(dacId3, daa2.getDaaId());
 
-    daaDAO.deleteDacDaaRelation(dacId, daaId1);
-    daaDAO.deleteDacDaaRelation(dacId2, daaId2);
+    // Delete DAC-DAA Relations
+    daaDAO.deleteDacDaaRelation(
+        daaId1, dacId1, userId, AuditActions.REMOVE.getValue().toUpperCase());
+    daaDAO.deleteDacDaaRelation(
+        daaId2, dacId2, userId, AuditActions.REMOVE.getValue().toUpperCase());
+
+    // Assert that only 2 of the 3 DAC-DAA relations are removed
+    DataAccessAgreement testDAA1 = daaDAO.findByDacId(daa1.getDaaId());
+    assertNotNull(testDAA1);
+    assertNull(testDAA1.getDacs());
+    // DAA 2 should have 1 DAC
+    DataAccessAgreement testDAA2 = daaDAO.findByDacId(daa2.getDaaId());
+    assertNotNull(testDAA2);
+    assertNotNull(testDAA2.getDacs());
+    assertFalse(testDAA2.getDacs().isEmpty());
+    assertFalse(testDAA2.getDacs().stream().anyMatch(dac -> dac.getDacId().equals(dacId1)));
+    assertFalse(testDAA2.getDacs().stream().anyMatch(dac -> dac.getDacId().equals(dacId2)));
+    assertTrue(testDAA2.getDacs().stream().anyMatch(dac -> dac.getDacId().equals(dacId3)));
+
+    // Assert that REMOVE audit records are created. Note that daaDAO.createDaa does not create
+    // audit records.
+    List<DaaAudit> daa1Audits = daaDAO.findAuditsByDaaId(daaId1);
+    assertNotNull(daa1Audits);
+    assertFalse(daa1Audits.isEmpty());
+    assertEquals(AuditActions.REMOVE, daa1Audits.getFirst().action());
+
+    List<DaaAudit> daa2Audits = daaDAO.findAuditsByDaaId(daaId2);
+    assertNotNull(daa2Audits);
+
+    assertFalse(daa2Audits.isEmpty());
+    assertEquals(AuditActions.REMOVE, daa2Audits.getFirst().action());
   }
 
   @Test
@@ -277,26 +308,6 @@ class DaaDAOTest extends DAOTestHelper {
   void testFindDaaDatasetIdsByUserIdNullUser() {
     List<Integer> datasetIds = daaDAO.findDaaDatasetIdsByUserId(null);
     assertTrue(datasetIds.isEmpty());
-  }
-
-  @Test
-  void testDeleteDaa() {
-    Integer userId = createUserId();
-    User user = userDAO.findUserById(userId);
-    Integer dacId = dacDAO.createDac(randomAlphabetic(5), randomAlphabetic(5), "", new Date());
-    Integer daaId1 =
-        daaDAO.createDaa(userId, new Date().toInstant(), userId, new Date().toInstant(), dacId);
-    LibraryCard lc = createRandomLibraryCard(user);
-    DataAccessAgreement daa1 = daaDAO.findById(daaId1);
-
-    daaDAO.createDacDaaRelation(dacId, daa1.getDaaId());
-    libraryCardDAO.createLibraryCardDaaRelation(lc.getId(), daaId1);
-
-    daaDAO.deleteDaa(daa1.getDaaId());
-
-    List<DataAccessAgreement> daas = daaDAO.findAll();
-    assertTrue(daas.isEmpty());
-    assertTrue(lc.getDaaIds().isEmpty());
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/db/DaaDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DaaDAOTest.java
@@ -36,8 +36,7 @@ class DaaDAOTest extends DAOTestHelper {
   void testInsert() {
     Integer userId = createUserId();
     Integer dacId = dacDAO.createDac(randomAlphabetic(5), randomAlphabetic(5), "", new Date());
-    Integer daaId =
-        daaDAO.createDaa(userId, new Date().toInstant(), userId, new Date().toInstant(), dacId);
+    Integer daaId = daaDAO.createDaa(userId, Instant.now(), userId, Instant.now(), dacId);
     assertNotNull(daaId);
   }
 
@@ -45,12 +44,9 @@ class DaaDAOTest extends DAOTestHelper {
   void testInsertMultipleDaasOneDacId() {
     Integer userId = createUserId();
     Integer dacId = dacDAO.createDac(randomAlphabetic(5), randomAlphabetic(5), "", new Date());
-    Integer daaId1 =
-        daaDAO.createDaa(userId, new Date().toInstant(), userId, new Date().toInstant(), dacId);
-    Integer daaId2 =
-        daaDAO.createDaa(userId, new Date().toInstant(), userId, new Date().toInstant(), dacId);
-    Integer daaId3 =
-        daaDAO.createDaa(userId, new Date().toInstant(), userId, new Date().toInstant(), dacId);
+    Integer daaId1 = daaDAO.createDaa(userId, Instant.now(), userId, Instant.now(), dacId);
+    Integer daaId2 = daaDAO.createDaa(userId, Instant.now(), userId, Instant.now(), dacId);
+    Integer daaId3 = daaDAO.createDaa(userId, Instant.now(), userId, Instant.now(), dacId);
     assertNotNull(daaId1);
     assertNotNull(daaId2);
     assertNotNull(daaId3);
@@ -66,8 +62,7 @@ class DaaDAOTest extends DAOTestHelper {
   void testFindAllOneDaa() {
     Integer userId = createUserId();
     Integer dacId = dacDAO.createDac(randomAlphabetic(5), randomAlphabetic(5), "", new Date());
-    Integer daaId =
-        daaDAO.createDaa(userId, new Date().toInstant(), userId, new Date().toInstant(), dacId);
+    Integer daaId = daaDAO.createDaa(userId, Instant.now(), userId, Instant.now(), dacId);
     assertNotNull(daaId);
     List<DataAccessAgreement> daas = daaDAO.findAll();
     assertNotNull(daas);
@@ -78,12 +73,9 @@ class DaaDAOTest extends DAOTestHelper {
   void testFindAllMultipleDaas() {
     Integer userId = createUserId();
     Integer dacId = dacDAO.createDac(randomAlphabetic(5), randomAlphabetic(5), "", new Date());
-    Integer daaId1 =
-        daaDAO.createDaa(userId, new Date().toInstant(), userId, new Date().toInstant(), dacId);
-    Integer daaId2 =
-        daaDAO.createDaa(userId, new Date().toInstant(), userId, new Date().toInstant(), dacId);
-    Integer daaId3 =
-        daaDAO.createDaa(userId, new Date().toInstant(), userId, new Date().toInstant(), dacId);
+    Integer daaId1 = daaDAO.createDaa(userId, Instant.now(), userId, Instant.now(), dacId);
+    Integer daaId2 = daaDAO.createDaa(userId, Instant.now(), userId, Instant.now(), dacId);
+    Integer daaId3 = daaDAO.createDaa(userId, Instant.now(), userId, Instant.now(), dacId);
     assertNotNull(daaId1);
     assertNotNull(daaId2);
     assertNotNull(daaId3);
@@ -103,10 +95,8 @@ class DaaDAOTest extends DAOTestHelper {
   void testFindById() {
     Integer userId = createUserId();
     Integer dacId = dacDAO.createDac(randomAlphabetic(5), randomAlphabetic(5), "", new Date());
-    Integer daaId1 =
-        daaDAO.createDaa(userId, new Date().toInstant(), userId, new Date().toInstant(), dacId);
-    Integer daaId2 =
-        daaDAO.createDaa(userId, new Date().toInstant(), userId, new Date().toInstant(), dacId);
+    Integer daaId1 = daaDAO.createDaa(userId, Instant.now(), userId, Instant.now(), dacId);
+    Integer daaId2 = daaDAO.createDaa(userId, Instant.now(), userId, Instant.now(), dacId);
     assertNotNull(daaId1);
     assertNotNull(daaId2);
     DataAccessAgreement daa1 = daaDAO.findById(daaId1);
@@ -128,9 +118,8 @@ class DaaDAOTest extends DAOTestHelper {
     Integer userId = createUserId();
     Integer dacId = dacDAO.createDac(randomAlphabetic(5), randomAlphabetic(5), "", new Date());
     Integer dacId2 = dacDAO.createDac(randomAlphabetic(5), randomAlphabetic(5), "", new Date());
-    Integer daaId1 =
-        daaDAO.createDaa(userId, new Date().toInstant(), userId, new Date().toInstant(), dacId);
-    daaDAO.createDaa(userId, new Date().toInstant(), userId, new Date().toInstant(), dacId2);
+    Integer daaId1 = daaDAO.createDaa(userId, Instant.now(), userId, Instant.now(), dacId);
+    daaDAO.createDaa(userId, Instant.now(), userId, Instant.now(), dacId2);
     assertNotNull(daaId1);
     DataAccessAgreement daa1 = daaDAO.findByDacId(dacId);
     assertNotNull(daa1);
@@ -147,8 +136,8 @@ class DaaDAOTest extends DAOTestHelper {
     Integer userId = createUserId();
     Integer dacId = dacDAO.createDac(randomAlphabetic(5), randomAlphabetic(5), "", new Date());
     Integer dacId2 = dacDAO.createDac(randomAlphabetic(5), randomAlphabetic(5), "", new Date());
-    daaDAO.createDaa(userId, new Date().toInstant(), userId, new Date().toInstant(), dacId);
-    daaDAO.createDaa(userId, new Date().toInstant(), userId, new Date().toInstant(), dacId2);
+    daaDAO.createDaa(userId, Instant.now(), userId, Instant.now(), dacId);
+    daaDAO.createDaa(userId, Instant.now(), userId, Instant.now(), dacId2);
     DataAccessAgreement daa1 = daaDAO.findByDacId(dacId);
     DataAccessAgreement daa2 = daaDAO.findByDacId(dacId2);
     DataAccessAgreement daa3 = daaDAO.findByDacId(randomInt(10000, 100000));
@@ -163,9 +152,8 @@ class DaaDAOTest extends DAOTestHelper {
     Integer dacId = dacDAO.createDac(randomAlphabetic(5), randomAlphabetic(5), "", new Date());
     Integer dacId2 = dacDAO.createDac(randomAlphabetic(5), randomAlphabetic(5), "", new Date());
     Integer dacId3 = dacDAO.createDac(randomAlphabetic(5), randomAlphabetic(5), "", new Date());
-    Integer daaId1 =
-        daaDAO.createDaa(userId, new Date().toInstant(), userId, new Date().toInstant(), dacId);
-    daaDAO.createDaa(userId, new Date().toInstant(), userId, new Date().toInstant(), dacId2);
+    Integer daaId1 = daaDAO.createDaa(userId, Instant.now(), userId, Instant.now(), dacId);
+    daaDAO.createDaa(userId, Instant.now(), userId, Instant.now(), dacId2);
     assertNotNull(daaId1);
     DataAccessAgreement daa1 = daaDAO.findByDacId(dacId);
     assertNotNull(daa1);
@@ -185,21 +173,21 @@ class DaaDAOTest extends DAOTestHelper {
     Integer dacId1 = dacDAO.createDac(randomAlphabetic(5), randomAlphabetic(5), "", new Date());
     Integer dacId2 = dacDAO.createDac(randomAlphabetic(5), randomAlphabetic(5), "", new Date());
     Integer dacId3 = dacDAO.createDac(randomAlphabetic(5), randomAlphabetic(5), "", new Date());
-    Integer daaId1 =
-        daaDAO.createDaa(userId, new Date().toInstant(), userId, new Date().toInstant(), dacId1);
-    Integer daaId2 =
-        daaDAO.createDaa(userId, new Date().toInstant(), userId, new Date().toInstant(), dacId2);
+
+    Integer daaId1 = daaDAO.createDaa(userId, Instant.now(), userId, Instant.now(), dacId1);
     assertNotNull(daaId1);
-    DataAccessAgreement daa1 = daaDAO.findByDacId(dacId1);
+    Integer daaId2 = daaDAO.createDaa(userId, Instant.now(), userId, Instant.now(), dacId2);
+    assertNotNull(daaId2);
+    DataAccessAgreement daa1 = daaDAO.findById(daaId1);
     assertNotNull(daa1);
     assertEquals(daa1.getInitialDacId(), dacId1);
-    DataAccessAgreement daa2 = daaDAO.findByDacId(dacId2);
+    DataAccessAgreement daa2 = daaDAO.findById(daaId2);
     assertNotNull(daa2);
     assertEquals(daa2.getInitialDacId(), dacId2);
 
-    daaDAO.createDacDaaRelation(dacId1, daa1.getDaaId());
-    daaDAO.createDacDaaRelation(dacId2, daa2.getDaaId());
-    daaDAO.createDacDaaRelation(dacId3, daa2.getDaaId());
+    daaDAO.createDacDaaRelation(dacId1, daaId1);
+    daaDAO.createDacDaaRelation(dacId2, daaId2);
+    daaDAO.createDacDaaRelation(dacId3, daaId2);
 
     // Delete DAC-DAA Relations
     daaDAO.deleteDacDaaRelation(
@@ -208,11 +196,12 @@ class DaaDAOTest extends DAOTestHelper {
         daaId2, dacId2, userId, AuditActions.REMOVE.getValue().toUpperCase());
 
     // Assert that only 2 of the 3 DAC-DAA relations are removed
-    DataAccessAgreement testDAA1 = daaDAO.findByDacId(daa1.getDaaId());
+    DataAccessAgreement testDAA1 = daaDAO.findById(daa1.getDaaId());
+    // DAA 1 should not have any DACs
     assertNotNull(testDAA1);
     assertNull(testDAA1.getDacs());
     // DAA 2 should have 1 DAC
-    DataAccessAgreement testDAA2 = daaDAO.findByDacId(daa2.getDaaId());
+    DataAccessAgreement testDAA2 = daaDAO.findById(daa2.getDaaId());
     assertNotNull(testDAA2);
     assertNotNull(testDAA2.getDacs());
     assertFalse(testDAA2.getDacs().isEmpty());
@@ -238,8 +227,7 @@ class DaaDAOTest extends DAOTestHelper {
   void testFindWithFileStorageObject() {
     Integer userId = createUserId();
     Integer dacId = dacDAO.createDac(randomAlphabetic(5), randomAlphabetic(5), "", new Date());
-    Integer daaId =
-        daaDAO.createDaa(userId, new Date().toInstant(), userId, new Date().toInstant(), dacId);
+    Integer daaId = daaDAO.createDaa(userId, Instant.now(), userId, Instant.now(), dacId);
     Integer fsoId =
         fileStorageObjectDAO.insertNewFile(
             randomAlphabetic(10),
@@ -264,8 +252,7 @@ class DaaDAOTest extends DAOTestHelper {
         dacDAO.createDac(randomAlphabetic(5), "Dac 2", randomAlphabetic(15), new Date());
     Integer dacId3 =
         dacDAO.createDac(randomAlphabetic(5), "Dac 3", randomAlphabetic(15), new Date());
-    Integer daaId =
-        daaDAO.createDaa(userId, new Date().toInstant(), userId, new Date().toInstant(), dacId);
+    Integer daaId = daaDAO.createDaa(userId, Instant.now(), userId, Instant.now(), dacId);
     daaDAO.createDacDaaRelation(dacId, daaId);
     daaDAO.createDacDaaRelation(dacId2, daaId);
     daaDAO.createDacDaaRelation(dacId3, daaId);
@@ -322,12 +309,7 @@ class DaaDAOTest extends DAOTestHelper {
     Integer dac1Id = dacDAO.createDac(randomAlphabetic(5), randomAlphabetic(5), "", new Date());
     Dac dac1 = dacDAO.findById(dac1Id);
     Integer daaId1 =
-        daaDAO.createDaa(
-            dataSubmitterId,
-            new Date().toInstant(),
-            dataSubmitterId,
-            new Date().toInstant(),
-            dac1Id);
+        daaDAO.createDaa(dataSubmitterId, Instant.now(), dataSubmitterId, Instant.now(), dac1Id);
     daaDAO.createDacDaaRelation(dac1Id, daaId1);
     DataAccessAgreement daa1 = daaDAO.findById(daaId1);
     Dataset d1 = createRandomDataset(dataSubmitter, dac1);
@@ -336,12 +318,7 @@ class DaaDAOTest extends DAOTestHelper {
     Integer dacId2 = dacDAO.createDac(randomAlphabetic(5), randomAlphabetic(5), "", new Date());
     Dac dac2 = dacDAO.findById(dacId2);
     Integer daaId2 =
-        daaDAO.createDaa(
-            dataSubmitterId,
-            new Date().toInstant(),
-            dataSubmitterId,
-            new Date().toInstant(),
-            dacId2);
+        daaDAO.createDaa(dataSubmitterId, Instant.now(), dataSubmitterId, Instant.now(), dacId2);
     daaDAO.createDacDaaRelation(dacId2, daaId2);
     DataAccessAgreement daa2 = daaDAO.findById(daaId2);
     Dataset d2 = createRandomDataset(dataSubmitter, dac2);
@@ -350,12 +327,7 @@ class DaaDAOTest extends DAOTestHelper {
     Integer dacId3 = dacDAO.createDac(randomAlphabetic(5), randomAlphabetic(5), "", new Date());
     Dac dac3 = dacDAO.findById(dacId3);
     Integer daaId3 =
-        daaDAO.createDaa(
-            dataSubmitterId,
-            new Date().toInstant(),
-            dataSubmitterId,
-            new Date().toInstant(),
-            dacId3);
+        daaDAO.createDaa(dataSubmitterId, Instant.now(), dataSubmitterId, Instant.now(), dacId3);
     daaDAO.createDacDaaRelation(dacId3, daaId3);
     DataAccessAgreement daa3 = daaDAO.findById(daaId3);
     createRandomDataset(dataSubmitter, dac3);

--- a/src/test/java/org/broadinstitute/consent/http/db/DacDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DacDAOTest.java
@@ -19,6 +19,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
+import org.broadinstitute.consent.http.enumeration.AuditActions;
 import org.broadinstitute.consent.http.enumeration.FileCategory;
 import org.broadinstitute.consent.http.enumeration.PropertyType;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
@@ -172,13 +173,15 @@ class DacDAOTest extends DAOTestHelper {
     Integer daaId1 =
         daaDAO.createDaa(user.getUserId(), Instant.now(), user.getUserId(), Instant.now(), dacId1);
     createFSO(user.getUserId(), daaId1);
-    daaDAO.createDacDaaRelation(dacId1, daaId1);
+    daaDAO.createDacDaaRelation(
+        dacId1, daaId1, user.getUserId(), AuditActions.ADD.getValue().toUpperCase());
 
     Integer dacId2 = createRandomDAC();
     Integer daaId2 =
         daaDAO.createDaa(user.getUserId(), Instant.now(), user.getUserId(), Instant.now(), dacId2);
     createFSO(user.getUserId(), daaId2);
-    daaDAO.createDacDaaRelation(dacId2, daaId2);
+    daaDAO.createDacDaaRelation(
+        dacId2, daaId2, user.getUserId(), AuditActions.ADD.getValue().toUpperCase());
 
     dacDAO
         .findAll()
@@ -204,7 +207,8 @@ class DacDAOTest extends DAOTestHelper {
     Integer daaId =
         daaDAO.createDaa(user.getUserId(), Instant.now(), user.getUserId(), Instant.now(), id);
     DataAccessAgreement daa = daaDAO.findById(daaId);
-    daaDAO.createDacDaaRelation(id, daaId);
+    daaDAO.createDacDaaRelation(
+        id, daaId, user.getUserId(), AuditActions.ADD.getValue().toUpperCase());
     Dac dac = dacDAO.findById(id);
     DataAccessAgreement dacDaa = dac.getAssociatedDaa();
     assertEquals(id, dac.getDacId());

--- a/src/test/java/org/broadinstitute/consent/http/db/DacDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DacDAOTest.java
@@ -19,7 +19,6 @@ import java.util.Date;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
-import org.broadinstitute.consent.http.enumeration.AuditActions;
 import org.broadinstitute.consent.http.enumeration.FileCategory;
 import org.broadinstitute.consent.http.enumeration.PropertyType;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
@@ -173,15 +172,13 @@ class DacDAOTest extends DAOTestHelper {
     Integer daaId1 =
         daaDAO.createDaa(user.getUserId(), Instant.now(), user.getUserId(), Instant.now(), dacId1);
     createFSO(user.getUserId(), daaId1);
-    daaDAO.createDacDaaRelation(
-        dacId1, daaId1, user.getUserId(), AuditActions.ADD.getValue().toUpperCase());
+    daaDAO.createDacDaaRelation(dacId1, daaId1, user.getUserId());
 
     Integer dacId2 = createRandomDAC();
     Integer daaId2 =
         daaDAO.createDaa(user.getUserId(), Instant.now(), user.getUserId(), Instant.now(), dacId2);
     createFSO(user.getUserId(), daaId2);
-    daaDAO.createDacDaaRelation(
-        dacId2, daaId2, user.getUserId(), AuditActions.ADD.getValue().toUpperCase());
+    daaDAO.createDacDaaRelation(dacId2, daaId2, user.getUserId());
 
     dacDAO
         .findAll()
@@ -207,8 +204,7 @@ class DacDAOTest extends DAOTestHelper {
     Integer daaId =
         daaDAO.createDaa(user.getUserId(), Instant.now(), user.getUserId(), Instant.now(), id);
     DataAccessAgreement daa = daaDAO.findById(daaId);
-    daaDAO.createDacDaaRelation(
-        id, daaId, user.getUserId(), AuditActions.ADD.getValue().toUpperCase());
+    daaDAO.createDacDaaRelation(id, daaId, user.getUserId());
     Dac dac = dacDAO.findById(id);
     DataAccessAgreement dacDaa = dac.getAssociatedDaa();
     assertEquals(id, dac.getDacId());

--- a/src/test/java/org/broadinstitute/consent/http/db/LibraryCardDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/LibraryCardDAOTest.java
@@ -10,6 +10,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 import java.time.Instant;
 import java.util.Date;
 import java.util.List;
+import org.broadinstitute.consent.http.enumeration.AuditActions;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.DataAccessAgreement;
 import org.broadinstitute.consent.http.models.Institution;
@@ -122,7 +123,8 @@ class LibraryCardDAOTest extends DAOTestHelper {
     int daaId =
         daaDAO.createDaa(
             card.getCreateUserId(), Instant.now(), card.getCreateUserId(), Instant.now(), dacId);
-    daaDAO.createDacDaaRelation(dacId, daaId);
+    daaDAO.createDacDaaRelation(
+        dacId, daaId, card.getUserId(), AuditActions.ADD.getValue().toUpperCase());
     libraryCardDAO.createLibraryCardDaaRelation(card.getId(), daaId);
 
     libraryCardDAO.deleteLibraryCardById(card.getId());
@@ -236,7 +238,8 @@ class LibraryCardDAOTest extends DAOTestHelper {
         dacDAO.createDac(randomAlphabetic(5), randomAlphabetic(5), randomAlphabetic(5), new Date());
     Instant now = Instant.now();
     int daaId = daaDAO.createDaa(libraryCard.getUserId(), now, libraryCard.getUserId(), now, dacId);
-    daaDAO.createDacDaaRelation(dacId, daaId);
+    daaDAO.createDacDaaRelation(
+        dacId, daaId, libraryCard.getUserId(), AuditActions.ADD.getValue().toUpperCase());
     libraryCardDAO.createLibraryCardDaaRelation(libraryCard.getId(), daaId);
     LibraryCard cardFromDAO = libraryCardDAO.findLibraryCardByUserId(libraryCard.getUserId());
     assertNotNull(cardFromDAO);

--- a/src/test/java/org/broadinstitute/consent/http/db/LibraryCardDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/LibraryCardDAOTest.java
@@ -10,7 +10,6 @@ import static org.junit.jupiter.api.Assertions.fail;
 import java.time.Instant;
 import java.util.Date;
 import java.util.List;
-import org.broadinstitute.consent.http.enumeration.AuditActions;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.DataAccessAgreement;
 import org.broadinstitute.consent.http.models.Institution;
@@ -123,8 +122,7 @@ class LibraryCardDAOTest extends DAOTestHelper {
     int daaId =
         daaDAO.createDaa(
             card.getCreateUserId(), Instant.now(), card.getCreateUserId(), Instant.now(), dacId);
-    daaDAO.createDacDaaRelation(
-        dacId, daaId, card.getUserId(), AuditActions.ADD.getValue().toUpperCase());
+    daaDAO.createDacDaaRelation(dacId, daaId, card.getUserId());
     libraryCardDAO.createLibraryCardDaaRelation(card.getId(), daaId);
 
     libraryCardDAO.deleteLibraryCardById(card.getId());
@@ -238,8 +236,7 @@ class LibraryCardDAOTest extends DAOTestHelper {
         dacDAO.createDac(randomAlphabetic(5), randomAlphabetic(5), randomAlphabetic(5), new Date());
     Instant now = Instant.now();
     int daaId = daaDAO.createDaa(libraryCard.getUserId(), now, libraryCard.getUserId(), now, dacId);
-    daaDAO.createDacDaaRelation(
-        dacId, daaId, libraryCard.getUserId(), AuditActions.ADD.getValue().toUpperCase());
+    daaDAO.createDacDaaRelation(dacId, daaId, libraryCard.getUserId());
     libraryCardDAO.createLibraryCardDaaRelation(libraryCard.getId(), daaId);
     LibraryCard cardFromDAO = libraryCardDAO.findLibraryCardByUserId(libraryCard.getUserId());
     assertNotNull(cardFromDAO);

--- a/src/test/java/org/broadinstitute/consent/http/service/DaaServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DaaServiceTest.java
@@ -108,7 +108,7 @@ class DaaServiceTest extends AbstractTestHelper {
 
   @Test
   void testAddDacToDaa() {
-    doNothing().when(daaDAO).createDacDaaRelation(any(), any(), any());
+    doNothing().when(daaDAO).createDacDaaRelation(1, 1, 1);
 
     initService();
     assertDoesNotThrow(() -> service.addDacToDaa(1, 1, 1));

--- a/src/test/java/org/broadinstitute/consent/http/service/DaaServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DaaServiceTest.java
@@ -28,7 +28,6 @@ import org.broadinstitute.consent.http.AbstractTestHelper;
 import org.broadinstitute.consent.http.cloudstore.GCSService;
 import org.broadinstitute.consent.http.db.DaaDAO;
 import org.broadinstitute.consent.http.db.DacDAO;
-import org.broadinstitute.consent.http.enumeration.AuditActions;
 import org.broadinstitute.consent.http.models.Dac;
 import org.broadinstitute.consent.http.models.DataAccessAgreement;
 import org.broadinstitute.consent.http.models.FileStorageObject;
@@ -109,7 +108,7 @@ class DaaServiceTest extends AbstractTestHelper {
 
   @Test
   void testAddDacToDaa() {
-    doNothing().when(daaDAO).createDacDaaRelation(any(), any(), any(), any());
+    doNothing().when(daaDAO).createDacDaaRelation(any(), any(), any());
 
     initService();
     assertDoesNotThrow(() -> service.addDacToDaa(1, 1, 1));
@@ -119,9 +118,7 @@ class DaaServiceTest extends AbstractTestHelper {
   void testRemoveDacFromDaa() {
     User user = new User();
     user.setUserId(1);
-    doNothing()
-        .when(daaDAO)
-        .deleteDacDaaRelation(1, 1, 1, AuditActions.REMOVE.getValue().toUpperCase());
+    doNothing().when(daaDAO).deleteDacDaaRelation(1, 1, 1);
 
     initService();
     assertDoesNotThrow(() -> service.removeDacFromDaa(user.getUserId(), 1, 1));

--- a/src/test/java/org/broadinstitute/consent/http/service/DaaServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DaaServiceTest.java
@@ -109,10 +109,10 @@ class DaaServiceTest extends AbstractTestHelper {
 
   @Test
   void testAddDacToDaa() {
-    doNothing().when(daaDAO).createDacDaaRelation(any(), any());
+    doNothing().when(daaDAO).createDacDaaRelation(any(), any(), any(), any());
 
     initService();
-    assertDoesNotThrow(() -> service.addDacToDaa(1, 1));
+    assertDoesNotThrow(() -> service.addDacToDaa(1, 1, 1));
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/DaaServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DaaServiceTest.java
@@ -28,6 +28,7 @@ import org.broadinstitute.consent.http.AbstractTestHelper;
 import org.broadinstitute.consent.http.cloudstore.GCSService;
 import org.broadinstitute.consent.http.db.DaaDAO;
 import org.broadinstitute.consent.http.db.DacDAO;
+import org.broadinstitute.consent.http.enumeration.AuditActions;
 import org.broadinstitute.consent.http.models.Dac;
 import org.broadinstitute.consent.http.models.DataAccessAgreement;
 import org.broadinstitute.consent.http.models.FileStorageObject;
@@ -116,10 +117,14 @@ class DaaServiceTest extends AbstractTestHelper {
 
   @Test
   void testRemoveDacFromDaa() {
-    doNothing().when(daaDAO).deleteDacDaaRelation(any(), any());
+    User user = new User();
+    user.setUserId(1);
+    doNothing()
+        .when(daaDAO)
+        .deleteDacDaaRelation(1, 1, 1, AuditActions.REMOVE.getValue().toUpperCase());
 
     initService();
-    assertDoesNotThrow(() -> service.removeDacFromDaa(1, 1));
+    assertDoesNotThrow(() -> service.removeDacFromDaa(user.getUserId(), 1, 1));
   }
 
   @Test
@@ -356,20 +361,6 @@ class DaaServiceTest extends AbstractTestHelper {
     String json = "{daaList:[1,2,3]}";
     initService();
     assertThrows(BadRequestException.class, () -> service.findDAAsInJsonArray(json, "invalidKey"));
-  }
-
-  @Test
-  void testDeleteDaa() {
-    when(daaDAO.findById(any())).thenReturn(new DataAccessAgreement());
-    doNothing().when(daaDAO).deleteDaa(any());
-    initService();
-    assertDoesNotThrow(() -> service.deleteDaa(1));
-  }
-
-  @Test
-  void testDeleteDaaDaaNotFound() {
-    initService();
-    assertThrows(NotFoundException.class, () -> service.deleteDaa(1));
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/DacServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DacServiceTest.java
@@ -20,7 +20,6 @@ import static org.mockito.Mockito.when;
 
 import com.google.gson.Gson;
 import jakarta.ws.rs.BadRequestException;
-import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -196,7 +195,7 @@ class DacServiceTest extends AbstractTestHelper {
   }
 
   @Test
-  void testDeleteDacServiceDAOException() throws SQLException {
+  void testDeleteDacServiceDAOException() {
     DataAccessAgreement daa = new DataAccessAgreement();
     daa.setDaaId(randomInt(1, 10));
     Dac dac = new Dac();

--- a/src/test/java/org/broadinstitute/consent/http/service/DacServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DacServiceTest.java
@@ -205,7 +205,9 @@ class DacServiceTest extends AbstractTestHelper {
     dac.setName("DAC name");
     dac.setAssociatedDaa(daa);
     when(dacDAO.findById(any())).thenReturn(dac);
-    doThrow(new IllegalArgumentException()).when(dacServiceDAO).deleteDacAndDaas(any(), any());
+    doThrow(new IllegalArgumentException())
+        .when(dacServiceDAO)
+        .deleteDacAndRemoveDaaAssociation(any(), any());
     initService();
     assertThrows(IllegalArgumentException.class, () -> service.deleteDac(any(), dac.getDacId()));
   }

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DaaServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DaaServiceDAOTest.java
@@ -3,6 +3,7 @@ package org.broadinstitute.consent.http.service.dao;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -17,7 +18,9 @@ import jakarta.ws.rs.core.MediaType;
 import java.util.Date;
 import java.util.List;
 import org.broadinstitute.consent.http.db.DAOTestHelper;
+import org.broadinstitute.consent.http.enumeration.AuditActions;
 import org.broadinstitute.consent.http.enumeration.FileCategory;
+import org.broadinstitute.consent.http.models.DaaAudit;
 import org.broadinstitute.consent.http.models.DataAccessAgreement;
 import org.broadinstitute.consent.http.models.FileStorageObject;
 import org.broadinstitute.consent.http.models.User;
@@ -70,6 +73,11 @@ class DaaServiceDAOTest extends DAOTestHelper {
           assertNotNull(daa.getFile());
           assertNotNull(daa.getInitialDacId());
           assertFalse(daa.getDacs().isEmpty());
+          // Assert that audit record is created
+          List<DaaAudit> audits = daaDAO.findAuditsByDaaId(daaId);
+          assertNotNull(audits);
+          assertFalse(audits.isEmpty());
+          assertEquals(AuditActions.CREATE.getValue(), audits.getFirst().action().getValue());
         });
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DaaServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DaaServiceDAOTest.java
@@ -3,7 +3,6 @@ package org.broadinstitute.consent.http.service.dao;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -77,7 +76,8 @@ class DaaServiceDAOTest extends DAOTestHelper {
           List<DaaAudit> audits = daaDAO.findAuditsByDaaId(daaId);
           assertNotNull(audits);
           assertFalse(audits.isEmpty());
-          assertEquals(AuditActions.CREATE, audits.getFirst().action());
+          assertTrue(audits.stream().anyMatch(a -> a.action().equals(AuditActions.CREATE)));
+          assertTrue(audits.stream().anyMatch(a -> a.action().equals(AuditActions.ADD)));
         });
   }
 
@@ -91,19 +91,6 @@ class DaaServiceDAOTest extends DAOTestHelper {
 
     List<FileStorageObject> fsos = fileStorageObjectDAO.findFilesByEntityId(daaId.toString());
     assertTrue(fsos.isEmpty(), "Expected no FileStorageObjects to be created when FSO is null");
-  }
-
-  @Test
-  void testCreateDaa_dacFKError() {
-    User user = createUser();
-    Integer dacId = 1; // Non-existent DAC ID to trigger daaDAO.createDaa error
-    FileStorageObject fso = createFileStorageObject();
-    assertThrows(
-        UnableToExecuteStatementException.class,
-        () -> serviceDAO.createDaaWithFso(user.getUserId(), dacId, fso));
-    ILoggingEvent event = testAppender.getLoggedEvents().getFirst();
-    assertThat(event.getFormattedMessage(), containsString("foreign key constraint"));
-    assertThat(event.getFormattedMessage(), containsString("fk_daa_initial_dac_id"));
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DaaServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DaaServiceDAOTest.java
@@ -77,7 +77,7 @@ class DaaServiceDAOTest extends DAOTestHelper {
           List<DaaAudit> audits = daaDAO.findAuditsByDaaId(daaId);
           assertNotNull(audits);
           assertFalse(audits.isEmpty());
-          assertEquals(AuditActions.CREATE.getValue(), audits.getFirst().action().getValue());
+          assertEquals(AuditActions.CREATE, audits.getFirst().action());
         });
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DaaServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DaaServiceDAOTest.java
@@ -91,6 +91,11 @@ class DaaServiceDAOTest extends DAOTestHelper {
 
     List<FileStorageObject> fsos = fileStorageObjectDAO.findFilesByEntityId(daaId.toString());
     assertTrue(fsos.isEmpty(), "Expected no FileStorageObjects to be created when FSO is null");
+    // Assert that CREATE audit records are created.
+    List<DaaAudit> daaAudits = daaDAO.findAuditsByDaaId(daaId);
+    assertNotNull(daaAudits);
+    assertFalse(daaAudits.isEmpty());
+    assertTrue(daaAudits.stream().anyMatch(a -> a.action().equals(AuditActions.CREATE)));
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DacServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DacServiceDAOTest.java
@@ -4,7 +4,9 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.sql.Timestamp;
 import java.time.Instant;
@@ -162,6 +164,32 @@ class DacServiceDAOTest extends DAOTestHelper {
           assertNull(ds.getDacId(), "Dataset should not have a DAC");
           assertNull(ds.getDacApproval(), "Dataset should not have a DAC approval");
         });
+  }
+
+  @Test
+  void testDeleteDac_nullDAC() {
+    User superUser = createUser();
+    assertThrows(IllegalArgumentException.class, () ->
+        serviceDAO.deleteDacAndRemoveDaaAssociation(superUser, null), "Should throw IllegalArgumentException when DAC is null");
+  }
+
+  @Test
+  void testDeleteDac_nullDAA() {
+    User superUser = createUser();
+    int dacId =
+        dacDAO.createDac(
+            "dac name: " + randomAlphabetic(10),
+            "dac description: " + randomAlphabetic(10),
+            "dac email: " + randomAlphabetic(10),
+            new Date());
+      Dac dac = dacDAO.findById(dacId);
+      try {
+        serviceDAO.deleteDacAndRemoveDaaAssociation(superUser, dac);
+        List<DaaAudit> daaAudits = daaDAO.findAllDaaAudits();
+        assertTrue(daaAudits.isEmpty(), "There should be no DaaAudits in a DAC delete operation");
+      } catch (Exception e) {
+        fail(e.getMessage());
+      }
   }
 
   /**

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DacServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DacServiceDAOTest.java
@@ -1,6 +1,8 @@
 package org.broadinstitute.consent.http.service.dao;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -9,15 +11,17 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.IntStream;
 import org.broadinstitute.consent.http.db.DAOTestHelper;
+import org.broadinstitute.consent.http.enumeration.AuditActions;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
+import org.broadinstitute.consent.http.models.DaaAudit;
 import org.broadinstitute.consent.http.models.Dac;
 import org.broadinstitute.consent.http.models.DataAccessAgreement;
 import org.broadinstitute.consent.http.models.DataUseBuilder;
 import org.broadinstitute.consent.http.models.Dataset;
+import org.broadinstitute.consent.http.models.LibraryCard;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.rules.DACAutomationRule;
 import org.broadinstitute.consent.http.rules.RuleState;
@@ -67,8 +71,8 @@ class DacServiceDAOTest extends DAOTestHelper {
                   superUser.getUserId(),
                   new Date().toInstant(),
                   dacId);
-          // Note that we are explicitly NOT creating DAC->DAA Association since that prevents DACs
-          // from being deleted
+          // DAC->DAA Association.
+          daaDAO.createDacDaaRelation(dacId, daaId, superUser.getUserId());
           // Library Card User
           User lcUser = createUser();
           // A user's library card needs an institution
@@ -125,7 +129,8 @@ class DacServiceDAOTest extends DAOTestHelper {
         .forEach(
             dac -> {
               assertDoesNotThrow(
-                  () -> serviceDAO.deleteDacAndDaas(superUser, dac), "Delete should not fail");
+                  () -> serviceDAO.deleteDacAndRemoveDaaAssociation(superUser, dac),
+                  "Delete should not fail");
               List<DACAutomationRule> rules =
                   dacAutomationRuleDAO.findAllDACAutomationRulesByDACId(dac.getDacId()).stream()
                       .filter(r -> r.enabledByUserId() != null)
@@ -136,35 +141,20 @@ class DacServiceDAOTest extends DAOTestHelper {
               assertTrue(datasets.isEmpty());
               List<User> members = dacDAO.findMembersByDacId(dac.getDacId());
               assertTrue(members.isEmpty());
+              // DAA deletion is not allowed even when deleting a DAC
               DataAccessAgreement daa = daaDAO.findByDacId(dac.getDacId());
-              assertNull(daa);
-              // Assert that there are no DAAs that reference this DAC
-              daaDAO
-                  .findAll()
-                  .forEach(
-                      d -> {
-                        assertTrue(
-                            d.getDacs() == null
-                                || d.getDacs().isEmpty()
-                                || d.getDacs().stream().allMatch(Objects::isNull));
-                      });
-              // Assert that there are no Library Cards with DAAs that reference this DAC
-              libraryCardDAO
-                  .findAllLibraryCards()
-                  .forEach(
-                      lc -> {
-                        List<Integer> daaIds = lc.getDaaIds();
-                        if (!daaIds.isEmpty()) {
-                          daaIds.forEach(
-                              daaId -> {
-                                DataAccessAgreement innerDaa = daaDAO.findById(daaId);
-                                assertTrue(
-                                    innerDaa.getDacs() == null
-                                        || innerDaa.getDacs().isEmpty()
-                                        || innerDaa.getDacs().stream().allMatch(Objects::isNull));
-                              });
-                        }
-                      });
+              assertNotNull(daa);
+              // Assert that there are DAA audit records for this dac deletion
+              List<DaaAudit> daaAudits = daaDAO.findAuditsByDaaId(daa.getDaaId());
+              assertFalse(daaAudits.isEmpty());
+              assertTrue(daaAudits.stream().anyMatch(a -> a.action().equals(AuditActions.REMOVE)));
+              // Assert that created library cards are not deleted and that their association to the
+              // DAA is not removed
+              List<LibraryCard> libraryCards =
+                  libraryCardDAO.findAllLibraryCards().stream()
+                      .filter(lc -> lc.getDaaIds().contains(daa.getDaaId()))
+                      .toList();
+              assertFalse(libraryCards.isEmpty());
             });
     createdDatasetIds.forEach(
         id -> {

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DacServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DacServiceDAOTest.java
@@ -13,7 +13,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.IntStream;
 import org.broadinstitute.consent.http.db.DAOTestHelper;
-import org.broadinstitute.consent.http.enumeration.AuditActions;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.Dac;
 import org.broadinstitute.consent.http.models.DataAccessAgreement;
@@ -69,8 +68,7 @@ class DacServiceDAOTest extends DAOTestHelper {
                   new Date().toInstant(),
                   dacId);
           // DAC->DAA Association.
-          daaDAO.createDacDaaRelation(
-              dacId, daaId, superUser.getUserId(), AuditActions.ADD.getValue().toUpperCase());
+          daaDAO.createDacDaaRelation(dacId, daaId, superUser.getUserId());
           // Library Card User
           User lcUser = createUser();
           // A user's library card needs an institution

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DacServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DacServiceDAOTest.java
@@ -11,11 +11,9 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import org.apache.commons.lang3.RandomStringUtils;
-import org.apache.commons.lang3.RandomUtils;
 import org.broadinstitute.consent.http.db.DAOTestHelper;
+import org.broadinstitute.consent.http.enumeration.AuditActions;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.Dac;
 import org.broadinstitute.consent.http.models.DataAccessAgreement;
@@ -54,13 +52,13 @@ class DacServiceDAOTest extends DAOTestHelper {
     List<Dac> dacs = createMockDACs();
     List<Integer> createdDatasetIds = new ArrayList<>();
     dacs.forEach(
-        dac -> {
+        _ -> {
           // DAC
           int dacId =
               dacDAO.createDac(
-                  "dac name: " + RandomStringUtils.randomAlphabetic(10),
-                  "dac description: " + RandomStringUtils.randomAlphabetic(10),
-                  "dac email: " + RandomStringUtils.randomAlphabetic(10),
+                  "dac name: " + randomAlphabetic(10),
+                  "dac description: " + randomAlphabetic(10),
+                  "dac email: " + randomAlphabetic(10),
                   new Date());
           // Data Access Agreement
           int daaId =
@@ -71,28 +69,29 @@ class DacServiceDAOTest extends DAOTestHelper {
                   new Date().toInstant(),
                   dacId);
           // DAC->DAA Association.
-          daaDAO.createDacDaaRelation(dacId, daaId);
+          daaDAO.createDacDaaRelation(
+              dacId, daaId, superUser.getUserId(), AuditActions.ADD.getValue().toUpperCase());
           // Library Card User
           User lcUser = createUser();
           // A user's library card needs an institution
-          int dunsNumber = RandomUtils.nextInt(10, 100);
+          int dunsNumber = randomInt(10, 100);
           institutionDAO.insertInstitution(
-              "institution name: " + RandomStringUtils.randomAlphabetic(10),
-              "it director name: " + RandomStringUtils.randomAlphabetic(10),
-              "it director email: " + RandomStringUtils.randomAlphabetic(10),
-              "institution url: " + RandomStringUtils.randomAlphabetic(10),
+              "institution name: " + randomAlphabetic(10),
+              "it director name: " + randomAlphabetic(10),
+              "it director email: " + randomAlphabetic(10),
+              "institution url: " + randomAlphabetic(10),
               dunsNumber,
-              "org chart url: " + RandomStringUtils.randomAlphabetic(10),
-              "verification url: " + RandomStringUtils.randomAlphabetic(10),
-              "verification file name: " + RandomStringUtils.randomAlphabetic(10),
-              "org type: " + RandomStringUtils.randomAlphabetic(10),
+              "org chart url: " + randomAlphabetic(10),
+              "verification url: " + randomAlphabetic(10),
+              "verification file name: " + randomAlphabetic(10),
+              "org type: " + randomAlphabetic(10),
               superUser.getUserId(),
               new Date());
           int userLcId =
               libraryCardDAO.insertLibraryCard(
                   lcUser.getUserId(),
-                  "library card user name: " + RandomStringUtils.randomAlphabetic(10),
-                  "library card user email: " + RandomStringUtils.randomAlphabetic(10),
+                  "library card user name: " + randomAlphabetic(10),
+                  "library card user email: " + randomAlphabetic(10),
                   superUser.getUserId(),
                   new Date());
           // Library Card User to Data Access Agreement association
@@ -107,10 +106,10 @@ class DacServiceDAOTest extends DAOTestHelper {
           // DAC.
           int datasetId =
               datasetDAO.insertDataset(
-                  "dataset name: " + RandomStringUtils.randomAlphabetic(10),
+                  "dataset name: " + randomAlphabetic(10),
                   Timestamp.from(Instant.now()),
                   superUser.getUserId(),
-                  "object id: " + RandomStringUtils.randomAlphabetic(10),
+                  "object id: " + randomAlphabetic(10),
                   new DataUseBuilder().setGeneralUse(true).build().toString(),
                   dacId);
           createdDatasetIds.add(datasetId);
@@ -194,6 +193,6 @@ class DacServiceDAOTest extends DAOTestHelper {
               dac.setAssociatedDaa(daa);
               return dac;
             })
-        .collect(Collectors.toList());
+        .toList();
   }
 }

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DacServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DacServiceDAOTest.java
@@ -57,7 +57,7 @@ class DacServiceDAOTest extends DAOTestHelper {
     List<Dac> dacs = createMockDACs();
     List<Integer> createdDatasetIds = new ArrayList<>();
     dacs.forEach(
-        _ -> {
+        ignored -> {
           // DAC
           int dacId =
               dacDAO.createDac(

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DacServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DacServiceDAOTest.java
@@ -1,7 +1,6 @@
 package org.broadinstitute.consent.http.service.dao;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -10,6 +9,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.IntStream;
 import org.broadinstitute.consent.http.db.DAOTestHelper;
@@ -67,8 +67,8 @@ class DacServiceDAOTest extends DAOTestHelper {
                   superUser.getUserId(),
                   new Date().toInstant(),
                   dacId);
-          // DAC->DAA Association.
-          daaDAO.createDacDaaRelation(dacId, daaId, superUser.getUserId());
+          // Note that we are explicitly NOT creating DAC->DAA Association since that prevents DACs
+          // from being deleted
           // Library Card User
           User lcUser = createUser();
           // A user's library card needs an institution
@@ -143,10 +143,10 @@ class DacServiceDAOTest extends DAOTestHelper {
                   .findAll()
                   .forEach(
                       d -> {
-                        List<Integer> daaDacIds = d.getDacs().stream().map(Dac::getDacId).toList();
-                        assertFalse(
-                            daaDacIds.contains(dac.getDacId()),
-                            "There should be no DAAs that have DACs matching this deleted Dac ID");
+                        assertTrue(
+                            d.getDacs() == null
+                                || d.getDacs().isEmpty()
+                                || d.getDacs().stream().allMatch(Objects::isNull));
                       });
               // Assert that there are no Library Cards with DAAs that reference this DAC
               libraryCardDAO
@@ -158,11 +158,10 @@ class DacServiceDAOTest extends DAOTestHelper {
                           daaIds.forEach(
                               daaId -> {
                                 DataAccessAgreement innerDaa = daaDAO.findById(daaId);
-                                List<Integer> innerDacIds =
-                                    innerDaa.getDacs().stream().map(Dac::getDacId).toList();
-                                assertFalse(
-                                    innerDacIds.contains(dac.getDacId()),
-                                    "There should be no Library Cards with DAAs that have DACs matching this deleted Dac ID");
+                                assertTrue(
+                                    innerDaa.getDacs() == null
+                                        || innerDaa.getDacs().isEmpty()
+                                        || innerDaa.getDacs().stream().allMatch(Objects::isNull));
                               });
                         }
                       });

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DacServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DacServiceDAOTest.java
@@ -169,8 +169,10 @@ class DacServiceDAOTest extends DAOTestHelper {
   @Test
   void testDeleteDac_nullDAC() {
     User superUser = createUser();
-    assertThrows(IllegalArgumentException.class, () ->
-        serviceDAO.deleteDacAndRemoveDaaAssociation(superUser, null), "Should throw IllegalArgumentException when DAC is null");
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> serviceDAO.deleteDacAndRemoveDaaAssociation(superUser, null),
+        "Should throw IllegalArgumentException when DAC is null");
   }
 
   @Test
@@ -182,14 +184,14 @@ class DacServiceDAOTest extends DAOTestHelper {
             "dac description: " + randomAlphabetic(10),
             "dac email: " + randomAlphabetic(10),
             new Date());
-      Dac dac = dacDAO.findById(dacId);
-      try {
-        serviceDAO.deleteDacAndRemoveDaaAssociation(superUser, dac);
-        List<DaaAudit> daaAudits = daaDAO.findAllDaaAudits();
-        assertTrue(daaAudits.isEmpty(), "There should be no DaaAudits in a DAC delete operation");
-      } catch (Exception e) {
-        fail(e.getMessage());
-      }
+    Dac dac = dacDAO.findById(dacId);
+    try {
+      serviceDAO.deleteDacAndRemoveDaaAssociation(superUser, dac);
+      List<DaaAudit> daaAudits = daaDAO.findAllDaaAudits();
+      assertTrue(daaAudits.isEmpty(), "There should be no DaaAudits in a DAC delete operation");
+    } catch (Exception e) {
+      fail(e.getMessage());
+    }
   }
 
   /**


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DT-3059

## Summary
This PR adds auditing for DAA creation, and DAA add/removal operations. Note that for removal, we no longer delete DAA entities. Instead, they are persisted so that in future work, we can know which version of a DAA a user agreed to when a DAR was submitted. For removal, we only dissociate the DAC from the DAA and an audit record is created for it.

### Of Note
The fact that we allow for DAC deletion is a complicating factor. To persist DAAs that are created by a DAC chair, we need to remove a foreign key constraint. We **should** migrate DAC deletion to a soft-delete process. That work can re-enable FK constraints that should be in place.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
