### PR TITLE
[DT-3200] Format link for computer, not human consumption.

### DIFF
--- a/src/main/resources/freemarker/new-study-digest.ftl
+++ b/src/main/resources/freemarker/new-study-digest.ftl
@@ -36,7 +36,7 @@
         </thead>
         <tbody>
       <#list newStudies as item>
-        <tr><td style="padding: 15px 15px 0px; font-family: 'Montserrat', sans-serif; font-size: 16px; color: #1F3B50; text-align: justify; line-height: 25px;"><a href="${serverUrl}studies/${item.id()}">${item.name()}</a></td><td style="padding: 15px 15px 0px; font-family: 'Montserrat', sans-serif; font-size: 16px; color: #1F3B50; text-align: justify; line-height: 25px;">${item.datasetCount()}</td></tr>
+        <tr><td style="padding: 15px 15px 0px; font-family: 'Montserrat', sans-serif; font-size: 16px; color: #1F3B50; text-align: justify; line-height: 25px;"><a href="${serverUrl}studies/${item.id()?c}">${item.name()}</a></td><td style="padding: 15px 15px 0px; font-family: 'Montserrat', sans-serif; font-size: 16px; color: #1F3B50; text-align: justify; line-height: 25px;">${item.datasetCount()}</td></tr>
       </#list>
         </tbody>
       </table>

--- a/src/test/java/org/broadinstitute/consent/http/mail/message/NewStudyDigestMessageTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mail/message/NewStudyDigestMessageTest.java
@@ -37,7 +37,7 @@ class NewStudyDigestMessageTest {
   void testNewStudyDigestMessage() throws TemplateException, IOException {
     List<StudyDatasetCountRecord> newStudies = new ArrayList<>();
     StudyDatasetCountRecord record1 = new StudyDatasetCountRecord("My new study", 3, 1);
-    StudyDatasetCountRecord record2 = new StudyDatasetCountRecord("My other new study", 4, 2);
+    StudyDatasetCountRecord record2 = new StudyDatasetCountRecord("My other new study", 4000, 2);
     newStudies.add(record1);
     newStudies.add(record2);
     String referenceId = "My reference id";


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-3200](https://broadworkbench.atlassian.net/browse/DT-3200)

### Summary

Freemarker is set to convert number to human format (e.g. 1000 -> 1,000).

This change updates:
A test with a study ID > 999 that was already confirming link format
The template with the necessary configuration to format without the comma.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
