### PR TITLE
[DT-3239] Handle Zendesk suspended_ticket response.

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/models/support/TicketFactory.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/support/TicketFactory.java
@@ -17,10 +17,10 @@ public class TicketFactory implements ConsentLogger {
   }
 
   /**
-   * Generate the created Request object from the Zendesk request response content.
+   * Validate and return the response from the Zendesk request.
    *
    * @param response The response content from the Zendesk Request API
-   * @return Parsed request.
+   * @return Parsed Json.
    */
   public JsonObject parseZendeskResponse(String response) {
     Gson gson = GsonUtil.getInstance();

--- a/src/main/java/org/broadinstitute/consent/http/models/support/TicketFactory.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/support/TicketFactory.java
@@ -5,12 +5,12 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
 import org.broadinstitute.consent.http.util.ConsentLogger;
 import org.broadinstitute.consent.http.util.gson.GsonUtil;
-import org.zendesk.client.v2.model.Request;
 import org.zendesk.client.v2.model.Ticket;
 
 public class TicketFactory implements ConsentLogger {
 
   private static final String REQUEST = "request";
+  private static final String SUSPENDED_TICKET = "suspended_ticket";
 
   public TicketFactory() {
     // public constructor to allow instantiation for instance methods
@@ -22,7 +22,7 @@ public class TicketFactory implements ConsentLogger {
    * @param response The response content from the Zendesk Request API
    * @return Parsed request.
    */
-  public Request parseRequestResponse(String response) {
+  public JsonObject parseZendeskResponse(String response) {
     Gson gson = GsonUtil.getInstance();
     JsonObject obj;
     try {
@@ -31,13 +31,21 @@ public class TicketFactory implements ConsentLogger {
       logException("Invalid Zendesk response: %s".formatted(response), e);
       throw e;
     }
-    if (obj == null || !obj.has(REQUEST) || !obj.get(REQUEST).isJsonObject()) {
+    if (obj == null || !(isVerifiedZendeskRequest(obj) || isSuspendedZendeskRequest(obj))) {
       logWarn("Invalid Zendesk response: %s".formatted(response));
       throw new IllegalStateException(
           "Invalid Zendesk response: 'request' field is missing or not a JSON object.");
     }
-    JsonObject request = obj.get(REQUEST).getAsJsonObject();
-    return gson.fromJson(request, Request.class);
+
+    return obj;
+  }
+
+  private boolean isVerifiedZendeskRequest(JsonObject obj) {
+    return obj != null && obj.has(REQUEST) && obj.get(REQUEST).isJsonObject();
+  }
+
+  private boolean isSuspendedZendeskRequest(JsonObject obj) {
+    return obj != null && obj.has(SUSPENDED_TICKET) && obj.get(SUSPENDED_TICKET).isJsonObject();
   }
 
   /**

--- a/src/main/java/org/broadinstitute/consent/http/models/support/TicketFactory.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/support/TicketFactory.java
@@ -31,7 +31,7 @@ public class TicketFactory implements ConsentLogger {
       logException("Invalid Zendesk response: %s".formatted(response), e);
       throw e;
     }
-    if (obj == null || !(isVerifiedZendeskRequest(obj) || isSuspendedZendeskRequest(obj))) {
+    if (!(isVerifiedZendeskRequest(obj) || isSuspendedZendeskRequest(obj))) {
       logWarn("Invalid Zendesk response: %s".formatted(response));
       throw new IllegalStateException(
           "Invalid Zendesk response: 'request' field is missing or not a JSON object.");

--- a/src/main/java/org/broadinstitute/consent/http/resources/SupportResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/SupportResource.java
@@ -16,7 +16,6 @@ import org.broadinstitute.consent.http.models.support.TicketFields;
 import org.broadinstitute.consent.http.service.SupportRequestService;
 import org.broadinstitute.consent.http.util.gson.GsonUtil;
 import org.owasp.fileio.FileValidator;
-import org.zendesk.client.v2.model.Request;
 
 @Path("support")
 public class SupportResource extends Resource {
@@ -39,7 +38,7 @@ public class SupportResource extends Resource {
       TicketFields ticketFields = gson.fromJson(body, TicketFields.class);
       DuosTicket ticket = TicketFactory.createTicket(ticketFields);
       logInfo("Support Request Ticket: " + ticket);
-      Request request = supportRequestService.postTicketToSupport(ticket);
+      JsonObject request = supportRequestService.postTicketToSupport(ticket);
       return Response.status(HttpStatusCodes.STATUS_CODE_CREATED).entity(request).build();
     } catch (Exception e) {
       return createExceptionResponse(e);

--- a/src/main/java/org/broadinstitute/consent/http/service/SupportRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/SupportRequestService.java
@@ -19,7 +19,6 @@ import org.broadinstitute.consent.http.models.support.TicketFactory;
 import org.broadinstitute.consent.http.util.ConsentLogger;
 import org.broadinstitute.consent.http.util.HttpClientUtil;
 import org.broadinstitute.consent.http.util.gson.GsonUtil;
-import org.zendesk.client.v2.model.Request;
 
 public class SupportRequestService implements ConsentLogger {
 
@@ -81,7 +80,7 @@ public class SupportRequestService implements ConsentLogger {
    * @return The response
    * @throws Exception The exception
    */
-  public Request postTicketToSupport(DuosTicket ticket) throws Exception {
+  public JsonObject postTicketToSupport(DuosTicket ticket) throws Exception {
     if (configuration.isActivateSupportNotifications()) {
       GenericUrl genericUrl = new GenericUrl(configuration.postSupportRequestUrl());
       ByteArrayContent content =
@@ -99,7 +98,7 @@ public class SupportRequestService implements ConsentLogger {
         logException(errorMessage, errorException);
         throw errorException;
       }
-      return ticketFactory.parseRequestResponse(
+      return ticketFactory.parseZendeskResponse(
           IOUtils.toString(response.getContent(), Charset.defaultCharset()));
     }
     throw new BadRequestException("Not configured to send support requests");

--- a/src/main/resources/assets/paths/supportRequest.yaml
+++ b/src/main/resources/assets/paths/supportRequest.yaml
@@ -1,7 +1,11 @@
 post:
   summary: Create a support request
   operationId: supportRequestPost
-  description: Create a support request
+  description: |
+    Create a support request ticket in Zendesk. 
+    The response may contain either a standard `request` object or a `suspended_ticket` object,
+    depending on whether the request was successfully processed by Zendesk or suspended
+    (e.g., for anonymous or invalid submissions).
   tags:
     - Support
   requestBody:
@@ -11,7 +15,10 @@ post:
           $ref: '../schemas/TicketFields.yaml'
   responses:
     201:
-      description: The created support request
+      description: |
+        Support request submitted successfully.
+        Response contains either a `request` field (successful submission) or a `suspended_ticket` field
+        (suspended/anonymous submission).
       content:
         application/json:
           schema:

--- a/src/main/resources/assets/schemas/SupportRequestResponse.yaml
+++ b/src/main/resources/assets/schemas/SupportRequestResponse.yaml
@@ -1,8 +1,12 @@
 type: object
+description: |
+  Response from Zendesk support integration. The response contains either a `request` field
+  (for normal support requests) or a `suspended_ticket` field (for suspended/anonymous requests).
 properties:
   request:
     type: object
     title: SupportRequest
+    description: Standard support request returned by Zendesk
     properties:
       url:
         description: The request location in Zendesk
@@ -82,3 +86,71 @@ properties:
               type: number
             value:
               type: string
+  suspended_ticket:
+    type: object
+    title: SuspendedTicket
+    description: |
+      Suspended/anonymous ticket returned by Zendesk when a request cannot be processed normally.
+      This occurs when submitting requests from unauthenticated or anonymous sources.
+    properties:
+      url:
+        description: The suspended ticket location in Zendesk
+        type: string
+      id:
+        type: number
+      author:
+        type: object
+        title: SuspendedTicketAuthor
+        description: The submitter of the suspended ticket
+        properties:
+          id:
+            type: number
+          name:
+            type: string
+          email:
+            type: string
+      subject:
+        type: string
+      content:
+        type: string
+      cause:
+        type: string
+        description: The reason the ticket was suspended
+      cause_id:
+        type: number
+      error_messages:
+        type: array
+        items:
+          type: string
+      message_id:
+        type: string
+      ticket_id:
+        type: string
+      created_at:
+        type: string
+      updated_at:
+        type: string
+      via:
+        type: object
+        title: SuspendedTicketVia
+        properties:
+          channel:
+            type: string
+          source:
+            type: object
+            title: SuspendedTicketViaSource
+            properties:
+              from:
+                type: object
+              to:
+                type: object
+              rel:
+                type: string
+      attachments:
+        type: array
+        items:
+          type: object
+      recipient:
+        type: string
+      brand_id:
+        type: number

--- a/src/test/java/org/broadinstitute/consent/http/models/support/TicketFactoryTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/support/TicketFactoryTest.java
@@ -89,8 +89,7 @@ class TicketFactoryTest {
     assertNotNull(parsedResponse);
     assertTrue(parsedResponse.has("suspended_ticket"));
     assertEquals(
-        5555,
-        parsedResponse.get("suspended_ticket").getAsJsonObject().get("id").getAsLong());
+        5555, parsedResponse.get("suspended_ticket").getAsJsonObject().get("id").getAsLong());
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/models/support/TicketFactoryTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/support/TicketFactoryTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.google.gson.JsonObject;
 import com.google.gson.JsonSyntaxException;
 import java.util.Collections;
 import org.broadinstitute.consent.http.enumeration.SupportRequestType;
@@ -22,8 +23,43 @@ class TicketFactoryTest {
   public static final String INVALID_RESPONSE_MESSAGE =
       "Invalid Zendesk response: 'request' field is missing or not a JSON object";
 
+  private static final String SANITIZED_SUSPENDED_TICKET_RESPONSE =
+      """
+          {
+            "suspended_ticket": {
+              "url": "https://example.zendesk.com/api/v2/suspended_tickets/5555.json",
+              "id": 5555,
+              "author": {
+                "id": 987654321,
+                "name": "Support User",
+                "email": "user@example.org"
+              },
+              "subject": "DUOS: User Request",
+              "content": "User (2222, user@example.org) submitted a support request.",
+              "cause": "Anonymous request",
+              "cause_id": 13,
+              "error_messages": null,
+              "message_id": null,
+              "ticket_id": null,
+              "created_at": "2026-05-15T16:58:43Z",
+              "updated_at": "2026-05-15T16:58:43Z",
+              "via": {
+                "channel": "api",
+                "source": {
+                  "from": {},
+                  "to": {},
+                  "rel": null
+                }
+              },
+              "attachments": [],
+              "recipient": null,
+              "brand_id": 1234
+            }
+          }
+          """;
+
   @Test
-  void testParseRequestResponse() {
+  void testParseZendeskResponse() {
     Request request = new Request();
     request.setId(12345L);
     request.setSubject("Test Subject");
@@ -35,31 +71,66 @@ class TicketFactoryTest {
                 }
                 """,
             GsonUtil.getInstance().toJson(request));
-    Request parsedRequest = new TicketFactory().parseRequestResponse(validResponse);
+    JsonObject parsedRequest = new TicketFactory().parseZendeskResponse(validResponse);
     assertNotNull(parsedRequest);
-    assertEquals(request.getId(), parsedRequest.getId());
-    assertEquals(request.getSubject(), parsedRequest.getSubject());
+    assertTrue(parsedRequest.has("request"));
+    assertEquals(
+        request.getId(), parsedRequest.get("request").getAsJsonObject().get("id").getAsLong());
+    assertEquals(
+        request.getSubject(),
+        parsedRequest.get("request").getAsJsonObject().get("subject").getAsString());
   }
 
   @Test
-  void testParseRequestResponse_InvalidJson() {
+  void testParseZendeskResponse_SuspendedTicket() {
+    JsonObject parsedResponse =
+        new TicketFactory().parseZendeskResponse(SANITIZED_SUSPENDED_TICKET_RESPONSE);
+
+    assertNotNull(parsedResponse);
+    assertTrue(parsedResponse.has("suspended_ticket"));
+    assertEquals(
+        5555,
+        parsedResponse.get("suspended_ticket").getAsJsonObject().get("id").getAsLong());
+  }
+
+  @Test
+  void testParseZendeskResponse_InvalidRequestButValidSuspendedTicket() {
+    String responseWithInvalidRequestAndValidSuspendedTicket =
+        """
+            {
+              "request": "not-an-object",
+              "suspended_ticket": {
+                "id": 50425014126235
+              }
+            }
+            """;
+
+    JsonObject parsedResponse =
+        new TicketFactory().parseZendeskResponse(responseWithInvalidRequestAndValidSuspendedTicket);
+
+    assertNotNull(parsedResponse);
+    assertTrue(parsedResponse.has("suspended_ticket"));
+  }
+
+  @Test
+  void testParseZendeskResponse_InvalidJson() {
     String invalidResponse = "invalid json";
     assertThrows(
-        JsonSyntaxException.class, () -> new TicketFactory().parseRequestResponse(invalidResponse));
+        JsonSyntaxException.class, () -> new TicketFactory().parseZendeskResponse(invalidResponse));
   }
 
   @Test
-  void testParseRequestResponse_MissingRequest() {
+  void testParseRequestResponse_MissingZendesk() {
     String missingRequestResponse = "{}";
     IllegalStateException e =
         assertThrows(
             IllegalStateException.class,
-            () -> new TicketFactory().parseRequestResponse(missingRequestResponse));
+            () -> new TicketFactory().parseZendeskResponse(missingRequestResponse));
     assertTrue(e.getMessage().startsWith(INVALID_RESPONSE_MESSAGE));
   }
 
   @Test
-  void testParseRequestResponse_NullRequest() {
+  void testParseRequestResponse_NullZendesk() {
     String nullRequestResponse =
         """
                 {
@@ -69,12 +140,12 @@ class TicketFactoryTest {
     IllegalStateException e =
         assertThrows(
             IllegalStateException.class,
-            () -> new TicketFactory().parseRequestResponse(nullRequestResponse));
+            () -> new TicketFactory().parseZendeskResponse(nullRequestResponse));
     assertTrue(e.getMessage().startsWith(INVALID_RESPONSE_MESSAGE));
   }
 
   @Test
-  void testParseRequestResponse_RequestNotAnObject() {
+  void testParseRequestResponse_ZendeskNotAnObject() {
     String notAnObjectResponse =
         """
                 {
@@ -84,16 +155,46 @@ class TicketFactoryTest {
     IllegalStateException e =
         assertThrows(
             IllegalStateException.class,
-            () -> new TicketFactory().parseRequestResponse(notAnObjectResponse));
+            () -> new TicketFactory().parseZendeskResponse(notAnObjectResponse));
     assertTrue(e.getMessage().startsWith(INVALID_RESPONSE_MESSAGE));
   }
 
   @Test
-  void testParseRequestResponse_NullInput() {
+  void testParseZendeskResponse_SuspendedTicketNull() {
+    String nullSuspendedTicketResponse =
+        """
+            {
+              "suspended_ticket": null
+            }
+            """;
+    IllegalStateException e =
+        assertThrows(
+            IllegalStateException.class,
+            () -> new TicketFactory().parseZendeskResponse(nullSuspendedTicketResponse));
+    assertTrue(e.getMessage().startsWith(INVALID_RESPONSE_MESSAGE));
+  }
+
+  @Test
+  void testParseZendeskResponse_SuspendedTicketNotAnObject() {
+    String suspendedTicketNotAnObjectResponse =
+        """
+            {
+              "suspended_ticket": "I am a string"
+            }
+            """;
+    IllegalStateException e =
+        assertThrows(
+            IllegalStateException.class,
+            () -> new TicketFactory().parseZendeskResponse(suspendedTicketNotAnObjectResponse));
+    assertTrue(e.getMessage().startsWith(INVALID_RESPONSE_MESSAGE));
+  }
+
+  @Test
+  void testParseZendeskResponse_NullInput() {
     String nullInput = null;
     IllegalStateException e =
         assertThrows(
-            IllegalStateException.class, () -> new TicketFactory().parseRequestResponse(nullInput));
+            IllegalStateException.class, () -> new TicketFactory().parseZendeskResponse(nullInput));
     assertTrue(e.getMessage().startsWith(INVALID_RESPONSE_MESSAGE));
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/resources/SupportResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/SupportResourceTest.java
@@ -22,7 +22,6 @@ import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.zendesk.client.v2.model.Request;
 
 @ExtendWith(MockitoExtension.class)
 public class SupportResourceTest extends ResourceTest {
@@ -55,7 +54,7 @@ public class SupportResourceTest extends ResourceTest {
         }
         """
             .formatted(type);
-    when(supportRequestService.postTicketToSupport(any())).thenReturn(new Request());
+    when(supportRequestService.postTicketToSupport(any())).thenReturn(new JsonObject());
     try (Response response = supportResource.postRequest(body)) {
       assertEquals(HttpStatusCodes.STATUS_CODE_CREATED, response.getStatus());
     }

--- a/src/test/java/org/broadinstitute/consent/http/service/SupportRequestServiceIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/SupportRequestServiceIntegrationTest.java
@@ -12,7 +12,6 @@ import org.broadinstitute.consent.http.models.support.TicketFields;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.zendesk.client.v2.model.Request;
 
 /** This test class should be used for manual integration testing only. */
 class SupportRequestServiceIntegrationTest {
@@ -41,7 +40,7 @@ class SupportRequestServiceIntegrationTest {
                 "Test Description",
                 "Test URL",
                 List.of(token)));
-    Request request = service.postTicketToSupport(ticket);
+    JsonObject request = service.postTicketToSupport(ticket);
     assertNotNull(request);
   }
 }


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-3239](https://broadworkbench.atlassian.net/browse/DT-3239)

### Summary

Consent logic had specific handling for the response from submitting zendesk.  Recent configuration changes created a new response from that platform when user's email addresses were not verified.  This PR updates consent to handle that new response type.

This work confirms that the errors in consent logs generated by this are not cause for concern.  The tickets have been created and users with these tickets are notified to verify their email address.  Once that happens, the ticket goes into the support queue.

With this fix, the proper response is now returned to the DUOS UI.  The UI does not inspect the response value, so no change is needed there.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
