### PR TITLE
DT-245: Standardize sql in MailMessageDAO

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/MailMessageDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/MailMessageDAO.java
@@ -17,9 +17,12 @@ import org.jdbi.v3.sqlobject.transaction.Transactional;
 public interface MailMessageDAO extends Transactional<MailMessageDAO> {
 
   @SqlUpdate(
-      "INSERT INTO email_entity "
-          + "(entity_reference_id, vote_id, user_id, email_type, date_sent, email_text, sendgrid_response, sendgrid_status, create_date) VALUES "
-          + "(:entityReferenceId, :voteId, :userId, :emailType, :dateSent, :emailText, :sendGridResponse, :sendGridStatus, :createDate)")
+      """
+      INSERT INTO email_entity
+          (entity_reference_id, vote_id, user_id, email_type, date_sent, email_text, sendgrid_response, sendgrid_status, create_date)
+      VALUES
+          (:entityReferenceId, :voteId, :userId, :emailType, :dateSent, :emailText, :sendGridResponse, :sendGridStatus, :createDate)
+      """)
   @GetGeneratedKeys
   Integer insert(
       @Nullable @Bind("entityReferenceId") String entityReferenceId,
@@ -34,7 +37,8 @@ public interface MailMessageDAO extends Transactional<MailMessageDAO> {
 
   @SqlQuery(
       """
-      SELECT entity_reference_id, email_entity_id, vote_id, user_id, email_type, date_sent, email_text, sendgrid_response, sendgrid_status, create_date FROM email_entity e
+      SELECT entity_reference_id, email_entity_id, vote_id, user_id, email_type, date_sent, email_text, sendgrid_response, sendgrid_status, create_date
+      FROM email_entity e
       WHERE email_type = :emailType
       ORDER BY create_date DESC
       OFFSET :offset
@@ -47,7 +51,8 @@ public interface MailMessageDAO extends Transactional<MailMessageDAO> {
 
   @SqlQuery(
       """
-      SELECT entity_reference_id, email_entity_id, vote_id, user_id, email_type, date_sent, email_text, sendgrid_response, sendgrid_status, create_date FROM email_entity e
+      SELECT entity_reference_id, email_entity_id, vote_id, user_id, email_type, date_sent, email_text, sendgrid_response, sendgrid_status, create_date
+      FROM email_entity e
       WHERE user_id = :userId
       ORDER BY create_date DESC
       OFFSET :offset
@@ -58,7 +63,8 @@ public interface MailMessageDAO extends Transactional<MailMessageDAO> {
 
   @SqlQuery(
       """
-      SELECT entity_reference_id, email_entity_id, vote_id, user_id, email_type, date_sent, email_text, sendgrid_response, sendgrid_status, create_date FROM email_entity e
+      SELECT entity_reference_id, email_entity_id, vote_id, user_id, email_type, date_sent, email_text, sendgrid_response, sendgrid_status, create_date
+      FROM email_entity e
       WHERE create_date BETWEEN SYMMETRIC :start AND :end
       ORDER BY create_date DESC
       OFFSET :offset
@@ -72,7 +78,8 @@ public interface MailMessageDAO extends Transactional<MailMessageDAO> {
 
   @SqlQuery(
       """
-      SELECT entity_reference_id, email_entity_id, vote_id, user_id, email_type, date_sent, email_text, sendgrid_response, sendgrid_status, create_date FROM email_entity e
+      SELECT entity_reference_id, email_entity_id, vote_id, user_id, email_type, date_sent, email_text, sendgrid_response, sendgrid_status, create_date
+      FROM email_entity e
       WHERE email_entity_id = :emailId
       """)
   MailMessage fetchMessageById(@Bind("emailId") Integer emailId);

--- a/src/main/java/org/broadinstitute/consent/http/db/MailMessageDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/MailMessageDAO.java
@@ -1,39 +1,29 @@
 package org.broadinstitute.consent.http.db;
 
-import java.time.Instant;
 import java.util.Date;
 import java.util.List;
-import javax.annotation.Nullable;
 import org.broadinstitute.consent.http.db.mapper.MailMessageMapper;
 import org.broadinstitute.consent.http.models.mail.MailMessage;
 import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
 import org.jdbi.v3.sqlobject.customizer.Bind;
-import org.jdbi.v3.sqlobject.statement.GetGeneratedKeys;
+import org.jdbi.v3.sqlobject.customizer.BindMethods;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
-import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 import org.jdbi.v3.sqlobject.transaction.Transactional;
 
 @RegisterRowMapper(MailMessageMapper.class)
 public interface MailMessageDAO extends Transactional<MailMessageDAO> {
 
-  @SqlUpdate(
+  @SqlQuery(
       """
-      INSERT INTO email_entity
+      WITH insterted_row AS (
+        INSERT INTO email_entity
           (entity_reference_id, vote_id, user_id, email_type, date_sent, email_text, sendgrid_response, sendgrid_status, create_date)
-      VALUES
-          (:entityReferenceId, :voteId, :userId, :emailType, :dateSent, :emailText, :sendGridResponse, :sendGridStatus, :createDate)
+        VALUES
+          (:entityReferenceId, :voteId, :userId, :emailType, :dateSent, :emailText, :sendgridResponse, :sendgridStatus, :createDate)
+        RETURNING *)
+      SELECT * FROM insterted_row
       """)
-  @GetGeneratedKeys
-  Integer insert(
-      @Nullable @Bind("entityReferenceId") String entityReferenceId,
-      @Nullable @Bind("voteId") Integer voteId,
-      @Bind("userId") Integer userId,
-      @Bind("emailType") Integer emailType,
-      @Nullable @Bind("dateSent") Instant dateSent,
-      @Bind("emailText") String emailText,
-      @Nullable @Bind("sendGridResponse") String sendGridResponse,
-      @Nullable @Bind("sendGridStatus") Integer sendGridStatus,
-      @Bind("createDate") Instant createDate);
+  MailMessage insert(@BindMethods MailMessage mail);
 
   @SqlQuery(
       """

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/MailMessageMapper.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/MailMessageMapper.java
@@ -14,11 +14,11 @@ public class MailMessageMapper implements RowMapper<MailMessage> {
         r.getInt("email_entity_id"),
         r.getInt("vote_id"),
         r.getInt("user_id"),
-        r.getString("email_type"),
-        r.getDate("date_sent"),
+        r.getInt("email_type"),
+        r.getTimestamp("date_sent"),
         r.getString("email_text"),
         r.getString("sendgrid_response"),
         r.getInt("sendgrid_status"),
-        r.getDate("create_date"));
+        r.getTimestamp("create_date"));
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/MailMessageMapper.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/MailMessageMapper.java
@@ -11,6 +11,7 @@ public class MailMessageMapper implements RowMapper<MailMessage> {
   public MailMessage map(ResultSet r, StatementContext ctx) throws SQLException {
 
     return new MailMessage(
+        r.getString("entity_reference_id"),
         r.getInt("email_entity_id"),
         r.getInt("vote_id"),
         r.getInt("user_id"),

--- a/src/main/java/org/broadinstitute/consent/http/models/mail/MailMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/mail/MailMessage.java
@@ -4,9 +4,10 @@ import java.util.Date;
 
 public class MailMessage {
 
+  private String entityReferenceId;
   private Integer emailId;
   private Integer voteId;
-  private Integer dacUserId;
+  private Integer userId;
   private Integer emailType;
   private Date dateSent;
   private String emailText;
@@ -15,24 +16,34 @@ public class MailMessage {
   private Date createDate;
 
   public MailMessage(
+      String entityReferenceId,
       Integer emailId,
       Integer voteId,
-      Integer dacUserId,
+      Integer userId,
       Integer emailType,
       Date dateSent,
       String emailText,
       String sendgridResponse,
       Integer sendgridStatus,
       Date createDate) {
+    this.entityReferenceId = entityReferenceId;
     this.emailId = emailId;
     this.voteId = voteId;
-    this.dacUserId = dacUserId;
+    this.userId = userId;
     this.emailType = emailType;
     this.dateSent = dateSent;
     this.emailText = emailText;
     this.sendgridResponse = sendgridResponse;
     this.sendgridStatus = sendgridStatus;
     this.createDate = createDate;
+  }
+
+  public String getEntityReferenceId() {
+    return entityReferenceId;
+  }
+
+  public void setEntityReferenceId(String entityReferenceId) {
+    this.entityReferenceId = entityReferenceId;
   }
 
   public Integer getEmailId() {
@@ -52,11 +63,11 @@ public class MailMessage {
   }
 
   public Integer getUserId() {
-    return dacUserId;
+    return userId;
   }
 
-  public void setDacUserId(Integer dacUserId) {
-    this.dacUserId = dacUserId;
+  public void setUserId(Integer userId) {
+    this.userId = userId;
   }
 
   public Integer getEmailType() {

--- a/src/main/java/org/broadinstitute/consent/http/models/mail/MailMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/mail/MailMessage.java
@@ -7,7 +7,7 @@ public class MailMessage {
   private Integer emailId;
   private Integer voteId;
   private Integer dacUserId;
-  private String emailType;
+  private Integer emailType;
   private Date dateSent;
   private String emailText;
   private String sendgridResponse;
@@ -18,7 +18,7 @@ public class MailMessage {
       Integer emailId,
       Integer voteId,
       Integer dacUserId,
-      String emailType,
+      Integer emailType,
       Date dateSent,
       String emailText,
       String sendgridResponse,
@@ -59,11 +59,11 @@ public class MailMessage {
     this.dacUserId = dacUserId;
   }
 
-  public String getEmailType() {
+  public Integer getEmailType() {
     return emailType;
   }
 
-  public void setEmailType(String emailType) {
+  public void setEmailType(Integer emailType) {
     this.emailType = emailType;
   }
 

--- a/src/main/java/org/broadinstitute/consent/http/models/mail/MailMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/mail/MailMessage.java
@@ -2,119 +2,14 @@ package org.broadinstitute.consent.http.models.mail;
 
 import java.util.Date;
 
-public class MailMessage {
-
-  private String entityReferenceId;
-  private Integer emailId;
-  private Integer voteId;
-  private Integer userId;
-  private Integer emailType;
-  private Date dateSent;
-  private String emailText;
-  private String sendgridResponse;
-  private Integer sendgridStatus;
-  private Date createDate;
-
-  public MailMessage(
-      String entityReferenceId,
-      Integer emailId,
-      Integer voteId,
-      Integer userId,
-      Integer emailType,
-      Date dateSent,
-      String emailText,
-      String sendgridResponse,
-      Integer sendgridStatus,
-      Date createDate) {
-    this.entityReferenceId = entityReferenceId;
-    this.emailId = emailId;
-    this.voteId = voteId;
-    this.userId = userId;
-    this.emailType = emailType;
-    this.dateSent = dateSent;
-    this.emailText = emailText;
-    this.sendgridResponse = sendgridResponse;
-    this.sendgridStatus = sendgridStatus;
-    this.createDate = createDate;
-  }
-
-  public String getEntityReferenceId() {
-    return entityReferenceId;
-  }
-
-  public void setEntityReferenceId(String entityReferenceId) {
-    this.entityReferenceId = entityReferenceId;
-  }
-
-  public Integer getEmailId() {
-    return emailId;
-  }
-
-  public void setEmailId(Integer emailId) {
-    this.emailId = emailId;
-  }
-
-  public Integer getVoteId() {
-    return voteId;
-  }
-
-  public void setVoteId(Integer voteId) {
-    this.voteId = voteId;
-  }
-
-  public Integer getUserId() {
-    return userId;
-  }
-
-  public void setUserId(Integer userId) {
-    this.userId = userId;
-  }
-
-  public Integer getEmailType() {
-    return emailType;
-  }
-
-  public void setEmailType(Integer emailType) {
-    this.emailType = emailType;
-  }
-
-  public Date getDateSent() {
-    return dateSent;
-  }
-
-  public void setDateSent(Date dateSent) {
-    this.dateSent = dateSent;
-  }
-
-  public String getEmailText() {
-    return emailText;
-  }
-
-  public void setEmailText(String emailText) {
-    this.emailText = emailText;
-  }
-
-  public String getSendgridResponse() {
-    return sendgridResponse;
-  }
-
-  public void setSendgridResponse(String sendgridResponse) {
-    this.sendgridResponse = sendgridResponse;
-  }
-
-  public Integer getSendgridStatus() {
-    return sendgridStatus;
-  }
-
-  public void setSendgridStatus(Integer sendgridStatus) {
-    this.sendgridStatus = sendgridStatus;
-  }
-
-  public Date getCreateDate() {
-    return createDate;
-  }
-
-  public void setCreateDate(Date createDate) {
-    this.createDate = createDate;
-  }
-}
+public record MailMessage(
+    String entityReferenceId,
+    Integer emailId,
+    Integer voteId,
+    Integer userId,
+    Integer emailType,
+    Date dateSent,
+    String emailText,
+    String sendgridResponse,
+    Integer sendgridStatus,
+    Date createDate) {}

--- a/src/main/java/org/broadinstitute/consent/http/service/EmailService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/EmailService.java
@@ -115,17 +115,23 @@ public class EmailService implements ConsentLogger {
       EmailType emailType,
       String content) {
     Instant now = Instant.now();
-    Instant dateSent = (Objects.nonNull(response) && response.getStatusCode() < 400) ? now : null;
-    emailDAO.insert(
-        entityReferenceId,
-        voteId,
-        userId,
-        emailType.getTypeInt(),
-        dateSent,
-        content,
-        Objects.nonNull(response) ? response.getBody() : null,
-        Objects.nonNull(response) ? response.getStatusCode() : null,
-        now);
+    Date dateSent =
+        (Objects.nonNull(response) && response.getStatusCode() < 400) ? Date.from(now) : null;
+    String sendgridResponse = Objects.nonNull(response) ? response.getBody() : null;
+    Integer sendgridStatus = Objects.nonNull(response) ? response.getStatusCode() : null;
+    org.broadinstitute.consent.http.models.mail.MailMessage mailMessage =
+        new org.broadinstitute.consent.http.models.mail.MailMessage(
+            entityReferenceId,
+            null,
+            voteId,
+            userId,
+            emailType.getTypeInt(),
+            dateSent,
+            content,
+            sendgridResponse,
+            sendgridStatus,
+            Date.from(now));
+    emailDAO.insert(mailMessage);
   }
 
   @VisibleForTesting

--- a/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
@@ -38,6 +38,7 @@ import org.broadinstitute.consent.http.models.DatasetProperty;
 import org.broadinstitute.consent.http.models.Election;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.Vote;
+import org.broadinstitute.consent.http.models.mail.MailMessage;
 import org.jdbi.v3.core.JdbiException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -1266,15 +1267,17 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
     dataAccessRequestDAO.insertDARDatasetRelation(
         darTwo.getReferenceId(), datasetThree.getDatasetId());
     mailMessageDAO.insert(
-        darOne.getReferenceId(),
-        null,
-        userOneId,
-        EmailType.DAR_EXPIRATION_REMINDER.getTypeInt(),
-        Instant.now(),
-        "hello world!",
-        "success",
-        200,
-        Instant.now());
+        new MailMessage(
+            darOne.getReferenceId(),
+            null,
+            null,
+            userOneId,
+            EmailType.DAR_EXPIRATION_REMINDER.getTypeInt(),
+            Date.from(Instant.now()),
+            "hello world!",
+            "success",
+            200,
+            Date.from(Instant.now())));
     List<DataAccessRequest> dars =
         dataAccessRequestDAO.findAgedDARsByEmailTypeOlderThanInterval(
             EmailType.DAR_EXPIRATION_REMINDER.getTypeInt(),

--- a/src/test/java/org/broadinstitute/consent/http/db/ElectionDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/ElectionDAOTest.java
@@ -31,6 +31,7 @@ import org.broadinstitute.consent.http.models.Reminder;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.UserVoteReminder;
 import org.broadinstitute.consent.http.models.Vote;
+import org.broadinstitute.consent.http.models.mail.MailMessage;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -691,15 +692,17 @@ class ElectionDAOTest extends DAOTestHelper {
     String referenceId = Instant.now().toString();
     Integer emailType = EmailType.COLLECT.getTypeInt();
     mailMessageDAO.insert(
-        referenceId,
-        null,
-        vote.getUserId(),
-        emailType,
-        null,
-        "Extra, Extra!",
-        null,
-        null,
-        Instant.now());
+        new MailMessage(
+            referenceId,
+            null,
+            vote.getVoteId(),
+            vote.getUserId(),
+            emailType,
+            Date.from(Instant.now()),
+            "Extra, Extra!",
+            null,
+            null,
+            Date.from(Instant.now())));
 
     List<UserVoteReminder> userVoteReminders =
         electionDAO.findElectionReminders(-1, emailType, referenceId);

--- a/src/test/java/org/broadinstitute/consent/http/db/MailMessageDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/MailMessageDAOTest.java
@@ -26,18 +26,20 @@ class MailMessageDAOTest extends DAOTestHelper {
   void testInsert_AllFields() {
     User user = createUser();
     Instant now = Instant.now();
-    Integer mailId =
+    MailMessage mail =
         mailMessageDAO.insert(
-            randomAlphanumeric(10),
-            randomInt(1, 1000),
-            user.getUserId(),
-            EmailType.COLLECT.getTypeInt(),
-            now,
-            randomAlphanumeric(10),
-            randomAlphanumeric(10),
-            randomInt(200, 399),
-            now);
-    assertNotNull(mailId);
+            new MailMessage(
+                randomAlphanumeric(10),
+                null,
+                randomInt(1, 1000),
+                user.getUserId(),
+                EmailType.COLLECT.getTypeInt(),
+                Date.from(now),
+                randomAlphanumeric(10),
+                randomAlphanumeric(10),
+                randomInt(200, 399),
+                Date.from(now)));
+    assertNotNull(mail);
   }
 
   @Test
@@ -47,18 +49,20 @@ class MailMessageDAOTest extends DAOTestHelper {
         .forEach(
             t -> {
               Instant now = Instant.now();
-              Integer mailId =
+              MailMessage mail =
                   mailMessageDAO.insert(
-                      randomAlphanumeric(10),
-                      randomInt(1, 1000),
-                      user.getUserId(),
-                      t.getTypeInt(),
-                      now,
-                      randomAlphanumeric(10),
-                      randomAlphanumeric(10),
-                      randomInt(200, 399),
-                      now);
-              assertNotNull(mailId);
+                      new MailMessage(
+                          randomAlphanumeric(10),
+                          null,
+                          randomInt(1, 1000),
+                          user.getUserId(),
+                          t.getTypeInt(),
+                          Date.from(now),
+                          randomAlphanumeric(10),
+                          randomAlphanumeric(10),
+                          randomInt(200, 399),
+                          Date.from(now)));
+              assertNotNull(mail);
             });
   }
 
@@ -66,90 +70,100 @@ class MailMessageDAOTest extends DAOTestHelper {
   void testInsert_NullEntityReferenceId() {
     User user = createUser();
     Instant now = Instant.now();
-    Integer mailId =
+    MailMessage mail =
         mailMessageDAO.insert(
-            null,
-            randomInt(1, 1000),
-            user.getUserId(),
-            EmailType.COLLECT.getTypeInt(),
-            now,
-            randomAlphanumeric(10),
-            randomAlphanumeric(10),
-            randomInt(200, 399),
-            now);
-    assertNotNull(mailId);
+            new MailMessage(
+                null,
+                null,
+                randomInt(1, 1000),
+                user.getUserId(),
+                EmailType.COLLECT.getTypeInt(),
+                Date.from(now),
+                randomAlphanumeric(10),
+                randomAlphanumeric(10),
+                randomInt(200, 399),
+                Date.from(now)));
+    assertNotNull(mail);
   }
 
   @Test
   void testInsert_NullVoteId() {
     User user = createUser();
     Instant now = Instant.now();
-    Integer mailId =
+    MailMessage mail =
         mailMessageDAO.insert(
-            randomAlphanumeric(10),
-            null,
-            user.getUserId(),
-            EmailType.COLLECT.getTypeInt(),
-            now,
-            randomAlphanumeric(10),
-            randomAlphanumeric(10),
-            randomInt(200, 399),
-            now);
-    assertNotNull(mailId);
+            new MailMessage(
+                randomAlphanumeric(10),
+                null,
+                null,
+                user.getUserId(),
+                EmailType.COLLECT.getTypeInt(),
+                Date.from(now),
+                randomAlphanumeric(10),
+                randomAlphanumeric(10),
+                randomInt(200, 399),
+                Date.from(now)));
+    assertNotNull(mail);
   }
 
   @Test
   void testInsert_NullDateSent() {
     User user = createUser();
     Instant now = Instant.now();
-    Integer mailId =
+    MailMessage mail =
         mailMessageDAO.insert(
-            randomAlphanumeric(10),
-            randomInt(1, 1000),
-            user.getUserId(),
-            EmailType.COLLECT.getTypeInt(),
-            null,
-            randomAlphanumeric(10),
-            randomAlphanumeric(10),
-            randomInt(200, 399),
-            now);
-    assertNotNull(mailId);
+            new MailMessage(
+                randomAlphanumeric(10),
+                null,
+                randomInt(1, 1000),
+                user.getUserId(),
+                EmailType.COLLECT.getTypeInt(),
+                null,
+                randomAlphanumeric(10),
+                randomAlphanumeric(10),
+                randomInt(200, 399),
+                Date.from(now)));
+    assertNotNull(mail);
   }
 
   @Test
   void testInsert_NullSendGridResponse() {
     User user = createUser();
     Instant now = Instant.now();
-    Integer mailId =
+    MailMessage mail =
         mailMessageDAO.insert(
-            randomAlphanumeric(10),
-            randomInt(1, 1000),
-            user.getUserId(),
-            EmailType.COLLECT.getTypeInt(),
-            now,
-            randomAlphanumeric(10),
-            null,
-            randomInt(200, 399),
-            now);
-    assertNotNull(mailId);
+            new MailMessage(
+                randomAlphanumeric(10),
+                null,
+                randomInt(1, 1000),
+                user.getUserId(),
+                EmailType.COLLECT.getTypeInt(),
+                Date.from(now),
+                randomAlphanumeric(10),
+                null,
+                randomInt(200, 399),
+                Date.from(now)));
+    assertNotNull(mail);
   }
 
   @Test
   void testInsert_NullSendGridStatus() {
     User user = createUser();
     Instant now = Instant.now();
-    Integer mailId =
+    MailMessage mail =
         mailMessageDAO.insert(
-            randomAlphanumeric(10),
-            randomInt(1, 1000),
-            user.getUserId(),
-            EmailType.COLLECT.getTypeInt(),
-            now,
-            randomAlphanumeric(10),
-            randomAlphanumeric(10),
-            null,
-            now);
-    assertNotNull(mailId);
+            new MailMessage(
+                randomAlphanumeric(10),
+                null,
+                randomInt(1, 1000),
+                user.getUserId(),
+                EmailType.COLLECT.getTypeInt(),
+                Date.from(now),
+                randomAlphanumeric(10),
+                randomAlphanumeric(10),
+                null,
+                Date.from(now)));
+    assertNotNull(mail);
   }
 
   @Test
@@ -163,15 +177,17 @@ class MailMessageDAOTest extends DAOTestHelper {
         UnableToExecuteStatementException.class,
         () ->
             mailMessageDAO.insert(
-                entityReferenceId,
-                voteId,
-                null,
-                null,
-                now,
-                null,
-                sendGridResponse,
-                sendGridStatus,
-                null));
+                new MailMessage(
+                    entityReferenceId,
+                    null,
+                    voteId,
+                    null,
+                    null,
+                    Date.from(now),
+                    null,
+                    sendGridResponse,
+                    sendGridStatus,
+                    null)));
   }
 
   @Test
@@ -186,15 +202,17 @@ class MailMessageDAOTest extends DAOTestHelper {
         UnableToExecuteStatementException.class,
         () ->
             mailMessageDAO.insert(
-                entityReferenceId,
-                voteId,
-                userId,
-                null,
-                now,
-                null,
-                sendGridResponse,
-                sendGridStatus,
-                null));
+                new MailMessage(
+                    entityReferenceId,
+                    null,
+                    voteId,
+                    userId,
+                    null,
+                    Date.from(now),
+                    null,
+                    sendGridResponse,
+                    sendGridStatus,
+                    null)));
   }
 
   @Test
@@ -210,15 +228,17 @@ class MailMessageDAOTest extends DAOTestHelper {
         UnableToExecuteStatementException.class,
         () ->
             mailMessageDAO.insert(
-                entityReferenceId,
-                voteId,
-                userId,
-                emailType,
-                now,
-                null,
-                sendGridResponse,
-                sendGridStatus,
-                null));
+                new MailMessage(
+                    entityReferenceId,
+                    null,
+                    voteId,
+                    userId,
+                    emailType,
+                    Date.from(now),
+                    null,
+                    sendGridResponse,
+                    sendGridStatus,
+                    null)));
   }
 
   @Test
@@ -235,15 +255,17 @@ class MailMessageDAOTest extends DAOTestHelper {
         UnableToExecuteStatementException.class,
         () ->
             mailMessageDAO.insert(
-                entityReferenceId,
-                voteId,
-                userId,
-                emailType,
-                now,
-                emailText,
-                sendGridResponse,
-                sendGridStatus,
-                null));
+                new MailMessage(
+                    entityReferenceId,
+                    null,
+                    voteId,
+                    userId,
+                    emailType,
+                    Date.from(now),
+                    emailText,
+                    sendGridResponse,
+                    sendGridStatus,
+                    null)));
   }
 
   @Test
@@ -254,15 +276,17 @@ class MailMessageDAOTest extends DAOTestHelper {
             t -> {
               Instant now = Instant.now();
               mailMessageDAO.insert(
-                  randomAlphanumeric(10),
-                  randomInt(1, 1000),
-                  user.getUserId(),
-                  t.getTypeInt(),
-                  now,
-                  randomAlphanumeric(10),
-                  randomAlphanumeric(10),
-                  randomInt(200, 399),
-                  now);
+                  new MailMessage(
+                      randomAlphanumeric(10),
+                      null,
+                      randomInt(1, 1000),
+                      user.getUserId(),
+                      t.getTypeInt(),
+                      Date.from(now),
+                      randomAlphanumeric(10),
+                      randomAlphanumeric(10),
+                      randomInt(200, 399),
+                      Date.from(now)));
             });
 
     EnumSet.allOf(EmailType.class)
@@ -275,15 +299,17 @@ class MailMessageDAOTest extends DAOTestHelper {
     User user = createUser();
     Instant now = Instant.now();
     mailMessageDAO.insert(
-        randomAlphanumeric(10),
-        randomInt(1, 1000),
-        user.getUserId(),
-        EmailType.COLLECT.getTypeInt(),
-        now,
-        randomAlphanumeric(10),
-        randomAlphanumeric(10),
-        randomInt(200, 399),
-        now);
+        new MailMessage(
+            randomAlphanumeric(10),
+            null,
+            randomInt(1, 1000),
+            user.getUserId(),
+            EmailType.COLLECT.getTypeInt(),
+            Date.from(now),
+            randomAlphanumeric(10),
+            randomAlphanumeric(10),
+            randomInt(200, 399),
+            Date.from(now)));
 
     List<MailMessage> mailMessageList =
         mailMessageDAO.fetchMessagesByType(EmailType.COLLECT.getTypeInt(), 1, 0);
@@ -293,22 +319,24 @@ class MailMessageDAOTest extends DAOTestHelper {
         mailMessageDAO.fetchMessagesByType(EmailType.COLLECT.getTypeInt(), 1, 1);
     assertEquals(0, mailMessageList2.size());
 
-    Integer mailId2 =
+    MailMessage mail2 =
         mailMessageDAO.insert(
-            randomAlphanumeric(10),
-            randomInt(1, 1000),
-            user.getUserId(),
-            EmailType.COLLECT.getTypeInt(),
-            now,
-            randomAlphanumeric(10),
-            randomAlphanumeric(10),
-            null,
-            now);
+            new MailMessage(
+                randomAlphanumeric(10),
+                null,
+                randomInt(1, 1000),
+                user.getUserId(),
+                EmailType.COLLECT.getTypeInt(),
+                Date.from(now),
+                randomAlphanumeric(10),
+                randomAlphanumeric(10),
+                null,
+                Date.from(now)));
 
     List<MailMessage> mailMessageList3 =
         mailMessageDAO.fetchMessagesByType(EmailType.COLLECT.getTypeInt(), 1, 1);
     assertEquals(1, mailMessageList3.size());
-    assertEquals(mailId2, mailMessageList3.getFirst().getEmailId());
+    assertEquals(mail2.emailId(), mailMessageList3.getFirst().emailId());
 
     List<MailMessage> mailMessageList4 =
         mailMessageDAO.fetchMessagesByType(EmailType.COLLECT.getTypeInt(), 20, 0);
@@ -320,35 +348,39 @@ class MailMessageDAOTest extends DAOTestHelper {
     Instant now = Instant.now();
     User user = createUser();
     mailMessageDAO.insert(
-        randomAlphanumeric(10),
-        randomInt(1, 1000),
-        user.getUserId(),
-        EmailType.COLLECT.getTypeInt(),
-        now,
-        randomAlphanumeric(10),
-        randomAlphanumeric(10),
-        randomInt(200, 399),
-        now);
+        new MailMessage(
+            randomAlphanumeric(10),
+            null,
+            randomInt(1, 1000),
+            user.getUserId(),
+            EmailType.COLLECT.getTypeInt(),
+            Date.from(now),
+            randomAlphanumeric(10),
+            randomAlphanumeric(10),
+            randomInt(200, 399),
+            Date.from(now)));
 
     List<MailMessage> mailMessageList =
         mailMessageDAO.fetchMessagesByUserId(user.getUserId(), 10, 0);
     assertEquals(1, mailMessageList.size());
-    assertEquals(user.getUserId(), mailMessageList.getFirst().getUserId());
+    assertEquals(user.getUserId(), mailMessageList.getFirst().userId());
 
     mailMessageDAO.insert(
-        randomAlphanumeric(10),
-        randomInt(1, 1000),
-        user.getUserId(),
-        EmailType.COLLECT.getTypeInt(),
-        now,
-        randomAlphanumeric(10),
-        randomAlphanumeric(10),
-        randomInt(200, 399),
-        now);
+        new MailMessage(
+            randomAlphanumeric(10),
+            null,
+            randomInt(1, 1000),
+            user.getUserId(),
+            EmailType.COLLECT.getTypeInt(),
+            Date.from(now),
+            randomAlphanumeric(10),
+            randomAlphanumeric(10),
+            randomInt(200, 399),
+            Date.from(now)));
     List<MailMessage> mailMessageList2 =
         mailMessageDAO.fetchMessagesByUserId(user.getUserId(), 10, 0);
     assertEquals(2, mailMessageList2.size());
-    assertEquals(user.getUserId(), mailMessageList2.getFirst().getUserId());
+    assertEquals(user.getUserId(), mailMessageList2.getFirst().userId());
 
     User user2 = createUser();
     List<MailMessage> mailMessageList3 =
@@ -375,7 +407,7 @@ class MailMessageDAOTest extends DAOTestHelper {
         mailMessageDAO.fetchMessagesByCreateDate(
             Date.from(todayStart), Date.from(tomorrowStart), 1, 0);
     assertEquals(1, messages.size());
-    assertEquals(messageToday.getEmailId(), messages.getFirst().getEmailId());
+    assertEquals(messageToday.emailId(), messages.getFirst().emailId());
 
     // Find messages from beginning of yesterday to tomorrow. Should return both messages.
     // Order is create date descending, so today is first, yesterday second.
@@ -383,8 +415,8 @@ class MailMessageDAOTest extends DAOTestHelper {
         mailMessageDAO.fetchMessagesByCreateDate(
             Date.from(yesterdayStart), Date.from(tomorrowStart), 2, 0);
     assertEquals(2, messages2.size());
-    assertEquals(messageToday.getEmailId(), messages2.get(0).getEmailId());
-    assertEquals(messageYesterday.getEmailId(), messages2.get(1).getEmailId());
+    assertEquals(messageToday.emailId(), messages2.get(0).emailId());
+    assertEquals(messageYesterday.emailId(), messages2.get(1).emailId());
 
     // Find messages from beginning of yesterday to tomorrow, offset by 1. Since messages are
     // ordered by create date descending, offset should trim today's message and only return
@@ -393,7 +425,7 @@ class MailMessageDAOTest extends DAOTestHelper {
         mailMessageDAO.fetchMessagesByCreateDate(
             Date.from(yesterdayStart), Date.from(tomorrowStart), 2, 1);
     assertEquals(1, messages3.size());
-    assertEquals(messageYesterday.getEmailId(), messages3.getFirst().getEmailId());
+    assertEquals(messageYesterday.emailId(), messages3.getFirst().emailId());
 
     // Find messages from beginning of yesterday to beginning today. Should return yesterday's
     // message.
@@ -401,11 +433,11 @@ class MailMessageDAOTest extends DAOTestHelper {
         mailMessageDAO.fetchMessagesByCreateDate(
             Date.from(yesterdayStart), Date.from(todayStart), 2, 0);
     assertEquals(1, messages4.size());
-    assertEquals(messageYesterday.getEmailId(), messages4.getFirst().getEmailId());
+    assertEquals(messageYesterday.emailId(), messages4.getFirst().emailId());
   }
 
   @Test
-  void testFetchMessageById() {
+  void testInsert() {
     User user = createUser();
     String entityReferenceId = randomAlphanumeric(10);
     Integer voteId = randomInt(1, 1000);
@@ -415,42 +447,45 @@ class MailMessageDAOTest extends DAOTestHelper {
     String emailText = randomAlphanumeric(1000);
     String sendGridResponse = randomAlphanumeric(1000);
     Integer sendGridStatus = 200;
-    Integer messageId =
-        mailMessageDAO.insert(
+    MailMessage unsavedMessage =
+        new MailMessage(
             entityReferenceId,
+            null,
             voteId,
             user.getUserId(),
             emailType,
-            now,
+            nowDate,
             emailText,
             sendGridResponse,
             sendGridStatus,
-            now);
+            nowDate);
 
-    MailMessage message = mailMessageDAO.fetchMessageById(messageId);
-    assertEquals(entityReferenceId, message.getEntityReferenceId());
-    assertEquals(user.getUserId(), message.getUserId());
-    assertEquals(emailType, message.getEmailType());
-    assertEquals(nowDate, message.getDateSent());
-    assertEquals(emailText, message.getEmailText());
-    assertEquals(sendGridStatus, message.getSendgridStatus());
-    assertEquals(sendGridResponse, message.getSendgridResponse());
-    assertEquals(nowDate, message.getCreateDate());
+    MailMessage savedMessage = mailMessageDAO.insert(unsavedMessage);
+    assertNotNull(savedMessage);
+    assertNotNull(savedMessage.emailId());
+    assertEquals(entityReferenceId, savedMessage.entityReferenceId());
+    assertEquals(user.getUserId(), savedMessage.userId());
+    assertEquals(emailType, savedMessage.emailType());
+    assertEquals(nowDate, savedMessage.dateSent());
+    assertEquals(emailText, savedMessage.emailText());
+    assertEquals(sendGridStatus, savedMessage.sendgridStatus());
+    assertEquals(sendGridResponse, savedMessage.sendgridResponse());
+    assertEquals(nowDate, savedMessage.createDate());
   }
 
   private MailMessage generateMessage(Instant instant) {
     User user = createUser();
-    Integer messageId =
-        mailMessageDAO.insert(
+    return mailMessageDAO.insert(
+        new MailMessage(
             randomAlphanumeric(10),
+            null,
             randomInt(1, 1000),
             user.getUserId(),
             EmailType.COLLECT.getTypeInt(),
-            instant,
+            Date.from(instant),
             randomAlphanumeric(10),
             randomAlphanumeric(10),
             randomInt(200, 399),
-            instant);
-    return mailMessageDAO.fetchMessageById(messageId);
+            Date.from(instant)));
   }
 }

--- a/src/test/java/org/broadinstitute/consent/http/db/MailMessageDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/MailMessageDAOTest.java
@@ -404,6 +404,15 @@ class MailMessageDAOTest extends DAOTestHelper {
     assertEquals(messageYesterday.getEmailId(), messages4.getFirst().getEmailId());
   }
 
+  @Test
+  void testFetchMessageById() {
+    MailMessage message = generateMessage(Instant.now());
+    MailMessage fetchedMessage = mailMessageDAO.fetchMessageById(message.getEmailId());
+    assertEquals(message.getEmailId(), fetchedMessage.getEmailId());
+    assertEquals(message.getUserId(), fetchedMessage.getUserId());
+    assertEquals(message.getEmailType(), fetchedMessage.getEmailType());
+  }
+
   private MailMessage generateMessage(Instant instant) {
     User user = createUser();
     Integer messageId =

--- a/src/test/java/org/broadinstitute/consent/http/db/MailMessageDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/MailMessageDAOTest.java
@@ -428,7 +428,7 @@ class MailMessageDAOTest extends DAOTestHelper {
             now);
 
     MailMessage message = mailMessageDAO.fetchMessageById(messageId);
-    // Note that entityReferenceId is not returned as part of MailMessage
+    assertEquals(entityReferenceId, message.getEntityReferenceId());
     assertEquals(user.getUserId(), message.getUserId());
     assertEquals(emailType, message.getEmailType());
     assertEquals(nowDate, message.getDateSent());

--- a/src/test/java/org/broadinstitute/consent/http/db/MailMessageDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/MailMessageDAOTest.java
@@ -406,11 +406,36 @@ class MailMessageDAOTest extends DAOTestHelper {
 
   @Test
   void testFetchMessageById() {
-    MailMessage message = generateMessage(Instant.now());
-    MailMessage fetchedMessage = mailMessageDAO.fetchMessageById(message.getEmailId());
-    assertEquals(message.getEmailId(), fetchedMessage.getEmailId());
-    assertEquals(message.getUserId(), fetchedMessage.getUserId());
-    assertEquals(message.getEmailType(), fetchedMessage.getEmailType());
+    User user = createUser();
+    String entityReferenceId = randomAlphanumeric(10);
+    Integer voteId = randomInt(1, 1000);
+    Integer emailType = EmailType.NEW_DAR.getTypeInt();
+    Instant now = Instant.now();
+    Date nowDate = Date.from(now);
+    String emailText = randomAlphanumeric(1000);
+    String sendGridResponse = randomAlphanumeric(1000);
+    Integer sendGridStatus = 200;
+    Integer messageId =
+        mailMessageDAO.insert(
+            entityReferenceId,
+            voteId,
+            user.getUserId(),
+            emailType,
+            now,
+            emailText,
+            sendGridResponse,
+            sendGridStatus,
+            now);
+
+    MailMessage message = mailMessageDAO.fetchMessageById(messageId);
+    // Note that entityReferenceId is not returned as part of MailMessage
+    assertEquals(user.getUserId(), message.getUserId());
+    assertEquals(emailType, message.getEmailType());
+    assertEquals(nowDate, message.getDateSent());
+    assertEquals(emailText, message.getEmailText());
+    assertEquals(sendGridStatus, message.getSendgridStatus());
+    assertEquals(sendGridResponse, message.getSendgridResponse());
+    assertEquals(nowDate, message.getCreateDate());
   }
 
   private MailMessage generateMessage(Instant instant) {

--- a/src/test/java/org/broadinstitute/consent/http/db/UserDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/UserDAOTest.java
@@ -32,6 +32,7 @@ import org.broadinstitute.consent.http.models.LibraryCard;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.UserProperty;
 import org.broadinstitute.consent.http.models.UserRole;
+import org.broadinstitute.consent.http.models.mail.MailMessage;
 import org.broadinstitute.consent.http.util.gson.GsonUtil;
 import org.jdbi.v3.core.result.ResultIterable;
 import org.jdbi.v3.core.statement.UnableToExecuteStatementException;
@@ -594,16 +595,19 @@ class UserDAOTest extends DAOTestHelper {
                   user3Found.set(true);
                 } else {
                   // simulate having sent a message so we won't send one again.
+                  Date now = Date.from(Instant.now());
                   mailMessageDAO.insert(
-                      referenceId,
-                      null,
-                      user.getUserId(),
-                      emailType,
-                      Instant.now(),
-                      "",
-                      null,
-                      null,
-                      Instant.now());
+                      new MailMessage(
+                          referenceId,
+                          null,
+                          null,
+                          user.getUserId(),
+                          emailType,
+                          now,
+                          "",
+                          null,
+                          null,
+                          now));
                 }
               }
             });

--- a/src/test/java/org/broadinstitute/consent/http/resources/MailResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/MailResourceTest.java
@@ -133,6 +133,7 @@ class MailResourceTest extends AbstractTestHelper {
 
   private MailMessage generateMailMessage(int emailType) {
     return new MailMessage(
+        randomAlphanumeric(10),
         nextInt(),
         nextInt(),
         nextInt(),

--- a/src/test/java/org/broadinstitute/consent/http/resources/MailResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/MailResourceTest.java
@@ -126,11 +126,12 @@ class MailResourceTest extends AbstractTestHelper {
 
   private List<MailMessage> generateMailMessageList() {
     List<MailMessage> messageList = new ArrayList<>();
-    EnumSet.allOf(EmailType.class).forEach(t -> messageList.add(generateMailMessage(t.toString())));
+    EnumSet.allOf(EmailType.class)
+        .forEach(t -> messageList.add(generateMailMessage(t.getTypeInt())));
     return messageList;
   }
 
-  private MailMessage generateMailMessage(String emailType) {
+  private MailMessage generateMailMessage(int emailType) {
     return new MailMessage(
         nextInt(),
         nextInt(),

--- a/src/test/java/org/broadinstitute/consent/http/service/EmailServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/EmailServiceTest.java
@@ -707,6 +707,7 @@ class EmailServiceTest extends AbstractTestHelper {
 
   private MailMessage generateMailMessage() {
     return new MailMessage(
+        randomAlphanumeric(10),
         randomInt(1, 10),
         randomInt(11, 20),
         randomInt(21, 30),

--- a/src/test/java/org/broadinstitute/consent/http/service/EmailServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/EmailServiceTest.java
@@ -710,7 +710,7 @@ class EmailServiceTest extends AbstractTestHelper {
         randomInt(1, 10),
         randomInt(11, 20),
         randomInt(21, 30),
-        randomAlphanumeric(10),
+        randomInt(1, 10),
         new Date(),
         randomAlphanumeric(10),
         randomAlphanumeric(10),

--- a/src/test/java/org/broadinstitute/consent/http/service/EmailServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/EmailServiceTest.java
@@ -7,7 +7,6 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
@@ -27,6 +26,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 import org.broadinstitute.consent.http.AbstractTestHelper;
 import org.broadinstitute.consent.http.configurations.ConsentConfiguration;
@@ -167,15 +167,17 @@ class EmailServiceTest extends AbstractTestHelper {
 
     verify(emailDAO)
         .insert(
-            entityReferenceId,
-            voteId,
-            1234,
-            EmailType.COLLECT.getTypeInt(),
-            fixedInstant,
-            emailText,
-            response.getBody(),
-            response.getStatusCode(),
-            fixedInstant);
+            argThat(
+                m ->
+                    Objects.equals(m.entityReferenceId(), entityReferenceId)
+                        && Objects.equals(m.voteId(), voteId)
+                        && Objects.equals(m.userId(), 1234)
+                        && Objects.equals(m.emailType(), EmailType.COLLECT.getTypeInt())
+                        && Objects.equals(m.dateSent(), Date.from(fixedInstant))
+                        && Objects.equals(m.emailText(), emailText)
+                        && Objects.equals(m.sendgridResponse(), response.getBody())
+                        && Objects.equals(m.sendgridStatus(), response.getStatusCode())
+                        && Objects.equals(m.createDate(), Date.from(fixedInstant))));
   }
 
   @Test
@@ -194,15 +196,12 @@ class EmailServiceTest extends AbstractTestHelper {
     verify(sendGridAPI).sendMessage(any(), any());
     verify(emailDAO)
         .insert(
-            eq("1234"),
-            eq(null),
-            eq(1234),
-            eq(EmailType.NEW_RESEARCHER.getTypeInt()),
-            any(),
-            any(),
-            any(),
-            any(),
-            any());
+            argThat(
+                m ->
+                    Objects.equals(m.entityReferenceId(), "1234")
+                        && m.voteId() == null
+                        && Objects.equals(m.userId(), 1234)
+                        && Objects.equals(m.emailType(), EmailType.NEW_RESEARCHER.getTypeInt())));
   }
 
   @Test
@@ -220,15 +219,12 @@ class EmailServiceTest extends AbstractTestHelper {
     verify(sendGridAPI).sendMessage(any(), eq(user.getEmail()));
     verify(emailDAO)
         .insert(
-            eq(referenceId),
-            isNull(),
-            eq(otherUserId),
-            eq(EmailType.DAR_EXPIRED.getTypeInt()),
-            any(),
-            any(),
-            any(),
-            any(),
-            any());
+            argThat(
+                m ->
+                    Objects.equals(m.entityReferenceId(), referenceId)
+                        && m.voteId() == null
+                        && Objects.equals(m.userId(), otherUserId)
+                        && Objects.equals(m.emailType(), EmailType.DAR_EXPIRED.getTypeInt())));
   }
 
   @Test
@@ -247,15 +243,13 @@ class EmailServiceTest extends AbstractTestHelper {
     verify(sendGridAPI).sendMessage(any(), eq(user.getEmail()));
     verify(emailDAO)
         .insert(
-            eq(referenceId),
-            isNull(),
-            eq(otherUserId),
-            eq(EmailType.DAR_EXPIRATION_REMINDER.getTypeInt()),
-            any(),
-            any(),
-            any(),
-            any(),
-            any());
+            argThat(
+                m ->
+                    Objects.equals(m.entityReferenceId(), referenceId)
+                        && m.voteId() == null
+                        && Objects.equals(m.userId(), otherUserId)
+                        && Objects.equals(
+                            m.emailType(), EmailType.DAR_EXPIRATION_REMINDER.getTypeInt())));
   }
 
   @Test
@@ -279,15 +273,12 @@ class EmailServiceTest extends AbstractTestHelper {
     verify(sendGridAPI).sendMessage(any(), any());
     verify(emailDAO)
         .insert(
-            eq(datasetName),
-            eq(null),
-            eq(456),
-            eq(EmailType.NEW_DATASET.getTypeInt()),
-            any(),
-            any(),
-            any(),
-            any(),
-            any());
+            argThat(
+                m ->
+                    Objects.equals(m.entityReferenceId(), datasetName)
+                        && m.voteId() == null
+                        && Objects.equals(m.userId(), 456)
+                        && Objects.equals(m.emailType(), EmailType.NEW_DATASET.getTypeInt())));
   }
 
   @Test
@@ -309,15 +300,14 @@ class EmailServiceTest extends AbstractTestHelper {
     verify(sendGridAPI).sendMessage(any(), any());
     verify(emailDAO)
         .insert(
-            eq(studyName),
-            eq(null),
-            eq(1), // userId
-            eq(EmailType.NEW_STUDY_REGISTRATION_CONFIRMATION.getTypeInt()),
-            any(),
-            any(),
-            any(),
-            any(),
-            any());
+            argThat(
+                m ->
+                    Objects.equals(m.entityReferenceId(), studyName)
+                        && m.voteId() == null
+                        && Objects.equals(m.userId(), 1)
+                        && Objects.equals(
+                            m.emailType(),
+                            EmailType.NEW_STUDY_REGISTRATION_CONFIRMATION.getTypeInt())));
   }
 
   @Test
@@ -345,15 +335,13 @@ class EmailServiceTest extends AbstractTestHelper {
     verify(sendGridAPI).sendMessage(any(), any());
     verify(emailDAO)
         .insert(
-            eq("DAC-01"),
-            eq(null),
-            eq(user.getUserId()),
-            eq(EmailType.NEW_DAA_UPLOAD_RESEARCHER.getTypeInt()),
-            any(),
-            any(),
-            any(),
-            any(),
-            any());
+            argThat(
+                m ->
+                    Objects.equals(m.entityReferenceId(), "DAC-01")
+                        && m.voteId() == null
+                        && Objects.equals(m.userId(), user.getUserId())
+                        && Objects.equals(
+                            m.emailType(), EmailType.NEW_DAA_UPLOAD_RESEARCHER.getTypeInt())));
   }
 
   @Test
@@ -380,15 +368,13 @@ class EmailServiceTest extends AbstractTestHelper {
     verify(sendGridAPI).sendMessage(any(), any());
     verify(emailDAO)
         .insert(
-            eq("DAC-01"),
-            eq(null),
-            eq(user.getUserId()),
-            eq(EmailType.NEW_DAA_UPLOAD_SO.getTypeInt()),
-            any(),
-            any(),
-            any(),
-            any(),
-            any());
+            argThat(
+                m ->
+                    Objects.equals(m.entityReferenceId(), "DAC-01")
+                        && m.voteId() == null
+                        && Objects.equals(m.userId(), user.getUserId())
+                        && Objects.equals(
+                            m.emailType(), EmailType.NEW_DAA_UPLOAD_SO.getTypeInt())));
   }
 
   @Test
@@ -406,15 +392,13 @@ class EmailServiceTest extends AbstractTestHelper {
     verify(sendGridAPI).sendMessage(any(), eq(user.getEmail()));
     verify(emailDAO)
         .insert(
-            eq(referenceId),
-            isNull(),
-            eq(user.getUserId()),
-            eq(EmailType.RESEARCHER_CLOSEOUT_COMPLETED.getTypeInt()),
-            any(),
-            any(),
-            any(),
-            any(),
-            any());
+            argThat(
+                m ->
+                    Objects.equals(m.entityReferenceId(), referenceId)
+                        && m.voteId() == null
+                        && Objects.equals(m.userId(), user.getUserId())
+                        && Objects.equals(
+                            m.emailType(), EmailType.RESEARCHER_CLOSEOUT_COMPLETED.getTypeInt())));
   }
 
   @Test
@@ -449,15 +433,13 @@ class EmailServiceTest extends AbstractTestHelper {
     verify(sendGridAPI).sendMessage(any(Mail.class), eq(toUser.getEmail()));
     verify(emailDAO)
         .insert(
-            eq(referenceId),
-            eq(null),
-            eq(toUser.getUserId()),
-            eq(EmailType.SUBMITTED_CLOSEOUT.getTypeInt()),
-            any(),
-            any(),
-            any(),
-            any(),
-            any());
+            argThat(
+                m ->
+                    Objects.equals(m.entityReferenceId(), referenceId)
+                        && m.voteId() == null
+                        && Objects.equals(m.userId(), toUser.getUserId())
+                        && Objects.equals(
+                            m.emailType(), EmailType.SUBMITTED_CLOSEOUT.getTypeInt())));
   }
 
   @Test
@@ -472,15 +454,13 @@ class EmailServiceTest extends AbstractTestHelper {
     verify(sendGridAPI).sendMessage(any(Mail.class), eq(toUser.getEmail()));
     verify(emailDAO)
         .insert(
-            eq(toUser.getEmail()),
-            eq(null),
-            eq(toUser.getUserId()),
-            eq(EmailType.NEW_LIBRARY_CARD_ISSUED.getTypeInt()),
-            any(),
-            any(),
-            any(),
-            any(),
-            any());
+            argThat(
+                m ->
+                    Objects.equals(m.entityReferenceId(), toUser.getEmail())
+                        && m.voteId() == null
+                        && Objects.equals(m.userId(), toUser.getUserId())
+                        && Objects.equals(
+                            m.emailType(), EmailType.NEW_LIBRARY_CARD_ISSUED.getTypeInt())));
   }
 
   @Test
@@ -505,15 +485,13 @@ class EmailServiceTest extends AbstractTestHelper {
     verify(sendGridAPI).sendMessage(any(Mail.class), eq(toUser.getEmail()));
     verify(emailDAO)
         .insert(
-            eq(referenceId),
-            eq(null),
-            eq(toUser.getUserId()),
-            eq(EmailType.DAC_RADAR_APPROVED.getTypeInt()),
-            any(),
-            any(),
-            any(),
-            any(),
-            any());
+            argThat(
+                m ->
+                    Objects.equals(m.entityReferenceId(), referenceId)
+                        && m.voteId() == null
+                        && Objects.equals(m.userId(), toUser.getUserId())
+                        && Objects.equals(
+                            m.emailType(), EmailType.DAC_RADAR_APPROVED.getTypeInt())));
   }
 
   @Test
@@ -535,15 +513,13 @@ class EmailServiceTest extends AbstractTestHelper {
     verify(sendGridAPI).sendMessage(any(Mail.class), eq(signingOfficial.getEmail()));
     verify(emailDAO)
         .insert(
-            eq(referenceId),
-            eq(null),
-            eq(signingOfficial.getUserId()),
-            eq(EmailType.NEW_DAR_SO_NEEDS_TO_APPROVE.getTypeInt()),
-            any(),
-            any(),
-            any(),
-            any(),
-            any());
+            argThat(
+                m ->
+                    Objects.equals(m.entityReferenceId(), referenceId)
+                        && m.voteId() == null
+                        && Objects.equals(m.userId(), signingOfficial.getUserId())
+                        && Objects.equals(
+                            m.emailType(), EmailType.NEW_DAR_SO_NEEDS_TO_APPROVE.getTypeInt())));
   }
 
   @Test
@@ -583,15 +559,11 @@ class EmailServiceTest extends AbstractTestHelper {
 
     verify(emailDAO, times(1))
         .insert(
-            any(),
-            any(),
-            eq(user2.getUserId()),
-            eq(EmailType.DAC_VOTE_REMINDER_DIGEST.getTypeInt()),
-            any(),
-            any(),
-            any(),
-            any(),
-            any());
+            argThat(
+                m ->
+                    Objects.equals(m.userId(), user2.getUserId())
+                        && Objects.equals(
+                            m.emailType(), EmailType.DAC_VOTE_REMINDER_DIGEST.getTypeInt())));
   }
 
   @Test
@@ -652,15 +624,10 @@ class EmailServiceTest extends AbstractTestHelper {
     verify(userDAO, times(1)).getHandle();
     verify(emailDAO, times(1))
         .insert(
-            any(),
-            any(),
-            eq(toUser.getUserId()),
-            eq(EmailType.NEW_STUDY_DIGEST.getTypeInt()),
-            any(),
-            any(),
-            any(),
-            any(),
-            any());
+            argThat(
+                m ->
+                    Objects.equals(m.userId(), toUser.getUserId())
+                        && Objects.equals(m.emailType(), EmailType.NEW_STUDY_DIGEST.getTypeInt())));
   }
 
   @Test


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DT-245

## Summary
This started out as a formatting PR, but there were several other errors that needed addressing so I ended up doing some significant refactoring:

* The `MailMessage` object did not have a field for `entity_reference_id` so that was added
* The create and update dates were being truncated so those are now populated from Timestamps in the mapper
* The `email_type` was being stored as an integer but coerced to a string in the model. It is now an integer
* `MailMessage` is now a record class
* Sonarqube warned about `MailMessageDAO.insert` argument count being too large so that is now a `@BindMethods` argument that takes a single populated object instead.
* While I was there, I modified the insert to return the populated object instead of just the ID.
* Many, many test updates to cover the changes.

### Testing Notes
This is fairly easily testable using Swagger. The Notifier section has a reminder API that can be used. Look for a recent vote id in the votes table. After sending a reminder, that email should show up in the email_entity table.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
