### PR TITLE
DT-1591: Consolidate send mail methods

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/MailMessageDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/MailMessageDAO.java
@@ -4,6 +4,7 @@ import java.util.Date;
 import java.util.List;
 import org.broadinstitute.consent.http.db.mapper.MailMessageMapper;
 import org.broadinstitute.consent.http.models.mail.MailMessage;
+import org.broadinstitute.consent.http.models.mail.MailMessageInsert;
 import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
 import org.jdbi.v3.sqlobject.customizer.Bind;
 import org.jdbi.v3.sqlobject.customizer.BindMethods;
@@ -19,11 +20,11 @@ public interface MailMessageDAO extends Transactional<MailMessageDAO> {
         INSERT INTO email_entity
           (entity_reference_id, vote_id, user_id, email_type, date_sent, email_text, sendgrid_response, sendgrid_status, create_date)
         VALUES
-          (:entityReferenceId, :voteId, :userId, :emailType, :dateSent, :emailText, :sendgridResponse, :sendgridStatus, :createDate)
+          (:entityReferenceId, :voteId, :userId, :emailType, :dateSent, :emailText, :sendgridResponse, :sendgridStatus, NOW())
         RETURNING *)
       SELECT * FROM insterted_row
       """)
-  MailMessage insert(@BindMethods MailMessage mail);
+  MailMessage insert(@BindMethods MailMessageInsert mail);
 
   @SqlQuery(
       """

--- a/src/main/java/org/broadinstitute/consent/http/models/mail/MailMessageInsert.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/mail/MailMessageInsert.java
@@ -1,0 +1,13 @@
+package org.broadinstitute.consent.http.models.mail;
+
+import java.util.Date;
+
+public record MailMessageInsert(
+    String entityReferenceId,
+    Integer voteId,
+    Integer userId,
+    Integer emailType,
+    Date dateSent,
+    String emailText,
+    String sendgridResponse,
+    Integer sendgridStatus) {}

--- a/src/main/java/org/broadinstitute/consent/http/service/EmailService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/EmailService.java
@@ -36,6 +36,7 @@ import org.broadinstitute.consent.http.mail.message.NewStudyDigestMessage;
 import org.broadinstitute.consent.http.models.StudyDatasetCountRecord;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.UserVoteReminder;
+import org.broadinstitute.consent.http.models.mail.MailMessageInsert;
 import org.broadinstitute.consent.http.util.ConsentLogger;
 import org.jdbi.v3.core.result.ResultIterable;
 
@@ -94,19 +95,17 @@ public class EmailService implements ConsentLogger {
     Date dateSent = (response != null && response.getStatusCode() < 400) ? Date.from(now) : null;
     String sendgridResponse = response != null ? response.getBody() : null;
     Integer sendgridStatus = response != null ? response.getStatusCode() : null;
-    org.broadinstitute.consent.http.models.mail.MailMessage persistedMailMessage =
-        new org.broadinstitute.consent.http.models.mail.MailMessage(
+    MailMessageInsert mailMessageInsert =
+        new MailMessageInsert(
             mailMessage.getEntityReferenceId(),
-            null,
             mailMessage.getVoteId(),
             userId,
             mailMessage.emailType.getTypeInt(),
             dateSent,
             content,
             sendgridResponse,
-            sendgridStatus,
-            Date.from(now));
-    emailDAO.insert(persistedMailMessage);
+            sendgridStatus);
+    emailDAO.insert(mailMessageInsert);
   }
 
   public List<org.broadinstitute.consent.http.models.mail.MailMessage> fetchEmailMessagesByType(

--- a/src/main/java/org/broadinstitute/consent/http/service/EmailService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/EmailService.java
@@ -18,10 +18,8 @@ import java.time.format.DateTimeFormatter;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
-import javax.annotation.Nullable;
 import org.broadinstitute.consent.http.configurations.ConsentConfiguration;
 import org.broadinstitute.consent.http.db.DAOContainer;
 import org.broadinstitute.consent.http.db.DatasetDAO;
@@ -73,37 +71,6 @@ public class EmailService implements ConsentLogger {
     this.fromAccount = config.getMailConfiguration().getGoogleAccount();
   }
 
-  /**
-   * This method saves an email (either sent or unsent) with all available metadata from the
-   * SendGrid response.
-   */
-  private void saveEmailAndResponse(
-      @Nullable Response response,
-      @Nullable String entityReferenceId,
-      @Nullable Integer voteId,
-      Integer userId,
-      EmailType emailType,
-      String content) {
-    Instant now = Instant.now();
-    Date dateSent =
-        (Objects.nonNull(response) && response.getStatusCode() < 400) ? Date.from(now) : null;
-    String sendgridResponse = Objects.nonNull(response) ? response.getBody() : null;
-    Integer sendgridStatus = Objects.nonNull(response) ? response.getStatusCode() : null;
-    org.broadinstitute.consent.http.models.mail.MailMessage mailMessage =
-        new org.broadinstitute.consent.http.models.mail.MailMessage(
-            entityReferenceId,
-            null,
-            voteId,
-            userId,
-            emailType.getTypeInt(),
-            dateSent,
-            content,
-            sendgridResponse,
-            sendgridStatus,
-            Date.from(now));
-    emailDAO.insert(mailMessage);
-  }
-
   public void sendMessage(MailMessage mailMessage, Integer userId)
       throws IOException, TemplateException {
     Writer out = new StringWriter();
@@ -123,13 +90,23 @@ public class EmailService implements ConsentLogger {
     }
     // Checks that the user has not disabled email before sending
     Response response = sendGridAPI.sendMessage(message, mailMessage.toUser.getEmail());
-    saveEmailAndResponse(
-        response,
-        mailMessage.getEntityReferenceId(),
-        mailMessage.getVoteId(),
-        userId,
-        mailMessage.emailType,
-        content);
+    Instant now = Instant.now();
+    Date dateSent = (response != null && response.getStatusCode() < 400) ? Date.from(now) : null;
+    String sendgridResponse = response != null ? response.getBody() : null;
+    Integer sendgridStatus = response != null ? response.getStatusCode() : null;
+    org.broadinstitute.consent.http.models.mail.MailMessage persistedMailMessage =
+        new org.broadinstitute.consent.http.models.mail.MailMessage(
+            mailMessage.getEntityReferenceId(),
+            null,
+            mailMessage.getVoteId(),
+            userId,
+            mailMessage.emailType.getTypeInt(),
+            dateSent,
+            content,
+            sendgridResponse,
+            sendgridStatus,
+            Date.from(now));
+    emailDAO.insert(persistedMailMessage);
   }
 
   public List<org.broadinstitute.consent.http.models.mail.MailMessage> fetchEmailMessagesByType(

--- a/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
@@ -38,7 +38,7 @@ import org.broadinstitute.consent.http.models.DatasetProperty;
 import org.broadinstitute.consent.http.models.Election;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.Vote;
-import org.broadinstitute.consent.http.models.mail.MailMessage;
+import org.broadinstitute.consent.http.models.mail.MailMessageInsert;
 import org.jdbi.v3.core.JdbiException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -1267,17 +1267,15 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
     dataAccessRequestDAO.insertDARDatasetRelation(
         darTwo.getReferenceId(), datasetThree.getDatasetId());
     mailMessageDAO.insert(
-        new MailMessage(
+        new MailMessageInsert(
             darOne.getReferenceId(),
-            null,
             null,
             userOneId,
             EmailType.DAR_EXPIRATION_REMINDER.getTypeInt(),
             Date.from(Instant.now()),
             "hello world!",
             "success",
-            200,
-            Date.from(Instant.now())));
+            200));
     List<DataAccessRequest> dars =
         dataAccessRequestDAO.findAgedDARsByEmailTypeOlderThanInterval(
             EmailType.DAR_EXPIRATION_REMINDER.getTypeInt(),

--- a/src/test/java/org/broadinstitute/consent/http/db/ElectionDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/ElectionDAOTest.java
@@ -31,7 +31,7 @@ import org.broadinstitute.consent.http.models.Reminder;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.UserVoteReminder;
 import org.broadinstitute.consent.http.models.Vote;
-import org.broadinstitute.consent.http.models.mail.MailMessage;
+import org.broadinstitute.consent.http.models.mail.MailMessageInsert;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -692,17 +692,15 @@ class ElectionDAOTest extends DAOTestHelper {
     String referenceId = Instant.now().toString();
     Integer emailType = EmailType.COLLECT.getTypeInt();
     mailMessageDAO.insert(
-        new MailMessage(
+        new MailMessageInsert(
             referenceId,
-            null,
             vote.getVoteId(),
             vote.getUserId(),
             emailType,
             Date.from(Instant.now()),
             "Extra, Extra!",
             null,
-            null,
-            Date.from(Instant.now())));
+            null));
 
     List<UserVoteReminder> userVoteReminders =
         electionDAO.findElectionReminders(-1, emailType, referenceId);

--- a/src/test/java/org/broadinstitute/consent/http/db/MailMessageDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/MailMessageDAOTest.java
@@ -285,7 +285,7 @@ class MailMessageDAOTest extends DAOTestHelper {
         mailMessageDAO.fetchMessagesByType(EmailType.COLLECT.getTypeInt(), 1, 1);
     assertEquals(0, mailMessageList2.size());
 
-    MailMessage mail2 = generateMessage(user, now);
+    generateMessage(user, now);
 
     List<MailMessage> mailMessageList3 =
         mailMessageDAO.fetchMessagesByType(EmailType.COLLECT.getTypeInt(), 1, 1);

--- a/src/test/java/org/broadinstitute/consent/http/db/MailMessageDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/MailMessageDAOTest.java
@@ -160,66 +160,63 @@ class MailMessageDAOTest extends DAOTestHelper {
     Integer voteId = randomInt(1, 1000);
     String sendGridResponse = randomAlphanumeric(10);
     Integer sendGridStatus = randomInt(200, 399);
+    MailMessageInsert mailMessageInsert =
+        new MailMessageInsert(
+            entityReferenceId,
+            voteId,
+            null,
+            null,
+            Date.from(now),
+            null,
+            sendGridResponse,
+            sendGridStatus);
     assertThrows(
-        UnableToExecuteStatementException.class,
-        () ->
-            mailMessageDAO.insert(
-                new MailMessageInsert(
-                    entityReferenceId,
-                    voteId,
-                    null,
-                    null,
-                    Date.from(now),
-                    null,
-                    sendGridResponse,
-                    sendGridStatus)));
+        UnableToExecuteStatementException.class, () -> mailMessageDAO.insert(mailMessageInsert));
   }
 
   @Test
   void testInsert_MissingEmailType() {
+    User user = createUser();
     Instant now = Instant.now();
     String entityReferenceId = randomAlphanumeric(10);
     Integer voteId = randomInt(1, 1000);
-    Integer userId = randomInt(1, 1000);
     String sendGridResponse = randomAlphanumeric(10);
     Integer sendGridStatus = randomInt(200, 399);
+    MailMessageInsert mailMessageInsert =
+        new MailMessageInsert(
+            entityReferenceId,
+            voteId,
+            user.getUserId(),
+            null,
+            Date.from(now),
+            null,
+            sendGridResponse,
+            sendGridStatus);
     assertThrows(
-        UnableToExecuteStatementException.class,
-        () ->
-            mailMessageDAO.insert(
-                new MailMessageInsert(
-                    entityReferenceId,
-                    voteId,
-                    userId,
-                    null,
-                    Date.from(now),
-                    null,
-                    sendGridResponse,
-                    sendGridStatus)));
+        UnableToExecuteStatementException.class, () -> mailMessageDAO.insert(mailMessageInsert));
   }
 
   @Test
   void testInsert_MissingEmailText() {
+    User user = createUser();
     Instant now = Instant.now();
     String entityReferenceId = randomAlphanumeric(10);
     Integer voteId = randomInt(1, 1000);
-    Integer userId = randomInt(1, 1000);
     Integer emailType = EmailType.COLLECT.getTypeInt();
     String sendGridResponse = randomAlphanumeric(10);
     Integer sendGridStatus = randomInt(200, 399);
+    MailMessageInsert mailMessageInsert =
+        new MailMessageInsert(
+            entityReferenceId,
+            voteId,
+            user.getUserId(),
+            emailType,
+            Date.from(now),
+            null,
+            sendGridResponse,
+            sendGridStatus);
     assertThrows(
-        UnableToExecuteStatementException.class,
-        () ->
-            mailMessageDAO.insert(
-                new MailMessageInsert(
-                    entityReferenceId,
-                    voteId,
-                    userId,
-                    emailType,
-                    Date.from(now),
-                    null,
-                    sendGridResponse,
-                    sendGridStatus)));
+        UnableToExecuteStatementException.class, () -> mailMessageDAO.insert(mailMessageInsert));
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/db/MailMessageDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/MailMessageDAOTest.java
@@ -1,9 +1,9 @@
 package org.broadinstitute.consent.http.db;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Instant;
 import java.time.LocalDate;
@@ -225,7 +225,7 @@ class MailMessageDAOTest extends DAOTestHelper {
   @Test
   void testInsert_ProvidesCreateDateFromDatabase() {
     User user = createUser();
-    Instant now = Instant.now();
+    Instant historicalInstant = Instant.parse("2000-01-01T00:00:00Z");
     String entityReferenceId = randomAlphanumeric(10);
     Integer voteId = randomInt(1, 1000);
     Integer emailType = EmailType.COLLECT.getTypeInt();
@@ -239,12 +239,12 @@ class MailMessageDAOTest extends DAOTestHelper {
                 voteId,
                 user.getUserId(),
                 emailType,
-                Date.from(now),
+                Date.from(historicalInstant),
                 emailText,
                 sendGridResponse,
                 sendGridStatus));
     assertNotNull(savedMessage.createDate());
-    assertNotEquals(Date.from(now), savedMessage.createDate());
+    assertTrue(savedMessage.createDate().toInstant().isAfter(historicalInstant));
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/db/MailMessageDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/MailMessageDAOTest.java
@@ -1,6 +1,7 @@
 package org.broadinstitute.consent.http.db;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -14,6 +15,7 @@ import java.util.List;
 import org.broadinstitute.consent.http.enumeration.EmailType;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.mail.MailMessage;
+import org.broadinstitute.consent.http.models.mail.MailMessageInsert;
 import org.jdbi.v3.core.statement.UnableToExecuteStatementException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -28,17 +30,15 @@ class MailMessageDAOTest extends DAOTestHelper {
     Instant now = Instant.now();
     MailMessage mail =
         mailMessageDAO.insert(
-            new MailMessage(
+            new MailMessageInsert(
                 randomAlphanumeric(10),
-                null,
                 randomInt(1, 1000),
                 user.getUserId(),
                 EmailType.COLLECT.getTypeInt(),
                 Date.from(now),
                 randomAlphanumeric(10),
                 randomAlphanumeric(10),
-                randomInt(200, 399),
-                Date.from(now)));
+                randomInt(200, 399)));
     assertNotNull(mail);
   }
 
@@ -51,17 +51,15 @@ class MailMessageDAOTest extends DAOTestHelper {
               Instant now = Instant.now();
               MailMessage mail =
                   mailMessageDAO.insert(
-                      new MailMessage(
+                      new MailMessageInsert(
                           randomAlphanumeric(10),
-                          null,
                           randomInt(1, 1000),
                           user.getUserId(),
                           t.getTypeInt(),
                           Date.from(now),
                           randomAlphanumeric(10),
                           randomAlphanumeric(10),
-                          randomInt(200, 399),
-                          Date.from(now)));
+                          randomInt(200, 399)));
               assertNotNull(mail);
             });
   }
@@ -72,8 +70,7 @@ class MailMessageDAOTest extends DAOTestHelper {
     Instant now = Instant.now();
     MailMessage mail =
         mailMessageDAO.insert(
-            new MailMessage(
-                null,
+            new MailMessageInsert(
                 null,
                 randomInt(1, 1000),
                 user.getUserId(),
@@ -81,8 +78,7 @@ class MailMessageDAOTest extends DAOTestHelper {
                 Date.from(now),
                 randomAlphanumeric(10),
                 randomAlphanumeric(10),
-                randomInt(200, 399),
-                Date.from(now)));
+                randomInt(200, 399)));
     assertNotNull(mail);
   }
 
@@ -92,37 +88,32 @@ class MailMessageDAOTest extends DAOTestHelper {
     Instant now = Instant.now();
     MailMessage mail =
         mailMessageDAO.insert(
-            new MailMessage(
+            new MailMessageInsert(
                 randomAlphanumeric(10),
-                null,
                 null,
                 user.getUserId(),
                 EmailType.COLLECT.getTypeInt(),
                 Date.from(now),
                 randomAlphanumeric(10),
                 randomAlphanumeric(10),
-                randomInt(200, 399),
-                Date.from(now)));
+                randomInt(200, 399)));
     assertNotNull(mail);
   }
 
   @Test
   void testInsert_NullDateSent() {
     User user = createUser();
-    Instant now = Instant.now();
     MailMessage mail =
         mailMessageDAO.insert(
-            new MailMessage(
+            new MailMessageInsert(
                 randomAlphanumeric(10),
-                null,
                 randomInt(1, 1000),
                 user.getUserId(),
                 EmailType.COLLECT.getTypeInt(),
                 null,
                 randomAlphanumeric(10),
                 randomAlphanumeric(10),
-                randomInt(200, 399),
-                Date.from(now)));
+                randomInt(200, 399)));
     assertNotNull(mail);
   }
 
@@ -132,17 +123,15 @@ class MailMessageDAOTest extends DAOTestHelper {
     Instant now = Instant.now();
     MailMessage mail =
         mailMessageDAO.insert(
-            new MailMessage(
+            new MailMessageInsert(
                 randomAlphanumeric(10),
-                null,
                 randomInt(1, 1000),
                 user.getUserId(),
                 EmailType.COLLECT.getTypeInt(),
                 Date.from(now),
                 randomAlphanumeric(10),
                 null,
-                randomInt(200, 399),
-                Date.from(now)));
+                randomInt(200, 399)));
     assertNotNull(mail);
   }
 
@@ -152,17 +141,15 @@ class MailMessageDAOTest extends DAOTestHelper {
     Instant now = Instant.now();
     MailMessage mail =
         mailMessageDAO.insert(
-            new MailMessage(
+            new MailMessageInsert(
                 randomAlphanumeric(10),
-                null,
                 randomInt(1, 1000),
                 user.getUserId(),
                 EmailType.COLLECT.getTypeInt(),
                 Date.from(now),
                 randomAlphanumeric(10),
                 randomAlphanumeric(10),
-                null,
-                Date.from(now)));
+                null));
     assertNotNull(mail);
   }
 
@@ -177,17 +164,15 @@ class MailMessageDAOTest extends DAOTestHelper {
         UnableToExecuteStatementException.class,
         () ->
             mailMessageDAO.insert(
-                new MailMessage(
+                new MailMessageInsert(
                     entityReferenceId,
-                    null,
                     voteId,
                     null,
                     null,
                     Date.from(now),
                     null,
                     sendGridResponse,
-                    sendGridStatus,
-                    null)));
+                    sendGridStatus)));
   }
 
   @Test
@@ -202,17 +187,15 @@ class MailMessageDAOTest extends DAOTestHelper {
         UnableToExecuteStatementException.class,
         () ->
             mailMessageDAO.insert(
-                new MailMessage(
+                new MailMessageInsert(
                     entityReferenceId,
-                    null,
                     voteId,
                     userId,
                     null,
                     Date.from(now),
                     null,
                     sendGridResponse,
-                    sendGridStatus,
-                    null)));
+                    sendGridStatus)));
   }
 
   @Test
@@ -228,44 +211,40 @@ class MailMessageDAOTest extends DAOTestHelper {
         UnableToExecuteStatementException.class,
         () ->
             mailMessageDAO.insert(
-                new MailMessage(
+                new MailMessageInsert(
                     entityReferenceId,
-                    null,
                     voteId,
                     userId,
                     emailType,
                     Date.from(now),
                     null,
                     sendGridResponse,
-                    sendGridStatus,
-                    null)));
+                    sendGridStatus)));
   }
 
   @Test
-  void testInsert_MissingCreateDate() {
+  void testInsert_ProvidesCreateDateFromDatabase() {
+    User user = createUser();
     Instant now = Instant.now();
     String entityReferenceId = randomAlphanumeric(10);
     Integer voteId = randomInt(1, 1000);
-    Integer userId = randomInt(1, 1000);
     Integer emailType = EmailType.COLLECT.getTypeInt();
     String emailText = randomAlphanumeric(10);
     String sendGridResponse = randomAlphanumeric(10);
     Integer sendGridStatus = randomInt(200, 399);
-    assertThrows(
-        UnableToExecuteStatementException.class,
-        () ->
-            mailMessageDAO.insert(
-                new MailMessage(
-                    entityReferenceId,
-                    null,
-                    voteId,
-                    userId,
-                    emailType,
-                    Date.from(now),
-                    emailText,
-                    sendGridResponse,
-                    sendGridStatus,
-                    null)));
+    MailMessage savedMessage =
+        mailMessageDAO.insert(
+            new MailMessageInsert(
+                entityReferenceId,
+                voteId,
+                user.getUserId(),
+                emailType,
+                Date.from(now),
+                emailText,
+                sendGridResponse,
+                sendGridStatus));
+    assertNotNull(savedMessage.createDate());
+    assertNotEquals(Date.from(now), savedMessage.createDate());
   }
 
   @Test
@@ -276,17 +255,15 @@ class MailMessageDAOTest extends DAOTestHelper {
             t -> {
               Instant now = Instant.now();
               mailMessageDAO.insert(
-                  new MailMessage(
+                  new MailMessageInsert(
                       randomAlphanumeric(10),
-                      null,
                       randomInt(1, 1000),
                       user.getUserId(),
                       t.getTypeInt(),
                       Date.from(now),
                       randomAlphanumeric(10),
                       randomAlphanumeric(10),
-                      randomInt(200, 399),
-                      Date.from(now)));
+                      randomInt(200, 399)));
             });
 
     EnumSet.allOf(EmailType.class)
@@ -298,18 +275,7 @@ class MailMessageDAOTest extends DAOTestHelper {
   void testFetchLimitAndOffset() {
     User user = createUser();
     Instant now = Instant.now();
-    mailMessageDAO.insert(
-        new MailMessage(
-            randomAlphanumeric(10),
-            null,
-            randomInt(1, 1000),
-            user.getUserId(),
-            EmailType.COLLECT.getTypeInt(),
-            Date.from(now),
-            randomAlphanumeric(10),
-            randomAlphanumeric(10),
-            randomInt(200, 399),
-            Date.from(now)));
+    MailMessage firstMail = generateMessage(user, now.minus(1, ChronoUnit.HOURS));
 
     List<MailMessage> mailMessageList =
         mailMessageDAO.fetchMessagesByType(EmailType.COLLECT.getTypeInt(), 1, 0);
@@ -319,24 +285,12 @@ class MailMessageDAOTest extends DAOTestHelper {
         mailMessageDAO.fetchMessagesByType(EmailType.COLLECT.getTypeInt(), 1, 1);
     assertEquals(0, mailMessageList2.size());
 
-    MailMessage mail2 =
-        mailMessageDAO.insert(
-            new MailMessage(
-                randomAlphanumeric(10),
-                null,
-                randomInt(1, 1000),
-                user.getUserId(),
-                EmailType.COLLECT.getTypeInt(),
-                Date.from(now),
-                randomAlphanumeric(10),
-                randomAlphanumeric(10),
-                null,
-                Date.from(now)));
+    MailMessage mail2 = generateMessage(user, now);
 
     List<MailMessage> mailMessageList3 =
         mailMessageDAO.fetchMessagesByType(EmailType.COLLECT.getTypeInt(), 1, 1);
     assertEquals(1, mailMessageList3.size());
-    assertEquals(mail2.emailId(), mailMessageList3.getFirst().emailId());
+    assertEquals(firstMail.emailId(), mailMessageList3.getFirst().emailId());
 
     List<MailMessage> mailMessageList4 =
         mailMessageDAO.fetchMessagesByType(EmailType.COLLECT.getTypeInt(), 20, 0);
@@ -348,17 +302,15 @@ class MailMessageDAOTest extends DAOTestHelper {
     Instant now = Instant.now();
     User user = createUser();
     mailMessageDAO.insert(
-        new MailMessage(
+        new MailMessageInsert(
             randomAlphanumeric(10),
-            null,
             randomInt(1, 1000),
             user.getUserId(),
             EmailType.COLLECT.getTypeInt(),
             Date.from(now),
             randomAlphanumeric(10),
             randomAlphanumeric(10),
-            randomInt(200, 399),
-            Date.from(now)));
+            randomInt(200, 399)));
 
     List<MailMessage> mailMessageList =
         mailMessageDAO.fetchMessagesByUserId(user.getUserId(), 10, 0);
@@ -366,17 +318,15 @@ class MailMessageDAOTest extends DAOTestHelper {
     assertEquals(user.getUserId(), mailMessageList.getFirst().userId());
 
     mailMessageDAO.insert(
-        new MailMessage(
+        new MailMessageInsert(
             randomAlphanumeric(10),
-            null,
             randomInt(1, 1000),
             user.getUserId(),
             EmailType.COLLECT.getTypeInt(),
             Date.from(now),
             randomAlphanumeric(10),
             randomAlphanumeric(10),
-            randomInt(200, 399),
-            Date.from(now)));
+            randomInt(200, 399)));
     List<MailMessage> mailMessageList2 =
         mailMessageDAO.fetchMessagesByUserId(user.getUserId(), 10, 0);
     assertEquals(2, mailMessageList2.size());
@@ -447,18 +397,16 @@ class MailMessageDAOTest extends DAOTestHelper {
     String emailText = randomAlphanumeric(1000);
     String sendGridResponse = randomAlphanumeric(1000);
     Integer sendGridStatus = 200;
-    MailMessage unsavedMessage =
-        new MailMessage(
+    MailMessageInsert unsavedMessage =
+        new MailMessageInsert(
             entityReferenceId,
-            null,
             voteId,
             user.getUserId(),
             emailType,
             nowDate,
             emailText,
             sendGridResponse,
-            sendGridStatus,
-            nowDate);
+            sendGridStatus);
 
     MailMessage savedMessage = mailMessageDAO.insert(unsavedMessage);
     assertNotNull(savedMessage);
@@ -470,22 +418,33 @@ class MailMessageDAOTest extends DAOTestHelper {
     assertEquals(emailText, savedMessage.emailText());
     assertEquals(sendGridStatus, savedMessage.sendgridStatus());
     assertEquals(sendGridResponse, savedMessage.sendgridResponse());
-    assertEquals(nowDate, savedMessage.createDate());
+    assertNotNull(savedMessage.createDate());
   }
 
   private MailMessage generateMessage(Instant instant) {
-    User user = createUser();
-    return mailMessageDAO.insert(
-        new MailMessage(
-            randomAlphanumeric(10),
-            null,
-            randomInt(1, 1000),
-            user.getUserId(),
-            EmailType.COLLECT.getTypeInt(),
-            Date.from(instant),
-            randomAlphanumeric(10),
-            randomAlphanumeric(10),
-            randomInt(200, 399),
-            Date.from(instant)));
+    return generateMessage(createUser(), instant);
+  }
+
+  private MailMessage generateMessage(User user, Instant instant) {
+    MailMessage savedMessage =
+        mailMessageDAO.insert(
+            new MailMessageInsert(
+                randomAlphanumeric(10),
+                randomInt(1, 1000),
+                user.getUserId(),
+                EmailType.COLLECT.getTypeInt(),
+                Date.from(instant),
+                randomAlphanumeric(10),
+                randomAlphanumeric(10),
+                randomInt(200, 399)));
+    jdbi.useHandle(
+        handle ->
+            handle
+                .createUpdate(
+                    "UPDATE email_entity SET create_date = :createDate WHERE email_entity_id = :emailId")
+                .bind("createDate", Date.from(instant))
+                .bind("emailId", savedMessage.emailId())
+                .execute());
+    return mailMessageDAO.fetchMessageById(savedMessage.emailId());
   }
 }

--- a/src/test/java/org/broadinstitute/consent/http/db/UserDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/UserDAOTest.java
@@ -32,7 +32,7 @@ import org.broadinstitute.consent.http.models.LibraryCard;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.UserProperty;
 import org.broadinstitute.consent.http.models.UserRole;
-import org.broadinstitute.consent.http.models.mail.MailMessage;
+import org.broadinstitute.consent.http.models.mail.MailMessageInsert;
 import org.broadinstitute.consent.http.util.gson.GsonUtil;
 import org.jdbi.v3.core.result.ResultIterable;
 import org.jdbi.v3.core.statement.UnableToExecuteStatementException;
@@ -597,17 +597,8 @@ class UserDAOTest extends DAOTestHelper {
                   // simulate having sent a message so we won't send one again.
                   Date now = Date.from(Instant.now());
                   mailMessageDAO.insert(
-                      new MailMessage(
-                          referenceId,
-                          null,
-                          null,
-                          user.getUserId(),
-                          emailType,
-                          now,
-                          "",
-                          null,
-                          null,
-                          now));
+                      new MailMessageInsert(
+                          referenceId, null, user.getUserId(), emailType, now, "", null, null));
                 }
               }
             });

--- a/src/test/java/org/broadinstitute/consent/http/service/EmailServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/EmailServiceTest.java
@@ -2,6 +2,7 @@ package org.broadinstitute.consent.http.service;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -202,7 +203,7 @@ class EmailServiceTest extends AbstractTestHelper {
     var captor = ArgumentCaptor.forClass(Mail.class);
     verify(sendGridAPI).sendMessage(captor.capture(), eq(user.getEmail()));
     var mail = captor.getValue();
-    assertTrue(mail.getCategories() == null || mail.getCategories().isEmpty());
+    assertNull(mail.getCategories());
 
     verify(emailDAO)
         .insert(

--- a/src/test/java/org/broadinstitute/consent/http/service/EmailServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/EmailServiceTest.java
@@ -101,32 +101,13 @@ class EmailServiceTest extends AbstractTestHelper {
     User user = new User();
     user.setEmail(userEmail);
     String subject = "subject";
-    var model = Map.of("key", "value");
+    Map<String, Object> model = Map.of("key", "value");
     String entityReferenceId = "entityReferenceId";
     Integer userId = 1234;
     Integer voteId = 4567;
     var message =
-        new org.broadinstitute.consent.http.mail.message.MailMessage(user, EmailType.NEW_CASE) {
-          @Override
-          public String createSubject() {
-            return subject;
-          }
-
-          @Override
-          public Object createModel(String serverUrl) {
-            return model;
-          }
-
-          @Override
-          public String getEntityReferenceId() {
-            return entityReferenceId;
-          }
-
-          @Override
-          public Integer getVoteId() {
-            return voteId;
-          }
-        };
+        createMailMessage(
+            user, EmailType.NEW_CASE, subject, model, entityReferenceId, voteId, null);
     Template template = mock();
     when(templateHelper.getTemplate(EmailType.NEW_CASE.templateName)).thenReturn(template);
     Response response = new Response();
@@ -178,6 +159,110 @@ class EmailServiceTest extends AbstractTestHelper {
                         && Objects.equals(m.userId(), 1234)
                         && Objects.equals(m.emailType(), EmailType.NEW_CASE.getTypeInt())
                         && Objects.equals(m.dateSent(), Date.from(fixedInstant))
+                        && Objects.equals(m.emailText(), emailText)
+                        && Objects.equals(m.sendgridResponse(), response.getBody())
+                        && Objects.equals(m.sendgridStatus(), response.getStatusCode())));
+  }
+
+  @Test
+  @SuppressWarnings("deprecation")
+  void testSendMessage_SkipsCategoriesAndPersistsNullSendGridValues_WhenResponseIsNull()
+      throws Exception {
+    String userEmail = "user@duos";
+    User user = new User();
+    user.setEmail(userEmail);
+    String subject = "subject";
+    Map<String, Object> model = Map.of("key", "value");
+    String entityReferenceId = "entityReferenceId";
+    Integer userId = 1234;
+    String templateName = "test-template.ftl";
+    var message =
+        createMailMessage(
+            user, EmailType.NEW_DAA_REQUEST, subject, model, entityReferenceId, null, templateName);
+    Template template = mock();
+    when(templateHelper.getTemplate(templateName)).thenReturn(template);
+    when(sendGridAPI.sendMessage(any(), any())).thenReturn(null);
+    String emailText = "emailText";
+    doNothing()
+        .when(template)
+        .process(
+            eq(model),
+            argThat(
+                writer -> {
+                  try {
+                    writer.append(emailText);
+                  } catch (IOException e) {
+                    throw new RuntimeException(e);
+                  }
+                  return true;
+                }));
+
+    service.sendMessage(message, userId);
+
+    var captor = ArgumentCaptor.forClass(Mail.class);
+    verify(sendGridAPI).sendMessage(captor.capture(), eq(user.getEmail()));
+    var mail = captor.getValue();
+    assertTrue(mail.getCategories() == null || mail.getCategories().isEmpty());
+
+    verify(emailDAO)
+        .insert(
+            argThat(
+                (MailMessageInsert m) ->
+                    Objects.equals(m.entityReferenceId(), entityReferenceId)
+                        && m.voteId() == null
+                        && Objects.equals(m.userId(), userId)
+                        && Objects.equals(m.emailType(), EmailType.NEW_DAA_REQUEST.getTypeInt())
+                        && m.dateSent() == null
+                        && Objects.equals(m.emailText(), emailText)
+                        && m.sendgridResponse() == null
+                        && m.sendgridStatus() == null));
+  }
+
+  @Test
+  void testSendMessage_DoesNotSetDateSent_WhenSendGridReturnsErrorResponse() throws Exception {
+    String userEmail = "user@duos";
+    User user = new User();
+    user.setEmail(userEmail);
+    String subject = "subject";
+    Map<String, Object> model = Map.of("key", "value");
+    String entityReferenceId = "entityReferenceId";
+    Integer userId = 1234;
+    Integer voteId = 4567;
+    var message =
+        createMailMessage(
+            user, EmailType.NEW_CASE, subject, model, entityReferenceId, voteId, null);
+    Template template = mock();
+    when(templateHelper.getTemplate(EmailType.NEW_CASE.templateName)).thenReturn(template);
+    Response response = new Response();
+    response.setStatusCode(500);
+    response.setBody("error");
+    when(sendGridAPI.sendMessage(any(), any())).thenReturn(response);
+    String emailText = "emailText";
+    doNothing()
+        .when(template)
+        .process(
+            eq(model),
+            argThat(
+                writer -> {
+                  try {
+                    writer.append(emailText);
+                  } catch (IOException e) {
+                    throw new RuntimeException(e);
+                  }
+                  return true;
+                }));
+
+    service.sendMessage(message, userId);
+
+    verify(emailDAO)
+        .insert(
+            argThat(
+                (MailMessageInsert m) ->
+                    Objects.equals(m.entityReferenceId(), entityReferenceId)
+                        && Objects.equals(m.voteId(), voteId)
+                        && Objects.equals(m.userId(), userId)
+                        && Objects.equals(m.emailType(), EmailType.NEW_CASE.getTypeInt())
+                        && m.dateSent() == null
                         && Objects.equals(m.emailText(), emailText)
                         && Objects.equals(m.sendgridResponse(), response.getBody())
                         && Objects.equals(m.sendgridStatus(), response.getStatusCode())));
@@ -351,13 +436,114 @@ class EmailServiceTest extends AbstractTestHelper {
         .getTemplate(EmailType.NEW_STUDY_DIGEST.templateName);
     EmailService.sendgridThrottleMessageCount = 1;
     EmailService.sendgridThrottleResetTime = 1;
-    Thread.currentThread().interrupt();
-    service.sendNewDatasetInDUOSNotifications();
+    try {
+      Thread.currentThread().interrupt();
+      service.sendNewDatasetInDUOSNotifications();
+    } finally {
+      boolean interruptStatusCleared = Thread.interrupted();
+      assertTrue(interruptStatusCleared || !Thread.currentThread().isInterrupted());
+      EmailService.sendgridThrottleMessageCount = 500;
+      EmailService.sendgridThrottleResetTime = 60;
+    }
     verify(userDAO, times(1)).getHandle();
+  }
+
+  @Test
+  void testSendNewDatasetInDUOSNotifications_ReinterruptsThreadWhenThrottleSleepIsInterrupted()
+      throws IOException {
+    User toUser = new User();
+    toUser.setDisplayName("Test User");
+    toUser.setUserId(1);
+    toUser.setEmail("test@example.com");
+    toUser.setEmailPreference(true);
+    when(datasetDAO.getRecentDacApprovedDatasetStudyIds()).thenReturn(List.of());
+    when(datasetDAO.getRecentlyCreatedOpenOrExternalDatasetStudyIds()).thenReturn(List.of());
+    when(studyDAO.findNameAndDatasetCount(any()))
+        .thenReturn(List.of(new StudyDatasetCountRecord("New Study", 1, 7)));
+    Handle handle = mock(Handle.class);
+    Jdbi jdbi = mock(Jdbi.class);
+    when(userDAO.getHandle()).thenReturn(handle);
+    when(handle.getJdbi()).thenReturn(jdbi);
+    doAnswer(
+            invocation -> {
+              HandleConsumer<Exception> consumer = invocation.getArgument(0);
+              consumer.useHandle(handle);
+              return null;
+            })
+        .when(jdbi)
+        .useHandle(any());
+    @SuppressWarnings("unchecked")
+    ResultIterator<User> mockIterator = mock(ResultIterator.class);
+    when(mockIterator.hasNext()).thenReturn(true, false);
+    when(mockIterator.next()).thenReturn(toUser);
+    when(userDAO.allEmailReceivingThinlyPopulatedUsers(any(), any()))
+        .thenReturn(ResultIterable.of(mockIterator));
+    when(templateHelper.getTemplate(EmailType.NEW_STUDY_DIGEST.templateName)).thenReturn(mock());
+    Response response = new Response();
+    response.setStatusCode(202);
+    response.setBody("accepted");
+    when(sendGridAPI.sendMessage(any(), any())).thenReturn(response);
+    EmailService.sendgridThrottleMessageCount = 1;
+    EmailService.sendgridThrottleResetTime = 1;
+
+    try {
+      Thread.currentThread().interrupt();
+      service.sendNewDatasetInDUOSNotifications();
+      assertTrue(Thread.currentThread().isInterrupted());
+    } finally {
+      boolean interruptStatusCleared = Thread.interrupted();
+      assertTrue(interruptStatusCleared || !Thread.currentThread().isInterrupted());
+      EmailService.sendgridThrottleMessageCount = 500;
+      EmailService.sendgridThrottleResetTime = 60;
+    }
+
+    verify(userDAO, times(1)).getHandle();
+    verify(emailDAO, times(1))
+        .insert(
+            argThat(
+                m ->
+                    Objects.equals(m.userId(), toUser.getUserId())
+                        && Objects.equals(m.emailType(), EmailType.NEW_STUDY_DIGEST.getTypeInt())));
   }
 
   private List<MailMessage> generateMailMessageList() {
     return Collections.nCopies(2, generateMailMessage());
+  }
+
+  private org.broadinstitute.consent.http.mail.message.MailMessage createMailMessage(
+      User user,
+      EmailType emailType,
+      String subject,
+      Object model,
+      String entityReferenceId,
+      Integer voteId,
+      String templateNameOverride) {
+    return new org.broadinstitute.consent.http.mail.message.MailMessage(user, emailType) {
+      @Override
+      public String getTemplateName() {
+        return templateNameOverride != null ? templateNameOverride : super.getTemplateName();
+      }
+
+      @Override
+      public String createSubject() {
+        return subject;
+      }
+
+      @Override
+      public Object createModel(String serverUrl) {
+        return model;
+      }
+
+      @Override
+      public String getEntityReferenceId() {
+        return entityReferenceId;
+      }
+
+      @Override
+      public Integer getVoteId() {
+        return voteId;
+      }
+    };
   }
 
   private MailMessage generateMailMessage() {

--- a/src/test/java/org/broadinstitute/consent/http/service/EmailServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/EmailServiceTest.java
@@ -191,6 +191,15 @@ class EmailServiceTest extends AbstractTestHelper {
   }
 
   @Test
+  void testFetchEmailsByUserId() {
+    Integer userId = 123;
+    List<MailMessage> mailMessages = generateMailMessageList();
+    when(emailDAO.fetchMessagesByUserId(eq(userId), anyInt(), anyInt())).thenReturn(mailMessages);
+
+    assertEquals(2, service.fetchEmailMessagesByUserId(userId, 20, 0).size());
+  }
+
+  @Test
   void testFetchEmailsByCreateDate() {
     List<MailMessage> mailMessages = generateMailMessageList();
     Date startDate = new Date();

--- a/src/test/java/org/broadinstitute/consent/http/service/EmailServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/EmailServiceTest.java
@@ -45,6 +45,7 @@ import org.broadinstitute.consent.http.models.StudyDatasetCountRecord;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.UserVoteReminder;
 import org.broadinstitute.consent.http.models.mail.MailMessage;
+import org.broadinstitute.consent.http.models.mail.MailMessageInsert;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.HandleConsumer;
 import org.jdbi.v3.core.Jdbi;
@@ -171,7 +172,7 @@ class EmailServiceTest extends AbstractTestHelper {
     verify(emailDAO)
         .insert(
             argThat(
-                m ->
+                (MailMessageInsert m) ->
                     Objects.equals(m.entityReferenceId(), entityReferenceId)
                         && Objects.equals(m.voteId(), voteId)
                         && Objects.equals(m.userId(), 1234)
@@ -179,8 +180,7 @@ class EmailServiceTest extends AbstractTestHelper {
                         && Objects.equals(m.dateSent(), Date.from(fixedInstant))
                         && Objects.equals(m.emailText(), emailText)
                         && Objects.equals(m.sendgridResponse(), response.getBody())
-                        && Objects.equals(m.sendgridStatus(), response.getStatusCode())
-                        && Objects.equals(m.createDate(), Date.from(fixedInstant))));
+                        && Objects.equals(m.sendgridStatus(), response.getStatusCode())));
   }
 
   @Test


### PR DESCRIPTION
### Addresses
Partially addresses https://broadworkbench.atlassian.net/browse/DT-1591
Specifically, bullet point 2:
> The EmailService methods saveEmailAndResponse and sendMessage could be further refactored now that saveEmailAndResponse is only used in one place.

### Summary
This PR simplifies `EmailService` by combining methods. We now delegate the creation date to the database instead of passing it in via application code. Additionally, tests are updated for coverage and comprehensiveness.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
