### PR TITLE
DT-2845: Handle known AzureB2C exception cases

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/SamDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/SamDAO.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import org.broadinstitute.consent.http.configurations.ServicesConfiguration;
+import org.broadinstitute.consent.http.exceptions.SamAzureB2CException;
 import org.broadinstitute.consent.http.models.AuthUser;
 import org.broadinstitute.consent.http.models.DuosUser;
 import org.broadinstitute.consent.http.models.sam.CombinedState;
@@ -120,6 +121,12 @@ public class SamDAO implements ConsentLogger {
       HttpResponse response = executeRequest(request);
       String body = response.parseAsString();
       if (!response.isSuccessStatusCode()) {
+        if (body.toLowerCase().contains("cannot update azureb2cid for user")) {
+          throw new SamAzureB2CException(
+              String.format(
+                  "AzureB2C authentication Error for user %s: %s. Please contact support for help with this error.",
+                  authUser.getEmail(), body));
+        }
         String errorMsg =
             String.format(
                 "Error getting combined user status info for user %s: %s",
@@ -142,6 +149,9 @@ public class SamDAO implements ConsentLogger {
           .setEnabled(combinedState.getSamUser().enabled())
           // Ensure that the user has both accepted the ToS and that it is the most recent version.
           .setTosAccepted(tosAccepted);
+    } catch (SamAzureB2CException e) {
+      logException(e);
+      throw e;
     } catch (ForbiddenException e) {
       // Sam throws a 403, not a 404, when the user is not found at this API
       // which is re-thrown in executeRequest

--- a/src/main/java/org/broadinstitute/consent/http/db/SamDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/SamDAO.java
@@ -124,8 +124,8 @@ public class SamDAO implements ConsentLogger {
         if (body.toLowerCase().contains("cannot update azureb2cid for user")) {
           throw new SamAzureB2CException(
               String.format(
-                  "AzureB2C authentication Error for user %s: %s. Please contact support for help with this error.",
-                  authUser.getEmail(), body));
+                  "AzureB2C authentication Error for user %s. Please contact support for help with this error.",
+                  authUser.getEmail()));
         }
         String errorMsg =
             String.format(
@@ -149,9 +149,6 @@ public class SamDAO implements ConsentLogger {
           .setEnabled(combinedState.getSamUser().enabled())
           // Ensure that the user has both accepted the ToS and that it is the most recent version.
           .setTosAccepted(tosAccepted);
-    } catch (SamAzureB2CException e) {
-      logException(e);
-      throw e;
     } catch (ForbiddenException e) {
       // Sam throws a 403, not a 404, when the user is not found at this API
       // which is re-thrown in executeRequest

--- a/src/main/java/org/broadinstitute/consent/http/exceptions/ECMException.java
+++ b/src/main/java/org/broadinstitute/consent/http/exceptions/ECMException.java
@@ -1,0 +1,8 @@
+package org.broadinstitute.consent.http.exceptions;
+
+public class ECMException extends Exception {
+
+  public ECMException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/org/broadinstitute/consent/http/exceptions/ECMException.java
+++ b/src/main/java/org/broadinstitute/consent/http/exceptions/ECMException.java
@@ -1,8 +1,0 @@
-package org.broadinstitute.consent.http.exceptions;
-
-public class ECMException extends Exception {
-
-  public ECMException(String message) {
-    super(message);
-  }
-}

--- a/src/main/java/org/broadinstitute/consent/http/exceptions/SamAzureB2CException.java
+++ b/src/main/java/org/broadinstitute/consent/http/exceptions/SamAzureB2CException.java
@@ -1,0 +1,8 @@
+package org.broadinstitute.consent.http.exceptions;
+
+public class SamAzureB2CException extends Exception {
+
+  public SamAzureB2CException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
@@ -33,6 +33,7 @@ import java.util.Map;
 import java.util.Objects;
 import org.broadinstitute.consent.http.configurations.ServicesConfiguration;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
+import org.broadinstitute.consent.http.exceptions.SamAzureB2CException;
 import org.broadinstitute.consent.http.models.Acknowledgement;
 import org.broadinstitute.consent.http.models.ApprovedDataset;
 import org.broadinstitute.consent.http.models.AuthUser;
@@ -134,9 +135,11 @@ public class UserResource extends Resource {
     }
   }
 
-  private UserStatusInfo getUserStatusInfo(DuosUser duosUser) {
+  private UserStatusInfo getUserStatusInfo(DuosUser duosUser) throws SamAzureB2CException {
     try {
       return samService.getCombinedUserStatusInfo(duosUser);
+    } catch (SamAzureB2CException e) {
+      throw e;
     } catch (Exception ex) {
       logWarn("Unable to retrieve user status info from Sam: " + ex.getMessage());
       // Intentionally ignore Sam errors here to avoid failing /me on transient outages.

--- a/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
@@ -139,6 +139,9 @@ public class UserResource extends Resource {
     try {
       return samService.getCombinedUserStatusInfo(duosUser);
     } catch (SamAzureB2CException e) {
+      logWarn(
+          "Sam azure b2c exception: %s for user: %s"
+              .formatted(e.getMessage(), duosUser.getEmail()));
       throw e;
     } catch (Exception ex) {
       logWarn("Unable to retrieve user status info from Sam: " + ex.getMessage());

--- a/src/main/java/org/broadinstitute/consent/http/service/NihService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/NihService.java
@@ -12,7 +12,6 @@ import java.time.Instant;
 import org.broadinstitute.consent.http.configurations.ServicesConfiguration;
 import org.broadinstitute.consent.http.db.UserDAO;
 import org.broadinstitute.consent.http.enumeration.UserFields;
-import org.broadinstitute.consent.http.exceptions.ECMException;
 import org.broadinstitute.consent.http.models.DuosUser;
 import org.broadinstitute.consent.http.models.NIHUserAccount;
 import org.broadinstitute.consent.http.models.User;
@@ -47,21 +46,23 @@ public class NihService implements ConsentLogger {
     HttpRequest request = clientUtil.buildGetRequest(ecmRasProviderUrl, duosUser);
     try {
       HttpResponse response = clientUtil.handleHttpRequest(request);
-      // ECM returns a 500 Internal Server Error when there is an AzureB2C error in Sam.
-      if (response.getStatusCode() == HttpStatusCodes.STATUS_CODE_SERVER_ERROR) {
-        throw new ECMException(
-            "ECM Server error while syncing account for user: %s".formatted(duosUser.getEmail()));
-      }
       if (!response.isSuccessStatusCode()) {
-        throw new ServerErrorException(response.getStatusMessage(), response.getStatusCode());
+        // ECM returns a 500 Internal Server Error when there is an AzureB2C error in Sam.
+        if (response.getStatusCode() == HttpStatusCodes.STATUS_CODE_SERVER_ERROR) {
+          // Log this case and remove the user's current account link until problem can be resolved
+          logException(
+              new Exception(
+                  "ECM Server error while syncing account for user: %s"
+                      .formatted(duosUser.getEmail())));
+          serviceDAO.deleteNihAccountById(user.getUserId());
+          return userDAO.findUserWithPropertiesById(user.getUserId(), UserFields.getValues());
+        } else {
+          throw new ServerErrorException(response.getStatusMessage(), response.getStatusCode());
+        }
       }
       String body = response.parseAsString();
       NIHUserAccount nihAccount = parseNihUserAccount(body);
       serviceDAO.updateUserNihStatus(user, nihAccount);
-    } catch (ECMException ecmException) {
-      // Log this case and remove the user's current account link until problem can be resolved
-      logException(ecmException);
-      serviceDAO.deleteNihAccountById(user.getUserId());
     } catch (NotFoundException _) {
       serviceDAO.deleteNihAccountById(user.getUserId());
     } catch (NotAuthorizedException _) {

--- a/src/main/java/org/broadinstitute/consent/http/service/NihService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/NihService.java
@@ -12,6 +12,7 @@ import java.time.Instant;
 import org.broadinstitute.consent.http.configurations.ServicesConfiguration;
 import org.broadinstitute.consent.http.db.UserDAO;
 import org.broadinstitute.consent.http.enumeration.UserFields;
+import org.broadinstitute.consent.http.exceptions.ECMException;
 import org.broadinstitute.consent.http.models.DuosUser;
 import org.broadinstitute.consent.http.models.NIHUserAccount;
 import org.broadinstitute.consent.http.models.User;
@@ -46,12 +47,21 @@ public class NihService implements ConsentLogger {
     HttpRequest request = clientUtil.buildGetRequest(ecmRasProviderUrl, duosUser);
     try {
       HttpResponse response = clientUtil.handleHttpRequest(request);
+      // ECM returns a 500 Internal Server Error when there is an AzureB2C error in Sam.
+      if (response.getStatusCode() == HttpStatusCodes.STATUS_CODE_SERVER_ERROR) {
+        throw new ECMException(
+            "ECM Server error while syncing account for user: %s".formatted(duosUser.getEmail()));
+      }
       if (!response.isSuccessStatusCode()) {
         throw new ServerErrorException(response.getStatusMessage(), response.getStatusCode());
       }
       String body = response.parseAsString();
       NIHUserAccount nihAccount = parseNihUserAccount(body);
       serviceDAO.updateUserNihStatus(user, nihAccount);
+    } catch (ECMException ecmException) {
+      // Log this case and remove the user's current account link until problem can be resolved
+      logException(ecmException);
+      serviceDAO.deleteNihAccountById(user.getUserId());
     } catch (NotFoundException _) {
       serviceDAO.deleteNihAccountById(user.getUserId());
     } catch (NotAuthorizedException _) {

--- a/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
@@ -37,6 +37,7 @@ import java.util.stream.Stream;
 import org.broadinstitute.consent.http.AbstractTestHelper;
 import org.broadinstitute.consent.http.configurations.ServicesConfiguration;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
+import org.broadinstitute.consent.http.exceptions.SamAzureB2CException;
 import org.broadinstitute.consent.http.models.Acknowledgement;
 import org.broadinstitute.consent.http.models.ApprovedDataset;
 import org.broadinstitute.consent.http.models.AuthUser;
@@ -168,6 +169,34 @@ class UserResourceTest extends AbstractTestHelper {
     Response response = userResource.getUser(du);
     // Ensure that even if Sam fails, we still return the user information.
     assertEquals(Status.OK.getStatusCode(), response.getStatus());
+  }
+
+  @Test
+  void testGetMe_SamAzureB2CException_Returns500() throws Exception {
+    // SamAzureB2CException should NOT be silently swallowed - it propagates and returns a 500
+    User user = createUserWithRole();
+    DuosUser du = new DuosUser(authUser, user);
+    when(samService.getCombinedUserStatusInfo(du))
+        .thenThrow(new SamAzureB2CException("AzureB2C error for user test@test.org"));
+
+    Response response = userResource.getUser(du);
+    assertEquals(Status.INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatus());
+  }
+
+  @Test
+  void testGetMe_SamAzureB2CException_ErrorMessageContainsDetails() throws Exception {
+    // The error message from SamAzureB2CException should be returned in the response
+    User user = createUserWithRole();
+    DuosUser du = new DuosUser(authUser, user);
+    String errorMessage =
+        "AzureB2C authentication Error for user test@test.org: Please contact support.";
+    when(samService.getCombinedUserStatusInfo(du))
+        .thenThrow(new SamAzureB2CException(errorMessage));
+
+    Response response = userResource.getUser(du);
+    assertEquals(Status.INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatus());
+    assertNotNull(response.getEntity());
+    assertTrue(response.getEntity().toString().contains(errorMessage));
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/NihServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/NihServiceTest.java
@@ -95,7 +95,7 @@ class NihServiceTest extends WireMockTestHelper {
 
   @Test
   void testSyncAccountServerError() throws Exception {
-    // A 500 from ECM is treated as an ECMException, which is caught gracefully:
+    // A 500 from ECM is treated specially, which is caught gracefully:
     // the NIH account is deleted locally and the user is returned without throwing.
     User user = new User();
     user.setUserId(1);

--- a/src/test/java/org/broadinstitute/consent/http/service/NihServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/NihServiceTest.java
@@ -5,7 +5,9 @@ import static com.github.tomakehurst.wiremock.client.WireMock.any;
 import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -92,18 +94,23 @@ class NihServiceTest extends WireMockTestHelper {
   }
 
   @Test
-  void testSyncAccountServerError() {
+  void testSyncAccountServerError() throws Exception {
+    // A 500 from ECM is treated as an ECMException, which is caught gracefully:
+    // the NIH account is deleted locally and the user is returned without throwing.
     User user = new User();
     user.setUserId(1);
     when(duosUser.getUser()).thenReturn(user);
-    LinkInfo ecmResponse = new LinkInfo("test", "test", true);
+    when(duosUser.getEmail()).thenReturn("test@test.org");
+    when(userDAO.findUserWithPropertiesById(user.getUserId(), UserFields.getValues()))
+        .thenReturn(user);
     wireMockServer.stubFor(
-        any(anyUrl())
-            .willReturn(
-                aResponse()
-                    .withStatus(HttpStatusCodes.STATUS_CODE_SERVER_ERROR)
-                    .withBody(GsonUtil.getInstance().toJson(ecmResponse))));
-    assertThrows(ServerErrorException.class, () -> service.syncAccount(duosUser));
+        any(anyUrl()).willReturn(aResponse().withStatus(HttpStatusCodes.STATUS_CODE_SERVER_ERROR)));
+
+    User syncedUser = service.syncAccount(duosUser);
+
+    assertEquals(user.getUserId(), syncedUser.getUserId());
+    verify(nihServiceDAO, times(1)).deleteNihAccountById(user.getUserId());
+    verify(nihServiceDAO, never()).updateUserNihStatus(any(), any());
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/SamDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/SamDAOTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.when;
 
@@ -27,6 +28,7 @@ import org.broadinstitute.consent.http.WireMockTestHelper;
 import org.broadinstitute.consent.http.configurations.ServicesConfiguration;
 import org.broadinstitute.consent.http.db.SamDAO;
 import org.broadinstitute.consent.http.exceptions.ConsentConflictException;
+import org.broadinstitute.consent.http.exceptions.SamAzureB2CException;
 import org.broadinstitute.consent.http.models.DuosUser;
 import org.broadinstitute.consent.http.models.sam.CombinedState;
 import org.broadinstitute.consent.http.models.sam.EmailResponse;
@@ -302,6 +304,35 @@ class SamDAOTest extends WireMockTestHelper {
             .willReturn(aResponse().withStatus(HttpStatusCodes.STATUS_CODE_MOVED_PERMANENTLY)));
 
     assertThrows(WebApplicationException.class, () -> samDAO.getCombinedUserStatusInfo(duosUser));
+  }
+
+  private static Stream<Arguments> provideAzureB2CErrorBodies() {
+    return Stream.of(
+        // JSON message field with mixed case
+        Arguments.of("{\"message\": \"Cannot update azureB2cId for user test@test.org\"}"),
+        // All uppercase (case-insensitive check)
+        Arguments.of("CANNOT UPDATE AZUREB2CID FOR USER test@test.org"),
+        // All lowercase
+        Arguments.of("cannot update azureb2cid for user test@test.org"),
+        // Plain string with surrounding context
+        Arguments.of("Error: cannot update azureB2cId for user test@test.org due to conflict"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideAzureB2CErrorBodies")
+  void testGetCombinedUserStatusInfoAzureB2CError(String errorBody) {
+    wireMockServer.stubFor(
+        any(anyUrl())
+            .willReturn(
+                aResponse()
+                    .withStatus(HttpStatusCodes.STATUS_CODE_SERVER_ERROR)
+                    .withBody(errorBody)));
+    when(duosUser.getEmail()).thenReturn("test@test.org");
+
+    SamAzureB2CException ex =
+        assertThrows(SamAzureB2CException.class, () -> samDAO.getCombinedUserStatusInfo(duosUser));
+    assertNotNull(ex.getMessage());
+    assertTrue(ex.getMessage().contains("test@test.org"));
   }
 
   @Test


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DT-2845

## Summary
See companion front end PR: https://github.com/DataBiosphere/duos-ui/pull/3442

This PR adds new error handling for Sam errors wrt AzureB2C errors. When a user first uses MS as an identity provider with a google account, then subsequently uses Google as an identity provider, Sam will respond with an error similar to:
```
AzureB2C authentication Error for user user@test.com: {
    "causes [],
    "exceptionClass":"org.broadinstitute.dsde.workbench.model.WorkbenchException",
    "message":"Cannot update azureB2cId for user 123... because user does not exist or the azureB2cId has already been set for this user",
    "source":"sam",
    "stackTrace":[]
}
```
When ECM encounters this underlying error (because it proxies requests to Sam), it merely responds with a 500 Internal Server Error.

This PR does two things:
1. When ECM responds with a 500 error, we assume the worst and remove the user's current linked account status. This needs to be done to ensure that users are not improperly linked.
2. When Sam responds with an AzureB2C error, we percolate that back up to the client in the primary case of a user getting their own information: `GET /api/user/me`

## Testing
Local testing is challenging. Using swagger in Consent, one uses google sign in. When using swagger in Sam, the google sign in is OIDC. Therefore, the bearer tokens you get in Consent swagger are the more compact ones, e.g. `ya29....`. The bearer tokens you get in Sam swagger are encoded jwts, e.g. `eyJhbGci...`. When using the compact token, Sam does NOT error out. When using the jwt token, Sam DOES error out. So, when using Consent locally, a problematic user will have successful responses from Sam. To test a problematic user, one has to use the jwt token in Consent using curl (OIDC auth does not work in Consent swagger). The DUOS UI uses OIDC, so generates full jwt bearer tokens that DO fail when Consent proxies those tokens against Sam and other services like ECM.

The fact that Sam works with compact tokens but fails with full jwt tokens opens up another approach. Since most UI requests are proxied through Consent, we could extract the compact token and use that against Sam. The UI does also communicate directly with ECM so that would still be problematic unless we were able to do that same manipulation in the UI.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
