### PR TITLE
DT-3194: Add Default SendGrid Categories

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/enumeration/EmailType.java
+++ b/src/main/java/org/broadinstitute/consent/http/enumeration/EmailType.java
@@ -2,7 +2,7 @@ package org.broadinstitute.consent.http.enumeration;
 
 import java.util.List;
 
-class EmailTypeConstants {
+final class EmailTypeConstants {
   public static final List<String> SENDGRID_CATEGORIES = List.of("DUOS");
 
   private EmailTypeConstants() {

--- a/src/main/java/org/broadinstitute/consent/http/enumeration/EmailType.java
+++ b/src/main/java/org/broadinstitute/consent/http/enumeration/EmailType.java
@@ -69,7 +69,7 @@ public enum EmailType {
   private final List<String> categories;
 
   EmailType(Integer typeInt) {
-    this(typeInt, null, null);
+    this(typeInt, null, EmailTypeConstants.SENDGRID_CATEGORIES);
   }
 
   EmailType(Integer typeInt, String templateName, List<String> categories) {

--- a/src/main/java/org/broadinstitute/consent/http/enumeration/EmailType.java
+++ b/src/main/java/org/broadinstitute/consent/http/enumeration/EmailType.java
@@ -1,60 +1,88 @@
 package org.broadinstitute.consent.http.enumeration;
 
+import java.util.List;
+
+class EmailTypeConstants {
+  public static final List<String> SENDGRID_CATEGORIES = List.of("DUOS");
+
+  private EmailTypeConstants() {
+    // Prevent instantiation
+  }
+}
+
 public enum EmailType {
   COLLECT(1),
-  NEW_CASE(2, "new-case.html"),
-  REMINDER(3, "reminder.html"),
-  NEW_DAR(4, "new-request.html"),
+  NEW_CASE(2, "new-case.html", EmailTypeConstants.SENDGRID_CATEGORIES),
+  REMINDER(3, "reminder.html", EmailTypeConstants.SENDGRID_CATEGORIES),
+  NEW_DAR(4, "new-request.html", EmailTypeConstants.SENDGRID_CATEGORIES),
   DISABLED_DATASET(5),
   CLOSED_DATASET_ELECTION(6),
-  DATA_CUSTODIAN_APPROVAL(7, "data-custodian-approval.ftl"),
-  RESEARCHER_DAR_APPROVED(8, "researcher-dar-approved.ftl"),
+  DATA_CUSTODIAN_APPROVAL(7, "data-custodian-approval.ftl", EmailTypeConstants.SENDGRID_CATEGORIES),
+  RESEARCHER_DAR_APPROVED(8, "researcher-dar-approved.ftl", EmailTypeConstants.SENDGRID_CATEGORIES),
   ADMIN_FLAGGED_DAR_APPROVED(9),
   DAR_CANCEL(10),
   DELEGATE_RESPONSIBILITIES(11),
-  NEW_RESEARCHER(12, "new-researcher-library-request.html"),
+  NEW_RESEARCHER(12, "new-researcher-library-request.html", EmailTypeConstants.SENDGRID_CATEGORIES),
   RESEARCHER_APPROVED(13),
-  NEW_DATASET(14, "dataset-submitted.html"),
+  NEW_DATASET(14, "dataset-submitted.html", EmailTypeConstants.SENDGRID_CATEGORIES),
   // Deprecated: maintained for historical purposes so legacy references to type 15 remain
   // representable.
   @Deprecated
-  NEW_DAA_REQUEST(15, null),
-  NEW_DAA_UPLOAD_RESEARCHER(16, "new-daa-upload-researcher.html"),
-  NEW_DAA_UPLOAD_SO(17, "new-daa-upload-signing-official.html"),
-  DATASET_DENIED(18, "dataset-denied.ftl"),
-  DATASET_APPROVED(19, "dataset-approved.ftl"),
-  DAR_EXPIRED(20, "dar-expired.html"),
-  DAR_EXPIRATION_REMINDER(21, "dar-expiration-reminder.html"),
-  NEW_PROGRESS_REPORT_REQUEST(22, "new-progress-report-request.html"),
-  NEW_PROGRESS_REPORT_CASE(23, "new-progress-report-case.html"),
-  RESEARCHER_PROGRESS_REPORT_APPROVED(24, "researcher-progress-report-approved.ftl"),
-  RESEARCHER_CLOSEOUT_COMPLETED(25, "researcher-closeout-completed.html"),
-  SUBMITTED_CLOSEOUT(26, "submitted-closeout.html"),
-  NEW_LIBRARY_CARD_ISSUED(27, "new-library-card-issued.html"),
-  SO_DAR_SUBMITTED(28, "so-dar-submitted.html"),
-  SO_DAR_APPROVED(29, "so-dar-approved.html"),
-  SO_PROGRESS_REPORT_SUBMITTED(30, "so-progress-report-submitted.html"),
-  SO_PROGRESS_REPORT_APPROVED(31, "so-progress-report-approved.html"),
-  DAC_RADAR_APPROVED(32, "dac-radar-approved.ftl"),
-  NEW_DAR_SO_NEEDS_TO_APPROVE(33, "new-dar-so-needs-to-approve.html"),
-  DAC_VOTE_REMINDER_DIGEST(34, "vote-digest.ftl"),
-  NEW_STUDY_REGISTRATION_CONFIRMATION(35, "new-study-registration-confirmation.ftl"),
-  NEW_STUDY_DIGEST(36, "new-study-digest.ftl"),
+  NEW_DAA_REQUEST(15, null, null),
+  NEW_DAA_UPLOAD_RESEARCHER(
+      16, "new-daa-upload-researcher.html", EmailTypeConstants.SENDGRID_CATEGORIES),
+  NEW_DAA_UPLOAD_SO(
+      17, "new-daa-upload-signing-official.html", EmailTypeConstants.SENDGRID_CATEGORIES),
+  DATASET_DENIED(18, "dataset-denied.ftl", EmailTypeConstants.SENDGRID_CATEGORIES),
+  DATASET_APPROVED(19, "dataset-approved.ftl", EmailTypeConstants.SENDGRID_CATEGORIES),
+  DAR_EXPIRED(20, "dar-expired.html", EmailTypeConstants.SENDGRID_CATEGORIES),
+  DAR_EXPIRATION_REMINDER(
+      21, "dar-expiration-reminder.html", EmailTypeConstants.SENDGRID_CATEGORIES),
+  NEW_PROGRESS_REPORT_REQUEST(
+      22, "new-progress-report-request.html", EmailTypeConstants.SENDGRID_CATEGORIES),
+  NEW_PROGRESS_REPORT_CASE(
+      23, "new-progress-report-case.html", EmailTypeConstants.SENDGRID_CATEGORIES),
+  RESEARCHER_PROGRESS_REPORT_APPROVED(
+      24, "researcher-progress-report-approved.ftl", EmailTypeConstants.SENDGRID_CATEGORIES),
+  RESEARCHER_CLOSEOUT_COMPLETED(
+      25, "researcher-closeout-completed.html", EmailTypeConstants.SENDGRID_CATEGORIES),
+  SUBMITTED_CLOSEOUT(26, "submitted-closeout.html", EmailTypeConstants.SENDGRID_CATEGORIES),
+  NEW_LIBRARY_CARD_ISSUED(
+      27, "new-library-card-issued.html", EmailTypeConstants.SENDGRID_CATEGORIES),
+  SO_DAR_SUBMITTED(28, "so-dar-submitted.html", EmailTypeConstants.SENDGRID_CATEGORIES),
+  SO_DAR_APPROVED(29, "so-dar-approved.html", EmailTypeConstants.SENDGRID_CATEGORIES),
+  SO_PROGRESS_REPORT_SUBMITTED(
+      30, "so-progress-report-submitted.html", EmailTypeConstants.SENDGRID_CATEGORIES),
+  SO_PROGRESS_REPORT_APPROVED(
+      31, "so-progress-report-approved.html", EmailTypeConstants.SENDGRID_CATEGORIES),
+  DAC_RADAR_APPROVED(32, "dac-radar-approved.ftl", EmailTypeConstants.SENDGRID_CATEGORIES),
+  NEW_DAR_SO_NEEDS_TO_APPROVE(
+      33, "new-dar-so-needs-to-approve.html", EmailTypeConstants.SENDGRID_CATEGORIES),
+  DAC_VOTE_REMINDER_DIGEST(34, "vote-digest.ftl", EmailTypeConstants.SENDGRID_CATEGORIES),
+  NEW_STUDY_REGISTRATION_CONFIRMATION(
+      35, "new-study-registration-confirmation.ftl", EmailTypeConstants.SENDGRID_CATEGORIES),
+  NEW_STUDY_DIGEST(36, "new-study-digest.ftl", EmailTypeConstants.SENDGRID_CATEGORIES),
   ;
 
   private final Integer typeInt;
   public final String templateName;
+  private final List<String> categories;
 
   EmailType(Integer typeInt) {
-    this(typeInt, null);
+    this(typeInt, null, null);
   }
 
-  EmailType(Integer typeInt, String templateName) {
+  EmailType(Integer typeInt, String templateName, List<String> categories) {
     this.typeInt = typeInt;
     this.templateName = templateName;
+    this.categories = categories;
   }
 
   public Integer getTypeInt() {
     return typeInt;
+  }
+
+  public List<String> getSendGridCategories() {
+    return categories;
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/service/EmailService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/EmailService.java
@@ -147,6 +147,11 @@ public class EmailService implements ConsentLogger {
             mailMessage.createSubject(),
             new Email(mailMessage.toUser.getEmail()),
             new Content("text/html", content));
+    // Add SendGrid categories for email analytics if categories are defined for the email type
+    if (mailMessage.emailType.getSendGridCategories() != null
+        && !mailMessage.emailType.getSendGridCategories().isEmpty()) {
+      mailMessage.emailType.getSendGridCategories().forEach(message::addCategory);
+    }
     // Checks that the user has not disabled email before sending
     Response response = sendGridAPI.sendMessage(message, mailMessage.toUser.getEmail());
     saveEmailAndResponse(

--- a/src/test/java/org/broadinstitute/consent/http/service/EmailServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/EmailServiceTest.java
@@ -662,6 +662,7 @@ class EmailServiceTest extends AbstractTestHelper {
             })
         .when(jdbi)
         .useHandle(any());
+    @SuppressWarnings("unchecked")
     ResultIterator<User> mockIterator = mock(ResultIterator.class);
     when(mockIterator.hasNext()).thenReturn(true, false);
     when(mockIterator.next()).thenReturn(toUser);

--- a/src/test/java/org/broadinstitute/consent/http/service/EmailServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/EmailServiceTest.java
@@ -108,7 +108,6 @@ class EmailServiceTest extends AbstractTestHelper {
     String entityReferenceId = "entityReferenceId";
     Integer userId = 1234;
     Integer voteId = 4567;
-    when(templateHelper.getTemplate(EmailType.NEW_CASE.templateName)).thenReturn(mock());
     var message =
         new org.broadinstitute.consent.http.mail.message.MailMessage(user, EmailType.NEW_CASE) {
           @Override
@@ -166,13 +165,12 @@ class EmailServiceTest extends AbstractTestHelper {
         user.getEmail(), mail.getPersonalization().getFirst().getTos().getFirst().getEmail());
     assertEquals(subject, mail.getSubject());
 
-    // Verify sendgrid categories are set according to the EmailType configuration
-    if (EmailType.NEW_CASE.getSendGridCategories() != null
-        && !EmailType.NEW_CASE.getSendGridCategories().isEmpty()) {
-      assertEquals(EmailType.NEW_CASE.getSendGridCategories(), mail.getCategories());
-    } else {
-      assertTrue(mail.getCategories() == null || mail.getCategories().isEmpty());
-    }
+    // Verify sendgrid categories are configured for NEW_CASE and applied to the outgoing mail
+    assertTrue(
+        EmailType.NEW_CASE.getSendGridCategories() != null
+            && !EmailType.NEW_CASE.getSendGridCategories().isEmpty(),
+        "Expected NEW_CASE to define SendGrid categories");
+    assertEquals(EmailType.NEW_CASE.getSendGridCategories(), mail.getCategories());
 
     verify(emailDAO)
         .insert(

--- a/src/test/java/org/broadinstitute/consent/http/service/EmailServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/EmailServiceTest.java
@@ -2,6 +2,7 @@ package org.broadinstitute.consent.http.service;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -98,7 +99,7 @@ class EmailServiceTest extends AbstractTestHelper {
   }
 
   @Test
-  void sendMessage() throws Exception {
+  void testSendMessage() throws Exception {
     String userEmail = "user@duos";
     User user = new User();
     user.setEmail(userEmail);
@@ -107,9 +108,9 @@ class EmailServiceTest extends AbstractTestHelper {
     String entityReferenceId = "entityReferenceId";
     Integer userId = 1234;
     Integer voteId = 4567;
-    when(templateHelper.getTemplate(EmailType.COLLECT.templateName)).thenReturn(mock());
+    when(templateHelper.getTemplate(EmailType.NEW_CASE.templateName)).thenReturn(mock());
     var message =
-        new org.broadinstitute.consent.http.mail.message.MailMessage(user, EmailType.COLLECT) {
+        new org.broadinstitute.consent.http.mail.message.MailMessage(user, EmailType.NEW_CASE) {
           @Override
           public String createSubject() {
             return subject;
@@ -131,7 +132,7 @@ class EmailServiceTest extends AbstractTestHelper {
           }
         };
     Template template = mock();
-    when(templateHelper.getTemplate(EmailType.COLLECT.templateName)).thenReturn(template);
+    when(templateHelper.getTemplate(EmailType.NEW_CASE.templateName)).thenReturn(template);
     Response response = new Response();
     response.setStatusCode(200);
     response.setBody("body");
@@ -165,6 +166,14 @@ class EmailServiceTest extends AbstractTestHelper {
         user.getEmail(), mail.getPersonalization().getFirst().getTos().getFirst().getEmail());
     assertEquals(subject, mail.getSubject());
 
+    // Verify sendgrid categories are set according to the EmailType configuration
+    if (EmailType.NEW_CASE.getSendGridCategories() != null
+        && !EmailType.NEW_CASE.getSendGridCategories().isEmpty()) {
+      assertEquals(EmailType.NEW_CASE.getSendGridCategories(), mail.getCategories());
+    } else {
+      assertTrue(mail.getCategories() == null || mail.getCategories().isEmpty());
+    }
+
     verify(emailDAO)
         .insert(
             argThat(
@@ -172,7 +181,7 @@ class EmailServiceTest extends AbstractTestHelper {
                     Objects.equals(m.entityReferenceId(), entityReferenceId)
                         && Objects.equals(m.voteId(), voteId)
                         && Objects.equals(m.userId(), 1234)
-                        && Objects.equals(m.emailType(), EmailType.COLLECT.getTypeInt())
+                        && Objects.equals(m.emailType(), EmailType.NEW_CASE.getTypeInt())
                         && Objects.equals(m.dateSent(), Date.from(fixedInstant))
                         && Objects.equals(m.emailText(), emailText)
                         && Objects.equals(m.sendgridResponse(), response.getBody())


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DT-3194

## Summary
Adds a default DUOS category to all sendgrid emails. Tested locally by enabling email notifications and sending myself a vote reminder email. Additional groups can be added by overriding what is provided in the `EmailType` enum.

### Examples in Sendgrid
My test email:
<img width="1858" height="1344" alt="Screenshot 2026-05-07 at 2 07 15 PM" src="https://github.com/user-attachments/assets/1ed2b746-5633-45ec-9d65-447e82872b55" />

The [category report](https://app.sendgrid.com/statistics/category):
<img width="1858" height="1344" alt="Screenshot 2026-05-07 at 2 07 24 PM" src="https://github.com/user-attachments/assets/3a25465a-ce23-4ab8-90ef-4ffd672cf870" />

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
