### PR TITLE
DT-3167: Bug fix for daa population in reducer

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/UserWithRolesReducer.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/UserWithRolesReducer.java
@@ -47,7 +47,7 @@ public class UserWithRolesReducer
     try {
       hasOptionalColumn(rowView, "i_id", Integer.class)
           .ifPresent(
-              id -> {
+              ignored -> {
                 Institution institution = rowView.getRow(Institution.class);
                 // There are unusual cases where we somehow create an institution with null values
                 if (Objects.nonNull(institution.getId())) {
@@ -66,7 +66,7 @@ public class UserWithRolesReducer
     try {
       hasOptionalColumn(rowView, "lc_id", Integer.class)
           .ifPresent(
-              lcId -> {
+              ignored -> {
                 if (Objects.isNull(user.getLibraryCard())) {
                   user.setLibraryCard(rowView.getRow(LibraryCard.class));
                 }
@@ -81,7 +81,7 @@ public class UserWithRolesReducer
   private void addUserProperty(RowView rowView, User user) {
     try {
       hasOptionalColumn(rowView, "up_property_id", Integer.class)
-          .ifPresent(id -> user.addProperty(rowView.getRow(UserProperty.class)));
+          .ifPresent(ignored -> user.addProperty(rowView.getRow(UserProperty.class)));
     } catch (MappingException e) {
       logDebug("Error adding User Property to User: %s".formatted(e.getMessage()));
     }

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/UserWithRolesReducer.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/UserWithRolesReducer.java
@@ -17,15 +17,22 @@ public class UserWithRolesReducer
 
   @Override
   public void accumulate(Map<Integer, User> map, RowView rowView) {
-    // Some queries look for `user_id` while those that use a prefix look for `u_user_id`
-    Integer userId = 0;
-    if (hasNonZeroColumn(rowView, "user_id")) {
-      userId = rowView.getColumn("user_id", Integer.class);
-    } else if (hasNonZeroColumn(rowView, "u_user_id")) {
-      userId = rowView.getColumn("u_user_id", Integer.class);
-    }
+    Integer userId = resolveUserId(rowView);
     User user = map.computeIfAbsent(userId, id -> rowView.getRow(User.class));
+    addUserRole(rowView, user, userId);
+    addInstitution(rowView, user);
+    addLibraryCard(rowView, user);
+    addUserProperty(rowView, user);
+  }
 
+  private Integer resolveUserId(RowView rowView) {
+    // Some queries look for `user_id` while those that use a prefix look for `u_user_id`
+    return hasOptionalColumn(rowView, "user_id", Integer.class)
+        .or(() -> hasOptionalColumn(rowView, "u_user_id", Integer.class))
+        .orElse(0);
+  }
+
+  private void addUserRole(RowView rowView, User user, Integer userId) {
     try {
       UserRole userRole = mapUserRoleFromRowView(rowView, userId);
       if (userRole != null) {
@@ -34,67 +41,76 @@ public class UserWithRolesReducer
     } catch (MappingException e) {
       logWarn("Error adding User Role to User", e);
     }
+  }
+
+  private void addInstitution(RowView rowView, User user) {
     try {
-      if (Objects.nonNull(rowView.getColumn("i_id", Integer.class))) {
-        Institution institution = rowView.getRow(Institution.class);
-        // There are unusual cases where we somehow create an institution with null values
-        if (Objects.nonNull(institution.getId())) {
-          user.setInstitution(institution);
-        }
-      }
+      hasOptionalColumn(rowView, "i_id", Integer.class)
+          .ifPresent(
+              id -> {
+                Institution institution = rowView.getRow(Institution.class);
+                // There are unusual cases where we somehow create an institution with null values
+                if (Objects.nonNull(institution.getId())) {
+                  user.setInstitution(institution);
+                }
+              });
     } catch (MappingException e) {
       logDebug("Error adding Institution to User: %s".formatted(e.getMessage()));
     }
-    // user role join can cause duplication of data if done in tandem with joins on other tables
-    // ex) The same LC can end up being repeated multiple times
-    // Below only adds LC if not currently saved on the array
+  }
+
+  // user role join can cause duplication of data if done in tandem with joins on other tables
+  // ex) The same LC can end up being repeated multiple times
+  // Below only adds LC if not currently saved on the user
+  private void addLibraryCard(RowView rowView, User user) {
     try {
-      if (rowView.getColumn("lc_id", Integer.class) != null) {
-        LibraryCard lc = rowView.getRow(LibraryCard.class);
-        if (Objects.isNull(user.getLibraryCard())) {
-          user.setLibraryCard(lc);
-        }
-        if (rowView.getColumn("lc_daa_id", Integer.class) != null) {
-          user.getLibraryCard().addDaa(rowView.getColumn("lc_daa_id", Integer.class));
-        }
-      }
+      hasOptionalColumn(rowView, "lc_id", Integer.class)
+          .ifPresent(
+              lcId -> {
+                if (Objects.isNull(user.getLibraryCard())) {
+                  user.setLibraryCard(rowView.getRow(LibraryCard.class));
+                }
+                hasOptionalColumn(rowView, "lc_daa_id", Integer.class)
+                    .ifPresent(daaId -> user.getLibraryCard().addDaa(daaId));
+              });
     } catch (MappingException e) {
       logDebug("Error adding Library Card to User: %s".formatted(e.getMessage()));
     }
+  }
+
+  private void addUserProperty(RowView rowView, User user) {
     try {
-      if (Objects.nonNull(rowView.getColumn("up_property_id", Integer.class))) {
-        UserProperty p = rowView.getRow(UserProperty.class);
-        user.addProperty(p);
-      }
+      hasOptionalColumn(rowView, "up_property_id", Integer.class)
+          .ifPresent(id -> user.addProperty(rowView.getRow(UserProperty.class)));
     } catch (MappingException e) {
       logDebug("Error adding User Property to User: %s".formatted(e.getMessage()));
     }
   }
 
-  // Some queries look for `user_role_id` while those that use a prefix look for `u_user_role_id`
+  // Some queries look for `user_role_id` while those that use a prefix look for `ur_user_role_id`
   private UserRole mapUserRoleFromRowView(RowView rowView, Integer userId) {
-    Integer userRoleId;
-    Integer roleId;
-    String name;
-    Integer dacId = null;
-    // Some queries look for `user_role_id` while those that use a prefix look for `ur_user_role_id`
     if (hasNonZeroColumn(rowView, "user_role_id")) {
-      userRoleId = rowView.getColumn("user_role_id", Integer.class);
-      roleId = rowView.getColumn("role_id", Integer.class);
-      name = rowView.getColumn("name", String.class);
-      if (hasNonZeroColumn(rowView, "dac_id")) {
-        dacId = rowView.getColumn("dac_id", Integer.class);
-      }
-      return new UserRole(userRoleId, userId, roleId, name, dacId);
-    } else if (hasNonZeroColumn(rowView, "ur_user_role_id")) {
-      userRoleId = rowView.getColumn("ur_user_role_id", Integer.class);
-      roleId = rowView.getColumn("ur_role_id", Integer.class);
-      name = rowView.getColumn("ur_name", String.class);
-      if (hasNonZeroColumn(rowView, "ur_dac_id")) {
-        dacId = rowView.getColumn("ur_dac_id", Integer.class);
-      }
-      return new UserRole(userRoleId, userId, roleId, name, dacId);
+      return buildUserRole(rowView, userId, "user_role_id", "role_id", "name", "dac_id");
+    }
+    if (hasNonZeroColumn(rowView, "ur_user_role_id")) {
+      return buildUserRole(
+          rowView, userId, "ur_user_role_id", "ur_role_id", "ur_name", "ur_dac_id");
     }
     return null;
+  }
+
+  private UserRole buildUserRole(
+      RowView rowView,
+      Integer userId,
+      String userRoleIdCol,
+      String roleIdCol,
+      String nameCol,
+      String dacIdCol) {
+    return new UserRole(
+        rowView.getColumn(userRoleIdCol, Integer.class),
+        userId,
+        rowView.getColumn(roleIdCol, Integer.class),
+        rowView.getColumn(nameCol, String.class),
+        hasOptionalColumn(rowView, dacIdCol, Integer.class).orElse(null));
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/UserWithRolesReducer.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/UserWithRolesReducer.java
@@ -18,7 +18,7 @@ public class UserWithRolesReducer
   @Override
   public void accumulate(Map<Integer, User> map, RowView rowView) {
     Integer userId = resolveUserId(rowView);
-    User user = map.computeIfAbsent(userId, id -> rowView.getRow(User.class));
+    User user = map.computeIfAbsent(userId, ignored -> rowView.getRow(User.class));
     addUserRole(rowView, user, userId);
     addInstitution(rowView, user);
     addLibraryCard(rowView, user);

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/UserWithRolesReducer.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/UserWithRolesReducer.java
@@ -51,10 +51,12 @@ public class UserWithRolesReducer
     try {
       if (rowView.getColumn("lc_id", Integer.class) != null) {
         LibraryCard lc = rowView.getRow(LibraryCard.class);
-        if (rowView.getColumn("lc_daa_id", Integer.class) != null) {
-          lc.addDaa(rowView.getColumn("lc_daa_id", Integer.class));
+        if (Objects.isNull(user.getLibraryCard())) {
+          user.setLibraryCard(lc);
         }
-        user.setLibraryCard(lc);
+        if (rowView.getColumn("lc_daa_id", Integer.class) != null) {
+          user.getLibraryCard().addDaa(rowView.getColumn("lc_daa_id", Integer.class));
+        }
       }
     } catch (MappingException e) {
       logDebug("Error adding Library Card to User: %s".formatted(e.getMessage()));

--- a/src/test/java/org/broadinstitute/consent/http/db/UserDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/UserDAOTest.java
@@ -79,6 +79,15 @@ class UserDAOTest extends DAOTestHelper {
     int lcId =
         libraryCardDAO.insertLibraryCard(
             user.getUserId(), user.getDisplayName(), user.getEmail(), user.getUserId(), new Date());
+    int dacId = dacDAO.createDac(randomAlphabetic(5), randomAlphabetic(5), new Date());
+    int daaId =
+        daaDAO.createDaa(user.getUserId(), Instant.now(), user.getUserId(), Instant.now(), dacId);
+    daaDAO.createDacDaaRelation(dacId, daaId, user.getUserId());
+    libraryCardDAO.createLibraryCardDaaRelation(lcId, daaId);
+    int dacId2 = dacDAO.createDac(randomAlphabetic(5), randomAlphabetic(5), new Date());
+    int daaId2 =
+        daaDAO.createDaa(user.getUserId(), Instant.now(), user.getUserId(), Instant.now(), dacId2);
+    libraryCardDAO.createLibraryCardDaaRelation(lcId, daaId2);
     UserProperty eraExpProp = new UserProperty();
     eraExpProp.setPropertyKey(UserFields.ERA_EXPIRATION_DATE.getValue());
     eraExpProp.setPropertyValue(Instant.now().toString());
@@ -107,6 +116,8 @@ class UserDAOTest extends DAOTestHelper {
                 p ->
                     p.getPropertyKey().equals(UserFields.ERA_STATUS.getValue())
                         && p.getPropertyValue().equals(eraAuthProp.getPropertyValue())));
+    assertTrue(foundUser.getLibraryCard().getDaaIds().contains(daaId));
+    assertTrue(foundUser.getLibraryCard().getDaaIds().contains(daaId2));
   }
 
   @Test


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-3167

### Summary
The reducer class was overwriting the user's LC on every row so only the last DAA processed was associated to the LC. This PR updates the logic so it only writes the LC if it doesn't already exist and then adds the DAA. Also updates a test for ensuring multiple DAAs are populated.

Sonar had quite a few warnings about this class so it is also refactored to a large degree to reduce cognitive complexity and ignored parameters.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
