### PR TITLE
[DT-3169] Fix templates that will all render with an extra slash based on the value of the URL passed in.

### DIFF
--- a/src/main/resources/freemarker/dataset-approved.ftl
+++ b/src/main/resources/freemarker/dataset-approved.ftl
@@ -24,7 +24,7 @@
                 <p id="content" style="margin: 0;">
                   Your dataset, <b>${datasetName}</b>, submitted to the <b>${dacName}</b> for management of future data access requests has been <b>accepted</b>
                   and can be found in the DUOS Data Library with this URL:
-                  <a href="${serverUrl}/dataset/${datasetIdentifier}" target="_blank"
+                  <a href="${serverUrl}dataset/${datasetIdentifier}" target="_blank"
                      style="text-decoration: none; font-family: 'Montserrat', sans-serif; color: #00609F; font-size: 16px; font-weight: bold;">
                     ${datasetIdentifier}.
                   </a>

--- a/src/main/resources/freemarker/new-daa-upload-signing-official.html
+++ b/src/main/resources/freemarker/new-daa-upload-signing-official.html
@@ -29,7 +29,7 @@
           the ${dacName}. The ${dacName} has recently transitioned to using the ${newDaaName}
           which will apply for all future requests to this DAC. In order for your researchers to
           request access to data from the ${dacName} in the future, you must pre-authorize them
-          under this new agreement on the <a id="serverUrl" href="${serverUrl}/signing_official_console/researchers_daa_associations" style="text-decoration: none; font-family: 'Montserrat', sans-serif; color: #00609F; font-size: 16px; font-weight: bold;">DUOS DAA Associations page</a>.
+          under this new agreement on the <a id="serverUrl" href="${serverUrl}signing_official_console/researchers_daa_associations" style="text-decoration: none; font-family: 'Montserrat', sans-serif; color: #00609F; font-size: 16px; font-weight: bold;">DUOS DAA Associations page</a>.
         </p>
         <p id="content2">
           Note, this transition to a new Data Access Agreement does not affect previously approved

--- a/src/main/resources/freemarker/new-study-digest.ftl
+++ b/src/main/resources/freemarker/new-study-digest.ftl
@@ -21,7 +21,7 @@
     </tr>
     <tr>
       <td style="padding: 15px 15px 0px; font-family: 'Montserrat', sans-serif; font-size: 16px; color: #1F3B50; text-align: justify; line-height: 25px;">
-        The studies below were registered in DUOS today! Click the Study link to view the study and its datasets, or go to the <a href="${serverUrl}/datalibrary">DUOS Data Library</a>  to view all studies.
+        The studies below were registered in DUOS today! Click the Study link to view the study and its datasets, or go to the <a href="${serverUrl}datalibrary">DUOS Data Library</a>  to view all studies.
       </td>
     </tr>
     <tr>
@@ -36,7 +36,7 @@
         </thead>
         <tbody>
       <#list newStudies as item>
-        <tr><td style="padding: 15px 15px 0px; font-family: 'Montserrat', sans-serif; font-size: 16px; color: #1F3B50; text-align: justify; line-height: 25px;"><a href="${serverUrl}/studies/${item.id()}">${item.name()}</a></td><td style="padding: 15px 15px 0px; font-family: 'Montserrat', sans-serif; font-size: 16px; color: #1F3B50; text-align: justify; line-height: 25px;">${item.datasetCount()}</td></tr>
+        <tr><td style="padding: 15px 15px 0px; font-family: 'Montserrat', sans-serif; font-size: 16px; color: #1F3B50; text-align: justify; line-height: 25px;"><a href="${serverUrl}studies/${item.id()}">${item.name()}</a></td><td style="padding: 15px 15px 0px; font-family: 'Montserrat', sans-serif; font-size: 16px; color: #1F3B50; text-align: justify; line-height: 25px;">${item.datasetCount()}</td></tr>
       </#list>
         </tbody>
       </table>

--- a/src/test/java/org/broadinstitute/consent/http/mail/message/DACMembersDARRADARApprovedMessageTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mail/message/DACMembersDARRADARApprovedMessageTest.java
@@ -40,7 +40,7 @@ class DACMembersDARRADARApprovedMessageTest {
     String datasetName = "dataset-name";
     List<DatasetMailDTO> datasetMailDTOs =
         List.of(new DatasetMailDTO(datasetName, "DUOS-00001", null));
-    String serverUrl = "http://localhost:8080";
+    String serverUrl = "http://localhost:8080/";
     String darCode = "DAR-0001";
     String referenceId = "abcd-12345";
 

--- a/src/test/java/org/broadinstitute/consent/http/mail/message/NewStudyDigestMessageTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mail/message/NewStudyDigestMessageTest.java
@@ -45,7 +45,7 @@ class NewStudyDigestMessageTest {
     user.setUserId(1);
     user.setEmail("testUser@duos.org");
     user.setDisplayName("Test User");
-    String serverUrl = "http://localhost:8080";
+    String serverUrl = "http://localhost:8080/";
 
     var message = new NewStudyDigestMessage(user, newStudies, referenceId);
 
@@ -62,7 +62,7 @@ class NewStudyDigestMessageTest {
     String templateString = out.toString();
     Document parsedTemplate = Jsoup.parse(templateString);
 
-    String urlStringPattern = "%s/studies/%d\">%s";
+    String urlStringPattern = "%sstudies/%d\">%s";
     assertTrue(templateString.contains(user.getDisplayName()));
     assertEquals(
         "Dear Test User,",


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-3169](https://broadworkbench.atlassian.net/browse/DT-3169)

### Summary

The URL in the configuration file includes a slash at the end.  This ticket fixes templates that include an extra slash in them between the environment provided value and the desired destination path.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
