### PR TITLE
[DT-3185] Add documentation structure and AI prompts

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,40 @@
+# Copilot Instructions for Consent
+
+These instructions apply to code suggestions and PR review in this repository.
+
+## Architecture and Boundaries
+
+- Keep the existing Dropwizard + Guice + JDBI architecture.
+- Preserve `Resource -> Service -> DAO` separation.
+- Prefer incremental changes to broad rewrites.
+- Reuse existing auth and error handling patterns (`@RolesAllowed`, `ErrorResource` usage patterns).
+
+## API and Auth Rules
+
+- Auth boundary is route-based:
+  - Paths under `/api` are authenticated through the proxy Auth section and include OAUTH-decorated request information.
+  - Non-`/api` paths are unauthenticated and must not assume OAUTH context.
+- Put authenticated endpoints under `/api`.
+- Keep public API behavior backward compatible unless explicitly approved.
+- If API contracts change, update OpenAPI spec in `src/main/resources/assets/api-docs.yaml`.
+
+## Quality and Performance Expectations
+
+- Run Spotless formatting for changed files.
+- Resolve SonarQube issues in touched code; do not introduce new blocker/critical issues.
+- For large DB-backed results, prefer pagination/streaming/projections and avoid unbounded in-memory collections.
+- Favor Java records for new immutable DTO/view models when framework/persistence mapping allows.
+
+## Testing and Test Data
+
+- Add or update tests for behavior changes in `src/test/java`.
+- Use synthetic test data only; do not include real or realistic PII, tokens, or secrets.
+
+## Source of Truth
+
+- `docs/API_GUIDELINES.md`
+- `docs/ARCHITECTURE.md`
+- `docs/ONBOARDING.md`
+- `docs/ai/prompts/`
+- `CONTRIBUTING.md`
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,28 @@
+# Agent Guidance Index
+
+This repository uses multiple instruction entry points.
+
+## For GitHub Copilot (GitHub UI / PR review)
+
+- Primary file: `.github/copilot-instructions.md`
+
+## For Repo Conventions and Implementation Details
+
+- `docs/API_GUIDELINES.md`
+- `docs/ARCHITECTURE.md`
+- `docs/ONBOARDING.md`
+- `docs/ai/prompts/README.md`
+- `docs/ai/prompts/api-endpoint.md`
+- `docs/ai/prompts/feature-development.md`
+- `docs/ai/prompts/bugfix.md`
+- `docs/ai/prompts/refactor.md`
+- `CONTRIBUTING.md`
+
+## Key Rules (Quick Reference)
+
+- Keep `Resource -> Service -> DAO` layering.
+- `/api` routes are authenticated (proxy/OAUTH-decorated); non-`/api` routes are unauthenticated.
+- Update `src/main/resources/assets/api-docs.yaml` when API contracts change.
+- Add/update tests for behavior changes.
+- Use synthetic test data only.
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,3 +67,12 @@ If you're making breaking changes to the API, do the following:
 If you're making changes to authentication, authorization, encryption, or audit 
 trails, you should check in with AppSec to see if our security documentation 
 should be updated.
+
+## AI-Assisted Development
+
+We support AI-assisted workflows to speed up development and maintain consistency:
+
+- Use `/docs/ai/README.md` for codebase-specific prompts.
+- Prompts are available for feature development, API endpoints, bugfixes, and refactoring.
+- Always use prompts that match the task and follow existing code patterns.
+- See the table in `/docs/ai/README.md` for which prompt to use for each task.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ tech lead, though ask. Do chase your reviewers (or find others) if they're
 slow; we don't like to let PRs linger. If you get PR feedback it's back to 
 you to address it and then nudge your reviewers for re-review.
 
-Your PR is ready to merge when all of the following things are true:
+Your PR is ready to merge when all the following things are true:
 
 1. At least one, preferably two, reviewers have thumbed (or otherwise approved) your PR
 2. If your change is user-facing, your PO has seen it and signed off
@@ -57,10 +57,10 @@ We strive to minimize breaking changes to the API, but sometimes they're unavoid
 
 If you're making breaking changes to the API, do the following:
 
-0. Try really hard not to make a breaking change to the API.
-1. Check in with Comms to explain the change and the impact on users.
-2. Write an email to users explaining the change and send it least a few days BEFORE the release goes out. You'll need to explain the change and what users need to do to update their code. Get Comms signoff on the wording.
-3. Get someone Suitable to send the email to api-users@firecloud.org.
+1. Try really hard not to make a breaking change to the API.
+2. Check in with Comms to explain the change and the impact on users.
+3. Write an email to users explaining the change and send it least a few days BEFORE the release goes out. You'll need to explain the change and what users need to do to update their code. Get Comms signoff on the wording.
+4. Get someone Suitable to send the email to api-users@firecloud.org.
 
 ## FISMA documentation changes
 
@@ -71,6 +71,7 @@ should be updated.
 ## AI-Assisted Development
 
 We support AI-assisted workflows to speed up development and maintain consistency:
+For GitHub review guidance, start with `/.github/copilot-instructions.md` and use `/AGENTS.md` as the instruction index.
 
 - Use `/docs/ai/README.md` for codebase-specific prompts.
 - Prompts are available for feature development, API endpoints, bugfixes, and refactoring.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ If you're making breaking changes to the API, do the following:
 
 1. Try really hard not to make a breaking change to the API.
 2. Check in with Comms to explain the change and the impact on users.
-3. Write an email to users explaining the change and send it least a few days BEFORE the release goes out. You'll need to explain the change and what users need to do to update their code. Get Comms signoff on the wording.
+3. Write an email to users explaining the change and send it at least a few days BEFORE the release goes out. You'll need to explain the change and what users need to do to update their code. Get Comms signoff on the wording.
 4. Get someone Suitable to send the email to api-users@firecloud.org.
 
 ## FISMA documentation changes
@@ -70,7 +70,7 @@ should be updated.
 
 ## AI-Assisted Development
 
-We support AI-assisted workflows to speed up development and maintain consistency:
+We support AI-assisted workflows to speed up development and maintain consistency.
 For GitHub review guidance, start with `/.github/copilot-instructions.md` and use `/AGENTS.md` as the instruction index.
 
 - Use `/docs/ai/README.md` for codebase-specific prompts.

--- a/README.md
+++ b/README.md
@@ -15,3 +15,4 @@ There are restrictions on researching human genomics data. For example: “Data 
 The Data Use Oversight system ensures that researchers using genomics data honor these restrictions.
 
 See [consent/DEVNOTES.md](DEVNOTES.md) to run locally.
+For contribution and review guidance, see [CONTRIBUTING.md](CONTRIBUTING.md), [.GitHub/copilot-instructions.md](.github/copilot-instructions.md), and [AGENTS.md](AGENTS.md).

--- a/README.md
+++ b/README.md
@@ -15,4 +15,4 @@ There are restrictions on researching human genomics data. For example: “Data 
 The Data Use Oversight system ensures that researchers using genomics data honor these restrictions.
 
 See [consent/DEVNOTES.md](DEVNOTES.md) to run locally.
-For contribution and review guidance, see [CONTRIBUTING.md](CONTRIBUTING.md), [.GitHub/copilot-instructions.md](.github/copilot-instructions.md), and [AGENTS.md](AGENTS.md).
+For contribution and review guidance, see [CONTRIBUTING.md](CONTRIBUTING.md), [.github/copilot-instructions.md](.github/copilot-instructions.md), and [AGENTS.md](AGENTS.md).

--- a/docs/API_GUIDELINES.md
+++ b/docs/API_GUIDELINES.md
@@ -4,7 +4,7 @@ Use these rules when adding or changing endpoints in the Consent service.
 
 ## Endpoint Design
 
-- Keep all routes under `/api/`.
+- Keep authenticated API endpoints under `/api` and only place intentionally public endpoints outside `/api`.
 - Use nouns for resources and HTTP verbs for actions.
 - Prefer plural collection routes (for example `/api/users`) and singular subresources only when semantically necessary.
 - Keep path depth shallow and avoid action-heavy route names.

--- a/docs/API_GUIDELINES.md
+++ b/docs/API_GUIDELINES.md
@@ -1,0 +1,54 @@
+# API Guidelines
+
+Use these rules when adding or changing endpoints in the Consent service.
+
+## Endpoint Design
+
+- Keep all routes under `/api/`.
+- Use nouns for resources and HTTP verbs for actions.
+- Prefer plural collection routes (for example `/api/users`) and singular subresources only when semantically necessary.
+- Keep path depth shallow and avoid action-heavy route names.
+
+## Request and Response Conventions
+
+- Use JSON request/response payloads.
+- Reuse models from `org.broadinstitute.consent.http.models` when possible.
+- Validate input at the boundary (resource layer) and return clear client-facing errors.
+- Do not leak internal exceptions, SQL details, or stack traces in responses.
+
+## Status Codes
+
+- `200 OK`: successful read/update or idempotent operation.
+- `201 Created`: successful creation.
+- `204 No Content`: successful operation without body.
+- `400 Bad Request`: malformed payload or validation failure.
+- `401 Unauthorized`: caller is unauthenticated.
+- `403 Forbidden`: caller lacks required permissions.
+- `404 Not Found`: resource does not exist.
+- `409 Conflict`: version/state conflict.
+- `500 Internal Server Error`: unhandled server-side error.
+
+## Security and Authorization
+
+- Use `@RolesAllowed` or `@PermitAll` explicitly on endpoints.
+- Apply least privilege and avoid broad role access by default.
+- Keep authorization checks consistent between Resource and Service logic.
+
+## Backward Compatibility
+
+- Treat existing response fields as contract.
+- Additive response changes are preferred over breaking removals/renames.
+- If a breaking change is unavoidable, document rollout and migration notes in the same PR.
+
+## Testing and Documentation Requirements
+
+For API changes, include all of the following:
+
+- Resource-level tests in `src/test/java`.
+- Updated OpenAPI contract at `src/main/resources/assets/api-docs.yaml`.
+- Relevant docs updates (`docs/ONBOARDING.md`, `docs/ARCHITECTURE.md`, or this file).
+- Clear PR notes on behavior changes and compatibility impact.
+
+---
+
+Keep this file updated as new patterns emerge.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,52 @@
+# Architecture
+
+## Overview
+
+Consent is a Dropwizard service with a layered design and explicit separation of HTTP, business logic, and persistence concerns.
+
+## Core Layers
+
+- **Resource layer** (`http/resources`): JAX-RS endpoints, request validation, auth annotations, HTTP status mapping.
+- **Service layer** (`http/service`): domain workflows and orchestration.
+- **DAO layer** (`http/db`): JDBI interfaces and SQL-backed data access.
+- **Model layer** (`http/models`): request/response and domain data models.
+
+Representative classes:
+
+- Resource: `UserResource`
+- Service: `UserService`
+- DAO: `UserDAO`
+- Application bootstrap: `ConsentApplication`
+
+## Request Lifecycle (Example)
+
+1. Request enters `UserResource` (for example `/api/user/me`).
+2. Resource validates/authenticates, then delegates to `UserService`.
+3. Service applies business rules and calls `UserDAO`.
+4. DAO executes database operations through JDBI.
+5. Service maps results to API-facing models.
+6. Resource returns JSON response.
+
+## Dependency Injection and Wiring
+
+- Guice modules provide constructor-injected dependencies.
+- Resource registration and app startup wiring happen in `ConsentApplication`.
+- Prefer constructor injection over static/service-locator patterns.
+
+## Persistence and Migrations
+
+- PostgreSQL is the primary datastore.
+- Liquibase changelogs manage schema evolution.
+- Keep schema and DAO changes in the same PR when possible.
+
+## Error and Security Model
+
+- Security is expressed at endpoint level (`@RolesAllowed`, `@PermitAll`).
+- Errors are normalized through existing exception/error response patterns (`ErrorResource` and related models).
+
+## Architectural Guardrails
+
+- Keep business logic out of resources.
+- Avoid DAO calls directly from resources.
+- Preserve existing package and naming conventions unless a broader refactor is planned.
+- Update `docs/API_GUIDELINES.md` and OpenAPI docs when API behavior changes.

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -1,0 +1,74 @@
+# Onboarding Guide
+
+This guide helps new contributors run the Consent service locally and make a safe first change.
+
+## Prerequisites
+
+From repository configuration:
+
+- Java 25 (`pom.xml`)
+- Maven 3.9+
+- Docker or another OCI runtime for integration tests and local compose workflows
+- PostgreSQL (only if not using the provided compose stack)
+
+## Quick Start (Docker Compose)
+
+Use this path for the most production-like local setup.
+
+```bash
+mvn clean compile
+docker-compose -p consent -f config/docker-compose.yaml up
+```
+
+### Verify the service
+
+- Swagger UI (compose path): `https://local.dsde-dev.broadinstitute.org:27443`
+- OpenAPI endpoint: `https://local.dsde-dev.broadinstitute.org:27443/api-docs/openapi.yaml`
+
+If needed, map the local host in your `/etc/hosts` file:
+
+```text
+127.0.0.1 local.dsde-dev.broadinstitute.org
+```
+
+## Alternative Run (Direct JAR)
+
+Use this when debugging outside containers.
+
+```bash
+mvn clean package
+java -jar target/consent-*.jar server config/consent.yaml
+```
+
+- Swagger UI (direct path): `http://localhost:8080/`
+- OpenAPI endpoint: `http://localhost:8080/api-docs/openapi.yaml`
+
+## Run Tests
+
+```bash
+mvn clean test
+```
+
+Note: tests use containerized dependencies (per `DEVNOTES.md`), so make sure your OCI runtime is available.
+
+## First Contribution Checklist
+
+- [ ] Read `docs/ARCHITECTURE.md`
+- [ ] Read `docs/API_GUIDELINES.md`
+- [ ] Run the service locally (compose or direct)
+- [ ] Run `mvn clean test`
+- [ ] Make a small change and include test updates
+- [ ] Update docs if behavior or API contracts changed
+
+## Adding a New Endpoint
+
+- Follow the Resource -> Service -> DAO pattern.
+- Reuse existing resources as reference (`UserResource`, `InstitutionResource`).
+- Register new resources in `ConsentApplication`.
+- Add resource/service tests in `src/test/java`.
+- Update `src/main/resources/assets/api-docs.yaml` for contract changes.
+
+## AI-Assisted Development
+
+- Start at `docs/ai/README.md`
+- Use task-specific prompts in `docs/ai/prompts/`

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,29 @@
+# Consent Service Documentation
+
+This directory is the canonical home for developer documentation for the Consent Dropwizard service.
+
+## Start Here
+
+If you are new to the repository, read in this order:
+
+1. `ONBOARDING.md`
+2. `ARCHITECTURE.md`
+3. `API_GUIDELINES.md`
+4. `../CONTRIBUTING.md`
+
+## Documentation Map
+
+| Document | Audience | Purpose |
+| --- | --- | --- |
+| `ONBOARDING.md` | New contributors | Local setup, run commands, and first tasks |
+| `ARCHITECTURE.md` | Contributors and reviewers | High-level system design and request flow |
+| `API_GUIDELINES.md` | API authors and reviewers | API conventions, validation, and compatibility rules |
+| `ai/README.md` | Developers using AI tooling | Prompt usage model and best practices |
+| `ai/prompts/*.md` | Developers using AI tooling | Task-specific prompt templates and examples |
+
+## Documentation Standards
+
+- Keep examples grounded in existing classes and packages.
+- Prefer short sections and checklists over long prose.
+- When behavior changes, update docs in the same PR as code changes.
+- If guidance is obsolete, remove or mark it clearly as historical.

--- a/docs/ai/README.md
+++ b/docs/ai/README.md
@@ -1,0 +1,33 @@
+# AI Prompt System for Consent Dropwizard Codebase
+
+These prompts are repository-specific and designed to produce changes that align with existing Consent patterns.
+
+## Prompt Catalog
+
+| Prompt | Use when you need to... |
+| --- | --- |
+| `feature-development.md` | Implement a new capability across Resource, Service, and DAO layers |
+| `api-endpoint.md` | Add or modify an HTTP endpoint and keep API contracts consistent |
+| `bugfix.md` | Diagnose and fix a production or test failure |
+| `refactor.md` | Improve readability/maintainability without changing behavior |
+
+## Recommended Workflow
+
+1. Choose one prompt based on task type.
+2. Fill in concrete repository context (class names, package paths, test files).
+3. Ask for a small implementation plan first.
+4. Apply changes incrementally with tests after each step.
+5. Verify docs/OpenAPI updates for endpoint behavior changes.
+
+## Quality Rules for AI-Assisted Changes
+
+- Reference real project classes and packages (for example `UserResource`, `UserService`, `UserDAO`).
+- Reuse existing patterns before introducing new abstractions.
+- Prefer minimal, reviewable diffs.
+- Require tests for behavior changes.
+- If a prompt output conflicts with repository conventions, repository conventions win.
+
+## Where Prompts Live
+
+- `docs/ai/prompts/README.md`
+- `docs/ai/prompts/*.md`

--- a/docs/ai/prompts/README.md
+++ b/docs/ai/prompts/README.md
@@ -1,0 +1,39 @@
+# AI Prompt Library (Consent)
+
+Use these prompts as templates for codebase-aware requests.
+
+## Before You Run a Prompt
+
+Include these inputs so responses are actionable:
+
+- Goal statement (what should change and why)
+- Target files (paths in this repository)
+- Existing classes to mirror (for example `UserResource`, `InstitutionService`)
+- Constraints (no API breaks, no new frameworks, test scope)
+- Definition of done (tests, docs, OpenAPI updates)
+
+## Expected Output Quality
+
+A good prompt result should include:
+
+- A short implementation plan
+- Concrete file-by-file changes
+- Tests to add/update
+- Risks or compatibility notes
+- Follow-up verification commands
+
+## Locator Matrix (Where to Look First)
+
+| Task type | Start here first | Then check |
+| --- | --- | --- |
+| `api-endpoint.md` | `src/main/java/org/broadinstitute/consent/http/resources/` | `src/main/java/org/broadinstitute/consent/http/service/`, `src/main/java/org/broadinstitute/consent/http/db/`, `src/main/resources/assets/api-docs.yaml`, `src/test/java/org/broadinstitute/consent/http/resources/` |
+| `feature-development.md` | `src/main/java/org/broadinstitute/consent/http/resources/`, `src/main/java/org/broadinstitute/consent/http/service/` | `src/main/java/org/broadinstitute/consent/http/db/`, `src/main/java/org/broadinstitute/consent/http/models/`, `src/test/java/`, `src/main/resources/assets/api-docs.yaml` |
+| `bugfix.md` | Failing test or relevant resource test in `src/test/java/` | Matching runtime classes in `src/main/java/org/broadinstitute/consent/http/resources/`, `src/main/java/org/broadinstitute/consent/http/service/`, `src/main/java/org/broadinstitute/consent/http/db/` |
+| `refactor.md` | In-scope classes under `src/main/java/org/broadinstitute/consent/http/` | Neighboring tests in `src/test/java/`, API contract references in `src/main/resources/assets/api-docs.yaml`, guidance in `docs/API_GUIDELINES.md` |
+
+## Available Prompt Templates
+
+- `api-endpoint.md`
+- `feature-development.md`
+- `bugfix.md`
+- `refactor.md`

--- a/docs/ai/prompts/api-endpoint.md
+++ b/docs/ai/prompts/api-endpoint.md
@@ -1,0 +1,94 @@
+# API Endpoint Prompt Template
+
+Use this when adding or modifying HTTP endpoints.
+
+## What to Provide
+
+- Endpoint goal and business behavior
+- Target route(s) and HTTP method(s)
+- Existing classes to mirror (for example `UserResource`, `InstitutionResource`)
+- Files expected to change
+- Constraints (backward compatibility, security rules, no new frameworks)
+
+## Required Constraints
+
+- Keep route conventions under `/api/`.
+- Preserve Resource -> Service -> DAO separation.
+- Reuse existing auth/error handling patterns (`@RolesAllowed`, `ErrorResource` patterns).
+- Update OpenAPI docs and tests for contract changes.
+
+## Copy/Paste Prompt
+
+```text
+Implement a new API endpoint in the Consent service.
+
+Goal:
+<describe behavior>
+
+API shape:
+- Method: <GET|POST|PUT|DELETE>
+- Route: </api/...>
+- Request body: <model or none>
+- Response: <model and status codes>
+
+Reuse patterns from:
+- Resource: <existing resource class>
+- Service: <existing service class>
+- DAO: <existing dao class>
+
+Files to update:
+- <resource file>
+- <service file>
+- <dao file or existing dao>
+- src/main/resources/assets/api-docs.yaml
+- <test files>
+
+Constraints:
+- Keep endpoint conventions from docs/API_GUIDELINES.md
+- Do not introduce new framework dependencies
+- Add or update tests in src/test/java
+
+Output format:
+1) short plan
+2) file-by-file diff summary
+3) tests added/updated
+4) follow-up verification commands
+```
+
+## Usage Example
+
+```text
+Implement a new API endpoint in the Consent service.
+
+Goal:
+Allow admins to list institutions with optional name filtering.
+
+API shape:
+- Method: GET
+- Route: /api/institutions
+- Request body: none
+- Response: 200 with a list of InstitutionSummary models
+
+Reuse patterns from:
+- Resource: InstitutionResource
+- Service: InstitutionService
+- DAO: InstitutionDAO
+
+Files to update:
+- src/main/java/org/broadinstitute/consent/http/resources/InstitutionResource.java
+- src/main/java/org/broadinstitute/consent/http/service/InstitutionService.java
+- src/main/java/org/broadinstitute/consent/http/db/InstitutionDAO.java
+- src/main/resources/assets/api-docs.yaml
+- src/test/java/org/broadinstitute/consent/http/resources/InstitutionResourceTest.java
+
+Constraints:
+- Keep endpoint conventions from docs/API_GUIDELINES.md
+- Do not introduce new framework dependencies
+- Add or update tests in src/test/java
+
+Output format:
+1) short plan
+2) file-by-file diff summary
+3) tests added/updated
+4) follow-up verification commands
+```

--- a/docs/ai/prompts/api-endpoint.md
+++ b/docs/ai/prompts/api-endpoint.md
@@ -12,7 +12,7 @@ Use this when adding or modifying HTTP endpoints.
 
 ## Required Constraints
 
-- Keep route conventions under `/api/`.
+- Route auth boundary: paths under `/api` are authenticated by the proxy and decorated with OAUTH context; non-`/api` paths are unauthenticated.
 - Preserve Resource -> Service -> DAO separation.
 - Reuse existing auth/error handling patterns (`@RolesAllowed`, `ErrorResource` patterns).
 - Update OpenAPI docs and tests for contract changes.
@@ -45,6 +45,7 @@ Files to update:
 
 Constraints:
 - Keep endpoint conventions from docs/API_GUIDELINES.md
+- Put authenticated endpoints under `/api`; only place intentionally public endpoints outside `/api`
 - Do not introduce new framework dependencies
 - Add or update tests in src/test/java
 
@@ -83,6 +84,7 @@ Files to update:
 
 Constraints:
 - Keep endpoint conventions from docs/API_GUIDELINES.md
+- Put authenticated endpoints under `/api`; only place intentionally public endpoints outside `/api`
 - Do not introduce new framework dependencies
 - Add or update tests in src/test/java
 

--- a/docs/ai/prompts/bugfix.md
+++ b/docs/ai/prompts/bugfix.md
@@ -1,0 +1,78 @@
+# Bugfix Prompt Template
+
+Use this when fixing an incorrect behavior, error response, or failing test.
+
+## What to Provide
+
+- Bug description and observed impact
+- How to reproduce (request, input, or failing test)
+- Expected behavior
+- Relevant logs/stack trace snippets
+- Candidate files/classes involved
+
+## Required Constraints
+
+- Reproduce first with a test when possible.
+- Fix the smallest responsible scope (Resource, Service, or DAO).
+- Reuse existing exception and error response patterns.
+- Avoid behavior changes outside the bug scope.
+
+## Copy/Paste Prompt
+
+```text
+Fix a bug in the Consent service.
+
+Bug summary:
+<describe incorrect behavior>
+
+Reproduction:
+- Request/test: <details>
+- Current output: <details>
+- Expected output: <details>
+
+Likely files:
+- <file path>
+- <file path>
+
+Constraints:
+- Add or update a test that reproduces the issue
+- Keep existing API contract unless the bug is contract-related
+- Reuse existing error handling patterns
+
+Output format:
+1) root-cause analysis
+2) file-by-file fix plan
+3) tests added/updated
+4) verification commands
+```
+
+## Usage Example
+
+```text
+Fix a bug in the Consent service.
+
+Bug summary:
+Role assignment endpoint returns 500 instead of 400 when role name is invalid.
+
+Reproduction:
+- Request/test: POST /api/user/roles with unsupported role string
+- Current output: 500 with generic error
+- Expected output: 400 with validation message
+
+Likely files:
+- src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
+- src/main/java/org/broadinstitute/consent/http/service/UserService.java
+- src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
+
+Constraints:
+- Add or update a test that reproduces the issue
+- Keep existing API contract unless the bug is contract-related
+- Reuse existing error handling patterns
+
+Output format:
+1) root-cause analysis
+2) file-by-file fix plan
+3) tests added/updated
+4) verification commands
+```
+

--- a/docs/ai/prompts/feature-development.md
+++ b/docs/ai/prompts/feature-development.md
@@ -13,9 +13,14 @@ Use this when implementing a new cross-layer feature.
 ## Required Constraints
 
 - Keep the Dropwizard + Guice + JDBI architecture intact.
-- Prefer incremental changes over broad rewrites.
+- Prefer incremental changes to broad rewrites.
 - Keep public API behavior backward compatible unless explicitly approved.
 - Include tests and docs for behavior changes.
+- Run Spotless formatting for changed files before finalizing.
+- Favor Java records for new immutable DTO/view models; use classes when framework or persistence mapping requires them.
+- For potentially large DB-backed results, prefer pagination/streaming/projections and avoid unbounded in-memory collections.
+- Resolve SonarQube issues in touched code and do not introduce new blocker/critical issues.
+- Use only synthetic test data; do not use real or realistic PII (emails, IDs, names, tokens, or secrets).
 
 ## Copy/Paste Prompt
 
@@ -47,6 +52,11 @@ Constraints:
 - No new framework dependencies
 - Preserve backward compatibility unless stated otherwise
 - Add/update tests and docs as needed
+- Run Spotless formatting for changed files before finalizing
+- Favor Java records for new immutable DTO/view models; use classes when framework or persistence mapping requires them
+- For potentially large DB-backed results, prefer pagination/streaming/projections and avoid unbounded in-memory collections
+- Resolve SonarQube issues in touched code and do not introduce new blocker/critical issues
+- Use only synthetic test data; do not use real or realistic PII (emails, IDs, names, tokens, or secrets)
 
 Output format:
 1) short implementation plan
@@ -89,6 +99,11 @@ Constraints:
 - No new framework dependencies
 - Preserve backward compatibility unless stated otherwise
 - Add/update tests and docs as needed
+- Run Spotless formatting for changed files before finalizing
+- Favor Java records for new immutable DTO/view models; use classes when framework or persistence mapping requires them
+- For potentially large DB-backed results, prefer pagination/streaming/projections and avoid unbounded in-memory collections
+- Resolve SonarQube issues in touched code and do not introduce new blocker/critical issues
+- Use only synthetic test data; do not use real or realistic PII (emails, IDs, names, tokens, or secrets)
 
 Output format:
 1) short implementation plan

--- a/docs/ai/prompts/feature-development.md
+++ b/docs/ai/prompts/feature-development.md
@@ -1,0 +1,98 @@
+# Feature Development Prompt Template
+
+Use this when implementing a new cross-layer feature.
+
+## What to Provide
+
+- User/problem statement
+- Scope boundaries (in scope and out of scope)
+- Existing classes to mirror
+- Data model or schema impacts
+- Required tests and documentation updates
+
+## Required Constraints
+
+- Keep the Dropwizard + Guice + JDBI architecture intact.
+- Prefer incremental changes over broad rewrites.
+- Keep public API behavior backward compatible unless explicitly approved.
+- Include tests and docs for behavior changes.
+
+## Copy/Paste Prompt
+
+```text
+Implement a new feature in the Consent service using existing architecture patterns.
+
+Feature goal:
+<describe user/business goal>
+
+Scope:
+- In scope: <list>
+- Out of scope: <list>
+
+Mirror existing patterns from:
+- Resource: <class>
+- Service: <class>
+- DAO: <class>
+
+Expected files to touch:
+- <list files>
+
+Acceptance criteria:
+- <criterion 1>
+- <criterion 2>
+- <criterion 3>
+
+Constraints:
+- Keep Resource -> Service -> DAO layering
+- No new framework dependencies
+- Preserve backward compatibility unless stated otherwise
+- Add/update tests and docs as needed
+
+Output format:
+1) short implementation plan
+2) proposed file changes
+3) test plan
+4) risk/compatibility notes
+```
+
+## Usage Example
+
+```text
+Implement a new feature in the Consent service using existing architecture patterns.
+
+Feature goal:
+Support searching users by partial display name for admin tools.
+
+Scope:
+- In scope: query endpoint, service filtering logic, DAO query support
+- Out of scope: UI changes, role model redesign
+
+Mirror existing patterns from:
+- Resource: UserResource
+- Service: UserService
+- DAO: UserDAO
+
+Expected files to touch:
+- src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
+- src/main/java/org/broadinstitute/consent/http/service/UserService.java
+- src/main/java/org/broadinstitute/consent/http/db/UserDAO.java
+- src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
+- src/main/resources/assets/api-docs.yaml
+
+Acceptance criteria:
+- Admins can search users by partial display name
+- Empty query returns validation error
+- Existing user endpoints are unaffected
+
+Constraints:
+- Keep Resource -> Service -> DAO layering
+- No new framework dependencies
+- Preserve backward compatibility unless stated otherwise
+- Add/update tests and docs as needed
+
+Output format:
+1) short implementation plan
+2) proposed file changes
+3) test plan
+4) risk/compatibility notes
+```

--- a/docs/ai/prompts/refactor.md
+++ b/docs/ai/prompts/refactor.md
@@ -1,0 +1,74 @@
+# Refactor Prompt Template
+
+Use this for behavior-preserving cleanup (readability, maintainability, duplication reduction).
+
+## What to Provide
+
+- Refactor goal and non-goals
+- Files/classes in scope
+- Current pain points (duplication, complexity, naming)
+- Test coverage expectations
+
+## Required Constraints
+
+- Preserve external behavior and API contracts.
+- Keep Resource -> Service -> DAO layering.
+- Do not introduce new frameworks unless explicitly approved.
+- Make changes in small, reviewable steps.
+
+## Copy/Paste Prompt
+
+```text
+Refactor selected Consent service code without changing behavior.
+
+Goal:
+<describe maintainability/readability goal>
+
+In scope:
+- <class/file>
+- <class/file>
+
+Out of scope:
+- API contract changes
+- new dependencies/frameworks
+
+Constraints:
+- Preserve behavior and endpoint contracts
+- Keep existing architecture and DI style
+- Update tests only as needed for maintainability or determinism
+
+Output format:
+1) refactor plan in small steps
+2) file-by-file changes
+3) behavior safety checks
+4) verification commands
+```
+
+## Usage Example
+
+```text
+Refactor selected Consent service code without changing behavior.
+
+Goal:
+Reduce duplication in dataset permission checks while keeping all endpoint behavior unchanged.
+
+In scope:
+- src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+- src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
+
+Out of scope:
+- API contract changes
+- new dependencies/frameworks
+
+Constraints:
+- Preserve behavior and endpoint contracts
+- Keep existing architecture and DI style
+- Update tests only as needed for maintainability or determinism
+
+Output format:
+1) refactor plan in small steps
+2) file-by-file changes
+3) behavior safety checks
+4) verification commands
+```
+


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-3185

### Summary

Introduces a structured /docs directory along with AI prompts to standardize development workflows.

- Adds core documentation (architecture, onboarding, contributing)
- Introduces /docs/ai/ with reusable prompts
- Includes initial prompts for API development, feature work, and bug fixes
- Encourages consistent patterns and improves developer onboarding

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
