### PR TITLE
[DT-3163] Memorialize and make available the dar->dataset->daa relationship

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/DaaDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DaaDAO.java
@@ -384,6 +384,17 @@ public interface DaaDAO extends Transactional<DaaDAO> {
 
   @SqlUpdate(
       """
+          DELETE FROM dar_dataset_daa_snapshot
+          WHERE dar_id = (
+              SELECT id
+              FROM data_access_request
+              WHERE reference_id = :referenceId
+          )
+          """)
+  void deleteDarDatasetDaaSnapshotsByReferenceId(@Bind("referenceId") String referenceId);
+
+  @SqlUpdate(
+      """
       DELETE FROM dar_daa WHERE dar_id = :darId
     """)
   void deleteDarDAARelationship(@Bind("darId") Integer darId);

--- a/src/main/java/org/broadinstitute/consent/http/db/DaaDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DaaDAO.java
@@ -1,6 +1,7 @@
 package org.broadinstitute.consent.http.db;
 
 import java.time.Instant;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -11,12 +12,17 @@ import org.broadinstitute.consent.http.db.mapper.DataAccessAgreementReducer;
 import org.broadinstitute.consent.http.db.mapper.FileStorageObjectMapper;
 import org.broadinstitute.consent.http.models.DaaAudit;
 import org.broadinstitute.consent.http.models.Dac;
+import org.broadinstitute.consent.http.models.DarDatasetDaaSnapshot;
 import org.broadinstitute.consent.http.models.DataAccessAgreement;
+import org.broadinstitute.consent.http.models.DatasetDaaMapping;
+import org.broadinstitute.consent.http.models.DatasetDaaSnapshotDetail;
 import org.jdbi.v3.sqlobject.config.RegisterBeanMapper;
+import org.jdbi.v3.sqlobject.config.RegisterConstructorMapper;
 import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
 import org.jdbi.v3.sqlobject.customizer.Bind;
 import org.jdbi.v3.sqlobject.customizer.BindList;
 import org.jdbi.v3.sqlobject.customizer.BindList.EmptyHandling;
+import org.jdbi.v3.sqlobject.customizer.BindMethods;
 import org.jdbi.v3.sqlobject.statement.SqlBatch;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
@@ -337,6 +343,44 @@ public interface DaaDAO extends Transactional<DaaDAO> {
         ON CONFLICT DO NOTHING
     """)
   void insertDarDAARelationship(@Bind("darId") Integer darId, @Bind("daaId") Set<Integer> daaIds);
+
+  @RegisterConstructorMapper(DatasetDaaMapping.class)
+  @SqlQuery(
+      """
+          SELECT dataset.dataset_id AS datasetId, daa.daa_id AS daaId
+          FROM dataset
+          INNER JOIN dac ON dataset.dac_id = dac.dac_id
+          INNER JOIN dac_daa ON dac.dac_id = dac_daa.dac_id
+          INNER JOIN data_access_agreement daa ON dac_daa.daa_id = daa.daa_id
+          WHERE dataset.dataset_id IN (<datasetIds>)
+          ORDER BY dataset.dataset_id
+          """)
+  List<DatasetDaaMapping> findCurrentDaaMappingsByDatasetIds(
+      @BindList(value = "datasetIds", onEmpty = EmptyHandling.NULL_STRING)
+          List<Integer> datasetIds);
+
+  @SqlBatch(
+      """
+          INSERT INTO dar_dataset_daa_snapshot (dar_id, dataset_id, daa_id, captured_at)
+          VALUES (:darId, :datasetId, :daaId, :capturedAt)
+          ON CONFLICT (dar_id, dataset_id)
+          DO UPDATE SET daa_id = EXCLUDED.daa_id, captured_at = EXCLUDED.captured_at
+          """)
+  void insertDarDatasetDaaSnapshots(@BindMethods Collection<DarDatasetDaaSnapshot> snapshots);
+
+  @RegisterConstructorMapper(DatasetDaaSnapshotDetail.class)
+  @SqlQuery(
+      """
+          SELECT ddds.dataset_id AS datasetId,
+                 ddds.daa_id AS daaId,
+                 ddds.captured_at AS capturedAt
+          FROM dar_dataset_daa_snapshot ddds
+          INNER JOIN data_access_request dar ON ddds.dar_id = dar.id
+          WHERE dar.reference_id = :referenceId
+          ORDER BY ddds.dataset_id
+          """)
+  List<DatasetDaaSnapshotDetail> findDatasetDaaSnapshotsByReferenceId(
+      @Bind("referenceId") String referenceId);
 
   @SqlUpdate(
       """

--- a/src/main/java/org/broadinstitute/consent/http/models/DarDatasetDaaSnapshot.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DarDatasetDaaSnapshot.java
@@ -1,0 +1,6 @@
+package org.broadinstitute.consent.http.models;
+
+import java.sql.Timestamp;
+
+public record DarDatasetDaaSnapshot(
+    Integer darId, Integer datasetId, Integer daaId, Timestamp capturedAt) {}

--- a/src/main/java/org/broadinstitute/consent/http/models/DatasetDaaMapping.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DatasetDaaMapping.java
@@ -1,0 +1,3 @@
+package org.broadinstitute.consent.http.models;
+
+public record DatasetDaaMapping(Integer datasetId, Integer daaId) {}

--- a/src/main/java/org/broadinstitute/consent/http/models/DatasetDaaSnapshot.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DatasetDaaSnapshot.java
@@ -1,0 +1,5 @@
+package org.broadinstitute.consent.http.models;
+
+import java.sql.Timestamp;
+
+public record DatasetDaaSnapshot(Integer daaId, Timestamp capturedAt) {}

--- a/src/main/java/org/broadinstitute/consent/http/models/DatasetDaaSnapshotDetail.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DatasetDaaSnapshotDetail.java
@@ -1,0 +1,5 @@
+package org.broadinstitute.consent.http.models;
+
+import java.sql.Timestamp;
+
+public record DatasetDaaSnapshotDetail(Integer datasetId, Integer daaId, Timestamp capturedAt) {}

--- a/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
@@ -29,8 +29,11 @@ import java.io.InputStream;
 import java.net.URI;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.UUID;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.consent.http.cloudstore.GCSService;
 import org.broadinstitute.consent.http.enumeration.DarDocumentType;
@@ -39,16 +42,19 @@ import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.exceptions.LibraryCardRequiredException;
 import org.broadinstitute.consent.http.exceptions.SubmittedDARCannotBeEditedException;
 import org.broadinstitute.consent.http.models.AuthUser;
+import org.broadinstitute.consent.http.models.Dac;
 import org.broadinstitute.consent.http.models.DataAccessAgreement;
 import org.broadinstitute.consent.http.models.DataAccessRequest;
 import org.broadinstitute.consent.http.models.DataAccessRequestData;
 import org.broadinstitute.consent.http.models.DataUse;
 import org.broadinstitute.consent.http.models.Dataset;
+import org.broadinstitute.consent.http.models.DatasetDaaSnapshot;
 import org.broadinstitute.consent.http.models.DuosUser;
 import org.broadinstitute.consent.http.models.Election;
 import org.broadinstitute.consent.http.models.Error;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.service.DaaService;
+import org.broadinstitute.consent.http.service.DacService;
 import org.broadinstitute.consent.http.service.DarCollectionService;
 import org.broadinstitute.consent.http.service.DataAccessRequestService;
 import org.broadinstitute.consent.http.service.DatasetService;
@@ -63,6 +69,7 @@ import org.glassfish.jersey.server.ContainerRequest;
 public class DataAccessRequestResource extends Resource {
 
   private final DaaService daaService;
+  private final DacService dacService;
   private final DataAccessRequestService dataAccessRequestService;
   private final DarCollectionService darCollectionService;
   private final GCSService gcsService;
@@ -73,6 +80,7 @@ public class DataAccessRequestResource extends Resource {
   @Inject
   public DataAccessRequestResource(
       DaaService daaService,
+      DacService dacService,
       DataAccessRequestService dataAccessRequestService,
       GCSService gcsService,
       UserService userService,
@@ -80,6 +88,7 @@ public class DataAccessRequestResource extends Resource {
       MatchService matchService,
       DarCollectionService darCollectionService) {
     this.daaService = daaService;
+    this.dacService = dacService;
     this.dataAccessRequestService = dataAccessRequestService;
     this.gcsService = gcsService;
     this.userService = userService;
@@ -134,12 +143,12 @@ public class DataAccessRequestResource extends Resource {
   @PermitAll
   public Response getByReferenceId(
       @Auth DuosUser duosUser, @PathParam("referenceId") String referenceId) {
-    validateAuthedRoleUser(
-        List.of(
-            UserRoles.ADMIN, UserRoles.CHAIRPERSON, UserRoles.MEMBER, UserRoles.SIGNINGOFFICIAL),
-        duosUser,
-        referenceId);
     try {
+      validateAuthedRoleUser(
+          List.of(
+              UserRoles.ADMIN, UserRoles.CHAIRPERSON, UserRoles.MEMBER, UserRoles.SIGNINGOFFICIAL),
+          duosUser,
+          referenceId);
       DataAccessRequest dar = dataAccessRequestService.findByReferenceId(referenceId);
       if (Objects.nonNull(dar)) {
         return Response.status(Response.Status.OK).entity(dar.convertToSimplifiedDar()).build();
@@ -166,6 +175,26 @@ public class DataAccessRequestResource extends Resource {
           List.of(UserRoles.ADMIN, UserRoles.CHAIRPERSON, UserRoles.MEMBER), duosUser, referenceId);
       List<DataAccessAgreement> dataAccessAgreements = daaService.findByDarReferenceId(referenceId);
       return Response.status(Response.Status.OK).entity(dataAccessAgreements).build();
+    } catch (Exception e) {
+      return createExceptionResponse(e);
+    }
+  }
+
+  @GET
+  @Path("/v2/{referenceId}/dataset-daa-snapshots")
+  @Produces("application/json")
+  @PermitAll
+  public Response getDatasetDaaSnapshotsByReferenceId(
+      @Auth DuosUser duosUser, @PathParam("referenceId") String referenceId) {
+    try {
+      validateAuthedRoleUser(
+          List.of(
+              UserRoles.ADMIN, UserRoles.CHAIRPERSON, UserRoles.MEMBER, UserRoles.SIGNINGOFFICIAL),
+          duosUser,
+          referenceId);
+      Map<Integer, DatasetDaaSnapshot> snapshots =
+          dataAccessRequestService.findDatasetDaaSnapshotsByReferenceId(referenceId);
+      return Response.status(Response.Status.OK).entity(snapshots).build();
     } catch (Exception e) {
       return createExceptionResponse(e);
     }
@@ -662,6 +691,13 @@ public class DataAccessRequestResource extends Resource {
    * access the resource. In practice, pass in allowableRoles for users that are not the create user
    * (i.e. Admin) so they can also have access to the DAR.
    *
+   * <p>Additional restrictions apply for non-admin, non-creator users:
+   *
+   * <ul>
+   *   <li>CHAIRPERSON / MEMBER: must belong to a DAC that governs at least one dataset on the DAR.
+   *   <li>SIGNINGOFFICIAL: must share an institution with the DAR creator.
+   * </ul>
+   *
    * @param allowableRoles List of roles that would allow the user to access the resource
    * @param duosUser The DuosUser
    * @param referenceId The referenceId of the resource.
@@ -677,6 +713,56 @@ public class DataAccessRequestResource extends Resource {
       logWarn("DataAccessRequest '" + referenceId + "' has an invalid userId");
       super.validateAuthedRoleUser(allowableRoles, user, dataAccessRequest.getUserId());
     }
+
+    boolean isCreator =
+        Objects.nonNull(dataAccessRequest.getUserId())
+            && dataAccessRequest.getUserId().equals(user.getUserId());
+    boolean isAdmin = user.hasUserRole(UserRoles.ADMIN);
+
+    if (!isCreator && !isAdmin) {
+      if (user.hasUserRole(UserRoles.CHAIRPERSON) || user.hasUserRole(UserRoles.MEMBER)) {
+        validateDacMembership(user, dataAccessRequest);
+      }
+      if (user.hasUserRole(UserRoles.SIGNINGOFFICIAL)) {
+        validateSigningOfficialInstitution(user, dataAccessRequest);
+      }
+    }
+
     return dataAccessRequest;
+  }
+
+  /**
+   * Verifies that the user is a chair or member of at least one DAC that governs a dataset
+   * referenced by the given DAR.
+   */
+  private void validateDacMembership(User user, DataAccessRequest dar) {
+    List<Integer> datasetIds = dar.getDatasetIds();
+    if (CollectionUtils.isEmpty(datasetIds)) {
+      throw new ForbiddenException("User does not have permission");
+    }
+    Set<Dac> dacsForDatasets = dacService.findByDatasetId(datasetIds);
+    boolean isMember =
+        dacsForDatasets.stream()
+            .anyMatch(
+                dac ->
+                    (dac.getChairpersons() != null
+                            && dac.getChairpersons().stream()
+                                .anyMatch(c -> c.getUserId().equals(user.getUserId())))
+                        || (dac.getMembers() != null
+                            && dac.getMembers().stream()
+                                .anyMatch(m -> m.getUserId().equals(user.getUserId()))));
+    if (!isMember) {
+      throw new ForbiddenException("User does not have permission");
+    }
+  }
+
+  /** Verifies that the signing official shares an institution with the user who created the DAR. */
+  private void validateSigningOfficialInstitution(User signingOfficial, DataAccessRequest dar) {
+    User darCreator = userService.findUserById(dar.getUserId());
+    if (darCreator == null
+        || signingOfficial.getInstitutionId() == null
+        || !signingOfficial.getInstitutionId().equals(darCreator.getInstitutionId())) {
+      throw new ForbiddenException("User does not have permission");
+    }
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
@@ -30,6 +30,7 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.broadinstitute.consent.http.db.DaaDAO;
 import org.broadinstitute.consent.http.db.DacDAO;
 import org.broadinstitute.consent.http.db.DarCollectionDAO;
 import org.broadinstitute.consent.http.db.DarCollectionSummaryDAO;
@@ -66,6 +67,7 @@ public class DarCollectionService implements ConsentLogger {
 
   private final SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
   private final DacDAO dacDAO;
+  private final DaaDAO daaDAO;
   private final DarCollectionDAO darCollectionDAO;
   private final DarCollectionSummaryDAO darCollectionSummaryDAO;
   private final DataAccessRequestDAO dataAccessRequestDAO;
@@ -84,6 +86,7 @@ public class DarCollectionService implements ConsentLogger {
       EmailService emailService,
       DACAutomationRuleService dacAutomationRuleService) {
     this.dacDAO = jdbi.onDemand(DacDAO.class);
+    this.daaDAO = jdbi.onDemand(DaaDAO.class);
     this.darCollectionDAO = jdbi.onDemand(DarCollectionDAO.class);
     this.darCollectionSummaryDAO = jdbi.onDemand(DarCollectionSummaryDAO.class);
     this.dataAccessRequestDAO = jdbi.onDemand(DataAccessRequestDAO.class);
@@ -491,6 +494,7 @@ public class DarCollectionService implements ConsentLogger {
                   new Gson().fromJson(d.getData().toString(), DataAccessRequestData.class);
               newData.setStatus(null);
               newData.setReferenceId(d.getReferenceId());
+              daaDAO.deleteDarDatasetDaaSnapshotsByReferenceId(d.getReferenceId());
               dataAccessRequestDAO.updateDataByReferenceId(
                   d.getReferenceId(), d.getUserId(), null, now, newData, null);
             });

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
@@ -18,7 +18,9 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
@@ -44,9 +46,13 @@ import org.broadinstitute.consent.http.models.Collaborator;
 import org.broadinstitute.consent.http.models.Dac;
 import org.broadinstitute.consent.http.models.DarCollection;
 import org.broadinstitute.consent.http.models.DarDataset;
+import org.broadinstitute.consent.http.models.DarDatasetDaaSnapshot;
 import org.broadinstitute.consent.http.models.DataAccessRequest;
 import org.broadinstitute.consent.http.models.DataAccessRequestData;
 import org.broadinstitute.consent.http.models.Dataset;
+import org.broadinstitute.consent.http.models.DatasetDaaMapping;
+import org.broadinstitute.consent.http.models.DatasetDaaSnapshot;
+import org.broadinstitute.consent.http.models.DatasetDaaSnapshotDetail;
 import org.broadinstitute.consent.http.models.Election;
 import org.broadinstitute.consent.http.models.Institution;
 import org.broadinstitute.consent.http.models.User;
@@ -262,6 +268,7 @@ public class DataAccessRequestService implements ConsentLogger {
     }
     daaDAO.insertDarDAARelationship(darId, dataAccessRequest.data.getDaaIds());
     syncDataAccessRequestDatasets(datasetIds, referenceId);
+    captureDatasetDaaSnapshots(darId, datasetIds, new Timestamp(now.getTime()));
     boolean requiresSOApproval = flagIfSOApprovalIsNeeded(user, datasetIds, referenceId);
     if (!requiresSOApproval) {
       ruleService.triggerDACRuleSettings(user, datasetIds, referenceId, request);
@@ -294,8 +301,9 @@ public class DataAccessRequestService implements ConsentLogger {
       throw new BadRequestException(
           "Progress report can only be created for approved datasets in the parent DAR");
     }
+    Integer id;
     try {
-      Integer id =
+      id =
           dataAccessRequestDAO.insertProgressReport(
               progressReport.getParentId(),
               progressReport.getCollectionId(),
@@ -330,6 +338,9 @@ public class DataAccessRequestService implements ConsentLogger {
     }
 
     syncDataAccessRequestDatasets(progressReportDatasetIds, referenceId);
+    if (!progressReport.getIsCloseoutProgressReport()) {
+      captureDatasetDaaSnapshots(id, progressReportDatasetIds, Timestamp.from(Instant.now()));
+    }
 
     if (!progressReport.getIsCloseoutProgressReport()
         && !progressReport.getHasDMI()
@@ -338,6 +349,23 @@ public class DataAccessRequestService implements ConsentLogger {
     }
 
     return findByReferenceId(referenceId);
+  }
+
+  public Map<Integer, DatasetDaaSnapshot> findDatasetDaaSnapshotsByReferenceId(String referenceId) {
+    findByReferenceId(referenceId);
+    List<DatasetDaaSnapshotDetail> snapshots =
+        Objects.requireNonNullElse(
+            daaDAO.findDatasetDaaSnapshotsByReferenceId(referenceId), List.of());
+    if (snapshots.isEmpty()) {
+      throw new NotFoundException(
+          "No dataset to DAA snapshot found for Data Access Request reference Id");
+    }
+    Map<Integer, DatasetDaaSnapshot> result = new LinkedHashMap<>();
+    for (DatasetDaaSnapshotDetail snapshot : snapshots) {
+      result.put(
+          snapshot.datasetId(), new DatasetDaaSnapshot(snapshot.daaId(), snapshot.capturedAt()));
+    }
+    return result;
   }
 
   public void approveDataAccessRequestCloseout(User signingOfficial, String referenceId) {
@@ -791,5 +819,23 @@ public class DataAccessRequestService implements ConsentLogger {
       return true;
     }
     return false;
+  }
+
+  private void captureDatasetDaaSnapshots(
+      Integer darId, List<Integer> datasetIds, Timestamp capturedAt) {
+    List<DatasetDaaMapping> datasetDaaMappings =
+        Objects.requireNonNullElse(
+            daaDAO.findCurrentDaaMappingsByDatasetIds(datasetIds), List.of());
+    if (datasetDaaMappings.isEmpty()) {
+      return;
+    }
+    List<DarDatasetDaaSnapshot> snapshots =
+        datasetDaaMappings.stream()
+            .map(
+                mapping ->
+                    new DarDatasetDaaSnapshot(
+                        darId, mapping.datasetId(), mapping.daaId(), capturedAt))
+            .toList();
+    daaDAO.insertDarDatasetDaaSnapshots(snapshots);
   }
 }

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -245,6 +245,9 @@ paths:
   /api/dar/v2/{referenceId}/daas:
     $ref: './paths/darV2DAAsByReferenceId.yaml'
 
+  /api/dar/v2/{referenceId}/dataset-daa-snapshots:
+    $ref: './paths/darV2DatasetDaaSnapshotsByReferenceId.yaml'
+
   /api/dar/v2/draft:
     post:
       deprecated: true
@@ -1032,6 +1035,8 @@ components:
       $ref: './schemas/DataAccessRequest.yaml'
     Dataset:
       $ref: './schemas/Dataset.yaml'
+    DatasetDaaSnapshot:
+      $ref: './schemas/DatasetDaaSnapshot.yaml'
     DatasetApproval:
       $ref: './schemas/DatasetApproval.yaml'
     DatasetProperty:

--- a/src/main/resources/assets/paths/darV2DatasetDaaSnapshotsByReferenceId.yaml
+++ b/src/main/resources/assets/paths/darV2DatasetDaaSnapshotsByReferenceId.yaml
@@ -1,5 +1,6 @@
 get:
   summary: Get dataset to DAA snapshots for a Data Access Request or Progress Report by reference Id
+  operationId: getDatasetDaaSnapshotsByReferenceId
   description: Returns a map of dataset IDs to the DAA snapshot that was captured when the DAR or non-closeout progress report was submitted.
   parameters:
     - name: referenceId

--- a/src/main/resources/assets/paths/darV2DatasetDaaSnapshotsByReferenceId.yaml
+++ b/src/main/resources/assets/paths/darV2DatasetDaaSnapshotsByReferenceId.yaml
@@ -1,0 +1,27 @@
+get:
+  summary: Get dataset to DAA snapshots for a Data Access Request or Progress Report by reference Id
+  description: Returns a map of dataset IDs to the DAA snapshot that was captured when the DAR or non-closeout progress report was submitted.
+  parameters:
+    - name: referenceId
+      in: path
+      description: The referenceId of the Data Access Request or Progress Report
+      required: true
+      schema:
+        type: string
+  tags:
+    - DAA
+    - Data Access Request
+  responses:
+    200:
+      description: Returns the dataset to DAA snapshot map
+      content:
+        application/json:
+          schema:
+            type: object
+            additionalProperties:
+              $ref: '../schemas/DatasetDaaSnapshot.yaml'
+    404:
+      description: No DAR or Progress Report can be found with the provided identifier, or no dataset to DAA snapshot map exists for it
+    500:
+      description: Server Error
+

--- a/src/main/resources/assets/schemas/DatasetDaaSnapshot.yaml
+++ b/src/main/resources/assets/schemas/DatasetDaaSnapshot.yaml
@@ -1,5 +1,5 @@
 type: object
-description: Snapshot of the DAA associated to a dataset when a DAR or progress report was submitted.
+description: Snapshot of the DAA associated to a dataset when a DAR or non-closeout progress report was submitted.
 required:
   - daaId
   - capturedAt
@@ -8,6 +8,7 @@ properties:
     type: integer
     description: The DAA ID captured for the dataset.
   capturedAt:
-    type: number
+    type: integer
+    format: int64
     description: When the snapshot was captured, in milliseconds since the epoch.
 

--- a/src/main/resources/assets/schemas/DatasetDaaSnapshot.yaml
+++ b/src/main/resources/assets/schemas/DatasetDaaSnapshot.yaml
@@ -1,0 +1,13 @@
+type: object
+description: Snapshot of the DAA associated to a dataset when a DAR or progress report was submitted.
+required:
+  - daaId
+  - capturedAt
+properties:
+  daaId:
+    type: integer
+    description: The DAA ID captured for the dataset.
+  capturedAt:
+    type: number
+    description: When the snapshot was captured, in milliseconds since the epoch.
+

--- a/src/main/resources/changelog-master.xml
+++ b/src/main/resources/changelog-master.xml
@@ -246,4 +246,5 @@
   <include file="changesets/changelog-consent-2026-04-24-dac-soft-delete.xml" relativeToChangelogFile="true" />
   <include file="changesets/changelog-consent-2026-04-23-dar-admin-notes.xml" relativeToChangelogFile="true" />
   <include file="changesets/changelog-consent-2026-04-08-dar-daa.xml" relativeToChangelogFile="true" />
+  <include file="changesets/changelog-consent-2026-04-28-dar-dataset-daa-snapshot.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/src/main/resources/changesets/changelog-consent-2026-04-28-dar-dataset-daa-snapshot.xml
+++ b/src/main/resources/changesets/changelog-consent-2026-04-28-dar-dataset-daa-snapshot.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+  <changeSet id="changelog-consent-2026-04-28-dar-dataset-daa-snapshot" author="copilot">
+    <createTable tableName="dar_dataset_daa_snapshot">
+      <column name="dar_id" type="bigint">
+        <constraints nullable="false"
+                     foreignKeyName="fkDarDatasetDaaSnapshot_DarId"
+                     referencedTableName="data_access_request"
+                     referencedColumnNames="id"/>
+      </column>
+      <column name="dataset_id" type="bigint">
+        <constraints nullable="false"
+                     foreignKeyName="fkDarDatasetDaaSnapshot_DatasetId"
+                     referencedTableName="dataset"
+                     referencedColumnNames="dataset_id"/>
+      </column>
+      <column name="daa_id" type="bigint">
+        <constraints nullable="false"
+                     foreignKeyName="fkDarDatasetDaaSnapshot_DaaId"
+                     referencedTableName="data_access_agreement"
+                     referencedColumnNames="daa_id"/>
+      </column>
+      <column name="captured_at" type="timestamp">
+        <constraints nullable="false"/>
+      </column>
+    </createTable>
+    <addUniqueConstraint tableName="dar_dataset_daa_snapshot"
+                         columnNames="dar_id,dataset_id"
+                         constraintName="uq_dar_dataset_daa_snapshot_dar_dataset"/>
+    <createIndex indexName="idx_dar_dataset_daa_snapshot_dar_id"
+                 tableName="dar_dataset_daa_snapshot">
+      <column name="dar_id"/>
+    </createIndex>
+    <createIndex indexName="idx_dar_dataset_daa_snapshot_dataset_id"
+                 tableName="dar_dataset_daa_snapshot">
+      <column name="dataset_id"/>
+    </createIndex>
+    <createIndex indexName="idx_dar_dataset_daa_snapshot_daa_id"
+                 tableName="dar_dataset_daa_snapshot">
+      <column name="daa_id"/>
+    </createIndex>
+  </changeSet>
+</databaseChangeLog>
+

--- a/src/main/resources/changesets/changelog-consent-2026-04-28-dar-dataset-daa-snapshot.xml
+++ b/src/main/resources/changesets/changelog-consent-2026-04-28-dar-dataset-daa-snapshot.xml
@@ -3,7 +3,7 @@
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                    https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
-  <changeSet id="changelog-consent-2026-04-28-dar-dataset-daa-snapshot" author="copilot">
+  <changeSet id="changelog-consent-2026-04-28-dar-dataset-daa-snapshot" author="otchet">
     <createTable tableName="dar_dataset_daa_snapshot">
       <column name="dar_id" type="bigint">
         <constraints nullable="false"

--- a/src/test/java/org/broadinstitute/consent/http/db/DaaDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DaaDAOTest.java
@@ -19,19 +19,21 @@ import org.broadinstitute.consent.http.enumeration.AuditActions;
 import org.broadinstitute.consent.http.enumeration.FileCategory;
 import org.broadinstitute.consent.http.models.DaaAudit;
 import org.broadinstitute.consent.http.models.Dac;
+import org.broadinstitute.consent.http.models.DarDatasetDaaSnapshot;
 import org.broadinstitute.consent.http.models.DataAccessAgreement;
 import org.broadinstitute.consent.http.models.DataAccessRequest;
 import org.broadinstitute.consent.http.models.DataAccessRequestData;
 import org.broadinstitute.consent.http.models.DataUseBuilder;
 import org.broadinstitute.consent.http.models.Dataset;
+import org.broadinstitute.consent.http.models.DatasetDaaMapping;
+import org.broadinstitute.consent.http.models.DatasetDaaSnapshotDetail;
 import org.broadinstitute.consent.http.models.LibraryCard;
 import org.broadinstitute.consent.http.models.User;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.junit.jupiter.MockitoExtension;
 
-@ExtendWith(MockitoExtension.class)
 class DaaDAOTest extends DAOTestHelper {
+
+  private static final int NON_EXISTENT_ID = Integer.MAX_VALUE;
 
   private Integer createUserId() {
     return createUser().getUserId();
@@ -124,7 +126,7 @@ class DaaDAOTest extends DAOTestHelper {
 
   @Test
   void testFindByIdInvalid() {
-    DataAccessAgreement daa3 = daaDAO.findById(randomInt(10000, 100000));
+    DataAccessAgreement daa3 = daaDAO.findById(NON_EXISTENT_ID);
     assertNull(daa3);
   }
 
@@ -144,7 +146,7 @@ class DaaDAOTest extends DAOTestHelper {
     DataAccessAgreement daa2 = daaDAO.findByDacId(dacId2);
     assertNotNull(daa2);
     assertEquals(daa2.getInitialDacId(), dacId2);
-    DataAccessAgreement daa3 = daaDAO.findByDacId(3);
+    DataAccessAgreement daa3 = daaDAO.findByDacId(NON_EXISTENT_ID);
     assertNull(daa3);
   }
 
@@ -173,13 +175,13 @@ class DaaDAOTest extends DAOTestHelper {
 
     // Assert new relations exist
     DataAccessAgreement testDAA1 = daaDAO.findById(daa1.getDaaId());
-    assertTrue(testDAA1.getDacs().stream().map(Dac::getDacId).toList().contains(dacId));
-    assertFalse(testDAA1.getDacs().stream().map(Dac::getDacId).toList().contains(dacId2));
-    assertFalse(testDAA1.getDacs().stream().map(Dac::getDacId).toList().contains(dacId3));
+    assertTrue(dacIdIn(testDAA1, dacId));
+    assertFalse(dacIdIn(testDAA1, dacId2));
+    assertFalse(dacIdIn(testDAA1, dacId3));
     DataAccessAgreement testDAA2 = daaDAO.findById(daa2.getDaaId());
-    assertFalse(testDAA2.getDacs().stream().map(Dac::getDacId).toList().contains(dacId));
-    assertTrue(testDAA2.getDacs().stream().map(Dac::getDacId).toList().contains(dacId2));
-    assertTrue(testDAA2.getDacs().stream().map(Dac::getDacId).toList().contains(dacId3));
+    assertFalse(dacIdIn(testDAA2, dacId));
+    assertTrue(dacIdIn(testDAA2, dacId2));
+    assertTrue(dacIdIn(testDAA2, dacId3));
 
     // Assert that ADD audit records are created.
     List<DaaAudit> daa1Audits = daaDAO.findAuditsByDaaId(daa1.getDaaId());
@@ -341,7 +343,7 @@ class DaaDAOTest extends DAOTestHelper {
     assertNotNull(daaBefore);
     assertNotNull(daaBefore.getDacs());
     assertFalse(daaBefore.getDacs().isEmpty());
-    assertTrue(daaBefore.getDacs().stream().map(Dac::getDacId).toList().contains(dacId));
+    assertTrue(dacIdIn(daaBefore, dacId));
 
     // Soft-delete the DAC
     dacDAO.deleteDac(dacId, userId);
@@ -376,8 +378,8 @@ class DaaDAOTest extends DAOTestHelper {
     DataAccessAgreement daaAfter = daasAfterDelete.getFirst();
     assertNotNull(daaAfter.getDacs());
     assertEquals(1, daaAfter.getDacs().size());
-    assertTrue(daaAfter.getDacs().stream().map(Dac::getDacId).toList().contains(dacId1));
-    assertFalse(daaAfter.getDacs().stream().map(Dac::getDacId).toList().contains(dacId2));
+    assertTrue(dacIdIn(daaAfter, dacId1));
+    assertFalse(dacIdIn(daaAfter, dacId2));
   }
 
   @Test
@@ -526,7 +528,9 @@ class DaaDAOTest extends DAOTestHelper {
 
   @Test
   void testFindDaaIdsWithDatasetIds_No_Data() {
-    Map<Integer, Set<Integer>> daaDatasetMap = daaDAO.mapDaaIdsToDatasetIds(Set.of(1, 2, 3));
+    Map<Integer, Set<Integer>> daaDatasetMap =
+        daaDAO.mapDaaIdsToDatasetIds(
+            Set.of(NON_EXISTENT_ID - 2, NON_EXISTENT_ID - 1, NON_EXISTENT_ID));
     assertTrue(daaDatasetMap.isEmpty());
   }
 
@@ -586,6 +590,130 @@ class DaaDAOTest extends DAOTestHelper {
 
     daaDAO.deleteDarDAARelationship(prId);
     assertEquals(0, getDarDaaCount(prId));
+  }
+
+  @Test
+  void testFindCurrentDaaMappingsByDatasetIds() {
+    Integer userId = createUserId();
+    Integer dacId1 = dacDAO.createDac("dac1", randomAlphabetic(5), "", userId);
+    Integer dacId2 = dacDAO.createDac("dac2", randomAlphabetic(5), "", userId);
+    Dataset dataset1 = createRandomDataset(userDAO.findUserById(userId), dacDAO.findById(dacId1));
+    Dataset dataset2 = createRandomDataset(userDAO.findUserById(userId), dacDAO.findById(dacId2));
+
+    Integer daa1 = daaDAO.createDaa(userId, Instant.now(), userId, Instant.now(), dacId1);
+    Integer daa2 = daaDAO.createDaa(userId, Instant.now(), userId, Instant.now(), dacId2);
+    daaDAO.createDacDaaRelation(dacId1, daa1, userId);
+    daaDAO.createDacDaaRelation(dacId2, daa2, userId);
+
+    List<DatasetDaaMapping> mappings =
+        daaDAO.findCurrentDaaMappingsByDatasetIds(
+            List.of(dataset1.getDatasetId(), dataset2.getDatasetId()));
+
+    assertEquals(2, mappings.size());
+    assertTrue(
+        mappings.stream()
+            .anyMatch(
+                mapping ->
+                    mapping.datasetId().equals(dataset1.getDatasetId())
+                        && mapping.daaId().equals(daa1)));
+    assertTrue(
+        mappings.stream()
+            .anyMatch(
+                mapping ->
+                    mapping.datasetId().equals(dataset2.getDatasetId())
+                        && mapping.daaId().equals(daa2)));
+  }
+
+  @Test
+  void testFindDatasetDaaSnapshotsByReferenceId() {
+    Integer userId = createUserId();
+    Integer dacId1 = dacDAO.createDac("dac1", randomAlphabetic(5), "", userId);
+    Integer dacId2 = dacDAO.createDac("dac2", randomAlphabetic(5), "", userId);
+    Dataset dataset1 = createRandomDataset(userDAO.findUserById(userId), dacDAO.findById(dacId1));
+    Dataset dataset2 = createRandomDataset(userDAO.findUserById(userId), dacDAO.findById(dacId2));
+    Integer daa1 = daaDAO.createDaa(userId, Instant.now(), userId, Instant.now(), dacId1);
+    Integer daa2 = daaDAO.createDaa(userId, Instant.now(), userId, Instant.now(), dacId2);
+    Date now = new Date();
+    Integer darCollectionId = darCollectionDAO.insertDarCollection("ABC", userId, now);
+    String referenceId = UUID.randomUUID().toString();
+    Integer darId =
+        dataAccessRequestDAO.insertDataAccessRequest(
+            darCollectionId,
+            referenceId,
+            userId,
+            now,
+            now,
+            now,
+            new DataAccessRequestData(),
+            "eraCommonsId");
+    Timestamp capturedAt = Timestamp.from(Instant.now());
+
+    daaDAO.insertDarDatasetDaaSnapshots(
+        List.of(
+            new DarDatasetDaaSnapshot(darId, dataset1.getDatasetId(), daa1, capturedAt),
+            new DarDatasetDaaSnapshot(darId, dataset2.getDatasetId(), daa2, capturedAt)));
+
+    List<DatasetDaaSnapshotDetail> snapshots =
+        daaDAO.findDatasetDaaSnapshotsByReferenceId(referenceId);
+
+    assertEquals(2, snapshots.size());
+    assertTrue(
+        snapshots.stream()
+            .anyMatch(
+                snapshot ->
+                    snapshot.datasetId().equals(dataset1.getDatasetId())
+                        && snapshot.daaId().equals(daa1)
+                        && snapshot.capturedAt().equals(capturedAt)));
+    assertTrue(
+        snapshots.stream()
+            .anyMatch(
+                snapshot ->
+                    snapshot.datasetId().equals(dataset2.getDatasetId())
+                        && snapshot.daaId().equals(daa2)
+                        && snapshot.capturedAt().equals(capturedAt)));
+  }
+
+  @Test
+  void testFindDatasetDaaSnapshotsByProgressReportReferenceId() {
+    Integer userId = createUserId();
+    Integer dacId = dacDAO.createDac("dac", randomAlphabetic(5), "", userId);
+    Dataset dataset = createRandomDataset(userDAO.findUserById(userId), dacDAO.findById(dacId));
+    Integer daaId = daaDAO.createDaa(userId, Instant.now(), userId, Instant.now(), dacId);
+    Date now = new Date();
+    Integer darCollectionId = darCollectionDAO.insertDarCollection("ABC", userId, now);
+    Integer parentDarId =
+        dataAccessRequestDAO.insertDataAccessRequest(
+            darCollectionId,
+            UUID.randomUUID().toString(),
+            userId,
+            now,
+            now,
+            now,
+            new DataAccessRequestData(),
+            "eraCommonsId");
+    String progressReportReferenceId = UUID.randomUUID().toString();
+    Integer progressReportId =
+        dataAccessRequestDAO.insertProgressReport(
+            parentDarId,
+            darCollectionId,
+            progressReportReferenceId,
+            userId,
+            new DataAccessRequestData(),
+            "eraCommonsId");
+    Timestamp capturedAt = Timestamp.from(Instant.now());
+
+    daaDAO.insertDarDatasetDaaSnapshots(
+        List.of(
+            new DarDatasetDaaSnapshot(
+                progressReportId, dataset.getDatasetId(), daaId, capturedAt)));
+
+    List<DatasetDaaSnapshotDetail> snapshots =
+        daaDAO.findDatasetDaaSnapshotsByReferenceId(progressReportReferenceId);
+
+    assertEquals(1, snapshots.size());
+    assertEquals(dataset.getDatasetId(), snapshots.getFirst().datasetId());
+    assertEquals(daaId, snapshots.getFirst().daaId());
+    assertEquals(capturedAt, snapshots.getFirst().capturedAt());
   }
 
   private static Integer getDarDaaCount(Integer prId) {
@@ -669,6 +797,33 @@ class DaaDAOTest extends DAOTestHelper {
     return datasetDAO.findDatasetById(datasetId);
   }
 
+  /** Returns true when {@code daa}'s dacs list contains the given dacId. */
+  private static boolean dacIdIn(DataAccessAgreement daa, Integer dacId) {
+    return daa.getDacs().stream().map(Dac::getDacId).toList().contains(dacId);
+  }
+
+  @Test
+  void testFindAllDaaAudits() {
+    Integer userId = createUserId();
+    Integer dacId1 = dacDAO.createDac(randomAlphabetic(5), randomAlphabetic(5), "", userId);
+    Integer dacId2 = dacDAO.createDac(randomAlphabetic(5), randomAlphabetic(5), "", userId);
+    Integer daaId1 = daaDAO.createDaa(userId, Instant.now(), userId, Instant.now(), dacId1);
+    Integer daaId2 = daaDAO.createDaa(userId, Instant.now(), userId, Instant.now(), dacId2);
+    daaDAO.createDacDaaRelation(dacId1, daaId1, userId);
+    daaDAO.createDacDaaRelation(dacId2, daaId2, userId);
+
+    List<DaaAudit> allAudits = daaDAO.findAllDaaAudits();
+    assertNotNull(allAudits);
+    assertFalse(allAudits.isEmpty());
+    // CREATE audit for each DAA + ADD audit for each relation = at least 4 records
+    assertTrue(allAudits.size() >= 4);
+    assertTrue(allAudits.stream().anyMatch(a -> a.action().equals(AuditActions.CREATE)));
+    assertTrue(allAudits.stream().anyMatch(a -> a.action().equals(AuditActions.ADD)));
+    List<Integer> auditDaaIds = allAudits.stream().map(DaaAudit::daaId).toList();
+    assertTrue(auditDaaIds.contains(daaId1));
+    assertTrue(auditDaaIds.contains(daaId2));
+  }
+
   @Test
   void testCreateDacDaaRelation_ReplaceExistingRelation() {
     Integer userId = createUserId();
@@ -679,7 +834,7 @@ class DaaDAOTest extends DAOTestHelper {
     // Create initial relation DAC -> DAA1
     daaDAO.createDacDaaRelation(dacId, daaId1, userId);
     DataAccessAgreement daa1FirstCreate = daaDAO.findById(daaId1);
-    assertTrue(daa1FirstCreate.getDacs().stream().map(Dac::getDacId).toList().contains(dacId));
+    assertTrue(dacIdIn(daa1FirstCreate, dacId));
 
     // Replace with DAC -> DAA2 (DAC to different DAA)
     daaDAO.createDacDaaRelation(dacId, daaId2, userId);
@@ -690,7 +845,7 @@ class DaaDAOTest extends DAOTestHelper {
 
     // Verify DAA2 now has DAC association
     DataAccessAgreement daa2AfterReplace = daaDAO.findById(daaId2);
-    assertTrue(daa2AfterReplace.getDacs().stream().map(Dac::getDacId).toList().contains(dacId));
+    assertTrue(dacIdIn(daa2AfterReplace, dacId));
 
     // Verify audit records for both REMOVE and ADD are created
     List<DaaAudit> audits1 = daaDAO.findAuditsByDaaId(daaId1);
@@ -711,21 +866,21 @@ class DaaDAOTest extends DAOTestHelper {
     // First assignment: DAC -> DAA1
     daaDAO.createDacDaaRelation(dacId, daaId1, userId);
     DataAccessAgreement daa1After1st = daaDAO.findById(daaId1);
-    assertTrue(daa1After1st.getDacs().stream().map(Dac::getDacId).toList().contains(dacId));
+    assertTrue(dacIdIn(daa1After1st, dacId));
 
     // Second assignment: DAC -> DAA2 (replaces DAA1)
     daaDAO.createDacDaaRelation(dacId, daaId2, userId);
     DataAccessAgreement daa1After2nd = daaDAO.findById(daaId1);
     assertNull(daa1After2nd.getDacs());
     DataAccessAgreement daa2After2nd = daaDAO.findById(daaId2);
-    assertTrue(daa2After2nd.getDacs().stream().map(Dac::getDacId).toList().contains(dacId));
+    assertTrue(dacIdIn(daa2After2nd, dacId));
 
     // Third assignment: DAC -> DAA3 (replaces DAA2)
     daaDAO.createDacDaaRelation(dacId, daaId3, userId);
     DataAccessAgreement daa2After3rd = daaDAO.findById(daaId2);
     assertNull(daa2After3rd.getDacs());
     DataAccessAgreement daa3After3rd = daaDAO.findById(daaId3);
-    assertTrue(daa3After3rd.getDacs().stream().map(Dac::getDacId).toList().contains(dacId));
+    assertTrue(dacIdIn(daa3After3rd, dacId));
 
     // Verify complete audit trail
     List<DaaAudit> audits1 = daaDAO.findAuditsByDaaId(daaId1);

--- a/src/test/java/org/broadinstitute/consent/http/db/DaaDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DaaDAOTest.java
@@ -716,6 +716,51 @@ class DaaDAOTest extends DAOTestHelper {
     assertEquals(capturedAt, snapshots.getFirst().capturedAt());
   }
 
+  @Test
+  void testDeleteDarDatasetDaaSnapshotsByReferenceId() {
+    Integer userId = createUserId();
+    Integer dacId = dacDAO.createDac("dac", randomAlphabetic(5), "", userId);
+    Dataset dataset = createRandomDataset(userDAO.findUserById(userId), dacDAO.findById(dacId));
+    Integer daaId = daaDAO.createDaa(userId, Instant.now(), userId, Instant.now(), dacId);
+    Date now = new Date();
+    Integer darCollectionId = darCollectionDAO.insertDarCollection("ABC", userId, now);
+
+    String targetReferenceId = UUID.randomUUID().toString();
+    Integer targetDarId =
+        dataAccessRequestDAO.insertDataAccessRequest(
+            darCollectionId,
+            targetReferenceId,
+            userId,
+            now,
+            now,
+            now,
+            new DataAccessRequestData(),
+            "eraCommonsId");
+
+    String otherReferenceId = UUID.randomUUID().toString();
+    Integer otherDarId =
+        dataAccessRequestDAO.insertDataAccessRequest(
+            darCollectionId,
+            otherReferenceId,
+            userId,
+            now,
+            now,
+            now,
+            new DataAccessRequestData(),
+            "eraCommonsId");
+
+    Timestamp capturedAt = Timestamp.from(Instant.now());
+    daaDAO.insertDarDatasetDaaSnapshots(
+        List.of(
+            new DarDatasetDaaSnapshot(targetDarId, dataset.getDatasetId(), daaId, capturedAt),
+            new DarDatasetDaaSnapshot(otherDarId, dataset.getDatasetId(), daaId, capturedAt)));
+
+    daaDAO.deleteDarDatasetDaaSnapshotsByReferenceId(targetReferenceId);
+
+    assertTrue(daaDAO.findDatasetDaaSnapshotsByReferenceId(targetReferenceId).isEmpty());
+    assertEquals(1, daaDAO.findDatasetDaaSnapshotsByReferenceId(otherReferenceId).size());
+  }
+
   private static Integer getDarDaaCount(Integer prId) {
     return jdbi.withHandle(
         handle ->

--- a/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceTest.java
@@ -11,6 +11,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -34,7 +35,9 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Stream;
 import org.apache.commons.io.FilenameUtils;
@@ -48,17 +51,20 @@ import org.broadinstitute.consent.http.enumeration.ElectionType;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.exceptions.SubmittedDARCannotBeEditedException;
 import org.broadinstitute.consent.http.models.AuthUser;
+import org.broadinstitute.consent.http.models.Dac;
 import org.broadinstitute.consent.http.models.DataAccessRequest;
 import org.broadinstitute.consent.http.models.DataAccessRequestData;
 import org.broadinstitute.consent.http.models.DataUse;
 import org.broadinstitute.consent.http.models.DataUseBuilder;
 import org.broadinstitute.consent.http.models.Dataset;
+import org.broadinstitute.consent.http.models.DatasetDaaSnapshot;
 import org.broadinstitute.consent.http.models.DuosUser;
 import org.broadinstitute.consent.http.models.Election;
 import org.broadinstitute.consent.http.models.LibraryCard;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.UserRole;
 import org.broadinstitute.consent.http.service.DaaService;
+import org.broadinstitute.consent.http.service.DacService;
 import org.broadinstitute.consent.http.service.DarCollectionService;
 import org.broadinstitute.consent.http.service.DataAccessRequestService;
 import org.broadinstitute.consent.http.service.DatasetService;
@@ -99,6 +105,7 @@ class DataAccessRequestResourceTest extends AbstractTestHelper {
       new User(4, memberUser.getEmail(), "Member user", new Date(), memberRoles);
   private final User bob = new User(5, anotherUser.getEmail(), "Bob", new Date(), roles);
   @Mock private DaaService daaService;
+  @Mock private DacService dacService;
   @Mock private DataAccessRequestService dataAccessRequestService;
   @Mock private MatchService matchService;
   @Mock private GCSService gcsService;
@@ -118,6 +125,7 @@ class DataAccessRequestResourceTest extends AbstractTestHelper {
       resource =
           new DataAccessRequestResource(
               daaService,
+              dacService,
               dataAccessRequestService,
               gcsService,
               userService,
@@ -206,9 +214,12 @@ class DataAccessRequestResourceTest extends AbstractTestHelper {
   void testGetByReferenceIdForbidden() {
     DuosUser mockedDuosUser = new DuosUser(authUser, mockUser);
     when(mockUser.getUserId()).thenReturn(user.getUserId() + 1);
-    when(dataAccessRequestService.findByReferenceId("id")).thenReturn(generateDataAccessRequest());
+    DataAccessRequest dar = generateDataAccessRequest();
+    when(dataAccessRequestService.findByReferenceId("id")).thenReturn(dar);
 
-    assertThrows(ForbiddenException.class, () -> resource.getByReferenceId(mockedDuosUser, "id"));
+    try (Response response = resource.getByReferenceId(mockedDuosUser, "id")) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_FORBIDDEN, response.getStatus());
+    }
   }
 
   @ParameterizedTest
@@ -218,10 +229,23 @@ class DataAccessRequestResourceTest extends AbstractTestHelper {
   void testGetByReferenceIdAllowedRoles(UserRoles role) {
     UserRole userRole = new UserRole(role.getRoleId(), role.getRoleName());
     User roleUser = new User(1, authUser.getEmail(), "Display Name", new Date(), List.of(userRole));
+    roleUser.setInstitutionId(7);
     // Set the DAR create user to be a different user from the roleUser
     DataAccessRequest dar = generateDataAccessRequest();
     dar.setUserId(roleUser.getUserId() + 1);
+    dar.setDatasetIds(List.of(10));
     when(dataAccessRequestService.findByReferenceId("id")).thenReturn(dar);
+
+    // CHAIRPERSON / MEMBER: user must be in a DAC governing a DAR dataset
+    Dac relevantDac = new Dac();
+    relevantDac.setChairpersons(List.of(roleUser));
+    relevantDac.setMembers(List.of(roleUser));
+    lenient().when(dacService.findByDatasetId(any())).thenReturn(Set.of(relevantDac));
+
+    // SIGNINGOFFICIAL: creator must share the same institution
+    User creator = new User(dar.getUserId(), "creator@test.com", "Creator", new Date(), roles);
+    creator.setInstitutionId(7);
+    lenient().when(userService.findUserById(dar.getUserId())).thenReturn(creator);
 
     Response response = resource.getByReferenceId(new DuosUser(authUser, roleUser), "id");
     assertEquals(200, response.getStatus());
@@ -239,7 +263,10 @@ class DataAccessRequestResourceTest extends AbstractTestHelper {
     DataAccessRequest dar = generateDataAccessRequest();
     dar.setUserId(roleUser.getUserId() + 1);
     when(dataAccessRequestService.findByReferenceId("id")).thenReturn(dar);
-    assertThrows(ForbiddenException.class, () -> resource.getByReferenceId(duosRoleUser, "id"));
+
+    try (Response response = resource.getByReferenceId(duosRoleUser, "id")) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_FORBIDDEN, response.getStatus());
+    }
   }
 
   @Test
@@ -324,6 +351,12 @@ class DataAccessRequestResourceTest extends AbstractTestHelper {
     dar.getData().setIrbDocumentLocation(randomAlphabetic(10));
     dar.getData().setIrbDocumentName(randomAlphabetic(10) + ".txt");
     when(dataAccessRequestService.findByReferenceId(any())).thenReturn(dar);
+
+    // For non-creator chair/member: stub DAC membership so validation passes
+    Dac dacWithAll = new Dac();
+    dacWithAll.setChairpersons(List.of(chairperson));
+    dacWithAll.setMembers(List.of(member));
+    when(dacService.findByDatasetId(any())).thenReturn(Set.of(dacWithAll));
 
     assertEquals(
         200, resource.getIrbDocument(new DuosUser(chairpersonUser, chairperson), "").getStatus());
@@ -854,6 +887,12 @@ class DataAccessRequestResourceTest extends AbstractTestHelper {
     dar.getData().setCollaborationLetterName(randomAlphabetic(10) + ".txt");
     when(dataAccessRequestService.findByReferenceId(any())).thenReturn(dar);
 
+    // For non-creator chair/member: stub DAC membership so validation passes
+    Dac dacWithAll = new Dac();
+    dacWithAll.setChairpersons(List.of(chairperson));
+    dacWithAll.setMembers(List.of(member));
+    when(dacService.findByDatasetId(any())).thenReturn(Set.of(dacWithAll));
+
     assertEquals(
         200,
         resource
@@ -1099,6 +1138,336 @@ class DataAccessRequestResourceTest extends AbstractTestHelper {
     try (Response response =
         resource.getDAAsByReferenceId(new DuosUser(authUser, user), dar.getReferenceId())) {
       assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
+    }
+  }
+
+  @Test
+  void testGetDatasetDaaSnapshotsByReferenceId() {
+    DataAccessRequest dar = generateDataAccessRequest();
+    Timestamp capturedAt = Timestamp.from(Instant.now());
+    Map<Integer, DatasetDaaSnapshot> snapshots =
+        Map.of(
+            1, new DatasetDaaSnapshot(10, capturedAt), 2, new DatasetDaaSnapshot(20, capturedAt));
+    when(dataAccessRequestService.findByReferenceId(any())).thenReturn(dar);
+    when(dataAccessRequestService.findDatasetDaaSnapshotsByReferenceId(any()))
+        .thenReturn(snapshots);
+
+    try (Response response =
+        resource.getDatasetDaaSnapshotsByReferenceId(
+            new DuosUser(authUser, user), dar.getReferenceId())) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+      assertEquals(snapshots, response.getEntity());
+    }
+  }
+
+  @Test
+  void testGetDatasetDaaSnapshotsByReferenceIdDarNotFound() {
+    when(dataAccessRequestService.findByReferenceId(any())).thenReturn(null);
+
+    try (Response response =
+        resource.getDatasetDaaSnapshotsByReferenceId(new DuosUser(authUser, user), "missing")) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
+    }
+  }
+
+  @Test
+  void testGetDatasetDaaSnapshotsByReferenceIdSnapshotNotFound() {
+    DataAccessRequest dar = generateDataAccessRequest();
+    when(dataAccessRequestService.findByReferenceId(any())).thenReturn(dar);
+    when(dataAccessRequestService.findDatasetDaaSnapshotsByReferenceId(any()))
+        .thenThrow(new NotFoundException("No snapshot"));
+
+    try (Response response =
+        resource.getDatasetDaaSnapshotsByReferenceId(
+            new DuosUser(authUser, user), dar.getReferenceId())) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
+    }
+  }
+
+  // ── validateAuthedRoleUser – DAC membership enforcement ─────────────────────────────────────
+
+  /** Builds a DAR owned by a *different* user (userId = 99) with one dataset. */
+  private DataAccessRequest buildDarOwnedByOther() {
+    DataAccessRequest dar = generateDataAccessRequest();
+    dar.setUserId(99); // not the chairperson/member/SO under test
+    dar.setDatasetIds(List.of(101));
+    return dar;
+  }
+
+  /** Builds a Dac whose chairpersons list contains the given user. */
+  private Dac dacWithChair(User chair) {
+    Dac dac = new Dac();
+    dac.setChairpersons(List.of(chair));
+    dac.setMembers(List.of());
+    return dac;
+  }
+
+  /** Builds a Dac whose members list contains the given user. */
+  private Dac dacWithMember(User member) {
+    Dac dac = new Dac();
+    dac.setChairpersons(List.of());
+    dac.setMembers(List.of(member));
+    return dac;
+  }
+
+  @Test
+  void testGetByReferenceId_Chairperson_InDac_Allowed() {
+    DataAccessRequest dar = buildDarOwnedByOther();
+    when(dataAccessRequestService.findByReferenceId(dar.getReferenceId())).thenReturn(dar);
+    when(dacService.findByDatasetId(dar.getDatasetIds()))
+        .thenReturn(Set.of(dacWithChair(chairperson)));
+
+    try (Response response =
+        resource.getByReferenceId(
+            new DuosUser(chairpersonUser, chairperson), dar.getReferenceId())) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+    }
+  }
+
+  @Test
+  void testGetByReferenceId_Chairperson_NotInDac_Forbidden() {
+    DataAccessRequest dar = buildDarOwnedByOther();
+    when(dataAccessRequestService.findByReferenceId(dar.getReferenceId())).thenReturn(dar);
+    // The DAC for the dataset has no members/chairs that match the chairperson
+    Dac emptyDac = new Dac();
+    emptyDac.setChairpersons(List.of());
+    emptyDac.setMembers(List.of());
+    when(dacService.findByDatasetId(dar.getDatasetIds())).thenReturn(Set.of(emptyDac));
+
+    try (Response response =
+        resource.getByReferenceId(
+            new DuosUser(chairpersonUser, chairperson), dar.getReferenceId())) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_FORBIDDEN, response.getStatus());
+    }
+  }
+
+  @Test
+  void testGetByReferenceId_Chairperson_DarHasNoDatasets_Forbidden() {
+    DataAccessRequest dar = buildDarOwnedByOther();
+    dar.setDatasetIds(List.of());
+    when(dataAccessRequestService.findByReferenceId(dar.getReferenceId())).thenReturn(dar);
+
+    try (Response response =
+        resource.getByReferenceId(
+            new DuosUser(chairpersonUser, chairperson), dar.getReferenceId())) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_FORBIDDEN, response.getStatus());
+    }
+  }
+
+  @Test
+  void testGetByReferenceId_Member_InDac_Allowed() {
+    DataAccessRequest dar = buildDarOwnedByOther();
+    when(dataAccessRequestService.findByReferenceId(dar.getReferenceId())).thenReturn(dar);
+    when(dacService.findByDatasetId(dar.getDatasetIds())).thenReturn(Set.of(dacWithMember(member)));
+
+    try (Response response =
+        resource.getByReferenceId(new DuosUser(memberUser, member), dar.getReferenceId())) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+    }
+  }
+
+  @Test
+  void testGetByReferenceId_Member_NotInDac_Forbidden() {
+    DataAccessRequest dar = buildDarOwnedByOther();
+    when(dataAccessRequestService.findByReferenceId(dar.getReferenceId())).thenReturn(dar);
+    Dac emptyDac = new Dac();
+    emptyDac.setChairpersons(List.of());
+    emptyDac.setMembers(List.of());
+    when(dacService.findByDatasetId(dar.getDatasetIds())).thenReturn(Set.of(emptyDac));
+
+    try (Response response =
+        resource.getByReferenceId(new DuosUser(memberUser, member), dar.getReferenceId())) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_FORBIDDEN, response.getStatus());
+    }
+  }
+
+  @Test
+  void testGetByReferenceId_Member_InDac_WithNullChairList_Allowed() {
+    DataAccessRequest dar = buildDarOwnedByOther();
+    when(dataAccessRequestService.findByReferenceId(dar.getReferenceId())).thenReturn(dar);
+    Dac dac = new Dac();
+    dac.setChairpersons(null);
+    dac.setMembers(List.of(member));
+    when(dacService.findByDatasetId(dar.getDatasetIds())).thenReturn(Set.of(dac));
+
+    try (Response response =
+        resource.getByReferenceId(new DuosUser(memberUser, member), dar.getReferenceId())) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+    }
+  }
+
+  @Test
+  void testGetByReferenceId_Chairperson_InDac_WithNullMemberList_Allowed() {
+    DataAccessRequest dar = buildDarOwnedByOther();
+    when(dataAccessRequestService.findByReferenceId(dar.getReferenceId())).thenReturn(dar);
+    Dac dac = new Dac();
+    dac.setChairpersons(List.of(chairperson));
+    dac.setMembers(null);
+    when(dacService.findByDatasetId(dar.getDatasetIds())).thenReturn(Set.of(dac));
+
+    try (Response response =
+        resource.getByReferenceId(
+            new DuosUser(chairpersonUser, chairperson), dar.getReferenceId())) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+    }
+  }
+
+  @Test
+  void testGetByReferenceId_Chairperson_DarHasNullDatasets_Forbidden() {
+    DataAccessRequest dar = buildDarOwnedByOther();
+    dar.setDatasetIds(null);
+    when(dataAccessRequestService.findByReferenceId(dar.getReferenceId())).thenReturn(dar);
+
+    try (Response response =
+        resource.getByReferenceId(
+            new DuosUser(chairpersonUser, chairperson), dar.getReferenceId())) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_FORBIDDEN, response.getStatus());
+    }
+  }
+
+  @Test
+  void testGetByReferenceId_Member_DacHasNullMembers_Forbidden() {
+    DataAccessRequest dar = buildDarOwnedByOther();
+    when(dataAccessRequestService.findByReferenceId(dar.getReferenceId())).thenReturn(dar);
+    Dac dac = new Dac();
+    dac.setChairpersons(List.of());
+    dac.setMembers(null);
+    when(dacService.findByDatasetId(dar.getDatasetIds())).thenReturn(Set.of(dac));
+
+    try (Response response =
+        resource.getByReferenceId(new DuosUser(memberUser, member), dar.getReferenceId())) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_FORBIDDEN, response.getStatus());
+    }
+  }
+
+  @Test
+  void testGetByReferenceId_Admin_BypassesDacCheck() {
+    // Admin should never be subject to the DAC-membership check
+    DataAccessRequest dar = buildDarOwnedByOther();
+    when(dataAccessRequestService.findByReferenceId(dar.getReferenceId())).thenReturn(dar);
+
+    try (Response response =
+        resource.getByReferenceId(new DuosUser(adminUser, admin), dar.getReferenceId())) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+    }
+  }
+
+  @Test
+  void testGetByReferenceId_Creator_BypassesDacCheck() {
+    // The DAR creator (userId == user.getUserId()) bypasses all additional checks
+    DataAccessRequest dar = generateDataAccessRequest();
+    dar.setUserId(user.getUserId());
+    dar.setDatasetIds(List.of(101));
+    when(dataAccessRequestService.findByReferenceId(dar.getReferenceId())).thenReturn(dar);
+
+    try (Response response =
+        resource.getByReferenceId(new DuosUser(authUser, user), dar.getReferenceId())) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+    }
+  }
+
+  @Test
+  void testGetByReferenceId_InvalidDarUserId_AdminAllowed() {
+    DataAccessRequest dar = generateDataAccessRequest();
+    dar.setUserId(null);
+    when(dataAccessRequestService.findByReferenceId(dar.getReferenceId())).thenReturn(dar);
+
+    try (Response response =
+        resource.getByReferenceId(new DuosUser(adminUser, admin), dar.getReferenceId())) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+    }
+  }
+
+  @Test
+  void testGetByReferenceId_NonPositiveDarUserId_AdminAllowed() {
+    DataAccessRequest dar = generateDataAccessRequest();
+    dar.setUserId(0);
+    when(dataAccessRequestService.findByReferenceId(dar.getReferenceId())).thenReturn(dar);
+
+    try (Response response =
+        resource.getByReferenceId(new DuosUser(adminUser, admin), dar.getReferenceId())) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+    }
+  }
+
+  // ── validateAuthedRoleUser – Signing Official institution enforcement ─────────────────────────
+
+  private User buildSigningOfficial(int userId, Integer institutionId) {
+    AuthUser soAuthUser = new AuthUser("so_" + userId + "@test.com");
+    List<UserRole> soRoles = List.of(UserRoles.SigningOfficial());
+    User so = new User(userId, soAuthUser.getEmail(), "SO User", new Date(), soRoles);
+    so.setInstitutionId(institutionId);
+    return so;
+  }
+
+  @Test
+  void testGetByReferenceId_SigningOfficial_SameInstitution_Allowed() {
+    User so = buildSigningOfficial(20, 5);
+    User darCreator = new User(99, "creator@test.com", "Creator", new Date(), roles);
+    darCreator.setInstitutionId(5); // same institution
+
+    DataAccessRequest dar = buildDarOwnedByOther();
+    dar.setUserId(darCreator.getUserId());
+    when(dataAccessRequestService.findByReferenceId(dar.getReferenceId())).thenReturn(dar);
+    when(userService.findUserById(darCreator.getUserId())).thenReturn(darCreator);
+
+    try (Response response =
+        resource.getByReferenceId(
+            new DuosUser(new AuthUser(so.getEmail()), so), dar.getReferenceId())) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+    }
+  }
+
+  @Test
+  void testGetByReferenceId_SigningOfficial_DifferentInstitution_Forbidden() {
+    User so = buildSigningOfficial(20, 5);
+    User darCreator = new User(99, "creator@test.com", "Creator", new Date(), roles);
+    darCreator.setInstitutionId(99); // different institution
+
+    DataAccessRequest dar = buildDarOwnedByOther();
+    dar.setUserId(darCreator.getUserId());
+    when(dataAccessRequestService.findByReferenceId(dar.getReferenceId())).thenReturn(dar);
+    when(userService.findUserById(darCreator.getUserId())).thenReturn(darCreator);
+
+    try (Response response =
+        resource.getByReferenceId(
+            new DuosUser(new AuthUser(so.getEmail()), so), dar.getReferenceId())) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_FORBIDDEN, response.getStatus());
+    }
+  }
+
+  @Test
+  void testGetByReferenceId_SigningOfficial_NoInstitution_Forbidden() {
+    // SO has no institution set
+    User so = buildSigningOfficial(20, null);
+    User darCreator = new User(99, "creator@test.com", "Creator", new Date(), roles);
+    darCreator.setInstitutionId(5);
+
+    DataAccessRequest dar = buildDarOwnedByOther();
+    dar.setUserId(darCreator.getUserId());
+    when(dataAccessRequestService.findByReferenceId(dar.getReferenceId())).thenReturn(dar);
+    when(userService.findUserById(darCreator.getUserId())).thenReturn(darCreator);
+
+    try (Response response =
+        resource.getByReferenceId(
+            new DuosUser(new AuthUser(so.getEmail()), so), dar.getReferenceId())) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_FORBIDDEN, response.getStatus());
+    }
+  }
+
+  @Test
+  void testGetByReferenceId_SigningOfficial_CreatorNotFound_Forbidden() {
+    User so = buildSigningOfficial(20, 5);
+
+    DataAccessRequest dar = buildDarOwnedByOther();
+    dar.setUserId(99);
+    when(dataAccessRequestService.findByReferenceId(dar.getReferenceId())).thenReturn(dar);
+    when(userService.findUserById(99)).thenReturn(null); // creator not resolvable
+
+    try (Response response =
+        resource.getByReferenceId(
+            new DuosUser(new AuthUser(so.getEmail()), so), dar.getReferenceId())) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_FORBIDDEN, response.getStatus());
     }
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
@@ -37,6 +37,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import org.broadinstitute.consent.http.AbstractTestHelper;
+import org.broadinstitute.consent.http.db.DaaDAO;
 import org.broadinstitute.consent.http.db.DacDAO;
 import org.broadinstitute.consent.http.db.DarCollectionDAO;
 import org.broadinstitute.consent.http.db.DarCollectionSummaryDAO;
@@ -93,6 +94,7 @@ class DarCollectionServiceTest extends AbstractTestHelper {
   @Mock private VoteDAO voteDAO;
   @Mock private UserDAO userDAO;
   @Mock private DacDAO dacDAO;
+  @Mock private DaaDAO daaDAO;
   @Mock private Jdbi jdbi;
   @Mock private DACAutomationRuleService dacAutomationRuleService;
   @Mock private ContainerRequest request;
@@ -107,9 +109,53 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     when(jdbi.onDemand(VoteDAO.class)).thenReturn(voteDAO);
     when(jdbi.onDemand(UserDAO.class)).thenReturn(userDAO);
     when(jdbi.onDemand(DacDAO.class)).thenReturn(dacDAO);
+    when(jdbi.onDemand(DaaDAO.class)).thenReturn(daaDAO);
     service =
         new DarCollectionService(
             jdbi, darCollectionServiceDAO, emailService, dacAutomationRuleService);
+  }
+
+  @Test
+  void testUpdateCollectionToDraftStatusDeletesSnapshots() {
+    String firstReferenceId = UUID.randomUUID().toString();
+    String secondReferenceId = UUID.randomUUID().toString();
+    Integer collectionId = 123;
+    Integer userId = 456;
+    Date now = new Date();
+
+    DataAccessRequest firstDar = new DataAccessRequest();
+    firstDar.setReferenceId(firstReferenceId);
+    firstDar.setUserId(userId);
+    firstDar.setCreateDate(new Timestamp(now.getTime() - 2_000));
+    firstDar.setSubmissionDate(new Timestamp(now.getTime() - 1_000));
+    DataAccessRequestData firstData = new DataAccessRequestData();
+    firstData.setProjectTitle("project-1");
+    firstDar.setData(firstData);
+
+    DataAccessRequest secondDar = new DataAccessRequest();
+    secondDar.setReferenceId(secondReferenceId);
+    secondDar.setUserId(userId);
+    secondDar.setCreateDate(new Timestamp(now.getTime()));
+    secondDar.setSubmissionDate(new Timestamp(now.getTime()));
+    DataAccessRequestData secondData = new DataAccessRequestData();
+    secondData.setProjectTitle("project-2");
+    secondDar.setData(secondData);
+
+    DarCollection sourceCollection = new DarCollection();
+    sourceCollection.setDarCollectionId(collectionId);
+    sourceCollection.addDar(firstDar);
+    sourceCollection.addDar(secondDar);
+
+    DarCollection updatedCollection = new DarCollection();
+    updatedCollection.setDarCollectionId(collectionId);
+    updatedCollection.addDar(firstDar);
+    when(darCollectionDAO.findDARCollectionByCollectionId(collectionId))
+        .thenReturn(updatedCollection);
+
+    service.updateCollectionToDraftStatus(sourceCollection);
+
+    verify(daaDAO).deleteDarDatasetDaaSnapshotsByReferenceId(firstReferenceId);
+    verify(daaDAO).deleteDarDatasetDaaSnapshotsByReferenceId(secondReferenceId);
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
@@ -33,6 +33,7 @@ import java.time.Instant;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
@@ -62,6 +63,9 @@ import org.broadinstitute.consent.http.models.DataAccessRequest;
 import org.broadinstitute.consent.http.models.DataAccessRequestData;
 import org.broadinstitute.consent.http.models.DataManagementIncident;
 import org.broadinstitute.consent.http.models.Dataset;
+import org.broadinstitute.consent.http.models.DatasetDaaMapping;
+import org.broadinstitute.consent.http.models.DatasetDaaSnapshot;
+import org.broadinstitute.consent.http.models.DatasetDaaSnapshotDetail;
 import org.broadinstitute.consent.http.models.Election;
 import org.broadinstitute.consent.http.models.Institution;
 import org.broadinstitute.consent.http.models.IntellectualProperty;
@@ -236,6 +240,58 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
   }
 
   @Test
+  void testCreateDataAccessRequest_CapturesDatasetDaaSnapshots() {
+    DataAccessRequest dar = generateDataAccessRequest();
+    dar.setReferenceId("id");
+    dar.setDatasetIds(List.of(1, 2));
+    User user = createUserWithPrerequisites();
+    when(institutionService.findInstitutionForEmail(any())).thenReturn(user.getInstitution());
+    when(counterService.getNextDarSequence()).thenReturn(1);
+    when(dataAccessRequestDAO.findByReferenceId("id")).thenReturn(null);
+    when(dataAccessRequestDAO.findByReferenceId(argThat(new LongerThanTwo()))).thenReturn(dar);
+    when(darCollectionDAO.insertDarCollection(anyString(), anyInt(), any(Date.class)))
+        .thenReturn(99);
+    when(dataAccessRequestDAO.insertDataAccessRequest(
+            anyInt(),
+            anyString(),
+            anyInt(),
+            any(Date.class),
+            any(Date.class),
+            any(Date.class),
+            any(DataAccessRequestData.class),
+            anyString()))
+        .thenReturn(12);
+    when(dataSetDAO.filterDatasetIdsByAutomationRuleType(
+            dar.getDatasetIds(), DACAutomationRuleType.REQUIRE_SO_DAR_APPROVAL.name()))
+        .thenReturn(List.of());
+    when(daaDAO.findDaaIdsByDatasetIds(anyList())).thenReturn(Set.of());
+    when(daaDAO.findCurrentDaaMappingsByDatasetIds(dar.getDatasetIds()))
+        .thenReturn(List.of(new DatasetDaaMapping(1, 10), new DatasetDaaMapping(2, 20)));
+
+    DataAccessRequest newDar = service.createDataAccessRequest(user, dar, request);
+
+    assertNotNull(newDar);
+    verify(daaDAO)
+        .insertDarDatasetDaaSnapshots(
+            argThat(
+                snapshots ->
+                    snapshots.size() == 2
+                        && snapshots.stream().allMatch(snapshot -> snapshot.darId().equals(12))
+                        && snapshots.stream()
+                            .anyMatch(
+                                snapshot ->
+                                    snapshot.datasetId().equals(1)
+                                        && snapshot.daaId().equals(10)
+                                        && snapshot.capturedAt() != null)
+                        && snapshots.stream()
+                            .anyMatch(
+                                snapshot ->
+                                    snapshot.datasetId().equals(2)
+                                        && snapshot.daaId().equals(20)
+                                        && snapshot.capturedAt() != null)));
+  }
+
+  @Test
   void testCreateDataAccessRequest_Create_Missing_DAAs() {
     DataAccessRequest dar = generateDataAccessRequest();
     dar.addDatasetIds(List.of(1, 2, 3));
@@ -379,6 +435,48 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
   }
 
   @Test
+  void createProgressReportCapturesDatasetDaaSnapshots() {
+    DataAccessRequest parentDar = generateDataAccessRequest();
+    DataAccessRequest progressReport = generateProgressReport();
+    progressReport.setParentId(parentDar.getId());
+    progressReport.setCollectionId(parentDar.getCollectionId());
+    progressReport.setDatasetIds(List.of(1, 2));
+    parentDar.setSubmissionDate(Timestamp.from(Instant.now()));
+    parentDar.setUserId(1);
+    parentDar.setDatasetIds(List.of(1, 2));
+    User user = createUserWithPrerequisites();
+    when(dataAccessRequestDAO.findByReferenceId(progressReport.getReferenceId()))
+        .thenReturn(progressReport);
+    when(dataAccessRequestDAO.findDatasetApprovalsByDar(parentDar.getReferenceId()))
+        .thenReturn(Set.copyOf(progressReport.getDatasetIds()));
+    when(daaDAO.findCurrentDaaMappingsByDatasetIds(progressReport.getDatasetIds()))
+        .thenReturn(List.of(new DatasetDaaMapping(1, 10), new DatasetDaaMapping(2, 20)));
+
+    DataAccessRequest newDar =
+        service.createProgressReport(user, progressReport, parentDar, request);
+
+    assertNotNull(newDar);
+    verify(daaDAO)
+        .insertDarDatasetDaaSnapshots(
+            argThat(
+                snapshots ->
+                    snapshots.size() == 2
+                        && snapshots.stream().allMatch(snapshot -> snapshot.darId() != null)
+                        && snapshots.stream()
+                            .anyMatch(
+                                snapshot ->
+                                    snapshot.datasetId().equals(1)
+                                        && snapshot.daaId().equals(10)
+                                        && snapshot.capturedAt() != null)
+                        && snapshots.stream()
+                            .anyMatch(
+                                snapshot ->
+                                    snapshot.datasetId().equals(2)
+                                        && snapshot.daaId().equals(20)
+                                        && snapshot.capturedAt() != null)));
+  }
+
+  @Test
   void createProgressReportDmi() {
     DataAccessRequest parentDar = generateDataAccessRequest();
     DataAccessRequest progressReport = generateProgressReport();
@@ -490,6 +588,37 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     verify(dataAccessRequestDAO)
         .insertAllDarDatasets(argThat(new DarDatasetMatcher(progressReport)));
     verify(dataAccessRequestDAO, never()).updateRequiresSOApproval(eq(true), anyString());
+    verify(daaDAO, never()).insertDarDatasetDaaSnapshots(any());
+  }
+
+  @Test
+  void findDatasetDaaSnapshotsByReferenceId() {
+    DataAccessRequest dar = generateDataAccessRequest();
+    Timestamp capturedAt = Timestamp.from(Instant.now());
+    when(dataAccessRequestDAO.findByReferenceId(dar.getReferenceId())).thenReturn(dar);
+    when(daaDAO.findDatasetDaaSnapshotsByReferenceId(dar.getReferenceId()))
+        .thenReturn(
+            List.of(
+                new DatasetDaaSnapshotDetail(1, 10, capturedAt),
+                new DatasetDaaSnapshotDetail(2, 20, capturedAt)));
+
+    Map<Integer, DatasetDaaSnapshot> snapshots =
+        service.findDatasetDaaSnapshotsByReferenceId(dar.getReferenceId());
+
+    assertEquals(2, snapshots.size());
+    assertEquals(new DatasetDaaSnapshot(10, capturedAt), snapshots.get(1));
+    assertEquals(new DatasetDaaSnapshot(20, capturedAt), snapshots.get(2));
+  }
+
+  @Test
+  void findDatasetDaaSnapshotsByReferenceIdNotFound() {
+    DataAccessRequest dar = generateDataAccessRequest();
+    when(dataAccessRequestDAO.findByReferenceId(dar.getReferenceId())).thenReturn(dar);
+    when(daaDAO.findDatasetDaaSnapshotsByReferenceId(dar.getReferenceId())).thenReturn(List.of());
+
+    assertThrows(
+        NotFoundException.class,
+        () -> service.findDatasetDaaSnapshotsByReferenceId(dar.getReferenceId()));
   }
 
   @Test


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-3163](https://broadworkbench.atlassian.net/browse/DT-3163)

### Summary

Memorializes the DAR-> DATASET-> DAA relationship as a snapshot that existed when a Data Access Request or Progress Report application is submitted
If a DAR is cancelled and converted to a draft, the snapshot memorialization is deleted
Validation of access to a Data Access Request has been tightened up.  ADMINS can access all DARs, Researchers can access the DARs they create, DAC Chairs and Members can access the DARs with associated data, and SOs can access DARs in their insitution.


<img width="1443" height="959" alt="image" src="https://github.com/user-attachments/assets/b60f7d16-745e-4bcd-b7ec-fedd4c0e01ed" />


----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
