### PR TITLE
[DT-3118] Update Document Resource Base Route

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/resources/DocumentResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DocumentResource.java
@@ -26,7 +26,7 @@ import org.broadinstitute.consent.http.service.FileStorageObjectService;
 import org.glassfish.jersey.media.multipart.FormDataContentDisposition;
 import org.glassfish.jersey.media.multipart.FormDataParam;
 
-@Path("api/{entity}")
+@Path("api/document/{entity}")
 public class DocumentResource extends Resource {
 
   private final FileStorageObjectService fileStorageObjectService;
@@ -37,7 +37,7 @@ public class DocumentResource extends Resource {
   }
 
   @GET
-  @Path("{entityId}/document")
+  @Path("/{entityId}")
   @Produces(MediaType.APPLICATION_JSON)
   @PermitAll
   public Response findDocumentsByEntity(
@@ -55,7 +55,7 @@ public class DocumentResource extends Resource {
   }
 
   @GET
-  @Path("/{entityId}/document/{id}")
+  @Path("/{entityId}/{id}")
   @Produces(MediaType.APPLICATION_JSON)
   @PermitAll
   public Response findDocumentByEntity(
@@ -74,7 +74,7 @@ public class DocumentResource extends Resource {
   }
 
   @DELETE
-  @Path("/{entityId}/document/{id}")
+  @Path("/{entityId}/{id}")
   @Produces(MediaType.APPLICATION_JSON)
   @PermitAll
   public Response deleteDocumentByEntity(
@@ -93,7 +93,7 @@ public class DocumentResource extends Resource {
   }
 
   @PUT
-  @Path("/{entityId}/document/{id}")
+  @Path("/{entityId}/{id}")
   @Consumes(MediaType.APPLICATION_JSON)
   @Produces(MediaType.APPLICATION_JSON)
   @PermitAll
@@ -115,7 +115,7 @@ public class DocumentResource extends Resource {
   }
 
   @POST
-  @Path("{entityId}/document")
+  @Path("{entityId}")
   @Consumes(MediaType.MULTIPART_FORM_DATA)
   @Produces(MediaType.APPLICATION_JSON)
   @PermitAll
@@ -139,7 +139,7 @@ public class DocumentResource extends Resource {
   }
 
   @GET
-  @Path("/{entityId}/document/{id}/file")
+  @Path("/{entityId}/{id}/file")
   @PermitAll
   public Response findDocumentFileByEntity(
       @Auth DuosUser duosUser,

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -516,9 +516,11 @@ paths:
     $ref: './paths/datasetAuthorizedUsers.yaml'
   /api/dataset/cleanupEmptyCertificationAndAlternativeSharingFiles:
     $ref: './paths/cleanupEmptyCertificationAndAlternativeSharingFiles.yaml'
-  /api/{entity}/{entityId}/document/{id}:
+  /api/document/{entity}/{entityId}:
+      $ref: './paths/documentsByEntityId.yaml'
+  /api/document/{entity}/{entityId}/{id}:
     $ref: './paths/documentById.yaml'
-  /api/{entity}/{entityId}/document/{id}/file:
+  /api/document/{entity}/{entityId}/{id}/file:
     $ref: './paths/documentFileById.yaml'
   /api/draft/v1:
     $ref: './paths/draftIndex.yaml'
@@ -528,8 +530,6 @@ paths:
     $ref: './paths/draftAttachmentsIndex.yaml'
   /api/draft/v1/{draftUUID}/attachments/{fileId}:
     $ref: './paths/draftAttachments.yaml'
-  /api/{entity}/{entityId}/document:
-    $ref: './paths/documentsByEntityId.yaml'
   /api/tdr/{identifier}/approved/users:
     $ref: './paths/tdrDatasetApprovedUsers.yaml'
   /api/tdr/{identifier}:


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-3118

### Summary

This PR updates the Document Resource Base Route from `/api/{entity}/{entityId}/document` to `/api/document/{entity}/{entityId}` to prevent route collisions with endpoints such as `/api/dac` and `/api/dataset`.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
