### PR TITLE
DT-3056: Audit Library Card DAA Associations and Removals

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
@@ -566,6 +566,7 @@ public class ConsentModule extends AbstractModule {
   @Provides
   LibraryCardService providesLibraryCardService() {
     return new LibraryCardService(
+        providesDaaDAO(),
         providesLibraryCardDAO(),
         providesInstitutionDAO(),
         providesInstitutionService(),

--- a/src/main/java/org/broadinstitute/consent/http/db/LibraryCardDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/LibraryCardDAO.java
@@ -134,19 +134,23 @@ public interface LibraryCardDAO extends Transactional<LibraryCardDAO> {
 
   @SqlUpdate(
       """
+      WITH audit AS (INSERT INTO lc_daa_audit (daa_id, lc_id, user_id, action, action_date) VALUES (:daaId, :lcId, :userId, 'ADD', NOW()))
       INSERT INTO lc_daa (lc_id, daa_id)
       VALUES (:lcId, :daaId)
       ON CONFLICT DO NOTHING
       """)
-  void createLibraryCardDaaRelation(@Bind("lcId") Integer lcId, @Bind("daaId") Integer daaId);
+  void createLibraryCardDaaRelation(
+      @Bind("userId") Integer userId, @Bind("lcId") Integer lcId, @Bind("daaId") Integer daaId);
 
   @SqlUpdate(
       """
+      WITH audit AS (INSERT INTO lc_daa_audit (daa_id, lc_id, user_id, action, action_date) VALUES (:daaId, :lcId, :userId, 'REMOVE', NOW()))
       DELETE FROM lc_daa
       WHERE lc_id = :lcId
       AND daa_id = :daaId
       """)
-  void deleteLibraryCardDaaRelation(@Bind("lcId") Integer lcId, @Bind("daaId") Integer daaId);
+  void deleteLibraryCardDaaRelation(
+      @Bind("userId") Integer userId, @Bind("lcId") Integer lcId, @Bind("daaId") Integer daaId);
 
   /**
    * Finds library cards by user emails.

--- a/src/main/java/org/broadinstitute/consent/http/db/LibraryCardDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/LibraryCardDAO.java
@@ -2,11 +2,14 @@ package org.broadinstitute.consent.http.db;
 
 import java.util.Date;
 import java.util.List;
+import org.broadinstitute.consent.http.db.mapper.LibraryCardDaaAuditMapper;
 import org.broadinstitute.consent.http.db.mapper.LibraryCardReducer;
 import org.broadinstitute.consent.http.db.mapper.LibraryCardWithDaaReducer;
 import org.broadinstitute.consent.http.models.DataAccessAgreement;
 import org.broadinstitute.consent.http.models.LibraryCard;
+import org.broadinstitute.consent.http.models.LibraryCardDaaAudit;
 import org.jdbi.v3.sqlobject.config.RegisterBeanMapper;
+import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
 import org.jdbi.v3.sqlobject.customizer.Bind;
 import org.jdbi.v3.sqlobject.customizer.BindList;
 import org.jdbi.v3.sqlobject.customizer.BindList.EmptyHandling;
@@ -151,6 +154,16 @@ public interface LibraryCardDAO extends Transactional<LibraryCardDAO> {
       """)
   void deleteLibraryCardDaaRelation(
       @Bind("userId") Integer userId, @Bind("lcId") Integer lcId, @Bind("daaId") Integer daaId);
+
+  @RegisterRowMapper(LibraryCardDaaAuditMapper.class)
+  @SqlQuery(
+      """
+    SELECT a.*
+    FROM lc_daa_audit a
+    INNER JOIN library_card lc ON a.lc_id = lc.id AND lc.user_id = :lcUserId
+    ORDER BY a.action_date DESC
+    """)
+  List<LibraryCardDaaAudit> findAuditsByLcUserId(@Bind("lcUserId") Integer lcUserId);
 
   /**
    * Finds library cards by user emails.

--- a/src/main/java/org/broadinstitute/consent/http/db/LibraryCardDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/LibraryCardDAO.java
@@ -137,10 +137,15 @@ public interface LibraryCardDAO extends Transactional<LibraryCardDAO> {
 
   @SqlUpdate(
       """
-      WITH audit AS (INSERT INTO lc_daa_audit (daa_id, lc_id, user_id, action, action_date) VALUES (:daaId, :lcId, :userId, 'ADD', NOW()))
-      INSERT INTO lc_daa (lc_id, daa_id)
-      VALUES (:lcId, :daaId)
-      ON CONFLICT DO NOTHING
+      WITH lc_daa_insert AS (
+        INSERT INTO lc_daa (lc_id, daa_id)
+        VALUES (:lcId, :daaId)
+        ON CONFLICT DO NOTHING
+        RETURNING lc_id
+      )
+      INSERT INTO lc_daa_audit (daa_id, lc_id, user_id, action, action_date)
+      SELECT :daaId, :lcId, :userId, 'ADD', NOW()
+      WHERE EXISTS (SELECT 1 FROM lc_daa_insert)
       """)
   void createLibraryCardDaaRelation(
       @Bind("userId") Integer userId, @Bind("lcId") Integer lcId, @Bind("daaId") Integer daaId);

--- a/src/main/java/org/broadinstitute/consent/http/db/LibraryCardDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/LibraryCardDAO.java
@@ -158,11 +158,11 @@ public interface LibraryCardDAO extends Transactional<LibraryCardDAO> {
   @RegisterRowMapper(LibraryCardDaaAuditMapper.class)
   @SqlQuery(
       """
-    SELECT a.*
-    FROM lc_daa_audit a
-    INNER JOIN library_card lc ON a.lc_id = lc.id AND lc.user_id = :lcUserId
-    ORDER BY a.action_date DESC
-    """)
+      SELECT a.*
+      FROM lc_daa_audit a
+      INNER JOIN library_card lc ON a.lc_id = lc.id AND lc.user_id = :lcUserId
+      ORDER BY a.action_date DESC
+      """)
   List<LibraryCardDaaAudit> findAuditsByLcUserId(@Bind("lcUserId") Integer lcUserId);
 
   /**

--- a/src/main/java/org/broadinstitute/consent/http/db/LibraryCardDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/LibraryCardDAO.java
@@ -143,12 +143,15 @@ public interface LibraryCardDAO extends Transactional<LibraryCardDAO> {
         ON CONFLICT DO NOTHING
         RETURNING lc_id
       )
-      INSERT INTO lc_daa_audit (daa_id, lc_id, user_id, action, action_date)
-      SELECT :daaId, :lcId, :userId, 'ADD', NOW()
+      INSERT INTO lc_daa_audit (daa_id, lc_id, lc_user_id, user_id, action, action_date)
+      SELECT :daaId, :lcId, :lcUserId, :userId, 'ADD', NOW()
       WHERE EXISTS (SELECT 1 FROM lc_daa_insert)
       """)
   void createLibraryCardDaaRelation(
-      @Bind("userId") Integer userId, @Bind("lcId") Integer lcId, @Bind("daaId") Integer daaId);
+      @Bind("lcUserId") Integer lcUserId,
+      @Bind("userId") Integer userId,
+      @Bind("lcId") Integer lcId,
+      @Bind("daaId") Integer daaId);
 
   @SqlUpdate(
       """
@@ -158,20 +161,23 @@ public interface LibraryCardDAO extends Transactional<LibraryCardDAO> {
         AND daa_id = :daaId
         RETURNING lc_id
       )
-      INSERT INTO lc_daa_audit (daa_id, lc_id, user_id, action, action_date)
-      SELECT :daaId, :lcId, :userId, 'REMOVE', NOW()
+      INSERT INTO lc_daa_audit (daa_id, lc_id, lc_user_id, user_id, action, action_date)
+      SELECT :daaId, :lcId, :lcUserId, :userId, 'REMOVE', NOW()
       WHERE EXISTS (SELECT 1 FROM lc_daa_delete)
       """)
   void deleteLibraryCardDaaRelation(
-      @Bind("userId") Integer userId, @Bind("lcId") Integer lcId, @Bind("daaId") Integer daaId);
+      @Bind("lcUserId") Integer lcUserId,
+      @Bind("userId") Integer userId,
+      @Bind("lcId") Integer lcId,
+      @Bind("daaId") Integer daaId);
 
   @RegisterRowMapper(LibraryCardDaaAuditMapper.class)
   @SqlQuery(
       """
-      SELECT a.*
-      FROM lc_daa_audit a
-      INNER JOIN library_card lc ON a.lc_id = lc.id AND lc.user_id = :lcUserId
-      ORDER BY a.action_date DESC
+      SELECT *
+      FROM lc_daa_audit
+      WHERE lc_user_id = :lcUserId
+      ORDER BY action_date DESC
       """)
   List<LibraryCardDaaAudit> findAuditsByLcUserId(@Bind("lcUserId") Integer lcUserId);
 

--- a/src/main/java/org/broadinstitute/consent/http/db/LibraryCardDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/LibraryCardDAO.java
@@ -152,10 +152,15 @@ public interface LibraryCardDAO extends Transactional<LibraryCardDAO> {
 
   @SqlUpdate(
       """
-      WITH audit AS (INSERT INTO lc_daa_audit (daa_id, lc_id, user_id, action, action_date) VALUES (:daaId, :lcId, :userId, 'REMOVE', NOW()))
-      DELETE FROM lc_daa
-      WHERE lc_id = :lcId
-      AND daa_id = :daaId
+      WITH lc_daa_delete AS (
+        DELETE FROM lc_daa
+        WHERE lc_id = :lcId
+        AND daa_id = :daaId
+        RETURNING lc_id
+      )
+      INSERT INTO lc_daa_audit (daa_id, lc_id, user_id, action, action_date)
+      SELECT :daaId, :lcId, :userId, 'REMOVE', NOW()
+      WHERE EXISTS (SELECT 1 FROM lc_daa_delete)
       """)
   void deleteLibraryCardDaaRelation(
       @Bind("userId") Integer userId, @Bind("lcId") Integer lcId, @Bind("daaId") Integer daaId);

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/LibraryCardDaaAuditMapper.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/LibraryCardDaaAuditMapper.java
@@ -1,0 +1,22 @@
+package org.broadinstitute.consent.http.db.mapper;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import org.broadinstitute.consent.http.enumeration.AuditActions;
+import org.broadinstitute.consent.http.models.LibraryCardDaaAudit;
+import org.jdbi.v3.core.mapper.RowMapper;
+import org.jdbi.v3.core.statement.StatementContext;
+
+public class LibraryCardDaaAuditMapper implements RowMapper<LibraryCardDaaAudit>, RowMapperHelper {
+  @Override
+  public LibraryCardDaaAudit map(ResultSet rs, StatementContext ctx) throws SQLException {
+    int lcId = hasColumn(rs, "lc_id") ? rs.getInt("lc_id") : 0;
+    return new LibraryCardDaaAudit(
+        rs.getLong("id"),
+        rs.getInt("daa_id"),
+        lcId > 0 ? lcId : null,
+        rs.getInt("user_id"),
+        AuditActions.valueOf(rs.getString("action").toUpperCase()),
+        rs.getTimestamp("action_date").toInstant());
+  }
+}

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/LibraryCardDaaAuditMapper.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/LibraryCardDaaAuditMapper.java
@@ -14,7 +14,7 @@ public class LibraryCardDaaAuditMapper implements RowMapper<LibraryCardDaaAudit>
     return new LibraryCardDaaAudit(
         rs.getLong("id"),
         rs.getInt("daa_id"),
-        lcId,
+        lcId > 0 ? lcId : null,
         rs.getInt("lc_user_id"),
         rs.getInt("user_id"),
         AuditActions.valueOf(rs.getString("action").toUpperCase()),

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/LibraryCardDaaAuditMapper.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/LibraryCardDaaAuditMapper.java
@@ -14,7 +14,8 @@ public class LibraryCardDaaAuditMapper implements RowMapper<LibraryCardDaaAudit>
     return new LibraryCardDaaAudit(
         rs.getLong("id"),
         rs.getInt("daa_id"),
-        lcId > 0 ? lcId : null,
+        lcId,
+        rs.getInt("lc_user_id"),
         rs.getInt("user_id"),
         AuditActions.valueOf(rs.getString("action").toUpperCase()),
         rs.getTimestamp("action_date").toInstant());

--- a/src/main/java/org/broadinstitute/consent/http/models/LibraryCardDaaAudit.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/LibraryCardDaaAudit.java
@@ -3,10 +3,20 @@ package org.broadinstitute.consent.http.models;
 import java.time.Instant;
 import org.broadinstitute.consent.http.enumeration.AuditActions;
 
+/**
+ * @param id The audit ID
+ * @param daaId The Data Access Agreement ID
+ * @param lcId The Library Card ID
+ * @param lcUserId The Library Card User ID (the user associated with the library card at the time of the audit action)
+ * @param userId The User ID who initiated the action
+ * @param action The action performed (e.g., ADD, REMOVE)
+ * @param actionDate The action date
+ */
 public record LibraryCardDaaAudit(
     Long id,
     Integer daaId,
     Integer lcId,
+    Integer lcUserId,
     Integer userId,
     AuditActions action,
     Instant actionDate) {}

--- a/src/main/java/org/broadinstitute/consent/http/models/LibraryCardDaaAudit.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/LibraryCardDaaAudit.java
@@ -1,0 +1,12 @@
+package org.broadinstitute.consent.http.models;
+
+import java.time.Instant;
+import org.broadinstitute.consent.http.enumeration.AuditActions;
+
+public record LibraryCardDaaAudit(
+    Long id,
+    Integer daaId,
+    Integer lcId,
+    Integer userId,
+    AuditActions action,
+    Instant actionDate) {}

--- a/src/main/java/org/broadinstitute/consent/http/models/LibraryCardDaaAudit.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/LibraryCardDaaAudit.java
@@ -7,7 +7,8 @@ import org.broadinstitute.consent.http.enumeration.AuditActions;
  * @param id The audit ID
  * @param daaId The Data Access Agreement ID
  * @param lcId The Library Card ID
- * @param lcUserId The Library Card User ID (the user associated with the library card at the time of the audit action)
+ * @param lcUserId The Library Card User ID (the user associated with the library card at the time
+ *     of the audit action)
  * @param userId The User ID who initiated the action
  * @param action The action performed (e.g., ADD, REMOVE)
  * @param actionDate The action date

--- a/src/main/java/org/broadinstitute/consent/http/resources/DaaResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DaaResource.java
@@ -126,7 +126,8 @@ public class DaaResource extends Resource implements ConsentLogger {
           user.getLibraryCard() == null
               ? libraryCardService.createLibraryCardForSigningOfficial(user, authedUser)
               : user.getLibraryCard();
-      libraryCardService.addDaaToLibraryCard(authedUser.getUserId(), libraryCard.getId(), daaId);
+      libraryCardService.addDaaToLibraryCard(
+          user.getUserId(), authedUser.getUserId(), libraryCard.getId(), daaId);
       URI uri =
           info.getBaseUriBuilder()
               .replacePath("api/libraryCards/{libraryCardId}")
@@ -195,7 +196,7 @@ public class DaaResource extends Resource implements ConsentLogger {
       }
       if (user.getLibraryCard() != null) {
         libraryCardService.removeDaaFromLibraryCard(
-            authedUser.getUserId(), user.getLibraryCard().getId(), daaId);
+            user.getUserId(), authedUser.getUserId(), user.getLibraryCard().getId(), daaId);
       }
       return Response.ok().build();
     } catch (Exception e) {
@@ -243,7 +244,7 @@ public class DaaResource extends Resource implements ConsentLogger {
       }
       daaService.findById(daaId);
       for (User user : users) {
-        libraryCardService.removeDaaFromUserLibraryCard(user, daaId);
+        libraryCardService.removeDaaFromUserLibraryCard(user, authedUser, daaId);
       }
       return Response.ok().build();
     } catch (Exception e) {
@@ -287,7 +288,7 @@ public class DaaResource extends Resource implements ConsentLogger {
       }
       List<DataAccessAgreement> daaList = daaService.findDAAsInJsonArray(json, "daaList");
       for (DataAccessAgreement daa : daaList) {
-        libraryCardService.removeDaaFromUserLibraryCard(user, daa.getDaaId());
+        libraryCardService.removeDaaFromUserLibraryCard(user, authedUser, daa.getDaaId());
       }
       return Response.ok().build();
     } catch (Exception e) {

--- a/src/main/java/org/broadinstitute/consent/http/resources/DaaResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DaaResource.java
@@ -128,11 +128,13 @@ public class DaaResource extends Resource implements ConsentLogger {
               : user.getLibraryCard();
       libraryCardService.addDaaToLibraryCard(
           user.getUserId(), authedUser.getUserId(), libraryCard.getId(), daaId);
+      LibraryCard updatedLibraryCard =
+          libraryCardService.findLibraryCardWithDaasById(libraryCard.getId());
       URI uri =
           info.getBaseUriBuilder()
               .replacePath("api/libraryCards/{libraryCardId}")
               .build(libraryCard.getId());
-      return Response.ok().location(uri).entity(libraryCard).build();
+      return Response.ok().location(uri).entity(updatedLibraryCard).build();
     } catch (Exception e) {
       return createExceptionResponse(e);
     }

--- a/src/main/java/org/broadinstitute/consent/http/resources/DaaResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DaaResource.java
@@ -126,7 +126,7 @@ public class DaaResource extends Resource implements ConsentLogger {
           user.getLibraryCard() == null
               ? libraryCardService.createLibraryCardForSigningOfficial(user, authedUser)
               : user.getLibraryCard();
-      libraryCardService.addDaaToLibraryCard(libraryCard.getId(), daaId);
+      libraryCardService.addDaaToLibraryCard(user.getUserId(), libraryCard.getId(), daaId);
       URI uri =
           info.getBaseUriBuilder()
               .replacePath("api/libraryCards/{libraryCardId}")
@@ -194,7 +194,8 @@ public class DaaResource extends Resource implements ConsentLogger {
         return Response.status(Status.FORBIDDEN).build();
       }
       if (user.getLibraryCard() != null) {
-        libraryCardService.removeDaaFromLibraryCard(user.getLibraryCard().getId(), daaId);
+        libraryCardService.removeDaaFromLibraryCard(
+            user.getUserId(), user.getLibraryCard().getId(), daaId);
       }
       return Response.ok().build();
     } catch (Exception e) {

--- a/src/main/java/org/broadinstitute/consent/http/resources/DaaResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DaaResource.java
@@ -126,7 +126,7 @@ public class DaaResource extends Resource implements ConsentLogger {
           user.getLibraryCard() == null
               ? libraryCardService.createLibraryCardForSigningOfficial(user, authedUser)
               : user.getLibraryCard();
-      libraryCardService.addDaaToLibraryCard(user.getUserId(), libraryCard.getId(), daaId);
+      libraryCardService.addDaaToLibraryCard(authedUser.getUserId(), libraryCard.getId(), daaId);
       URI uri =
           info.getBaseUriBuilder()
               .replacePath("api/libraryCards/{libraryCardId}")
@@ -195,7 +195,7 @@ public class DaaResource extends Resource implements ConsentLogger {
       }
       if (user.getLibraryCard() != null) {
         libraryCardService.removeDaaFromLibraryCard(
-            user.getUserId(), user.getLibraryCard().getId(), daaId);
+            authedUser.getUserId(), user.getLibraryCard().getId(), daaId);
       }
       return Response.ok().build();
     } catch (Exception e) {

--- a/src/main/java/org/broadinstitute/consent/http/resources/LibraryCardResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/LibraryCardResource.java
@@ -13,14 +13,17 @@ import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import java.util.List;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
-import org.broadinstitute.consent.http.models.AuthUser;
+import org.broadinstitute.consent.http.models.DuosUser;
 import org.broadinstitute.consent.http.models.LibraryCard;
+import org.broadinstitute.consent.http.models.LibraryCardDaaAudit;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.service.LibraryCardService;
 import org.broadinstitute.consent.http.service.UserService;
+import org.broadinstitute.consent.http.service.feature.InstitutionAndLibraryCardEnforcement;
 import org.broadinstitute.consent.http.util.gson.GsonUtil;
 
 @Path("api/libraryCards")
@@ -28,17 +31,22 @@ public class LibraryCardResource extends Resource {
 
   private final UserService userService;
   private final LibraryCardService libraryCardService;
+  private final InstitutionAndLibraryCardEnforcement institutionAndLibraryCardEnforcement;
 
   @Inject
-  public LibraryCardResource(UserService userService, LibraryCardService libraryCardService) {
+  public LibraryCardResource(
+      UserService userService,
+      LibraryCardService libraryCardService,
+      InstitutionAndLibraryCardEnforcement institutionAndLibraryCardEnforcement) {
     this.userService = userService;
     this.libraryCardService = libraryCardService;
+    this.institutionAndLibraryCardEnforcement = institutionAndLibraryCardEnforcement;
   }
 
   @GET
-  @Produces("application/json")
+  @Produces(MediaType.APPLICATION_JSON)
   @RolesAllowed(ADMIN)
-  public Response getLibraryCards(@Auth AuthUser authUser) {
+  public Response getLibraryCards(@SuppressWarnings("unused") @Auth DuosUser duosUser) {
     try {
       List<LibraryCard> libraryCards = libraryCardService.findAllLibraryCards();
       return Response.ok().entity(libraryCards).build();
@@ -48,10 +56,11 @@ public class LibraryCardResource extends Resource {
   }
 
   @GET
-  @Produces("application/json")
+  @Produces(MediaType.APPLICATION_JSON)
   @Path("/{id}")
   @RolesAllowed(ADMIN)
-  public Response getLibraryCardById(@Auth AuthUser authUser, @PathParam("id") Integer id) {
+  public Response getLibraryCardById(
+      @SuppressWarnings("unused") @Auth DuosUser duosUser, @PathParam("id") Integer id) {
     try {
       LibraryCard libraryCard = libraryCardService.findLibraryCardById(id);
       return Response.ok().entity(libraryCard).build();
@@ -61,11 +70,11 @@ public class LibraryCardResource extends Resource {
   }
 
   @GET
-  @Produces("application/json")
+  @Produces(MediaType.APPLICATION_JSON)
   @Path("/institution/{id}")
   @RolesAllowed({ADMIN})
   public Response getLibraryCardsByInstitutionId(
-      @Auth AuthUser authUser, @PathParam("id") Integer id) {
+      @SuppressWarnings("unused") @Auth DuosUser duosUser, @PathParam("id") Integer id) {
     try {
       List<LibraryCard> libraryCards = libraryCardService.findLibraryCardsByInstitutionId(id);
       return Response.ok().entity(libraryCards).build();
@@ -75,12 +84,12 @@ public class LibraryCardResource extends Resource {
   }
 
   @POST
-  @Consumes("application/json")
-  @Produces("application/json")
+  @Consumes(MediaType.APPLICATION_JSON)
+  @Produces(MediaType.APPLICATION_JSON)
   @RolesAllowed({SIGNINGOFFICIAL})
-  public Response createLibraryCard(@Auth AuthUser authUser, String libraryCard) {
+  public Response createLibraryCard(@Auth DuosUser duosUser, String libraryCard) {
     try {
-      User user = userService.findUserByEmail(authUser.getEmail());
+      User user = duosUser.getUser();
       LibraryCard payload = GsonUtil.getInstance().fromJson(libraryCard, LibraryCard.class);
       payload.setCreateUserId(user.getUserId());
       LibraryCard newLibraryCard = libraryCardService.createLibraryCard(payload, user);
@@ -91,11 +100,11 @@ public class LibraryCardResource extends Resource {
   }
 
   @DELETE
-  @Produces("application/json")
+  @Produces(MediaType.APPLICATION_JSON)
   @Path("/{id}")
   @RolesAllowed({ADMIN, SIGNINGOFFICIAL})
-  public Response deleteLibraryCard(@Auth AuthUser authUser, @PathParam("id") Integer id) {
-    User user = userService.findUserByEmail(authUser.getEmail());
+  public Response deleteLibraryCard(@Auth DuosUser duosUser, @PathParam("id") Integer id) {
+    User user = duosUser.getUser();
     LibraryCard card = libraryCardService.findLibraryCardById(id);
     User lcUser = null;
     try {
@@ -112,6 +121,27 @@ public class LibraryCardResource extends Resource {
       }
       libraryCardService.deleteLibraryCardById(id);
       return Response.status(204).build();
+    } catch (Exception e) {
+      return createExceptionResponse(e);
+    }
+  }
+
+  @GET
+  @Produces(MediaType.APPLICATION_JSON)
+  @Path("history/{userId}")
+  @RolesAllowed({ADMIN, SIGNINGOFFICIAL})
+  public Response findLibraryCardDaaAuditsByUserId(
+      @Auth DuosUser duosUser, @PathParam("userId") Integer userId) {
+    try {
+      User libraryCardUser = userService.findUserById(userId);
+      User authedUser = duosUser.getUser();
+      if (!checkIsAdmin(authedUser)) {
+        institutionAndLibraryCardEnforcement.validateEmailsFromSameInstitution(
+            authedUser.getEmail(), libraryCardUser.getEmail());
+      }
+      List<LibraryCardDaaAudit> audits =
+          libraryCardService.findLibraryCardDaaAuditsByUserId(userId);
+      return Response.ok().entity(audits).build();
     } catch (Exception e) {
       return createExceptionResponse(e);
     }

--- a/src/main/java/org/broadinstitute/consent/http/resources/LibraryCardResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/LibraryCardResource.java
@@ -128,7 +128,7 @@ public class LibraryCardResource extends Resource {
 
   @GET
   @Produces(MediaType.APPLICATION_JSON)
-  @Path("history/{userId}")
+  @Path("/history/{userId}")
   @RolesAllowed({ADMIN, SIGNINGOFFICIAL})
   public Response findLibraryCardDaaAuditsByUserId(
       @Auth DuosUser duosUser, @PathParam("userId") Integer userId) {

--- a/src/main/java/org/broadinstitute/consent/http/service/LibraryCardService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/LibraryCardService.java
@@ -8,10 +8,12 @@ import java.io.IOException;
 import java.util.Date;
 import java.util.List;
 import java.util.Objects;
+import org.broadinstitute.consent.http.db.DaaDAO;
 import org.broadinstitute.consent.http.db.InstitutionDAO;
 import org.broadinstitute.consent.http.db.LibraryCardDAO;
 import org.broadinstitute.consent.http.db.UserDAO;
 import org.broadinstitute.consent.http.exceptions.ConsentConflictException;
+import org.broadinstitute.consent.http.models.DataAccessAgreement;
 import org.broadinstitute.consent.http.models.Institution;
 import org.broadinstitute.consent.http.models.LibraryCard;
 import org.broadinstitute.consent.http.models.LibraryCardDaaAudit;
@@ -20,6 +22,7 @@ import org.broadinstitute.consent.http.util.ConsentLogger;
 
 public class LibraryCardService implements ConsentLogger {
 
+  private final DaaDAO daaDAO;
   private final LibraryCardDAO libraryCardDAO;
   private final InstitutionDAO institutionDAO;
   private final InstitutionService institutionService;
@@ -28,11 +31,13 @@ public class LibraryCardService implements ConsentLogger {
 
   @Inject
   public LibraryCardService(
+      DaaDAO daaDAO,
       LibraryCardDAO libraryCardDAO,
       InstitutionDAO institutionDAO,
       InstitutionService institutionService,
       UserDAO userDAO,
       EmailService emailService) {
+    this.daaDAO = daaDAO;
     this.libraryCardDAO = libraryCardDAO;
     this.institutionDAO = institutionDAO;
     this.institutionService = institutionService;
@@ -97,6 +102,18 @@ public class LibraryCardService implements ConsentLogger {
 
   public void addDaaToLibraryCard(
       Integer lcUserId, Integer userId, Integer libraryCardId, Integer daaId) {
+    User lcUser = userDAO.findUserById(lcUserId);
+    if (lcUser == null) {
+      throw new NotFoundException("User with id " + lcUserId + " not found");
+    }
+    LibraryCard lc = libraryCardDAO.findLibraryCardById(libraryCardId);
+    if (lc == null) {
+      throw new NotFoundException("Library card with id " + libraryCardId + " not found");
+    }
+    DataAccessAgreement daa = daaDAO.findById(daaId);
+    if (daa == null) {
+      throw new NotFoundException("Data Access Agreeement id " + daaId + " not found");
+    }
     libraryCardDAO.createLibraryCardDaaRelation(lcUserId, userId, libraryCardId, daaId);
   }
 

--- a/src/main/java/org/broadinstitute/consent/http/service/LibraryCardService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/LibraryCardService.java
@@ -171,7 +171,7 @@ public class LibraryCardService implements ConsentLogger {
 
   // helper method for create method, checks to see if card already exists
   private void checkIfCardExists(LibraryCard payload) {
-    LibraryCard result = null;
+    LibraryCard result;
 
     if (payload.getUserId() != null) {
       result = libraryCardDAO.findLibraryCardByUserId(payload.getUserId());

--- a/src/main/java/org/broadinstitute/consent/http/service/LibraryCardService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/LibraryCardService.java
@@ -14,6 +14,7 @@ import org.broadinstitute.consent.http.db.UserDAO;
 import org.broadinstitute.consent.http.exceptions.ConsentConflictException;
 import org.broadinstitute.consent.http.models.Institution;
 import org.broadinstitute.consent.http.models.LibraryCard;
+import org.broadinstitute.consent.http.models.LibraryCardDaaAudit;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.util.ConsentLogger;
 
@@ -130,6 +131,10 @@ public class LibraryCardService implements ConsentLogger {
     lc.setUserEmail(user.getEmail());
     lc.setCreateUserId(signingOfficial.getUserId());
     return createLibraryCard(lc, user);
+  }
+
+  public List<LibraryCardDaaAudit> findLibraryCardDaaAuditsByUserId(Integer userId) {
+    return libraryCardDAO.findAuditsByLcUserId(userId);
   }
 
   private void checkForValidInstitution(Integer institutionId, String userEmail) {

--- a/src/main/java/org/broadinstitute/consent/http/service/LibraryCardService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/LibraryCardService.java
@@ -95,12 +95,14 @@ public class LibraryCardService implements ConsentLogger {
     return libraryCard;
   }
 
-  public void addDaaToLibraryCard(Integer userId, Integer libraryCardId, Integer daaId) {
-    libraryCardDAO.createLibraryCardDaaRelation(userId, libraryCardId, daaId);
+  public void addDaaToLibraryCard(
+      Integer lcUserId, Integer userId, Integer libraryCardId, Integer daaId) {
+    libraryCardDAO.createLibraryCardDaaRelation(lcUserId, userId, libraryCardId, daaId);
   }
 
-  public void removeDaaFromLibraryCard(Integer userId, Integer libraryCardId, Integer daaId) {
-    libraryCardDAO.deleteLibraryCardDaaRelation(userId, libraryCardId, daaId);
+  public void removeDaaFromLibraryCard(
+      Integer lcUserId, Integer userId, Integer libraryCardId, Integer daaId) {
+    libraryCardDAO.deleteLibraryCardDaaRelation(lcUserId, userId, libraryCardId, daaId);
   }
 
   public LibraryCard addDaaToUserLibraryCard(User user, User signingOfficial, Integer daaId) {
@@ -111,17 +113,19 @@ public class LibraryCardService implements ConsentLogger {
     if (libraryCard == null) {
       libraryCard = createLibraryCardForSigningOfficial(user, signingOfficial);
     }
-    addDaaToLibraryCard(user.getUserId(), libraryCard.getId(), daaId);
+    addDaaToLibraryCard(user.getUserId(), signingOfficial.getUserId(), libraryCard.getId(), daaId);
     return libraryCardDAO.findLibraryCardByUserId(user.getUserId());
   }
 
-  public LibraryCard removeDaaFromUserLibraryCard(User user, Integer daaId) {
-    LibraryCard libraryCard = findLibraryCardByUserId(user.getUserId());
+  public LibraryCard removeDaaFromUserLibraryCard(
+      User lcUser, User signingOfficial, Integer daaId) {
+    LibraryCard libraryCard = findLibraryCardByUserId(lcUser.getUserId());
     // typically there should be one library card per user
     if (libraryCard != null) {
-      removeDaaFromLibraryCard(user.getUserId(), libraryCard.getId(), daaId);
+      removeDaaFromLibraryCard(
+          lcUser.getUserId(), signingOfficial.getUserId(), libraryCard.getId(), daaId);
     }
-    return findLibraryCardByUserId(user.getUserId());
+    return findLibraryCardByUserId(lcUser.getUserId());
   }
 
   public LibraryCard createLibraryCardForSigningOfficial(User user, User signingOfficial) {

--- a/src/main/java/org/broadinstitute/consent/http/service/LibraryCardService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/LibraryCardService.java
@@ -94,12 +94,12 @@ public class LibraryCardService implements ConsentLogger {
     return libraryCard;
   }
 
-  public void addDaaToLibraryCard(Integer libraryCardId, Integer daaId) {
-    libraryCardDAO.createLibraryCardDaaRelation(libraryCardId, daaId);
+  public void addDaaToLibraryCard(Integer userId, Integer libraryCardId, Integer daaId) {
+    libraryCardDAO.createLibraryCardDaaRelation(userId, libraryCardId, daaId);
   }
 
-  public void removeDaaFromLibraryCard(Integer libraryCardId, Integer daaId) {
-    libraryCardDAO.deleteLibraryCardDaaRelation(libraryCardId, daaId);
+  public void removeDaaFromLibraryCard(Integer userId, Integer libraryCardId, Integer daaId) {
+    libraryCardDAO.deleteLibraryCardDaaRelation(userId, libraryCardId, daaId);
   }
 
   public LibraryCard addDaaToUserLibraryCard(User user, User signingOfficial, Integer daaId) {
@@ -110,7 +110,7 @@ public class LibraryCardService implements ConsentLogger {
     if (libraryCard == null) {
       libraryCard = createLibraryCardForSigningOfficial(user, signingOfficial);
     }
-    addDaaToLibraryCard(libraryCard.getId(), daaId);
+    addDaaToLibraryCard(user.getUserId(), libraryCard.getId(), daaId);
     return libraryCardDAO.findLibraryCardByUserId(user.getUserId());
   }
 
@@ -118,7 +118,7 @@ public class LibraryCardService implements ConsentLogger {
     LibraryCard libraryCard = findLibraryCardByUserId(user.getUserId());
     // typically there should be one library card per user
     if (libraryCard != null) {
-      removeDaaFromLibraryCard(libraryCard.getId(), daaId);
+      removeDaaFromLibraryCard(user.getUserId(), libraryCard.getId(), daaId);
     }
     return findLibraryCardByUserId(user.getUserId());
   }
@@ -129,8 +129,7 @@ public class LibraryCardService implements ConsentLogger {
     lc.setUserName(user.getDisplayName());
     lc.setUserEmail(user.getEmail());
     lc.setCreateUserId(signingOfficial.getUserId());
-    LibraryCard createdLc = createLibraryCard(lc, user);
-    return createdLc;
+    return createLibraryCard(lc, user);
   }
 
   private void checkForValidInstitution(Integer institutionId, String userEmail) {

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -682,6 +682,8 @@ paths:
           description: Institution not found
         500:
           description: Internal server error
+  /api/libraryCards/history/{userId}:
+    $ref: './paths/libraryCardHistoryByUserId.yaml'
   /api/match/reprocess/purpose/{purposeId}:
     post:
       summary: Process all matches for this research purpose (DAR) id

--- a/src/main/resources/assets/paths/daaForUserId.yaml
+++ b/src/main/resources/assets/paths/daaForUserId.yaml
@@ -57,6 +57,6 @@ put:
     403:
       description: User not authorized to create a relationship between a DAA and a User.
     404:
-      description: Data Access Agreement or Library Card Not Found
+      description: User, Data Access Agreement, or Library Card Not Found
     500:
       description: Internal Server Error

--- a/src/main/resources/assets/paths/libraryCardHistoryByUserId.yaml
+++ b/src/main/resources/assets/paths/libraryCardHistoryByUserId.yaml
@@ -1,0 +1,24 @@
+get:
+  description: | 
+    Fetches all library card history records for a given user ID.
+    Admins can see all details of the library card history records.
+    Signing Officials will only see records for users in their institution.
+  tags:
+    - Library Card
+    - Admin
+  parameters:
+    - name: userId
+      in: path
+      description: The User ID of the user whose library card history is being requested.
+      required: true
+      schema:
+        type: integer
+  responses:
+    200:
+      description: Returns all library card history records for the specified user ID. If no records are found, an empty array is returned.
+    400:
+      description: Bad Request - Invalid user ID provided.
+    403:
+      description: Forbidden - The requester does not have permission to access this resource.
+    404:
+      description: Not Found - User not found

--- a/src/main/resources/assets/paths/libraryCardHistoryByUserId.yaml
+++ b/src/main/resources/assets/paths/libraryCardHistoryByUserId.yaml
@@ -19,7 +19,9 @@ get:
       content:
         application/json:
           schema:
-            $ref: '../schemas/FeatureFlag.yaml'
+            type: array
+            items:
+              $ref: '../schemas/LibraryCardDaaAudit.yaml'
     400:
       description: Bad Request - Invalid user ID provided.
     403:

--- a/src/main/resources/assets/paths/libraryCardHistoryByUserId.yaml
+++ b/src/main/resources/assets/paths/libraryCardHistoryByUserId.yaml
@@ -22,3 +22,5 @@ get:
       description: Forbidden - The requester does not have permission to access this resource.
     404:
       description: Not Found - User not found
+    500:
+      description: Internal Server Error - An error occurred while processing the request.

--- a/src/main/resources/assets/paths/libraryCardHistoryByUserId.yaml
+++ b/src/main/resources/assets/paths/libraryCardHistoryByUserId.yaml
@@ -16,6 +16,10 @@ get:
   responses:
     200:
       description: Returns all library card history records for the specified user ID. If no records are found, an empty array is returned.
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/FeatureFlag.yaml'
     400:
       description: Bad Request - Invalid user ID provided.
     403:

--- a/src/main/resources/assets/schemas/LibraryCardDaaAudit.yaml
+++ b/src/main/resources/assets/schemas/LibraryCardDaaAudit.yaml
@@ -1,0 +1,39 @@
+type: object
+description: An audit record representing a DAA association or removal event on a Library Card.
+properties:
+  id:
+    type: integer
+    format: int64
+    description: The audit record ID.
+  daaId:
+    type: integer
+    description: The ID of the Data Access Agreement involved in the action.
+  lcId:
+    type: integer
+    nullable: true
+    description: The ID of the Library Card. May be null if the library card has since been deleted.
+  lcUserId:
+    type: integer
+    nullable: true
+    description: The ID of the user associated with the library card at the time of the audit action.
+  userId:
+    type: integer
+    description: The ID of the user who initiated the action (e.g., the Signing Official).
+  action:
+    type: string
+    enum:
+      - ADD
+      - REMOVE
+    description: The action performed on the library card DAA relationship.
+  actionDate:
+    type: integer
+    description: The UTC epoch time this action was created.
+example:
+  id: 1
+  daaId: 10
+  lcId: 5
+  lcUserId: 42
+  userId: 7
+  action: ADD
+  actionDate: 1775312038006
+

--- a/src/main/resources/changelog-master.xml
+++ b/src/main/resources/changelog-master.xml
@@ -241,4 +241,5 @@
   <include file="changesets/changelog-consent-2026-03-05-user-id-fks.xml" relativeToChangelogFile="true" />
   <include file="changesets/changelog-consent-2026-03-25-users-data.xml" relativeToChangelogFile="true" />
   <include file="changesets/changelog-consent-2026-03-31-daa-audit.xml" relativeToChangelogFile="true" />
+  <include file="changesets/changelog-consent-2026-04-03-lc-daa-audit.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/src/main/resources/changesets/changelog-consent-2026-04-03-lc-daa-audit.xml
+++ b/src/main/resources/changesets/changelog-consent-2026-04-03-lc-daa-audit.xml
@@ -15,6 +15,11 @@
         Note that library cards are deletable so nullable is true here.
        -->
       <column name="lc_id" type="bigint"/>
+      <!-- user who the audit action affects -->
+      <column name="lc_user_id" type="bigint">
+        <constraints nullable="false"/>
+      </column>
+      <!-- user who initiated the audit action -->
       <column name="user_id" type="bigint">
         <constraints nullable="false"/>
       </column>
@@ -42,6 +47,10 @@
       baseTableName="lc_daa_audit" baseColumnNames="daa_id"
       constraintName="fk_lc_daa_audit_daa_id"
       referencedTableName="data_access_agreement" referencedColumnNames="daa_id"/>
+    <addForeignKeyConstraint
+      baseTableName="lc_daa_audit" baseColumnNames="lc_user_id"
+      constraintName="fk_lc_daa_audit_lc_user_id"
+      referencedTableName="users" referencedColumnNames="user_id"/>
     <addForeignKeyConstraint
       baseTableName="lc_daa_audit" baseColumnNames="user_id"
       constraintName="fk_lc_daa_audit_user_id"

--- a/src/main/resources/changesets/changelog-consent-2026-04-03-lc-daa-audit.xml
+++ b/src/main/resources/changesets/changelog-consent-2026-04-03-lc-daa-audit.xml
@@ -3,7 +3,7 @@
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                    https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.33.xsd">
-  <changeSet id="changelog-consent-2026-03-31-daa-audit" author="grushton">
+  <changeSet id="changelog-consent-2026-04-03-lc-daa-audit" author="grushton">
     <createTable tableName="lc_daa_audit">
       <column name="id" type="bigint" autoIncrement="true">
         <constraints primaryKey="true" nullable="false"/>

--- a/src/main/resources/changesets/changelog-consent-2026-04-03-lc-daa-audit.xml
+++ b/src/main/resources/changesets/changelog-consent-2026-04-03-lc-daa-audit.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.33.xsd">
+  <changeSet id="changelog-consent-2026-03-31-daa-audit" author="grushton">
+    <createTable tableName="lc_daa_audit">
+      <column name="id" type="bigint" autoIncrement="true">
+        <constraints primaryKey="true" nullable="false"/>
+      </column>
+      <column name="daa_id" type="bigint">
+        <constraints nullable="false"/>
+      </column>
+      <!--
+        Note that library cards are deletable so nullable is true here.
+       -->
+      <column name="lc_id" type="bigint"/>
+      <column name="user_id" type="bigint">
+        <constraints nullable="false"/>
+      </column>
+      <column name="action" type="varchar(255)">
+        <constraints nullable="false"/>
+      </column>
+      <column name="action_date" type="timestamp" defaultValueDate="current_timestamp">
+        <constraints nullable="false"/>
+      </column>
+    </createTable>
+    <createIndex indexName="idx_lc_daa_audit_daa_id_and_action_date_descending"
+                 tableName="lc_daa_audit">
+      <column name="daa_id"/>
+      <column name="action_date" descending="true"/>
+    </createIndex>
+    <createIndex indexName="idx_lc_daa_audit_lc_id_and_action_date_descending"
+                 tableName="lc_daa_audit">
+      <column name="lc_id"/>
+      <column name="action_date" descending="true"/>
+    </createIndex>
+    <!--
+      Note that we are not including a FK to the LC table since library cards are deletable
+     -->
+    <addForeignKeyConstraint
+      baseTableName="lc_daa_audit" baseColumnNames="daa_id"
+      constraintName="fk_lc_daa_audit_daa_id"
+      referencedTableName="data_access_agreement" referencedColumnNames="daa_id"/>
+    <addForeignKeyConstraint
+      baseTableName="lc_daa_audit" baseColumnNames="user_id"
+      constraintName="fk_lc_daa_audit_user_id"
+      referencedTableName="users" referencedColumnNames="user_id"/>
+  </changeSet>
+</databaseChangeLog>

--- a/src/test/java/org/broadinstitute/consent/http/db/DaaDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DaaDAOTest.java
@@ -299,7 +299,7 @@ class DaaDAOTest extends DAOTestHelper {
     // Associate the DAC to the Data Access Agreeement:
     daaDAO.createDacDaaRelation(dac1.getDacId(), daa.getDaaId(), user.getUserId());
     // Associate the user's Library Card to the Data Access Agreement:
-    libraryCardDAO.createLibraryCardDaaRelation(lc.getId(), daa.getDaaId());
+    libraryCardDAO.createLibraryCardDaaRelation(lc.getUserId(), lc.getId(), daa.getDaaId());
     // Create two datasets associated to the DAC and DAA
     Dataset dataset1 = createRandomDataset(user, dac1);
     Dataset dataset2 = createRandomDataset(user, dac1);

--- a/src/test/java/org/broadinstitute/consent/http/db/DaaDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DaaDAOTest.java
@@ -292,6 +292,7 @@ class DaaDAOTest extends DAOTestHelper {
     // Testing the case of a user requesting DAR access to a dataset.
     // That user must have an LC with a DAA associated to the same DAC that the dataset is
     // associated to.
+    User signingOfficial = createUser();
     User user = createUserWithInstitution();
     LibraryCard lc = createRandomLibraryCard(user);
     Dac dac1 = createRandomDac();
@@ -300,7 +301,8 @@ class DaaDAOTest extends DAOTestHelper {
     // Associate the DAC to the Data Access Agreeement:
     daaDAO.createDacDaaRelation(dac1.getDacId(), daa.getDaaId(), user.getUserId());
     // Associate the user's Library Card to the Data Access Agreement:
-    libraryCardDAO.createLibraryCardDaaRelation(lc.getUserId(), lc.getId(), daa.getDaaId());
+    libraryCardDAO.createLibraryCardDaaRelation(
+        lc.getUserId(), signingOfficial.getUserId(), lc.getId(), daa.getDaaId());
     // Create two datasets associated to the DAC and DAA
     Dataset dataset1 = createRandomDataset(user, dac1);
     Dataset dataset2 = createRandomDataset(user, dac1);

--- a/src/test/java/org/broadinstitute/consent/http/db/LibraryCardDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/LibraryCardDAOTest.java
@@ -120,13 +120,15 @@ class LibraryCardDAOTest extends DAOTestHelper {
     // 3. DAA so we can link it to a user's Library Card
     // 4. Library Card <-> DAA relationship that represents a Signing Official's acceptance of a DAA
     // for the user
+    User signingOfficial = createUser();
     LibraryCard card = createLibraryCard();
     int dacId = dacDAO.createDac(randomAlphabetic(10), randomAlphabetic(10), new Date());
     int daaId =
         daaDAO.createDaa(
             card.getCreateUserId(), Instant.now(), card.getCreateUserId(), Instant.now(), dacId);
     daaDAO.createDacDaaRelation(dacId, daaId, card.getUserId());
-    libraryCardDAO.createLibraryCardDaaRelation(card.getUserId(), card.getId(), daaId);
+    libraryCardDAO.createLibraryCardDaaRelation(
+        card.getUserId(), signingOfficial.getUserId(), card.getId(), daaId);
 
     libraryCardDAO.deleteLibraryCardById(card.getId());
     assertNull(libraryCardDAO.findLibraryCardById(card.getId()));
@@ -152,6 +154,7 @@ class LibraryCardDAOTest extends DAOTestHelper {
 
   @Test
   void testFindLibraryCardDaaByIdMultipleDaas() {
+    User signingOfficial = createUser();
     LibraryCard card = createLibraryCard();
     Integer userId = createUser().getUserId();
     Integer dacId = dacDAO.createDac(randomAlphabetic(5), randomAlphabetic(5), "", new Date());
@@ -163,8 +166,10 @@ class LibraryCardDAOTest extends DAOTestHelper {
     card.addDaa(daa2.getDaaId());
     card.addDaaObject(daa1);
     card.addDaaObject(daa2);
-    libraryCardDAO.createLibraryCardDaaRelation(card.getUserId(), card.getId(), daaId1);
-    libraryCardDAO.createLibraryCardDaaRelation(card.getUserId(), card.getId(), daaId2);
+    libraryCardDAO.createLibraryCardDaaRelation(
+        card.getUserId(), signingOfficial.getUserId(), card.getId(), daaId1);
+    libraryCardDAO.createLibraryCardDaaRelation(
+        card.getUserId(), signingOfficial.getUserId(), card.getId(), daaId2);
     Integer id = card.getId();
     LibraryCard cardFromDAO = libraryCardDAO.findLibraryCardDaaById(id);
 
@@ -232,6 +237,7 @@ class LibraryCardDAOTest extends DAOTestHelper {
 
   @Test
   void testFindLibraryCardByUserIdInstitutionId() {
+    User signingOfficial = createUser();
     LibraryCard libraryCard = createLibraryCard();
     int dacId =
         dacDAO.createDac(randomAlphabetic(5), randomAlphabetic(5), randomAlphabetic(5), new Date());
@@ -239,7 +245,7 @@ class LibraryCardDAOTest extends DAOTestHelper {
     int daaId = daaDAO.createDaa(libraryCard.getUserId(), now, libraryCard.getUserId(), now, dacId);
     daaDAO.createDacDaaRelation(dacId, daaId, libraryCard.getUserId());
     libraryCardDAO.createLibraryCardDaaRelation(
-        libraryCard.getUserId(), libraryCard.getId(), daaId);
+        libraryCard.getUserId(), signingOfficial.getUserId(), libraryCard.getId(), daaId);
     LibraryCard cardFromDAO = libraryCardDAO.findLibraryCardByUserId(libraryCard.getUserId());
     assertNotNull(cardFromDAO);
     assertEquals(cardFromDAO, libraryCard);
@@ -284,6 +290,7 @@ class LibraryCardDAOTest extends DAOTestHelper {
 
   @Test
   void testCreateLibraryCardDaaAssociation() {
+    User signingOfficial = createUser();
     User user = createUser();
     User user2 = createUser();
     LibraryCard card = createLibraryCard(user);
@@ -293,9 +300,12 @@ class LibraryCardDAOTest extends DAOTestHelper {
     Integer dacId2 = dacDAO.createDac(randomAlphabetic(5), randomAlphabetic(5), "", new Date());
     Integer daaId1 = daaDAO.createDaa(userId, Instant.now(), userId, Instant.now(), dacId);
     Integer daaId2 = daaDAO.createDaa(userId, Instant.now(), userId, Instant.now(), dacId2);
-    libraryCardDAO.createLibraryCardDaaRelation(card.getUserId(), card.getId(), daaId1);
-    libraryCardDAO.createLibraryCardDaaRelation(card.getUserId(), card.getId(), daaId2);
-    libraryCardDAO.createLibraryCardDaaRelation(card2.getUserId(), card2.getId(), daaId1);
+    libraryCardDAO.createLibraryCardDaaRelation(
+        card.getUserId(), signingOfficial.getUserId(), card.getId(), daaId1);
+    libraryCardDAO.createLibraryCardDaaRelation(
+        card.getUserId(), signingOfficial.getUserId(), card.getId(), daaId2);
+    libraryCardDAO.createLibraryCardDaaRelation(
+        card2.getUserId(), signingOfficial.getUserId(), card2.getId(), daaId1);
 
     List<LibraryCard> lcs = libraryCardDAO.findAllLibraryCards();
     LibraryCard lc1 = lcs.get(0);
@@ -308,6 +318,7 @@ class LibraryCardDAOTest extends DAOTestHelper {
 
   @Test
   void testCreateLibraryCardDaaAssociationInvalid() {
+    User signingOfficial = createUser();
     User user = createUser();
     LibraryCard card = createLibraryCard(user);
     Integer userId = user.getUserId();
@@ -315,14 +326,16 @@ class LibraryCardDAOTest extends DAOTestHelper {
     Integer daaId1 = daaDAO.createDaa(userId, Instant.now(), userId, Instant.now(), dacId);
 
     try {
-      libraryCardDAO.createLibraryCardDaaRelation(card.getUserId(), card.getId(), 2);
+      libraryCardDAO.createLibraryCardDaaRelation(
+          card.getUserId(), signingOfficial.getUserId(), card.getId(), 2);
     } catch (Exception e) {
       assertEquals(
           PSQLState.FOREIGN_KEY_VIOLATION.getState(), ((PSQLException) e.getCause()).getSQLState());
     }
 
     try {
-      libraryCardDAO.createLibraryCardDaaRelation(card.getUserId(), 2, daaId1);
+      libraryCardDAO.createLibraryCardDaaRelation(
+          card.getUserId(), signingOfficial.getUserId(), 2, daaId1);
     } catch (Exception e) {
       assertEquals(
           PSQLState.FOREIGN_KEY_VIOLATION.getState(), ((PSQLException) e.getCause()).getSQLState());
@@ -335,6 +348,7 @@ class LibraryCardDAOTest extends DAOTestHelper {
 
   @Test
   void testDeleteLibraryCardDaaAssociation() {
+    User signingOfficial = createUser();
     User user = createUser();
     User user2 = createUser();
     LibraryCard card = createLibraryCard(user);
@@ -344,19 +358,23 @@ class LibraryCardDAOTest extends DAOTestHelper {
     Integer dacId2 = dacDAO.createDac(randomAlphabetic(5), randomAlphabetic(5), "", new Date());
     Integer daaId1 = daaDAO.createDaa(userId, Instant.now(), userId, Instant.now(), dacId);
     Integer daaId2 = daaDAO.createDaa(userId, Instant.now(), userId, Instant.now(), dacId2);
-    libraryCardDAO.createLibraryCardDaaRelation(card.getUserId(), card.getId(), daaId1);
-    libraryCardDAO.createLibraryCardDaaRelation(card.getUserId(), card.getId(), daaId2);
+    libraryCardDAO.createLibraryCardDaaRelation(
+        card.getUserId(), signingOfficial.getUserId(), card.getId(), daaId1);
+    libraryCardDAO.createLibraryCardDaaRelation(
+        card.getUserId(), signingOfficial.getUserId(), card.getId(), daaId2);
 
     List<LibraryCard> lcs = libraryCardDAO.findAllLibraryCards();
     LibraryCard lc1 = lcs.getFirst();
     assertEquals(2, lc1.getDaaIds().size());
 
-    libraryCardDAO.deleteLibraryCardDaaRelation(card.getUserId(), card.getId(), daaId1);
+    libraryCardDAO.deleteLibraryCardDaaRelation(
+        card.getUserId(), signingOfficial.getUserId(), card.getId(), daaId1);
     lcs = libraryCardDAO.findAllLibraryCards();
     lc1 = lcs.getFirst();
     assertEquals(1, lc1.getDaaIds().size());
 
-    libraryCardDAO.deleteLibraryCardDaaRelation(card.getUserId(), card.getId(), daaId2);
+    libraryCardDAO.deleteLibraryCardDaaRelation(
+        card.getUserId(), signingOfficial.getUserId(), card.getId(), daaId2);
     lcs = libraryCardDAO.findAllLibraryCards();
     lc1 = lcs.getFirst();
     assertTrue(lc1.getDaaIds().isEmpty());
@@ -387,7 +405,8 @@ class LibraryCardDAOTest extends DAOTestHelper {
             chairperson1.getUserId(),
             Instant.now(),
             dacId1);
-    libraryCardDAO.createLibraryCardDaaRelation(signingOfficial.getUserId(), lcId, daaId1);
+    libraryCardDAO.createLibraryCardDaaRelation(
+        user.getUserId(), signingOfficial.getUserId(), lcId, daaId1);
 
     // SO associates user to access agreement 2
     User chairperson2 = createUser();
@@ -401,7 +420,8 @@ class LibraryCardDAOTest extends DAOTestHelper {
             chairperson2.getUserId(),
             Instant.now(),
             dacId2);
-    libraryCardDAO.createLibraryCardDaaRelation(signingOfficial.getUserId(), lcId, daaId2);
+    libraryCardDAO.createLibraryCardDaaRelation(
+        user.getUserId(), signingOfficial.getUserId(), lcId, daaId2);
 
     List<LibraryCardDaaAudit> audits = libraryCardDAO.findAuditsByLcUserId(user.getUserId());
     assertFalse(audits.isEmpty());
@@ -412,7 +432,8 @@ class LibraryCardDAOTest extends DAOTestHelper {
             .allMatch(action -> action == AuditActions.ADD));
 
     // Dissociate user from DAA 1 and check that we have a REMOVE audit.
-    libraryCardDAO.deleteLibraryCardDaaRelation(signingOfficial.getUserId(), lcId, daaId1);
+    libraryCardDAO.deleteLibraryCardDaaRelation(
+        user.getUserId(), signingOfficial.getUserId(), lcId, daaId1);
     List<LibraryCardDaaAudit> audits2 = libraryCardDAO.findAuditsByLcUserId(user.getUserId());
     assertFalse(audits2.isEmpty());
     assertEquals(3, audits2.size());
@@ -440,11 +461,13 @@ class LibraryCardDAOTest extends DAOTestHelper {
     Integer daaId =
         daaDAO.createDaa(
             chairperson.getUserId(), Instant.now(), chairperson.getUserId(), Instant.now(), dacId);
-    libraryCardDAO.createLibraryCardDaaRelation(signingOfficial.getUserId(), lcId, daaId);
+    libraryCardDAO.createLibraryCardDaaRelation(
+        user.getUserId(), signingOfficial.getUserId(), lcId, daaId);
 
     // Repeat the same association which should trigger the ON CONFLICT in the SQL and ensure that
     // we do not insert a duplicate audit record.
-    libraryCardDAO.createLibraryCardDaaRelation(signingOfficial.getUserId(), lcId, daaId);
+    libraryCardDAO.createLibraryCardDaaRelation(
+        user.getUserId(), signingOfficial.getUserId(), lcId, daaId);
 
     List<LibraryCardDaaAudit> audits = libraryCardDAO.findAuditsByLcUserId(user.getUserId());
     assertFalse(audits.isEmpty());

--- a/src/test/java/org/broadinstitute/consent/http/db/LibraryCardDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/LibraryCardDAOTest.java
@@ -441,7 +441,7 @@ class LibraryCardDAOTest extends DAOTestHelper {
   }
 
   @Test
-  void testEnsureAuditInsertsSkippedOnConflict() {
+  void testEnsureAuditInsertsSkippedOnConflict_Add() {
     // Create a user, signing official, and library card
     User user = createUser();
     User signingOfficial = createUser();
@@ -473,6 +473,48 @@ class LibraryCardDAOTest extends DAOTestHelper {
     assertFalse(audits.isEmpty());
     assertEquals(1, audits.size());
     assertSame(AuditActions.ADD, audits.getFirst().action());
+  }
+
+  @Test
+  void testEnsureAuditInsertsSkippedOnConflict_Remove() {
+    // Create a user, signing official, and library card
+    User user = createUser();
+    User signingOfficial = createUser();
+    Integer lcId =
+        libraryCardDAO.insertLibraryCard(
+            user.getUserId(),
+            user.getDisplayName(),
+            user.getEmail(),
+            signingOfficial.getUserId(),
+            new Date());
+
+    // SO associates user to data access agreement
+    User chairperson = createUser();
+    Integer dacId =
+        dacDAO.createDac(
+            randomAlphabetic(5), randomAlphabetic(5), chairperson.getEmail(), new Date());
+    Integer daaId =
+        daaDAO.createDaa(
+            chairperson.getUserId(), Instant.now(), chairperson.getUserId(), Instant.now(), dacId);
+    libraryCardDAO.createLibraryCardDaaRelation(
+        user.getUserId(), signingOfficial.getUserId(), lcId, daaId);
+
+    // SO Removes association
+    libraryCardDAO.deleteLibraryCardDaaRelation(
+        user.getUserId(), signingOfficial.getUserId(), lcId, daaId);
+
+    // Repeat the same delection which should trigger the ON CONFLICT in the SQL and ensure that
+    // we do not insert a duplicate audit record.
+    libraryCardDAO.deleteLibraryCardDaaRelation(
+        user.getUserId(), signingOfficial.getUserId(), lcId, daaId);
+
+    List<LibraryCardDaaAudit> audits =
+        libraryCardDAO.findAuditsByLcUserId(user.getUserId()).stream()
+            .filter(audit -> audit.action() == AuditActions.REMOVE)
+            .toList();
+    assertFalse(audits.isEmpty());
+    assertEquals(1, audits.size());
+    assertSame(AuditActions.REMOVE, audits.getFirst().action());
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/db/LibraryCardDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/LibraryCardDAOTest.java
@@ -573,12 +573,10 @@ class LibraryCardDAOTest extends DAOTestHelper {
     assertFalse(cardsFromDAO.contains(card4));
   }
 
-  private LibraryCard createLibraryCardForIndex() {
+  private void createLibraryCardForIndex() {
     Integer userId = createUser().getUserId();
     String stringValue = "value";
-    Integer id =
-        libraryCardDAO.insertLibraryCard(userId, stringValue, stringValue, userId, new Date());
-    return libraryCardDAO.findLibraryCardById(id);
+    libraryCardDAO.insertLibraryCard(userId, stringValue, stringValue, userId, new Date());
   }
 
   private Institution createInstitution() {

--- a/src/test/java/org/broadinstitute/consent/http/db/LibraryCardDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/LibraryCardDAOTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -362,7 +363,7 @@ class LibraryCardDAOTest extends DAOTestHelper {
   }
 
   @Test
-  void findAuditsByLibraryCardUserId() {
+  void testFindAuditsByLibraryCardUserId() {
     // Create a user, signing official, and library card
     User user = createUser();
     User signingOfficial = createUser();
@@ -416,6 +417,39 @@ class LibraryCardDAOTest extends DAOTestHelper {
     assertFalse(audits2.isEmpty());
     assertEquals(3, audits2.size());
     assertTrue(audits2.stream().anyMatch(audit -> audit.action() == AuditActions.REMOVE));
+  }
+
+  @Test
+  void testEnsureAuditInsertsSkippedOnConflict() {
+    // Create a user, signing official, and library card
+    User user = createUser();
+    User signingOfficial = createUser();
+    Integer lcId =
+        libraryCardDAO.insertLibraryCard(
+            user.getUserId(),
+            user.getDisplayName(),
+            user.getEmail(),
+            signingOfficial.getUserId(),
+            new Date());
+
+    // SO associates user to data access agreement
+    User chairperson = createUser();
+    Integer dacId =
+        dacDAO.createDac(
+            randomAlphabetic(5), randomAlphabetic(5), chairperson.getEmail(), new Date());
+    Integer daaId =
+        daaDAO.createDaa(
+            chairperson.getUserId(), Instant.now(), chairperson.getUserId(), Instant.now(), dacId);
+    libraryCardDAO.createLibraryCardDaaRelation(signingOfficial.getUserId(), lcId, daaId);
+
+    // Repeat the same association which should trigger the ON CONFLICT in the SQL and ensure that
+    // we do not insert a duplicate audit record.
+    libraryCardDAO.createLibraryCardDaaRelation(signingOfficial.getUserId(), lcId, daaId);
+
+    List<LibraryCardDaaAudit> audits = libraryCardDAO.findAuditsByLcUserId(user.getUserId());
+    assertFalse(audits.isEmpty());
+    assertEquals(1, audits.size());
+    assertSame(AuditActions.ADD, audits.getFirst().action());
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/db/LibraryCardDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/LibraryCardDAOTest.java
@@ -123,7 +123,7 @@ class LibraryCardDAOTest extends DAOTestHelper {
         daaDAO.createDaa(
             card.getCreateUserId(), Instant.now(), card.getCreateUserId(), Instant.now(), dacId);
     daaDAO.createDacDaaRelation(dacId, daaId, card.getUserId());
-    libraryCardDAO.createLibraryCardDaaRelation(card.getId(), daaId);
+    libraryCardDAO.createLibraryCardDaaRelation(card.getUserId(), card.getId(), daaId);
 
     libraryCardDAO.deleteLibraryCardById(card.getId());
     assertNull(libraryCardDAO.findLibraryCardById(card.getId()));
@@ -162,8 +162,8 @@ class LibraryCardDAOTest extends DAOTestHelper {
     card.addDaa(daa2.getDaaId());
     card.addDaaObject(daa1);
     card.addDaaObject(daa2);
-    libraryCardDAO.createLibraryCardDaaRelation(card.getId(), daaId1);
-    libraryCardDAO.createLibraryCardDaaRelation(card.getId(), daaId2);
+    libraryCardDAO.createLibraryCardDaaRelation(card.getUserId(), card.getId(), daaId1);
+    libraryCardDAO.createLibraryCardDaaRelation(card.getUserId(), card.getId(), daaId2);
     Integer id = card.getId();
     LibraryCard cardFromDAO = libraryCardDAO.findLibraryCardDaaById(id);
 
@@ -174,7 +174,7 @@ class LibraryCardDAOTest extends DAOTestHelper {
     assertEquals(cardFromDAO.getCreateDate(), card.getCreateDate());
     assertEquals(cardFromDAO.getDaaIds(), card.getDaaIds());
 
-    DataAccessAgreement daaFromDAO1 = cardFromDAO.getDaas().get(0);
+    DataAccessAgreement daaFromDAO1 = cardFromDAO.getDaas().getFirst();
     assertEquals(daaFromDAO1.getDaaId(), daa1.getDaaId());
     assertEquals(daaFromDAO1.getCreateUserId(), daa1.getCreateUserId());
     assertEquals(daaFromDAO1.getCreateDate(), daa1.getCreateDate());
@@ -225,8 +225,8 @@ class LibraryCardDAOTest extends DAOTestHelper {
 
     assertNotNull(cardsFromDAO);
     assertEquals(1, cardsFromDAO.size());
-    assertEquals(cardsFromDAO.get(0).getId(), lcId);
-    assertTrue(cardsFromDAO.get(0).getDaaIds().isEmpty());
+    assertEquals(cardsFromDAO.getFirst().getId(), lcId);
+    assertTrue(cardsFromDAO.getFirst().getDaaIds().isEmpty());
   }
 
   @Test
@@ -237,7 +237,8 @@ class LibraryCardDAOTest extends DAOTestHelper {
     Instant now = Instant.now();
     int daaId = daaDAO.createDaa(libraryCard.getUserId(), now, libraryCard.getUserId(), now, dacId);
     daaDAO.createDacDaaRelation(dacId, daaId, libraryCard.getUserId());
-    libraryCardDAO.createLibraryCardDaaRelation(libraryCard.getId(), daaId);
+    libraryCardDAO.createLibraryCardDaaRelation(
+        libraryCard.getUserId(), libraryCard.getId(), daaId);
     LibraryCard cardFromDAO = libraryCardDAO.findLibraryCardByUserId(libraryCard.getUserId());
     assertNotNull(cardFromDAO);
     assertEquals(cardFromDAO, libraryCard);
@@ -250,7 +251,7 @@ class LibraryCardDAOTest extends DAOTestHelper {
     createLibraryCardForIndex();
     List<LibraryCard> cardListUpdated = libraryCardDAO.findAllLibraryCards();
     assertEquals(1, cardListUpdated.size());
-    LibraryCard card = cardListUpdated.get(0);
+    LibraryCard card = cardListUpdated.getFirst();
     assertTrue(card.getDaaIds().isEmpty());
   }
 
@@ -293,9 +294,9 @@ class LibraryCardDAOTest extends DAOTestHelper {
         daaDAO.createDaa(userId, new Date().toInstant(), userId, new Date().toInstant(), dacId);
     Integer daaId2 =
         daaDAO.createDaa(userId, new Date().toInstant(), userId, new Date().toInstant(), dacId2);
-    libraryCardDAO.createLibraryCardDaaRelation(card.getId(), daaId1);
-    libraryCardDAO.createLibraryCardDaaRelation(card.getId(), daaId2);
-    libraryCardDAO.createLibraryCardDaaRelation(card2.getId(), daaId1);
+    libraryCardDAO.createLibraryCardDaaRelation(card.getUserId(), card.getId(), daaId1);
+    libraryCardDAO.createLibraryCardDaaRelation(card.getUserId(), card.getId(), daaId2);
+    libraryCardDAO.createLibraryCardDaaRelation(card2.getUserId(), card2.getId(), daaId1);
 
     List<LibraryCard> lcs = libraryCardDAO.findAllLibraryCards();
     LibraryCard lc1 = lcs.get(0);
@@ -316,21 +317,21 @@ class LibraryCardDAOTest extends DAOTestHelper {
         daaDAO.createDaa(userId, new Date().toInstant(), userId, new Date().toInstant(), dacId);
 
     try {
-      libraryCardDAO.createLibraryCardDaaRelation(card.getId(), 2);
+      libraryCardDAO.createLibraryCardDaaRelation(card.getUserId(), card.getId(), 2);
     } catch (Exception e) {
       assertEquals(
           PSQLState.FOREIGN_KEY_VIOLATION.getState(), ((PSQLException) e.getCause()).getSQLState());
     }
 
     try {
-      libraryCardDAO.createLibraryCardDaaRelation(2, daaId1);
+      libraryCardDAO.createLibraryCardDaaRelation(card.getUserId(), 2, daaId1);
     } catch (Exception e) {
       assertEquals(
           PSQLState.FOREIGN_KEY_VIOLATION.getState(), ((PSQLException) e.getCause()).getSQLState());
     }
 
     List<LibraryCard> lcs = libraryCardDAO.findAllLibraryCards();
-    LibraryCard lc1 = lcs.get(0);
+    LibraryCard lc1 = lcs.getFirst();
     assertTrue(lc1.getDaaIds().isEmpty());
   }
 
@@ -339,7 +340,7 @@ class LibraryCardDAOTest extends DAOTestHelper {
     User user = createUser();
     User user2 = createUser();
     LibraryCard card = createLibraryCard(user);
-    LibraryCard card2 = createLibraryCard(user2);
+    createLibraryCard(user2);
     Integer userId = user.getUserId();
     Integer dacId = dacDAO.createDac(randomAlphabetic(5), randomAlphabetic(5), "", new Date());
     Integer dacId2 = dacDAO.createDac(randomAlphabetic(5), randomAlphabetic(5), "", new Date());
@@ -347,21 +348,21 @@ class LibraryCardDAOTest extends DAOTestHelper {
         daaDAO.createDaa(userId, new Date().toInstant(), userId, new Date().toInstant(), dacId);
     Integer daaId2 =
         daaDAO.createDaa(userId, new Date().toInstant(), userId, new Date().toInstant(), dacId2);
-    libraryCardDAO.createLibraryCardDaaRelation(card.getId(), daaId1);
-    libraryCardDAO.createLibraryCardDaaRelation(card.getId(), daaId2);
+    libraryCardDAO.createLibraryCardDaaRelation(card.getUserId(), card.getId(), daaId1);
+    libraryCardDAO.createLibraryCardDaaRelation(card.getUserId(), card.getId(), daaId2);
 
     List<LibraryCard> lcs = libraryCardDAO.findAllLibraryCards();
-    LibraryCard lc1 = lcs.get(0);
+    LibraryCard lc1 = lcs.getFirst();
     assertEquals(2, lc1.getDaaIds().size());
 
-    libraryCardDAO.deleteLibraryCardDaaRelation(card.getId(), daaId1);
+    libraryCardDAO.deleteLibraryCardDaaRelation(card.getUserId(), card.getId(), daaId1);
     lcs = libraryCardDAO.findAllLibraryCards();
-    lc1 = lcs.get(0);
+    lc1 = lcs.getFirst();
     assertEquals(1, lc1.getDaaIds().size());
 
-    libraryCardDAO.deleteLibraryCardDaaRelation(card.getId(), daaId2);
+    libraryCardDAO.deleteLibraryCardDaaRelation(card.getUserId(), card.getId(), daaId2);
     lcs = libraryCardDAO.findAllLibraryCards();
-    lc1 = lcs.get(0);
+    lc1 = lcs.getFirst();
     assertTrue(lc1.getDaaIds().isEmpty());
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/db/LibraryCardDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/LibraryCardDAOTest.java
@@ -10,10 +10,12 @@ import static org.junit.jupiter.api.Assertions.fail;
 import java.time.Instant;
 import java.util.Date;
 import java.util.List;
+import org.broadinstitute.consent.http.enumeration.AuditActions;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.DataAccessAgreement;
 import org.broadinstitute.consent.http.models.Institution;
 import org.broadinstitute.consent.http.models.LibraryCard;
+import org.broadinstitute.consent.http.models.LibraryCardDaaAudit;
 import org.broadinstitute.consent.http.models.User;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -152,10 +154,8 @@ class LibraryCardDAOTest extends DAOTestHelper {
     LibraryCard card = createLibraryCard();
     Integer userId = createUser().getUserId();
     Integer dacId = dacDAO.createDac(randomAlphabetic(5), randomAlphabetic(5), "", new Date());
-    Integer daaId1 =
-        daaDAO.createDaa(userId, new Date().toInstant(), userId, new Date().toInstant(), dacId);
-    Integer daaId2 =
-        daaDAO.createDaa(userId, new Date().toInstant(), userId, new Date().toInstant(), dacId);
+    Integer daaId1 = daaDAO.createDaa(userId, Instant.now(), userId, Instant.now(), dacId);
+    Integer daaId2 = daaDAO.createDaa(userId, Instant.now(), userId, Instant.now(), dacId);
     DataAccessAgreement daa1 = daaDAO.findById(daaId1);
     DataAccessAgreement daa2 = daaDAO.findById(daaId2);
     card.addDaa(daa1.getDaaId());
@@ -290,10 +290,8 @@ class LibraryCardDAOTest extends DAOTestHelper {
     Integer userId = user.getUserId();
     Integer dacId = dacDAO.createDac(randomAlphabetic(5), randomAlphabetic(5), "", new Date());
     Integer dacId2 = dacDAO.createDac(randomAlphabetic(5), randomAlphabetic(5), "", new Date());
-    Integer daaId1 =
-        daaDAO.createDaa(userId, new Date().toInstant(), userId, new Date().toInstant(), dacId);
-    Integer daaId2 =
-        daaDAO.createDaa(userId, new Date().toInstant(), userId, new Date().toInstant(), dacId2);
+    Integer daaId1 = daaDAO.createDaa(userId, Instant.now(), userId, Instant.now(), dacId);
+    Integer daaId2 = daaDAO.createDaa(userId, Instant.now(), userId, Instant.now(), dacId2);
     libraryCardDAO.createLibraryCardDaaRelation(card.getUserId(), card.getId(), daaId1);
     libraryCardDAO.createLibraryCardDaaRelation(card.getUserId(), card.getId(), daaId2);
     libraryCardDAO.createLibraryCardDaaRelation(card2.getUserId(), card2.getId(), daaId1);
@@ -313,8 +311,7 @@ class LibraryCardDAOTest extends DAOTestHelper {
     LibraryCard card = createLibraryCard(user);
     Integer userId = user.getUserId();
     Integer dacId = dacDAO.createDac(randomAlphabetic(5), randomAlphabetic(5), "", new Date());
-    Integer daaId1 =
-        daaDAO.createDaa(userId, new Date().toInstant(), userId, new Date().toInstant(), dacId);
+    Integer daaId1 = daaDAO.createDaa(userId, Instant.now(), userId, Instant.now(), dacId);
 
     try {
       libraryCardDAO.createLibraryCardDaaRelation(card.getUserId(), card.getId(), 2);
@@ -344,10 +341,8 @@ class LibraryCardDAOTest extends DAOTestHelper {
     Integer userId = user.getUserId();
     Integer dacId = dacDAO.createDac(randomAlphabetic(5), randomAlphabetic(5), "", new Date());
     Integer dacId2 = dacDAO.createDac(randomAlphabetic(5), randomAlphabetic(5), "", new Date());
-    Integer daaId1 =
-        daaDAO.createDaa(userId, new Date().toInstant(), userId, new Date().toInstant(), dacId);
-    Integer daaId2 =
-        daaDAO.createDaa(userId, new Date().toInstant(), userId, new Date().toInstant(), dacId2);
+    Integer daaId1 = daaDAO.createDaa(userId, Instant.now(), userId, Instant.now(), dacId);
+    Integer daaId2 = daaDAO.createDaa(userId, Instant.now(), userId, Instant.now(), dacId2);
     libraryCardDAO.createLibraryCardDaaRelation(card.getUserId(), card.getId(), daaId1);
     libraryCardDAO.createLibraryCardDaaRelation(card.getUserId(), card.getId(), daaId2);
 
@@ -364,6 +359,63 @@ class LibraryCardDAOTest extends DAOTestHelper {
     lcs = libraryCardDAO.findAllLibraryCards();
     lc1 = lcs.getFirst();
     assertTrue(lc1.getDaaIds().isEmpty());
+  }
+
+  @Test
+  void findAuditsByLibraryCardUserId() {
+    // Create a user, signing official, and library card
+    User user = createUser();
+    User signingOfficial = createUser();
+    Integer lcId =
+        libraryCardDAO.insertLibraryCard(
+            user.getUserId(),
+            user.getDisplayName(),
+            user.getEmail(),
+            signingOfficial.getUserId(),
+            new Date());
+
+    // SO associates user to access agreement 1
+    User chairperson1 = createUser();
+    Integer dacId1 =
+        dacDAO.createDac(
+            randomAlphabetic(5), randomAlphabetic(5), chairperson1.getEmail(), new Date());
+    Integer daaId1 =
+        daaDAO.createDaa(
+            chairperson1.getUserId(),
+            Instant.now(),
+            chairperson1.getUserId(),
+            Instant.now(),
+            dacId1);
+    libraryCardDAO.createLibraryCardDaaRelation(signingOfficial.getUserId(), lcId, daaId1);
+
+    // SO associates user to access agreement 2
+    User chairperson2 = createUser();
+    Integer dacId2 =
+        dacDAO.createDac(
+            randomAlphabetic(5), randomAlphabetic(5), chairperson2.getEmail(), new Date());
+    Integer daaId2 =
+        daaDAO.createDaa(
+            chairperson1.getUserId(),
+            Instant.now(),
+            chairperson2.getUserId(),
+            Instant.now(),
+            dacId2);
+    libraryCardDAO.createLibraryCardDaaRelation(signingOfficial.getUserId(), lcId, daaId2);
+
+    List<LibraryCardDaaAudit> audits = libraryCardDAO.findAuditsByLcUserId(user.getUserId());
+    assertFalse(audits.isEmpty());
+    assertEquals(2, audits.size());
+    assertTrue(
+        audits.stream()
+            .map(LibraryCardDaaAudit::action)
+            .allMatch(action -> action == AuditActions.ADD));
+
+    // Dissociate user from DAA 1 and check that we have a REMOVE audit.
+    libraryCardDAO.deleteLibraryCardDaaRelation(signingOfficial.getUserId(), lcId, daaId1);
+    List<LibraryCardDaaAudit> audits2 = libraryCardDAO.findAuditsByLcUserId(user.getUserId());
+    assertFalse(audits2.isEmpty());
+    assertEquals(3, audits2.size());
+    assertTrue(audits2.stream().anyMatch(audit -> audit.action() == AuditActions.REMOVE));
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/db/UserDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/UserDAOTest.java
@@ -246,17 +246,26 @@ class UserDAOTest extends DAOTestHelper {
     // Creates an Admin and an SO, and returns the SO
     User signingOfficial = createUserWithInstitution();
     // Creates a researcher
-    User user = createUserWithRole(UserRoles.RESEARCHER.getRoleId(), signingOfficial.getInstitutionId());
+    User user =
+        createUserWithRole(UserRoles.RESEARCHER.getRoleId(), signingOfficial.getInstitutionId());
     int dacId = dacDAO.createDac(randomAlphabetic(5), randomAlphabetic(5), new Date());
     Instant now = Instant.now();
     int daaId = daaDAO.createDaa(user.getUserId(), now, user.getUserId(), now, dacId);
-    int lcId1 = libraryCardDAO.insertLibraryCard(user.getUserId(), user.getDisplayName(), user.getEmail(), signingOfficial.getUserId(), new Date());
-    libraryCardDAO.createLibraryCardDaaRelation(user.getUserId(), signingOfficial.getUserId(), lcId1, daaId);
+    int lcId1 =
+        libraryCardDAO.insertLibraryCard(
+            user.getUserId(),
+            user.getDisplayName(),
+            user.getEmail(),
+            signingOfficial.getUserId(),
+            new Date());
+    libraryCardDAO.createLibraryCardDaaRelation(
+        user.getUserId(), signingOfficial.getUserId(), lcId1, daaId);
 
     // Creates another admin and another SO
     User signingOfficial2 = createUserWithInstitution();
     // Creates a researcher
-    User user2 = createUserWithRole(UserRoles.RESEARCHER.getRoleId(), signingOfficial2.getInstitutionId());
+    User user2 =
+        createUserWithRole(UserRoles.RESEARCHER.getRoleId(), signingOfficial2.getInstitutionId());
     int lcId2 =
         libraryCardDAO.insertLibraryCard(
             user2.getUserId(),
@@ -264,16 +273,18 @@ class UserDAOTest extends DAOTestHelper {
             user2.getEmail(),
             signingOfficial2.getUserId(),
             new Date());
-    libraryCardDAO.createLibraryCardDaaRelation(user2.getUserId(), signingOfficial2.getUserId(), lcId2, daaId);
+    libraryCardDAO.createLibraryCardDaaRelation(
+        user2.getUserId(), signingOfficial2.getUserId(), lcId2, daaId);
 
     List<User> users = userDAO.findUsersWithLCsAndInstitution();
     // Filter out non-researchers since those are the ones we've added LCs to and are under test.
     users = users.stream().filter(u -> u.hasUserRole(UserRoles.RESEARCHER)).toList();
     assertEquals(2, users.size());
-    users.forEach(u -> {
-      assertNotNull(u.getInstitution());
-      assertNotNull(u.getLibraryCard());
-    });
+    users.forEach(
+        u -> {
+          assertNotNull(u.getInstitution());
+          assertNotNull(u.getLibraryCard());
+        });
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/db/UserDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/UserDAOTest.java
@@ -400,8 +400,8 @@ class UserDAOTest extends DAOTestHelper {
     String email = user.getEmail();
     List<User> users = userDAO.getSOsByInstitution(institutionId);
     assertEquals(1, users.size());
-    assertEquals(displayName, users.get(0).getDisplayName());
-    assertEquals(email, users.get(0).getEmail());
+    assertEquals(displayName, users.getFirst().getDisplayName());
+    assertEquals(email, users.getFirst().getEmail());
 
     List<User> differentInstitutionUsers = userDAO.getSOsByInstitution(institutionId + 1);
     assertEquals(0, differentInstitutionUsers.size());
@@ -420,7 +420,7 @@ class UserDAOTest extends DAOTestHelper {
     Integer userId = card.getUserId();
     List<User> users = userDAO.getUsersFromInstitutionWithCards(lcUser.getInstitutionId());
     assertEquals(1, users.size());
-    User returnedUser = users.get(0);
+    User returnedUser = users.getFirst();
     assertEquals(userId, returnedUser.getUserId());
 
     LibraryCard returnedCard = returnedUser.getLibraryCard();
@@ -449,11 +449,11 @@ class UserDAOTest extends DAOTestHelper {
     assertEquals(1, daa2UserList.size());
     assertNotEquals(daa1UserList, daa2UserList);
 
-    User daa1User = daa1UserList.get(0);
+    User daa1User = daa1UserList.getFirst();
     assertEquals(card1, daa1User.getLibraryCard());
     assertEquals(daa1User.getLibraryCard().getDaaIds(), List.of(daaId1));
 
-    User daa2User = daa2UserList.get(0);
+    User daa2User = daa2UserList.getFirst();
     assertEquals(card2, daa2User.getLibraryCard());
     assertEquals(daa2User.getLibraryCard().getDaaIds(), List.of(daaId2));
   }
@@ -540,7 +540,7 @@ class UserDAOTest extends DAOTestHelper {
         .getHandle()
         .getJdbi()
         .useHandle(
-            handle -> {
+            ignored -> {
               ResultIterable<User> users =
                   userDAO.allEmailReceivingThinlyPopulatedUsers(emailType, referenceId);
               for (User user : users) {
@@ -571,7 +571,7 @@ class UserDAOTest extends DAOTestHelper {
         .getHandle()
         .getJdbi()
         .useHandle(
-            handle -> {
+            ignored -> {
               ResultIterable<User> users =
                   userDAO.allEmailReceivingThinlyPopulatedUsers(emailType, referenceId);
               for (User user : users) {

--- a/src/test/java/org/broadinstitute/consent/http/db/UserDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/UserDAOTest.java
@@ -83,11 +83,11 @@ class UserDAOTest extends DAOTestHelper {
     int daaId =
         daaDAO.createDaa(user.getUserId(), Instant.now(), user.getUserId(), Instant.now(), dacId);
     daaDAO.createDacDaaRelation(dacId, daaId, user.getUserId());
-    libraryCardDAO.createLibraryCardDaaRelation(lcId, daaId);
+    libraryCardDAO.createLibraryCardDaaRelation(user.getUserId(), user.getUserId(), lcId, daaId);
     int dacId2 = dacDAO.createDac(randomAlphabetic(5), randomAlphabetic(5), new Date());
     int daaId2 =
         daaDAO.createDaa(user.getUserId(), Instant.now(), user.getUserId(), Instant.now(), dacId2);
-    libraryCardDAO.createLibraryCardDaaRelation(lcId, daaId2);
+    libraryCardDAO.createLibraryCardDaaRelation(user.getUserId(), user.getUserId(), lcId, daaId2);
     UserProperty eraExpProp = new UserProperty();
     eraExpProp.setPropertyKey(UserFields.ERA_EXPIRATION_DATE.getValue());
     eraExpProp.setPropertyValue(Instant.now().toString());

--- a/src/test/java/org/broadinstitute/consent/http/db/UserDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/UserDAOTest.java
@@ -243,6 +243,7 @@ class UserDAOTest extends DAOTestHelper {
 
   @Test
   void testFindUsersWithLCsAndInstitution() {
+    User signingOfficial = createUser();
     User user = createUserWithInstitution();
     int dacId = dacDAO.createDac(randomAlphabetic(5), randomAlphabetic(5), new Date());
     Instant now = Instant.now();
@@ -250,7 +251,8 @@ class UserDAOTest extends DAOTestHelper {
     int lcId1 =
         libraryCardDAO.insertLibraryCard(
             user.getUserId(), user.getDisplayName(), user.getEmail(), user.getUserId(), new Date());
-    libraryCardDAO.createLibraryCardDaaRelation(user.getUserId(), lcId1, daaId);
+    libraryCardDAO.createLibraryCardDaaRelation(
+        user.getUserId(), signingOfficial.getUserId(), lcId1, daaId);
 
     User user2 = createUserWithInstitution();
     int lcId2 =
@@ -260,7 +262,8 @@ class UserDAOTest extends DAOTestHelper {
             user2.getEmail(),
             user2.getUserId(),
             new Date());
-    libraryCardDAO.createLibraryCardDaaRelation(user2.getUserId(), lcId2, daaId);
+    libraryCardDAO.createLibraryCardDaaRelation(
+        user2.getUserId(), signingOfficial.getUserId(), lcId2, daaId);
 
     List<User> users = userDAO.findUsersWithLCsAndInstitution();
     // Four users: two admin users, two signing official users with library cards.
@@ -406,11 +409,13 @@ class UserDAOTest extends DAOTestHelper {
 
   @Test
   void testGetUsersFromInstitutionWithCards() {
+    User signingOfficial = createUser();
     int dacId = dacDAO.createDac(randomAlphabetic(5), randomAlphabetic(5), new Date());
     Instant now = Instant.now();
     LibraryCard card = createLibraryCard();
     int daaId = daaDAO.createDaa(card.getUserId(), now, card.getUserId(), now, dacId);
-    libraryCardDAO.createLibraryCardDaaRelation(card.getUserId(), card.getId(), daaId);
+    libraryCardDAO.createLibraryCardDaaRelation(
+        card.getUserId(), signingOfficial.getUserId(), card.getId(), daaId);
     User lcUser = userDAO.findUserById(card.getUserId());
     Integer userId = card.getUserId();
     List<User> users = userDAO.getUsersFromInstitutionWithCards(lcUser.getInstitutionId());
@@ -425,14 +430,17 @@ class UserDAOTest extends DAOTestHelper {
 
   @Test
   void testGetUsersWithCardsByDaaId() {
+    User signingOfficial = createUser();
     int dacId = dacDAO.createDac(randomAlphabetic(5), randomAlphabetic(5), new Date());
     Instant now = Instant.now();
     LibraryCard card1 = createLibraryCard();
     int daaId1 = daaDAO.createDaa(card1.getUserId(), now, card1.getUserId(), now, dacId);
-    libraryCardDAO.createLibraryCardDaaRelation(card1.getUserId(), card1.getId(), daaId1);
+    libraryCardDAO.createLibraryCardDaaRelation(
+        card1.getUserId(), signingOfficial.getUserId(), card1.getId(), daaId1);
     LibraryCard card2 = createLibraryCard();
     int daaId2 = daaDAO.createDaa(card2.getUserId(), now, card2.getUserId(), now, dacId);
-    libraryCardDAO.createLibraryCardDaaRelation(card2.getUserId(), card2.getId(), daaId2);
+    libraryCardDAO.createLibraryCardDaaRelation(
+        card2.getUserId(), signingOfficial.getUserId(), card2.getId(), daaId2);
 
     List<User> daa1UserList = userDAO.getUsersWithCardsByDaaId(daaId1);
     assertEquals(1, daa1UserList.size());

--- a/src/test/java/org/broadinstitute/consent/http/db/UserDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/UserDAOTest.java
@@ -250,7 +250,7 @@ class UserDAOTest extends DAOTestHelper {
     int lcId1 =
         libraryCardDAO.insertLibraryCard(
             user.getUserId(), user.getDisplayName(), user.getEmail(), user.getUserId(), new Date());
-    libraryCardDAO.createLibraryCardDaaRelation(lcId1, daaId);
+    libraryCardDAO.createLibraryCardDaaRelation(user.getUserId(), lcId1, daaId);
 
     User user2 = createUserWithInstitution();
     int lcId2 =
@@ -260,7 +260,7 @@ class UserDAOTest extends DAOTestHelper {
             user2.getEmail(),
             user2.getUserId(),
             new Date());
-    libraryCardDAO.createLibraryCardDaaRelation(lcId2, daaId);
+    libraryCardDAO.createLibraryCardDaaRelation(user2.getUserId(), lcId2, daaId);
 
     List<User> users = userDAO.findUsersWithLCsAndInstitution();
     // Four users: two admin users, two signing official users with library cards.
@@ -410,7 +410,7 @@ class UserDAOTest extends DAOTestHelper {
     Instant now = Instant.now();
     LibraryCard card = createLibraryCard();
     int daaId = daaDAO.createDaa(card.getUserId(), now, card.getUserId(), now, dacId);
-    libraryCardDAO.createLibraryCardDaaRelation(card.getId(), daaId);
+    libraryCardDAO.createLibraryCardDaaRelation(card.getUserId(), card.getId(), daaId);
     User lcUser = userDAO.findUserById(card.getUserId());
     Integer userId = card.getUserId();
     List<User> users = userDAO.getUsersFromInstitutionWithCards(lcUser.getInstitutionId());
@@ -429,10 +429,10 @@ class UserDAOTest extends DAOTestHelper {
     Instant now = Instant.now();
     LibraryCard card1 = createLibraryCard();
     int daaId1 = daaDAO.createDaa(card1.getUserId(), now, card1.getUserId(), now, dacId);
-    libraryCardDAO.createLibraryCardDaaRelation(card1.getId(), daaId1);
+    libraryCardDAO.createLibraryCardDaaRelation(card1.getUserId(), card1.getId(), daaId1);
     LibraryCard card2 = createLibraryCard();
     int daaId2 = daaDAO.createDaa(card2.getUserId(), now, card2.getUserId(), now, dacId);
-    libraryCardDAO.createLibraryCardDaaRelation(card2.getId(), daaId2);
+    libraryCardDAO.createLibraryCardDaaRelation(card2.getUserId(), card2.getId(), daaId2);
 
     List<User> daa1UserList = userDAO.getUsersWithCardsByDaaId(daaId1);
     assertEquals(1, daa1UserList.size());

--- a/src/test/java/org/broadinstitute/consent/http/db/UserDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/UserDAOTest.java
@@ -243,38 +243,37 @@ class UserDAOTest extends DAOTestHelper {
 
   @Test
   void testFindUsersWithLCsAndInstitution() {
-    User signingOfficial = createUser();
-    User user = createUserWithInstitution();
+    // Creates an Admin and an SO, and returns the SO
+    User signingOfficial = createUserWithInstitution();
+    // Creates a researcher
+    User user = createUserWithRole(UserRoles.RESEARCHER.getRoleId(), signingOfficial.getInstitutionId());
     int dacId = dacDAO.createDac(randomAlphabetic(5), randomAlphabetic(5), new Date());
     Instant now = Instant.now();
     int daaId = daaDAO.createDaa(user.getUserId(), now, user.getUserId(), now, dacId);
-    int lcId1 =
-        libraryCardDAO.insertLibraryCard(
-            user.getUserId(), user.getDisplayName(), user.getEmail(), user.getUserId(), new Date());
-    libraryCardDAO.createLibraryCardDaaRelation(
-        user.getUserId(), signingOfficial.getUserId(), lcId1, daaId);
+    int lcId1 = libraryCardDAO.insertLibraryCard(user.getUserId(), user.getDisplayName(), user.getEmail(), signingOfficial.getUserId(), new Date());
+    libraryCardDAO.createLibraryCardDaaRelation(user.getUserId(), signingOfficial.getUserId(), lcId1, daaId);
 
-    User user2 = createUserWithInstitution();
+    // Creates another admin and another SO
+    User signingOfficial2 = createUserWithInstitution();
+    // Creates a researcher
+    User user2 = createUserWithRole(UserRoles.RESEARCHER.getRoleId(), signingOfficial2.getInstitutionId());
     int lcId2 =
         libraryCardDAO.insertLibraryCard(
             user2.getUserId(),
             user2.getDisplayName(),
             user2.getEmail(),
-            user2.getUserId(),
+            signingOfficial2.getUserId(),
             new Date());
-    libraryCardDAO.createLibraryCardDaaRelation(
-        user2.getUserId(), signingOfficial.getUserId(), lcId2, daaId);
+    libraryCardDAO.createLibraryCardDaaRelation(user2.getUserId(), signingOfficial2.getUserId(), lcId2, daaId);
 
     List<User> users = userDAO.findUsersWithLCsAndInstitution();
-    // Four users: two admin users, two signing official users with library cards.
-    assertEquals(4, users.size());
-    // Filter out admin users, which don't have institutions.
-    users = users.stream().filter(u -> u.getInstitution() != null).toList();
+    // Filter out non-researchers since those are the ones we've added LCs to and are under test.
+    users = users.stream().filter(u -> u.hasUserRole(UserRoles.RESEARCHER)).toList();
     assertEquals(2, users.size());
-    assertNotNull(users.get(0).getInstitution());
-    assertNotNull(users.get(0).getLibraryCard());
-    assertNotNull(users.get(1).getInstitution());
-    assertNotNull(users.get(1).getLibraryCard());
+    users.forEach(u -> {
+      assertNotNull(u.getInstitution());
+      assertNotNull(u.getLibraryCard());
+    });
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/resources/DaaResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DaaResourceTest.java
@@ -447,7 +447,7 @@ class DaaResourceTest extends AbstractTestHelper {
     researcher.setLibraryCard(libraryCard);
 
     when(userService.findUserById(researcher.getUserId())).thenReturn(researcher);
-    doNothing().when(libraryCardService).removeDaaFromLibraryCard(any(), any());
+    doNothing().when(libraryCardService).removeDaaFromLibraryCard(any(), any(), any());
 
     resource = new DaaResource(daaService, dacService, userService, libraryCardService);
     try (Response response = resource.deleteDaaForUser(duosUser, daaId, researcher.getUserId())) {
@@ -474,7 +474,7 @@ class DaaResourceTest extends AbstractTestHelper {
 
     resource = new DaaResource(daaService, dacService, userService, libraryCardService);
     try (Response response = resource.deleteDaaForUser(duosUser, daaId, researcher.getUserId())) {
-      verify(libraryCardService, never()).removeDaaFromLibraryCard(any(), any());
+      verify(libraryCardService, never()).removeDaaFromLibraryCard(any(), any(), any());
       assertEquals(HttpStatus.SC_OK, response.getStatus());
     }
   }
@@ -516,7 +516,7 @@ class DaaResourceTest extends AbstractTestHelper {
     try (Response response =
         resource.deleteDaaForUser(duosUser, daaId, differentInstitutionUser.getUserId())) {
       assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatus());
-      verify(libraryCardService, never()).removeDaaFromLibraryCard(any(), any());
+      verify(libraryCardService, never()).removeDaaFromLibraryCard(any(), any(), any());
     }
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/resources/DaaResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DaaResourceTest.java
@@ -447,7 +447,7 @@ class DaaResourceTest extends AbstractTestHelper {
     researcher.setLibraryCard(libraryCard);
 
     when(userService.findUserById(researcher.getUserId())).thenReturn(researcher);
-    doNothing().when(libraryCardService).removeDaaFromLibraryCard(any(), any(), any());
+    doNothing().when(libraryCardService).removeDaaFromLibraryCard(any(), any(), any(), any());
 
     resource = new DaaResource(daaService, dacService, userService, libraryCardService);
     try (Response response = resource.deleteDaaForUser(duosUser, daaId, researcher.getUserId())) {
@@ -474,7 +474,7 @@ class DaaResourceTest extends AbstractTestHelper {
 
     resource = new DaaResource(daaService, dacService, userService, libraryCardService);
     try (Response response = resource.deleteDaaForUser(duosUser, daaId, researcher.getUserId())) {
-      verify(libraryCardService, never()).removeDaaFromLibraryCard(any(), any(), any());
+      verify(libraryCardService, never()).removeDaaFromLibraryCard(any(), any(), any(), any());
       assertEquals(HttpStatus.SC_OK, response.getStatus());
     }
   }
@@ -516,7 +516,7 @@ class DaaResourceTest extends AbstractTestHelper {
     try (Response response =
         resource.deleteDaaForUser(duosUser, daaId, differentInstitutionUser.getUserId())) {
       assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatus());
-      verify(libraryCardService, never()).removeDaaFromLibraryCard(any(), any(), any());
+      verify(libraryCardService, never()).removeDaaFromLibraryCard(any(), any(), any(), any());
     }
   }
 
@@ -721,7 +721,7 @@ class DaaResourceTest extends AbstractTestHelper {
 
     when(userService.findUsersInJsonArray(any(), any())).thenReturn(users);
     when(daaService.findById(daaId)).thenReturn(new DataAccessAgreement());
-    when(libraryCardService.removeDaaFromUserLibraryCard(any(), any())).thenReturn(null);
+    when(libraryCardService.removeDaaFromUserLibraryCard(any(), any(), any())).thenReturn(null);
 
     resource = new DaaResource(daaService, dacService, userService, libraryCardService);
 
@@ -865,7 +865,7 @@ class DaaResourceTest extends AbstractTestHelper {
 
     when(userService.findUserById(userId)).thenReturn(researcher);
     when(daaService.findDAAsInJsonArray(any(), any())).thenReturn(agreements);
-    when(libraryCardService.removeDaaFromUserLibraryCard(any(), any())).thenReturn(null);
+    when(libraryCardService.removeDaaFromUserLibraryCard(any(), any(), any())).thenReturn(null);
 
     resource = new DaaResource(daaService, dacService, userService, libraryCardService);
 

--- a/src/test/java/org/broadinstitute/consent/http/resources/LibraryCardResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/LibraryCardResourceTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -18,14 +17,17 @@ import java.util.Date;
 import java.util.List;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.AuthUser;
+import org.broadinstitute.consent.http.models.DuosUser;
 import org.broadinstitute.consent.http.models.Institution;
 import org.broadinstitute.consent.http.models.LibraryCard;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.UserRole;
 import org.broadinstitute.consent.http.service.LibraryCardService;
 import org.broadinstitute.consent.http.service.UserService;
+import org.broadinstitute.consent.http.service.feature.InstitutionAndLibraryCardEnforcement;
 import org.broadinstitute.consent.http.util.gson.GsonUtil;
 import org.jdbi.v3.core.statement.UnableToExecuteStatementException;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -40,6 +42,7 @@ class LibraryCardResourceTest {
   private final List<UserRole> adminRoles = Collections.singletonList(UserRoles.Admin());
   private final User user =
       new User(1, authUser.getEmail(), "Display Name", new Date(), adminRoles);
+  private final DuosUser duosUser = new DuosUser(authUser, user);
   private final User lcUser =
       new User(
           2,
@@ -52,6 +55,7 @@ class LibraryCardResourceTest {
 
   @Mock private UserService userService;
   @Mock private LibraryCardService libraryCardService;
+  @Mock private InstitutionAndLibraryCardEnforcement institutionAndLibraryCardEnforcement;
 
   private LibraryCard mockLibraryCardSetup() {
     LibraryCard mockCard = new LibraryCard();
@@ -62,18 +66,19 @@ class LibraryCardResourceTest {
   }
 
   private User mockSOUser() {
-    User mockUser =
-        new User(
-            2,
-            "testuser@gmail.com",
-            "Test User",
-            new Date(),
-            Collections.singletonList(UserRoles.SigningOfficial()));
-    return mockUser;
+    return new User(
+        2,
+        "testuser@gmail.com",
+        "Test User",
+        new Date(),
+        Collections.singletonList(UserRoles.SigningOfficial()));
   }
 
-  private void initResource() {
-    resource = new LibraryCardResource(userService, libraryCardService);
+  @BeforeEach
+  void initResource() {
+    resource =
+        new LibraryCardResource(
+            userService, libraryCardService, institutionAndLibraryCardEnforcement);
   }
 
   private UnableToExecuteStatementException generateUniqueViolationException() {
@@ -86,123 +91,116 @@ class LibraryCardResourceTest {
   void testGetLibraryCardsAsAdmin() {
     List<LibraryCard> libraryCards = Collections.singletonList(mockLibraryCardSetup());
     when(libraryCardService.findAllLibraryCards()).thenReturn(libraryCards);
-    initResource();
-    Response response = resource.getLibraryCards(authUser);
-    String json = response.getEntity().toString();
-    assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
-    assertNotNull(json);
+    try (Response response = resource.getLibraryCards(duosUser)) {
+      String json = response.getEntity().toString();
+      assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+      assertNotNull(json);
+    }
   }
 
   @Test
   void testGetLibraryCardsById() {
     LibraryCard card = mockLibraryCardSetup();
     when(libraryCardService.findLibraryCardById(anyInt())).thenReturn(card);
-    initResource();
-    Response response = resource.getLibraryCardById(authUser, 1);
-    String json = response.getEntity().toString();
-    assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
-    assertNotNull(json);
+    try (Response response = resource.getLibraryCardById(duosUser, 1)) {
+      String json = response.getEntity().toString();
+      assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+      assertNotNull(json);
+    }
   }
 
   @Test
   void testGetLibraryCardsByIdThrowsNotFoundException() {
     when(libraryCardService.findLibraryCardById(anyInt())).thenThrow(new NotFoundException());
-    initResource();
-    Response response = resource.getLibraryCardById(authUser, 1);
-    assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
+    try (Response response = resource.getLibraryCardById(duosUser, 1)) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
+    }
   }
 
   @Test
   void testGetLibraryCardByInstitutionId() {
     List<LibraryCard> cards = Collections.singletonList(mockLibraryCardSetup());
     when(libraryCardService.findLibraryCardsByInstitutionId(anyInt())).thenReturn(cards);
-    initResource();
-    Response response = resource.getLibraryCardsByInstitutionId(authUser, 1);
-    assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+    try (Response response = resource.getLibraryCardsByInstitutionId(duosUser, 1)) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+    }
   }
 
   @Test
   void testGetLibraryCardByInstitutionIdThrowsNotFoundException() {
     when(libraryCardService.findLibraryCardsByInstitutionId(anyInt()))
         .thenThrow(new NotFoundException());
-    initResource();
-    Response response = resource.getLibraryCardsByInstitutionId(authUser, 1);
-    assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
+    try (Response response = resource.getLibraryCardsByInstitutionId(duosUser, 1)) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
+    }
   }
 
   @Test
-  void testCreateLibraryCard() throws Exception {
+  void testCreateLibraryCard() {
     LibraryCard mockCard = mockLibraryCardSetup();
     String payload = GsonUtil.getInstance().toJson(mockCard);
-    when(userService.findUserByEmail(authUser.getEmail())).thenReturn(user);
     when(libraryCardService.createLibraryCard(any(LibraryCard.class), any(User.class)))
         .thenReturn(mockCard);
-    initResource();
-    Response response = resource.createLibraryCard(authUser, payload);
-    String json = response.getEntity().toString();
-    assertEquals(HttpStatusCodes.STATUS_CODE_CREATED, response.getStatus());
-    assertNotNull(json);
+    try (Response response = resource.createLibraryCard(duosUser, payload)) {
+      String json = response.getEntity().toString();
+      assertEquals(HttpStatusCodes.STATUS_CODE_CREATED, response.getStatus());
+      assertNotNull(json);
+    }
   }
 
   @Test
-  void testCreateLibraryCardThrowsIllegalArgumentException() throws Exception {
+  void testCreateLibraryCardThrowsIllegalArgumentException() {
     LibraryCard mockCard = mockLibraryCardSetup();
     String payload = GsonUtil.getInstance().toJson(mockCard);
-    when(userService.findUserByEmail(anyString())).thenReturn(user);
     when(libraryCardService.createLibraryCard(any(LibraryCard.class), any(User.class)))
         .thenThrow(new IllegalArgumentException());
-    initResource();
-    Response response = resource.createLibraryCard(authUser, payload);
-    assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
+    try (Response response = resource.createLibraryCard(duosUser, payload)) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
+    }
   }
 
   @Test
-  void testCreateLibraryCardThrowsConflictException() throws Exception {
+  void testCreateLibraryCardThrowsConflictException() {
     UnableToExecuteStatementException exception = generateUniqueViolationException();
     String json = GsonUtil.getInstance().toJson(mockLibraryCardSetup());
-    when(userService.findUserByEmail(anyString())).thenReturn(user);
     when(libraryCardService.createLibraryCard(any(LibraryCard.class), any(User.class)))
         .thenThrow(exception);
-    initResource();
-    Response response = resource.createLibraryCard(authUser, json);
-    assertEquals(HttpStatusCodes.STATUS_CODE_CONFLICT, response.getStatus());
+    try (Response response = resource.createLibraryCard(duosUser, json)) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_CONFLICT, response.getStatus());
+    }
   }
 
   @Test
-  void testCreateLibraryCardThrowsBadRequestException() throws Exception {
+  void testCreateLibraryCardThrowsBadRequestException() {
     BadRequestException exception = new BadRequestException();
     String json = GsonUtil.getInstance().toJson(mockLibraryCardSetup());
-    when(userService.findUserByEmail(anyString())).thenReturn(user);
     when(libraryCardService.createLibraryCard(any(LibraryCard.class), any(User.class)))
         .thenThrow(exception);
-    initResource();
-    Response response = resource.createLibraryCard(authUser, json);
-    assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
+    try (Response response = resource.createLibraryCard(duosUser, json)) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
+    }
   }
 
   @Test
-  void testCreateLibraruCardThrowsNotFoundException() throws Exception {
+  void testCreateLibraruCardThrowsNotFoundException() {
     NotFoundException exception = new NotFoundException();
     String json = GsonUtil.getInstance().toJson(mockLibraryCardSetup());
-    when(userService.findUserByEmail(anyString())).thenReturn(user);
     when(libraryCardService.createLibraryCard(any(LibraryCard.class), any(User.class)))
         .thenThrow(exception);
-    initResource();
-    Response response = resource.createLibraryCard(authUser, json);
-    assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
+    try (Response response = resource.createLibraryCard(duosUser, json)) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
+    }
   }
 
   @Test
   void deleteLibraryCard() {
     LibraryCard card = mockLibraryCardSetup();
     card.setId(1);
-    when(userService.findUserByEmail(anyString())).thenReturn(user);
     when(libraryCardService.findLibraryCardById(anyInt())).thenReturn(card);
-    initResource();
-
-    Response response = resource.deleteLibraryCard(authUser, card.getId());
-    assertEquals(HttpStatusCodes.STATUS_CODE_NO_CONTENT, response.getStatus());
-    verify(libraryCardService).deleteLibraryCardById(card.getId());
+    try (Response response = resource.deleteLibraryCard(duosUser, card.getId())) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_NO_CONTENT, response.getStatus());
+      verify(libraryCardService).deleteLibraryCardById(card.getId());
+    }
   }
 
   @Test
@@ -210,26 +208,22 @@ class LibraryCardResourceTest {
     LibraryCard card = mockLibraryCardSetup();
     card.setId(1);
     card.setUserId(null);
-    when(userService.findUserByEmail(user.getEmail())).thenReturn(user);
     when(userService.findUserById(null)).thenThrow(new NotFoundException());
     when(libraryCardService.findLibraryCardById(anyInt())).thenReturn(card);
-    initResource();
-
-    Response response = resource.deleteLibraryCard(authUser, card.getId());
-    assertEquals(HttpStatusCodes.STATUS_CODE_NO_CONTENT, response.getStatus());
-    verify(libraryCardService).deleteLibraryCardById(card.getId());
+    try (Response response = resource.deleteLibraryCard(duosUser, card.getId())) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_NO_CONTENT, response.getStatus());
+      verify(libraryCardService).deleteLibraryCardById(card.getId());
+    }
   }
 
   @Test
   void deleteLibraryCardThrowsNotFoundException() {
     LibraryCard card = mockLibraryCardSetup();
-    when(userService.findUserByEmail(anyString())).thenReturn(user);
     when(libraryCardService.findLibraryCardById(anyInt())).thenReturn(card);
     doThrow(new NotFoundException()).when(libraryCardService).deleteLibraryCardById(anyInt());
-    initResource();
-
-    Response response = resource.deleteLibraryCard(authUser, 1);
-    assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
+    try (Response response = resource.deleteLibraryCard(duosUser, 1)) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
+    }
   }
 
   @Test
@@ -240,18 +234,18 @@ class LibraryCardResourceTest {
     soInstitution.setId(1);
     soUser.setInstitution(soInstitution);
     soUser.setInstitutionId(soInstitution.getId());
-    // Mocks that the user is in a different institution than the SO
+    DuosUser soDuosUser = new DuosUser(authUser, mockSOUser());
+
     Institution lcUserInstitution = new Institution();
     lcUserInstitution.setId(2);
     lcUser.setInstitution(lcUserInstitution);
     lcUser.setInstitutionId(lcUserInstitution.getId());
 
-    when(userService.findUserByEmail(anyString())).thenReturn(soUser);
     when(libraryCardService.findLibraryCardById(anyInt())).thenReturn(card);
     when(userService.findUserById(card.getUserId())).thenReturn(lcUser);
 
-    initResource();
-    Response response = resource.deleteLibraryCard(authUser, 1);
-    assertEquals(HttpStatusCodes.STATUS_CODE_FORBIDDEN, response.getStatus());
+    try (Response response = resource.deleteLibraryCard(soDuosUser, 1)) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_FORBIDDEN, response.getStatus());
+    }
   }
 }

--- a/src/test/java/org/broadinstitute/consent/http/resources/LibraryCardResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/LibraryCardResourceTest.java
@@ -4,12 +4,15 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.api.client.http.HttpStatusCodes;
 import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.ForbiddenException;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.core.Response;
 import java.util.Collections;
@@ -21,7 +24,6 @@ import org.broadinstitute.consent.http.models.DuosUser;
 import org.broadinstitute.consent.http.models.Institution;
 import org.broadinstitute.consent.http.models.LibraryCard;
 import org.broadinstitute.consent.http.models.User;
-import org.broadinstitute.consent.http.models.UserRole;
 import org.broadinstitute.consent.http.service.LibraryCardService;
 import org.broadinstitute.consent.http.service.UserService;
 import org.broadinstitute.consent.http.service.feature.InstitutionAndLibraryCardEnforcement;
@@ -39,17 +41,28 @@ import org.postgresql.util.PSQLState;
 class LibraryCardResourceTest {
 
   private final AuthUser authUser = new AuthUser("test@test.com");
-  private final List<UserRole> adminRoles = Collections.singletonList(UserRoles.Admin());
-  private final User user =
-      new User(1, authUser.getEmail(), "Display Name", new Date(), adminRoles);
-  private final DuosUser duosUser = new DuosUser(authUser, user);
+  private final User adminUser =
+      new User(
+          1,
+          authUser.getEmail(),
+          "Admin",
+          new Date(),
+          Collections.singletonList(UserRoles.Admin()));
+  private final DuosUser duosAdminUser = new DuosUser(authUser, adminUser);
   private final User lcUser =
       new User(
           2,
-          "testuser@gmail.com",
-          "Test User",
+          "lc_user@gmail.com",
+          "Researcher",
           new Date(),
           Collections.singletonList(UserRoles.Researcher()));
+  private final User soUser =
+      new User(
+          3,
+          "so_user@gmail.com",
+          "Signing Official",
+          new Date(),
+          Collections.singletonList(UserRoles.SigningOfficial()));
 
   private LibraryCardResource resource;
 
@@ -63,15 +76,6 @@ class LibraryCardResourceTest {
     mockCard.setCreateUserId(1);
     mockCard.setUserEmail(lcUser.getEmail());
     return mockCard;
-  }
-
-  private User mockSOUser() {
-    return new User(
-        2,
-        "testuser@gmail.com",
-        "Test User",
-        new Date(),
-        Collections.singletonList(UserRoles.SigningOfficial()));
   }
 
   @BeforeEach
@@ -91,7 +95,7 @@ class LibraryCardResourceTest {
   void testGetLibraryCardsAsAdmin() {
     List<LibraryCard> libraryCards = Collections.singletonList(mockLibraryCardSetup());
     when(libraryCardService.findAllLibraryCards()).thenReturn(libraryCards);
-    try (Response response = resource.getLibraryCards(duosUser)) {
+    try (Response response = resource.getLibraryCards(duosAdminUser)) {
       String json = response.getEntity().toString();
       assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
       assertNotNull(json);
@@ -102,7 +106,7 @@ class LibraryCardResourceTest {
   void testGetLibraryCardsById() {
     LibraryCard card = mockLibraryCardSetup();
     when(libraryCardService.findLibraryCardById(anyInt())).thenReturn(card);
-    try (Response response = resource.getLibraryCardById(duosUser, 1)) {
+    try (Response response = resource.getLibraryCardById(duosAdminUser, 1)) {
       String json = response.getEntity().toString();
       assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
       assertNotNull(json);
@@ -112,7 +116,7 @@ class LibraryCardResourceTest {
   @Test
   void testGetLibraryCardsByIdThrowsNotFoundException() {
     when(libraryCardService.findLibraryCardById(anyInt())).thenThrow(new NotFoundException());
-    try (Response response = resource.getLibraryCardById(duosUser, 1)) {
+    try (Response response = resource.getLibraryCardById(duosAdminUser, 1)) {
       assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
     }
   }
@@ -121,7 +125,7 @@ class LibraryCardResourceTest {
   void testGetLibraryCardByInstitutionId() {
     List<LibraryCard> cards = Collections.singletonList(mockLibraryCardSetup());
     when(libraryCardService.findLibraryCardsByInstitutionId(anyInt())).thenReturn(cards);
-    try (Response response = resource.getLibraryCardsByInstitutionId(duosUser, 1)) {
+    try (Response response = resource.getLibraryCardsByInstitutionId(duosAdminUser, 1)) {
       assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
     }
   }
@@ -130,7 +134,7 @@ class LibraryCardResourceTest {
   void testGetLibraryCardByInstitutionIdThrowsNotFoundException() {
     when(libraryCardService.findLibraryCardsByInstitutionId(anyInt()))
         .thenThrow(new NotFoundException());
-    try (Response response = resource.getLibraryCardsByInstitutionId(duosUser, 1)) {
+    try (Response response = resource.getLibraryCardsByInstitutionId(duosAdminUser, 1)) {
       assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
     }
   }
@@ -141,7 +145,7 @@ class LibraryCardResourceTest {
     String payload = GsonUtil.getInstance().toJson(mockCard);
     when(libraryCardService.createLibraryCard(any(LibraryCard.class), any(User.class)))
         .thenReturn(mockCard);
-    try (Response response = resource.createLibraryCard(duosUser, payload)) {
+    try (Response response = resource.createLibraryCard(duosAdminUser, payload)) {
       String json = response.getEntity().toString();
       assertEquals(HttpStatusCodes.STATUS_CODE_CREATED, response.getStatus());
       assertNotNull(json);
@@ -154,7 +158,7 @@ class LibraryCardResourceTest {
     String payload = GsonUtil.getInstance().toJson(mockCard);
     when(libraryCardService.createLibraryCard(any(LibraryCard.class), any(User.class)))
         .thenThrow(new IllegalArgumentException());
-    try (Response response = resource.createLibraryCard(duosUser, payload)) {
+    try (Response response = resource.createLibraryCard(duosAdminUser, payload)) {
       assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
     }
   }
@@ -165,7 +169,7 @@ class LibraryCardResourceTest {
     String json = GsonUtil.getInstance().toJson(mockLibraryCardSetup());
     when(libraryCardService.createLibraryCard(any(LibraryCard.class), any(User.class)))
         .thenThrow(exception);
-    try (Response response = resource.createLibraryCard(duosUser, json)) {
+    try (Response response = resource.createLibraryCard(duosAdminUser, json)) {
       assertEquals(HttpStatusCodes.STATUS_CODE_CONFLICT, response.getStatus());
     }
   }
@@ -176,7 +180,7 @@ class LibraryCardResourceTest {
     String json = GsonUtil.getInstance().toJson(mockLibraryCardSetup());
     when(libraryCardService.createLibraryCard(any(LibraryCard.class), any(User.class)))
         .thenThrow(exception);
-    try (Response response = resource.createLibraryCard(duosUser, json)) {
+    try (Response response = resource.createLibraryCard(duosAdminUser, json)) {
       assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
     }
   }
@@ -187,54 +191,53 @@ class LibraryCardResourceTest {
     String json = GsonUtil.getInstance().toJson(mockLibraryCardSetup());
     when(libraryCardService.createLibraryCard(any(LibraryCard.class), any(User.class)))
         .thenThrow(exception);
-    try (Response response = resource.createLibraryCard(duosUser, json)) {
+    try (Response response = resource.createLibraryCard(duosAdminUser, json)) {
       assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
     }
   }
 
   @Test
-  void deleteLibraryCard() {
+  void testDeleteLibraryCard() {
     LibraryCard card = mockLibraryCardSetup();
     card.setId(1);
     when(libraryCardService.findLibraryCardById(anyInt())).thenReturn(card);
-    try (Response response = resource.deleteLibraryCard(duosUser, card.getId())) {
+    try (Response response = resource.deleteLibraryCard(duosAdminUser, card.getId())) {
       assertEquals(HttpStatusCodes.STATUS_CODE_NO_CONTENT, response.getStatus());
       verify(libraryCardService).deleteLibraryCardById(card.getId());
     }
   }
 
   @Test
-  void deleteLibraryCardUserNotFound() {
+  void testDeleteLibraryCardUserNotFound() {
     LibraryCard card = mockLibraryCardSetup();
     card.setId(1);
     card.setUserId(null);
     when(userService.findUserById(null)).thenThrow(new NotFoundException());
     when(libraryCardService.findLibraryCardById(anyInt())).thenReturn(card);
-    try (Response response = resource.deleteLibraryCard(duosUser, card.getId())) {
+    try (Response response = resource.deleteLibraryCard(duosAdminUser, card.getId())) {
       assertEquals(HttpStatusCodes.STATUS_CODE_NO_CONTENT, response.getStatus());
       verify(libraryCardService).deleteLibraryCardById(card.getId());
     }
   }
 
   @Test
-  void deleteLibraryCardThrowsNotFoundException() {
+  void testDeleteLibraryCardThrowsNotFoundException() {
     LibraryCard card = mockLibraryCardSetup();
     when(libraryCardService.findLibraryCardById(anyInt())).thenReturn(card);
     doThrow(new NotFoundException()).when(libraryCardService).deleteLibraryCardById(anyInt());
-    try (Response response = resource.deleteLibraryCard(duosUser, 1)) {
+    try (Response response = resource.deleteLibraryCard(duosAdminUser, 1)) {
       assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
     }
   }
 
   @Test
-  void deleteLibraryCardThrowsForbiddenException() {
+  void testDeleteLibraryCardThrowsForbiddenException() {
     LibraryCard card = mockLibraryCardSetup();
-    User soUser = mockSOUser();
     Institution soInstitution = new Institution();
     soInstitution.setId(1);
     soUser.setInstitution(soInstitution);
     soUser.setInstitutionId(soInstitution.getId());
-    DuosUser soDuosUser = new DuosUser(authUser, mockSOUser());
+    DuosUser soDuosUser = new DuosUser(authUser, soUser);
 
     Institution lcUserInstitution = new Institution();
     lcUserInstitution.setId(2);
@@ -246,6 +249,63 @@ class LibraryCardResourceTest {
 
     try (Response response = resource.deleteLibraryCard(soDuosUser, 1)) {
       assertEquals(HttpStatusCodes.STATUS_CODE_FORBIDDEN, response.getStatus());
+    }
+  }
+
+  @Test
+  void testFindLibraryCardDaaAuditsByUserId_ValidSO() {
+    when(userService.findUserById(lcUser.getUserId())).thenReturn(lcUser);
+    doNothing()
+        .when(institutionAndLibraryCardEnforcement)
+        .validateEmailsFromSameInstitution(soUser.getEmail(), lcUser.getEmail());
+    when(libraryCardService.findLibraryCardDaaAuditsByUserId(lcUser.getUserId()))
+        .thenReturn(List.of());
+    DuosUser soDuosUser = new DuosUser(authUser, soUser);
+
+    try (Response response =
+        resource.findLibraryCardDaaAuditsByUserId(soDuosUser, lcUser.getUserId())) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+    }
+  }
+
+  @Test
+  void testFindLibraryCardDaaAuditsByUserId_ValidAdmin() {
+    when(userService.findUserById(lcUser.getUserId())).thenReturn(lcUser);
+    when(libraryCardService.findLibraryCardDaaAuditsByUserId(lcUser.getUserId()))
+        .thenReturn(List.of());
+
+    try (Response response =
+        resource.findLibraryCardDaaAuditsByUserId(duosAdminUser, lcUser.getUserId())) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+      verify(institutionAndLibraryCardEnforcement, never())
+          .validateEmailsFromSameInstitution(any(), any());
+    }
+  }
+
+  @Test
+  void testFindLibraryCardDaaAuditsByUserId_InvalidSO() {
+    soUser.setEmail("some.other.email@other.domain.com");
+    when(userService.findUserById(lcUser.getUserId())).thenReturn(lcUser);
+    doThrow(new ForbiddenException())
+        .when(institutionAndLibraryCardEnforcement)
+        .validateEmailsFromSameInstitution(soUser.getEmail(), lcUser.getEmail());
+    DuosUser soDuosUser = new DuosUser(authUser, soUser);
+
+    try (Response response =
+        resource.findLibraryCardDaaAuditsByUserId(soDuosUser, lcUser.getUserId())) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_FORBIDDEN, response.getStatus());
+    }
+  }
+
+  @Test
+  void testFindLibraryCardDaaAuditsByUserId_UserNotFound() {
+    soUser.setEmail("some.other.email@other.domain.com");
+    doThrow(new NotFoundException()).when(userService).findUserById(lcUser.getUserId());
+    DuosUser soDuosUser = new DuosUser(authUser, soUser);
+
+    try (Response response =
+        resource.findLibraryCardDaaAuditsByUserId(soDuosUser, lcUser.getUserId())) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
     }
   }
 }

--- a/src/test/java/org/broadinstitute/consent/http/service/LibraryCardServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/LibraryCardServiceTest.java
@@ -29,6 +29,7 @@ import org.broadinstitute.consent.http.exceptions.ConsentConflictException;
 import org.broadinstitute.consent.http.models.DataAccessAgreement;
 import org.broadinstitute.consent.http.models.Institution;
 import org.broadinstitute.consent.http.models.LibraryCard;
+import org.broadinstitute.consent.http.models.LibraryCardDaaAudit;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.UserRole;
 import org.junit.jupiter.api.BeforeEach;
@@ -499,6 +500,15 @@ class LibraryCardServiceTest extends AbstractTestHelper {
     when(libraryCardDAO.findLibraryCardByUserId(userId)).thenReturn(null);
     LibraryCard card = service.removeDaaFromUserLibraryCard(user, 1);
     assertNull(card);
+  }
+
+  @Test
+  void testFindLibraryCardDaaAuditsByUserId() {
+    User user = testUser(1);
+    when(libraryCardDAO.findAuditsByLcUserId(user.getUserId())).thenReturn(List.of());
+
+    List<LibraryCardDaaAudit> audits = service.findLibraryCardDaaAuditsByUserId(user.getUserId());
+    assertTrue(audits.isEmpty());
   }
 
   private User testUser(Integer institutionId) {

--- a/src/test/java/org/broadinstitute/consent/http/service/LibraryCardServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/LibraryCardServiceTest.java
@@ -232,9 +232,7 @@ class LibraryCardServiceTest extends AbstractTestHelper {
     when(libraryCardDAO.findLibraryCardByUserEmail(any())).thenReturn(savedCard);
     assertThrows(
         ConsentConflictException.class,
-        () -> {
-          service.createLibraryCard(payload, signingOfficialUser);
-        });
+        () -> service.createLibraryCard(payload, signingOfficialUser));
   }
 
   @Test
@@ -246,10 +244,7 @@ class LibraryCardServiceTest extends AbstractTestHelper {
     LibraryCard payload = testLibraryCard(null);
 
     assertThrows(
-        BadRequestException.class,
-        () -> {
-          service.createLibraryCard(payload, signingOfficialUser);
-        });
+        BadRequestException.class, () -> service.createLibraryCard(payload, signingOfficialUser));
   }
 
   @Test
@@ -293,11 +288,7 @@ class LibraryCardServiceTest extends AbstractTestHelper {
             UserRoles.SIGNINGOFFICIAL.getRoleId(), UserRoles.SIGNINGOFFICIAL.getRoleName());
     soUser.setInstitutionId(1);
     LibraryCard card = testLibraryCard(2);
-    assertThrows(
-        BadRequestException.class,
-        () -> {
-          service.createLibraryCard(card, soUser);
-        });
+    assertThrows(BadRequestException.class, () -> service.createLibraryCard(card, soUser));
   }
 
   @Test
@@ -313,11 +304,7 @@ class LibraryCardServiceTest extends AbstractTestHelper {
   @Test
   void testFindLibraryCardById_NotFound() {
     when(libraryCardDAO.findLibraryCardById(any())).thenReturn(null);
-    assertThrows(
-        NotFoundException.class,
-        () -> {
-          service.findLibraryCardById(1);
-        });
+    assertThrows(NotFoundException.class, () -> service.findLibraryCardById(1));
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/LibraryCardServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/LibraryCardServiceTest.java
@@ -206,12 +206,11 @@ class LibraryCardServiceTest extends AbstractTestHelper {
         createUserWithRole(
             UserRoles.SIGNINGOFFICIAL.getRoleId(), UserRoles.SIGNINGOFFICIAL.getRoleName());
     LibraryCard savedCard = testLibraryCard(user.getUserId());
-    LibraryCard payload = savedCard;
 
     when(libraryCardDAO.findLibraryCardByUserId(anyInt())).thenReturn(savedCard);
     assertThrows(
         ConsentConflictException.class,
-        () -> service.createLibraryCard(payload, signingOfficialUser));
+        () -> service.createLibraryCard(savedCard, signingOfficialUser));
   }
 
   @Test
@@ -227,12 +226,10 @@ class LibraryCardServiceTest extends AbstractTestHelper {
     LibraryCard savedCard = testLibraryCard(null);
     savedCard.setUserEmail(user.getEmail());
 
-    LibraryCard payload = savedCard;
-
     when(libraryCardDAO.findLibraryCardByUserEmail(any())).thenReturn(savedCard);
     assertThrows(
         ConsentConflictException.class,
-        () -> service.createLibraryCard(payload, signingOfficialUser));
+        () -> service.createLibraryCard(savedCard, signingOfficialUser));
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/LibraryCardServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/LibraryCardServiceTest.java
@@ -333,11 +333,14 @@ class LibraryCardServiceTest extends AbstractTestHelper {
     User user = new User();
     user.setUserId(1);
     LibraryCard card = testLibraryCard(user.getUserId());
+    User so = new User();
+    so.setUserId(2);
     doNothing()
         .when(libraryCardDAO)
-        .createLibraryCardDaaRelation(user.getUserId(), card.getId(), 1);
+        .createLibraryCardDaaRelation(user.getUserId(), so.getUserId(), card.getId(), 1);
 
-    assertDoesNotThrow(() -> service.addDaaToLibraryCard(user.getUserId(), card.getId(), 1));
+    assertDoesNotThrow(
+        () -> service.addDaaToLibraryCard(user.getUserId(), so.getUserId(), card.getId(), 1));
   }
 
   @Test
@@ -345,11 +348,14 @@ class LibraryCardServiceTest extends AbstractTestHelper {
     User user = new User();
     user.setUserId(1);
     LibraryCard card = testLibraryCard(1);
+    User so = new User();
+    so.setUserId(2);
     doNothing()
         .when(libraryCardDAO)
-        .deleteLibraryCardDaaRelation(user.getUserId(), card.getId(), 1);
+        .deleteLibraryCardDaaRelation(user.getUserId(), so.getUserId(), card.getId(), 1);
 
-    assertDoesNotThrow(() -> service.removeDaaFromLibraryCard(user.getUserId(), card.getId(), 1));
+    assertDoesNotThrow(
+        () -> service.removeDaaFromLibraryCard(user.getUserId(), so.getUserId(), card.getId(), 1));
   }
 
   @Test
@@ -365,7 +371,7 @@ class LibraryCardServiceTest extends AbstractTestHelper {
     Integer userId = user.getUserId();
     when(libraryCardDAO.findLibraryCardByUserId(user.getUserId()))
         .thenReturn(testLibraryCard(userId));
-    doNothing().when(libraryCardDAO).createLibraryCardDaaRelation(any(), any(), any());
+    doNothing().when(libraryCardDAO).createLibraryCardDaaRelation(any(), any(), any(), any());
     LibraryCard card = service.addDaaToUserLibraryCard(user, signingOfficial, 1);
     assertNotNull(card);
   }
@@ -419,8 +425,10 @@ class LibraryCardServiceTest extends AbstractTestHelper {
     Integer userId = user.getUserId();
     when(libraryCardDAO.findLibraryCardByUserId(user.getUserId()))
         .thenReturn(testLibraryCard(userId));
-    doNothing().when(libraryCardDAO).deleteLibraryCardDaaRelation(any(), any(), any());
-    LibraryCard card = service.removeDaaFromUserLibraryCard(user, 1);
+    User so = new User();
+    so.setUserId(2);
+    doNothing().when(libraryCardDAO).deleteLibraryCardDaaRelation(any(), any(), any(), any());
+    LibraryCard card = service.removeDaaFromUserLibraryCard(user, so, 1);
     // The above deletion only affects the lc-daa join table and does not remove library cards
     assertNotNull(card);
     assertTrue(card.getDaaIds().isEmpty());
@@ -432,7 +440,9 @@ class LibraryCardServiceTest extends AbstractTestHelper {
     Integer userId = user.getUserId();
     when(libraryCardDAO.findLibraryCardByUserId(user.getUserId()))
         .thenReturn(testLibraryCard(userId));
-    LibraryCard card = service.removeDaaFromUserLibraryCard(user, 1);
+    User so = new User();
+    so.setUserId(2);
+    LibraryCard card = service.removeDaaFromUserLibraryCard(user, so, 1);
     // DAA removal should not delete library cards
     assertNotNull(card);
     assertTrue(card.getDaaIds().isEmpty());
@@ -472,7 +482,9 @@ class LibraryCardServiceTest extends AbstractTestHelper {
     User user = testUser(1);
     Integer userId = user.getUserId();
     when(libraryCardDAO.findLibraryCardByUserId(userId)).thenReturn(null);
-    LibraryCard card = service.removeDaaFromUserLibraryCard(user, 1);
+    User so = new User();
+    so.setUserId(2);
+    LibraryCard card = service.removeDaaFromUserLibraryCard(user, so, 1);
     assertNull(card);
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/service/LibraryCardServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/LibraryCardServiceTest.java
@@ -282,16 +282,6 @@ class LibraryCardServiceTest extends AbstractTestHelper {
   }
 
   @Test
-  void testCreateLibraryCard_InstitutionMismatch() {
-    User soUser =
-        createUserWithRole(
-            UserRoles.SIGNINGOFFICIAL.getRoleId(), UserRoles.SIGNINGOFFICIAL.getRoleName());
-    soUser.setInstitutionId(1);
-    LibraryCard card = testLibraryCard(2);
-    assertThrows(BadRequestException.class, () -> service.createLibraryCard(card, soUser));
-  }
-
-  @Test
   void testDeleteLibraryCard_NotFound() {
     Institution institution = testInstitution();
     User user = testUser(institution.getId());

--- a/src/test/java/org/broadinstitute/consent/http/service/LibraryCardServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/LibraryCardServiceTest.java
@@ -19,8 +19,10 @@ import freemarker.template.TemplateException;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.NotFoundException;
 import java.io.IOException;
+import java.util.Date;
 import java.util.List;
 import org.broadinstitute.consent.http.AbstractTestHelper;
+import org.broadinstitute.consent.http.db.DaaDAO;
 import org.broadinstitute.consent.http.db.InstitutionDAO;
 import org.broadinstitute.consent.http.db.LibraryCardDAO;
 import org.broadinstitute.consent.http.db.UserDAO;
@@ -43,6 +45,7 @@ class LibraryCardServiceTest extends AbstractTestHelper {
 
   private LibraryCardService service;
 
+  @Mock private DaaDAO daaDAO;
   @Mock private InstitutionDAO institutionDAO;
   @Mock private LibraryCardDAO libraryCardDAO;
   @Mock private InstitutionService institutionService;
@@ -53,7 +56,7 @@ class LibraryCardServiceTest extends AbstractTestHelper {
   void initService() {
     service =
         new LibraryCardService(
-            libraryCardDAO, institutionDAO, institutionService, userDAO, emailService);
+            daaDAO, libraryCardDAO, institutionDAO, institutionService, userDAO, emailService);
   }
 
   @Test
@@ -333,8 +336,13 @@ class LibraryCardServiceTest extends AbstractTestHelper {
     User user = new User();
     user.setUserId(1);
     LibraryCard card = testLibraryCard(user.getUserId());
+    DataAccessAgreement daa = new DataAccessAgreement();
+    daa.setDaaId(1);
     User so = new User();
     so.setUserId(2);
+    when(userDAO.findUserById(user.getUserId())).thenReturn(user);
+    when(libraryCardDAO.findLibraryCardById(card.getId())).thenReturn(card);
+    when(daaDAO.findById(daa.getDaaId())).thenReturn(daa);
     doNothing()
         .when(libraryCardDAO)
         .createLibraryCardDaaRelation(user.getUserId(), so.getUserId(), card.getId(), 1);
@@ -361,6 +369,9 @@ class LibraryCardServiceTest extends AbstractTestHelper {
   @Test
   void testAddDaaToUserLibraryCard() {
     User user = testUser(1);
+    LibraryCard card = testLibraryCard(user.getUserId());
+    DataAccessAgreement daa = new DataAccessAgreement();
+    daa.setDaaId(1);
     user.setRoles(
         List.of(
             new UserRole(UserRoles.RESEARCHER.getRoleId(), UserRoles.RESEARCHER.getRoleName())));
@@ -369,11 +380,13 @@ class LibraryCardServiceTest extends AbstractTestHelper {
             UserRoles.SIGNINGOFFICIAL.getRoleId(), UserRoles.SIGNINGOFFICIAL.getRoleName());
     signingOfficial.setInstitutionId(1);
     Integer userId = user.getUserId();
-    when(libraryCardDAO.findLibraryCardByUserId(user.getUserId()))
-        .thenReturn(testLibraryCard(userId));
+    when(userDAO.findUserById(userId)).thenReturn(user);
+    when(libraryCardDAO.findLibraryCardById(card.getId())).thenReturn(card);
+    when(daaDAO.findById(daa.getDaaId())).thenReturn(daa);
+    when(libraryCardDAO.findLibraryCardByUserId(user.getUserId())).thenReturn(card);
     doNothing().when(libraryCardDAO).createLibraryCardDaaRelation(any(), any(), any(), any());
-    LibraryCard card = service.addDaaToUserLibraryCard(user, signingOfficial, 1);
-    assertNotNull(card);
+    LibraryCard foundCard = service.addDaaToUserLibraryCard(user, signingOfficial, 1);
+    assertNotNull(foundCard);
   }
 
   @Test
@@ -404,6 +417,8 @@ class LibraryCardServiceTest extends AbstractTestHelper {
     Integer userId = user.getUserId();
     LibraryCard payload = testLibraryCard(user.getUserId());
     payload.setUserEmail("testemail");
+    DataAccessAgreement daa = new DataAccessAgreement();
+    daa.setDaaId(1);
     // There are two calls to findLibraryCardsByUserId for checks before creation
     when(libraryCardDAO.findLibraryCardByUserId(userId))
         .thenReturn(null)
@@ -412,11 +427,69 @@ class LibraryCardServiceTest extends AbstractTestHelper {
     when(institutionDAO.findInstitutionById(institution.getId())).thenReturn(institution);
     when(institutionService.findInstitutionForEmail(any())).thenReturn(institution);
     when(userDAO.findUserById(user.getUserId())).thenReturn(user);
-    when(libraryCardDAO.insertLibraryCard(anyInt(), any(), any(), anyInt(), any())).thenReturn(1);
-    when(libraryCardDAO.findLibraryCardById(anyInt())).thenReturn(new LibraryCard());
+    when(libraryCardDAO.insertLibraryCard(
+            eq(user.getUserId()),
+            eq(user.getDisplayName()),
+            eq(user.getEmail()),
+            eq(signingOfficial.getUserId()),
+            any(Date.class)))
+        .thenReturn(payload.getId());
+    when(libraryCardDAO.findLibraryCardById(payload.getId())).thenReturn(payload);
+    when(daaDAO.findById(daa.getDaaId())).thenReturn(daa);
 
     LibraryCard card = service.addDaaToUserLibraryCard(user, signingOfficial, 1);
     assertNotNull(card);
+  }
+
+  @Test
+  void testAddDaaToLibraryCardUserNotFound() {
+    User user = testUser(1);
+    user.setRoles(
+        List.of(
+            new UserRole(UserRoles.RESEARCHER.getRoleId(), UserRoles.RESEARCHER.getRoleName())));
+    User signingOfficial =
+        createUserWithRole(
+            UserRoles.SIGNINGOFFICIAL.getRoleId(), UserRoles.SIGNINGOFFICIAL.getRoleName());
+    signingOfficial.setInstitutionId(4);
+    when(userDAO.findUserById(user.getUserId())).thenReturn(null);
+    assertThrows(
+        NotFoundException.class,
+        () -> service.addDaaToLibraryCard(user.getUserId(), signingOfficial.getUserId(), 1, 1));
+  }
+
+  @Test
+  void testAddDaaToLibraryCardLCNotFound() {
+    User user = testUser(1);
+    user.setRoles(
+        List.of(
+            new UserRole(UserRoles.RESEARCHER.getRoleId(), UserRoles.RESEARCHER.getRoleName())));
+    User signingOfficial =
+        createUserWithRole(
+            UserRoles.SIGNINGOFFICIAL.getRoleId(), UserRoles.SIGNINGOFFICIAL.getRoleName());
+    signingOfficial.setInstitutionId(4);
+    when(userDAO.findUserById(user.getUserId())).thenReturn(user);
+    when(libraryCardDAO.findLibraryCardById(1)).thenReturn(null);
+    assertThrows(
+        NotFoundException.class,
+        () -> service.addDaaToLibraryCard(user.getUserId(), signingOfficial.getUserId(), 1, 1));
+  }
+
+  @Test
+  void testAddDaaToLibraryCardDAANotFound() {
+    User user = testUser(1);
+    user.setRoles(
+        List.of(
+            new UserRole(UserRoles.RESEARCHER.getRoleId(), UserRoles.RESEARCHER.getRoleName())));
+    User signingOfficial =
+        createUserWithRole(
+            UserRoles.SIGNINGOFFICIAL.getRoleId(), UserRoles.SIGNINGOFFICIAL.getRoleName());
+    signingOfficial.setInstitutionId(4);
+    when(userDAO.findUserById(user.getUserId())).thenReturn(user);
+    when(libraryCardDAO.findLibraryCardById(1)).thenReturn(new LibraryCard());
+    when(daaDAO.findById(1)).thenReturn(null);
+    assertThrows(
+        NotFoundException.class,
+        () -> service.addDaaToLibraryCard(user.getUserId(), signingOfficial.getUserId(), 1, 1));
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/LibraryCardServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/LibraryCardServiceTest.java
@@ -355,18 +355,26 @@ class LibraryCardServiceTest extends AbstractTestHelper {
 
   @Test
   void testAddDaaToLibraryCard() {
-    doNothing().when(libraryCardDAO).createLibraryCardDaaRelation(any(), any());
+    User user = new User();
+    user.setUserId(1);
+    LibraryCard card = testLibraryCard(user.getUserId());
+    doNothing()
+        .when(libraryCardDAO)
+        .createLibraryCardDaaRelation(user.getUserId(), card.getId(), 1);
 
-    LibraryCard libraryCard = testLibraryCard(1);
-    assertDoesNotThrow(() -> service.addDaaToLibraryCard(libraryCard.getId(), 1));
+    assertDoesNotThrow(() -> service.addDaaToLibraryCard(user.getUserId(), card.getId(), 1));
   }
 
   @Test
   void testRemoveDaaFromLibraryCard() {
-    doNothing().when(libraryCardDAO).deleteLibraryCardDaaRelation(any(), any());
+    User user = new User();
+    user.setUserId(1);
+    LibraryCard card = testLibraryCard(1);
+    doNothing()
+        .when(libraryCardDAO)
+        .deleteLibraryCardDaaRelation(user.getUserId(), card.getId(), 1);
 
-    LibraryCard libraryCard = testLibraryCard(1);
-    assertDoesNotThrow(() -> service.removeDaaFromLibraryCard(libraryCard.getId(), 1));
+    assertDoesNotThrow(() -> service.removeDaaFromLibraryCard(user.getUserId(), card.getId(), 1));
   }
 
   @Test
@@ -382,7 +390,7 @@ class LibraryCardServiceTest extends AbstractTestHelper {
     Integer userId = user.getUserId();
     when(libraryCardDAO.findLibraryCardByUserId(user.getUserId()))
         .thenReturn(testLibraryCard(userId));
-    doNothing().when(libraryCardDAO).createLibraryCardDaaRelation(any(), any());
+    doNothing().when(libraryCardDAO).createLibraryCardDaaRelation(any(), any(), any());
     LibraryCard card = service.addDaaToUserLibraryCard(user, signingOfficial, 1);
     assertNotNull(card);
   }
@@ -436,7 +444,7 @@ class LibraryCardServiceTest extends AbstractTestHelper {
     Integer userId = user.getUserId();
     when(libraryCardDAO.findLibraryCardByUserId(user.getUserId()))
         .thenReturn(testLibraryCard(userId));
-    doNothing().when(libraryCardDAO).deleteLibraryCardDaaRelation(any(), any());
+    doNothing().when(libraryCardDAO).deleteLibraryCardDaaRelation(any(), any(), any());
     LibraryCard card = service.removeDaaFromUserLibraryCard(user, 1);
     // The above deletion only affects the lc-daa join table and does not remove library cards
     assertNotNull(card);

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DacServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DacServiceDAOTest.java
@@ -99,7 +99,7 @@ class DacServiceDAOTest extends DAOTestHelper {
                   superUser.getUserId(),
                   new Date());
           // Library Card User to Data Access Agreement association
-          libraryCardDAO.createLibraryCardDaaRelation(userLcId, daaId);
+          libraryCardDAO.createLibraryCardDaaRelation(superUser.getUserId(), userLcId, daaId);
           // DAC Member User. When deleting the dac, this role will be deleted
           User member = createUser();
           userRoleDAO.insertSingleUserRole(UserRoles.MEMBER.getRoleId(), member.getUserId());

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DacServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DacServiceDAOTest.java
@@ -99,7 +99,8 @@ class DacServiceDAOTest extends DAOTestHelper {
                   superUser.getUserId(),
                   new Date());
           // Library Card User to Data Access Agreement association
-          libraryCardDAO.createLibraryCardDaaRelation(superUser.getUserId(), userLcId, daaId);
+          libraryCardDAO.createLibraryCardDaaRelation(
+              lcUser.getUserId(), superUser.getUserId(), userLcId, daaId);
           // DAC Member User. When deleting the dac, this role will be deleted
           User member = createUser();
           userRoleDAO.insertSingleUserRole(UserRoles.MEMBER.getRoleId(), member.getUserId());


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DT-3056

## Summary
This PR adds auditing for Library Card <-> Data Access Agreement modifications. When a Signing Official adds or removes a DAA to/from a user's Library card, an audit record is created. There is also and Admin/SO endpoint to list these entities for a user. SOs are restricted to library cards whose users are in the same institution. Admins have no restrictions.

Future tickets will flesh this information out so users can see who made changes and when.

### New API

`GET /api/libraryCards/history/{userId}`

```
[
  {
    "id": 5,
    "daaId": 1,           --> This is the Data Access Agreement ID
    "lcId": 350,          --> This is the Library Card of the user who was updated
    "lcUserId": 3351,     --> This is the user who was updated
    "userId": 3351,       --> This is the user who made the change
    "action": "REMOVE",   --> This is the action that was performed
    "actionDate": 1775329908015
  },
  {
    "id": 4,
    "daaId": 10,
    "lcId": 350,
    "lcUserId": 3351,
    "userId": 3351,
    "action": "REMOVE",
    "actionDate": 1775329905768
  },
  {
    "id": 3,
    "daaId": 10,
    "lcId": 350,
    "lcUserId": 3351,
    "userId": 3351,
    "action": "ADD",
    "actionDate": 1775329901093
  },
  {
    "id": 1,
    "daaId": 1,
    "lcId": 350,
    "lcUserId": 3351,
    "userId": 3351,
    "action": "ADD",
    "actionDate": 1775329893526
  }
]
```

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
