### PR TITLE
[DT-3256] Fix document upload permissions for ADMIN role

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/service/FileStorageObjectService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/FileStorageObjectService.java
@@ -260,23 +260,23 @@ public class FileStorageObjectService implements ConsentLogger {
    *       FileCategory#DATA_USE_LETTER}:
    *       <ul>
    *         <li>WRITE: DAR creator only.
-   *         <li>READ: CHAIRPERSON, MEMBER, or DAR creator.
+   *         <li>READ: ADMIN, CHAIRPERSON, MEMBER, or DAR creator.
    *       </ul>
    *   <li><b>DAC</b> – {@link FileCategory#DATA_ACCESS_AGREEMENT}:
    *       <ul>
    *         <li>WRITE: CHAIRPERSON of the specific DAC (entity-scoped).
-   *         <li>READ: any authenticated non-ADMIN user.
+   *         <li>READ: any authenticated user.
    *       </ul>
    *   <li><b>DATASET</b> – {@link FileCategory#NIH_INSTITUTIONAL_CERTIFICATION}:
    *       <ul>
    *         <li>WRITE: DATASUBMITTER or CHAIRPERSON.
-   *         <li>READ: DATASUBMITTER, CHAIRPERSON, or MEMBER.
+   *         <li>READ: ADMIN, DATASUBMITTER, CHAIRPERSON, or MEMBER.
    *       </ul>
    *   <li><b>STUDY</b> – {@link FileCategory#ALTERNATIVE_DATA_SHARING_PLAN}:
    *       <ul>
    *         <li>WRITE: DATASUBMITTER or CHAIRPERSON.
-   *         <li>READ: DATASUBMITTER or CHAIRPERSON (study must be DAC-linked; enforced by entity
-   *             resolution via DatasetService).
+   *         <li>READ: ADMIN, DATASUBMITTER, or CHAIRPERSON (study must be DAC-linked; enforced by
+   *             entity resolution via DatasetService).
    *       </ul>
    * </ul>
    *
@@ -288,7 +288,7 @@ public class FileStorageObjectService implements ConsentLogger {
    */
   public void checkAccess(
       User user, String entity, String entityId, FileCategory category, OperationType op) {
-    if (hasRole(user, UserRoles.ADMIN)) {
+    if (op == OperationType.WRITE && hasRole(user, UserRoles.ADMIN)) {
       throw new ForbiddenException(PERMISSION_DENIED);
     }
 
@@ -306,7 +306,7 @@ public class FileStorageObjectService implements ConsentLogger {
       case DAR -> checkDarAccess(user, entityId, op);
       case DAC -> checkDacAccess(user, entityId, op);
       case DATASET -> checkDatasetAccess(user, op);
-      case STUDY -> checkStudyAccess(user);
+      case STUDY -> checkStudyAccess(user, op);
     }
   }
 
@@ -323,17 +323,18 @@ public class FileStorageObjectService implements ConsentLogger {
     if (entity == DocumentEntity.DAR) {
       boolean isCreator = isDarCreator(user, entityId);
       if (!isCreator) {
-        ensureHasAnyRole(user, UserRoles.CHAIRPERSON, UserRoles.MEMBER);
+        ensureHasAnyRole(user, UserRoles.ADMIN, UserRoles.CHAIRPERSON, UserRoles.MEMBER);
       }
       return;
     }
 
     if (entity == DocumentEntity.STUDY) {
-      ensureHasAnyRole(user, UserRoles.DATASUBMITTER, UserRoles.CHAIRPERSON);
+      ensureHasAnyRole(user, UserRoles.ADMIN, UserRoles.DATASUBMITTER, UserRoles.CHAIRPERSON);
       return;
     }
 
-    ensureHasAnyRole(user, UserRoles.DATASUBMITTER, UserRoles.CHAIRPERSON, UserRoles.MEMBER);
+    ensureHasAnyRole(
+        user, UserRoles.ADMIN, UserRoles.DATASUBMITTER, UserRoles.CHAIRPERSON, UserRoles.MEMBER);
   }
 
   private void checkDarAccess(User user, String entityId, OperationType op) {
@@ -344,7 +345,7 @@ public class FileStorageObjectService implements ConsentLogger {
     }
 
     if (op == OperationType.READ && !isCreator) {
-      ensureHasAnyRole(user, UserRoles.CHAIRPERSON, UserRoles.MEMBER);
+      ensureHasAnyRole(user, UserRoles.ADMIN, UserRoles.CHAIRPERSON, UserRoles.MEMBER);
     }
   }
 
@@ -365,14 +366,20 @@ public class FileStorageObjectService implements ConsentLogger {
       return;
     }
 
-    ensureHasAnyRole(user, UserRoles.DATASUBMITTER, UserRoles.CHAIRPERSON, UserRoles.MEMBER);
+    ensureHasAnyRole(
+        user, UserRoles.ADMIN, UserRoles.DATASUBMITTER, UserRoles.CHAIRPERSON, UserRoles.MEMBER);
   }
 
-  private void checkStudyAccess(User user) {
-    // Both READ and WRITE require DATASUBMITTER or CHAIRPERSON.
+  private void checkStudyAccess(User user, OperationType op) {
+    if (op == OperationType.WRITE) {
+      ensureHasAnyRole(user, UserRoles.DATASUBMITTER, UserRoles.CHAIRPERSON);
+      return;
+    }
+
+    // READ requires ADMIN, DATASUBMITTER, or CHAIRPERSON.
     // For READ the study must be DAC-linked; that constraint is enforced during entity
     // resolution via DatasetService.findStudyByIdForRead.
-    ensureHasAnyRole(user, UserRoles.DATASUBMITTER, UserRoles.CHAIRPERSON);
+    ensureHasAnyRole(user, UserRoles.ADMIN, UserRoles.DATASUBMITTER, UserRoles.CHAIRPERSON);
   }
 
   // ---------------------------------------------------------------------------

--- a/src/main/java/org/broadinstitute/consent/http/service/FileStorageObjectService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/FileStorageObjectService.java
@@ -260,23 +260,23 @@ public class FileStorageObjectService implements ConsentLogger {
    *       FileCategory#DATA_USE_LETTER}:
    *       <ul>
    *         <li>WRITE: DAR creator only.
-   *         <li>READ: ADMIN, CHAIRPERSON, MEMBER, or DAR creator.
+   *         <li>READ: CHAIRPERSON, MEMBER, or DAR creator.
    *       </ul>
    *   <li><b>DAC</b> – {@link FileCategory#DATA_ACCESS_AGREEMENT}:
    *       <ul>
-   *         <li>WRITE: CHAIRPERSON of the specific DAC (entity-scoped) or ADMIN.
-   *         <li>READ: any authenticated user.
+   *         <li>WRITE: CHAIRPERSON of the specific DAC (entity-scoped).
+   *         <li>READ: any authenticated non-ADMIN user.
    *       </ul>
    *   <li><b>DATASET</b> – {@link FileCategory#NIH_INSTITUTIONAL_CERTIFICATION}:
    *       <ul>
-   *         <li>WRITE: ADMIN, DATASUBMITTER, or CHAIRPERSON.
-   *         <li>READ: ADMIN, DATASUBMITTER, CHAIRPERSON, or MEMBER.
+   *         <li>WRITE: DATASUBMITTER or CHAIRPERSON.
+   *         <li>READ: DATASUBMITTER, CHAIRPERSON, or MEMBER.
    *       </ul>
    *   <li><b>STUDY</b> – {@link FileCategory#ALTERNATIVE_DATA_SHARING_PLAN}:
    *       <ul>
-   *         <li>WRITE: ADMIN, DATASUBMITTER, or CHAIRPERSON.
-   *         <li>READ: ADMIN, DATASUBMITTER, or CHAIRPERSON (study must be DAC-linked; enforced by
-   *             entity resolution via DatasetService).
+   *         <li>WRITE: DATASUBMITTER or CHAIRPERSON.
+   *         <li>READ: DATASUBMITTER or CHAIRPERSON (study must be DAC-linked; enforced by entity
+   *             resolution via DatasetService).
    *       </ul>
    * </ul>
    *
@@ -288,6 +288,10 @@ public class FileStorageObjectService implements ConsentLogger {
    */
   public void checkAccess(
       User user, String entity, String entityId, FileCategory category, OperationType op) {
+    if (hasRole(user, UserRoles.ADMIN)) {
+      throw new ForbiddenException(PERMISSION_DENIED);
+    }
+
     DocumentEntity documentEntity = requireDocumentEntity(entity);
 
     if (category == null) {
@@ -319,18 +323,17 @@ public class FileStorageObjectService implements ConsentLogger {
     if (entity == DocumentEntity.DAR) {
       boolean isCreator = isDarCreator(user, entityId);
       if (!isCreator) {
-        ensureHasAnyRole(user, UserRoles.ADMIN, UserRoles.CHAIRPERSON, UserRoles.MEMBER);
+        ensureHasAnyRole(user, UserRoles.CHAIRPERSON, UserRoles.MEMBER);
       }
       return;
     }
 
     if (entity == DocumentEntity.STUDY) {
-      ensureHasAnyRole(user, UserRoles.ADMIN, UserRoles.DATASUBMITTER, UserRoles.CHAIRPERSON);
+      ensureHasAnyRole(user, UserRoles.DATASUBMITTER, UserRoles.CHAIRPERSON);
       return;
     }
 
-    ensureHasAnyRole(
-        user, UserRoles.ADMIN, UserRoles.DATASUBMITTER, UserRoles.CHAIRPERSON, UserRoles.MEMBER);
+    ensureHasAnyRole(user, UserRoles.DATASUBMITTER, UserRoles.CHAIRPERSON, UserRoles.MEMBER);
   }
 
   private void checkDarAccess(User user, String entityId, OperationType op) {
@@ -341,7 +344,7 @@ public class FileStorageObjectService implements ConsentLogger {
     }
 
     if (op == OperationType.READ && !isCreator) {
-      ensureHasAnyRole(user, UserRoles.ADMIN, UserRoles.CHAIRPERSON, UserRoles.MEMBER);
+      ensureHasAnyRole(user, UserRoles.CHAIRPERSON, UserRoles.MEMBER);
     }
   }
 
@@ -358,19 +361,18 @@ public class FileStorageObjectService implements ConsentLogger {
 
   private void checkDatasetAccess(User user, OperationType op) {
     if (op == OperationType.WRITE) {
-      ensureHasAnyRole(user, UserRoles.ADMIN, UserRoles.DATASUBMITTER, UserRoles.CHAIRPERSON);
+      ensureHasAnyRole(user, UserRoles.DATASUBMITTER, UserRoles.CHAIRPERSON);
       return;
     }
 
-    ensureHasAnyRole(
-        user, UserRoles.ADMIN, UserRoles.DATASUBMITTER, UserRoles.CHAIRPERSON, UserRoles.MEMBER);
+    ensureHasAnyRole(user, UserRoles.DATASUBMITTER, UserRoles.CHAIRPERSON, UserRoles.MEMBER);
   }
 
   private void checkStudyAccess(User user) {
-    // Both READ and WRITE require ADMIN, DATASUBMITTER, or CHAIRPERSON.
+    // Both READ and WRITE require DATASUBMITTER or CHAIRPERSON.
     // For READ the study must be DAC-linked; that constraint is enforced during entity
     // resolution via DatasetService.findStudyByIdForRead.
-    ensureHasAnyRole(user, UserRoles.ADMIN, UserRoles.DATASUBMITTER, UserRoles.CHAIRPERSON);
+    ensureHasAnyRole(user, UserRoles.DATASUBMITTER, UserRoles.CHAIRPERSON);
   }
 
   // ---------------------------------------------------------------------------
@@ -383,14 +385,8 @@ public class FileStorageObjectService implements ConsentLogger {
     return dar.getUserId() != null && dar.getUserId().equals(user.getUserId());
   }
 
-  /**
-   * Returns {@code true} when the user holds the CHAIRPERSON role scoped to the given DAC ID. ADMIN
-   * users are treated as implicit chairs for all DACs.
-   */
+  /** Returns {@code true} when the user holds the CHAIRPERSON role scoped to the given DAC ID. */
   boolean isDacChair(User user, Integer dacId) {
-    if (hasRole(user, UserRoles.ADMIN)) {
-      return true;
-    }
     if (user.getRoles() == null) {
       return false;
     }

--- a/src/test/java/org/broadinstitute/consent/http/resources/DocumentResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DocumentResourceTest.java
@@ -147,16 +147,17 @@ class DocumentResourceTest {
   }
 
   @Test
-  void testFindDocumentsByEntityAdminForbidden() {
+  void testFindDocumentsByEntityAdminReadAllowed() {
     User admin = new User();
     admin.setAdminRole();
+    List<FileStorageObject> files = List.of(new FileStorageObject());
 
     when(duosUser.getUser()).thenReturn(admin);
-    when(fileStorageObjectService.listDocuments(admin, "dataset", "222"))
-        .thenThrow(new jakarta.ws.rs.ForbiddenException("User does not have permission"));
+    when(fileStorageObjectService.listDocuments(admin, "dataset", "222")).thenReturn(files);
 
     try (var response = resource.findDocumentsByEntity(duosUser, "dataset", "222")) {
-      assertEquals(HttpStatusCodes.STATUS_CODE_FORBIDDEN, response.getStatus());
+      assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+      assertEquals(files, response.getEntity());
     }
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/resources/DocumentResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DocumentResourceTest.java
@@ -147,6 +147,20 @@ class DocumentResourceTest {
   }
 
   @Test
+  void testFindDocumentsByEntityAdminForbidden() {
+    User admin = new User();
+    admin.setAdminRole();
+
+    when(duosUser.getUser()).thenReturn(admin);
+    when(fileStorageObjectService.listDocuments(admin, "dataset", "222"))
+        .thenThrow(new jakarta.ws.rs.ForbiddenException("User does not have permission"));
+
+    try (var response = resource.findDocumentsByEntity(duosUser, "dataset", "222")) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_FORBIDDEN, response.getStatus());
+    }
+  }
+
+  @Test
   void testFindDocumentsByStudyEntityReturnsEmptyList() {
     int studyId = 333;
 
@@ -404,6 +418,26 @@ class DocumentResourceTest {
         resource.uploadDocument(
             duosUser, "dataset", "123", inputStream, fileDetail, "badCategory")) {
       assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
+    }
+  }
+
+  @Test
+  void testUploadDocumentAdminForbidden() throws Exception {
+    ByteArrayInputStream inputStream = new ByteArrayInputStream("file-content".getBytes());
+    User admin = new User();
+    admin.setAdminRole();
+
+    when(fileDetail.getFileName()).thenReturn("document.pdf");
+    when(fileDetail.getSize()).thenReturn(1024L);
+    when(duosUser.getUser()).thenReturn(admin);
+    when(fileStorageObjectService.uploadDocument(
+            admin, "dataset", "123", inputStream, fileDetail, "dataUseLetter"))
+        .thenThrow(new jakarta.ws.rs.ForbiddenException("User does not have permission"));
+
+    try (var response =
+        resource.uploadDocument(
+            duosUser, "dataset", "123", inputStream, fileDetail, "dataUseLetter")) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_FORBIDDEN, response.getStatus());
     }
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/service/FileStorageObjectServiceAccessTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/FileStorageObjectServiceAccessTest.java
@@ -31,11 +31,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
  * <pre>
  * Entity   | Category                     | WRITE                           | READ
  * ---------+------------------------------+--------------------------------+-----------------------------
- * DAR      | IRB_COLLABORATION_LETTER     | creator only                   | creator, ADMIN, CHAIR, MEMBER
- * DAR      | DATA_USE_LETTER              | creator only                   | creator, ADMIN, CHAIR, MEMBER
- * DAC      | DATA_ACCESS_AGREEMENT        | ADMIN or DAC-scoped CHAIR      | any authenticated user
- * DATASET  | NIH_INSTITUTIONAL_CERT       | ADMIN, DATASUBMITTER, CHAIR    | + MEMBER
- * STUDY    | ALTERNATIVE_DATA_SHARING_PLAN| ADMIN, DATASUBMITTER, CHAIR    | same (no MEMBER)
+ * DAR      | IRB_COLLABORATION_LETTER     | creator only (ADMIN denied)    | creator, ADMIN, CHAIR, MEMBER
+ * DAR      | DATA_USE_LETTER              | creator only (ADMIN denied)    | creator, ADMIN, CHAIR, MEMBER
+ * DAC      | DATA_ACCESS_AGREEMENT        | DAC-scoped CHAIR only          | any authenticated user
+ * DATASET  | NIH_INSTITUTIONAL_CERT       | DATASUBMITTER, CHAIR           | ADMIN, DATASUBMITTER, CHAIR, MEMBER
+ * STUDY    | ALTERNATIVE_DATA_SHARING_PLAN| DATASUBMITTER, CHAIR           | ADMIN, DATASUBMITTER, CHAIR
  * </pre>
  */
 @ExtendWith(MockitoExtension.class)
@@ -300,9 +300,10 @@ class FileStorageObjectServiceAccessTest {
     private static final int DAC_INT_ID = 10;
 
     @Test
-    void crudAllowedForAdmin() {
+    void crudDeniedForAdmin() {
       User admin = adminUser();
-      assertDoesNotThrow(
+      assertThrows(
+          ForbiddenException.class,
           () ->
               service.checkAccess(
                   admin, "dac", DAC_ID, FileCategory.DATA_ACCESS_AGREEMENT, OperationType.WRITE));
@@ -382,9 +383,10 @@ class FileStorageObjectServiceAccessTest {
   class DatasetNihInstitutionalCertification {
 
     @Test
-    void crudAllowedForAdmin() {
+    void crudDeniedForAdmin() {
       User admin = adminUser();
-      assertDoesNotThrow(
+      assertThrows(
+          ForbiddenException.class,
           () ->
               service.checkAccess(
                   admin,
@@ -511,9 +513,10 @@ class FileStorageObjectServiceAccessTest {
   class StudyAlternativeDataSharingPlan {
 
     @Test
-    void crudAllowedForAdmin() {
+    void crudDeniedForAdmin() {
       User admin = adminUser();
-      assertDoesNotThrow(
+      assertThrows(
+          ForbiddenException.class,
           () ->
               service.checkAccess(
                   admin,
@@ -809,9 +812,9 @@ class FileStorageObjectServiceAccessTest {
   }
 
   @Test
-  void isDacChairReturnsTrueForAdmin() {
+  void isDacChairReturnsFalseForAdmin() {
     User admin = adminUser();
-    assertTrue(service.isDacChair(admin, 10));
+    assertFalse(service.isDacChair(admin, 10));
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/FileStorageObjectServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/FileStorageObjectServiceTest.java
@@ -29,6 +29,7 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.broadinstitute.consent.http.cloudstore.GCSService;
 import org.broadinstitute.consent.http.db.FileStorageObjectDAO;
 import org.broadinstitute.consent.http.enumeration.FileCategory;
+import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.Dac;
 import org.broadinstitute.consent.http.models.DataAccessRequest;
 import org.broadinstitute.consent.http.models.Dataset;
@@ -293,7 +294,7 @@ class FileStorageObjectServiceTest {
   @Test
   void testFetchMetadataByEntityAndEntityIdForReadDataset() {
     User user = new User();
-    user.setAdminRole(); // ADMIN can read dataset documents
+    user.setMemberRole();
     Integer datasetId = 123;
     Integer fileId = 10;
     FileStorageObject fileStorageObject = new FileStorageObject();
@@ -315,7 +316,7 @@ class FileStorageObjectServiceTest {
   @Test
   void testAllFetchMetadataByEntityAndEntityIdForReadStudy() {
     User user = new User();
-    user.setAdminRole(); // ADMIN can read study documents
+    user.setChairpersonRole();
     Integer studyId = 456;
     Study study = new Study();
     study.setUuid(java.util.UUID.randomUUID());
@@ -383,7 +384,6 @@ class FileStorageObjectServiceTest {
   @Test
   void testFetchAllMetadataByEntityAndEntityIdForReadDac() {
     User user = new User();
-    user.setAdminRole();
     Integer dacId = 456;
     List<FileStorageObject> fileStorageObjects = List.of(new FileStorageObject());
 
@@ -435,7 +435,7 @@ class FileStorageObjectServiceTest {
   @Test
   void testFetchMetadataByEntityAndEntityIdForReadStudy() {
     User user = new User();
-    user.setAdminRole(); // ADMIN can read study documents
+    user.setChairpersonRole();
     Integer studyId = 456;
     Integer fileId = 11;
     Study study = new Study();
@@ -464,7 +464,7 @@ class FileStorageObjectServiceTest {
 
     User user = new User();
     user.setUserId(25);
-    user.setAdminRole(); // ADMIN can CRUD DATASET NIH_INSTITUTIONAL_CERTIFICATION
+    user.setRoles(List.of(UserRoles.DataSubmitter()));
 
     Dataset dataset = new Dataset();
     FileStorageObject created = new FileStorageObject();
@@ -525,7 +525,7 @@ class FileStorageObjectServiceTest {
   @Test
   void testGetDocumentFileByEntityAndEntityIdForReadDataset() throws Exception {
     User user = new User();
-    user.setAdminRole(); // ADMIN can read any dataset document
+    user.setMemberRole();
     Integer datasetId = 123;
     Integer fileId = 10;
 
@@ -562,7 +562,7 @@ class FileStorageObjectServiceTest {
   @Test
   void testGetDocumentFileThrowsBadGatewayWhenGcsFails() {
     User user = new User();
-    user.setAdminRole(); // ADMIN can read dataset documents
+    user.setMemberRole();
     Integer datasetId = 123;
     Integer fileId = 10;
     String entityId = datasetId.toString();
@@ -611,7 +611,7 @@ class FileStorageObjectServiceTest {
   void testDeleteDocumentSetsDeletedFieldsAndCallsDao() {
     User user = new User();
     user.setUserId(25);
-    user.setAdminRole(); // ADMIN can CRUD dataset documents
+    user.setRoles(List.of(UserRoles.DataSubmitter()));
     Integer datasetId = 123;
     Integer fileId = 10;
     String entityId = datasetId.toString();
@@ -674,7 +674,7 @@ class FileStorageObjectServiceTest {
   void testUpdateDocumentCategoryUpdatesCategoryAndAuditFields() {
     User user = new User();
     user.setUserId(25);
-    user.setAdminRole(); // ADMIN can CRUD dataset documents
+    user.setRoles(List.of(UserRoles.DataSubmitter()));
     Integer datasetId = 123;
     Integer fileId = 10;
     String entityId = datasetId.toString();
@@ -731,7 +731,7 @@ class FileStorageObjectServiceTest {
   void testUpdateDocumentCategoryThrowsNotFoundWhenFileDeletedOrMissing() {
     User user = new User();
     user.setUserId(25);
-    user.setAdminRole(); // ADMIN can CRUD dataset documents; passes checkAccess
+    user.setRoles(List.of(UserRoles.DataSubmitter()));
     Integer datasetId = 123;
     Integer fileId = 10;
     String entityId = datasetId.toString();
@@ -774,5 +774,40 @@ class FileStorageObjectServiceTest {
     assertEquals("Category is not allowed for entity", exception.getMessage());
     verifyNoInteractions(fileStorageObjectDAO);
     verifyNoInteractions(datasetService);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"dataset", "study", "dac", "dar"})
+  void testListDocumentsForbiddenForAdmin(String entity) {
+    User user = new User();
+    user.setAdminRole();
+
+    initService();
+
+    assertThrows(ForbiddenException.class, () -> service.listDocuments(user, entity, "123"));
+    verifyNoInteractions(datasetService);
+    verifyNoInteractions(dacService);
+    verifyNoInteractions(dataAccessRequestService);
+    verifyNoInteractions(fileStorageObjectDAO);
+  }
+
+  @Test
+  void testUploadDocumentForbiddenForAdmin() {
+    InputStream inputStream = new ByteArrayInputStream("metadata".getBytes());
+    FormDataContentDisposition fileDetail =
+        FormDataContentDisposition.name("file").fileName("upload.pdf").size(32).build();
+    User user = new User();
+    user.setAdminRole();
+
+    initService();
+
+    assertThrows(
+        ForbiddenException.class,
+        () ->
+            service.uploadDocument(
+                user, "dataset", "123", inputStream, fileDetail, "nihInstitutionalCertification"));
+    verifyNoInteractions(datasetService);
+    verifyNoInteractions(fileStorageObjectDAO);
+    verifyNoInteractions(gcsService);
   }
 }

--- a/src/test/java/org/broadinstitute/consent/http/service/FileStorageObjectServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/FileStorageObjectServiceTest.java
@@ -776,19 +776,28 @@ class FileStorageObjectServiceTest {
     verifyNoInteractions(datasetService);
   }
 
-  @ParameterizedTest
-  @ValueSource(strings = {"dataset", "study", "dac", "dar"})
-  void testListDocumentsForbiddenForAdmin(String entity) {
+  @Test
+  void testListDocumentsAllowedForAdminRead() {
     User user = new User();
     user.setAdminRole();
+    String entityId = "123";
+    List<FileStorageObject> fileStorageObjects = List.of(new FileStorageObject());
+
+    when(datasetService.findDatasetByIdForRead(user, Integer.valueOf(entityId)))
+        .thenReturn(new Dataset());
+    when(fileStorageObjectDAO.findFileMetadataByEntityIdAndCategories(
+            entityId, List.of(FileCategory.NIH_INSTITUTIONAL_CERTIFICATION.getValue())))
+        .thenReturn(fileStorageObjects);
 
     initService();
 
-    assertThrows(ForbiddenException.class, () -> service.listDocuments(user, entity, "123"));
-    verifyNoInteractions(datasetService);
-    verifyNoInteractions(dacService);
-    verifyNoInteractions(dataAccessRequestService);
-    verifyNoInteractions(fileStorageObjectDAO);
+    List<FileStorageObject> returned = service.listDocuments(user, "dataset", entityId);
+
+    assertEquals(fileStorageObjects, returned);
+    verify(datasetService).findDatasetByIdForRead(user, Integer.valueOf(entityId));
+    verify(fileStorageObjectDAO)
+        .findFileMetadataByEntityIdAndCategories(
+            entityId, List.of(FileCategory.NIH_INSTITUTIONAL_CERTIFICATION.getValue()));
   }
 
   @Test


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-3256

### Summary

This PR fixes overly broad ADMIN write permissions in the document upload process.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
