### PR TITLE
[DT-3109] Add GET endpoint for FileStorageObject metadata retrieval

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
@@ -56,6 +56,7 @@ import org.broadinstitute.consent.http.resources.DacResource;
 import org.broadinstitute.consent.http.resources.DarCollectionResource;
 import org.broadinstitute.consent.http.resources.DataAccessRequestResource;
 import org.broadinstitute.consent.http.resources.DatasetResource;
+import org.broadinstitute.consent.http.resources.DocumentResource;
 import org.broadinstitute.consent.http.resources.DraftResource;
 import org.broadinstitute.consent.http.resources.EmailNotifierResource;
 import org.broadinstitute.consent.http.resources.ErrorResource;
@@ -167,6 +168,7 @@ public class ConsentApplication extends Application<ConsentConfiguration> {
     env.jersey().register(injector.getInstance(DarCollectionResource.class));
     env.jersey().register(injector.getInstance(DataAccessRequestResource.class));
     env.jersey().register(injector.getInstance(DatasetResource.class));
+    env.jersey().register(injector.getInstance(DocumentResource.class));
     env.jersey().register(injector.getInstance(DraftResource.class));
     env.jersey().register(injector.getInstance(EmailNotifierResource.class));
     env.jersey().register(injector.getInstance(FeatureFlagResource.class));

--- a/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
@@ -278,7 +278,8 @@ public class ConsentModule extends AbstractModule {
 
   @Provides
   FileStorageObjectService providesFileStorageObjectService() {
-    return new FileStorageObjectService(providesFileStorageObjectDAO(), providesGCSService());
+    return new FileStorageObjectService(
+        providesFileStorageObjectDAO(), providesGCSService(), providesDatasetService());
   }
 
   @Provides

--- a/src/main/java/org/broadinstitute/consent/http/db/FileStorageObjectDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/FileStorageObjectDAO.java
@@ -3,6 +3,7 @@ package org.broadinstitute.consent.http.db;
 import java.time.Instant;
 import java.util.List;
 import org.broadinstitute.consent.http.db.mapper.FileStorageObjectMapper;
+import org.broadinstitute.consent.http.db.mapper.FileStorageObjectMapperWithFSOPrefix;
 import org.broadinstitute.consent.http.models.FileStorageObject;
 import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
 import org.jdbi.v3.sqlobject.customizer.Bind;
@@ -83,6 +84,30 @@ public interface FileStorageObjectDAO extends Transactional<InstitutionDAO> {
           WHERE file_storage_object_id = :fileStorageObjectId
           """)
   FileStorageObject findFileById(@Bind("fileStorageObjectId") Integer fileStorageObjectId);
+
+  @RegisterRowMapper(FileStorageObjectMapperWithFSOPrefix.class)
+  @SqlQuery(
+      """
+          SELECT
+              fso.file_storage_object_id AS fso_file_storage_object_id,
+              fso.entity_id AS fso_entity_id,
+              fso.file_name AS fso_file_name,
+              fso.category AS fso_category,
+              fso.gcs_file_uri AS fso_gcs_file_uri,
+              fso.media_type AS fso_media_type,
+              fso.create_date AS fso_create_date,
+              fso.create_user_id AS fso_create_user_id,
+              fso.update_date AS fso_update_date,
+              fso.update_user_id AS fso_update_user_id,
+              fso.deleted AS fso_deleted,
+              fso.delete_user_id AS fso_delete_user_id
+          FROM file_storage_object fso
+          WHERE fso.entity_id = :entityId
+                AND fso.file_storage_object_id = :fileStorageObjectId
+                AND (fso.deleted = false OR fso.deleted IS NULL)
+          """)
+  FileStorageObject findActiveFileByIdAndEntityId(
+      @Bind("entityId") String entityId, @Bind("fileStorageObjectId") Integer fileStorageObjectId);
 
   @SqlQuery(
       """

--- a/src/main/java/org/broadinstitute/consent/http/enumeration/DocumentEntity.java
+++ b/src/main/java/org/broadinstitute/consent/http/enumeration/DocumentEntity.java
@@ -1,0 +1,28 @@
+package org.broadinstitute.consent.http.enumeration;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+public enum DocumentEntity {
+  DATASET("dataset"),
+  STUDY("study");
+
+  private final String value;
+
+  DocumentEntity(String value) {
+    this.value = value;
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+  public static Optional<DocumentEntity> fromValue(String value) {
+    if (value == null) {
+      return Optional.empty();
+    }
+    return Arrays.stream(values())
+        .filter(entity -> entity.getValue().equalsIgnoreCase(value))
+        .findFirst();
+  }
+}

--- a/src/main/java/org/broadinstitute/consent/http/resources/DocumentResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DocumentResource.java
@@ -3,32 +3,24 @@ package org.broadinstitute.consent.http.resources;
 import com.google.inject.Inject;
 import io.dropwizard.auth.Auth;
 import jakarta.annotation.security.PermitAll;
-import jakarta.ws.rs.ForbiddenException;
 import jakarta.ws.rs.GET;
-import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
-import org.broadinstitute.consent.http.enumeration.DocumentEntity;
 import org.broadinstitute.consent.http.models.DuosUser;
 import org.broadinstitute.consent.http.models.FileStorageObject;
-import org.broadinstitute.consent.http.models.Study;
 import org.broadinstitute.consent.http.models.User;
-import org.broadinstitute.consent.http.service.DatasetService;
 import org.broadinstitute.consent.http.service.FileStorageObjectService;
 
 @Path("api/{entity}")
 public class DocumentResource extends Resource {
 
-  private final DatasetService datasetService;
   private final FileStorageObjectService fileStorageObjectService;
 
   @Inject
-  public DocumentResource(
-      DatasetService datasetService, FileStorageObjectService fileStorageObjectService) {
-    this.datasetService = datasetService;
+  public DocumentResource(FileStorageObjectService fileStorageObjectService) {
     this.fileStorageObjectService = fileStorageObjectService;
   }
 
@@ -43,50 +35,12 @@ public class DocumentResource extends Resource {
       @PathParam("id") Integer id) {
     try {
       User user = duosUser.getUser();
-      String fsoEntityId = validateEntityAndReadAccess(entity, entityId, user);
       FileStorageObject fileStorageObject =
-          fileStorageObjectService.fetchMetadataByEntityIdAndId(fsoEntityId, id);
+          fileStorageObjectService.fetchMetadataByEntityAndEntityIdForRead(
+              user, entity, entityId, id);
       return Response.ok(fileStorageObject).build();
     } catch (Exception e) {
       return createExceptionResponse(e);
-    }
-  }
-
-  private String validateEntityAndReadAccess(String entity, String entityId, User user) {
-    DocumentEntity documentEntity =
-        DocumentEntity.fromValue(entity)
-            .orElseThrow(() -> new NotFoundException("Entity not found"));
-
-    return switch (documentEntity) {
-      case DATASET -> validateDatasetReadAccess(entityId, user);
-      case STUDY -> validateStudyReadAccess(entityId, user);
-    };
-  }
-
-  private String validateDatasetReadAccess(String entityId, User user) {
-    Integer datasetId = parseNumericEntityId(entityId);
-    datasetService.findDatasetByIdForRead(user, datasetId);
-    return datasetId.toString();
-  }
-
-  private String validateStudyReadAccess(String entityId, User user) {
-    Integer studyId = parseNumericEntityId(entityId);
-    Study study = datasetService.findStudy(studyId);
-    if (study == null || study.getUuid() == null) {
-      throw new NotFoundException("Entity not found");
-    }
-    if (!Boolean.TRUE.equals(study.getPublicVisibility())
-        && !datasetService.isCreatorCustodianOrAdmin(user, study)) {
-      throw new ForbiddenException("User does not have permission");
-    }
-    return study.getUuid().toString();
-  }
-
-  private Integer parseNumericEntityId(String entityId) {
-    try {
-      return Integer.valueOf(entityId);
-    } catch (NumberFormatException _) {
-      throw new NotFoundException("Entity not found");
     }
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/resources/DocumentResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DocumentResource.java
@@ -1,0 +1,92 @@
+package org.broadinstitute.consent.http.resources;
+
+import com.google.inject.Inject;
+import io.dropwizard.auth.Auth;
+import jakarta.annotation.security.PermitAll;
+import jakarta.ws.rs.ForbiddenException;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.broadinstitute.consent.http.enumeration.DocumentEntity;
+import org.broadinstitute.consent.http.models.DuosUser;
+import org.broadinstitute.consent.http.models.FileStorageObject;
+import org.broadinstitute.consent.http.models.Study;
+import org.broadinstitute.consent.http.models.User;
+import org.broadinstitute.consent.http.service.DatasetService;
+import org.broadinstitute.consent.http.service.FileStorageObjectService;
+
+@Path("api/{entity}")
+public class DocumentResource extends Resource {
+
+  private final DatasetService datasetService;
+  private final FileStorageObjectService fileStorageObjectService;
+
+  @Inject
+  public DocumentResource(
+      DatasetService datasetService, FileStorageObjectService fileStorageObjectService) {
+    this.datasetService = datasetService;
+    this.fileStorageObjectService = fileStorageObjectService;
+  }
+
+  @GET
+  @Path("/{entityId}/document/{id}")
+  @Produces(MediaType.APPLICATION_JSON)
+  @PermitAll
+  public Response findDocumentByEntity(
+      @Auth DuosUser duosUser,
+      @PathParam("entity") String entity,
+      @PathParam("entityId") String entityId,
+      @PathParam("id") Integer id) {
+    try {
+      User user = duosUser.getUser();
+      String fsoEntityId = validateEntityAndReadAccess(entity, entityId, user);
+      FileStorageObject fileStorageObject =
+          fileStorageObjectService.fetchMetadataByEntityIdAndId(fsoEntityId, id);
+      return Response.ok(fileStorageObject).build();
+    } catch (Exception e) {
+      return createExceptionResponse(e);
+    }
+  }
+
+  private String validateEntityAndReadAccess(String entity, String entityId, User user) {
+    DocumentEntity documentEntity =
+        DocumentEntity.fromValue(entity)
+            .orElseThrow(() -> new NotFoundException("Entity not found"));
+
+    return switch (documentEntity) {
+      case DATASET -> validateDatasetReadAccess(entityId, user);
+      case STUDY -> validateStudyReadAccess(entityId, user);
+    };
+  }
+
+  private String validateDatasetReadAccess(String entityId, User user) {
+    Integer datasetId = parseNumericEntityId(entityId);
+    datasetService.findDatasetByIdForRead(user, datasetId);
+    return datasetId.toString();
+  }
+
+  private String validateStudyReadAccess(String entityId, User user) {
+    Integer studyId = parseNumericEntityId(entityId);
+    Study study = datasetService.findStudy(studyId);
+    if (study == null || study.getUuid() == null) {
+      throw new NotFoundException("Entity not found");
+    }
+    if (!Boolean.TRUE.equals(study.getPublicVisibility())
+        && !datasetService.isCreatorCustodianOrAdmin(user, study)) {
+      throw new ForbiddenException("User does not have permission");
+    }
+    return study.getUuid().toString();
+  }
+
+  private Integer parseNumericEntityId(String entityId) {
+    try {
+      return Integer.valueOf(entityId);
+    } catch (NumberFormatException _) {
+      throw new NotFoundException("Entity not found");
+    }
+  }
+}

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -182,15 +182,24 @@ public class DatasetService implements ConsentLogger {
     if (dataset.getStudy() == null) {
       dataset.setStudy(studyDAO.findStudyById(dataset.getStudyId()));
     }
-    // If not visible, check that the user is authorized to see it
-    if (Boolean.FALSE.equals(dataset.getStudy().getPublicVisibility())) {
-      if (isCreatorOrCustodian(user, dataset)) {
-        return dataset;
-      } else {
-        return null;
-      }
+    if (canReadStudy(user, dataset.getStudy())
+        || Objects.equals(dataset.getCreateUserId(), user.getUserId())) {
+      return dataset;
     }
-    return dataset;
+    return null;
+  }
+
+  protected boolean canReadStudy(User user, Study study) {
+    if (study == null) {
+      return false;
+    }
+    if (user.hasUserRole(UserRoles.ADMIN)) {
+      return true;
+    }
+    if (!Boolean.FALSE.equals(study.getPublicVisibility())) {
+      return true;
+    }
+    return isCreatorOrCustodian(user, study);
   }
 
   protected boolean isCreatorOrCustodian(User user, Dataset dataset) {
@@ -336,6 +345,17 @@ public class DatasetService implements ConsentLogger {
 
   public Study findStudy(Integer studyId) {
     return studyDAO.findStudyById(studyId);
+  }
+
+  public Study findStudyByIdForRead(User user, Integer studyId) {
+    Study study = studyDAO.findStudyById(studyId);
+    if (study == null) {
+      throw new NotFoundException("Entity not found");
+    }
+    if (!canReadStudy(user, study)) {
+      throw new ForbiddenException("User does not have permission");
+    }
+    return study;
   }
 
   public List<DatasetStudySummary> findAllDatasetStudySummaries(User user) {

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -7,6 +7,7 @@ import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import com.google.inject.Inject;
 import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.ForbiddenException;
 import jakarta.ws.rs.InternalServerErrorException;
 import jakarta.ws.rs.NotAuthorizedException;
 import jakarta.ws.rs.NotFoundException;
@@ -245,6 +246,24 @@ public class DatasetService implements ConsentLogger {
   public Dataset findDatasetById(User user, Integer id) {
     Dataset dataset = datasetDAO.findDatasetById(id);
     return verifyPublicVisibilityAccess(dataset, user);
+  }
+
+  /**
+   * Finds a dataset by ID and enforces read access using a single dataset query.
+   *
+   * @throws NotFoundException if the dataset does not exist
+   * @throws ForbiddenException if the user cannot view the dataset
+   */
+  public Dataset findDatasetByIdForRead(User user, Integer id) {
+    Dataset dataset = datasetDAO.findDatasetById(id);
+    if (dataset == null) {
+      throw new NotFoundException("Entity not found");
+    }
+    Dataset authorizedDataset = verifyPublicVisibilityAccess(dataset, user);
+    if (authorizedDataset == null) {
+      throw new ForbiddenException("User does not have permission");
+    }
+    return authorizedDataset;
   }
 
   /**

--- a/src/main/java/org/broadinstitute/consent/http/service/FileStorageObjectService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/FileStorageObjectService.java
@@ -8,7 +8,6 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import java.util.stream.Collectors;
 import org.broadinstitute.consent.http.cloudstore.GCSService;
 import org.broadinstitute.consent.http.db.FileStorageObjectDAO;
 import org.broadinstitute.consent.http.enumeration.FileCategory;
@@ -78,11 +77,9 @@ public class FileStorageObjectService implements ConsentLogger {
     try {
       Map<BlobId, InputStream> documentMap =
           gcsService.getDocuments(
-              fileStorageObjects.stream()
-                  .map(FileStorageObject::getBlobId)
-                  .collect(Collectors.toList()));
+              fileStorageObjects.stream().map(FileStorageObject::getBlobId).toList());
 
-      fileStorageObjects.forEach((fso) -> fso.setUploadedFile(documentMap.get(fso.getBlobId())));
+      fileStorageObjects.forEach(fso -> fso.setUploadedFile(documentMap.get(fso.getBlobId())));
     } catch (NotFoundException e) {
       throw e; // pass along
     } catch (Exception e) {
@@ -96,6 +93,16 @@ public class FileStorageObjectService implements ConsentLogger {
     FileStorageObject fileStorageObject = fileStorageObjectDAO.findFileById(fileStorageObjectId);
     // download file from GCS
     fetchAndPopulateUploadedFile(fileStorageObject);
+    return fileStorageObject;
+  }
+
+  public FileStorageObject fetchMetadataByEntityIdAndId(
+      String entityId, Integer fileStorageObjectId) throws NotFoundException {
+    FileStorageObject fileStorageObject =
+        fileStorageObjectDAO.findActiveFileByIdAndEntityId(entityId, fileStorageObjectId);
+    if (fileStorageObject == null) {
+      throw new NotFoundException("File not found");
+    }
     return fileStorageObject;
   }
 

--- a/src/main/java/org/broadinstitute/consent/http/service/FileStorageObjectService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/FileStorageObjectService.java
@@ -10,19 +10,26 @@ import java.util.Map;
 import java.util.UUID;
 import org.broadinstitute.consent.http.cloudstore.GCSService;
 import org.broadinstitute.consent.http.db.FileStorageObjectDAO;
+import org.broadinstitute.consent.http.enumeration.DocumentEntity;
 import org.broadinstitute.consent.http.enumeration.FileCategory;
 import org.broadinstitute.consent.http.models.FileStorageObject;
+import org.broadinstitute.consent.http.models.Study;
+import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.util.ConsentLogger;
 
 public class FileStorageObjectService implements ConsentLogger {
 
   GCSService gcsService;
   FileStorageObjectDAO fileStorageObjectDAO;
+  DatasetService datasetService;
 
   public FileStorageObjectService(
-      FileStorageObjectDAO fileStorageObjectDAO, GCSService gcsService) {
+      FileStorageObjectDAO fileStorageObjectDAO,
+      GCSService gcsService,
+      DatasetService datasetService) {
     this.fileStorageObjectDAO = fileStorageObjectDAO;
     this.gcsService = gcsService;
+    this.datasetService = datasetService;
   }
 
   FileStorageObject uploadAndStoreFile(
@@ -104,6 +111,47 @@ public class FileStorageObjectService implements ConsentLogger {
       throw new NotFoundException("File not found");
     }
     return fileStorageObject;
+  }
+
+  public FileStorageObject fetchMetadataByEntityAndEntityIdForRead(
+      User user, String entity, String entityId, Integer fileStorageObjectId)
+      throws NotFoundException {
+    String fsoEntityId = resolveFsoEntityIdForRead(user, entity, entityId);
+    return fetchMetadataByEntityIdAndId(fsoEntityId, fileStorageObjectId);
+  }
+
+  private String resolveFsoEntityIdForRead(User user, String entity, String entityId) {
+    DocumentEntity documentEntity =
+        DocumentEntity.fromValue(entity)
+            .orElseThrow(() -> new NotFoundException("Entity not found"));
+
+    return switch (documentEntity) {
+      case DATASET -> resolveDatasetFsoEntityIdForRead(entityId, user);
+      case STUDY -> resolveStudyFsoEntityIdForRead(entityId, user);
+    };
+  }
+
+  private String resolveDatasetFsoEntityIdForRead(String entityId, User user) {
+    Integer datasetId = parseNumericEntityId(entityId);
+    datasetService.findDatasetByIdForRead(user, datasetId);
+    return datasetId.toString();
+  }
+
+  private String resolveStudyFsoEntityIdForRead(String entityId, User user) {
+    Integer studyId = parseNumericEntityId(entityId);
+    Study study = datasetService.findStudyByIdForRead(user, studyId);
+    if (study.getUuid() == null) {
+      throw new NotFoundException("Entity not found");
+    }
+    return study.getUuid().toString();
+  }
+
+  private Integer parseNumericEntityId(String entityId) {
+    try {
+      return Integer.valueOf(entityId);
+    } catch (NumberFormatException _) {
+      throw new NotFoundException("Entity not found");
+    }
   }
 
   public List<FileStorageObject> fetchAllByEntityId(String entityId) throws NotFoundException {

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -516,6 +516,8 @@ paths:
     $ref: './paths/datasetAuthorizedUsers.yaml'
   /api/dataset/cleanupEmptyCertificationAndAlternativeSharingFiles:
     $ref: './paths/cleanupEmptyCertificationAndAlternativeSharingFiles.yaml'
+  /api/{entity}/{entityId}/document/{id}:
+    $ref: './paths/entityDocumentById.yaml'
   /api/draft/v1:
     $ref: './paths/draftIndex.yaml'
   /api/draft/v1/{draftUUID}:
@@ -1029,6 +1031,8 @@ components:
       $ref: './schemas/DatasetRegistrationSchemaV1.yaml'
     Election:
       $ref: './schemas/Election.yaml'
+    FileStorageObject:
+      $ref: './schemas/FileStorageObject.yaml'
     Institution:
       $ref: './schemas/Institution.yaml'
     LibraryCard:

--- a/src/main/resources/assets/paths/entityDocumentById.yaml
+++ b/src/main/resources/assets/paths/entityDocumentById.yaml
@@ -1,0 +1,37 @@
+get:
+  summary: Get document metadata by entity and file id
+  operationId: findDocumentByEntity
+  description: Returns FileStorageObject metadata only. File bytes are not returned.
+  parameters:
+    - name: entity
+      in: path
+      required: true
+      description: Entity type that owns the file
+      schema:
+        type: string
+        enum: [dataset, study]
+    - name: entityId
+      in: path
+      required: true
+      description: Numeric id of the owning entity
+      schema:
+        type: string
+    - name: id
+      in: path
+      required: true
+      description: FileStorageObject id
+      schema:
+        type: integer
+  tags:
+    - Document
+  responses:
+    200:
+      description: FileStorageObject metadata
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/FileStorageObject.yaml'
+    403:
+      description: Forbidden
+    404:
+      description: Not Found

--- a/src/main/resources/assets/paths/entityDocumentById.yaml
+++ b/src/main/resources/assets/paths/entityDocumentById.yaml
@@ -31,6 +31,8 @@ get:
         application/json:
           schema:
             $ref: '../schemas/FileStorageObject.yaml'
+    401:
+      description: Unauthorized
     403:
       description: Forbidden
     404:

--- a/src/main/resources/assets/schemas/FileStorageObject.yaml
+++ b/src/main/resources/assets/schemas/FileStorageObject.yaml
@@ -11,7 +11,7 @@ properties:
     description: Name of the file
   category:
     type: string
-    enum: [irbCollaborationLetter, dataUseLetter, alternativeDataSharingPlan, nihInstitutionalCertification]
+    enum: [irbCollaborationLetter, dataUseLetter, alternativeDataSharingPlan, nihInstitutionalCertification, dataAccessAgreement, draftUploadedFile]
     description: The purpose of the file uploaded
   mediaType:
     type: string

--- a/src/test/java/org/broadinstitute/consent/http/db/FileStorageObjectDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/FileStorageObjectDAOTest.java
@@ -185,6 +185,44 @@ class FileStorageObjectDAOTest extends DAOTestHelper {
     assertTrue(altDataSharingFiles.contains(file3));
   }
 
+  @Test
+  void testFindActiveFileByIdAndEntityId() {
+    String entityId = randomAlphabetic(10);
+    FileStorageObject file = createFileStorageObject(entityId, FileCategory.DATA_USE_LETTER);
+
+    FileStorageObject found =
+        fileStorageObjectDAO.findActiveFileByIdAndEntityId(entityId, file.getFileStorageObjectId());
+
+    assertNotNull(found);
+    assertEquals(file.getFileStorageObjectId(), found.getFileStorageObjectId());
+    assertEquals(entityId, found.getEntityId());
+  }
+
+  @Test
+  void testFindActiveFileByIdAndEntityIdDeletedReturnsNull() {
+    String entityId = randomAlphabetic(10);
+    FileStorageObject file = createFileStorageObject(entityId, FileCategory.DATA_USE_LETTER);
+    User deleteUser = createUser();
+    fileStorageObjectDAO.deleteFileById(file.getFileStorageObjectId(), deleteUser.getUserId());
+
+    FileStorageObject found =
+        fileStorageObjectDAO.findActiveFileByIdAndEntityId(entityId, file.getFileStorageObjectId());
+
+    assertNull(found);
+  }
+
+  @Test
+  void testFindActiveFileByIdAndEntityIdWrongEntityReturnsNull() {
+    String entityId = randomAlphabetic(10);
+    FileStorageObject file = createFileStorageObject(entityId, FileCategory.DATA_USE_LETTER);
+
+    FileStorageObject found =
+        fileStorageObjectDAO.findActiveFileByIdAndEntityId(
+            randomAlphabetic(8), file.getFileStorageObjectId());
+
+    assertNull(found);
+  }
+
   private FileStorageObject createFileStorageObject() {
     FileCategory category =
         List.of(FileCategory.values()).get(new Random().nextInt(FileCategory.values().length));

--- a/src/test/java/org/broadinstitute/consent/http/models/FileStorageObjectTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/FileStorageObjectTest.java
@@ -69,4 +69,15 @@ class FileStorageObjectTest {
     FileStorageObject fso = GsonUtil.buildGson().fromJson(json, FileStorageObject.class);
     assertNull(fso.getBlobId());
   }
+
+  @Test
+  void testFileCategorySerializedNameValue() {
+    FileStorageObject fso = new FileStorageObject();
+    fso.setCategory(FileCategory.DATA_ACCESS_AGREEMENT);
+
+    JsonObject jsonObject =
+        GsonUtil.buildGson().fromJson(GsonUtil.buildGson().toJson(fso), JsonObject.class);
+
+    assertEquals("dataAccessAgreement", jsonObject.get("category").getAsString());
+  }
 }

--- a/src/test/java/org/broadinstitute/consent/http/resources/DocumentResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DocumentResourceTest.java
@@ -1,0 +1,129 @@
+package org.broadinstitute.consent.http.resources;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.api.client.http.HttpStatusCodes;
+import jakarta.ws.rs.NotFoundException;
+import java.util.UUID;
+import org.broadinstitute.consent.http.models.Dataset;
+import org.broadinstitute.consent.http.models.DuosUser;
+import org.broadinstitute.consent.http.models.FileStorageObject;
+import org.broadinstitute.consent.http.models.Study;
+import org.broadinstitute.consent.http.models.User;
+import org.broadinstitute.consent.http.service.DatasetService;
+import org.broadinstitute.consent.http.service.FileStorageObjectService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class DocumentResourceTest {
+
+  @Mock private DatasetService datasetService;
+  @Mock private FileStorageObjectService fileStorageObjectService;
+  @Mock private DuosUser duosUser;
+  @Mock private User user;
+
+  private DocumentResource resource;
+
+  @BeforeEach
+  void setUp() {
+    resource = new DocumentResource(datasetService, fileStorageObjectService);
+  }
+
+  @Test
+  void testFindDocumentByDatasetEntityReturnsMetadata() {
+    Integer datasetId = 123;
+    Integer fileId = 10;
+    FileStorageObject fileStorageObject = new FileStorageObject();
+
+    when(duosUser.getUser()).thenReturn(user);
+    when(datasetService.findDatasetByIdForRead(user, datasetId)).thenReturn(new Dataset());
+    when(fileStorageObjectService.fetchMetadataByEntityIdAndId(datasetId.toString(), fileId))
+        .thenReturn(fileStorageObject);
+
+    try (var response =
+        resource.findDocumentByEntity(duosUser, "dataset", datasetId.toString(), fileId)) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+      assertEquals(fileStorageObject, response.getEntity());
+    }
+
+    verify(fileStorageObjectService).fetchMetadataByEntityIdAndId(datasetId.toString(), fileId);
+  }
+
+  @Test
+  void testFindDocumentByStudyEntityReturnsMetadata() {
+    Integer studyId = 456;
+    Integer fileId = 11;
+    Study study = new Study();
+    study.setUuid(UUID.randomUUID());
+    study.setPublicVisibility(true);
+    FileStorageObject fileStorageObject = new FileStorageObject();
+
+    when(duosUser.getUser()).thenReturn(user);
+    when(datasetService.findStudy(studyId)).thenReturn(study);
+    when(fileStorageObjectService.fetchMetadataByEntityIdAndId(study.getUuid().toString(), fileId))
+        .thenReturn(fileStorageObject);
+
+    try (var response =
+        resource.findDocumentByEntity(duosUser, "study", studyId.toString(), fileId)) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+      assertEquals(fileStorageObject, response.getEntity());
+    }
+
+    verify(fileStorageObjectService)
+        .fetchMetadataByEntityIdAndId(study.getUuid().toString(), fileId);
+  }
+
+  @Test
+  void testFindDocumentByEntityUnauthenticatedForbidden() {
+    try (var response = resource.findDocumentByEntity(null, "dataset", "123", 10)) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_SERVER_ERROR, response.getStatus());
+    }
+  }
+
+  @Test
+  void testFindDocumentByEntityNotFoundWhenEntityMissing() {
+    when(duosUser.getUser()).thenReturn(user);
+    when(datasetService.findDatasetByIdForRead(user, 123))
+        .thenThrow(new NotFoundException("Entity not found"));
+
+    try (var response = resource.findDocumentByEntity(duosUser, "dataset", "123", 10)) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
+    }
+  }
+
+  @Test
+  void testFindDocumentByEntityForbiddenWhenNoReadAccess() {
+    when(duosUser.getUser()).thenReturn(user);
+    when(datasetService.findDatasetByIdForRead(user, 123))
+        .thenThrow(new jakarta.ws.rs.ForbiddenException("User does not have permission"));
+
+    try (var response = resource.findDocumentByEntity(duosUser, "dataset", "123", 10)) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_FORBIDDEN, response.getStatus());
+    }
+  }
+
+  @ParameterizedTest(name = "Not found when metadata lookup fails: {1}")
+  @CsvSource({"10,file not found", "11,file deleted", "12,file belongs to different entity"})
+  void testFindDocumentByEntityNotFoundWhenFileLookupFails(
+      Integer fileId, String scenarioDescription) {
+    when(duosUser.getUser()).thenReturn(user);
+    when(datasetService.findDatasetByIdForRead(user, 123)).thenReturn(new Dataset());
+    when(fileStorageObjectService.fetchMetadataByEntityIdAndId("123", fileId))
+        .thenThrow(new NotFoundException("File not found"));
+
+    try (var response = resource.findDocumentByEntity(duosUser, "dataset", "123", fileId)) {
+      assertEquals(
+          HttpStatusCodes.STATUS_CODE_NOT_FOUND,
+          response.getStatus(),
+          "Expected 404 for scenario: " + scenarioDescription);
+    }
+  }
+}

--- a/src/test/java/org/broadinstitute/consent/http/resources/DocumentResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DocumentResourceTest.java
@@ -6,13 +6,9 @@ import static org.mockito.Mockito.when;
 
 import com.google.api.client.http.HttpStatusCodes;
 import jakarta.ws.rs.NotFoundException;
-import java.util.UUID;
-import org.broadinstitute.consent.http.models.Dataset;
 import org.broadinstitute.consent.http.models.DuosUser;
 import org.broadinstitute.consent.http.models.FileStorageObject;
-import org.broadinstitute.consent.http.models.Study;
 import org.broadinstitute.consent.http.models.User;
-import org.broadinstitute.consent.http.service.DatasetService;
 import org.broadinstitute.consent.http.service.FileStorageObjectService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -25,7 +21,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class DocumentResourceTest {
 
-  @Mock private DatasetService datasetService;
   @Mock private FileStorageObjectService fileStorageObjectService;
   @Mock private DuosUser duosUser;
   @Mock private User user;
@@ -34,7 +29,7 @@ class DocumentResourceTest {
 
   @BeforeEach
   void setUp() {
-    resource = new DocumentResource(datasetService, fileStorageObjectService);
+    resource = new DocumentResource(fileStorageObjectService);
   }
 
   @Test
@@ -44,8 +39,8 @@ class DocumentResourceTest {
     FileStorageObject fileStorageObject = new FileStorageObject();
 
     when(duosUser.getUser()).thenReturn(user);
-    when(datasetService.findDatasetByIdForRead(user, datasetId)).thenReturn(new Dataset());
-    when(fileStorageObjectService.fetchMetadataByEntityIdAndId(datasetId.toString(), fileId))
+    when(fileStorageObjectService.fetchMetadataByEntityAndEntityIdForRead(
+            user, "dataset", datasetId.toString(), fileId))
         .thenReturn(fileStorageObject);
 
     try (var response =
@@ -54,21 +49,19 @@ class DocumentResourceTest {
       assertEquals(fileStorageObject, response.getEntity());
     }
 
-    verify(fileStorageObjectService).fetchMetadataByEntityIdAndId(datasetId.toString(), fileId);
+    verify(fileStorageObjectService)
+        .fetchMetadataByEntityAndEntityIdForRead(user, "dataset", datasetId.toString(), fileId);
   }
 
   @Test
   void testFindDocumentByStudyEntityReturnsMetadata() {
     Integer studyId = 456;
     Integer fileId = 11;
-    Study study = new Study();
-    study.setUuid(UUID.randomUUID());
-    study.setPublicVisibility(true);
     FileStorageObject fileStorageObject = new FileStorageObject();
 
     when(duosUser.getUser()).thenReturn(user);
-    when(datasetService.findStudy(studyId)).thenReturn(study);
-    when(fileStorageObjectService.fetchMetadataByEntityIdAndId(study.getUuid().toString(), fileId))
+    when(fileStorageObjectService.fetchMetadataByEntityAndEntityIdForRead(
+            user, "study", studyId.toString(), fileId))
         .thenReturn(fileStorageObject);
 
     try (var response =
@@ -78,7 +71,7 @@ class DocumentResourceTest {
     }
 
     verify(fileStorageObjectService)
-        .fetchMetadataByEntityIdAndId(study.getUuid().toString(), fileId);
+        .fetchMetadataByEntityAndEntityIdForRead(user, "study", studyId.toString(), fileId);
   }
 
   @Test
@@ -91,7 +84,8 @@ class DocumentResourceTest {
   @Test
   void testFindDocumentByEntityNotFoundWhenEntityMissing() {
     when(duosUser.getUser()).thenReturn(user);
-    when(datasetService.findDatasetByIdForRead(user, 123))
+    when(fileStorageObjectService.fetchMetadataByEntityAndEntityIdForRead(
+            user, "dataset", "123", 10))
         .thenThrow(new NotFoundException("Entity not found"));
 
     try (var response = resource.findDocumentByEntity(duosUser, "dataset", "123", 10)) {
@@ -102,7 +96,8 @@ class DocumentResourceTest {
   @Test
   void testFindDocumentByEntityForbiddenWhenNoReadAccess() {
     when(duosUser.getUser()).thenReturn(user);
-    when(datasetService.findDatasetByIdForRead(user, 123))
+    when(fileStorageObjectService.fetchMetadataByEntityAndEntityIdForRead(
+            user, "dataset", "123", 10))
         .thenThrow(new jakarta.ws.rs.ForbiddenException("User does not have permission"));
 
     try (var response = resource.findDocumentByEntity(duosUser, "dataset", "123", 10)) {
@@ -115,8 +110,8 @@ class DocumentResourceTest {
   void testFindDocumentByEntityNotFoundWhenFileLookupFails(
       Integer fileId, String scenarioDescription) {
     when(duosUser.getUser()).thenReturn(user);
-    when(datasetService.findDatasetByIdForRead(user, 123)).thenReturn(new Dataset());
-    when(fileStorageObjectService.fetchMetadataByEntityIdAndId("123", fileId))
+    when(fileStorageObjectService.fetchMetadataByEntityAndEntityIdForRead(
+            user, "dataset", "123", fileId))
         .thenThrow(new NotFoundException("File not found"));
 
     try (var response = resource.findDocumentByEntity(duosUser, "dataset", "123", fileId)) {

--- a/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
@@ -198,6 +198,48 @@ class DatasetServiceTest extends AbstractTestHelper {
   }
 
   @Test
+  void testFindStudyByIdForRead() {
+    User user = new User();
+    user.setUserId(1);
+    Study study = new Study();
+    study.setStudyId(7);
+    study.setPublicVisibility(true);
+
+    when(studyDAO.findStudyById(study.getStudyId())).thenReturn(study);
+
+    Study result = datasetService.findStudyByIdForRead(user, study.getStudyId());
+    assertEquals(study.getStudyId(), result.getStudyId());
+  }
+
+  @Test
+  void testFindStudyByIdForReadNotFound() {
+    when(studyDAO.findStudyById(99)).thenReturn(null);
+
+    assertThrows(NotFoundException.class, () -> datasetService.findStudyByIdForRead(mockUser, 99));
+  }
+
+  @Test
+  void testFindStudyByIdForReadForbidden() {
+    User user = new User();
+    user.setUserId(1);
+    user.setEmail("user@email.com");
+    Study study = new Study();
+    study.setStudyId(7);
+    study.setCreateUserId(4);
+    study.setPublicVisibility(false);
+    StudyProperty property = new StudyProperty();
+    property.setKey("other");
+    property.setValue("[]");
+    study.addProperties(property);
+
+    when(studyDAO.findStudyById(study.getStudyId())).thenReturn(study);
+
+    assertThrows(
+        ForbiddenException.class,
+        () -> datasetService.findStudyByIdForRead(user, study.getStudyId()));
+  }
+
+  @Test
   void testFindDatasetByIdentifier() {
     Dataset d = new Dataset();
     d.setCreateUserId(1);

--- a/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.when;
 
 import com.google.gson.Gson;
 import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.ForbiddenException;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.core.Response;
 import java.sql.Timestamp;
@@ -148,6 +149,52 @@ class DatasetServiceTest extends AbstractTestHelper {
 
     assertNotNull(dataset);
     assertEquals(dataset.getName(), getDatasets().getFirst().getName());
+  }
+
+  @Test
+  void testFindDatasetByIdForRead() {
+    Dataset dataset = getDatasets().getFirst();
+    dataset.setStudyId(null);
+    when(datasetDAO.findDatasetById(dataset.getDatasetId())).thenReturn(dataset);
+
+    Dataset result = datasetService.findDatasetByIdForRead(mockUser, dataset.getDatasetId());
+
+    assertNotNull(result);
+    assertEquals(dataset.getDatasetId(), result.getDatasetId());
+  }
+
+  @Test
+  void testFindDatasetByIdForReadNotFound() {
+    when(datasetDAO.findDatasetById(99)).thenReturn(null);
+
+    assertThrows(
+        NotFoundException.class, () -> datasetService.findDatasetByIdForRead(mockUser, 99));
+  }
+
+  @Test
+  void testFindDatasetByIdForReadForbidden() {
+    User user = new User();
+    user.setUserId(1);
+    user.setEmail("user@email.com");
+    Dataset dataset = new Dataset();
+    dataset.setDatasetId(5);
+    dataset.setCreateUserId(3);
+    Study study = new Study();
+    study.setStudyId(7);
+    study.setCreateUserId(4);
+    study.setPublicVisibility(false);
+    StudyProperty property = new StudyProperty();
+    property.setKey("other");
+    property.setValue("[]");
+    study.addProperties(property);
+    dataset.setStudyId(study.getStudyId());
+    dataset.setStudy(study);
+
+    int datasetId = dataset.getDatasetId();
+    when(datasetDAO.findDatasetById(datasetId)).thenReturn(dataset);
+
+    assertThrows(
+        ForbiddenException.class, () -> datasetService.findDatasetByIdForRead(user, datasetId));
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
@@ -232,11 +232,11 @@ class DatasetServiceTest extends AbstractTestHelper {
     property.setValue("[]");
     study.addProperties(property);
 
+    int studyId = study.getStudyId();
     when(studyDAO.findStudyById(study.getStudyId())).thenReturn(study);
 
     assertThrows(
-        ForbiddenException.class,
-        () -> datasetService.findStudyByIdForRead(user, study.getStudyId()));
+        ForbiddenException.class, () -> datasetService.findStudyByIdForRead(user, studyId));
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/FileStorageObjectServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/FileStorageObjectServiceTest.java
@@ -1,7 +1,11 @@
 package org.broadinstitute.consent.http.service;
 
+import static org.broadinstitute.consent.http.AbstractTestHelper.nextInt;
+import static org.broadinstitute.consent.http.AbstractTestHelper.randomAlphabetic;
+import static org.broadinstitute.consent.http.AbstractTestHelper.randomAlphanumeric;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
@@ -9,19 +13,20 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.cloud.storage.BlobId;
+import jakarta.ws.rs.NotFoundException;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.broadinstitute.consent.http.cloudstore.GCSService;
 import org.broadinstitute.consent.http.db.FileStorageObjectDAO;
 import org.broadinstitute.consent.http.enumeration.FileCategory;
 import org.broadinstitute.consent.http.models.FileStorageObject;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -40,16 +45,19 @@ class FileStorageObjectServiceTest {
 
   @Test
   void testUploadAndStoreFile() throws IOException {
-    InputStream content = new ByteArrayInputStream(RandomStringUtils.random(20).getBytes());
-    String fileName = RandomStringUtils.randomAlphabetic(10);
-    String mediaType = RandomStringUtils.randomAlphabetic(10);
+    InputStream content = new ByteArrayInputStream(randomAlphanumeric(20).getBytes());
+    String fileName = randomAlphabetic(10);
+    String mediaType = randomAlphabetic(10);
     FileCategory category =
-        List.of(FileCategory.values()).get(new Random().nextInt(FileCategory.values().length));
-    String entityId = RandomStringUtils.randomAlphabetic(10);
-    Integer createUserId = new Random().nextInt();
+        List.of(FileCategory.values())
+            .get(
+                org.broadinstitute.consent.http.AbstractTestHelper.randomInt(
+                    0, FileCategory.values().length));
+    String entityId = randomAlphabetic(10);
+    Integer createUserId = nextInt();
 
-    String bucket = RandomStringUtils.randomAlphabetic(10);
-    String blob = RandomStringUtils.randomAlphabetic(10);
+    String bucket = randomAlphabetic(10);
+    String blob = randomAlphabetic(10);
 
     when(fileStorageObjectDAO.insertNewFile(
             eq(fileName),
@@ -62,7 +70,7 @@ class FileStorageObjectServiceTest {
         .thenReturn(10);
 
     FileStorageObject newFileStorageObject = new FileStorageObject();
-    newFileStorageObject.setFileName(RandomStringUtils.randomAlphabetic(10));
+    newFileStorageObject.setFileName(randomAlphabetic(10));
 
     when(fileStorageObjectDAO.findFileById(10)).thenReturn(newFileStorageObject);
     when(gcsService.storeDocument(eq(content), eq(mediaType), any()))
@@ -90,13 +98,13 @@ class FileStorageObjectServiceTest {
 
   @Test
   void testFetchById() throws IOException {
-    String bucket = RandomStringUtils.randomAlphabetic(10);
-    String blob = RandomStringUtils.randomAlphabetic(10);
+    String bucket = randomAlphabetic(10);
+    String blob = randomAlphabetic(10);
 
     FileStorageObject file = new FileStorageObject();
     file.setBlobId(BlobId.of(bucket, blob));
 
-    String content = RandomStringUtils.random(100);
+    String content = randomAlphanumeric(100);
 
     when(gcsService.getDocument(BlobId.of(bucket, blob)))
         .thenReturn(new ByteArrayInputStream(content.getBytes()));
@@ -114,12 +122,12 @@ class FileStorageObjectServiceTest {
 
   @Test
   void testFetchAllByEntityId() throws IOException {
-    String bucket1Name = RandomStringUtils.randomAlphabetic(10);
-    String blob1Name = RandomStringUtils.randomAlphabetic(10);
-    String bucket2Name = RandomStringUtils.randomAlphabetic(10);
-    String blob2Name = RandomStringUtils.randomAlphabetic(10);
-    String bucket3Name = RandomStringUtils.randomAlphabetic(10);
-    String blob3Name = RandomStringUtils.randomAlphabetic(10);
+    String bucket1Name = randomAlphabetic(10);
+    String blob1Name = randomAlphabetic(10);
+    String bucket2Name = randomAlphabetic(10);
+    String blob2Name = randomAlphabetic(10);
+    String bucket3Name = randomAlphabetic(10);
+    String blob3Name = randomAlphabetic(10);
 
     FileStorageObject file1 = new FileStorageObject();
     file1.setBlobId(BlobId.of(bucket1Name, blob1Name));
@@ -130,9 +138,9 @@ class FileStorageObjectServiceTest {
     FileStorageObject file3 = new FileStorageObject();
     file3.setBlobId(BlobId.of(bucket3Name, blob3Name));
 
-    String content1 = RandomStringUtils.randomAlphabetic(10);
-    String content2 = RandomStringUtils.randomAlphabetic(10);
-    String content3 = RandomStringUtils.randomAlphabetic(10);
+    String content1 = randomAlphabetic(10);
+    String content2 = randomAlphabetic(10);
+    String content3 = randomAlphabetic(10);
 
     when(gcsService.getDocuments(List.of(file1.getBlobId(), file2.getBlobId(), file3.getBlobId())))
         .thenReturn(
@@ -141,7 +149,7 @@ class FileStorageObjectServiceTest {
                 file2.getBlobId(), new ByteArrayInputStream(content2.getBytes()),
                 file3.getBlobId(), new ByteArrayInputStream(content3.getBytes())));
 
-    String entityId = RandomStringUtils.randomAlphabetic(10);
+    String entityId = randomAlphabetic(10);
 
     when(fileStorageObjectDAO.findFilesByEntityId(entityId))
         .thenReturn(List.of(file1, file2, file3));
@@ -163,12 +171,12 @@ class FileStorageObjectServiceTest {
 
   @Test
   void testFetchAllByEntityIdAndCategory() throws IOException {
-    String bucket1Name = RandomStringUtils.randomAlphabetic(10);
-    String blob1Name = RandomStringUtils.randomAlphabetic(10);
-    String bucket2Name = RandomStringUtils.randomAlphabetic(10);
-    String blob2Name = RandomStringUtils.randomAlphabetic(10);
-    String bucket3Name = RandomStringUtils.randomAlphabetic(10);
-    String blob3Name = RandomStringUtils.randomAlphabetic(10);
+    String bucket1Name = randomAlphabetic(10);
+    String blob1Name = randomAlphabetic(10);
+    String bucket2Name = randomAlphabetic(10);
+    String blob2Name = randomAlphabetic(10);
+    String bucket3Name = randomAlphabetic(10);
+    String blob3Name = randomAlphabetic(10);
 
     FileStorageObject file1 = new FileStorageObject();
     file1.setBlobId(BlobId.of(bucket1Name, blob1Name));
@@ -179,9 +187,9 @@ class FileStorageObjectServiceTest {
     FileStorageObject file3 = new FileStorageObject();
     file3.setBlobId(BlobId.of(bucket3Name, blob3Name));
 
-    String content1 = RandomStringUtils.randomAlphabetic(10);
-    String content2 = RandomStringUtils.randomAlphabetic(10);
-    String content3 = RandomStringUtils.randomAlphabetic(10);
+    String content1 = randomAlphabetic(10);
+    String content2 = randomAlphabetic(10);
+    String content3 = randomAlphabetic(10);
 
     when(gcsService.getDocuments(List.of(file1.getBlobId(), file2.getBlobId(), file3.getBlobId())))
         .thenReturn(
@@ -190,9 +198,12 @@ class FileStorageObjectServiceTest {
                 file2.getBlobId(), new ByteArrayInputStream(content2.getBytes()),
                 file3.getBlobId(), new ByteArrayInputStream(content3.getBytes())));
 
-    String entityId = RandomStringUtils.randomAlphabetic(10);
+    String entityId = randomAlphabetic(10);
     FileCategory category =
-        List.of(FileCategory.values()).get(new Random().nextInt(FileCategory.values().length));
+        List.of(FileCategory.values())
+            .get(
+                org.broadinstitute.consent.http.AbstractTestHelper.randomInt(
+                    0, FileCategory.values().length));
 
     when(fileStorageObjectDAO.findFilesByEntityIdAndCategory(entityId, category.getValue()))
         .thenReturn(List.of(file1, file2, file3));
@@ -210,5 +221,35 @@ class FileStorageObjectServiceTest {
     assertArrayEquals(content1.getBytes(), returned.get(0).getUploadedFile().readAllBytes());
     assertArrayEquals(content2.getBytes(), returned.get(1).getUploadedFile().readAllBytes());
     assertArrayEquals(content3.getBytes(), returned.get(2).getUploadedFile().readAllBytes());
+  }
+
+  @Test
+  void testFetchMetadataByIdForEntity() {
+    Integer fileId = 10;
+    String entityId = randomAlphabetic(10);
+    FileStorageObject fileStorageObject = new FileStorageObject();
+
+    when(fileStorageObjectDAO.findActiveFileByIdAndEntityId(entityId, fileId))
+        .thenReturn(fileStorageObject);
+
+    initService();
+
+    FileStorageObject returned = service.fetchMetadataByEntityIdAndId(entityId, fileId);
+
+    assertEquals(fileStorageObject, returned);
+    verify(fileStorageObjectDAO).findActiveFileByIdAndEntityId(entityId, fileId);
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {10, 11, 12})
+  void testFetchMetadataByIdForEntityNotFoundWhenFileMissingDeletedOrWrongEntity(Integer fileId) {
+    String entityId = randomAlphabetic(10);
+
+    when(fileStorageObjectDAO.findActiveFileByIdAndEntityId(entityId, fileId)).thenReturn(null);
+
+    initService();
+
+    assertThrows(
+        NotFoundException.class, () -> service.fetchMetadataByEntityIdAndId(entityId, fileId));
   }
 }

--- a/src/test/java/org/broadinstitute/consent/http/service/FileStorageObjectServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/FileStorageObjectServiceTest.java
@@ -22,7 +22,10 @@ import java.util.Map;
 import org.broadinstitute.consent.http.cloudstore.GCSService;
 import org.broadinstitute.consent.http.db.FileStorageObjectDAO;
 import org.broadinstitute.consent.http.enumeration.FileCategory;
+import org.broadinstitute.consent.http.models.Dataset;
 import org.broadinstitute.consent.http.models.FileStorageObject;
+import org.broadinstitute.consent.http.models.Study;
+import org.broadinstitute.consent.http.models.User;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -36,11 +39,12 @@ class FileStorageObjectServiceTest {
   @Mock private FileStorageObjectDAO fileStorageObjectDAO;
 
   @Mock private GCSService gcsService;
+  @Mock private DatasetService datasetService;
 
   private FileStorageObjectService service;
 
   private void initService() {
-    service = new FileStorageObjectService(fileStorageObjectDAO, gcsService);
+    service = new FileStorageObjectService(fileStorageObjectDAO, gcsService, datasetService);
   }
 
   @Test
@@ -251,5 +255,46 @@ class FileStorageObjectServiceTest {
 
     assertThrows(
         NotFoundException.class, () -> service.fetchMetadataByEntityIdAndId(entityId, fileId));
+  }
+
+  @Test
+  void testFetchMetadataByEntityAndEntityIdForReadDataset() {
+    User user = new User();
+    Integer datasetId = 123;
+    Integer fileId = 10;
+    FileStorageObject fileStorageObject = new FileStorageObject();
+
+    when(datasetService.findDatasetByIdForRead(user, datasetId)).thenReturn(new Dataset());
+    when(fileStorageObjectDAO.findActiveFileByIdAndEntityId(datasetId.toString(), fileId))
+        .thenReturn(fileStorageObject);
+
+    initService();
+
+    FileStorageObject returned =
+        service.fetchMetadataByEntityAndEntityIdForRead(
+            user, "dataset", datasetId.toString(), fileId);
+
+    assertEquals(fileStorageObject, returned);
+  }
+
+  @Test
+  void testFetchMetadataByEntityAndEntityIdForReadStudy() {
+    User user = new User();
+    Integer studyId = 456;
+    Integer fileId = 11;
+    Study study = new Study();
+    study.setUuid(java.util.UUID.randomUUID());
+    FileStorageObject fileStorageObject = new FileStorageObject();
+
+    when(datasetService.findStudyByIdForRead(user, studyId)).thenReturn(study);
+    when(fileStorageObjectDAO.findActiveFileByIdAndEntityId(study.getUuid().toString(), fileId))
+        .thenReturn(fileStorageObject);
+
+    initService();
+
+    FileStorageObject returned =
+        service.fetchMetadataByEntityAndEntityIdForRead(user, "study", studyId.toString(), fileId);
+
+    assertEquals(fileStorageObject, returned);
   }
 }


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-3109

### Summary

This PR introduces a new GET endpoint to retrieve metadata for a FileStorageObject associated with an entity. The endpoint returns document details such as filename, category, upload date, and uploader, without including file bytes.

The implementation includes validation for entity ownership, non-deleted state, and access permissions (403/404 handling). Swagger documentation has been updated accordingly, and test coverage has been added for controller, service, and serialization layers.

<img width="1427" height="1170" alt="After" src="https://github.com/user-attachments/assets/b543fa90-e2bd-4433-a59a-53f1663b754c" />

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
