### PR TITLE
[DT-3108] Add PUT endpoint to Update FileStorageObject category

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/FileStorageObjectDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/FileStorageObjectDAO.java
@@ -68,6 +68,21 @@ public interface FileStorageObjectDAO extends Transactional<InstitutionDAO> {
   @SqlUpdate(
       """
           UPDATE file_storage_object
+          SET category=:category,
+              update_user_id=:updateUserId,
+              update_date=:updateDate
+          WHERE file_storage_object_id = :fileStorageObjectId
+            AND (deleted = false OR deleted IS NULL)
+          """)
+  int updateCategory(
+      @Bind("fileStorageObjectId") Integer fileStorageObjectId,
+      @Bind("category") String category,
+      @Bind("updateUserId") Integer updateUserId,
+      @Bind("updateDate") Instant updateDate);
+
+  @SqlUpdate(
+      """
+          UPDATE file_storage_object
           SET deleted=true,
               delete_user_id=:deleteUserId,
               delete_date=:deleteDate
@@ -108,6 +123,16 @@ public interface FileStorageObjectDAO extends Transactional<InstitutionDAO> {
                 AND (fso.deleted = false OR fso.deleted IS NULL)
           """)
   FileStorageObject findActiveFileByIdAndEntityId(
+      @Bind("entityId") String entityId, @Bind("fileStorageObjectId") Integer fileStorageObjectId);
+
+  @SqlQuery(
+      """
+          SELECT *
+          FROM file_storage_object
+          WHERE entity_id = :entityId
+            AND file_storage_object_id = :fileStorageObjectId
+          """)
+  FileStorageObject findFileByIdAndEntityId(
       @Bind("entityId") String entityId, @Bind("fileStorageObjectId") Integer fileStorageObjectId);
 
   @SqlQuery(

--- a/src/main/java/org/broadinstitute/consent/http/models/FileStorageObjectCategoryUpdateRequest.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/FileStorageObjectCategoryUpdateRequest.java
@@ -1,0 +1,14 @@
+package org.broadinstitute.consent.http.models;
+
+public class FileStorageObjectCategoryUpdateRequest {
+
+  private String category;
+
+  public String getCategory() {
+    return category;
+  }
+
+  public void setCategory(String category) {
+    this.category = category;
+  }
+}

--- a/src/main/java/org/broadinstitute/consent/http/resources/DocumentResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DocumentResource.java
@@ -3,7 +3,9 @@ package org.broadinstitute.consent.http.resources;
 import com.google.inject.Inject;
 import io.dropwizard.auth.Auth;
 import jakarta.annotation.security.PermitAll;
+import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PUT;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
@@ -12,6 +14,7 @@ import jakarta.ws.rs.core.Response;
 import java.util.List;
 import org.broadinstitute.consent.http.models.DuosUser;
 import org.broadinstitute.consent.http.models.FileStorageObject;
+import org.broadinstitute.consent.http.models.FileStorageObjectCategoryUpdateRequest;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.service.FileStorageObjectService;
 
@@ -59,6 +62,28 @@ public class DocumentResource extends Resource {
           fileStorageObjectService.fetchMetadataByEntityAndEntityIdForRead(
               user, entity, entityId, id);
       return Response.ok(fileStorageObject).build();
+    } catch (Exception e) {
+      return createExceptionResponse(e);
+    }
+  }
+
+  @PUT
+  @Path("/{entityId}/document/{id}")
+  @Consumes(MediaType.APPLICATION_JSON)
+  @Produces(MediaType.APPLICATION_JSON)
+  @PermitAll
+  public Response updateDocumentCategoryByEntity(
+      @Auth DuosUser duosUser,
+      @PathParam("entity") String entity,
+      @PathParam("entityId") String entityId,
+      @PathParam("id") Integer id,
+      FileStorageObjectCategoryUpdateRequest request) {
+    try {
+      User user = duosUser.getUser();
+      FileStorageObject updatedFileStorageObject =
+          fileStorageObjectService.updateCategoryByEntityAndEntityIdForWrite(
+              user, entity, entityId, id, request == null ? null : request.getCategory());
+      return Response.ok(updatedFileStorageObject).build();
     } catch (Exception e) {
       return createExceptionResponse(e);
     }

--- a/src/main/java/org/broadinstitute/consent/http/service/FileStorageObjectService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/FileStorageObjectService.java
@@ -1,17 +1,22 @@
 package org.broadinstitute.consent.http.service;
 
 import com.google.cloud.storage.BlobId;
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.ForbiddenException;
 import jakarta.ws.rs.NotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import org.broadinstitute.consent.http.cloudstore.GCSService;
 import org.broadinstitute.consent.http.db.FileStorageObjectDAO;
 import org.broadinstitute.consent.http.enumeration.DocumentEntity;
 import org.broadinstitute.consent.http.enumeration.FileCategory;
+import org.broadinstitute.consent.http.enumeration.UserRoles;
+import org.broadinstitute.consent.http.models.Dataset;
 import org.broadinstitute.consent.http.models.FileStorageObject;
 import org.broadinstitute.consent.http.models.Study;
 import org.broadinstitute.consent.http.models.User;
@@ -126,6 +131,33 @@ public class FileStorageObjectService implements ConsentLogger {
     return fetchMetadataByEntityIdAndId(fsoEntityId, fileStorageObjectId);
   }
 
+  public FileStorageObject updateCategoryByEntityAndEntityIdForWrite(
+      User user, String entity, String entityId, Integer fileStorageObjectId, String categoryValue)
+      throws NotFoundException {
+    if (categoryValue == null || categoryValue.trim().isEmpty()) {
+      throw new BadRequestException("Invalid category");
+    }
+
+    FileCategory category = FileCategory.findValue(categoryValue.trim());
+    if (category == null) {
+      throw new BadRequestException("Invalid category");
+    }
+
+    validateCategoryAllowedForEntity(entity, category);
+
+    String fsoEntityId = resolveFsoEntityIdForWrite(user, entity, entityId);
+    FileStorageObject existingFileStorageObject =
+        fileStorageObjectDAO.findFileByIdAndEntityId(fsoEntityId, fileStorageObjectId);
+    if (existingFileStorageObject == null
+        || Boolean.TRUE.equals(existingFileStorageObject.getDeleted())) {
+      throw new NotFoundException("File not found");
+    }
+
+    fileStorageObjectDAO.updateCategory(
+        fileStorageObjectId, category.getValue(), user.getUserId(), Instant.now());
+    return fileStorageObjectDAO.findFileById(fileStorageObjectId);
+  }
+
   private String resolveFsoEntityIdForRead(User user, String entity, String entityId) {
     DocumentEntity documentEntity =
         DocumentEntity.fromValue(entity)
@@ -134,6 +166,25 @@ public class FileStorageObjectService implements ConsentLogger {
     return switch (documentEntity) {
       case DATASET -> resolveDatasetFsoEntityIdForRead(entityId, user);
       case STUDY -> resolveStudyFsoEntityIdForRead(entityId, user);
+    };
+  }
+
+  private String resolveFsoEntityIdForWrite(User user, String entity, String entityId) {
+    if ("dac".equalsIgnoreCase(entity) || "dar".equalsIgnoreCase(entity)) {
+      if (!user.hasUserRole(UserRoles.ADMIN)) {
+        throw new ForbiddenException("User does not have permission");
+      }
+      Integer numericEntityId = parseNumericEntityId(entityId);
+      return numericEntityId.toString();
+    }
+
+    DocumentEntity documentEntity =
+        DocumentEntity.fromValue(entity)
+            .orElseThrow(() -> new NotFoundException("Entity not found"));
+
+    return switch (documentEntity) {
+      case DATASET -> resolveDatasetFsoEntityIdForWrite(entityId, user);
+      case STUDY -> resolveStudyFsoEntityIdForWrite(entityId, user);
     };
   }
 
@@ -152,11 +203,54 @@ public class FileStorageObjectService implements ConsentLogger {
     return study.getUuid().toString();
   }
 
+  private String resolveDatasetFsoEntityIdForWrite(String entityId, User user) {
+    Integer datasetId = parseNumericEntityId(entityId);
+    Dataset dataset = datasetService.findDatasetByIdForRead(user, datasetId);
+    if (!user.hasUserRole(UserRoles.ADMIN) && !user.getUserId().equals(dataset.getCreateUserId())) {
+      throw new ForbiddenException("User does not have permission");
+    }
+    return datasetId.toString();
+  }
+
+  private String resolveStudyFsoEntityIdForWrite(String entityId, User user) {
+    Integer studyId = parseNumericEntityId(entityId);
+    Study study = datasetService.findStudyByIdForRead(user, studyId);
+    if (!datasetService.isCreatorCustodianOrAdmin(user, study)) {
+      throw new ForbiddenException("User does not have permission");
+    }
+    if (study.getUuid() == null) {
+      throw new NotFoundException("Entity not found");
+    }
+    return study.getUuid().toString();
+  }
+
   private Integer parseNumericEntityId(String entityId) {
     try {
       return Integer.valueOf(entityId);
     } catch (NumberFormatException _) {
       throw new NotFoundException("Entity not found");
+    }
+  }
+
+  private void validateCategoryAllowedForEntity(String entity, FileCategory category) {
+    Set<FileCategory> allowedCategories;
+    if ("dataset".equalsIgnoreCase(entity) || "study".equalsIgnoreCase(entity)) {
+      allowedCategories =
+          Set.of(
+              FileCategory.IRB_COLLABORATION_LETTER,
+              FileCategory.DATA_USE_LETTER,
+              FileCategory.ALTERNATIVE_DATA_SHARING_PLAN,
+              FileCategory.NIH_INSTITUTIONAL_CERTIFICATION);
+    } else if ("dac".equalsIgnoreCase(entity) || "dar".equalsIgnoreCase(entity)) {
+      allowedCategories = Set.of(FileCategory.DATA_ACCESS_AGREEMENT);
+    } else {
+      throw new NotFoundException("Entity not found");
+    }
+
+    if (!allowedCategories.contains(category)) {
+      throw new BadRequestException(
+          String.format(
+              "Category '%s' is not allowed for entity '%s'", category.getValue(), entity));
     }
   }
 

--- a/src/main/resources/assets/paths/entityDocumentById.yaml
+++ b/src/main/resources/assets/paths/entityDocumentById.yaml
@@ -37,3 +37,52 @@ get:
       description: Forbidden
     404:
       description: Not Found
+
+put:
+  summary: Update FileStorageObject category
+  operationId: updateDocumentCategoryByEntity
+  description: Updates only the FileStorageObject category for re-categorization. File content is immutable.
+  parameters:
+    - name: entity
+      in: path
+      required: true
+      description: Entity type
+      schema:
+        type: string
+        enum: [dac, dar, dataset, study]
+    - name: entityId
+      in: path
+      required: true
+      description: Entity identifier
+      schema:
+        type: string
+    - name: id
+      in: path
+      required: true
+      description: FileStorageObject id
+      schema:
+        type: integer
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: '../schemas/FileStorageObjectCategoryUpdateRequest.yaml'
+  tags:
+    - Document
+  responses:
+    200:
+      description: Updated FileStorageObject metadata
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/FileStorageObject.yaml'
+    400:
+      description: Bad request
+    401:
+      description: Unauthorized
+    403:
+      description: Forbidden
+    404:
+      description: Not Found
+

--- a/src/main/resources/assets/schemas/FileStorageObjectCategoryUpdateRequest.yaml
+++ b/src/main/resources/assets/schemas/FileStorageObjectCategoryUpdateRequest.yaml
@@ -1,0 +1,16 @@
+type: object
+description: Request payload to update an existing FileStorageObject category.
+required:
+  - category
+properties:
+  category:
+    type: string
+    description: File category value.
+    enum:
+      - irbCollaborationLetter
+      - dataUseLetter
+      - alternativeDataSharingPlan
+      - nihInstitutionalCertification
+      - dataAccessAgreement
+      - draftUploadedFile
+

--- a/src/test/java/org/broadinstitute/consent/http/db/FileStorageObjectDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/FileStorageObjectDAOTest.java
@@ -307,6 +307,63 @@ class FileStorageObjectDAOTest extends DAOTestHelper {
     assertNull(found);
   }
 
+  @Test
+  void testUpdateCategory() {
+    String entityId = randomAlphabetic(10);
+    FileStorageObject original = createFileStorageObject(entityId, FileCategory.DATA_USE_LETTER);
+    User updateUser = createUser();
+    Instant updateDate = Instant.now();
+
+    String originalFileName = original.getFileName();
+    String originalMediaType = original.getMediaType();
+    String originalGcsUri = original.getBlobId().toGsUtilUri();
+    Integer originalCreateUserId = original.getCreateUserId();
+    Instant originalCreateDate = original.getCreateDate();
+
+    int rows =
+        fileStorageObjectDAO.updateCategory(
+            original.getFileStorageObjectId(),
+            FileCategory.ALTERNATIVE_DATA_SHARING_PLAN.getValue(),
+            updateUser.getUserId(),
+            updateDate);
+
+    FileStorageObject updated =
+        fileStorageObjectDAO.findFileById(original.getFileStorageObjectId());
+
+    assertEquals(1, rows);
+    assertEquals(FileCategory.ALTERNATIVE_DATA_SHARING_PLAN, updated.getCategory());
+    assertEquals(updateUser.getUserId(), updated.getUpdateUserId());
+    assertEquals(updateDate.getEpochSecond(), updated.getUpdateDate().getEpochSecond());
+
+    assertEquals(originalFileName, updated.getFileName());
+    assertEquals(originalMediaType, updated.getMediaType());
+    assertEquals(originalGcsUri, updated.getBlobId().toGsUtilUri());
+    assertEquals(originalCreateUserId, updated.getCreateUserId());
+    assertEquals(originalCreateDate.getEpochSecond(), updated.getCreateDate().getEpochSecond());
+  }
+
+  @Test
+  void testUpdateCategorySameCategoryStillSucceeds() {
+    FileStorageObject original = createFileStorageObject();
+    User updateUser = createUser();
+    Instant updateDate = Instant.now();
+
+    int rows =
+        fileStorageObjectDAO.updateCategory(
+            original.getFileStorageObjectId(),
+            original.getCategory().getValue(),
+            updateUser.getUserId(),
+            updateDate);
+
+    FileStorageObject updated =
+        fileStorageObjectDAO.findFileById(original.getFileStorageObjectId());
+
+    assertEquals(1, rows);
+    assertEquals(original.getCategory(), updated.getCategory());
+    assertEquals(updateUser.getUserId(), updated.getUpdateUserId());
+    assertEquals(updateDate.getEpochSecond(), updated.getUpdateDate().getEpochSecond());
+  }
+
   private FileStorageObject createFileStorageObject() {
     FileCategory category =
         List.of(FileCategory.values()).get(new Random().nextInt(FileCategory.values().length));

--- a/src/test/java/org/broadinstitute/consent/http/resources/DocumentResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DocumentResourceTest.java
@@ -5,10 +5,12 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.api.client.http.HttpStatusCodes;
+import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.NotFoundException;
 import java.util.List;
 import org.broadinstitute.consent.http.models.DuosUser;
 import org.broadinstitute.consent.http.models.FileStorageObject;
+import org.broadinstitute.consent.http.models.FileStorageObjectCategoryUpdateRequest;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.service.FileStorageObjectService;
 import org.junit.jupiter.api.BeforeEach;
@@ -55,15 +57,16 @@ class DocumentResourceTest {
 
   @Test
   void testFindDocumentsByDatasetEntityMixedCaseReturnsMetadata() {
-    Integer datasetId = 123;
+    int datasetId = 123;
     List<FileStorageObject> files = List.of(new FileStorageObject());
 
     when(duosUser.getUser()).thenReturn(user);
     when(fileStorageObjectService.fetchAllMetadataByEntityAndEntityIdForRead(
-            user, "DaTaSeT", datasetId.toString()))
+            user, "DaTaSeT", Integer.toString(datasetId)))
         .thenReturn(files);
 
-    try (var response = resource.findDocumentsByEntity(duosUser, "DaTaSeT", datasetId.toString())) {
+    try (var response =
+        resource.findDocumentsByEntity(duosUser, "DaTaSeT", Integer.toString(datasetId))) {
       assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
       assertEquals(files, response.getEntity());
     }
@@ -71,21 +74,22 @@ class DocumentResourceTest {
 
   @Test
   void testFindDocumentsByStudyEntityReturnsMetadata() {
-    Integer studyId = 456;
+    int studyId = 456;
     List<FileStorageObject> files = List.of(new FileStorageObject());
 
     when(duosUser.getUser()).thenReturn(user);
     when(fileStorageObjectService.fetchAllMetadataByEntityAndEntityIdForRead(
-            user, "study", studyId.toString()))
+            user, "study", Integer.toString(studyId)))
         .thenReturn(files);
 
-    try (var response = resource.findDocumentsByEntity(duosUser, "study", studyId.toString())) {
+    try (var response =
+        resource.findDocumentsByEntity(duosUser, "study", Integer.toString(studyId))) {
       assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
       assertEquals(files, response.getEntity());
     }
 
     verify(fileStorageObjectService)
-        .fetchAllMetadataByEntityAndEntityIdForRead(user, "study", studyId.toString());
+        .fetchAllMetadataByEntityAndEntityIdForRead(user, "study", Integer.toString(studyId));
   }
 
   @Test
@@ -114,14 +118,15 @@ class DocumentResourceTest {
 
   @Test
   void testFindDocumentsByStudyEntityReturnsEmptyList() {
-    Integer studyId = 333;
+    int studyId = 333;
 
     when(duosUser.getUser()).thenReturn(user);
     when(fileStorageObjectService.fetchAllMetadataByEntityAndEntityIdForRead(
-            user, "study", studyId.toString()))
+            user, "study", Integer.toString(studyId)))
         .thenReturn(List.of());
 
-    try (var response = resource.findDocumentsByEntity(duosUser, "study", studyId.toString())) {
+    try (var response =
+        resource.findDocumentsByEntity(duosUser, "study", Integer.toString(studyId))) {
       assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
       assertEquals(List.of(), response.getEntity());
     }
@@ -129,58 +134,60 @@ class DocumentResourceTest {
 
   @Test
   void testFindDocumentsByStudyEntityForbidden() {
-    Integer studyId = 444;
+    int studyId = 444;
 
     when(duosUser.getUser()).thenReturn(user);
     when(fileStorageObjectService.fetchAllMetadataByEntityAndEntityIdForRead(
-            user, "study", studyId.toString()))
+            user, "study", Integer.toString(studyId)))
         .thenThrow(new jakarta.ws.rs.ForbiddenException("User does not have permission"));
 
-    try (var response = resource.findDocumentsByEntity(duosUser, "study", studyId.toString())) {
+    try (var response =
+        resource.findDocumentsByEntity(duosUser, "study", Integer.toString(studyId))) {
       assertEquals(HttpStatusCodes.STATUS_CODE_FORBIDDEN, response.getStatus());
     }
   }
 
   @Test
   void testFindDocumentByDatasetEntityReturnsMetadata() {
-    Integer datasetId = 123;
+    int datasetId = 123;
     Integer fileId = 10;
     FileStorageObject fileStorageObject = new FileStorageObject();
 
     when(duosUser.getUser()).thenReturn(user);
     when(fileStorageObjectService.fetchMetadataByEntityAndEntityIdForRead(
-            user, "dataset", datasetId.toString(), fileId))
+            user, "dataset", Integer.toString(datasetId), fileId))
         .thenReturn(fileStorageObject);
 
     try (var response =
-        resource.findDocumentByEntity(duosUser, "dataset", datasetId.toString(), fileId)) {
+        resource.findDocumentByEntity(duosUser, "dataset", Integer.toString(datasetId), fileId)) {
       assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
       assertEquals(fileStorageObject, response.getEntity());
     }
 
     verify(fileStorageObjectService)
-        .fetchMetadataByEntityAndEntityIdForRead(user, "dataset", datasetId.toString(), fileId);
+        .fetchMetadataByEntityAndEntityIdForRead(
+            user, "dataset", Integer.toString(datasetId), fileId);
   }
 
   @Test
   void testFindDocumentByStudyEntityReturnsMetadata() {
-    Integer studyId = 456;
+    int studyId = 456;
     Integer fileId = 11;
     FileStorageObject fileStorageObject = new FileStorageObject();
 
     when(duosUser.getUser()).thenReturn(user);
     when(fileStorageObjectService.fetchMetadataByEntityAndEntityIdForRead(
-            user, "study", studyId.toString(), fileId))
+            user, "study", Integer.toString(studyId), fileId))
         .thenReturn(fileStorageObject);
 
     try (var response =
-        resource.findDocumentByEntity(duosUser, "study", studyId.toString(), fileId)) {
+        resource.findDocumentByEntity(duosUser, "study", Integer.toString(studyId), fileId)) {
       assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
       assertEquals(fileStorageObject, response.getEntity());
     }
 
     verify(fileStorageObjectService)
-        .fetchMetadataByEntityAndEntityIdForRead(user, "study", studyId.toString(), fileId);
+        .fetchMetadataByEntityAndEntityIdForRead(user, "study", Integer.toString(studyId), fileId);
   }
 
   @Test
@@ -228,6 +235,102 @@ class DocumentResourceTest {
           HttpStatusCodes.STATUS_CODE_NOT_FOUND,
           response.getStatus(),
           "Expected 404 for scenario: " + scenarioDescription);
+    }
+  }
+
+  @Test
+  void testUpdateDocumentCategoryByEntitySuccess() {
+    FileStorageObjectCategoryUpdateRequest request = new FileStorageObjectCategoryUpdateRequest();
+    request.setCategory("dataUseLetter");
+    FileStorageObject updated = new FileStorageObject();
+
+    when(duosUser.getUser()).thenReturn(user);
+    when(fileStorageObjectService.updateCategoryByEntityAndEntityIdForWrite(
+            user, "dataset", "123", 10, "dataUseLetter"))
+        .thenReturn(updated);
+
+    try (var response =
+        resource.updateDocumentCategoryByEntity(duosUser, "dataset", "123", 10, request)) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+      assertEquals(updated, response.getEntity());
+    }
+  }
+
+  @Test
+  void testUpdateDocumentCategoryByEntityInvalidCategoryBadRequest() {
+    FileStorageObjectCategoryUpdateRequest request = new FileStorageObjectCategoryUpdateRequest();
+    request.setCategory("invalidCategory");
+
+    when(duosUser.getUser()).thenReturn(user);
+    when(fileStorageObjectService.updateCategoryByEntityAndEntityIdForWrite(
+            user, "dataset", "123", 10, "invalidCategory"))
+        .thenThrow(new BadRequestException("Invalid category"));
+
+    try (var response =
+        resource.updateDocumentCategoryByEntity(duosUser, "dataset", "123", 10, request)) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
+    }
+  }
+
+  @Test
+  void testUpdateDocumentCategoryByEntityInvalidCategoryEntityMappingBadRequest() {
+    FileStorageObjectCategoryUpdateRequest request = new FileStorageObjectCategoryUpdateRequest();
+    request.setCategory("dataAccessAgreement");
+
+    when(duosUser.getUser()).thenReturn(user);
+    when(fileStorageObjectService.updateCategoryByEntityAndEntityIdForWrite(
+            user, "dataset", "123", 10, "dataAccessAgreement"))
+        .thenThrow(new BadRequestException("Category not allowed"));
+
+    try (var response =
+        resource.updateDocumentCategoryByEntity(duosUser, "dataset", "123", 10, request)) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
+    }
+  }
+
+  @Test
+  void testUpdateDocumentCategoryByEntityNotFound() {
+    FileStorageObjectCategoryUpdateRequest request = new FileStorageObjectCategoryUpdateRequest();
+    request.setCategory("dataUseLetter");
+
+    when(duosUser.getUser()).thenReturn(user);
+    when(fileStorageObjectService.updateCategoryByEntityAndEntityIdForWrite(
+            user, "dataset", "123", 10, "dataUseLetter"))
+        .thenThrow(new NotFoundException("File not found"));
+
+    try (var response =
+        resource.updateDocumentCategoryByEntity(duosUser, "dataset", "123", 10, request)) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
+    }
+  }
+
+  @Test
+  void testUpdateDocumentCategoryByEntityForbidden() {
+    FileStorageObjectCategoryUpdateRequest request = new FileStorageObjectCategoryUpdateRequest();
+    request.setCategory("dataUseLetter");
+
+    when(duosUser.getUser()).thenReturn(user);
+    when(fileStorageObjectService.updateCategoryByEntityAndEntityIdForWrite(
+            user, "dataset", "123", 10, "dataUseLetter"))
+        .thenThrow(new jakarta.ws.rs.ForbiddenException("User does not have permission"));
+
+    try (var response =
+        resource.updateDocumentCategoryByEntity(duosUser, "dataset", "123", 10, request)) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_FORBIDDEN, response.getStatus());
+    }
+  }
+
+  @Test
+  void testUpdateDocumentCategoryByEntityNullRequestCategoryBadRequest() {
+    when(duosUser.getUser()).thenReturn(user);
+    when(fileStorageObjectService.updateCategoryByEntityAndEntityIdForWrite(
+            user, "dataset", "123", 10, null))
+        .thenThrow(new BadRequestException("Invalid category"));
+
+    try (var response =
+        resource.updateDocumentCategoryByEntity(
+            duosUser, "dataset", "123", 10, new FileStorageObjectCategoryUpdateRequest())) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
     }
   }
 }

--- a/src/test/java/org/broadinstitute/consent/http/service/FileStorageObjectServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/FileStorageObjectServiceTest.java
@@ -14,6 +14,8 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.google.cloud.storage.BlobId;
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.ForbiddenException;
 import jakarta.ws.rs.NotFoundException;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -31,6 +33,7 @@ import org.broadinstitute.consent.http.models.User;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -336,5 +339,179 @@ class FileStorageObjectServiceTest {
         service.fetchMetadataByEntityAndEntityIdForRead(user, "study", studyId.toString(), fileId);
 
     assertEquals(fileStorageObject, returned);
+  }
+
+  @Test
+  void testUpdateCategoryByEntityAndEntityIdForWriteSuccess() {
+    User user = new User();
+    user.setUserId(200);
+    Integer datasetId = 123;
+    Integer fileId = 10;
+    String entityId = datasetId.toString();
+
+    Dataset dataset = new Dataset();
+    dataset.setCreateUserId(user.getUserId());
+    FileStorageObject existing = new FileStorageObject();
+    existing.setDeleted(false);
+    FileStorageObject updated = new FileStorageObject();
+    updated.setCategory(FileCategory.DATA_USE_LETTER);
+
+    when(datasetService.findDatasetByIdForRead(user, datasetId)).thenReturn(dataset);
+    when(fileStorageObjectDAO.findFileByIdAndEntityId(entityId, fileId)).thenReturn(existing);
+    when(fileStorageObjectDAO.updateCategory(
+            eq(fileId), eq("dataUseLetter"), eq(user.getUserId()), any()))
+        .thenReturn(1);
+    when(fileStorageObjectDAO.findFileById(fileId)).thenReturn(updated);
+
+    initService();
+
+    FileStorageObject result =
+        service.updateCategoryByEntityAndEntityIdForWrite(
+            user, "dataset", entityId, fileId, "dataUseLetter");
+
+    assertEquals(updated, result);
+    verify(fileStorageObjectDAO)
+        .updateCategory(eq(fileId), eq("dataUseLetter"), eq(user.getUserId()), any());
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"invalidCategory", "dataAccessAgreement"})
+  void testUpdateCategoryByEntityAndEntityIdForWriteBadRequestForCategory(String category) {
+    User user = new User();
+    user.setUserId(201);
+
+    initService();
+
+    String entityId = "123";
+    assertThrows(
+        BadRequestException.class,
+        () ->
+            service.updateCategoryByEntityAndEntityIdForWrite(
+                user, "dataset", entityId, 10, category));
+  }
+
+  @Test
+  void testUpdateCategoryByEntityAndEntityIdForWriteNotFoundWhenMissingFile() {
+    User user = new User();
+    user.setUserId(203);
+    Integer datasetId = 123;
+    Integer fileId = 10;
+    String entityId = datasetId.toString();
+    Dataset dataset = new Dataset();
+    dataset.setCreateUserId(user.getUserId());
+
+    when(datasetService.findDatasetByIdForRead(user, datasetId)).thenReturn(dataset);
+    when(fileStorageObjectDAO.findFileByIdAndEntityId(entityId, fileId)).thenReturn(null);
+
+    initService();
+
+    assertThrows(
+        NotFoundException.class,
+        () ->
+            service.updateCategoryByEntityAndEntityIdForWrite(
+                user, "dataset", entityId, fileId, "dataUseLetter"));
+  }
+
+  @Test
+  void testUpdateCategoryByEntityAndEntityIdForWriteNotFoundWhenDeletedFile() {
+    User user = new User();
+    user.setUserId(204);
+    Integer datasetId = 123;
+    Integer fileId = 10;
+    String entityId = datasetId.toString();
+    Dataset dataset = new Dataset();
+    dataset.setCreateUserId(user.getUserId());
+    FileStorageObject deleted = new FileStorageObject();
+    deleted.setDeleted(true);
+
+    when(datasetService.findDatasetByIdForRead(user, datasetId)).thenReturn(dataset);
+    when(fileStorageObjectDAO.findFileByIdAndEntityId(entityId, fileId)).thenReturn(deleted);
+
+    initService();
+
+    assertThrows(
+        NotFoundException.class,
+        () ->
+            service.updateCategoryByEntityAndEntityIdForWrite(
+                user, "dataset", entityId, fileId, "dataUseLetter"));
+  }
+
+  @Test
+  void testUpdateCategoryByEntityAndEntityIdForWriteForbidden() {
+    User user = new User();
+    user.setUserId(205);
+    Integer datasetId = 123;
+    String entityId = datasetId.toString();
+    Dataset dataset = new Dataset();
+    dataset.setCreateUserId(999);
+
+    when(datasetService.findDatasetByIdForRead(user, datasetId)).thenReturn(dataset);
+
+    initService();
+
+    assertThrows(
+        ForbiddenException.class,
+        () ->
+            service.updateCategoryByEntityAndEntityIdForWrite(
+                user, "dataset", entityId, 10, "dataUseLetter"));
+  }
+
+  @Test
+  void testUpdateCategoryByEntityAndEntityIdForWriteInvalidEntityType() {
+    User user = new User();
+    user.setUserId(206);
+
+    initService();
+
+    assertThrows(
+        NotFoundException.class,
+        () ->
+            service.updateCategoryByEntityAndEntityIdForWrite(
+                user, "invalid", "123", 10, "dataUseLetter"));
+  }
+
+  @ParameterizedTest
+  @NullSource
+  @ValueSource(strings = {"", "   "})
+  void testUpdateCategoryByEntityAndEntityIdForWriteNullOrEmptyCategory(String category) {
+    User user = new User();
+    user.setUserId(207);
+
+    initService();
+
+    assertThrows(
+        BadRequestException.class,
+        () ->
+            service.updateCategoryByEntityAndEntityIdForWrite(
+                user, "dataset", "123", 10, category));
+  }
+
+  @Test
+  void testUpdateCategoryByEntityAndEntityIdForWriteSameCategoryStillSucceeds() {
+    User user = new User();
+    user.setUserId(208);
+    Integer datasetId = 123;
+    Integer fileId = 10;
+    Dataset dataset = new Dataset();
+    dataset.setCreateUserId(user.getUserId());
+    FileStorageObject existing = new FileStorageObject();
+    existing.setDeleted(false);
+    existing.setCategory(FileCategory.DATA_USE_LETTER);
+
+    when(datasetService.findDatasetByIdForRead(user, datasetId)).thenReturn(dataset);
+    when(fileStorageObjectDAO.findFileByIdAndEntityId(datasetId.toString(), fileId))
+        .thenReturn(existing);
+    when(fileStorageObjectDAO.updateCategory(
+            eq(fileId), eq("dataUseLetter"), eq(user.getUserId()), any()))
+        .thenReturn(1);
+    when(fileStorageObjectDAO.findFileById(fileId)).thenReturn(existing);
+
+    initService();
+
+    FileStorageObject result =
+        service.updateCategoryByEntityAndEntityIdForWrite(
+            user, "dataset", datasetId.toString(), fileId, "dataUseLetter");
+
+    assertEquals(existing, result);
   }
 }


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-3108

### Summary

Adds a new endpoint to update the `FileCategory` of an existing FileStorageObject (`PUT` `/api/{entity}/{entityId}/document/{id}`) without requiring file re-upload. The change ensures that only the category is mutable while preserving file content and storage references.

Implements validation for valid and entity-appropriate categories, enforces entity ownership and access control, and prevents updates to soft-deleted or mismatched records. Adds DAO support for updating category metadata (`updateUserId`, `updateDate`) and includes Swagger documentation and unit tests for resource and DAO behavior.

<img width="1149" height="1306" alt="After" src="https://github.com/user-attachments/assets/ad13e76c-d249-490f-8008-b24fae15c9eb" />

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
