### PR TITLE
[DT-3112] Add DELETE endpoint to Soft delete FileStorageObject

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/FileStorageObjectDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/FileStorageObjectDAO.java
@@ -114,6 +114,30 @@ public interface FileStorageObjectDAO extends Transactional<InstitutionDAO> {
       """
           SELECT *
           FROM file_storage_object
+          WHERE entity_id = :entityId
+            AND file_storage_object_id = :fileStorageObjectId
+          """)
+  FileStorageObject findFileByIdAndEntityId(
+      @Bind("entityId") String entityId, @Bind("fileStorageObjectId") Integer fileStorageObjectId);
+
+  @SqlUpdate(
+      """
+          UPDATE file_storage_object
+          SET deleted=true,
+              delete_user_id=:deleteUserId,
+              delete_date=:deleteDate
+          WHERE file_storage_object_id = :fileStorageObjectId
+            AND (deleted = false OR deleted IS NULL)
+          """)
+  int softDelete(
+      @Bind("fileStorageObjectId") Integer fileStorageObjectId,
+      @Bind("deleteUserId") Integer deleteUserId,
+      @Bind("deleteDate") Instant deleteDate);
+
+  @SqlQuery(
+      """
+          SELECT *
+          FROM file_storage_object
           WHERE entity_id = :entityId AND
                 deleted != true
           """)

--- a/src/main/java/org/broadinstitute/consent/http/resources/DocumentResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DocumentResource.java
@@ -3,6 +3,7 @@ package org.broadinstitute.consent.http.resources;
 import com.google.inject.Inject;
 import io.dropwizard.auth.Auth;
 import jakarta.annotation.security.PermitAll;
+import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
@@ -59,6 +60,24 @@ public class DocumentResource extends Resource {
           fileStorageObjectService.fetchMetadataByEntityAndEntityIdForRead(
               user, entity, entityId, id);
       return Response.ok(fileStorageObject).build();
+    } catch (Exception e) {
+      return createExceptionResponse(e);
+    }
+  }
+
+  @DELETE
+  @Path("/{entityId}/document/{id}")
+  @Produces(MediaType.APPLICATION_JSON)
+  @PermitAll
+  public Response softDeleteDocumentByEntity(
+      @Auth DuosUser duosUser,
+      @PathParam("entity") String entity,
+      @PathParam("entityId") String entityId,
+      @PathParam("id") Integer id) {
+    try {
+      User user = duosUser.getUser();
+      fileStorageObjectService.softDeleteByEntityAndEntityIdForWrite(user, entity, entityId, id);
+      return Response.ok().build();
     } catch (Exception e) {
       return createExceptionResponse(e);
     }

--- a/src/main/java/org/broadinstitute/consent/http/service/FileStorageObjectService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/FileStorageObjectService.java
@@ -1,6 +1,7 @@
 package org.broadinstitute.consent.http.service;
 
 import com.google.cloud.storage.BlobId;
+import jakarta.ws.rs.ForbiddenException;
 import jakarta.ws.rs.NotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
@@ -12,6 +13,8 @@ import org.broadinstitute.consent.http.cloudstore.GCSService;
 import org.broadinstitute.consent.http.db.FileStorageObjectDAO;
 import org.broadinstitute.consent.http.enumeration.DocumentEntity;
 import org.broadinstitute.consent.http.enumeration.FileCategory;
+import org.broadinstitute.consent.http.enumeration.UserRoles;
+import org.broadinstitute.consent.http.models.Dataset;
 import org.broadinstitute.consent.http.models.FileStorageObject;
 import org.broadinstitute.consent.http.models.Study;
 import org.broadinstitute.consent.http.models.User;
@@ -126,6 +129,22 @@ public class FileStorageObjectService implements ConsentLogger {
     return fetchMetadataByEntityIdAndId(fsoEntityId, fileStorageObjectId);
   }
 
+  public void softDeleteByEntityAndEntityIdForWrite(
+      User user, String entity, String entityId, Integer fileStorageObjectId)
+      throws NotFoundException {
+    String fsoEntityId = resolveFsoEntityIdForWrite(user, entity, entityId);
+    FileStorageObject existingFileStorageObject =
+        fileStorageObjectDAO.findFileByIdAndEntityId(fsoEntityId, fileStorageObjectId);
+
+    // Idempotent delete: treat missing or already-deleted records as successful deletes.
+    if (existingFileStorageObject == null
+        || Boolean.TRUE.equals(existingFileStorageObject.getDeleted())) {
+      return;
+    }
+
+    fileStorageObjectDAO.softDelete(fileStorageObjectId, user.getUserId(), Instant.now());
+  }
+
   private String resolveFsoEntityIdForRead(User user, String entity, String entityId) {
     DocumentEntity documentEntity =
         DocumentEntity.fromValue(entity)
@@ -134,6 +153,17 @@ public class FileStorageObjectService implements ConsentLogger {
     return switch (documentEntity) {
       case DATASET -> resolveDatasetFsoEntityIdForRead(entityId, user);
       case STUDY -> resolveStudyFsoEntityIdForRead(entityId, user);
+    };
+  }
+
+  private String resolveFsoEntityIdForWrite(User user, String entity, String entityId) {
+    DocumentEntity documentEntity =
+        DocumentEntity.fromValue(entity)
+            .orElseThrow(() -> new NotFoundException("Entity not found"));
+
+    return switch (documentEntity) {
+      case DATASET -> resolveDatasetFsoEntityIdForWrite(entityId, user);
+      case STUDY -> resolveStudyFsoEntityIdForWrite(entityId, user);
     };
   }
 
@@ -146,6 +176,27 @@ public class FileStorageObjectService implements ConsentLogger {
   private String resolveStudyFsoEntityIdForRead(String entityId, User user) {
     Integer studyId = parseNumericEntityId(entityId);
     Study study = datasetService.findStudyByIdForRead(user, studyId);
+    if (study.getUuid() == null) {
+      throw new NotFoundException("Entity not found");
+    }
+    return study.getUuid().toString();
+  }
+
+  private String resolveDatasetFsoEntityIdForWrite(String entityId, User user) {
+    Integer datasetId = parseNumericEntityId(entityId);
+    Dataset dataset = datasetService.findDatasetByIdForRead(user, datasetId);
+    if (!user.hasUserRole(UserRoles.ADMIN) && !user.getUserId().equals(dataset.getCreateUserId())) {
+      throw new ForbiddenException("User does not have permission");
+    }
+    return datasetId.toString();
+  }
+
+  private String resolveStudyFsoEntityIdForWrite(String entityId, User user) {
+    Integer studyId = parseNumericEntityId(entityId);
+    Study study = datasetService.findStudyByIdForRead(user, studyId);
+    if (!datasetService.isCreatorCustodianOrAdmin(user, study)) {
+      throw new ForbiddenException("User does not have permission");
+    }
     if (study.getUuid() == null) {
       throw new NotFoundException("Entity not found");
     }

--- a/src/main/resources/assets/paths/entityDocumentById.yaml
+++ b/src/main/resources/assets/paths/entityDocumentById.yaml
@@ -37,3 +37,40 @@ get:
       description: Forbidden
     404:
       description: Not Found
+
+delete:
+  summary: Soft delete a FileStorageObject
+  operationId: softDeleteDocumentByEntity
+  description: Logically deletes a FileStorageObject only. The underlying GCS blob is not removed. This endpoint is idempotent.
+  parameters:
+    - name: entity
+      in: path
+      required: true
+      description: Entity type
+      schema:
+        type: string
+        enum: [dataset, study]
+    - name: entityId
+      in: path
+      required: true
+      description: Entity identifier
+      schema:
+        type: string
+    - name: id
+      in: path
+      required: true
+      description: FileStorageObject id
+      schema:
+        type: integer
+  tags:
+    - Document
+  responses:
+    200:
+      description: FileStorageObject deleted (or already deleted/not found for idempotency)
+    401:
+      description: Unauthorized
+    403:
+      description: Forbidden
+    404:
+      description: Not Found
+

--- a/src/test/java/org/broadinstitute/consent/http/db/FileStorageObjectDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/FileStorageObjectDAOTest.java
@@ -307,6 +307,75 @@ class FileStorageObjectDAOTest extends DAOTestHelper {
     assertNull(found);
   }
 
+  @Test
+  void testFindFileByIdAndEntityIdReturnsDeletedFile() {
+    String entityId = randomAlphabetic(10);
+    FileStorageObject file = createFileStorageObject(entityId, FileCategory.DATA_USE_LETTER);
+    User deleteUser = createUser();
+    fileStorageObjectDAO.deleteFileById(file.getFileStorageObjectId(), deleteUser.getUserId());
+
+    FileStorageObject found =
+        fileStorageObjectDAO.findFileByIdAndEntityId(entityId, file.getFileStorageObjectId());
+
+    assertNotNull(found);
+    assertTrue(found.getDeleted());
+  }
+
+  @Test
+  void testSoftDeleteSetsDeleteFieldsAndPreservesOtherFields() {
+    String entityId = randomAlphabetic(10);
+    FileStorageObject file =
+        createFileStorageObject(entityId, FileCategory.IRB_COLLABORATION_LETTER);
+    User deleteUser = createUser();
+    Instant deleteDate = Instant.now();
+
+    String originalName = file.getFileName();
+    String originalEntityId = file.getEntityId();
+    String originalMediaType = file.getMediaType();
+    Integer originalCreateUserId = file.getCreateUserId();
+
+    int updatedRows =
+        fileStorageObjectDAO.softDelete(
+            file.getFileStorageObjectId(), deleteUser.getUserId(), deleteDate);
+
+    FileStorageObject deletedFile =
+        fileStorageObjectDAO.findFileById(file.getFileStorageObjectId());
+
+    assertEquals(1, updatedRows);
+    assertTrue(deletedFile.getDeleted());
+    assertEquals(deleteUser.getUserId(), deletedFile.getDeleteUserId());
+    assertEquals(deleteDate.getEpochSecond(), deletedFile.getDeleteDate().getEpochSecond());
+    assertEquals(originalName, deletedFile.getFileName());
+    assertEquals(originalEntityId, deletedFile.getEntityId());
+    assertEquals(originalMediaType, deletedFile.getMediaType());
+    assertEquals(originalCreateUserId, deletedFile.getCreateUserId());
+  }
+
+  @Test
+  void testSoftDeleteIdempotentOnRepeatedDelete() {
+    FileStorageObject file = createFileStorageObject();
+    User firstDeleteUser = createUser();
+    User secondDeleteUser = createUser();
+    Instant firstDeleteDate = Instant.now();
+    Instant secondDeleteDate = Instant.now().plusSeconds(5);
+
+    int firstUpdateRows =
+        fileStorageObjectDAO.softDelete(
+            file.getFileStorageObjectId(), firstDeleteUser.getUserId(), firstDeleteDate);
+    int secondUpdateRows =
+        fileStorageObjectDAO.softDelete(
+            file.getFileStorageObjectId(), secondDeleteUser.getUserId(), secondDeleteDate);
+
+    FileStorageObject deletedFile =
+        fileStorageObjectDAO.findFileById(file.getFileStorageObjectId());
+
+    assertEquals(1, firstUpdateRows);
+    assertEquals(0, secondUpdateRows);
+    assertTrue(deletedFile.getDeleted());
+    assertEquals(firstDeleteUser.getUserId(), deletedFile.getDeleteUserId());
+    assertEquals(firstDeleteDate.getEpochSecond(), deletedFile.getDeleteDate().getEpochSecond());
+  }
+
   private FileStorageObject createFileStorageObject() {
     FileCategory category =
         List.of(FileCategory.values()).get(new Random().nextInt(FileCategory.values().length));

--- a/src/test/java/org/broadinstitute/consent/http/resources/DocumentResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DocumentResourceTest.java
@@ -1,6 +1,8 @@
 package org.broadinstitute.consent.http.resources;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -55,15 +57,16 @@ class DocumentResourceTest {
 
   @Test
   void testFindDocumentsByDatasetEntityMixedCaseReturnsMetadata() {
-    Integer datasetId = 123;
+    int datasetId = 123;
     List<FileStorageObject> files = List.of(new FileStorageObject());
 
     when(duosUser.getUser()).thenReturn(user);
     when(fileStorageObjectService.fetchAllMetadataByEntityAndEntityIdForRead(
-            user, "DaTaSeT", datasetId.toString()))
+            user, "DaTaSeT", Integer.toString(datasetId)))
         .thenReturn(files);
 
-    try (var response = resource.findDocumentsByEntity(duosUser, "DaTaSeT", datasetId.toString())) {
+    try (var response =
+        resource.findDocumentsByEntity(duosUser, "DaTaSeT", Integer.toString(datasetId))) {
       assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
       assertEquals(files, response.getEntity());
     }
@@ -71,21 +74,22 @@ class DocumentResourceTest {
 
   @Test
   void testFindDocumentsByStudyEntityReturnsMetadata() {
-    Integer studyId = 456;
+    int studyId = 456;
     List<FileStorageObject> files = List.of(new FileStorageObject());
 
     when(duosUser.getUser()).thenReturn(user);
     when(fileStorageObjectService.fetchAllMetadataByEntityAndEntityIdForRead(
-            user, "study", studyId.toString()))
+            user, "study", Integer.toString(studyId)))
         .thenReturn(files);
 
-    try (var response = resource.findDocumentsByEntity(duosUser, "study", studyId.toString())) {
+    try (var response =
+        resource.findDocumentsByEntity(duosUser, "study", Integer.toString(studyId))) {
       assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
       assertEquals(files, response.getEntity());
     }
 
     verify(fileStorageObjectService)
-        .fetchAllMetadataByEntityAndEntityIdForRead(user, "study", studyId.toString());
+        .fetchAllMetadataByEntityAndEntityIdForRead(user, "study", Integer.toString(studyId));
   }
 
   @Test
@@ -114,14 +118,15 @@ class DocumentResourceTest {
 
   @Test
   void testFindDocumentsByStudyEntityReturnsEmptyList() {
-    Integer studyId = 333;
+    int studyId = 333;
 
     when(duosUser.getUser()).thenReturn(user);
     when(fileStorageObjectService.fetchAllMetadataByEntityAndEntityIdForRead(
-            user, "study", studyId.toString()))
+            user, "study", Integer.toString(studyId)))
         .thenReturn(List.of());
 
-    try (var response = resource.findDocumentsByEntity(duosUser, "study", studyId.toString())) {
+    try (var response =
+        resource.findDocumentsByEntity(duosUser, "study", Integer.toString(studyId))) {
       assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
       assertEquals(List.of(), response.getEntity());
     }
@@ -129,58 +134,60 @@ class DocumentResourceTest {
 
   @Test
   void testFindDocumentsByStudyEntityForbidden() {
-    Integer studyId = 444;
+    int studyId = 444;
 
     when(duosUser.getUser()).thenReturn(user);
     when(fileStorageObjectService.fetchAllMetadataByEntityAndEntityIdForRead(
-            user, "study", studyId.toString()))
+            user, "study", Integer.toString(studyId)))
         .thenThrow(new jakarta.ws.rs.ForbiddenException("User does not have permission"));
 
-    try (var response = resource.findDocumentsByEntity(duosUser, "study", studyId.toString())) {
+    try (var response =
+        resource.findDocumentsByEntity(duosUser, "study", Integer.toString(studyId))) {
       assertEquals(HttpStatusCodes.STATUS_CODE_FORBIDDEN, response.getStatus());
     }
   }
 
   @Test
   void testFindDocumentByDatasetEntityReturnsMetadata() {
-    Integer datasetId = 123;
-    Integer fileId = 10;
+    int datasetId = 123;
+    int fileId = 10;
     FileStorageObject fileStorageObject = new FileStorageObject();
 
     when(duosUser.getUser()).thenReturn(user);
     when(fileStorageObjectService.fetchMetadataByEntityAndEntityIdForRead(
-            user, "dataset", datasetId.toString(), fileId))
+            user, "dataset", Integer.toString(datasetId), fileId))
         .thenReturn(fileStorageObject);
 
     try (var response =
-        resource.findDocumentByEntity(duosUser, "dataset", datasetId.toString(), fileId)) {
+        resource.findDocumentByEntity(duosUser, "dataset", Integer.toString(datasetId), fileId)) {
       assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
       assertEquals(fileStorageObject, response.getEntity());
     }
 
     verify(fileStorageObjectService)
-        .fetchMetadataByEntityAndEntityIdForRead(user, "dataset", datasetId.toString(), fileId);
+        .fetchMetadataByEntityAndEntityIdForRead(
+            user, "dataset", Integer.toString(datasetId), fileId);
   }
 
   @Test
   void testFindDocumentByStudyEntityReturnsMetadata() {
-    Integer studyId = 456;
+    int studyId = 456;
     Integer fileId = 11;
     FileStorageObject fileStorageObject = new FileStorageObject();
 
     when(duosUser.getUser()).thenReturn(user);
     when(fileStorageObjectService.fetchMetadataByEntityAndEntityIdForRead(
-            user, "study", studyId.toString(), fileId))
+            user, "study", Integer.toString(studyId), fileId))
         .thenReturn(fileStorageObject);
 
     try (var response =
-        resource.findDocumentByEntity(duosUser, "study", studyId.toString(), fileId)) {
+        resource.findDocumentByEntity(duosUser, "study", Integer.toString(studyId), fileId)) {
       assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
       assertEquals(fileStorageObject, response.getEntity());
     }
 
     verify(fileStorageObjectService)
-        .fetchMetadataByEntityAndEntityIdForRead(user, "study", studyId.toString(), fileId);
+        .fetchMetadataByEntityAndEntityIdForRead(user, "study", Integer.toString(studyId), fileId);
   }
 
   @Test
@@ -228,6 +235,57 @@ class DocumentResourceTest {
           HttpStatusCodes.STATUS_CODE_NOT_FOUND,
           response.getStatus(),
           "Expected 404 for scenario: " + scenarioDescription);
+    }
+  }
+
+  @Test
+  void testSoftDeleteDocumentByEntitySuccess() {
+    when(duosUser.getUser()).thenReturn(user);
+    doNothing()
+        .when(fileStorageObjectService)
+        .softDeleteByEntityAndEntityIdForWrite(user, "dataset", "123", 10);
+
+    try (var response = resource.softDeleteDocumentByEntity(duosUser, "dataset", "123", 10)) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+    }
+
+    verify(fileStorageObjectService)
+        .softDeleteByEntityAndEntityIdForWrite(user, "dataset", "123", 10);
+  }
+
+  @Test
+  void testSoftDeleteDocumentByEntityIdempotentWhenAlreadyDeleted() {
+    when(duosUser.getUser()).thenReturn(user);
+    doNothing()
+        .when(fileStorageObjectService)
+        .softDeleteByEntityAndEntityIdForWrite(user, "study", "456", 11);
+
+    try (var response = resource.softDeleteDocumentByEntity(duosUser, "study", "456", 11)) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+    }
+  }
+
+  @Test
+  void testSoftDeleteDocumentByEntityForbidden() {
+    when(duosUser.getUser()).thenReturn(user);
+    doThrow(new jakarta.ws.rs.ForbiddenException("User does not have permission"))
+        .when(fileStorageObjectService)
+        .softDeleteByEntityAndEntityIdForWrite(user, "dataset", "123", 10);
+
+    try (var response = resource.softDeleteDocumentByEntity(duosUser, "dataset", "123", 10)) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_FORBIDDEN, response.getStatus());
+    }
+  }
+
+  @Test
+  void testSoftDeleteDocumentByEntityNotFound() {
+    when(duosUser.getUser()).thenReturn(user);
+    doThrow(new NotFoundException("Entity not found"))
+        .when(fileStorageObjectService)
+        .softDeleteByEntityAndEntityIdForWrite(user, "invalid", "123", 10);
+
+    try (var response = resource.softDeleteDocumentByEntity(duosUser, "invalid", "123", 10)) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
     }
   }
 }

--- a/src/test/java/org/broadinstitute/consent/http/service/FileStorageObjectServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/FileStorageObjectServiceTest.java
@@ -8,12 +8,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.google.cloud.storage.BlobId;
+import jakarta.ws.rs.ForbiddenException;
 import jakarta.ws.rs.NotFoundException;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -336,5 +338,129 @@ class FileStorageObjectServiceTest {
         service.fetchMetadataByEntityAndEntityIdForRead(user, "study", studyId.toString(), fileId);
 
     assertEquals(fileStorageObject, returned);
+  }
+
+  @Test
+  void testSoftDeleteByEntityAndEntityIdForWriteDatasetSuccess() {
+    User user = new User();
+    user.setUserId(100);
+    Integer datasetId = 123;
+    Integer fileId = 10;
+
+    Dataset dataset = new Dataset();
+    dataset.setCreateUserId(user.getUserId());
+    FileStorageObject fileStorageObject = new FileStorageObject();
+    fileStorageObject.setDeleted(false);
+
+    when(datasetService.findDatasetByIdForRead(user, datasetId)).thenReturn(dataset);
+    when(fileStorageObjectDAO.findFileByIdAndEntityId(datasetId.toString(), fileId))
+        .thenReturn(fileStorageObject);
+    when(fileStorageObjectDAO.softDelete(eq(fileId), eq(user.getUserId()), any())).thenReturn(1);
+
+    initService();
+
+    service.softDeleteByEntityAndEntityIdForWrite(user, "dataset", datasetId.toString(), fileId);
+
+    verify(fileStorageObjectDAO).softDelete(eq(fileId), eq(user.getUserId()), any());
+  }
+
+  @Test
+  void testSoftDeleteByEntityAndEntityIdForWriteStudySuccess() {
+    User user = new User();
+    user.setUserId(101);
+    Integer studyId = 456;
+    Integer fileId = 11;
+
+    Study study = new Study();
+    study.setUuid(java.util.UUID.randomUUID());
+    FileStorageObject fileStorageObject = new FileStorageObject();
+    fileStorageObject.setDeleted(false);
+
+    when(datasetService.findStudyByIdForRead(user, studyId)).thenReturn(study);
+    when(datasetService.isCreatorCustodianOrAdmin(user, study)).thenReturn(true);
+    when(fileStorageObjectDAO.findFileByIdAndEntityId(study.getUuid().toString(), fileId))
+        .thenReturn(fileStorageObject);
+    when(fileStorageObjectDAO.softDelete(eq(fileId), eq(user.getUserId()), any())).thenReturn(1);
+
+    initService();
+
+    service.softDeleteByEntityAndEntityIdForWrite(user, "study", studyId.toString(), fileId);
+
+    verify(fileStorageObjectDAO).softDelete(eq(fileId), eq(user.getUserId()), any());
+  }
+
+  @Test
+  void testSoftDeleteByEntityAndEntityIdForWriteIdempotentWhenMissing() {
+    User user = new User();
+    user.setUserId(102);
+    Integer datasetId = 123;
+    Integer fileId = 10;
+
+    Dataset dataset = new Dataset();
+    dataset.setCreateUserId(user.getUserId());
+
+    when(datasetService.findDatasetByIdForRead(user, datasetId)).thenReturn(dataset);
+    when(fileStorageObjectDAO.findFileByIdAndEntityId(datasetId.toString(), fileId))
+        .thenReturn(null);
+
+    initService();
+
+    service.softDeleteByEntityAndEntityIdForWrite(user, "dataset", datasetId.toString(), fileId);
+
+    verify(fileStorageObjectDAO, never()).softDelete(eq(fileId), eq(user.getUserId()), any());
+  }
+
+  @Test
+  void testSoftDeleteByEntityAndEntityIdForWriteIdempotentWhenAlreadyDeleted() {
+    User user = new User();
+    user.setUserId(103);
+    Integer datasetId = 123;
+    Integer fileId = 10;
+
+    Dataset dataset = new Dataset();
+    dataset.setCreateUserId(user.getUserId());
+    FileStorageObject fileStorageObject = new FileStorageObject();
+    fileStorageObject.setDeleted(true);
+
+    when(datasetService.findDatasetByIdForRead(user, datasetId)).thenReturn(dataset);
+    when(fileStorageObjectDAO.findFileByIdAndEntityId(datasetId.toString(), fileId))
+        .thenReturn(fileStorageObject);
+
+    initService();
+
+    service.softDeleteByEntityAndEntityIdForWrite(user, "dataset", datasetId.toString(), fileId);
+
+    verify(fileStorageObjectDAO, never()).softDelete(eq(fileId), eq(user.getUserId()), any());
+  }
+
+  @Test
+  void testSoftDeleteByEntityAndEntityIdForWriteDatasetForbidden() {
+    User user = new User();
+    user.setUserId(104);
+    Integer datasetId = 123;
+    String entityId = datasetId.toString();
+
+    Dataset dataset = new Dataset();
+    dataset.setCreateUserId(999);
+
+    when(datasetService.findDatasetByIdForRead(user, datasetId)).thenReturn(dataset);
+
+    initService();
+
+    assertThrows(
+        ForbiddenException.class,
+        () -> service.softDeleteByEntityAndEntityIdForWrite(user, "dataset", entityId, 10));
+  }
+
+  @Test
+  void testSoftDeleteByEntityAndEntityIdForWriteInvalidEntityId() {
+    User user = new User();
+    user.setUserId(105);
+
+    initService();
+
+    assertThrows(
+        NotFoundException.class,
+        () -> service.softDeleteByEntityAndEntityIdForWrite(user, "dataset", "not-a-number", 10));
   }
 }


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-3112

### Summary

This PR implements a soft delete endpoint for FileStorageObject (DELETE `/api/{entity}/{entityId}/document/{id}`), marking records as deleted without removing the underlying GCS blob. The change sets deleted, deleteUserId, and deleteDate fields while preserving audit history and enabling recovery.

Adds DAO support for soft deletion, enforces entity ownership and write access, and ensures idempotent behavior aligned with existing delete patterns. Also includes Swagger documentation and unit tests covering resource and DAO logic.

<img width="1446" height="1204" alt="After" src="https://github.com/user-attachments/assets/507a5129-4b1a-4eed-9fe0-b338ed9eecce" />

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
