### PR TITLE
DT-3156: Refactor to avoid user id collision

### DIFF
--- a/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/UserServiceTest.java
@@ -685,7 +685,7 @@ class UserServiceTest extends AbstractTestHelper {
   void testFindUserWithPropertiesAsJsonObjectById_by_Roles_That_Throw(List<UserRole> userRoles) {
     User user = generateUser();
     Integer userId = user.getUserId();
-    DuosUser requestingDuosUser = generateDuosUserWithRoles(userRoles);
+    DuosUser requestingDuosUser = generateDuosUserWithRoles(userRoles, user.getUserId());
     assertNotEquals(requestingDuosUser.getUser().getUserId(), user.getUserId());
 
     when(userDAO.findUserById(user.getUserId())).thenReturn(user);
@@ -700,7 +700,7 @@ class UserServiceTest extends AbstractTestHelper {
       List<UserRole> userRoles) {
     User user = generateUser();
     Integer userId = user.getUserId();
-    DuosUser requestingDuosUser = generateDuosUserWithRoles(userRoles);
+    DuosUser requestingDuosUser = generateDuosUserWithRoles(userRoles, user.getUserId());
     assertNotEquals(requestingDuosUser.getUser().getUserId(), user.getUserId());
 
     when(userDAO.findUserById(user.getUserId())).thenReturn(user);
@@ -714,7 +714,7 @@ class UserServiceTest extends AbstractTestHelper {
       List<UserRole> userRoles) {
     User user = generateUser();
     Integer userId = user.getUserId();
-    DuosUser requestingDuosUser = generateDuosUserWithRoles(userRoles);
+    DuosUser requestingDuosUser = generateDuosUserWithRoles(userRoles, user.getUserId());
     assertNotEquals(requestingDuosUser.getUser().getUserId(), user.getUserId());
     user.setInstitutionId(requestingDuosUser.getUser().getInstitutionId() + 1);
 
@@ -730,7 +730,7 @@ class UserServiceTest extends AbstractTestHelper {
       List<UserRole> userRoles) {
     User user = generateUser();
     Integer userId = user.getUserId();
-    DuosUser requestingDuosUser = generateDuosUserWithRoles(userRoles);
+    DuosUser requestingDuosUser = generateDuosUserWithRoles(userRoles, user.getUserId());
     assertNotEquals(requestingDuosUser.getUser().getUserId(), user.getUserId());
     user.setInstitutionId(requestingDuosUser.getUser().getInstitutionId());
 
@@ -758,7 +758,7 @@ class UserServiceTest extends AbstractTestHelper {
 
   @Test
   void testFindUserWithPropertiesAsJsonObjectById_Null_User() {
-    DuosUser requestingDuosUser = generateDuosUserWithRoles(List.of());
+    DuosUser requestingDuosUser = generateDuosUserWithRoles(List.of(), null);
 
     when(userDAO.findUserById(any())).thenReturn(null);
     assertThrows(
@@ -878,8 +878,11 @@ class UserServiceTest extends AbstractTestHelper {
     assertThrows(BadRequestException.class, () -> service.findUsersInJsonArray(json, "invalidKey"));
   }
 
-  private DuosUser generateDuosUserWithRoles(List<UserRole> roles) {
+  private DuosUser generateDuosUserWithRoles(List<UserRole> roles, Integer excludedUserId) {
     User requestingUser = generateUser();
+    if (Objects.equals(requestingUser.getUserId(), excludedUserId)) {
+      requestingUser.setUserId(requestingUser.getUserId() + 1);
+    }
     if (Objects.nonNull(roles) && !roles.isEmpty()) {
       requestingUser.setRoles(roles);
     }


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-3156

### Summary
Fixes cases where user ids can collide from the random user creation utilities

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
