### PR TITLE
[DT-3265] Fix DAC <> DAA document linkage and resolution 

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
@@ -281,6 +281,7 @@ public class ConsentModule extends AbstractModule {
         providesGCSService(),
         providesDatasetService(),
         providesDacService(),
+        providesDaaService(),
         providesDataAccessRequestService());
   }
 

--- a/src/main/java/org/broadinstitute/consent/http/db/DaaDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DaaDAO.java
@@ -159,22 +159,9 @@ public interface DaaDAO extends Transactional<DaaDAO> {
 
   @SqlQuery(
       """
-          WITH linked_daa AS (
-              SELECT daa_id
-              FROM dac_daa
-              WHERE dac_id = :dacId
-          ),
-          initial_daa AS (
-              SELECT daa_id
-              FROM data_access_agreement
-              WHERE initial_dac_id = :dacId
-          )
-          SELECT DISTINCT daa_id
-          FROM (
-              SELECT daa_id FROM linked_daa
-              UNION ALL
-              SELECT daa_id FROM initial_daa
-          ) all_daa
+          SELECT daa_id FROM dac_daa WHERE dac_id = :dacId
+          UNION
+          SELECT daa_id FROM data_access_agreement WHERE initial_dac_id = :dacId
           ORDER BY daa_id DESC
           """)
   List<Integer> findDaaIdsByDacId(@Bind("dacId") Integer dacId);

--- a/src/main/java/org/broadinstitute/consent/http/db/DaaDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DaaDAO.java
@@ -157,6 +157,50 @@ public interface DaaDAO extends Transactional<DaaDAO> {
       """)
   DataAccessAgreement findByDacId(@Bind("dacId") Integer dacId);
 
+  @SqlQuery(
+      """
+          WITH linked_daa AS (
+              SELECT daa_id
+              FROM dac_daa
+              WHERE dac_id = :dacId
+          ),
+          initial_daa AS (
+              SELECT daa_id
+              FROM data_access_agreement
+              WHERE initial_dac_id = :dacId
+          )
+          SELECT DISTINCT daa_id
+          FROM (
+              SELECT daa_id FROM linked_daa
+              UNION ALL
+              SELECT daa_id FROM initial_daa
+          ) all_daa
+          ORDER BY daa_id DESC
+          """)
+  List<Integer> findDaaIdsByDacId(@Bind("dacId") Integer dacId);
+
+  @SqlQuery(
+      """
+          SELECT EXISTS (
+              SELECT 1
+              FROM dac_daa
+              WHERE dac_id = :dacId
+                    AND daa_id = :daaId
+          )
+          """)
+  boolean isDaaLinkedToDac(@Bind("dacId") Integer dacId, @Bind("daaId") Integer daaId);
+
+  @SqlQuery(
+      """
+          SELECT EXISTS (
+              SELECT 1
+              FROM data_access_agreement
+              WHERE initial_dac_id = :dacId
+                    AND daa_id = :daaId
+          )
+          """)
+  boolean isDaaInitiallyLinkedToDac(@Bind("dacId") Integer dacId, @Bind("daaId") Integer daaId);
+
   /**
    * Create a Daa given name, description, and create date
    *

--- a/src/main/java/org/broadinstitute/consent/http/service/DaaService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DaaService.java
@@ -11,6 +11,7 @@ import jakarta.ws.rs.ServerErrorException;
 import jakarta.ws.rs.core.MediaType;
 import java.io.IOException;
 import java.io.InputStream;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -151,10 +152,7 @@ public class DaaService implements ConsentLogger {
     List<DataAccessAgreement> daas = daaDAO.findAll();
     List<Dac> allDacs = dacDAO.findAll();
     if (daas != null) {
-      daas.forEach(
-          daa -> {
-            daa.setBroadDaa(isBroadDAA(daa.getDaaId(), daas, allDacs));
-          });
+      daas.forEach(daa -> daa.setBroadDaa(isBroadDAA(daa.getDaaId(), daas, allDacs)));
       return daas;
     }
     return List.of();
@@ -166,6 +164,28 @@ public class DaaService implements ConsentLogger {
       return daa;
     }
     throw new NotFoundException("Could not find DAA with the provided ID: " + daaId);
+  }
+
+  /**
+   * Returns all DAA IDs associated to a DAC, including both explicit dac_daa links and DAAs whose
+   * initial_dac_id matches the DAC.
+   */
+  public List<Integer> findDaaIdsByDacId(Integer dacId) {
+    List<Integer> daaIds = daaDAO.findDaaIdsByDacId(dacId);
+    return daaIds == null ? List.of() : daaIds;
+  }
+
+  /** Returns true when the provided DAA is associated to the DAC (directly or as initial DAC). */
+  public boolean isDaaLinkedToDac(Integer dacId, Integer daaId) {
+    return daaDAO.isDaaLinkedToDac(dacId, daaId) || daaDAO.isDaaInitiallyLinkedToDac(dacId, daaId);
+  }
+
+  /** Creates a new DAA for the DAC and links it for DAC document upload workflows. */
+  public Integer createAndLinkDaaIdForDac(User user, Integer dacId) {
+    Instant now = Instant.now();
+    Integer daaId = daaDAO.createDaa(user.getUserId(), now, user.getUserId(), now, dacId);
+    addDacToDaa(user.getUserId(), dacId, daaId);
+    return daaId;
   }
 
   public void sendNewDaaEmails(User user, Integer daaId, String dacName, String newDaaName)
@@ -219,7 +239,7 @@ public class DaaService implements ConsentLogger {
     try {
       JsonObject jsonObject = new Gson().fromJson(json, JsonObject.class);
       jsonElementList = jsonObject.getAsJsonArray(arrayKey).asList();
-    } catch (Exception e) {
+    } catch (Exception _) {
       throw new BadRequestException("Invalid JSON or missing array with key: " + arrayKey);
     }
     return jsonElementList.stream().distinct().map(e -> findById(e.getAsInt())).toList();

--- a/src/main/java/org/broadinstitute/consent/http/service/FileStorageObjectService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/FileStorageObjectService.java
@@ -41,11 +41,25 @@ public class FileStorageObjectService implements ConsentLogger {
 
   private static final String ENTITY_NOT_FOUND = "Entity not found";
   private static final String PERMISSION_DENIED = "User does not have permission";
+  private static final String FILE_NOT_FOUND = "File not found";
+  private static final List<String> DAC_ALLOWED_CATEGORY_VALUES =
+      List.of(FileCategory.DATA_ACCESS_AGREEMENT.getValue());
+  private static final UserRoles[] DAR_READ_ROLES =
+      new UserRoles[] {UserRoles.ADMIN, UserRoles.CHAIRPERSON, UserRoles.MEMBER};
+  private static final UserRoles[] DATASET_WRITE_ROLES =
+      new UserRoles[] {UserRoles.ADMIN, UserRoles.DATASUBMITTER, UserRoles.CHAIRPERSON};
+  private static final UserRoles[] DATASET_READ_ROLES =
+      new UserRoles[] {
+        UserRoles.ADMIN, UserRoles.DATASUBMITTER, UserRoles.CHAIRPERSON, UserRoles.MEMBER
+      };
+  private static final UserRoles[] STUDY_ROLES =
+      new UserRoles[] {UserRoles.ADMIN, UserRoles.DATASUBMITTER, UserRoles.CHAIRPERSON};
 
   GCSService gcsService;
   FileStorageObjectDAO fileStorageObjectDAO;
   DatasetService datasetService;
   DacService dacService;
+  DaaService daaService;
   DataAccessRequestService dataAccessRequestService;
 
   public FileStorageObjectService(
@@ -53,11 +67,13 @@ public class FileStorageObjectService implements ConsentLogger {
       GCSService gcsService,
       DatasetService datasetService,
       DacService dacService,
+      DaaService daaService,
       DataAccessRequestService dataAccessRequestService) {
     this.fileStorageObjectDAO = fileStorageObjectDAO;
     this.gcsService = gcsService;
     this.datasetService = datasetService;
     this.dacService = dacService;
+    this.daaService = daaService;
     this.dataAccessRequestService = dataAccessRequestService;
   }
 
@@ -92,7 +108,7 @@ public class FileStorageObjectService implements ConsentLogger {
     validateCategoryForEntity(documentEntity, category);
     checkAccess(user, entity, entityId, category, OperationType.WRITE);
 
-    String resolvedEntityId = resolveEntityId(user, documentEntity, entityId);
+    String resolvedEntityId = resolveEntityIdForUpload(user, documentEntity, entityId);
     return uploadAndStoreFile(
         content,
         fileDetail.getFileName(),
@@ -115,9 +131,7 @@ public class FileStorageObjectService implements ConsentLogger {
       User user, String entity, String entityId, Integer fileStorageObjectId) {
     DocumentEntity documentEntity = requireDocumentEntity(entity);
     checkAccess(user, entity, entityId, null, OperationType.READ);
-
-    String resolvedEntityId = resolveEntityId(user, documentEntity, entityId);
-    return fetchMetadataByEntityIdAndId(resolvedEntityId, fileStorageObjectId, documentEntity);
+    return resolveMetadataForEntity(user, documentEntity, entityId, fileStorageObjectId);
   }
 
   /**
@@ -133,9 +147,8 @@ public class FileStorageObjectService implements ConsentLogger {
   public FileStorageObject getDocumentFile(
       User user, String entity, String entityId, Integer fileStorageObjectId) {
     DocumentEntity documentEntity = requireDocumentEntity(entity);
-    String resolvedEntityId = resolveEntityId(user, documentEntity, entityId);
     FileStorageObject fso =
-        fetchMetadataByEntityIdAndId(resolvedEntityId, fileStorageObjectId, documentEntity);
+        resolveMetadataForEntity(user, documentEntity, entityId, fileStorageObjectId);
 
     checkAccess(user, entity, entityId, fso.getCategory(), OperationType.READ);
 
@@ -166,9 +179,7 @@ public class FileStorageObjectService implements ConsentLogger {
   public List<FileStorageObject> listDocuments(User user, String entity, String entityId) {
     DocumentEntity documentEntity = requireDocumentEntity(entity);
     checkAccess(user, entity, entityId, null, OperationType.READ);
-
-    String resolvedEntityId = resolveEntityId(user, documentEntity, entityId);
-    return fetchAllMetadataByEntityId(resolvedEntityId, documentEntity);
+    return resolveMetadataListForEntity(user, documentEntity, entityId);
   }
 
   /**
@@ -187,9 +198,8 @@ public class FileStorageObjectService implements ConsentLogger {
     validateCategoryForEntity(documentEntity, category);
     checkAccess(user, entity, entityId, category, OperationType.WRITE);
 
-    String resolvedEntityId = resolveEntityId(user, documentEntity, entityId);
     FileStorageObject fileStorageObject =
-        fetchMetadataByEntityIdAndId(resolvedEntityId, fileStorageObjectId, documentEntity);
+        resolveMetadataForEntity(user, documentEntity, entityId, fileStorageObjectId);
 
     Instant updateDate = Instant.now();
     fileStorageObjectDAO.updateCategory(fileStorageObjectId, category.getValue(), user.getUserId());
@@ -218,14 +228,14 @@ public class FileStorageObjectService implements ConsentLogger {
   public FileStorageObject deleteDocument(
       User user, String entity, String entityId, Integer fileStorageObjectId) {
     DocumentEntity documentEntity = requireDocumentEntity(entity);
-    String resolvedEntityId = resolveEntityId(user, documentEntity, entityId);
     FileStorageObject fileStorageObject =
-        fetchMetadataByEntityIdAndId(resolvedEntityId, fileStorageObjectId, documentEntity);
+        resolveMetadataForEntity(user, documentEntity, entityId, fileStorageObjectId);
 
     checkAccess(user, entity, entityId, fileStorageObject.getCategory(), OperationType.WRITE);
 
     Instant deleteDate = Instant.now();
-    fileStorageObjectDAO.softDelete(resolvedEntityId, fileStorageObjectId, user.getUserId());
+    fileStorageObjectDAO.softDelete(
+        fileStorageObject.getEntityId(), fileStorageObjectId, user.getUserId());
 
     FileStorageObject deleted = fileStorageObjectDAO.findById(fileStorageObjectId);
     if (deleted != null) {
@@ -237,7 +247,7 @@ public class FileStorageObjectService implements ConsentLogger {
         "Database did not return deleted FileStorageObject (id: "
             + fileStorageObjectId
             + ", entity: "
-            + resolvedEntityId
+            + fileStorageObject.getEntityId()
             + "). Applying deletion flags in memory. "
             + "Next query for this file may show inconsistent state.");
     fileStorageObject.setDeleted(true);
@@ -311,26 +321,18 @@ public class FileStorageObjectService implements ConsentLogger {
   // ---------------------------------------------------------------------------
 
   private void checkEntityLevelReadAccess(User user, DocumentEntity entity, String entityId) {
-    if (entity == DocumentEntity.DAC) {
-      // All authenticated users may list DAC documents.
-      return;
-    }
-
-    if (entity == DocumentEntity.DAR) {
-      boolean isCreator = isDarCreator(user, entityId);
-      if (!isCreator) {
-        ensureHasAnyRole(user, UserRoles.ADMIN, UserRoles.CHAIRPERSON, UserRoles.MEMBER);
+    switch (entity) {
+      case DAC -> {
+        // All authenticated users may list DAC documents.
       }
-      return;
+      case DAR -> {
+        if (!isDarCreator(user, entityId)) {
+          ensureHasAnyRole(user, DAR_READ_ROLES);
+        }
+      }
+      case STUDY -> ensureHasAnyRole(user, STUDY_ROLES);
+      case DATASET -> ensureHasAnyRole(user, DATASET_READ_ROLES);
     }
-
-    if (entity == DocumentEntity.STUDY) {
-      ensureHasAnyRole(user, UserRoles.ADMIN, UserRoles.DATASUBMITTER, UserRoles.CHAIRPERSON);
-      return;
-    }
-
-    ensureHasAnyRole(
-        user, UserRoles.ADMIN, UserRoles.DATASUBMITTER, UserRoles.CHAIRPERSON, UserRoles.MEMBER);
   }
 
   private void checkDarAccess(User user, String entityId, OperationType op) {
@@ -341,7 +343,7 @@ public class FileStorageObjectService implements ConsentLogger {
     }
 
     if (op == OperationType.READ && !isCreator) {
-      ensureHasAnyRole(user, UserRoles.ADMIN, UserRoles.CHAIRPERSON, UserRoles.MEMBER);
+      ensureHasAnyRole(user, DAR_READ_ROLES);
     }
   }
 
@@ -357,20 +359,20 @@ public class FileStorageObjectService implements ConsentLogger {
   }
 
   private void checkDatasetAccess(User user, OperationType op) {
-    if (op == OperationType.WRITE) {
-      ensureHasAnyRole(user, UserRoles.ADMIN, UserRoles.DATASUBMITTER, UserRoles.CHAIRPERSON);
-      return;
-    }
-
-    ensureHasAnyRole(
-        user, UserRoles.ADMIN, UserRoles.DATASUBMITTER, UserRoles.CHAIRPERSON, UserRoles.MEMBER);
+    checkRoleAccessByOperation(user, op);
   }
 
   private void checkStudyAccess(User user) {
-    // Both READ and WRITE require ADMIN, DATASUBMITTER, or CHAIRPERSON.
-    // For READ the study must be DAC-linked; that constraint is enforced during entity
-    // resolution via DatasetService.findStudyByIdForRead.
-    ensureHasAnyRole(user, UserRoles.ADMIN, UserRoles.DATASUBMITTER, UserRoles.CHAIRPERSON);
+    // Both READ and WRITE require the same role set.
+    ensureHasAnyRole(user, STUDY_ROLES);
+  }
+
+  private void checkRoleAccessByOperation(User user, OperationType op) {
+    ensureHasAnyRole(
+        user,
+        op == OperationType.WRITE
+            ? FileStorageObjectService.DATASET_WRITE_ROLES
+            : FileStorageObjectService.DATASET_READ_ROLES);
   }
 
   // ---------------------------------------------------------------------------
@@ -448,6 +450,76 @@ public class FileStorageObjectService implements ConsentLogger {
     return dacId.toString();
   }
 
+  private String resolveOrCreateDaaEntityIdForDac(User user, String entityId) {
+    Integer dacId = parseNumericEntityId(entityId);
+    dacService.findById(dacId);
+    return daaService.createAndLinkDaaIdForDac(user, dacId).toString();
+  }
+
+  private String resolveEntityIdForUpload(User user, DocumentEntity entity, String entityId) {
+    return entity == DocumentEntity.DAC
+        ? resolveOrCreateDaaEntityIdForDac(user, entityId)
+        : resolveEntityId(user, entity, entityId);
+  }
+
+  private FileStorageObject resolveMetadataForEntity(
+      User user, DocumentEntity entity, String entityId, Integer fileStorageObjectId) {
+    if (entity == DocumentEntity.DAC) {
+      // DAC requests keep dacId in the route and validate that the FSO's daaId belongs to it.
+      return fetchDacMetadataByDacIdAndFileId(entityId, fileStorageObjectId);
+    }
+    String resolvedEntityId = resolveEntityId(user, entity, entityId);
+    return fetchMetadataByEntityIdAndId(resolvedEntityId, fileStorageObjectId, entity);
+  }
+
+  private List<FileStorageObject> resolveMetadataListForEntity(
+      User user, DocumentEntity entity, String entityId) {
+    if (entity == DocumentEntity.DAC) {
+      return fetchAllMetadataByDacId(entityId);
+    }
+    String resolvedEntityId = resolveEntityId(user, entity, entityId);
+    return fetchAllMetadataByEntityId(resolvedEntityId, entity);
+  }
+
+  private List<FileStorageObject> fetchAllMetadataByDacId(String entityId) {
+    Integer dacId = parseNumericEntityId(entityId);
+    dacService.findById(dacId);
+
+    List<Integer> daaIds = daaService.findDaaIdsByDacId(dacId);
+    if (daaIds == null || daaIds.isEmpty()) {
+      return List.of();
+    }
+
+    return daaIds.stream()
+        .map(String::valueOf)
+        .flatMap(
+            daaId ->
+                fileStorageObjectDAO
+                    .findFileMetadataByEntityIdAndCategories(daaId, DAC_ALLOWED_CATEGORY_VALUES)
+                    .stream())
+        .toList();
+  }
+
+  private FileStorageObject fetchDacMetadataByDacIdAndFileId(
+      String entityId, Integer fileStorageObjectId) {
+    Integer dacId = parseNumericEntityId(entityId);
+    dacService.findById(dacId);
+
+    FileStorageObject fso = fileStorageObjectDAO.findFileById(fileStorageObjectId);
+    if (fso == null || Boolean.TRUE.equals(fso.getDeleted())) {
+      throw new NotFoundException(FILE_NOT_FOUND);
+    }
+    if (fso.getCategory() != FileCategory.DATA_ACCESS_AGREEMENT) {
+      throw new NotFoundException(FILE_NOT_FOUND);
+    }
+
+    Integer daaId = parseNumericEntityId(fso.getEntityId());
+    if (!daaService.isDaaLinkedToDac(dacId, daaId)) {
+      throw new NotFoundException(FILE_NOT_FOUND);
+    }
+    return fso;
+  }
+
   // ---------------------------------------------------------------------------
   // Low-level GCS / DAO helpers
   // ---------------------------------------------------------------------------
@@ -499,13 +571,13 @@ public class FileStorageObjectService implements ConsentLogger {
     FileStorageObject fileStorageObject =
         fileStorageObjectDAO.findActiveFileByIdAndEntityId(entityId, fileStorageObjectId);
     if (fileStorageObject == null) {
-      throw new NotFoundException("File not found");
+      throw new NotFoundException(FILE_NOT_FOUND);
     }
     return fileStorageObject;
   }
 
   /**
-   * Fetches metadata for an active file constrained to categories valid for the requested entity.
+   * Fetches metadata for an active file constrained to valid categories for the requested entity.
    * This prevents records for another document domain from being returned when IDs overlap.
    */
   public FileStorageObject fetchMetadataByEntityIdAndId(
@@ -515,7 +587,7 @@ public class FileStorageObjectService implements ConsentLogger {
         fileStorageObjectDAO.findActiveFileByIdAndEntityIdAndCategories(
             entityId, fileStorageObjectId, allowedCategoryValuesForEntity(entity));
     if (fileStorageObject == null) {
-      throw new NotFoundException("File not found");
+      throw new NotFoundException(FILE_NOT_FOUND);
     }
     return fileStorageObject;
   }
@@ -528,7 +600,7 @@ public class FileStorageObjectService implements ConsentLogger {
     return fileStorageObjectDAO.findFileMetadataByEntityId(entityId);
   }
 
-  /** Returns file metadata scoped to categories valid for the requested entity. */
+  /** Returns file metadata scoped to valid categories for the requested entity. */
   public List<FileStorageObject> fetchAllMetadataByEntityId(
       String entityId, DocumentEntity entity) {
     return fileStorageObjectDAO.findFileMetadataByEntityIdAndCategories(

--- a/src/test/java/org/broadinstitute/consent/http/db/DaaDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DaaDAOTest.java
@@ -189,6 +189,43 @@ class DaaDAOTest extends DAOTestHelper {
   }
 
   @Test
+  void testFindDaaIdsByDacIdReturnsAllLinkedAndInitialDaaIds() {
+    Integer userId = createUserId();
+    Integer dacId =
+        dacDAO.createDac(randomAlphabetic(5), randomAlphabetic(5), "", createUser().getUserId());
+
+    Integer daaId1 = daaDAO.createDaa(userId, Instant.now(), userId, Instant.now(), dacId);
+    Integer daaId2 = daaDAO.createDaa(userId, Instant.now(), userId, Instant.now(), dacId);
+
+    daaDAO.createDacDaaRelation(dacId, daaId1, userId);
+    // Re-assignment updates DAC -> DAA mapping to the latest DAA.
+    daaDAO.createDacDaaRelation(dacId, daaId2, userId);
+
+    List<Integer> linkedDaaIds = daaDAO.findDaaIdsByDacId(dacId);
+
+    assertEquals(List.of(daaId2, daaId1), linkedDaaIds);
+  }
+
+  @Test
+  void testIsDaaLinkedToDac() {
+    Integer userId = createUserId();
+    Integer dacId =
+        dacDAO.createDac(randomAlphabetic(5), randomAlphabetic(5), "", createUser().getUserId());
+    Integer otherDacId =
+        dacDAO.createDac(randomAlphabetic(5), randomAlphabetic(5), "", createUser().getUserId());
+
+    Integer daaId = daaDAO.createDaa(userId, Instant.now(), userId, Instant.now(), dacId);
+    daaDAO.createDacDaaRelation(dacId, daaId, userId);
+
+    assertTrue(daaDAO.isDaaLinkedToDac(dacId, daaId));
+    assertFalse(daaDAO.isDaaLinkedToDac(otherDacId, daaId));
+    assertFalse(daaDAO.isDaaLinkedToDac(dacId, NON_EXISTENT_ID));
+    assertTrue(daaDAO.isDaaInitiallyLinkedToDac(dacId, daaId));
+    assertFalse(daaDAO.isDaaInitiallyLinkedToDac(otherDacId, daaId));
+    assertFalse(daaDAO.isDaaInitiallyLinkedToDac(dacId, NON_EXISTENT_ID));
+  }
+
+  @Test
   void testCreateDaaDacRelation() {
     Integer userId = createUserId();
     Integer dacId =

--- a/src/test/java/org/broadinstitute/consent/http/service/DaaServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DaaServiceTest.java
@@ -11,6 +11,7 @@ import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -567,5 +568,91 @@ class DaaServiceTest extends AbstractTestHelper {
 
     Map<Integer, Set<Integer>> daaMap = service.findDaaIdsByDatasetIds(Set.of(1, 2, 3));
     assertTrue(daaMap.isEmpty());
+  }
+
+  @Test
+  void testFindDaaIdsByDacIdReturnsDirectLinks() {
+    Integer dacId = 12;
+    when(daaDAO.findDaaIdsByDacId(dacId)).thenReturn(List.of(101, 102));
+
+    initService();
+
+    List<Integer> result = service.findDaaIdsByDacId(dacId);
+
+    assertEquals(List.of(101, 102), result);
+    verify(daaDAO).findDaaIdsByDacId(dacId);
+  }
+
+  @Test
+  void testFindDaaIdsByDacIdReturnsEmptyWhenNoMappingExists() {
+    Integer dacId = 33;
+    when(daaDAO.findDaaIdsByDacId(dacId)).thenReturn(List.of());
+
+    initService();
+
+    assertTrue(service.findDaaIdsByDacId(dacId).isEmpty());
+  }
+
+  @Test
+  void testIsDaaLinkedToDacReturnsTrueForDirectRelation() {
+    Integer dacId = 7;
+    Integer daaId = 55;
+    when(daaDAO.isDaaLinkedToDac(dacId, daaId)).thenReturn(true);
+
+    initService();
+
+    assertTrue(service.isDaaLinkedToDac(dacId, daaId));
+  }
+
+  @Test
+  void testIsDaaLinkedToDacReturnsTrueForInitialDacLink() {
+    Integer dacId = 7;
+    Integer daaId = 88;
+    when(daaDAO.isDaaLinkedToDac(dacId, daaId)).thenReturn(false);
+    when(daaDAO.isDaaInitiallyLinkedToDac(dacId, daaId)).thenReturn(true);
+
+    initService();
+
+    assertTrue(service.isDaaLinkedToDac(dacId, daaId));
+  }
+
+  @Test
+  void testIsDaaLinkedToDacReturnsFalseWhenNoRelationExists() {
+    Integer dacId = 7;
+    Integer daaId = 89;
+    when(daaDAO.isDaaLinkedToDac(dacId, daaId)).thenReturn(false);
+    when(daaDAO.isDaaInitiallyLinkedToDac(dacId, daaId)).thenReturn(false);
+
+    initService();
+
+    assertFalse(service.isDaaLinkedToDac(dacId, daaId));
+  }
+
+  @Test
+  void testCreateAndLinkDaaIdForDacCreatesAndLinksNewDaa() {
+    User user = new User();
+    user.setUserId(999);
+    Integer dacId = 17;
+    when(daaDAO.createDaa(any(), any(), any(), any(), any())).thenReturn(700);
+
+    initService();
+
+    assertEquals(700, service.createAndLinkDaaIdForDac(user, dacId));
+    verify(daaDAO).createDacDaaRelation(dacId, 700, user.getUserId());
+  }
+
+  @Test
+  void testCreateAndLinkDaaIdForDacCreatesNewDaaEvenWhenLinkedDaaExists() {
+    User user = new User();
+    user.setUserId(77);
+    Integer dacId = 18;
+    when(daaDAO.createDaa(any(), any(), any(), any(), any())).thenReturn(801);
+
+    initService();
+
+    assertEquals(801, service.createAndLinkDaaIdForDac(user, dacId));
+    verify(daaDAO).createDacDaaRelation(dacId, 801, user.getUserId());
+    verify(daaDAO, never()).findByDacId(dacId);
+    verify(daaDAO, never()).findDaaIdsByDacId(dacId);
   }
 }

--- a/src/test/java/org/broadinstitute/consent/http/service/FileStorageObjectServiceAccessTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/FileStorageObjectServiceAccessTest.java
@@ -45,6 +45,7 @@ class FileStorageObjectServiceAccessTest {
   @Mock private GCSService gcsService;
   @Mock private DatasetService datasetService;
   @Mock private DacService dacService;
+  @Mock private DaaService daaService;
   @Mock private DataAccessRequestService dataAccessRequestService;
 
   private FileStorageObjectService service;
@@ -53,7 +54,12 @@ class FileStorageObjectServiceAccessTest {
   void setUp() {
     service =
         new FileStorageObjectService(
-            fileStorageObjectDAO, gcsService, datasetService, dacService, dataAccessRequestService);
+            fileStorageObjectDAO,
+            gcsService,
+            datasetService,
+            dacService,
+            daaService,
+            dataAccessRequestService);
   }
 
   // ---------------------------------------------------------------------------
@@ -787,7 +793,12 @@ class FileStorageObjectServiceAccessTest {
 
     service =
         new FileStorageObjectService(
-            fileStorageObjectDAO, gcsService, datasetService, dacService, dataAccessRequestService);
+            fileStorageObjectDAO,
+            gcsService,
+            datasetService,
+            dacService,
+            daaService,
+            dataAccessRequestService);
 
     assertTrue(service.isDarCreator(user, darId));
   }
@@ -803,7 +814,12 @@ class FileStorageObjectServiceAccessTest {
 
     service =
         new FileStorageObjectService(
-            fileStorageObjectDAO, gcsService, datasetService, dacService, dataAccessRequestService);
+            fileStorageObjectDAO,
+            gcsService,
+            datasetService,
+            dacService,
+            daaService,
+            dataAccessRequestService);
 
     assertFalse(service.isDarCreator(user, darId));
   }

--- a/src/test/java/org/broadinstitute/consent/http/service/FileStorageObjectServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/FileStorageObjectServiceTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
@@ -52,6 +53,7 @@ class FileStorageObjectServiceTest {
   @Mock private GCSService gcsService;
   @Mock private DatasetService datasetService;
   @Mock private DacService dacService;
+  @Mock private DaaService daaService;
   @Mock private DataAccessRequestService dataAccessRequestService;
 
   private FileStorageObjectService service;
@@ -59,7 +61,12 @@ class FileStorageObjectServiceTest {
   private void initService() {
     service =
         new FileStorageObjectService(
-            fileStorageObjectDAO, gcsService, datasetService, dacService, dataAccessRequestService);
+            fileStorageObjectDAO,
+            gcsService,
+            datasetService,
+            dacService,
+            daaService,
+            dataAccessRequestService);
   }
 
   @Test
@@ -385,11 +392,13 @@ class FileStorageObjectServiceTest {
     User user = new User();
     user.setAdminRole();
     Integer dacId = 456;
+    Integer daaId = 789;
     List<FileStorageObject> fileStorageObjects = List.of(new FileStorageObject());
 
     when(dacService.findById(dacId)).thenReturn(new Dac());
+    when(daaService.findDaaIdsByDacId(dacId)).thenReturn(List.of(daaId));
     when(fileStorageObjectDAO.findFileMetadataByEntityIdAndCategories(
-            dacId.toString(), List.of(FileCategory.DATA_ACCESS_AGREEMENT.getValue())))
+            daaId.toString(), List.of(FileCategory.DATA_ACCESS_AGREEMENT.getValue())))
         .thenReturn(fileStorageObjects);
 
     initService();
@@ -399,7 +408,223 @@ class FileStorageObjectServiceTest {
     assertEquals(fileStorageObjects, returnedFiles);
     verify(fileStorageObjectDAO)
         .findFileMetadataByEntityIdAndCategories(
-            dacId.toString(), List.of(FileCategory.DATA_ACCESS_AGREEMENT.getValue()));
+            daaId.toString(), List.of(FileCategory.DATA_ACCESS_AGREEMENT.getValue()));
+  }
+
+  @Test
+  void testUploadDocumentForDacStoresUsingDaaId() throws Exception {
+    InputStream inputStream = new ByteArrayInputStream("metadata".getBytes());
+    FormDataContentDisposition fileDetail =
+        FormDataContentDisposition.name("file").fileName("upload.pdf").size(32).build();
+
+    User user = new User();
+    user.setUserId(25);
+    user.setAdminRole();
+
+    FileStorageObject created = new FileStorageObject();
+    created.setFileStorageObjectId(90);
+
+    when(daaService.createAndLinkDaaIdForDac(user, 123)).thenReturn(456);
+    when(gcsService.storeDocument(eq(inputStream), eq("application/octet-stream"), any()))
+        .thenReturn(BlobId.of("bucket", "object"));
+    when(fileStorageObjectDAO.insertNewFile(
+            eq("upload.pdf"),
+            eq(FileCategory.DATA_ACCESS_AGREEMENT.getValue()),
+            eq(BlobId.of("bucket", "object").toGsUtilUri()),
+            eq("application/octet-stream"),
+            eq("456"),
+            eq(25),
+            any()))
+        .thenReturn(90);
+    when(fileStorageObjectDAO.findFileById(90)).thenReturn(created);
+
+    initService();
+
+    FileStorageObject result =
+        service.uploadDocument(user, "dac", "123", inputStream, fileDetail, "dataAccessAgreement");
+
+    assertEquals(created, result);
+    verify(fileStorageObjectDAO)
+        .insertNewFile(
+            eq("upload.pdf"),
+            eq(FileCategory.DATA_ACCESS_AGREEMENT.getValue()),
+            eq(BlobId.of("bucket", "object").toGsUtilUri()),
+            eq("application/octet-stream"),
+            eq("456"),
+            eq(25),
+            any());
+  }
+
+  @Test
+  void testGetDocumentForDacFailsWhenFileDaaNotLinkedToDac() {
+    User user = new User();
+    user.setAdminRole();
+    Integer dacId = 123;
+    Integer fileId = 10;
+
+    FileStorageObject fso = new FileStorageObject();
+    fso.setFileStorageObjectId(fileId);
+    fso.setEntityId("999");
+    fso.setCategory(FileCategory.DATA_ACCESS_AGREEMENT);
+    fso.setDeleted(false);
+
+    when(dacService.findById(dacId)).thenReturn(new Dac());
+    when(fileStorageObjectDAO.findFileById(fileId)).thenReturn(fso);
+    when(daaService.isDaaLinkedToDac(dacId, 999)).thenReturn(false);
+
+    initService();
+
+    assertThrows(NotFoundException.class, () -> service.getDocument(user, "dac", "123", fileId));
+  }
+
+  @Test
+  void testListDocumentsForDacAggregatesAcrossLinkedDaaIds() {
+    User user = new User();
+    user.setAdminRole();
+    Integer dacId = 456;
+
+    FileStorageObject daa1File = new FileStorageObject();
+    FileStorageObject daa2File = new FileStorageObject();
+
+    when(dacService.findById(dacId)).thenReturn(new Dac());
+    when(daaService.findDaaIdsByDacId(dacId)).thenReturn(List.of(1001, 1002));
+    when(fileStorageObjectDAO.findFileMetadataByEntityIdAndCategories(
+            "1001", List.of(FileCategory.DATA_ACCESS_AGREEMENT.getValue())))
+        .thenReturn(List.of(daa1File));
+    when(fileStorageObjectDAO.findFileMetadataByEntityIdAndCategories(
+            "1002", List.of(FileCategory.DATA_ACCESS_AGREEMENT.getValue())))
+        .thenReturn(List.of(daa2File));
+
+    initService();
+
+    List<FileStorageObject> returnedFiles = service.listDocuments(user, "dac", dacId.toString());
+
+    assertEquals(2, returnedFiles.size());
+    assertEquals(List.of(daa1File, daa2File), returnedFiles);
+  }
+
+  @Test
+  void testListDocumentsForDacReturnsEmptyWhenNoLinkedDaaIds() {
+    User user = new User();
+    user.setAdminRole();
+    Integer dacId = 456;
+
+    when(dacService.findById(dacId)).thenReturn(new Dac());
+    when(daaService.findDaaIdsByDacId(dacId)).thenReturn(List.of());
+
+    initService();
+
+    List<FileStorageObject> returnedFiles = service.listDocuments(user, "dac", dacId.toString());
+
+    assertTrue(returnedFiles.isEmpty());
+    verifyNoInteractions(fileStorageObjectDAO);
+  }
+
+  @Test
+  void testGetDocumentFileForDacFailsWhenFileDaaNotLinkedToDac() {
+    User user = new User();
+    user.setAdminRole();
+    Integer dacId = 123;
+    Integer fileId = 10;
+
+    FileStorageObject fso = new FileStorageObject();
+    fso.setFileStorageObjectId(fileId);
+    fso.setEntityId("999");
+    fso.setCategory(FileCategory.DATA_ACCESS_AGREEMENT);
+    fso.setDeleted(false);
+
+    when(dacService.findById(dacId)).thenReturn(new Dac());
+    when(fileStorageObjectDAO.findFileById(fileId)).thenReturn(fso);
+    when(daaService.isDaaLinkedToDac(dacId, 999)).thenReturn(false);
+
+    initService();
+
+    assertThrows(
+        NotFoundException.class, () -> service.getDocumentFile(user, "dac", "123", fileId));
+    verifyNoInteractions(gcsService);
+  }
+
+  @Test
+  void testUpdateDocumentCategoryForDacFailsWhenFileDaaNotLinkedToDac() {
+    User user = new User();
+    user.setUserId(25);
+    user.setAdminRole();
+    Integer dacId = 123;
+    Integer fileId = 10;
+
+    FileStorageObject fso = new FileStorageObject();
+    fso.setFileStorageObjectId(fileId);
+    fso.setEntityId("999");
+    fso.setCategory(FileCategory.DATA_ACCESS_AGREEMENT);
+    fso.setDeleted(false);
+
+    when(dacService.findById(dacId)).thenReturn(new Dac());
+    when(fileStorageObjectDAO.findFileById(fileId)).thenReturn(fso);
+    when(daaService.isDaaLinkedToDac(dacId, 999)).thenReturn(false);
+    String category = FileCategory.DATA_ACCESS_AGREEMENT.getValue();
+
+    initService();
+
+    assertThrows(
+        NotFoundException.class,
+        () -> service.updateDocumentCategory(user, "dac", "123", fileId, category));
+    verify(fileStorageObjectDAO, never()).updateCategory(any(), any(), any());
+  }
+
+  @Test
+  void testDeleteDocumentForDacFailsWhenFileDaaNotLinkedToDac() {
+    User user = new User();
+    user.setUserId(25);
+    user.setAdminRole();
+    Integer dacId = 123;
+    Integer fileId = 10;
+
+    FileStorageObject fso = new FileStorageObject();
+    fso.setFileStorageObjectId(fileId);
+    fso.setEntityId("999");
+    fso.setCategory(FileCategory.DATA_ACCESS_AGREEMENT);
+    fso.setDeleted(false);
+
+    when(dacService.findById(dacId)).thenReturn(new Dac());
+    when(fileStorageObjectDAO.findFileById(fileId)).thenReturn(fso);
+    when(daaService.isDaaLinkedToDac(dacId, 999)).thenReturn(false);
+
+    initService();
+
+    assertThrows(NotFoundException.class, () -> service.deleteDocument(user, "dac", "123", fileId));
+    verify(fileStorageObjectDAO, never()).softDelete(any(), any(), any());
+  }
+
+  @Test
+  void testDeleteDocumentForDacUsesDaaEntityIdWhenLinked() {
+    User user = new User();
+    user.setUserId(25);
+    user.setAdminRole();
+    Integer dacId = 123;
+    Integer fileId = 10;
+
+    FileStorageObject active = new FileStorageObject();
+    active.setFileStorageObjectId(fileId);
+    active.setEntityId("777");
+    active.setCategory(FileCategory.DATA_ACCESS_AGREEMENT);
+    active.setDeleted(false);
+
+    FileStorageObject deleted = new FileStorageObject();
+    deleted.setFileStorageObjectId(fileId);
+    deleted.setEntityId("777");
+    deleted.setDeleted(true);
+
+    when(dacService.findById(dacId)).thenReturn(new Dac());
+    when(fileStorageObjectDAO.findFileById(fileId)).thenReturn(active);
+    when(daaService.isDaaLinkedToDac(dacId, 777)).thenReturn(true);
+    when(fileStorageObjectDAO.findById(fileId)).thenReturn(deleted);
+
+    initService();
+
+    FileStorageObject result = service.deleteDocument(user, "dac", "123", fileId);
+
+    assertEquals(deleted, result);
+    verify(fileStorageObjectDAO).softDelete("777", fileId, user.getUserId());
   }
 
   @Test


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-3265

### Summary

This PR fixes the DAC <entity> Document APIs by correctly mapping `DAC IDs` to `DAA IDs` in FileStorageObjects.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
