### PR TITLE
[DT-3258] Ensure that FSOs are limited to DAAs for this DAO.

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/DaaDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DaaDAO.java
@@ -67,7 +67,7 @@ public interface DaaDAO extends Transactional<DaaDAO> {
                 dac.name,
                 dac.description
           FROM data_access_agreement daa
-          LEFT JOIN file_storage_object fso ON daa.daa_id::text = fso.entity_id
+          LEFT JOIN file_storage_object fso ON daa.daa_id::text = fso.entity_id AND fso.category = 'dataAccessAgreement'
           LEFT JOIN dac_daa dd ON daa.daa_id = dd.daa_id
           LEFT JOIN dac ON dd.dac_id = dac.dac_id AND dac.deleted IS NOT TRUE
       """)
@@ -108,7 +108,7 @@ public interface DaaDAO extends Transactional<DaaDAO> {
                 dac.name,
                 dac.description
           FROM data_access_agreement daa
-          LEFT JOIN file_storage_object fso ON daa.daa_id::text = fso.entity_id
+          LEFT JOIN file_storage_object fso ON daa.daa_id::text = fso.entity_id AND fso.category = 'dataAccessAgreement'
           LEFT JOIN dac_daa dd ON daa.daa_id = dd.daa_id
           LEFT JOIN dac ON dd.dac_id = dac.dac_id AND dac.deleted IS NOT TRUE
           WHERE daa.daa_id = :daaId
@@ -150,7 +150,7 @@ public interface DaaDAO extends Transactional<DaaDAO> {
                 dac.name,
                 dac.description
           FROM data_access_agreement daa
-          LEFT JOIN file_storage_object fso ON daa.daa_id::text = fso.entity_id
+          LEFT JOIN file_storage_object fso ON daa.daa_id::text = fso.entity_id AND fso.category = 'dataAccessAgreement'
           LEFT JOIN dac_daa dd ON daa.daa_id = dd.daa_id
           LEFT JOIN dac ON dd.dac_id = dac.dac_id
           WHERE daa.initial_dac_id = :dacId
@@ -272,7 +272,7 @@ public interface DaaDAO extends Transactional<DaaDAO> {
                 dac.name,
                 dac.description
           FROM data_access_agreement daa
-          LEFT JOIN file_storage_object fso ON daa.daa_id::text = fso.entity_id
+          LEFT JOIN file_storage_object fso ON daa.daa_id::text = fso.entity_id AND fso.category = 'dataAccessAgreement'
           INNER JOIN dac_daa ON daa.daa_id = dac_daa.daa_id
           INNER JOIN dac ON dac.dac_id = dac_daa.dac_id
           INNER JOIN dataset ON dataset.dac_id = dac.dac_id

--- a/src/test/java/org/broadinstitute/consent/http/db/DaaDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DaaDAOTest.java
@@ -85,6 +85,44 @@ class DaaDAOTest extends DAOTestHelper {
   }
 
   @Test
+  void testFindAllDacOnlyProperFileCategory() {
+    Integer userId = createUserId();
+    Integer dacId =
+        dacDAO.createDac(randomAlphabetic(5), randomAlphabetic(5), "", createUser().getUserId());
+    Integer daaId = daaDAO.createDaa(userId, Instant.now(), userId, Instant.now(), dacId);
+    fileStorageObjectDAO.insertNewFile(
+        randomAlphabetic(10),
+        FileCategory.ALTERNATIVE_DATA_SHARING_PLAN.getValue(),
+        randomAlphabetic(10),
+        MediaType.TEXT_PLAIN_TYPE.getType(),
+        daaId.toString(),
+        userId,
+        Instant.now());
+    Integer fsoId =
+        fileStorageObjectDAO.insertNewFile(
+            randomAlphabetic(10),
+            FileCategory.DATA_ACCESS_AGREEMENT.getValue(),
+            randomAlphabetic(10),
+            MediaType.TEXT_PLAIN_TYPE.getType(),
+            daaId.toString(),
+            userId,
+            Instant.now());
+    fileStorageObjectDAO.insertNewFile(
+        randomAlphabetic(10),
+        FileCategory.ALTERNATIVE_DATA_SHARING_PLAN.getValue(),
+        randomAlphabetic(10),
+        MediaType.TEXT_PLAIN_TYPE.getType(),
+        daaId.toString(),
+        userId,
+        Instant.now());
+    List<DataAccessAgreement> daa = daaDAO.findAll();
+    assertNotNull(daa);
+    assertEquals(1, daa.size());
+    assertNotNull(daa.getFirst().getFile());
+    assertEquals(fsoId, daa.getFirst().getFile().getFileStorageObjectId());
+  }
+
+  @Test
   void testFindAllMultipleDaas() {
     Integer userId = createUserId();
     Integer dacId =
@@ -266,6 +304,14 @@ class DaaDAOTest extends DAOTestHelper {
             daaId.toString(),
             userId,
             Instant.now());
+    fileStorageObjectDAO.insertNewFile(
+        randomAlphabetic(10),
+        FileCategory.DATA_USE_LETTER.getValue(),
+        randomAlphabetic(10),
+        MediaType.TEXT_PLAIN_TYPE.getType(),
+        daaId.toString(),
+        userId,
+        Instant.now());
     DataAccessAgreement daa = daaDAO.findById(daaId);
     assertNotNull(daa);
     assertNotNull(daa.getFile());


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-3258](https://broadworkbench.atlassian.net/browse/DT-3258)

### Summary

Limits retrieval of FSOs to data access agreements when including FSOs.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
